### PR TITLE
fix(agent-cli): hide completed background tasks

### DIFF
--- a/.agents/rules/common-mistakes.md
+++ b/.agents/rules/common-mistakes.md
@@ -3,35 +3,35 @@
 Mistakes observed repeatedly in this codebase. Every item below has caused a real failure.
 Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 
-| #   | Mistake                                                          | Correct approach                                                                |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| 1   | Using `any` or `{}` in production code                           | Use `unknown` + narrowing, or define a proper interface                         |
-| 2   | Forgetting `pnpm build` before `pnpm test` in a dependency chain | Always run `pnpm build:deps` first, or use `harness:verify`                     |
-| 3   | Creating bidirectional package dependencies                      | Dependency direction is one-way; see `.agents/project-structure.md`             |
-| 4   | Pass-through re-exports (`export * from '@robota-sdk/other'`)    | Import from the owning package directly                                         |
-| 5   | Committing without running `pnpm typecheck`                      | Pre-commit hook runs lint-staged; always verify locally                         |
-| 6   | Adding a new package without `docs/SPEC.md`                      | Every workspace package requires a SPEC.md; see `spec-writing-standard` skill   |
-| 7   | Using `console.*` in production code                             | Use dependency-injected logger                                                  |
-| 8   | Modifying a spec without running the conformance loop            | Every spec change requires `spec-code-conformance` verification                 |
-| 9   | Using `try/catch` as a fallback mechanism                        | No fallback policy; terminal failures stay terminal                             |
-| 10  | Writing implementation before a failing test                     | TDD: red-green-refactor; write the test first                                   |
-| 11  | Publishing without dry-run                                       | Always run `publish --dry-run` first; see `process.md` Publish Safety Gate      |
-| 12  | Publishing packages without user approval on scope               | Confirm publish manifest with user; see `process.md` Publish Scope Approval     |
-| 13  | agent-core depending on agent-\* packages                        | agent-core MUST NOT depend on any @robota-sdk/agent-\* package                  |
-| 14  | Using `npm publish` instead of `pnpm publish`                    | pnpm resolves workspace:\* deps; npm publishes them literally, breaking install |
-| 15  | Adding a feature without updating SPEC.md/README.md              | Every new feature requires documentation updates in the same commit/PR          |
-| 16  | Hardcoding cross-cutting concerns (fs.appendFile, console.log)   | Use plugin/event architecture; see `code-quality.md` Layered Assembly           |
-| 17  | Bypassing layer boundaries (CLI using core internals directly)   | Each layer consumes only its direct dependency's public API                     |
-| 18  | Maintaining separate parallel arrays that must stay in sync      | Use a single data structure (array of objects, Map); see `code-quality.md`      |
-| 19  | Firing post-event hooks before state mutation is complete        | Post hooks/callbacks fire only after all side effects are done                  |
-| 20  | Factory ignoring values available in its config/context object   | Use `options.x ?? context.x`; see `code-quality.md` Layered Assembly            |
-| 21  | Refactoring code without updating SPEC.md                        | Reverse verify SPEC after boundary-affecting refactors; see `process.md`        |
-| 22  | SPEC hardcoding another package's counts or details              | Reference owning SPEC or describe only observable facts; see `process.md`       |
-| 23  | Defining identical interface/type independently in two packages  | One SSOT owner, others import; see `code-quality.md` Type System                |
-| 24  | Modifying code without updating SPEC first                       | Update SPEC to describe intended state, then fix code to match                  |
-| 25  | Publishing a package without removing "not yet published" labels | Search content/ and docs/ for stale labels when first publishing a package      |
-| 26  | Refactoring/modularizing code without test coverage first        | Write characterization tests before extraction; see `pre-refactor-test-harness` |
-| 27  | Using `pnpm publish` or `npm publish` directly                   | Always use `pnpm publish:beta`; see `publish.md` Publish Command                |
-| 28  | Publishing only some packages (cherry-picking)                   | ALL non-private packages must be published together; see `publish.md`           |
-| 29  | Modifying SPEC during verification to match code                 | NEVER. Fix code to match SPEC. SPEC is source of truth during verification.     |
-| 30  | Accumulating reusable runtime features inside SDK or CLI         | Extract reusable lifecycle/state/ports into composable packages or modules      |
+| #   | Mistake                                                          | Correct approach                                                                           |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 1   | Using `any` or `{}` in production code                           | Use `unknown` + narrowing, or define a proper interface                                    |
+| 2   | Forgetting `pnpm build` before `pnpm test` in a dependency chain | Always run `pnpm build:deps` first, or use `harness:verify`                                |
+| 3   | Creating bidirectional package dependencies                      | Dependency direction is one-way; see `.agents/project-structure.md`                        |
+| 4   | Pass-through re-exports (`export * from '@robota-sdk/other'`)    | Import from the owning package directly                                                    |
+| 5   | Committing without running `pnpm typecheck`                      | Pre-commit hook runs lint-staged; always verify locally                                    |
+| 6   | Adding a new package without `docs/SPEC.md`                      | Every workspace package requires a SPEC.md; see `spec-writing-standard` skill              |
+| 7   | Using `console.*` in production code                             | Use dependency-injected logger                                                             |
+| 8   | Modifying a spec without running the conformance loop            | Every spec change requires `spec-code-conformance` verification                            |
+| 9   | Using `try/catch` as a fallback mechanism                        | No fallback policy; terminal failures stay terminal                                        |
+| 10  | Writing implementation before a failing test                     | TDD: red-green-refactor; write the test first                                              |
+| 11  | Publishing without dry-run                                       | Always run `publish --dry-run` first; see `process.md` Publish Safety Gate                 |
+| 12  | Publishing packages without user approval on scope               | Confirm publish manifest with user; see `process.md` Publish Scope Approval                |
+| 13  | agent-core depending on agent-\* packages                        | agent-core MUST NOT depend on any @robota-sdk/agent-\* package                             |
+| 14  | Using `npm publish` instead of `pnpm publish`                    | pnpm resolves workspace:\* deps; npm publishes them literally, breaking install            |
+| 15  | Adding a feature without updating SPEC.md/README.md              | Every new feature requires documentation updates in the same commit/PR                     |
+| 16  | Hardcoding cross-cutting concerns (fs.appendFile, console.log)   | Use plugin/event architecture; see `code-quality.md` Layered Assembly                      |
+| 17  | Bypassing layer boundaries (CLI using core internals directly)   | Each layer consumes only its direct dependency's public API                                |
+| 18  | Maintaining separate parallel arrays that must stay in sync      | Use a single data structure (array of objects, Map); see `code-quality.md`                 |
+| 19  | Firing post-event hooks before state mutation is complete        | Post hooks/callbacks fire only after all side effects are done                             |
+| 20  | Factory ignoring values available in its config/context object   | Use `options.x ?? context.x`; see `code-quality.md` Layered Assembly                       |
+| 21  | Refactoring code without updating SPEC.md                        | Reverse verify SPEC after boundary-affecting refactors; see `process.md`                   |
+| 22  | SPEC hardcoding another package's counts or details              | Reference owning SPEC or describe only observable facts; see `process.md`                  |
+| 23  | Defining identical interface/type independently in two packages  | One SSOT owner, others import; see `code-quality.md` Type System                           |
+| 24  | Modifying code without updating SPEC first                       | Update SPEC to describe intended state, then fix code to match                             |
+| 25  | Publishing a package without removing "not yet published" labels | Search content/ and docs/ for stale labels when first publishing a package                 |
+| 26  | Refactoring/modularizing code without test coverage first        | Write characterization tests before extraction; see `pre-refactor-test-harness`            |
+| 27  | Using `pnpm publish` or `npm publish` directly                   | Always use `pnpm publish:beta`; see `publish.md` Publish Command                           |
+| 28  | Publishing only some packages (cherry-picking)                   | ALL non-private packages must be published together; see `publish.md`                      |
+| 29  | Modifying SPEC during verification to match code                 | NEVER. Fix code to match SPEC. SPEC is source of truth during verification.                |
+| 30  | Accumulating reusable runtime features inside SDK or CLI         | Extract reusable lifecycle/state/ports into composable packages and update structural docs |

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -12,14 +12,14 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 | API Boundary    | [api-boundary.md](api-boundary.md)       | Runtime/Orchestrator API rules             |
 | Naming & Style  | [naming-style.md](naming-style.md)       | Language policy, agent identity, styling   |
 | Git & Branch    | [git-branch.md](git-branch.md)           | Git operations, branch policy, worktree    |
