### PR TITLE
[codex] support OpenAI-compatible LM Studio provider

### DIFF
--- a/.agents/tasks/CLI-BL-024-provider-configuration-ux.md
+++ b/.agents/tasks/CLI-BL-024-provider-configuration-ux.md
@@ -1,0 +1,291 @@
+# CLI Provider Configuration UX
+
+- **Status**: todo
+- **Created**: 2026-04-29
+- **Branch**: feat/openai-compatible-lm-studio
+- **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-transport-headless
+
+## Objective
+
+Define a unified provider configuration experience for Robota CLI across first-run setup, TUI slash commands, and non-interactive headless execution.
+
+This work must make LM Studio/OpenAI-compatible setup easy without moving concrete provider construction out of `agent-cli` or making `agent-sdk` depend on provider packages.
+
+## Problem Statement
+
+Provider profiles can be loaded from settings, but users still need to edit JSON manually or use an Anthropic-only first-run prompt. The missing UX:
+
+- First-run setup cannot choose Anthropic vs LM Studio/OpenAI-compatible.
+- TUI users cannot inspect, add, test, or switch provider profiles.
+- Headless users cannot configure or select providers in a deterministic scriptable way.
+
+## Configuration Contract
+
+Provider profiles remain the canonical settings shape:
+
+```json
+{
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "apiKey": "$ENV:ANTHROPIC_API_KEY"
+    }
+  }
+}
+```
+
+Legacy `provider` settings remain supported. Resolution order:
+
+1. `currentProvider` plus `providers[currentProvider]`
+2. Legacy `provider`
+3. Provider defaults
+
+LM Studio is `type: "openai"` with `baseURL`, not a native `lmstudio` provider.
+
+## Target UX
+
+### First Run
+
+When no usable provider configuration exists and the process is attached to a TTY, `robota` prompts for provider setup instead of assuming Anthropic.
+
+| Choice                      | Profile output                             | Prompts                                     |
+| --------------------------- | ------------------------------------------ | ------------------------------------------- |
+| Anthropic                   | `providers.anthropic`, `type: "anthropic"` | API key, model, language                    |
+| LM Studio/OpenAI-compatible | `providers.openai`, `type: "openai"`       | base URL, model, optional API key, language |
+
+LM Studio defaults:
+
+| Field       | Default                         |
+| ----------- | ------------------------------- |
+| profile key | `openai`                        |
+| type        | `openai`                        |
+| baseURL     | `http://localhost:1234/v1`      |
+| apiKey      | `lm-studio`                     |
+| model       | `supergemma4-26b-uncensored-v2` |
+
+If `GET <baseURL>/models` succeeds, setup may offer discovered models. If discovery fails, manual model entry must still work.
+
+### CLI Commands
+
+Required commands:
+
+```bash
+robota --configure
+robota --provider openai --set-current
+robota --configure-provider openai --type openai --base-url http://localhost:1234/v1 --model supergemma4-26b-uncensored-v2 --api-key lm-studio --set-current
+robota --configure-provider anthropic --type anthropic --model claude-sonnet-4-6 --api-key-env ANTHROPIC_API_KEY --set-current
+```
+
+Rules:
+
+- `--api-key-env NAME` stores `$ENV:NAME`.
+- `--api-key VALUE` stores the literal value.
+- `--provider <profile>` selects an existing profile for this invocation.
+- `--provider <profile> --set-current` persists `currentProvider`.
+- `--model <model>` remains an execution override unless used with a configuration command.
+- `--configure-provider` writes settings and exits unless a prompt is also supplied.
+
+### Headless
+
+Applies to `-p`, `--output-format json`, `--output-format stream-json`, and stdin-piped prompts.
+
+Rules:
+
+- Do not prompt in non-interactive mode.
+- If no usable provider config exists, exit with an actionable error.
+- Support one-shot `--provider <profile>` and `--model <model>`.
+- Support scriptable setup through `--configure-provider`.
+
+Required missing-config message:
+
+```text
+No provider configuration found.
+Run `robota --configure` in an interactive terminal, or configure a provider:
+  robota --configure-provider openai --type openai --base-url http://localhost:1234/v1 --model <model> --api-key lm-studio --set-current
+```
+
+### TUI Slash Commands
+
+Required commands:
+
+```text
+/provider
+/provider current
+/provider list
+/provider use <profile>
+/provider add openai
+/provider add anthropic
+/provider test [profile]
+```
+
+| Command                    | Behavior                                                |
+| -------------------------- | ------------------------------------------------------- |
+| `/provider`                | Show current provider and subcommands                   |
+| `/provider current`        | Show active profile, type, model, and baseURL           |
+| `/provider list`           | Show provider profiles from merged settings             |
+| `/provider use <profile>`  | Confirm, persist `currentProvider`, and restart session |
+| `/provider add openai`     | Start guided OpenAI-compatible setup                    |
+| `/provider add anthropic`  | Start guided Anthropic setup                            |
+| `/provider test [profile]` | Validate fields and optionally probe model list/chat    |
+
+Provider changes must follow the `/model` restart pattern: command returns structured side-effect data, TUI confirms, settings are written after confirmation, and the App remounts with a new provider instance.
+
+## Architecture
+
+| Concern                                      | Owner                                  |
+| -------------------------------------------- | -------------------------------------- |
+| Settings schema and resolved provider config | `@robota-sdk/agent-sdk`                |
+| Settings write helpers and setup UX          | `@robota-sdk/agent-cli`                |
+| Concrete provider imports/instantiation      | `@robota-sdk/agent-cli`                |
+| TUI provider command chrome                  | `@robota-sdk/agent-cli`                |
+| Headless output semantics                    | `@robota-sdk/agent-transport-headless` |
+| Provider runtime behavior                    | `@robota-sdk/agent-provider-*`         |
+
+Use functional core / imperative shell:
+
+- Pure helpers: `upsertProviderProfile`, `setCurrentProvider`, `resolveProviderSelection`, `validateProviderProfile`, `buildProviderSetupPatch`
+- IO shell: read/write settings, prompt users, probe endpoints, restart TUI session
+
+Default write target is `~/.robota/settings.json`. Project-local writes may be added with an explicit `--settings-scope` flag.
+
+## Validation Rules
+
+| Type        | Required fields   | Optional fields                |
+| ----------- | ----------------- | ------------------------------ |
+| `anthropic` | `apiKey`, `model` | `baseURL`, `timeout`           |
+| `openai`    | `model`           | `apiKey`, `baseURL`, `timeout` |
+
+OpenAI-compatible defaults:
+
+- LM Studio `apiKey`: `lm-studio`
+- LM Studio `baseURL`: `http://localhost:1234/v1`
+
+Invalid profile errors must include profile key, type, missing field, and settings path when available.
+
+## Data Flow
+
+- First-run: `parseCliArgs()` -> `ensureConfig()` -> prompt when TTY and no valid profile -> write settings -> create provider -> start `InteractiveSession`.
+- Headless override: `parseCliArgs()` -> validate non-interactive config -> create provider with provider/model overrides -> start headless transport.
+- TUI switch: `/provider use <profile>` -> structured side-effect data -> `ConfirmPrompt` -> write `currentProvider` -> remount App with new provider.
+
+## Interface Changes
+
+Add CLI args:
+
+| Arg                              | Meaning                                   |
+| -------------------------------- | ----------------------------------------- |
+| `--configure`                    | Run interactive provider setup and exit   |
+| `--configure-provider <profile>` | Upsert provider profile                   |
+| `--provider <profile>`           | Select provider profile                   |
+| `--type <type>`                  | Provider implementation type              |
+| `--base-url <url>`               | Provider API base URL                     |
+| `--api-key <value>`              | Literal API key                           |
+| `--api-key-env <name>`           | Store `$ENV:<name>`                       |
+| `--set-current`                  | Persist selected/configured profile       |
+| `--settings-scope <scope>`       | Optional `user` or `project-local` target |
+
+Provider slash commands return structured data via `ICommandResult.data`, including `providerSwitch`, `providerSetup`, and `providerTest` payloads.
+
+## Backward Compatibility
+
+- Legacy `provider` settings stay valid.
+- Anthropic first-run setup remains available.
+- Existing `--model`, `/model`, `--reset`, JSON output, and stream-json output behavior must remain compatible.
+- `.claude/settings.json` compatibility remains read-only for Robota-specific provider profile creation unless explicitly changed later.
+
+## Package SPEC Updates Required
+
+Before implementation:
+
+- `packages/agent-sdk/docs/SPEC.md`: provider profile schema, resolution, validation, legacy fallback
+- `packages/agent-cli/docs/SPEC.md`: first-run setup, setup flags, provider slash commands, settings write ownership
+- `packages/agent-transport-headless/docs/SPEC.md`: non-interactive provider setup/error behavior
+
+## Test Strategy
+
+Unit test assertions:
+
+| Area                        | Given                                                                                | When                                                | Then                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| SDK profile resolution      | `currentProvider: "openai"` and both `providers.openai` plus legacy `provider` exist | `loadConfig()` resolves settings                    | active provider is OpenAI profile; model, apiKey, baseURL, timeout are preserved; legacy provider does not win            |
+| SDK legacy fallback         | only legacy `provider` exists                                                        | `loadConfig()` resolves settings                    | resolved provider matches legacy Anthropic config                                                                         |
+| Invalid current provider    | `currentProvider` points to a missing profile                                        | config is resolved                                  | error mentions `currentProvider`, missing profile name, and settings path when available                                  |
+| Pure profile upsert         | settings contain `providers.openai` and `providers.anthropic`                        | Anthropic profile is updated                        | only Anthropic changes; OpenAI profile and unrelated settings remain unchanged                                            |
+| Current provider helper     | requested profile does not exist                                                     | `setCurrentProvider()` runs                         | no partial settings mutation occurs and a validation error is returned/thrown                                             |
+| Env API key storage         | `--api-key-env ANTHROPIC_API_KEY` is provided and env has a real value               | setup patch is built/written                        | stored value is `$ENV:ANTHROPIC_API_KEY`, not the process env value                                                       |
+| CLI arg parsing             | setup flags are passed together                                                      | `parseCliArgs()` runs                               | parsed fields preserve `--configure-provider`, `--provider`, `--type`, `--base-url`, `--api-key-env`, and `--set-current` |
+| Scriptable setup            | existing settings have an OpenAI profile                                             | `--configure-provider anthropic --set-current` runs | Anthropic profile is added/updated, OpenAI profile is preserved, and `currentProvider` becomes `anthropic`                |
+| Invocation override         | current settings use OpenAI                                                          | `--provider anthropic` runs without `--set-current` | Anthropic provider is used for that run and settings file remains unchanged                                               |
+| First-run setup             | no config exists and TTY is available                                                | `--configure` or first-run setup runs               | selected provider profile is written with defaults and language; alternate provider is not invented                       |
+| Non-interactive setup guard | no config exists and stdin/stdout are non-TTY                                        | print/headless execution starts                     | prompt function is not called; process exits with actionable missing-config text                                          |
+| Headless output contracts   | valid provider config exists                                                         | `json` or `stream-json` print mode runs             | result line contract remains stable; stream mode still emits `stream_event` deltas before final result                    |
+| TUI provider switch         | `/provider use openai` is executed                                                   | before and after confirmation are observed          | no file write occurs before confirm; after confirm `currentProvider` is persisted and App remount is requested            |
+| Provider probing            | fetch is mocked as success, unreachable, and malformed                               | `/provider test` or setup probe runs                | success reports discovered models; failures are non-blocking and allow manual continuation                                |
+
+Local LM Studio smoke: `curl /v1/models`, `--configure-provider openai`, one text print run, and one `stream-json` print run.
+
+Verification:
+
+```bash
+pnpm --filter @robota-sdk/agent-sdk test
+pnpm --filter @robota-sdk/agent-cli test
+pnpm --filter @robota-sdk/agent-cli build
+pnpm --filter @robota-sdk/agent-transport-headless test
+pnpm harness:scan
+```
+
+## Implementation Plan
+
+- [ ] Update package SPEC documents.
+- [ ] Write the unit tests above first, grouped by pure helpers, CLI args/setup, headless behavior, TUI side effects, and provider probing.
+- [ ] Extract provider settings pure helpers and settings write helpers.
+- [ ] Add CLI args for setup and provider selection.
+- [ ] Implement first-run provider setup and scriptable `--configure-provider`.
+- [ ] Implement headless missing-config behavior.
+- [ ] Add provider slash commands and TUI side effects.
+- [ ] Add optional provider probing with non-blocking failures.
+- [ ] Update docs and run verification.
+
+## Risks
+
+- SDK and CLI provider resolution can drift unless helper logic is shared or tested together.
+- Provider probing can be flaky when LM Studio is not running; setup must allow manual continuation.
+- Literal `--api-key` can leak into shell history; docs should prefer `--api-key-env`.
+- TUI provider switching requires restart; in-place mutation risks inconsistent session state.
+
+## Open Questions
+
+- Should `baseURL` support `$ENV:` substitution?
+- Should project-local settings be supported in the first implementation?
+- Should `/provider add openai` include model discovery in the first implementation?
+- Should setup use `providers.openai` or `providers.lmstudio` with `type: "openai"` for clearer UX?
+
+## Progress
+
+### 2026-04-29
+
+- Created this spec from the provider configuration UX plan.
+
+## Decisions
+
+- Provider profiles remain the canonical settings contract.
+- LM Studio remains `type: "openai"` with `baseURL`.
+- TUI provider changes restart the session.
+- Headless mode never prompts for missing provider setup.
+
+## Blockers
+
+- None for spec writing.
+- Implementation should not begin until package SPEC updates are made.
+
+## Result
+
+Not implemented yet.

