### PR TITLE
docs(agents): specify background task layer

### DIFF
--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -5,7 +5,8 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 
 ## Index
 
-| Spec                                                       | Scope                                                                  |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| (See `packages/*/docs/SPEC.md` for package-level specs)    | Per-package contracts                                                  |
-| [subagent-process-manager.md](subagent-process-manager.md) | CLI subagent process management, parallel execution, and TUI lifecycle |
+| Spec                                                       | Scope                                                                                 |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| (See `packages/*/docs/SPEC.md` for package-level specs)    | Per-package contracts                                                                 |
+| [background-task-layer.md](background-task-layer.md)       | Generic background task lifecycle, composition, runners, and TUI/transport projection |
+| [subagent-process-manager.md](subagent-process-manager.md) | CLI subagent process management, parallel execution, and TUI lifecycle                |

--- a/.agents/specs/background-task-layer.md
+++ b/.agents/specs/background-task-layer.md
@@ -1,0 +1,683 @@
+# Background Task Layer Specification
+
+Status: Proposed
+Created: 2026-04-30
+Source research: `.agents/tasks/completed/CLI-BL-024-background-task-layer-research.md`
+Related spec: `.agents/specs/subagent-process-manager.md`
+
+## Scope
+
+This specification defines a shared background task layer for Robota. The layer manages long-running work started by tool calls or user commands, including background agents and background shell/process work.
+
+The goal is to make background execution a composable library capability rather than a TUI-only feature or a subagent-only feature. Agent jobs and process jobs must share one lifecycle model, one registry, one cancellation model, and one UI/transport event projection.
+
+## Non-Goals
+
+- Full multi-agent team coordination with mailboxes or shared task boards.
+- Remote/cloud worker execution.
+- Worktree creation and branch cleanup implementation.
+- Replacing foreground `Bash` behavior for existing callers.
+- Turning every tool call into a background task.
+- Persisting resumable running tasks across CLI process restarts.
+
+## Architectural Principles
+
+Robota's background task architecture MUST follow the existing package composition model:
+
+- Lower packages own generic contracts and pure execution semantics.
+- Upper packages compose concrete dependencies and UI/runtime adapters.
+- Business rules live in SDK/application services, not React components.
+- Side effects are behind ports and runner adapters.
+- TUI state is a projection of SDK events.
+- Provider instances and child process handles never cross package boundaries where they cannot be represented safely.
+
+## Layer Stack
+
+| Layer               | Owner                   | Background responsibility                                                                           | Must not own                                                      |
+| ------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `agent-core`        | Core contracts          | Generic value types, event/history primitives already used by execution                             | Background task manager, child processes, TUI state               |
+| `agent-tools`       | Tool implementations    | Foreground tool behavior and reusable tool factories                                                | SDK background registry or TUI controls                           |
+| `agent-sessions`    | Session runtime         | `Session.run()`, `Session.abort()`, permissions, per-run streaming callbacks                        | Background job registry or child worker orchestration             |
+| `agent-sdk`         | Application composition | `BackgroundTaskManager`, state machine, runner ports, task events, `InteractiveSession` integration | Ink components, provider package selection, direct CLI process UI |
+| `agent-transport-*` | Protocol adapters       | Forward background task events and expose control messages                                          | Task state transitions or runner implementations                  |
+| `agent-cli`         | Runtime shell and TUI   | Provider creation, child process runner wiring, worker entrypoints, Ink rendering from state        | SDK lifecycle logic                                               |
+
+Dependency direction remains:
+
+```text
+agent-cli / transports
+  -> agent-sdk
+    -> agent-sessions
+      -> agent-core
+
+agent-sdk
+  -> agent-tools
+```
+
+`agent-tools` MUST NOT import `agent-sdk`. If a tool needs background behavior, SDK assembly must wrap or replace that tool through dependency injection.
+
+## Composition Model
+
+The background task layer is divided into four composable levels.
+
+```text
+Pure state machine
+  status + event -> next status
+
+BackgroundTaskManager
+  registry, queue, limits, wait/cancel/close/send/read APIs
+
+Runner ports
+  task kind specific execution boundary: agent, process
+
+Adapters and shells
+  in-process test runners, child process runners, shell process runners, TUI and transports
+```
+
+### Functional Core
+
+The lifecycle transition function MUST be pure and table-driven. It owns:
+
+- allowed status transitions
+- terminal state detection
+- invalid transition errors
+- state snapshot projection
+
+It MUST NOT:
+
+- start processes
+- create providers
+- write logs
+- emit UI events
+- read settings
+
+### Application Service
+
+`BackgroundTaskManager` is the application service. It owns:
+
+- task IDs
+- task registry
+- bounded queue
+- active task count
+- task timeout scheduling
+- wait promises
+- event emission
+- targeted cancellation
+- terminal-state close/dismiss behavior
+
+It depends on runner ports and a small event sink. It does not depend on Ink, provider packages, `child_process`, or settings file readers.
+
+### Runner Ports
+
+Runners execute one task. They do not own global task state.
+
+```ts
+interface IBackgroundTaskStart<TRequest extends IBackgroundTaskRequest = IBackgroundTaskRequest> {
+  taskId: string;
+  request: TRequest;
+}
+
+interface IBackgroundTaskRunner<TRequest extends IBackgroundTaskRequest = IBackgroundTaskRequest> {
+  readonly kind: TRequest['kind'];
+  start(task: IBackgroundTaskStart<TRequest>): IBackgroundTaskHandle;
+}
+
+interface IBackgroundTaskHandle {
+  readonly taskId: string;
+  readonly pid?: number;
+  result: Promise<IBackgroundTaskResult>;
+  cancel(reason?: string): Promise<void>;
+  send?(input: IBackgroundTaskInput): Promise<void>;
+  readLog?(cursor?: IBackgroundTaskLogCursor): Promise<IBackgroundTaskLogPage>;
+}
+```
+
+Runner implementations MUST report progress through manager events or the handle result. They MUST NOT mutate TUI state directly.
+
+### Adapter Shells
+
+Adapters implement runner ports:
+
+- `InProcessAgentTaskRunner` for unit tests and foreground compatibility.
+- `ChildProcessAgentTaskRunner` for CLI runtime agent isolation.
+- `ManagedShellProcessRunner` for addressable background shell/process jobs.
+- `FakeBackgroundTaskRunner` for deterministic tests.
+
+CLI composition wires concrete runners into the SDK manager. SDK code owns the ports, not the Node-specific implementations.
+
+## Type Model
+
+### Task Kinds
+
+```ts
+type TBackgroundTaskKind = 'agent' | 'process';
+type TBackgroundTaskMode = 'foreground' | 'background';
+```
+
+### Task Status
+
+```ts
+type TBackgroundTaskStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting_permission'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+```
+
+Terminal states are `completed`, `failed`, and `cancelled`. Terminal states are immutable except for `close()` removing the task from the registry.
+
+### Task State
+
+```ts
+interface IBackgroundTaskState {
+  id: string;
+  kind: TBackgroundTaskKind;
+  label: string;
+  status: TBackgroundTaskStatus;
+  mode: TBackgroundTaskMode;
+  parentSessionId: string;
+  parentTaskId?: string;
+  depth: number;
+  cwd: string;
+  pid?: number;
+  startedAt?: string;
+  updatedAt: string;
+  completedAt?: string;
+  promptPreview?: string;
+  commandPreview?: string;
+  currentAction?: string;
+  unread: boolean;
+  result?: IBackgroundTaskResult;
+  error?: IBackgroundTaskError;
+  logPath?: string;
+  transcriptPath?: string;
+  worktreePath?: string;
+  branchName?: string;
+}
+```
+
+### Requests
+
+```ts
+type IBackgroundTaskRequest = IAgentBackgroundTaskRequest | IProcessBackgroundTaskRequest;
+
+interface IBaseBackgroundTaskRequest {
+  kind: TBackgroundTaskKind;
+  label: string;
+  mode: TBackgroundTaskMode;
+  parentSessionId: string;
+  parentTaskId?: string;
+  depth: number;
+  cwd: string;
+  timeoutMs?: number;
+}
+
+interface IAgentBackgroundTaskRequest extends IBaseBackgroundTaskRequest {
+  kind: 'agent';
+  agentType: string;
+  prompt: string;
+  model?: string;
+  allowedTools?: string[];
+  disallowedTools?: string[];
+  permissionPolicy: TBackgroundPermissionPolicy;
+  providerProfile?: ISerializableProviderProfile;
+}
+
+interface IProcessBackgroundTaskRequest extends IBaseBackgroundTaskRequest {
+  kind: 'process';
+  command: string;
+  shell?: string;
+  env?: Record<string, string>;
+  stdin?: string;
+  outputLimitBytes?: number;
+}
+```
+
+`ISerializableProviderProfile` is a data-only snapshot. It may include provider type, model, base URL, timeout, and API key reference. It MUST NOT include live SDK client instances.
+
+```ts
+type TBackgroundPermissionPolicy = 'inherit-allowlist' | 'preapproved' | 'prompt' | 'deny';
+
+interface ISerializableProviderProfile {
+  profileName?: string;
+  type: string;
+  model: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  baseURL?: string;
+  timeout?: number;
+}
+```
+
+### Results
+
+```ts
+interface IBackgroundTaskResult {
+  taskId: string;
+  kind: TBackgroundTaskKind;
+  output: string;
+  exitCode?: number;
+  signalCode?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+interface IBackgroundTaskError {
+  category:
+    | 'validation'
+    | 'capacity'
+    | 'permission'
+    | 'timeout'
+    | 'runner'
+    | 'crash'
+    | 'provider'
+    | 'process';
+  message: string;
+  recoverable: boolean;
+}
+```
+
+### Control and Logs
+
+```ts
+interface IBackgroundTaskListFilter {
+  kind?: TBackgroundTaskKind;
+  status?: TBackgroundTaskStatus;
+  mode?: TBackgroundTaskMode;
+  includeClosed?: boolean;
+}
+
+interface IBackgroundTaskInput {
+  prompt?: string;
+  stdin?: string;
+}
+
+interface IBackgroundTaskLogCursor {
+  offset: number;
+}
+
+interface IBackgroundTaskLogPage {
+  taskId: string;
+  cursor?: IBackgroundTaskLogCursor;
+  nextCursor?: IBackgroundTaskLogCursor;
+  lines: string[];
+}
+```
+
+## State Machine
+
+Allowed transitions:
+
+| From                 | Event                | To                   |
+| -------------------- | -------------------- | -------------------- |
+| `queued`             | `START`              | `running`            |
+| `queued`             | `CANCEL`             | `cancelled`          |
+| `running`            | `REQUEST_PERMISSION` | `waiting_permission` |
+| `running`            | `COMPLETE`           | `completed`          |
+| `running`            | `FAIL`               | `failed`             |
+| `running`            | `CANCEL`             | `cancelled`          |
+| `waiting_permission` | `PERMISSION_ALLOWED` | `running`            |
+| `waiting_permission` | `PERMISSION_DENIED`  | `failed`             |
+| `waiting_permission` | `CANCEL`             | `cancelled`          |
+
+Any unlisted transition MUST return a typed transition error. The transition function MUST be covered by table-driven tests.
+
+## Manager API
+
+The generic manager API MUST be equivalent to:
+
+```ts
+interface IBackgroundTaskManager {
+  spawn(request: IBackgroundTaskRequest): Promise<IBackgroundTaskState>;
+  wait(taskId: string): Promise<IBackgroundTaskResult>;
+  list(filter?: IBackgroundTaskListFilter): IBackgroundTaskState[];
+  get(taskId: string): IBackgroundTaskState | undefined;
+  cancel(taskId: string, reason?: string): Promise<void>;
+  close(taskId: string): Promise<void>;
+  send(taskId: string, input: IBackgroundTaskInput): Promise<void>;
+  readLog(taskId: string, cursor?: IBackgroundTaskLogCursor): Promise<IBackgroundTaskLogPage>;
+  subscribe(listener: TBackgroundTaskEventListener): () => void;
+}
+```
+
+Manager behavior:
+
+- `spawn()` creates an addressable task record and either starts it or queues it.
+- `wait()` resolves or rejects when the task reaches a terminal state.
+- `list()` returns cloned immutable snapshots.
+- `cancel()` targets exactly one task.
+- `close()` removes only terminal tasks.
+- `send()` is optional per runner and MUST reject when unsupported.
+- `readLog()` is optional per runner and MUST return a structured unsupported error when unavailable.
+
+## Events
+
+The SDK owns background task events. They are emitted by `InteractiveSession` and forwarded by transports and TUI bridges.
+
+```ts
+type TBackgroundTaskEventListener = (event: TBackgroundTaskEvent) => void;
+
+type TBackgroundTaskEvent =
+  | { type: 'background_task_created'; task: IBackgroundTaskState }
+  | { type: 'background_task_started'; task: IBackgroundTaskState }
+  | { type: 'background_task_updated'; task: IBackgroundTaskState }
+  | { type: 'background_task_text_delta'; taskId: string; delta: string }
+  | { type: 'background_task_tool_start'; taskId: string; toolName: string; firstArg?: string }
+  | {
+      type: 'background_task_tool_end';
+      taskId: string;
+      toolName: string;
+      success: boolean;
+      error?: string;
+    }
+  | {
+      type: 'background_task_permission_request';
+      taskId: string;
+      requestId: string;
+      toolName: string;
+      toolArgs: Record<string, string | number | boolean>;
+    }
+  | { type: 'background_task_completed'; task: IBackgroundTaskState }
+  | { type: 'background_task_failed'; task: IBackgroundTaskState }
+  | { type: 'background_task_cancelled'; task: IBackgroundTaskState }
+  | { type: 'background_task_closed'; taskId: string };
+```
+
+Interactive session event names MAY mirror the `type` values directly or expose a single `background_task_event` event with this union. The first implementation SHOULD prefer one event carrying the discriminated union to avoid listener explosion.
+
+## Agent Task Specialization
+
+Agent background tasks replace the current subagent-specific runtime as the generic manager matures.
+
+Foreground agent flow:
+
+1. `Agent` tool validates the agent type.
+2. It calls `BackgroundTaskManager.spawn({ kind: 'agent', mode: 'foreground', ... })`.
+3. It waits on `manager.wait(taskId)`.
+4. It returns the existing JSON shape:
+
+```json
+{ "success": true, "output": "result text", "agentId": "task_1" }
+```
+
+Background agent flow:
+
+1. `Agent` tool receives a background mode request from schema, config, or explicit command.
+2. It calls `BackgroundTaskManager.spawn({ kind: 'agent', mode: 'background', ... })`.
+3. It returns immediately:
+
+```json
+{ "success": true, "background": true, "agentId": "task_1", "status": "running" }
+```
+
+`SubagentManager` MAY remain as a compatibility facade while implementation migrates:
+
+```text
+SubagentManager
+  -> BackgroundTaskManager(kind='agent')
+```
+
+After migration, subagent-specific types should either become aliases or be deprecated in favor of background task types.
+
+## Process Task Specialization
+
+Process background tasks manage shell commands or other spawned local processes.
+
+The first implementation SHOULD NOT silently change existing foreground `Bash` behavior. Instead, SDK assembly may add one of these background-aware compositions:
+
+1. A separate model-callable `BackgroundProcess` tool.
+2. A SDK-composed `Bash` wrapper with an optional `background: boolean` field.
+
+If option 2 is chosen, `agent-sdk` must compose the wrapper in `createDefaultTools()` or `createSession()` because `agent-tools` cannot depend on `agent-sdk`.
+
+Foreground process behavior remains:
+
+- command runs to completion
+- result returns in the tool result
+- existing callers are compatible
+
+Background process behavior:
+
+- command starts through `ManagedShellProcessRunner`
+- tool returns task metadata immediately
+- stdout/stderr are captured into task logs
+- TUI can open/follow/cancel the task
+- cancellation sends `SIGTERM`, then escalates to `SIGKILL` after a grace period
+
+## Permission Model
+
+Foreground tasks MAY use the existing interactive permission prompt.
+
+Background tasks MUST fail closed unless one of these is true:
+
+- the tool/action is already allowed by inherited permission rules
+- the task was launched after explicit pre-approval
+- a future cross-thread permission UI routes and resolves the permission request
+
+The initial implementation SHOULD use inherited allow rules plus fail-closed behavior for new permission requests. Every denied background action must be visible in the task result or log.
+
+## Configuration
+
+Background task settings SHOULD live under a `backgroundTasks` namespace.
+
+```ts
+interface IBackgroundTaskConfig {
+  enabled: boolean;
+  maxConcurrent: number;
+  maxDepth: number;
+  defaultAgentMode: 'foreground' | 'background';
+  defaultProcessMode: 'foreground' | 'background';
+  agentIsolation: 'in-process' | 'child-process';
+  processTimeoutMs: number;
+  agentTimeoutMs?: number;
+  logRetentionDays?: number;
+}
+```
+
+Defaults:
+
+| Field                | Default                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `enabled`            | `true`                                                                                     |
+| `maxConcurrent`      | `4`                                                                                        |
+| `maxDepth`           | `1`                                                                                        |
+| `defaultAgentMode`   | `foreground`                                                                               |
+| `defaultProcessMode` | `foreground`                                                                               |
+| `agentIsolation`     | `in-process` for tests, `child-process` for CLI runtime when provider serialization exists |
+| `processTimeoutMs`   | `120000`                                                                                   |
+| `agentTimeoutMs`     | unset                                                                                      |
+
+## TUI Projection
+
+The TUI MUST treat background tasks as first-class render state, not as normal tool summaries.
+
+`TuiStateManager` should own:
+
+```ts
+interface IBackgroundTaskViewModel {
+  id: string;
+  kind: TBackgroundTaskKind;
+  label: string;
+  status: TBackgroundTaskStatus;
+  mode: TBackgroundTaskMode;
+  currentAction?: string;
+  elapsedMs?: number;
+  unread: boolean;
+  preview: string;
+  resultPreview?: string;
+  errorPreview?: string;
+}
+```
+
+Required TUI behavior:
+
+- show running and recently completed background tasks in a distinct panel or thread list
+- show status, kind, label, and current action
+- indicate unread completed results
+- allow stop/cancel for running tasks
+- allow dismiss/close for terminal tasks
+- allow open/follow to inspect transcript or logs
+
+TUI components MUST remain thin renderers. Keyboard/input behavior should live in flow modules that can be unit-tested without Ink.
+
+## Transport Projection
+
+Transport packages should forward SDK-owned task events and expose control messages.
+
+Minimum WebSocket additions:
+
+| Client message        | Payload               | Maps to                           |
+| --------------------- | --------------------- | --------------------------------- |
+| `background-list`     | optional filter       | `session.listBackgroundTasks()`   |
+| `background-cancel`   | `{ taskId, reason? }` | `session.cancelBackgroundTask()`  |
+| `background-close`    | `{ taskId }`          | `session.closeBackgroundTask()`   |
+| `background-send`     | `{ taskId, input }`   | `session.sendBackgroundTask()`    |
+| `background-read-log` | `{ taskId, cursor? }` | `session.readBackgroundTaskLog()` |
+
+Server events should carry `TBackgroundTaskEvent`.
+
+Headless transport should not render interactive controls. It may expose background task events in `stream-json` mode once the SDK event exists.
+
+## Process and Agent Isolation
+
+Agent child process execution SHOULD use `child_process.fork()` because it provides structured IPC and process isolation for Node workers.
+
+Shell process execution SHOULD use `child_process.spawn()` because it runs arbitrary commands and exposes stdout/stderr streams.
+
+Child workers MUST receive serializable data only:
+
+- task request
+- cwd
+- provider profile snapshot
+- permission policy
+- agent definition or agent lookup metadata
+- config/context snapshot
+
+Child workers MUST NOT receive:
+
+- live provider instances
+- live `Session` instances
+- React callbacks
+- parent `AbortController` objects
+
+## Logging and Persistence
+
+The manager keeps runtime state in memory. Runners may write structured logs.
+
+Recommended paths:
+
+```text
+<logsDir>/<sessionId>/background/<taskId>.jsonl
+<logsDir>/<sessionId>/background/<taskId>.stdout.log
+<logsDir>/<sessionId>/background/<taskId>.stderr.log
+```
+
+JSONL records SHOULD include:
+
+- timestamp
+- taskId
+- event type
+- status snapshot or delta payload
+- output chunk metadata
+- error metadata
+
+Running task resume across process restarts is out of scope. Completed task log inspection is in scope.
+
+## Cancellation and Shutdown
+
+Cancellation must be targeted:
+
+- cancelling one task must not cancel siblings
+- parent foreground abort cancels only foreground child tasks attached to that run
+- background tasks continue when the parent prompt completes
+- CLI shutdown cancels or terminates all owned background child processes
+- process cancellation sends `SIGTERM` first, then `SIGKILL` after a grace timeout
+
+The manager must treat cancellation as a terminal state even if the runner later resolves or rejects.
+
+## Error Taxonomy
+
+| Category     | Examples                                                    | Recoverable |
+| ------------ | ----------------------------------------------------------- | ----------- |
+| `validation` | unknown kind, invalid depth, missing command                | yes         |
+| `capacity`   | queue rejected, max concurrent exceeded under reject policy | yes         |
+| `permission` | background action not pre-approved                          | yes         |
+| `timeout`    | task runtime exceeded                                       | yes         |
+| `runner`     | runner missing, unsupported send/log                        | maybe       |
+| `crash`      | child process exited unexpectedly                           | maybe       |
+| `provider`   | model/provider request failed                               | maybe       |
+| `process`    | shell spawn failed, non-cancellable process                 | maybe       |
+
+Errors returned to the model must be concise and structured. Detailed logs belong in task logs.
+
+## Test Strategy
+
+### Unit Tests
+
+- Given a valid transition table, when each allowed event is applied, then the expected status is returned.
+- Given a terminal state, when any non-close transition is requested, then a typed invalid transition error is returned.
+- Given `maxConcurrent = 1`, when two tasks spawn, then the second remains queued until the first reaches terminal state.
+- Given a queued task, when it is cancelled, then no runner starts and wait rejects with cancellation.
+- Given a running task, when it is cancelled, then only that handle receives `cancel()`.
+- Given a background task event, when `TuiStateManager` receives it, then the view model updates without React.
+- Given a completed task, when it is closed, then it disappears from list output.
+- Given unsupported `send()` or `readLog()`, when called, then the manager returns a structured unsupported error.
+
+### Integration Tests
+
+- Foreground `Agent` tool still returns `{ success, output, agentId }`.
+- Background `Agent` tool returns metadata immediately and later emits completion.
+- A managed background process returns metadata immediately and writes stdout/stderr logs.
+- Parent prompt remains usable while a background task runs.
+- Cancelling a background process terminates only that process.
+- Child process crash marks only the affected task as failed.
+- WebSocket transport forwards task events and maps cancel/list/open controls.
+
+### TUI Tests
+
+- `TuiStateManager` projects task created/running/completed/failed/cancelled rows.
+- Background panel renders status, kind, label, current action, and unread marker.
+- Stop/dismiss/open key flows produce pure actions before React wiring.
+- Permission prompt source attribution includes task label and ID when cross-thread prompts are added.
+
+### Manual Verification
+
+- Start a background agent from the TUI and continue chatting in the parent prompt.
+- Start a background process and open/follow its output.
+- Cancel one running background task while another continues.
+- Exit the CLI and confirm no owned child process remains.
+
+## Implementation Order
+
+1. Add `background-tasks` types, pure state machine, and unit tests in `agent-sdk`.
+2. Implement `BackgroundTaskManager` with fake runner tests.
+3. Add `InteractiveSession` background task APIs and a single `background_task_event` event.
+4. Add `TuiStateManager` background task projection and unit tests.
+5. Migrate `SubagentManager` to delegate to `BackgroundTaskManager` for `kind: 'agent'` while preserving public compatibility.
+6. Add background mode to the `Agent` tool with foreground compatibility tests.
+7. Add managed process runner and SDK-composed background process tool/wrapper.
+8. Add TUI background task panel and pure input flow controls.
+9. Add CLI child process agent runner and worker IPC protocol.
+10. Extend WebSocket/headless transports with background task events and controls.
+11. Update `.agents/specs/subagent-process-manager.md` to reference this spec as the common runtime layer.
+
+## Acceptance Criteria
+
+- Background task lifecycle is generic and not subagent-specific.
+- Agent and process background work use the same registry and control API.
+- Existing foreground `Agent` and `Bash` behavior remains compatible.
+- Background tasks do not block unrelated parent prompts.
+- Every background task has an addressable ID, visible status, and targeted cancellation.
+- TUI can list, open, stop, and dismiss background tasks through state-manager projections.
+- Transport packages can forward task events without knowing runner internals.
+- Child process runners do not receive live provider/session instances.
+- Unit tests cover lifecycle, queueing, cancellation, and TUI projection behavior.
+
+## Source References
+
+- Node.js child process API: <https://nodejs.org/api/child_process.html>
+- Node.js worker threads API: <https://nodejs.org/api/worker_threads.html>
+- Claude Code SDK subagents: <https://code.claude.com/docs/en/agent-sdk/subagents>
+- Codex subagents: <https://developers.openai.com/codex/subagents>
+- GitHub Copilot cloud agent: <https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent>