-| Common Mistakes | [common-mistakes.md](common-mistakes.md) | 29 observed failure patterns               |
+| Common Mistakes | [common-mistakes.md](common-mistakes.md) | Observed failure patterns                  |
 
 ## Process Sub-Rules (linked from process.md)
 
-| Document                                   | Scope                                                    |
-| ------------------------------------------ | -------------------------------------------------------- |
-| [spec-workflow.md](spec-workflow.md)       | Spec-first development, conformance verification         |
-| [tdd-and-planning.md](tdd-and-planning.md) | TDD red-green-refactor, planning requirements            |
-| [verification.md](verification.md)         | Build, browser, harness, and pre-push verification gates |
-| [publish.md](publish.md)                   | Package publish safety gate and scope approval           |
-| [operational.md](operational.md)           | No fallback policy, idea capture, feature documentation  |
+| Document                                   | Scope                                                             |
+| ------------------------------------------ | ----------------------------------------------------------------- |
+| [spec-workflow.md](spec-workflow.md)       | Spec-first development, conformance verification, structural docs |
+| [tdd-and-planning.md](tdd-and-planning.md) | TDD red-green-refactor, planning requirements                     |
+| [verification.md](verification.md)         | Build, browser, harness, and pre-push verification gates          |
+| [publish.md](publish.md)                   | Package publish safety gate and scope approval                    |
+| [operational.md](operational.md)           | No fallback policy, idea capture, feature documentation           |