--- a/.agents/tasks/completed/CLI-BL-017-openai-compatible-lm-studio.md
+++ b/.agents/tasks/completed/CLI-BL-017-openai-compatible-lm-studio.md
@@ -1,0 +1,194 @@
+# CLI OpenAI-Compatible LM Studio Provider
+
+- **Status**: completed
+- **Created**: 2026-04-29
+- **Branch**: feat/openai-compatible-lm-studio
+- **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-provider-openai
+
+## Objective
+
+Add Robota CLI support for an OpenAI-compatible provider profile that can connect to LM Studio through the `/v1/chat/completions` API. The initial target is a local LM Studio server at `http://localhost:1234/v1` using the model `supergemma4-26b-uncensored-v2`.
+
+This work must keep provider creation in the CLI, keep session assembly provider-neutral, and reuse the existing `OpenAIProvider` rather than introducing an LM Studio native provider.
+
+## Current Findings
+
+- LM Studio exposes an OpenAI-compatible API under `http://localhost:1234/v1`.
+- Local smoke checks succeeded for:
+  - `GET /v1/models`
+  - `POST /v1/chat/completions`
+  - `stream: true` server-sent event streaming
+  - OpenAI-style `tools` / function calling
+- The local LM Studio model `supergemma4-26b-uncensored-v2` successfully returned text responses and tool calls.
+- Robota CLI currently supports only the Anthropic provider in `packages/agent-cli/src/utils/provider-factory.ts`.
+- `OpenAIProvider` already supports `baseURL`, non-streaming chat completions, tool calls, and `chatStream()`.
+- `OpenAIProvider.chat()` is behind `AnthropicProvider.chat()` for CLI parity because it does not use `options.onTextDelta` and does not assemble streamed tool-call deltas.
+- `agent-provider-openai` is currently `private: true` and marked non-publishable in `.agents/publish-registry.md`, which affects public CLI packaging.
+
+## Target Configuration
+
+Use provider profiles plus an active provider key:
+
+```json
+{
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "apiKey": "$ENV:ANTHROPIC_API_KEY"
+    }
+  }
+}
+```
+
+Legacy settings must continue to work during the migration:
+
+```json
+{
+  "provider": {
+    "name": "anthropic",
+    "model": "claude-sonnet-4-6",
+    "apiKey": "$ENV:ANTHROPIC_API_KEY"
+  }
+}
+```
+
+Provider resolution order:
+
+1. `currentProvider` plus `providers[currentProvider]`
+2. Legacy `provider`
+3. Existing defaults
+
+## Design Decisions
+
+- Use `providers.openai` and `type: "openai"` for LM Studio because the transport is OpenAI-compatible, not LM Studio native.
+- Treat LM Studio as a `baseURL` override for `OpenAIProvider`.
+- Do not use LM Studio native `/api/v1/*` APIs.
+- Do not use LM Studio Anthropic compatibility.
+- Do not migrate to OpenAI Responses API for this work. Chat Completions is the correct compatibility layer for LM Studio.
+- Keep `lmstudio` out of the first schema unless a preset UX is added later.
+- Keep legacy `provider` support to avoid breaking existing Anthropic CLI users.
+
+## Plan
+
+- [x] Update package specs before code changes.
+  - [x] `packages/agent-cli/docs/SPEC.md`: document provider profile selection and OpenAI-compatible provider creation.
+  - [x] `packages/agent-sdk/docs/SPEC.md`: document `currentProvider`, `providers`, and resolved provider profile fields.
+  - [x] `packages/agent-provider-openai/docs/SPEC.md`: document CLI-oriented OpenAI-compatible usage and streaming parity expectations if provider behavior changes.
+- [x] Extend SDK config schema and resolution.
+  - [x] Add `currentProvider?: string`.
+  - [x] Add `providers?: Record<string, ProviderProfile>`.
+  - [x] Add provider profile fields: `type`, `model`, `apiKey`, `baseURL`, optional `timeout`.
+  - [x] Preserve legacy `provider` support.
+  - [x] Ensure `IResolvedConfig.provider` resolves to the active profile with `name`, `model`, `apiKey`, and `baseURL`.
+  - [x] Add tests for active provider resolution and legacy fallback.
+- [x] Update CLI provider factory.
+  - [x] Read the active provider profile from the same settings chain.
+  - [x] Support `type: "anthropic"` with existing `AnthropicProvider`.
+  - [x] Support `type: "openai"` with `OpenAIProvider`.
+  - [x] Pass `apiKey`, `baseURL`, `timeout`, and model defaults correctly.
+  - [x] Add tests for the LM Studio OpenAI-compatible profile.
+- [x] Decide the package dependency path for `agent-provider-openai`.
+  - [x] For local development, add it as a workspace dependency of `agent-cli`.
+  - [x] Document the public publishing risk for the `private: true` / publish registry conflict.
+- [x] Modernize `OpenAIProvider` only as much as needed for CLI parity.
+  - [x] Keep the existing non-streaming `chat()` path as a fallback.
+  - [x] When `options.onTextDelta` is present, use streaming internally and return an assembled final `TUniversalMessage`.
+  - [x] Accumulate `delta.content` and call `onTextDelta` for text chunks.
+  - [x] Accumulate streamed `tool_calls` by index and return final tool calls.
+  - [x] Pass `AbortSignal` into OpenAI SDK requests where supported.
+  - [x] Add tests for text streaming, tool-call streaming assembly, abort behavior, and non-streaming regression.
+- [x] Add local smoke verification notes.
+  - [x] Confirm LM Studio server is running.
+  - [x] Confirm `GET http://localhost:1234/v1/models` includes `supergemma4-26b-uncensored-v2`.
+  - [x] Run a chat completion request.
+  - [x] Run a tool-calling request.
+  - [x] Run `robota` with the OpenAI-compatible profile.
+
+## Test Strategy
+
+Targeted commands:
+
+```bash
+pnpm --filter @robota-sdk/agent-sdk test
+pnpm --filter @robota-sdk/agent-provider-openai test
+pnpm --filter @robota-sdk/agent-cli test
+pnpm --filter @robota-sdk/agent-cli build
+pnpm harness:scan
+```
+
+Local smoke commands:
+
+```bash
+curl -sS http://localhost:1234/v1/models
+curl -sS http://localhost:1234/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"supergemma4-26b-uncensored-v2","messages":[{"role":"user","content":"Say hello in one sentence."}],"max_tokens":32}'
+```
+
+## Risks
+
+- `agent-provider-openai` is private and not currently approved for publishing. Adding it to a published CLI package needs a release-policy decision before npm publication.
+- The CLI and SDK both currently read config in different places. Provider profile resolution must stay behaviorally aligned or the CLI provider and SDK `defaultModel` can drift.
+- Streaming tool-call chunks from OpenAI-compatible servers may arrive as partial arguments. The provider must assemble them before returning final tool calls.
+- LM Studio model availability is local state. The CLI should surface provider errors clearly when the server is down or the model is not loaded.
+- OpenAI-compatible implementations vary. The first implementation should be tested against LM Studio and avoid assuming full OpenAI API coverage.
+
+## Open Questions
+
+- Should `baseURL` support `$ENV:` substitution, or should env substitution remain limited to `apiKey` for now?
+- Should `timeout` be part of the first provider profile schema?
+- Should `providers.openai` be the only supported OpenAI-compatible profile key, or should arbitrary keys with `type: "openai"` be allowed?
+- Should public CLI packaging make `agent-provider-openai` publishable, or should a smaller public OpenAI-compatible provider package be introduced later?
+
+## Progress
+
+### 2026-04-29
+
+- Researched LM Studio OpenAI-compatible behavior with the local server.
+- Verified `supergemma4-26b-uncensored-v2` can produce text responses and OpenAI-style tool calls.
+- Compared `AnthropicProvider` and `OpenAIProvider` implementation gaps.
+- Chose the provider profile shape using `providers.openai` and `type: "openai"`.
+- Created this implementation plan.
+- Updated package SPECs, READMEs, and current guide docs for provider profiles and OpenAI-compatible LM Studio configuration.
+- Added SDK config support for `currentProvider` plus `providers`, including deep profile merge, `$ENV:` API key resolution, `baseURL`, `timeout`, and legacy `provider` fallback.
+- Added CLI provider creation for `type: "openai"` using `OpenAIProvider`; Anthropic provider creation remains supported.
+- Added first-run settings detection for active provider profiles so local OpenAI-compatible profiles do not trigger the Anthropic setup prompt.
+- Aligned first-run settings detection with the same `.robota` and `.claude` settings paths used by provider resolution.
+- Added OpenAIProvider streaming assembly for `chat()` when `onTextDelta` is provided, including streamed tool-call reconstruction and abort signal propagation.
+- Added tests for SDK provider profile resolution, CLI provider factory behavior, first-run settings detection, and OpenAIProvider streaming assembly.
+- Verified LM Studio local model discovery, chat completions, tool calling, and CLI print mode with `supergemma4-26b-uncensored-v2`.
+
+## Blockers
+
+- No implementation blocker for local development.
+- Public publishing requires a decision on `agent-provider-openai` package status.
+
+## Result
+
+Implemented.
+
+Verification completed:
+
+- `pnpm --filter @robota-sdk/agent-sdk test`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk build`
+- `pnpm --filter @robota-sdk/agent-sdk lint` (exit 0; existing warnings remain)
+- `pnpm --filter @robota-sdk/agent-provider-openai test -- src/provider.test.ts`
+- `pnpm --filter @robota-sdk/agent-provider-openai typecheck`
+- `pnpm --filter @robota-sdk/agent-provider-openai build`
+- `pnpm --filter @robota-sdk/agent-provider-openai lint` (exit 0; existing warnings remain)
+- `pnpm --filter @robota-sdk/agent-cli test`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli build`
+- `pnpm --filter @robota-sdk/agent-cli lint` (exit 0; existing warnings remain)
+- `pnpm build` in `apps/docs`
+- `pnpm harness:scan`
+- Local LM Studio smoke: `curl /v1/models`, chat completion, streaming, tool-call request, and built CLI print mode returned `CLI_SMOKE_OK`.

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -314,17 +314,18 @@ Events are logged to `.robota/logs/{sessionId}.jsonl` in JSONL format. Events in
 
 ## First-Run Setup
 
-When no settings file exists, the CLI prompts for an Anthropic API key (input is masked with asterisks) and creates `~/.robota/settings.json` with a minimal config. Use `robota --reset` to delete the settings file and return to the first-run state.
+When no usable settings file exists, the CLI prompts for an Anthropic API key (input is masked with asterisks) and creates `~/.robota/settings.json` with a minimal config. Use `robota --reset` to delete the settings file and return to the first-run state. OpenAI-compatible local profiles can be configured manually without using the first-run Anthropic prompt.
 
 ## Configuration
 
 The CLI uses a layered configuration system. `.robota/` is the primary configuration convention; `.claude/` paths are supported as a Claude Code compatibility layer. Later layers override earlier ones:
 
 1. `~/.robota/settings.json` (user global)
-2. `.robota/settings.json` (project, primary)
-3. `.robota/settings.local.json` (local override, gitignored)
-4. `.claude/settings.json` (project, Claude Code compatible)
-5. `.claude/settings.local.json` (local override, gitignored, Claude Code compatible)
+2. `~/.claude/settings.json` (user global, Claude Code compatible)
+3. `.robota/settings.json` (project, primary)
+4. `.robota/settings.local.json` (local override, gitignored)
+5. `.claude/settings.json` (project, Claude Code compatible)
+6. `.claude/settings.local.json` (local override, gitignored, Claude Code compatible)
 
 The `.claude/` paths take higher runtime priority so that Claude Code settings override `.robota/` defaults.
 

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -110,22 +110,32 @@ const response = await query('Refactor this function');
 
 ## Configuration
 
-Config is loaded from 5 layers. `.robota/` is the primary configuration convention; `.claude/` paths are supported as a Claude Code compatibility layer. Later layers override earlier ones:
+Config is loaded from 6 settings-file layers. `.robota/` is the primary configuration convention; `.claude/` paths are supported as a Claude Code compatibility layer. Later layers override earlier ones:
 
 1. **User global**: `~/.robota/settings.json` (lowest priority)
-2. **Project (primary)**: `.robota/settings.json`
-3. **Project local**: `.robota/settings.local.json` (gitignored)
-4. **Project (Claude Code compatible)**: `.claude/settings.json`
-5. **Project local (Claude Code compatible)**: `.claude/settings.local.json` (gitignored, highest priority)
+2. **User global (Claude Code compatible)**: `~/.claude/settings.json`
+3. **Project (primary)**: `.robota/settings.json`
+4. **Project local**: `.robota/settings.local.json` (gitignored)
+5. **Project (Claude Code compatible)**: `.claude/settings.json`
+6. **Project local (Claude Code compatible)**: `.claude/settings.local.json` (gitignored, highest priority)
 
 The `.claude/` paths take higher runtime priority so that Claude Code settings override `.robota/` defaults.
 
 ```json
 {
-  "provider": {
-    "name": "anthropic",
-    "model": "claude-sonnet-4-6",
-    "apiKey": "$ENV:ANTHROPIC_API_KEY"
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "apiKey": "$ENV:ANTHROPIC_API_KEY"
+    }
   },
   "defaultTrustLevel": "moderate",
   "permissions": {
@@ -142,6 +152,8 @@ The `.claude/` paths take higher runtime priority so that Claude Code settings o
   }
 }
 ```
+
+`currentProvider` selects the active profile from `providers`. The active profile is normalized into the resolved `provider` object with `name`, `model`, `apiKey`, optional `baseURL`, and optional `timeout`. LM Studio and other OpenAI-compatible endpoints use `type: "openai"` plus `baseURL`; the legacy single `provider` object remains supported when no active profile is configured.
 
 The `$ENV:` prefix resolves environment variables at load time.
 