--- a/.agents/specs/subagent-process-manager.md
+++ b/.agents/specs/subagent-process-manager.md
@@ -3,10 +3,11 @@
 Status: Proposed
 Created: 2026-04-30
 Source research: `.agents/tasks/completed/CLI-BL-019-subagent-process-manager-research.md`
+Common runtime layer: `.agents/specs/background-task-layer.md`
 
 ## Scope
 
-This specification defines Robota CLI subagent process management, parallel execution, lifecycle events, and TUI visibility. It spans `agent-sdk`, `agent-cli`, `agent-sessions`, and `agent-core` because the feature crosses model-callable tools, interactive session orchestration, provider/session isolation, process supervision, and terminal rendering.
+This specification defines Robota CLI subagent process management, parallel execution, lifecycle events, and TUI visibility. It is the agent-specific specialization of the shared background task runtime defined in `.agents/specs/background-task-layer.md`. It spans `agent-sdk`, `agent-cli`, `agent-sessions`, and `agent-core` because the feature crosses model-callable tools, interactive session orchestration, provider/session isolation, process supervision, and terminal rendering.
 
 The goal is to turn subagents from awaited in-process tool calls into managed agent jobs that can run in foreground or background, be observed in the TUI, be cancelled safely, and later run in isolated worktrees.
 
