### PR TITLE
feat(harness): PreToolUse hook blocking any/console/try-catch-fallback

### DIFF
--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# PreToolUse hook: block forbidden patterns in production TypeScript source.
+# PreToolUse hook: block forbidden patterns in NEW content being written.
 # Covers common-mistakes #1 (any), #7 (console.*), #9 (try/catch fallback).
 #
+# Reads tool_input.content (Write) or tool_input.new_string (Edit) from stdin —
+# NOT the existing file — so only newly introduced violations are caught.
+#
 # Escape mechanism (per-line):
-#   const x: any = y;           // allow-any: <reason>
-#   console.log(msg);           // allow-console: <reason>
-#   try { ... } catch { ... }   // allow-fallback: <reason>
+#   const x: any = y;         // allow-any: <reason>
+#   console.log(msg);         // allow-console: <reason>
+#   } catch (e) {             // allow-fallback: <reason>
 #
 # Exit codes: 0 = pass, 2 = hard block
 
@@ -15,18 +18,18 @@ INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 LOG_FILE="$PROJECT_DIR/.agents/evals/harness-log/blocks.jsonl"
 
-# Extract file_path from tool_input
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+# ── scope filter ──────────────────────────────────────────────────────────────
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
 
-if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only check production TypeScript under packages/*/src (not tests, not apps)
+# Only check production TypeScript under packages/*/src
 case "$FILE_PATH" in
-  "$PROJECT_DIR"/packages/*/src/*.ts) ;;
-  "$PROJECT_DIR"/packages/*/src/**/*.ts) ;;
-  "$PROJECT_DIR"/packages/*/src/*.tsx) ;;
+  "$PROJECT_DIR"/packages/*/src/*.ts|\
+  "$PROJECT_DIR"/packages/*/src/**/*.ts|\
+  "$PROJECT_DIR"/packages/*/src/*.tsx|\
   "$PROJECT_DIR"/packages/*/src/**/*.tsx) ;;
   *) exit 0 ;;
 esac
@@ -35,6 +38,14 @@ esac
 case "$FILE_PATH" in
   */__tests__/*|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx) exit 0 ;;
 esac
+
+# ── extract NEW content from stdin (not disk) ─────────────────────────────────
+# Write tool → tool_input.content  |  Edit tool → tool_input.new_string
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // ""')
+
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 RELATIVE_PATH="${FILE_PATH#$PROJECT_DIR/}"
@@ -57,54 +68,47 @@ while IFS= read -r match; do
   [ -z "$match" ] && continue
   line_num=$(echo "$match" | cut -d: -f1)
   line_content=$(echo "$match" | cut -d: -f2-)
-  # skip comment lines (JSDoc, inline comments)
   echo "$line_content" | grep -qE '^\s*\*|^\s*//' && continue
   echo "$line_content" | grep -q '//[[:space:]]*allow-any:' && continue
   append_block "any-type" "$line_num" "$line_content"
-done < <(grep -nE ':\s*any(\s|;|,|\)|>|$)|\bas\s+any\b' "$FILE_PATH" 2>/dev/null || true)
+done < <(echo "$CONTENT" | grep -nE ':\s*any(\s|;|,|\)|>|$)|\bas\s+any\b' 2>/dev/null || true)
 
 # ── #7: console.* ─────────────────────────────────────────────────────────────
 while IFS= read -r match; do
   [ -z "$match" ] && continue
   line_num=$(echo "$match" | cut -d: -f1)
   line_content=$(echo "$match" | cut -d: -f2-)
-  # skip comment lines (JSDoc, inline comments)
   echo "$line_content" | grep -qE '^\s*\*|^\s*//' && continue
   echo "$line_content" | grep -q '//[[:space:]]*allow-console:' && continue
   append_block "console-usage" "$line_num" "$line_content"
-done < <(grep -nE '\bconsole\.(log|warn|error|info|debug|trace)\b' "$FILE_PATH" 2>/dev/null || true)
+done < <(echo "$CONTENT" | grep -nE '\bconsole\.(log|warn|error|info|debug|trace)\b' 2>/dev/null || true)
 
-# ── #9: try/catch fallback (catch block that swallows/suppresses the error) ───
-# Heuristic: catch block body is empty or only contains a comment/return/continue
-# We scan for catch blocks where the body has no rethrow and no error propagation
-CATCH_LINES=$(grep -nE '^\s*}\s*catch\s*(\(|{)' "$FILE_PATH" 2>/dev/null || true)
+# ── #9: try/catch fallback ────────────────────────────────────────────────────
+# Flag catch blocks where the body has no rethrow/reject/error propagation
 while IFS= read -r match; do
   [ -z "$match" ] && continue
   line_num=$(echo "$match" | cut -d: -f1)
   line_content=$(echo "$match" | cut -d: -f2-)
   echo "$line_content" | grep -q '//[[:space:]]*allow-fallback:' && continue
