### PR TITLE
refactor(agent-cli): extract TUI input flows

### DIFF
--- a/.agents/tasks/completed/CLI-BL-025-tui-pty-e2e-harness.md
+++ b/.agents/tasks/completed/CLI-BL-025-tui-pty-e2e-harness.md
@@ -1,0 +1,49 @@
+# CLI TUI PTY E2E Harness
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: test/cli-tui-pty-e2e-harness
+- **Scope**: packages/agent-cli
+
+## Objective
+
+Add a PTY-backed E2E harness for terminal UI prompt interactions without moving prompt semantics back into Ink components.
+
+The harness must verify that TUI input is only transport for prompt values while provider setup meaning remains unit-tested in `provider-setup-flow`.
+
+## Plan
+
+- [x] Inspect existing agent-cli test setup and dependency constraints.
+- [x] Add a small PTY harness for spawning Ink prompt drivers in tests.
+- [x] Add E2E coverage for provider setup prompt input flow through a real pseudo terminal.
+- [x] Keep prompt semantics covered by pure unit tests, not assertions over key meaning inside TUI.
+- [x] Run affected tests, typecheck, build, and harness scan.
+
+## Test Plan
+
+Verify the new PTY E2E harness at three levels: targeted PTY tests prove the Ink provider prompt can render and accept terminal input through a real pseudo terminal; full `@robota-sdk/agent-cli` tests prove the new harness does not regress existing prompt-flow and TUI unit coverage; package typecheck, lint, build, and repository harness scan prove the changed test files and dependency metadata remain valid.
+
+## Progress
+
+### 2026-04-30
+
+- Created task branch from updated `develop`.
+- Added `node-pty` as an agent-cli dev dependency.
+- Added a PTY driver and E2E test for provider setup prompt progression through a real pseudo terminal.
+- Replaced `node-pty` with `@homebridge/node-pty-prebuilt-multiarch` after local `node-pty` PTY spawning failed with `posix_spawnp failed`.
+- Fixed the PTY wait helper to re-check output on every terminal chunk and to reject timeouts cleanly.
+- Passed targeted PTY E2E, full agent-cli tests, typecheck, lint, and build.
+
+## Decisions
+
+- TUI E2E should use a pseudo terminal, not plain `child_process.spawn`, because Ink behavior depends on TTY semantics.
+- Provider setup semantics remain owned by `provider-setup-flow`; E2E only verifies terminal wiring and rendered prompt progression.
+- Use `@homebridge/node-pty-prebuilt-multiarch` instead of `node-pty` because it provides the same PTY API and works in the current Node 24 local environment.
+
+## Blockers
+
+- `pnpm harness:scan` initially failed because this task document lacked a `Test Plan` section. The document was updated and scan was rerun.
+
+## Result
+
+Added a PTY-backed E2E harness for `ProviderSetupPrompt` that runs through a real pseudo terminal. The harness verifies OpenAI-compatible default submissions and Anthropic typed-value submissions while leaving prompt meaning and validation covered by existing unit tests. Verification passed for targeted PTY E2E, full `@robota-sdk/agent-cli` tests, typecheck, lint, build, and `pnpm harness:scan`.

--- a/.agents/tasks/completed/CLI-BL-026-tui-input-flow-migration.md
+++ b/.agents/tasks/completed/CLI-BL-026-tui-input-flow-migration.md
@@ -1,0 +1,49 @@
+# CLI TUI Input Flow Migration
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: test/cli-tui-pty-e2e-harness
+- **Scope**: packages/agent-cli
+
+## Objective
+
+Move prompt and input semantics out of Ink `useInput` handlers into pure flow modules. TUI components should translate terminal key events into flow actions and apply flow results, while unit tests cover the behavior without rendering Ink.
+
+## Plan
+
+- [x] Extract text prompt input semantics into a pure flow with unit tests.
+- [x] Extract selection prompt semantics for confirm/list/menu/permission prompts into pure flows with unit tests.
+- [x] Extract input-area autocomplete and paste-label behavior into a pure flow with unit tests.
+- [x] Extract CJK text input editing and paste handling into a pure flow with unit tests.
+- [x] Update TUI components to use the flow modules as thin shells.
+- [x] Update package SPEC to document TUI input flow ownership.
+- [x] Run targeted tests, full agent-cli tests, typecheck, lint, build, and harness scan.
+
+## Test Plan
+
+Each migrated flow must have Given/When/Then-style unit assertions that call pure functions directly: text prompt submit/cancel/editing, bounded and wrapping selection, confirmation and permission shortcuts, slash autocomplete submit/tab behavior, paste-label insertion, CJK cursor movement, bracketed paste, multiline paste, and submit effects. Existing Ink component tests remain as integration coverage for terminal wiring, and the PTY E2E harness verifies real pseudo-terminal behavior for provider setup.
+
+## Progress
+
+### 2026-04-30
+
+- Started after PTY E2E harness implementation when the migration scope was expanded to all TUI input-linked semantics.
+- Added `src/ui/flows/*` modules for text prompt, shared selection, confirmation, permission, input area, and CJK text input behavior.
+- Added direct unit tests for every new flow, using Given/When/Then-style assertions.
+- Updated `TextPrompt`, `ConfirmPrompt`, `ListPicker`, `MenuSelect`, `PermissionPrompt`, `InputArea`, and `CjkTextInput` to delegate input meaning to flow modules.
+- Updated `packages/agent-cli/docs/SPEC.md` with TUI input flow ownership and file structure.
+- Verified targeted flow/component tests, full agent-cli tests, typecheck, lint, build, and `pnpm harness:scan`.
+
+## Decisions
+
+- Keep React/Ink components as imperative shells; pure flow modules own key meaning and state transitions.
+- Preserve existing component behavior first, then rely on unit tests for the extracted flow contracts.
+- Keep PTY E2E focused on terminal wiring; migrated flow semantics are covered by fast unit tests.
+
+## Blockers
+
+- None.
+
+## Result
+
+Migrated TUI input-linked semantics out of Ink handlers into pure flow modules with unit tests. Components now translate terminal input into flow actions and apply returned effects. Full verification passed, including `@robota-sdk/agent-cli` tests, typecheck, lint, build, and repository harness scan.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -106,6 +106,19 @@ Provider changes must follow the existing `/model` restart pattern: command retu
 
 Provider setup prompt semantics must live outside Ink components. `provider-setup-flow` owns setup steps, defaults, required-field validation, masked-field metadata, and final `IProviderSetupInput` construction. TUI components may only render the current prompt step and pass submitted values back to the flow module.
 