--- a/.agents/rules/process.md
+++ b/.agents/rules/process.md
@@ -5,10 +5,10 @@ Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 
 This file routes to detailed rule documents. Each linked file contains the full rule text.
 
-| Document                                   | Key rules                                                                                                 |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| [spec-workflow.md](spec-workflow.md)       | Spec-first development, feature gap process, conformance verification, reverse verify, cross-package refs |
-| [tdd-and-planning.md](tdd-and-planning.md) | TDD red-green-refactor, planning requirements, plan documentation                                         |
-| [verification.md](verification.md)         | Build requirements, browser verification, harness verification                                            |
-| [publish.md](publish.md)                   | Foundation dependency rule, publish safety gate, publish scope approval                                   |
-| [operational.md](operational.md)           | No fallback policy, idea capture, prior art research, feature documentation                               |
+| Document                                   | Key rules                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| [spec-workflow.md](spec-workflow.md)       | Spec-first development, feature gap process, conformance verification, reverse verify, structural docs |
+| [tdd-and-planning.md](tdd-and-planning.md) | TDD red-green-refactor, planning requirements, plan documentation                                      |
+| [verification.md](verification.md)         | Build requirements, browser verification, harness verification                                         |
+| [publish.md](publish.md)                   | Foundation dependency rule, publish safety gate, publish scope approval                                |
+| [operational.md](operational.md)           | No fallback policy, idea capture, prior art research, feature documentation                            |

--- a/.agents/rules/spec-workflow.md
+++ b/.agents/rules/spec-workflow.md
@@ -54,6 +54,13 @@ Skipping step 1–3 (coding before spec) is a process violation. This applies ev
 - The verification checks that the SPEC still accurately describes the current code — not just that the code matches the spec.
 - A refactoring without updated SPEC.md is an incomplete change, same as a spec change without conformance verification.
 
