### PR TITLE
feat(cli): add --bare, --allowed-tools, --no-session-persistence, --json-schema flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ scripts/audit/output/
 
 # Auto-generated API reference from docs:build (typedoc output)
 content/api-reference/
+.worktrees/

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -239,13 +239,32 @@ export async function startCli(): Promise<void> {
       process.exit(1);
     }
 
+    // Build appendSystemPrompt from --append-system-prompt and --json-schema
+    const appendParts: string[] = [];
+    if (args.appendSystemPrompt) appendParts.push(args.appendSystemPrompt);
+    if (args.jsonSchema)
+      appendParts.push(
+        `Respond with valid JSON only, matching this JSON schema:\n${args.jsonSchema}`,
+      );
+    const appendSystemPrompt = appendParts.length > 0 ? appendParts.join('\n\n') : undefined;
+
+    // TODO: wire --system-prompt once IInteractiveSessionStandardOptions adds systemPrompt field
+
     const session = new InteractiveSession({
       cwd,
       provider,
       permissionMode: args.permissionMode ?? 'bypassPermissions',
       maxTurns: args.maxTurns,
-      sessionStore,
+      sessionStore: args.noSessionPersistence ? undefined : sessionStore,
       sessionName: args.sessionName,
+      bare: args.bare || undefined,
+      allowedTools: args.allowedTools
+        ? args.allowedTools
+            .split(',')
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0)
+        : undefined,
+      appendSystemPrompt,
     });
 
     const transport = createHeadlessTransport({

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -94,3 +94,55 @@ describe('parseCliArgs', () => {
     expect(args.outputFormat).toBeUndefined();
   });
 });
+
+describe('new non-interactive flags', () => {
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    originalArgv = process.argv;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it('parses --bare flag', () => {
+    process.argv = ['node', 'cli', '--bare'];
+    expect(parseCliArgs().bare).toBe(true);
+  });
+
+  it('defaults bare to false', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().bare).toBe(false);
+  });
+
+  it('parses --allowed-tools flag', () => {
+    process.argv = ['node', 'cli', '--allowed-tools', 'Bash,Read,Write'];
+    expect(parseCliArgs().allowedTools).toBe('Bash,Read,Write');
+  });
+
+  it('defaults allowedTools to undefined', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().allowedTools).toBeUndefined();
+  });
+
+  it('parses --no-session-persistence flag', () => {
+    process.argv = ['node', 'cli', '--no-session-persistence'];
+    expect(parseCliArgs().noSessionPersistence).toBe(true);
+  });
+
+  it('defaults noSessionPersistence to false', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().noSessionPersistence).toBe(false);
+  });
+
+  it('parses --json-schema flag', () => {
+    process.argv = ['node', 'cli', '--json-schema', '{"type":"object"}'];
+    expect(parseCliArgs().jsonSchema).toBe('{"type":"object"}');
+  });
+
+  it('defaults jsonSchema to undefined', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().jsonSchema).toBeUndefined();
+  });
+});

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -24,6 +24,10 @@ export interface IParsedCliArgs {
   appendSystemPrompt: string | undefined;
   version: boolean;
   reset: boolean;
+  bare: boolean;
+  allowedTools: string | undefined;
+  noSessionPersistence: boolean;
+  jsonSchema: string | undefined;
 }
 
 /** Validate and return a TPermissionMode from a raw CLI string, or exit on error. */
@@ -66,6 +70,10 @@ export function parseCliArgs(): IParsedCliArgs {
       'append-system-prompt': { type: 'string' },
       version: { type: 'boolean', default: false },
       reset: { type: 'boolean', default: false },
+      bare: { type: 'boolean', default: false },
+      'allowed-tools': { type: 'string' },
+      'no-session-persistence': { type: 'boolean', default: false },
+      'json-schema': { type: 'string' },
     },
   });
 