--- a/docs/plans/2026-04-29-openai-compatible-lm-studio-design.md
+++ b/docs/plans/2026-04-29-openai-compatible-lm-studio-design.md
@@ -1,0 +1,94 @@
+# OpenAI-Compatible LM Studio Provider Design
+
+## Goal
+
+Enable Robota CLI to use a local LM Studio model through the OpenAI-compatible Chat Completions API. The initial target profile is `providers.openai` with `type: "openai"`, `baseURL: "http://localhost:1234/v1"`, and model `supergemma4-26b-uncensored-v2`.
+
+The implementation must keep `agent-sdk` provider-neutral and keep concrete provider construction in `agent-cli`.
+
+## Architecture
+
+The design introduces provider profiles in settings while keeping the existing legacy `provider` object supported.
+
+```json
+{
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    }
+  }
+}
+```
+
+Resolution order:
+
+1. `currentProvider` plus `providers[currentProvider]`
+2. Legacy `provider`
+3. Existing defaults
+
+`agent-sdk` owns config parsing and resolved provider metadata. `agent-cli` owns provider construction and maps the resolved provider profile to `AnthropicProvider` or `OpenAIProvider`.
+
+LM Studio is not represented as a native provider. It is an OpenAI-compatible endpoint selected by `baseURL`.
+
+## Data Flow
+
+1. CLI starts and reads provider settings from the configured settings file chain.
+2. The active profile is resolved from `currentProvider` and `providers`.
+3. For `type: "openai"`, CLI creates `OpenAIProvider` with `apiKey`, `baseURL`, and optional `timeout`.
+4. CLI passes the provider to `InteractiveSession`.
+5. `InteractiveSession` loads SDK config and uses the same resolved model in session assembly.
+6. The execution loop calls `provider.chat(messages, options)`.
+7. `OpenAIProvider.chat()` uses Chat Completions.
+8. When `options.onTextDelta` is present, `OpenAIProvider.chat()` streams internally, emits text deltas, assembles text and tool-call chunks, and returns the final assistant message.
+
+## Affected Files
+
+- `packages/agent-sdk/docs/SPEC.md`
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-provider-openai/docs/SPEC.md`
+- `packages/agent-sdk/src/config/config-types.ts`
+- `packages/agent-sdk/src/config/config-loader.ts`
+- `packages/agent-sdk/src/config/*.test.ts`
+- `packages/agent-cli/src/utils/provider-factory.ts`
+- `packages/agent-cli/src/utils/*.test.ts`
+- `packages/agent-cli/package.json`
+- `packages/agent-provider-openai/src/provider.ts`
+- `packages/agent-provider-openai/src/streaming/*`
+- `packages/agent-provider-openai/src/*.test.ts`
+
+## Test Strategy
+
+Use unit tests for config resolution, provider factory behavior, and OpenAI streaming assembly.
+
+- SDK config tests verify active provider profile resolution, `baseURL` preservation, `$ENV:` api key resolution, and legacy `provider` fallback.
+- CLI provider factory tests verify `type: "openai"` creates `OpenAIProvider` with LM Studio-compatible options and `type: "anthropic"` keeps existing behavior.
+- OpenAI provider tests verify non-streaming regression, streaming text delta assembly, streaming tool-call assembly, and abort signal propagation where the SDK accepts a request option.
+- Package verification commands:
+
+```bash
+pnpm --filter @robota-sdk/agent-sdk test
+pnpm --filter @robota-sdk/agent-provider-openai test
+pnpm --filter @robota-sdk/agent-cli test
+pnpm --filter @robota-sdk/agent-cli build
+pnpm harness:scan
+```
+
+Local smoke verification uses LM Studio:
+
+```bash
+curl -sS http://localhost:1234/v1/models
+curl -sS http://localhost:1234/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"supergemma4-26b-uncensored-v2","messages":[{"role":"user","content":"Say hello in one sentence."}],"max_tokens":32}'
+```
+
+## Risks
+
+- `agent-provider-openai` is currently private and non-publishable. Local workspace integration is straightforward, but public CLI publication needs a release-policy decision.
+- The CLI currently has its own settings reader while `InteractiveSession` loads config internally. The implementation must keep active provider/model resolution aligned.
+- OpenAI-compatible servers vary. The provider must target the common Chat Completions subset used by LM Studio and avoid assuming full OpenAI platform support.
+- Streaming tool calls can arrive as partial chunks, so provider-level assembly is required before returning final tool calls to the Robota execution loop.

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -26,9 +26,9 @@ robota -p "List all files"    # Print mode (one-shot, exit after response)
 
 ### Environment Variables
 
-| Variable            | Description       | Required |
-| ------------------- | ----------------- | -------- |
-| `ANTHROPIC_API_KEY` | Anthropic API key | Yes      |
+| Variable            | Description                                    | Required       |
+| ------------------- | ---------------------------------------------- | -------------- |
+| `ANTHROPIC_API_KEY` | Anthropic API key for the `anthropic` provider | Anthropic only |
 
 Set your key before running:
 
@@ -107,12 +107,12 @@ git diff | robota -p "Summarize changes" --output-format stream-json
 
 ## First-Run Setup
 
-When no settings file exists, the CLI prompts for:
+When no usable settings file exists, the CLI prompts for:
 
 1. **Anthropic API key** (input masked with asterisks)
 2. **Response language** (ko/en/ja/zh, default: en)
 
-Creates `~/.robota/settings.json`. Use `robota --reset` to return to first-run state.
+Creates `~/.robota/settings.json`. Use `robota --reset` to return to first-run state. OpenAI-compatible local profiles, such as LM Studio, can be configured manually without using the first-run Anthropic prompt.
 
 ## Built-in Tools
 
@@ -267,26 +267,48 @@ The `/plugin` command opens an interactive TUI for managing bundle plugins:
 
 ## Configuration
 
-Settings are loaded from (highest priority first):
+Settings are merged in this order, from lowest to highest priority:
 
-1. `.robota/settings.local.json` (local, gitignored)
-2. `.robota/settings.json` (project, shared)
-3. `.claude/settings.json` (project, Claude Code compatible)
-4. `~/.robota/settings.json` (user global)
-5. `~/.claude/settings.json` (user global, Claude Code compatible)
+1. `~/.robota/settings.json` (user global)
+2. `~/.claude/settings.json` (user global, Claude Code compatible)
+3. `.robota/settings.json` (project, shared)
+4. `.robota/settings.local.json` (local, gitignored)
+5. `.claude/settings.json` (project, Claude Code compatible)
+6. `.claude/settings.local.json` (local, gitignored, Claude Code compatible)
 
 ```json
 {
   "defaultMode": "default",
   "language": "en",
-  "provider": {
-    "name": "anthropic",
-    "model": "claude-sonnet-4-6",
-    "apiKey": "$ENV:ANTHROPIC_API_KEY"
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "apiKey": "$ENV:ANTHROPIC_API_KEY"
+    }
   },
   "permissions": {
     "allow": ["Bash(pnpm *)"],
     "deny": ["Bash(rm -rf *)"]
+  }
+}
+```
+
+`currentProvider` selects a profile from `providers`. LM Studio uses `type: "openai"` because the CLI talks to its OpenAI-compatible `/v1/chat/completions` API through `baseURL`. The legacy single-provider shape remains supported:
+
+```json
+{
+  "provider": {
+    "name": "anthropic",
+    "model": "claude-sonnet-4-6",
+    "apiKey": "$ENV:ANTHROPIC_API_KEY"
   }
 }
 ```

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -22,23 +22,56 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 
 ## Import Rules
 
-| Source             | Allowed                       | Examples                                                                         |
-| ------------------ | ----------------------------- | -------------------------------------------------------------------------------- |
-| `agent-sdk`        | SDK-owned APIs                | `InteractiveSession`, `TInteractivePermissionHandler`                            |
-| `agent-core`       | Public types + utilities only | `TUniversalMessage`, `TPermissionMode`, `createSystemMessage`, `getModelName`    |
-| `agent-core`       | ❌ Internal engine            | ~~`Robota`~~, ~~`ExecutionService`~~, ~~`ConversationStore`~~                    |
-| `agent-sessions`   | ❌ Forbidden                  | SDK provides its own session and permission types                                |
-| `agent-tools`      | ❌ Forbidden                  | SDK assembles tools internally                                                   |
-| `agent-provider-*` | ✅ Provider creation only     | `AnthropicProvider` (CLI picks which to use; currently only anthropic supported) |
+| Source             | Allowed                       | Examples                                                                      |
+| ------------------ | ----------------------------- | ----------------------------------------------------------------------------- |
+| `agent-sdk`        | SDK-owned APIs                | `InteractiveSession`, `TInteractivePermissionHandler`                         |
+| `agent-core`       | Public types + utilities only | `TUniversalMessage`, `TPermissionMode`, `createSystemMessage`, `getModelName` |
+| `agent-core`       | ❌ Internal engine            | ~~`Robota`~~, ~~`ExecutionService`~~, ~~`ConversationStore`~~                 |
+| `agent-sessions`   | ❌ Forbidden                  | SDK provides its own session and permission types                             |
+| `agent-tools`      | ❌ Forbidden                  | SDK assembles tools internally                                                |
+| `agent-provider-*` | ✅ Provider creation only     | `AnthropicProvider`, `OpenAIProvider` (CLI picks which to use from settings)  |
 
 ## Architecture
 
 The CLI is a pure TUI layer. All business logic (session lifecycle, slash command execution, tool orchestration, abort handling) lives in `@robota-sdk/agent-sdk`'s `InteractiveSession`. The CLI:
 
-1. Reads config to determine which provider to use.
-2. Creates the provider instance (e.g., `new AnthropicProvider(options)`).
+1. Reads config to determine which provider profile to use.
+2. Creates the provider instance (e.g., `new AnthropicProvider(options)` or `new OpenAIProvider(options)`).
 3. Creates `InteractiveSession({ cwd, provider })` — config and context loading happen internally inside the SDK.
 4. Subscribes to `InteractiveSession` events and converts them to React state for rendering.
+
+### Provider Profile Creation
+
+The CLI owns concrete provider construction. Settings may define an active provider profile:
+
+```json
+{
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    }
+  }
+}
+```
+
+Provider resolution order:
+
+1. `currentProvider` plus `providers[currentProvider]`
+2. Legacy `provider`
+3. Provider-specific field defaults for omitted profile fields
+
+Supported provider profile types:
+
+| Type        | Provider class      | Required settings                     | Notes                                           |
+| ----------- | ------------------- | ------------------------------------- | ----------------------------------------------- |
+| `anthropic` | `AnthropicProvider` | `apiKey`, `model`                     | Existing Claude-compatible CLI path             |
+| `openai`    | `OpenAIProvider`    | `apiKey`, `model`, optional `baseURL` | Used for OpenAI and OpenAI-compatible endpoints |
+
+LM Studio is represented as `type: "openai"` with `baseURL: "http://localhost:1234/v1"`. The CLI must not use LM Studio native `/api/v1/*` APIs or Anthropic-compatible endpoints for this path.
 
 ```
 bin.ts → cli.ts (arg parsing + provider creation)
@@ -856,17 +889,18 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 
 ## Dependencies
 
-| Package                                | Purpose                                                                     |
-| -------------------------------------- | --------------------------------------------------------------------------- |
-| `@robota-sdk/agent-sdk`                | `InteractiveSession`, `CommandRegistry`, command sources, plugin management |
-| `@robota-sdk/agent-core`               | Public types (`TPermissionMode`, `TToolArgs`, `TUniversalMessage`, etc.)    |
-| `@robota-sdk/agent-provider-anthropic` | Anthropic provider creation (CLI picks provider based on config)            |
-| `@robota-sdk/agent-transport-headless` | Headless runner for print mode (`-p`) execution                             |
-| `ink`, `react`                         | TUI rendering                                                               |
-| `ink-select-input`                     | Arrow-key selection (permission prompt)                                     |
-| `ink-spinner`                          | Loading spinner                                                             |
-| `chalk`                                | Terminal colors                                                             |
-| `ink-text-input`                       | Base text input (extended by CjkTextInput)                                  |
-| `marked`, `marked-terminal`            | Markdown parsing and terminal rendering                                     |
-| `cli-highlight`                        | Syntax highlighting for code blocks                                         |
-| `string-width`                         | Unicode-aware string width calculation                                      |
+| Package                                | Purpose                                                                      |
+| -------------------------------------- | ---------------------------------------------------------------------------- |
+| `@robota-sdk/agent-sdk`                | `InteractiveSession`, `CommandRegistry`, command sources, plugin management  |
+| `@robota-sdk/agent-core`               | Public types (`TPermissionMode`, `TToolArgs`, `TUniversalMessage`, etc.)     |
+| `@robota-sdk/agent-provider-anthropic` | Anthropic provider creation (CLI picks provider based on config)             |
+| `@robota-sdk/agent-provider-openai`    | OpenAI/OpenAI-compatible provider creation (including LM Studio via baseURL) |
+| `@robota-sdk/agent-transport-headless` | Headless runner for print mode (`-p`) execution                              |
+| `ink`, `react`                         | TUI rendering                                                                |
+| `ink-select-input`                     | Arrow-key selection (permission prompt)                                      |
+| `ink-spinner`                          | Loading spinner                                                              |
+| `chalk`                                | Terminal colors                                                              |
+| `ink-text-input`                       | Base text input (extended by CjkTextInput)                                   |
+| `marked`, `marked-terminal`            | Markdown parsing and terminal rendering                                      |
+| `cli-highlight`                        | Syntax highlighting for code blocks                                          |
+| `string-width`                         | Unicode-aware string width calculation                                       |

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-provider-anthropic": "workspace:*",
+    "@robota-sdk/agent-provider-openai": "workspace:*",
     "@robota-sdk/agent-sdk": "workspace:*",
     "@robota-sdk/agent-sessions": "workspace:3.0.0-beta.55",
     "@robota-sdk/agent-transport-headless": "workspace:*",

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -5,34 +5,27 @@
  * (config, context, session, tools).
  */
 
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
 import { parseCliArgs } from './utils/cli-args.js';
 import { getUserSettingsPath, deleteSettings } from './utils/settings-io.js';