+### Structural Architecture Documentation
+
+- Any change that creates, removes, renames, or reassigns responsibilities across workspace packages MUST update the architecture documents that describe the structure in the same PR.
+- Required structural docs include `.agents/project-structure.md` for package inventory/dependency direction and `.agents/specs/*.md` for cross-cutting architecture that spans packages.
+- Package `docs/SPEC.md` files remain required for owner-level contracts; architecture docs do not replace package specs.
+- A structural architecture change without updated structure/spec architecture documents is incomplete.
+
 ### Cross-Package SPEC Reference Policy
 
 - SPEC.md MUST NOT hardcode counts, lists, or implementation details owned by another package (e.g., "6 built-in tools" when the tools are owned by a different package).

--- a/.agents/specs/background-task-layer.md
+++ b/.agents/specs/background-task-layer.md
@@ -521,6 +521,8 @@ Required TUI behavior:
 - allow stop/cancel for running tasks
 - allow dismiss/close for terminal tasks
 - allow open/follow to inspect transcript or logs
+- hide clean completed tasks from the always-visible panel at the next accepted user turn while keeping the runtime record available through background task APIs
+- keep failed, cancelled, non-zero exit, signal-terminated, and artifact-bearing terminal tasks visible until explicit close or acknowledge
 
 TUI components MUST remain thin renderers. Keyboard/input behavior should live in flow modules that can be unit-tested without Ink.
 

--- a/.agents/tasks/completed/CLI-BL-031-background-task-terminal-visibility.md
+++ b/.agents/tasks/completed/CLI-BL-031-background-task-terminal-visibility.md
@@ -1,6 +1,6 @@
 ---
 title: CLI-BL-031 Background Task Terminal Visibility
-status: backlog
+status: completed
 priority: high
 urgency: next
 created: 2026-05-01
@@ -8,6 +8,8 @@ packages:
   - agent-cli
   - agent-sdk
   - agent-runtime
+branch: fix/background-task-terminal-visibility
+completed: 2026-05-01
 ---
 
 ## Summary
@@ -139,11 +141,29 @@ Recommended later command:
 
 ## Implementation Plan
 
-1. Add characterization tests for the current TUI projection so the existing completed-task persistence is explicit.
-2. Add a pure TUI visibility policy helper that classifies clean completed vs actionable terminal tasks.
-3. Add a turn-boundary method to `TuiStateManager` or the prompt flow bridge that hides clean completed tasks from the main panel.
-4. Keep `/background list/read/close` backed by `InteractiveSession`, not by the TUI visible projection.
-5. Update package SPEC files after implementation so `agent-cli`, `agent-sdk`, and `agent-runtime` reflect the final code behavior.
+1. [x] Add characterization tests for the current TUI projection so the existing completed-task persistence is explicit.
+2. [x] Add a pure TUI visibility policy helper that classifies clean completed vs actionable terminal tasks.
+3. [x] Add a turn-boundary method to `TuiStateManager` or the prompt flow bridge that hides clean completed tasks from the main panel.
+4. [x] Keep `/background list/read/close` backed by `InteractiveSession`, not by the TUI visible projection.
+5. [x] Update package SPEC files after implementation so `agent-cli`, `agent-sdk`, and `agent-runtime` reflect the final code behavior.
+
+## Progress
+
+### 2026-05-01
+
+- Started implementation on `fix/background-task-terminal-visibility` after PR #103 merged to `develop`.
+- Confirmed `agent-runtime` and `agent-sdk` already retain terminal-state task records; the missing behavior is TUI-only presentation auto-hide.
+- Added TUI state tests for clean completed auto-hide, actionable terminal visibility, preserved worktree visibility, non-zero process exit visibility, and hidden task close cleanup.
+- Implemented `TuiStateManager.onUserTurnAccepted()` and wired slash/normal prompt submission to trigger the turn-boundary visibility policy.
+- Extracted background task view-model and visibility classification helpers to keep `tui-state-manager.ts` below the production file-size guard.
+- Updated background task and CLI package specs with the runtime-retention vs TUI-visibility contract.
+- Added process rules requiring structural architecture documentation updates when package responsibilities or cross-package architecture change.
+
+## Result
+
+Implemented deterministic TUI-only auto-hide for clean completed background tasks at the next accepted user turn.
+Runtime background task records remain retained for `/background list`, `/background read`, and explicit close flows.
+Actionable terminal tasks remain visible when they failed, were cancelled, exited non-zero, ended by signal, or preserved worktree/branch artifacts.
 
 ## Test Plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This file contains only domain-free rules and routing. It does not contain packa
 | [.agents/rules/api-boundary.md](.agents/rules/api-boundary.md)           | API spec, runtime/orchestrator boundary                                            |
 | [.agents/rules/naming-style.md](.agents/rules/naming-style.md)           | Language policy, agent identity, styling                                           |
 | [.agents/rules/git-branch.md](.agents/rules/git-branch.md)               | Git ops, branch policy, worktree                                                   |