@@ -85,5 +93,9 @@ export function parseCliArgs(): IParsedCliArgs {
     appendSystemPrompt: values['append-system-prompt'],
     version: values['version'] ?? false,
     reset: values['reset'] ?? false,
+    bare: values['bare'] ?? false,
+    allowedTools: values['allowed-tools'],
+    noSessionPersistence: values['no-session-persistence'] ?? false,
+    jsonSchema: values['json-schema'],
   };
 }

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Behavioral tests for new createSession options: allowedTools and appendSystemPrompt.
+ *
+ * Verifies:
+ * - allowedTools: ['Bash', 'Read'] → Session receives permissions.allow containing 'Bash(*)' and 'Read(*)'
+ * - appendSystemPrompt: 'EXTRA TEXT' → Session receives systemMessage ending with '\n\nEXTRA TEXT'
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture all Session constructor calls to inspect the options passed
+const sessionCtorCalls: Array<Record<string, unknown>> = [];
+
+vi.mock('@robota-sdk/agent-sessions', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-sessions');
+  return {
+    ...actual,
+    Session: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+      sessionCtorCalls.push(options);
+      // Return a minimal mock session
+      return {
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
+        run: vi.fn().mockResolvedValue('mock response'),
+        abort: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        clearHistory: vi.fn(),
+        injectMessage: vi.fn(),
+      };
+    }),
+    FileSessionLogger: vi.fn().mockImplementation(() => ({})),
+  };
+});
+
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue('mock AI response'),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+    })),
+    runHooks: vi.fn().mockResolvedValue({ blocked: false }),
+  };
+});
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+} as never;
+
+function createMockProvider() {
+  return {
+    name: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      role: 'assistant',
+      content: 'mock response',
+      timestamp: new Date(),
+    }),
+  } as never;
+}
+
+function baseConfig() {
+  return {
+    defaultTrustLevel: 'moderate' as const,
+    provider: { name: 'mock', apiKey: 'test-key', model: 'test-model' },
+    permissions: { allow: [], deny: [] },
+    language: 'en' as const,
+    env: {},
+  };
+}
+
+describe('createSession — allowedTools option', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('passes allowedTools as ToolName(*) patterns in permissions.allow', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      allowedTools: ['Bash', 'Read'],
+    });
+
+    expect(sessionCtorCalls.length).toBe(1);
+    const opts = sessionCtorCalls[0]!;
+    const allow = (opts.permissions as { allow: string[] }).allow;
+    expect(allow).toContain('Bash(*)');
+    expect(allow).toContain('Read(*)');
+  });
+
+  it('permissions.allow includes Bash(*) and Read(*) alongside default allow patterns', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      allowedTools: ['Bash', 'Read'],
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const allow = (opts.permissions as { allow: string[] }).allow;
+
+    // Should still include the default config folder allow patterns
+    expect(allow.some((p: string) => p.startsWith('Read(.agents/'))).toBe(true);
+    // And the new allowedTools patterns
+    expect(allow).toContain('Bash(*)');
+    expect(allow).toContain('Read(*)');
+  });
+
+  it('empty allowedTools produces no extra ToolName(*) patterns beyond defaults', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      allowedTools: [],
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const allow = (opts.permissions as { allow: string[] }).allow;
+
+    // Bash(*) should NOT appear when allowedTools is empty
+    expect(allow).not.toContain('Bash(*)');
+    expect(allow).not.toContain('Read(*)');
+  });
+
+  it('omitting allowedTools does not add any ToolName(*) patterns', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      // allowedTools not provided
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const allow = (opts.permissions as { allow: string[] }).allow;
+
+    // No Bash(*) or Read(*) should appear when allowedTools is not specified
+    const toolStarPatterns = allow.filter((p: string) => /^\w+\(\*\)$/.test(p));
+    expect(toolStarPatterns).toHaveLength(0);
+  });
+});
+
+describe('createSession — appendSystemPrompt option', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('appends text to system message separated by double newline', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      appendSystemPrompt: 'EXTRA TEXT',
+    });
+
+    expect(sessionCtorCalls.length).toBe(1);
+    const opts = sessionCtorCalls[0]!;
+    const systemMessage = opts.systemMessage as string;
+    expect(systemMessage.endsWith('\n\nEXTRA TEXT')).toBe(true);
+  });
+
+  it('system message without appendSystemPrompt does not have trailing double newline', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      // no appendSystemPrompt
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const systemMessage = opts.systemMessage as string;
+    expect(systemMessage.endsWith('\n\nEXTRA TEXT')).toBe(false);
+  });
+
+  it('appendSystemPrompt with multi-word text is appended verbatim after \\n\\n', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+    const extraText = 'You must respond only in JSON format.';
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      appendSystemPrompt: extraText,
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const systemMessage = opts.systemMessage as string;
+    expect(systemMessage).toContain('\n\n' + extraText);
+    expect(systemMessage.endsWith(extraText)).toBe(true);
+  });
+});

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -85,6 +85,8 @@ export interface ICreateSessionOptions {
   additionalHookExecutors?: IHookTypeExecutor[];
   /** Override session ID (used when resuming a session to reuse the original ID) */
   sessionId?: string;
+  /** Pre-approved tool names — added to permissions.allow as ToolName(*) patterns. */
+  allowedTools?: string[];
 }
 
 /**
@@ -165,8 +167,9 @@ export function createSession(options: ICreateSessionOptions): Session {
     'Glob(.claude/**)',
     'Glob(.robota/**)',
   ];
+  const allowedToolPatterns = (options.allowedTools ?? []).map((name) => `${name}(*)`);
   const mergedPermissions = {
-    allow: [...defaultAllow, ...(options.config.permissions.allow ?? [])],
+    allow: [...defaultAllow, ...(options.config.permissions.allow ?? []), ...allowedToolPatterns],
     deny: options.config.permissions.deny ?? [],
   };
 

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -87,6 +87,8 @@ export interface ICreateSessionOptions {
   sessionId?: string;
   /** Pre-approved tool names — added to permissions.allow as ToolName(*) patterns. */
   allowedTools?: string[];