+TUI input semantics must live outside Ink components. `src/ui/flows/*` owns prompt and input state transitions, shortcut meaning, selection bounds, slash autocomplete command selection, paste label insertion, and CJK cursor movement. Components may only translate `useInput` key data into flow actions, apply returned state, render the result, and call external callbacks.
+
+Flow ownership:
+
+| Flow module                 | Owns                                                                        | Thin shell consumers                                     |
+| --------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `text-prompt-flow.ts`       | text prompt editing, submit/cancel effects, validation state                | `TextPrompt`, `ProviderSetupPrompt` through `TextPrompt` |
+| `selection-flow.ts`         | bounded/wrapping selection, select/cancel effects, viewport scrolling       | `ListPicker`, `MenuSelect`, choice prompt flows          |
+| `confirm-prompt-flow.ts`    | confirmation shortcuts and option selection                                 | `ConfirmPrompt`                                          |
+| `permission-prompt-flow.ts` | permission shortcuts and `true`/`allow-session`/`false` decisions           | `PermissionPrompt`                                       |
+| `input-area-flow.ts`        | slash autocomplete movement, command completion, queue cancel, paste labels | `InputArea`                                              |
+| `cjk-text-input-flow.ts`    | printable filtering, cursor movement, bracketed paste, submit effects       | `CjkTextInput`                                           |
+
 ```
 bin.ts → cli.ts (arg parsing + provider creation)
               └── ui/render.tsx → App.tsx (Ink TUI)
@@ -546,6 +559,13 @@ src/
     │   ├── TuiStateManager.ts       ← Holds history: IHistoryEntry[]; syncs from getFullHistory();
     │   │                              manages windowing (MAX_RENDERED_MESSAGES) and local event entries
     │   └── usePluginCallbacks.ts    ← Plugin TUI callback wiring
+    ├── flows/
+    │   ├── text-prompt-flow.ts      ← Text prompt editing, validation, submit/cancel effects
+    │   ├── selection-flow.ts        ← Shared bounded/wrapping selection state machine
+    │   ├── confirm-prompt-flow.ts   ← Confirmation shortcuts and option selection
+    │   ├── permission-prompt-flow.ts← Permission shortcuts and decision mapping
+    │   ├── input-area-flow.ts       ← Slash autocomplete and paste-label input flow
+    │   └── cjk-text-input-flow.ts   ← CJK-aware text editing and paste flow
     ├── render.tsx                   ← Ink render() invocation
     ├── MessageList.tsx              ← Renders IHistoryEntry[] via EntryItem (dispatches on category)
     ├── InputArea.tsx                ← Bottom fixed input (CjkTextInput), slash detection
@@ -802,13 +822,13 @@ When input text wraps across multiple visual lines (exceeds terminal width), up/
 
 **Architecture:**
 
-- Cursor-only manipulation — text is never modified, only `cursorRef` position changes
+- Cursor-only manipulation — text is never modified, only flow `cursor` position changes
 - External value sync with `cursorHint` — when parent sets value, cursor position is determined by `cursorHint` prop: `null` (default) moves cursor to end (tab completion, clear), a number moves cursor to that position (paste). `cursorHint` is consumed once and reset to `null` after use.
-- Two private helpers in `CjkTextInput.tsx` (no separate module):
+- Helpers in `cjk-text-input-flow.ts`:
   - `displayOffset(chars, charIndex, width)` → cumulative display column offset, accounting for CJK line-end gaps
   - `charIndexAtDisplayOffset(chars, targetOffset, width)` → char index closest to target offset
-- Up arrow: `cursorRef = charIndexAtDisplayOffset(chars, offset - availableWidth, width)`
-- Down arrow: `cursorRef = charIndexAtDisplayOffset(chars, offset + availableWidth, width)`
+- Up arrow: `cursor = charIndexAtDisplayOffset(chars, offset - availableWidth, width)`
+- Down arrow: `cursor = charIndexAtDisplayOffset(chars, offset + availableWidth, width)`
 - Uses `string-width` for CJK character support (2 columns per CJK character)
 
 **Available width calculation:**
@@ -834,7 +854,7 @@ When input text wraps across multiple visual lines (exceeds terminal width), up/
 - Only enabled when `process.stdin.isTTY && process.stdout.isTTY`
 - Terminal wraps pasted content with `\x1b[200~` (start) and `\x1b[201~` (end) markers
 - Ink's CSI parser strips the ESC prefix, so `useInput` receives `[200~` and `[201~`
-- `CjkTextInput` detects these markers and buffers all input between them
+- `cjk-text-input-flow` detects these markers and buffers all input between them
 - On paste-end marker, the complete buffer is flushed with `\r\n`/`\r` normalized to `\n`
 - Deterministic boundary detection — no debounce or timing heuristics
 

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -66,6 +66,7 @@
     "string-width": "^8.2.0"
   },
   "devDependencies": {
+    "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
     "@types/marked": "^6.0.0",
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",

--- a/packages/agent-cli/src/ui/CjkTextInput.tsx
+++ b/packages/agent-cli/src/ui/CjkTextInput.tsx
@@ -14,63 +14,12 @@
 import React, { useRef, useState } from 'react';
 import { Text, useInput } from 'ink';
 import chalk from 'chalk';
-import stringWidth from 'string-width';
-
-/** Bracketed paste mode markers as delivered by Ink's input parser.
- *  Ink's CSI parser consumes the ESC (\x1b) prefix, so useInput
- *  receives only the remainder: "[200~" and "[201~". */
-const PASTE_START = '[200~';
-const PASTE_END = '[201~';
-
-/**
- * Filter non-printable characters from input. Returns empty string if
- * input is null/undefined/empty or contains only control characters.
- * Exported for testing.
- */
-export function filterPrintable(input: string | null | undefined): string {
-  if (!input || input.length === 0) return '';
-  // eslint-disable-next-line no-control-regex
-  return input.replace(/[\x00-\x1f\x7f]/g, '');
-}
-
-/**
- * Insert text into a value at the given cursor position.
- * Returns { value, cursor } with updated state.
- * Exported for testing.
- */
-export function insertAtCursor(
-  value: string,
-  cursor: number,
-  input: string,
-): { value: string; cursor: number } {
-  const next = value.slice(0, cursor) + input + value.slice(cursor);
-  return { value: next, cursor: cursor + input.length };
-}
-
-/** Cumulative display offset of cursor, accounting for CJK line-end gaps. Exported for testing. */
-export function displayOffset(chars: string[], charIndex: number, width: number): number {
-  let offset = 0;
-  for (let i = 0; i < charIndex && i < chars.length; i++) {
-    const w = stringWidth(chars[i]!);
-    const col = offset % width;
-    if (col + w > width) offset += width - col;
-    offset += w;
-  }
-  return offset;
-}
-
-/** Find char index closest to a target display offset. Exported for testing. */
-export function charIndexAtDisplayOffset(chars: string[], target: number, width: number): number {
-  let offset = 0;
-  for (let i = 0; i < chars.length; i++) {
-    if (offset >= target) return i;
-    const w = stringWidth(chars[i]!);
-    const col = offset % width;
-    if (col + w > width) offset += width - col;
-    offset += w;
-  }
-  return chars.length;
-}
+import {
+  applyCjkTextInput,
+  createCjkTextInputFlowState,
+  syncCjkTextInputFlowState,
+  type ICjkTextInputFlowState,
+} from './flows/cjk-text-input-flow.js';
 
 interface IProps {
   value: string;
@@ -97,136 +46,23 @@ export default function CjkTextInput({
   availableWidth,
   cursorHint = null,
 }: IProps): React.ReactElement {
-  // Use refs for value and cursor to avoid React batching issues.
-  // When IME sends "다" + "." in rapid succession, setState is async
-  // and the second keystroke reads stale state. Refs are synchronous.
-  const valueRef = useRef(value);
-  const cursorRef = useRef(value.length);
+  const stateRef = useRef<ICjkTextInputFlowState>(createCjkTextInputFlowState(value));
   const [, forceRender] = useState(0);
-
-  // Bracketed paste mode: terminal sends \x1b[200~ before paste and
-  // \x1b[201~ after. We buffer all input between these markers.
-  const isPastingRef = useRef(false);
-  const pasteBufferRef = useRef('');
 
   // useCursor removed — see comment below about Terminal.app SIGSEGV
 
   // Sync ref when value changes from parent (e.g., setValue(''), tab completion, paste)
-  if (value !== valueRef.current) {
-    valueRef.current = value;
-    // cursorHint: number = move to that position, null = move to end
-    cursorRef.current = cursorHint != null ? Math.min(cursorHint, value.length) : value.length;
-  }
+  stateRef.current = syncCjkTextInputFlowState(stateRef.current, value, cursorHint);
 
   useInput(
     (input, key) => {
       try {
-        // Bracketed paste mode: detect start/end markers
-        if (input === PASTE_START || input.startsWith(PASTE_START)) {
-          isPastingRef.current = true;
-          const afterMarker = input.slice(PASTE_START.length);
-          if (afterMarker.length > 0) {
-            pasteBufferRef.current += afterMarker;
-          }
-          return;
-        }
-
-        if (isPastingRef.current) {
-          if (input === PASTE_END || input.includes(PASTE_END)) {
-            const beforeMarker = input.split(PASTE_END)[0] ?? '';
-            pasteBufferRef.current += beforeMarker;
-            const text = pasteBufferRef.current.replace(/\r\n?/g, '\n');
-            pasteBufferRef.current = '';
-            isPastingRef.current = false;
-            if (text.length > 0) {
-              // Multiline paste → label replacement via onPaste
-              // Single-line paste → insert directly as typed text
-              if (text.includes('\n') && onPaste) {
-                onPaste(text, cursorRef.current);
-              } else {
-                const printable = filterPrintable(text);
-                if (printable.length > 0) {
-                  const result = insertAtCursor(valueRef.current, cursorRef.current, printable);
-                  cursorRef.current = result.cursor;
-                  valueRef.current = result.value;
-                  onChange(result.value);
-                }
-              }
-            }
-          } else {
-            pasteBufferRef.current += input;
-          }
-          return;
-        }
-
-        if ((key.ctrl && input === 'c') || key.tab || (key.shift && key.tab)) {
-          return;
-        }
-
-        if (key.upArrow || key.downArrow) {
-          if (availableWidth && availableWidth > 0) {
-            const chars = [...valueRef.current];
-            const offset = displayOffset(chars, cursorRef.current, availableWidth);
-            const target = key.upArrow ? offset - availableWidth : offset + availableWidth;
-            if (target >= 0) {
-              const newCursor = charIndexAtDisplayOffset(chars, target, availableWidth);
-              if (newCursor !== cursorRef.current) {
-                cursorRef.current = newCursor;
-                forceRender((n) => n + 1);
-              }
-            }
-          }
-          return;
-        }
-
-        if (key.return) {
-          onSubmit?.(valueRef.current);
-          return;
-        }
-
-        // Fallback for terminals without bracketed paste mode:
-        // multi-char input with newlines is likely a paste
-        if (input.length > 1 && (input.includes('\n') || input.includes('\r')) && onPaste) {
-          onPaste(input.replace(/\r\n?/g, '\n'), cursorRef.current);
-          return;
-        }
-
-        if (key.leftArrow) {
-          if (cursorRef.current > 0) {
-            cursorRef.current -= 1;
-            forceRender((n) => n + 1);
-          }
-          return;
-        }
-
-        if (key.rightArrow) {
-          if (cursorRef.current < valueRef.current.length) {
-            cursorRef.current += 1;
-            forceRender((n) => n + 1);
-          }
-          return;
-        }
-
-        if (key.backspace || key.delete) {
-          if (cursorRef.current > 0) {
-            const v = valueRef.current;
-            const next = v.slice(0, cursorRef.current - 1) + v.slice(cursorRef.current);
-            cursorRef.current -= 1;
-            valueRef.current = next;
-            onChange(next);
-          }
-          return;
-        }
-
-        // Guard against IME sending empty or control characters
-        const printable = filterPrintable(input);
-        if (printable.length === 0) return;
-
-        // Regular character input — update ref synchronously
-        const result = insertAtCursor(valueRef.current, cursorRef.current, printable);
-        cursorRef.current = result.cursor;
-        valueRef.current = result.value;
-        onChange(result.value);
+        const result = applyCjkTextInput(stateRef.current, input, key, {
+          availableWidth,
+          canPaste: onPaste !== undefined,
+        });
+        stateRef.current = result.state;
+        applyCjkTextInputEffect(result.effect, onChange, onSubmit, onPaste, forceRender);
       } catch {
         // Swallow IME-related errors to prevent terminal crash.
         // Korean IME in raw mode can produce unexpected byte sequences.
@@ -246,9 +82,32 @@ export default function CjkTextInput({
 
   return (
     <Text>
-      {renderWithCursor(valueRef.current, cursorRef.current, placeholder, showCursor && focus)}
+      {renderWithCursor(
+        stateRef.current.value,
+        stateRef.current.cursor,
+        placeholder,
+        showCursor && focus,
+      )}
     </Text>
   );
+}
+
+function applyCjkTextInputEffect(
+  effect: ReturnType<typeof applyCjkTextInput>['effect'],
+  onChange: (value: string) => void,
+  onSubmit: ((value: string) => void) | undefined,
+  onPaste: ((text: string, cursorPosition: number) => void) | undefined,
+  forceRender: React.Dispatch<React.SetStateAction<number>>,
+): void {
+  if (effect.type === 'change') {
+    onChange(effect.value);
+  } else if (effect.type === 'submit') {
+    onSubmit?.(effect.value);
+  } else if (effect.type === 'paste') {
+    onPaste?.(effect.text, effect.cursor);
+  } else if (effect.type === 'render') {
+    forceRender((n) => n + 1);
+  }
 }
 
 /** Render text with an inverse-style cursor at the correct position */

--- a/packages/agent-cli/src/ui/ConfirmPrompt.tsx
+++ b/packages/agent-cli/src/ui/ConfirmPrompt.tsx
@@ -3,8 +3,14 @@
  * Used by model change, permission prompts, and other yes/no confirmations.
  */
 
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
+import {
+  applyConfirmPromptInput,
+  getConfirmPromptInputAction,
+  type TConfirmPromptInputAction,
+} from './flows/confirm-prompt-flow.js';
+import { createSelectionFlowState, type ISelectionFlowState } from './flows/selection-flow.js';
 
 interface IProps {
   /** Message to display above the options */
@@ -20,30 +26,24 @@ export default function ConfirmPrompt({
   options = ['Yes', 'No'],
   onSelect,
 }: IProps): React.ReactElement {
-  const [selected, setSelected] = useState(0);
-  const resolvedRef = useRef(false);
-
-  const doSelect = useCallback(
-    (index: number) => {
-      if (resolvedRef.current) return;
-      resolvedRef.current = true;
-      onSelect(index);
+  const [state, setState] = useState<ISelectionFlowState>(() => createSelectionFlowState());
+  const stateRef = useRef(state);
+  const applyAction = useCallback(
+    (action: TConfirmPromptInputAction): void => {
+      const result = applyConfirmPromptInput(stateRef.current, action, options.length);
+      stateRef.current = result.state;
+      setState(result.state);
+      if (result.effect.type === 'select') {
+        onSelect(result.effect.index);
+      }
     },
-    [onSelect],
+    [onSelect, options.length],
   );
 
   useInput((input, key) => {
-    if (resolvedRef.current) return;
-    if (key.leftArrow || key.upArrow) {
-      setSelected((prev) => (prev > 0 ? prev - 1 : prev));
-    } else if (key.rightArrow || key.downArrow) {
-      setSelected((prev) => (prev < options.length - 1 ? prev + 1 : prev));
-    } else if (key.return) {
-      doSelect(selected);
-    } else if (input === 'y' && options.length === 2) {
-      doSelect(0);
-    } else if (input === 'n' && options.length === 2) {
-      doSelect(1);
+    const action = getConfirmPromptInputAction(input, key, options.length);
+    if (action !== undefined) {
+      applyAction(action);
     }
   });
 
@@ -53,8 +53,11 @@ export default function ConfirmPrompt({
       <Box marginTop={1}>
         {options.map((opt, i) => (
           <Box key={opt} marginRight={2}>
-            <Text color={i === selected ? 'cyan' : undefined} bold={i === selected}>
-              {i === selected ? '> ' : '  '}
+            <Text
+              color={i === state.selectedIndex ? 'cyan' : undefined}
+              bold={i === state.selectedIndex}
+            >
+              {i === state.selectedIndex ? '> ' : '  '}
               {opt}
             </Text>
           </Box>

--- a/packages/agent-cli/src/ui/InputArea.tsx
+++ b/packages/agent-cli/src/ui/InputArea.tsx
@@ -6,7 +6,16 @@ import type { CommandRegistry } from '../commands/command-registry.js';
 import type { ISlashCommand } from '../commands/types.js';
 import SlashAutocomplete from './SlashAutocomplete.js';
 import { expandPasteLabels } from '../utils/paste-labels.js';
-import { parseSlashInput, useAutocomplete } from './hooks/useAutocomplete.js';
+import { useAutocomplete } from './hooks/useAutocomplete.js';
+import {
+  createPasteLabelChange,
+  getAutocompletePopupAction,
+  getPendingPromptInputAction,
+  moveAutocompleteSelection,
+  resolveEnterCommandSelection,
+  resolveTabCompletion,
+  shouldSubmitInput,
+} from './flows/input-area-flow.js';
 
 interface IProps {
   onSubmit: (value: string) => void;
@@ -67,30 +76,23 @@ export default function InputArea({
     pasteIdRef.current += 1;
     const id = pasteIdRef.current;
     pasteStore.current.set(id, text);
-    const lineCount = text.split('\n').length;
-    const label = `[Pasted text #${id} +${lineCount} lines]`;
-    const newCursorPos = cursorPosition + label.length;
-    setCursorHint(newCursorPos);
-    setValue((prev) => prev.slice(0, cursorPosition) + label + prev.slice(cursorPosition));
+    setValue((prev) => {
+      const change = createPasteLabelChange(prev, cursorPosition, id, text);
+      setCursorHint(change.cursorHint);
+      return change.value;
+    });
   }, []);
 
   /** Tab: insert command into input field without executing */
   const tabCompleteCommand = useCallback(
     (cmd: ISlashCommand): void => {
-      const parsed = parseSlashInput(value);
-
-      if (parsed.parentCommand) {
-        setValue(`/${parsed.parentCommand} ${cmd.name} `);
-        return;
+      const result = resolveTabCompletion(value, cmd);
+      if (result.type === 'insert') {
+        setValue(result.value);
+        if (result.selectedIndex !== undefined) {
+          setSelectedIndex(result.selectedIndex);
+        }
       }
-
-      if (cmd.subcommands && cmd.subcommands.length > 0) {
-        setValue(`/${cmd.name} `);
-        setSelectedIndex(0);
-        return;
-      }
-
-      setValue(`/${cmd.name} `);
     },
     [value, setSelectedIndex],
   );
@@ -98,31 +100,23 @@ export default function InputArea({
   /** Enter: insert and execute command immediately */
   const enterSelectCommand = useCallback(
     (cmd: ISlashCommand): void => {
-      const parsed = parseSlashInput(value);
-
-      if (parsed.parentCommand) {
-        const fullCommand = `/${parsed.parentCommand} ${cmd.name}`;
-        setValue('');
-        onSubmit(fullCommand);
+      const result = resolveEnterCommandSelection(value, cmd);
+      if (result.type === 'insert') {
+        setValue(result.value);
+        if (result.selectedIndex !== undefined) {
+          setSelectedIndex(result.selectedIndex);
+        }
         return;
       }
-
-      if (cmd.subcommands && cmd.subcommands.length > 0) {
-        setValue(`/${cmd.name} `);
-        setSelectedIndex(0);
-        return;
-      }
-
       setValue('');
-      onSubmit(`/${cmd.name}`);
+      onSubmit(result.value);
     },
     [value, onSubmit, setSelectedIndex],
   );
 
   const handleSubmit = useCallback(
     (text: string): void => {
-      const trimmed = text.trim();
-      if (trimmed.length === 0) return;
+      if (!shouldSubmitInput(text)) return;
 
       if (showPopup && filteredCommands[selectedIndex]) {
         enterSelectCommand(filteredCommands[selectedIndex]);
@@ -130,7 +124,7 @@ export default function InputArea({
       }
 
       // Expand paste labels before submitting
-      const expanded = expandPasteLabels(trimmed, pasteStore.current);
+      const expanded = expandPasteLabels(text.trim(), pasteStore.current);
 
       setValue('');
       // Reset paste state
@@ -148,14 +142,14 @@ export default function InputArea({
       key: { upArrow: boolean; downArrow: boolean; escape: boolean; tab: boolean },
     ) => {
       if (!showPopup) return;
-
-      if (key.upArrow) {
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : filteredCommands.length - 1));
-      } else if (key.downArrow) {
-        setSelectedIndex((prev) => (prev < filteredCommands.length - 1 ? prev + 1 : 0));
-      } else if (key.escape) {
+      const action = getAutocompletePopupAction(key);
+      if (action === 'previous' || action === 'next') {
+        setSelectedIndex((prev) =>
+          moveAutocompleteSelection(prev, filteredCommands.length, action),
+        );
+      } else if (action === 'close') {
         setShowPopup(false);
-      } else if (key.tab) {
+      } else if (action === 'complete') {
         const cmd = filteredCommands[selectedIndex];
         if (cmd) tabCompleteCommand(cmd);
       }
@@ -166,7 +160,7 @@ export default function InputArea({
   // Backspace cancels queued prompt
   useInput(
     (_input, key) => {
-      if ((key.backspace || key.delete) && pendingPrompt) {
+      if (getPendingPromptInputAction(key) === 'cancelQueue' && pendingPrompt) {
         onCancelQueue?.();
       }
     },

--- a/packages/agent-cli/src/ui/ListPicker.tsx
+++ b/packages/agent-cli/src/ui/ListPicker.tsx
@@ -4,8 +4,16 @@
  * Shows a limited number of items at a time; scrolls as the cursor moves.
  */
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
+import {
+  applySelectionInput,
+  createSelectionFlowState,
+  getVerticalSelectionInputAction,
+  normalizeSelectionState,
+  type ISelectionFlowState,
+  type TSelectionInputAction,
+} from './flows/selection-flow.js';
 
 /** Default number of visible items */
 const DEFAULT_MAX_VISIBLE = 3;
@@ -30,42 +38,32 @@ export default function ListPicker<T>({
   onCancel,
   maxVisible = DEFAULT_MAX_VISIBLE,
 }: IListPickerProps<T>): React.ReactElement {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
-  const selectedRef = useRef(0);
-  const resolvedRef = useRef(false);
+  const [state, setState] = useState<ISelectionFlowState>(() => createSelectionFlowState());
+  const stateRef = useRef(state);
+  const applyAction = useCallback(
+    (action: TSelectionInputAction): void => {
+      const result = applySelectionInput(stateRef.current, action, {
+        itemCount: items.length,
+        maxVisible,
+      });
+      stateRef.current = result.state;
+      setState(result.state);
+      if (result.effect.type === 'cancel') {
+        onCancel();
+      } else if (result.effect.type === 'select') {
+        const item = items[result.effect.index];
+        if (item !== undefined) {
+          onSelect(item);
+        }
+      }
+    },
+    [items, maxVisible, onCancel, onSelect],
+  );
 
   useInput((_input, key) => {
-    if (resolvedRef.current) return;
-    if (key.escape) {
-      resolvedRef.current = true;
-      onCancel();
-      return;
-    }
-    if (items.length === 0) return;
-    if (key.upArrow) {
-      const next = selectedRef.current > 0 ? selectedRef.current - 1 : selectedRef.current;
-      selectedRef.current = next;
-      setSelectedIndex(next);
-      // Scroll up if cursor goes above viewport
-      if (next < scrollOffset) {
-        setScrollOffset(next);
-      }
-    } else if (key.downArrow) {
-      const next =
-        selectedRef.current < items.length - 1 ? selectedRef.current + 1 : selectedRef.current;
-      selectedRef.current = next;
-      setSelectedIndex(next);
-      // Scroll down if cursor goes below viewport
-      if (next >= scrollOffset + maxVisible) {
-        setScrollOffset(next - maxVisible + 1);
-      }
-    } else if (key.return) {
-      const item = items[selectedRef.current];
-      if (item !== undefined) {
-        resolvedRef.current = true;
-        onSelect(item);
-      }
+    const action = getVerticalSelectionInputAction(key);
+    if (action !== undefined) {
+      applyAction(action);
     }
   });
 
@@ -73,6 +71,11 @@ export default function ListPicker<T>({
     return <Box />;
   }
 
+  const normalizedState = normalizeSelectionState(state, { itemCount: items.length, maxVisible });
+  if (normalizedState !== state) {
+    stateRef.current = normalizedState;
+  }
+  const { selectedIndex, scrollOffset } = normalizedState;
   const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
   const hasMore = scrollOffset + maxVisible < items.length;
   const hasLess = scrollOffset > 0;

--- a/packages/agent-cli/src/ui/MenuSelect.tsx
+++ b/packages/agent-cli/src/ui/MenuSelect.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { Box, Text, useInput } from 'ink';
+import {
+  applySelectionInput,
+  createSelectionFlowState,
+  getVerticalSelectionInputAction,
+  normalizeSelectionState,
+  type ISelectionFlowState,
+  type TSelectionInputAction,
+} from './flows/selection-flow.js';
 
 export interface IMenuSelectItem {
   label: string;
@@ -24,40 +32,41 @@ export default function MenuSelect({
   loading,
   error,
 }: IProps): React.ReactElement {
-  const [selected, setSelected] = useState(0);
-  const selectedRef = useRef(0);
-  const resolvedRef = useRef(false);
-
-  const doSelect = useCallback(
-    (index: number) => {
-      if (resolvedRef.current || items.length === 0) return;
-      resolvedRef.current = true;
-      onSelect(items[index].value);
+  const [state, setState] = useState<ISelectionFlowState>(() => createSelectionFlowState());
+  const stateRef = useRef(state);
+  const isEnabled = !loading && !error;
+  const applyAction = useCallback(
+    (action: TSelectionInputAction): void => {
+      const result = applySelectionInput(stateRef.current, action, {
+        itemCount: items.length,
+        enabled: isEnabled,
+      });
+      stateRef.current = result.state;
+      setState(result.state);
+      if (result.effect.type === 'cancel') {
+        onBack();
+      } else if (result.effect.type === 'select') {
+        const item = items[result.effect.index];
+        if (item !== undefined) {
+          onSelect(item.value);
+        }
+      }
     },
-    [items, onSelect],
+    [isEnabled, items, onBack, onSelect],
   );
 
   useInput((input, key) => {
-    if (resolvedRef.current) return;
-    if (key.escape) {
-      resolvedRef.current = true;
-      onBack();
-      return;
-    }
-    if (loading || error || items.length === 0) return;
-    if (key.upArrow) {
-      const next = selectedRef.current > 0 ? selectedRef.current - 1 : selectedRef.current;
-      selectedRef.current = next;
-      setSelected(next);
-    } else if (key.downArrow) {
-      const next =
-        selectedRef.current < items.length - 1 ? selectedRef.current + 1 : selectedRef.current;
-      selectedRef.current = next;
-      setSelected(next);
-    } else if (key.return) {
-      doSelect(selectedRef.current);
+    const action = getVerticalSelectionInputAction(key);
+    if (action !== undefined) {
+      applyAction(action);
     }
   });
+
+  const normalizedState = normalizeSelectionState(state, { itemCount: items.length });
+  if (normalizedState !== state) {
+    stateRef.current = normalizedState;
+  }
+  const selected = normalizedState.selectedIndex;
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor="yellow" paddingX={1}>

--- a/packages/agent-cli/src/ui/PermissionPrompt.tsx
+++ b/packages/agent-cli/src/ui/PermissionPrompt.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { IPermissionRequest } from './types.js';
 import type { TToolArgs } from '@robota-sdk/agent-core';
+import {
+  applyPermissionPromptInput,
+  getPermissionPromptInputAction,
+  PERMISSION_PROMPT_OPTIONS,
+  type TPermissionPromptInputAction,
+} from './flows/permission-prompt-flow.js';
+import { createSelectionFlowState, type ISelectionFlowState } from './flows/selection-flow.js';
 
 interface IProps {
   request: IPermissionRequest;
 }
-
-const OPTIONS = ['Allow', 'Allow always (this session)', 'Deny'] as const;
 
 function formatArgs(args: TToolArgs): string {
   const entries = Object.entries(args);
@@ -18,42 +23,33 @@ function formatArgs(args: TToolArgs): string {
 }
 
 export default function PermissionPrompt({ request }: IProps): React.ReactElement {
-  const [selected, setSelected] = React.useState(0);
-  const resolvedRef = React.useRef(false);
+  const [state, setState] = React.useState<ISelectionFlowState>(() => createSelectionFlowState());
+  const stateRef = React.useRef(state);
   const prevRequestRef = React.useRef(request);
 
-  // Reset state when a new permission request comes in
   if (prevRequestRef.current !== request) {
     prevRequestRef.current = request;
-    resolvedRef.current = false;
-    setSelected(0);
+    const nextState = createSelectionFlowState();
+    stateRef.current = nextState;
+    setState(nextState);
   }
 
-  const doResolve = React.useCallback(
-    (index: number) => {
-      if (resolvedRef.current) return;
-      resolvedRef.current = true;
-      if (index === 0) request.resolve(true);
-      else if (index === 1) request.resolve('allow-session');
-      else request.resolve(false);
+  const applyAction = React.useCallback(
+    (action: TPermissionPromptInputAction): void => {
+      const result = applyPermissionPromptInput(stateRef.current, action);
+      stateRef.current = result.state;
+      setState(result.state);
+      if (result.effect.type === 'resolve') {
+        request.resolve(result.effect.decision);
+      }
     },
     [request],
   );
 
   useInput((input, key) => {
-    if (resolvedRef.current) return;
-    if (key.upArrow || key.leftArrow) {
-      setSelected((prev) => (prev > 0 ? prev - 1 : prev));
-    } else if (key.downArrow || key.rightArrow) {
-      setSelected((prev) => (prev < OPTIONS.length - 1 ? prev + 1 : prev));
-    } else if (key.return) {
-      doResolve(selected);
-    } else if (input === 'y' || input === '1') {
-      doResolve(0);
-    } else if (input === 'a' || input === '2') {
-      doResolve(1);
-    } else if (input === 'n' || input === 'd' || input === '3') {
-      doResolve(2);
+    const action = getPermissionPromptInputAction(input, key);
+    if (action !== undefined) {
+      applyAction(action);
     }
   });
 
@@ -70,10 +66,13 @@ export default function PermissionPrompt({ request }: IProps): React.ReactElemen
       </Text>
       <Text dimColor> {formatArgs(request.toolArgs)}</Text>
       <Box marginTop={1}>
-        {OPTIONS.map((opt, i) => (
+        {PERMISSION_PROMPT_OPTIONS.map((opt, i) => (
           <Box key={opt} marginRight={2}>
-            <Text color={i === selected ? 'cyan' : undefined} bold={i === selected}>
-              {i === selected ? '> ' : '  '}
+            <Text
+              color={i === state.selectedIndex ? 'cyan' : undefined}
+              bold={i === state.selectedIndex}
+            >
+              {i === state.selectedIndex ? '> ' : '  '}
               {opt}
             </Text>
           </Box>

--- a/packages/agent-cli/src/ui/TextPrompt.tsx
+++ b/packages/agent-cli/src/ui/TextPrompt.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
+import {
+  applyTextPromptInput,
+  createTextPromptFlowState,
+  getTextPromptInputAction,
+  type ITextPromptFlowState,
+  type TTextPromptInputAction,
+} from './flows/text-prompt-flow.js';
 
 interface IProps {
   title: string;
@@ -20,52 +27,26 @@ export default function TextPrompt({
   allowEmpty = false,
   masked = false,
 }: IProps): React.ReactElement {
-  const [value, setValue] = useState('');
-  const [error, setError] = useState<string | undefined>();
-  const resolvedRef = useRef(false);
-  const valueRef = useRef('');
-  const handleSubmit = useCallback(() => {
-    if (resolvedRef.current) return;
-    const trimmed = valueRef.current.trim();
-    if (!trimmed && !allowEmpty) {
-      const emptyError = validate?.(trimmed);
-      if (emptyError) {
-        setError(emptyError);
+  const [state, setState] = useState<ITextPromptFlowState>(() => createTextPromptFlowState());
+  const stateRef = useRef(state);
+  const applyAction = useCallback(
+    (action: TTextPromptInputAction): void => {
+      const result = applyTextPromptInput(stateRef.current, action, { allowEmpty, validate });
+      stateRef.current = result.state;
+      setState(result.state);
+      if (result.effect.type === 'cancel') {
+        onCancel();
+      } else if (result.effect.type === 'submit') {
+        onSubmit(result.effect.value);
       }
-      return;
-    }
-    if (validate) {
-      const err = validate(trimmed);
-      if (err) {
-        setError(err);
-        return;
-      }
-    }
-    resolvedRef.current = true;
-    onSubmit(trimmed);
-  }, [allowEmpty, validate, onSubmit]);
+    },
+    [allowEmpty, validate, onCancel, onSubmit],
+  );
 
   useInput((input, key) => {
-    if (resolvedRef.current) return;
-    if (key.escape) {
-      resolvedRef.current = true;
-      onCancel();
-      return;
-    }
-    if (key.return) {
-      handleSubmit();
-      return;
-    }
-    if (key.backspace || key.delete) {
-      valueRef.current = valueRef.current.slice(0, -1);
-      setValue(valueRef.current);
-      setError(undefined);
-      return;
-    }
-    if (input && !key.ctrl && !key.meta) {
-      valueRef.current = valueRef.current + input;
-      setValue(valueRef.current);
-      setError(undefined);
+    const action = getTextPromptInputAction(input, key);
+    if (action !== undefined) {
+      applyAction(action);
     }
   });
 
@@ -76,14 +57,14 @@ export default function TextPrompt({
       </Text>
       <Box marginTop={1}>
         <Text color="cyan">&gt; </Text>
-        {value ? (
-          <Text>{masked ? '*'.repeat(value.length) : value}</Text>
+        {state.value ? (
+          <Text>{masked ? '*'.repeat(state.value.length) : state.value}</Text>
         ) : placeholder ? (
           <Text dimColor>{placeholder}</Text>
         ) : null}
         <Text color="cyan">█</Text>
       </Box>
-      {error && <Text color="red">{error}</Text>}
+      {state.error && <Text color="red">{state.error}</Text>}
       <Text dimColor> Enter Submit Esc Cancel</Text>
     </Box>
   );

--- a/packages/agent-cli/src/ui/__tests__/cjk-text-input-flow.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/cjk-text-input-flow.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyCjkTextInput,
+  createCjkTextInputFlowState,
+  syncCjkTextInputFlowState,
+} from '../flows/cjk-text-input-flow.js';
+
+describe('cjk text input flow', () => {
+  it('Given printable input When applied Then value changes at cursor', () => {
+    const result = applyCjkTextInput(
+      createCjkTextInputFlowState('ab'),
+      'c',
+      {},
+      { canPaste: true },
+    );
+
+    expect(result.state).toMatchObject({ value: 'abc', cursor: 3 });
+    expect(result.effect).toEqual({ type: 'change', value: 'abc' });
+  });
+
+  it('Given cursor in middle When backspace is applied Then previous char is removed', () => {
+    const state = { ...createCjkTextInputFlowState('abc'), cursor: 2 };
+
+    const result = applyCjkTextInput(state, '', { backspace: true }, { canPaste: true });
+
+    expect(result.state).toMatchObject({ value: 'ac', cursor: 1 });
+    expect(result.effect).toEqual({ type: 'change', value: 'ac' });
+  });
+
+  it('Given return key When applied Then submit effect contains current value', () => {
+    const result = applyCjkTextInput(
+      createCjkTextInputFlowState('hello'),
+      '',
+      { return: true },
+      { canPaste: true },
+    );
+
+    expect(result.effect).toEqual({ type: 'submit', value: 'hello' });
+  });
+
+  it('Given multiline fallback paste When applied Then paste effect is emitted', () => {
+    const result = applyCjkTextInput(
+      createCjkTextInputFlowState(''),
+      'a\nb',
+      {},
+      { canPaste: true },
+    );
+
+    expect(result.effect).toEqual({ type: 'paste', text: 'a\nb', cursor: 0 });
+  });
+
+  it('Given bracketed multiline paste When end marker arrives Then buffered paste is emitted', () => {
+    const started = applyCjkTextInput(
+      createCjkTextInputFlowState('x'),
+      '[200~hello',
+      {},
+      { canPaste: true },
+    ).state;
+    const result = applyCjkTextInput(started, '\nworld[201~', {}, { canPaste: true });
+
+    expect(result.effect).toEqual({ type: 'paste', text: 'hello\nworld', cursor: 1 });
+    expect(result.state.isPasting).toBe(false);
+  });
+
+  it('Given external value update When synced Then cursor hint is honored', () => {
+    const state = createCjkTextInputFlowState('abc');
+
+    const result = syncCjkTextInputFlowState(state, 'a[Pasted]bc', 9);
+
+    expect(result).toMatchObject({ value: 'a[Pasted]bc', cursor: 9 });
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/cjk-text-input.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/cjk-text-input.test.ts
@@ -11,7 +11,7 @@ import {
   insertAtCursor,
   displayOffset,
   charIndexAtDisplayOffset,
-} from '../CjkTextInput.js';
+} from '../flows/cjk-text-input-flow.js';
 
 describe('filterPrintable', () => {
   it('returns empty string for null input', () => {

--- a/packages/agent-cli/src/ui/__tests__/confirm-permission-flow.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/confirm-permission-flow.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyConfirmPromptInput,
+  getConfirmPromptInputAction,
+} from '../flows/confirm-prompt-flow.js';
+import {
+  applyPermissionPromptInput,
+  getPermissionPromptInputAction,
+} from '../flows/permission-prompt-flow.js';
+import { createSelectionFlowState } from '../flows/selection-flow.js';
+
+describe('confirm prompt flow', () => {
+  it('Given two options When y shortcut is mapped and applied Then first option is selected', () => {
+    const action = getConfirmPromptInputAction('y', {}, 2);
+    expect(action).toEqual({ type: 'shortcut', index: 0 });
+
+    const result = applyConfirmPromptInput(createSelectionFlowState(), action!, 2);
+
+    expect(result.effect).toEqual({ type: 'select', index: 0 });
+  });
+
+  it('Given more than two options When y or n is typed Then shortcuts are ignored', () => {
+    expect(getConfirmPromptInputAction('y', {}, 3)).toBeUndefined();
+    expect(getConfirmPromptInputAction('n', {}, 3)).toBeUndefined();
+  });
+
+  it('Given selection moved right When enter is applied Then current option is selected', () => {
+    const moved = applyConfirmPromptInput(createSelectionFlowState(), 'next', 2).state;
+
+    const result = applyConfirmPromptInput(moved, 'select', 2);
+
+    expect(result.effect).toEqual({ type: 'select', index: 1 });
+  });
+
+  it('Given prompt is resolved When shortcut is applied Then no second selection is emitted', () => {
+    const selected = applyConfirmPromptInput(createSelectionFlowState(), 'select', 2).state;
+
+    const result = applyConfirmPromptInput(selected, { type: 'shortcut', index: 1 }, 2);
+
+    expect(result.effect).toEqual({ type: 'none' });
+  });
+});
+
+describe('permission prompt flow', () => {
+  it('Given y shortcut When applied Then allow decision is emitted', () => {
+    const action = getPermissionPromptInputAction('y', {});
+
+    const result = applyPermissionPromptInput(createSelectionFlowState(), action!);
+
+    expect(result.effect).toEqual({ type: 'resolve', decision: true });
+  });
+
+  it('Given a shortcut When applied Then allow-session decision is emitted', () => {
+    const action = getPermissionPromptInputAction('a', {});
+
+    const result = applyPermissionPromptInput(createSelectionFlowState(), action!);
+
+    expect(result.effect).toEqual({ type: 'resolve', decision: 'allow-session' });
+  });
+
+  it('Given deny shortcuts When applied Then false decision is emitted', () => {
+    expect(
+      applyPermissionPromptInput(
+        createSelectionFlowState(),
+        getPermissionPromptInputAction('n', {})!,
+      ).effect,
+    ).toEqual({ type: 'resolve', decision: false });
+    expect(
+      applyPermissionPromptInput(
+        createSelectionFlowState(),
+        getPermissionPromptInputAction('3', {})!,
+      ).effect,
+    ).toEqual({ type: 'resolve', decision: false });
+  });
+
+  it('Given arrow navigation When enter is applied Then selected permission is resolved', () => {
+    const moved = applyPermissionPromptInput(createSelectionFlowState(), 'next').state;
+
+    const result = applyPermissionPromptInput(moved, 'select');
+
+    expect(result.effect).toEqual({ type: 'resolve', decision: 'allow-session' });
+  });
+
+  it('Given permission is resolved When shortcut is applied Then no second decision is emitted', () => {
+    const resolved = applyPermissionPromptInput(createSelectionFlowState(), 'select').state;
+
+    const result = applyPermissionPromptInput(resolved, { type: 'shortcut', index: 2 });
+
+    expect(result.effect).toEqual({ type: 'none' });
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/fixtures/provider-setup-prompt-driver.tsx
+++ b/packages/agent-cli/src/ui/__tests__/fixtures/provider-setup-prompt-driver.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { writeFileSync } from 'node:fs';
+import { render, useApp } from 'ink';
+import ProviderSetupPrompt from '../../ProviderSetupPrompt.js';
+import type { TProviderSetupType } from '../../../utils/provider-setup-flow.js';
+
+const [, , outputPath, rawType] = process.argv;
+
+if (!outputPath || (rawType !== 'openai' && rawType !== 'anthropic')) {
+  process.stderr.write('Usage: provider-setup-prompt-driver <output-path> <openai|anthropic>\n');
+  process.exit(1);
+}
+
+function Driver({ type }: { type: TProviderSetupType }): React.ReactElement {
+  const { exit } = useApp();
+  return (
+    <ProviderSetupPrompt
+      type={type}
+      onSubmit={(input) => {
+        writeFileSync(outputPath, JSON.stringify(input), 'utf8');
+        exit();
+        setTimeout(() => process.exit(0), 0);
+      }}
+      onCancel={() => {
+        exit();
+        setTimeout(() => process.exit(2), 0);
+      }}
+    />
+  );
+}
+
+render(<Driver type={rawType} />);

--- a/packages/agent-cli/src/ui/__tests__/input-area-flow.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/input-area-flow.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPasteLabelChange,
+  getAutocompletePopupAction,
+  getPendingPromptInputAction,
+  moveAutocompleteSelection,
+  resolveEnterCommandSelection,
+  resolveTabCompletion,
+  shouldSubmitInput,
+} from '../flows/input-area-flow.js';
+import type { ISlashCommand } from '../../commands/types.js';
+
+const command = (name: string, subcommands?: ISlashCommand[]): ISlashCommand => ({
+  name,
+  description: `${name} command`,
+  source: 'test',
+  subcommands,
+  execute: async () => {},
+});
+
+describe('input area flow', () => {
+  it('Given autocomplete key info When mapped Then popup actions are produced', () => {
+    expect(getAutocompletePopupAction({ upArrow: true })).toBe('previous');
+    expect(getAutocompletePopupAction({ downArrow: true })).toBe('next');
+    expect(getAutocompletePopupAction({ escape: true })).toBe('close');
+    expect(getAutocompletePopupAction({ tab: true })).toBe('complete');
+  });
+
+  it('Given pending prompt key info When mapped Then cancel queue action is produced', () => {
+    expect(getPendingPromptInputAction({ backspace: true })).toBe('cancelQueue');
+    expect(getPendingPromptInputAction({ delete: true })).toBe('cancelQueue');
+    expect(getPendingPromptInputAction({ downArrow: true })).toBeUndefined();
+  });
+
+  it('Given wrapping autocomplete When moving beyond bounds Then index wraps', () => {
+    expect(moveAutocompleteSelection(0, 3, 'previous')).toBe(2);
+    expect(moveAutocompleteSelection(2, 3, 'next')).toBe(0);
+  });
+
+  it('Given parent command input When tab completes subcommand Then child name is inserted', () => {
+    const result = resolveTabCompletion('/plugin i', command('install'));
+
+    expect(result).toEqual({ type: 'insert', value: '/plugin install ' });
+  });
+
+  it('Given command with subcommands When enter selects it Then command name is inserted', () => {
+    const result = resolveEnterCommandSelection('/pl', command('plugin', [command('list')]));
+
+    expect(result).toEqual({ type: 'insert', value: '/plugin ', selectedIndex: 0 });
+  });
+
+  it('Given leaf command When enter selects it Then submit value is emitted', () => {
+    const result = resolveEnterCommandSelection('/he', command('help'));
+
+    expect(result).toEqual({ type: 'submit', value: '/help' });
+  });
+
+  it('Given multiline paste When label change is created Then label is inserted at cursor', () => {
+    const result = createPasteLabelChange('abef', 2, 7, 'c\nd\ne');
+
+    expect(result).toEqual({
+      value: 'ab[Pasted text #7 +3 lines]ef',
+      cursorHint: 27,
+      label: '[Pasted text #7 +3 lines]',
+      lineCount: 3,
+    });
+  });
+
+  it('Given blank prompt When checked Then submit is rejected', () => {
+    expect(shouldSubmitInput('   ')).toBe(false);
+    expect(shouldSubmitInput(' hello ')).toBe(true);
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/provider-setup-pty-e2e.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/provider-setup-pty-e2e.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as pty from '@homebridge/node-pty-prebuilt-multiarch';
+import {
+  DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+  DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_PROVIDER_MODELS,
+} from '../../utils/provider-settings.js';
+
+const DRIVER_PATH = fileURLToPath(
+  new URL('./fixtures/provider-setup-prompt-driver.tsx', import.meta.url),
+);
+const TEST_TIMEOUT_MS = 10000;
+const WAIT_TIMEOUT_MS = 5000;
+const INPUT_SETTLE_MS = 75;
+const OUTPUT_TAIL_LENGTH = 2000;
+
+interface IPtyHarness {
+  submit(input?: string): Promise<void>;
+  waitFor(text: string): Promise<void>;
+  waitForExit(): Promise<number>;
+  dispose(): void;
+}
+
+const tempDirs: string[] = [];
+const activeHarnesses: IPtyHarness[] = [];
+
+afterEach(() => {
+  for (const harness of activeHarnesses.splice(0)) {
+    harness.dispose();
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('ProviderSetupPrompt PTY E2E', () => {
+  it(
+    'submits OpenAI-compatible defaults through a real pseudo terminal',
+    async () => {
+      const { harness, outputPath } = spawnProviderSetupDriver('openai');
+
+      await harness.waitFor('OpenAI-compatible base URL');
+      await harness.submit();
+      await harness.waitFor('OpenAI-compatible model');
+      await harness.submit();
+      await harness.waitFor('OpenAI-compatible API key');
+      await harness.submit();
+
+      expect(await harness.waitForExit()).toBe(0);
+      harness.dispose();
+      expect(readResult(outputPath)).toEqual({
+        profile: 'openai',
+        type: 'openai',
+        baseURL: DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+        model: DEFAULT_PROVIDER_MODELS.openai,
+        apiKey: DEFAULT_OPENAI_COMPATIBLE_API_KEY,
+        setCurrent: true,
+      });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'submits Anthropic values typed through a real pseudo terminal',
+    async () => {
+      const { harness, outputPath } = spawnProviderSetupDriver('anthropic');
+
+      await harness.waitFor('Anthropic API key');
+      await harness.submit('sk-test');
+      await harness.waitFor('Anthropic model');
+      await harness.submit('claude-test');
+
+      expect(await harness.waitForExit()).toBe(0);
+      harness.dispose();
+      expect(readResult(outputPath)).toEqual({
+        profile: 'anthropic',
+        type: 'anthropic',
+        model: 'claude-test',
+        apiKey: 'sk-test',
+        setCurrent: true,
+      });
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+function spawnProviderSetupDriver(type: 'openai' | 'anthropic'): {
+  harness: IPtyHarness;
+  outputPath: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'robota-provider-pty-'));
+  tempDirs.push(dir);
+  const outputPath = join(dir, 'result.json');
+  const proc = pty.spawn(process.execPath, ['--import', 'tsx', DRIVER_PATH, outputPath, type], {
+    cols: 120,
+    rows: 40,
+    cwd: fileURLToPath(new URL('../../../../..', import.meta.url)),
+    env: createPtyEnv(),
+  });
+  const harness = createHarness(proc);
+  activeHarnesses.push(harness);
+  return { harness, outputPath };
+}
+
+function createHarness(proc: pty.IPty): IPtyHarness {
+  let output = '';
+  let exitCode: number | undefined;
+  const waiters: Array<() => void> = [];
+
+  proc.onData((data) => {
+    output += data;
+    notifyWaiters(waiters);
+  });
+  proc.onExit((event) => {
+    exitCode = event.exitCode;
+    notifyWaiters(waiters);
+  });
+
+  return {
+    async submit(input = '') {
+      await sleep(INPUT_SETTLE_MS);
+      if (input) {
+        proc.write(input);
+        await sleep(INPUT_SETTLE_MS);
+      }
+      proc.write('\r');
+    },
+    waitFor(text: string) {
+      return waitUntil(
+        () => output.includes(text),
+        waiters,
+        () => {
+          return new Error(`Timed out waiting for "${text}". Output:\n${tail(output)}`);
+        },
+      );
+    },
+    waitForExit() {
+      return waitUntil(
+        () => exitCode !== undefined,
+        waiters,
+        () => {
+          return new Error(`Timed out waiting for PTY exit. Output:\n${tail(output)}`);
+        },
+      ).then(() => exitCode ?? -1);
+    },
+    dispose() {
+      if (exitCode === undefined) {
+        proc.kill();
+      }
+    },
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function createPtyEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    FORCE_COLOR: '0',
+    TERM: 'xterm-256color',
+  };
+  delete env.CI;
+  return env;
+}
+
+function waitUntil(
+  predicate: () => boolean,
+  waiters: Array<() => void>,
+  createTimeoutError: () => Error,
+): Promise<void> {
+  if (predicate()) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const removeWaiter = (waiter: () => void): void => {
+      const index = waiters.indexOf(waiter);
+      if (index >= 0) {
+        waiters.splice(index, 1);
+      }
+    };
+    const check = () => {
+      if (settled) {
+        return;
+      }
+      if (!predicate()) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      removeWaiter(check);
+      resolve();
+    };
+    const deadline = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      removeWaiter(check);
+      reject(createTimeoutError());
+    }, WAIT_TIMEOUT_MS);
+    waiters.push(check);
+  });
+}
+
+function notifyWaiters(waiters: Array<() => void>): void {
+  for (const waiter of [...waiters]) {
+    waiter();
+  }
+}
+
+function readResult(outputPath: string): Record<string, string | boolean> {
+  expect(existsSync(outputPath)).toBe(true);
+  return JSON.parse(readFileSync(outputPath, 'utf8')) as Record<string, string | boolean>;
+}
+
+function tail(output: string): string {
+  return output.slice(-OUTPUT_TAIL_LENGTH);
+}

--- a/packages/agent-cli/src/ui/__tests__/selection-flow.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/selection-flow.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySelectionInput,
+  createSelectionFlowState,
+  getDirectionalSelectionInputAction,
+  getVerticalSelectionInputAction,
+} from '../flows/selection-flow.js';
+
+describe('selection flow', () => {
+  it('Given first item selected When previous is applied Then selection stays bounded', () => {
+    const result = applySelectionInput(createSelectionFlowState(), 'previous', { itemCount: 3 });
+
+    expect(result.state.selectedIndex).toBe(0);
+    expect(result.effect).toEqual({ type: 'none' });
+  });
+
+  it('Given last item selected When next is applied Then selection stays bounded', () => {
+    const state = { selectedIndex: 2, scrollOffset: 0, resolved: false };
+
+    const result = applySelectionInput(state, 'next', { itemCount: 3 });
+
+    expect(result.state.selectedIndex).toBe(2);
+  });
+
+  it('Given wrapping selection When previous from first is applied Then it wraps to last', () => {
+    const result = applySelectionInput(createSelectionFlowState(), 'previous', {
+      itemCount: 3,
+      wrap: true,
+    });
+
+    expect(result.state.selectedIndex).toBe(2);
+  });
+
+  it('Given max visible window When moving below viewport Then scroll offset follows', () => {
+    const state = applySelectionInput(createSelectionFlowState(), 'next', {
+      itemCount: 4,
+      maxVisible: 2,
+    }).state;
+
+    const result = applySelectionInput(state, 'next', { itemCount: 4, maxVisible: 2 });
+
+    expect(result.state).toMatchObject({ selectedIndex: 2, scrollOffset: 1 });
+  });
+
+  it('Given selected item When select is applied Then selected index is emitted once', () => {
+    const state = { selectedIndex: 1, scrollOffset: 0, resolved: false };
+
+    const selected = applySelectionInput(state, 'select', { itemCount: 3 });
+    const ignored = applySelectionInput(selected.state, 'select', { itemCount: 3 });
+
+    expect(selected.effect).toEqual({ type: 'select', index: 1 });
+    expect(ignored.effect).toEqual({ type: 'none' });
+  });
+
+  it('Given raw key info When mapped Then vertical and directional actions are produced', () => {
+    expect(getVerticalSelectionInputAction({ downArrow: true })).toBe('next');
+    expect(getVerticalSelectionInputAction({ escape: true })).toBe('cancel');
+    expect(getDirectionalSelectionInputAction({ leftArrow: true })).toBe('previous');
+    expect(getDirectionalSelectionInputAction({ rightArrow: true })).toBe('next');
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/text-prompt-flow.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/text-prompt-flow.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyTextPromptInput,
+  createTextPromptFlowState,
+  getTextPromptInputAction,
+  type ITextPromptFlowState,
+} from '../flows/text-prompt-flow.js';
+
+describe('text prompt flow', () => {
+  it('Given typed text When submit is applied Then it emits trimmed submit value', () => {
+    const typed = applyTextPromptInput(
+      createTextPromptFlowState(),
+      { type: 'insert', value: '  hello  ' },
+      { allowEmpty: false },
+    ).state;
+
+    const result = applyTextPromptInput(typed, { type: 'submit' }, { allowEmpty: false });
+
+    expect(result.effect).toEqual({ type: 'submit', value: 'hello' });
+    expect(result.state.resolved).toBe(true);
+  });
+
+  it('Given empty required text When submit is applied Then validation error stays in state', () => {
+    const result = applyTextPromptInput(
+      createTextPromptFlowState(),
+      { type: 'submit' },
+      { allowEmpty: false, validate: (value) => (value.length === 0 ? 'Required' : undefined) },
+    );
+
+    expect(result.effect).toEqual({ type: 'none' });
+    expect(result.state.error).toBe('Required');
+    expect(result.state.resolved).toBe(false);
+  });
+
+  it('Given defaultable empty text When submit is applied Then empty submit is allowed', () => {
+    const result = applyTextPromptInput(
+      createTextPromptFlowState(),
+      { type: 'submit' },
+      { allowEmpty: true },
+    );
+
+    expect(result.effect).toEqual({ type: 'submit', value: '' });
+  });
+
+  it('Given text with an error When delete or insert is applied Then the error is cleared', () => {
+    const state: ITextPromptFlowState = { value: 'ab', error: 'Invalid', resolved: false };
+
+    const deleted = applyTextPromptInput(state, { type: 'delete' }, { allowEmpty: false });
+    const inserted = applyTextPromptInput(
+      state,
+      { type: 'insert', value: 'c' },
+      { allowEmpty: false },
+    );
+
+    expect(deleted.state).toMatchObject({ value: 'a', error: undefined });
+    expect(inserted.state).toMatchObject({ value: 'abc', error: undefined });
+  });
+
+  it('Given prompt is already resolved When input is applied Then no second effect is emitted', () => {
+    const state: ITextPromptFlowState = { value: 'done', resolved: true };
+
+    const result = applyTextPromptInput(state, { type: 'submit' }, { allowEmpty: false });
+
+    expect(result.effect).toEqual({ type: 'none' });
+    expect(result.state).toBe(state);
+  });
+
+  it('Given raw Ink key info When mapped Then terminal details become prompt actions', () => {
+    expect(getTextPromptInputAction('', { escape: true })).toEqual({ type: 'cancel' });
+    expect(getTextPromptInputAction('', { return: true })).toEqual({ type: 'submit' });
+    expect(getTextPromptInputAction('', { backspace: true })).toEqual({ type: 'delete' });
+    expect(getTextPromptInputAction('x', { ctrl: false, meta: false })).toEqual({
+      type: 'insert',
+      value: 'x',
+    });
+  });
+});

--- a/packages/agent-cli/src/ui/flows/cjk-text-input-flow.ts
+++ b/packages/agent-cli/src/ui/flows/cjk-text-input-flow.ts
@@ -1,0 +1,269 @@
+import stringWidth from 'string-width';
+
+const PASTE_START = '[200~';
+const PASTE_END = '[201~';
+const LAST_ASCII_CONTROL_CODE = 0x1f;
+const DELETE_CONTROL_CODE = 0x7f;
+
+export interface ICjkTextInputFlowState {
+  value: string;
+  cursor: number;
+  isPasting: boolean;
+  pasteBuffer: string;
+}
+
+export interface ICjkTextInputKey {
+  ctrl?: boolean;
+  tab?: boolean;
+  shift?: boolean;
+  upArrow?: boolean;
+  downArrow?: boolean;
+  return?: boolean;
+  leftArrow?: boolean;
+  rightArrow?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+}
+
+export interface ICjkTextInputFlowOptions {
+  availableWidth?: number;
+  canPaste: boolean;
+}
+
+export type TCjkTextInputEffect =
+  | { type: 'none' }
+  | { type: 'change'; value: string }
+  | { type: 'submit'; value: string }
+  | { type: 'paste'; text: string; cursor: number }
+  | { type: 'render' };
+
+interface ICjkTextInputFlowResult {
+  state: ICjkTextInputFlowState;
+  effect: TCjkTextInputEffect;
+}
+
+export function createCjkTextInputFlowState(value: string): ICjkTextInputFlowState {
+  return { value, cursor: value.length, isPasting: false, pasteBuffer: '' };
+}
+
+export function syncCjkTextInputFlowState(
+  state: ICjkTextInputFlowState,
+  value: string,
+  cursorHint: number | null,
+): ICjkTextInputFlowState {
+  if (value === state.value) {
+    return state;
+  }
+  return {
+    ...state,
+    value,
+    cursor: cursorHint != null ? Math.min(cursorHint, value.length) : value.length,
+  };
+}
+
+export function applyCjkTextInput(
+  state: ICjkTextInputFlowState,
+  input: string,
+  key: ICjkTextInputKey,
+  options: ICjkTextInputFlowOptions,
+): ICjkTextInputFlowResult {
+  const pasteResult = applyPasteBoundaryInput(state, input, options);
+  if (pasteResult !== undefined) return pasteResult;
+  const controlResult = applyControlInput(state, input, key, options);
+  if (controlResult !== undefined) return controlResult;
+  const cursorResult = applyCursorInput(state, key, options.availableWidth);
+  if (cursorResult !== undefined) return cursorResult;
+  return insertPrintableInput(state, input);
+}
+
+function applyPasteBoundaryInput(
+  state: ICjkTextInputFlowState,
+  input: string,
+  options: ICjkTextInputFlowOptions,
+): ICjkTextInputFlowResult | undefined {
+  if (input === PASTE_START || input.startsWith(PASTE_START)) {
+    return startBracketedPaste(state, input);
+  }
+  if (state.isPasting) {
+    return continueBracketedPaste(state, input, options);
+  }
+  return undefined;
+}
+
+function applyControlInput(
+  state: ICjkTextInputFlowState,
+  input: string,
+  key: ICjkTextInputKey,
+  options: ICjkTextInputFlowOptions,
+): ICjkTextInputFlowResult | undefined {
+  if ((key.ctrl === true && input === 'c') || key.tab === true) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (key.return === true) {
+    return { state, effect: { type: 'submit', value: state.value } };
+  }
+  if (input.length > 1 && (input.includes('\n') || input.includes('\r')) && options.canPaste) {
+    return {
+      state,
+      effect: { type: 'paste', text: input.replace(/\r\n?/g, '\n'), cursor: state.cursor },
+    };
+  }
+  return undefined;
+}
+
+function applyCursorInput(
+  state: ICjkTextInputFlowState,
+  key: ICjkTextInputKey,
+  availableWidth: number | undefined,
+): ICjkTextInputFlowResult | undefined {
+  if (key.upArrow === true || key.downArrow === true) {
+    return moveCursorVertically(state, key.upArrow === true ? 'up' : 'down', availableWidth);
+  }
+  if (key.leftArrow === true) {
+    return moveCursorHorizontally(state, 'left');
+  }
+  if (key.rightArrow === true) {
+    return moveCursorHorizontally(state, 'right');
+  }
+  if (key.backspace === true || key.delete === true) {
+    return deleteBeforeCursor(state);
+  }
+  return undefined;
+}
+
+export function filterPrintable(input: string | null | undefined): string {
+  if (!input || input.length === 0) return '';
+  let output = '';
+  for (const char of input) {
+    const code = char.charCodeAt(0);
+    if (code > LAST_ASCII_CONTROL_CODE && code !== DELETE_CONTROL_CODE) {
+      output += char;
+    }
+  }
+  return output;
+}
+
+export function insertAtCursor(
+  value: string,
+  cursor: number,
+  input: string,
+): { value: string; cursor: number } {
+  const next = value.slice(0, cursor) + input + value.slice(cursor);
+  return { value: next, cursor: cursor + input.length };
+}
+
+export function displayOffset(chars: string[], charIndex: number, width: number): number {
+  let offset = 0;
+  for (let i = 0; i < charIndex && i < chars.length; i++) {
+    const w = stringWidth(chars[i]!);
+    const col = offset % width;
+    if (col + w > width) offset += width - col;
+    offset += w;
+  }
+  return offset;
+}
+
+export function charIndexAtDisplayOffset(chars: string[], target: number, width: number): number {
+  let offset = 0;
+  for (let i = 0; i < chars.length; i++) {
+    if (offset >= target) return i;
+    const w = stringWidth(chars[i]!);
+    const col = offset % width;
+    if (col + w > width) offset += width - col;
+    offset += w;
+  }
+  return chars.length;
+}
+
+function startBracketedPaste(
+  state: ICjkTextInputFlowState,
+  input: string,
+): ICjkTextInputFlowResult {
+  return {
+    state: { ...state, isPasting: true, pasteBuffer: input.slice(PASTE_START.length) },
+    effect: { type: 'none' },
+  };
+}
+
+function continueBracketedPaste(
+  state: ICjkTextInputFlowState,
+  input: string,
+  options: ICjkTextInputFlowOptions,
+): ICjkTextInputFlowResult {
+  if (input !== PASTE_END && !input.includes(PASTE_END)) {
+    return {
+      state: { ...state, pasteBuffer: state.pasteBuffer + input },
+      effect: { type: 'none' },
+    };
+  }
+  const beforeMarker = input.split(PASTE_END)[0] ?? '';
+  const text = (state.pasteBuffer + beforeMarker).replace(/\r\n?/g, '\n');
+  const nextState = { ...state, isPasting: false, pasteBuffer: '' };
+  if (text.length === 0) {
+    return { state: nextState, effect: { type: 'none' } };
+  }
+  if (text.includes('\n') && options.canPaste) {
+    return { state: nextState, effect: { type: 'paste', text, cursor: state.cursor } };
+  }
+  return insertPrintableInput(nextState, text);
+}
+
+function moveCursorVertically(
+  state: ICjkTextInputFlowState,
+  direction: 'up' | 'down',
+  availableWidth: number | undefined,
+): ICjkTextInputFlowResult {
+  if (!availableWidth || availableWidth <= 0) {
+    return { state, effect: { type: 'none' } };
+  }
+  const chars = [...state.value];
+  const offset = displayOffset(chars, state.cursor, availableWidth);
+  const target = direction === 'up' ? offset - availableWidth : offset + availableWidth;
+  if (target < 0) {
+    return { state, effect: { type: 'none' } };
+  }
+  const cursor = charIndexAtDisplayOffset(chars, target, availableWidth);
+  if (cursor === state.cursor) {
+    return { state, effect: { type: 'none' } };
+  }
+  return { state: { ...state, cursor }, effect: { type: 'render' } };
+}
+
+function moveCursorHorizontally(
+  state: ICjkTextInputFlowState,
+  direction: 'left' | 'right',
+): ICjkTextInputFlowResult {
+  if (direction === 'left' && state.cursor > 0) {
+    return { state: { ...state, cursor: state.cursor - 1 }, effect: { type: 'render' } };
+  }
+  if (direction === 'right' && state.cursor < state.value.length) {
+    return { state: { ...state, cursor: state.cursor + 1 }, effect: { type: 'render' } };
+  }
+  return { state, effect: { type: 'none' } };
+}
+
+function deleteBeforeCursor(state: ICjkTextInputFlowState): ICjkTextInputFlowResult {
+  if (state.cursor === 0) {
+    return { state, effect: { type: 'none' } };
+  }
+  const value = state.value.slice(0, state.cursor - 1) + state.value.slice(state.cursor);
+  return {
+    state: { ...state, value, cursor: state.cursor - 1 },
+    effect: { type: 'change', value },
+  };
+}
+
+function insertPrintableInput(
+  state: ICjkTextInputFlowState,
+  input: string,
+): ICjkTextInputFlowResult {
+  const printable = filterPrintable(input);
+  if (printable.length === 0) {
+    return { state, effect: { type: 'none' } };
+  }
+  const result = insertAtCursor(state.value, state.cursor, printable);
+  return {
+    state: { ...state, value: result.value, cursor: result.cursor },
+    effect: { type: 'change', value: result.value },
+  };
+}

--- a/packages/agent-cli/src/ui/flows/confirm-prompt-flow.ts
+++ b/packages/agent-cli/src/ui/flows/confirm-prompt-flow.ts
@@ -1,0 +1,45 @@
+import {
+  applySelectionInput,
+  getDirectionalSelectionInputAction,
+  type ISelectionFlowState,
+  type ISelectionInputKey,
+  type TSelectionEffect,
+  type TSelectionInputAction,
+} from './selection-flow.js';
+
+export type TConfirmPromptInputAction = TSelectionInputAction | { type: 'shortcut'; index: number };
+
+export function getConfirmPromptInputAction(
+  input: string,
+  key: ISelectionInputKey,
+  optionCount: number,
+): TConfirmPromptInputAction | undefined {
+  const action = getDirectionalSelectionInputAction({ ...key, escape: false });
+  if (action !== undefined) {
+    return action;
+  }
+  if (optionCount === 2 && input === 'y') {
+    return { type: 'shortcut', index: 0 };
+  }
+  if (optionCount === 2 && input === 'n') {
+    return { type: 'shortcut', index: 1 };
+  }
+  return undefined;
+}
+
+export function applyConfirmPromptInput(
+  state: ISelectionFlowState,
+  action: TConfirmPromptInputAction,
+  optionCount: number,
+): { state: ISelectionFlowState; effect: TSelectionEffect } {
+  if (state.resolved) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (typeof action !== 'string') {
+    return {
+      state: { ...state, selectedIndex: action.index, resolved: true },
+      effect: { type: 'select', index: action.index },
+    };
+  }
+  return applySelectionInput(state, action, { itemCount: optionCount });
+}

--- a/packages/agent-cli/src/ui/flows/input-area-flow.ts
+++ b/packages/agent-cli/src/ui/flows/input-area-flow.ts
@@ -1,0 +1,104 @@
+import type { ISlashCommand } from '../../commands/types.js';
+import { parseSlashInput } from '../hooks/useAutocomplete.js';
+
+export interface IAutocompleteInputKey {
+  upArrow?: boolean;
+  downArrow?: boolean;
+  escape?: boolean;
+  tab?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+}
+
+export type TAutocompletePopupAction = 'previous' | 'next' | 'close' | 'complete';
+export type TPendingPromptInputAction = 'cancelQueue';
+
+export type TCommandSelectionResult =
+  | { type: 'insert'; value: string; selectedIndex?: number }
+  | { type: 'submit'; value: string };
+
+export interface IPasteLabelChange {
+  value: string;
+  cursorHint: number;
+  label: string;
+  lineCount: number;
+}
+
+export function getAutocompletePopupAction(
+  key: IAutocompleteInputKey,
+): TAutocompletePopupAction | undefined {
+  if (key.upArrow === true) return 'previous';
+  if (key.downArrow === true) return 'next';
+  if (key.escape === true) return 'close';
+  if (key.tab === true) return 'complete';
+  return undefined;
+}
+
+export function getPendingPromptInputAction(
+  key: IAutocompleteInputKey,
+): TPendingPromptInputAction | undefined {
+  if (key.backspace === true || key.delete === true) {
+    return 'cancelQueue';
+  }
+  return undefined;
+}
+
+export function moveAutocompleteSelection(
+  selectedIndex: number,
+  commandCount: number,
+  direction: 'previous' | 'next',
+): number {
+  if (commandCount === 0) return 0;
+  if (direction === 'previous') {
+    return selectedIndex > 0 ? selectedIndex - 1 : commandCount - 1;
+  }
+  return selectedIndex < commandCount - 1 ? selectedIndex + 1 : 0;
+}
+
+export function resolveTabCompletion(
+  value: string,
+  command: ISlashCommand,
+): TCommandSelectionResult {
+  const parsed = parseSlashInput(value);
+  if (parsed.parentCommand) {
+    return { type: 'insert', value: `/${parsed.parentCommand} ${command.name} ` };
+  }
+  if (command.subcommands && command.subcommands.length > 0) {
+    return { type: 'insert', value: `/${command.name} `, selectedIndex: 0 };
+  }
+  return { type: 'insert', value: `/${command.name} ` };
+}
+
+export function resolveEnterCommandSelection(
+  value: string,
+  command: ISlashCommand,
+): TCommandSelectionResult {
+  const parsed = parseSlashInput(value);
+  if (parsed.parentCommand) {
+    return { type: 'submit', value: `/${parsed.parentCommand} ${command.name}` };
+  }
+  if (command.subcommands && command.subcommands.length > 0) {
+    return { type: 'insert', value: `/${command.name} `, selectedIndex: 0 };
+  }
+  return { type: 'submit', value: `/${command.name}` };
+}
+
+export function createPasteLabelChange(
+  value: string,
+  cursorPosition: number,
+  pasteId: number,
+  text: string,
+): IPasteLabelChange {
+  const lineCount = text.split('\n').length;
+  const label = `[Pasted text #${pasteId} +${lineCount} lines]`;
+  return {
+    value: value.slice(0, cursorPosition) + label + value.slice(cursorPosition),
+    cursorHint: cursorPosition + label.length,
+    label,
+    lineCount,
+  };
+}
+
+export function shouldSubmitInput(text: string): boolean {
+  return text.trim().length > 0;
+}

--- a/packages/agent-cli/src/ui/flows/permission-prompt-flow.ts
+++ b/packages/agent-cli/src/ui/flows/permission-prompt-flow.ts
@@ -1,0 +1,76 @@
+import {
+  applySelectionInput,
+  getDirectionalSelectionInputAction,
+  type ISelectionFlowState,
+  type ISelectionInputKey,
+  type TSelectionInputAction,
+} from './selection-flow.js';
+
+export const PERMISSION_PROMPT_OPTIONS = ['Allow', 'Allow always (this session)', 'Deny'] as const;
+
+export type TPermissionPromptDecision = true | 'allow-session' | false;
+export type TPermissionPromptInputAction =
+  | TSelectionInputAction
+  | { type: 'shortcut'; index: number };
+
+export type TPermissionPromptEffect =
+  | { type: 'none' }
+  | { type: 'resolve'; decision: TPermissionPromptDecision };
+
+export function getPermissionPromptInputAction(
+  input: string,
+  key: ISelectionInputKey,
+): TPermissionPromptInputAction | undefined {
+  const action = getDirectionalSelectionInputAction({ ...key, escape: false });
+  if (action !== undefined) {
+    return action;
+  }
+  if (input === 'y' || input === '1') {
+    return { type: 'shortcut', index: 0 };
+  }
+  if (input === 'a' || input === '2') {
+    return { type: 'shortcut', index: 1 };
+  }
+  if (input === 'n' || input === 'd' || input === '3') {
+    return { type: 'shortcut', index: 2 };
+  }
+  return undefined;
+}
+
+export function applyPermissionPromptInput(
+  state: ISelectionFlowState,
+  action: TPermissionPromptInputAction,
+): { state: ISelectionFlowState; effect: TPermissionPromptEffect } {
+  if (state.resolved) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (typeof action !== 'string') {
+    return resolvePermissionIndex(state, action.index);
+  }
+  const result = applySelectionInput(state, action, {
+    itemCount: PERMISSION_PROMPT_OPTIONS.length,
+  });
+  if (result.effect.type !== 'select') {
+    return { state: result.state, effect: { type: 'none' } };
+  }
+  return {
+    state: result.state,
+    effect: { type: 'resolve', decision: getPermissionDecision(result.effect.index) },
+  };
+}
+
+export function getPermissionDecision(index: number): TPermissionPromptDecision {
+  if (index === 0) return true;
+  if (index === 1) return 'allow-session';
+  return false;
+}
+
+function resolvePermissionIndex(
+  state: ISelectionFlowState,
+  index: number,
+): { state: ISelectionFlowState; effect: TPermissionPromptEffect } {
+  return {
+    state: { ...state, selectedIndex: index, resolved: true },
+    effect: { type: 'resolve', decision: getPermissionDecision(index) },
+  };
+}

--- a/packages/agent-cli/src/ui/flows/selection-flow.ts
+++ b/packages/agent-cli/src/ui/flows/selection-flow.ts
@@ -1,0 +1,126 @@
+export interface ISelectionFlowState {
+  selectedIndex: number;
+  scrollOffset: number;
+  resolved: boolean;
+}
+
+export interface ISelectionInputKey {
+  escape?: boolean;
+  return?: boolean;
+  upArrow?: boolean;
+  downArrow?: boolean;
+  leftArrow?: boolean;
+  rightArrow?: boolean;
+}
+
+export type TSelectionInputAction = 'cancel' | 'select' | 'previous' | 'next';
+
+export type TSelectionEffect =
+  | { type: 'none' }
+  | { type: 'cancel' }
+  | { type: 'select'; index: number };
+
+export interface ISelectionFlowOptions {
+  itemCount: number;
+  maxVisible?: number;
+  wrap?: boolean;
+  enabled?: boolean;
+}
+
+export function createSelectionFlowState(): ISelectionFlowState {
+  return { selectedIndex: 0, scrollOffset: 0, resolved: false };
+}
+
+export function getVerticalSelectionInputAction(
+  key: ISelectionInputKey,
+): TSelectionInputAction | undefined {
+  if (key.escape === true) return 'cancel';
+  if (key.upArrow === true) return 'previous';
+  if (key.downArrow === true) return 'next';
+  if (key.return === true) return 'select';
+  return undefined;
+}
+
+export function getDirectionalSelectionInputAction(
+  key: ISelectionInputKey,
+): TSelectionInputAction | undefined {
+  if (key.escape === true) return 'cancel';
+  if (key.leftArrow === true || key.upArrow === true) return 'previous';
+  if (key.rightArrow === true || key.downArrow === true) return 'next';
+  if (key.return === true) return 'select';
+  return undefined;
+}
+
+export function applySelectionInput(
+  state: ISelectionFlowState,
+  action: TSelectionInputAction,
+  options: ISelectionFlowOptions,
+): { state: ISelectionFlowState; effect: TSelectionEffect } {
+  if (state.resolved) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (action === 'cancel') {
+    return { state: { ...state, resolved: true }, effect: { type: 'cancel' } };
+  }
+  if (options.enabled === false || options.itemCount === 0) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (action === 'select') {
+    const index = clampIndex(state.selectedIndex, options.itemCount);
+    return {
+      state: { ...state, selectedIndex: index, resolved: true },
+      effect: { type: 'select', index },
+    };
+  }
+  const selectedIndex = moveSelection(state.selectedIndex, action, options);
+  const scrollOffset = resolveScrollOffset(selectedIndex, state.scrollOffset, options);
+  return { state: { ...state, selectedIndex, scrollOffset }, effect: { type: 'none' } };
+}
+
+export function normalizeSelectionState(
+  state: ISelectionFlowState,
+  options: ISelectionFlowOptions,
+): ISelectionFlowState {
+  if (options.itemCount === 0) {
+    return { ...state, selectedIndex: 0, scrollOffset: 0 };
+  }
+  const selectedIndex = clampIndex(state.selectedIndex, options.itemCount);
+  const scrollOffset = resolveScrollOffset(selectedIndex, state.scrollOffset, options);
+  if (selectedIndex === state.selectedIndex && scrollOffset === state.scrollOffset) {
+    return state;
+  }
+  return {
+    ...state,
+    selectedIndex,
+    scrollOffset,
+  };
+}
+
+function moveSelection(
+  selectedIndex: number,
+  action: TSelectionInputAction,
+  options: ISelectionFlowOptions,
+): number {
+  if (action === 'previous') {
+    if (options.wrap === true && selectedIndex === 0) return options.itemCount - 1;
+    return Math.max(0, selectedIndex - 1);
+  }
+  if (options.wrap === true && selectedIndex === options.itemCount - 1) return 0;
+  return Math.min(options.itemCount - 1, selectedIndex + 1);
+}
+
+function resolveScrollOffset(
+  selectedIndex: number,
+  scrollOffset: number,
+  options: ISelectionFlowOptions,
+): number {
+  const maxVisible = options.maxVisible ?? options.itemCount;
+  if (maxVisible <= 0) return 0;
+  if (selectedIndex < scrollOffset) return selectedIndex;
+  if (selectedIndex >= scrollOffset + maxVisible) return selectedIndex - maxVisible + 1;
+  return Math.max(0, scrollOffset);
+}
+
+function clampIndex(index: number, itemCount: number): number {
+  return Math.min(Math.max(index, 0), itemCount - 1);
+}

--- a/packages/agent-cli/src/ui/flows/text-prompt-flow.ts
+++ b/packages/agent-cli/src/ui/flows/text-prompt-flow.ts
@@ -1,0 +1,98 @@
+export interface ITextPromptFlowState {
+  value: string;
+  error?: string;
+  resolved: boolean;
+}
+
+export interface ITextPromptInputKey {
+  escape?: boolean;
+  return?: boolean;
+  backspace?: boolean;
+  delete?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+}
+
+export type TTextPromptInputAction =
+  | { type: 'cancel' }
+  | { type: 'submit' }
+  | { type: 'delete' }
+  | { type: 'insert'; value: string };
+
+export type TTextPromptEffect =
+  | { type: 'none' }
+  | { type: 'cancel' }
+  | { type: 'submit'; value: string };
+
+export interface ITextPromptFlowOptions {
+  allowEmpty: boolean;
+  validate?: (value: string) => string | undefined;
+}
+
+export function createTextPromptFlowState(): ITextPromptFlowState {
+  return { value: '', resolved: false };
+}
+
+export function getTextPromptInputAction(
+  input: string,
+  key: ITextPromptInputKey,
+): TTextPromptInputAction | undefined {
+  if (key.escape === true) {
+    return { type: 'cancel' };
+  }
+  if (key.return === true) {
+    return { type: 'submit' };
+  }
+  if (key.backspace === true || key.delete === true) {
+    return { type: 'delete' };
+  }
+  if (input && key.ctrl !== true && key.meta !== true) {
+    return { type: 'insert', value: input };
+  }
+  return undefined;
+}
+
+export function applyTextPromptInput(
+  state: ITextPromptFlowState,
+  action: TTextPromptInputAction,
+  options: ITextPromptFlowOptions,
+): { state: ITextPromptFlowState; effect: TTextPromptEffect } {
+  if (state.resolved) {
+    return { state, effect: { type: 'none' } };
+  }
+  if (action.type === 'cancel') {
+    return { state: { ...state, resolved: true }, effect: { type: 'cancel' } };
+  }
+  if (action.type === 'delete') {
+    return {
+      state: { ...state, value: state.value.slice(0, -1), error: undefined },
+      effect: { type: 'none' },
+    };
+  }
+  if (action.type === 'insert') {
+    return {
+      state: { ...state, value: state.value + action.value, error: undefined },
+      effect: { type: 'none' },
+    };
+  }
+  return submitTextPromptValue(state, options);
+}
+
+function submitTextPromptValue(
+  state: ITextPromptFlowState,
+  options: ITextPromptFlowOptions,
+): { state: ITextPromptFlowState; effect: TTextPromptEffect } {
+  const trimmed = state.value.trim();
+  if (!trimmed && !options.allowEmpty) {
+    const emptyError = options.validate?.(trimmed);
+    return {
+      state: emptyError ? { ...state, error: emptyError } : state,
+      effect: { type: 'none' },
+    };
+  }
+  const error = options.validate?.(trimmed);
+  if (error !== undefined) {
+    return { state: { ...state, error }, effect: { type: 'none' } };
+  }
+  return { state: { ...state, resolved: true }, effect: { type: 'submit', value: trimmed } };
+}

--- a/packages/agent-cli/src/utils/__tests__/paste-detection.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/paste-detection.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { filterPrintable } from '../../ui/CjkTextInput.js';
+import { filterPrintable } from '../../ui/flows/cjk-text-input-flow.js';
 import { expandPasteLabels } from '../paste-labels.js';
 
 describe('filterPrintable and newlines', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,9 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
     devDependencies:
+      '@homebridge/node-pty-prebuilt-multiarch':
+        specifier: ^0.13.1
+        version: 0.13.1
       '@types/marked':
         specifier: ^6.0.0
         version: 6.0.0
@@ -4559,6 +4562,18 @@ packages:
       yargs: 17.7.2
     dev: false
     optional: true
+
+  /@homebridge/node-pty-prebuilt-multiarch@0.13.1:
+    resolution:
+      {
+        integrity: sha512-ccQ60nMcbEGrQh0U9E6x0ajW9qJNeazpcM/9CH6J8leyNtJgb+gu24WTBAfBUVeO486ZhscnaxLEITI2HXwhow==,
+      }
+    engines: { node: '>=18.0.0 <25.0.0' }
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+    dev: true
 
   /@hono/node-server@1.19.11(hono@4.12.9):
     resolution:
@@ -10355,6 +10370,17 @@ packages:
       }
     dev: true
 
+  /bl@4.1.0:
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    dev: true
+
   /body-parser@1.20.3:
     resolution:
       {
@@ -10466,6 +10492,16 @@ packages:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
       }
+
+  /buffer@5.7.1:
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
 
   /buffer@6.0.3:
     resolution:
@@ -10716,6 +10752,13 @@ packages:
     dependencies:
       readdirp: 5.0.0
     dev: false
+
+  /chownr@1.1.4:
+    resolution:
+      {
+        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
+      }
+    dev: true
 
   /chownr@3.0.0:
     resolution:
@@ -11550,6 +11593,16 @@ packages:
       character-entities: 2.0.2
     dev: false
 
+  /decompress-response@6.0.0:
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: '>=10' }
+    dependencies:
+      mimic-response: 3.1.0
+    dev: true
+
   /dedent@1.6.0:
     resolution:
       {
@@ -11570,6 +11623,14 @@ packages:
     engines: { node: '>=6' }
     dependencies:
       type-detect: 4.1.0
+    dev: true
+
+  /deep-extend@0.6.0:
+    resolution:
+      {
+        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
+      }
+    engines: { node: '>=4.0.0' }
     dev: true
 
   /deep-is@0.1.4:
@@ -11989,8 +12050,6 @@ packages:
     requiresBuild: true
     dependencies:
       once: 1.4.0
-    dev: false
-    optional: true
 
   /enhanced-resolve@5.18.2:
     resolution:
@@ -13095,6 +13154,14 @@ packages:
     engines: { node: '>= 0.8.0' }
     dev: true
 
+  /expand-template@2.0.3:
+    resolution:
+      {
+        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
+      }
+    engines: { node: '>=6' }
+    dev: true
+
   /expect@30.0.4:
     resolution:
       {
@@ -13745,6 +13812,13 @@ packages:
       js-yaml: 3.14.1
     dev: true
 
+  /fs-constants@1.0.0:
+    resolution:
+      {
+        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
+      }
+    dev: true
+
   /fs-extra@11.3.0:
     resolution:
       {
@@ -13978,6 +14052,13 @@ packages:
       }
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  /github-from-package@0.0.0:
+    resolution:
+      {
+        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
+      }
+    dev: true
 
   /github-slugger@2.0.0:
     resolution:
@@ -14816,6 +14897,13 @@ packages:
       {
         integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
       }
+
+  /ini@1.3.8:
+    resolution:
+      {
+        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
+      }
+    dev: true
 
   /ini@4.1.1:
     resolution:
@@ -18011,6 +18099,14 @@ packages:
     engines: { node: '>=18' }
     dev: true
 
+  /mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: '>=10' }
+    dev: true
+
   /min-indent@1.0.1:
     resolution:
       {
@@ -18074,6 +18170,13 @@ packages:
     resolution:
       {
         integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==,
+      }
+    dev: true
+
+  /mkdirp-classic@0.5.3:
+    resolution:
+      {
+        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
       }
     dev: true
 
@@ -18153,6 +18256,13 @@ packages:
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
+
+  /napi-build-utils@2.0.0:
+    resolution:
+      {
+        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
+      }
+    dev: true
 
   /napi-postinstall@0.3.2:
     resolution:
@@ -18254,6 +18364,23 @@ packages:
     dependencies:
       '@types/nlcst': 2.0.3
     dev: false
+
+  /node-abi@3.89.0:
+    resolution:
+      {
+        integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==,
+      }
+    engines: { node: '>=10' }
+    dependencies:
+      semver: 7.7.4
+    dev: true
+
+  /node-addon-api@7.1.1:
+    resolution:
+      {
+        integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==,
+      }
+    dev: true
 
   /node-domexception@1.0.0:
     resolution:
@@ -19185,6 +19312,29 @@ packages:
       }
     dev: true
 
+  /prebuild-install@7.1.3:
+    resolution:
+      {
+        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
+      }
+    engines: { node: '>=10' }
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+    dependencies:
+      detect-libc: 2.0.4
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+    dev: true
+
   /prelude-ls@1.2.1:
     resolution:
       {
@@ -19335,6 +19485,16 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  /pump@3.0.4:
+    resolution:
+      {
+        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+      }
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    dev: true
+
   /punycode@2.3.1:
     resolution:
       {
@@ -19429,6 +19589,19 @@ packages:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  /rc@1.2.8:
+    resolution:
+      {
+        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
+      }
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    dev: true
 
   /react-dom@19.1.0(react@19.1.0):
     resolution:
@@ -20573,6 +20746,24 @@ packages:
     engines: { node: '>=14' }
     dev: true
 
+  /simple-concat@1.0.1:
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
+      }
+    dev: true
+
+  /simple-get@4.0.1:
+    resolution:
+      {
+        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
+      }
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    dev: true
+
   /simple-swizzle@0.2.2:
     resolution:
       {
@@ -21092,6 +21283,14 @@ packages:
       min-indent: 1.0.1
     dev: true
 
+  /strip-json-comments@2.0.1:
+    resolution:
+      {
+        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
+      }
+    engines: { node: '>=0.10.0' }
+    dev: true
+
   /strip-json-comments@3.1.1:
     resolution:
       {
@@ -21324,6 +21523,32 @@ packages:
         integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
       }
     engines: { node: '>=6' }
+    dev: true
+
+  /tar-fs@2.1.4:
+    resolution:
+      {
+        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
+      }
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+    dev: true
+
+  /tar-stream@2.2.0:
+    resolution:
+      {
+        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
+      }
+    engines: { node: '>=6' }
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
     dev: true
 
   /tar@7.5.13:
@@ -21791,6 +22016,15 @@ packages:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  /tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
 
   /tw-animate-css@1.3.5:
     resolution:


### PR DESCRIPTION
## Summary
- Extract TUI prompt/input semantics into pure `src/ui/flows/*` modules.
- Migrate TextPrompt, ConfirmPrompt, ListPicker, MenuSelect, PermissionPrompt, InputArea, and CjkTextInput to thin UI shells over flow modules.
- Add Given/When/Then-style unit coverage for text prompt, selection, confirm/permission prompts, input area behavior, and CJK text input behavior.
- Add ProviderSetupPrompt PTY E2E coverage with `@homebridge/node-pty-prebuilt-multiarch`.
- Update agent-cli SPEC and task records.

## Verification
- `pnpm --filter @robota-sdk/agent-cli test`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli lint` (passes with existing warnings)
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm harness:scan`
- Pre-push hook `harness:verify -- --base-ref origin/main` passed for changed scopes.