-| [.agents/rules/common-mistakes.md](.agents/rules/common-mistakes.md)     | 29 observed failure patterns                                                       |
+| [.agents/rules/common-mistakes.md](.agents/rules/common-mistakes.md)     | Observed failure patterns                                                          |
 | [.agents/project-structure.md](.agents/project-structure.md)             | Package listing and dependency rules                                               |
 | [.agents/skills/index.md](.agents/skills/index.md)                       | All procedural workflow skills                                                     |
 | [.agents/backlog/README.md](.agents/backlog/README.md)                   | Future work items and backlog process                                              |
@@ -91,7 +91,7 @@ All rules below are mandatory, non-negotiable, and domain-free. Each rule group 
 | Naming & Style       | [naming-style.md](.agents/rules/naming-style.md)               | Language policy, agent identity, Tailwind only                                      |
 | Git & Branch         | [git-branch.md](.agents/rules/git-branch.md)                   | Branch policy, conventional commits, worktree                                       |
 | Package Dependencies | [`.agents/project-structure.md`](.agents/project-structure.md) | One-way deps, no cycles, no pass-through re-exports                                 |
-| Common Mistakes      | [common-mistakes.md](.agents/rules/common-mistakes.md)         | 29 observed failure patterns with correct approaches                                |
+| Common Mistakes      | [common-mistakes.md](.agents/rules/common-mistakes.md)         | Observed failure patterns with correct approaches                                   |
 
 ## Skills Reference
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -930,6 +930,8 @@ When a user asks in normal conversation to call or delegate to an agent, the req
 
 Background agent task lifecycle and progress are projected into `TuiStateManager.backgroundTasks` through the runtime-owned event union exposed as the SDK `background_task_event` event. Text deltas are accumulated into a short preview, and tool start/end events update the current action. React components must render this state only; they must not own task transition or cancellation logic.
 
+`TuiStateManager` owns presentation-only visibility policy. Clean completed tasks remain visible as an unread completion notice until the next accepted user turn, then leave the always-visible background panel without calling `closeBackgroundTask()`. Failed, cancelled, non-zero exit, signal-terminated, and worktree/branch-bearing terminal tasks remain visible until explicit close or acknowledge. `/background list` and `/background read` continue to use the SDK runtime registry, so tasks hidden from the panel remain inspectable until runtime close or session cleanup.
+
 `BackgroundTaskPanel` renders active and recently completed background tasks with status, kind, label, task ID, unread marker, and a short preview. User controls are routed through SDK system commands:
 
 | Command                               | Behavior                       |

