### PR TITLE
feat(cli): add provider configuration UX

### DIFF
--- a/.agents/tasks/completed/CLI-BL-024-provider-configuration-ux.md
+++ b/.agents/tasks/completed/CLI-BL-024-provider-configuration-ux.md
@@ -1,8 +1,8 @@
 # CLI Provider Configuration UX
 
-- **Status**: todo
+- **Status**: completed
 - **Created**: 2026-04-29
-- **Branch**: feat/openai-compatible-lm-studio
+- **Branch**: feat/provider-configuration-ux
 - **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-transport-headless
 
 ## Objective
@@ -244,15 +244,15 @@ pnpm harness:scan
 
 ## Implementation Plan
 
-- [ ] Update package SPEC documents.
-- [ ] Write the unit tests above first, grouped by pure helpers, CLI args/setup, headless behavior, TUI side effects, and provider probing.
-- [ ] Extract provider settings pure helpers and settings write helpers.
-- [ ] Add CLI args for setup and provider selection.
-- [ ] Implement first-run provider setup and scriptable `--configure-provider`.
-- [ ] Implement headless missing-config behavior.
-- [ ] Add provider slash commands and TUI side effects.
-- [ ] Add optional provider probing with non-blocking failures.
-- [ ] Update docs and run verification.
+- [x] Update package SPEC documents.
+- [x] Write the unit tests above first, grouped by pure helpers, CLI args/setup, headless behavior, TUI side effects, and provider probing.
+- [x] Extract provider settings pure helpers and settings write helpers.
+- [x] Add CLI args for setup and provider selection.
+- [x] Implement first-run provider setup and scriptable `--configure-provider`.
+- [x] Implement headless missing-config behavior.
+- [x] Add provider slash commands and TUI side effects.
+- [x] Add optional provider probing with non-blocking failures.
+- [x] Update docs and run verification.
 
 ## Risks
 
@@ -274,6 +274,18 @@ pnpm harness:scan
 
 - Created this spec from the provider configuration UX plan.
 
+### 2026-04-30
+
+- Started implementation on `feat/provider-configuration-ux` from the merged `develop` branch.
+- Implemented provider profile settings helpers, scriptable configuration writes, invocation provider override, and first-run provider setup.
+- Added `/provider` slash command handling with confirm-before-persist behavior for provider switches.
+- Added `/provider add openai|anthropic` guided TUI setup prompts with defaults, masking, validation, and restart behavior.
+- Split provider setup prompt semantics into a pure `provider-setup-flow` module so Ink components remain thin adapters.
+- Added SDK built-in command metadata for provider commands and headless provider configuration contract docs.
+- Added unit coverage for CLI arg parsing, provider settings, settings writes, provider command handling, first-run setup, and provider factory resolution.
+- Verified LM Studio `supergemma4-26b-uncensored-v2` text and `stream-json` smoke through the OpenAI-compatible provider.
+- Re-ran affected package tests, build, typecheck, lint, and `pnpm harness:scan`.
+
 ## Decisions
 
 - Provider profiles remain the canonical settings contract.
@@ -283,9 +295,8 @@ pnpm harness:scan
 
 ## Blockers
 
-- None for spec writing.
-- Implementation should not begin until package SPEC updates are made.
+- None.
 
 ## Result
 
-Not implemented yet.
+Completed provider configuration UX for LM Studio/OpenAI-compatible and Anthropic profiles across CLI flags, first-run setup, TUI provider commands, and headless missing-config behavior. Existing legacy `provider` settings remain supported, while new `providers` profiles and `currentProvider` are preferred.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -73,6 +73,39 @@ Supported provider profile types:
 
 LM Studio is represented as `type: "openai"` with `baseURL: "http://localhost:1234/v1"`. The CLI must not use LM Studio native `/api/v1/*` APIs or Anthropic-compatible endpoints for this path.
 