+import { checkSettingsFile } from './utils/settings-check.js';
 import { createProviderFromSettings, readProviderSettings } from './utils/provider-factory.js';
 import { createHeadlessTransport } from '@robota-sdk/agent-transport-headless';
 import { renderApp } from './ui/render.js';
 
-/** Result of checking a settings file. */
-type TSettingsCheck = 'missing' | 'valid' | 'corrupt' | 'incomplete';
-
-/** Check a settings file's state. */
-function checkSettingsFile(filePath: string): TSettingsCheck {
-  if (!existsSync(filePath)) return 'missing';
-  try {
-    const raw = readFileSync(filePath, 'utf8').trim();
-    if (raw.length === 0) return 'incomplete';
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const provider = parsed.provider as Record<string, unknown> | undefined;
-    if (!provider?.apiKey) return 'incomplete';
-    return 'valid';
-  } catch {
-    return 'corrupt';
-  }
+interface IFirstRunSettings {
+  provider: {
+    name: 'anthropic';
+    model: string;
+    apiKey: string;
+  };
+  language?: string;
 }
 
 /** Read version from package.json at runtime. */
@@ -104,7 +97,14 @@ async function ensureConfig(cwd: string): Promise<void> {
   const projectPath = join(cwd, '.robota', 'settings.json');
   const localPath = join(cwd, '.robota', 'settings.local.json');
 
-  const paths = [userPath, projectPath, localPath];
+  const paths = [
+    userPath,
+    join(homedir(), '.claude', 'settings.json'),
+    projectPath,
+    localPath,
+    join(cwd, '.claude', 'settings.json'),
+    join(cwd, '.claude', 'settings.local.json'),
+  ];
   const checks = paths.map((p) => ({ path: p, status: checkSettingsFile(p) }));
 
   if (checks.some((c) => c.status === 'valid')) {
@@ -146,7 +146,7 @@ async function ensureConfig(cwd: string): Promise<void> {
 
   const settingsDir = dirname(userPath);
   mkdirSync(settingsDir, { recursive: true });
-  const settings: Record<string, unknown> = {
+  const settings: IFirstRunSettings = {
     provider: {
       name: 'anthropic',
       model: 'claude-sonnet-4-6',

--- a/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createProviderFromSettings, readProviderSettings } from '../provider-factory.js';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
+
+vi.mock('@robota-sdk/agent-provider-anthropic', () => ({
+  AnthropicProvider: vi.fn().mockImplementation((options: unknown) => ({
+    name: 'anthropic',
+    version: 'test',
+    options,
+  })),
+}));
+
+vi.mock('@robota-sdk/agent-provider-openai', () => ({
+  OpenAIProvider: vi.fn().mockImplementation((options: unknown) => ({
+    name: 'openai',
+    version: 'test',
+    options,
+  })),
+}));
+
+const TMP_BASE = join(tmpdir(), `robota-provider-factory-test-${process.pid}`);
+
+function writeJson(path: string, data: unknown): void {
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf8');
+}
+
+describe('provider-factory', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cwd = join(TMP_BASE, Math.random().toString(36).slice(2));
+    mkdirSync(join(cwd, '.robota'), { recursive: true });
+  });
+
+  afterEach(() => {
+    delete process.env.ROBOTA_TEST_ANTHROPIC_API_KEY;
+    rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('reads active OpenAI-compatible provider profile', () => {
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+          baseURL: 'http://localhost:1234/v1',
+          timeout: 30000,
+        },
+      },
+    });
+
+    expect(readProviderSettings(cwd)).toEqual({
+      name: 'openai',
+      model: 'supergemma4-26b-uncensored-v2',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+      timeout: 30000,
+    });
+  });
+
+  it('creates OpenAIProvider for an OpenAI-compatible profile', () => {
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+
+    const provider = createProviderFromSettings(cwd);
+
+    expect(provider.name).toBe('openai');
+    expect(OpenAIProvider).toHaveBeenCalledWith({
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+      defaultModel: 'supergemma4-26b-uncensored-v2',
+    });
+  });
+
+  it('keeps legacy Anthropic provider creation working', () => {
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-ant-test',
+      },
+    });
+
+    const provider = createProviderFromSettings(cwd);
+
+    expect(provider.name).toBe('anthropic');
+    expect(AnthropicProvider).toHaveBeenCalledWith({
+      apiKey: 'sk-ant-test',
+      defaultModel: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('resolves env references in provider api keys', () => {
+    process.env.ROBOTA_TEST_ANTHROPIC_API_KEY = 'sk-ant-from-env';
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: '$ENV:ROBOTA_TEST_ANTHROPIC_API_KEY',
+      },
+    });
+
+    createProviderFromSettings(cwd);
+
+    expect(AnthropicProvider).toHaveBeenCalledWith({
+      apiKey: 'sk-ant-from-env',
+      defaultModel: 'claude-sonnet-4-6',
+    });
+  });
+});

--- a/packages/agent-cli/src/utils/__tests__/settings-check.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/settings-check.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { checkSettingsFile } from '../settings-check.js';
+
+const TMP_BASE = join(tmpdir(), `robota-settings-check-test-${process.pid}`);
+
+function writeJson(path: string, data: unknown): void {
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf8');
+}
+
+describe('checkSettingsFile', () => {
+  afterEach(() => {
+    rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('returns missing when the file does not exist', () => {
+    expect(checkSettingsFile(join(TMP_BASE, 'missing.json'))).toBe('missing');
+  });
+
+  it('returns incomplete for an empty file', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeFileSync(path, '', 'utf8');
+
+    expect(checkSettingsFile(path)).toBe('incomplete');
+  });
+
+  it('returns corrupt for invalid JSON', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeFileSync(path, '{', 'utf8');
+
+    expect(checkSettingsFile(path)).toBe('corrupt');
+  });
+
+  it('accepts legacy provider config with an apiKey', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeJson(path, {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: '$ENV:ANTHROPIC_API_KEY',
+      },
+    });
+
+    expect(checkSettingsFile(path)).toBe('valid');
+  });
+
+  it('accepts an OpenAI-compatible profile without a real API key', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeJson(path, {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+
+    expect(checkSettingsFile(path)).toBe('valid');
+  });
+
+  it('returns incomplete when currentProvider points to a profile without usable provider data', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeJson(path, {
+      currentProvider: 'anthropic',
+      providers: {
+        anthropic: {
+          type: 'anthropic',
+          model: 'claude-sonnet-4-6',
+        },
+      },
+    });
+
+    expect(checkSettingsFile(path)).toBe('incomplete');
+  });
+});

--- a/packages/agent-cli/src/utils/provider-factory.ts
+++ b/packages/agent-cli/src/utils/provider-factory.ts
@@ -10,45 +10,190 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
 
 interface IProviderConfig {
   name: string;
   model: string;
-  apiKey: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
 }