--- a/packages/agent-cli/src/ui/__tests__/tui-state-manager.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/tui-state-manager.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { TuiStateManager } from '../tui-state-manager.js';
-import type { IToolState, IExecutionResult } from '@robota-sdk/agent-sdk';
+import type { IToolState, IExecutionResult, IBackgroundTaskState } from '@robota-sdk/agent-sdk';
 
 function makeResult(overrides?: Partial<IExecutionResult>): IExecutionResult {
   return {
@@ -18,6 +18,23 @@ function makeResult(overrides?: Partial<IExecutionResult>): IExecutionResult {
       usedTokens: 1000,
       maxTokens: 200000,
     },
+    ...overrides,
+  };
+}
+
+function makeBackgroundTask(
+  overrides: Partial<IBackgroundTaskState> & Pick<IBackgroundTaskState, 'id' | 'status'>,
+): IBackgroundTaskState {
+  return {
+    kind: 'agent',
+    label: 'Explore',
+    mode: 'background',
+    parentSessionId: 'session_parent',
+    depth: 1,
+    cwd: '/workspace',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    unread: false,
+    promptPreview: 'Find files',
     ...overrides,
   };
 }
@@ -310,6 +327,104 @@ describe('TuiStateManager', () => {
 
     expect(mgr.backgroundTasks[0]!.currentAction).toBe('file.ts');
     expect(mgr.backgroundTasks[0]!.resultPreview).toBe('partial answer');
+  });
+
+  it('hides clean completed background tasks at the next user turn boundary', () => {
+    const mgr = new TuiStateManager();
+
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_completed',
+      task: makeBackgroundTask({
+        id: 'agent_1',
+        status: 'completed',
+        unread: true,
+        result: { taskId: 'agent_1', kind: 'agent', output: 'Done' },
+      }),
+    });
+
+    expect(mgr.backgroundTasks).toHaveLength(1);
+
+    mgr.onUserTurnAccepted();
+
+    expect(mgr.backgroundTasks).toEqual([]);
+  });
+
+  it('keeps active and actionable terminal background tasks visible at turn boundaries', () => {
+    const mgr = new TuiStateManager();
+
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_started',
+      task: makeBackgroundTask({ id: 'agent_running', status: 'running' }),
+    });
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_failed',
+      task: makeBackgroundTask({
+        id: 'agent_failed',
+        status: 'failed',
+        unread: true,
+        error: { category: 'runner', message: 'failed', recoverable: true },
+      }),
+    });
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_cancelled',
+      task: makeBackgroundTask({
+        id: 'agent_cancelled',
+        status: 'cancelled',
+        unread: true,
+        error: { category: 'runner', message: 'cancelled', recoverable: true },
+      }),
+    });
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_completed',
+      task: makeBackgroundTask({
+        id: 'agent_worktree',
+        status: 'completed',
+        unread: true,
+        worktreePath: '/workspace/.robota/worktrees/agent_worktree',
+        branchName: 'robota/agent_worktree',
+        result: { taskId: 'agent_worktree', kind: 'agent', output: 'Dirty worktree' },
+      }),
+    });
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_completed',
+      task: makeBackgroundTask({
+        id: 'process_nonzero',
+        kind: 'process',
+        status: 'completed',
+        unread: true,
+        commandPreview: 'pnpm test',
+        result: { taskId: 'process_nonzero', kind: 'process', output: 'failed', exitCode: 1 },
+      }),
+    });
+
+    mgr.onUserTurnAccepted();
+
+    expect(mgr.backgroundTasks.map((task) => task.id)).toEqual([
+      'agent_running',
+      'agent_failed',
+      'agent_cancelled',
+      'agent_worktree',
+      'process_nonzero',
+    ]);
+  });
+
+  it('clears hidden completed task presentation state when the runtime closes it', () => {
+    const mgr = new TuiStateManager();
+
+    mgr.onBackgroundTaskEvent({
+      type: 'background_task_completed',
+      task: makeBackgroundTask({
+        id: 'agent_1',
+        status: 'completed',
+        unread: true,
+        result: { taskId: 'agent_1', kind: 'agent', output: 'Done' },
+      }),
+    });
+    mgr.onUserTurnAccepted();
+
+    mgr.onBackgroundTaskEvent({ type: 'background_task_closed', taskId: 'agent_1' });
+
+    expect(mgr.backgroundTasks).toEqual([]);
   });
 
   // ── Display order: Tool → Robota ──────────────────────────────