@@ -51,7 +52,7 @@ Robota MUST support managed subagent jobs with these capabilities:
 
 ### Layered Design
 
-The implementation MUST use a manager/runner split.
+The implementation MUST use the common background task manager/runner split. Subagent-specific APIs may remain as compatibility facades, but new lifecycle, event, queueing, and TUI projection behavior should be expressed through the generic background task layer first.
 
 | Layer                        | Owner                                     | Responsibility                                                                                                   |
 | ---------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/.agents/tasks/completed/CLI-BL-024-background-task-layer-research.md
+++ b/.agents/tasks/completed/CLI-BL-024-background-task-layer-research.md
@@ -1,0 +1,79 @@
+# Background Task Layer Research
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: feat/background-task-layer
+- **Scope**: .agents/specs, packages/agent-sdk, packages/agent-cli, packages/agent-core, packages/agent-sessions
+
+## Objective
+
+Research a shared background task layer that can manage tool-called processes and agents as background threads, then support TUI access and control.
+
+## Plan
+
+- [x] Audit current subagent manager, tool execution, process execution, and TUI state paths.
+- [x] Identify reusable primitives for a generic background task registry and runner model.
+- [x] Compare product/reference patterns for background agent/process control.
+- [x] Define the recommended spec direction and implementation slices.
+- [x] Report findings before writing the final spec document.
+
+## Test Plan
+
+- Research-only task. No production code changes are expected in this slice.
+- If a spec document is created in a follow-up slice, run `pnpm harness:scan:specs` and `pnpm harness:scan`.
+
+## Progress
+
+### 2026-04-30
+
+- Created branch from latest `develop`.
+- Started codebase and product research for a generic background task layer.
+- Audited current `SubagentManager`, `Agent` tool routing, fork skill execution, TUI state bridge, transport specs, and `Bash` process execution.
+- Reviewed official references for Node child processes/worker threads, Claude Code subagents, Codex subagents, and GitHub Copilot cloud agent.
+
+## Research Notes
+
+### Current Robota State
+
+- `agent-sdk/src/subagents/` now contains a provider-neutral `SubagentManager` with job registry, queueing, bounded concurrency, `wait/list/get/cancel/close/send`, and an injected runner port.
+- `Agent` tool execution is foreground-only today. It calls `SubagentManager.spawn()` and then immediately `wait()`, preserving the current JSON result shape.
+- `InteractiveSession.runSkillInFork()` still bypasses `SubagentManager` and directly creates an awaited subagent session.
+- `InteractiveSession` emits parent-level events only: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, and `interrupted`.
+- `TuiStateManager` is already the right thin boundary for TUI behavior. It is pure TypeScript, unit-tested, and owns render state derived from `InteractiveSession` events.
+- `agent-cli` renders only one foreground execution stream. There is no background task list, focused task view, result unread marker, or task control surface.
+- `agent-transport-ws` and `agent-transport-headless` forward `InteractiveSession` events. If background task events are added at the SDK layer, transport packages can expose the same model without TUI-specific logic.
+- `Bash` currently runs `child_process.spawn()` directly inside `agent-tools`. On timeout it resolves immediately and leaves child cleanup to the process lifecycle. There is no addressable process ID, background log, explicit cancel, output follow, or TUI visibility.
+- `agent-tools` must not depend on `agent-sdk`, so background-aware process execution should be added by SDK assembly/wrapping or by a separate tool that can receive a background manager dependency.
+
+### External Reference Findings
+
+- Node `child_process.fork()` is a special `spawn()` case for Node child processes and includes an IPC channel. Spawned child processes have independent memory and V8 instances, so this is the right isolation primitive for agent workers.
+- Node `subprocess.send()` supports parent/child IPC for `fork()` workers and returns backpressure information when the send queue is overloaded.
+- Node `worker_threads` supports message events and resource limits, but it shares the parent process and is better for CPU work than process/tool isolation.
+- Claude Code subagent definitions support fields such as `background`, `permissionMode`, `maxTurns`, `tools`, and `model`; subagents cannot spawn their own subagents.
+- Codex exposes global subagent controls under `[agents]`, including `max_threads`, `max_depth`, and per-worker runtime timeout.
+- GitHub Copilot cloud agent is explicitly asynchronous/background and frames the handoff around a branch, logs, review, and optional pull request. Robota should preserve branch/worktree metadata even if local worktree support is deferred.
+
+### Design Implications
+
+- A subagent-only manager is now too narrow. The next layer should be a generic `BackgroundTaskManager` with task `kind` specializations for `agent` and `process`.
+- Existing `SubagentManager` logic can be migrated or wrapped into this generic manager because it already has most registry/queue/cancel/wait primitives.
+- Background task events should be SDK-owned and UI-neutral, then bridged into `TuiStateManager`.
+- Process execution should use a managed runner, not direct fire-and-forget shell execution, when the model requests background execution.
+- Agent child process execution should use a process runner that reconstructs provider/session inside the child from serializable settings. The live provider instance should not cross the process boundary.
+- Background permission handling should fail closed initially unless the action is already allowed by inherited policy. Interactive cross-thread prompts can be added later.
+
+## Decisions
+
+- Treat background agent execution as a specialization of a more general background task runtime, not as a subagent-only manager.
+- Place the common background task manager in `agent-sdk`, because `InteractiveSession` and transports are SDK-owned and UI-neutral.
+- Keep process/agent runner adapters behind ports. CLI can own child-process agent runner composition because CLI owns provider profile creation.
+- Keep TUI state as a projection of SDK events; do not put task orchestration in React components.
+
+## Blockers
+
+- None.
+
+## Result
+
+- Initial research is complete. Recommended direction is a generic SDK-owned `BackgroundTaskManager` with `agent` and `process` task kinds, runner ports, SDK-level lifecycle events, TUI state projections, and CLI-owned child-process agent runner composition.

