### PR TITLE
chore: add branch policy rules and merge direction guards

### DIFF
--- a/.agents/skills/branch-guard/SKILL.md
+++ b/.agents/skills/branch-guard/SKILL.md
@@ -52,9 +52,32 @@ description: Guard against committing directly to protected branches (main, mast
 - `master`
 - `develop`
 
+4. **When merging a branch** (PR or local merge):
+
+   **Determine merge target:**
+   - Check the fork point of the current branch:
+     ```bash
+     git log --oneline --first-parent develop..HEAD
+     git log --oneline --first-parent main..HEAD
+     ```
+   - The merge target must be the branch it was forked from.
+   - If the branch was forked from `develop`, merge back into `develop`.
+   - If the branch was forked from `main`, merge back into `main` (rare, requires justification).
+
+   **Never assume `main` as the default target.** The default is always the fork origin.
+
+   **If the agent wants a different merge target:**
+   - Explicitly state the recommendation and reasoning.
+   - Wait for user approval before proceeding.
+
+   **Merging `develop` into `main`:**
+   - This is a release-level action. Always ask for explicit user approval.
+   - Never do this as part of a regular feature workflow.
+
 ## Stop Conditions
 - User declines branch creation — do not commit on the protected branch.
 - Branch name conflicts with an existing branch — ask for an alternative name.
+- Merge target differs from fork origin — ask user before proceeding.
 
 ## Checklist
 - [ ] Current branch checked before every commit
@@ -62,9 +85,13 @@ description: Guard against committing directly to protected branches (main, mast
 - [ ] Branch name suggested with conventional prefix
 - [ ] User approved the branch name
 - [ ] New branch created before committing
+- [ ] Merge target matches fork origin
+- [ ] Release merge (develop → main) explicitly approved by user
 
 ## Anti-Patterns
 - Committing directly to `main`, `master`, or `develop` without asking.
 - Creating a branch without user approval of the name.
 - Using generic branch names like `temp` or `wip` without a descriptive suffix.
 - Creating a new branch for every intermediate commit within a single task.
+- Merging into `main` when the branch was forked from `develop`.
+- Assuming `main` as the default merge/PR target.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -23,10 +23,12 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 # Detect git action type
 IS_COMMIT=false
 IS_PUSH=false
+IS_MERGE=false
 echo "$COMMAND" | grep -qE '^\s*git\s+commit\b' && IS_COMMIT=true
 echo "$COMMAND" | grep -qE '^\s*git\s+(push|push\s)' && IS_PUSH=true
+echo "$COMMAND" | grep -qE '^\s*git\s+merge\b' && IS_MERGE=true
 
-if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" ]]; then
+if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" && "$IS_MERGE" == "false" ]]; then
   exit 0
 fi
 
@@ -53,6 +55,16 @@ if [[ "$IS_PUSH" == "true" ]]; then
   for branch in main master; do
     if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
       echo "[branch-guard] Blocked: cannot git push on protected branch '${branch}'." >&2
+      exit 2
+    fi
+  done
+fi
+
+# Block merge into main/master (release merge requires explicit user approval via PR)
+if [[ "$IS_MERGE" == "true" ]]; then
+  for branch in main master; do
+    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+      echo "[branch-guard] Blocked: cannot git merge into '${branch}'. Use a PR or get explicit user approval for release merges." >&2
       exit 2
     fi
   done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,16 @@ All rules below are mandatory and non-negotiable.
 - Conventional commit format: `<type>(<scope>): <message>` (max 80 chars).
 - Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`.
 
+### Branch Policy
+
+- `main` is the production branch. Direct commits and pushes to `main` are prohibited.
+- `develop` is the integration branch. All feature work branches from `develop`.
+- Feature branches must be created from `develop` and merged back into `develop`.
+- Merging `develop` into `main` requires explicit user approval and is a release-level action.
+- When merging a branch, always merge back to the branch it was forked from. Verify the fork point before proposing a merge target.
+- If the agent wants to suggest a different merge target than the fork origin, it must explicitly recommend and receive user approval before proceeding.
+- Never assume `main` as the default merge target. Always check the actual fork point.
+
 ### DAG Node Implementation
 
 - Every node class must extend `AbstractNodeDefinition`.


### PR DESCRIPTION
## Summary

- Add Branch Policy section to AGENTS.md (main protected, develop-based workflow)
- Update branch-guard skill with merge direction verification steps
- Add git merge block to branch-guard.sh hook for main/master

### Rules added
- `main` = production branch, no direct commits/pushes/merges
- `develop` = integration branch, all feature work branches from here
- Feature branches merge back to fork origin (not main by default)
- Release merges (develop → main) require explicit user approval

## Test plan
- [x] Hook correctly blocks `git merge` on main
- [x] Hook allows merge on non-protected branches
- [x] Existing commit/push guards unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)