--- a/packages/agent-cli/src/ui/background-task-view-model.ts
+++ b/packages/agent-cli/src/ui/background-task-view-model.ts
@@ -1,0 +1,58 @@
+import type {
+  IBackgroundTaskState,
+  TBackgroundTaskKind,
+  TBackgroundTaskMode,
+  TBackgroundTaskStatus,
+} from '@robota-sdk/agent-sdk';
+
+const BACKGROUND_PREVIEW_LENGTH = 120;
+const SUCCESS_EXIT_CODE = 0;
+
+export interface IBackgroundTaskViewModel {
+  id: string;
+  kind: TBackgroundTaskKind;
+  label: string;
+  status: TBackgroundTaskStatus;
+  mode: TBackgroundTaskMode;
+  currentAction?: string;
+  unread: boolean;
+  preview: string;
+  resultPreview?: string;
+  errorPreview?: string;
+}
+
+export function toBackgroundTaskViewModel(
+  state: IBackgroundTaskState,
+  partialText?: string,
+): IBackgroundTaskViewModel {
+  return {
+    id: state.id,
+    kind: state.kind,
+    label: state.label,
+    status: state.status,
+    mode: state.mode,
+    currentAction: state.currentAction,
+    unread: state.unread,
+    preview: trimBackgroundPreview(state.promptPreview ?? state.commandPreview) ?? '',
+    resultPreview: trimBackgroundPreview(state.result?.output ?? partialText),
+    errorPreview: trimBackgroundPreview(state.error?.message),
+  };
+}
+
+export function shouldHideAtNextUserTurn(state: IBackgroundTaskState): boolean {
+  return (
+    state.status === 'completed' &&
+    !state.error &&
+    (state.result?.exitCode === undefined || state.result.exitCode === SUCCESS_EXIT_CODE) &&
+    !state.result?.signalCode &&
+    !state.worktreePath &&
+    !state.branchName
+  );
+}
+
+export function trimBackgroundPreview(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.length > BACKGROUND_PREVIEW_LENGTH
+    ? `${value.slice(0, BACKGROUND_PREVIEW_LENGTH)}...`
+    : value;
+}