-  # Read ahead a few lines to check if error is suppressed (no throw/reject/return error)
-  block=$(sed -n "$((line_num)),$((line_num + 6))p" "$FILE_PATH" 2>/dev/null || true)
-  # If catch block has no throw/reject/Promise.reject/return.*[Ee]rr — flag as fallback
+  # Read ahead 6 lines from CONTENT (not disk)
+  block=$(echo "$CONTENT" | sed -n "$((line_num)),$((line_num + 6))p")
   if ! echo "$block" | grep -qE '\bthrow\b|\bPromise\.reject\b|return.*[Ee]rr'; then
     append_block "try-catch-fallback" "$line_num" "$line_content"
   fi
-done <<< "$CATCH_LINES"
+done < <(echo "$CONTENT" | grep -nE '^\s*}\s*catch\s*(\(|{)' 2>/dev/null || true)
 
+# ── report ────────────────────────────────────────────────────────────────────
 if [ "$BLOCKED" = true ]; then
   echo "" >&2
   echo "❌ [check-forbidden-patterns] Blocked — forbidden pattern(s) in $RELATIVE_PATH:" >&2
   echo -e "$BLOCK_MESSAGES" >&2
   echo "" >&2
   echo "Rules:" >&2
-  echo "  any-type        → common-mistakes #1: use unknown + narrowing or a proper interface" >&2
-  echo "  console-usage   → common-mistakes #7: use dependency-injected logger" >&2
+  echo "  any-type           → common-mistakes #1: use unknown + narrowing or a proper interface" >&2
+  echo "  console-usage      → common-mistakes #7: use dependency-injected logger" >&2
   echo "  try-catch-fallback → common-mistakes #9: no fallback; terminal failures stay terminal" >&2
   echo "" >&2
