### PR TITLE
chore(cli): update ink to 7

### DIFF
--- a/.agents/tasks/CLI-BL-028-ink-7-cjk-tui-followups.md
+++ b/.agents/tasks/CLI-BL-028-ink-7-cjk-tui-followups.md
@@ -1,0 +1,52 @@
+---
+title: CLI-BL-028 Ink 7 CJK and TUI Follow-ups
+status: backlog
+priority: medium
+urgency: soon
+created: 2026-04-30
+packages:
+  - agent-cli
+---
+
+## 요약
+
+Ink 7 업데이트 리서치에서 확인한 CJK/wide character 개선과 신규 TUI API를 Robota CLI에 단계적으로 반영한다. 현재 Ink 7 업데이트는 의존성/호환성 반영에 집중하고, paste/resize/layout/animation API 도입은 별도 테스트 보호 아래 후속 작업으로 진행한다.
+
+## 리서치 결과
+
+- Ink 7.0.0은 Node.js 22와 React 19.2+를 요구한다.
+- Ink 7.0.0은 Backspace 입력을 `key.delete`가 아니라 `key.backspace`로 정확히 보고한다.
+- Ink 7.0.0은 plain Escape에서 `key.meta=true`를 더 이상 설정하지 않고 `key.escape=true`만 설정한다.
+- Ink 7.0.0은 `usePaste`, `useWindowSize`, `useBoxMetrics`, `useAnimation`, `render({ alternateScreen })`, `render({ interactive })`를 추가했다.
+- Ink 7.0.0 릴리즈 노트에 CJK가 명시되어 있다. `<Box>` width를 초과하는 CJK text truncation 문제와 overlapping writes에서 emoji/CJK wide character가 쪼개지는 문제가 수정되었다.
+- Ink 7.0.1은 `useApp().exit` typing과 disabled focus 상태에서 Escape 처리 문제를 수정했다.
+
+## 참고 링크
+
+- Ink v6.8.0 release: https://github.com/vadimdemedes/ink/releases/tag/v6.8.0
+- Ink v7.0.0 release: https://github.com/vadimdemedes/ink/releases/tag/v7.0.0
+- Ink v7.0.1 release: https://github.com/vadimdemedes/ink/releases/tag/v7.0.1
+
+## 반영 계획
+
+1. `usePaste` 검토: 현재 `CjkTextInput`의 bracketed paste/manual paste handling을 바로 대체하지 않고, 기존 paste label, multi-line paste, Korean/CJK cursor behavior characterization test를 먼저 만든 뒤 적용한다.
+2. `useWindowSize` 검토: `InputArea`의 `useStdout().stdout.columns` 기반 width 계산을 terminal resize reactive API로 대체할 수 있는지 확인한다.
+3. CJK 렌더링 회귀 검증: MessageList, StreamingIndicator, DiffBlock, markdown rendering에서 긴 CJK 문장, emoji 포함 문자열, overlapping streaming write 상황을 테스트한다.
+4. `alternateScreen` 검토: 기본값으로 도입하지 않고 opt-in TUI mode 후보로 UX를 검토한다. scrollback 보존 기대와 충돌할 수 있다.
+5. `useAnimation` 검토: `WaveText`나 streaming indicator 애니메이션 정리에 쓸 수 있는지 확인하되, `TuiStateManager`의 streaming debounce는 유지한다.
+
+## 수용 기준
+
+- Korean/CJK 입력과 paste 관련 기존 동작이 유지된다.
+- CJK/wide character truncation 또는 split 문제가 실제로 개선되는지 테스트로 확인된다.
+- terminal resize가 필요한 UI는 resize 이벤트에 따라 안정적으로 다시 렌더링된다.
+- 신규 Ink API 도입 시 App-level ESC abort, permission prompt, plugin TUI, session picker 입력 우선순위가 깨지지 않는다.
+
+## 검증
+
+- `pnpm --filter @robota-sdk/agent-cli test`
+- `pnpm --filter @robota-sdk/agent-cli build`
+- `pnpm --filter @robota-sdk/agent-cli lint`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- PTY 기반 provider setup and paste tests 통과 확인
+- Korean/CJK manual smoke test: iTerm2와 macOS Terminal.app에서 입력, paste, cursor movement, abort 동작 확인

