### PR TITLE
feat(agent-sdk): add subagent manager core

### DIFF
--- a/.agents/specs/subagent-process-manager.md
+++ b/.agents/specs/subagent-process-manager.md
@@ -30,7 +30,7 @@ Robota currently supports subagents as in-process awaited executions:
 - TUI state has no subagent-specific state model.
 - Core tool execution supports bounded parallel dispatch and enforces the configured `maxConcurrency`.
 
-This baseline is not sufficient for managed parallel subagent work because it has no durable job registry, no cancellation handle per child, no process isolation, no provider callback isolation, and no TUI thread visibility.
+This baseline is not sufficient for managed parallel subagent work because it has no durable job registry, no cancellation handle per child, no process isolation, and no TUI thread visibility. Provider callback isolation has been added with per-run streaming callback context while child process provider construction remains future work.
 
 ## Target Behavior
 
@@ -314,6 +314,8 @@ Acceptable implementations:
 - create a new provider instance per subagent job; or
 - refactor provider streaming callbacks to be per request/session rather than mutable properties on a shared provider object.
 
+Current implementation uses the second approach for in-process sessions: `ISessionOptions.onTextDelta` is stored on the `Session` and passed to `Robota.run()` as `IRunOptions.onTextDelta`, which is threaded through `IExecutionContext` and preferred over provider-level callback fallback.
+
 The child process runner MUST create providers inside the child process from serializable provider profile data.
 
 ## TUI Requirements
@@ -432,7 +434,7 @@ Errors returned to the model MUST be concise and structured. Detailed process lo
 2. Implement manager with fake/in-process runner. (Completed in `agent-sdk`; keep regression coverage.)
 3. Route existing `Agent` tool through manager in foreground mode. (Completed in `agent-sdk`; keep regression coverage.)
 4. Enforce `maxConcurrency` in core parallel tool execution. (Completed in `agent-core`; keep regression coverage.)
-5. Fix provider callback isolation.
+5. Fix provider callback isolation. (Completed in `agent-core` and `agent-sessions`; keep regression coverage.)
 6. Add background mode and manager events to `InteractiveSession`.
 7. Add TUI state manager and rendering for subagent rows.
 8. Add child process runner and worker IPC protocol.

--- a/.agents/specs/subagent-process-manager.md
+++ b/.agents/specs/subagent-process-manager.md
@@ -428,9 +428,9 @@ Errors returned to the model MUST be concise and structured. Detailed process lo
 
 ## Implementation Order
 
-1. Add types and unit tests for `SubagentManager`, `SubagentRunner`, and job state transitions.
-2. Implement manager with fake/in-process runner.
-3. Route existing `Agent` tool through manager in foreground mode.
+1. Add types and unit tests for `SubagentManager`, `SubagentRunner`, and job state transitions. (Completed in `agent-sdk`; keep regression coverage.)
+2. Implement manager with fake/in-process runner. (Completed in `agent-sdk`; keep regression coverage.)
+3. Route existing `Agent` tool through manager in foreground mode. (Completed in `agent-sdk`; keep regression coverage.)
 4. Enforce `maxConcurrency` in core parallel tool execution. (Completed in `agent-core`; keep regression coverage.)
 5. Fix provider callback isolation.
 6. Add background mode and manager events to `InteractiveSession`.

--- a/.agents/specs/subagent-process-manager.md
+++ b/.agents/specs/subagent-process-manager.md
@@ -28,7 +28,7 @@ Robota currently supports subagents as in-process awaited executions:
 - `Agent` tool waits for `session.run(prompt)` and returns JSON containing `success`, `output`, and `agentId`.
 - `InteractiveSession` fork skill execution also awaits an in-process subagent session.
 - TUI state has no subagent-specific state model.
-- Core tool execution uses parallel dispatch but currently does not enforce the configured `maxConcurrency`.
+- Core tool execution supports bounded parallel dispatch and enforces the configured `maxConcurrency`.
 
 This baseline is not sufficient for managed parallel subagent work because it has no durable job registry, no cancellation handle per child, no process isolation, no provider callback isolation, and no TUI thread visibility.
 
@@ -356,7 +356,7 @@ Persistence format is not mandated in this spec, but it MUST be structured enoug
 
 ## Concurrency Requirements
 
-`agent-core` MUST enforce `maxConcurrency` for parallel tool execution. The current behavior of mapping all tool calls into `Promise.allSettled()` without limiting concurrency is not acceptable for subagent fan-out.
+`agent-core` MUST enforce `maxConcurrency` for parallel tool execution. Parallel tool dispatch MUST use a bounded worker pool or equivalent limiter rather than mapping all tool calls into unbounded `Promise.allSettled()` execution.
 
 `SubagentManager` MUST enforce its own `maxConcurrent` independently of core tool batch concurrency.
 
@@ -431,7 +431,7 @@ Errors returned to the model MUST be concise and structured. Detailed process lo
 1. Add types and unit tests for `SubagentManager`, `SubagentRunner`, and job state transitions.
 2. Implement manager with fake/in-process runner.
 3. Route existing `Agent` tool through manager in foreground mode.
-4. Enforce `maxConcurrency` in core parallel tool execution.
+4. Enforce `maxConcurrency` in core parallel tool execution. (Completed in `agent-core`; keep regression coverage.)
 5. Fix provider callback isolation.
 6. Add background mode and manager events to `InteractiveSession`.
 7. Add TUI state manager and rendering for subagent rows.

--- a/.agents/tasks/completed/CLI-BL-020-subagent-manager-core.md
+++ b/.agents/tasks/completed/CLI-BL-020-subagent-manager-core.md
@@ -1,0 +1,60 @@
+---
+title: CLI-BL-020 Subagent manager core implementation
+status: completed
+priority: high
+urgency: now
+created: 2026-04-30
+branch: feat/subagent-manager-core
+packages:
+  - agent-sdk
+  - agent-core
+  - agent-cli
+---
+
+# CLI-BL-020: Subagent Manager Core Implementation
+
+## Objective
+
+Implement the first slice of the Subagent Process Manager spec: a testable SDK-owned manager/runner contract with job lifecycle state, bounded concurrency, wait, cancel, and close semantics.
+
+## Plan
+
+- [x] Add failing unit tests for manager lifecycle and concurrency behavior.
+- [x] Add subagent runtime types and runner port.
+- [x] Implement `SubagentManager` with in-memory job registry.
+- [x] Export SDK types for future Agent tool and TUI integration.
+- [x] Update package SPEC.md to reflect the new SDK-owned manager contract.
+- [x] Run targeted `agent-sdk` tests/build.
+
+## Test List
+
+- [x] Given a spawn request, when runner starts, then the job moves from queued to running.
+- [x] Given a successful runner result, when it resolves, then the job moves to completed and stores output.
+- [x] Given a runner failure, when it rejects, then the job moves to failed and stores the error message.
+- [x] Given a running job, when cancel is requested, then only that job is cancelled.
+- [x] Given `maxConcurrent = 1`, when two jobs are spawned, then only one starts until the first completes.
+- [x] Given a completed job, when close is requested, then it is removed from the registry.
+
+## Progress
+
+### 2026-04-30
+
+- Created implementation branch from merged `develop`.
+- Started the core manager slice.
+- Added `SubagentManager`, subagent runtime types, and unit tests in `agent-sdk`.
+- Exported manager contracts from `@robota-sdk/agent-sdk`.
+- Updated `packages/agent-sdk/docs/SPEC.md`.
+- Verified with `agent-sdk` test/typecheck/lint/build and `harness:scan:specs`.
+
+## Decisions
+
+- Start with a pure in-memory manager and runner port in `agent-sdk`.
+- Leave child process runner, Agent tool integration, provider isolation, and TUI rendering for follow-up slices.
+
+## Blockers
+
+- None.
+
+## Result
+
+Completed the first implementation slice for the SDK-owned subagent manager core. Follow-up slices should connect the `Agent` tool to the manager, add background mode events to `InteractiveSession`, and implement the CLI child-process runner.

--- a/.agents/tasks/completed/CLI-BL-021-tool-batch-concurrency-limit.md
+++ b/.agents/tasks/completed/CLI-BL-021-tool-batch-concurrency-limit.md
@@ -1,0 +1,42 @@
+# Tool Batch Concurrency Limit
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: feat/subagent-manager-core
+- **Scope**: packages/agent-core, .agents/specs
+
+## Objective
+
+Enforce `maxConcurrency` for parallel tool batch execution so future subagent orchestration can rely on bounded parallel work rather than unbounded `Promise.all` execution.
+
+## Plan
+
+- [x] Add a unit test that proves parallel tool execution starts no more than `maxConcurrency` tools at once.
+- [x] Implement bounded parallel execution while preserving per-request result mapping and existing error behavior.
+- [x] Run targeted `agent-core` verification.
+- [x] Archive this task with the implementation result.
+
+## Progress
+
+### 2026-04-30
+
+- Started implementation on `feat/subagent-manager-core`.
+- Added a failing unit test for parallel `maxConcurrency` enforcement, then implemented bounded worker-pool execution and confirmed the targeted test passes.
+- Verified `agent-core` tests, typecheck, lint, and build pass. Lint still reports existing package warnings, with no errors.
+- Updated package and cross-cutting specs so the documented concurrency contract matches the implementation.
+- Ran `pnpm harness:scan`; it passed with existing file-size warnings reported by the scan.
+
+## Decisions
+
+- Keep the change inside the existing tool batch helper so callers that already pass `maxConcurrency` gain the behavior without API changes.
+
+## Blockers
+
+- None.
+
+## Result
+
+- `maxConcurrency` now bounds parallel tool execution with a worker pool while preserving per-request result order and existing error aggregation behavior.
+- Added a unit test that fails on unbounded parallel startup and passes with the bounded implementation.
+- Updated `agent-core` and subagent process manager specs for the completed concurrency slice.
+- Repository harness scan passes for this change.

--- a/.agents/tasks/completed/CLI-BL-022-agent-tool-subagent-manager-route.md
+++ b/.agents/tasks/completed/CLI-BL-022-agent-tool-subagent-manager-route.md
@@ -1,0 +1,49 @@
+# Agent Tool SubagentManager Route
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: feat/subagent-manager-core
+- **Scope**: packages/agent-sdk
+
+## Objective
+
+Route the model-callable `Agent` tool through `SubagentManager` in foreground mode while preserving the existing JSON result shape for callers.
+
+## Plan
+
+- [x] Add a unit test proving `Agent` tool uses an injected manager for `spawn()` and `wait()`.
+- [x] Add an in-process runner adapter so default `Agent` tool behavior still creates and runs subagent sessions.
+- [x] Wire session-created Agent tools to a per-session `SubagentManager`.
+- [x] Update SDK specs and run targeted verification.
+- [x] Archive this task with the implementation result.
+
+## Progress
+
+### 2026-04-30
+
+- Started follow-up slice on `feat/subagent-manager-core` after tool batch concurrency was pushed to PR #100.
+- Added a failing unit test for injected `SubagentManager` routing, then connected `Agent` tool foreground execution to `spawn()` and `wait()`.
+- Added `createInProcessSubagentRunner()` so the default managed path still uses isolated subagent sessions.
+- Verified targeted Agent tool tests, full `agent-sdk` tests, typecheck, lint, and build. Lint reports existing warnings with no errors.
+- Updated `agent-sdk` and cross-cutting subagent specs for the completed foreground manager route.
+- Ran repository `pnpm harness:scan`; it passes with existing file-size warnings reported by the scan.
+
+## Decisions
+
+- Keep foreground compatibility first: the `Agent` tool should still return `{ success, output, agentId }` while using the manager internally.
+
+## Test Plan
+
+- Add a unit test where a fake `SubagentManager` is injected into `createAgentTool()`, then assert the tool calls `spawn()` with a foreground job request and `wait()` with the returned job id.
+- Keep existing Agent tool tests passing to prove the default in-process runner still creates subagent sessions, forwards callbacks, applies model overrides, preserves unknown-agent errors, and returns the existing JSON result shape.
+- Run targeted Agent tool tests, full `agent-sdk` tests, `agent-sdk` typecheck, lint, build, and repository `harness:scan`.
+
+## Blockers
+
+- None.
+
+## Result
+
+- `Agent` tool foreground calls now run through `SubagentManager` while preserving the existing `{ success, output, agentId }` result shape.
+- `createSession()` wires a per-session manager backed by the in-process runner.
+- `ISubagentManager`, `createInProcessSubagentRunner()`, and runner deps are exported from `agent-sdk` for follow-up integration work.