+
+interface IProviderProfileSettings {
+  type?: string;
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
+}
+
+interface ILegacyProviderSettings {
+  name?: string;
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
+}
+
+interface IProviderSettingsFile {
+  currentProvider?: string;
+  providers?: Record<string, IProviderProfileSettings>;
+  provider?: ILegacyProviderSettings;
+}
+
+const DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  openai: 'supergemma4-26b-uncensored-v2',
+};
+
+const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = 'http://localhost:1234/v1';
+const DEFAULT_OPENAI_COMPATIBLE_API_KEY = 'lm-studio';
 
 /** Read provider settings from the settings file chain. */
 export function readProviderSettings(cwd: string): IProviderConfig {
   const paths = [
-    join(cwd, '.robota', 'settings.local.json'),
-    join(cwd, '.robota', 'settings.json'),
-    join(cwd, '.claude', 'settings.local.json'),
-    join(cwd, '.claude', 'settings.json'),
     join(homedir(), '.robota', 'settings.json'),
     join(homedir(), '.claude', 'settings.json'),
+    join(cwd, '.robota', 'settings.json'),
+    join(cwd, '.robota', 'settings.local.json'),
+    join(cwd, '.claude', 'settings.json'),
+    join(cwd, '.claude', 'settings.local.json'),
   ];
 
-  for (const filePath of paths) {
-    if (!existsSync(filePath)) continue;
-    try {
-      const raw = readFileSync(filePath, 'utf8');
-      const parsed = JSON.parse(raw) as {
-        provider?: { name?: string; model?: string; apiKey?: string };
-      };
-      const provider = parsed.provider;
-      if (provider?.apiKey && provider?.name) {
-        return {
-          name: provider.name,
-          model: provider.model ?? 'claude-sonnet-4-6',
-          apiKey: provider.apiKey,
-        };
-      }
-    } catch {
-      continue;
+  const merged = paths.reduce<IProviderSettingsFile>((settings, filePath) => {
+    const parsed = readSettingsFile(filePath);
+    if (parsed === undefined) {
+      return settings;
     }
+    return mergeSettings(settings, parsed);
+  }, {});
+
+  const providerConfig = resolveActiveProvider(merged);
+  if (providerConfig !== undefined) {
+    return providerConfig;
   }
 
   throw new Error('No provider configuration found. Run `robota` to set up.');
+}
+
+function readSettingsFile(filePath: string): IProviderSettingsFile | undefined {
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw) as IProviderSettingsFile;
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeSettings(
+  base: IProviderSettingsFile,
+  override: IProviderSettingsFile,
+): IProviderSettingsFile {
+  return {
+    ...base,
+    ...override,
+    provider:
+      base.provider !== undefined || override.provider !== undefined
+        ? { ...base.provider, ...override.provider }
+        : undefined,
+    providers:
+      base.providers !== undefined || override.providers !== undefined
+        ? mergeProviders(base.providers, override.providers)
+        : undefined,
+  };
+}
+
+function mergeProviders(
+  base: IProviderSettingsFile['providers'],
+  override: IProviderSettingsFile['providers'],
+): IProviderSettingsFile['providers'] {
+  const result: NonNullable<IProviderSettingsFile['providers']> = { ...(base ?? {}) };
+  for (const [name, profile] of Object.entries(override ?? {})) {
+    result[name] = { ...result[name], ...profile };
+  }
+  return result;
+}
+
+function resolveActiveProvider(settings: IProviderSettingsFile): IProviderConfig | undefined {
+  if (settings.currentProvider !== undefined) {
+    const profile = settings.providers?.[settings.currentProvider];
+    if (profile === undefined) {
+      throw new Error(`currentProvider "${settings.currentProvider}" was not found in providers`);
+    }
+    if (!profile.type) {
+      throw new Error(`Provider profile "${settings.currentProvider}" is missing type`);
+    }
+    return normalizeProviderConfig({
+      name: profile.type,
+      model: profile.model,
+      apiKey: profile.apiKey,
+      baseURL: profile.baseURL,
+      timeout: profile.timeout,
+    });
+  }
+
+  const provider = settings.provider;
+  if (provider?.name) {
+    return normalizeProviderConfig({
+      name: provider.name,
+      model: provider.model,
+      apiKey: provider.apiKey,
+      baseURL: provider.baseURL,
+      timeout: provider.timeout,
+    });
+  }
+
+  return undefined;
+}
+
+function normalizeProviderConfig(settings: {
+  name: string;
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
+}): IProviderConfig {
+  const defaults = getProviderDefaults(settings.name);
+  return {
+    name: settings.name,
+    model: settings.model ?? defaults.model,
+    apiKey: settings.apiKey !== undefined ? resolveEnvRef(settings.apiKey) : defaults.apiKey,
+    baseURL: settings.baseURL ?? defaults.baseURL,
+    timeout: settings.timeout,
+  };
+}
+
+function resolveEnvRef(value: string): string {
+  const envPrefix = '$ENV:';
+  if (!value.startsWith(envPrefix)) {
+    return value;
+  }
+  const envName = value.slice(envPrefix.length);
+  return process.env[envName] ?? value;
+}
+
+function getProviderDefaults(name: string): { model: string; apiKey?: string; baseURL?: string } {
+  if (name === 'openai') {
+    return {
+      model: DEFAULT_MODELS['openai'] ?? 'supergemma4-26b-uncensored-v2',
+      apiKey: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+      baseURL: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+    };
+  }
+  return {
+    model: DEFAULT_MODELS[name] ?? DEFAULT_MODELS['anthropic'] ?? 'claude-sonnet-4-6',
+  };
+}
+
+function requireApiKey(settings: IProviderConfig): string {
+  if (!settings.apiKey) {
+    throw new Error(`Provider ${settings.name} requires apiKey`);
+  }
+  return settings.apiKey;
 }
 
 /** Create a provider instance from settings. */
@@ -58,8 +203,20 @@ export function createProviderFromSettings(cwd: string, modelOverride?: string):
 
   switch (settings.name) {
     case 'anthropic':
-      return new AnthropicProvider({ apiKey: settings.apiKey, defaultModel: model });
+      return new AnthropicProvider({
+        apiKey: requireApiKey(settings),
+        ...(settings.baseURL !== undefined && { baseURL: settings.baseURL }),
+        ...(settings.timeout !== undefined && { timeout: settings.timeout }),
+        defaultModel: model,
+      });
+    case 'openai':
+      return new OpenAIProvider({
+        apiKey: requireApiKey(settings),
+        ...(settings.baseURL !== undefined && { baseURL: settings.baseURL }),
+        ...(settings.timeout !== undefined && { timeout: settings.timeout }),
+        defaultModel: model,
+      });
     default:
-      throw new Error(`Unknown provider: ${settings.name}. Currently supported: anthropic`);
+      throw new Error(`Unknown provider: ${settings.name}. Currently supported: anthropic, openai`);
   }
 }

--- a/packages/agent-cli/src/utils/settings-check.ts
+++ b/packages/agent-cli/src/utils/settings-check.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+/** Result of checking a settings file. */
+export type TSettingsCheck = 'missing' | 'valid' | 'corrupt' | 'incomplete';
+
+interface IProviderSettingsShape {
+  provider?: { apiKey?: string };
+  currentProvider?: string;
+  providers?: Record<string, { type?: string; apiKey?: string }>;
+}
+
+/** Check a settings file's state for first-run setup. */
+export function checkSettingsFile(filePath: string): TSettingsCheck {
+  if (!existsSync(filePath)) return 'missing';
+  try {
+    const raw = readFileSync(filePath, 'utf8').trim();
+    if (raw.length === 0) return 'incomplete';
+    const parsed = JSON.parse(raw) as IProviderSettingsShape;
+    if (!hasUsableProviderConfig(parsed)) return 'incomplete';
+    return 'valid';
+  } catch {
+    return 'corrupt';
+  }
+}
+
+function hasUsableProviderConfig(settings: IProviderSettingsShape): boolean {
+  if (settings.provider?.apiKey) {
+    return true;
+  }
+  if (typeof settings.currentProvider !== 'string') {
+    return false;
+  }
+  const profile = settings.providers?.[settings.currentProvider];
+  return !!profile?.apiKey || profile?.type === 'openai';
+}

--- a/packages/agent-provider-openai/README.md
+++ b/packages/agent-provider-openai/README.md
@@ -7,7 +7,7 @@ OpenAI Provider for Robota SDK - Complete type-safe integration with OpenAI's GP
 ### Core Capabilities
 
 - **🎯 Type-Safe Integration**: Complete TypeScript support with zero `any` types
-- **🤖 GPT Model Support**: GPT-4, GPT-3.5 Turbo, and all OpenAI models
+- **🤖 GPT Model Support**: GPT-4, GPT-3.5 Turbo, OpenAI models, and OpenAI-compatible chat completion models
 - **⚡ Real-Time Streaming**: Asynchronous streaming responses with proper error handling
 - **🛠️ Function Calling**: Native OpenAI function calling with type validation
 - **🔄 Provider-Agnostic Design**: Seamless integration with other Robota providers
@@ -59,6 +59,20 @@ console.log(response);
 await agent.destroy();
 ```
 
+### OpenAI-Compatible Endpoints
+
+Use `baseURL` to point the provider at an OpenAI-compatible Chat Completions endpoint. For LM Studio, the local API typically listens on `http://localhost:1234/v1` and accepts a local placeholder API key:
+
+```typescript
+import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
+
+const provider = new OpenAIProvider({
+  apiKey: 'lm-studio',
+  baseURL: 'http://localhost:1234/v1',
+  defaultModel: 'supergemma4-26b-uncensored-v2',
+});
+```
+
 ### Streaming Responses
 
 ```typescript
@@ -76,6 +90,8 @@ for await (const chunk of stream) {
   }
 }
 ```
+
+When `chat()` receives an `onTextDelta` callback, the provider uses the streaming Chat Completions path internally, forwards text deltas to the callback, assembles streamed tool-call chunks, and returns the final assistant message.
 
 ## 🛠️ Function Calling
 

--- a/packages/agent-provider-openai/docs/SPEC.md
+++ b/packages/agent-provider-openai/docs/SPEC.md
@@ -6,6 +6,7 @@
 - Owns bidirectional message conversion between `TUniversalMessage` and OpenAI SDK native types.
 - Owns payload logging infrastructure with environment-specific implementations (Node.js file-based, browser console-based).
 - Owns OpenAI-specific API type definitions for request parameters, streaming chunks, tool calls, and error structures.
+- Supports OpenAI-compatible Chat Completions endpoints through `baseURL`, including local endpoints such as LM Studio.
 
 ## Boundaries
 
@@ -33,6 +34,7 @@ src/
     response-parser.ts              # OpenAIResponseParser (completion + streaming chunk parsing)
   streaming/
     stream-handler.ts               # OpenAIStreamHandler (modular streaming logic)
+    stream-assembler.ts             # Assembles Chat Completions stream chunks into one TUniversalMessage
   loggers/
     index.ts                        # Logger barrel exports
     console.ts                      # Subpath entry: ConsolePayloadLogger
@@ -110,11 +112,12 @@ Types imported from `@robota-sdk/agent-core` (not owned here):
 
 ### Internal (not exported from main entry)
 
-| Class                   | File                                  | Description                                                      |
-| ----------------------- | ------------------------------------- | ---------------------------------------------------------------- |
-| `OpenAIResponseParser`  | `parsers/response-parser.ts`          | Parses completions and streaming chunks into `TUniversalMessage` |
-| `OpenAIStreamHandler`   | `streaming/stream-handler.ts`         | Modular streaming handler (used internally by provider)          |
-| `sanitizeOpenAILogData` | `loggers/sanitize-openai-log-data.ts` | Deep-copy sanitization for log payloads                          |
+| Class                   | File                                  | Description                                                            |
+| ----------------------- | ------------------------------------- | ---------------------------------------------------------------------- |
+| `OpenAIResponseParser`  | `parsers/response-parser.ts`          | Parses completions and streaming chunks into `TUniversalMessage`       |
+| `OpenAIStreamHandler`   | `streaming/stream-handler.ts`         | Modular streaming generator for raw streaming APIs                     |
+| `assembleOpenAIStream`  | `streaming/stream-assembler.ts`       | Assembles streamed Chat Completions chunks for `OpenAIProvider.chat()` |
+| `sanitizeOpenAILogData` | `loggers/sanitize-openai-log-data.ts` | Deep-copy sanitization for log payloads                                |
 
 ## Extension Points
 
@@ -143,6 +146,20 @@ Consumers can pass a pre-configured `OpenAI` client instance via `IOpenAIProvide
 
 The `baseURL` option in `IOpenAIProviderOptions` allows consumers to point the provider at OpenAI-compatible APIs (e.g., Azure OpenAI, local proxies).
 
+### Streaming Assembly for CLI
+
+`OpenAIProvider.chat()` must honor `IChatOptions.onTextDelta`. When the callback is provided, `chat()` uses Chat Completions streaming internally while still returning one complete `TUniversalMessage`.
+
+Streaming assembly responsibilities:
+
+- Accumulate `delta.content` into the final assistant content.
+- Call `onTextDelta` for every text delta.
+- Accumulate streamed `tool_calls` by `index`, preserving `id`, function `name`, and partial `arguments`.
+- Return final `toolCalls` only after streamed arguments have been assembled.
+- Pass `AbortSignal` through to the OpenAI SDK request where supported.
+
+The non-streaming Chat Completions path remains supported for callers that do not provide `onTextDelta`.
+
 ## Error Taxonomy
 
 This package does not define a custom error class hierarchy. It uses standard `Error` instances with descriptive messages. Error scenarios:
@@ -153,7 +170,7 @@ This package does not define a custom error class hierarchy. It uses standard `E
 | Missing model in chat options        | `"Model is required in chat options..."`                  | `provider.ts` chat/chatStream |
 | Client unavailable (no executor)     | `"OpenAI client not available..."`                        | `provider.ts` chat/chatStream |
 | API call failure                     | `"OpenAI chat failed: <message>"`                         | `provider.ts` chat            |
-| Streaming failure                    | `"OpenAI stream failed: <message>"`                       | `provider.ts` chatStream      |
+| Streaming failure                    | `"OpenAI stream failed: <message>"`                       | `provider.ts` chat/chatStream |
 | Response parsing failure             | `"OpenAI response parsing failed: <message>"`             | `parsers/response-parser.ts`  |
 | Chunk parsing failure                | `"OpenAI chunk parsing failed: <message>"`                | `parsers/response-parser.ts`  |
 | Stream handler failure               | `"OpenAI streaming failed: <message>"`                    | `streaming/stream-handler.ts` |
@@ -191,13 +208,8 @@ Payload loggers (`FilePayloadLogger`, `ConsolePayloadLogger`) catch and log thei
 | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------- |
 | `adapter.test.ts`              | Unit        | `OpenAIConversationAdapter` -- all message types, tool call content handling, filtering, complete conversation flow |
 | `executor-integration.test.ts` | Integration | `OpenAIProvider` with `LocalExecutor` -- chat, streaming, error handling, mixed mode, initialization                |
+| `provider.test.ts`             | Unit        | Direct client path, baseURL construction, non-streaming chat, streaming text/tool-call assembly                     |
 
 ### Test Gaps
 
-- No unit tests for `OpenAIResponseParser` (completion parsing, streaming chunk parsing, error cases).
-- No unit tests for `OpenAIStreamHandler` (stream handling, payload logging during streams).
 - No unit tests for `FilePayloadLogger` or `ConsolePayloadLogger`.
-- No unit tests for `sanitizeOpenAILogData`.
-- No direct unit tests for `OpenAIProvider.chat` and `OpenAIProvider.chatStream` with a mocked OpenAI client (non-executor path).
-- No tests for `OpenAIProvider.validateConfig` or `OpenAIProvider.validateMessages` specific behavior.
-- No tests verifying payload logger integration within the provider (logging is called with correct data).

--- a/packages/agent-provider-openai/src/provider.test.ts
+++ b/packages/agent-provider-openai/src/provider.test.ts
@@ -64,6 +64,11 @@ describe('OpenAIProvider', () => {
       expect(provider.version).toBe('1.0.0');
     });
 
+    it('exposes onTextDelta so Session can wire streaming callbacks', () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+      expect('onTextDelta' in provider).toBe(true);
+    });
+
     it('should create provider with client', () => {
       const mockClient = { chat: { completions: { create: vi.fn() } } };
       const provider = new OpenAIProvider({ client: mockClient as never });
@@ -569,6 +574,192 @@ describe('OpenAIProvider', () => {
           ]),
           tool_choice: 'auto',
         }),
+      );
+    });
+  });
+
+  describe('chat streaming assembly', () => {
+    async function* createTextStream() {
+      yield {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: null, logprobs: null }],
+      };
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: { content: ' world' }, finish_reason: null, logprobs: null }],
+      };
+      yield {
+        id: 'chunk-3',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop', logprobs: null }],
+      };
+    }
+
+    async function* createToolCallStream() {
+      yield {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_weather',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{"city"' },
+                },
+              ],
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      };
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: ':"Seoul"}' },
+                },
+              ],
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      };
+      yield {
+        id: 'chunk-3',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls', logprobs: null }],
+      };
+    }
+
+    it('streams text through onTextDelta and returns an assembled message', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+      const messages: TUniversalMessage[] = [createUserMessage('Hello')];
+      const client = (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client;
+      client.chat.completions.create.mockResolvedValue(createTextStream());
+      const deltas: string[] = [];
+
+      const result = await provider.chat(messages, {
+        model: 'gpt-4',
+        onTextDelta: (delta) => deltas.push(delta),
+      });
+
+      expect(deltas).toEqual(['Hello', ' world']);
+      expect(result.content).toBe('Hello world');
+      expect(client.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-4', stream: true }),
+        undefined,
+      );
+    });
+
+    it('streams through the provider-level onTextDelta callback when configured by Session', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+      const messages: TUniversalMessage[] = [createUserMessage('Hello')];
+      const client = (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client;
+      client.chat.completions.create.mockResolvedValue(createTextStream());
+      const deltas: string[] = [];
+      provider.onTextDelta = (delta) => deltas.push(delta);
+
+      const result = await provider.chat(messages, {
+        model: 'gpt-4',
+      });
+
+      expect(deltas).toEqual(['Hello', ' world']);
+      expect(result.content).toBe('Hello world');
+      expect(client.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-4', stream: true }),
+        undefined,
+      );
+    });
+
+    it('assembles streaming tool-call deltas before returning', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+      const messages: TUniversalMessage[] = [createUserMessage('Weather in Seoul')];
+      const client = (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client;
+      client.chat.completions.create.mockResolvedValue(createToolCallStream());
+
+      const result = await provider.chat(messages, {
+        model: 'gpt-4',
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get weather',
+            parameters: { type: 'object' as const, properties: { city: { type: 'string' } } },
+          },
+        ],
+        onTextDelta: vi.fn(),
+      });
+
+      const assistant = result as TUniversalMessage & {
+        toolCalls: Array<{ id: string; function: { name: string; arguments: string } }>;
+      };
+      expect(assistant.content).toBe('');
+      expect(assistant.toolCalls).toEqual([
+        {
+          id: 'call_weather',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
+        },
+      ]);
+    });
+
+    it('passes AbortSignal to the streaming request used by chat', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+      const messages: TUniversalMessage[] = [createUserMessage('Hello')];
+      const client = (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client;
+      client.chat.completions.create.mockResolvedValue(createTextStream());
+      const controller = new AbortController();
+
+      await provider.chat(messages, {
+        model: 'gpt-4',
+        onTextDelta: vi.fn(),
+        signal: controller.signal,
+      });
+
+      expect(client.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true }),
+        { signal: controller.signal },
       );
     });
   });