--- a/.agents/tasks/CLI-BL-029-markdown-diff-rendering.md
+++ b/.agents/tasks/CLI-BL-029-markdown-diff-rendering.md
@@ -1,0 +1,48 @@
+---
+title: CLI-BL-029 Markdown Diff Rendering
+status: backlog
+priority: medium
+urgency: soon
+created: 2026-04-30
+packages:
+  - agent-cli
+---
+
+## 요약
+
+Robota CLI에서 에이전트 응답 중 코드 diff를 표시할 때, 별도 인위적 구조를 만들기보다 Markdown fenced code block의 `diff` 문법을 그대로 렌더링하는 방식을 검토한다. 상용 코딩 어시스턴트들은 일반 Markdown 응답 안에 ` ```diff ` 블록을 넣고 diff syntax highlighting으로 표시하는 패턴을 사용하는 것으로 보이며, Robota도 가능한 한 이 단순한 경로를 우선한다.
+
+## 배경
+
+현재 CLI에는 diff 표시를 위한 별도 구조와 렌더링 컴포넌트가 존재한다. 하지만 에이전트 응답 자체가 Markdown이라면, diff 표시도 Markdown renderer가 `diff` fenced code block을 처리하도록 만드는 편이 더 단순하고 유지보수하기 쉽다.
+
+## 목표
+
+- Markdown 응답 안의 ` ```diff ` fenced code block을 terminal에서 읽기 좋은 diff 색상으로 렌더링한다.
+- 별도 diff 전용 메시지 구조가 꼭 필요한 경우와 Markdown 렌더링만으로 충분한 경우를 구분한다.
+- 기존 `DiffBlock`, `render-markdown`, `marked`, `marked-terminal`, `cli-highlight` 사용 경로를 조사해 가장 작은 변경으로 붙일 수 있는지 확인한다.
+- 에이전트가 파일 변경 제안이나 patch preview를 답변할 때 Markdown diff block을 자연스럽게 사용하도록 문서/프롬프트/출력 규칙을 정리한다.
+
+## 리서치 필요 항목
+
+- 상용 코딩 어시스턴트가 응답 내 diff를 Markdown fenced `diff` block으로 표현하는 UX 패턴 확인
+- `marked-terminal` 또는 `cli-highlight`가 `diff` language highlighting을 안정적으로 지원하는지 확인
+- ANSI color 출력이 CJK/emoji/wide character width 계산과 충돌하지 않는지 확인
+- 기존 tool result diff 표시와 assistant response diff 표시를 동일 렌더러로 합칠 수 있는지 확인
+
+## 수용 기준
+
+- Assistant Markdown 응답의 ` ```diff ` block이 terminal에서 추가/삭제 줄을 구분해 렌더링된다.
+- 일반 code block, Markdown paragraph, tool summary 출력이 회귀하지 않는다.
+- 기존 Edit tool 결과 표시가 Markdown diff rendering으로 대체 가능한지 판단이 문서화된다.
+- 대체가 가능하면 별도 구조를 줄이는 마이그레이션 계획이 포함된다.
+
+## 검증
+
+- `render-markdown` 단위 테스트에 `diff` fenced code block Given/When/Then assertion 추가
+- 일반 fenced code block과 Markdown inline formatting 회귀 테스트 추가
+- `MessageList` 또는 assistant response rendering 테스트에서 diff block 포함 응답 snapshot/substring assertion 추가
+- `pnpm --filter @robota-sdk/agent-cli test`
+- `pnpm --filter @robota-sdk/agent-cli build`
+- `pnpm --filter @robota-sdk/agent-cli lint`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`