--- a/.agents/tasks/completed/CLI-BL-023-provider-callback-isolation.md
+++ b/.agents/tasks/completed/CLI-BL-023-provider-callback-isolation.md
@@ -1,0 +1,47 @@
+# Provider Callback Isolation
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: feat/subagent-manager-core
+- **Scope**: packages/agent-core, packages/agent-sessions
+
+## Objective
+
+Prevent parent and subagent sessions that share a provider instance from overwriting each other's streaming text callbacks.
+
+## Plan
+
+- [x] Add a regression test proving two sessions sharing one provider keep `onTextDelta` callbacks isolated.
+- [x] Thread `onTextDelta` through per-run options/context instead of relying on mutable provider-level callback state.
+- [x] Preserve existing provider-level callback behavior for direct Robota/provider callers.
+- [x] Update specs and run targeted verification.
+- [x] Archive this task with the result.
+
+## Test Plan
+
+- Create two `Session` instances with the same provider and different `onTextDelta` callbacks. Run the first session after constructing the second session, then assert only the first callback receives streamed text.
+- Run targeted `agent-sessions` tests for the new regression and compaction behavior, plus `agent-core` execution tests affected by the new run option.
+- Run package typecheck/build/lint for touched packages and repository `harness:scan`.
+
+## Progress
+
+### 2026-04-30
+
+- Started provider callback isolation slice after `Agent` tool foreground manager routing was pushed to PR #100.
+- Added a failing regression test showing a later child session could overwrite the parent's streaming callback when the same provider instance was shared.
+- Added `IRunOptions.onTextDelta` and `IExecutionContext.onTextDelta`, then routed session streaming through per-run context.
+- Removed `Session` provider callback mutation while preserving provider-level callback fallback for lower-level callers.
+- Updated package and subagent process manager specs.
+- Verified `agent-core` and `agent-sessions` tests, typecheck, lint, and build for the touched scope.
+
+## Decisions
+
+- Use per-run callback context as the isolation boundary. Provider-level callback fallback remains available for direct lower-level use.
+
+## Blockers
+
+- None.
+
+## Result
+
+- Parent and subagent sessions sharing one provider now keep streaming callbacks isolated per run. `Session` stores its callback and passes it into `Robota.run()`, while `executeRound` and forced summary streaming prefer run-scoped callbacks before falling back to provider-level callback state.

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -361,13 +361,14 @@ The execution loop supports cooperative cancellation via the standard `AbortSign
 
 ### Interface Changes
 
-| Interface                    | Field                   | Description                                                       |
-| ---------------------------- | ----------------------- | ----------------------------------------------------------------- |
-| `IRunOptions`                | `signal?: AbortSignal`  | Allows callers to cancel execution of `Robota.run()`              |
-| `IChatOptions`               | `signal?: AbortSignal`  | Passed to provider `chat()` / `chatStream()` for cancelling calls |
-| `IExecutionContext`          | `signal?: AbortSignal`  | Threaded through the execution context for round-level checks     |
-| `IExecutionResult`           | `interrupted?: boolean` | Indicates the execution was aborted before natural completion     |
-| `IToolExecutionBatchContext` | `signal?: AbortSignal`  | Allows skipping queued tool executions when abort is signalled    |
+| Interface                    | Field                     | Description                                                       |
+| ---------------------------- | ------------------------- | ----------------------------------------------------------------- |
+| `IRunOptions`                | `signal?: AbortSignal`    | Allows callers to cancel execution of `Robota.run()`              |
+| `IChatOptions`               | `signal?: AbortSignal`    | Passed to provider `chat()` / `chatStream()` for cancelling calls |
+| `IExecutionContext`          | `signal?: AbortSignal`    | Threaded through the execution context for round-level checks     |
+| `IExecutionResult`           | `interrupted?: boolean`   | Indicates the execution was aborted before natural completion     |
+| `IToolExecutionBatchContext` | `signal?: AbortSignal`    | Allows skipping queued tool executions when abort is signalled    |
+| `IToolExecutionBatchContext` | `maxConcurrency?: number` | Bounds active tool executions when batch mode is `parallel`       |
 
 ### Signal Propagation
 
@@ -378,6 +379,10 @@ AbortSignal flows through: Session -> `robota.run()` -> ExecutionService -> `cal
 - **executeAndRecordToolCalls**: Passes `signal` to the tool batch context so queued tools are skipped once abort is triggered.
 - **streamWithAbort**: Checks `signal.aborted` after each yielded event, breaking out of the stream iteration loop.
 - **AbortError handling**: `AbortError` exceptions thrown by the fetch layer are caught by the execution loop and treated as a clean interruption (not an error).
+
+### Tool Batch Concurrency
+
+When `IToolExecutionBatchContext.mode` is `parallel`, `ToolExecutionService` enforces `maxConcurrency` with bounded worker execution. The batch result preserves one result slot per request in request order, while errors are aggregated after all started or skipped work settles. If `maxConcurrency` is omitted, all requests may run concurrently; if it is less than 1, execution is clamped to one active tool.
 
 ### Partial Content Preservation on Abort
 

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -173,7 +173,7 @@ NOTE: `ToolRegistry`, `FunctionTool`, `createFunctionTool`, `createZodFunctionTo
 | -------------------- | ---- | --------------------------------------------------- |
 | `TTextDeltaCallback` | type | `(delta: string) => void` — streaming text callback |
 
-This callback is declared in `IChatOptions.onTextDelta` and used by providers to emit text chunks during streaming responses.
+This callback is declared in `IChatOptions.onTextDelta` and `IRunOptions.onTextDelta`. Provider implementations use `IChatOptions.onTextDelta` to emit text chunks during streaming responses. Higher-level callers should prefer `IRunOptions.onTextDelta` for per-run streaming output so multiple sessions can share a provider instance without overwriting mutable provider callback state.
 
 ### Context Window Tracking
 
@@ -361,14 +361,16 @@ The execution loop supports cooperative cancellation via the standard `AbortSign
 
 ### Interface Changes
 
-| Interface                    | Field                     | Description                                                       |
-| ---------------------------- | ------------------------- | ----------------------------------------------------------------- |
-| `IRunOptions`                | `signal?: AbortSignal`    | Allows callers to cancel execution of `Robota.run()`              |
-| `IChatOptions`               | `signal?: AbortSignal`    | Passed to provider `chat()` / `chatStream()` for cancelling calls |
-| `IExecutionContext`          | `signal?: AbortSignal`    | Threaded through the execution context for round-level checks     |
-| `IExecutionResult`           | `interrupted?: boolean`   | Indicates the execution was aborted before natural completion     |
-| `IToolExecutionBatchContext` | `signal?: AbortSignal`    | Allows skipping queued tool executions when abort is signalled    |
-| `IToolExecutionBatchContext` | `maxConcurrency?: number` | Bounds active tool executions when batch mode is `parallel`       |
+| Interface                    | Field                              | Description                                                       |
+| ---------------------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| `IRunOptions`                | `signal?: AbortSignal`             | Allows callers to cancel execution of `Robota.run()`              |
+| `IRunOptions`                | `onTextDelta?: TTextDeltaCallback` | Per-run streaming callback forwarded through execution context    |
+| `IChatOptions`               | `signal?: AbortSignal`             | Passed to provider `chat()` / `chatStream()` for cancelling calls |
+| `IExecutionContext`          | `signal?: AbortSignal`             | Threaded through the execution context for round-level checks     |
+| `IExecutionContext`          | `onTextDelta?: TTextDeltaCallback` | Run-scoped callback used before provider-level callback fallback  |
+| `IExecutionResult`           | `interrupted?: boolean`            | Indicates the execution was aborted before natural completion     |
+| `IToolExecutionBatchContext` | `signal?: AbortSignal`             | Allows skipping queued tool executions when abort is signalled    |
+| `IToolExecutionBatchContext` | `maxConcurrency?: number`          | Bounds active tool executions when batch mode is `parallel`       |
 
 ### Signal Propagation
 