+  /** Text to append to the generated system prompt. */
+  appendSystemPrompt?: string;
 }
 
 /**
@@ -157,6 +159,9 @@ export function createSession(options: ICreateSessionOptions): Session {
     cwd: process.cwd(),
     language: options.config.language,
   });
+  const finalSystemMessage = options.appendSystemPrompt
+    ? `${systemMessage}\n\n${options.appendSystemPrompt}`
+    : systemMessage;
 
   // Merge default allow patterns for config folders with user-configured permissions
   const defaultAllow = [
@@ -176,7 +181,7 @@ export function createSession(options: ICreateSessionOptions): Session {
   const session = new Session({
     tools,
     provider,
-    systemMessage,
+    systemMessage: finalSystemMessage,
     terminal: options.terminal,
     permissions: mergedPermissions,
     hooks: options.config.hooks,

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-bare.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-bare.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for bare mode in createInteractiveSession.
+ *
+ * Verifies:
+ * - bare=true: loadContext is NOT called, BundlePluginLoader.loadPluginsSync is NOT called
+ * - bare=false (default): loadContext IS called
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock loadContext — bare mode must skip this
+// Paths are relative to the test file location (interactive/__tests__/)
+const mockLoadContext = vi.fn().mockResolvedValue({ agentsMd: '', claudeMd: '' });
+vi.mock('../../context/context-loader.js', () => ({
+  loadContext: mockLoadContext,
+}));
+
+// Mock detectProject — bare mode must skip this
+const mockDetectProject = vi.fn().mockResolvedValue({ type: 'unknown', language: 'unknown' });
+vi.mock('../../context/project-detector.js', () => ({
+  detectProject: mockDetectProject,
+}));
+
+// Mock loadConfig — always returns a minimal valid config
+const mockLoadConfig = vi.fn().mockResolvedValue({
+  defaultTrustLevel: 'moderate',
+  provider: { name: 'mock', apiKey: 'test-key', model: 'test-model' },
+  permissions: { allow: [], deny: [] },
+  language: 'en',
+  env: {},
+});
+vi.mock('../../config/config-loader.js', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+// Mock BundlePluginLoader — bare mode must skip plugin loading
+const mockLoadPluginsSync = vi.fn().mockReturnValue([]);
+vi.mock('../../plugins/index.js', () => ({
+  BundlePluginLoader: vi.fn().mockImplementation(() => ({
+    loadPluginsSync: mockLoadPluginsSync,
+  })),
+}));
+
+// Mock agent-sessions so we don't need real file I/O
+vi.mock('@robota-sdk/agent-sessions', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-sessions');
+  return {
+    ...actual,
+    Session: vi.fn().mockImplementation(() => ({
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      run: vi.fn().mockResolvedValue('mock response'),
+      abort: vi.fn(),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+    })),
+    FileSessionLogger: vi.fn().mockImplementation(() => ({})),
+  };
+});
+
+// Mock agent-core to avoid real Robota construction
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue('mock AI response'),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+    })),
+    runHooks: vi.fn().mockResolvedValue({ blocked: false }),
+  };
+});
+
+function createMockProvider() {
+  return {
+    name: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      role: 'assistant',
+      content: 'mock response',
+      timestamp: new Date(),
+    }),
+  } as never;
+}
+
+const NOOP_DELTA = (): void => {};
+const NOOP_TOOL = (): void => {};
+
+describe('createInteractiveSession — bare mode', () => {
+  beforeEach(() => {
+    mockLoadContext.mockClear();
+    mockDetectProject.mockClear();
+    mockLoadConfig.mockClear();
+    mockLoadPluginsSync.mockClear();
+  });
+
+  it('bare=true: loadContext is NOT called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: true,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockLoadContext).not.toHaveBeenCalled();
+  });
+
+  it('bare=true: detectProject is NOT called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: true,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockDetectProject).not.toHaveBeenCalled();
+  });
+
+  it('bare=true: plugin loading (loadPluginsSync) is NOT called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: true,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockLoadPluginsSync).not.toHaveBeenCalled();
+  });
+
+  it('bare=false (default): loadContext IS called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: false,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockLoadContext).toHaveBeenCalledTimes(1);
+    expect(mockLoadContext).toHaveBeenCalledWith('/tmp/test');
+  });
+
+  it('bare=false (default): detectProject IS called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: false,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockDetectProject).toHaveBeenCalledTimes(1);
+    expect(mockDetectProject).toHaveBeenCalledWith('/tmp/test');
+  });
+
+  it('bare omitted (default behavior): loadContext IS called', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      // bare not specified → default false behavior
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    expect(mockLoadContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('bare=true: session is still successfully created and returned', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    const session = await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: true,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    // Should return a valid session object with getSessionId
+    expect(session).toBeDefined();
+    expect(typeof session.getSessionId).toBe('function');
+  });
+
+  it('bare=true: loadConfig IS still called (config loading is not skipped)', async () => {
+    const { createInteractiveSession } = await import('../interactive-session-init.js');
+
+    await createInteractiveSession({
+      cwd: '/tmp/test',
+      provider: createMockProvider(),
+      bare: true,
+      onTextDelta: NOOP_DELTA,
+      onToolExecution: NOOP_TOOL,
+    });
+
+    // Config loading is always needed even in bare mode
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+    expect(mockLoadConfig).toHaveBeenCalledWith('/tmp/test');
+  });
+});

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -34,6 +34,12 @@ export interface IInteractiveSessionStandardOptions {
   sessionName?: string;
   resumeSessionId?: string;
   forkSession?: boolean;
+  /** Skip AGENTS.md/CLAUDE.md loading and plugin discovery. */
+  bare?: boolean;
+  /** Pre-approved tool names passed to createSession. */
+  allowedTools?: string[];
+  /** Text to append to the system prompt. */
+  appendSystemPrompt?: string;
 }
 
 /** Test/advanced construction: inject pre-built session directly. */