--- a/.agents/tasks/completed/CLI-TK-027-update-ink-7.md
+++ b/.agents/tasks/completed/CLI-TK-027-update-ink-7.md
@@ -1,0 +1,77 @@
+# CLI-TK-027 Update Ink 7
+
+- **Status**: completed
+- **Created**: 2026-04-30
+- **Branch**: chore/update-tui-library
+- **Scope**: packages/agent-cli
+
+## Objective
+
+Update the CLI TUI library dependency after checking the latest Ink release notes, verify compatibility with Robota's TUI input flows, and document recommended follow-up uses of new Ink capabilities.
+
+## Plan
+
+- [x] Identify current TUI dependencies and latest available versions.
+- [x] Review upstream Ink 7 release notes.
+- [x] Update the relevant dependency versions and lockfile.
+- [x] Fix compile/test regressions caused by Ink 7.
+- [x] Run targeted agent-cli verification.
+- [x] Record impact and recommendations.
+
+## Prior Art Research
+
+Ink is the current TUI framework used by `@robota-sdk/agent-cli`.
+
+- Current Robota version: `ink@6.8.0`
+- Latest npm version checked on 2026-04-30: `ink@7.0.1`
+- Companion packages already current: `ink-select-input@6.2.0`, `ink-spinner@5.0.0`, `ink-text-input@6.0.0`, `ink-testing-library@4.0.0`
+- Ink 7.0.0 requires Node.js 22 and React 19.2+, which matches Robota CLI's Node 22 workspace and `react@19.2.4`.
+- Ink 7.0.0 changes key semantics: physical Backspace is now `key.backspace` instead of `key.delete`; plain Escape no longer sets `key.meta`.
+- Ink 7.0.0 adds `usePaste`, `useWindowSize`, `useBoxMetrics`, `useAnimation`, `render({ alternateScreen })`, `render({ interactive })`, `Text wrap="hard"`, and new Box layout props.
+- Ink 7.0.1 fixes `useApp().exit` typing and Escape handling with disabled focus.
+
+## Progress
+
+### 2026-04-30
+
+- Created task after opening PR #101 for the previous background task spec work.
+- Confirmed `packages/agent-cli` owns the Ink TUI dependency.
+- Confirmed latest Ink release from npm and upstream GitHub release notes.
+- Updated `ink` to `^7.0.1` and regenerated `pnpm-lock.yaml` via `pnpm install`.
+- Updated the CLI package engine/docs to Node.js 22+ because Ink 7 requires Node.js 22.
+- Found Ink 7 regression risk around toggling the App-level ESC `useInput` handler with overlays. Changed App to keep the listener mounted and guard overlay state inside the handler.
+
+## Decisions
+
+- Only update the core TUI library (`ink`) in this task unless verification shows a required peer or companion package change.
+- Do not manually edit `pnpm-lock.yaml`; regenerate it with `pnpm install`.
+- Keep the App-level ESC abort listener mounted. Overlay state should be checked inside the handler to preserve abort behavior after permission/plugin/session overlays close.
+
+## Impact
+
+- Node.js support for `@robota-sdk/agent-cli` moves from Node.js 20+ to Node.js 22+ because Ink 7 declares `engines.node >=22`.
+- Current key handling already supports Ink 7's Backspace semantics because prompt flows check `key.backspace || key.delete`.
+- Current ESC handling uses `key.escape`, so the Ink 7 `key.meta` change does not require production logic changes.
+- Tests that used fixed wall-clock delays around TUI input became sensitive under full-suite concurrency; prompt queue tests now use deterministic completion control and assertion polling.
+
+## Recommendations
+
+- Consider replacing Robota's manual bracketed paste handling with Ink 7's `usePaste` in a focused follow-up. This is promising for `CjkTextInput` and paste-template behavior, but should be done behind characterization tests because Robota has custom Korean/CJK cursor handling.
+- Consider replacing `useStdout().stdout.columns` width reads with Ink 7's `useWindowSize` for terminal resize reactivity.
+- Consider `render({ alternateScreen: true })` only as an opt-in mode. It would make the TUI feel more like a full-screen terminal app, but it changes scrollback expectations and should not be the default without UX review.
+- Consider `useAnimation` for `WaveText` or streaming indicators if animation timing needs cleanup, but keep the current rendering debounce in `TuiStateManager`.
+
+## Test Plan
+
+- Run targeted ESC overlay regression tests to prove the App-level abort handler still works after a permission prompt closes and remains ignored while the prompt is active.
+- Run prompt queue tests to prove queued prompt replacement, ESC queue clearing, and Backspace queue clearing remain deterministic under Ink 7.
+- Run full `@robota-sdk/agent-cli` build, test, lint, and typecheck via `pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop`.
+- Run repository scan gates for spec coverage, test-plan coverage, dependency direction, publish safety, file-size warnings, dist freshness, and docs structure.
+
+## Blockers
+
+- None.
+
+## Result
+
+Updated `@robota-sdk/agent-cli` from Ink 6.8.0 to Ink 7.0.1, regenerated the lockfile with `pnpm install`, aligned the CLI package engine/docs to Node.js 22+, and adjusted App-level ESC handling to remain mounted while guarding overlays in the handler. Verified package build, 399 agent-cli tests, lint, typecheck, targeted harness verification, `harness:scan`, and `git diff --check`.

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -6,6 +6,8 @@ AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for proje
 
 ## Installation
 