@@ -460,7 +462,7 @@ All message factory functions auto-generate `id` via `randomUUID()` and set `sta
 The `executeRound` function manages streaming through `ConversationStore`:
 
 1. `beginAssistant()` initializes pending state before the provider call.
-2. Provider's `onTextDelta` callback is wrapped to call `appendStreaming(delta)` on each delta.
+2. The run-scoped `onTextDelta` callback is preferred over provider-level callback state, then wrapped to call `appendStreaming(delta)` on each delta.
 3. After the provider returns: tool calls are added via `appendToolCall(toolCall)`.
 4. `commitAssistant(state, metadata?)` is called with state determined by `signal.aborted` — `'interrupted'` if aborted, `'complete'` otherwise.
 5. Single commit path — no branching between normal and abort flows.
@@ -567,7 +569,7 @@ Error: Context window near capacity. Tool execution result skipped.
 
 ### Streaming Round Separator
 
-When the execution loop starts round 2+ (after tool execution), `execution-round.ts` emits `'\n\n'` through `provider.onTextDelta` before calling `provider.chat()`. This separates streaming text from different rounds in the CLI, which would otherwise concatenate without line breaks.
+When the execution loop starts round 2+ (after tool execution), `execution-round.ts` emits `'\n\n'` through the run-scoped `onTextDelta` callback before calling `provider.chat()`, falling back to `provider.onTextDelta` only when no run callback is present. This separates streaming text from different rounds in the CLI, which would otherwise concatenate without line breaks.
 
 ## Class Contract Registry
 

--- a/packages/agent-core/src/core/robota-execution.ts
+++ b/packages/agent-core/src/core/robota-execution.ts
@@ -5,6 +5,7 @@
  */
 import type { TUniversalMessage, IAgentConfig, IRunOptions } from '../interfaces/agent';
 import type { ExecutionService } from '../services/execution-service';
+import type { IExecutionContext } from '../services/execution-types';
 import type { ILogger } from '../utils/logger';
 import type { IAgentEventData } from '../interfaces/event-service';
 import { AGENT_EVENTS } from '../agents/constants';
@@ -17,6 +18,20 @@ export interface IRobotaExecutionDeps {
   getHistory(): TUniversalMessage[];
   getExecutionService(): ExecutionService;
   emitAgentEvent(eventType: string, data: Omit<IAgentEventData, 'timestamp'>): void;
+}
+
+function buildRunContext(
+  deps: IRobotaExecutionDeps,
+  options: IRunOptions,
+): Partial<IExecutionContext> {
+  return {
+    conversationId: deps.conversationId,
+    ...(options.sessionId && { sessionId: options.sessionId }),
+    ...(options.userId && { userId: options.userId }),
+    ...(options.metadata && { metadata: options.metadata }),
+    ...(options.signal && { signal: options.signal }),
+    ...(options.onTextDelta && { onTextDelta: options.onTextDelta }),
+  };
 }
 
 /** Execute a single conversation turn. @internal */
@@ -39,13 +54,9 @@ export async function robotaRun(
     const messages = deps.getHistory();
     const executionConfig: IAgentConfig = { ...deps.config };
 
-    const result = await deps.getExecutionService().execute(input, messages, executionConfig, {
-      conversationId: deps.conversationId,
-      ...(options.sessionId && { sessionId: options.sessionId }),
-      ...(options.userId && { userId: options.userId }),
-      ...(options.metadata && { metadata: options.metadata }),
-      ...(options.signal && { signal: options.signal }),
-    });
+    const result = await deps
+      .getExecutionService()
+      .execute(input, messages, executionConfig, buildRunContext(deps, options));
 
     deps.logger.debug('Robota execution completed', {
       success: result.success,

--- a/packages/agent-core/src/interfaces/agent.ts
+++ b/packages/agent-core/src/interfaces/agent.ts
@@ -1,4 +1,4 @@
-import type { TProviderConfigValue, IAIProvider } from './provider';
+import type { TProviderConfigValue, IAIProvider, TTextDeltaCallback } from './provider';
 import type { IPluginContract, IPluginOptions, IPluginStats } from '../abstracts/abstract-plugin';
 import type { IModule } from '../abstracts/abstract-module';
 import type { IToolWithEventService } from '../abstracts/abstract-tool';
@@ -164,6 +164,8 @@ export interface IRunOptions {
   metadata?: TMetadata;
   /** AbortSignal for cancelling execution */
   signal?: AbortSignal;
+  /** Per-run streaming text callback. Prefer this over mutating provider callback state. */
+  onTextDelta?: TTextDeltaCallback;
 }
 
 /**

--- a/packages/agent-core/src/services/execution-pipeline.ts
+++ b/packages/agent-core/src/services/execution-pipeline.ts
@@ -82,6 +82,7 @@ export async function runExecutionLoop(
       executionId,
       roundState,
       conversationId,
+      fullContext,
       deps.logger,
     );
   }
@@ -98,6 +99,7 @@ export async function forceSummaryCall(
   executionId: string,
   roundState: IExecutionRoundState,
   conversationId: string,
+  fullContext: IExecutionContext,
   logger: ILogger,
 ): Promise<void> {
   const maxRounds = 10;
@@ -133,8 +135,11 @@ export async function forceSummaryCall(
     const chatOptions: { model: string; onTextDelta?: (delta: string) => void } = {
       model: resolved.aiProviderInfo.model,
     };
-    if ('onTextDelta' in resolved.provider && typeof resolved.provider.onTextDelta === 'function') {
-      chatOptions.onTextDelta = resolved.provider.onTextDelta as (delta: string) => void;
+    const runTextDelta =
+      fullContext.onTextDelta ??
+      (resolved.provider as { onTextDelta?: (delta: string) => void }).onTextDelta;
+    if (runTextDelta) {
+      chatOptions.onTextDelta = runTextDelta;
     }
 
     const forceResponse = await resolved.provider.chat(messagesForProvider, chatOptions);

--- a/packages/agent-core/src/services/execution-round.ts
+++ b/packages/agent-core/src/services/execution-round.ts
@@ -156,19 +156,20 @@ export async function executeRound(
     return true;
   }
 
+  const runTextDelta =
+    fullContext.onTextDelta ??
+    (resolved.provider as { onTextDelta?: (delta: string) => void }).onTextDelta;
+
   // Round separator for streaming UI
-  if (currentRound > 1 && 'onTextDelta' in resolved.provider) {
-    const cb = (resolved.provider as { onTextDelta?: (delta: string) => void }).onTextDelta;
-    if (cb) cb('\n\n');
+  if (currentRound > 1) {
+    runTextDelta?.('\n\n');
   }
 
   conversationStore.beginAssistant();
 
-  const originalOnTextDelta = (resolved.provider as { onTextDelta?: (delta: string) => void })
-    .onTextDelta;
   const wrappedOnTextDelta = (delta: string): void => {
     conversationStore.appendStreaming(delta);
-    originalOnTextDelta?.call(resolved.provider, delta);
+    runTextDelta?.(delta);
   };
 
   let response: TUniversalMessage;

--- a/packages/agent-core/src/services/execution-service.ts
+++ b/packages/agent-core/src/services/execution-service.ts
@@ -30,6 +30,28 @@ import {
 } from './execution-service-helpers';
 import { runExecutionLoop, finalizeExecution } from './execution-pipeline';
 
+function buildFullExecutionContext(
+  messages: TUniversalMessage[],
+  config: IAgentConfig,
+  startTime: Date,
+  executionId: string,
+  conversationId: string,
+  context?: Partial<IExecutionContext>,
+): IExecutionContext {
+  return {
+    messages,
+    config,
+    startTime,
+    executionId,
+    conversationId,
+    ...(context?.sessionId && { sessionId: context.sessionId }),
+    ...(context?.userId && { userId: context.userId }),
+    ...(context?.metadata && { metadata: context.metadata }),
+    ...(context?.signal && { signal: context.signal }),
+    ...(context?.onTextDelta && { onTextDelta: context.onTextDelta }),
+  };
+}
+
 /**
  * Service that orchestrates the entire execution pipeline.
  * Coordinates AI provider execution, tool execution service, and plugin lifecycle.
@@ -117,17 +139,14 @@ export class ExecutionService {
     const startTime = new Date();
     const conversationId = requireConversationId(context, 'execute');
 
-    const fullContext: IExecutionContext = {
+    const fullContext = buildFullExecutionContext(
       messages,
       config,
       startTime,
       executionId,
       conversationId,
-      ...(context?.sessionId && { sessionId: context.sessionId }),
-      ...(context?.userId && { userId: context.userId }),
-      ...(context?.metadata && { metadata: context.metadata }),
-      ...(context?.signal && { signal: context.signal }),
-    };
+      context,
+    );
 
     this.eventEmitter.prepareOwnerPathBases(conversationId);
 

--- a/packages/agent-core/src/services/execution-types.ts
+++ b/packages/agent-core/src/services/execution-types.ts
@@ -2,7 +2,7 @@ import type { IAgentConfig, IAssistantMessage } from '../interfaces/agent';
 import type { TMetadata } from '../interfaces/types';
 import type { IAIProviderManager } from '../interfaces/manager';
 import type { IToolManager } from '../interfaces/manager';
-import type { IChatOptions } from '../interfaces/provider';
+import type { IChatOptions, TTextDeltaCallback } from '../interfaces/provider';
 import type { TUniversalMessage } from '../interfaces/messages';
 
 /** Preview length for general content truncation */
@@ -103,6 +103,8 @@ export interface IExecutionContext {
   executionId: string;
   /** AbortSignal for cancelling execution */
   signal?: AbortSignal;
+  /** Per-run streaming text callback. */
+  onTextDelta?: TTextDeltaCallback;
 }
 
 /**

--- a/packages/agent-core/src/services/tool-execution-batch.ts
+++ b/packages/agent-core/src/services/tool-execution-batch.ts
@@ -1,7 +1,14 @@
-import type { IToolExecutionResult, IToolExecutionContext } from '../interfaces/tool';
+import type {
+  IToolExecutionResult,
+  IToolExecutionContext,
+  TToolParameters,
+} from '../interfaces/tool';
 import type { ILogger } from '../utils/logger';
 import { ValidationError } from '../utils/errors';
 import type { IToolExecutionBatchContext } from './tool-execution-service';
+import type { IToolExecutionRequest } from '../interfaces/service';
+
+const MIN_PARALLEL_CONCURRENCY = 1;
 
 /**
  * Shared interface for the minimal ToolExecutionService surface needed by batch helpers.
@@ -9,9 +16,15 @@ import type { IToolExecutionBatchContext } from './tool-execution-service';
 export interface IToolExecutor {
   executeTool(
     toolName: string,
-    parameters: Record<string, unknown>,
+    parameters: TToolParameters,
     context?: IToolExecutionContext,
   ): Promise<IToolExecutionResult>;
+}
+
+interface IParallelExecutionState {
+  resultsByIndex: Array<IToolExecutionResult | undefined>;
+  errorsByIndex: Array<Error | undefined>;
+  nextRequestIndex: number;
 }
 
 function requireExecutionRequestFields(request: {
@@ -41,73 +54,138 @@ function requireExecutionRequestFields(request: {
   };
 }
 
+function createExecutionContext(request: IToolExecutionRequest): IToolExecutionContext {
+  const required = requireExecutionRequestFields(request);
+  return {
+    toolName: request.toolName,
+    parameters: request.parameters,
+    executionId: required.executionId,
+    ownerType: required.ownerType,
+    ownerId: required.ownerId,
+    ownerPath: request.ownerPath,
+    metadata: request.metadata,
+    eventService: request.eventService,
+    baseEventService: request.baseEventService,
+  };
+}
+
+function createInterruptedResult(request: IToolExecutionRequest): IToolExecutionResult {
+  return {
+    toolName: request.toolName,
+    executionId: request.executionId ?? '',
+    success: false,
+    error: 'Execution interrupted by user',
+    result: null,
+  };
+}
+
+function createErrorResult(request: IToolExecutionRequest, error: Error): IToolExecutionResult {
+  return {
+    toolName: request.toolName,
+    result: null,
+    success: false,
+    error: error.message,
+    executionId: request.executionId,
+  };
+}
+
+function createToolFailureError(result: IToolExecutionResult): Error {
+  return new Error(
+    `Tool execution failed: toolName=${String(result.toolName)} executionId=${String(result.executionId)} error=${String(result.error || 'Unknown error')}`,
+  );
+}
+
+function isDefinedResult(result: IToolExecutionResult | undefined): result is IToolExecutionResult {
+  return result !== undefined;
+}
+
+function isDefinedError(error: Error | undefined): error is Error {
+  return error !== undefined;
+}
+
+function resolveMaxConcurrency(requestCount: number, maxConcurrency?: number): number {
+  if (requestCount === 0) {
+    return 0;
+  }
+  if (maxConcurrency === undefined || !Number.isFinite(maxConcurrency)) {
+    return requestCount;
+  }
+
+  const normalized = Math.floor(maxConcurrency);
+  if (normalized < MIN_PARALLEL_CONCURRENCY) {
+    return MIN_PARALLEL_CONCURRENCY;
+  }
+
+  return Math.min(normalized, requestCount);
+}
+
+async function executeParallelRequest(
+  batchContext: IToolExecutionBatchContext,
+  executor: IToolExecutor,
+  state: IParallelExecutionState,
+  index: number,
+): Promise<void> {
+  const request = batchContext.requests[index];
+  if (!request) {
+    return;
+  }
+
+  try {
+    const result = batchContext.signal?.aborted
+      ? createInterruptedResult(request)
+      : await executor.executeTool(
+          request.toolName,
+          request.parameters,
+          createExecutionContext(request),
+        );
+    state.resultsByIndex[index] = result;
+    if (!result.success) {
+      state.errorsByIndex[index] = createToolFailureError(result);
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    state.errorsByIndex[index] = err;
+    state.resultsByIndex[index] = createErrorResult(request, err);
+  }
+}
+
+async function runParallelWorker(
+  batchContext: IToolExecutionBatchContext,
+  executor: IToolExecutor,
+  state: IParallelExecutionState,
+): Promise<void> {
+  while (state.nextRequestIndex < batchContext.requests.length) {
+    const currentIndex = state.nextRequestIndex;
+    state.nextRequestIndex += 1;
+    await executeParallelRequest(batchContext, executor, state, currentIndex);
+  }
+}
+
 /**
- * Execute tool requests in parallel with Promise.allSettled.
+ * Execute tool requests in parallel with a bounded worker pool.
  * Preserves a result entry for every request (SSOT for toolCallId → result mapping).
  */
 async function executeParallel(
   batchContext: IToolExecutionBatchContext,
   executor: IToolExecutor,
 ): Promise<{ results: IToolExecutionResult[]; errors: Error[] }> {
-  const results: IToolExecutionResult[] = [];
-  const errors: Error[] = [];
-
-  const promises = batchContext.requests.map((request) =>
-    (() => {
-      if (batchContext.signal?.aborted) {
-        return Promise.resolve({
-          toolName: request.toolName,
-          executionId: request.executionId ?? '',
-          success: false,
-          error: 'Execution interrupted by user',
-          result: null,
-        } as IToolExecutionResult);
-      }
-      const required = requireExecutionRequestFields(request);
-      return executor.executeTool(request.toolName, request.parameters, {
-        toolName: request.toolName,
-        parameters: request.parameters,
-        executionId: required.executionId,
-        ownerType: required.ownerType,
-        ownerId: required.ownerId,
-        ownerPath: request.ownerPath,
-        metadata: request.metadata,
-        eventService: request.eventService,
-        baseEventService: request.baseEventService,
-      });
-    })(),
+  const state: IParallelExecutionState = {
+    resultsByIndex: new Array(batchContext.requests.length),
+    errorsByIndex: new Array(batchContext.requests.length),
+    nextRequestIndex: 0,
+  };
+  const concurrency = resolveMaxConcurrency(
+    batchContext.requests.length,
+    batchContext.maxConcurrency,
   );
 
-  const allResults = await Promise.allSettled(promises);
+  const workers = Array.from({ length: concurrency }, () =>
+    runParallelWorker(batchContext, executor, state),
+  );
+  await Promise.all(workers);
 
-  allResults.forEach((settledResult, index) => {
-    const request = batchContext.requests[index];
-    if (!request) return;
-    if (settledResult.status === 'fulfilled') {
-      const result = settledResult.value;
-      results.push(result);
-      if (!result.success) {
-        errors.push(
-          new Error(
-            `Tool execution failed: toolName=${String(result.toolName)} executionId=${String(result.executionId)} error=${String(result.error || 'Unknown error')}`,
-          ),
-        );
-      }
-      return;
-    }
-    const err =
-      settledResult.reason instanceof Error
-        ? settledResult.reason
-        : new Error(String(settledResult.reason));
-    errors.push(err);
-    results.push({
-      toolName: request.toolName,
-      result: null,
-      success: false,
-      error: err.message,
-      executionId: request.executionId,
-    });
-  });
+  const results = state.resultsByIndex.filter(isDefinedResult);
+  const errors = state.errorsByIndex.filter(isDefinedError);
 
   if (errors.length > 0 && !batchContext.continueOnError) {
     throw errors[0];
@@ -128,25 +206,14 @@ async function executeSequential(
 
   for (const request of batchContext.requests) {
     try {
-      const required = requireExecutionRequestFields(request);
-      const result = await executor.executeTool(request.toolName, request.parameters, {
-        toolName: request.toolName,
-        parameters: request.parameters,
-        executionId: required.executionId,
-        ownerType: required.ownerType,
-        ownerId: required.ownerId,
-        ownerPath: request.ownerPath,
-        metadata: request.metadata,
-        eventService: request.eventService,
-        baseEventService: request.baseEventService,
-      });
+      const result = await executor.executeTool(
+        request.toolName,
+        request.parameters,
+        createExecutionContext(request),
+      );
       results.push(result);
       if (!result.success) {
-        errors.push(
-          new Error(
-            `Tool execution failed: toolName=${String(result.toolName)} executionId=${String(result.executionId)} error=${String(result.error || 'Unknown error')}`,
-          ),
-        );
+        errors.push(createToolFailureError(result));
       }
       if (!result.success && !batchContext.continueOnError) {
         break;

--- a/packages/agent-core/src/services/tool-execution-service.test.ts
+++ b/packages/agent-core/src/services/tool-execution-service.test.ts
@@ -296,6 +296,61 @@ describe('ToolExecutionService', () => {
         expect(errors).toHaveLength(0);
       });
 
+      it('should limit active parallel tools by maxConcurrency', async () => {
+        const startedToolNames: string[] = [];
+        const resolvers = new Map<string, (value: string) => void>();
+        const tools = createMockToolManager({
+          executeTool: vi.fn().mockImplementation((toolName: string) => {
+            startedToolNames.push(toolName);
+            return new Promise<string>((resolve) => {
+              resolvers.set(toolName, resolve);
+            });
+          }),
+        });
+        const service = new ToolExecutionService(tools, createMockLogger());
+
+        const execution = service.executeTools({
+          requests: [
+            createRequest({ toolName: 'tool_1', executionId: 'p1', ownerId: 'p1' }),
+            createRequest({ toolName: 'tool_2', executionId: 'p2', ownerId: 'p2' }),
+            createRequest({ toolName: 'tool_3', executionId: 'p3', ownerId: 'p3' }),
+            createRequest({ toolName: 'tool_4', executionId: 'p4', ownerId: 'p4' }),
+          ],
+          mode: 'parallel',
+          continueOnError: true,
+          maxConcurrency: 2,
+        });
+
+        await Promise.resolve();
+
+        expect(startedToolNames).toEqual(['tool_1', 'tool_2']);
+
+        resolvers.get('tool_1')?.('result_tool_1');
+
+        await vi.waitFor(() => {
+          expect(startedToolNames).toEqual(['tool_1', 'tool_2', 'tool_3']);
+        });
+
+        resolvers.get('tool_2')?.('result_tool_2');
+
+        await vi.waitFor(() => {
+          expect(startedToolNames).toEqual(['tool_1', 'tool_2', 'tool_3', 'tool_4']);
+        });
+
+        resolvers.get('tool_3')?.('result_tool_3');
+        resolvers.get('tool_4')?.('result_tool_4');
+
+        const { results, errors } = await execution;
+
+        expect(results.map((result) => result.toolName)).toEqual([
+          'tool_1',
+          'tool_2',
+          'tool_3',
+          'tool_4',
+        ]);
+        expect(errors).toHaveLength(0);
+      });
+
       it('should throw on first error when continueOnError is false', async () => {
         const tools = createMockToolManager({
           executeTool: vi.fn().mockResolvedValueOnce('ok').mockRejectedValueOnce(new Error('fail')),

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -117,7 +117,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md walk-up discovery, project detection, system prompt
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
-├── src/subagents/              ← SubagentManager + runner port for managed subagent jobs
+├── src/subagents/              ← SubagentManager + runner ports/adapters for managed subagent jobs
 ├── src/permissions/            ← permission-prompt.ts (terminal approval prompt)
 ├── src/paths.ts                ← projectPaths / userPaths helpers
 ├── src/types.ts                ← re-exports shared types from agent-sessions
@@ -422,16 +422,19 @@ const result = await manager.wait(job.id);
 
 Exported subagent runtime types:
 
-| Export                  | Kind      | Description                                      |
-| ----------------------- | --------- | ------------------------------------------------ |
-| `SubagentManager`       | class     | In-memory subagent job registry and scheduler    |
-| `ISubagentRunner`       | interface | Port implemented by in-process or process runner |
-| `ISubagentJobHandle`    | interface | Targeted job cancellation/result handle          |
-| `ISubagentJobState`     | interface | Runtime lifecycle state for one subagent job     |
-| `ISubagentSpawnRequest` | interface | Input for spawning a managed subagent job        |
-| `ISubagentJobResult`    | interface | Completed subagent output                        |
-| `TSubagentJobMode`      | type      | `foreground` or `background`                     |
-| `TSubagentJobStatus`    | type      | Job lifecycle status union                       |
+| Export                          | Kind      | Description                                                               |
+| ------------------------------- | --------- | ------------------------------------------------------------------------- |
+| `SubagentManager`               | class     | In-memory subagent job registry and scheduler                             |
+| `createInProcessSubagentRunner` | function  | Runner adapter that executes subagent jobs with `createSubagentSession()` |
+| `ISubagentManager`              | interface | Manager API for spawn/wait/list/get/cancel/close/send                     |
+| `ISubagentRunner`               | interface | Port implemented by in-process or process runner                          |
+| `IInProcessSubagentRunnerDeps`  | interface | Dependencies captured by the in-process runner adapter                    |
+| `ISubagentJobHandle`            | interface | Targeted job cancellation/result handle                                   |
+| `ISubagentJobState`             | interface | Runtime lifecycle state for one subagent job                              |
+| `ISubagentSpawnRequest`         | interface | Input for spawning a managed subagent job                                 |
+| `ISubagentJobResult`            | interface | Completed subagent output                                                 |
+| `TSubagentJobMode`              | type      | `foreground` or `background`                                              |
+| `TSubagentJobStatus`            | type      | Job lifecycle status union                                                |
 
 ### History Entry Types
 
@@ -781,6 +784,8 @@ Agent definitions are also exposed to the system prompt by metadata only: name a
 
 The `Agent` tool must be part of the available tool set and must be described in `DEFAULT_TOOL_DESCRIPTIONS`.
 
+The `Agent` tool routes execution through a per-session `SubagentManager` in foreground mode. It resolves unknown agent types before spawning so existing error results remain compatible, then calls `spawn()` and `wait()` and returns the existing JSON shape: `{ success, output, agentId }`.
+
 ### Skill Execution Semantics
 
 `InteractiveSession.executeSkillCommand(skill, args, displayInput?, rawInput?)` is the SDK-owned skill execution path.
@@ -841,6 +846,8 @@ interface ISubagentJobHandle {
 ```
 
 The runner reports completion through its `result` promise and supports targeted cancellation through `cancel()`. Follow-up routing via `send()` is optional until a runner supports it.