--- a/.agents/tasks/completed/CLI-BL-025-background-task-layer-spec.md
+++ b/.agents/tasks/completed/CLI-BL-025-background-task-layer-spec.md
@@ -1,0 +1,45 @@
+# Background Task Layer Specification
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: feat/background-task-layer
+- **Scope**: .agents/specs
+
+## Objective
+
+Write a cross-cutting specification for a composable background task architecture that supports managed background agents and processes while preserving Robota's layered library composition model.
+
+## Plan
+
+- [x] Define ownership boundaries across core, tools, sessions, sdk, transports, and cli.
+- [x] Specify the generic background task manager, runner ports, state machine, and event model.
+- [x] Specify how agent and process tasks compose on top of the generic layer.
+- [x] Specify TUI and transport projection boundaries.
+- [x] Update cross-cutting specs index.
+
+## Test Plan
+
+- Run `pnpm harness:scan:specs`.
+- Run `pnpm harness:scan`.
+
+## Progress
+
+### 2026-04-30
+
+- Started spec authoring from completed background task layer research.
+- Added `.agents/specs/background-task-layer.md`.
+- Updated `.agents/specs/README.md` with the new cross-cutting spec.
+- Updated `.agents/specs/subagent-process-manager.md` to reference the shared runtime layer.
+- Ran `pnpm harness:scan:specs` and `pnpm harness:scan`.
+
+## Decisions
+
+- The generic background task layer is the source of truth; subagent process management becomes an agent-task specialization.
+
+## Blockers
+
+- None.
+
+## Result
+
+- Background task layer architecture spec is written. It defines a generic SDK-owned manager, pure lifecycle state machine, runner ports, agent/process specializations, TUI/transport projections, permission model, logging, cancellation, tests, and implementation order.


### PR DESCRIPTION
## Summary
- Add cross-cutting background task layer spec for generic agent/process background execution
- Update specs index and connect subagent process manager spec to the shared runtime layer
- Archive background task research/spec task records

## Validation
- pnpm harness:scan:specs
- pnpm harness:scan
- git diff --check
- pre-push harness verification