+Requires Node.js 22+.
+
 ```bash
 # Global install
 npm install -g @robota-sdk/agent-cli
@@ -367,7 +369,7 @@ bin.ts → cli.ts (arg parsing)
 | `@robota-sdk/agent-sdk`                | Session factory, query, config, context    |
 | `@robota-sdk/agent-core`               | Types (TPermissionMode, TToolArgs)         |
 | `@robota-sdk/agent-transport-headless` | Headless runner for print mode (`-p`)      |
-| `ink`, `react`                         | TUI rendering                              |
+| `ink` 7, `react` 19.2+                 | TUI rendering                              |
 | `ink-select-input`                     | Arrow-key selection (permission prompt)    |
 | `ink-spinner`                          | Loading spinner                            |
 | `chalk`                                | Terminal colors                            |

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -780,7 +780,7 @@ Ctrl+C always exits the process immediately. This is handled by Ink's `exitOnCtr
 
 ESC aborts the current execution gracefully (unlike Ctrl+C which kills the process):
 
-1. ESC key handler in `App.tsx` calls `handleAbort()` (from `useInteractiveSession`)
+1. ESC key handler in `App.tsx` calls `handleAbort()` (from `useInteractiveSession`). The App-level ESC listener remains mounted and guards permission, plugin, and session-picker overlays inside the handler instead of toggling `useInput({ isActive })`.
 2. `handleAbort` sets `isAborting: true` and calls `interactiveSession.abort()`
 3. AbortSignal propagates through the entire stack (ExecutionService -> Provider -> `streamWithAbort`)
 4. `executeRound` calls `commitAssistant('interrupted')` — the partial response is saved to conversation history with `state: 'interrupted'`. Text is ALWAYS preserved (no stripping).
@@ -946,6 +946,8 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 
 ## Dependencies
 
+`@robota-sdk/agent-cli` requires Node.js 22+ because Ink 7 requires Node.js 22 and React 19.2+.
+
 | Package                                | Purpose                                                                      |
 | -------------------------------------- | ---------------------------------------------------------------------------- |
 | `@robota-sdk/agent-sdk`                | `InteractiveSession`, `CommandRegistry`, command sources, plugin management  |
@@ -953,7 +955,7 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 | `@robota-sdk/agent-provider-anthropic` | Anthropic provider creation (CLI picks provider based on config)             |
 | `@robota-sdk/agent-provider-openai`    | OpenAI/OpenAI-compatible provider creation (including LM Studio via baseURL) |
 | `@robota-sdk/agent-transport-headless` | Headless runner for print mode (`-p`) execution                              |
-| `ink`, `react`                         | TUI rendering                                                                |
+| `ink` 7, `react` 19.2+                 | TUI rendering                                                                |
 | `ink-select-input`                     | Arrow-key selection (permission prompt)                                      |
 | `ink-spinner`                          | Loading spinner                                                              |
 | `chalk`                                | Terminal colors                                                              |

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/woojubb/robota/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "dist"
@@ -56,7 +56,7 @@
     "@robota-sdk/agent-transport-headless": "workspace:*",
     "chalk": "^5.3.0",
     "cli-highlight": "^2.1.0",
-    "ink": "^6.8.0",
+    "ink": "^7.0.1",
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -115,12 +115,11 @@ function AppInner(
   }, [sessionName]);
 
   // ESC abort
-  useInput(
-    (_input: string, key: { escape: boolean }) => {
-      if (key.escape && isThinking) handleAbort();
-    },
-    { isActive: !permissionRequest && !showPluginTUI && !showSessionPicker },
-  );
+  useInput((_input: string, key: { escape: boolean }) => {
+    if (!key.escape || !isThinking) return;
+    if (permissionRequest || showPluginTUI || showSessionPicker) return;
+    handleAbort();
+  });
 
   // Session may not be initialized yet
   let permissionMode: TPermissionMode = props.permissionMode ?? 'default';