+### Provider Configuration UX
+
+The CLI owns provider setup and provider profile writes. Default writes go to `~/.robota/settings.json`; `.claude/settings.json` compatibility is read-only for Robota-specific provider profile creation.
+
+Supported setup flags:
+
+| Flag                             | Behavior                                                            |
+| -------------------------------- | ------------------------------------------------------------------- |
+| `--configure`                    | Run interactive provider setup and exit                             |
+| `--configure-provider <profile>` | Upsert a provider profile and exit unless a prompt is also provided |
+| `--provider <profile>`           | Select an existing provider profile for this invocation             |
+| `--set-current`                  | Persist the selected or configured profile as `currentProvider`     |
+| `--type <type>`                  | Provider implementation type used by `--configure-provider`         |
+| `--base-url <url>`               | Provider API base URL                                               |
+| `--api-key <value>`              | Store a literal API key                                             |
+| `--api-key-env <name>`           | Store `$ENV:<name>`, not the current environment value              |
+
+First-run setup must offer Anthropic and LM Studio/OpenAI-compatible choices when stdin/stdout are TTYs. Non-interactive print/headless execution must not prompt; missing provider config must produce an actionable error that points to `robota --configure` and `robota --configure-provider`.
+
+Provider slash commands are TUI side effects:
+
+| Command                    | Behavior                                                    |
+| -------------------------- | ----------------------------------------------------------- |
+| `/provider`                | Show current provider and subcommands                       |
+| `/provider current`        | Show active profile, type, model, and baseURL               |
+| `/provider list`           | Show provider profiles from merged settings                 |
+| `/provider use <profile>`  | Confirm, persist `currentProvider`, and restart the session |
+| `/provider test [profile]` | Validate fields and optionally probe the endpoint           |
+
+Provider changes must follow the existing `/model` restart pattern: command returns structured data, TUI confirms, settings are written after confirmation, and the App remounts with a new provider instance.
+
+Provider setup prompt semantics must live outside Ink components. `provider-setup-flow` owns setup steps, defaults, required-field validation, masked-field metadata, and final `IProviderSetupInput` construction. TUI components may only render the current prompt step and pass submitted values back to the flow module.
+
 ```
 bin.ts → cli.ts (arg parsing + provider creation)
               └── ui/render.tsx → App.tsx (Ink TUI)

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -5,28 +5,22 @@
  * (config, context, session, tools).
  */
 
-import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
 import { parseCliArgs } from './utils/cli-args.js';
 import { getUserSettingsPath, deleteSettings } from './utils/settings-io.js';
-import { checkSettingsFile } from './utils/settings-check.js';
 import { createProviderFromSettings, readProviderSettings } from './utils/provider-factory.js';
+import {
+  ensureConfig,
+  handleProviderConfigurationArgs,
+  runInteractiveProviderSetup,
+} from './utils/provider-setup.js';
 import { createHeadlessTransport } from '@robota-sdk/agent-transport-headless';
 import { renderApp } from './ui/render.js';
-
-interface IFirstRunSettings {
-  provider: {
-    name: 'anthropic';
-    model: string;
-    apiKey: string;
-  };
-  language?: string;
-}
 
 /** Read version from package.json at runtime. */
 function readVersion(): string {
@@ -89,77 +83,6 @@ function promptInput(label: string, masked = false): Promise<string> {
   });
 }
 
-/**
- * Check if any settings file exists. If not, prompt for setup and create one.
- */
-async function ensureConfig(cwd: string): Promise<void> {
-  const userPath = getUserSettingsPath();
-  const projectPath = join(cwd, '.robota', 'settings.json');
-  const localPath = join(cwd, '.robota', 'settings.local.json');
-
-  const paths = [
-    userPath,
-    join(homedir(), '.claude', 'settings.json'),
-    projectPath,
-    localPath,
-    join(cwd, '.claude', 'settings.json'),
-    join(cwd, '.claude', 'settings.local.json'),
-  ];
-  const checks = paths.map((p) => ({ path: p, status: checkSettingsFile(p) }));
-
-  if (checks.some((c) => c.status === 'valid')) {
-    return;
-  }
-
-  const corrupt = checks.filter((c) => c.status === 'corrupt');
-  const incomplete = checks.filter((c) => c.status === 'incomplete');
-
-  process.stdout.write('\n');
-  if (corrupt.length > 0) {
-    for (const c of corrupt) {
-      process.stderr.write(`  ERROR: Settings file is corrupt (invalid JSON): ${c.path}\n`);
-    }
-    process.stdout.write('\n');
-  }
-  if (incomplete.length > 0) {
-    for (const c of incomplete) {
-      process.stderr.write(`  WARNING: Settings file is missing provider.apiKey: ${c.path}\n`);
-    }
-    process.stdout.write('\n');
-  }
-
-  if (corrupt.length === 0 && incomplete.length === 0) {
-    process.stdout.write('  Welcome to Robota CLI!\n');
-    process.stdout.write("  No configuration found. Let's set up.\n");
-  } else {
-    process.stdout.write('  Reconfiguring...\n');
-  }
-  process.stdout.write('\n');
-
-  const apiKey = await promptInput('  Anthropic API key: ', true);
-  if (!apiKey) {
-    process.stderr.write('\n  No API key provided. Exiting.\n');
-    process.exit(1);
-  }
-
-  const language = await promptInput('  Response language (ko/en/ja/zh, default: en): ');
-
-  const settingsDir = dirname(userPath);
-  mkdirSync(settingsDir, { recursive: true });
-  const settings: IFirstRunSettings = {
-    provider: {
-      name: 'anthropic',
-      model: 'claude-sonnet-4-6',
-      apiKey,
-    },
-  };
-  if (language) {
-    settings.language = language;
-  }
-  writeFileSync(userPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
-  process.stdout.write(`\n  Config saved to ${userPath}\n\n`);
-}
-
 /** Delete user settings and exit. */
 function resetConfig(): void {
   const userPath = getUserSettingsPath();
@@ -188,13 +111,27 @@ export async function startCli(): Promise<void> {
 
   const cwd = process.cwd();
 
-  // First-run setup: prompt for API key if no config exists
-  await ensureConfig(cwd);
+  if (args.configure) {
+    await runInteractiveProviderSetup(cwd, args, promptInput);
+    return;
+  }
+
+  if (handleProviderConfigurationArgs(cwd, args)) {
+    return;
+  }
+
+  try {
+    await ensureConfig(cwd, args, promptInput);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
 
   // CLI owns provider creation
-  const providerSettings = readProviderSettings(cwd);
+  const providerOptions = args.provider ? { providerOverride: args.provider } : {};
+  const providerSettings = readProviderSettings(cwd, providerOptions);
   const modelId = args.model ?? providerSettings.model;
-  const provider: IAIProvider = createProviderFromSettings(cwd, args.model);
+  const provider: IAIProvider = createProviderFromSettings(cwd, args.model, providerOptions);
 
   // Session management
   const sessionStore = new SessionStore();

--- a/packages/agent-cli/src/commands/__tests__/slash-executor.test.ts
+++ b/packages/agent-cli/src/commands/__tests__/slash-executor.test.ts
@@ -308,6 +308,7 @@ describe('Command routing completeness', () => {
       'context',
       'resume',
       'rename',
+      'provider',
       'reset',
       'exit',
       'plugin',

--- a/packages/agent-cli/src/commands/slash-executor.ts
+++ b/packages/agent-cli/src/commands/slash-executor.ts
@@ -224,6 +224,8 @@ export async function executeSlashCommand(
       return handleContext(session, addMessage);
     case 'reset':
       return handleReset(addMessage);
+    case 'provider':
+      return { handled: false }; // TUI routes provider commands with settings side effects
     case 'exit':
       return { handled: true, exitRequested: true };
     case 'plugin':

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -10,6 +10,7 @@ import MessageList from './MessageList.js';
 import StatusBar from './StatusBar.js';
 import InputArea from './InputArea.js';
 import ConfirmPrompt from './ConfirmPrompt.js';
+import ProviderSetupPrompt from './ProviderSetupPrompt.js';
 import PermissionPrompt from './PermissionPrompt.js';
 import StreamingIndicator from './StreamingIndicator.js';
 import PluginTUI from './PluginTUI.js';
@@ -83,12 +84,18 @@ function AppInner(
   const {
     handleSubmit,
     pendingModelId,
+    pendingProviderProfile,
+    pendingProviderSetupType,
     showPluginTUI,
     showSessionPicker,
     setShowPluginTUI,
     setShowSessionPicker,
     handleModelConfirm,
+    handleProviderConfirm,
+    handleProviderSetupSubmit,
+    handleProviderSetupCancel,
   } = useSideEffects({
+    cwd,
     interactiveSession,
     addEntry,
     baseHandleSubmit,
@@ -153,6 +160,19 @@ function AppInner(
           onSelect={handleModelConfirm}
         />
       )}
+      {pendingProviderProfile && (
+        <ConfirmPrompt
+          message={`Change provider to ${pendingProviderProfile}? This will restart the session.`}
+          onSelect={handleProviderConfirm}
+        />
+      )}
+      {pendingProviderSetupType && (
+        <ProviderSetupPrompt
+          type={pendingProviderSetupType}
+          onSubmit={handleProviderSetupSubmit}
+          onCancel={handleProviderSetupCancel}
+        />
+      )}
       {showPluginTUI && (
         <PluginTUI
           callbacks={pluginCallbacks}
@@ -192,6 +212,7 @@ function AppInner(
           !!permissionRequest ||
           showPluginTUI ||
           showSessionPicker ||
+          !!pendingProviderSetupType ||
           (isThinking && !!pendingPrompt)
         }
         isAborting={isAborting}

--- a/packages/agent-cli/src/ui/ProviderSetupPrompt.tsx
+++ b/packages/agent-cli/src/ui/ProviderSetupPrompt.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import type { IProviderSetupInput } from '../utils/provider-settings.js';
+import {
+  createProviderSetupFlow,
+  getProviderSetupStep,
+  submitProviderSetupValue,
+  validateProviderSetupValue,
+  type IProviderSetupFlowState,
+  type TProviderSetupType,
+} from '../utils/provider-setup-flow.js';
+import TextPrompt from './TextPrompt.js';
+
+interface IProviderSetupPromptProps {
+  type: TProviderSetupType;
+  onSubmit: (input: IProviderSetupInput) => void;
+  onCancel: () => void;
+}
+
+export default function ProviderSetupPrompt({
+  type,
+  onSubmit,
+  onCancel,
+}: IProviderSetupPromptProps): React.ReactElement {
+  const [state, setState] = useState<IProviderSetupFlowState>(() => createProviderSetupFlow(type));
+  const step = getProviderSetupStep(state);
+
+  const handleStepSubmit = (rawValue: string): void => {
+    const result = submitProviderSetupValue(state, rawValue);
+    if (result.status === 'next') {
+      setState(result.state);
+      return;
+    }
+    if (result.status === 'complete') {
+      onSubmit(result.input);
+    }
+  };
+
+  return (
+    <TextPrompt
+      key={`${type}-${step.key}`}
+      title={step.title}
+      placeholder={step.defaultValue}
+      allowEmpty={step.defaultValue !== undefined}
+      masked={step.masked}
+      validate={(value) => validateProviderSetupValue(step, value)}
+      onSubmit={handleStepSubmit}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/packages/agent-cli/src/ui/TextPrompt.tsx
+++ b/packages/agent-cli/src/ui/TextPrompt.tsx
@@ -7,6 +7,8 @@ interface IProps {
   onSubmit: (value: string) => void;
   onCancel: () => void;
   validate?: (value: string) => string | undefined;
+  allowEmpty?: boolean;
+  masked?: boolean;
 }
 
 export default function TextPrompt({
@@ -15,6 +17,8 @@ export default function TextPrompt({
   onSubmit,
   onCancel,
   validate,
+  allowEmpty = false,
+  masked = false,
 }: IProps): React.ReactElement {
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | undefined>();
@@ -23,7 +27,13 @@ export default function TextPrompt({
   const handleSubmit = useCallback(() => {
     if (resolvedRef.current) return;
     const trimmed = valueRef.current.trim();
-    if (!trimmed) return;
+    if (!trimmed && !allowEmpty) {
+      const emptyError = validate?.(trimmed);
+      if (emptyError) {
+        setError(emptyError);
+      }
+      return;
+    }
     if (validate) {
       const err = validate(trimmed);
       if (err) {
@@ -33,7 +43,7 @@ export default function TextPrompt({
     }
     resolvedRef.current = true;
     onSubmit(trimmed);
-  }, [validate, onSubmit]);
+  }, [allowEmpty, validate, onSubmit]);
 
   useInput((input, key) => {
     if (resolvedRef.current) return;
@@ -66,7 +76,11 @@ export default function TextPrompt({
       </Text>
       <Box marginTop={1}>
         <Text color="cyan">&gt; </Text>
-        {value ? <Text>{value}</Text> : placeholder ? <Text dimColor>{placeholder}</Text> : null}
+        {value ? (
+          <Text>{masked ? '*'.repeat(value.length) : value}</Text>
+        ) : placeholder ? (
+          <Text dimColor>{placeholder}</Text>
+        ) : null}
         <Text color="cyan">█</Text>
       </Box>
       {error && <Text color="red">{error}</Text>}

--- a/packages/agent-cli/src/ui/__tests__/ProviderSetupPrompt.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/ProviderSetupPrompt.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+import ProviderSetupPrompt from '../ProviderSetupPrompt.js';
+import {
+  DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_PROVIDER_MODELS,
+} from '../../utils/provider-settings.js';
+
+const delay = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+describe('ProviderSetupPrompt', () => {
+  it('submits OpenAI-compatible defaults when fields are left empty', async () => {
+    const onSubmit = vi.fn();
+    const { stdin } = render(
+      <ProviderSetupPrompt type="openai" onSubmit={onSubmit} onCancel={() => {}} />,
+    );
+
+    stdin.write('\r');
+    await delay();
+    stdin.write('\r');
+    await delay();
+    stdin.write('\r');
+    await delay();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      profile: 'openai',
+      type: 'openai',
+      baseURL: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+      model: DEFAULT_PROVIDER_MODELS.openai,
+      apiKey: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+      setCurrent: true,
+    });
+  });
+
+  it('requires an Anthropic API key before model selection', async () => {
+    const onSubmit = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ProviderSetupPrompt type="anthropic" onSubmit={onSubmit} onCancel={() => {}} />,
+    );
+
+    stdin.write('\r');
+    await delay();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(lastFrame()!).toContain('Required');
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/TextPrompt.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/TextPrompt.test.tsx
@@ -50,6 +50,32 @@ describe('TextPrompt', () => {
     expect(submitted).toBe('hello');
   });
 
+  it('can submit an empty value when allowed', () => {
+    let submitted = 'not-called';
+    const { stdin } = render(
+      <TextPrompt
+        title="Enter"
+        allowEmpty
+        onSubmit={(v) => {
+          submitted = v;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('\r');
+    expect(submitted).toBe('');
+  });
+
+  it('masks typed values when requested', async () => {
+    const { stdin, lastFrame } = render(
+      <TextPrompt title="Secret" masked onSubmit={() => {}} onCancel={() => {}} />,
+    );
+    stdin.write('abc');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()!).toContain('***');
+    expect(lastFrame()!).not.toContain('abc');
+  });
+
   it('shows validation error and blocks submit', async () => {
     let submitted = false;
     const validate = (v: string) => (v.length < 3 ? 'Too short' : undefined);

--- a/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
+++ b/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
@@ -32,6 +32,8 @@ export interface ISideEffects {
   _triggerPluginTUI?: boolean;
   _triggerResumePicker?: boolean;
   _sessionName?: string;
+  _pendingProviderProfile?: string;
+  _pendingProviderSetupType?: 'openai' | 'anthropic';
 }
 
 import type { SessionStore } from '@robota-sdk/agent-sessions';
@@ -221,7 +223,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   }, [manager.isThinking, interactiveSession, manager]);
 
   // Slash command routing (delegated to useSlashRouting)
-  const handleSubmit = useSlashRouting(interactiveSession, registry, manager);
+  const handleSubmit = useSlashRouting(props.cwd, interactiveSession, registry, manager);
 
   const handleAbort = useCallback(() => {
     manager.setAborting(true);

--- a/packages/agent-cli/src/ui/hooks/useSideEffects.ts
+++ b/packages/agent-cli/src/ui/hooks/useSideEffects.ts
@@ -15,11 +15,19 @@ import {
   readSettings,
   writeSettings,
 } from '../../utils/settings-io.js';
+import {
+  applyProviderConfiguration,
+  applyProviderSwitch,
+} from '../../utils/provider-configuration.js';
+import { readMergedProviderSettings } from '../../utils/provider-factory.js';
+import type { IProviderSetupInput } from '../../utils/provider-settings.js';
+import type { TProviderSetupType } from '../../utils/provider-setup-flow.js';
 import type { ISideEffects } from './useInteractiveSession.js';
 
 const EXIT_DELAY_MS = 500;
 
 interface IUseSideEffectsOptions {
+  cwd: string;
   interactiveSession: InteractiveSession;
   addEntry: (entry: IHistoryEntry) => void;
   baseHandleSubmit: (input: string) => Promise<void>;
@@ -29,15 +37,21 @@ interface IUseSideEffectsOptions {
 interface IUseSideEffectsResult {
   handleSubmit: (input: string) => Promise<void>;
   pendingModelId: string | null;
+  pendingProviderProfile: string | null;
+  pendingProviderSetupType: TProviderSetupType | null;
   showPluginTUI: boolean;
   showSessionPicker: boolean;
   setPendingModelId: (id: string | null) => void;
   setShowPluginTUI: (show: boolean) => void;
   setShowSessionPicker: (show: boolean) => void;
   handleModelConfirm: (index: number) => void;
+  handleProviderConfirm: (index: number) => void;
+  handleProviderSetupSubmit: (input: IProviderSetupInput) => void;
+  handleProviderSetupCancel: () => void;
 }
 
 export function useSideEffects({
+  cwd,
   interactiveSession,
   addEntry,
   baseHandleSubmit,
@@ -46,6 +60,10 @@ export function useSideEffects({
   const { exit } = useApp();
   const [pendingModelId, setPendingModelId] = useState<string | null>(null);
   const pendingModelChangeRef = useRef<string | null>(null);
+  const [pendingProviderProfile, setPendingProviderProfile] = useState<string | null>(null);
+  const pendingProviderProfileRef = useRef<string | null>(null);
+  const [pendingProviderSetupType, setPendingProviderSetupType] =
+    useState<TProviderSetupType | null>(null);
   const [showPluginTUI, setShowPluginTUI] = useState(false);
   const [showSessionPicker, setShowSessionPicker] = useState(false);
 
@@ -74,6 +92,21 @@ export function useSideEffects({
           messageToHistoryEntry(createSystemMessage(`Language set to "${lang}". Restarting...`)),
         );
         setTimeout(() => exit(), EXIT_DELAY_MS);
+        return;
+      }
+
+      if (sideEffects._pendingProviderProfile) {
+        const profile = sideEffects._pendingProviderProfile as string;
+        delete sideEffects._pendingProviderProfile;
+        pendingProviderProfileRef.current = profile;
+        setPendingProviderProfile(profile);
+        return;
+      }
+
+      if (sideEffects._pendingProviderSetupType) {
+        const type = sideEffects._pendingProviderSetupType;
+        delete sideEffects._pendingProviderSetupType;
+        setPendingProviderSetupType(type);
         return;
       }
 
@@ -149,14 +182,78 @@ export function useSideEffects({
     [addEntry, exit],
   );
 
+  const handleProviderConfirm = useCallback(
+    (index: number) => {
+      const profile = pendingProviderProfileRef.current;
+      setPendingProviderProfile(null);
+      pendingProviderProfileRef.current = null;
+      if (index === 0 && profile) {
+        try {
+          const settingsPath = getUserSettingsPath();
+          applyProviderSwitch(settingsPath, profile, {
+            knownProviders: readMergedProviderSettings(cwd).providers,
+          });
+          addEntry(
+            messageToHistoryEntry(
+              createSystemMessage(`Provider changed to ${profile}. Restarting...`),
+            ),
+          );
+          setTimeout(() => exit(), EXIT_DELAY_MS);
+        } catch (err) {
+          addEntry(
+            messageToHistoryEntry(
+              createSystemMessage(`Failed: ${err instanceof Error ? err.message : String(err)}`),
+            ),
+          );
+        }
+      } else {
+        addEntry(messageToHistoryEntry(createSystemMessage('Provider change cancelled.')));
+      }
+    },
+    [cwd, addEntry, exit],
+  );
+
+  const handleProviderSetupSubmit = useCallback(
+    (input: IProviderSetupInput) => {
+      setPendingProviderSetupType(null);
+      try {
+        const settingsPath = getUserSettingsPath();
+        applyProviderConfiguration(settingsPath, input);
+        addEntry(
+          messageToHistoryEntry(
+            createSystemMessage(`Provider ${input.profile} configured. Restarting...`),
+          ),
+        );
+        setTimeout(() => exit(), EXIT_DELAY_MS);
+      } catch (err) {
+        addEntry(
+          messageToHistoryEntry(
+            createSystemMessage(`Failed: ${err instanceof Error ? err.message : String(err)}`),
+          ),
+        );
+      }
+    },
+    [addEntry, exit],
+  );
+
+  const handleProviderSetupCancel = useCallback(() => {
+    setPendingProviderSetupType(null);
+    addEntry(messageToHistoryEntry(createSystemMessage('Provider setup cancelled.')));
+  }, [addEntry]);
+
   return {
     handleSubmit,
     pendingModelId,
+    pendingProviderProfile,
+    pendingProviderSetupType,
     showPluginTUI,
     showSessionPicker,
     setPendingModelId,
     setShowPluginTUI,
     setShowSessionPicker,
     handleModelConfirm,
+    handleProviderConfirm,
+    handleProviderSetupSubmit,
+    handleProviderSetupCancel,
   };
 }

--- a/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
+++ b/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
@@ -5,13 +5,17 @@
 
 import { useCallback } from 'react';
 import { randomUUID } from 'node:crypto';
-import type { InteractiveSession, CommandRegistry } from '@robota-sdk/agent-sdk';
+import type { InteractiveSession, CommandRegistry, ICommandResult } from '@robota-sdk/agent-sdk';
 import { buildSkillPrompt } from '@robota-sdk/agent-sdk';
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import type { TuiStateManager } from '../tui-state-manager.js';
 import type { ISideEffects } from './useInteractiveSession.js';
+import { handleProviderCommand } from '../../utils/provider-command.js';
+
+type TSessionWithEffects = InteractiveSession & ISideEffects;
 
 export function useSlashRouting(
+  cwd: string,
   interactiveSession: InteractiveSession,
   registry: CommandRegistry,
   manager: TuiStateManager,
@@ -28,75 +32,25 @@ export function useSlashRouting(
       const cmd = parts[0]?.toLowerCase() ?? '';
       const args = parts.slice(1).join(' ');
 
+      if (cmd === 'provider') {
+        await routeProviderCommand(cwd, args, interactiveSession, manager);
+        return;
+      }
+
       // Try system command first
       const result = await interactiveSession.executeCommand(cmd, args);
       if (result) {
-        manager.addEntry(messageToHistoryEntry(createSystemMessage(result.message)));
-        const effects = interactiveSession as InteractiveSession & ISideEffects;
-        if (result.data?.modelId) {
-          effects._pendingModelId = result.data.modelId as string;
-          return;
-        }
-        if (result.data?.language) {
-          effects._pendingLanguage = result.data.language as string;
-          return;
-        }
-        if (result.data?.resetRequested) {
-          effects._resetRequested = true;
-          return;
-        }
-        if (result.data?.triggerResumePicker) {
-          effects._triggerResumePicker = true;
-          return;
-        }
-        if (result.data?.name) {
-          effects._sessionName = result.data.name as string;
-          return;
-        }
-        const ctx = interactiveSession.getContextState();
-        manager.setContextState({
-          percentage: ctx.usedPercentage,
-          usedTokens: ctx.usedTokens,
-          maxTokens: ctx.maxTokens,
-        });
+        applySystemCommandResult(result, interactiveSession, manager);
         return;
       }
 
       // Try skill/plugin command
-      const skillCmd = registry
-        .getCommands()
-        .find((c) => c.name === cmd && (c.source === 'skill' || c.source === 'plugin'));
-      if (skillCmd) {
-        manager.addEntry({
-          id: randomUUID(),
-          timestamp: new Date(),
-          category: 'event',
-          type: 'skill-invocation',
-          data: {
-            skillName: cmd,
-            source: skillCmd.source,
-            message: `Invoking ${skillCmd.source}: ${cmd}`,
-          },
-        });
-        const prompt = await buildSkillPrompt(input, registry);
-        if (prompt) {
-          const qualifiedName = registry.resolveQualifiedName(cmd);
-          const hookInput = qualifiedName
-            ? `/${qualifiedName}${input.slice(1 + cmd.length)}`
-            : input;
-          await interactiveSession.submit(prompt, input, hookInput);
-          manager.setPendingPrompt(interactiveSession.getPendingPrompt());
-          return;
-        }
+      if (await routeSkillCommand(input, cmd, registry, interactiveSession, manager)) {
+        return;
       }
 
       // TUI-only commands
-      if (cmd === 'exit') {
-        (interactiveSession as InteractiveSession & ISideEffects)._exitRequested = true;
-        return;
-      }
-      if (cmd === 'plugin') {
-        (interactiveSession as InteractiveSession & ISideEffects)._triggerPluginTUI = true;
+      if (routeTuiCommand(cmd, interactiveSession)) {
         return;
       }
 
@@ -106,6 +60,115 @@ export function useSlashRouting(
         ),
       );
     },
-    [interactiveSession, registry, manager],
+    [cwd, interactiveSession, registry, manager],
   );
+}
+
+async function routeProviderCommand(
+  cwd: string,
+  args: string,
+  interactiveSession: InteractiveSession,
+  manager: TuiStateManager,
+): Promise<void> {
+  const result = await handleProviderCommand(cwd, args);
+  manager.addEntry(messageToHistoryEntry(createSystemMessage(result.message)));
+  const providerSwitch = result.data?.providerSwitch;
+  if (providerSwitch?.profile) {
+    getEffects(interactiveSession)._pendingProviderProfile = providerSwitch.profile;
+  }
+  const providerSetup = result.data?.providerSetup;
+  if (providerSetup?.type) {
+    getEffects(interactiveSession)._pendingProviderSetupType = providerSetup.type;
+  }
+}
+
+function applySystemCommandResult(
+  result: ICommandResult,
+  interactiveSession: InteractiveSession,
+  manager: TuiStateManager,
+): void {
+  manager.addEntry(messageToHistoryEntry(createSystemMessage(result.message)));
+  const data = result.data;
+  const effects = getEffects(interactiveSession);
+
+  if (typeof data?.modelId === 'string') {
+    effects._pendingModelId = data.modelId;
+    return;
+  }
+  if (typeof data?.language === 'string') {
+    effects._pendingLanguage = data.language;
+    return;
+  }
+  if (data?.resetRequested === true) {
+    effects._resetRequested = true;
+    return;
+  }
+  if (data?.triggerResumePicker === true) {
+    effects._triggerResumePicker = true;
+    return;
+  }
+  if (typeof data?.name === 'string') {
+    effects._sessionName = data.name;
+    return;
+  }
+
+  const ctx = interactiveSession.getContextState();
+  manager.setContextState({
+    percentage: ctx.usedPercentage,
+    usedTokens: ctx.usedTokens,
+    maxTokens: ctx.maxTokens,
+  });
+}
+
+async function routeSkillCommand(
+  input: string,
+  cmd: string,
+  registry: CommandRegistry,
+  interactiveSession: InteractiveSession,
+  manager: TuiStateManager,
+): Promise<boolean> {
+  const skillCmd = registry
+    .getCommands()
+    .find((c) => c.name === cmd && (c.source === 'skill' || c.source === 'plugin'));
+  if (!skillCmd) {
+    return false;
+  }
+
+  manager.addEntry({
+    id: randomUUID(),
+    timestamp: new Date(),
+    category: 'event',
+    type: 'skill-invocation',
+    data: {
+      skillName: cmd,
+      source: skillCmd.source,
+      message: `Invoking ${skillCmd.source}: ${cmd}`,
+    },
+  });
+
+  const prompt = await buildSkillPrompt(input, registry);
+  if (!prompt) {
+    return true;
+  }
+  const qualifiedName = registry.resolveQualifiedName(cmd);
+  const hookInput = qualifiedName ? `/${qualifiedName}${input.slice(1 + cmd.length)}` : input;
+  await interactiveSession.submit(prompt, input, hookInput);
+  manager.setPendingPrompt(interactiveSession.getPendingPrompt());
+  return true;
+}
+
+function routeTuiCommand(cmd: string, interactiveSession: InteractiveSession): boolean {
+  if (cmd === 'exit') {
+    getEffects(interactiveSession)._exitRequested = true;
+    return true;
+  }
+  if (cmd === 'plugin') {
+    getEffects(interactiveSession)._triggerPluginTUI = true;
+    return true;
+  }
+  return false;
+}
+
+function getEffects(interactiveSession: InteractiveSession): TSessionWithEffects {
+  return interactiveSession as TSessionWithEffects;
 }

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -93,6 +93,33 @@ describe('parseCliArgs', () => {
     const args = parseCliArgs();
     expect(args.outputFormat).toBeUndefined();
   });
+
+  it('parses provider configuration flags', () => {
+    process.argv = [
+      'node',
+      'cli',
+      '--configure-provider',
+      'openai',
+      '--provider',
+      'openai',
+      '--type',
+      'openai',
+      '--base-url',
+      'http://localhost:1234/v1',
+      '--api-key-env',
+      'LM_STUDIO_API_KEY',
+      '--set-current',
+    ];
+
+    const args = parseCliArgs();
+
+    expect(args.configureProvider).toBe('openai');
+    expect(args.provider).toBe('openai');
+    expect(args.providerType).toBe('openai');
+    expect(args.baseURL).toBe('http://localhost:1234/v1');
+    expect(args.apiKeyEnv).toBe('LM_STUDIO_API_KEY');
+    expect(args.setCurrent).toBe(true);
+  });
 });
 
 describe('new non-interactive flags', () => {

--- a/packages/agent-cli/src/utils/__tests__/provider-command.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-command.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { handleProviderCommand } from '../provider-command.js';
+
+const TMP_BASE = join(tmpdir(), `robota-provider-command-test-${process.pid}`);
+
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf8');
+}
+
+describe('provider command handler', () => {
+  afterEach(() => {
+    rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('lists current provider profiles from settings', async () => {
+    const cwd = join(TMP_BASE, 'list');
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+        anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+      },
+    });
+
+    const result = await handleProviderCommand(cwd, 'list');
+
+    expect(result.message).toContain('* openai');
+    expect(result.message).toContain('anthropic');
+  });
+
+  it('returns providerSwitch data for use without writing settings', async () => {
+    const cwd = join(TMP_BASE, 'use');
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'anthropic',
+      providers: {
+        anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+        openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+      },
+    });
+
+    const result = await handleProviderCommand(cwd, 'use openai');
+
+    expect(result.data?.providerSwitch).toEqual({ profile: 'openai' });
+    expect(result.message).toContain('Provider change requested');
+  });
+
+  it('reports probe failures as non-blocking provider test results', async () => {
+    const cwd = join(TMP_BASE, 'test');
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      },
+    });
+    const probe = vi.fn().mockResolvedValue({ ok: false, message: 'Connection failed' });
+
+    const result = await handleProviderCommand(cwd, 'test openai', { probe });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Connection failed');
+    expect(result.message).toContain('manual configuration can continue');
+  });
+
+  it('returns providerSetup data for add commands', async () => {
+    const result = await handleProviderCommand(TMP_BASE, 'add openai');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.providerSetup).toEqual({ type: 'openai' });
+  });
+});

--- a/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { applyProviderConfiguration, applyProviderSwitch } from '../provider-configuration.js';
+
+const TMP_BASE = join(tmpdir(), `robota-provider-configuration-test-${process.pid}`);
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+}
+
+describe('provider configuration writes', () => {
+  afterEach(() => {
+    rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('adds an Anthropic profile, preserves OpenAI profile, and sets current provider', () => {
+    const settingsPath = join(TMP_BASE, '.robota', 'settings.json');
+    mkdirSync(join(TMP_BASE, '.robota'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        currentProvider: 'openai',
+        providers: {
+          openai: {
+            type: 'openai',
+            model: 'supergemma4-26b-uncensored-v2',
+            apiKey: 'lm-studio',
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    applyProviderConfiguration(settingsPath, {
+      profile: 'anthropic',
+      type: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKeyEnv: 'ANTHROPIC_API_KEY',
+      setCurrent: true,
+    });
+
+    const settings = readJson(settingsPath);
+    const providers = settings.providers as Record<string, Record<string, unknown>>;
+    expect(settings.currentProvider).toBe('anthropic');
+    expect(providers.openai?.model).toBe('supergemma4-26b-uncensored-v2');
+    expect(providers.anthropic).toEqual({
+      type: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKey: '$ENV:ANTHROPIC_API_KEY',
+    });
+  });
+
+  it('writes only the requested settings path', () => {
+    const userPath = join(TMP_BASE, '.robota', 'settings.json');
+    const claudePath = join(TMP_BASE, '.claude', 'settings.json');
+
+    applyProviderConfiguration(userPath, {
+      profile: 'openai',
+      type: 'openai',
+      model: 'supergemma4-26b-uncensored-v2',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+      setCurrent: true,
+    });
+
+    expect(existsSync(userPath)).toBe(true);
+    expect(existsSync(claudePath)).toBe(false);
+  });
+
+  it('persists provider switch only when explicitly applied', () => {
+    const settingsPath = join(TMP_BASE, '.robota', 'settings.json');
+    mkdirSync(join(TMP_BASE, '.robota'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        currentProvider: 'anthropic',
+        providers: {
+          anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+          openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+        },
+      }),
+      'utf8',
+    );
+
+    applyProviderSwitch(settingsPath, 'openai');
+
+    expect(readJson(settingsPath).currentProvider).toBe('openai');
+  });
+
+  it('persists currentProvider when profile is known from merged settings', () => {
+    const settingsPath = join(TMP_BASE, '.robota', 'settings.json');
+
+    applyProviderSwitch(settingsPath, 'openai', {
+      knownProviders: {
+        openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+      },
+    });
+
+    const settings = readJson(settingsPath);
+    expect(settings.currentProvider).toBe('openai');
+    expect(settings.providers).toBeUndefined();
+  });
+});

--- a/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createProviderFromSettings, readProviderSettings } from '../provider-factory.js';
@@ -45,6 +45,11 @@ describe('provider-factory', () => {
   it('reads active OpenAI-compatible provider profile', () => {
     writeJson(join(cwd, '.robota', 'settings.json'), {
       currentProvider: 'openai',
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-legacy',
+      },
       providers: {
         openai: {
           type: 'openai',
@@ -62,6 +67,33 @@ describe('provider-factory', () => {
       apiKey: 'lm-studio',
       baseURL: 'http://localhost:1234/v1',
       timeout: 30000,
+    });
+  });
+
+  it('selects a provider override without changing settings', () => {
+    const settingsPath = join(cwd, '.robota', 'settings.json');
+    writeJson(settingsPath, {
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+        },
+        anthropic: {
+          type: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          apiKey: 'sk-ant-test',
+        },
+      },
+    });
+
+    const settings = readProviderSettings(cwd, { providerOverride: 'anthropic' });
+
+    expect(settings.name).toBe('anthropic');
+    expect(settings.model).toBe('claude-sonnet-4-6');
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toMatchObject({
+      currentProvider: 'openai',
     });
   });
 

--- a/packages/agent-cli/src/utils/__tests__/provider-settings.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-settings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildProviderSetupPatch,
+  setCurrentProvider,
+  upsertProviderProfile,
+  validateProviderProfile,
+} from '../provider-settings.js';
+
+describe('provider settings helpers', () => {
+  it('updates one profile without changing other profiles or unrelated settings', () => {
+    const settings = {
+      language: 'ko',
+      currentProvider: 'openai',
+      providers: {
+        openai: {
+          type: 'openai',
+          model: 'supergemma4-26b-uncensored-v2',
+          apiKey: 'lm-studio',
+        },
+        anthropic: {
+          type: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          apiKey: '$ENV:ANTHROPIC_API_KEY',
+        },
+      },
+    };
+
+    const next = upsertProviderProfile(settings, 'anthropic', {
+      type: 'anthropic',
+      model: 'claude-opus-4-5',
+      apiKey: '$ENV:NEW_ANTHROPIC_KEY',
+    });
+
+    expect(next.language).toBe('ko');
+    expect(next.currentProvider).toBe('openai');
+    expect(next.providers?.openai).toEqual(settings.providers.openai);
+    expect(next.providers?.anthropic).toEqual({
+      type: 'anthropic',
+      model: 'claude-opus-4-5',
+      apiKey: '$ENV:NEW_ANTHROPIC_KEY',
+    });
+  });
+
+  it('does not mutate settings when setting a missing current provider', () => {
+    const settings = {
+      currentProvider: 'openai',
+      providers: {
+        openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+      },
+    };
+
+    expect(() => setCurrentProvider(settings, 'anthropic')).toThrow(
+      'Provider profile "anthropic" was not found',
+    );
+    expect(settings.currentProvider).toBe('openai');
+  });
+
+  it('stores api-key-env as an env reference without reading the environment value', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-real-value';
+
+    const patch = buildProviderSetupPatch({
+      profile: 'anthropic',
+      type: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKeyEnv: 'ANTHROPIC_API_KEY',
+      setCurrent: true,
+    });
+
+    expect(patch.providers.anthropic?.apiKey).toBe('$ENV:ANTHROPIC_API_KEY');
+    expect(patch.providers.anthropic?.apiKey).not.toBe('sk-real-value');
+    expect(patch.currentProvider).toBe('anthropic');
+  });
+
+  it('validates required fields by provider type', () => {
+    expect(() =>
+      validateProviderProfile('anthropic', { type: 'anthropic', model: 'claude-sonnet-4-6' }),
+    ).toThrow('missing apiKey');
+
+    expect(() =>
+      validateProviderProfile('openai', { type: 'openai', apiKey: 'lm-studio' }),
+    ).toThrow('missing model');
+  });
+});

--- a/packages/agent-cli/src/utils/__tests__/provider-setup-flow.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup-flow.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createProviderSetupFlow,
+  formatProviderSetupPromptLabel,
+  getProviderSetupStep,
+  runProviderSetupPromptFlow,
+  submitProviderSetupValue,
+} from '../provider-setup-flow.js';
+import {
+  DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_PROVIDER_MODELS,
+} from '../provider-settings.js';
+
+describe('provider setup prompt flow', () => {
+  it('builds OpenAI-compatible setup input from defaulted prompt submissions', () => {
+    let state = createProviderSetupFlow('openai');
+    expect(getProviderSetupStep(state)).toMatchObject({
+      key: 'baseURL',
+      defaultValue: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+    });
+
+    const baseURLResult = submitProviderSetupValue(state, '');
+    expect(baseURLResult.status).toBe('next');
+    if (baseURLResult.status !== 'next') throw new Error('expected next');
+    state = baseURLResult.state;
+
+    const modelResult = submitProviderSetupValue(state, '');
+    expect(modelResult.status).toBe('next');
+    if (modelResult.status !== 'next') throw new Error('expected next');
+    state = modelResult.state;
+
+    const apiKeyResult = submitProviderSetupValue(state, '');
+    expect(apiKeyResult).toEqual({
+      status: 'complete',
+      input: {
+        profile: 'openai',
+        type: 'openai',
+        baseURL: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+        model: DEFAULT_PROVIDER_MODELS.openai,
+        apiKey: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+        setCurrent: true,
+      },
+    });
+  });
+
+  it('keeps Anthropic API key validation outside the TUI component', () => {
+    const state = createProviderSetupFlow('anthropic');
+
+    expect(submitProviderSetupValue(state, '')).toEqual({
+      status: 'error',
+      state,
+      message: 'Required',
+    });
+  });
+
+  it('runs prompt input with masked API key steps', async () => {
+    const promptInput = vi.fn(async () => '');
+
+    const input = await runProviderSetupPromptFlow('openai', promptInput);
+
+    expect(input.apiKey).toBe(DEFAULT_OPENAI_COMPATIBLE_API_KEY);
+    expect(promptInput).toHaveBeenNthCalledWith(
+      1,
+      formatProviderSetupPromptLabel({
+        key: 'baseURL',
+        title: 'OpenAI-compatible base URL',
+        defaultValue: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+      }),
+      false,
+    );
+    expect(promptInput).toHaveBeenNthCalledWith(
+      3,
+      formatProviderSetupPromptLabel({
+        key: 'apiKey',
+        title: 'OpenAI-compatible API key',
+        defaultValue: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+        masked: true,
+      }),
+      true,
+    );
+  });
+});

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IParsedCliArgs } from '../cli-args.js';
+import { ensureConfig, runInteractiveProviderSetup } from '../provider-setup.js';
+
+const TMP_BASE = join(tmpdir(), `robota-provider-setup-test-${process.pid}`);
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_STDIN_TTY = process.stdin.isTTY;
+const ORIGINAL_STDOUT_TTY = process.stdout.isTTY;
+
+function baseArgs(): IParsedCliArgs {
+  return {
+    positional: [],
+    printMode: false,
+    continueMode: false,
+    resumeId: undefined,
+    model: undefined,
+    language: undefined,
+    permissionMode: undefined,
+    maxTurns: undefined,
+    forkSession: false,
+    sessionName: undefined,
+    outputFormat: undefined,
+    systemPrompt: undefined,
+    appendSystemPrompt: undefined,
+    version: false,
+    reset: false,
+    bare: false,
+    allowedTools: undefined,
+    noSessionPersistence: false,
+    jsonSchema: undefined,
+    configure: false,
+    configureProvider: undefined,
+    provider: undefined,
+    providerType: undefined,
+    baseURL: undefined,
+    apiKey: undefined,
+    apiKeyEnv: undefined,
+    setCurrent: false,
+    settingsScope: undefined,
+  };
+}
+
+function readUserSettings(home: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(home, '.robota', 'settings.json'), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('provider setup', () => {
+  afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: ORIGINAL_STDIN_TTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: ORIGINAL_STDOUT_TTY,
+      configurable: true,
+    });
+    rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('writes LM Studio defaults during interactive setup', async () => {
+    const home = join(TMP_BASE, 'home-openai');
+    process.env.HOME = home;
+    const answers = ['openai', '', '', '', 'ko'];
+    const promptInput = async (): Promise<string> => answers.shift() ?? '';
+
+    await runInteractiveProviderSetup(join(TMP_BASE, 'project'), baseArgs(), promptInput);
+
+    const settings = readUserSettings(home);
+    const providers = settings.providers as Record<string, Record<string, unknown>>;
+    expect(settings.currentProvider).toBe('openai');
+    expect(settings.language).toBe('ko');
+    expect(providers.openai).toMatchObject({
+      type: 'openai',
+      model: 'supergemma4-26b-uncensored-v2',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+    });
+    expect(providers.anthropic).toBeUndefined();
+  });
+
+  it('does not prompt in non-interactive missing-config mode', async () => {
+    process.env.HOME = join(TMP_BASE, 'home-missing');
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    let prompted = false;
+    const promptInput = async (): Promise<string> => {
+      prompted = true;
+      return '';
+    };
+
+    await expect(ensureConfig(join(TMP_BASE, 'project'), baseArgs(), promptInput)).rejects.toThrow(
+      'No provider configuration found',
+    );
+    expect(prompted).toBe(false);
+  });
+});

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -28,6 +28,15 @@ export interface IParsedCliArgs {
   allowedTools: string | undefined;
   noSessionPersistence: boolean;
   jsonSchema: string | undefined;
+  configure: boolean;
+  configureProvider: string | undefined;
+  provider: string | undefined;
+  providerType: string | undefined;
+  baseURL: string | undefined;
+  apiKey: string | undefined;
+  apiKeyEnv: string | undefined;
+  setCurrent: boolean;
+  settingsScope: string | undefined;
 }
 
 /** Validate and return a TPermissionMode from a raw CLI string, or exit on error. */
@@ -74,6 +83,15 @@ export function parseCliArgs(): IParsedCliArgs {
       'allowed-tools': { type: 'string' },
       'no-session-persistence': { type: 'boolean', default: false },
       'json-schema': { type: 'string' },
+      configure: { type: 'boolean', default: false },
+      'configure-provider': { type: 'string' },
+      provider: { type: 'string' },
+      type: { type: 'string' },
+      'base-url': { type: 'string' },
+      'api-key': { type: 'string' },
+      'api-key-env': { type: 'string' },
+      'set-current': { type: 'boolean', default: false },
+      'settings-scope': { type: 'string' },
     },
   });
 
@@ -97,5 +115,14 @@ export function parseCliArgs(): IParsedCliArgs {
     allowedTools: values['allowed-tools'],
     noSessionPersistence: values['no-session-persistence'] ?? false,
     jsonSchema: values['json-schema'],
+    configure: values['configure'] ?? false,
+    configureProvider: values['configure-provider'],
+    provider: values['provider'],
+    providerType: values['type'],
+    baseURL: values['base-url'],
+    apiKey: values['api-key'],
+    apiKeyEnv: values['api-key-env'],
+    setCurrent: values['set-current'] ?? false,
+    settingsScope: values['settings-scope'],
   };
 }

--- a/packages/agent-cli/src/utils/provider-command.ts
+++ b/packages/agent-cli/src/utils/provider-command.ts
@@ -1,0 +1,178 @@
+import { readMergedProviderSettings } from './provider-factory.js';
+import { validateProviderProfile, type IProviderProfileSettings } from './provider-settings.js';
+
+export interface IProviderCommandData {
+  providerSwitch?: {
+    profile: string;
+  };
+  providerSetup?: {
+    type: 'openai' | 'anthropic';
+  };
+  providerTest?: {
+    profile: string;
+  };
+}
+
+export interface IProviderCommandResult {
+  message: string;
+  success: boolean;
+  data?: IProviderCommandData;
+}
+
+export interface IProviderProbeResult {
+  ok: boolean;
+  message: string;
+  models?: string[];
+}
+
+export interface IProviderCommandDeps {
+  probe?: (profile: IProviderProfileSettings) => Promise<IProviderProbeResult>;
+}
+
+export async function handleProviderCommand(
+  cwd: string,
+  args: string,
+  deps: IProviderCommandDeps = {},
+): Promise<IProviderCommandResult> {
+  const settings = readMergedProviderSettings(cwd);
+  const [subcommand = 'current', profileArg] = args.trim().split(/\s+/);
+
+  if (subcommand === 'list') {
+    return {
+      message: formatProviderList(settings.currentProvider, settings.providers),
+      success: true,
+    };
+  }
+  if (subcommand === 'current' || subcommand === '') {
+    return {
+      message: formatCurrentProvider(settings.currentProvider, settings.providers),
+      success: true,
+    };
+  }
+  if (subcommand === 'use') {
+    return buildProviderSwitch(settings.providers, profileArg);
+  }
+  if (subcommand === 'test') {
+    return await testProvider(settings.currentProvider, settings.providers, profileArg, deps);
+  }
+  if (subcommand === 'add') {
+    return buildProviderSetup(profileArg);
+  }
+
+  return {
+    message: 'Usage: provider [current|list|use <profile>|add <type>|test [profile]]',
+    success: false,
+  };
+}
+
+function formatProviderList(
+  currentProvider: string | undefined,
+  providers: Record<string, IProviderProfileSettings> | undefined,
+): string {
+  const entries = Object.entries(providers ?? {});
+  if (entries.length === 0) {
+    return 'No provider profiles configured.';
+  }
+  return entries
+    .map(([name, profile]) => {
+      const marker = name === currentProvider ? '*' : '-';
+      return `${marker} ${name}: ${profile.type ?? 'unknown'} ${profile.model ?? '(no model)'}`;
+    })
+    .join('\n');
+}
+
+function formatCurrentProvider(
+  currentProvider: string | undefined,
+  providers: Record<string, IProviderProfileSettings> | undefined,
+): string {
+  if (!currentProvider) {
+    return 'No current provider configured.';
+  }
+  const profile = providers?.[currentProvider];
+  if (!profile) {
+    return `Current provider "${currentProvider}" was not found in providers.`;
+  }
+  return [
+    `Current provider: ${currentProvider}`,
+    `Type: ${profile.type ?? 'unknown'}`,
+    `Model: ${profile.model ?? '(no model)'}`,
+    ...(profile.baseURL ? [`Base URL: ${profile.baseURL}`] : []),
+  ].join('\n');
+}
+
+function buildProviderSwitch(
+  providers: Record<string, IProviderProfileSettings> | undefined,
+  profileName: string | undefined,
+): IProviderCommandResult {
+  if (!profileName) {
+    return { message: 'Usage: provider use <profile>', success: false };
+  }
+  if (!providers?.[profileName]) {
+    return { message: `Provider profile "${profileName}" was not found.`, success: false };
+  }
+  return {
+    message: `Provider change requested: ${profileName}`,
+    success: true,
+    data: { providerSwitch: { profile: profileName } },
+  };
+}
+
+function buildProviderSetup(type: string | undefined): IProviderCommandResult {
+  if (type !== 'openai' && type !== 'anthropic') {
+    return { message: 'Usage: provider add openai|anthropic', success: false };
+  }
+  return {
+    message: `Provider setup requested: ${type}`,
+    success: true,
+    data: { providerSetup: { type } },
+  };
+}
+
+async function testProvider(
+  currentProvider: string | undefined,
+  providers: Record<string, IProviderProfileSettings> | undefined,
+  profileArg: string | undefined,
+  deps: IProviderCommandDeps,
+): Promise<IProviderCommandResult> {
+  const profileName = profileArg ?? currentProvider;
+  if (!profileName) {
+    return { message: 'No provider profile selected.', success: false };
+  }
+  const profile = providers?.[profileName];
+  if (!profile) {
+    return { message: `Provider profile "${profileName}" was not found.`, success: false };
+  }
+  try {
+    validateProviderProfile(profileName, profile);
+  } catch (error) {
+    return { message: error instanceof Error ? error.message : String(error), success: false };
+  }
+  const probe = deps.probe ?? probeProviderProfile;
+  const result = await probe(profile);
+  return {
+    message: result.ok
+      ? `Provider "${profileName}" test passed: ${result.message}`
+      : `Provider "${profileName}" test failed: ${result.message}; manual configuration can continue.`,
+    success: true,
+    data: { providerTest: { profile: profileName } },
+  };
+}
+
+export async function probeProviderProfile(
+  profile: IProviderProfileSettings,
+): Promise<IProviderProbeResult> {
+  if (profile.type !== 'openai' || !profile.baseURL) {
+    return { ok: true, message: 'Profile fields are valid; no endpoint probe required.' };
+  }
+  try {
+    const response = await fetch(`${profile.baseURL.replace(/\/$/, '')}/models`);
+    if (!response.ok) {
+      return { ok: false, message: `HTTP ${response.status}` };
+    }
+    const body = (await response.json()) as { data?: Array<{ id?: string }> };
+    const models = (body.data ?? []).map((item) => item.id).filter((id): id is string => !!id);
+    return { ok: true, message: `${models.length} model(s) discovered`, models };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/agent-cli/src/utils/provider-configuration.ts
+++ b/packages/agent-cli/src/utils/provider-configuration.ts
@@ -1,0 +1,44 @@
+import { readSettings, writeSettings } from './settings-io.js';
+import {
+  buildProviderSetupPatch,
+  mergeProviderPatch,
+  setCurrentProvider,
+  type IProviderProfileSettings,
+  type IProviderSetupInput,
+  type TProviderSettingsDocument,
+} from './provider-settings.js';
+
+export interface IProviderSwitchOptions {
+  knownProviders?: Record<string, IProviderProfileSettings>;
+}
+
+function readProviderDocument(settingsPath: string): TProviderSettingsDocument {
+  return readSettings(settingsPath) as TProviderSettingsDocument;
+}
+
+export function applyProviderConfiguration(
+  settingsPath: string,
+  input: IProviderSetupInput,
+): TProviderSettingsDocument {
+  const settings = readProviderDocument(settingsPath);
+  const patch = buildProviderSetupPatch(input);
+  const next = mergeProviderPatch(settings, patch);
+  writeSettings(settingsPath, next);
+  return next;
+}
+
+export function applyProviderSwitch(
+  settingsPath: string,
+  profileName: string,
+  options: IProviderSwitchOptions = {},
+): TProviderSettingsDocument {
+  const settings = readProviderDocument(settingsPath);
+  const hasLocalProfile = settings.providers?.[profileName] !== undefined;
+  const hasKnownProfile = options.knownProviders?.[profileName] !== undefined;
+  const next =
+    hasLocalProfile || hasKnownProfile
+      ? { ...settings, currentProvider: profileName }
+      : setCurrentProvider(settings, profileName);
+  writeSettings(settingsPath, next);
+  return next;
+}

--- a/packages/agent-cli/src/utils/provider-factory.ts
+++ b/packages/agent-cli/src/utils/provider-factory.ts
@@ -11,8 +11,14 @@ import { homedir } from 'node:os';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
+import {
+  DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_PROVIDER_MODELS,
+  type TProviderSettingsDocument,
+} from './provider-settings.js';
 
-interface IProviderConfig {
+export interface IProviderConfig {
   name: string;
   model: string;
   apiKey?: string;
@@ -20,38 +26,25 @@ interface IProviderConfig {
   timeout?: number;
 }
 
-interface IProviderProfileSettings {
-  type?: string;
-  model?: string;
-  apiKey?: string;
-  baseURL?: string;
-  timeout?: number;
+export interface IReadProviderSettingsOptions {
+  providerOverride?: string;
 }
-
-interface ILegacyProviderSettings {
-  name?: string;
-  model?: string;
-  apiKey?: string;
-  baseURL?: string;
-  timeout?: number;
-}
-
-interface IProviderSettingsFile {
-  currentProvider?: string;
-  providers?: Record<string, IProviderProfileSettings>;
-  provider?: ILegacyProviderSettings;
-}
-
-const DEFAULT_MODELS: Record<string, string> = {
-  anthropic: 'claude-sonnet-4-6',
-  openai: 'supergemma4-26b-uncensored-v2',
-};
-
-const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = 'http://localhost:1234/v1';
-const DEFAULT_OPENAI_COMPATIBLE_API_KEY = 'lm-studio';
 
 /** Read provider settings from the settings file chain. */
-export function readProviderSettings(cwd: string): IProviderConfig {
+export function readProviderSettings(
+  cwd: string,
+  options: IReadProviderSettingsOptions = {},
+): IProviderConfig {
+  const merged = readMergedProviderSettings(cwd);
+  const providerConfig = resolveActiveProvider(merged, options.providerOverride);
+  if (providerConfig !== undefined) {
+    return providerConfig;
+  }
+
+  throw new Error('No provider configuration found. Run `robota` to set up.');
+}
+
+export function readMergedProviderSettings(cwd: string): TProviderSettingsDocument {
   const paths = [
     join(homedir(), '.robota', 'settings.json'),
     join(homedir(), '.claude', 'settings.json'),
@@ -61,38 +54,31 @@ export function readProviderSettings(cwd: string): IProviderConfig {
     join(cwd, '.claude', 'settings.local.json'),
   ];
 
-  const merged = paths.reduce<IProviderSettingsFile>((settings, filePath) => {
+  return paths.reduce<TProviderSettingsDocument>((settings, filePath) => {
     const parsed = readSettingsFile(filePath);
     if (parsed === undefined) {
       return settings;
     }
     return mergeSettings(settings, parsed);
   }, {});
-
-  const providerConfig = resolveActiveProvider(merged);
-  if (providerConfig !== undefined) {
-    return providerConfig;
-  }
-
-  throw new Error('No provider configuration found. Run `robota` to set up.');
 }
 
-function readSettingsFile(filePath: string): IProviderSettingsFile | undefined {
+function readSettingsFile(filePath: string): TProviderSettingsDocument | undefined {
   if (!existsSync(filePath)) {
     return undefined;
   }
   try {
     const raw = readFileSync(filePath, 'utf8');
-    return JSON.parse(raw) as IProviderSettingsFile;
+    return JSON.parse(raw) as TProviderSettingsDocument;
   } catch {
     return undefined;
   }
 }
 
 function mergeSettings(
-  base: IProviderSettingsFile,
-  override: IProviderSettingsFile,
-): IProviderSettingsFile {
+  base: TProviderSettingsDocument,
+  override: TProviderSettingsDocument,
+): TProviderSettingsDocument {
   return {
     ...base,
     ...override,
@@ -108,24 +94,28 @@ function mergeSettings(
 }
 
 function mergeProviders(
-  base: IProviderSettingsFile['providers'],
-  override: IProviderSettingsFile['providers'],
-): IProviderSettingsFile['providers'] {
-  const result: NonNullable<IProviderSettingsFile['providers']> = { ...(base ?? {}) };
+  base: TProviderSettingsDocument['providers'],
+  override: TProviderSettingsDocument['providers'],
+): TProviderSettingsDocument['providers'] {
+  const result: NonNullable<TProviderSettingsDocument['providers']> = { ...(base ?? {}) };
   for (const [name, profile] of Object.entries(override ?? {})) {
     result[name] = { ...result[name], ...profile };
   }
   return result;
 }
 
-function resolveActiveProvider(settings: IProviderSettingsFile): IProviderConfig | undefined {
-  if (settings.currentProvider !== undefined) {
-    const profile = settings.providers?.[settings.currentProvider];
+function resolveActiveProvider(
+  settings: TProviderSettingsDocument,
+  providerOverride?: string,
+): IProviderConfig | undefined {
+  const activeProvider = providerOverride ?? settings.currentProvider;
+  if (activeProvider !== undefined) {
+    const profile = settings.providers?.[activeProvider];
     if (profile === undefined) {
-      throw new Error(`currentProvider "${settings.currentProvider}" was not found in providers`);
+      throw new Error(`Provider profile "${activeProvider}" was not found in providers`);
     }
     if (!profile.type) {
-      throw new Error(`Provider profile "${settings.currentProvider}" is missing type`);
+      throw new Error(`Provider profile "${activeProvider}" is missing type`);
     }
     return normalizeProviderConfig({
       name: profile.type,
@@ -179,13 +169,14 @@ function resolveEnvRef(value: string): string {
 function getProviderDefaults(name: string): { model: string; apiKey?: string; baseURL?: string } {
   if (name === 'openai') {
     return {
-      model: DEFAULT_MODELS['openai'] ?? 'supergemma4-26b-uncensored-v2',
+      model: DEFAULT_PROVIDER_MODELS['openai'] ?? 'supergemma4-26b-uncensored-v2',
       apiKey: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
       baseURL: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
     };
   }
   return {
-    model: DEFAULT_MODELS[name] ?? DEFAULT_MODELS['anthropic'] ?? 'claude-sonnet-4-6',
+    model:
+      DEFAULT_PROVIDER_MODELS[name] ?? DEFAULT_PROVIDER_MODELS['anthropic'] ?? 'claude-sonnet-4-6',
   };
 }
 
@@ -197,8 +188,12 @@ function requireApiKey(settings: IProviderConfig): string {
 }
 
 /** Create a provider instance from settings. */
-export function createProviderFromSettings(cwd: string, modelOverride?: string): IAIProvider {
-  const settings = readProviderSettings(cwd);
+export function createProviderFromSettings(
+  cwd: string,
+  modelOverride?: string,
+  options: IReadProviderSettingsOptions = {},
+): IAIProvider {
+  const settings = readProviderSettings(cwd, options);
   const model = modelOverride ?? settings.model;
 
   switch (settings.name) {

--- a/packages/agent-cli/src/utils/provider-settings.ts
+++ b/packages/agent-cli/src/utils/provider-settings.ts
@@ -1,0 +1,133 @@
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+
+export interface IProviderProfileSettings {
+  [key: string]: TUniversalValue;
+  type?: string;
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
+}
+
+export interface ILegacyProviderSettings {
+  [key: string]: TUniversalValue;
+  name?: string;
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+  timeout?: number;
+}
+
+export type TProviderSettingsDocument = Record<string, TUniversalValue> & {
+  currentProvider?: string;
+  providers?: Record<string, IProviderProfileSettings>;
+  provider?: ILegacyProviderSettings;
+};
+
+export interface IProviderSetupInput {
+  profile: string;
+  type: string;
+  model?: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  baseURL?: string;
+  timeout?: number;
+  setCurrent?: boolean;
+}
+
+export interface IProviderSetupPatch {
+  currentProvider?: string;
+  providers: Record<string, IProviderProfileSettings>;
+}
+
+export const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  openai: 'supergemma4-26b-uncensored-v2',
+};
+
+export const DEFAULT_OPENAI_COMPATIBLE_BASE_URL = 'http://localhost:1234/v1';
+export const DEFAULT_OPENAI_COMPATIBLE_API_KEY = 'lm-studio';
+
+export function upsertProviderProfile(
+  settings: TProviderSettingsDocument,
+  profileName: string,
+  profile: IProviderProfileSettings,
+): TProviderSettingsDocument {
+  return {
+    ...settings,
+    providers: {
+      ...(settings.providers ?? {}),
+      [profileName]: profile,
+    },
+  };
+}
+
+export function setCurrentProvider(
+  settings: TProviderSettingsDocument,
+  profileName: string,
+): TProviderSettingsDocument {
+  if (!settings.providers?.[profileName]) {
+    throw new Error(`Provider profile "${profileName}" was not found`);
+  }
+  return {
+    ...settings,
+    currentProvider: profileName,
+  };
+}
+
+export function validateProviderProfile(
+  profileName: string,
+  profile: IProviderProfileSettings,
+): void {
+  if (!profile.type) {
+    throw new Error(`Provider profile "${profileName}" is missing type`);
+  }
+  if (!profile.model) {
+    throw new Error(`Provider profile "${profileName}" is missing model`);
+  }
+  if (profile.type === 'anthropic' && !profile.apiKey) {
+    throw new Error(`Provider profile "${profileName}" is missing apiKey`);
+  }
+}
+
+export function buildProviderSetupPatch(input: IProviderSetupInput): IProviderSetupPatch {
+  const profile = buildProviderProfile(input);
+  validateProviderProfile(input.profile, profile);
+  return {
+    ...(input.setCurrent && { currentProvider: input.profile }),
+    providers: {
+      [input.profile]: profile,
+    },
+  };
+}
+
+export function buildProviderProfile(input: IProviderSetupInput): IProviderProfileSettings {
+  const apiKey =
+    input.apiKeyEnv !== undefined
+      ? `$ENV:${input.apiKeyEnv}`
+      : (input.apiKey ?? (input.type === 'openai' ? DEFAULT_OPENAI_COMPATIBLE_API_KEY : undefined));
+  const baseURL =
+    input.baseURL ?? (input.type === 'openai' ? DEFAULT_OPENAI_COMPATIBLE_BASE_URL : undefined);
+
+  return {
+    type: input.type,
+    model: input.model ?? DEFAULT_PROVIDER_MODELS[input.type],
+    ...(apiKey !== undefined && { apiKey }),
+    ...(baseURL !== undefined && { baseURL }),
+    ...(input.timeout !== undefined && { timeout: input.timeout }),
+  };
+}
+
+export function mergeProviderPatch(
+  settings: TProviderSettingsDocument,
+  patch: IProviderSetupPatch,
+): TProviderSettingsDocument {
+  const [profileName, profile] = Object.entries(patch.providers)[0] ?? [];
+  if (!profileName || !profile) {
+    return settings;
+  }
+  const withProfile = upsertProviderProfile(settings, profileName, profile);
+  return patch.currentProvider
+    ? setCurrentProvider(withProfile, patch.currentProvider)
+    : withProfile;
+}

--- a/packages/agent-cli/src/utils/provider-setup-flow.ts
+++ b/packages/agent-cli/src/utils/provider-setup-flow.ts
@@ -1,0 +1,147 @@
+import type { IProviderSetupInput } from './provider-settings.js';
+import {
+  DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_PROVIDER_MODELS,
+} from './provider-settings.js';
+
+export type TProviderSetupType = 'openai' | 'anthropic';
+export type TProviderSetupField = 'baseURL' | 'model' | 'apiKey';
+export type TPromptInput = (label: string, masked?: boolean) => Promise<string>;
+
+export interface IProviderSetupPromptStep {
+  key: TProviderSetupField;
+  title: string;
+  defaultValue?: string;
+  required?: boolean;
+  masked?: boolean;
+}
+
+export interface IProviderSetupFlowState {
+  type: TProviderSetupType;
+  stepIndex: number;
+  values: Partial<Record<TProviderSetupField, string>>;
+}
+
+export type TProviderSetupFlowSubmitResult =
+  | {
+      status: 'next';
+      state: IProviderSetupFlowState;
+    }
+  | {
+      status: 'complete';
+      input: IProviderSetupInput;
+    }
+  | {
+      status: 'error';
+      state: IProviderSetupFlowState;
+      message: string;
+    };
+
+export function createProviderSetupFlow(type: TProviderSetupType): IProviderSetupFlowState {
+  return { type, stepIndex: 0, values: {} };
+}
+
+export function getProviderSetupStep(state: IProviderSetupFlowState): IProviderSetupPromptStep {
+  const step = getProviderSetupSteps(state.type)[state.stepIndex];
+  if (step === undefined) {
+    throw new Error(`Provider setup step ${state.stepIndex} is out of range`);
+  }
+  return step;
+}
+
+export function submitProviderSetupValue(
+  state: IProviderSetupFlowState,
+  rawValue: string,
+): TProviderSetupFlowSubmitResult {
+  const step = getProviderSetupStep(state);
+  const value = rawValue.trim() || step.defaultValue || '';
+  const validationMessage = validateProviderSetupValue(step, value);
+  if (validationMessage !== undefined) {
+    return { status: 'error', state, message: validationMessage };
+  }
+
+  const nextState = {
+    ...state,
+    stepIndex: state.stepIndex + 1,
+    values: { ...state.values, [step.key]: value },
+  };
+  if (nextState.stepIndex < getProviderSetupSteps(state.type).length) {
+    return { status: 'next', state: nextState };
+  }
+  return { status: 'complete', input: buildProviderSetupInput(nextState) };
+}
+
+export async function runProviderSetupPromptFlow(
+  type: TProviderSetupType,
+  promptInput: TPromptInput,
+): Promise<IProviderSetupInput> {
+  let state = createProviderSetupFlow(type);
+  const stepCount = getProviderSetupSteps(type).length;
+  while (state.stepIndex < stepCount) {
+    const step = getProviderSetupStep(state);
+    const value = await promptInput(formatProviderSetupPromptLabel(step), step.masked === true);
+    const result = submitProviderSetupValue(state, value);
+    if (result.status === 'complete') {
+      return result.input;
+    }
+    if (result.status === 'error') {
+      throw new Error(result.message);
+    }
+    state = result.state;
+  }
+  throw new Error('Provider setup flow ended without completion');
+}
+
+export function formatProviderSetupPromptLabel(step: IProviderSetupPromptStep): string {
+  const suffix = step.defaultValue !== undefined ? ` (default: ${step.defaultValue})` : '';
+  return `  ${step.title}${suffix}: `;
+}
+
+export function validateProviderSetupValue(
+  step: IProviderSetupPromptStep,
+  value: string,
+): string | undefined {
+  if (step.required === true && value.length === 0) {
+    return 'Required';
+  }
+  return undefined;
+}
+
+function getProviderSetupSteps(type: TProviderSetupType): IProviderSetupPromptStep[] {
+  if (type === 'openai') {
+    return [
+      {
+        key: 'baseURL',
+        title: 'OpenAI-compatible base URL',
+        defaultValue: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+      },
+      {
+        key: 'model',
+        title: 'OpenAI-compatible model',
+        defaultValue: DEFAULT_PROVIDER_MODELS.openai,
+      },
+      {
+        key: 'apiKey',
+        title: 'OpenAI-compatible API key',
+        defaultValue: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+        masked: true,
+      },
+    ];
+  }
+  return [
+    { key: 'apiKey', title: 'Anthropic API key', required: true, masked: true },
+    { key: 'model', title: 'Anthropic model', defaultValue: DEFAULT_PROVIDER_MODELS.anthropic },
+  ];
+}
+
+function buildProviderSetupInput(state: IProviderSetupFlowState): IProviderSetupInput {
+  return {
+    profile: state.type,
+    type: state.type,
+    model: state.values.model,
+    apiKey: state.values.apiKey,
+    ...(state.type === 'openai' && { baseURL: state.values.baseURL }),
+    setCurrent: true,
+  };
+}

--- a/packages/agent-cli/src/utils/provider-setup.ts
+++ b/packages/agent-cli/src/utils/provider-setup.ts
@@ -1,0 +1,121 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { IParsedCliArgs } from './cli-args.js';
+import { checkSettingsFile } from './settings-check.js';
+import { getUserSettingsPath, readSettings, writeSettings } from './settings-io.js';
+import { applyProviderConfiguration, applyProviderSwitch } from './provider-configuration.js';
+import { readMergedProviderSettings } from './provider-factory.js';
+import { type IProviderSetupInput } from './provider-settings.js';
+import {
+  runProviderSetupPromptFlow,
+  type TPromptInput,
+  type TProviderSetupType,
+} from './provider-setup-flow.js';
+
+export function getSettingsPathForScope(cwd: string, scope: string | undefined): string {
+  if (scope === undefined || scope === 'user') {
+    return getUserSettingsPath();
+  }
+  if (scope === 'project-local') {
+    return join(cwd, '.robota', 'settings.local.json');
+  }
+  throw new Error(`Invalid --settings-scope "${scope}". Valid: user | project-local`);
+}
+
+export function handleProviderConfigurationArgs(cwd: string, args: IParsedCliArgs): boolean {
+  const settingsPath = getSettingsPathForScope(cwd, args.settingsScope);
+  if (args.configureProvider) {
+    applyProviderConfiguration(settingsPath, buildSetupInputFromArgs(args));
+    process.stdout.write(`Provider profile saved to ${settingsPath}\n`);
+    return !args.printMode && args.positional.length === 0;
+  }
+  if (args.provider && args.setCurrent) {
+    applyProviderSwitch(settingsPath, args.provider, {
+      knownProviders: readMergedProviderSettings(cwd).providers,
+    });
+    process.stdout.write(`Current provider set to ${args.provider}\n`);
+    return !args.printMode && args.positional.length === 0;
+  }
+  return false;
+}
+
+export async function ensureConfig(
+  cwd: string,
+  args: IParsedCliArgs,
+  promptInput: TPromptInput,
+): Promise<void> {
+  const checks = getSettingsCheckPaths(cwd).map((path) => ({
+    path,
+    status: checkSettingsFile(path),
+  }));
+  if (checks.some((check) => check.status === 'valid')) {
+    return;
+  }
+  if (!isInteractiveTerminal()) {
+    throw new Error(formatMissingProviderConfigMessage());
+  }
+  await runInteractiveProviderSetup(cwd, args, promptInput);
+}
+
+export async function runInteractiveProviderSetup(
+  cwd: string,
+  args: IParsedCliArgs,
+  promptInput: TPromptInput,
+): Promise<void> {
+  const providerChoice =
+    (await promptInput('  Provider (anthropic/openai, default: anthropic): ')) || 'anthropic';
+  const type = parseProviderSetupType(providerChoice);
+  const settingsPath = getSettingsPathForScope(cwd, args.settingsScope);
+  const input = await runProviderSetupPromptFlow(type, promptInput);
+  applyProviderConfiguration(settingsPath, input);
+  const language = await promptInput('  Response language (ko/en/ja/zh, default: en): ');
+  if (language) {
+    const settings = readSettings(settingsPath);
+    settings.language = language;
+    writeSettings(settingsPath, settings);
+  }
+  process.stdout.write(`\n  Config saved to ${settingsPath}\n\n`);
+}
+
+function parseProviderSetupType(value: string): TProviderSetupType {
+  return value === 'openai' ? 'openai' : 'anthropic';
+}
+
+function buildSetupInputFromArgs(args: IParsedCliArgs): IProviderSetupInput {
+  const type = args.providerType ?? args.configureProvider;
+  if (!args.configureProvider || !type) {
+    throw new Error('--configure-provider requires a provider profile and --type');
+  }
+  return {
+    profile: args.configureProvider,
+    type,
+    ...(args.model !== undefined && { model: args.model }),
+    ...(args.apiKey !== undefined && { apiKey: args.apiKey }),
+    ...(args.apiKeyEnv !== undefined && { apiKeyEnv: args.apiKeyEnv }),
+    ...(args.baseURL !== undefined && { baseURL: args.baseURL }),
+    setCurrent: args.setCurrent,
+  };
+}
+
+function getSettingsCheckPaths(cwd: string): string[] {
+  return [
+    getUserSettingsPath(),
+    join(homedir(), '.claude', 'settings.json'),
+    join(cwd, '.robota', 'settings.json'),
+    join(cwd, '.robota', 'settings.local.json'),
+    join(cwd, '.claude', 'settings.json'),
+    join(cwd, '.claude', 'settings.local.json'),
+  ];
+}
+
+function isInteractiveTerminal(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+export function formatMissingProviderConfigMessage(): string {
+  return [
+    'No provider configuration found.',
+    'Run `robota --configure` in an interactive terminal, or configure a provider:',
+    '  robota --configure-provider openai --type openai --base-url http://localhost:1234/v1 --model <model> --api-key lm-studio --set-current',
+  ].join('\n');
+}

--- a/packages/agent-cli/src/utils/settings-io.ts
+++ b/packages/agent-cli/src/utils/settings-io.ts
@@ -5,6 +5,9 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+
+export type TSettingsData = Record<string, TUniversalValue>;
 
 /** Get the user-global settings file path */
 export function getUserSettingsPath(): string {
@@ -13,11 +16,11 @@ export function getUserSettingsPath(): string {
 }
 
 /** Read settings from a JSON file. Returns empty object if file doesn't exist or is corrupt. */
-export function readSettings(path: string): Record<string, unknown> {
+export function readSettings(path: string): TSettingsData {
   if (!existsSync(path)) return {};
   const raw = readFileSync(path, 'utf8');
   try {
-    return JSON.parse(raw) as Record<string, unknown>;
+    return JSON.parse(raw) as TSettingsData;
   } catch {
     process.stderr.write(`Warning: corrupt settings file at ${path}, resetting to defaults\n`);
     return {};
@@ -25,7 +28,7 @@ export function readSettings(path: string): Record<string, unknown> {
 }
 
 /** Write settings to a JSON file, creating parent directories as needed. */
-export function writeSettings(path: string, settings: Record<string, unknown>): void {
+export function writeSettings(path: string, settings: TSettingsData): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf8');
 }
@@ -33,10 +36,28 @@ export function writeSettings(path: string, settings: Record<string, unknown>): 
 /** Update the provider.model field in a settings file. */
 export function updateModelInSettings(settingsPath: string, modelId: string): void {
   const settings = readSettings(settingsPath);
-  const provider = (settings.provider ?? {}) as Record<string, unknown>;
-  provider.model = modelId;
-  settings.provider = provider;
+  const currentProvider = settings.currentProvider;
+  const providers = settings.providers;
+  if (typeof currentProvider === 'string' && isSettingsData(providers)) {
+    const providerMap = providers as Record<string, TSettingsData | undefined>;
+    providerMap[currentProvider] = {
+      ...(isSettingsData(providerMap[currentProvider]) ? providerMap[currentProvider] : {}),
+      model: modelId,
+    };
+    settings.providers = providerMap;
+  } else {
+    settings.provider = {
+      ...(isSettingsData(settings.provider) ? settings.provider : {}),
+      model: modelId,
+    };
+  }
   writeSettings(settingsPath, settings);
+}
+
+function isSettingsData(value: TUniversalValue): value is TSettingsData {
+  return (
+    value !== null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)
+  );
 }
 
 /** Delete a settings file if it exists. Returns true if deleted. */

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -683,6 +683,18 @@ Provider resolution order:
 2. Legacy `provider`
 3. Existing defaults
 
+Provider profile schema:
+
+| Field     | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `type`    | Provider implementation type such as `anthropic` or `openai` |
+| `model`   | Default model ID for the profile                             |
+| `apiKey`  | Literal key or `$ENV:<name>` reference                       |
+| `baseURL` | Optional OpenAI-compatible or provider-specific endpoint     |
+| `timeout` | Optional request timeout                                     |
+
+`currentProvider` must point to an existing profile. Missing profiles and profiles without `type` are configuration errors. Legacy `provider` remains accepted for backward compatibility, but it must not override an explicit active provider profile.
+
 The SDK remains provider-neutral: it resolves provider metadata for session assembly, but consumers such as `agent-cli` still construct concrete provider instances.
 
 ## Bundle Plugin System

--- a/packages/agent-sdk/src/commands/builtin-source.ts
+++ b/packages/agent-sdk/src/commands/builtin-source.ts
@@ -17,6 +17,15 @@ function buildModelSubcommands(): ICommand[] {
   return commands;
 }
 
+function buildProviderSubcommands(): ICommand[] {
+  return [
+    { name: 'current', description: 'Show current provider', source: 'builtin' },
+    { name: 'list', description: 'List provider profiles', source: 'builtin' },
+    { name: 'use', description: 'Switch provider profile', source: 'builtin' },
+    { name: 'test', description: 'Test provider profile', source: 'builtin' },
+  ];
+}
+
 /** Built-in commands. Execute callbacks are wired externally by clients. */
 function createBuiltinCommands(): ICommand[] {
   return [
@@ -54,6 +63,12 @@ function createBuiltinCommands(): ICommand[] {
     { name: 'cost', description: 'Show session info', source: 'builtin' },
     { name: 'context', description: 'Context window info', source: 'builtin' },
     { name: 'permissions', description: 'Permission rules', source: 'builtin' },
+    {
+      name: 'provider',
+      description: 'Manage provider profiles',
+      source: 'builtin',
+      subcommands: buildProviderSubcommands(),
+    },
     { name: 'resume', description: 'Resume a previous session', source: 'builtin' },
     { name: 'rename', description: 'Rename the current session', source: 'builtin' },
     { name: 'plugin', description: 'Manage plugins', source: 'builtin' },

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -46,6 +46,7 @@ export function createSystemCommands(): ISystemCommand[] {
           '  cost              — Show session info',
           '  context           — Context window info',
           '  permissions       — Permission rules',
+          '  provider          — Provider profile status and switching',
           '  resume            — Resume a previous session',
           '  rename <name>     — Rename the current session',
           '  reset             — Delete settings and exit',

--- a/packages/agent-transport-headless/docs/SPEC.md
+++ b/packages/agent-transport-headless/docs/SPEC.md
@@ -8,7 +8,7 @@ Headless transport adapter for non-interactive `InteractiveSession` execution. P
 
 - Does NOT own `InteractiveSession` — imported from `@robota-sdk/agent-sdk`
 - Does NOT own CLI argument parsing — handled by `@robota-sdk/agent-cli`
-- Does NOT own provider creation — provider is created upstream and injected via session
+- Does NOT own provider creation or provider configuration prompting — provider is created upstream and injected via session
 - OWNS: output format rendering (text, json, stream-json) and exit code determination
 
 ## Public API Surface
@@ -72,6 +72,16 @@ Writes newline-delimited JSON events to stdout during execution:
 ## Claude Code Field Name Compatibility
 
 JSON and stream-json output formats use field names that match Claude Code's `--output-format json` and `--output-format stream-json` (e.g., `type: 'result'`, `session_id`, `subtype`, `content_block_delta`). This is a **reference-only alignment** for user convenience — it allows reuse of `jq` pipelines and parsing scripts. Robota does NOT depend on Claude Code and will NOT track Claude Code's field name changes. The output format is independently owned and versioned by this package.
+
+## Non-Interactive Provider Configuration Contract
+
+Headless transport assumes the upstream CLI has already resolved provider configuration. It must not prompt for provider setup, API keys, or model selection.
+
+When the CLI cannot create a provider for headless execution, the CLI must fail before creating the transport and print an actionable setup message. This package preserves output contracts once a valid `InteractiveSession` is attached:
+
+- `json` writes exactly one result object.
+- `stream-json` writes zero or more `stream_event` objects before one final result object.
+- Provider selection failures are upstream CLI errors, not transport events.
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary
- add provider profile settings, resolution, CLI setup flags, and LM Studio/OpenAI-compatible defaults
- add /provider TUI commands for current/list/use/add/test with confirm-before-persist switching
- split provider setup prompt semantics into a pure provider-setup-flow module so Ink components stay thin
- document provider configuration contracts across agent-cli, agent-sdk, and headless transport

## Verification
- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint (passes with existing warnings)
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-sdk test
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-sdk lint (passes with existing warnings)
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-transport-headless test
- pnpm --filter @robota-sdk/agent-transport-headless typecheck
- pnpm --filter @robota-sdk/agent-transport-headless build
- pnpm harness:scan
- LM Studio local smoke: text and stream-json via supergemma4-26b-uncensored-v2