-  echo "To allow an exception, add an escape comment on the same line:" >&2
-  echo "  const x: any = y;    // allow-any: <reason>" >&2
-  echo "  console.log(msg);    // allow-console: <reason>" >&2
-  echo "  } catch (e) {        // allow-fallback: <reason>" >&2
+  echo "Escape (same line): // allow-any: <reason>  |  // allow-console: <reason>  |  // allow-fallback: <reason>" >&2
   echo "" >&2
   exit 2
 fi

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block forbidden patterns in production TypeScript source.
+# Covers common-mistakes #1 (any), #7 (console.*), #9 (try/catch fallback).
+#
+# Escape mechanism (per-line):
+#   const x: any = y;           // allow-any: <reason>
+#   console.log(msg);           // allow-console: <reason>
+#   try { ... } catch { ... }   // allow-fallback: <reason>
+#
+# Exit codes: 0 = pass, 2 = hard block
+
+set -uo pipefail
+
+INPUT=$(cat)
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+LOG_FILE="$PROJECT_DIR/.agents/evals/harness-log/blocks.jsonl"
+
+# Extract file_path from tool_input
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only check production TypeScript under packages/*/src (not tests, not apps)
+case "$FILE_PATH" in
+  "$PROJECT_DIR"/packages/*/src/*.ts) ;;
+  "$PROJECT_DIR"/packages/*/src/**/*.ts) ;;
+  "$PROJECT_DIR"/packages/*/src/*.tsx) ;;
+  "$PROJECT_DIR"/packages/*/src/**/*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Skip test files
+case "$FILE_PATH" in
+  */__tests__/*|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx) exit 0 ;;
+esac
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RELATIVE_PATH="${FILE_PATH#$PROJECT_DIR/}"
+BLOCKED=false
+BLOCK_MESSAGES=""
+
+append_block() {
+  local pattern="$1"
+  local line_num="$2"
+  local line_content="$3"
+  mkdir -p "$(dirname "$LOG_FILE")"
+  printf '{"timestamp":"%s","pattern":"%s","file":"%s","line":%d,"escape_attempted":false}\n' \
+    "$TIMESTAMP" "$pattern" "$RELATIVE_PATH" "$line_num" >> "$LOG_FILE"
+  BLOCK_MESSAGES="$BLOCK_MESSAGES\n  line $line_num: $line_content"
+  BLOCKED=true
+}
+
+# ── #1: any type ──────────────────────────────────────────────────────────────
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+  line_num=$(echo "$match" | cut -d: -f1)
+  line_content=$(echo "$match" | cut -d: -f2-)
+  # skip comment lines (JSDoc, inline comments)
+  echo "$line_content" | grep -qE '^\s*\*|^\s*//' && continue
+  echo "$line_content" | grep -q '//[[:space:]]*allow-any:' && continue
+  append_block "any-type" "$line_num" "$line_content"
+done < <(grep -nE ':\s*any(\s|;|,|\)|>|$)|\bas\s+any\b' "$FILE_PATH" 2>/dev/null || true)
+
+# ── #7: console.* ─────────────────────────────────────────────────────────────
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+  line_num=$(echo "$match" | cut -d: -f1)
+  line_content=$(echo "$match" | cut -d: -f2-)
+  # skip comment lines (JSDoc, inline comments)
+  echo "$line_content" | grep -qE '^\s*\*|^\s*//' && continue
+  echo "$line_content" | grep -q '//[[:space:]]*allow-console:' && continue
+  append_block "console-usage" "$line_num" "$line_content"
+done < <(grep -nE '\bconsole\.(log|warn|error|info|debug|trace)\b' "$FILE_PATH" 2>/dev/null || true)
+
+# ── #9: try/catch fallback (catch block that swallows/suppresses the error) ───
+# Heuristic: catch block body is empty or only contains a comment/return/continue
+# We scan for catch blocks where the body has no rethrow and no error propagation
+CATCH_LINES=$(grep -nE '^\s*}\s*catch\s*(\(|{)' "$FILE_PATH" 2>/dev/null || true)
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+  line_num=$(echo "$match" | cut -d: -f1)
+  line_content=$(echo "$match" | cut -d: -f2-)
+  echo "$line_content" | grep -q '//[[:space:]]*allow-fallback:' && continue
+  # Read ahead a few lines to check if error is suppressed (no throw/reject/return error)
+  block=$(sed -n "$((line_num)),$((line_num + 6))p" "$FILE_PATH" 2>/dev/null || true)
+  # If catch block has no throw/reject/Promise.reject/return.*[Ee]rr — flag as fallback
+  if ! echo "$block" | grep -qE '\bthrow\b|\bPromise\.reject\b|return.*[Ee]rr'; then
+    append_block "try-catch-fallback" "$line_num" "$line_content"
+  fi
+done <<< "$CATCH_LINES"
+
+if [ "$BLOCKED" = true ]; then
+  echo "" >&2
+  echo "❌ [check-forbidden-patterns] Blocked — forbidden pattern(s) in $RELATIVE_PATH:" >&2
+  echo -e "$BLOCK_MESSAGES" >&2
+  echo "" >&2
+  echo "Rules:" >&2
+  echo "  any-type        → common-mistakes #1: use unknown + narrowing or a proper interface" >&2
+  echo "  console-usage   → common-mistakes #7: use dependency-injected logger" >&2
+  echo "  try-catch-fallback → common-mistakes #9: no fallback; terminal failures stay terminal" >&2
+  echo "" >&2
+  echo "To allow an exception, add an escape comment on the same line:" >&2
+  echo "  const x: any = y;    // allow-any: <reason>" >&2
+  echo "  console.log(msg);    // allow-console: <reason>" >&2
+  echo "  } catch (e) {        // allow-fallback: <reason>" >&2
+  echo "" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-check.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-forbidden-patterns.sh"
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## Summary

- `check-forbidden-patterns.sh`: common-mistakes #1(any), #7(console.*), #9(try/catch fallback)을 Write/Edit 전에 hard-block (exit 2)
- 새로 작성되는 콘텐츠(`tool_input.content` / `tool_input.new_string`)만 검사 — 기존 파일의 기왕 위반은 false positive 없음
- 차단 시 `.agents/evals/harness-log/blocks.jsonl`에 자동 기록 → 랄프 루프 신호 수집 시작
- 탈출 주석: `// allow-any: <reason>` | `// allow-console: <reason>` | `// allow-fallback: <reason>`
- `settings.json`에 PreToolUse `Edit|Write` 매처로 등록

## Test plan

- [x] Write 시뮬레이션: `any`/`console.*`/`try-catch` 포함 콘텐츠 → exit 2 확인
- [x] Edit 시뮬레이션: `new_string`에 위반 포함 → exit 2 확인
- [x] 클린 Edit → exit 0 통과 확인
- [x] JSDoc 주석 내 `console.log` → false positive 없음 확인
- [x] `blocks.jsonl` 항목 정상 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)