### PR TITLE
feat(agent-sdk): wire subagent skill execution

### DIFF
--- a/.agents/tasks/CLI-BL-014-self-hosting-loop-verification.md
+++ b/.agents/tasks/CLI-BL-014-self-hosting-loop-verification.md
@@ -20,6 +20,12 @@ Define the mechanism to safely execute the "Edit -> Build -> Verify" loop where 
 - [ ] A verification protocol that ensures `pnpm build` can succeed even when parts of the codebase are in flux.
 - [ ] Integration with our CI/CD-like local environment to prevent "suicide" (the agent accidentally deleting its own ability to run).
 
+## Test Plan
+
+- Add unit tests for any atomic write planner or handoff state machine introduced by the implementation.
+- Add integration tests that simulate edit/build/verify sequencing without replacing the running process.
+- Run affected package `test`, `typecheck`, and `build`, then run `pnpm harness:scan`.
+
 ## Notes
 
 This task is a prerequisite for all recursive development tasks.

--- a/.agents/tasks/CLI-BL-017-context-injection-from-task-files.md
+++ b/.agents/tasks/CLI-BL-017-context-injection-from-task-files.md
@@ -20,6 +20,12 @@ Develop a standardized method for injecting relevant task-level metadata (status
 - [ ] Implementation of an automated 'Status Update' mechanism that updates the task file when an agent completes an action.
 - [ ] Definition of how context-injected data interacts with existing `system-reminder` mechanisms.
 
+## Test Plan
+
+- Add unit tests for task file discovery, task selection, and structured prompt formatting.
+- Add unit tests for status update behavior using temporary task files and deterministic timestamps.
+- Run affected package `test`, `typecheck`, and `build`, then run `pnpm harness:scan`.
+
 ## Notes
 
 This is critical for maintaining "Focus" in a recursive development environment.

--- a/.agents/tasks/completed/CLI-BL-018-subagent-capability-parity.md
+++ b/.agents/tasks/completed/CLI-BL-018-subagent-capability-parity.md
@@ -1,0 +1,83 @@
+---
+title: CLI-BL-018 Subagent capability parity for Robota CLI
+status: completed
+priority: high
+urgency: now
+created: 2026-04-30
+branch: feat/cli-subagent-capabilities
+packages:
+  - agent-cli
+  - agent-sdk
+  - agent-core
+---
+
+# CLI-BL-018: Subagent Capability Parity for Robota CLI
+
+## Objective
+
+Define and implement Robota CLI subagent behavior that matches the practical capability level of Claude Code and Codex: user-requested delegation during conversation, skill-driven fork execution, discoverable agent definitions, and model-visible invocation affordances.
+
+## Prior Art Research
+
+- [x] Claude Code subagents, skills, and `context: fork`
+- [x] Codex subagents, skills, and AGENTS.md interaction
+- [x] Robota current implementation audit
+
+### Findings
+
+- Claude Code defines subagents as markdown files with YAML frontmatter. Project definitions live under `.claude/agents/`, user definitions under `~/.claude/agents/`, and CLI-defined agents can be passed through `--agents` JSON. Skills can use `context: fork` and `agent: <name>` so the skill content runs in an isolated agent context.
+- Claude Code skill frontmatter controls both user invocation and model invocation. `disable-model-invocation: true` hides a skill from model-triggered use, while `context: fork` creates an isolated execution context.
+- Codex exposes subagents through configured agent definitions and a `spawn_agent`-style tool path. Codex skills are progressive-disclosure bundles: the model sees skill name/description/path first, then reads full `SKILL.md` only when selected.
+- Robota already has an SDK-owned `Agent` tool, built-in `general-purpose`/`Explore`/`Plan` definitions, `AgentDefinitionLoader`, and `createSubagentSession()`.
+- Current gaps: available agents are not injected into the model-visible system prompt, `context: fork` skill slash commands are injected as normal prompts by the CLI instead of running a fork session, and custom agent discovery does not cover all Robota/Claude-compatible paths described by the desired contract.
+
+### Sources
+
+- Claude Code subagents: https://code.claude.com/docs/en/sub-agents
+- Claude Code skills: https://code.claude.com/docs/en/skills
+- Codex subagents: https://developers.openai.com/codex/subagents
+- Codex skills: https://developers.openai.com/codex/skills
+- Codex AGENTS.md: https://developers.openai.com/codex/guides/agents-md
+
+## Plan
+
+- [x] Register the backlog/task and capture current implementation gaps.
+- [x] Update affected SPEC.md files with the target subagent contract.
+- [x] Add tests for skill fork execution, agent definition discovery, and model-visible agent invocation guidance.
+- [x] Implement the smallest contract-compliant changes.
+- [x] Run targeted verification for affected packages.
+
+## Progress
+
+### 2026-04-30
+
+- Created this task from the user request to support Claude Code/Codex-level subagent behavior in Robota CLI.
+- Started prior art and implementation audit.
+- Updated agent-sdk and agent-cli SPEC files with model-visible agent invocation and deterministic `context: fork` skill execution contracts.
+- Implemented model-visible agent metadata injection, Agent tool prompt description, expanded agent discovery paths, whitespace-separated `allowed-tools` parsing, custom-over-built-in agent resolution, and SDK-owned `executeSkillCommand(...)`.
+- Routed CLI skill slash execution through `interactiveSession.executeSkillCommand(...)` so fork skills no longer degrade to parent prompt injection.
+- Verified `agent-sdk` full tests/build/typecheck/lint, `agent-cli` full tests/build/typecheck/lint, and `pnpm harness:scan`.
+
+## Decisions
+
+- The existing `CLI-BL-013` worktree isolation task remains separate and covers isolation strategy only.
+- This task owns invocation semantics: how users, skills, and the model trigger agent execution.
+- Fork skill execution is deterministic SDK behavior, not a prompt asking the parent model to call `Agent`.
+- Model-requested delegation uses the existing `Agent` function tool, with available agent names/descriptions injected into the system prompt.
+
+## Test Plan
+
+- Unit-test system prompt agent metadata injection and skill metadata filtering.
+- Unit-test agent definition discovery order across Robota-native and Claude-compatible paths.
+- Unit-test `InteractiveSession.executeSkillCommand(...)` for parent-session injection and `context: fork` isolated execution.
+- Run `agent-sdk` test/typecheck/lint/build, `agent-cli` test/typecheck/lint/build, and `pnpm harness:scan`.
+
+## Blockers
+
+- None.
+
+## Result
+
+Implemented the first subagent capability parity slice. Robota CLI now routes skill slash commands through the SDK-owned skill execution path, `context: fork` skills run in an isolated subagent session, and the model-visible system prompt includes available agent metadata plus guidance to call the `Agent` tool when the user asks for delegation.
+
+Follow-up scope remains in separate backlog items for worktree isolation and broader CLI/plugin agent definition compatibility.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -894,6 +894,10 @@ ESC navigates back in the stack. When the stack is empty, the TUI closes and ret
 
 Subagent execution (Agent tool, fork sessions, agent definition loading) is managed entirely by `@robota-sdk/agent-sdk` internally. The CLI does not wire these components directly — `InteractiveSession` handles all subagent lifecycle.
 
+When a user invokes a skill slash command with `context: fork`, the CLI must call `interactiveSession.executeSkillCommand(...)`. The CLI may render a `skill-invocation` event, but it must not convert fork skills into plain prompt injection. This keeps fork execution deterministic and preserves the CLI as a thin TUI shell.
+
+When a user asks in normal conversation to call or delegate to an agent, the request is handled by the model through the SDK-owned `Agent` tool. The CLI only displays the resulting tool execution events and final assistant response.
+
 For implementation details of subagent execution (Agent tool, `context: fork` skills, agent definition scanning), see the agent-sdk SPEC.
 
 ## Memory Management

--- a/packages/agent-cli/src/commands/__tests__/skill-source.test.ts
+++ b/packages/agent-cli/src/commands/__tests__/skill-source.test.ts
@@ -114,6 +114,29 @@ describe('SkillCommandSource multi-path', () => {
     expect(cmd!.agent).toBe('researcher');
   });
 
+  it('should parse whitespace-separated allowed-tools', () => {
+    const claudeSkills = join(projectDir, '.claude', 'skills');
+    mkdirSync(claudeSkills, { recursive: true });
+    createSkillDir(
+      claudeSkills,
+      'space-tools',
+      [
+        '---',
+        'name: space-tools',
+        'description: Skill with space-separated tools',
+        'allowed-tools: Read Grep Glob',
+        '---',
+        '# Space Tools Skill',
+      ].join('\n'),
+    );
+
+    const source = new SkillCommandSource(projectDir, homeDir);
+    const cmd = source.getCommands().find((c) => c.name === 'space-tools');
+
+    expect(cmd).toBeDefined();
+    expect(cmd!.allowedTools).toEqual(['Read', 'Grep', 'Glob']);
+  });
+
   it('should filter model-invocable skills', () => {
     const claudeSkills = join(projectDir, '.claude', 'skills');
     mkdirSync(claudeSkills, { recursive: true });

--- a/packages/agent-cli/src/commands/skill-executor.ts
+++ b/packages/agent-cli/src/commands/skill-executor.ts
@@ -3,7 +3,7 @@
  * Handles both fork-based (subagent) and inject-based (user message) execution.
  */
 
-import { substituteVariables } from '@robota-sdk/agent-sdk';
+import { preprocessShellCommands, substituteVariables } from '@robota-sdk/agent-sdk';
 import type { SkillPromptContext } from '@robota-sdk/agent-sdk';
 import type { ISlashCommand } from './types.js';
 
@@ -39,25 +39,26 @@ export interface ISkillExecutionResult {
  * Build the processed skill content with variable substitution.
  * Returns the raw content after substitution (no XML wrapping).
  */
-function buildProcessedContent(
+async function buildProcessedContent(
   skill: ISlashCommand,
   args: string,
   context?: SkillPromptContext,
-): string | null {
+): Promise<string | null> {
   if (!skill.skillContent) return null;
-  return substituteVariables(skill.skillContent, args, context);
+  const preprocessed = await preprocessShellCommands(skill.skillContent);
+  return substituteVariables(preprocessed, args, context);
 }
 
 /**
  * Build an inject-mode prompt from a skill command.
  * Wraps content in skill XML tags for the model.
  */
-function buildInjectPrompt(
+async function buildInjectPrompt(
   skill: ISlashCommand,
   args: string,
   context?: SkillPromptContext,
-): string {
-  const processed = buildProcessedContent(skill, args, context);
+): Promise<string> {
+  const processed = await buildProcessedContent(skill, args, context);
   if (processed) {
     const userInstruction = args || skill.description;
     return `<skill name="${skill.name}">\n${processed}\n</skill>\n\nExecute the "${skill.name}" skill: ${userInstruction}`;
@@ -85,7 +86,7 @@ export async function executeSkill(
       throw new Error('Fork execution is not available. Agent tool deps may not be initialized.');
     }
 
-    const content = buildProcessedContent(skill, args, context);
+    const content = await buildProcessedContent(skill, args, context);
     const prompt = content ?? `Use the "${skill.name}" skill: ${args || skill.description}`;
 
     const options: IForkExecutionOptions = {};
@@ -97,6 +98,6 @@ export async function executeSkill(
   }
 
   // Inject execution: return prompt for current session
-  const prompt = buildInjectPrompt(skill, args, context);
+  const prompt = await buildInjectPrompt(skill, args, context);
   return { mode: 'inject', prompt };
 }

--- a/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
+++ b/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
@@ -6,7 +6,6 @@
 import { useCallback } from 'react';
 import { randomUUID } from 'node:crypto';
 import type { InteractiveSession, CommandRegistry, ICommandResult } from '@robota-sdk/agent-sdk';
-import { buildSkillPrompt } from '@robota-sdk/agent-sdk';
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import type { TuiStateManager } from '../tui-state-manager.js';
 import type { ISideEffects } from './useInteractiveSession.js';
@@ -146,13 +145,10 @@ async function routeSkillCommand(
     },
   });
 
-  const prompt = await buildSkillPrompt(input, registry);
-  if (!prompt) {
-    return true;
-  }
+  const args = input.slice(1 + cmd.length).trimStart();
   const qualifiedName = registry.resolveQualifiedName(cmd);
   const hookInput = qualifiedName ? `/${qualifiedName}${input.slice(1 + cmd.length)}` : input;
-  await interactiveSession.submit(prompt, input, hookInput);
+  await interactiveSession.executeSkillCommand(skillCmd, args, input, hookInput);
   manager.setPendingPrompt(interactiveSession.getPendingPrompt());
   return true;
 }

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -26,6 +26,7 @@ agent-provider-*     ← provider implementations (unchanged)
 agent-sdk            ← InteractiveSession (single entry point)
   ├── embedded: SystemCommandExecutor (session.executeCommand())
   ├── embedded: CommandRegistry, BuiltinCommandSource, SkillCommandSource, PluginCommandSource
+  ├── embedded: Agent tool + AgentDefinitionLoader for model-requested delegation
   ├── internal: createSession(), createDefaultTools(), loadConfig(), loadContext()
   ├── exposed: createQuery({ provider }) → (prompt) => result
   └── NO provider dependency (provider-neutral)
@@ -50,6 +51,7 @@ Any client (CLI, web, API server, worker)
     ↓
 InteractiveSession  (agent-sdk — pure TypeScript, no React)
     │  submit(input, displayInput?, rawInput?)
+    │  executeSkillCommand(skill, args, displayInput?, rawInput?)
     │  executeCommand(name, args)
     │  abort() / cancelQueue()
     │  getMessages() / getContextState() / getActiveTools()
@@ -304,6 +306,10 @@ session.on('interrupted', (result: IExecutionResult) => { /* abort completed */ 
 // displayInput: shown in UI (e.g., "/audit") instead of full built prompt
 // rawInput: passed to Session.run() for hook matching
 await session.submit(input, displayInput?, rawInput?);
+
+// Execute a discovered skill command. Non-fork skills submit into the current session.
+// `context: fork` skills run through an isolated subagent session.
+await session.executeSkillCommand(skillCommand, args, displayInput?, rawInput?);
 
 // Execute a named system command (embedded SystemCommandExecutor)
 const result = await session.executeCommand('context', '');
@@ -729,9 +735,27 @@ Bundle plugins package reusable extensions (tools, hooks, permissions, system pr
 - **Search**: Query available plugins by name, keyword, or category
 - **Install**: Download and install plugins via `BundlePluginInstaller`
 
-## System Prompt Skill Injection
+## System Prompt Skill and Agent Injection
 
-Skills discovered from `.agents/skills/` directories are injected into the system prompt during `buildSystemPrompt()`. Each skill's content is included as a reference the model can consult when relevant tasks are requested.
+Skills discovered from skill directories are exposed to the system prompt by metadata only: name and description. Full `SKILL.md` content is loaded only when a skill is invoked. Skills with `disable-model-invocation: true` are omitted from model-visible metadata.
+
+Agent definitions are also exposed to the system prompt by metadata only: name and description. The system prompt instructs the model to use the `Agent` tool when the user explicitly requests delegation, asks to call an agent, or when a task should be isolated into a separate context. The model must pass the selected agent name through `subagent_type`.
+
+The `Agent` tool must be part of the available tool set and must be described in `DEFAULT_TOOL_DESCRIPTIONS`.
+
+### Skill Execution Semantics
+
+`InteractiveSession.executeSkillCommand(skill, args, displayInput?, rawInput?)` is the SDK-owned skill execution path.
+
+| Skill metadata             | Behavior                                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| no `context`               | Render skill content and submit it into the current session                                           |
+| `context: fork`            | Run rendered skill content in an isolated subagent session using `skill.agent` or `general-purpose`   |
+| `allowed-tools`            | Restrict fork-session tools to the listed names, after the selected agent definition denylist applies |
+| `disable-model-invocation` | Hide from model-visible skill metadata; user slash invocation still works                             |
+| `user-invocable: false`    | Hide from user slash menus; model metadata remains available unless model invocation is disabled      |
+
+Fork skill execution must not rely on prompting the parent model to call the `Agent` tool. It must call `createSubagentSession()` directly through the per-session agent tool dependencies so the behavior is deterministic and unit-testable.
 
 ## Hook Wiring into Session Lifecycle
 
@@ -780,15 +804,29 @@ Assembles an isolated child Session for subagent execution. Unlike `createSessio
 | `Explore`         | `claude-haiku-4-5` | Denies Write, Edit  | Read-only code exploration  |
 | `Plan`            | (parent)           | Denies Write, Edit  | Read-only planning/research |
 
+### Model-Requested Agent Invocation
+
+The parent session exposes an `Agent` function tool with parameters:
+
+| Parameter       | Type     | Required | Description                                            |
+| --------------- | -------- | -------- | ------------------------------------------------------ |
+| `prompt`        | `string` | Yes      | Task prompt for the isolated agent session             |
+| `subagent_type` | `string` | No       | Agent name. Defaults to `general-purpose` when omitted |
+| `model`         | `string` | No       | Optional model override for this invocation            |
+
+The parent model may call this tool when the user asks for an agent to be called or asks for delegation. The tool result is private to the model; the parent model must summarize the returned output for the user.
+
 ### AgentDefinitionLoader (Internal)
 
 `AgentDefinitionLoader` is an internal class — it is not exported from `src/index.ts`. It scans directories for custom `.md` agent definitions with YAML frontmatter, merged with built-in agents. Custom agents override built-in agents on name collision.
 
 **Scan directories (highest priority first):**
 
-1. `<cwd>/.robota/agents/` — project-level (primary)
-2. `<cwd>/.claude/agents/` — project-level (Claude Code compatible)
-3. `<home>/.robota/agents/` — user-level
+1. `<cwd>/.robota/agents/` — project-level (Robota native)
+2. `<cwd>/.agents/agents/` — project-level (Robota repository convention)
+3. `<cwd>/.claude/agents/` — project-level (Claude Code compatible)
+4. `<home>/.robota/agents/` — user-level (Robota native)
+5. `<home>/.claude/agents/` — user-level (Claude Code compatible)
 
 ### Framework System Prompt Suffixes
 

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // Capture all Session constructor calls to inspect the options passed
 const sessionCtorCalls: Array<Record<string, unknown>> = [];
@@ -213,5 +216,40 @@ describe('createSession — appendSystemPrompt option', () => {
     const systemMessage = opts.systemMessage as string;
     expect(systemMessage).toContain('\n\n' + extraText);
     expect(systemMessage.endsWith(extraText)).toBe(true);
+  });
+
+  it('includes Agent tool and discovered agent metadata in the system prompt', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-create-session-agents-'));
+    const agentsDir = join(cwd, '.robota', 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'reviewer.md'),
+      [
+        '---',
+        'name: reviewer',
+        'description: Reviews code for risks and missing tests',
+        '---',
+        'Review code like an owner.',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    try {
+      createSession({
+        config: baseConfig(),
+        cwd,
+        context: { agentsMd: '', claudeMd: '' },
+        terminal: MOCK_TERMINAL,
+        provider: createMockProvider(),
+      });
+
+      const opts = sessionCtorCalls[0]!;
+      const systemMessage = opts.systemMessage as string;
+      expect(systemMessage).toContain('Agent — launch an isolated agent');
+      expect(systemMessage).toContain('- reviewer: Reviews code for risks and missing tests');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
@@ -154,4 +154,27 @@ describe('buildSystemPrompt', () => {
       expect(skillsIdx).toBeGreaterThan(toolsIdx);
     });
   });
+
+  describe('System prompt agent injection', () => {
+    it('should include available agents and Agent tool guidance', () => {
+      const result = buildSystemPrompt({
+        ...BASE_PARAMS,
+        agents: [
+          { name: 'general-purpose', description: 'General task execution' },
+          { name: 'Explore', description: 'Read-only exploration' },
+        ],
+      });
+
+      expect(result).toContain('## Subagents');
+      expect(result).toContain('Agent tool');
+      expect(result).toContain('subagent_type');
+      expect(result).toContain('- general-purpose: General task execution');
+      expect(result).toContain('- Explore: Read-only exploration');
+    });
+
+    it('should not include agents section when no agents are provided', () => {
+      const result = buildSystemPrompt({ ...BASE_PARAMS, agents: [] });
+      expect(result).not.toContain('## Subagents');
+    });
+  });
 });

--- a/packages/agent-sdk/src/agents/__tests__/agent-definition-loader.test.ts
+++ b/packages/agent-sdk/src/agents/__tests__/agent-definition-loader.test.ts
@@ -82,53 +82,100 @@ System prompt body here.`,
     expect(agent!.description).toBe('An agent without an explicit name');
   });
 
-  it('should load from .claude/agents/ and ~/.robota/agents/', () => {
+  it('should load from Robota and Claude-compatible project/user agent paths', () => {
     const cwd = makeTempDir();
     const home = makeTempDir();
 
     writeAgentFile(
-      join(cwd, '.claude', 'agents'),
-      'project-agent.md',
+      join(cwd, '.robota', 'agents'),
+      'robota-project-agent.md',
       `---
-name: project-agent
-description: Project-level agent
+name: robota-project-agent
+description: Robota project-level agent
 ---
 
-Project agent prompt.`,
+Robota project agent prompt.`,
+    );
+
+    writeAgentFile(
+      join(cwd, '.agents', 'agents'),
+      'agents-project-agent.md',
+      `---
+name: agents-project-agent
+description: Agents project-level agent
+---
+
+Agents project agent prompt.`,
+    );
+
+    writeAgentFile(
+      join(cwd, '.claude', 'agents'),
+      'claude-project-agent.md',
+      `---
+name: claude-project-agent
+description: Claude project-level agent
+---
+
+Claude project agent prompt.`,
     );
 
     writeAgentFile(
       join(home, '.robota', 'agents'),
-      'user-agent.md',
+      'robota-user-agent.md',
       `---
-name: user-agent
-description: User-level agent
+name: robota-user-agent
+description: Robota user-level agent
 ---
 
-User agent prompt.`,
+Robota user agent prompt.`,
+    );
+
+    writeAgentFile(
+      join(home, '.claude', 'agents'),
+      'claude-user-agent.md',
+      `---
+name: claude-user-agent
+description: Claude user-level agent
+---
+
+Claude user agent prompt.`,
     );
 
     const loader = new AgentDefinitionLoader(cwd, home);
     const all = loader.loadAll();
     const names = all.map((a) => a.name);
 
-    expect(names).toContain('project-agent');
-    expect(names).toContain('user-agent');
+    expect(names).toContain('robota-project-agent');
+    expect(names).toContain('agents-project-agent');
+    expect(names).toContain('claude-project-agent');
+    expect(names).toContain('robota-user-agent');
+    expect(names).toContain('claude-user-agent');
   });
 
-  it('should prioritize .claude/agents/ over ~/.robota/agents/', () => {
+  it('should prioritize project Robota agents over project Claude and user agents', () => {
     const cwd = makeTempDir();
     const home = makeTempDir();
+
+    writeAgentFile(
+      join(cwd, '.robota', 'agents'),
+      'shared.md',
+      `---
+name: shared
+description: Robota project version
+---
+
+Robota project prompt.`,
+    );
 
     writeAgentFile(
       join(cwd, '.claude', 'agents'),
       'shared.md',
       `---
 name: shared
-description: Project version
+description: Claude project version
 ---
 
-Project prompt.`,
+Claude project prompt.`,
     );
 
     writeAgentFile(
@@ -146,7 +193,7 @@ User prompt.`,
     const agent = loader.getAgent('shared');
 
     expect(agent).toBeDefined();
-    expect(agent!.description).toBe('Project version');
+    expect(agent!.description).toBe('Robota project version');
   });
 
   it('should merge with built-in agents', () => {
@@ -218,6 +265,29 @@ Prompt.`,
 
     const loader = new AgentDefinitionLoader(cwd);
     const agent = loader.getAgent('tools-test');
+
+    expect(agent).toBeDefined();
+    expect(agent!.tools).toEqual(['Read', 'Grep', 'Glob']);
+    expect(agent!.disallowedTools).toEqual(['Bash', 'Write']);
+  });
+
+  it('should parse whitespace-separated tools fields', () => {
+    const cwd = makeTempDir();
+    writeAgentFile(
+      join(cwd, '.claude', 'agents'),
+      'tools-space-test.md',
+      `---
+name: tools-space-test
+description: Agent with space separated tools
+tools: Read Grep Glob
+disallowedTools: Bash Write
+---
+
+Prompt.`,
+    );
+
+    const loader = new AgentDefinitionLoader(cwd);
+    const agent = loader.getAgent('tools-space-test');
 
     expect(agent).toBeDefined();
     expect(agent!.tools).toEqual(['Read', 'Grep', 'Glob']);

--- a/packages/agent-sdk/src/agents/agent-definition-loader.ts
+++ b/packages/agent-sdk/src/agents/agent-definition-loader.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import type { IAgentDefinition } from './agent-definition-types.js';
 import { BUILT_IN_AGENTS } from './built-in-agents.js';
 
-/** Known frontmatter keys that should be parsed as comma-separated lists. */
+/** Known frontmatter keys that should be parsed as comma-separated or whitespace-separated lists. */
 const LIST_KEYS = new Set(['tools', 'disallowedTools']);
 
 /** Known frontmatter keys that should be parsed as numbers. */
@@ -17,6 +17,14 @@ interface IRawFrontmatter {
   maxTurns?: number;
   tools?: string[];
   disallowedTools?: string[];
+}
+
+function parseListValue(rawValue: string): string[] {
+  const separator = rawValue.includes(',') ? /\s*,\s*/ : /\s+/;
+  return rawValue
+    .split(separator)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
 }
 
 /**
@@ -52,7 +60,7 @@ function parseFrontmatter(content: string): { frontmatter: IRawFrontmatter | nul
     const rawValue = match[2]!.trim();
 
     if (LIST_KEYS.has(key)) {
-      result[key] = rawValue.split(',').map((s) => s.trim());
+      result[key] = parseListValue(rawValue);
     } else if (NUMBER_KEYS.has(key)) {
       result[key] = parseInt(rawValue, 10);
     } else {
@@ -115,8 +123,11 @@ function scanAgentsDir(dir: string): IAgentDefinition[] {
  * them with built-in agents.
  *
  * Scan directories (highest priority first):
- * 1. `<cwd>/.claude/agents/` — project-level
- * 2. `<home>/.robota/agents/` — user-level
+ * 1. `<cwd>/.robota/agents/` — project-level Robota native
+ * 2. `<cwd>/.agents/agents/` — project-level Robota repository convention
+ * 3. `<cwd>/.claude/agents/` — project-level Claude Code compatible
+ * 4. `<home>/.robota/agents/` — user-level Robota native
+ * 5. `<home>/.claude/agents/` — user-level Claude Code compatible
  *
  * Custom agents override built-in agents on name collision.
  */
@@ -132,8 +143,11 @@ export class AgentDefinitionLoader {
   /** Load all agent definitions, merged with built-in agents. Custom overrides built-in on name collision. */
   loadAll(): IAgentDefinition[] {
     const sources: IAgentDefinition[][] = [
+      scanAgentsDir(join(this.cwd, '.robota', 'agents')),
+      scanAgentsDir(join(this.cwd, '.agents', 'agents')),
       scanAgentsDir(join(this.cwd, '.claude', 'agents')),
       scanAgentsDir(join(this.home, '.robota', 'agents')),
+      scanAgentsDir(join(this.home, '.claude', 'agents')),
     ];
 
     // Deduplicate custom agents: higher-priority source wins

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -29,11 +29,14 @@ import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js
 
 import { createAgentTool, storeAgentToolDeps } from '../tools/agent-tool.js';
 import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
+import { SkillCommandSource } from '../commands/skill-source.js';
 
 /** Options for the createSession factory */
 export interface ICreateSessionOptions {
   /** Resolved CLI configuration (model, API key, permissions) */
   config: IResolvedConfig;
+  /** Working directory used for project context, skills, and agent definitions. */
+  cwd?: string;
   /** Loaded AGENTS.md / CLAUDE.md context */
   context: ILoadedContext;
   /** Terminal I/O for permission prompts */
@@ -104,13 +107,14 @@ export function createSession(options: ICreateSessionOptions): Session {
     );
   }
   const provider = options.provider;
+  const cwd = options.cwd ?? process.cwd();
 
   const defaultTools = createDefaultTools();
   const tools = [...defaultTools, ...(options.additionalTools ?? [])];
 
   // Wire agent tool — create a fresh instance with deps captured in closure.
   // Must happen after default tools are assembled so sub-agents inherit the full set.
-  const agentLoader = new AgentDefinitionLoader(process.cwd());
+  const agentLoader = new AgentDefinitionLoader(cwd);
 
   // Build hook type executors early so they can be forwarded to subagents.
   const hookTypeExecutors: IHookTypeExecutor[] = [];
@@ -156,8 +160,17 @@ export function createSession(options: ICreateSessionOptions): Session {
     toolDescriptions: options.toolDescriptions ?? DEFAULT_TOOL_DESCRIPTIONS,
     trustLevel: options.config.defaultTrustLevel,
     projectInfo: options.projectInfo ?? { type: 'unknown', language: 'unknown' },
-    cwd: process.cwd(),
+    cwd,
     language: options.config.language,
+    skills: new SkillCommandSource(cwd).getModelInvocableSkills().map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      disableModelInvocation: skill.disableModelInvocation,
+    })),
+    agents: agentLoader.loadAll().map((agent) => ({
+      name: agent.name,
+      description: agent.description,
+    })),
   });
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`

--- a/packages/agent-sdk/src/assembly/create-tools.ts
+++ b/packages/agent-sdk/src/assembly/create-tools.ts
@@ -23,6 +23,7 @@ export const DEFAULT_TOOL_DESCRIPTIONS = [
   'Glob — find files matching a pattern',
   'Grep — search file contents with regex',
   'WebSearch — search the internet (Anthropic built-in)',
+  'Agent — launch an isolated agent for delegated work',
 ];
 
 /**

--- a/packages/agent-sdk/src/commands/index.ts
+++ b/packages/agent-sdk/src/commands/index.ts
@@ -5,3 +5,9 @@ export { SkillCommandSource, parseFrontmatter } from './skill-source.js';
 export { PluginCommandSource } from './plugin-source.js';
 export { SystemCommandExecutor, createSystemCommands } from './system-command.js';
 export type { ISystemCommand, ICommandResult } from './system-command.js';
+export { executeSkill } from './skill-executor.js';
+export type {
+  IForkExecutionOptions,
+  ISkillExecutionCallbacks,
+  ISkillExecutionResult,
+} from './skill-executor.js';

--- a/packages/agent-sdk/src/commands/skill-executor.ts
+++ b/packages/agent-sdk/src/commands/skill-executor.ts
@@ -3,7 +3,11 @@
  * Handles both fork-based (subagent) and inject-based (user message) execution.
  */
 
-import { substituteVariables, type SkillPromptContext } from '../utils/skill-prompt.js';
+import {
+  preprocessShellCommands,
+  substituteVariables,
+  type SkillPromptContext,
+} from '../utils/skill-prompt.js';
 import type { ICommand } from './types.js';
 
 /** Options passed to the fork execution callback */
@@ -38,21 +42,26 @@ export interface ISkillExecutionResult {
  * Build the processed skill content with variable substitution.
  * Returns the raw content after substitution (no XML wrapping).
  */
-function buildProcessedContent(
+async function buildProcessedContent(
   skill: ICommand,
   args: string,
   context?: SkillPromptContext,
-): string | null {
+): Promise<string | null> {
   if (!skill.skillContent) return null;
-  return substituteVariables(skill.skillContent, args, context);
+  const preprocessed = await preprocessShellCommands(skill.skillContent);
+  return substituteVariables(preprocessed, args, context);
 }
 
 /**
  * Build an inject-mode prompt from a skill command.
  * Wraps content in skill XML tags for the model.
  */
-function buildInjectPrompt(skill: ICommand, args: string, context?: SkillPromptContext): string {
-  const processed = buildProcessedContent(skill, args, context);
+async function buildInjectPrompt(
+  skill: ICommand,
+  args: string,
+  context?: SkillPromptContext,
+): Promise<string> {
+  const processed = await buildProcessedContent(skill, args, context);
   if (processed) {
     const userInstruction = args || skill.description;
     return `<skill name="${skill.name}">\n${processed}\n</skill>\n\nExecute the "${skill.name}" skill: ${userInstruction}`;
@@ -80,7 +89,7 @@ export async function executeSkill(
       throw new Error('Fork execution is not available. Agent tool deps may not be initialized.');
     }
 
-    const content = buildProcessedContent(skill, args, context);
+    const content = await buildProcessedContent(skill, args, context);
     const prompt = content ?? `Use the "${skill.name}" skill: ${args || skill.description}`;
 
     const options: IForkExecutionOptions = {};
@@ -92,6 +101,6 @@ export async function executeSkill(
   }
 
   // Inject execution: return prompt for current session
-  const prompt = buildInjectPrompt(skill, args, context);
+  const prompt = await buildInjectPrompt(skill, args, context);
   return { mode: 'inject', prompt };
 }

--- a/packages/agent-sdk/src/commands/skill-source.ts
+++ b/packages/agent-sdk/src/commands/skill-source.ts
@@ -19,12 +19,20 @@ interface IFrontmatter {
 /** Known boolean frontmatter keys */
 const BOOLEAN_KEYS = new Set(['disable-model-invocation', 'user-invocable']);
 
-/** Known comma-separated list frontmatter keys */
+/** Known comma-separated or whitespace-separated list frontmatter keys */
 const LIST_KEYS = new Set(['allowed-tools']);
 
 /** Convert kebab-case to camelCase */
 function kebabToCamel(key: string): string {
   return key.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase());
+}
+
+function parseListValue(rawValue: string): string[] {
+  const separator = rawValue.includes(',') ? /\s*,\s*/ : /\s+/;
+  return rawValue
+    .split(separator)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
 }
 
 /** Parse YAML-like frontmatter between --- markers */
@@ -48,7 +56,7 @@ export function parseFrontmatter(content: string): IFrontmatter | null {
     if (BOOLEAN_KEYS.has(key)) {
       result[camelKey] = rawValue === 'true';
     } else if (LIST_KEYS.has(key)) {
-      result[camelKey] = rawValue.split(',').map((s) => s.trim());
+      result[camelKey] = parseListValue(rawValue);
     } else {
       result[camelKey] = rawValue;
     }

--- a/packages/agent-sdk/src/context/system-prompt-builder.ts
+++ b/packages/agent-sdk/src/context/system-prompt-builder.ts
@@ -23,6 +23,8 @@ export interface ISystemPromptParams {
   language?: string;
   /** Discovered skills to expose in the system prompt */
   skills?: Array<{ name: string; description: string; disableModelInvocation?: boolean }>;
+  /** Discovered agents to expose in the system prompt */
+  agents?: Array<{ name: string; description: string }>;
 }
 
 const TRUST_LEVEL_DESCRIPTIONS: Record<TTrustLevel, string> = {
@@ -73,6 +75,40 @@ function buildSkillsSection(
     ...invocable.map((s) => `- ${s.name}: ${s.description}`),
   ];
   return lines.join('\n');
+}
+
+function buildAgentsSection(agents: Array<{ name: string; description: string }>): string {
+  if (agents.length === 0) {
+    return '';
+  }
+  const lines = [
+    '## Subagents',
+    'You can launch isolated agents with the Agent tool.',
+    'Use the Agent tool when the user explicitly asks to call an agent, asks you to delegate work, or a task should run in an isolated context.',
+    'Pass the selected agent name as subagent_type and summarize the returned result for the user.',
+    '',
+    'Available agents:',
+    ...agents.map((agent) => `- ${agent.name}: ${agent.description}`),
+  ];
+  return lines.join('\n');
+}
+
+function appendSection(sections: string[], section: string): void {
+  if (section.length > 0) {
+    sections.push(section);
+  }
+}
+
+function appendModelVisibleMetadataSections(
+  sections: string[],
+  params: Pick<ISystemPromptParams, 'skills' | 'agents'>,
+): void {
+  if (params.skills !== undefined && params.skills.length > 0) {
+    appendSection(sections, buildSkillsSection(params.skills));
+  }
+  if (params.agents !== undefined && params.agents.length > 0) {
+    appendSection(sections, buildAgentsSection(params.agents));
+  }
 }
 
 export function buildSystemPrompt(params: ISystemPromptParams): string {
@@ -137,12 +173,7 @@ export function buildSystemPrompt(params: ISystemPromptParams): string {
   }
 
   // Skills list
-  if (params.skills !== undefined && params.skills.length > 0) {
-    const skillsSection = buildSkillsSection(params.skills);
-    if (skillsSection.length > 0) {
-      sections.push(skillsSection);
-    }
-  }
+  appendModelVisibleMetadataSections(sections, params);
 
   return sections.join('\n\n');
 }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -27,8 +27,17 @@ export {
   SkillCommandSource,
   PluginCommandSource,
   parseFrontmatter,
+  executeSkill,
 } from './commands/index.js';
-export type { ICommand, ICommandSource, ISystemCommand, ICommandResult } from './commands/index.js';
+export type {
+  ICommand,
+  ICommandSource,
+  ISystemCommand,
+  ICommandResult,
+  IForkExecutionOptions,
+  ISkillExecutionCallbacks,
+  ISkillExecutionResult,
+} from './commands/index.js';
 
 // ── Skill prompt utilities ───────────────────────────────────
 export {

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-skill-command.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-skill-command.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IToolWithEventService, IAIProvider } from '@robota-sdk/agent-core';
+import type { ITerminalOutput } from '@robota-sdk/agent-sessions';
+import type { IResolvedConfig } from '../../config/config-types.js';
+import type { ILoadedContext } from '../../context/context-loader.js';
+import type { IAgentDefinition } from '../../agents/agent-definition-types.js';
+import type { ICommand } from '../../commands/types.js';
+
+const mocks = vi.hoisted(() => ({
+  createSubagentSession: vi.fn(),
+  forkRun: vi.fn(),
+}));
+
+vi.mock('../../assembly/create-subagent-session.js', () => ({
+  createSubagentSession: mocks.createSubagentSession,
+}));
+
+import { InteractiveSession } from '../interactive-session.js';
+import { storeAgentToolDeps } from '../../tools/agent-tool.js';
+
+function makeParentSession() {
+  return {
+    run: vi.fn().mockResolvedValue('parent response'),
+    abort: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getContextState: vi.fn().mockReturnValue({
+      usedPercentage: 10,
+      usedTokens: 100,
+      maxTokens: 1000,
+    }),
+    injectMessage: vi.fn(),
+    getSessionId: vi.fn().mockReturnValue('parent-session-id'),
+  };
+}
+
+function makeTool(name: string): IToolWithEventService {
+  return {
+    getName: () => name,
+    getDescription: () => `Mock ${name}`,
+    schema: {
+      name,
+      description: `Mock ${name}`,
+      parameters: { type: 'object', properties: {} },
+    },
+    execute: vi.fn(),
+    validate: vi.fn(),
+    validateParameters: vi.fn(),
+    setEventService: vi.fn(),
+  } as unknown as IToolWithEventService;
+}
+
+function makeConfig(): IResolvedConfig {
+  return {
+    defaultTrustLevel: 'moderate',
+    provider: { name: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'test-key' },
+    permissions: { allow: [], deny: [] },
+    env: {},
+  };
+}
+
+function makeContext(): ILoadedContext {
+  return { agentsMd: '# AGENTS', claudeMd: '# CLAUDE' };
+}
+
+function makeTerminal(): ITerminalOutput {
+  return {
+    write: vi.fn(),
+    writeLine: vi.fn(),
+    spinner: vi.fn(),
+  } as unknown as ITerminalOutput;
+}
+
+function makeSkill(overrides?: Partial<ICommand>): ICommand {
+  return {
+    name: 'audit',
+    description: 'Audit code',
+    source: 'skill',
+    skillContent: 'Audit $ARGUMENTS',
+    ...overrides,
+  };
+}
+
+describe('InteractiveSession.executeSkillCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.forkRun.mockResolvedValue('fork result');
+    mocks.createSubagentSession.mockReturnValue({ run: mocks.forkRun });
+  });
+
+  it('submits non-fork skills into the parent session', async () => {
+    const parentSession = makeParentSession();
+    const session = new InteractiveSession({ session: parentSession as never });
+    const skill = makeSkill();
+
+    await session.executeSkillCommand(
+      skill,
+      'src/index.ts',
+      '/audit src/index.ts',
+      '/audit src/index.ts',
+    );
+
+    expect(parentSession.run).toHaveBeenCalledWith(
+      expect.stringContaining('Audit src/index.ts'),
+      '/audit src/index.ts',
+    );
+    expect(mocks.createSubagentSession).not.toHaveBeenCalled();
+  });
+
+  it('runs context: fork skills through an isolated subagent session', async () => {
+    const parentSession = makeParentSession();
+    const session = new InteractiveSession({ session: parentSession as never });
+    const exploreAgent: IAgentDefinition = {
+      name: 'Explore',
+      description: 'Read-only explorer',
+      systemPrompt: 'Explore the codebase.',
+      disallowedTools: ['Write', 'Edit'],
+    };
+
+    storeAgentToolDeps(parentSession, {
+      config: makeConfig(),
+      context: makeContext(),
+      tools: [makeTool('Read'), makeTool('Write'), makeTool('Agent')],
+      terminal: makeTerminal(),
+      provider: {} as IAIProvider,
+      customAgentRegistry: (name) => (name === 'Explore' ? exploreAgent : undefined),
+    });
+
+    const complete = vi.fn();
+    session.on('complete', complete);
+
+    const result = await session.executeSkillCommand(
+      makeSkill({ context: 'fork', agent: 'Explore', allowedTools: ['Read'] }),
+      'src/index.ts',
+      '/audit src/index.ts',
+      '/audit src/index.ts',
+    );
+
+    expect(result).toEqual({ mode: 'fork', result: 'fork result' });
+    expect(parentSession.run).not.toHaveBeenCalled();
+    expect(mocks.createSubagentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDefinition: expect.objectContaining({
+          name: 'Explore',
+          tools: ['Read'],
+          disallowedTools: ['Write', 'Edit'],
+        }),
+        isForkWorker: true,
+      }),
+    );
+    expect(mocks.forkRun).toHaveBeenCalledWith('Audit src/index.ts');
+    expect(complete).toHaveBeenCalledWith(expect.objectContaining({ response: 'fork result' }));
+    expect(session.getMessages().map((message) => message.content)).toContain(
+      '/audit src/index.ts',
+    );
+    expect(session.getMessages().map((message) => message.content)).toContain('fork result');
+  });
+});

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -133,6 +133,7 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
 
   return createSession({
     config: mergedConfig,
+    cwd,
     context,
     projectInfo,
     permissionMode: options.permissionMode,

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -17,6 +17,12 @@ import {
   createSystemMessage,
   messageToHistoryEntry,
 } from '@robota-sdk/agent-core';
+import type { ICommand, ISkillExecutionResult, IForkExecutionOptions } from '../commands/index.js';
+import { executeSkill } from '../commands/index.js';
+import { createSubagentSession } from '../assembly/create-subagent-session.js';
+import { getBuiltInAgent } from '../agents/built-in-agents.js';
+import type { IAgentDefinition } from '../agents/agent-definition-types.js';
+import { retrieveAgentToolDeps } from '../tools/agent-tool.js';
 import { SystemCommandExecutor, createSystemCommands } from '../commands/system-command.js';
 import type {
   IToolState,
@@ -167,6 +173,38 @@ export class InteractiveSession {
     return this.commandExecutor.execute(name, this, args);
   }
 
+  async executeSkillCommand(
+    skill: ICommand,
+    args: string,
+    displayInput?: string,
+    rawInput?: string,
+  ): Promise<ISkillExecutionResult> {
+    await this.ensureInitialized();
+
+    if (skill.context === 'fork') {
+      return this.executeForkSkillCommand(skill, args, displayInput);
+    }
+
+    const result = await executeSkill(
+      skill,
+      args,
+      {
+        runInFork: (content, options) => this.runSkillInFork(content, options),
+      },
+      { sessionId: this.getSessionOrThrow().getSessionId() },
+    );
+
+    if (result.mode === 'inject') {
+      if (result.prompt) {
+        await this.submit(result.prompt, displayInput, rawInput);
+      }
+      return result;
+    }
+
+    await this.applyForkSkillResult(result.result ?? '(empty response)');
+    return result;
+  }
+
   listCommands(): Array<{ name: string; description: string }> {
     return this.commandExecutor.listCommands().map((cmd) => ({
       name: cmd.name,
@@ -237,6 +275,123 @@ export class InteractiveSession {
 
   attachTransport(transport: ITransportAdapter): void {
     transport.attach(this);
+  }
+
+  private async executeForkSkillCommand(
+    skill: ICommand,
+    args: string,
+    displayInput?: string,
+  ): Promise<ISkillExecutionResult> {
+    if (this.executing) {
+      throw new Error('Cannot execute fork skill while another prompt is running.');
+    }
+
+    this.startForkSkillExecution(displayInput ?? `/${skill.name}`);
+
+    try {
+      const result = await executeSkill(
+        skill,
+        args,
+        { runInFork: (content, options) => this.runSkillInFork(content, options) },
+        { sessionId: this.getSessionOrThrow().getSessionId() },
+      );
+      await this.applyForkSkillResult(result.result ?? '(empty response)');
+      return result;
+    } catch (err) {
+      this.recordForkSkillError(err instanceof Error ? err : new Error(String(err)));
+      return { mode: 'fork', result: '' };
+    } finally {
+      this.finishForkSkillExecution();
+    }
+  }
+
+  private startForkSkillExecution(displayInput: string): void {
+    this.executing = true;
+    this.clearStreaming();
+    this.emit('thinking', true);
+    this.history.push(messageToHistoryEntry(createUserMessage(displayInput)));
+  }
+
+  private finishForkSkillExecution(): void {
+    this.executing = false;
+    this.emit('thinking', false);
+    if (this.sessionStore && this.session) {
+      persistSession(
+        this.sessionStore,
+        this.session,
+        this.sessionName,
+        this.cwd ?? '',
+        this.history,
+      );
+    }
+    if (this.pendingPrompt) {
+      const queued = this.pendingPrompt;
+      const queuedDisplay = this.pendingDisplayInput;
+      const queuedRaw = this.pendingRawInput;
+      this.clearPendingQueue();
+      setTimeout(() => this.executePrompt(queued, queuedDisplay, queuedRaw), 0);
+    }
+  }
+
+  private recordForkSkillError(err: Error): void {
+    this.history.push(messageToHistoryEntry(createSystemMessage(`Error: ${err.message}`)));
+    this.emit('error', err);
+  }
+
+  private resolveForkAgentDefinition(
+    agentType: string,
+    options: IForkExecutionOptions,
+  ): IAgentDefinition {
+    const deps = retrieveAgentToolDeps(this.getSessionOrThrow());
+    const definition = deps?.customAgentRegistry?.(agentType) ?? getBuiltInAgent(agentType);
+    if (!definition) {
+      throw new Error(`Unknown agent type: ${agentType}`);
+    }
+    if (options.allowedTools) {
+      return { ...definition, tools: options.allowedTools };
+    }
+    return definition;
+  }
+
+  private async runSkillInFork(content: string, options: IForkExecutionOptions): Promise<string> {
+    const parentSession = this.getSessionOrThrow();
+    const deps = retrieveAgentToolDeps(parentSession);
+    if (!deps) {
+      throw new Error('Fork execution is not available. Agent tool deps may not be initialized.');
+    }
+    const agentType = options.agent ?? 'general-purpose';
+    const agentDefinition = this.resolveForkAgentDefinition(agentType, options);
+    const forkSession = createSubagentSession({
+      agentDefinition,
+      parentConfig: deps.config,
+      parentContext: deps.context,
+      parentTools: deps.tools,
+      provider: deps.provider,
+      terminal: deps.terminal,
+      isForkWorker: true,
+      permissionMode: deps.permissionMode,
+      permissionHandler: deps.permissionHandler,
+      hooks: deps.hooks,
+      hookTypeExecutors: deps.hookTypeExecutors,
+      onTextDelta: deps.onTextDelta,
+      onToolExecution: deps.onToolExecution,
+    });
+    return forkSession.run(content);
+  }
+
+  private async applyForkSkillResult(result: string): Promise<void> {
+    this.flushStreaming();
+    pushToolSummaryToHistory({ activeTools: this.activeTools, history: this.history });
+    this.clearStreaming();
+    const executionResult = {
+      response: result,
+      history: this.history,
+      toolSummaries: [],
+      contextState: this.getContextState(),
+    };
+    this.history.push(messageToHistoryEntry(createAssistantMessage(result)));
+    this.emit('complete', executionResult);
+    this.emit('context_update', this.getContextState());
   }
 
   private async executePrompt(

--- a/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
@@ -345,7 +345,7 @@ describe('Agent tool', () => {
     );
   });
 
-  it('should prefer built-in over custom registry when both match', async () => {
+  it('should prefer custom registry over built-in when both match', async () => {
     const customAgent: IAgentDefinition = {
       name: 'Explore',
       description: 'Custom explore',
@@ -360,13 +360,12 @@ describe('Agent tool', () => {
       subagent_type: 'Explore',
     });
 
-    // Built-in should be found first, custom registry should NOT be called
-    expect(customRegistry).not.toHaveBeenCalled();
+    expect(customRegistry).toHaveBeenCalledWith('Explore');
     expect(createSubagentSession).toHaveBeenCalledWith(
       expect.objectContaining({
         agentDefinition: expect.objectContaining({
           name: 'Explore',
-          description: 'Exploration agent', // built-in description
+          description: 'Custom explore',
         }),
       }),
     );

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -90,15 +90,18 @@ export function retrieveAgentToolDeps(key: object): IAgentToolDeps | undefined {
 
 /**
  * Resolve an agent type name to an IAgentDefinition.
- * Checks built-in agents first, then falls back to custom registry.
+ * Checks custom registry first so project/user definitions can override built-ins.
  */
 function resolveAgentDefinition(
   agentType: string,
   customRegistry?: (name: string) => IAgentDefinition | undefined,
 ): IAgentDefinition | undefined {
+  if (customRegistry) {
+    const custom = customRegistry(agentType);
+    if (custom) return custom;
+  }
   const builtIn = getBuiltInAgent(agentType);
   if (builtIn) return builtIn;
-  if (customRegistry) return customRegistry(agentType);
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

- expose available subagents and Agent tool guidance in the model-visible SDK system prompt
- route CLI skill slash execution through SDK-owned skill execution so `context: fork` runs in an isolated subagent session
- expand agent definition discovery paths and prefer custom definitions over built-ins
- add unit coverage for agent discovery, system prompt injection, skill parsing, and interactive skill fork execution

## Verification

- `pnpm --filter @robota-sdk/agent-sdk test`
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-sdk lint` (warnings only)
- `pnpm --filter @robota-sdk/agent-cli test`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli lint` (warnings only)
- `pnpm harness:scan`
- pre-push harness verification passed

## Notes

- This PR is opened against `develop`.
- Worktree isolation and broader CLI/plugin agent definition compatibility remain tracked as separate follow-up backlog scope.