--- a/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
+++ b/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
@@ -21,6 +21,8 @@ export function useSlashRouting(
 ): (input: string) => Promise<void> {
   return useCallback(
     async (input: string) => {
+      manager.onUserTurnAccepted();
+
       if (!input.startsWith('/')) {
         await interactiveSession.submit(input);
         manager.setPendingPrompt(interactiveSession.getPendingPrompt());

--- a/packages/agent-cli/src/ui/tui-state-manager.ts
+++ b/packages/agent-cli/src/ui/tui-state-manager.ts
@@ -14,35 +14,25 @@ import type {
   IExecutionResult,
   IBackgroundTaskState,
   TBackgroundTaskEvent,
-  TBackgroundTaskKind,
-  TBackgroundTaskMode,
-  TBackgroundTaskStatus,
 } from '@robota-sdk/agent-sdk';
+import {
+  shouldHideAtNextUserTurn,
+  toBackgroundTaskViewModel,
+  trimBackgroundPreview,
+  type IBackgroundTaskViewModel,
+} from './background-task-view-model.js';
+
+export type { IBackgroundTaskViewModel } from './background-task-view-model.js';
 
 /** Max messages kept in rendering state */
 const MAX_RENDERED_MESSAGES = 100;
 
 /** Debounce interval for streaming text notify (limits renderMarkdown frequency) */
 const STREAMING_DEBOUNCE_MS = 300;
-const BACKGROUND_PREVIEW_LENGTH = 120;
-
 export interface IContextState {
   percentage: number;
   usedTokens: number;
   maxTokens: number;
-}
-
-export interface IBackgroundTaskViewModel {
-  id: string;
-  kind: TBackgroundTaskKind;
-  label: string;
-  status: TBackgroundTaskStatus;
-  mode: TBackgroundTaskMode;
-  currentAction?: string;
-  unread: boolean;
-  preview: string;
-  resultPreview?: string;
-  errorPreview?: string;
 }
 
 /** Create a debounced notify — schedules at most one call per interval. */
@@ -86,6 +76,7 @@ export class TuiStateManager {
   // ── Internal ──────────────────────────────────────────────────
   private streamBuf = '';
   private backgroundTextBuffers = new Map<string, string>();
+  private backgroundTasksHiddenOnNextTurn = new Set<string>();
   private debouncedStreamNotify = createDebouncedNotify(() => this.notify(), STREAMING_DEBOUNCE_MS);
 
   private notify(): void {
@@ -170,6 +161,7 @@ export class TuiStateManager {
 
     if (event.type === 'background_task_closed') {
       this.backgroundTextBuffers.delete(event.taskId);
+      this.backgroundTasksHiddenOnNextTurn.delete(event.taskId);
       this.backgroundTasks = this.backgroundTasks.filter((task) => task.id !== event.taskId);
       this.notify();
       return;
@@ -226,6 +218,17 @@ export class TuiStateManager {
     this.notify();
   }
 
+  onUserTurnAccepted(): void {
+    if (this.backgroundTasksHiddenOnNextTurn.size === 0) return;
+    const visible = this.backgroundTasks.filter(
+      (task) => !this.backgroundTasksHiddenOnNextTurn.has(task.id),
+    );
+    this.backgroundTasksHiddenOnNextTurn.clear();
+    if (visible.length === this.backgroundTasks.length) return;
+    this.backgroundTasks = visible;
+    this.notify();
+  }
+
   private upsertBackgroundTask(state: IBackgroundTaskState): void {
     const partialText = state.result ? undefined : this.backgroundTextBuffers.get(state.id);
     const viewModel = toBackgroundTaskViewModel(state, partialText);
@@ -239,6 +242,11 @@ export class TuiStateManager {
     }
     if (state.status === 'completed' || state.status === 'failed' || state.status === 'cancelled') {
       this.backgroundTextBuffers.delete(state.id);
+    }
+    if (shouldHideAtNextUserTurn(state)) {
+      this.backgroundTasksHiddenOnNextTurn.add(state.id);
+    } else {
+      this.backgroundTasksHiddenOnNextTurn.delete(state.id);
     }
     this.notify();
   }
@@ -258,29 +266,4 @@ export class TuiStateManager {
     );
     this.notify();
   }
-}
-
-function trimBackgroundPreview(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  return value.length > BACKGROUND_PREVIEW_LENGTH
-    ? `${value.slice(0, BACKGROUND_PREVIEW_LENGTH)}...`
-    : value;
-}
-
-function toBackgroundTaskViewModel(
-  state: IBackgroundTaskState,
-  partialText?: string,
-): IBackgroundTaskViewModel {
-  return {
-    id: state.id,
-    kind: state.kind,
-    label: state.label,
-    status: state.status,
-    mode: state.mode,
-    currentAction: state.currentAction,
-    unread: state.unread,
-    preview: trimBackgroundPreview(state.promptPreview ?? state.commandPreview) ?? '',
-    resultPreview: trimBackgroundPreview(state.result?.output ?? partialText),
-    errorPreview: trimBackgroundPreview(state.error?.message),
-  };
 }


### PR DESCRIPTION
## Summary

- Hide clean completed background tasks from the TUI main panel at the next accepted user turn while keeping runtime registry records available.
- Keep actionable terminal tasks visible when they failed, were cancelled, exited non-zero, ended by signal, or preserved worktree/branch artifacts.
- Add structural architecture documentation rules for package responsibility and cross-package architecture changes.

## Validation

- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-cli exec tsc -p tsconfig.json --noEmit
- pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop
- pnpm harness:scan
- pre-push harness verify changed scopes