+
+`createInProcessSubagentRunner(deps)` is the default SDK adapter for foreground compatibility. It resolves the requested agent definition, creates an isolated child `Session` with `createSubagentSession()`, runs the prompt, and maps the response to `ISubagentJobResult`.
 
 ### createSubagentSession(options)
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -117,6 +117,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md walk-up discovery, project detection, system prompt
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
+├── src/subagents/              ← SubagentManager + runner port for managed subagent jobs
 ├── src/permissions/            ← permission-prompt.ts (terminal approval prompt)
 ├── src/paths.ts                ← projectPaths / userPaths helpers
 ├── src/types.ts                ← re-exports shared types from agent-sessions
@@ -394,6 +395,43 @@ interface ITransportAdapter {
 ```
 
 Common interface for all transport adapters. Defined in `src/interactive/types.ts` and exported from `@robota-sdk/agent-sdk`. Each `agent-transport-*` package provides a factory that returns an `ITransportAdapter` implementation.
+
+### SubagentManager — Managed Subagent Job Registry
+
+`SubagentManager` and its associated types are exported for clients that need to compose managed subagent execution.
+
+```typescript
+import { SubagentManager } from '@robota-sdk/agent-sdk';
+import type { ISubagentRunner } from '@robota-sdk/agent-sdk';
+
+const runner: ISubagentRunner = createRunner();
+const manager = new SubagentManager({ runner, maxConcurrent: 2 });
+
+const job = await manager.spawn({
+  type: 'general-purpose',
+  label: 'General purpose',
+  parentSessionId: 'session_parent',
+  mode: 'foreground',
+  depth: 1,
+  cwd: process.cwd(),
+  prompt: 'Review the codebase',
+});
+
+const result = await manager.wait(job.id);
+```
+
+Exported subagent runtime types:
+
+| Export                  | Kind      | Description                                      |
+| ----------------------- | --------- | ------------------------------------------------ |
+| `SubagentManager`       | class     | In-memory subagent job registry and scheduler    |
+| `ISubagentRunner`       | interface | Port implemented by in-process or process runner |
+| `ISubagentJobHandle`    | interface | Targeted job cancellation/result handle          |
+| `ISubagentJobState`     | interface | Runtime lifecycle state for one subagent job     |
+| `ISubagentSpawnRequest` | interface | Input for spawning a managed subagent job        |
+| `ISubagentJobResult`    | interface | Completed subagent output                        |
+| `TSubagentJobMode`      | type      | `foreground` or `background`                     |
+| `TSubagentJobStatus`    | type      | Job lifecycle status union                       |
 
 ### History Entry Types
 
@@ -769,6 +807,40 @@ During `createSession()`, hooks from the merged settings configuration are wired
 6. `Stop` hooks fire on session termination
 
 ## Subagent Execution
+
+### SubagentManager
+
+`SubagentManager` is the SDK-owned runtime registry for managed subagent jobs. It is a provider-neutral application service that depends on an injected `ISubagentRunner` port.
+
+Responsibilities:
+
+- create addressable subagent job records
+- enforce bounded concurrency
+- track lifecycle state: `queued`, `running`, `waiting_permission`, `completed`, `failed`, `cancelled`
+- expose `spawn`, `wait`, `list`, `get`, `cancel`, `close`, and `send` operations
+- keep runner implementation details out of TUI and Agent tool code
+
+`SubagentManager` does not create providers, sessions, child processes, worktrees, or TUI state directly. Those concerns belong to runner adapters and outer composition layers.
+
+### SubagentRunner Port
+
+`ISubagentRunner` is the execution boundary for one subagent job. Implementations can run jobs in-process for tests or in a child process for CLI runtime.
+
+```typescript
+interface ISubagentRunner {
+  start(job: ISubagentJobStart): ISubagentJobHandle;
+}
+
+interface ISubagentJobHandle {
+  readonly jobId: string;
+  readonly pid?: number;
+  result: Promise<ISubagentJobResult>;
+  cancel(reason?: string): Promise<void>;
+  send?(prompt: string): Promise<void>;
+}
+```
+
+The runner reports completion through its `result` promise and supports targeted cancellation through `cancel()`. Follow-up routing via `send()` is optional until a runner supports it.
 
 ### createSubagentSession(options)
 

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -28,6 +28,9 @@ import type { ISystemPromptParams } from '../context/system-prompt-builder.js';
 import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
 
 import { createAgentTool, storeAgentToolDeps } from '../tools/agent-tool.js';
+import type { IAgentToolDeps } from '../tools/agent-tool.js';
+import { SubagentManager } from '../subagents/subagent-manager.js';
+import { createInProcessSubagentRunner } from '../subagents/in-process-subagent-runner.js';
 import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
 
@@ -137,20 +140,25 @@ export function createSession(options: ICreateSessionOptions): Session {
     hookTypeExecutors.push(...options.additionalHookExecutors);
   }
 
-  const agentToolDeps = {
+  const agentToolDeps: IAgentToolDeps = {
     config: options.config,
     context: options.context,
     tools,
     terminal: options.terminal,
     provider,
+    cwd,
+    parentSessionId: options.sessionId ?? 'pending-session',
     permissionMode: options.permissionMode,
     permissionHandler: options.permissionHandler,
-    hooks: options.config.hooks as Record<string, unknown> | undefined,
+    hooks: options.config.hooks,
     hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
     onTextDelta: options.onTextDelta,
     onToolExecution: options.onToolExecution,
     customAgentRegistry: (name: string) => agentLoader.getAgent(name),
   };
+  agentToolDeps.subagentManager = new SubagentManager({
+    runner: createInProcessSubagentRunner(agentToolDeps),
+  });
   tools.push(createAgentTool(agentToolDeps));
 
   const buildPrompt = options.systemPromptBuilder ?? buildSystemPrompt;
@@ -216,6 +224,7 @@ export function createSession(options: ICreateSessionOptions): Session {
 
   // Store deps keyed by session so consumers (e.g. fork runner) can retrieve
   // per-session deps without relying on global mutable state.
+  agentToolDeps.parentSessionId = session.getSessionId();
   storeAgentToolDeps(session, agentToolDeps);
 
   return session;

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -110,6 +110,20 @@ export type { ISubagentPromptOptions, ISubagentOptions } from './assembly/index.
 export { createAgentTool, storeAgentToolDeps, retrieveAgentToolDeps } from './tools/agent-tool.js';
 export type { IAgentToolDeps } from './tools/agent-tool.js';
 
+// ── Subagent process manager contracts ─────────────────────
+export { SubagentManager } from './subagents/index.js';
+export type {
+  ISubagentJobHandle,
+  ISubagentJobResult,
+  ISubagentJobStart,
+  ISubagentJobState,
+  ISubagentManagerOptions,
+  ISubagentRunner,
+  ISubagentSpawnRequest,
+  TSubagentJobMode,
+  TSubagentJobStatus,
+} from './subagents/index.js';
+
 // ── Hook executors ──────────────────────────────────────────
 export { PromptExecutor, AgentExecutor } from './hooks/index.js';
 export type { TProviderFactory, IPromptProvider, IPromptExecutorOptions } from './hooks/index.js';

--- a/packages/agent-sdk/src/subagents/__tests__/subagent-manager.test.ts
+++ b/packages/agent-sdk/src/subagents/__tests__/subagent-manager.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { SubagentManager } from '../subagent-manager.js';
+import type {
+  ISubagentJobHandle,
+  ISubagentJobResult,
+  ISubagentJobStart,
+  ISubagentRunner,
+} from '../types.js';
+
+interface ITestDeferred {
+  promise: Promise<ISubagentJobResult>;
+  resolve: (result: ISubagentJobResult) => void;
+  reject: (error: Error) => void;
+}
+
+interface IStartedJob {
+  jobId: string;
+  deferred: ITestDeferred;
+  cancelReason?: string;
+}
+
+function createTestDeferred(): ITestDeferred {
+  let resolveFn: (result: ISubagentJobResult) => void = () => {};
+  let rejectFn: (error: Error) => void = () => {};
+  const promise = new Promise<ISubagentJobResult>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+function createControllableRunner(): { runner: ISubagentRunner; started: IStartedJob[] } {
+  const started: IStartedJob[] = [];
+  return {
+    started,
+    runner: {
+      start(job: ISubagentJobStart): ISubagentJobHandle {
+        const deferred = createTestDeferred();
+        const startedJob: IStartedJob = {
+          jobId: job.jobId,
+          deferred,
+        };
+        started.push(startedJob);
+        return {
+          jobId: job.jobId,
+          result: deferred.promise,
+          cancel: (reason?: string) => {
+            startedJob.cancelReason = reason;
+            return Promise.resolve();
+          },
+        };
+      },
+    },
+  };
+}
+
+function createResolvedRunner(output: string): ISubagentRunner {
+  return {
+    start(job: ISubagentJobStart): ISubagentJobHandle {
+      return {
+        jobId: job.jobId,
+        result: Promise.resolve({
+          jobId: job.jobId,
+          output,
+        }),
+        cancel: () => Promise.resolve(),
+      };
+    },
+  };
+}
+
+function createSpawnRequest(prompt: string) {
+  return {
+    type: 'general-purpose',
+    label: 'General purpose',
+    parentSessionId: 'session_parent',
+    mode: 'foreground' as const,
+    depth: 1,
+    cwd: '/workspace',
+    prompt,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe('SubagentManager', () => {
+  it('moves a spawned job from running to completed and stores the result', async () => {
+    const manager = new SubagentManager({
+      runner: createResolvedRunner('done'),
+      now: () => '2026-04-30T00:00:00.000Z',
+    });
+
+    const created = await manager.spawn(createSpawnRequest('Summarize the project'));
+
+    expect(created.status).toBe('running');
+
+    const result: ISubagentJobResult = await manager.wait(created.id);
+    const completed = manager.get(created.id);
+
+    expect(result.output).toBe('done');
+    expect(completed?.status).toBe('completed');
+    expect(completed?.result).toBe('done');
+  });
+
+  it('moves a failed runner result to failed and stores the error', async () => {
+    const controlled = createControllableRunner();
+    const manager = new SubagentManager({ runner: controlled.runner });
+    const created = await manager.spawn(createSpawnRequest('Fail this job'));
+
+    controlled.started[0]?.deferred.reject(new Error('boom'));
+
+    await expect(manager.wait(created.id)).rejects.toThrow('boom');
+    const failed = manager.get(created.id);
+
+    expect(failed?.status).toBe('failed');
+    expect(failed?.error).toBe('boom');
+  });
+
+  it('cancels only the requested running job', async () => {
+    const controlled = createControllableRunner();
+    const manager = new SubagentManager({
+      runner: controlled.runner,
+      maxConcurrent: 2,
+    });
+    const first = await manager.spawn(createSpawnRequest('First job'));
+    const second = await manager.spawn(createSpawnRequest('Second job'));
+
+    await manager.cancel(first.id, 'stop first');
+
+    await expect(manager.wait(first.id)).rejects.toThrow('stop first');
+    expect(manager.get(first.id)?.status).toBe('cancelled');
+    expect(manager.get(second.id)?.status).toBe('running');
+    expect(controlled.started[0]?.cancelReason).toBe('stop first');
+  });
+
+  it('starts queued jobs only when capacity is available', async () => {
+    const controlled = createControllableRunner();
+    const manager = new SubagentManager({
+      runner: controlled.runner,
+      maxConcurrent: 1,
+    });
+
+    const first = await manager.spawn(createSpawnRequest('First job'));
+    const second = await manager.spawn(createSpawnRequest('Second job'));
+
+    expect(first.status).toBe('running');
+    expect(second.status).toBe('queued');
+    expect(controlled.started).toHaveLength(1);
+
+    controlled.started[0]?.deferred.resolve({
+      jobId: first.id,
+      output: 'first done',
+    });
+
+    await manager.wait(first.id);
+    await flushMicrotasks();
+
+    expect(controlled.started).toHaveLength(2);
+    expect(manager.get(second.id)?.status).toBe('running');
+  });
+
+  it('closes completed jobs from the registry', async () => {
+    const manager = new SubagentManager({ runner: createResolvedRunner('done') });
+    const created = await manager.spawn(createSpawnRequest('Close this job'));
+
+    await manager.wait(created.id);
+    await manager.close(created.id);
+
+    expect(manager.get(created.id)).toBeUndefined();
+  });
+});

--- a/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
@@ -1,0 +1,91 @@
+import type {
+  IAIProvider,
+  IHookTypeExecutor,
+  IToolWithEventService,
+  TPermissionMode,
+  TToolArgs,
+} from '@robota-sdk/agent-core';
+import type { ITerminalOutput, TPermissionHandler } from '@robota-sdk/agent-sessions';
+import type { IAgentDefinition } from '../agents/agent-definition-types.js';
+import { getBuiltInAgent } from '../agents/built-in-agents.js';
+import type { ISubagentOptions } from '../assembly/create-subagent-session.js';
+import { createSubagentSession } from '../assembly/create-subagent-session.js';
+import type { IResolvedConfig } from '../config/config-types.js';
+import type { ILoadedContext } from '../context/context-loader.js';
+import type { ISubagentJobHandle, ISubagentJobStart, ISubagentRunner } from './types.js';
+
+export interface IInProcessSubagentRunnerDeps {
+  config: IResolvedConfig;
+  context: ILoadedContext;
+  tools: IToolWithEventService[];
+  terminal: ITerminalOutput;
+  provider: IAIProvider;
+  permissionMode?: TPermissionMode;
+  permissionHandler?: TPermissionHandler;
+  hooks?: ISubagentOptions['hooks'];
+  hookTypeExecutors?: IHookTypeExecutor[];
+  onTextDelta?: (delta: string) => void;
+  onToolExecution?: (event: {
+    type: 'start' | 'end';
+    toolName: string;
+    toolArgs?: TToolArgs;
+    success?: boolean;
+  }) => void;
+  customAgentRegistry?: (name: string) => IAgentDefinition | undefined;
+}
+
+function resolveAgentDefinition(
+  agentType: string,
+  customRegistry?: (name: string) => IAgentDefinition | undefined,
+): IAgentDefinition {
+  const definition = customRegistry?.(agentType) ?? getBuiltInAgent(agentType);
+  if (!definition) {
+    throw new Error(`Unknown agent type: ${agentType}`);
+  }
+  return definition;
+}
+
+function applyRequestOverrides(
+  definition: IAgentDefinition,
+  job: ISubagentJobStart,
+): IAgentDefinition {
+  return {
+    ...definition,
+    ...(job.request.model ? { model: job.request.model } : {}),
+    ...(job.request.allowedTools ? { tools: job.request.allowedTools } : {}),
+  };
+}
+
+export function createInProcessSubagentRunner(deps: IInProcessSubagentRunnerDeps): ISubagentRunner {
+  return {
+    start(job: ISubagentJobStart): ISubagentJobHandle {
+      const definition = resolveAgentDefinition(job.request.type, deps.customAgentRegistry);
+      const session = createSubagentSession({
+        agentDefinition: applyRequestOverrides(definition, job),
+        parentConfig: deps.config,
+        parentContext: deps.context,
+        parentTools: deps.tools,
+        provider: deps.provider,
+        terminal: deps.terminal,
+        permissionMode: deps.permissionMode,
+        permissionHandler: deps.permissionHandler,
+        hooks: deps.hooks,
+        hookTypeExecutors: deps.hookTypeExecutors,
+        onTextDelta: deps.onTextDelta,
+        onToolExecution: deps.onToolExecution,
+      });
+
+      return {
+        jobId: job.jobId,
+        result: session.run(job.request.prompt).then((output) => ({
+          jobId: job.jobId,
+          output,
+        })),
+        cancel: () => {
+          session.abort();
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+}

--- a/packages/agent-sdk/src/subagents/index.ts
+++ b/packages/agent-sdk/src/subagents/index.ts
@@ -1,9 +1,12 @@
 export { SubagentManager } from './subagent-manager.js';
+export { createInProcessSubagentRunner } from './in-process-subagent-runner.js';
+export type { IInProcessSubagentRunnerDeps } from './in-process-subagent-runner.js';
 export type {
   ISubagentJobHandle,
   ISubagentJobResult,
   ISubagentJobStart,
   ISubagentJobState,
+  ISubagentManager,
   ISubagentManagerOptions,
   ISubagentRunner,
   ISubagentSpawnRequest,

--- a/packages/agent-sdk/src/subagents/index.ts
+++ b/packages/agent-sdk/src/subagents/index.ts
@@ -1,0 +1,12 @@
+export { SubagentManager } from './subagent-manager.js';
+export type {
+  ISubagentJobHandle,
+  ISubagentJobResult,
+  ISubagentJobStart,
+  ISubagentJobState,
+  ISubagentManagerOptions,
+  ISubagentRunner,
+  ISubagentSpawnRequest,
+  TSubagentJobMode,
+  TSubagentJobStatus,
+} from './types.js';

--- a/packages/agent-sdk/src/subagents/subagent-manager.ts
+++ b/packages/agent-sdk/src/subagents/subagent-manager.ts
@@ -1,0 +1,223 @@
+import type {
+  ISubagentJobHandle,
+  ISubagentJobResult,
+  ISubagentJobState,
+  ISubagentManagerOptions,
+  ISubagentSpawnRequest,
+} from './types.js';
+
+const DEFAULT_MAX_CONCURRENT = 4;
+const DEFAULT_MAX_DEPTH = 1;
+const PROMPT_PREVIEW_LENGTH = 120;
+
+interface ITrackedSubagentJob {
+  state: ISubagentJobState;
+  request: ISubagentSpawnRequest;
+  completion: Promise<ISubagentJobResult>;
+  resolve: (result: ISubagentJobResult) => void;
+  reject: (error: Error) => void;
+  handle?: ISubagentJobHandle;
+}
+
+function createDeferred(): {
+  promise: Promise<ISubagentJobResult>;
+  resolve: (result: ISubagentJobResult) => void;
+  reject: (error: Error) => void;
+} {
+  let resolveFn: (result: ISubagentJobResult) => void = () => {};
+  let rejectFn: (error: Error) => void = () => {};
+  const promise = new Promise<ISubagentJobResult>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  promise.catch(() => {});
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+function toErrorMessage(error: Error | string): string {
+  return error instanceof Error ? error.message : error;
+}
+
+export class SubagentManager {
+  private readonly runner: ISubagentManagerOptions['runner'];
+  private readonly maxConcurrent: number;
+  private readonly maxDepth: number;
+  private readonly now: () => string;
+  private readonly idFactory: () => string;
+  private readonly jobs = new Map<string, ITrackedSubagentJob>();
+  private readonly queue: string[] = [];
+  private activeCount = 0;
+  private sequence = 0;
+
+  constructor(options: ISubagentManagerOptions) {
+    this.runner = options.runner;
+    this.maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+    this.maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idFactory =
+      options.idFactory ??
+      (() => {
+        this.sequence += 1;
+        return `agent_${this.sequence}`;
+      });
+  }
+
+  async spawn(request: ISubagentSpawnRequest): Promise<ISubagentJobState> {
+    if (request.depth > this.maxDepth) {
+      throw new Error(
+        `Subagent depth limit exceeded: depth=${request.depth} maxDepth=${this.maxDepth}`,
+      );
+    }
+
+    const id = this.idFactory();
+    const deferred = createDeferred();
+    const state: ISubagentJobState = {
+      id,
+      type: request.type,
+      label: request.label,
+      parentSessionId: request.parentSessionId,
+      status: 'queued',
+      mode: request.mode,
+      depth: request.depth,
+      cwd: request.cwd,
+      promptPreview: request.prompt.slice(0, PROMPT_PREVIEW_LENGTH),
+      updatedAt: this.now(),
+    };
+
+    this.jobs.set(id, {
+      state,
+      request,
+      completion: deferred.promise,
+      resolve: deferred.resolve,
+      reject: deferred.reject,
+    });
+    this.queue.push(id);
+    this.drainQueue();
+    return this.cloneState(state);
+  }
+
+  wait(jobId: string): Promise<ISubagentJobResult> {
+    return this.requireJob(jobId).completion;
+  }
+
+  list(): ISubagentJobState[] {
+    return [...this.jobs.values()].map((job) => this.cloneState(job.state));
+  }
+
+  get(jobId: string): ISubagentJobState | undefined {
+    const job = this.jobs.get(jobId);
+    return job ? this.cloneState(job.state) : undefined;
+  }
+
+  async cancel(jobId: string, reason?: string): Promise<void> {
+    const job = this.requireJob(jobId);
+    if (this.isTerminal(job.state.status)) return;
+
+    if (job.state.status === 'queued') {
+      this.removeFromQueue(jobId);
+      this.markCancelled(job, reason);
+      return;
+    }
+
+    await job.handle?.cancel(reason);
+    this.markCancelled(job, reason);
+  }
+
+  async close(jobId: string): Promise<void> {
+    const job = this.requireJob(jobId);
+    if (!this.isTerminal(job.state.status)) {
+      throw new Error(`Cannot close active subagent job: ${jobId}`);
+    }
+    this.jobs.delete(jobId);
+  }
+
+  async send(jobId: string, prompt: string): Promise<void> {
+    const job = this.requireJob(jobId);
+    if (!job.handle?.send) {
+      throw new Error(`Subagent runner does not support follow-up messages: ${jobId}`);
+    }
+    await job.handle.send(prompt);
+  }
+
+  private drainQueue(): void {
+    while (this.activeCount < this.maxConcurrent) {
+      const jobId = this.queue.shift();
+      if (!jobId) return;
+      const job = this.jobs.get(jobId);
+      if (!job || job.state.status !== 'queued') continue;
+      this.startJob(job);
+    }
+  }
+
+  private startJob(job: ITrackedSubagentJob): void {
+    job.state.status = 'running';
+    job.state.startedAt = this.now();
+    job.state.updatedAt = job.state.startedAt;
+    this.activeCount += 1;
+
+    try {
+      const handle = this.runner.start({ jobId: job.state.id, request: job.request });
+      job.handle = handle;
+      if (handle.pid) job.state.pid = handle.pid;
+      handle.result.then(
+        (result) => this.completeJob(job, result),
+        (error) =>
+          this.failJob(job, toErrorMessage(error instanceof Error ? error : String(error))),
+      );
+    } catch (error) {
+      this.failJob(job, toErrorMessage(error instanceof Error ? error : String(error)));
+    }
+  }
+
+  private completeJob(job: ITrackedSubagentJob, result: ISubagentJobResult): void {
+    if (this.isTerminal(job.state.status)) return;
+    job.state.status = 'completed';
+    job.state.result = result.output;
+    job.state.completedAt = this.now();
+    job.state.updatedAt = job.state.completedAt;
+    this.activeCount -= 1;
+    job.resolve(result);
+    this.drainQueue();
+  }
+
+  private failJob(job: ITrackedSubagentJob, message: string): void {
+    if (this.isTerminal(job.state.status)) return;
+    job.state.status = 'failed';
+    job.state.error = message;
+    job.state.completedAt = this.now();
+    job.state.updatedAt = job.state.completedAt;
+    this.activeCount -= 1;
+    job.reject(new Error(message));
+    this.drainQueue();
+  }
+
+  private markCancelled(job: ITrackedSubagentJob, reason?: string): void {
+    if (this.isTerminal(job.state.status)) return;
+    job.state.status = 'cancelled';
+    job.state.error = reason;
+    job.state.completedAt = this.now();
+    job.state.updatedAt = job.state.completedAt;
+    if (job.handle) this.activeCount -= 1;
+    job.reject(new Error(reason ?? 'Subagent job cancelled'));
+    this.drainQueue();
+  }
+
+  private removeFromQueue(jobId: string): void {
+    const index = this.queue.indexOf(jobId);
+    if (index >= 0) this.queue.splice(index, 1);
+  }
+
+  private requireJob(jobId: string): ITrackedSubagentJob {
+    const job = this.jobs.get(jobId);
+    if (!job) throw new Error(`Unknown subagent job: ${jobId}`);
+    return job;
+  }
+
+  private isTerminal(status: ISubagentJobState['status']): boolean {
+    return status === 'completed' || status === 'failed' || status === 'cancelled';
+  }
+
+  private cloneState(state: ISubagentJobState): ISubagentJobState {
+    return { ...state };
+  }
+}

--- a/packages/agent-sdk/src/subagents/subagent-manager.ts
+++ b/packages/agent-sdk/src/subagents/subagent-manager.ts
@@ -2,6 +2,7 @@ import type {
   ISubagentJobHandle,
   ISubagentJobResult,
   ISubagentJobState,
+  ISubagentManager,
   ISubagentManagerOptions,
   ISubagentSpawnRequest,
 } from './types.js';
@@ -38,7 +39,7 @@ function toErrorMessage(error: Error | string): string {
   return error instanceof Error ? error.message : error;
 }
 
-export class SubagentManager {
+export class SubagentManager implements ISubagentManager {
   private readonly runner: ISubagentManagerOptions['runner'];
   private readonly maxConcurrent: number;
   private readonly maxDepth: number;

--- a/packages/agent-sdk/src/subagents/types.ts
+++ b/packages/agent-sdk/src/subagents/types.ts
@@ -16,6 +16,8 @@ export interface ISubagentSpawnRequest {
   depth: number;
   cwd: string;
   prompt: string;
+  model?: string;
+  allowedTools?: string[];
   timeoutMs?: number;
 }
 
@@ -60,6 +62,16 @@ export interface ISubagentJobHandle {
 
 export interface ISubagentRunner {
   start(job: ISubagentJobStart): ISubagentJobHandle;
+}
+
+export interface ISubagentManager {
+  spawn(request: ISubagentSpawnRequest): Promise<ISubagentJobState>;
+  wait(jobId: string): Promise<ISubagentJobResult>;
+  list(): ISubagentJobState[];
+  get(jobId: string): ISubagentJobState | undefined;
+  cancel(jobId: string, reason?: string): Promise<void>;
+  close(jobId: string): Promise<void>;
+  send(jobId: string, prompt: string): Promise<void>;
 }
 
 export interface ISubagentManagerOptions {

--- a/packages/agent-sdk/src/subagents/types.ts
+++ b/packages/agent-sdk/src/subagents/types.ts
@@ -1,0 +1,71 @@
+export type TSubagentJobStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting_permission'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type TSubagentJobMode = 'foreground' | 'background';
+
+export interface ISubagentSpawnRequest {
+  type: string;
+  label: string;
+  parentSessionId: string;
+  mode: TSubagentJobMode;
+  depth: number;
+  cwd: string;
+  prompt: string;
+  timeoutMs?: number;
+}
+
+export interface ISubagentJobState {
+  id: string;
+  type: string;
+  label: string;
+  parentSessionId: string;
+  status: TSubagentJobStatus;
+  mode: TSubagentJobMode;
+  depth: number;
+  pid?: number;
+  cwd: string;
+  worktreePath?: string;
+  branchName?: string;
+  promptPreview: string;
+  currentTool?: string;
+  startedAt?: string;
+  updatedAt: string;
+  completedAt?: string;
+  result?: string;
+  error?: string;
+}
+
+export interface ISubagentJobResult {
+  jobId: string;
+  output: string;
+}
+
+export interface ISubagentJobStart {
+  jobId: string;
+  request: ISubagentSpawnRequest;
+}
+
+export interface ISubagentJobHandle {
+  readonly jobId: string;
+  readonly pid?: number;
+  result: Promise<ISubagentJobResult>;
+  cancel(reason?: string): Promise<void>;
+  send?(prompt: string): Promise<void>;
+}
+
+export interface ISubagentRunner {
+  start(job: ISubagentJobStart): ISubagentJobHandle;
+}
+
+export interface ISubagentManagerOptions {
+  runner: ISubagentRunner;
+  maxConcurrent?: number;
+  maxDepth?: number;
+  now?: () => string;
+  idFactory?: () => string;
+}

--- a/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
@@ -190,7 +190,66 @@ describe('Agent tool', () => {
     expect(result['success']).toBe(true);
     expect(result['output']).toBe('task completed successfully');
     expect(result['agentId']).toBeDefined();
-    expect(result['agentId']).toMatch(/^agent_\d+_[a-z0-9]+$/);
+    expect(result['agentId']).toMatch(/^agent_/);
+  });
+
+  it('should route foreground execution through injected SubagentManager', async () => {
+    const subagentManager = {
+      spawn: vi.fn().mockResolvedValue({
+        id: 'agent_managed_1',
+        type: 'Explore',
+        label: 'Explore',
+        parentSessionId: 'session_parent',
+        status: 'running',
+        mode: 'foreground',
+        depth: 1,
+        cwd: '/workspace',
+        promptPreview: 'Find files',
+        updatedAt: '2026-04-30T00:00:00.000Z',
+      }),
+      wait: vi.fn().mockResolvedValue({
+        jobId: 'agent_managed_1',
+        output: 'managed output',
+      }),
+      list: vi.fn(),
+      get: vi.fn(),
+      cancel: vi.fn(),
+      close: vi.fn(),
+      send: vi.fn(),
+    };
+
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+      }),
+    );
+
+    const toolResult = await tool.execute({
+      prompt: 'Find files',
+      subagent_type: 'Explore',
+    });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'Explore',
+        label: 'Explore',
+        parentSessionId: 'session_parent',
+        mode: 'foreground',
+        depth: 1,
+        cwd: '/workspace',
+        prompt: 'Find files',
+      }),
+    );
+    expect(subagentManager.wait).toHaveBeenCalledWith('agent_managed_1');
+    expect(createSubagentSession).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      output: 'managed output',
+      agentId: 'agent_managed_1',
+    });
   });
 
   it('should return error for unknown agent type', async () => {

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -1,9 +1,10 @@
 /**
  * AgentTool — spawn a sub-agent with isolated context.
  *
- * Uses `createSubagentSession` to assemble a child Session with filtered tools,
- * model resolution, and framework system prompt. The sub-agent shares the same
- * config and context but has its own conversation history.
+ * Uses `SubagentManager` with an in-process runner to assemble a child Session
+ * with filtered tools, model resolution, and framework system prompt. The
+ * sub-agent shares the same config and context but has its own conversation
+ * history.
  *
  * Each call to `createAgentTool(deps)` returns a fresh tool instance with deps
  * captured in closure, eliminating module-level mutable state and enabling
@@ -13,19 +14,15 @@
 import { z } from 'zod';
 import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import type { IZodSchema } from '@robota-sdk/agent-tools';
-import type {
-  IAIProvider,
-  IToolWithEventService,
-  IHookTypeExecutor,
-  TToolArgs,
-} from '@robota-sdk/agent-core';
-import type { TPermissionMode } from '@robota-sdk/agent-core';
-import type { ITerminalOutput, TPermissionHandler } from '@robota-sdk/agent-sessions';
-import type { IResolvedConfig } from '../config/config-types.js';
-import type { ILoadedContext } from '../context/context-loader.js';
 import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
-import { createSubagentSession } from '../assembly/create-subagent-session.js';
+import { SubagentManager } from '../subagents/subagent-manager.js';
+import { createInProcessSubagentRunner } from '../subagents/in-process-subagent-runner.js';
+import type {
+  IInProcessSubagentRunnerDeps,
+  ISubagentManager,
+  ISubagentSpawnRequest,
+} from '../subagents/index.js';
 
 /** Cast a Zod schema to the IZodSchema interface expected by createZodFunctionTool */
 function asZodSchema(schema: z.ZodType): IZodSchema {
@@ -44,27 +41,11 @@ const AgentSchema = z.object({
 type TAgentArgs = z.infer<typeof AgentSchema>;
 
 /** Dependencies injected at creation time via createAgentTool factory */
-export interface IAgentToolDeps {
-  config: IResolvedConfig;
-  context: ILoadedContext;
-  tools: IToolWithEventService[];
-  terminal: ITerminalOutput;
-  /** AI provider instance (passed from consumer). */
-  provider: IAIProvider;
-  /** Permission mode from parent session (bypassPermissions, acceptEdits, etc.). */
-  permissionMode?: TPermissionMode;
-  permissionHandler?: TPermissionHandler;
-  /** Plugin hooks configuration from parent session. */
-  hooks?: Record<string, unknown>;
-  /** Hook type executors from parent session (prompt, agent, etc.). */
-  hookTypeExecutors?: IHookTypeExecutor[];
-  onTextDelta?: (delta: string) => void;
-  onToolExecution?: (event: {
-    type: 'start' | 'end';
-    toolName: string;
-    toolArgs?: TToolArgs;
-    success?: boolean;
-  }) => void;
+export interface IAgentToolDeps extends IInProcessSubagentRunnerDeps {
+  cwd?: string;
+  parentSessionId?: string;
+  subagentDepth?: number;
+  subagentManager?: ISubagentManager;
   /** Optional custom agent registry for resolving non-built-in agent types. */
   customAgentRegistry?: (name: string) => IAgentDefinition | undefined;
 }
@@ -105,9 +86,79 @@ function resolveAgentDefinition(
   return undefined;
 }
 
-/** Generate a unique agent ID for tracking. */
-function generateAgentId(): string {
-  return `agent_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+function createSubagentManager(deps: IAgentToolDeps): ISubagentManager {
+  return (
+    deps.subagentManager ??
+    new SubagentManager({
+      runner: createInProcessSubagentRunner(deps),
+    })
+  );
+}
+
+function createSpawnRequest(
+  args: TAgentArgs,
+  agentType: string,
+  agentDef: IAgentDefinition,
+  deps: IAgentToolDeps,
+): ISubagentSpawnRequest {
+  return {
+    type: agentType,
+    label: agentDef.name,
+    parentSessionId: deps.parentSessionId ?? 'unknown-session',
+    mode: 'foreground',
+    depth: deps.subagentDepth ?? 1,
+    cwd: deps.cwd ?? process.cwd(),
+    prompt: args.prompt,
+    model: args.model,
+  };
+}
+
+function stringifyUnknownAgentType(agentType: string): string {
+  return JSON.stringify({
+    success: false,
+    output: '',
+    error: `Unknown agent type: ${agentType}`,
+  });
+}
+
+function stringifyAgentSuccess(output: string, agentId: string): string {
+  return JSON.stringify({
+    success: true,
+    output,
+    agentId,
+  });
+}
+
+function stringifyAgentError(message: string, agentId?: string): string {
+  return JSON.stringify({
+    success: false,
+    output: '',
+    error: `Sub-agent error: ${message}`,
+    agentId,
+  });
+}
+
+async function runManagedAgent(
+  args: TAgentArgs,
+  deps: IAgentToolDeps,
+  manager: ISubagentManager,
+): Promise<string> {
+  const agentType = args.subagent_type ?? 'general-purpose';
+  const agentDef = resolveAgentDefinition(agentType, deps.customAgentRegistry);
+  if (!agentDef) {
+    return stringifyUnknownAgentType(agentType);
+  }
+
+  let agentId: string | undefined;
+  try {
+    const state = await manager.spawn(createSpawnRequest(args, agentType, agentDef, deps));
+    agentId = state.id;
+    const response = await manager.wait(state.id);
+    return stringifyAgentSuccess(response.output, state.id);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return stringifyAgentError(message, agentId);
+  }
 }
 
 /**
@@ -116,66 +167,14 @@ function generateAgentId(): string {
  * Each session gets its own tool instance — no shared mutable state.
  */
 export function createAgentTool(deps: IAgentToolDeps): ReturnType<typeof createZodFunctionTool> {
-  async function runAgent(args: TAgentArgs): Promise<string> {
-    const agentType = args.subagent_type ?? 'general-purpose';
-
-    // Resolve agent definition
-    const agentDef = resolveAgentDefinition(agentType, deps.customAgentRegistry);
-    if (!agentDef) {
-      return JSON.stringify({
-        success: false,
-        output: '',
-        error: `Unknown agent type: ${agentType}`,
-      });
-    }
-
-    // Override model if specified in tool args
-    const effectiveDef: IAgentDefinition = args.model
-      ? { ...agentDef, model: args.model }
-      : agentDef;
-
-    // Create subagent session
-    const session = createSubagentSession({
-      agentDefinition: effectiveDef,
-      parentConfig: deps.config,
-      parentContext: deps.context,
-      parentTools: deps.tools,
-      provider: deps.provider,
-      terminal: deps.terminal,
-      permissionMode: deps.permissionMode,
-      permissionHandler: deps.permissionHandler,
-      hooks: deps.hooks,
-      hookTypeExecutors: deps.hookTypeExecutors,
-      onTextDelta: deps.onTextDelta,
-      onToolExecution: deps.onToolExecution,
-    });
-
-    const agentId = generateAgentId();
-
-    try {
-      const response = await session.run(args.prompt);
-      return JSON.stringify({
-        success: true,
-        output: response,
-        agentId,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return JSON.stringify({
-        success: false,
-        output: '',
-        error: `Sub-agent error: ${message}`,
-        agentId,
-      });
-    }
-  }
+  const manager = createSubagentManager(deps);
 
   return createZodFunctionTool(
     'Agent',
     'Launch a subagent to handle a task in an isolated context. The subagent gets its own context window and returns a result when done. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.',
     asZodSchema(AgentSchema),
     async (params) => {
-      return runAgent(params as TAgentArgs);
+      return runManagedAgent(params as TAgentArgs, deps, manager);
     },
   );
 }

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -169,7 +169,7 @@ The session log records structured events to a JSONL file for diagnostics and re
 
 6. **`ISessionOptions.promptForApproval`** -- Alternative approval function that receives the terminal handle.
 
-7. **`ISessionOptions.onTextDelta`** -- Streaming callback for real-time text output to the UI.
+7. **`ISessionOptions.onTextDelta`** -- Streaming callback for real-time text output to the UI. `Session` stores this callback and passes it to `Robota.run()` as a per-run option; it MUST NOT mutate provider-level `onTextDelta` state because parent/subagent sessions may share the same provider instance.
 
 8. **`ISessionOptions.onToolExecution`** -- Callback for real-time tool execution events. Fires `{ type: 'start', toolName }` when a tool begins and `{ type: 'end', toolName, success }` when it completes. Wired through `PermissionEnforcer.wrapToolWithPermission()`.
 
@@ -268,10 +268,11 @@ None. Classes are standalone.
 ### Current Test Coverage
 
 - **Session system prompt delivery** -- 6 tests verifying system prompt is passed to Robota at both top-level and defaultModel.
+- **Session provider callback isolation** -- 1 regression test verifying two sessions sharing one provider keep `onTextDelta` output isolated per run.
 
 ### Gaps
 
-- **Session** -- `run()`, permission mode switching, hook integration, streaming callback wiring, and session persistence are untested.
+- **Session** -- permission mode switching, hook integration, and session persistence are untested.
 - **PermissionEnforcer** -- `wrapTools()`, `checkPermission()`, session-scoped allow, tool truncation are untested.
 - **ContextWindowTracker** -- `updateFromHistory()`, `shouldAutoCompact()`, metadata vs fallback estimation are untested.
 - **CompactionOrchestrator** -- `compact()`, hook firing, prompt building are untested.

--- a/packages/agent-sessions/src/__tests__/session-provider-callback-isolation.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-provider-callback-isolation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IAIProvider, IChatOptions, TUniversalMessage } from '@robota-sdk/agent-core';
+import { Session } from '../session.js';
+
+function createSharedProvider(): IAIProvider & {
+  onTextDelta?: (delta: string) => void;
+} {
+  return {
+    name: 'mock-provider',
+    version: '1.0.0',
+    onTextDelta: undefined,
+    chat: vi.fn(async (_messages: TUniversalMessage[], options?: IChatOptions) => {
+      options?.onTextDelta?.('streamed text');
+      return {
+        id: 'assistant_1',
+        role: 'assistant',
+        content: 'final text',
+        timestamp: new Date(),
+        state: 'complete',
+      };
+    }),
+    generateResponse: vi.fn(),
+    supportsTools: () => true,
+    validateConfig: () => true,
+  };
+}
+
+function createTerminal() {
+  return {
+    write: vi.fn(),
+    writeLine: vi.fn(),
+    writeMarkdown: vi.fn(),
+    writeError: vi.fn(),
+    prompt: vi.fn(),
+    select: vi.fn(),
+    spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+  };
+}
+
+function createSession(provider: IAIProvider, onTextDelta: (delta: string) => void): Session {
+  return new Session({
+    tools: [],
+    provider,
+    systemMessage: 'test system',
+    terminal: createTerminal(),
+    model: 'test-model',
+    onTextDelta,
+  });
+}
+
+describe('Session provider callback isolation', () => {
+  it('keeps onTextDelta isolated when sessions share a provider instance', async () => {
+    const provider = createSharedProvider();
+    const parentDeltas: string[] = [];
+    const childDeltas: string[] = [];
+
+    const parentSession = createSession(provider, (delta) => parentDeltas.push(delta));
+    createSession(provider, (delta) => childDeltas.push(delta));
+
+    expect(provider.onTextDelta).toBeUndefined();
+
+    await parentSession.run('parent prompt');
+
+    expect(parentDeltas).toEqual(['streamed text']);
+    expect(childDeltas).toEqual([]);
+  });
+});

--- a/packages/agent-sessions/src/session-lifecycle.ts
+++ b/packages/agent-sessions/src/session-lifecycle.ts
@@ -21,16 +21,12 @@ import type { TSessionLogData } from './session-logger.js';
  */
 export function configureProvider(
   provider: IAIProvider,
-  options: ISessionOptions,
+  _options: ISessionOptions,
   log: (event: string, data: TSessionLogData) => void,
 ): void {
   // Enable Anthropic server web tools (web_search)
   if (provider.name === 'anthropic' && 'enableWebTools' in provider) {
     (provider as { enableWebTools: boolean }).enableWebTools = true;
-  }
-
-  if (options.onTextDelta && 'onTextDelta' in provider) {
-    (provider as { onTextDelta?: (delta: string) => void }).onTextDelta = options.onTextDelta;
   }
 
   // Wire server tool logging

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -6,7 +6,12 @@
  */
 
 import { runHooks } from '@robota-sdk/agent-core';
-import type { IAIProvider, THooksConfig, IHookTypeExecutor } from '@robota-sdk/agent-core';
+import type {
+  IAIProvider,
+  THooksConfig,
+  IHookTypeExecutor,
+  TTextDeltaCallback,
+} from '@robota-sdk/agent-core';
 import type { Robota } from '@robota-sdk/agent-core';
 import type { ContextWindowTracker } from './context-window-tracker.js';
 import type { TSessionLogData } from './session-logger.js';
@@ -27,6 +32,7 @@ export interface IRunContext {
   persistSession: () => void;
   getSessionStore: () => boolean;
   clearSessionStartStdout: () => void;
+  onTextDelta?: TTextDeltaCallback;
 }
 
 /**
@@ -103,7 +109,10 @@ export async function executeRun(
 
   let response: string;
   try {
-    response = await ctx.robota.run(enrichedMessage, { signal: abortSignal });
+    response = await ctx.robota.run(enrichedMessage, {
+      signal: abortSignal,
+      ...(ctx.onTextDelta && { onTextDelta: ctx.onTextDelta }),
+    });
 
     // If execution was interrupted (abort fired during execution),
     // throw AbortError so the caller (useSubmitHandler) shows "Cancelled."

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -54,6 +54,7 @@ export class Session {
   private model: string;
   private readonly hooks?: Record<string, unknown>;
   private readonly hookTypeExecutors?: IHookTypeExecutor[];
+  private readonly onTextDeltaCallback?: (delta: string) => void;
   private readonly onCompactCallback?: (summary: string) => void;
   private readonly sessionLogger?: ISessionLogger;
   private readonly permissionEnforcer: PermissionEnforcer;
@@ -74,6 +75,7 @@ export class Session {
     this.sessionLogger = options.sessionLogger;
     this.hooks = options.hooks;
     this.hookTypeExecutors = options.hookTypeExecutors;
+    this.onTextDeltaCallback = options.onTextDelta;
     this.onCompactCallback = options.onCompact;
     this.model = options.model ?? 'claude-sonnet-4-5';
     this.sessionId =
@@ -168,6 +170,7 @@ export class Session {
           clearSessionStartStdout: () => {
             this.sessionStartStdout = '';
           },
+          onTextDelta: this.onTextDeltaCallback,
         },
         signal,
       );


### PR DESCRIPTION
## Summary
- add SDK-owned SubagentManager and runner port contracts
- add managed subagent job state, wait, cancel, close, and bounded concurrency behavior
- export subagent manager types from `@robota-sdk/agent-sdk`
- update agent-sdk SPEC and archive the implementation task record

## Validation
- pnpm --filter @robota-sdk/agent-sdk test
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-sdk lint
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm harness:scan:specs
- pre-push harness verify changed scopes