--- a/packages/agent-cli/src/ui/__tests__/abort-after-permission.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/abort-after-permission.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Test: ESC abort after permission prompt was shown and dismissed.
- * Verifies that useInput re-registers properly after isActive toggles.
+ * Verifies that the global ESC handler remains available after overlays close.
  */
 
 import React, { useState, useCallback } from 'react';
@@ -9,10 +9,10 @@ import { Box, Text, useInput } from 'ink';
 import { describe, it, expect } from 'vitest';
 
 /**
- * Simulates App's useInput pattern with permission prompt toggle.
+ * Simulates App's global ESC handler with permission prompt overlay guard.
  * 1. Start with "thinking" active
- * 2. Permission prompt appears (useInput disabled)
- * 3. Permission resolved (useInput re-enabled)
+ * 2. Permission prompt appears (App-level ESC ignores while overlay is active)
+ * 3. Permission resolved (App-level ESC handles abort again)
  * 4. ESC should trigger abort
  */
 function AbortAfterPermissionApp({
@@ -48,15 +48,12 @@ function AbortAfterPermissionApp({
   }, [onPermissionReady]);
 
   // App's ESC handler — same pattern as real App.tsx
-  useInput(
-    (_input: string, key: { escape: boolean }) => {
-      if (key.escape && isThinking) {
-        setAborted(true);
-        onAbort();
-      }
-    },
-    { isActive: !permissionRequest },
-  );
+  useInput((_input: string, key: { escape: boolean }) => {
+    if (!key.escape || !isThinking) return;
+    if (permissionRequest) return;
+    setAborted(true);
+    onAbort();
+  });
 
   // Permission prompt's own useInput (when active)
   useInput(

--- a/packages/agent-cli/src/ui/__tests__/prompt-queue.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/prompt-queue.test.tsx
@@ -8,15 +8,39 @@ import { render } from 'ink-testing-library';
 import { Box, Text, useInput } from 'ink';
 import { describe, it, expect, vi } from 'vitest';
 
+interface IQueueTestController {
+  completeCurrent?: () => void;
+}
+
+async function waitForAssertion(assertion: () => void, timeoutMs = 1500): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: Error | undefined;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+
+  if (lastError) throw lastError;
+  throw new Error('Timed out waiting for assertion');
+}
+
 /**
  * Minimal App that simulates the prompt queue behavior.
  */
 function QueueTestApp({
   onExecute,
   onAbort,
+  controller,
 }: {
   onExecute: (prompt: string) => void;
   onAbort?: () => void;
+  controller?: IQueueTestController;
 }): React.ReactElement {
   const [isThinking, setIsThinking] = useState(false);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
@@ -29,10 +53,19 @@ function QueueTestApp({
       setIsThinking(true);
       setLog((prev) => [...prev, `exec:${input}`]);
       onExecute(input);
-      await new Promise((r) => setTimeout(r, 300));
+      await new Promise<void>((resolve) => {
+        if (controller) {
+          controller.completeCurrent = () => {
+            controller.completeCurrent = undefined;
+            resolve();
+          };
+          return;
+        }
+        setTimeout(resolve, 300);
+      });
       setIsThinking(false);
     },
-    [onExecute],
+    [controller, onExecute],
   );
 
   const handleSubmit = useCallback(
@@ -117,17 +150,19 @@ describe('Prompt Queue', () => {
 
   it('queues prompt when thinking, auto-executes after completion', async () => {
     const onExecute = vi.fn();
-    const { stdin, lastFrame } = render(<QueueTestApp onExecute={onExecute} />);
+    const controller: IQueueTestController = {};
+    const { stdin, lastFrame } = render(
+      <QueueTestApp onExecute={onExecute} controller={controller} />,
+    );
 
     stdin.write('s:first');
-    await new Promise((r) => setTimeout(r, 50));
-    expect(lastFrame()!).toContain('thinking=true');
+    await waitForAssertion(() => expect(lastFrame()!).toContain('thinking=true'));
 
     stdin.write('s:second');
-    await new Promise((r) => setTimeout(r, 50));
-    expect(lastFrame()!).toContain('pending=second');
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=second'));
 
-    await new Promise((r) => setTimeout(r, 700));
+    controller.completeCurrent?.();
+    await waitForAssertion(() => expect(onExecute).toHaveBeenCalledWith('second'));
 
     expect(onExecute).toHaveBeenCalledWith('first');
     expect(onExecute).toHaveBeenCalledWith('second');
@@ -135,19 +170,21 @@ describe('Prompt Queue', () => {
 
   it('only queues 1 prompt — last one wins', async () => {
     const onExecute = vi.fn();
-    const { stdin, lastFrame } = render(<QueueTestApp onExecute={onExecute} />);
+    const controller: IQueueTestController = {};
+    const { stdin, lastFrame } = render(
+      <QueueTestApp onExecute={onExecute} controller={controller} />,
+    );
 
     stdin.write('s:first');
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('thinking=true'));
 
     stdin.write('s:second');
     await new Promise((r) => setTimeout(r, 5));
     stdin.write('s:third');
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=third'));
 
-    expect(lastFrame()!).toContain('pending=third');
-
-    await new Promise((r) => setTimeout(r, 700));
+    controller.completeCurrent?.();
+    await waitForAssertion(() => expect(onExecute).toHaveBeenCalledWith('third'));
 
     expect(onExecute).toHaveBeenCalledWith('first');
     expect(onExecute).toHaveBeenCalledWith('third');
@@ -157,46 +194,50 @@ describe('Prompt Queue', () => {
   it('ESC aborts execution and clears queue', async () => {
     const onExecute = vi.fn();
     const onAbort = vi.fn();
-    const { stdin, lastFrame } = render(<QueueTestApp onExecute={onExecute} onAbort={onAbort} />);
+    const controller: IQueueTestController = {};
+    const { stdin, lastFrame } = render(
+      <QueueTestApp onExecute={onExecute} onAbort={onAbort} controller={controller} />,
+    );
 
     stdin.write('s:first');
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('thinking=true'));
 
     stdin.write('s:queued');
-    await new Promise((r) => setTimeout(r, 50));
-    expect(lastFrame()!).toContain('pending=queued');
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=queued'));
 
     stdin.write('\x1B');
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=none'));
 
-    expect(lastFrame()!).toContain('pending=none');
     expect(onAbort).toHaveBeenCalled();
 
-    await new Promise((r) => setTimeout(r, 700));
+    controller.completeCurrent?.();
+    await new Promise((r) => setTimeout(r, 50));
     expect(onExecute).not.toHaveBeenCalledWith('queued');
   });
 
   it('Backspace cancels queue without aborting', async () => {
     const onExecute = vi.fn();
     const onAbort = vi.fn();
-    const { stdin, lastFrame } = render(<QueueTestApp onExecute={onExecute} onAbort={onAbort} />);
+    const controller: IQueueTestController = {};
+    const { stdin, lastFrame } = render(
+      <QueueTestApp onExecute={onExecute} onAbort={onAbort} controller={controller} />,
+    );
 
     stdin.write('s:first');
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('thinking=true'));
 
     stdin.write('s:queued');
-    await new Promise((r) => setTimeout(r, 50));
-    expect(lastFrame()!).toContain('pending=queued');
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=queued'));
 
     stdin.write('\x7F'); // backspace
-    await new Promise((r) => setTimeout(r, 100));
+    await waitForAssertion(() => expect(lastFrame()!).toContain('pending=none'));
 
-    expect(lastFrame()!).toContain('pending=none');
     expect(lastFrame()!).toContain('queue-cleared');
     expect(onAbort).not.toHaveBeenCalled();
 
     // Execution continues normally
-    await new Promise((r) => setTimeout(r, 700));
+    controller.completeCurrent?.();
+    await new Promise((r) => setTimeout(r, 50));
     expect(onExecute).toHaveBeenCalledWith('first');
     expect(onExecute).not.toHaveBeenCalledWith('queued');
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,17 +577,17 @@ importers:
         specifier: ^2.1.0
         version: 2.1.11
       ink:
-        specifier: ^6.8.0
-        version: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+        specifier: ^7.0.1
+        version: 7.0.1(@types/react@19.2.14)(react@19.2.4)
       ink-select-input:
         specifier: ^6.2.0
-        version: 6.2.0(ink@6.8.0)(react@19.2.4)
+        version: 6.2.0(ink@7.0.1)(react@19.2.4)
       ink-spinner:
         specifier: ^5.0.0
-        version: 5.0.0(ink@6.8.0)(react@19.2.4)
+        version: 5.0.0(ink@7.0.1)(react@19.2.4)
       ink-text-input:
         specifier: ^6.0.0
-        version: 6.0.0(ink@6.8.0)(react@19.2.4)
+        version: 6.0.0(ink@7.0.1)(react@19.2.4)
       marked:
         specifier: ^9.1.5
         version: 9.1.6
@@ -2019,15 +2019,15 @@ packages:
       }
     dev: true
 
-  /@alcalzone/ansi-tokenize@0.2.5:
+  /@alcalzone/ansi-tokenize@0.3.0:
     resolution:
       {
-        integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==,
+        integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==,
       }
     engines: { node: '>=18' }
     dependencies:
-      ansi-styles: 6.2.1
-      is-fullwidth-code-point: 5.0.0
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
     dev: false
 
   /@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.34.0)(algoliasearch@5.34.0)(search-insights@2.17.3):
@@ -9828,6 +9828,7 @@ packages:
         integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
       }
     engines: { node: '>=12' }
+    dev: true
 
   /ansi-styles@6.2.3:
     resolution:
@@ -10815,12 +10816,12 @@ packages:
       }
     dev: false
 
-  /cli-boxes@3.0.0:
+  /cli-boxes@4.0.1:
     resolution:
       {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
+        integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==,
       }
-    engines: { node: '>=10' }
+    engines: { node: '>=18.20 <19 || >=20.10' }
     dev: false
 
   /cli-cursor@4.0.0:
@@ -10890,14 +10891,14 @@ packages:
       string-width: 7.2.0
     dev: true
 
-  /cli-truncate@5.2.0:
+  /cli-truncate@6.0.0:
     resolution:
       {
-        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
+        integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==,
       }
-    engines: { node: '>=20' }
+    engines: { node: '>=22' }
     dependencies:
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       string-width: 8.2.0
     dev: false
 
@@ -11999,6 +12000,7 @@ packages:
       {
         integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==,
       }
+    dev: true
 
   /emoji-regex@8.0.0:
     resolution:
@@ -14913,7 +14915,7 @@ packages:
     engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
     dev: true
 
-  /ink-select-input@6.2.0(ink@6.8.0)(react@19.2.4):
+  /ink-select-input@6.2.0(ink@7.0.1)(react@19.2.4):
     resolution:
       {
         integrity: sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==,
@@ -14924,12 +14926,12 @@ packages:
       react: '>=18.0.0'
     dependencies:
       figures: 6.1.0
-      ink: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+      ink: 7.0.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       to-rotated: 1.0.0
     dev: false
 
-  /ink-spinner@5.0.0(ink@6.8.0)(react@19.2.4):
+  /ink-spinner@5.0.0(ink@7.0.1)(react@19.2.4):
     resolution:
       {
         integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==,
@@ -14940,7 +14942,7 @@ packages:
       react: '>=18.0.0'
     dependencies:
       cli-spinners: 2.9.2
-      ink: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+      ink: 7.0.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     dev: false
 
@@ -14959,7 +14961,7 @@ packages:
       '@types/react': 19.2.14
     dev: true
 
-  /ink-text-input@6.0.0(ink@6.8.0)(react@19.2.4):
+  /ink-text-input@6.0.0(ink@7.0.1)(react@19.2.4):
     resolution:
       {
         integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==,
@@ -14970,20 +14972,20 @@ packages:
       react: '>=18'
     dependencies:
       chalk: 5.6.2
-      ink: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+      ink: 7.0.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       type-fest: 4.41.0
     dev: false
 
-  /ink@6.8.0(@types/react@19.2.14)(react@19.2.4):
+  /ink@7.0.1(@types/react@19.2.14)(react@19.2.4):
     resolution:
       {
-        integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==,
+        integrity: sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==,
       }
-    engines: { node: '>=20' }
+    engines: { node: '>=22' }
     peerDependencies:
-      '@types/react': '>=19.0.0'
-      react: '>=19.0.0'
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
       react-devtools-core: '>=6.1.2'
     peerDependenciesMeta:
       '@types/react':
@@ -14991,15 +14993,15 @@ packages:
       react-devtools-core:
         optional: true
     dependencies:
-      '@alcalzone/ansi-tokenize': 0.2.5
+      '@alcalzone/ansi-tokenize': 0.3.0
       '@types/react': 19.2.14
       ansi-escapes: 7.3.0
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       auto-bind: 5.0.1
       chalk: 5.6.2
-      cli-boxes: 3.0.0
+      cli-boxes: 4.0.1
       cli-cursor: 4.0.0
-      cli-truncate: 5.2.0
+      cli-truncate: 6.0.0
       code-excerpt: 4.0.0
       es-toolkit: 1.45.1
       indent-string: 5.0.0
@@ -15009,14 +15011,14 @@ packages:
       react-reconciler: 0.33.0(react@19.2.4)
       scheduler: 0.27.0
       signal-exit: 3.0.7
-      slice-ansi: 8.0.0
+      slice-ansi: 9.0.0
       stack-utils: 2.0.6
       string-width: 8.2.0
       terminal-size: 4.0.1
-      type-fest: 5.4.4
+      type-fest: 5.6.0
       widest-line: 6.0.0
-      wrap-ansi: 9.0.0
-      ws: 8.18.3
+      wrap-ansi: 10.0.0
+      ws: 8.20.0
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -15257,6 +15259,7 @@ packages:
     engines: { node: '>=18' }
     dependencies:
       get-east-asian-width: 1.5.0
+    dev: true
 
   /is-fullwidth-code-point@5.1.0:
     resolution:
@@ -20846,12 +20849,12 @@ packages:
       is-fullwidth-code-point: 5.0.0
     dev: true
 
-  /slice-ansi@8.0.0:
+  /slice-ansi@9.0.0:
     resolution:
       {
-        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+        integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==,
       }
-    engines: { node: '>=20' }
+    engines: { node: '>=22' }
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
@@ -21099,6 +21102,7 @@ packages:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
+    dev: true
 
   /string-width@8.2.0:
     resolution:
@@ -21231,6 +21235,7 @@ packages:
     engines: { node: '>=12' }
     dependencies:
       ansi-regex: 6.2.2
+    dev: true
 
   /strip-ansi@7.2.0:
     resolution:
@@ -22083,10 +22088,10 @@ packages:
     engines: { node: '>=16' }
     dev: false
 
-  /type-fest@5.4.4:
+  /type-fest@5.6.0:
     resolution:
       {
-        integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==,
+        integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==,
       }
     engines: { node: '>=20' }
     dependencies:
@@ -23352,6 +23357,18 @@ packages:
       }
     dev: true
 
+  /wrap-ansi@10.0.0:
+    resolution:
+      {
+        integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==,
+      }
+    engines: { node: '>=20' }
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.0
+      strip-ansi: 7.2.0
+    dev: false
+
   /wrap-ansi@7.0.0:
     resolution:
       {
@@ -23385,6 +23402,7 @@ packages:
       ansi-styles: 6.2.1
       string-width: 7.2.0
       strip-ansi: 7.1.0
+    dev: true
 
   /wrappy@1.0.2:
     resolution:
@@ -23433,6 +23451,22 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  /ws@8.20.0:
+    resolution:
+      {
+        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
+      }
+    engines: { node: '>=10.0.0' }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /xml-name-validator@5.0.0:
     resolution:


### PR DESCRIPTION
## Summary
- Update agent-cli from Ink 6.8 to Ink 7.0.1 and align CLI Node engine/docs to Node 22+.
- Keep the App-level ESC abort listener mounted while guarding overlay state for Ink 7 input behavior.
- Stabilize TUI ESC/prompt queue tests and record Ink 7 CJK plus markdown diff rendering follow-up backlog items.

## Validation
- pnpm run typecheck
- pnpm run lint (0 errors, existing warnings)
- pnpm run test
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop
- pnpm harness:scan
- git diff --check
- pre-push harness verify changed scopes

## Notes
- pnpm-lock.yaml was regenerated via pnpm install per repository package manager flow.
- harness:scan reports existing file-size warnings and app/internal dist warnings; no blocking failures.
- Push hook compares against origin/main, so it verified additional already-merged develop scopes as well.