--- a/packages/agent-provider-openai/src/provider.ts
+++ b/packages/agent-provider-openai/src/provider.ts
@@ -2,11 +2,17 @@ import OpenAI from 'openai';
 import type { IOpenAIProviderOptions } from './types';
 import type { IOpenAIError } from './types/api-types';
 import { AbstractAIProvider } from '@robota-sdk/agent-core';
-import type { TUniversalMessage, IChatOptions, IAssistantMessage } from '@robota-sdk/agent-core';
+import type {
+  TUniversalMessage,
+  IChatOptions,
+  IAssistantMessage,
+  TTextDeltaCallback,
+} from '@robota-sdk/agent-core';
 import type { IPayloadLogger } from './interfaces/payload-logger';
 import { OpenAIResponseParser } from './parsers/response-parser';
 import { SilentLogger } from '@robota-sdk/agent-core';
 import { convertToOpenAIMessages, convertToOpenAITools } from './message-converter';
+import { assembleOpenAIStream } from './streaming/stream-assembler';
 
 /**
  * OpenAI provider implementation for Robota
@@ -25,18 +31,23 @@ export class OpenAIProvider extends AbstractAIProvider {
   private readonly payloadLogger: IPayloadLogger | undefined;
   private readonly responseParser: OpenAIResponseParser;
 
+  /**
+   * Optional callback for text deltas during streaming.
+   * Set by the consumer (e.g., Session) to receive real-time text chunks.
+   * When set, chat() uses streaming internally while still returning
+   * the complete assembled message.
+   */
+  onTextDelta?: TTextDeltaCallback;
+
   constructor(options: IOpenAIProviderOptions) {
     super(options.logger || SilentLogger);
     this.options = options;
 
-    // Set executor if provided
     if (options.executor) {
       this.executor = options.executor;
     }
 
-    // Only create client if not using executor
     if (!this.executor) {
-      // Create client from apiKey if not provided
       if (options.client) {
         this.client = options.client;
       } else if (options.apiKey) {
@@ -52,21 +63,15 @@ export class OpenAIProvider extends AbstractAIProvider {
     }
 
     this.responseParser = new OpenAIResponseParser(this.logger);
-
-    // Initialize payload logger
     this.payloadLogger = options.payloadLogger;
   }
 
-  /**
-   * Generate response using TUniversalMessage
-   */
   override async chat(
     messages: TUniversalMessage[],
     options?: IChatOptions,
   ): Promise<TUniversalMessage> {
     this.validateMessages(messages);
 
-    // Use executor when configured; otherwise use direct execution
     if (this.executor) {
       try {
         return await this.executeViaExecutorOrDirect(messages, options);
@@ -79,7 +84,6 @@ export class OpenAIProvider extends AbstractAIProvider {
       }
     }
 
-    // Direct execution with OpenAI client
     if (!this.client) {
       throw new Error(
         'OpenAI client not available. Either provide a client/apiKey or use an executor.',
@@ -87,29 +91,40 @@ export class OpenAIProvider extends AbstractAIProvider {
     }
 
     try {
-      // 1. Convert TUniversalMessage → OpenAI format
       const openaiMessages = convertToOpenAIMessages(messages);
 
-      // 2. Validate required model parameter
-      if (!options?.model) {
+      const chatOptions = options;
+      if (!chatOptions?.model) {
         throw new Error(
           'Model is required in chat options. Please specify a model in defaultModel configuration.',
         );
       }
 
-      // 3. Call OpenAI API (native SDK types)
       const requestParams: OpenAI.Chat.ChatCompletionCreateParamsNonStreaming = {
-        model: options.model,
+        model: chatOptions.model,
         messages: openaiMessages,
-        ...(options?.temperature !== undefined && { temperature: options.temperature }),
-        ...(options?.maxTokens && { max_tokens: options.maxTokens }),
-        ...(options?.tools && {
-          tools: convertToOpenAITools(options.tools),
+        ...(chatOptions.temperature !== undefined && { temperature: chatOptions.temperature }),
+        ...(chatOptions.maxTokens && { max_tokens: chatOptions.maxTokens }),
+        ...(chatOptions.tools && {
+          tools: convertToOpenAITools(chatOptions.tools),
           tool_choice: 'auto',
         }),
       };
 
-      // Log payload for debugging if logger is available
+      const textDeltaCb = chatOptions.onTextDelta ?? this.onTextDelta;
+      if (textDeltaCb) {
+        return await this.chatWithStreamingAssembly(
+          {
+            ...requestParams,
+            stream: true,
+          },
+          {
+            ...chatOptions,
+            onTextDelta: textDeltaCb,
+          },
+        );
+      }
+
       if (this.payloadLogger?.isEnabled()) {
         const logData = {
           model: requestParams.model,
@@ -124,7 +139,6 @@ export class OpenAIProvider extends AbstractAIProvider {
 
       const response = await this.client.chat.completions.create(requestParams);
 
-      // 4. Convert OpenAI response → TUniversalMessage
       return this.responseParser.parseResponse(response);
     } catch (error) {
       const openaiError = error as IOpenAIError;
@@ -133,9 +147,46 @@ export class OpenAIProvider extends AbstractAIProvider {
     }
   }
 
-  /**
-   * Generate streaming response using TUniversalMessage
-   */
+  private async chatWithStreamingAssembly(
+    requestParams: OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+    options: IChatOptions,
+  ): Promise<TUniversalMessage> {
+    if (!this.client) {
+      throw new Error(
+        'OpenAI client not available. Either provide a client/apiKey or use an executor.',
+      );
+    }
+
+    try {
+      if (this.payloadLogger?.isEnabled()) {
+        const logData = {
+          model: requestParams.model,
+          messagesCount: requestParams.messages.length,
+          hasTools: !!requestParams.tools,
+          temperature: requestParams.temperature ?? undefined,
+          maxTokens: requestParams.max_tokens ?? undefined,
+          timestamp: new Date().toISOString(),
+        };
+        await this.payloadLogger.logPayload(logData, 'stream');
+      }
+
+      const stream = await this.client.chat.completions.create(
+        requestParams,
+        options.signal ? { signal: options.signal } : undefined,
+      );
+
+      return assembleOpenAIStream({
+        stream,
+        onTextDelta: options.onTextDelta,
+        signal: options.signal,
+      });
+    } catch (error) {
+      const openaiError = error as IOpenAIError;
+      const errorMessage = openaiError.message || 'OpenAI streaming request failed';
+      throw new Error(`OpenAI stream failed: ${errorMessage}`);
+    }
+  }
+
   override async *chatStream(
     messages: TUniversalMessage[],
     options?: IChatOptions,
@@ -153,7 +204,6 @@ export class OpenAIProvider extends AbstractAIProvider {
       }
     }
 
-    // Direct execution with OpenAI client
     if (!this.client) {
       throw new Error(
         'OpenAI client not available. Either provide a client/apiKey or use an executor.',
@@ -161,17 +211,14 @@ export class OpenAIProvider extends AbstractAIProvider {
     }
 
     try {
-      // 1. Convert TUniversalMessage → OpenAI format
       const openaiMessages = convertToOpenAIMessages(messages);
 
-      // 2. Validate required model parameter
       if (!options?.model) {
         throw new Error(
           'Model is required in chat options. Please specify a model in defaultModel configuration.',
         );
       }
 
-      // 3. Call OpenAI streaming API
       const requestParams: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
         model: options.model,
         messages: openaiMessages,
@@ -184,7 +231,6 @@ export class OpenAIProvider extends AbstractAIProvider {
         }),
       };
 
-      // Log payload for debugging if logger is available
       if (this.payloadLogger?.isEnabled()) {
         const logData = {
           model: requestParams.model,
@@ -199,7 +245,6 @@ export class OpenAIProvider extends AbstractAIProvider {
 
       const stream = await this.client.chat.completions.create(requestParams);
 
-      // 4. Stream conversion: OpenAI chunks → TUniversalMessage
       for await (const chunk of stream) {
         const universalMessage = this.responseParser.parseStreamingChunk(chunk);
         if (universalMessage) {
@@ -225,35 +270,9 @@ export class OpenAIProvider extends AbstractAIProvider {
     // OpenAI client doesn't need explicit cleanup
   }
 
-  /**
-   * Validate messages before sending to API.
-   *
-   * IMPORTANT: OpenAI API Content Handling Policy
-   * =============================================
-   *
-   * Based on OpenAI API documentation and community feedback:
-   *
-   * 1. When sending TO OpenAI API:
-   *    - Assistant messages with tool_calls: content MUST be null (not empty string)
-   *    - Regular assistant messages: content can be string or null
-   *    - This prevents "400 Bad Request" errors
-   *
-   * 2. When receiving FROM our API (TUniversalMessage):
-   *    - All messages must have content as string (TypeScript requirement)
-   *    - Convert null to empty string for type compatibility
-   *
-   * 3. This dual handling ensures:
-   *    - OpenAI API compatibility (null for tool calls)
-   *    - TypeScript type safety (string content in TUniversalMessage)
-   *    - No infinite loops in tool execution
-   *
-   * Reference: OpenAI Community discussions confirm that tool_calls
-   * require content to be null, not empty string.
-   */
   protected override validateMessages(messages: TUniversalMessage[]): void {
     super.validateMessages(messages);
 
-    // Additional OpenAI-specific validation
     for (const message of messages) {
       if (message.role === 'assistant') {
         const assistantMsg = message as IAssistantMessage;
@@ -262,7 +281,6 @@ export class OpenAIProvider extends AbstractAIProvider {
           assistantMsg.toolCalls.length > 0 &&
           assistantMsg.content === ''
         ) {
-          // This is valid - we'll convert to null when sending to OpenAI
           continue;
         }
       }

--- a/packages/agent-provider-openai/src/streaming/stream-assembler.ts
+++ b/packages/agent-provider-openai/src/streaming/stream-assembler.ts
@@ -1,0 +1,134 @@
+import { randomUUID } from 'node:crypto';
+import type OpenAI from 'openai';
+import type { IToolCall, TTextDeltaCallback, TUniversalMessage } from '@robota-sdk/agent-core';
+
+interface IStreamAssemblyOptions {
+  stream: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
+  onTextDelta?: TTextDeltaCallback;
+  signal?: AbortSignal;
+}
+
+interface IToolCallPart {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+interface IAssemblyState {
+  textParts: string[];
+  toolCallParts: Map<number, IToolCallPart>;
+  model: string;
+  finishReason: string | null;
+}
+
+export async function assembleOpenAIStream(
+  options: IStreamAssemblyOptions,
+): Promise<TUniversalMessage> {
+  const state: IAssemblyState = {
+    textParts: [],
+    toolCallParts: new Map(),
+    model: '',
+    finishReason: null,
+  };
+
+  for await (const chunk of streamWithAbort(options.stream, options.signal)) {
+    applyChunk(state, chunk, options.onTextDelta);
+  }
+
+  return buildMessage(state);
+}
+
+function applyChunk(
+  state: IAssemblyState,
+  chunk: OpenAI.Chat.ChatCompletionChunk,
+  onTextDelta: TTextDeltaCallback | undefined,
+): void {
+  if (chunk.model) {
+    state.model = chunk.model;
+  }
+
+  const choice = chunk.choices?.[0];
+  if (!choice) {
+    return;
+  }
+
+  state.finishReason = choice.finish_reason ?? state.finishReason;
+  applyTextDelta(state, choice.delta.content, onTextDelta);
+  applyToolCallDeltas(state, choice.delta.tool_calls ?? []);
+}
+
+function applyTextDelta(
+  state: IAssemblyState,
+  content: string | null | undefined,
+  onTextDelta: TTextDeltaCallback | undefined,
+): void {
+  if (!content) {
+    return;
+  }
+  state.textParts.push(content);
+  onTextDelta?.(content);
+}
+
+function applyToolCallDeltas(
+  state: IAssemblyState,
+  deltas: OpenAI.Chat.ChatCompletionChunk.Choice.Delta.ToolCall[],
+): void {
+  for (const delta of deltas) {
+    const index = delta.index ?? 0;
+    const current = state.toolCallParts.get(index) ?? { id: '', name: '', arguments: '' };
+    state.toolCallParts.set(index, {
+      id: delta.id ?? current.id,
+      name: delta.function?.name ?? current.name,
+      arguments: current.arguments + (delta.function?.arguments ?? ''),
+    });
+  }
+}
+
+function buildMessage(state: IAssemblyState): TUniversalMessage {
+  const metadata: NonNullable<TUniversalMessage['metadata']> = {};
+  if (state.model) {
+    metadata['model'] = state.model;
+  }
+  if (state.finishReason) {
+    metadata['finishReason'] = state.finishReason;
+  }
+
+  return {
+    id: randomUUID(),
+    role: 'assistant',
+    content: state.textParts.join(''),
+    state: 'complete' as const,
+    timestamp: new Date(),
+    ...(state.toolCallParts.size > 0 && { toolCalls: buildToolCalls(state.toolCallParts) }),
+    ...(Object.keys(metadata).length > 0 && { metadata }),
+  };
+}
+
+function buildToolCalls(toolCallParts: Map<number, IToolCallPart>): IToolCall[] {
+  return Array.from(toolCallParts.entries())
+    .sort(([left], [right]) => left - right)
+    .map(([index, toolCall]) => ({
+      id: toolCall.id || `call_${index}`,
+      type: 'function' as const,
+      function: {
+        name: toolCall.name,
+        arguments: toolCall.arguments || '{}',
+      },
+    }));
+}
+
+async function* streamWithAbort<T>(
+  source: AsyncIterable<T>,
+  signal?: AbortSignal,
+): AsyncGenerator<T> {
+  for await (const item of source) {
+    if (signal?.aborted) {
+      break;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    if (signal?.aborted) {
+      break;
+    }
+    yield item;
+  }
+}

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -44,7 +44,7 @@ const response = await query('Analyze the code', {
 - **Hooks** — `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `UserPromptSubmit`, `Stop` events with shell command execution
 - **Streaming** — Real-time text delta callbacks via `onTextDelta`
 - **Context Loading** — AGENTS.md / CLAUDE.md walk-up discovery and system prompt assembly
-- **Config Loading** — 6-layer merge (CLI flags, local, project, Claude Code compat, user global, user global Claude Code compat) with `$ENV:VAR` substitution
+- **Config Loading** — 6-file settings merge with provider profiles, legacy provider compatibility, and `$ENV:VAR` substitution for provider API keys
 - **Context Window Management** — Token tracking, auto-compaction at ~83.5%, manual `session.compact()`
 - **Bundle Plugin System** — Install and manage reusable extensions packaged as bundle plugins
 
@@ -330,26 +330,35 @@ Manages plugin installation and uninstallation:
 
 ## Configuration
 
-Settings are loaded from (highest priority first):
+Settings are merged from lowest to highest priority:
 
-| Layer | Path                              | Scope                                |
-| ----- | --------------------------------- | ------------------------------------ |
-| 1     | CLI flags / environment variables | Invocation                           |
-| 2     | `.robota/settings.local.json`     | Project (local)                      |
-| 3     | `.robota/settings.json`           | Project                              |
-| 4     | `.claude/settings.json`           | Project (Claude Code compatible)     |
-| 5     | `~/.robota/settings.json`         | User global                          |
-| 6     | `~/.claude/settings.json`         | User global (Claude Code compatible) |
+| Layer | Path                          | Scope                                   |
+| ----- | ----------------------------- | --------------------------------------- |
+| 1     | `~/.robota/settings.json`     | User global                             |
+| 2     | `~/.claude/settings.json`     | User global (Claude Code compatible)    |
+| 3     | `.robota/settings.json`       | Project                                 |
+| 4     | `.robota/settings.local.json` | Project (local)                         |
+| 5     | `.claude/settings.json`       | Project (Claude Code compatible)        |
+| 6     | `.claude/settings.local.json` | Project (local, Claude Code compatible) |
 
-`$ENV:VAR` substitution is applied after merge.
+`$ENV:VAR` substitution is applied after merge for provider API keys.
 
 ```json
 {
   "defaultMode": "default",
-  "provider": {
-    "name": "anthropic",
-    "model": "claude-sonnet-4-6",
-    "apiKey": "$ENV:ANTHROPIC_API_KEY"
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    },
+    "anthropic": {
+      "type": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "apiKey": "$ENV:ANTHROPIC_API_KEY"
+    }
   },
   "permissions": {
     "allow": ["Bash(pnpm *)"],
@@ -357,6 +366,8 @@ Settings are loaded from (highest priority first):
   }
 }
 ```
+
+`currentProvider` selects the active entry from `providers`. The resolved SDK config normalizes that profile into `provider.name`, `provider.model`, `provider.apiKey`, optional `provider.baseURL`, and optional `provider.timeout`. The legacy `provider` object remains supported when `currentProvider` is not configured.
 
 ## Permission Modes
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -223,7 +223,35 @@ agent-cli (Ink TUI — CLI-specific)
 
 - **Package**: `agent-sdk/config/`
 - **Rationale**: `.robota/settings.json` file-based configuration is for local development environments only (servers use environment variables/DB)
-- **Implementation**: 3-layer merge (user global → project → local), `$ENV:VAR` substitution, Zod validation
+- **Implementation**: settings file merge, `$ENV:VAR` substitution for provider API keys, Zod validation, provider profile resolution
+- **Provider profiles**: settings may define `currentProvider` and `providers`. The active profile is resolved from `providers[currentProvider]`, then normalized into `IResolvedConfig.provider`.
+- **Legacy compatibility**: legacy `provider` settings remain supported and are used when no active provider profile is configured.
+
+Provider profile shape:
+
+```json
+{
+  "currentProvider": "openai",
+  "providers": {
+    "openai": {
+      "type": "openai",
+      "model": "supergemma4-26b-uncensored-v2",
+      "apiKey": "lm-studio",
+      "baseURL": "http://localhost:1234/v1"
+    }
+  }
+}
+```
+
+Resolved provider fields:
+
+| Field     | Description                                                        |
+| --------- | ------------------------------------------------------------------ |
+| `name`    | Provider type used by session model config (`anthropic`, `openai`) |
+| `model`   | Active model id                                                    |
+| `apiKey`  | API key or local placeholder token                                 |
+| `baseURL` | Optional OpenAI-compatible endpoint override                       |
+| `timeout` | Optional provider request timeout in milliseconds                  |
 
 ### Context Loading (SDK-Specific)
 
@@ -636,18 +664,26 @@ These executors are registered with `runHooks` via the `executors` map during se
 
 ## Settings Configuration
 
-Settings are loaded with a 6-layer precedence model (highest priority first). `.robota/` is the primary configuration convention; `.claude/` paths are supported for Claude Code compatibility.
+Settings are loaded with a 6-file precedence model (lowest priority first). `.robota/` is the primary configuration convention; `.claude/` paths are supported for Claude Code compatibility.
 
-| Layer | Path                              | Scope                                |
-| ----- | --------------------------------- | ------------------------------------ |
-| 1     | CLI flags / environment variables | Invocation                           |
-| 2     | `.robota/settings.local.json`     | Project (local)                      |
-| 3     | `.robota/settings.json`           | Project                              |
-| 4     | `.claude/settings.json`           | Project (Claude Code compatible)     |
-| 5     | `~/.robota/settings.json`         | User global                          |
-| 6     | `~/.claude/settings.json`         | User global (Claude Code compatible) |
+| Layer | Path                          | Scope                                   |
+| ----- | ----------------------------- | --------------------------------------- |
+| 1     | `~/.robota/settings.json`     | User global                             |
+| 2     | `~/.claude/settings.json`     | User global (Claude Code compatible)    |
+| 3     | `.robota/settings.json`       | Project                                 |
+| 4     | `.robota/settings.local.json` | Project (local)                         |
+| 5     | `.claude/settings.json`       | Project (Claude Code compatible)        |
+| 6     | `.claude/settings.local.json` | Project (local, Claude Code compatible) |
 
-The `.claude/settings.json` layers (4 and 6) provide Claude Code compatibility — settings written by Claude Code are automatically picked up by Robota. Higher layers override lower layers via deep merge. `$ENV:VAR` substitution is applied after merge.
+The `.claude/settings.json` layers provide Claude Code compatibility — settings written by Claude Code are automatically picked up by Robota. Higher layers override lower layers via deep merge. `$ENV:VAR` substitution is applied after merge for provider API keys.
+
+Provider resolution order:
+
+1. `currentProvider` plus `providers[currentProvider]`
+2. Legacy `provider`
+3. Existing defaults
+
+The SDK remains provider-neutral: it resolves provider metadata for session assembly, but consumers such as `agent-cli` still construct concrete provider instances.
 
 ## Bundle Plugin System
 

--- a/packages/agent-sdk/src/__tests__/config-loader.test.ts
+++ b/packages/agent-sdk/src/__tests__/config-loader.test.ts
@@ -18,6 +18,7 @@ describe('loadConfig', () => {
   let cwd: string;
   let projectDir: string;
   let userDir: string;
+  let claudeUserDir: string;
   let claudeProjectDir: string;
   const originalHome = process.env.HOME;
 
@@ -27,9 +28,11 @@ describe('loadConfig', () => {
     claudeProjectDir = join(cwd, '.claude');
     const homeBase = join(TMP_BASE, 'home-' + Math.random().toString(36).slice(2));
     userDir = join(homeBase, '.robota');
+    claudeUserDir = join(homeBase, '.claude');
     setupDir(cwd);
     setupDir(projectDir);
     setupDir(userDir);
+    setupDir(claudeUserDir);
     setupDir(claudeProjectDir);
     process.env.HOME = homeBase;
   });
@@ -61,6 +64,14 @@ describe('loadConfig', () => {
 
   it('loads user settings from ~/.robota/settings.json', async () => {
     writeJson(join(userDir, 'settings.json'), {
+      defaultTrustLevel: 'full',
+    });
+    const config = await loadConfig(cwd);
+    expect(config.defaultTrustLevel).toBe('full');
+  });
+
+  it('loads user Claude-compatible settings from ~/.claude/settings.json', async () => {
+    writeJson(join(claudeUserDir, 'settings.json'), {
       defaultTrustLevel: 'full',
     });
     const config = await loadConfig(cwd);
@@ -121,6 +132,119 @@ describe('loadConfig', () => {
     delete process.env.TEST_API_KEY_XYZ;
   });
 
+  it('resolves active provider profile from currentProvider and providers', async () => {
+    writeJson(join(projectDir, 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+          baseURL: 'http://localhost:1234/v1',
+          timeout: 30000,
+        },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.provider).toEqual({
+      name: 'openai',
+      model: 'supergemma4-26b-uncensored-v2',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+      timeout: 30000,
+    });
+  });
+
+  it('resolves $ENV: prefix in active provider profile apiKey', async () => {
+    process.env.TEST_OPENAI_COMPAT_KEY = 'sk-profile-value';
+    writeJson(join(projectDir, 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: '$ENV:TEST_OPENAI_COMPAT_KEY',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.provider.apiKey).toBe('sk-profile-value');
+    delete process.env.TEST_OPENAI_COMPAT_KEY;
+  });
+
+  it('deep-merges provider profiles across settings layers', async () => {
+    writeJson(join(userDir, 'settings.json'), {
+      providers: {
+        openai: {
+          type: 'openai',
+          apiKey: 'lm-studio',
+        },
+      },
+    });
+    writeJson(join(projectDir, 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          model: 'supergemma4-26b-uncensored-v2',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.provider).toMatchObject({
+      name: 'openai',
+      model: 'supergemma4-26b-uncensored-v2',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+    });
+  });
+
+  it('falls back to legacy provider when currentProvider is not configured', async () => {
+    writeJson(join(projectDir, 'settings.json'), {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-ant-test',
+      },
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.provider.name).toBe('anthropic');
+    expect(config.provider.model).toBe('claude-sonnet-4-6');
+    expect(config.provider.apiKey).toBe('sk-ant-test');
+  });
+
+  it('throws when currentProvider does not exist in providers', async () => {
+    writeJson(join(projectDir, 'settings.json'), {
+      currentProvider: 'missing',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+        },
+      },
+    });
+
+    await expect(loadConfig(cwd)).rejects.toThrow('currentProvider "missing" was not found');
+  });
+
   // --- .claude/ path support ---
 
   it('loads settings from .claude/settings.json', async () => {
@@ -157,8 +281,9 @@ describe('loadConfig', () => {
     expect(config.provider.model).toBe('legacy-model');
   });
 
-  it('full 5-layer precedence: .claude/settings.local.json wins over all', async () => {
+  it('full 6-file precedence: .claude/settings.local.json wins over all', async () => {
     writeJson(join(userDir, 'settings.json'), { defaultTrustLevel: 'safe' });
+    writeJson(join(claudeUserDir, 'settings.json'), { defaultTrustLevel: 'safe' });
     writeJson(join(projectDir, 'settings.json'), { defaultTrustLevel: 'safe' });
     writeJson(join(projectDir, 'settings.local.json'), { defaultTrustLevel: 'safe' });
     writeJson(join(claudeProjectDir, 'settings.json'), { defaultTrustLevel: 'safe' });
@@ -229,5 +354,19 @@ describe('loadConfig', () => {
     expect(config.extraKnownMarketplaces).toEqual({
       'my-market': { source: { type: 'github', repo: 'org/plugins' } },
     });
+  });
+
+  it('ignores incompatible extraKnownMarketplaces from Claude-compatible settings', async () => {
+    writeJson(join(claudeUserDir, 'settings.json'), {
+      defaultTrustLevel: 'full',
+      extraKnownMarketplaces: {
+        'external-market': { source: { repo: 'org/plugins' } },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.defaultTrustLevel).toBe('full');
+    expect(config.extraKnownMarketplaces).toBeUndefined();
   });
 });

--- a/packages/agent-sdk/src/config/config-loader.ts
+++ b/packages/agent-sdk/src/config/config-loader.ts
@@ -3,10 +3,11 @@
  *
  * Precedence (lowest → highest):
  *   1. ~/.robota/settings.json       (user)
- *   2. .robota/settings.json         (project)
- *   3. .robota/settings.local.json   (project-local)
- *   4. .claude/settings.json         (project, Claude Code compat)
- *   5. .claude/settings.local.json   (project-local, highest priority)
+ *   2. ~/.claude/settings.json       (user, Claude Code compat)
+ *   3. .robota/settings.json         (project)
+ *   4. .robota/settings.local.json   (project-local)
+ *   5. .claude/settings.json         (project, Claude Code compat)
+ *   6. .claude/settings.local.json   (project-local, highest priority)
  */
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
@@ -73,16 +74,35 @@ function resolveEnvRef(value: string): string {
  * Apply env-ref resolution to all string fields in a settings object.
  */
 function resolveEnvRefs(settings: TSettings): TSettings {
-  if (settings.provider?.apiKey !== undefined) {
+  const provider =
+    settings.provider?.apiKey !== undefined
+      ? {
+          ...settings.provider,
+          apiKey: resolveEnvRef(settings.provider.apiKey),
+        }
+      : settings.provider;
+
+  if (settings.providers !== undefined) {
+    const providers = Object.fromEntries(
+      Object.entries(settings.providers).map(([name, profile]) => [
+        name,
+        {
+          ...profile,
+          ...(profile.apiKey !== undefined && { apiKey: resolveEnvRef(profile.apiKey) }),
+        },
+      ]),
+    );
     return {
       ...settings,
-      provider: {
-        ...settings.provider,
-        apiKey: resolveEnvRef(settings.provider.apiKey),
-      },
+      provider,
+      providers,
     };
   }
-  return settings;
+
+  return {
+    ...settings,
+    provider,
+  };
 }
 
 /**
@@ -110,6 +130,10 @@ function mergeSettings(layers: TSettings[]): TSettings {
         ...(merged.env ?? {}),
         ...(layer.env ?? {}),
       },
+      providers:
+        merged.providers !== undefined || layer.providers !== undefined
+          ? mergeProviders(merged.providers, layer.providers)
+          : undefined,
       enabledPlugins:
         merged.enabledPlugins !== undefined || layer.enabledPlugins !== undefined
           ? { ...(merged.enabledPlugins ?? {}), ...(layer.enabledPlugins ?? {}) }
@@ -119,6 +143,47 @@ function mergeSettings(layers: TSettings[]): TSettings {
   }, {});
 }
 
+function mergeProviders(
+  base: TSettings['providers'],
+  override: TSettings['providers'],
+): TSettings['providers'] {
+  const result: NonNullable<TSettings['providers']> = { ...(base ?? {}) };
+  for (const [name, profile] of Object.entries(override ?? {})) {
+    result[name] = {
+      ...result[name],
+      ...profile,
+    };
+  }
+  return result;
+}
+
+function resolveProvider(merged: TSettings): IResolvedConfig['provider'] {
+  if (merged.currentProvider !== undefined) {
+    const profile = merged.providers?.[merged.currentProvider];
+    if (profile === undefined) {
+      throw new Error(`currentProvider "${merged.currentProvider}" was not found in providers`);
+    }
+    if (profile.type === undefined) {
+      throw new Error(`Provider profile "${merged.currentProvider}" is missing type`);
+    }
+    return {
+      name: profile.type,
+      model: profile.model ?? DEFAULTS.provider.model,
+      apiKey: profile.apiKey ?? DEFAULTS.provider.apiKey,
+      ...(profile.baseURL !== undefined && { baseURL: profile.baseURL }),
+      ...(profile.timeout !== undefined && { timeout: profile.timeout }),
+    };
+  }
+
+  return {
+    name: merged.provider?.name ?? DEFAULTS.provider.name,
+    model: merged.provider?.model ?? DEFAULTS.provider.model,
+    apiKey: merged.provider?.apiKey ?? DEFAULTS.provider.apiKey,
+    ...(merged.provider?.baseURL !== undefined && { baseURL: merged.provider.baseURL }),
+    ...(merged.provider?.timeout !== undefined && { timeout: merged.provider.timeout }),
+  };
+}
+
 /**
  * Convert merged TSettings into a fully-resolved IResolvedConfig with defaults.
  */
@@ -126,11 +191,8 @@ function toResolvedConfig(merged: TSettings): IResolvedConfig {
   return {
     defaultTrustLevel: merged.defaultTrustLevel ?? DEFAULTS.defaultTrustLevel,
     language: merged.language,
-    provider: {
-      name: merged.provider?.name ?? DEFAULTS.provider.name,
-      model: merged.provider?.model ?? DEFAULTS.provider.model,
-      apiKey: merged.provider?.apiKey ?? DEFAULTS.provider.apiKey,
-    },
+    currentProvider: merged.currentProvider,
+    provider: resolveProvider(merged),
     permissions: {
       allow: merged.permissions?.allow ?? DEFAULTS.permissions.allow,
       deny: merged.permissions?.deny ?? DEFAULTS.permissions.deny,
@@ -149,6 +211,7 @@ function getSettingsPaths(cwd: string): string[] {
   const home = getHomeDir();
   return [
     join(home, '.robota', 'settings.json'), // 1. user (lowest)
+    join(home, '.claude', 'settings.json'), // 1b. user (Claude Code compat)
     join(cwd, '.robota', 'settings.json'), // 2. project
     join(cwd, '.robota', 'settings.local.json'), // 3. project-local
     join(cwd, '.claude', 'settings.json'), // 4. project, Claude Code compat

--- a/packages/agent-sdk/src/config/config-types.ts
+++ b/packages/agent-sdk/src/config/config-types.ts
@@ -8,6 +8,16 @@ const ProviderSchema = z.object({
   name: z.string().optional(),
   model: z.string().optional(),
   apiKey: z.string().optional(),
+  baseURL: z.string().optional(),
+  timeout: z.number().optional(),
+});
+
+const ProviderProfileSchema = z.object({
+  type: z.string().optional(),
+  model: z.string().optional(),
+  apiKey: z.string().optional(),
+  baseURL: z.string().optional(),
+  timeout: z.number().optional(),
 });
 
 const PermissionsSchema = z.object({
@@ -89,13 +99,18 @@ const MarketplaceSourceSchema = z.object({
     ref: z.string().optional(),
   }),
 });
-const ExtraKnownMarketplacesSchema = z.record(MarketplaceSourceSchema).optional();
+const ExtraKnownMarketplacesSchema = z.record(MarketplaceSourceSchema).optional().catch(undefined);
 
 export const SettingsSchema = z.object({
   /** Trust level used when no --permission-mode flag is given */
   defaultTrustLevel: z.enum(['safe', 'moderate', 'full']).optional(),
   /** Response language (e.g., "ko", "en", "ja"). Injected into system prompt. */
   language: z.string().optional(),
+  /** Active provider profile key from providers. */
+  currentProvider: z.string().optional(),
+  /** Provider profiles keyed by user-facing profile name. */
+  providers: z.record(ProviderProfileSchema).optional(),
+  /** Legacy single-provider settings. Prefer currentProvider + providers for new config. */
   provider: ProviderSchema.optional(),
   permissions: PermissionsSchema.optional(),
   env: EnvSchema,
@@ -117,10 +132,14 @@ export interface IResolvedConfig {
   defaultTrustLevel: 'safe' | 'moderate' | 'full';
   /** Response language code (e.g., "ko", "en"). Undefined = no language constraint. */
   language?: string;
+  /** Active provider profile key when providers/currentProvider are used. */
+  currentProvider?: string;
   provider: {
     name: string;
     model: string;
     apiKey: string | undefined;
+    baseURL?: string;
+    timeout?: number;
   };
   permissions: {
     allow: string[];

--- a/packages/agent-transport-headless/src/__tests__/headless-runner-initialization.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner-initialization.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { createHeadlessRunner } from '../headless-runner.js';
+
+describe('createHeadlessRunner initialization', () => {
+  it('stream-json reads the session id after submit initializes the session', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    let initialized = false;
+    const session = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event)!.push(handler);
+      }),
+      off: vi.fn(),
+      submit: vi.fn(async () => {
+        initialized = true;
+        for (const h of listeners.get('text_delta') ?? []) {
+          h('Hello');
+        }
+        for (const h of listeners.get('complete') ?? []) {
+          h({ response: 'Hello', history: [], toolSummaries: [], contextState: {} });
+        }
+      }),
+      getSession: vi.fn(() => {
+        if (!initialized) {
+          throw new Error('InteractiveSession not initialized');
+        }
+        return { getSessionId: () => 'initialized-session' };
+      }),
+    } as unknown as InteractiveSession;
+
+    try {
+      const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
+      const exitCode = await runner.run('test prompt');
+
+      expect(exitCode).toBe(0);
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"session_id":"initialized-session"'),
+      );
+    } finally {
+      stdoutWriteSpy.mockRestore();
+    }
+  });
+});

--- a/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
@@ -206,7 +206,9 @@ describe('createHeadlessRunner (stream-json format)', () => {
     expect(exitCode).toBe(0);
 
     const lines = stdoutWriteSpy.mock.calls.map((call: unknown[]) => (call as [string])[0].trim());
-    const parsed = lines.map((line: string) => JSON.parse(line) as Record<string, unknown>);
+    const parsed: Array<Record<string, unknown>> = lines.map(
+      (line: string) => JSON.parse(line) as Record<string, unknown>,
+    );
 
     // 2 stream_event lines + 1 final result line
     expect(parsed).toHaveLength(3);
@@ -269,7 +271,9 @@ describe('createHeadlessRunner (stream-json format)', () => {
     expect(exitCode).toBe(1);
 
     const lines = stdoutWriteSpy.mock.calls.map((call: unknown[]) => (call as [string])[0].trim());
-    const parsed = lines.map((line: string) => JSON.parse(line) as Record<string, unknown>);
+    const parsed: Array<Record<string, unknown>> = lines.map(
+      (line: string) => JSON.parse(line) as Record<string, unknown>,
+    );
 
     expect(parsed).toHaveLength(1);
     expect(parsed[0]).toEqual({

--- a/packages/agent-transport-headless/src/headless-runner.ts
+++ b/packages/agent-transport-headless/src/headless-runner.ts
@@ -31,10 +31,16 @@ function writeJsonResult(sessionId: string, result: string, subtype: 'success' |
   process.stdout.write(output + '\n');
 }
 
+function getSessionId(session: InteractiveSession): string {
+  try {
+    return session.getSession().getSessionId();
+  } catch {
+    return '';
+  }
+}
+
 function runJsonFormat(session: InteractiveSession, prompt: string): Promise<number> {
   return new Promise<number>((resolve) => {
-    const sessionId = session.getSession().getSessionId();
-
     const cleanup = (): void => {
       session.off('complete', onComplete);
       session.off('interrupted', onInterrupted);
@@ -43,19 +49,19 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
 
     const onComplete = (result: IExecutionResult): void => {
       cleanup();
-      writeJsonResult(sessionId, result.response, 'success');
+      writeJsonResult(getSessionId(session), result.response, 'success');
       resolve(0);
     };
 
     const onInterrupted = (result: IExecutionResult): void => {
       cleanup();
-      writeJsonResult(sessionId, result.response, 'success');
+      writeJsonResult(getSessionId(session), result.response, 'success');
       resolve(0);
     };
 
     const onError = (_error: Error): void => {
       cleanup();
-      writeJsonResult(sessionId, '', 'error');
+      writeJsonResult(getSessionId(session), '', 'error');
       resolve(1);
     };
 
@@ -69,8 +75,6 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
 
 function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promise<number> {
   return new Promise<number>((resolve) => {
-    const sessionId = session.getSession().getSessionId();
-
     const cleanup = (): void => {
       session.off('text_delta', onTextDelta);
       session.off('complete', onComplete);
@@ -85,7 +89,7 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
           type: 'content_block_delta',
           delta: { type: 'text_delta', text },
         },
-        session_id: sessionId,
+        session_id: getSessionId(session),
         uuid: randomUUID(),
       });
       process.stdout.write(output + '\n');
@@ -93,19 +97,19 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
 
     const onComplete = (result: IExecutionResult): void => {
       cleanup();
-      writeJsonResult(sessionId, result.response, 'success');
+      writeJsonResult(getSessionId(session), result.response, 'success');
       resolve(0);
     };
 
     const onInterrupted = (result: IExecutionResult): void => {
       cleanup();
-      writeJsonResult(sessionId, result.response, 'success');
+      writeJsonResult(getSessionId(session), result.response, 'success');
       resolve(0);
     };
 
     const onError = (_error: Error): void => {
       cleanup();
-      writeJsonResult(sessionId, '', 'error');
+      writeJsonResult(getSessionId(session), '', 'error');
       resolve(1);
     };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
       '@robota-sdk/agent-provider-anthropic':
         specifier: workspace:*
         version: link:../agent-provider-anthropic
+      '@robota-sdk/agent-provider-openai':
+        specifier: workspace:*
+        version: link:../agent-provider-openai
       '@robota-sdk/agent-sdk':
         specifier: workspace:*
         version: link:../agent-sdk


### PR DESCRIPTION
## Summary

- Add provider profile configuration for Robota CLI using `currentProvider` plus `providers`.
- Add OpenAI-compatible provider construction for LM Studio through `OpenAIProvider` with `baseURL`.
- Bring OpenAI provider `chat()` streaming behavior closer to Anthropic by wiring provider-level `onTextDelta`, assembling streamed text and tool-call chunks, and preserving final response assembly.
- Fix headless `stream-json` session ID lookup so non-interactive streaming works after async session initialization.
- Document the implemented LM Studio plan and add the next provider configuration UX spec with Given/When/Then unit-test assertions.

## Why

Robota CLI previously assumed Anthropic-first configuration and could not use the local LM Studio OpenAI-compatible API without manual setup. OpenAI provider streaming also did not expose the same provider-level delta callback shape as Anthropic, so CLI/TUI streaming could appear as a single final response.

## Validation

- `pnpm --filter @robota-sdk/agent-sdk test`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-sdk lint`
- `pnpm --filter @robota-sdk/agent-cli test`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm --filter @robota-sdk/agent-cli lint`
- `pnpm --filter @robota-sdk/agent-provider-openai test -- src/provider.test.ts`
- `pnpm --filter @robota-sdk/agent-provider-openai typecheck`
- `pnpm --filter @robota-sdk/agent-provider-openai build`
- `pnpm --filter @robota-sdk/agent-provider-openai lint`
- `pnpm --filter @robota-sdk/agent-transport-headless test`
- `pnpm --filter @robota-sdk/agent-transport-headless typecheck`
- `pnpm --filter @robota-sdk/agent-transport-headless build`
- `pnpm --filter @robota-sdk/agent-transport-headless lint`
- `pnpm build` in `apps/docs`
- `pnpm harness:scan`
- Local LM Studio smoke with `pnpm cli:dev --bare ... --output-format stream-json`, confirming multiple `content_block_delta` / `text_delta` events before the final result.

## Notes

- `.agents/evals/harness-log/sessions.jsonl` was left unstaged because it is a local harness execution log.