@@ -73,6 +79,12 @@ export interface IInitOptions {
     denied?: boolean;
     toolResultData?: string;
   }) => void;
+  /** Skip AGENTS.md/CLAUDE.md loading and plugin discovery. */
+  bare?: boolean;
+  /** Pre-approved tool names passed to createSession. */
+  allowedTools?: string[];
+  /** Text to append to the system prompt. */
+  appendSystemPrompt?: string;
 }
 
 /**
@@ -85,28 +97,32 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
   const cwd = options.cwd;
   const [config, context, projectInfo] = await Promise.all([
     loadConfig(cwd),
-    loadContext(cwd),
-    detectProject(cwd),
+    options.bare ? Promise.resolve({ agentsMd: '', claudeMd: '' }) : loadContext(cwd),
+    options.bare
+      ? Promise.resolve({ type: 'unknown' as const, language: 'unknown' as const })
+      : detectProject(cwd),
   ]);
 
   // Load plugin hooks and merge into config
   const pluginsDir = join(homedir(), '.robota', 'plugins');
   const pluginLoader = new BundlePluginLoader(pluginsDir);
   let mergedConfig = config;
-  try {
-    const plugins = pluginLoader.loadPluginsSync();
-    if (plugins.length > 0) {
-      const pluginHooks = mergePluginHooks(plugins);
-      mergedConfig = {
-        ...config,
-        hooks: mergeHooksIntoConfig(
-          config.hooks as Record<string, Array<Record<string, unknown>>> | undefined,
-          pluginHooks as Record<string, Array<Record<string, unknown>>>,
-        ),
-      };
+  if (!options.bare) {
+    try {
+      const plugins = pluginLoader.loadPluginsSync();
+      if (plugins.length > 0) {
+        const pluginHooks = mergePluginHooks(plugins);
+        mergedConfig = {
+          ...config,
+          hooks: mergeHooksIntoConfig(
+            config.hooks as Record<string, Array<Record<string, unknown>>> | undefined,
+            pluginHooks as Record<string, Array<Record<string, unknown>>>,
+          ),
+        };
+      }
+    } catch {
+      // No plugins dir or load failed
     }
-  } catch {
-    // No plugins dir or load failed
   }
 
   const paths = projectPaths(cwd);
@@ -128,6 +144,8 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
     onTextDelta: options.onTextDelta,
     onToolExecution: options.onToolExecution,
     sessionId,
+    allowedTools: options.allowedTools,
+    appendSystemPrompt: options.appendSystemPrompt,
   });
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -109,6 +109,9 @@ export class InteractiveSession {
       forkSession: this.forkSession,
       onTextDelta: (delta: string) => this.handleTextDelta(delta),
       onToolExecution: (event) => this.handleToolExecution(event),
+      bare: options.bare,
+      allowedTools: options.allowedTools,
+      appendSystemPrompt: options.appendSystemPrompt,
     });
 
     if (this.pendingRestoreMessages) {


### PR DESCRIPTION
## Summary

- `--bare`: AGENTS.md/CLAUDE.md 로딩 및 플러그인 자동 탐색 스킵 (스크립트/CI 실행용)
- `--allowed-tools <Bash,Read,...>`: 지정 툴 권한 프롬프트 없이 사전 승인
- `--no-session-persistence`: 비대화형 실행 시 세션 파일 저장 안 함
- `--json-schema <schema>`: 구조화 JSON 출력 — 시스템 프롬프트에 스키마 주입
- `--append-system-prompt` wiring 추가 (CLI-BL-012에서 파싱만 됐고 미연결 상태였음)

## Architecture

- `packages/agent-cli/src/utils/cli-args.ts` — 4개 플래그 파싱
- `packages/agent-sdk/src/assembly/create-session.ts` — `allowedTools` → `permissions.allow` 주입
- `packages/agent-sdk/src/interactive/interactive-session-init.ts` — `bare`/`allowedTools`/`appendSystemPrompt` wire
- `packages/agent-cli/src/cli.ts` — print mode에 연결

## Test Plan

- [ ] `pnpm --filter @robota-sdk/agent-cli test` — 327 tests pass
- [ ] `pnpm --filter @robota-sdk/agent-sdk test` — 501 tests pass
- [ ] `pnpm typecheck` — no errors
- [ ] `pnpm lint` — no errors

## Related

- Closes CLI-BL-017
- Prerequisite for SDK-BL-004 (Ralph Loop)