### PR TITLE
fix(agent): persist subagent diagnostics and prompts

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -8,6 +8,7 @@ packages/
 ├── agent-tools/                 # Tool implementations: FunctionTool, built-ins, schema helpers
 ├── agent-tool-mcp/              # MCP tool implementations
 ├── agent-sdk/                   # SDK assembly layer: InteractiveSession, config/context, commands
+├── agent-command-agent/         # Optional command module that contributes /agent
 ├── agent-cli/                   # Terminal UI and local runtime adapters
 ├── agent-event-service/         # Compatibility re-export package for event service APIs
 ├── agent-provider-anthropic/    # Anthropic provider

--- a/.agents/rules/code-quality.md
+++ b/.agents/rules/code-quality.md
@@ -54,7 +54,9 @@ agent-plugins     ← cross-cutting concerns (logging, usage, etc.)
   ↑
 agent-sdk         ← assembly layer: composes core + sessions + tools + providers
   ↑
-agent-cli         ← UI layer: consumes SDK, adds terminal UI
+agent-command-*   ← optional command modules that consume SDK command interfaces
+  ↑
+agent-cli         ← product/UI layer: consumes SDK and selected command modules
 ```
 
 **Rules:**
@@ -68,3 +70,4 @@ agent-cli         ← UI layer: consumes SDK, adds terminal UI
 - **Composable material first.** Reusable capabilities must be shaped as small composable packages, ports, adapters, classes, and pure functions before they are wired into SDK or UI flows. The SDK should assemble reusable materials; CLI/TUI should render and inject runtime adapters. Do not let a feature become a CLI-only or SDK-only monolith when it has its own lifecycle, state model, adapters, or non-UI consumers.
 - **Package extraction trigger.** Before adding a substantial capability to an existing package, ask whether it is reusable outside that package's primary role. If the answer is yes, prefer a dedicated lower-level package or a clearly isolated module with public ports. A runtime capability with multiple adapters, transport projections, or independent tests is a strong candidate for package extraction.
 - **Orchestrator/adapter split.** Lifecycle orchestration, state transitions, and handoff metadata belong in reusable lower layers. Concrete I/O such as `child_process`, local files, Git commands, HTTP servers, and React/Ink rendering belongs in injected adapters or shell packages.
+- **Command module isolation.** Optional command packages (`agent-command-*`) consume SDK command interfaces and are selected by composition roots. `agent-sdk` must not import or special-case optional command packages. Product shells such as `agent-cli` may import selected command modules to assemble a default product experience.

--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -258,7 +258,18 @@ The `Agent` tool remains necessary for model-initiated delegation. It must conti
 
 But the `Agent` tool is no longer the only model path for user-requested agent execution. Explicit slash commands and model-callable command tool invocations may call runtime APIs directly.
 
-The model-visible `Agent` tool description should stay concise and tool-local. Broader instructions about `/agent` command usage must come from command descriptors.
+The model-visible `Agent` tool description should stay tool-local, but it must be explicit enough for smaller OpenAI-compatible local models to understand that subagent work starts only through a real tool call.
+
+Rules:
+
+- If the user explicitly asks to create, spawn, run, delegate to, or use subagents/agents, the assistant should call the `Agent` tool in the same assistant turn instead of replying with a plan.
+- For multiple or parallel subagents, the assistant should emit one `Agent` tool call per requested role in the same assistant turn.
+- Agent tool calls are background-first. `background` defaults to `true`; `background: false` is only for an explicit foreground/wait request.
+- The assistant must not print XML/HTML-like `<agent ... />` text as a substitute for a tool call.
+- The assistant must not say an agent is running unless the tool result returned an `agentId` or an equivalent runtime event exists.
+- Role naming should prefer available agent definitions. Developer, implementation, and engineering requests map to `general-purpose` when no more specific agent exists. Designer, planning, and architecture requests map to `Plan` when available.
+- If the user asks to analyze one backlog/task/item, the assistant may choose a reasonable target when visible context lists candidates. If no candidate is currently visible, it should include target selection/discovery inside each subagent prompt instead of first replying with an inspection plan.
+- Tool and command descriptors may include short multilingual examples for common local usage patterns when they materially improve model reliability. For Korean, phrases such as "백로그 중에 하나를 분석할건데..." must be interpreted as an immediate execution request when the sentence also asks to create/run subagents.
 
 The `Agent` tool MUST be registered only when an injected command module requests the `agent-runtime` session requirement.
 
@@ -416,7 +427,9 @@ Rules:
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then Robota starts no background jobs.
 - Given no `agentId` or `background_task_created` event exists, when runtime execution state is projected, then it reports no started agent jobs.
 - Given a real `background_task_created` event for each created job, when runtime execution state is projected, then it reports those jobs as started.
-- Given a model emits the `Agent` tool with `background: true`, when the tool executes, then existing background runtime behavior remains unchanged.
+- Given a model emits the `Agent` tool without a `background` argument, when the tool executes, then it starts a background job and returns immediately with an `agentId`.
+- Given a model emits the `Agent` tool with `background: false`, when the tool executes, then it uses the explicit foreground/wait path.
+- Given the `Agent` tool schema is exposed, when its description is inspected, then it states that real subagent execution requires calling the tool, parallel roles require multiple same-turn tool calls, and `<agent ... />` assistant text is invalid.
 - Given a CLI session is created, when it is persisted, then the record is written under project `.robota/sessions` and includes provider messages, UI history, the exact system prompt, and registered tool schemas.
 - Given diagnostic logs are inspected, when the session has run, then `session_init`, `pre_run`, and `assistant` events contain full prompt/input/history/response data instead of only lengths or truncated assistant text.
 

--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -167,19 +167,22 @@ Recommended descriptor:
 
 ### Required Subcommands
 
-| Command                                      | Behavior                                                                                                 |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `/agent list`                                | List available agent definitions and active/terminal agent jobs.                                         |
-| `/agent run [<agent>] <prompt>`              | Run one agent in foreground mode and return its result. Defaults to `general-purpose` when omitted.      |
-| `/agent run [<agent>] --background <prompt>` | Spawn one background agent and return `agentId` immediately. Defaults to `general-purpose` when omitted. |
-| `/agent parallel <spec>`                     | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.     |
-| `/agent read <agentId> [offset]`             | Read retained transcript/log output for an agent job.                                                    |
-| `/agent send <agentId> <prompt>`             | Send follow-up input to a running/open agent when supported.                                             |
-| `/agent stop <agentId> [reason]`             | Cancel a running/queued agent job.                                                                       |
-| `/agent close <agentId>`                     | Close a terminal agent job.                                                                              |
-| `/agent open <agentId>`                      | Switch or focus the TUI agent thread/detail view when the TUI supports it.                               |
+| Command                          | Behavior                                                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `/agent`                         | List available agent definitions and active/terminal agent jobs, or open a picker when the host supports it.    |
+| `/agent <prompt>`                | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
+| `/agent <agent> <prompt>`        | Spawn the named background agent when `<agent>` matches an available agent definition.                          |
+| `/agent run [<agent>] <prompt>`  | Compatibility alias for background agent spawn. Defaults to `general-purpose` when omitted.                     |
+| `/agent parallel <spec>`         | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.            |
+| `/agent read <agentId> [offset]` | Read retained transcript/log output for an agent job.                                                           |
+| `/agent send <agentId> <prompt>` | Send follow-up input to a running/open agent when supported.                                                    |
+| `/agent stop <agentId> [reason]` | Cancel a running/queued agent job.                                                                              |
+| `/agent close <agentId>`         | Close a terminal agent job.                                                                                     |
+| `/agent open <agentId>`          | Switch or focus the TUI agent thread/detail view when the TUI supports it.                                      |
 
 `/background` remains the generic task manager command. `/agent` is the agent-specific control surface and may delegate task reads/cancel/close to the shared background task registry.
+
+Agent spawn commands are background-first. The user-facing syntax does not require `--background`; the flag is accepted only as a compatibility no-op.
 
 ### Parallel Invocation Syntax
 
@@ -188,8 +191,7 @@ The first implementation should support a simple deterministic syntax:
 ```text
 /agent parallel \
   developer=general-purpose:"Analyze implementation risks for DAG-BL-011" \
-  designer=Plan:"Analyze architecture boundaries for DAG-BL-011" \
-  --background
+  designer=Plan:"Analyze architecture boundaries for DAG-BL-011"
 ```
 
 The command parser may later support JSON input for headless clients:
@@ -212,7 +214,7 @@ The command parser may later support JSON input for headless clients:
 }
 ```
 
-`parallel` MUST spawn all valid jobs before waiting for any result. It MUST return created job IDs immediately when `--background` is present.
+`parallel` MUST spawn all valid jobs before waiting for any result. It MUST return created job IDs immediately.
 
 The first implementation MUST also support a simpler `label:"prompt"` parallel token. In that form, the label is used for display and the agent type defaults to `general-purpose`, unless the label itself matches an available agent definition.
 
@@ -220,7 +222,7 @@ The first implementation MUST also support a simpler `label:"prompt"` parallel t
 
 Robota MUST NOT add a natural-language pre-router that decides whether prose should become an agent command before the model sees it.
 
-Instead, Robota exposes model-invocable command descriptors and a command execution tool generated from the command registry. The model receives concise descriptions of commands such as `/agent` in startup context. When the user asks for agent work in natural language, the model can choose the command execution tool and pass the selected command plus arguments.
+Instead, Robota exposes model-invocable command descriptors and a command execution tool generated from the command registry. The model receives concise descriptions of commands such as `/agent` in startup context. When the user asks for agent work in natural language, the model can choose the command execution tool and pass the selected command plus natural-language arguments.
 
 The model-callable command execution tool is a generic bridge over registered commands, not a second implementation of command behavior.
 
@@ -332,7 +334,7 @@ Robota MUST use runtime evidence as the only authoritative source for agent exec
 Robota-owned UI, transport, logs, and command results may report that agents are running only when one of these is true:
 
 - an `Agent` tool call completed with `background: true` and returned an `agentId`;
-- `/agent run --background` or `/agent parallel --background` returned one or more `agentId` values;
+- `/agent <prompt>`, `/agent run`, or `/agent parallel` returned one or more `agentId` values;
 - a `background_task_created` event was observed for each claimed job.
 
 Rules:
@@ -385,10 +387,11 @@ Rules:
 4. Keep core SDK system commands free of agent-specific behavior unless the agent command module is injected.
 5. Add a model-callable command execution tool that projects `modelInvocable` command registry entries and calls the same command handlers.
 6. Add `InteractiveSession` APIs that let command handlers spawn/list/read/send/stop/close agent jobs through the existing runtime manager.
-7. Add `/agent run` and `/agent parallel` parsers with deterministic background spawn behavior.
+7. Add `/agent <prompt>`, `/agent run`, and `/agent parallel` parsers with deterministic background spawn behavior.
 8. Wire CLI/TUI slash input, headless slash input, and model command tool calls through the same command handler path.
 9. Add runtime evidence tests that fail when Robota-owned execution state reports agent execution without a runtime event or returned `agentId`.
-10. Update package SPEC files after code matches this cross-cutting spec.
+10. Persist the exact composed system prompt, registered tool schemas, provider messages, UI history, and diagnostic run data under the project `.robota` tree so resume and debugging inspect the same source of truth.
+11. Update package SPEC files after code matches this cross-cutting spec.
 
 ## Test Plan
 
@@ -403,21 +406,24 @@ Rules:
 - Given an unrelated command module such as `/diagnose` is injected, when the command registry and system executor are assembled, then `/diagnose` is visible/executable without adding any command-specific code to `agent-sdk`.
 - Given the composer source is scanned, then it contains no hardcoded instructions for role behavior, web search, permissions, tools, skills, slash commands, or agents.
 - Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
-- Given `/agent run "analyze this"` is submitted without an agent type, when the command executes, then it defaults to `general-purpose` instead of treating the first prompt word as an agent type.
-- Given a model calls the command execution tool with `/agent run Plan --background "draft architecture"`, when the command executes, then `SubagentManager.spawn()` receives `mode: "background"` and the command returns an `agentId` without awaiting completion.
-- Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when the command executes, then two background jobs are spawned before any wait path is called.
-- Given `/agent parallel developer:"x" designer:"y" --background`, when the command executes, then two background jobs are spawned with labels `developer` and `designer` and default agent type `general-purpose`.
+- Given `/agent "analyze this"` is submitted, when the command executes, then it defaults to `general-purpose` and starts a background job without waiting for completion.
+- Given `/agent Plan "draft architecture"` is submitted, when the command executes, then `SubagentManager.spawn()` receives `mode: "background"` and the command returns an `agentId` without awaiting completion.
+- Given `/agent run "analyze this"` is submitted without an agent type, when the command executes, then it remains a compatibility alias for the same background behavior.
+- Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y"`, when the command executes, then two background jobs are spawned before any wait path is called.
+- Given `/agent parallel developer:"x" designer:"y"`, when the command executes, then two background jobs are spawned with labels `developer` and `designer` and default agent type `general-purpose`.
 - Given an explicit unknown agent type is requested, when the command executes, then it returns a structured command failure listing available agents instead of throwing an unhandled rejection.
 - Given natural-language input asks for two named agents in parallel, when the model calls the command execution tool, then Robota executes `/agent parallel` through the command handler.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then Robota starts no background jobs.
 - Given no `agentId` or `background_task_created` event exists, when runtime execution state is projected, then it reports no started agent jobs.
 - Given a real `background_task_created` event for each created job, when runtime execution state is projected, then it reports those jobs as started.
 - Given a model emits the `Agent` tool with `background: true`, when the tool executes, then existing background runtime behavior remains unchanged.
+- Given a CLI session is created, when it is persisted, then the record is written under project `.robota/sessions` and includes provider messages, UI history, the exact system prompt, and registered tool schemas.
+- Given diagnostic logs are inspected, when the session has run, then `session_init`, `pre_run`, and `assistant` events contain full prompt/input/history/response data instead of only lengths or truncated assistant text.
 
 ### Integration Tests
 
-- In TUI flow, submit `/agent parallel ... --background` and verify visible background rows appear while the prompt remains usable.
-- In headless text mode, submit `/agent run general-purpose --background "..."` and verify the command returns an agent ID immediately.
+- In TUI flow, submit `/agent parallel ...` and verify visible background rows appear while the prompt remains usable.
+- In headless text mode, submit `/agent general-purpose "..."` and verify the command returns an agent ID immediately.
 - In `stream-json`, submit `/agent parallel` and verify background task events are emitted.
 - Submit a natural-language explicit parallel-agent request with a test model that calls the command execution tool and verify jobs start before runtime-owned status reports execution.
 
@@ -440,8 +446,9 @@ pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop
 - Startup prompt context includes model-visible capability descriptors sourced from registries.
 - `/agent` exists as an injected CLI default command with user-visible and model-visible metadata.
 - SDK core can be assembled without the agent command module.
-- `/agent run --background` starts an actual background agent and returns an `agentId`.
-- `/agent parallel --background` starts multiple background agents before waiting for any result.
+- `/agent <prompt>` starts an actual background agent and returns an `agentId`.
+- `/agent parallel` starts multiple background agents before waiting for any result.
 - Natural-language requests for agent execution can succeed when the model selects the command execution tool from registered descriptors.
 - Robota-owned execution state cannot report background agents as running unless runtime evidence exists.
 - Existing `Agent` tool behavior remains compatible for model-initiated delegation.
+- Project-local `.robota/sessions` and `.robota/logs` contain enough raw data to debug prompt composition and restore session context, including command descriptors such as `/agent` and the `ExecuteCommand` tool schema when injected.

--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -167,17 +167,17 @@ Recommended descriptor:
 
 ### Required Subcommands
 
-| Command                                    | Behavior                                                                                             |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `/agent list`                              | List available agent definitions and active/terminal agent jobs.                                     |
-| `/agent run <agent> <prompt>`              | Run one agent in foreground mode and return its result.                                              |
-| `/agent run <agent> --background <prompt>` | Spawn one background agent and return `agentId` immediately.                                         |
-| `/agent parallel <spec>`                   | Spawn multiple background agents from a structured spec and return all `agentId` values immediately. |
-| `/agent read <agentId> [offset]`           | Read retained transcript/log output for an agent job.                                                |
-| `/agent send <agentId> <prompt>`           | Send follow-up input to a running/open agent when supported.                                         |
-| `/agent stop <agentId> [reason]`           | Cancel a running/queued agent job.                                                                   |
-| `/agent close <agentId>`                   | Close a terminal agent job.                                                                          |
-| `/agent open <agentId>`                    | Switch or focus the TUI agent thread/detail view when the TUI supports it.                           |
+| Command                                      | Behavior                                                                                                 |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `/agent list`                                | List available agent definitions and active/terminal agent jobs.                                         |
+| `/agent run [<agent>] <prompt>`              | Run one agent in foreground mode and return its result. Defaults to `general-purpose` when omitted.      |
+| `/agent run [<agent>] --background <prompt>` | Spawn one background agent and return `agentId` immediately. Defaults to `general-purpose` when omitted. |
+| `/agent parallel <spec>`                     | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.     |
+| `/agent read <agentId> [offset]`             | Read retained transcript/log output for an agent job.                                                    |
+| `/agent send <agentId> <prompt>`             | Send follow-up input to a running/open agent when supported.                                             |
+| `/agent stop <agentId> [reason]`             | Cancel a running/queued agent job.                                                                       |
+| `/agent close <agentId>`                     | Close a terminal agent job.                                                                              |
+| `/agent open <agentId>`                      | Switch or focus the TUI agent thread/detail view when the TUI supports it.                               |
 
 `/background` remains the generic task manager command. `/agent` is the agent-specific control surface and may delegate task reads/cancel/close to the shared background task registry.
 
@@ -214,6 +214,8 @@ The command parser may later support JSON input for headless clients:
 
 `parallel` MUST spawn all valid jobs before waiting for any result. It MUST return created job IDs immediately when `--background` is present.
 
+The first implementation MUST also support a simpler `label:"prompt"` parallel token. In that form, the label is used for display and the agent type defaults to `general-purpose`, unless the label itself matches an available agent definition.
+
 ## Model-Routed Command Invocation
 
 Robota MUST NOT add a natural-language pre-router that decides whether prose should become an agent command before the model sees it.
@@ -238,6 +240,7 @@ Rules:
 - The command execution tool must call the same command handler used by user-entered slash commands.
 - The command execution tool must return structured command results, including `agentId` values for created background agents.
 - Prompt text alone is not command execution. If the model writes `/agent ...` as assistant text instead of calling the command tool, no agent job has started.
+- XML/HTML-like assistant text such as `<agent ... />` is not command execution. Owner-provided command descriptors should explicitly point model-routed execution at the `ExecuteCommand` tool.
 - If the model does not call the command tool, Robota must not synthesize an agent job from natural language after the fact.
 - User-entered prompts that begin with `/agent` may bypass the model and execute the slash command handler directly.
 
@@ -400,8 +403,11 @@ Rules:
 - Given an unrelated command module such as `/diagnose` is injected, when the command registry and system executor are assembled, then `/diagnose` is visible/executable without adding any command-specific code to `agent-sdk`.
 - Given the composer source is scanned, then it contains no hardcoded instructions for role behavior, web search, permissions, tools, skills, slash commands, or agents.
 - Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
+- Given `/agent run "analyze this"` is submitted without an agent type, when the command executes, then it defaults to `general-purpose` instead of treating the first prompt word as an agent type.
 - Given a model calls the command execution tool with `/agent run Plan --background "draft architecture"`, when the command executes, then `SubagentManager.spawn()` receives `mode: "background"` and the command returns an `agentId` without awaiting completion.
 - Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when the command executes, then two background jobs are spawned before any wait path is called.
+- Given `/agent parallel developer:"x" designer:"y" --background`, when the command executes, then two background jobs are spawned with labels `developer` and `designer` and default agent type `general-purpose`.
+- Given an explicit unknown agent type is requested, when the command executes, then it returns a structured command failure listing available agents instead of throwing an unhandled rejection.
 - Given natural-language input asks for two named agents in parallel, when the model calls the command execution tool, then Robota executes `/agent parallel` through the command handler.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then Robota starts no background jobs.
 - Given no `agentId` or `background_task_created` event exists, when runtime execution state is projected, then it reports no started agent jobs.

--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -1,4 +1,4 @@
-# Agent Invocation Router Specification
+# Agent Command Invocation Specification
 
 Status: Proposed
 Created: 2026-05-01
@@ -9,11 +9,13 @@ Related specs:
 
 ## Scope
 
-This specification defines how Robota turns user intent, slash commands, built-in command metadata, skills, and model-callable tools into deterministic agent invocation behavior.
+This specification defines how Robota turns slash commands, injected command metadata, skills, and model-callable command tools into deterministic agent command execution behavior.
 
-The goal is to prevent the assistant from merely describing agent execution when the user requested actual subagent execution. Robota must have a command and routing layer that can start, inspect, steer, stop, and close agent jobs without relying only on the model deciding to call the `Agent` tool.
+The goal is to prevent the assistant from merely describing agent execution when the user requested actual subagent execution. Robota must expose agent commands as owner-provided descriptors in startup context and as model-callable command tools so the model can choose the command and the runtime can execute it through the same command handler used by slash input.
 
-This spec spans `agent-sdk`, `agent-cli`, `agent-runtime`, `agent-sessions`, and transport packages because the feature touches command registry metadata, prompt/context assembly, interactive routing, runtime background task creation, TUI projection, and non-interactive/headless behavior.
+`built-in` does not mean the command must be hardcoded into every SDK session. In this spec, a built-in command is a command module that a composition root can inject as part of the default product assembly. If an SDK consumer does not inject the agent command module, that session must not expose `/agent`, model-visible `/agent` descriptors, or the `Agent` tool.
+
+This spec spans `agent-sdk`, `agent-command-agent`, `agent-cli`, `agent-runtime`, `agent-sessions`, and transport packages because the feature touches command module metadata, prompt/context assembly, model-callable command execution, runtime background task creation, TUI projection, and non-interactive/headless behavior.
 
 ## Prior Art Research
 
@@ -57,27 +59,29 @@ References:
 
 ## Problem
 
-Robota currently has working background/subagent runtime pieces, but agent invocation still depends too much on model discretion.
+Robota currently has working background/subagent runtime pieces, but agent invocation lacks a clear bridge between model-visible command descriptions and actual command execution.
 
 Observed failure mode:
 
 1. The user asks for developer and designer subagents to analyze work in parallel.
 2. The assistant describes the plan and claims agents are running.
-3. No `Agent` tool call is emitted.
+3. No model-callable command or `Agent` tool call is emitted.
 4. No `background_task_created` event appears.
 5. No background task row appears in the TUI.
 
-This is a product bug even if the model is weak at tool calling. If Robota exposes agent execution as a user-facing capability, explicit user commands must have a deterministic execution path.
+This is a product bug. If Robota exposes agent execution as a user-facing capability, the capability must have a descriptor, a model-callable execution surface, and a deterministic command handler. Robota must not add a separate natural-language pre-router that interprets user prose before the model. Natural language remains model input; command execution happens when the model calls the model-callable command tool or when the user enters a slash command directly.
 
 ## Design Principles
 
 - Project instruction context and capability metadata are separate.
 - `AGENTS.md`, `CLAUDE.md`, and equivalent memory files define persistent project guidance. They are not the owner of built-in command behavior.
 - `system-prompt-builder` must not hardcode operational guidance. It may compose sections supplied by instruction, command, skill, tool, provider, permission, and agent registries, but it must not author behavior text itself.
-- Built-in commands, skills, model-callable tools, and agent definitions must each have owner-provided descriptors.
+- Built-in command modules, skills, model-callable tools, and agent definitions must each have owner-provided descriptors.
 - The first model turn may include capability descriptors, but those descriptors must come from registries, not hand-written feature sections in a generic prompt builder.
-- Side-effectful or explicitly requested command behavior must have a deterministic handler before the model is allowed to improvise.
+- Side-effectful command behavior must have a deterministic handler, but natural-language prompts must not be pre-routed by a CLI heuristic layer.
+- Model-invocable command selection is driven by owner-provided descriptors rendered into startup context and exposed through model-callable command tools.
 - The assistant must not claim an agent is running unless Robota has observed an `agentId`, `background_task_created`, or equivalent runtime event.
+- Capability modules are optional and must be composed through interfaces. SDK core must be able to run without the agent module.
 
 ## Context Assembly Model
 
@@ -87,7 +91,7 @@ Robota startup context is assembled from owner-provided sources.
 | ---------------------- | --------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------- |
 | Project instructions   | `AGENTS.md`, `CLAUDE.md`, `.robota`/future config readers | Session startup or path-scoped discovery | Persistent repository guidance and rules                                    |
 | Runtime descriptors    | SDK/session/runtime configuration                         | Before the first user prompt             | Current cwd, provider/model, language, permission mode, and trust metadata  |
-| Command descriptors    | Built-in and plugin command registries                    | Before the first user prompt             | Short descriptions of available slash commands and model-invocable commands |
+| Command descriptors    | Injected command registries and plugin command registries | Before the first user prompt             | Short descriptions of available slash commands and model-invocable commands |
 | Skill descriptors      | `SkillCommandSource` and plugin skill sources             | Before the first user prompt             | Short descriptions that help the model decide whether a skill is relevant   |
 | Tool descriptors       | Tool registry entries                                     | Before the first user prompt             | Short descriptions and safety metadata for model-callable tools             |
 | Agent descriptors      | Built-in and custom agent registries                      | Before the first user prompt             | Short descriptions of available subagent identities and expertise           |
@@ -97,6 +101,31 @@ Robota startup context is assembled from owner-provided sources.
 Full command, skill, or agent bodies must not be dumped into the startup prompt unless the corresponding feature explicitly requires preloading. Descriptions are the default model-visible surface.
 
 No source should be represented by ad hoc text inside a generic prompt builder. Each source must expose a descriptor or instruction section owned by the package that owns the behavior.
+
+## Capability Module Composition
+
+Agent support MUST be represented as an optional capability module, not as unconditional SDK behavior.
+
+Minimum module shape:
+
+```ts
+interface ICommandModule {
+  readonly name: string;
+  readonly commandSources?: readonly ICommandSource[];
+  readonly systemCommands?: readonly ISystemCommand[];
+  readonly commandDescriptors?: readonly ICapabilityDescriptor[];
+  readonly sessionRequirements?: readonly TCommandModuleSessionRequirement[];
+}
+```
+
+Rules:
+
+- SDK core owns the command module interface and composition points.
+- `@robota-sdk/agent-command-agent` owns the `/agent` command handler, `/agent` command descriptor, agent command palette entry, and request for agent runtime/tool wiring.
+- The Robota binary composition root may inject the agent module for the Robota CLI product.
+- Programmatic SDK consumers may omit the agent module and receive a session without `/agent`, model-visible `/agent` descriptors, or the `Agent` tool.
+- Other future command modules must be injected through the same feature or command source mechanism.
+- Command palette metadata and model-visible descriptors must come from the injected module, not from separate hardcoded lists.
 
 ## Capability Descriptor Contract
 
@@ -122,9 +151,13 @@ Rules:
 - `userInvocable: false` capabilities may still be shown to the model if `modelInvocable: true`.
 - Descriptions must state when to use the capability, not implementation internals.
 
-## `/agent` Built-In Command
+## `/agent` Agent Capability Command
 
-Robota MUST add `/agent` as a built-in command. It is command-like in the UI and skill-like in metadata because it has a descriptor that can be shown to the model, but its execution is coded in the SDK/CLI command handler.
+Robota CLI's product composition MAY inject `/agent` as a default product command through `@robota-sdk/agent-command-agent`. It is command-like in the UI and skill-like in metadata because it has a descriptor that can be shown to the model, but its execution is coded in an agent command module.
+
+The command must not be part of the SDK's unconditional core command set. It becomes a built-in command only in assemblies that inject the agent command module.
+
+`agent-sdk` and reusable `agent-cli` UI code must not import or special-case the `/agent` command module. They may accept generic `ICommandModule` values. A product entrypoint may choose to include `@robota-sdk/agent-command-agent`.
 
 Recommended descriptor:
 
@@ -181,41 +214,32 @@ The command parser may later support JSON input for headless clients:
 
 `parallel` MUST spawn all valid jobs before waiting for any result. It MUST return created job IDs immediately when `--background` is present.
 
-## Natural-Language Agent Intent Router
+## Model-Routed Command Invocation
 
-Robota SHOULD add a pre-model intent router for explicit agent requests. This router runs after slash command parsing and before sending a normal prompt to the model.
+Robota MUST NOT add a natural-language pre-router that decides whether prose should become an agent command before the model sees it.
 
-The router does not replace the model. It only handles explicit user requests that would be misleading if no agent job is created.
+Instead, Robota exposes model-invocable command descriptors and a command execution tool generated from the command registry. The model receives concise descriptions of commands such as `/agent` in startup context. When the user asks for agent work in natural language, the model can choose the command execution tool and pass the selected command plus arguments.
 
-### Positive Signals
+The model-callable command execution tool is a generic bridge over registered commands, not a second implementation of command behavior.
 
-The router may trigger when the user prompt contains explicit intent such as:
+Recommended tool contract:
 
-- "create/spawn/run/call/use an agent"
-- "developer agent and designer agent"
-- "subagent"
-- "parallel agents"
-- "background agents"
-- `@agent-name`-style forced invocation if Robota adopts that syntax
+```ts
+interface IExecuteCommandToolInput {
+  readonly command: string;
+  readonly args: string;
+}
+```
 
-### Negative Signals
+Rules:
 
-The router must not trigger when:
-
-- the user asks conceptually how agents work;
-- the user asks for a plan only;
-- the target agent names are ambiguous and no default mapping is safe;
-- the request would require write-capable background work without an explicit permission/isolation policy.
-
-### Router Outcomes
-
-| Outcome              | Behavior                                                                                       |
-| -------------------- | ---------------------------------------------------------------------------------------------- |
-| Deterministic route  | Convert the user input into `/agent run` or `/agent parallel` and execute the command handler. |
-| Clarification needed | Ask a concise question for missing agent names, target task, or foreground/background mode.    |
-| No route             | Send the prompt to the model unchanged.                                                        |
-
-When the router triggers, the assistant response must be grounded in actual command results, not speculative text.
+- Only command registry entries with `modelInvocable: true` may be exposed through the model-callable command tool.
+- The command execution tool must validate that the requested command exists and is model-invocable before running it.
+- The command execution tool must call the same command handler used by user-entered slash commands.
+- The command execution tool must return structured command results, including `agentId` values for created background agents.
+- Prompt text alone is not command execution. If the model writes `/agent ...` as assistant text instead of calling the command tool, no agent job has started.
+- If the model does not call the command tool, Robota must not synthesize an agent job from natural language after the fact.
+- User-entered prompts that begin with `/agent` may bypass the model and execute the slash command handler directly.
 
 ## Model-Callable `Agent` Tool
 
@@ -227,9 +251,11 @@ The `Agent` tool remains necessary for model-initiated delegation. It must conti
 - `background`
 - `isolation`
 
-But the `Agent` tool is no longer the only path for user-requested agent execution. Explicit slash commands and router-selected command handlers may call runtime APIs directly.
+But the `Agent` tool is no longer the only model path for user-requested agent execution. Explicit slash commands and model-callable command tool invocations may call runtime APIs directly.
 
 The model-visible `Agent` tool description should stay concise and tool-local. Broader instructions about `/agent` command usage must come from command descriptors.
+
+The `Agent` tool MUST be registered only when an injected command module requests the `agent-runtime` session requirement.
 
 ## Prompt Builder Requirements
 
@@ -265,7 +291,7 @@ Rules:
 - Provider capability text must come from the active provider adapter.
 - Tool text must come from tool descriptors.
 - Command and skill text must come from command/skill descriptors.
-- Agent text must come from agent definitions and the `/agent` command descriptor.
+- Agent text must come from agent definitions and the injected `/agent` command descriptor.
 - Tests must be able to prove that a new capability can appear in the system prompt by registering a descriptor, without editing the composer.
 
 Required refactor:
@@ -278,10 +304,10 @@ Required refactor:
 
 ## Runtime Execution Contract
 
-The `/agent` command handler and intent router MUST execute through the same runtime stack as the `Agent` tool:
+The `/agent` command handler and model-callable command tool MUST execute through the same runtime stack as the `Agent` tool:
 
 ```text
-Command/Router
+Slash Input or Model Command Tool
   -> InteractiveSession agent command API
     -> SubagentManager
       -> BackgroundTaskManager
@@ -296,28 +322,30 @@ Rules:
 - Runtime packages remain responsible for lifecycle and registry state.
 - The command path must emit the same background task events as the tool path.
 
-## Assistant Claim Guard
+## Runtime Evidence Reporting Contract
 
-Robota MUST prevent false execution claims.
+Robota MUST use runtime evidence as the only authoritative source for agent execution state.
 
-If a user asks to run agents and the assistant says agents are running, one of these must be true:
+Robota-owned UI, transport, logs, and command results may report that agents are running only when one of these is true:
 
 - an `Agent` tool call completed with `background: true` and returned an `agentId`;
 - `/agent run --background` or `/agent parallel --background` returned one or more `agentId` values;
 - a `background_task_created` event was observed for each claimed job.
 
-If none of those occurred, Robota must either:
+Rules:
 
-- execute the deterministic command route; or
-- report that no agent was started and ask for missing parameters.
-
-This guard should be testable without calling a real model.
+- Robota must not parse assistant prose to synthesize or infer that an agent job exists.
+- Robota must not create agent jobs after the fact because assistant prose mentioned agents.
+- If no command/tool execution occurred, structured runtime state must remain "no agent job started" for that turn.
+- If a user-entered slash command was incomplete, the command handler returns an explicit missing-parameter error.
+- Tests must validate runtime evidence state and command/tool results, not arbitrary natural-language claim detection.
 
 ## TUI Requirements
 
 The TUI should keep React/Ink components thin:
 
-- input text is routed through a pure command/intent flow before model submission;
+- input text beginning with a slash command is routed through the command handler before model submission;
+- natural-language input is sent to the model with command descriptors and model-callable command tools available;
 - `/agent` command results update the same background task projection used by `BackgroundTaskPanel`;
 - active agent jobs can be inspected with `/agent list`, `/agent read`, and future thread-focus UI;
 - completed clean background jobs may leave the always-visible panel according to `.agents/specs/background-task-layer.md`, but remain accessible through command APIs.
@@ -329,6 +357,7 @@ Headless and protocol transports must expose deterministic agent invocation with
 Required behavior:
 
 - headless prompt beginning with `/agent` executes the command handler;
+- natural-language headless prompts can execute agent jobs only when the model calls the model-callable command tool or `Agent` tool;
 - structured transport clients can request agent run/list/read/stop/close operations;
 - `stream-json` includes background task events for agent jobs;
 - failure responses include explicit errors when a requested agent was not started.
@@ -342,20 +371,21 @@ Rules:
 - Background write-capable agent work should default to worktree isolation when available.
 - Background agents inherit the current permission mode and allowlist, but fresh approval requests from background threads must be source-attributed.
 - If a fresh approval cannot be surfaced in the active UI or transport, the background action must fail closed.
-- The router must not silently start write-capable parallel agents from ambiguous prompts.
+- Robota must not silently start write-capable parallel agents from ambiguous natural language without a slash command, model command tool call, or structured transport request.
 - `/agent parallel` must have a configurable max jobs limit and respect `BackgroundTaskManager.maxConcurrent`.
 
 ## Implementation Plan
 
 1. Add `ISystemPromptSection` and `ICapabilityDescriptor` models plus registry projections in `agent-sdk`.
 2. Replace `system-prompt-builder` with a data-driven prompt composer and move existing hardcoded role, permission, web search, tool, skill, and subagent prose into owner-provided section/descriptor providers.
-3. Add a built-in `/agent` command descriptor and command handler in the SDK command layer.
-4. Add `InteractiveSession` APIs that let command handlers spawn/list/read/send/stop/close agent jobs through the existing runtime manager.
-5. Add `/agent run` and `/agent parallel` parsers with deterministic background spawn behavior.
-6. Add a pure natural-language agent intent router for explicit agent execution requests.
-7. Wire CLI/TUI prompt flow through the router before normal model submission.
-8. Add assistant claim guard tests that fail when a response claims agent execution without a runtime event or returned `agentId`.
-9. Update package SPEC files after code matches this cross-cutting spec.
+3. Add an optional `@robota-sdk/agent-command-agent` package that contributes `/agent` command metadata, `/agent` command execution, and agent runtime/tool enablement through the generic command module contract.
+4. Keep core SDK system commands free of agent-specific behavior unless the agent command module is injected.
+5. Add a model-callable command execution tool that projects `modelInvocable` command registry entries and calls the same command handlers.
+6. Add `InteractiveSession` APIs that let command handlers spawn/list/read/send/stop/close agent jobs through the existing runtime manager.
+7. Add `/agent run` and `/agent parallel` parsers with deterministic background spawn behavior.
+8. Wire CLI/TUI slash input, headless slash input, and model command tool calls through the same command handler path.
+9. Add runtime evidence tests that fail when Robota-owned execution state reports agent execution without a runtime event or returned `agentId`.
+10. Update package SPEC files after code matches this cross-cutting spec.
 
 ## Test Plan
 
@@ -365,13 +395,17 @@ Rules:
 - Given framework, permission, provider, command, skill, tool, and agent section providers, when startup context is built, then each section's content appears from its owner provider.
 - Given a new capability descriptor is registered, when startup context is built, then the capability appears without editing the composer.
 - Given no agents are configured, when startup context is built, then no subagent-specific section is rendered.
+- Given the SDK session is created without the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are absent.
+- Given the Robota product composition injects the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are present.
+- Given an unrelated command module such as `/diagnose` is injected, when the command registry and system executor are assembled, then `/diagnose` is visible/executable without adding any command-specific code to `agent-sdk`.
 - Given the composer source is scanned, then it contains no hardcoded instructions for role behavior, web search, permissions, tools, skills, slash commands, or agents.
-- Given `/agent run Plan --background "draft architecture"`, when the command executes, then `SubagentManager.spawn()` receives `mode: "background"` and the command returns an `agentId` without awaiting completion.
+- Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
+- Given a model calls the command execution tool with `/agent run Plan --background "draft architecture"`, when the command executes, then `SubagentManager.spawn()` receives `mode: "background"` and the command returns an `agentId` without awaiting completion.
 - Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when the command executes, then two background jobs are spawned before any wait path is called.
-- Given an explicit natural-language request to run two named agents in parallel, when the router handles it, then it returns a deterministic `/agent parallel` route instead of sending the prompt directly to the model.
-- Given an ambiguous request to "think about agents", when the router handles it, then it does not route.
-- Given a response claims "agents are running" but no `agentId` or `background_task_created` event exists, when the claim guard runs, then it reports a violation.
-- Given a real `background_task_created` event for each claimed job, when the claim guard runs, then it allows the response.
+- Given natural-language input asks for two named agents in parallel, when the model calls the command execution tool, then Robota executes `/agent parallel` through the command handler.
+- Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then Robota starts no background jobs.
+- Given no `agentId` or `background_task_created` event exists, when runtime execution state is projected, then it reports no started agent jobs.
+- Given a real `background_task_created` event for each created job, when runtime execution state is projected, then it reports those jobs as started.
 - Given a model emits the `Agent` tool with `background: true`, when the tool executes, then existing background runtime behavior remains unchanged.
 
 ### Integration Tests
@@ -379,7 +413,7 @@ Rules:
 - In TUI flow, submit `/agent parallel ... --background` and verify visible background rows appear while the prompt remains usable.
 - In headless text mode, submit `/agent run general-purpose --background "..."` and verify the command returns an agent ID immediately.
 - In `stream-json`, submit `/agent parallel` and verify background task events are emitted.
-- Submit a natural-language explicit parallel-agent request and verify the pre-router starts jobs before any assistant text claims execution.
+- Submit a natural-language explicit parallel-agent request with a test model that calls the command execution tool and verify jobs start before runtime-owned status reports execution.
 
 ### Verification Commands
 
@@ -398,9 +432,10 @@ pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop
 
 - Operational guidance is not hardcoded in `system-prompt-builder`; it is supplied by owner section providers and descriptors.
 - Startup prompt context includes model-visible capability descriptors sourced from registries.
-- `/agent` exists as a built-in command with user-visible and model-visible metadata.
+- `/agent` exists as an injected CLI default command with user-visible and model-visible metadata.
+- SDK core can be assembled without the agent command module.
 - `/agent run --background` starts an actual background agent and returns an `agentId`.
 - `/agent parallel --background` starts multiple background agents before waiting for any result.
-- Explicit natural-language requests for agent execution can route deterministically without relying on model tool-call compliance.
-- The assistant cannot claim background agents are running unless runtime evidence exists.
+- Natural-language requests for agent execution can succeed when the model selects the command execution tool from registered descriptors.
+- Robota-owned execution state cannot report background agents as running unless runtime evidence exists.
 - Existing `Agent` tool behavior remains compatible for model-initiated delegation.

--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -170,15 +170,15 @@ Recommended descriptor:
 | Command                          | Behavior                                                                                                        |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `/agent`                         | List available agent definitions and active/terminal agent jobs, or open a picker when the host supports it.    |
-| `/agent <prompt>`                | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
-| `/agent <agent> <prompt>`        | Spawn the named background agent when `<agent>` matches an available agent definition.                          |
-| `/agent run [<agent>] <prompt>`  | Compatibility alias for background agent spawn. Defaults to `general-purpose` when omitted.                     |
+| `/agent PROMPT`                  | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
+| `/agent AGENT_NAME PROMPT`       | Spawn the named background agent when `AGENT_NAME` matches an available agent definition.                       |
+| `/agent run [AGENT_NAME] PROMPT` | Compatibility alias for background agent spawn. Defaults to `general-purpose` when omitted.                     |
 | `/agent parallel <spec>`         | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.            |
-| `/agent read <agentId> [offset]` | Read retained transcript/log output for an agent job.                                                           |
-| `/agent send <agentId> <prompt>` | Send follow-up input to a running/open agent when supported.                                                    |
-| `/agent stop <agentId> [reason]` | Cancel a running/queued agent job.                                                                              |
-| `/agent close <agentId>`         | Close a terminal agent job.                                                                                     |
-| `/agent open <agentId>`          | Switch or focus the TUI agent thread/detail view when the TUI supports it.                                      |
+| `/agent read AGENT_ID [OFFSET]`  | Read retained transcript/log output for an agent job.                                                           |
+| `/agent send AGENT_ID PROMPT`    | Send follow-up input to a running/open agent when supported.                                                    |
+| `/agent stop AGENT_ID [REASON]`  | Cancel a running/queued agent job.                                                                              |
+| `/agent close AGENT_ID`          | Close a terminal agent job.                                                                                     |
+| `/agent open AGENT_ID`           | Switch or focus the TUI agent thread/detail view when the TUI supports it.                                      |
 
 `/background` remains the generic task manager command. `/agent` is the agent-specific control surface and may delegate task reads/cancel/close to the shared background task registry.
 
@@ -242,7 +242,7 @@ Rules:
 - The command execution tool must call the same command handler used by user-entered slash commands.
 - The command execution tool must return structured command results, including `agentId` values for created background agents.
 - Prompt text alone is not command execution. If the model writes `/agent ...` as assistant text instead of calling the command tool, no agent job has started.
-- XML/HTML-like assistant text such as `<agent ... />` is not command execution. Owner-provided command descriptors should explicitly point model-routed execution at the `ExecuteCommand` tool.
+- Tag-like assistant markup is not command execution. Owner-provided command descriptors should explicitly point model-routed execution at the `ExecuteCommand` tool without showing tag-shaped examples that local models may copy.
 - If the model does not call the command tool, Robota must not synthesize an agent job from natural language after the fact.
 - User-entered prompts that begin with `/agent` may bypass the model and execute the slash command handler directly.
 
@@ -265,7 +265,7 @@ Rules:
 - If the user explicitly asks to create, spawn, run, delegate to, or use subagents/agents, the assistant should call the `Agent` tool in the same assistant turn instead of replying with a plan.
 - For multiple or parallel subagents, the assistant should emit one `Agent` tool call per requested role in the same assistant turn.
 - Agent tool calls are background-first. `background` defaults to `true`; `background: false` is only for an explicit foreground/wait request.
-- The assistant must not print XML/HTML-like `<agent ... />` text as a substitute for a tool call.
+- The assistant must not print tag-like assistant markup as a substitute for a tool call.
 - The assistant must not say an agent is running unless the tool result returned an `agentId` or an equivalent runtime event exists.
 - Role naming should prefer available agent definitions. Developer, implementation, and engineering requests map to `general-purpose` when no more specific agent exists. Designer, planning, and architecture requests map to `Plan` when available.
 - If the user asks to analyze one backlog/task/item, the assistant may choose a reasonable target when visible context lists candidates. If no candidate is currently visible, it should include target selection/discovery inside each subagent prompt instead of first replying with an inspection plan.
@@ -345,7 +345,7 @@ Robota MUST use runtime evidence as the only authoritative source for agent exec
 Robota-owned UI, transport, logs, and command results may report that agents are running only when one of these is true:
 
 - an `Agent` tool call completed with `background: true` and returned an `agentId`;
-- `/agent <prompt>`, `/agent run`, or `/agent parallel` returned one or more `agentId` values;
+- `/agent PROMPT`, `/agent run`, or `/agent parallel` returned one or more `agentId` values;
 - a `background_task_created` event was observed for each claimed job.
 
 Rules:
@@ -398,7 +398,7 @@ Rules:
 4. Keep core SDK system commands free of agent-specific behavior unless the agent command module is injected.
 5. Add a model-callable command execution tool that projects `modelInvocable` command registry entries and calls the same command handlers.
 6. Add `InteractiveSession` APIs that let command handlers spawn/list/read/send/stop/close agent jobs through the existing runtime manager.
-7. Add `/agent <prompt>`, `/agent run`, and `/agent parallel` parsers with deterministic background spawn behavior.
+7. Add `/agent PROMPT`, `/agent run`, and `/agent parallel` parsers with deterministic background spawn behavior.
 8. Wire CLI/TUI slash input, headless slash input, and model command tool calls through the same command handler path.
 9. Add runtime evidence tests that fail when Robota-owned execution state reports agent execution without a runtime event or returned `agentId`.
 10. Persist the exact composed system prompt, registered tool schemas, provider messages, UI history, and diagnostic run data under the project `.robota` tree so resume and debugging inspect the same source of truth.
@@ -429,7 +429,7 @@ Rules:
 - Given a real `background_task_created` event for each created job, when runtime execution state is projected, then it reports those jobs as started.
 - Given a model emits the `Agent` tool without a `background` argument, when the tool executes, then it starts a background job and returns immediately with an `agentId`.
 - Given a model emits the `Agent` tool with `background: false`, when the tool executes, then it uses the explicit foreground/wait path.
-- Given the `Agent` tool schema is exposed, when its description is inspected, then it states that real subagent execution requires calling the tool, parallel roles require multiple same-turn tool calls, and `<agent ... />` assistant text is invalid.
+- Given the `Agent` tool schema is exposed, when its description is inspected, then it states that real subagent execution requires calling the tool and parallel roles require multiple same-turn tool calls, without exposing tag-shaped execution examples.
 - Given a CLI session is created, when it is persisted, then the record is written under project `.robota/sessions` and includes provider messages, UI history, the exact system prompt, and registered tool schemas.
 - Given diagnostic logs are inspected, when the session has run, then `session_init`, `pre_run`, and `assistant` events contain full prompt/input/history/response data instead of only lengths or truncated assistant text.
 
@@ -459,7 +459,7 @@ pnpm harness:verify -- --scope packages/agent-cli --base-ref origin/develop
 - Startup prompt context includes model-visible capability descriptors sourced from registries.
 - `/agent` exists as an injected CLI default command with user-visible and model-visible metadata.
 - SDK core can be assembled without the agent command module.
-- `/agent <prompt>` starts an actual background agent and returns an `agentId`.
+- `/agent PROMPT` starts an actual background agent and returns an `agentId`.
 - `/agent parallel` starts multiple background agents before waiting for any result.
 - Natural-language requests for agent execution can succeed when the model selects the command execution tool from registered descriptors.
 - Robota-owned execution state cannot report background agents as running unless runtime evidence exists.

--- a/.agents/tasks/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/CLI-BL-032-agent-invocation-router.md
@@ -72,8 +72,11 @@ The implementation must prove command handler behavior without a real model firs
 - Given Robota product composition injects the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are present.
 - Given an unrelated command module such as `/diagnose` is injected, when registry and executor are assembled, then it is visible/executable without adding command-specific SDK code.
 - Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
+- Given `/agent run "analyze this"` is submitted without an agent type, when the command executes, then it defaults to `general-purpose` instead of treating the first prompt word as an agent type.
 - Given the model command execution tool receives `/agent run Plan --background "draft architecture"`, when executed, then a background agent is spawned and an `agentId` returns without awaiting completion.
 - Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when executed, then both jobs are spawned before any wait path.
+- Given `/agent parallel developer:"x" designer:"y" --background`, when executed, then labels are preserved and both jobs use the default `general-purpose` agent type.
+- Given an explicit unknown agent type is requested, when executed, then the command returns a structured failure instead of throwing an unhandled rejection.
 - Given natural-language input asks for parallel agents and a test model calls the command execution tool, when executed, then it becomes a deterministic `/agent parallel` execution.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then no background job is started.
 - Given no runtime evidence exists, when Robota-owned execution state is projected, then it reports no started agent jobs.

--- a/.agents/tasks/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/CLI-BL-032-agent-invocation-router.md
@@ -21,6 +21,8 @@ Implement deterministic, composable agent command invocation so injected slash c
 
 Robota can already run background agent jobs when the `Agent` tool is called with `background: true`, but natural-language user prompts may produce assistant text that claims agents are running without any command/tool call or background task event.
 
+LM Studio replay shows that the provider and model can emit tool calls in simple cases, but the full Robota prompt can still lead the model to print prose or `<agent ... />` pseudo-tags instead of calling `Agent` or `ExecuteCommand`. The fix must make the model-visible command/tool contracts explicit enough that real execution is the easy path, while keeping Robota free of natural-language pre-routing.
+
 The current startup prompt contains hardcoded operational guidance in `system-prompt-builder`. Startup prompt content should instead be assembled from owner-provided framework instructions, project instructions, runtime metadata, permission descriptors, provider capabilities, command descriptors, skill descriptors, tool descriptors, and agent descriptors.
 
 The agent command must not be treated as an unconditional SDK core command. `/agent`, the `Agent` tool, and agent descriptors are contributed by an optional `@robota-sdk/agent-command-agent` command module. Robota's product entrypoint may inject that module as a default capability, but SDK consumers must be able to omit it.
@@ -55,10 +57,12 @@ References:
 5. Add a model-callable command execution tool that exposes only `modelInvocable` command descriptors and calls the same handlers as slash input.
 6. Add `InteractiveSession` agent job APIs backed by the existing `SubagentManager` and `BackgroundTaskManager`.
 7. Implement `/agent <prompt>`, `/agent run`, and `/agent parallel` as deterministic background spawn paths.
-8. Add runtime evidence reporting checks so Robota-owned execution state cannot report agents running without `agentId` or background task events.
-9. Wire TUI slash input, headless slash input, structured transports, and model command tool calls through the same command handler path.
-10. Ensure project-local `.robota/sessions` and `.robota/logs` contain the full prompt/tool/command context needed for resume and debugging.
-11. Update package SPEC files and run package/harness verification.
+8. Make the `Agent` tool description and `/agent` command descriptor state the standardized execution protocol: call the tool/command bridge, spawn background jobs by default, use one same-turn tool call per parallel role, include backlog/task target selection inside the delegated prompt when needed, include a short Korean example for the observed local-model phrasing, and never print pseudo-tags as execution.
+9. Default omitted `Agent.background` to background execution while keeping explicit `background: false` as a foreground compatibility path.
+10. Add runtime evidence reporting checks so Robota-owned execution state cannot report agents running without `agentId` or background task events.
+11. Wire TUI slash input, headless slash input, structured transports, and model command tool calls through the same command handler path.
+12. Ensure project-local `.robota/sessions` and `.robota/logs` contain the full prompt/tool/command context needed for resume and debugging.
+13. Update package SPEC files and run package/harness verification.
 
 ## Test Plan
 
@@ -81,6 +85,9 @@ The implementation must prove command handler behavior without a real model firs
 - Given an explicit unknown agent type is requested, when executed, then the command returns a structured failure instead of throwing an unhandled rejection.
 - Given natural-language input asks for parallel agents and a test model calls the command execution tool, when executed, then it becomes a deterministic `/agent parallel` execution.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then no background job is started.
+- Given the `Agent` tool is exposed, when its schema description is inspected, then it tells the model to call the tool in the same assistant turn for explicit subagent requests, emit one call per parallel role, default to background work, and avoid `<agent ... />` pseudo-tags.
+- Given the `Agent` tool is executed without `background`, when the run starts, then `SubagentManager.spawn()` receives `mode: "background"` and `wait()` is not called.
+- Given the `Agent` tool is executed with `background: false`, when the run starts, then `SubagentManager.spawn()` receives `mode: "foreground"` and `wait()` is called.
 - Given no runtime evidence exists, when Robota-owned execution state is projected, then it reports no started agent jobs.
 - Given a session starts with model-visible `/agent` descriptors, when session data is saved, then the exact system prompt and registered tool schemas are persisted in `.robota/sessions`.
 - Given a session run completes, when diagnostic JSONL is inspected, then session initialization, pre-run, and assistant events include full system/input/history/response data rather than length-only or truncated data.

--- a/.agents/tasks/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/CLI-BL-032-agent-invocation-router.md
@@ -21,7 +21,7 @@ Implement deterministic, composable agent command invocation so injected slash c
 
 Robota can already run background agent jobs when the `Agent` tool is called with `background: true`, but natural-language user prompts may produce assistant text that claims agents are running without any command/tool call or background task event.
 
-LM Studio replay shows that the provider and model can emit tool calls in simple cases, but the full Robota prompt can still lead the model to print prose or `<agent ... />` pseudo-tags instead of calling `Agent` or `ExecuteCommand`. The fix must make the model-visible command/tool contracts explicit enough that real execution is the easy path, while keeping Robota free of natural-language pre-routing.
+LM Studio replay shows that the provider and model can emit tool calls in simple cases, but the full Robota prompt can still lead the model to print prose or tag-like assistant markup instead of calling `Agent` or `ExecuteCommand`. The fix must make the model-visible command/tool contracts explicit enough that real execution is the easy path, while keeping Robota free of natural-language pre-routing.
 
 The current startup prompt contains hardcoded operational guidance in `system-prompt-builder`. Startup prompt content should instead be assembled from owner-provided framework instructions, project instructions, runtime metadata, permission descriptors, provider capabilities, command descriptors, skill descriptors, tool descriptors, and agent descriptors.
 
@@ -57,7 +57,7 @@ References:
 5. Add a model-callable command execution tool that exposes only `modelInvocable` command descriptors and calls the same handlers as slash input.
 6. Add `InteractiveSession` agent job APIs backed by the existing `SubagentManager` and `BackgroundTaskManager`.
 7. Implement `/agent <prompt>`, `/agent run`, and `/agent parallel` as deterministic background spawn paths.
-8. Make the `Agent` tool description and `/agent` command descriptor state the standardized execution protocol: call the tool/command bridge, spawn background jobs by default, use one same-turn tool call per parallel role, include backlog/task target selection inside the delegated prompt when needed, include a short Korean example for the observed local-model phrasing, and never print pseudo-tags as execution.
+8. Make the `Agent` tool description and `/agent` command descriptor state the standardized execution protocol: call the tool/command bridge, spawn background jobs by default, use one same-turn tool call per parallel role, include backlog/task target selection inside the delegated prompt when needed, include a short Korean example for the observed local-model phrasing, and avoid tag-shaped examples that local models may copy as assistant text.
 9. Default omitted `Agent.background` to background execution while keeping explicit `background: false` as a foreground compatibility path.
 10. Add runtime evidence reporting checks so Robota-owned execution state cannot report agents running without `agentId` or background task events.
 11. Wire TUI slash input, headless slash input, structured transports, and model command tool calls through the same command handler path.
@@ -85,7 +85,7 @@ The implementation must prove command handler behavior without a real model firs
 - Given an explicit unknown agent type is requested, when executed, then the command returns a structured failure instead of throwing an unhandled rejection.
 - Given natural-language input asks for parallel agents and a test model calls the command execution tool, when executed, then it becomes a deterministic `/agent parallel` execution.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then no background job is started.
-- Given the `Agent` tool is exposed, when its schema description is inspected, then it tells the model to call the tool in the same assistant turn for explicit subagent requests, emit one call per parallel role, default to background work, and avoid `<agent ... />` pseudo-tags.
+- Given the `Agent` tool is exposed, when its schema description is inspected, then it tells the model to call the tool in the same assistant turn for explicit subagent requests, emit one call per parallel role, default to background work, and avoid tag-shaped execution examples.
 - Given the `Agent` tool is executed without `background`, when the run starts, then `SubagentManager.spawn()` receives `mode: "background"` and `wait()` is not called.
 - Given the `Agent` tool is executed with `background: false`, when the run starts, then `SubagentManager.spawn()` receives `mode: "foreground"` and `wait()` is called.
 - Given no runtime evidence exists, when Robota-owned execution state is projected, then it reports no started agent jobs.

--- a/.agents/tasks/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/CLI-BL-032-agent-invocation-router.md
@@ -54,10 +54,11 @@ References:
 4. Keep the SDK core command set free of `/agent` unless the command module is injected.
 5. Add a model-callable command execution tool that exposes only `modelInvocable` command descriptors and calls the same handlers as slash input.
 6. Add `InteractiveSession` agent job APIs backed by the existing `SubagentManager` and `BackgroundTaskManager`.
-7. Implement `/agent run --background` and `/agent parallel --background` as deterministic background spawn paths.
+7. Implement `/agent <prompt>`, `/agent run`, and `/agent parallel` as deterministic background spawn paths.
 8. Add runtime evidence reporting checks so Robota-owned execution state cannot report agents running without `agentId` or background task events.
 9. Wire TUI slash input, headless slash input, structured transports, and model command tool calls through the same command handler path.
-10. Update package SPEC files and run package/harness verification.
+10. Ensure project-local `.robota/sessions` and `.robota/logs` contain the full prompt/tool/command context needed for resume and debugging.
+11. Update package SPEC files and run package/harness verification.
 
 ## Test Plan
 
@@ -72,19 +73,22 @@ The implementation must prove command handler behavior without a real model firs
 - Given Robota product composition injects the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are present.
 - Given an unrelated command module such as `/diagnose` is injected, when registry and executor are assembled, then it is visible/executable without adding command-specific SDK code.
 - Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
-- Given `/agent run "analyze this"` is submitted without an agent type, when the command executes, then it defaults to `general-purpose` instead of treating the first prompt word as an agent type.
-- Given the model command execution tool receives `/agent run Plan --background "draft architecture"`, when executed, then a background agent is spawned and an `agentId` returns without awaiting completion.
-- Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when executed, then both jobs are spawned before any wait path.
-- Given `/agent parallel developer:"x" designer:"y" --background`, when executed, then labels are preserved and both jobs use the default `general-purpose` agent type.
+- Given `/agent "analyze this"` is submitted, when the command executes, then it defaults to `general-purpose` and starts a background job without awaiting completion.
+- Given the model command execution tool receives `/agent Plan "draft architecture"`, when executed, then a background agent is spawned and an `agentId` returns without awaiting completion.
+- Given `/agent run "analyze this"` is submitted without an agent type, when executed, then it remains a compatibility alias for default background execution.
+- Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y"`, when executed, then both jobs are spawned before any wait path.
+- Given `/agent parallel developer:"x" designer:"y"`, when executed, then labels are preserved and both jobs use the default `general-purpose` agent type.
 - Given an explicit unknown agent type is requested, when executed, then the command returns a structured failure instead of throwing an unhandled rejection.
 - Given natural-language input asks for parallel agents and a test model calls the command execution tool, when executed, then it becomes a deterministic `/agent parallel` execution.
 - Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then no background job is started.
 - Given no runtime evidence exists, when Robota-owned execution state is projected, then it reports no started agent jobs.
+- Given a session starts with model-visible `/agent` descriptors, when session data is saved, then the exact system prompt and registered tool schemas are persisted in `.robota/sessions`.
+- Given a session run completes, when diagnostic JSONL is inspected, then session initialization, pre-run, and assistant events include full system/input/history/response data rather than length-only or truncated data.
 
 ### Integration Tests
 
-- TUI `/agent parallel ... --background` shows background task rows and keeps the prompt usable.
-- Headless `/agent run ... --background` returns an `agentId` immediately.
+- TUI `/agent parallel ...` shows background task rows and keeps the prompt usable.
+- Headless `/agent ...` returns an `agentId` immediately.
 - `stream-json` emits background task events for `/agent parallel`.
 
 ### Verification Commands

--- a/.agents/tasks/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/CLI-BL-032-agent-invocation-router.md
@@ -15,13 +15,15 @@ spec: .agents/specs/agent-invocation-router.md
 
 ## Summary
 
-Implement deterministic agent invocation routing so explicit user requests to run, spawn, or parallelize agents create real background jobs instead of relying only on the model to call the `Agent` tool.
+Implement deterministic, composable agent command invocation so injected slash commands and model-selected command tools create real background jobs instead of relying only on the model to call the `Agent` tool.
 
 ## Problem
 
-Robota can already run background agent jobs when the `Agent` tool is called with `background: true`, but natural-language user prompts may produce assistant text that claims agents are running without any tool call or background task event.
+Robota can already run background agent jobs when the `Agent` tool is called with `background: true`, but natural-language user prompts may produce assistant text that claims agents are running without any command/tool call or background task event.
 
 The current startup prompt contains hardcoded operational guidance in `system-prompt-builder`. Startup prompt content should instead be assembled from owner-provided framework instructions, project instructions, runtime metadata, permission descriptors, provider capabilities, command descriptors, skill descriptors, tool descriptors, and agent descriptors.
+
+The agent command must not be treated as an unconditional SDK core command. `/agent`, the `Agent` tool, and agent descriptors are contributed by an optional `@robota-sdk/agent-command-agent` command module. Robota's product entrypoint may inject that module as a default capability, but SDK consumers must be able to omit it.
 
 ## Specification
 
@@ -48,28 +50,33 @@ References:
 
 1. Add shared system prompt section and capability descriptor projection for framework instructions, runtime metadata, permissions, providers, built-in commands, skills, tools, and agent definitions.
 2. Replace `system-prompt-builder` with a data-driven prompt composer that only orders and joins owner-provided sections.
-3. Add `/agent` as a built-in command with `run`, `parallel`, `list`, `read`, `send`, `stop`, `close`, and `open` subcommands.
-4. Add `InteractiveSession` agent job APIs backed by the existing `SubagentManager` and `BackgroundTaskManager`.
-5. Implement `/agent run --background` and `/agent parallel --background` as deterministic background spawn paths.
-6. Add a pure natural-language agent intent router for explicit agent execution requests.
-7. Add assistant claim guards so Robota cannot report agents running without `agentId` or background task events.
-8. Wire TUI, headless, and transport flows through the same command/router path.
-9. Update package SPEC files and run package/harness verification.
+3. Add an optional `@robota-sdk/agent-command-agent` package with `/agent` command metadata, execution, and agent runtime/tool enablement through a generic command module interface.
+4. Keep the SDK core command set free of `/agent` unless the command module is injected.
+5. Add a model-callable command execution tool that exposes only `modelInvocable` command descriptors and calls the same handlers as slash input.
+6. Add `InteractiveSession` agent job APIs backed by the existing `SubagentManager` and `BackgroundTaskManager`.
+7. Implement `/agent run --background` and `/agent parallel --background` as deterministic background spawn paths.
+8. Add runtime evidence reporting checks so Robota-owned execution state cannot report agents running without `agentId` or background task events.
+9. Wire TUI slash input, headless slash input, structured transports, and model command tool calls through the same command handler path.
+10. Update package SPEC files and run package/harness verification.
 
 ## Test Plan
 
-The implementation must prove routing behavior without a real model first, then verify CLI/TUI/headless integration creates observable background task events and returned agent IDs.
+The implementation must prove command handler behavior without a real model first, then verify CLI/TUI/headless integration creates observable background task events and returned agent IDs.
 
 ### Unit Tests
 
 - Given synthetic prompt sections, when startup context is built, then the composer orders and joins only supplied content without adding behavioral instructions.
 - Given capability descriptors, when startup context is built, then capabilities render from registries and no hardcoded subagent section appears.
 - Given composer source is scanned, then it contains no hardcoded role, permission, web search, tool, skill, slash command, or agent guidance.
-- Given `/agent run Plan --background "draft architecture"`, when executed, then a background agent is spawned and an `agentId` returns without awaiting completion.
+- Given an SDK session is created without the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are absent.
+- Given Robota product composition injects the agent command module, when commands/tools/system prompt are assembled, then `/agent`, `Agent`, and agent descriptors are present.
+- Given an unrelated command module such as `/diagnose` is injected, when registry and executor are assembled, then it is visible/executable without adding command-specific SDK code.
+- Given `/agent` is injected with `modelInvocable: true`, when model tools are built, then the command execution tool allows `/agent` and rejects non-model-invocable commands.
+- Given the model command execution tool receives `/agent run Plan --background "draft architecture"`, when executed, then a background agent is spawned and an `agentId` returns without awaiting completion.
 - Given `/agent parallel developer=general-purpose:"x" designer=Plan:"y" --background`, when executed, then both jobs are spawned before any wait path.
-- Given an explicit natural-language parallel-agent request, when routed, then it becomes a deterministic `/agent parallel` execution.
-- Given ambiguous agent-related discussion, when routed, then it remains a normal model prompt.
-- Given assistant text claims agents are running without runtime evidence, when the claim guard runs, then it fails.
+- Given natural-language input asks for parallel agents and a test model calls the command execution tool, when executed, then it becomes a deterministic `/agent parallel` execution.
+- Given natural-language input asks about agents but the model does not call a tool, when the turn completes, then no background job is started.
+- Given no runtime evidence exists, when Robota-owned execution state is projected, then it reports no started agent jobs.
 
 ### Integration Tests
 
@@ -91,7 +98,8 @@ pnpm harness:scan
 ## Acceptance Criteria
 
 - `system-prompt-builder` does not own operational guidance; prompt content comes from owner-provided sections and descriptors.
-- `/agent` is model-visible through descriptors and user-invocable through command parsing.
-- Explicit `/agent` and routed natural-language requests create real runtime jobs.
+- `/agent` is model-visible through injected descriptors and user-invocable through command parsing when the agent command module is composed.
+- SDK core can run without the agent command module.
+- Explicit `/agent` requests and model command tool calls create real runtime jobs.
 - Parallel background agent execution returns job IDs immediately.
-- Assistant execution claims are backed by runtime evidence.
+- Robota-owned execution status is backed by runtime evidence.

--- a/.agents/tasks/CLI-BL-033-gemma-provider-openai-compatible-transport.md
+++ b/.agents/tasks/CLI-BL-033-gemma-provider-openai-compatible-transport.md
@@ -1,0 +1,58 @@
+# CLI-BL-033 Gemma Provider and OpenAI-Compatible Transport Reuse
+
+- **Status**: todo
+- **Created**: 2026-05-01
+- **Branch**: feat/agent-invocation-router
+- **Scope**: packages/agent-provider-gemma, packages/agent-provider-google, packages/agent-provider-openai, packages/agent-sdk, packages/agent-cli
+
+## Objective
+
+Design and implement a first-class Gemma provider path for Robota instead of relying on local user-side LM Studio tweaks or ad hoc OpenAI-compatible post-processing. Robota should provide a consistent, general-purpose environment for non-expert users while keeping model-family behavior out of the generic OpenAI-compatible provider.
+
+## Problem
+
+Gemma 4 models can use a model-native Jinja chat template that emits reasoning-channel markers such as `<|channel>thought` and `<channel|>`. In LM Studio, these markers may leak into streamed assistant content when the serving layer does not parse them as reasoning sections.
+
+Robota should not solve this by asking every user to manually edit LM Studio templates, nor by adding `if gemma` branches to the generic OpenAI-compatible provider. The system needs a composable provider architecture where model-family behavior is opt-in, explicit, and reusable.
+
+## Plan
+
+- [ ] Research whether Gemma should be implemented as a dedicated `agent-provider-gemma` package or as a Gemma-specific module under the existing Google provider.
+- [ ] Extract OpenAI-compatible transport pieces from `agent-provider-openai` into a reusable internal module or package so local providers can share request, streaming, tool schema conversion, and response parsing infrastructure.
+- [ ] Define a Gemma provider contract that owns Gemma chat-template assumptions, reasoning-channel parsing, tool-call parsing expectations, and compatibility notes for LM Studio, vLLM, and other OpenAI-compatible servers.
+- [ ] Keep `agent-provider-openai` model-family neutral. It must not contain Gemma-specific marker filtering or model-name heuristics.
+- [ ] Add CLI configuration support for selecting the Gemma provider explicitly while still pointing at an OpenAI-compatible base URL.
+- [ ] Add unit tests for Gemma reasoning marker parsing, streamed content projection, and provider composition with shared OpenAI-compatible transport.
+- [ ] Add integration or replay tests using captured `.robota/logs` samples where Gemma emits reasoning-channel markers in streamed deltas.
+- [ ] Update package SPEC files and user docs so provider selection and supported local-model behavior are clear.
+
+## Decisions
+
+- Robota should not choose the easiest local workaround as the product direction. Manual LM Studio Reasoning Parsing or prompt-template edits may be useful diagnostics, but they are not the primary product solution.
+- The generic OpenAI-compatible provider should remain transport-oriented and model-family neutral.
+- A dedicated `agent-provider-gemma` package is preferred unless research shows that the existing Google provider is the cleaner ownership boundary for Gemma-local behavior.
+- Any Gemma-specific behavior must be explicit through provider selection or an equivalent typed configuration, not inferred from model name strings.
+- Shared OpenAI-compatible transport code should be composable so future model-family providers can reuse it without copy-pasting the OpenAI provider.
+
+## Verification Plan
+
+- Given Gemma reasoning-channel markers arrive in streamed deltas, when the Gemma provider is selected, then user-facing streamed text excludes reasoning markers while diagnostic logs retain raw provider data.
+- Given the same response arrives through the generic OpenAI-compatible provider, when no Gemma provider/profile is selected, then Robota does not apply Gemma-specific filtering.
+- Given a local LM Studio endpoint is configured with the Gemma provider, when Robota creates a session, then tool schemas, streaming, and background subagent logging still work through the shared OpenAI-compatible transport layer.
+- Given shared transport code is extracted, when `agent-provider-openai` builds and tests run, then existing OpenAI-compatible behavior remains unchanged.
+- Given Gemma provider docs are generated, when a non-expert user follows the provider setup, then no manual prompt-template editing is required for the default supported path.
+
+## Progress
+
+### 2026-05-01
+
+- Backlog created after Gemma 4 LM Studio investigation showed reasoning-channel markers are model-template/serving behavior rather than Robota prompt content.
+
+## Blockers
+
+- Need an architectural decision on whether Gemma ownership belongs in a new `agent-provider-gemma` package or under `agent-provider-google`.
+- Need to identify the right shared transport boundary before extracting code from `agent-provider-openai`.
+
+## Result
+
+Not started.

--- a/.agents/tasks/CLI-BL-033-gemma-provider-openai-compatible-transport.md
+++ b/.agents/tasks/CLI-BL-033-gemma-provider-openai-compatible-transport.md
@@ -34,7 +34,7 @@ Robota should not solve this by asking every user to manually edit LM Studio tem
 - Any Gemma-specific behavior must be explicit through provider selection or an equivalent typed configuration, not inferred from model name strings.
 - Shared OpenAI-compatible transport code should be composable so future model-family providers can reuse it without copy-pasting the OpenAI provider.
 
-## Verification Plan
+## Test Plan
 
 - Given Gemma reasoning-channel markers arrive in streamed deltas, when the Gemma provider is selected, then user-facing streamed text excludes reasoning markers while diagnostic logs retain raw provider data.
 - Given the same response arrives through the generic OpenAI-compatible provider, when no Gemma provider/profile is selected, then Robota does not apply Gemma-specific filtering.

--- a/.agents/tasks/ORCH-BL-001-orchestration-cli.md
+++ b/.agents/tasks/ORCH-BL-001-orchestration-cli.md
@@ -24,9 +24,9 @@ created: 2026-03-15
 ### Robota Agent 제어
 
 - `robota agent list` — 에이전트 목록 조회
-- `robota agent run <agentId>` — 에이전트 실행
-- `robota agent chat <agentId>` — 에이전트와 대화
-- `robota agent status <agentId>` — 에이전트 상태 확인
+- `robota agent run AGENT_ID` — 에이전트 실행
+- `robota agent chat AGENT_ID` — 에이전트와 대화
+- `robota agent status AGENT_ID` — 에이전트 상태 확인
 - @robota-sdk/agent-core 패키지의 기능을 CLI로 노출
 
 ## AI 에이전트 사용

--- a/content/guide/architecture.md
+++ b/content/guide/architecture.md
@@ -53,6 +53,8 @@ agent-remote-client                    (HTTP client, no agent-sdk dependency)
 
 `InteractiveSession` maintains history as `IHistoryEntry[]` — a universal timeline that includes both chat messages (user/assistant turns) and session events (tool calls, system events, status changes). This is the single source of truth for display and persistence.
 
+Background tasks are tracked alongside the session through runtime snapshots and append-only JSONL event/transcript streams. High-frequency streaming output is stored in logs/transcripts, while session JSON stores resumable task state and references.
+
 ```
 User input
   → InteractiveSession.submit()

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -310,7 +310,9 @@ The AI can spawn subagents via the **Agent** tool to handle complex subtasks (e.
 
 ## Session Logging
 
-Events are logged to `.robota/logs/{sessionId}.jsonl` in JSONL format. Events include `session_init`, `pre_run`, `assistant`, `server_tool`, and `context`.
+Events are logged to `.robota/logs/{sessionId}.jsonl` in JSONL format. Events include `session_init`, `pre_run`, `text_delta`, `assistant`, `server_tool`, `context`, and `background_task_event`.
+
+Background subagents write append-only transcripts to `.robota/logs/{sessionId}/subagents/{agentId}.jsonl`. These transcripts include streaming deltas, tool calls/results, final output, and errors as they occur. The resumable `.robota/sessions/{sessionId}.json` file stores background task snapshots and transcript paths, not every token chunk.
 
 ## First-Run Setup
 

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -190,17 +190,17 @@ const systemMessage = buildSystemPrompt({
 
 `InteractiveSession` provides these capabilities:
 
-| Feature                    | Description                                                                                                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Permission enforcement** | Tool calls are gated by the permission system                                                                                                                 |
-| **Hook execution**         | PreToolUse/PostToolUse/PreCompact/PostCompact hooks fire automatically                                                                                        |
-| **Context tracking**       | Token usage is tracked and available via `getContextState()`                                                                                                  |
-| **Auto-compaction**        | Context is compressed when usage exceeds ~83.5%                                                                                                               |
-| **Session persistence**    | Conversations can be saved/loaded via `SessionStore`. `ISessionRecord` includes `history` (`IHistoryEntry[]`) for full UI restoration                         |
-| **Session resume/fork**    | Restore a previous session with `resumeSessionId` or fork with `forkSession`. On resume, `session.injectMessage()` restores AI context from persisted history |
-| **Session naming**         | `getName()` / `setName()` for human-friendly session identification                                                                                           |
-| **Abort**                  | `session.abort()` cancels via AbortSignal. Partial response committed as `'interrupted'`                                                                      |
-| **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                              |
+| Feature                    | Description                                                                                                                                                                |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Permission enforcement** | Tool calls are gated by the permission system                                                                                                                              |
+| **Hook execution**         | PreToolUse/PostToolUse/PreCompact/PostCompact hooks fire automatically                                                                                                     |
+| **Context tracking**       | Token usage is tracked and available via `getContextState()`                                                                                                               |
+| **Auto-compaction**        | Context is compressed when usage exceeds ~83.5%                                                                                                                            |
+| **Session persistence**    | Conversations can be saved/loaded via `SessionStore`. `ISessionRecord` includes `history` (`IHistoryEntry[]`) plus background task snapshots for restoration and debugging |
+| **Session resume/fork**    | Restore a previous session with `resumeSessionId` or fork with `forkSession`. On resume, `session.injectMessage()` restores AI context from persisted history              |
+| **Session naming**         | `getName()` / `setName()` for human-friendly session identification                                                                                                        |
+| **Abort**                  | `session.abort()` cancels via AbortSignal. Partial response committed as `'interrupted'`                                                                                   |
+| **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                                           |
 
 ## Subagent Sessions
 
@@ -256,7 +256,7 @@ The SDK appends a framework suffix to the subagent's system prompt to shape its 
 
 ### Subagent Transcript
 
-Subagent execution is logged to `{logsDir}/{parentSessionId}/subagents/{agentId}.jsonl` for debugging and audit purposes.
+Subagent execution is logged to `{logsDir}/{parentSessionId}/subagents/{agentId}.jsonl` for debugging and audit purposes. Streaming text deltas are appended to this transcript while the provider request is still running. The parent session JSON stores the background task snapshot and transcript path; it does not rewrite the whole session file for every token chunk.
 
 ## Always-Streaming Policy
 

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -333,7 +333,9 @@ All context is assembled into the system prompt.
 
 ## Session Logging
 
-Session logs are written to `.robota/logs/{sessionId}.jsonl` in JSONL format by default, capturing structured events for diagnostics and replay. Resumable session JSON is written to `.robota/sessions/{sessionId}.json` for the current project and includes messages, UI history, the exact system prompt, and registered tool schemas.
+Session logs are written to `.robota/logs/{sessionId}.jsonl` in JSONL format by default, capturing structured events for diagnostics and replay. Background task lifecycle/progress events are logged there as they happen. Child-process subagents also write append-only transcripts to `.robota/logs/{sessionId}/subagents/{agentId}.jsonl`, including streaming text deltas while the local provider request is still running.
+
+Resumable session JSON is written to `.robota/sessions/{sessionId}.json` for the current project and includes messages, UI history, the exact system prompt, registered tool schemas, and background task snapshots. High-frequency streaming chunks stay in JSONL transcript files; the session JSON stores task state and transcript paths.
 
 ## Architecture
 

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -333,7 +333,7 @@ All context is assembled into the system prompt.
 
 ## Session Logging
 
-Session logs are written to `.robota/logs/{sessionId}.jsonl` in JSONL format by default, capturing structured events for diagnostics and replay.
+Session logs are written to `.robota/logs/{sessionId}.jsonl` in JSONL format by default, capturing structured events for diagnostics and replay. Resumable session JSON is written to `.robota/sessions/{sessionId}.json` for the current project and includes messages, UI history, the exact system prompt, and registered tool schemas.
 
 ## Architecture
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -659,6 +659,10 @@ If both stdin and a positional argument are provided, stdin content is prepended
 
 When `--resume` is used without a value, a `ListPicker` overlay is shown with all saved sessions. The user selects one to resume.
 
+### Session Storage
+
+The CLI constructs `SessionStore` with the current project path `.robota/sessions`, not the generic user-level default. Every resumable session record must stay beside the project logs and must include provider messages, UI history, the exact system prompt, and registered tool schemas. This makes `/continue`, `/resume`, and local debugging inspect the same project-local `.robota` tree.
+
 ## Tool Output Limits
 
 - **Universal cap**: Tool output is capped at 30,000 characters. Outputs exceeding this limit are middle-truncated (first and last portions are kept, with a truncation marker in the middle).

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -915,6 +915,7 @@ Child-process subagent runner responsibilities:
 - pass `ISubagentSpawnRequest`, agent definition, parent config/context, permission mode, and serialized provider profile over IPC
 - expose child `pid` on the background task state
 - forward worker text/tool IPC messages to `BackgroundTaskManager` progress events
+- create an append-only subagent transcript at `.robota/logs/PARENT_SESSION_ID/subagents/AGENT_ID.jsonl` and make `/agent read AGENT_ID` read that transcript while the worker is still running
 - forward cancellation to the worker and terminate it after a grace period
 - forward follow-up prompts to workers that support input
 - keep runtime-owned lifecycle state inside `BackgroundTaskManager`; the CLI owns only the Node process adapter

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -368,7 +368,7 @@ Installed plugins contribute skills via `PluginCommandSource`, which discovers s
 
 `useInteractiveSession` is the single boundary between React and the SDK. It:
 
-1. Creates `InteractiveSession({ cwd, provider })` and `CommandRegistry` once (via `useRef` — never recreated on re-render). The provider instance is passed in from the caller; `InteractiveSession` handles config/context loading internally.
+1. Creates `InteractiveSession({ cwd, provider, commandModules })` and `CommandRegistry` once (via `useRef` — never recreated on re-render). The provider instance is passed in from the caller; `InteractiveSession` handles config/context loading internally.
 2. Creates a `TuiStateManager` instance that holds `history: IHistoryEntry[]` as the primary state for the message list. On each execution update (when `thinking` transitions to `false`, or on `complete`/`interrupted`), the hook delegates to `TuiStateManager` to sync state from `interactiveSession.getFullHistory()`.
 3. Subscribes to `InteractiveSession` events (`text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `interrupted`, `error`) and converts them to React state.
 4. Exposes `handleSubmit`, `handleAbort`, `handleCancelQueue` as stable callbacks to the TUI.
@@ -399,7 +399,9 @@ The `StreamingIndicator` (showing active tools) is rendered when `isThinking || 
 
 ## Command Registry Architecture
 
-The slash command system uses an extensible registry pattern. Multiple `ICommandSource` implementations provide commands, and the `CommandRegistry` aggregates them. `CommandRegistry`, `BuiltinCommandSource`, and `SkillCommandSource` are all owned by `@robota-sdk/agent-sdk`. Slash command execution is routed through `session.executeCommand(name, args)` — the CLI does not instantiate `SystemCommandExecutor` directly. The CLI adds only `PluginCommandSource`.
+The slash command system uses an extensible registry pattern. Multiple `ICommandSource` implementations provide commands, and the `CommandRegistry` aggregates them. `CommandRegistry`, `BuiltinCommandSource`, and `SkillCommandSource` are all owned by `@robota-sdk/agent-sdk`. Slash command execution is routed through `session.executeCommand(name, args)` — the CLI does not instantiate `SystemCommandExecutor` directly. The CLI adds `PluginCommandSource` and any injected `ICommandModule` sources generically.
+
+Reusable CLI/TUI code must not special-case command module names such as `/agent`. It accepts `commandModules` and registers them with the SDK registry. The package binary may choose product defaults by passing modules into `startCli()`.
 
 ### ICommandSource Interface
 
@@ -428,6 +430,7 @@ interface ISlashCommand {
 | Source   | Class                  | Owner                   | Description                                          |
 | -------- | ---------------------- | ----------------------- | ---------------------------------------------------- |
 | Built-in | `BuiltinCommandSource` | `@robota-sdk/agent-sdk` | Built-in commands with subcommands for /mode, /model |
+| Modules  | `ICommandModule`       | Module package          | Optional command modules injected by composition     |
 | Skills   | `SkillCommandSource`   | `@robota-sdk/agent-sdk` | Discovered from 4 scan paths (see Skill Discovery)   |
 | Plugins  | `PluginCommandSource`  | `@robota-sdk/agent-sdk` | Skills provided by installed bundle plugins          |
 
@@ -587,7 +590,7 @@ src/
     └── types.ts                     ← IPermissionRequest
 ```
 
-**Note:** `CommandRegistry`, `BuiltinCommandSource`, `SkillCommandSource`, `PluginCommandSource`, and `SystemCommandExecutor` are all owned by `@robota-sdk/agent-sdk`. The CLI does not use `SystemCommandExecutor` directly; slash command execution goes through `session.executeCommand(name, args)`. The CLI's `src/commands/` directory holds re-export shims (`builtin-source.ts`, `command-registry.ts`, `skill-source.ts`) for backward compatibility, plus `slash-executor.ts` (plugin TUI handlers and IPluginCallbacks interface) and `skill-executor.ts` (fork/inject execution helpers). The CLI's `src/index.ts` exports only `startCli` and local CLI types.
+**Note:** `CommandRegistry`, `BuiltinCommandSource`, `SkillCommandSource`, `PluginCommandSource`, and `SystemCommandExecutor` are owned by `@robota-sdk/agent-sdk`. The CLI does not use `SystemCommandExecutor` directly; slash command execution goes through `session.executeCommand(name, args)`. The CLI's `src/commands/` directory holds re-export shims (`builtin-source.ts`, `command-registry.ts`, `skill-source.ts`) for backward compatibility, plus `slash-executor.ts` (plugin TUI handlers and IPluginCallbacks interface) and `skill-executor.ts` (fork/inject execution helpers). The CLI's `src/index.ts` exports only `startCli` and local CLI types.
 
 ## CLI Usage
 
@@ -614,6 +617,8 @@ robota --version                    # Version
 ### Print Mode and Headless Transport
 
 Print mode (`-p`) delegates execution to `@robota-sdk/agent-transport-headless` via `createHeadlessTransport`. The CLI creates an `InteractiveSession`, attaches the headless transport via `session.attachTransport(transport)`, calls `transport.start()`, and exits with `transport.getExitCode()`.
+
+Any command modules supplied to `startCli({ commandModules })` are passed to the same `InteractiveSession` in both print mode and TUI mode.
 
 **`--output-format`** controls how the response is written to stdout:
 
@@ -898,6 +903,8 @@ The CLI owns Node runtime process adapters. It injects `createManagedShellProces
 
 The CLI also injects `createChildProcessSubagentRunnerFactory()` into `InteractiveSession` as the production subagent runner factory. The factory receives SDK-assembled subagent dependencies, but the runner starts a child Node worker and sends only serializable config/context/provider/agent-definition data over IPC. The worker reconstructs its provider inside the child process using the same concrete provider profile the CLI used for the parent session.
 
+Agent command behavior is not owned by the TUI. The Robota binary can compose `@robota-sdk/agent-command-agent` as a default command module, but reusable CLI UI code only handles generic command modules.
+
 Child-process subagent runner responsibilities:
 
 - fork one worker process per subagent job
@@ -993,6 +1000,7 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 
 | Package                                | Purpose                                                                                                    |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `@robota-sdk/agent-command-agent`      | Optional default `/agent` command module composed by the Robota binary                                     |
 | `@robota-sdk/agent-sdk`                | `InteractiveSession`, `CommandRegistry`, command sources, plugin management, re-exported runtime contracts |
 | `@robota-sdk/agent-core`               | Public types (`TPermissionMode`, `TToolArgs`, `TUniversalMessage`, etc.)                                   |
 | `@robota-sdk/agent-provider-anthropic` | Anthropic provider creation (CLI picks provider based on config)                                           |

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -48,6 +48,7 @@
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
   },
   "dependencies": {
+    "@robota-sdk/agent-command-agent": "workspace:*",
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-provider-anthropic": "workspace:*",
     "@robota-sdk/agent-provider-openai": "workspace:*",

--- a/packages/agent-cli/src/bin.ts
+++ b/packages/agent-cli/src/bin.ts
@@ -5,6 +5,7 @@
  * Boots the CLI and handles any uncaught top-level errors gracefully.
  */
 import { startCli } from './cli.js';
+import { createAgentCommandModule } from '@robota-sdk/agent-command-agent';
 
 // Last-resort crash prevention for IME-related errors only.
 // Korean IME in raw mode can cause errors that escape React/Ink.
@@ -25,7 +26,7 @@ process.on('uncaughtException', (err) => {
   throw err;
 });
 
-startCli().catch((err: unknown) => {
+startCli({ commandModules: [createAgentCommandModule()] }).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);
   process.stderr.write(message + '\n');
   process.exit(1);

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -10,6 +10,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { ICommandModule } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
 import { parseCliArgs } from './utils/cli-args.js';
 import { getUserSettingsPath, deleteSettings } from './utils/settings-io.js';
@@ -98,7 +99,11 @@ function resetConfig(): void {
 /**
  * Main CLI orchestration function.
  */
-export async function startCli(): Promise<void> {
+export interface IStartCliOptions {
+  commandModules?: readonly ICommandModule[];
+}
+
+export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const args = parseCliArgs();
 
   if (args.version) {
@@ -210,6 +215,7 @@ export async function startCli(): Promise<void> {
       appendSystemPrompt,
       backgroundTaskRunners,
       subagentRunnerFactory,
+      commandModules: options.commandModules,
     });
 
     const transport = createHeadlessTransport({
@@ -236,5 +242,6 @@ export async function startCli(): Promise<void> {
     sessionName: args.sessionName,
     backgroundTaskRunners,
     subagentRunnerFactory,
+    commandModules: options.commandModules,
   });
 }

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -140,12 +140,14 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const modelId = args.model ?? providerSettings.model;
   const provider: IAIProvider = createProviderFromSettings(cwd, args.model, providerOptions);
   const backgroundTaskRunners = [createManagedShellProcessRunner()];
+  const paths = projectPaths(cwd);
   const subagentRunnerFactory = createChildProcessSubagentRunnerFactory({
     providerConfig: { ...providerSettings, model: modelId },
+    logsDir: paths.logs,
   });
 
   // Session management
-  const sessionStore = new SessionStore(projectPaths(cwd).sessions);
+  const sessionStore = new SessionStore(paths.sessions);
   let resumeSessionId: string | undefined;
 
   if (args.continueMode) {

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { IAIProvider } from '@robota-sdk/agent-core';
-import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { InteractiveSession, projectPaths } from '@robota-sdk/agent-sdk';
 import type { ICommandModule } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
 import { parseCliArgs } from './utils/cli-args.js';
@@ -145,7 +145,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   });
 
   // Session management
-  const sessionStore = new SessionStore();
+  const sessionStore = new SessionStore(projectPaths(cwd).sessions);
   let resumeSessionId: string | undefined;
 
   if (args.continueMode) {

--- a/packages/agent-cli/src/subagents/__tests__/child-process-subagent-runner.test.ts
+++ b/packages/agent-cli/src/subagents/__tests__/child-process-subagent-runner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import type {
   IInProcessSubagentRunnerDeps,
   ISubagentJobStart,
@@ -121,6 +124,30 @@ describe('ChildProcessSubagentRunner', () => {
         toolName: 'Read',
         success: true,
       });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'exposes a deterministic transcript path and reads transcript pages',
+    async () => {
+      const logsDir = mkdtempSync(join(tmpdir(), 'robota-subagent-logs-'));
+      const transcriptDir = join(logsDir, 'session_1', 'subagents');
+      mkdirSync(transcriptDir, { recursive: true });
+      writeFileSync(join(transcriptDir, 'agent_1.jsonl'), 'line1\nline2\n', 'utf8');
+      const runner = new ChildProcessSubagentRunner(createDeps(), {
+        workerPath: FIXTURE_WORKER,
+        execArgv: [],
+        logsDir,
+      });
+
+      const handle = runner.start(createJob());
+      const page = await handle.readLog?.({ offset: 0 });
+      await handle.result;
+
+      expect(handle.transcriptPath).toBe(join(transcriptDir, 'agent_1.jsonl'));
+      expect(handle.logPath).toBe(join(transcriptDir, 'agent_1.jsonl'));
+      expect(page?.lines).toEqual(['line1', 'line2']);
     },
     TEST_TIMEOUT_MS,
   );

--- a/packages/agent-cli/src/subagents/child-process-subagent-ipc.ts
+++ b/packages/agent-cli/src/subagents/child-process-subagent-ipc.ts
@@ -19,6 +19,7 @@ export interface ISubagentWorkerStartPayload {
   parentContext: IInProcessSubagentRunnerDeps['context'];
   providerProfile: ISerializableProviderProfile;
   permissionMode?: TPermissionMode;
+  logsDir?: string;
 }
 
 export interface ISubagentWorkerStartMessage {

--- a/packages/agent-cli/src/subagents/child-process-subagent-runner.ts
+++ b/packages/agent-cli/src/subagents/child-process-subagent-runner.ts
@@ -1,5 +1,5 @@
 import { fork } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
   BackgroundTaskError,
@@ -8,6 +8,8 @@ import {
   type IAgentDefinition,
   type IInProcessSubagentRunnerDeps,
   type ISerializableProviderProfile,
+  type IBackgroundTaskLogCursor,
+  type IBackgroundTaskLogPage,
   type ISubagentJobHandle,
   type ISubagentJobResult,
   type ISubagentJobStart,
@@ -30,6 +32,7 @@ import {
 import { createGitWorktreeIsolationAdapter } from './git-worktree-isolation-adapter.js';
 
 const DEFAULT_KILL_GRACE_MS = 2_000;
+const LOG_PAGE_SIZE = 200;
 
 export interface IChildProcessSubagentRunnerOptions {
   providerConfig?: IProviderConfig;
@@ -39,6 +42,7 @@ export interface IChildProcessSubagentRunnerOptions {
   env?: NodeJS.ProcessEnv;
   worktreeIsolation?: boolean;
   worktreeAdapter?: ISubagentWorktreeAdapter;
+  logsDir?: string;
 }
 
 interface ICancellationResult {
@@ -67,6 +71,7 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
   private readonly killGraceMs: number;
   private readonly providerConfig?: IProviderConfig;
   private readonly env?: NodeJS.ProcessEnv;
+  private readonly logsDir?: string;
 
   constructor(
     private readonly deps: IInProcessSubagentRunnerDeps,
@@ -77,6 +82,7 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
     this.killGraceMs = options.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
     this.providerConfig = options.providerConfig;
     this.env = options.env;
+    this.logsDir = options.logsDir;
   }
 
   start(job: ISubagentJobStart): ISubagentJobHandle {
@@ -96,10 +102,12 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
     const cancellation = createCancellationResult(job.jobId);
     void workerResult.catch(() => undefined);
     const result = Promise.race([workerResult, cancellation.promise]);
+    const transcriptPath = this.resolveTranscriptPath(job);
 
     return {
       jobId: job.jobId,
       ...(child.pid !== undefined && { pid: child.pid }),
+      ...(transcriptPath !== undefined && { transcriptPath, logPath: transcriptPath }),
       result,
       cancel: async (reason?: string) => {
         cancellation.reject(reason);
@@ -108,6 +116,10 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
       send: async (prompt: string) => {
         await sendWorkerMessage(child, { type: 'send', prompt });
       },
+      ...(transcriptPath !== undefined && {
+        readLog: async (cursor?: IBackgroundTaskLogCursor) =>
+          readTranscriptLog(job.jobId, transcriptPath, cursor),
+      }),
     };
   }
 
@@ -121,7 +133,13 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
       parentContext: this.deps.context,
       providerProfile: createProviderProfile(this.providerConfig, this.deps, job),
       permissionMode: this.deps.permissionMode,
+      ...(this.logsDir ? { logsDir: this.logsDir } : {}),
     };
+  }
+
+  private resolveTranscriptPath(job: ISubagentJobStart): string | undefined {
+    if (!this.logsDir) return undefined;
+    return join(this.logsDir, job.request.parentSessionId, 'subagents', `${job.jobId}.jsonl`);
   }
 
   private createResult(
@@ -149,7 +167,12 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
         settled = true;
         clearTimers();
         cleanup();
-        resolve({ jobId: runtime.job.jobId, output });
+        const transcriptPath = this.resolveTranscriptPath(runtime.job);
+        resolve({
+          jobId: runtime.job.jobId,
+          output,
+          ...(transcriptPath ? { metadata: { transcriptPath, logPath: transcriptPath } } : {}),
+        });
       };
 
       const rejectOnce = (error: Error): void => {
@@ -286,4 +309,27 @@ function resolveDefaultExecArgv(workerPath: string): string[] {
     return process.execArgv;
   }
   return [...process.execArgv, '--import', 'tsx'];
+}
+
+function readTranscriptLog(
+  jobId: string,
+  transcriptPath: string,
+  cursor?: IBackgroundTaskLogCursor,
+): IBackgroundTaskLogPage {
+  const offset = cursor?.offset ?? 0;
+  if (!existsSync(transcriptPath)) {
+    return {
+      taskId: jobId,
+      cursor,
+      lines: [],
+    };
+  }
+  const lines = readFileSync(transcriptPath, 'utf8').split(/\r?\n/).filter(Boolean);
+  const nextOffset = Math.min(offset + LOG_PAGE_SIZE, lines.length);
+  return {
+    taskId: jobId,
+    cursor,
+    nextCursor: nextOffset < lines.length ? { offset: nextOffset } : undefined,
+    lines: lines.slice(offset, nextOffset),
+  };
 }

--- a/packages/agent-cli/src/subagents/child-process-subagent-worker.ts
+++ b/packages/agent-cli/src/subagents/child-process-subagent-worker.ts
@@ -1,5 +1,6 @@
 import {
   createDefaultTools,
+  createSubagentLogger,
   createSubagentSession,
   type ITerminalOutput,
 } from '@robota-sdk/agent-sdk';
@@ -36,6 +37,9 @@ function sendChildMessage(message: TSubagentWorkerChildMessage): void {
 async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<void> {
   try {
     const provider = createProviderFromProfile(payload.providerProfile, payload.request.model);
+    const sessionLogger = payload.logsDir
+      ? createSubagentLogger(payload.request.parentSessionId, payload.jobId, payload.logsDir)
+      : undefined;
     session = createSubagentSession({
       agentDefinition: payload.agentDefinition,
       parentConfig: payload.parentConfig,
@@ -43,6 +47,8 @@ async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<v
       parentTools: createDefaultTools(),
       provider,
       terminal: NOOP_TERMINAL,
+      sessionId: payload.jobId,
+      ...(sessionLogger ? { sessionLogger } : {}),
       permissionMode: payload.permissionMode,
       hooks: payload.parentConfig.hooks,
       onTextDelta: (delta) => sendChildMessage({ type: 'text_delta', delta }),

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -2,7 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
-import type { IBackgroundTaskRunner, TSubagentRunnerFactory } from '@robota-sdk/agent-sdk';
+import type {
+  IBackgroundTaskRunner,
+  ICommandModule,
+  TSubagentRunnerFactory,
+} from '@robota-sdk/agent-sdk';
 import { getModelName, createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import { useInteractiveSession } from './hooks/useInteractiveSession.js';
 import { usePluginCallbacks } from './hooks/usePluginCallbacks.js';
@@ -33,6 +37,7 @@ interface IProps {
   sessionName?: string;
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  commandModules?: readonly ICommandModule[];
 }
 
 /**
@@ -83,6 +88,7 @@ function AppInner(
     sessionName: props.sessionName,
     backgroundTaskRunners: props.backgroundTaskRunners,
     subagentRunnerFactory: props.subagentRunnerFactory,
+    commandModules: props.commandModules,
   });
 
   const pluginCallbacks = usePluginCallbacks(cwd);

--- a/packages/agent-cli/src/ui/__tests__/confirm-prompt.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/confirm-prompt.test.tsx
@@ -7,16 +7,12 @@ const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('ConfirmPrompt', () => {
   it('renders message text', () => {
-    const { lastFrame } = render(
-      <ConfirmPrompt message="Are you sure?" onSelect={() => {}} />,
-    );
+    const { lastFrame } = render(<ConfirmPrompt message="Are you sure?" onSelect={() => {}} />);
     expect(lastFrame()).toContain('Are you sure?');
   });
 
   it('renders default Yes/No options', () => {
-    const { lastFrame } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={() => {}} />,
-    );
+    const { lastFrame } = render(<ConfirmPrompt message="Confirm?" onSelect={() => {}} />);
     const frame = lastFrame()!;
     expect(frame).toContain('Yes');
     expect(frame).toContain('No');
@@ -33,9 +29,7 @@ describe('ConfirmPrompt', () => {
   });
 
   it('first option is highlighted by default', () => {
-    const { lastFrame } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={() => {}} />,
-    );
+    const { lastFrame } = render(<ConfirmPrompt message="Confirm?" onSelect={() => {}} />);
     const frame = lastFrame()!;
     // The selected item has '> ' prefix
     expect(frame).toContain('> Yes');
@@ -43,18 +37,14 @@ describe('ConfirmPrompt', () => {
 
   it('selects first option on Enter', () => {
     const onSelect = vi.fn();
-    const { stdin } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={onSelect} />,
-    );
+    const { stdin } = render(<ConfirmPrompt message="Confirm?" onSelect={onSelect} />);
     stdin.write('\r');
     expect(onSelect).toHaveBeenCalledWith(0);
   });
 
   it('navigates to second option with arrow down and selects', async () => {
     const onSelect = vi.fn();
-    const { stdin } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={onSelect} />,
-    );
+    const { stdin } = render(<ConfirmPrompt message="Confirm?" onSelect={onSelect} />);
     // Arrow down (move to No)
     stdin.write('\x1b[B');
     await delay(50);
@@ -64,18 +54,14 @@ describe('ConfirmPrompt', () => {
 
   it('y shortcut selects first option (Yes)', () => {
     const onSelect = vi.fn();
-    const { stdin } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={onSelect} />,
-    );
+    const { stdin } = render(<ConfirmPrompt message="Confirm?" onSelect={onSelect} />);
     stdin.write('y');
     expect(onSelect).toHaveBeenCalledWith(0);
   });
 
   it('n shortcut selects second option (No)', () => {
     const onSelect = vi.fn();
-    const { stdin } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={onSelect} />,
-    );
+    const { stdin } = render(<ConfirmPrompt message="Confirm?" onSelect={onSelect} />);
     stdin.write('n');
     expect(onSelect).toHaveBeenCalledWith(1);
   });
@@ -92,9 +78,7 @@ describe('ConfirmPrompt', () => {
 
   it('ignores input after selection (no double-fire)', () => {
     const onSelect = vi.fn();
-    const { stdin } = render(
-      <ConfirmPrompt message="Confirm?" onSelect={onSelect} />,
-    );
+    const { stdin } = render(<ConfirmPrompt message="Confirm?" onSelect={onSelect} />);
     stdin.write('\r');
     stdin.write('\r');
     stdin.write('y');

--- a/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
+++ b/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
@@ -20,6 +20,7 @@ import {
 import type {
   IAIProvider,
   IBackgroundTaskRunner,
+  ICommandModule,
   TSubagentRunnerFactory,
   TPermissionResultValue,
 } from '@robota-sdk/agent-sdk';
@@ -54,6 +55,7 @@ export interface IInteractiveSessionProps {
   sessionName?: string;
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  commandModules?: readonly ICommandModule[];
 }
 
 export interface IInteractiveSessionState {
@@ -96,10 +98,14 @@ function initializeSession(
     sessionName: props.sessionName,
     backgroundTaskRunners: props.backgroundTaskRunners,
     subagentRunnerFactory: props.subagentRunnerFactory,
+    commandModules: props.commandModules,
   });
 
   const registry = new CommandRegistry();
   registry.addSource(new BuiltinCommandSource());
+  for (const module of props.commandModules ?? []) {
+    registry.addModule(module);
+  }
   registry.addSource(new SkillCommandSource(props.cwd));
 
   const pluginsDir = join(homedir(), '.robota', 'plugins');

--- a/packages/agent-cli/src/ui/render.tsx
+++ b/packages/agent-cli/src/ui/render.tsx
@@ -8,7 +8,11 @@ import App from './App.js';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
-import type { IBackgroundTaskRunner, TSubagentRunnerFactory } from '@robota-sdk/agent-sdk';
+import type {
+  IBackgroundTaskRunner,
+  ICommandModule,
+  TSubagentRunnerFactory,
+} from '@robota-sdk/agent-sdk';
 
 export interface IRenderOptions {
   cwd: string;
@@ -24,6 +28,7 @@ export interface IRenderOptions {
   sessionName?: string;
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  commandModules?: readonly ICommandModule[];
 }
 
 export function renderApp(options: IRenderOptions): void {

--- a/packages/agent-command-agent/README.md
+++ b/packages/agent-command-agent/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-command-agent
+
+Composable `/agent` command module for Robota sessions.
+
+This package contributes command metadata and execution for agent job control. It is intentionally outside `@robota-sdk/agent-sdk` so SDK consumers can choose whether to compose the command.

--- a/packages/agent-command-agent/docs/README.md
+++ b/packages/agent-command-agent/docs/README.md
@@ -1,0 +1,3 @@
+# Agent Command Agent Docs
+
+- [SPEC.md](SPEC.md) - package contract, ownership, public API, and verification expectations.

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -1,0 +1,89 @@
+# SPEC.md — @robota-sdk/agent-command-agent
+
+## Package Scope
+
+`@robota-sdk/agent-command-agent` owns the composable `/agent` command module.
+
+This package:
+
+- exports a command module compatible with `@robota-sdk/agent-sdk`'s `ICommandModule` interface;
+- owns `/agent` command palette metadata;
+- owns `/agent` system command parsing and execution;
+- requests the SDK `agent-runtime` session requirement so the host session wires agent tools and background runtime support.
+
+This package does not own:
+
+- `InteractiveSession` lifecycle or storage;
+- `SubagentManager` or `BackgroundTaskManager` state machines;
+- TUI rendering;
+- provider creation.
+
+## Public API
+
+```ts
+import { createAgentCommandModule } from '@robota-sdk/agent-command-agent';
+```
+
+| Symbol                     | Kind     | Description                                      |
+| -------------------------- | -------- | ------------------------------------------------ |
+| `createAgentCommandModule` | function | Returns an `ICommandModule` for `/agent` support |
+
+## Composition Contract
+
+Hosts compose this package by passing the returned command module into `InteractiveSession` and command palette registries.
+
+```ts
+const agentCommandModule = createAgentCommandModule();
+
+const session = new InteractiveSession({
+  cwd,
+  provider,
+  commandModules: [agentCommandModule],
+});
+
+const registry = new CommandRegistry();
+registry.addModule(agentCommandModule);
+```
+
+If this module is not composed, the host must not expose `/agent`, model-visible `/agent` descriptors, or `/agent` execution.
+
+## Command Behavior
+
+| Command                                    | Behavior                                                                                             |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `/agent list`                              | List available agent definitions and active/terminal agent jobs.                                     |
+| `/agent run <agent> <prompt>`              | Run one agent in foreground mode and return its result.                                              |
+| `/agent run <agent> --background <prompt>` | Spawn one background agent and return `agentId` immediately.                                         |
+| `/agent parallel <spec>`                   | Spawn multiple background agents from a structured spec and return all `agentId` values immediately. |
+| `/agent read <agentId> [offset]`           | Read retained transcript/log output for an agent job.                                                |
+| `/agent send <agentId> <prompt>`           | Send follow-up input to a running/open agent when supported.                                         |
+| `/agent stop <agentId> [reason]`           | Cancel a running/queued agent job.                                                                   |
+| `/agent close <agentId>`                   | Close a terminal agent job.                                                                          |
+| `/agent open <agentId>`                    | Read/focus an agent job detail view when supported by the host.                                      |
+
+`parallel` spawns all valid jobs before waiting for any foreground result. With `--background`, it returns created job IDs immediately.
+
+## Class Contract Registry
+
+| Class/Function             | Implements/Uses                     | Notes                                     |
+| -------------------------- | ----------------------------------- | ----------------------------------------- |
+| `AgentCommandSource`       | `ICommandSource`                    | Supplies slash palette metadata           |
+| `createAgentSystemCommand` | `ISystemCommand`                    | Supplies executable command handler       |
+| `createAgentCommandModule` | `ICommandModule`                    | Composes source, command, and requirement |
+| `executeAgentCommand`      | `InteractiveSession` agent job APIs | Calls injected SDK runtime APIs only      |
+
+## Dependencies
+
+| Package                 | Purpose                                   |
+| ----------------------- | ----------------------------------------- |
+| `@robota-sdk/agent-sdk` | Command interfaces and InteractiveSession |
+
+No dependency from `agent-sdk` or reusable CLI/TUI internals back into this package is required by the command contract. Product composition roots such as the Robota CLI binary may import this package to make `/agent` available.
+
+## Verification
+
+```bash
+pnpm --filter @robota-sdk/agent-command-agent test
+pnpm --filter @robota-sdk/agent-command-agent typecheck
+pnpm --filter @robota-sdk/agent-command-agent build
+```

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -49,19 +49,21 @@ If this module is not composed, the host must not expose `/agent`, model-visible
 
 ## Command Behavior
 
-| Command                                    | Behavior                                                                                             |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `/agent list`                              | List available agent definitions and active/terminal agent jobs.                                     |
-| `/agent run <agent> <prompt>`              | Run one agent in foreground mode and return its result.                                              |
-| `/agent run <agent> --background <prompt>` | Spawn one background agent and return `agentId` immediately.                                         |
-| `/agent parallel <spec>`                   | Spawn multiple background agents from a structured spec and return all `agentId` values immediately. |
-| `/agent read <agentId> [offset]`           | Read retained transcript/log output for an agent job.                                                |
-| `/agent send <agentId> <prompt>`           | Send follow-up input to a running/open agent when supported.                                         |
-| `/agent stop <agentId> [reason]`           | Cancel a running/queued agent job.                                                                   |
-| `/agent close <agentId>`                   | Close a terminal agent job.                                                                          |
-| `/agent open <agentId>`                    | Read/focus an agent job detail view when supported by the host.                                      |
+| Command                                      | Behavior                                                                                                 |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `/agent list`                                | List available agent definitions and active/terminal agent jobs.                                         |
+| `/agent run [<agent>] <prompt>`              | Run one agent in foreground mode. Defaults to `general-purpose` when `<agent>` is omitted.               |
+| `/agent run [<agent>] --background <prompt>` | Spawn one background agent and return `agentId` immediately. Defaults to `general-purpose` when omitted. |
+| `/agent parallel <spec>`                     | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.     |
+| `/agent read <agentId> [offset]`             | Read retained transcript/log output for an agent job.                                                    |
+| `/agent send <agentId> <prompt>`             | Send follow-up input to a running/open agent when supported.                                             |
+| `/agent stop <agentId> [reason]`             | Cancel a running/queued agent job.                                                                       |
+| `/agent close <agentId>`                     | Close a terminal agent job.                                                                              |
+| `/agent open <agentId>`                      | Read/focus an agent job detail view when supported by the host.                                          |
 
-`parallel` spawns all valid jobs before waiting for any foreground result. With `--background`, it returns created job IDs immediately.
+`parallel` accepts both `label=agent:"prompt"` and simpler `label:"prompt"` tokens. The simpler form defaults to `general-purpose`. `parallel` spawns all valid jobs before waiting for any foreground result. With `--background`, it returns created job IDs immediately.
+
+Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and command arguments. Assistant text such as `<agent ... />` is not command execution and must not be emitted as a substitute for the tool call.
 
 ## Class Contract Registry
 

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -52,21 +52,21 @@ If this module is not composed, the host must not expose `/agent`, model-visible
 | Command                          | Behavior                                                                                                        |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `/agent`                         | List available agent definitions and active/terminal agent jobs.                                                |
-| `/agent <prompt>`                | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
-| `/agent <agent> <prompt>`        | Spawn the named background agent when `<agent>` matches an available agent definition.                          |
-| `/agent run [<agent>] <prompt>`  | Compatibility alias for background agent spawn. Defaults to `general-purpose` when `<agent>` is omitted.        |
+| `/agent PROMPT`                  | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
+| `/agent AGENT_NAME PROMPT`       | Spawn the named background agent when `AGENT_NAME` matches an available agent definition.                       |
+| `/agent run [AGENT_NAME] PROMPT` | Compatibility alias for background agent spawn. Defaults to `general-purpose` when `AGENT_NAME` is omitted.     |
 | `/agent parallel <spec>`         | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.            |
-| `/agent read <agentId> [offset]` | Read retained transcript/log output for an agent job.                                                           |
-| `/agent send <agentId> <prompt>` | Send follow-up input to a running/open agent when supported.                                                    |
-| `/agent stop <agentId> [reason]` | Cancel a running/queued agent job.                                                                              |
-| `/agent close <agentId>`         | Close a terminal agent job.                                                                                     |
-| `/agent open <agentId>`          | Read/focus an agent job detail view when supported by the host.                                                 |
+| `/agent read AGENT_ID [OFFSET]`  | Read retained transcript/log output for an agent job.                                                           |
+| `/agent send AGENT_ID PROMPT`    | Send follow-up input to a running/open agent when supported.                                                    |
+| `/agent stop AGENT_ID [REASON]`  | Cancel a running/queued agent job.                                                                              |
+| `/agent close AGENT_ID`          | Close a terminal agent job.                                                                                     |
+| `/agent open AGENT_ID`           | Read/focus an agent job detail view when supported by the host.                                                 |
 
 Agent spawn commands are background-first. The user-facing syntax does not require `--background`; the flag is accepted only as a compatibility no-op.
 
 `parallel` accepts both `label=agent:"prompt"` and simpler `label:"prompt"` tokens. The simpler form defaults to `general-purpose`. `parallel` spawns all valid jobs before waiting for any result and returns created job IDs immediately.
 
-Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and natural command arguments. Assistant text such as `<agent ... />` is not command execution and must not be emitted as a substitute for the tool call.
+Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and natural command arguments. Assistant text is not command execution and must not be emitted as a substitute for the tool call.
 
 When the user enters `/agent run <natural-language prompt>`, the first unflagged token is treated as an agent type only if it matches an available agent definition or was supplied through `--agent`/`--type`. Otherwise the whole phrase remains the prompt and the command defaults to `general-purpose`. This keeps Korean or other natural-language prompts such as `/agent run 이걸로 분석해` from being misread as unknown agent names.
 

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -68,6 +68,8 @@ Agent spawn commands are background-first. The user-facing syntax does not requi
 
 Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and natural command arguments. Assistant text such as `<agent ... />` is not command execution and must not be emitted as a substitute for the tool call.
 
+When the user enters `/agent run <natural-language prompt>`, the first unflagged token is treated as an agent type only if it matches an available agent definition or was supplied through `--agent`/`--type`. Otherwise the whole phrase remains the prompt and the command defaults to `general-purpose`. This keeps Korean or other natural-language prompts such as `/agent run 이걸로 분석해` from being misread as unknown agent names.
+
 ## Class Contract Registry
 
 | Class/Function             | Implements/Uses                     | Notes                                     |

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -49,21 +49,24 @@ If this module is not composed, the host must not expose `/agent`, model-visible
 
 ## Command Behavior
 
-| Command                                      | Behavior                                                                                                 |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `/agent list`                                | List available agent definitions and active/terminal agent jobs.                                         |
-| `/agent run [<agent>] <prompt>`              | Run one agent in foreground mode. Defaults to `general-purpose` when `<agent>` is omitted.               |
-| `/agent run [<agent>] --background <prompt>` | Spawn one background agent and return `agentId` immediately. Defaults to `general-purpose` when omitted. |
-| `/agent parallel <spec>`                     | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.     |
-| `/agent read <agentId> [offset]`             | Read retained transcript/log output for an agent job.                                                    |
-| `/agent send <agentId> <prompt>`             | Send follow-up input to a running/open agent when supported.                                             |
-| `/agent stop <agentId> [reason]`             | Cancel a running/queued agent job.                                                                       |
-| `/agent close <agentId>`                     | Close a terminal agent job.                                                                              |
-| `/agent open <agentId>`                      | Read/focus an agent job detail view when supported by the host.                                          |
+| Command                          | Behavior                                                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `/agent`                         | List available agent definitions and active/terminal agent jobs.                                                |
+| `/agent <prompt>`                | Spawn one `general-purpose` background agent with the natural-language prompt and return `agentId` immediately. |
+| `/agent <agent> <prompt>`        | Spawn the named background agent when `<agent>` matches an available agent definition.                          |
+| `/agent run [<agent>] <prompt>`  | Compatibility alias for background agent spawn. Defaults to `general-purpose` when `<agent>` is omitted.        |
+| `/agent parallel <spec>`         | Spawn multiple background agents from a structured spec and return all `agentId` values immediately.            |
+| `/agent read <agentId> [offset]` | Read retained transcript/log output for an agent job.                                                           |
+| `/agent send <agentId> <prompt>` | Send follow-up input to a running/open agent when supported.                                                    |
+| `/agent stop <agentId> [reason]` | Cancel a running/queued agent job.                                                                              |
+| `/agent close <agentId>`         | Close a terminal agent job.                                                                                     |
+| `/agent open <agentId>`          | Read/focus an agent job detail view when supported by the host.                                                 |
 
-`parallel` accepts both `label=agent:"prompt"` and simpler `label:"prompt"` tokens. The simpler form defaults to `general-purpose`. `parallel` spawns all valid jobs before waiting for any foreground result. With `--background`, it returns created job IDs immediately.
+Agent spawn commands are background-first. The user-facing syntax does not require `--background`; the flag is accepted only as a compatibility no-op.
 
-Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and command arguments. Assistant text such as `<agent ... />` is not command execution and must not be emitted as a substitute for the tool call.
+`parallel` accepts both `label=agent:"prompt"` and simpler `label:"prompt"` tokens. The simpler form defaults to `general-purpose`. `parallel` spawns all valid jobs before waiting for any result and returns created job IDs immediately.
+
+Model-routed command execution must call the generic `ExecuteCommand` tool with `command: "agent"` and natural command arguments. Assistant text such as `<agent ... />` is not command execution and must not be emitted as a substitute for the tool call.
 
 ## Class Contract Registry
 

--- a/packages/agent-command-agent/package.json
+++ b/packages/agent-command-agent/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@robota-sdk/agent-command-agent",
+  "version": "3.0.0-beta.55",
+  "description": "Composable /agent command module for Robota sessions",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/woojubb/robota.git",
+    "directory": "packages/agent-command-agent"
+  },
+  "homepage": "https://robota.io/",
+  "bugs": {
+    "url": "https://github.com/woojubb/robota/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
+    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/ --ext .ts",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-command-agent/package.json
+++ b/packages/agent-command-agent/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
     "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -77,6 +77,9 @@ describe('agent command module', () => {
       safety: 'background-agent',
     });
     expect(agent?.description).toContain('subagent jobs');
+    expect(agent?.description).toContain('ExecuteCommand');
+    expect(agent?.description).toContain('<agent>');
+    expect(agent?.argumentHint).toContain('run [<agent>]');
   });
 
   it('spawns a background agent and returns the agentId', async () => {
@@ -103,6 +106,49 @@ describe('agent command module', () => {
       mode: 'background',
       prompt: 'draft architecture',
     });
+  });
+
+  it('defaults /agent run prompt-only syntax to general-purpose', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute('agent', session, 'run --background "이걸로 분석해"');
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.agentId).toBe('agent_1');
+    expect(
+      (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
+    ).toHaveBeenCalledWith({
+      agentType: 'general-purpose',
+      label: 'general-purpose',
+      mode: 'background',
+      prompt: '이걸로 분석해',
+    });
+  });
+
+  it('returns a command failure for explicit unknown agent types instead of throwing', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute(
+      'agent',
+      session,
+      'run --agent missing --background "draft architecture"',
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('Unknown agent type: missing');
+    expect(
+      (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
+    ).not.toHaveBeenCalled();
   });
 
   it('spawns every parallel background job before any wait path', async () => {
@@ -143,5 +189,36 @@ describe('agent command module', () => {
     expect(result?.success).toBe(true);
     expect(result?.data?.agentIds).toEqual(['agent_1', 'agent_2']);
     expect(callOrder).toEqual(['spawn:developer', 'spawn:designer']);
+  });
+
+  it('supports simple parallel label prompt syntax with default agent type', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute(
+      'agent',
+      session,
+      'parallel developer:"implementation risks" designer:"architecture boundaries" --background',
+    );
+
+    expect(result?.success).toBe(true);
+    const spawnAgentJob = (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> })
+      .spawnAgentJob;
+    expect(spawnAgentJob).toHaveBeenNthCalledWith(1, {
+      agentType: 'general-purpose',
+      label: 'developer',
+      mode: 'background',
+      prompt: 'implementation risks',
+    });
+    expect(spawnAgentJob).toHaveBeenNthCalledWith(2, {
+      agentType: 'general-purpose',
+      label: 'designer',
+      mode: 'background',
+      prompt: 'architecture boundaries',
+    });
   });
 });

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -79,10 +79,10 @@ describe('agent command module', () => {
     expect(agent?.description).toContain('subagent jobs');
     expect(agent?.description).toContain('ExecuteCommand');
     expect(agent?.description).toContain('<agent>');
-    expect(agent?.argumentHint).toContain('run [<agent>]');
+    expect(agent?.argumentHint).toContain('<prompt>');
   });
 
-  it('spawns a background agent and returns the agentId', async () => {
+  it('spawns a background agent from direct natural-language /agent input', async () => {
     const module = createAgentCommandModule();
     const executor = new SystemCommandExecutor([
       ...createSystemCommands(),
@@ -90,11 +90,32 @@ describe('agent command module', () => {
     ]);
     const session = createMockSession();
 
-    const result = await executor.execute(
-      'agent',
-      session,
-      'run Plan --background "draft architecture"',
-    );
+    const result = await executor.execute('agent', session, '이 백로그를 분석해');
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.agentId).toBe('agent_1');
+    expect(
+      (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
+    ).toHaveBeenCalledWith({
+      agentType: 'general-purpose',
+      label: 'general-purpose',
+      mode: 'background',
+      prompt: '이 백로그를 분석해',
+    });
+    expect(
+      (session as unknown as { waitAgentJob: ReturnType<typeof vi.fn> }).waitAgentJob,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('spawns a named background agent from direct /agent input', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute('agent', session, 'Plan "draft architecture"');
 
     expect(result?.success).toBe(true);
     expect(result?.data?.agentId).toBe('agent_1');
@@ -106,9 +127,12 @@ describe('agent command module', () => {
       mode: 'background',
       prompt: 'draft architecture',
     });
+    expect(
+      (session as unknown as { waitAgentJob: ReturnType<typeof vi.fn> }).waitAgentJob,
+    ).not.toHaveBeenCalled();
   });
 
-  it('defaults /agent run prompt-only syntax to general-purpose', async () => {
+  it('keeps /agent run as a compatibility alias that defaults to background general-purpose', async () => {
     const module = createAgentCommandModule();
     const executor = new SystemCommandExecutor([
       ...createSystemCommands(),
@@ -116,7 +140,7 @@ describe('agent command module', () => {
     ]);
     const session = createMockSession();
 
-    const result = await executor.execute('agent', session, 'run --background "이걸로 분석해"');
+    const result = await executor.execute('agent', session, 'run "이걸로 분석해"');
 
     expect(result?.success).toBe(true);
     expect(result?.data?.agentId).toBe('agent_1');
@@ -183,7 +207,7 @@ describe('agent command module', () => {
     const result = await executor.execute(
       'agent',
       session,
-      'parallel developer=general-purpose:"implementation risks" designer=Plan:"architecture boundaries" --background',
+      'parallel developer=general-purpose:"implementation risks" designer=Plan:"architecture boundaries"',
     );
 
     expect(result?.success).toBe(true);
@@ -202,7 +226,7 @@ describe('agent command module', () => {
     const result = await executor.execute(
       'agent',
       session,
-      'parallel developer:"implementation risks" designer:"architecture boundaries" --background',
+      'parallel developer:"implementation risks" designer:"architecture boundaries"',
     );
 
     expect(result?.success).toBe(true);

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -78,6 +78,9 @@ describe('agent command module', () => {
     });
     expect(agent?.description).toContain('subagent jobs');
     expect(agent?.description).toContain('ExecuteCommand');
+    expect(agent?.description).toContain('choose one backlog');
+    expect(agent?.description).toContain('Korean example');
+    expect(agent?.description).toContain('백로그 중에 하나');
     expect(agent?.description).toContain('<agent>');
     expect(agent?.argumentHint).toContain('<prompt>');
   });
@@ -144,6 +147,27 @@ describe('agent command module', () => {
 
     expect(result?.success).toBe(true);
     expect(result?.data?.agentId).toBe('agent_1');
+    expect(
+      (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
+    ).toHaveBeenCalledWith({
+      agentType: 'general-purpose',
+      label: 'general-purpose',
+      mode: 'background',
+      prompt: '이걸로 분석해',
+    });
+  });
+
+  it('does not treat the first natural-language token as an agent type for /agent run', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute('agent', session, 'run 이걸로 분석해');
+
+    expect(result?.success).toBe(true);
     expect(
       (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
     ).toHaveBeenCalledWith({

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CommandRegistry,
+  SystemCommandExecutor,
+  createSystemCommands,
+} from '@robota-sdk/agent-sdk';
+import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { createAgentCommandModule } from '../agent-command-module.js';
+
+function createMockSession(overrides?: Record<string, unknown>): InteractiveSession {
+  const session = {
+    listAgentDefinitions: vi.fn().mockReturnValue([
+      { name: 'general-purpose', description: 'General-purpose task execution agent.' },
+      { name: 'Plan', description: 'Read-only planning agent.' },
+    ]),
+    listAgentJobs: vi.fn().mockReturnValue([]),
+    readBackgroundTaskLog: vi.fn().mockResolvedValue({ taskId: 'agent_1', lines: [] }),
+    spawnAgentJob: vi.fn().mockResolvedValue({
+      id: 'agent_1',
+      type: 'Plan',
+      label: 'Plan',
+      parentSessionId: 'test-session-id',
+      status: 'running',
+      mode: 'background',
+      depth: 1,
+      cwd: '/workspace',
+      promptPreview: 'draft architecture',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    }),
+    waitAgentJob: vi.fn(),
+    sendAgentJob: vi.fn(),
+    cancelAgentJob: vi.fn(),
+    closeAgentJob: vi.fn(),
+    ...overrides,
+  };
+  return session as unknown as InteractiveSession;
+}
+
+describe('agent command module', () => {
+  it('contributes /agent without changing SDK core commands', () => {
+    const coreExecutor = new SystemCommandExecutor(createSystemCommands());
+    expect(coreExecutor.hasCommand('agent')).toBe(false);
+
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+
+    expect(executor.hasCommand('agent')).toBe(true);
+    expect(executor.listModelInvocableCommands().map((command) => command.name)).toEqual([
+      '/agent',
+    ]);
+  });
+
+  it('requests agent runtime wiring through the command module contract', () => {
+    const module = createAgentCommandModule();
+
+    expect(module.sessionRequirements).toEqual(['agent-runtime']);
+    expect(module.commandSources).toHaveLength(1);
+    expect(module.systemCommands).toHaveLength(1);
+  });
+
+  it('projects /agent from its injected command source', () => {
+    const module = createAgentCommandModule();
+    const registry = new CommandRegistry();
+    registry.addModule(module);
+
+    const agent = registry
+      .getCapabilityDescriptors()
+      .find((descriptor) => descriptor.name === '/agent');
+
+    expect(agent).toMatchObject({
+      kind: 'builtin-command',
+      userInvocable: true,
+      modelInvocable: true,
+      safety: 'background-agent',
+    });
+    expect(agent?.description).toContain('subagent jobs');
+  });
+
+  it('spawns a background agent and returns the agentId', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute(
+      'agent',
+      session,
+      'run Plan --background "draft architecture"',
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.agentId).toBe('agent_1');
+    expect(
+      (session as unknown as { spawnAgentJob: ReturnType<typeof vi.fn> }).spawnAgentJob,
+    ).toHaveBeenCalledWith({
+      agentType: 'Plan',
+      label: 'Plan',
+      mode: 'background',
+      prompt: 'draft architecture',
+    });
+  });
+
+  it('spawns every parallel background job before any wait path', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const callOrder: string[] = [];
+    const session = createMockSession({
+      spawnAgentJob: vi.fn().mockImplementation((request: { label: string }) => {
+        callOrder.push(`spawn:${request.label}`);
+        return Promise.resolve({
+          id: `agent_${callOrder.length}`,
+          type: request.label,
+          label: request.label,
+          parentSessionId: 'test-session-id',
+          status: 'running',
+          mode: 'background',
+          depth: 1,
+          cwd: '/workspace',
+          promptPreview: request.label,
+          updatedAt: '2026-05-01T00:00:00.000Z',
+        });
+      }),
+      waitAgentJob: vi.fn().mockImplementation((jobId: string) => {
+        callOrder.push(`wait:${jobId}`);
+        return Promise.resolve({ jobId, output: 'done' });
+      }),
+    });
+
+    const result = await executor.execute(
+      'agent',
+      session,
+      'parallel developer=general-purpose:"implementation risks" designer=Plan:"architecture boundaries" --background',
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.agentIds).toEqual(['agent_1', 'agent_2']);
+    expect(callOrder).toEqual(['spawn:developer', 'spawn:designer']);
+  });
+});

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -81,8 +81,11 @@ describe('agent command module', () => {
     expect(agent?.description).toContain('choose one backlog');
     expect(agent?.description).toContain('Korean example');
     expect(agent?.description).toContain('백로그 중에 하나');
-    expect(agent?.description).toContain('<agent>');
-    expect(agent?.argumentHint).toContain('<prompt>');
+    expect(agent?.description).toContain('ExecuteCommand tool');
+    expect(agent?.description).not.toContain('<agent>');
+    expect(agent?.description).not.toContain('XML/HTML');
+    expect(agent?.argumentHint).toContain('PROMPT');
+    expect(agent?.argumentHint).not.toContain('<');
   });
 
   it('spawns a background agent from direct natural-language /agent input', async () => {
@@ -108,6 +111,23 @@ describe('agent command module', () => {
     expect(
       (session as unknown as { waitAgentJob: ReturnType<typeof vi.fn> }).waitAgentJob,
     ).not.toHaveBeenCalled();
+  });
+
+  it('uses plain placeholder names in usage errors', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const runResult = await executor.execute('agent', session, 'run');
+    const parallelResult = await executor.execute('agent', session, 'parallel');
+
+    expect(runResult?.message).toContain('AGENT_NAME');
+    expect(parallelResult?.message).toContain('LABEL');
+    expect(runResult?.message).not.toContain('<');
+    expect(parallelResult?.message).not.toContain('<');
   });
 
   it('spawns a named background agent from direct /agent input', async () => {

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -23,11 +23,11 @@ export function createAgentCommandEntry(): ICommand {
   return {
     name: 'agent',
     description:
-      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents, especially for parallel or background work.',
+      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents, especially for parallel or background work. Model-routed execution must call ExecuteCommand with command "agent" and args such as `parallel developer:"..." designer:"..." --background`; do not print XML/HTML-like <agent> tags as assistant text.',
     source: 'agent',
     modelInvocable: true,
     argumentHint:
-      'list | run <agent> [--background] <prompt> | parallel <label>=<agent>:"<prompt>" --background',
+      'list | run [<agent>] [--background] <prompt> | parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background',
     safety: 'background-agent',
     subcommands: createAgentSubcommands(),
   };

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -23,11 +23,11 @@ export function createAgentCommandEntry(): ICommand {
   return {
     name: 'agent',
     description:
-      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents. To run an agent, pass the natural-language task directly as args; Robota starts agent jobs in the background by default. If the user asks to choose one backlog, task, or item, include that target-selection instruction in the agent prompt instead of delaying execution. Korean example: "백로그 중에 하나를 분석할건데..." means start the requested agents now. For model-routed command execution, call ExecuteCommand in the same assistant turn with command "agent" and args such as `analyze the auth changes with a code-review agent` or `parallel developer=general-purpose:"analyze implementation" designer=Plan:"analyze architecture"`; do not print XML/HTML-like <agent> tags as assistant text.',
+      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents. To run an agent, pass the natural-language task directly as args; Robota starts agent jobs in the background by default. If the user asks to choose one backlog, task, or item, include that target-selection instruction in the agent prompt instead of delaying execution. Korean example: "백로그 중에 하나를 분석할건데..." means start the requested agents now. For model-routed command execution, call the ExecuteCommand tool in the same assistant turn with command "agent" and args such as `analyze the auth changes with a code-review agent` or `parallel developer=general-purpose:"analyze implementation" designer=Plan:"analyze architecture"`; assistant text does not start agent jobs.',
     source: 'agent',
     modelInvocable: true,
     argumentHint:
-      '<prompt> | <agent> <prompt> | list | parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] | read <agent-id> [offset] | send <agent-id> <prompt> | stop <agent-id> | close <agent-id>',
+      'PROMPT | AGENT_NAME PROMPT | list | parallel LABEL:"PROMPT" [LABEL=AGENT_NAME:"PROMPT"] | read AGENT_ID [OFFSET] | send AGENT_ID PROMPT | stop AGENT_ID | close AGENT_ID',
     safety: 'background-agent',
     subcommands: createAgentSubcommands(),
   };

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -23,7 +23,7 @@ export function createAgentCommandEntry(): ICommand {
   return {
     name: 'agent',
     description:
-      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents. To run an agent, pass the natural-language task directly as args; Robota starts agent jobs in the background by default. Model-routed execution must call ExecuteCommand with command "agent" and args such as `analyze the auth changes with a code-review agent`; do not print XML/HTML-like <agent> tags as assistant text.',
+      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents. To run an agent, pass the natural-language task directly as args; Robota starts agent jobs in the background by default. If the user asks to choose one backlog, task, or item, include that target-selection instruction in the agent prompt instead of delaying execution. Korean example: "백로그 중에 하나를 분석할건데..." means start the requested agents now. For model-routed command execution, call ExecuteCommand in the same assistant turn with command "agent" and args such as `analyze the auth changes with a code-review agent` or `parallel developer=general-purpose:"analyze implementation" designer=Plan:"analyze architecture"`; do not print XML/HTML-like <agent> tags as assistant text.',
     source: 'agent',
     modelInvocable: true,
     argumentHint:

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -9,7 +9,7 @@ import { executeAgentCommand } from './agent-command.js';
 function createAgentSubcommands(): ICommand[] {
   return [
     { name: 'list', description: 'List available agents and active jobs', source: 'agent' },
-    { name: 'run', description: 'Run one agent foreground or background', source: 'agent' },
+    { name: 'run', description: 'Start one background agent job', source: 'agent' },
     { name: 'parallel', description: 'Run multiple agents in parallel', source: 'agent' },
     { name: 'read', description: 'Read an agent job log page', source: 'agent' },
     { name: 'send', description: 'Send follow-up input to an agent job', source: 'agent' },
@@ -23,11 +23,11 @@ export function createAgentCommandEntry(): ICommand {
   return {
     name: 'agent',
     description:
-      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents, especially for parallel or background work. Model-routed execution must call ExecuteCommand with command "agent" and args such as `parallel developer:"..." designer:"..." --background`; do not print XML/HTML-like <agent> tags as assistant text.',
+      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents. To run an agent, pass the natural-language task directly as args; Robota starts agent jobs in the background by default. Model-routed execution must call ExecuteCommand with command "agent" and args such as `analyze the auth changes with a code-review agent`; do not print XML/HTML-like <agent> tags as assistant text.',
     source: 'agent',
     modelInvocable: true,
     argumentHint:
-      'list | run [<agent>] [--background] <prompt> | parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background',
+      '<prompt> | <agent> <prompt> | list | parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] | read <agent-id> [offset] | send <agent-id> <prompt> | stop <agent-id> | close <agent-id>',
     safety: 'background-agent',
     subcommands: createAgentSubcommands(),
   };

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -1,0 +1,64 @@
+import type {
+  ICommand,
+  ICommandModule,
+  ICommandSource,
+  ISystemCommand,
+} from '@robota-sdk/agent-sdk';
+import { executeAgentCommand } from './agent-command.js';
+
+function createAgentSubcommands(): ICommand[] {
+  return [
+    { name: 'list', description: 'List available agents and active jobs', source: 'agent' },
+    { name: 'run', description: 'Run one agent foreground or background', source: 'agent' },
+    { name: 'parallel', description: 'Run multiple agents in parallel', source: 'agent' },
+    { name: 'read', description: 'Read an agent job log page', source: 'agent' },
+    { name: 'send', description: 'Send follow-up input to an agent job', source: 'agent' },
+    { name: 'stop', description: 'Cancel a running agent job', source: 'agent' },
+    { name: 'close', description: 'Dismiss a terminal agent job', source: 'agent' },
+    { name: 'open', description: 'Focus an agent job detail view when supported', source: 'agent' },
+  ];
+}
+
+export function createAgentCommandEntry(): ICommand {
+  return {
+    name: 'agent',
+    description:
+      'Start, inspect, steer, stop, and close subagent jobs. Use this when the user explicitly asks to create, spawn, delegate to, run, or manage agents, especially for parallel or background work.',
+    source: 'agent',
+    modelInvocable: true,
+    argumentHint:
+      'list | run <agent> [--background] <prompt> | parallel <label>=<agent>:"<prompt>" --background',
+    safety: 'background-agent',
+    subcommands: createAgentSubcommands(),
+  };
+}
+
+export function createAgentSystemCommand(): ISystemCommand {
+  const entry = createAgentCommandEntry();
+  return {
+    name: entry.name,
+    description: entry.description,
+    execute: executeAgentCommand,
+    ...(entry.modelInvocable !== undefined ? { modelInvocable: entry.modelInvocable } : {}),
+    ...(entry.userInvocable !== undefined ? { userInvocable: entry.userInvocable } : {}),
+    ...(entry.argumentHint !== undefined ? { argumentHint: entry.argumentHint } : {}),
+    ...(entry.safety !== undefined ? { safety: entry.safety } : {}),
+  };
+}
+
+export class AgentCommandSource implements ICommandSource {
+  readonly name = 'agent';
+
+  getCommands(): ICommand[] {
+    return [createAgentCommandEntry()];
+  }
+}
+
+export function createAgentCommandModule(): ICommandModule {
+  return {
+    name: 'agent-command-agent',
+    commandSources: [new AgentCommandSource()],
+    systemCommands: [createAgentSystemCommand()],
+    sessionRequirements: ['agent-runtime'],
+  };
+}

--- a/packages/agent-command-agent/src/agent-command-parser.ts
+++ b/packages/agent-command-agent/src/agent-command-parser.ts
@@ -1,0 +1,184 @@
+import type { TBackgroundTaskIsolation } from '@robota-sdk/agent-sdk';
+
+export const DEFAULT_AGENT_TYPE = 'general-purpose';
+
+export type TAgentMode = 'foreground' | 'background';
+
+export interface IAgentRunRequest {
+  readonly agentType: string;
+  readonly label: string;
+  readonly mode: TAgentMode;
+  readonly prompt: string;
+  readonly model?: string;
+  readonly isolation?: TBackgroundTaskIsolation;
+}
+
+interface IParsedAgentOptions {
+  readonly background: boolean;
+  readonly agentType?: string;
+  readonly model?: string;
+  readonly isolation?: TBackgroundTaskIsolation;
+  readonly positional: string[];
+}
+
+export function tokenizeArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const char of args) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (quote && char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = undefined;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
+  const positional: string[] = [];
+  let background = false;
+  let agentType: string | undefined;
+  let model: string | undefined;
+  let isolation: TBackgroundTaskIsolation | undefined;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--background') {
+      background = true;
+      continue;
+    }
+    if (token === '--agent' || token === '--type' || token === '-a') {
+      agentType = tokens[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--model') {
+      model = tokens[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--isolation') {
+      const value = tokens[index + 1];
+      if (value === 'none' || value === 'worktree') isolation = value;
+      index += 1;
+      continue;
+    }
+    if (token !== undefined) positional.push(token);
+  }
+
+  return {
+    background,
+    positional,
+    ...(agentType ? { agentType } : {}),
+    ...(model ? { model } : {}),
+    ...(isolation ? { isolation } : {}),
+  };
+}
+
+function createRequest(
+  options: IParsedAgentOptions,
+  agentType: string,
+  label: string,
+  prompt: string,
+): IAgentRunRequest {
+  return {
+    agentType,
+    label,
+    mode: options.background ? 'background' : 'foreground',
+    prompt,
+    ...(options.model ? { model: options.model } : {}),
+    ...(options.isolation ? { isolation: options.isolation } : {}),
+  };
+}
+
+export function parseRunRequest(
+  tokens: readonly string[],
+  availableAgentNames: ReadonlySet<string>,
+): IAgentRunRequest | undefined {
+  const options = parseOptions(tokens);
+  const [first, ...rest] = options.positional;
+  let agentType = options.agentType ?? DEFAULT_AGENT_TYPE;
+  let promptParts = options.positional;
+
+  if (!options.agentType && first && availableAgentNames.has(first)) {
+    agentType = first;
+    promptParts = rest;
+  }
+
+  const prompt = promptParts.join(' ').trim();
+  if (!prompt) return undefined;
+  return createRequest(options, agentType, agentType, prompt);
+}
+
+export function parseParallelRequests(
+  tokens: readonly string[],
+  availableAgentNames: ReadonlySet<string>,
+): IAgentRunRequest[] {
+  const options = parseOptions(tokens);
+  return options.positional
+    .map((token) => parseAgentJobToken(token, options, availableAgentNames))
+    .filter((job): job is IAgentRunRequest => job !== undefined);
+}
+
+function parseAgentJobToken(
+  token: string,
+  options: IParsedAgentOptions,
+  availableAgentNames: ReadonlySet<string>,
+): IAgentRunRequest | undefined {
+  const equalsIndex = token.indexOf('=');
+  if (equalsIndex > 0) {
+    const label = token.slice(0, equalsIndex);
+    const spec = token.slice(equalsIndex + 1);
+    return parseAgentPromptSpec(label, spec, options, availableAgentNames);
+  }
+
+  const colonIndex = token.indexOf(':');
+  if (colonIndex <= 0 || colonIndex === token.length - 1) return undefined;
+  const head = token.slice(0, colonIndex);
+  const prompt = token.slice(colonIndex + 1);
+  const agentType =
+    options.agentType ?? (availableAgentNames.has(head) ? head : DEFAULT_AGENT_TYPE);
+  return createRequest(options, agentType, head, prompt);
+}
+
+function parseAgentPromptSpec(
+  label: string,
+  spec: string,
+  options: IParsedAgentOptions,
+  availableAgentNames: ReadonlySet<string>,
+): IAgentRunRequest | undefined {
+  const colonIndex = spec.indexOf(':');
+  if (colonIndex === -1) {
+    const agentType =
+      options.agentType ?? (availableAgentNames.has(label) ? label : DEFAULT_AGENT_TYPE);
+    return createRequest(options, agentType, label, spec);
+  }
+  if (colonIndex === 0 || colonIndex === spec.length - 1) return undefined;
+  return createRequest(options, spec.slice(0, colonIndex), label, spec.slice(colonIndex + 1));
+}

--- a/packages/agent-command-agent/src/agent-command-parser.ts
+++ b/packages/agent-command-agent/src/agent-command-parser.ts
@@ -2,7 +2,7 @@ import type { TBackgroundTaskIsolation } from '@robota-sdk/agent-sdk';
 
 export const DEFAULT_AGENT_TYPE = 'general-purpose';
 
-export type TAgentMode = 'foreground' | 'background';
+export type TAgentMode = 'background';
 
 export interface IAgentRunRequest {
   readonly agentType: string;
@@ -14,7 +14,6 @@ export interface IAgentRunRequest {
 }
 
 interface IParsedAgentOptions {
-  readonly background: boolean;
   readonly agentType?: string;
   readonly model?: string;
   readonly isolation?: TBackgroundTaskIsolation;
@@ -62,7 +61,6 @@ export function tokenizeArgs(args: string): string[] {
 
 function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
   const positional: string[] = [];
-  let background = false;
   let agentType: string | undefined;
   let model: string | undefined;
   let isolation: TBackgroundTaskIsolation | undefined;
@@ -70,7 +68,6 @@ function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (token === '--background') {
-      background = true;
       continue;
     }
     if (token === '--agent' || token === '--type' || token === '-a') {
@@ -93,7 +90,6 @@ function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
   }
 
   return {
-    background,
     positional,
     ...(agentType ? { agentType } : {}),
     ...(model ? { model } : {}),
@@ -110,7 +106,7 @@ function createRequest(
   return {
     agentType,
     label,
-    mode: options.background ? 'background' : 'foreground',
+    mode: 'background',
     prompt,
     ...(options.model ? { model: options.model } : {}),
     ...(options.isolation ? { isolation: options.isolation } : {}),

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -59,7 +59,7 @@ async function executeRun(
   const request = parseRunRequest(tokens, getAvailableAgentNames(session));
   if (!request) {
     return {
-      message: 'Usage: agent run [<agent>] [--agent <agent>] <prompt>',
+      message: 'Usage: agent run [AGENT_NAME] [--agent AGENT_NAME] PROMPT',
       success: false,
     };
   }
@@ -83,7 +83,7 @@ async function executeParallel(
 
   if (jobs.length === 0) {
     return {
-      message: 'Usage: agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"]',
+      message: 'Usage: agent parallel LABEL:"PROMPT" [LABEL=AGENT_NAME:"PROMPT"]',
       success: false,
     };
   }
@@ -114,7 +114,7 @@ async function executeRead(
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId, offset] = tokens;
-  if (!agentId) return { message: 'Usage: agent read <agent-id> [offset]', success: false };
+  if (!agentId) return { message: 'Usage: agent read AGENT_ID [OFFSET]', success: false };
   const cursor = offset ? { offset: Number.parseInt(offset, 10) } : undefined;
   const page = await session.readBackgroundTaskLog(agentId, cursor);
   const next = page.nextCursor ? `\nNext offset: ${page.nextCursor.offset}` : '';
@@ -132,7 +132,7 @@ async function executeSend(
   const [agentId, ...promptParts] = tokens;
   const prompt = promptParts.join(' ').trim();
   if (!agentId || !prompt) {
-    return { message: 'Usage: agent send <agent-id> <prompt>', success: false };
+    return { message: 'Usage: agent send AGENT_ID PROMPT', success: false };
   }
   await session.sendAgentJob(agentId, prompt);
   return { message: `Sent input to agent job: ${agentId}`, success: true, data: { agentId } };
@@ -143,7 +143,7 @@ async function executeStop(
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId, ...reasonParts] = tokens;
-  if (!agentId) return { message: 'Usage: agent stop <agent-id> [reason]', success: false };
+  if (!agentId) return { message: 'Usage: agent stop AGENT_ID [REASON]', success: false };
   await session.cancelAgentJob(agentId, reasonParts.join(' ') || undefined);
   return { message: `Agent job stopped: ${agentId}`, success: true, data: { agentId } };
 }
@@ -153,7 +153,7 @@ async function executeClose(
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId] = tokens;
-  if (!agentId) return { message: 'Usage: agent close <agent-id>', success: false };
+  if (!agentId) return { message: 'Usage: agent close AGENT_ID', success: false };
   await session.closeAgentJob(agentId);
   return { message: `Agent job closed: ${agentId}`, success: true, data: { agentId } };
 }

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -1,121 +1,41 @@
-import type {
-  ICommandResult,
-  InteractiveSession,
-  TBackgroundTaskIsolation,
-} from '@robota-sdk/agent-sdk';
-
-type TAgentMode = 'foreground' | 'background';
-
-interface IAgentRunRequest {
-  readonly agentType: string;
-  readonly label: string;
-  readonly mode: TAgentMode;
-  readonly prompt: string;
-  readonly model?: string;
-  readonly isolation?: TBackgroundTaskIsolation;
-}
-
-interface IParsedAgentOptions {
-  readonly background: boolean;
-  readonly model?: string;
-  readonly isolation?: TBackgroundTaskIsolation;
-  readonly positional: string[];
-}
+import type { ICommandResult, InteractiveSession } from '@robota-sdk/agent-sdk';
+import { parseParallelRequests, parseRunRequest, tokenizeArgs } from './agent-command-parser.js';
+import type { IAgentRunRequest } from './agent-command-parser.js';
 
 const USAGE =
-  'Usage: agent list | agent run <agent> [--background] <prompt> | agent parallel <label>=<agent>:"<prompt>" --background | agent read <agent-id> [offset] | agent send <agent-id> <prompt> | agent stop <agent-id> [reason] | agent close <agent-id>';
+  'Usage: agent list | agent run [<agent>] [--agent <agent>] [--background] <prompt> | agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background | agent read <agent-id> [offset] | agent send <agent-id> <prompt> | agent stop <agent-id> [reason] | agent close <agent-id>';
 
-function tokenizeArgs(args: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | undefined;
-  let escaped = false;
-
-  for (const char of args) {
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
-    if (quote && char === '\\') {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = undefined;
-      else current += char;
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-    if (/\s/.test(char)) {
-      if (current.length > 0) {
-        tokens.push(current);
-        current = '';
-      }
-      continue;
-    }
-    current += char;
-  }
-
-  if (current.length > 0) tokens.push(current);
-  return tokens;
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
-function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
-  const positional: string[] = [];
-  let background = false;
-  let model: string | undefined;
-  let isolation: TBackgroundTaskIsolation | undefined;
+function getAvailableAgentNames(session: InteractiveSession): ReadonlySet<string> {
+  return new Set(session.listAgentDefinitions().map((agent) => agent.name));
+}
 
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    if (token === '--background') {
-      background = true;
-      continue;
-    }
-    if (token === '--model') {
-      model = tokens[index + 1];
-      index += 1;
-      continue;
-    }
-    if (token === '--isolation') {
-      const value = tokens[index + 1];
-      if (value === 'none' || value === 'worktree') isolation = value;
-      index += 1;
-      continue;
-    }
-    if (token !== undefined) positional.push(token);
-  }
-
+function validateAgentType(
+  session: InteractiveSession,
+  agentType: string,
+): ICommandResult | undefined {
+  const agents = session.listAgentDefinitions();
+  if (agents.some((agent) => agent.name === agentType)) return undefined;
   return {
-    background,
-    positional,
-    ...(model ? { model } : {}),
-    ...(isolation ? { isolation } : {}),
+    message: `Unknown agent type: ${agentType}\nAvailable agents: ${agents.map((agent) => agent.name).join(', ')}`,
+    success: false,
   };
 }
 
-function parseAgentJobToken(
-  token: string,
-  options: IParsedAgentOptions,
-): IAgentRunRequest | undefined {
-  const equalsIndex = token.indexOf('=');
-  const colonIndex = token.indexOf(':', equalsIndex + 1);
-  if (equalsIndex <= 0 || colonIndex <= equalsIndex + 1 || colonIndex === token.length - 1) {
-    return undefined;
+async function spawnAgentJob(
+  session: InteractiveSession,
+  request: IAgentRunRequest,
+): Promise<ICommandResult | { state: Awaited<ReturnType<InteractiveSession['spawnAgentJob']>> }> {
+  const invalid = validateAgentType(session, request.agentType);
+  if (invalid) return invalid;
+  try {
+    return { state: await session.spawnAgentJob(request) };
+  } catch (error) {
+    return { message: formatError(error), success: false };
   }
-
-  return {
-    label: token.slice(0, equalsIndex),
-    agentType: token.slice(equalsIndex + 1, colonIndex),
-    prompt: token.slice(colonIndex + 1),
-    mode: options.background ? 'background' : 'foreground',
-    ...(options.model ? { model: options.model } : {}),
-    ...(options.isolation ? { isolation: options.isolation } : {}),
-  };
 }
 
 async function executeList(session: InteractiveSession): Promise<ICommandResult> {
@@ -139,23 +59,19 @@ async function executeRun(
   session: InteractiveSession,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
-  const options = parseOptions(tokens);
-  const [agentType, ...promptParts] = options.positional;
-  const prompt = promptParts.join(' ').trim();
-  if (!agentType || !prompt) {
-    return { message: 'Usage: agent run <agent> [--background] <prompt>', success: false };
+  const request = parseRunRequest(tokens, getAvailableAgentNames(session));
+  if (!request) {
+    return {
+      message: 'Usage: agent run [<agent>] [--agent <agent>] [--background] <prompt>',
+      success: false,
+    };
   }
 
-  const state = await session.spawnAgentJob({
-    agentType,
-    label: agentType,
-    mode: options.background ? 'background' : 'foreground',
-    prompt,
-    ...(options.model ? { model: options.model } : {}),
-    ...(options.isolation ? { isolation: options.isolation } : {}),
-  });
+  const spawned = await spawnAgentJob(session, request);
+  if ('success' in spawned) return spawned;
+  const { state } = spawned;
 
-  if (options.background) {
+  if (request.mode === 'background') {
     return {
       message: `Started agent job: ${state.id}`,
       success: true,
@@ -163,32 +79,44 @@ async function executeRun(
     };
   }
 
-  const result = await session.waitAgentJob(state.id);
-  return {
-    message: result.output,
-    success: true,
-    data: { agentId: state.id, output: result.output },
-  };
+  try {
+    const result = await session.waitAgentJob(state.id);
+    return {
+      message: result.output,
+      success: true,
+      data: { agentId: state.id, output: result.output },
+    };
+  } catch (error) {
+    return { message: formatError(error), success: false, data: { agentId: state.id } };
+  }
 }
 
 async function executeParallel(
   session: InteractiveSession,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
-  const options = parseOptions(tokens);
-  const jobs = options.positional
-    .map((token) => parseAgentJobToken(token, options))
-    .filter((job): job is IAgentRunRequest => job !== undefined);
+  const jobs = parseParallelRequests(tokens, getAvailableAgentNames(session));
 
   if (jobs.length === 0) {
     return {
-      message: 'Usage: agent parallel <label>=<agent>:"<prompt>" [more...] --background',
+      message: 'Usage: agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background',
       success: false,
     };
   }
 
-  const states = await Promise.all(jobs.map((job) => session.spawnAgentJob(job)));
-  if (options.background) {
+  const invalid = jobs
+    .map((job) => validateAgentType(session, job.agentType))
+    .find((result): result is ICommandResult => result !== undefined);
+  if (invalid) return invalid;
+
+  let states: Array<Awaited<ReturnType<InteractiveSession['spawnAgentJob']>>>;
+  try {
+    states = await Promise.all(jobs.map((job) => session.spawnAgentJob(job)));
+  } catch (error) {
+    return { message: formatError(error), success: false };
+  }
+
+  if (jobs.every((job) => job.mode === 'background')) {
     return {
       message: [
         'Started agent jobs:',
@@ -199,12 +127,16 @@ async function executeParallel(
     };
   }
 
-  const results = await Promise.all(states.map((state) => session.waitAgentJob(state.id)));
-  return {
-    message: results.map((result) => result.output).join('\n\n'),
-    success: true,
-    data: { agentIds: states.map((state) => state.id) },
-  };
+  try {
+    const results = await Promise.all(states.map((state) => session.waitAgentJob(state.id)));
+    return {
+      message: results.map((result) => result.output).join('\n\n'),
+      success: true,
+      data: { agentIds: states.map((state) => state.id) },
+    };
+  } catch (error) {
+    return { message: formatError(error), success: false };
+  }
 }
 
 async function executeRead(
@@ -260,13 +192,17 @@ export async function executeAgentCommand(
   session: InteractiveSession,
   args: string,
 ): Promise<ICommandResult> {
-  const [action = 'list', ...tokens] = tokenizeArgs(args);
-  if (action === 'list') return executeList(session);
-  if (action === 'run') return executeRun(session, tokens);
-  if (action === 'parallel') return executeParallel(session, tokens);
-  if (action === 'read' || action === 'open') return executeRead(session, tokens);
-  if (action === 'send') return executeSend(session, tokens);
-  if (action === 'stop' || action === 'cancel') return executeStop(session, tokens);
-  if (action === 'close') return executeClose(session, tokens);
-  return { message: USAGE, success: false };
+  try {
+    const [action = 'list', ...tokens] = tokenizeArgs(args);
+    if (action === 'list') return executeList(session);
+    if (action === 'run') return executeRun(session, tokens);
+    if (action === 'parallel') return executeParallel(session, tokens);
+    if (action === 'read' || action === 'open') return executeRead(session, tokens);
+    if (action === 'send') return executeSend(session, tokens);
+    if (action === 'stop' || action === 'cancel') return executeStop(session, tokens);
+    if (action === 'close') return executeClose(session, tokens);
+    return { message: USAGE, success: false };
+  } catch (error) {
+    return { message: formatError(error), success: false };
+  }
 }

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -1,0 +1,272 @@
+import type {
+  ICommandResult,
+  InteractiveSession,
+  TBackgroundTaskIsolation,
+} from '@robota-sdk/agent-sdk';
+
+type TAgentMode = 'foreground' | 'background';
+
+interface IAgentRunRequest {
+  readonly agentType: string;
+  readonly label: string;
+  readonly mode: TAgentMode;
+  readonly prompt: string;
+  readonly model?: string;
+  readonly isolation?: TBackgroundTaskIsolation;
+}
+
+interface IParsedAgentOptions {
+  readonly background: boolean;
+  readonly model?: string;
+  readonly isolation?: TBackgroundTaskIsolation;
+  readonly positional: string[];
+}
+
+const USAGE =
+  'Usage: agent list | agent run <agent> [--background] <prompt> | agent parallel <label>=<agent>:"<prompt>" --background | agent read <agent-id> [offset] | agent send <agent-id> <prompt> | agent stop <agent-id> [reason] | agent close <agent-id>';
+
+function tokenizeArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (const char of args) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (quote && char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = undefined;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function parseOptions(tokens: readonly string[]): IParsedAgentOptions {
+  const positional: string[] = [];
+  let background = false;
+  let model: string | undefined;
+  let isolation: TBackgroundTaskIsolation | undefined;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--background') {
+      background = true;
+      continue;
+    }
+    if (token === '--model') {
+      model = tokens[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--isolation') {
+      const value = tokens[index + 1];
+      if (value === 'none' || value === 'worktree') isolation = value;
+      index += 1;
+      continue;
+    }
+    if (token !== undefined) positional.push(token);
+  }
+
+  return {
+    background,
+    positional,
+    ...(model ? { model } : {}),
+    ...(isolation ? { isolation } : {}),
+  };
+}
+
+function parseAgentJobToken(
+  token: string,
+  options: IParsedAgentOptions,
+): IAgentRunRequest | undefined {
+  const equalsIndex = token.indexOf('=');
+  const colonIndex = token.indexOf(':', equalsIndex + 1);
+  if (equalsIndex <= 0 || colonIndex <= equalsIndex + 1 || colonIndex === token.length - 1) {
+    return undefined;
+  }
+
+  return {
+    label: token.slice(0, equalsIndex),
+    agentType: token.slice(equalsIndex + 1, colonIndex),
+    prompt: token.slice(colonIndex + 1),
+    mode: options.background ? 'background' : 'foreground',
+    ...(options.model ? { model: options.model } : {}),
+    ...(options.isolation ? { isolation: options.isolation } : {}),
+  };
+}
+
+async function executeList(session: InteractiveSession): Promise<ICommandResult> {
+  const agents = session.listAgentDefinitions();
+  const jobs = session.listAgentJobs();
+  const lines = [
+    'Available agents:',
+    ...agents.map((agent) => `  ${agent.name} - ${agent.description}`),
+    '',
+    jobs.length === 0 ? 'No active agent jobs.' : 'Agent jobs:',
+    ...jobs.map((job) => `  ${job.id} [${job.status}] ${job.label} - ${job.promptPreview}`),
+  ];
+  return {
+    message: lines.join('\n'),
+    success: true,
+    data: { agents: agents.length, jobs: jobs.length },
+  };
+}
+
+async function executeRun(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const options = parseOptions(tokens);
+  const [agentType, ...promptParts] = options.positional;
+  const prompt = promptParts.join(' ').trim();
+  if (!agentType || !prompt) {
+    return { message: 'Usage: agent run <agent> [--background] <prompt>', success: false };
+  }
+
+  const state = await session.spawnAgentJob({
+    agentType,
+    label: agentType,
+    mode: options.background ? 'background' : 'foreground',
+    prompt,
+    ...(options.model ? { model: options.model } : {}),
+    ...(options.isolation ? { isolation: options.isolation } : {}),
+  });
+
+  if (options.background) {
+    return {
+      message: `Started agent job: ${state.id}`,
+      success: true,
+      data: { agentId: state.id, status: state.status },
+    };
+  }
+
+  const result = await session.waitAgentJob(state.id);
+  return {
+    message: result.output,
+    success: true,
+    data: { agentId: state.id, output: result.output },
+  };
+}
+
+async function executeParallel(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const options = parseOptions(tokens);
+  const jobs = options.positional
+    .map((token) => parseAgentJobToken(token, options))
+    .filter((job): job is IAgentRunRequest => job !== undefined);
+
+  if (jobs.length === 0) {
+    return {
+      message: 'Usage: agent parallel <label>=<agent>:"<prompt>" [more...] --background',
+      success: false,
+    };
+  }
+
+  const states = await Promise.all(jobs.map((job) => session.spawnAgentJob(job)));
+  if (options.background) {
+    return {
+      message: [
+        'Started agent jobs:',
+        ...states.map((state) => `${state.label}: ${state.id}`),
+      ].join('\n'),
+      success: true,
+      data: { agentIds: states.map((state) => state.id) },
+    };
+  }
+
+  const results = await Promise.all(states.map((state) => session.waitAgentJob(state.id)));
+  return {
+    message: results.map((result) => result.output).join('\n\n'),
+    success: true,
+    data: { agentIds: states.map((state) => state.id) },
+  };
+}
+
+async function executeRead(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const [agentId, offset] = tokens;
+  if (!agentId) return { message: 'Usage: agent read <agent-id> [offset]', success: false };
+  const cursor = offset ? { offset: Number.parseInt(offset, 10) } : undefined;
+  const page = await session.readBackgroundTaskLog(agentId, cursor);
+  const next = page.nextCursor ? `\nNext offset: ${page.nextCursor.offset}` : '';
+  return {
+    message: page.lines.length > 0 ? `${page.lines.join('\n')}${next}` : `No log lines: ${agentId}`,
+    success: true,
+    data: { agentId, nextOffset: page.nextCursor?.offset },
+  };
+}
+
+async function executeSend(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const [agentId, ...promptParts] = tokens;
+  const prompt = promptParts.join(' ').trim();
+  if (!agentId || !prompt) {
+    return { message: 'Usage: agent send <agent-id> <prompt>', success: false };
+  }
+  await session.sendAgentJob(agentId, prompt);
+  return { message: `Sent input to agent job: ${agentId}`, success: true, data: { agentId } };
+}
+
+async function executeStop(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const [agentId, ...reasonParts] = tokens;
+  if (!agentId) return { message: 'Usage: agent stop <agent-id> [reason]', success: false };
+  await session.cancelAgentJob(agentId, reasonParts.join(' ') || undefined);
+  return { message: `Agent job stopped: ${agentId}`, success: true, data: { agentId } };
+}
+
+async function executeClose(
+  session: InteractiveSession,
+  tokens: readonly string[],
+): Promise<ICommandResult> {
+  const [agentId] = tokens;
+  if (!agentId) return { message: 'Usage: agent close <agent-id>', success: false };
+  await session.closeAgentJob(agentId);
+  return { message: `Agent job closed: ${agentId}`, success: true, data: { agentId } };
+}
+
+export async function executeAgentCommand(
+  session: InteractiveSession,
+  args: string,
+): Promise<ICommandResult> {
+  const [action = 'list', ...tokens] = tokenizeArgs(args);
+  if (action === 'list') return executeList(session);
+  if (action === 'run') return executeRun(session, tokens);
+  if (action === 'parallel') return executeParallel(session, tokens);
+  if (action === 'read' || action === 'open') return executeRead(session, tokens);
+  if (action === 'send') return executeSend(session, tokens);
+  if (action === 'stop' || action === 'cancel') return executeStop(session, tokens);
+  if (action === 'close') return executeClose(session, tokens);
+  return { message: USAGE, success: false };
+}

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -2,9 +2,6 @@ import type { ICommandResult, InteractiveSession } from '@robota-sdk/agent-sdk';
 import { parseParallelRequests, parseRunRequest, tokenizeArgs } from './agent-command-parser.js';
 import type { IAgentRunRequest } from './agent-command-parser.js';
 
-const USAGE =
-  'Usage: agent list | agent run [<agent>] [--agent <agent>] [--background] <prompt> | agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background | agent read <agent-id> [offset] | agent send <agent-id> <prompt> | agent stop <agent-id> [reason] | agent close <agent-id>';
-
 function formatError<TError>(error: TError): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -62,7 +59,7 @@ async function executeRun(
   const request = parseRunRequest(tokens, getAvailableAgentNames(session));
   if (!request) {
     return {
-      message: 'Usage: agent run [<agent>] [--agent <agent>] [--background] <prompt>',
+      message: 'Usage: agent run [<agent>] [--agent <agent>] <prompt>',
       success: false,
     };
   }
@@ -71,24 +68,11 @@ async function executeRun(
   if ('success' in spawned) return spawned;
   const { state } = spawned;
 
-  if (request.mode === 'background') {
-    return {
-      message: `Started agent job: ${state.id}`,
-      success: true,
-      data: { agentId: state.id, status: state.status },
-    };
-  }
-
-  try {
-    const result = await session.waitAgentJob(state.id);
-    return {
-      message: result.output,
-      success: true,
-      data: { agentId: state.id, output: result.output },
-    };
-  } catch (error) {
-    return { message: formatError(error), success: false, data: { agentId: state.id } };
-  }
+  return {
+    message: `Started agent job: ${state.id}`,
+    success: true,
+    data: { agentId: state.id, status: state.status },
+  };
 }
 
 async function executeParallel(
@@ -99,7 +83,7 @@ async function executeParallel(
 
   if (jobs.length === 0) {
     return {
-      message: 'Usage: agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background',
+      message: 'Usage: agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"]',
       success: false,
     };
   }
@@ -116,27 +100,13 @@ async function executeParallel(
     return { message: formatError(error), success: false };
   }
 
-  if (jobs.every((job) => job.mode === 'background')) {
-    return {
-      message: [
-        'Started agent jobs:',
-        ...states.map((state) => `${state.label}: ${state.id}`),
-      ].join('\n'),
-      success: true,
-      data: { agentIds: states.map((state) => state.id) },
-    };
-  }
-
-  try {
-    const results = await Promise.all(states.map((state) => session.waitAgentJob(state.id)));
-    return {
-      message: results.map((result) => result.output).join('\n\n'),
-      success: true,
-      data: { agentIds: states.map((state) => state.id) },
-    };
-  } catch (error) {
-    return { message: formatError(error), success: false };
-  }
+  return {
+    message: ['Started agent jobs:', ...states.map((state) => `${state.label}: ${state.id}`)].join(
+      '\n',
+    ),
+    success: true,
+    data: { agentIds: states.map((state) => state.id) },
+  };
 }
 
 async function executeRead(
@@ -194,14 +164,14 @@ export async function executeAgentCommand(
 ): Promise<ICommandResult> {
   try {
     const [action = 'list', ...tokens] = tokenizeArgs(args);
-    if (action === 'list') return executeList(session);
+    if (action === 'list' && tokens.length === 0) return executeList(session);
     if (action === 'run') return executeRun(session, tokens);
     if (action === 'parallel') return executeParallel(session, tokens);
     if (action === 'read' || action === 'open') return executeRead(session, tokens);
     if (action === 'send') return executeSend(session, tokens);
     if (action === 'stop' || action === 'cancel') return executeStop(session, tokens);
     if (action === 'close') return executeClose(session, tokens);
-    return { message: USAGE, success: false };
+    return executeRun(session, [action, ...tokens]);
   } catch (error) {
     return { message: formatError(error), success: false };
   }

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -5,7 +5,7 @@ import type { IAgentRunRequest } from './agent-command-parser.js';
 const USAGE =
   'Usage: agent list | agent run [<agent>] [--agent <agent>] [--background] <prompt> | agent parallel <label>:"<prompt>" [<label>=<agent>:"<prompt>"] --background | agent read <agent-id> [offset] | agent send <agent-id> <prompt> | agent stop <agent-id> [reason] | agent close <agent-id>';
 
-function formatError(error: unknown): string {
+function formatError<TError>(error: TError): string {
   return error instanceof Error ? error.message : String(error);
 }
 

--- a/packages/agent-command-agent/src/index.ts
+++ b/packages/agent-command-agent/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  AgentCommandSource,
+  createAgentCommandEntry,
+  createAgentCommandModule,
+  createAgentSystemCommand,
+} from './agent-command-module.js';
+export { executeAgentCommand } from './agent-command.js';

--- a/packages/agent-command-agent/tsconfig.json
+++ b/packages/agent-command-agent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/agent-command-agent/tsup.config.ts
+++ b/packages/agent-command-agent/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist/node',
+  format: ['esm', 'cjs'],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  treeshake: true,
+  target: 'node18',
+  platform: 'node',
+  skipNodeModulesBundle: true,
+  external: [/^@robota-sdk\/.*/],
+});

--- a/packages/agent-command-agent/vitest.config.ts
+++ b/packages/agent-command-agent/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/packages/agent-runtime/README.md
+++ b/packages/agent-runtime/README.md
@@ -3,3 +3,5 @@
 Composable runtime primitives for Robota background tasks and subagent orchestration.
 
 This package owns lifecycle/state/port contracts that are reused by SDK assembly, transports, and runtime shells. It does not create providers, sessions, child processes, Git worktrees, or UI state directly.
+
+Background task handles may expose `logPath` and `transcriptPath` for append-only diagnostic streams. The runtime projects those paths into task state so SDK/CLI layers can persist resumable snapshots while high-frequency output stays in JSONL logs.

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -95,6 +95,8 @@ Consumers extend the runtime by implementing ports:
 
 Runtime ports own required shapes. Adapter packages own concrete I/O and must not add global task registries outside `BackgroundTaskManager`.
 
+Runner handles may expose `logPath` and `transcriptPath` for append-only diagnostic streams. `BackgroundTaskManager` projects those paths into task state immediately after runner start and preserves matching result metadata on completion.
+
 ## Error Taxonomy
 
 `BackgroundTaskError` is the package error class for lifecycle and runner failures.

--- a/packages/agent-runtime/src/background-tasks/background-task-manager-helpers.ts
+++ b/packages/agent-runtime/src/background-tasks/background-task-manager-helpers.ts
@@ -60,6 +60,10 @@ export function applyBackgroundTaskResultMetadataToState(
   if (typeof worktreePath === 'string') state.worktreePath = worktreePath;
   const branchName = result.metadata?.['branchName'];
   if (typeof branchName === 'string') state.branchName = branchName;
+  const logPath = result.metadata?.['logPath'];
+  if (typeof logPath === 'string') state.logPath = logPath;
+  const transcriptPath = result.metadata?.['transcriptPath'];
+  if (typeof transcriptPath === 'string') state.transcriptPath = transcriptPath;
 }
 
 export function createQueuedBackgroundTaskState(

--- a/packages/agent-runtime/src/background-tasks/background-task-manager.ts
+++ b/packages/agent-runtime/src/background-tasks/background-task-manager.ts
@@ -190,6 +190,12 @@ export class BackgroundTaskManager implements IBackgroundTaskManager {
       });
       task.handle = handle;
       if (handle.pid) task.state.pid = handle.pid;
+      if (handle.logPath) task.state.logPath = handle.logPath;
+      if (handle.transcriptPath) task.state.transcriptPath = handle.transcriptPath;
+      if (handle.pid || handle.logPath || handle.transcriptPath) {
+        task.state.updatedAt = this.now();
+        this.emit({ type: 'background_task_updated', task: cloneBackgroundTaskState(task.state) });
+      }
       handle.result.then(
         (result) => this.completeTask(task, result),
         (error) => this.failTask(task, error instanceof Error ? error : String(error)),

--- a/packages/agent-runtime/src/background-tasks/types.ts
+++ b/packages/agent-runtime/src/background-tasks/types.ts
@@ -173,6 +173,8 @@ export interface IBackgroundTaskStart {
 export interface IBackgroundTaskHandle {
   readonly taskId: string;
   readonly pid?: number;
+  readonly logPath?: string;
+  readonly transcriptPath?: string;
   result: Promise<IBackgroundTaskResult>;
   cancel(reason?: string): Promise<void>;
   send?(input: IBackgroundTaskInput): Promise<void>;

--- a/packages/agent-runtime/src/subagents/subagent-manager.ts
+++ b/packages/agent-runtime/src/subagents/subagent-manager.ts
@@ -130,6 +130,8 @@ export class SubagentManager implements ISubagentManager {
       branchName: state.branchName,
       promptPreview: state.promptPreview ?? '',
       currentTool: state.currentAction,
+      logPath: state.logPath,
+      transcriptPath: state.transcriptPath,
       startedAt: state.startedAt,
       updatedAt: state.updatedAt,
       completedAt: state.completedAt,
@@ -155,6 +157,8 @@ function createSubagentBackgroundRunner(runner: ISubagentRunner): IBackgroundTas
       const handle: IBackgroundTaskHandle = {
         taskId: task.taskId,
         pid: subagentHandle.pid,
+        logPath: subagentHandle.logPath,
+        transcriptPath: subagentHandle.transcriptPath,
         result: subagentHandle.result.then((result) => toBackgroundResult(result)),
         cancel: (reason?: string) => subagentHandle.cancel(reason),
       };
@@ -162,6 +166,10 @@ function createSubagentBackgroundRunner(runner: ISubagentRunner): IBackgroundTas
       if (subagentHandle.send) {
         const send = subagentHandle.send;
         handle.send = (input) => send(input.prompt ?? '');
+      }
+      if (subagentHandle.readLog) {
+        const readLog = subagentHandle.readLog;
+        handle.readLog = (cursor) => readLog(cursor);
       }
 
       return handle;

--- a/packages/agent-runtime/src/subagents/types.ts
+++ b/packages/agent-runtime/src/subagents/types.ts
@@ -1,5 +1,7 @@
 import type {
   IBackgroundTaskManager,
+  IBackgroundTaskLogCursor,
+  IBackgroundTaskLogPage,
   IBackgroundTaskRunner,
   IBackgroundTaskRequest,
   TBackgroundPrimitive,
@@ -49,6 +51,8 @@ export interface ISubagentJobState {
   branchName?: string;
   promptPreview: string;
   currentTool?: string;
+  logPath?: string;
+  transcriptPath?: string;
   startedAt?: string;
   updatedAt: string;
   completedAt?: string;
@@ -71,9 +75,12 @@ export interface ISubagentJobStart {
 export interface ISubagentJobHandle {
   readonly jobId: string;
   readonly pid?: number;
+  readonly logPath?: string;
+  readonly transcriptPath?: string;
   result: Promise<ISubagentJobResult>;
   cancel(reason?: string): Promise<void>;
   send?(prompt: string): Promise<void>;
+  readLog?(cursor?: IBackgroundTaskLogCursor): Promise<IBackgroundTaskLogPage>;
 }
 
 export interface ISubagentRunner {

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -273,7 +273,7 @@ import { webFetchTool, webSearchTool } from '@robota-sdk/agent-tools';
 
 ## Subagent Sessions
 
-`createSubagentSession()` creates an isolated child session for delegating subtasks. The subagent receives pre-resolved config and context from the parent — it does not load config files or context from disk.
+`createSubagentSession()` creates an isolated child session for delegating subtasks. The subagent receives pre-resolved config and context from the parent — it does not load config files or context from disk. Callers may provide a stable `sessionId` and `sessionLogger` so the child session writes a durable transcript.
 
 ```typescript
 import { createSubagentSession } from '@robota-sdk/agent-sdk';
@@ -295,6 +295,8 @@ Built-in agents: `general-purpose` (full tool access), `Explore` (read-only, Hai
 ### createAgentTool()
 
 `createAgentTool()` wraps subagent creation into a tool the AI can invoke directly. The parent session's hooks, permissions, and context are forwarded to the child.
+
+Background subagent lifecycle events are persisted through `InteractiveSession` when a `SessionStore` is configured. Streaming chunks are written to append-only JSONL logs/transcripts rather than rewriting the main session JSON per token.
 
 ## Hook Executors (SDK-Specific)
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -179,7 +179,7 @@ agent-cli (Ink TUI — CLI-specific)
 
 - **Infrastructure**: `agent-tools` (createZodFunctionTool, FunctionTool, Zod→JSON conversion)
 - **Built-in tools**: `agent-tools/builtins/` — Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
-- **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific)
+- **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific). Registered only when the composed command modules request agent runtime support. The tool description is the owner-provided model contract for direct subagent delegation: explicit subagent requests require a same-turn `Agent` tool call, parallel roles require one tool call per role, omitted `background` means background execution, and pseudo-tags such as `<agent ... />` are not execution.
 - **Tool result type**: `TToolResult` in `agent-tools/types/tool-result.ts`
 
 ### Web Search

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -179,7 +179,7 @@ agent-cli (Ink TUI — CLI-specific)
 
 - **Infrastructure**: `agent-tools` (createZodFunctionTool, FunctionTool, Zod→JSON conversion)
 - **Built-in tools**: `agent-tools/builtins/` — Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
-- **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific). Registered only when the composed command modules request agent runtime support. The tool description is the owner-provided model contract for direct subagent delegation: explicit subagent requests require a same-turn `Agent` tool call, parallel roles require one tool call per role, omitted `background` means background execution, and pseudo-tags such as `<agent ... />` are not execution.
+- **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific). Registered only when the composed command modules request agent runtime support. The tool description is the owner-provided model contract for direct subagent delegation: explicit subagent requests require a same-turn `Agent` tool call, parallel roles require one tool call per role, omitted `background` means background execution, and assistant text alone is not execution.
 - **Tool result type**: `TToolResult` in `agent-tools/types/tool-result.ts`
 
 ### Web Search
@@ -912,6 +912,8 @@ The manager does not create providers, sessions, child processes, worktrees, or 
 
 `InteractiveSession` emits `background_task_event` with `TBackgroundTaskEvent`.
 
+When session persistence is enabled, `InteractiveSession` must persist background task state as part of the project-local session record. Lifecycle, tool start/end, permission, completion, failure, cancellation, and close events update the session JSON with the latest task snapshots and durable event summaries. High-frequency `background_task_text_delta` events must not rewrite the main session JSON per chunk; they are written to append-only JSONL session logs and task/subagent transcript files so debugging data is available while streaming is still in progress without risking partial JSON writes.
+
 `createSession()` accepts `backgroundTaskRunners?: IBackgroundTaskRunner[]`. When a runner with `kind: 'process'` is present, SDK composition registers the model-callable `BackgroundProcess` tool:
 
 - `BackgroundProcess` starts a command as `kind: 'process'`, `mode: 'background'`
@@ -927,6 +929,7 @@ Runner progress semantics:
 - `background_task_tool_start` sets `IBackgroundTaskState.currentAction`
 - `background_task_tool_end` clears `currentAction` on success or stores the error/action on failure
 - progress events do not complete, fail, cancel, or close tasks; lifecycle remains manager-owned
+- progress and lifecycle events are diagnostic data, not just UI state; SDK composition must route them to session logging/persistence when those facilities are configured
 
 The built-in `/background` system command maps to these APIs:
 
@@ -971,13 +974,16 @@ interface ISubagentJobStart {
 interface ISubagentJobHandle {
   readonly jobId: string;
   readonly pid?: number;
+  readonly logPath?: string;
+  readonly transcriptPath?: string;
   result: Promise<ISubagentJobResult>;
   cancel(reason?: string): Promise<void>;
   send?(prompt: string): Promise<void>;
+  readLog?(cursor?: IBackgroundTaskLogCursor): Promise<IBackgroundTaskLogPage>;
 }
 ```
 
-The runner reports completion through its `result` promise and supports targeted cancellation through `cancel()`. Follow-up routing via `send()` is optional until a runner supports it.
+The runner reports completion through its `result` promise and supports targeted cancellation through `cancel()`. Follow-up routing via `send()` is optional until a runner supports it. Log reading via `readLog()` is optional, but process-backed subagent runners should implement it so `/agent read AGENT_ID` can inspect append-only transcripts while a job is still running.
 
 `createInProcessSubagentRunner(deps)` is the default SDK adapter for foreground compatibility. It resolves the requested agent definition, creates an isolated child `Session` with `createSubagentSession()`, runs the prompt, and maps the response to `ISubagentJobResult`.
 
@@ -1083,7 +1089,9 @@ Assembles the full system prompt for a subagent session:
 
 ### Subagent Transcript Logger
 
-`createSubagentLogger(parentSessionId, agentId, baseLogsDir)` creates a `FileSessionLogger` that writes subagent session logs to `{baseLogsDir}/{parentSessionId}/subagents/{agentId}.jsonl`.
+`createSubagentLogger(parentSessionId, agentId, baseLogsDir)` creates a `FileSessionLogger` for append-only subagent transcripts. Subagent sessions must run with `sessionId = agentId`, so the transcript is written to `{baseLogsDir}/{parentSessionId}/subagents/{agentId}.jsonl`.
+
+Subagent transcript logs must include session initialization, prompts, tool calls/results, streaming `text_delta` chunks, final assistant output, context state, and errors. Parent sessions may store only transcript paths and task snapshots in `.robota/sessions/*.json`; the transcript JSONL remains the source of truth for high-frequency streaming data.
 
 ## Unconnected Packages (Future Integration Targets)
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -27,15 +27,21 @@ agent-provider-*     ← provider implementations (unchanged)
 agent-sdk            ← InteractiveSession (single entry point)
   ├── embedded: SystemCommandExecutor (session.executeCommand())
   ├── embedded: CommandRegistry, BuiltinCommandSource, SkillCommandSource, PluginCommandSource
-  ├── embedded: Agent tool + AgentDefinitionLoader for model-requested delegation
+  ├── extension: ICommandModule command/source/session-requirement injection
+  ├── optional: Agent tool + AgentDefinitionLoader when a module requests agent-runtime
   ├── composed: agent-runtime BackgroundTaskManager, SubagentManager, runner ports
   ├── internal: createSession(), createDefaultTools(), loadConfig(), loadContext()
   ├── exposed: createQuery({ provider }) → (prompt) => result
   └── NO provider dependency (provider-neutral)
 
+agent-command-*      ← optional command modules
+  ├── consumes SDK command interfaces
+  └── NO dependency from agent-sdk back to command modules
+
 agent-cli            ← minimal TUI
   ├── creates provider (reads config, picks provider package)
-  ├── creates InteractiveSession({ cwd, provider })
+  ├── selects product-default command modules such as @robota-sdk/agent-command-agent
+  ├── creates InteractiveSession({ cwd, provider, commandModules })
   ├── subscribes to events → renders to terminal
   └── owns: slash prefix parsing, Ink components, paste handling, CJK input
 ```
@@ -64,7 +70,7 @@ Session  (agent-sessions — generic run loop)
 Robota engine + Provider  (agent-core / agent-provider-*)
 
 agent-cli (Ink TUI — thin bridge layer)
-    creates provider → passes to InteractiveSession({ cwd, provider })
+    creates provider → passes to InteractiveSession({ cwd, provider, commandModules })
     subscribes to InteractiveSession events → maps to React/Ink state
     routes /commands → session.executeCommand()
 ```
@@ -73,15 +79,16 @@ The SDK layer has **no React dependency** and **no provider dependency**. The CL
 
 ### Package Roles
 
-| Package               | Role                                                                                                       | General/Specialized |
-| --------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------- |
-| **agent-core**        | Robota engine, execution loop, provider abstraction, permissions, hooks                                    | General             |
-| **agent-runtime**     | Background task and subagent lifecycle primitives, runner ports, worktree runner decorator                 | General             |
-| **agent-tools**       | Tool creation infrastructure + 8 built-in tools                                                            | General             |
-| **agent-sessions**    | Generic Session class, SessionStore (persistence)                                                          | General             |
-| **agent-sdk**         | Assembly layer: InteractiveSession (single entry point), embedded commands, createQuery(), config, context | SDK-specific        |
-| **agent-cli**         | Ink TUI (terminal UI). Creates provider, passes to InteractiveSession. No agent-sessions import.           | CLI-specific        |
-| **agent-provider-\*** | AI provider implementations. CLI depends on these directly; SDK does not.                                  | Provider-specific   |
+| Package               | Role                                                                                                                                     | General/Specialized |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **agent-core**        | Robota engine, execution loop, provider abstraction, permissions, hooks                                                                  | General             |
+| **agent-runtime**     | Background task and subagent lifecycle primitives, runner ports, worktree runner decorator                                               | General             |
+| **agent-tools**       | Tool creation infrastructure + 8 built-in tools                                                                                          | General             |
+| **agent-sessions**    | Generic Session class, SessionStore (persistence)                                                                                        | General             |
+| **agent-sdk**         | Assembly layer: InteractiveSession (single entry point), embedded commands, createQuery(), config, context                               | SDK-specific        |
+| **agent-command-\***  | Optional command modules that consume SDK command interfaces and can be selected by composition roots                                    | Command-specific    |
+| **agent-cli**         | Ink TUI and product composition. Creates provider, selects command modules, passes both to InteractiveSession. No agent-sessions import. | CLI-specific        |
+| **agent-provider-\*** | AI provider implementations. CLI depends on these directly; SDK does not.                                                                | Provider-specific   |
 
 ### Feature Layout (Current Implementation State)
 
@@ -118,7 +125,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── builtin-source.ts       ← BuiltinCommandSource: built-in commands
 │   ├── skill-source.ts         ← SkillCommandSource: discovers SKILL.md files
 │   ├── plugin-source.ts        ← PluginCommandSource: discovers plugin commands (moved from agent-cli)
-│   ├── system-command.ts       ← SystemCommandExecutor + ISystemCommand + createSystemCommands() (internal)
+│   ├── system-command.ts       ← SystemCommandExecutor + ISystemCommand + createSystemCommands()
 │   └── types.ts                ← ICommand, ICommandSource
 ├── src/assembly/               ← Session factory: createSession (internal), createDefaultTools (internal)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
@@ -192,12 +199,12 @@ agent-cli (Ink TUI — CLI-specific)
 
 - **Package**: `agent-sdk/interactive/`
 - **Pattern**: Composition over Session (holds a `Session` instance, does not extend it)
-- **Constructor**: Accepts `{ cwd, provider }` only. Config and context are loaded internally from `cwd`.
+- **Constructor**: Accepts `{ cwd, provider }` plus optional composition inputs such as `commandModules`. Config and context are loaded internally from `cwd`.
 - **Responsibility**: Streaming accumulation, tool state tracking, prompt queue (max 1), abort orchestration, full history management (`IHistoryEntry[]`), embedded command execution
 - **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. The `tool-summary` entry (aggregated) is still pushed at execution completion for backward compatibility.
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
-- **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Replaces direct `SystemCommandExecutor` usage by consumers.
+- **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Core commands are always present; additional command modules may contribute more commands.
 - **listCommands()**: `listCommands()` — returns `Array<{ name, description }>` of all registered system commands. Used by transport adapters (e.g., MCP) to expose commands as tools.
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued. The queued prompt auto-executes after the current one completes. Only one prompt can be queued at a time.
 - **Abort**: `abort()` clears the queue and delegates to `session.abort()`. An `interrupted` event fires when the abort completes.
@@ -213,12 +220,13 @@ agent-cli (Ink TUI — CLI-specific)
 
 - **Package**: `agent-sdk/commands/`
 - **Purpose**: SDK-level command execution logic — pure TypeScript, no React, no TUI dependency
-- **Embedding**: `SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers call `session.executeCommand(name, args)` directly. `SystemCommandExecutor` is not independently exported.
+- **Embedding**: `SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers normally call `session.executeCommand(name, args)` directly. `SystemCommandExecutor` and `createSystemCommands()` are exported so independent command modules can compose and test against the same command contract.
 - **Classes**:
   - `SystemCommandExecutor` — registry + executor for `ISystemCommand` instances (internal to InteractiveSession)
   - `createSystemCommands()` — factory for all built-in commands (internal)
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional `data`. Side effects that require caller context (file I/O for `reset`, model switching for `model`) are signaled via `data` — the caller applies them.
-- **Built-in commands**: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `resume`, `rename`, `reset`
+- **Core built-in commands**: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `resume`, `rename`, `reset`
+- **Command modules**: Optional `ICommandModule` instances may contribute `ICommandSource` palette metadata, `ISystemCommand` handlers, model-visible descriptors, and session requirements. The SDK does not know command names contributed by modules in advance.
 
 ### Slash Command Registry (SDK-Specific)
 
@@ -520,7 +528,7 @@ Consumers that need only AI messages call `getMessages()` (returns `TUniversalMe
 
 ### System Commands — Embedded in InteractiveSession
 
-`SystemCommandExecutor` is embedded inside `InteractiveSession` and is **not independently exported**. Consumers access system commands via `session.executeCommand(name, args)`.
+`SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers access system commands via `session.executeCommand(name, args)`. Command module packages may import `ISystemCommand`, `ICommandModule`, `SystemCommandExecutor`, and `createSystemCommands()` for composition tests.
 
 The command types and result interface are exported for consumers that need to inspect results:
 
@@ -557,9 +565,27 @@ const result: ICommandResult | null = await session.executeCommand('context', ''
 interface ISystemCommand {
   name: string;
   description: string;
+  modelInvocable?: boolean;
+  userInvocable?: boolean;
+  argumentHint?: string;
+  safety?: TCapabilitySafety;
   execute(session: InteractiveSession, args: string): Promise<ICommandResult> | ICommandResult;
 }
 ```
+
+**ICommandModule:**
+
+```typescript
+interface ICommandModule {
+  name: string;
+  commandSources?: readonly ICommandSource[];
+  systemCommands?: readonly ISystemCommand[];
+  commandDescriptors?: readonly ICapabilityDescriptor[];
+  sessionRequirements?: readonly TCommandModuleSessionRequirement[];
+}
+```
+
+`sessionRequirements` is how command modules request optional SDK wiring. The current requirement is `agent-runtime`, which enables `Agent` tool registration, agent definitions, and the shared background/subagent managers.
 
 **ICommandResult:**
 
@@ -573,7 +599,7 @@ interface ICommandResult {
 
 ### CommandRegistry, BuiltinCommandSource, SkillCommandSource, PluginCommandSource
 
-Command discovery and aggregation for clients that expose a slash command palette or autocomplete UI. Owned by `agent-sdk`; agent-cli re-exports `CommandRegistry` from here. `PluginCommandSource` was moved from `agent-cli` to `agent-sdk` so all clients benefit from plugin command discovery.
+Command discovery and aggregation for clients that expose a slash command palette or autocomplete UI. Owned by `agent-sdk`; agent-cli re-exports `CommandRegistry` from here. `PluginCommandSource` was moved from `agent-cli` to `agent-sdk` so all clients benefit from plugin command discovery. Command modules can be added through `registry.addModule(module)` without the registry knowing their command names.
 
 ```typescript
 import {
@@ -585,6 +611,7 @@ import {
 
 const registry = new CommandRegistry();
 registry.addSource(new BuiltinCommandSource());
+registry.addModule(commandModule);
 registry.addSource(new SkillCommandSource(process.cwd()));
 
 registry.getCommands(); // ICommand[] — all commands
@@ -721,19 +748,19 @@ These rules define which packages each layer is allowed to import from. Violatio
 
 Each module's placement is determined by "Is this used only in the SDK, or is it general-purpose?":
 
-| Module                 | Verdict                      | Rationale                                                                            |
-| ---------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
-| Permissions            | **General** → agent-core     | Tool permission checks are needed on servers too                                     |
-| Hooks                  | **General** → agent-core     | Audit/validation is needed on servers too                                            |
-| Built-in tools         | **General** → agent-tools    | File system tools are needed in playground/server environments too                   |
-| Session                | **General** → agent-sessions | Session management is needed in any environment                                      |
-| Config loading         | **SDK-specific** → agent-sdk | `.robota/settings.json` is for local environments only                               |
-| Context loading        | **SDK-specific** → agent-sdk | AGENTS.md walk-up is for local environments only                                     |
-| Agent tool             | **SDK-specific** → agent-sdk | Sub-session creation is an SDK assembly concern                                      |
-| InteractiveSession     | **SDK-specific** → agent-sdk | Client-facing event wrapper; no CLI/React dependency; reusable by all clients        |
-| SystemCommandExecutor  | **SDK-specific** → agent-sdk | Embedded in InteractiveSession; accessed via session.executeCommand(); not exported  |
-| CommandRegistry et al. | **SDK-specific** → agent-sdk | Slash command discovery is useful for any client; moved from CLI to SDK              |
-| ITerminalOutput        | **General** → agent-sessions | Terminal I/O abstraction (SSOT in permission-enforcer.ts; agent-cli has a duplicate) |
+| Module                 | Verdict                      | Rationale                                                                                                            |
+| ---------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Permissions            | **General** → agent-core     | Tool permission checks are needed on servers too                                                                     |
+| Hooks                  | **General** → agent-core     | Audit/validation is needed on servers too                                                                            |
+| Built-in tools         | **General** → agent-tools    | File system tools are needed in playground/server environments too                                                   |
+| Session                | **General** → agent-sessions | Session management is needed in any environment                                                                      |
+| Config loading         | **SDK-specific** → agent-sdk | `.robota/settings.json` is for local environments only                                                               |
+| Context loading        | **SDK-specific** → agent-sdk | AGENTS.md walk-up is for local environments only                                                                     |
+| Agent tool             | **SDK-specific** → agent-sdk | Sub-session creation is an SDK assembly concern                                                                      |
+| InteractiveSession     | **SDK-specific** → agent-sdk | Client-facing event wrapper; no CLI/React dependency; reusable by all clients                                        |
+| SystemCommandExecutor  | **SDK-specific** → agent-sdk | Embedded in InteractiveSession; accessed via session.executeCommand(); exported for command module composition tests |
+| CommandRegistry et al. | **SDK-specific** → agent-sdk | Slash command discovery is useful for any client; moved from CLI to SDK                                              |
+| ITerminalOutput        | **General** → agent-sessions | Terminal I/O abstraction (SSOT in permission-enforcer.ts; agent-cli has a duplicate)                                 |
 
 ### Existing Package Refactoring History
 
@@ -824,9 +851,9 @@ Bundle plugins package reusable extensions (tools, hooks, permissions, system pr
 
 Skills discovered from skill directories are exposed to the system prompt by metadata only: name and description. Full `SKILL.md` content is loaded only when a skill is invoked. Skills with `disable-model-invocation: true` are omitted from model-visible metadata.
 
-Agent definitions are also exposed to the system prompt by metadata only: name and description. The system prompt instructs the model to use the `Agent` tool when the user explicitly requests delegation, asks to call an agent, or when a task should be isolated into a separate context. The model must pass the selected agent name through `subagent_type`.
+Agent definitions are exposed to the system prompt by metadata only when an injected command module requests `agent-runtime`. Without that session requirement, `Agent` tool registration, agent definitions, and model-visible agent metadata are omitted.
 
-The `Agent` tool must be part of the available tool set and must be described in `DEFAULT_TOOL_DESCRIPTIONS`.
+When enabled, the `Agent` tool is part of the available tool set and is described in tool descriptors.
 
 The `Agent` tool routes execution through a per-session `SubagentManager`, which delegates to the shared `BackgroundTaskManager` for `kind: 'agent'` tasks. It resolves unknown agent types before spawning so existing error results remain compatible.
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -157,7 +157,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Package**: `agent-sessions` (generic, depends only on agent-core)
 - **Implementation**: Session accepts pre-constructed tools, provider, and system message. Internal concerns are delegated to PermissionEnforcer, ContextWindowTracker, and CompactionOrchestrator.
 - **Assembly**: `agent-sdk/assembly/` provides `createSession()` (internal — not exported) which wires tools, provider, and system prompt from config/context. Consumers use `InteractiveSession({ cwd, provider })` instead.
-- **Persistence**: SessionStore saves/loads/lists/deletes JSON at `~/.robota/sessions/{id}.json`
+- **Persistence**: `SessionStore` defaults to `~/.robota/sessions/{id}.json` for generic consumers. CLI composition injects a project-local `.robota/sessions` directory so project runs keep resumable session JSON beside project logs.
 
 ### Permission System
 
@@ -209,7 +209,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued. The queued prompt auto-executes after the current one completes. Only one prompt can be queued at a time.
 - **Abort**: `abort()` clears the queue and delegates to `session.abort()`. An `interrupted` event fires when the abort completes.
 - **No-op terminal**: Uses a built-in NOOP_TERMINAL so no `ITerminalOutput` implementation is required by callers
-- **Session persistence**: When `sessionStore` is provided in options, auto-persists session state (messages, history, cwd, timestamps) to disk after each `submit()` completion. Uses `SessionStore` from `agent-sessions`.
+- **Session persistence**: When `sessionStore` is provided in options, auto-persists session state (messages, history, cwd, timestamps, system prompt, tool schemas) to disk after each `submit()` completion. Uses `SessionStore` from `agent-sessions`. `messages` remains the replay source for context restoration; `systemPrompt` and `toolSchemas` are duplicated top-level diagnostic fields.
 - **Session restore**: When `resumeSessionId` is provided, loads the saved session record and restores AI context. Messages are stored as `pendingRestoreMessages` and injected via `session.injectMessage()` after async initialization completes (deferred injection pattern). This avoids injection failures caused by the Session not yet being fully initialized when the constructor runs.
 - **forkSession option**: `forkSession?: boolean` (default `false`). When `false` (resume), the original session ID is passed to the Session constructor so it reuses the same file. When `true` (fork), `sessionId` is omitted, generating a fresh UUID — the original session remains untouched.
 - **getName()/setName(name)**: Get or set the session's user-facing name. Persists to the session record when a store is configured.

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -264,6 +264,11 @@ describe('createSession — appendSystemPrompt option', () => {
       const opts = sessionCtorCalls[0]!;
       const systemMessage = opts.systemMessage as string;
       expect(systemMessage).toContain('Agent — launch an isolated agent');
+      expect(systemMessage).toContain('one Agent tool call per role');
+      expect(systemMessage).toContain('choose one backlog');
+      expect(systemMessage).toContain('Korean example');
+      expect(systemMessage).toContain('백로그 중에 하나');
+      expect(systemMessage).toContain('<agent');
       expect(systemMessage).toContain('- reviewer: Reviews code for risks and missing tests');
     } finally {
       rmSync(cwd, { recursive: true, force: true });

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -268,7 +268,7 @@ describe('createSession — appendSystemPrompt option', () => {
       expect(systemMessage).toContain('choose one backlog');
       expect(systemMessage).toContain('Korean example');
       expect(systemMessage).toContain('백로그 중에 하나');
-      expect(systemMessage).toContain('<agent');
+      expect(systemMessage).not.toContain('<agent');
       expect(systemMessage).toContain('- reviewer: Reviews code for risks and missing tests');
     } finally {
       rmSync(cwd, { recursive: true, force: true });

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -218,7 +218,23 @@ describe('createSession — appendSystemPrompt option', () => {
     expect(systemMessage.endsWith(extraText)).toBe(true);
   });
 
-  it('includes Agent tool and discovered agent metadata in the system prompt', async () => {
+  it('does not include Agent tool or agent metadata unless agent runtime is enabled', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+    });
+
+    const opts = sessionCtorCalls[0]!;
+    const systemMessage = opts.systemMessage as string;
+    expect(systemMessage).not.toContain('Agent — launch an isolated agent');
+    expect(systemMessage).not.toContain('general-purpose');
+  });
+
+  it('includes Agent tool and discovered agent metadata when agent runtime is enabled', async () => {
     const { createSession } = await import('../assembly/create-session.js');
     const cwd = mkdtempSync(join(tmpdir(), 'robota-create-session-agents-'));
     const agentsDir = join(cwd, '.robota', 'agents');
@@ -242,6 +258,7 @@ describe('createSession — appendSystemPrompt option', () => {
         context: { agentsMd: '', claudeMd: '' },
         terminal: MOCK_TERMINAL,
         provider: createMockProvider(),
+        enableAgentRuntime: true,
       });
 
       const opts = sessionCtorCalls[0]!;
@@ -271,6 +288,7 @@ describe('createSession — subagent runner factory option', () => {
       terminal: MOCK_TERMINAL,
       provider: createMockProvider(),
       subagentRunnerFactory,
+      enableAgentRuntime: true,
     });
 
     expect(subagentRunnerFactory).toHaveBeenCalledTimes(1);

--- a/packages/agent-sdk/src/__tests__/cross-package-hooks.test.ts
+++ b/packages/agent-sdk/src/__tests__/cross-package-hooks.test.ts
@@ -371,7 +371,7 @@ describe('Cross-package: BundlePlugin -> system prompt', () => {
 
     const prompt = buildSystemPrompt(params);
 
-    expect(prompt).toContain('## Skills');
+    expect(prompt).toContain('## Capabilities');
     expect(prompt).toContain('deploy');
     expect(prompt).toContain('Deploy application to production');
   });

--- a/packages/agent-sdk/src/__tests__/cross-package-skills.test.ts
+++ b/packages/agent-sdk/src/__tests__/cross-package-skills.test.ts
@@ -84,7 +84,7 @@ describe('Cross-package: skill discovery -> system prompt', () => {
 
     const prompt = buildSystemPrompt(params);
 
-    expect(prompt).toContain('## Skills');
+    expect(prompt).toContain('## Capabilities');
     expect(prompt).toContain('my-skill');
     expect(prompt).toContain('A custom development skill');
   });
@@ -301,7 +301,7 @@ describe('Cross-package: BundlePlugin -> CLI commands', () => {
       skills,
     });
 
-    expect(prompt).toContain('## Skills');
+    expect(prompt).toContain('## Capabilities');
     expect(prompt).toContain('summarize');
     expect(prompt).toContain('(ai-tools) Summarize text');
   });

--- a/packages/agent-sdk/src/__tests__/grep-tool.test.ts
+++ b/packages/agent-sdk/src/__tests__/grep-tool.test.ts
@@ -131,11 +131,7 @@ describe('GrepTool', () => {
 
   it('content mode shows -- separator between non-adjacent context blocks', async () => {
     const filePath = join(tmpDir, 'separated.txt');
-    await writeFile(
-      filePath,
-      'match1\na\nb\nc\nd\ne\nf\nmatch2\n',
-      'utf8',
-    );
+    await writeFile(filePath, 'match1\na\nb\nc\nd\ne\nf\nmatch2\n', 'utf8');
 
     const result = await run({
       pattern: 'match',

--- a/packages/agent-sdk/src/__tests__/history-cross-package.test.ts
+++ b/packages/agent-sdk/src/__tests__/history-cross-package.test.ts
@@ -37,6 +37,8 @@ function createMockSession(options?: {
     getSessionAllowedTools: vi.fn().mockReturnValue([]),
     compact: vi.fn(),
     injectMessage: vi.fn(),
+    getSystemMessage: vi.fn().mockReturnValue('mock system prompt'),
+    getToolSchemas: vi.fn().mockReturnValue([]),
   };
 }
 

--- a/packages/agent-sdk/src/__tests__/paths.test.ts
+++ b/packages/agent-sdk/src/__tests__/paths.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import { projectPaths } from '../paths.js';
+
+describe('projectPaths', () => {
+  it('places logs and resumable sessions under the project .robota directory', () => {
+    const cwd = join('tmp', 'robota-project');
+
+    expect(projectPaths(cwd).logs).toBe(join(cwd, '.robota', 'logs'));
+    expect(projectPaths(cwd).sessions).toBe(join(cwd, '.robota', 'sessions'));
+  });
+});

--- a/packages/agent-sdk/src/__tests__/session-store.test.ts
+++ b/packages/agent-sdk/src/__tests__/session-store.test.ts
@@ -45,11 +45,27 @@ describe('SessionStore', () => {
           { role: 'user', content: 'hello' },
           { role: 'assistant', content: 'world' },
         ],
+        systemPrompt: 'system prompt with /agent capability',
+        toolSchemas: [
+          {
+            name: 'ExecuteCommand',
+            description: 'Execute commands',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
       });
       store.save(record);
       const loaded = store.load(record.id);
       expect(loaded?.messages).toHaveLength(2);
       expect(loaded?.name).toBe('My Session');
+      expect(loaded?.systemPrompt).toBe('system prompt with /agent capability');
+      expect(loaded?.toolSchemas).toEqual([
+        {
+          name: 'ExecuteCommand',
+          description: 'Execute commands',
+          parameters: { type: 'object', properties: {} },
+        },
+      ]);
     });
 
     it('overwrites an existing session on re-save', () => {

--- a/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
@@ -105,19 +105,19 @@ describe('buildSystemPrompt', () => {
         ],
       });
 
-      expect(result).toContain('The following skills are available');
+      expect(result).toContain('## Capabilities');
       expect(result).toContain('my-skill: Does useful things');
       expect(result).not.toContain('hidden');
     });
 
     it('should not include skills section when no skills provided', () => {
       const result = buildSystemPrompt({ ...BASE_PARAMS });
-      expect(result).not.toContain('The following skills are available');
+      expect(result).not.toContain('## Capabilities');
     });
 
     it('should not include skills section when skills array is empty', () => {
       const result = buildSystemPrompt({ ...BASE_PARAMS, skills: [] });
-      expect(result).not.toContain('The following skills are available');
+      expect(result).not.toContain('## Capabilities');
     });
 
     it('should not include skills section when all skills are model-invocation disabled', () => {
@@ -125,7 +125,7 @@ describe('buildSystemPrompt', () => {
         ...BASE_PARAMS,
         skills: [{ name: 'hidden', description: 'Secret', disableModelInvocation: true }],
       });
-      expect(result).not.toContain('The following skills are available');
+      expect(result).not.toContain('## Capabilities');
     });
 
     it('should include multiple invocable skills', () => {
@@ -149,14 +149,14 @@ describe('buildSystemPrompt', () => {
       });
 
       const toolsIdx = result.indexOf('## Available Tools');
-      const skillsIdx = result.indexOf('The following skills are available');
+      const skillsIdx = result.indexOf('## Capabilities');
       expect(toolsIdx).toBeGreaterThanOrEqual(0);
       expect(skillsIdx).toBeGreaterThan(toolsIdx);
     });
   });
 
   describe('System prompt agent injection', () => {
-    it('should include available agents and Agent tool guidance', () => {
+    it('should include available agents as capability descriptors', () => {
       const result = buildSystemPrompt({
         ...BASE_PARAMS,
         agents: [
@@ -165,16 +165,14 @@ describe('buildSystemPrompt', () => {
         ],
       });
 
-      expect(result).toContain('## Subagents');
-      expect(result).toContain('Agent tool');
-      expect(result).toContain('subagent_type');
+      expect(result).toContain('## Capabilities');
       expect(result).toContain('- general-purpose: General task execution');
       expect(result).toContain('- Explore: Read-only exploration');
     });
 
     it('should not include agents section when no agents are provided', () => {
       const result = buildSystemPrompt({ ...BASE_PARAMS, agents: [] });
-      expect(result).not.toContain('## Subagents');
+      expect(result).not.toContain('## Capabilities');
     });
   });
 });

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -31,12 +31,17 @@ import { createAgentTool, storeAgentToolDeps } from '../tools/agent-tool.js';
 import type { IAgentToolDeps } from '../tools/agent-tool.js';
 import { createBackgroundProcessTool } from '../tools/background-process-tool.js';
 import type { IBackgroundProcessToolDeps } from '../tools/background-process-tool.js';
-import { SubagentManager } from '@robota-sdk/agent-runtime';
+import { createCommandExecutionTool } from '../tools/command-execution-tool.js';
+import type { ICommandResult } from '../commands/system-command.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import { BackgroundTaskManager, SubagentManager } from '@robota-sdk/agent-runtime';
 import { createInProcessSubagentRunner } from '../subagents/in-process-subagent-runner.js';
 import type { TSubagentRunnerFactory } from '../subagents/in-process-subagent-runner.js';
 import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
+import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
-import type { IBackgroundTaskRunner } from '../background-tasks/index.js';
+import type { IBackgroundTaskManager, IBackgroundTaskRunner } from '../background-tasks/index.js';
+import { storeSessionBackgroundTaskManager } from '../background-tasks/session-background-store.js';
 
 /** Options for the createSession factory */
 export interface ICreateSessionOptions {
@@ -74,6 +79,8 @@ export interface ICreateSessionOptions {
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   /** Runtime shell override for subagent execution. Defaults to the SDK in-process runner. */
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  /** Enable agent tool, agent definitions, and subagent runtime wiring for this session. */
+  enableAgentRuntime?: boolean;
   /** Callback when a tool starts or finishes execution — enables real-time tool display in UI */
   onToolExecution?: (event: {
     type: 'start' | 'end';
@@ -103,6 +110,12 @@ export interface ICreateSessionOptions {
   allowedTools?: string[];
   /** Text to append to the generated system prompt. */
   appendSystemPrompt?: string;
+  /** Model command execution bridge. */
+  modelCommandExecutor?: (command: string, args: string) => Promise<ICommandResult | null>;
+  /** Predicate for commands allowed through the model command execution bridge. */
+  isModelCommandInvocable?: (command: string) => boolean;
+  /** Model-visible command descriptors. */
+  commandDescriptors?: ICapabilityDescriptor[];
 }
 
 /**
@@ -122,10 +135,14 @@ export function createSession(options: ICreateSessionOptions): Session {
 
   const defaultTools = createDefaultTools();
   const tools = [...defaultTools, ...(options.additionalTools ?? [])];
-
-  // Wire agent tool — create a fresh instance with deps captured in closure.
-  // Must happen after default tools are assembled so sub-agents inherit the full set.
-  const agentLoader = new AgentDefinitionLoader(cwd);
+  if (options.modelCommandExecutor && options.isModelCommandInvocable) {
+    tools.push(
+      createCommandExecutionTool({
+        execute: options.modelCommandExecutor,
+        isModelInvocable: options.isModelCommandInvocable,
+      }),
+    );
+  }
 
   // Build hook type executors early so they can be forwarded to subagents.
   const hookTypeExecutors: IHookTypeExecutor[] = [];
@@ -148,40 +165,69 @@ export function createSession(options: ICreateSessionOptions): Session {
     hookTypeExecutors.push(...options.additionalHookExecutors);
   }
 
-  const agentToolDeps: IAgentToolDeps = {
-    config: options.config,
-    context: options.context,
-    tools,
-    terminal: options.terminal,
-    provider,
-    cwd,
-    parentSessionId: options.sessionId ?? 'pending-session',
-    permissionMode: options.permissionMode,
-    permissionHandler: options.permissionHandler,
-    hooks: options.config.hooks,
-    hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
-    onTextDelta: options.onTextDelta,
-    onToolExecution: options.onToolExecution,
-    customAgentRegistry: (name: string) => agentLoader.getAgent(name),
-  };
-  const subagentManager = new SubagentManager({
-    runner: (options.subagentRunnerFactory ?? createInProcessSubagentRunner)(agentToolDeps),
-    backgroundTaskRunners: options.backgroundTaskRunners,
-  });
-  agentToolDeps.subagentManager = subagentManager;
-  agentToolDeps.backgroundTaskManager = subagentManager.getBackgroundTaskManager();
+  let agentToolDeps: IAgentToolDeps | undefined;
+  let agentDefinitions: IAgentDefinition[] = [];
+  let backgroundTaskManager: IBackgroundTaskManager | undefined;
+
+  if (options.enableAgentRuntime) {
+    // Wire agent tool only when the caller composes the agent capability module.
+    // Must happen after default tools are assembled so sub-agents inherit the full set.
+    const agentLoader = new AgentDefinitionLoader(cwd);
+    agentDefinitions = agentLoader.loadAll();
+    agentToolDeps = {
+      config: options.config,
+      context: options.context,
+      tools,
+      terminal: options.terminal,
+      provider,
+      cwd,
+      parentSessionId: options.sessionId ?? 'pending-session',
+      permissionMode: options.permissionMode,
+      permissionHandler: options.permissionHandler,
+      hooks: options.config.hooks,
+      hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
+      onTextDelta: options.onTextDelta,
+      onToolExecution: options.onToolExecution,
+      customAgentRegistry: (name: string) => agentLoader.getAgent(name),
+      agentDefinitions,
+    };
+    const subagentManager = new SubagentManager({
+      runner: (options.subagentRunnerFactory ?? createInProcessSubagentRunner)(agentToolDeps),
+      backgroundTaskRunners: options.backgroundTaskRunners,
+    });
+    agentToolDeps.subagentManager = subagentManager;
+    backgroundTaskManager = subagentManager.getBackgroundTaskManager();
+    agentToolDeps.backgroundTaskManager = backgroundTaskManager;
+  } else {
+    backgroundTaskManager = new BackgroundTaskManager({
+      runners: options.backgroundTaskRunners ?? [],
+    });
+  }
+
   let backgroundProcessToolDeps: IBackgroundProcessToolDeps | undefined;
-  if (options.backgroundTaskRunners?.some((runner) => runner.kind === 'process')) {
+  if (
+    backgroundTaskManager &&
+    options.backgroundTaskRunners?.some((runner) => runner.kind === 'process')
+  ) {
     backgroundProcessToolDeps = {
-      backgroundTaskManager: subagentManager.getBackgroundTaskManager(),
+      backgroundTaskManager,
       cwd,
       parentSessionId: options.sessionId ?? 'pending-session',
     };
     tools.push(createBackgroundProcessTool(backgroundProcessToolDeps));
   }
-  tools.push(createAgentTool(agentToolDeps));
+  if (agentToolDeps) {
+    tools.push(createAgentTool(agentToolDeps));
+  }
 
   const buildPrompt = options.systemPromptBuilder ?? buildSystemPrompt;
+  const defaultToolDescriptions = [
+    ...DEFAULT_TOOL_DESCRIPTIONS,
+    ...(agentToolDeps ? ['Agent — launch an isolated agent for delegated work'] : []),
+    ...(options.modelCommandExecutor
+      ? ['ExecuteCommand — execute model-invocable Robota commands']
+      : []),
+  ];
   const systemMessage = buildPrompt({
     agentsMd: options.context.agentsMd,
     claudeMd: options.context.claudeMd,
@@ -189,10 +235,10 @@ export function createSession(options: ICreateSessionOptions): Session {
       options.toolDescriptions ??
       (backgroundProcessToolDeps
         ? [
-            ...DEFAULT_TOOL_DESCRIPTIONS,
+            ...defaultToolDescriptions,
             'BackgroundProcess — start long-running shell commands as managed background tasks',
           ]
-        : DEFAULT_TOOL_DESCRIPTIONS),
+        : defaultToolDescriptions),
     trustLevel: options.config.defaultTrustLevel,
     projectInfo: options.projectInfo ?? { type: 'unknown', language: 'unknown' },
     cwd,
@@ -202,10 +248,15 @@ export function createSession(options: ICreateSessionOptions): Session {
       description: skill.description,
       disableModelInvocation: skill.disableModelInvocation,
     })),
-    agents: agentLoader.loadAll().map((agent) => ({
-      name: agent.name,
-      description: agent.description,
-    })),
+    ...(agentDefinitions.length > 0
+      ? {
+          agents: agentDefinitions.map((agent) => ({
+            name: agent.name,
+            description: agent.description,
+          })),
+        }
+      : {}),
+    commandDescriptors: options.commandDescriptors ?? [],
   });
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`
@@ -251,9 +302,10 @@ export function createSession(options: ICreateSessionOptions): Session {
 
   // Store deps keyed by session so consumers (e.g. fork runner) can retrieve
   // per-session deps without relying on global mutable state.
-  agentToolDeps.parentSessionId = session.getSessionId();
+  if (agentToolDeps) agentToolDeps.parentSessionId = session.getSessionId();
   if (backgroundProcessToolDeps) backgroundProcessToolDeps.parentSessionId = session.getSessionId();
-  storeAgentToolDeps(session, agentToolDeps);
+  if (backgroundTaskManager) storeSessionBackgroundTaskManager(session, backgroundTaskManager);
+  if (agentToolDeps) storeAgentToolDeps(session, agentToolDeps);
 
   return session;
 }

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -27,7 +27,11 @@ import { buildSystemPrompt } from '../context/system-prompt-builder.js';
 import type { ISystemPromptParams } from '../context/system-prompt-builder.js';
 import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
 
-import { createAgentTool, storeAgentToolDeps } from '../tools/agent-tool.js';
+import {
+  createAgentTool,
+  createAgentToolPromptDescription,
+  storeAgentToolDeps,
+} from '../tools/agent-tool.js';
 import type { IAgentToolDeps } from '../tools/agent-tool.js';
 import { createBackgroundProcessTool } from '../tools/background-process-tool.js';
 import type { IBackgroundProcessToolDeps } from '../tools/background-process-tool.js';
@@ -223,7 +227,7 @@ export function createSession(options: ICreateSessionOptions): Session {
   const buildPrompt = options.systemPromptBuilder ?? buildSystemPrompt;
   const defaultToolDescriptions = [
     ...DEFAULT_TOOL_DESCRIPTIONS,
-    ...(agentToolDeps ? ['Agent — launch an isolated agent for delegated work'] : []),
+    ...(agentToolDeps ? [createAgentToolPromptDescription(agentDefinitions)] : []),
     ...(options.modelCommandExecutor
       ? ['ExecuteCommand — execute model-invocable Robota commands']
       : []),

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -44,8 +44,15 @@ import type { TSubagentRunnerFactory } from '../subagents/in-process-subagent-ru
 import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
 import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
-import type { IBackgroundTaskManager, IBackgroundTaskRunner } from '../background-tasks/index.js';
+import type {
+  IBackgroundTaskManager,
+  IBackgroundTaskRunner,
+  TBackgroundTaskEvent,
+} from '../background-tasks/index.js';
 import { storeSessionBackgroundTaskManager } from '../background-tasks/session-background-store.js';
+
+const ID_RADIX = 36;
+const ID_RANDOM_LENGTH = 9;
 
 /** Options for the createSession factory */
 export interface ICreateSessionOptions {
@@ -136,6 +143,7 @@ export function createSession(options: ICreateSessionOptions): Session {
   }
   const provider = options.provider;
   const cwd = options.cwd ?? process.cwd();
+  const sessionId = options.sessionId ?? createSessionId();
 
   const defaultTools = createDefaultTools();
   const tools = [...defaultTools, ...(options.additionalTools ?? [])];
@@ -185,7 +193,7 @@ export function createSession(options: ICreateSessionOptions): Session {
       terminal: options.terminal,
       provider,
       cwd,
-      parentSessionId: options.sessionId ?? 'pending-session',
+      parentSessionId: sessionId,
       permissionMode: options.permissionMode,
       permissionHandler: options.permissionHandler,
       hooks: options.config.hooks,
@@ -207,6 +215,12 @@ export function createSession(options: ICreateSessionOptions): Session {
       runners: options.backgroundTaskRunners ?? [],
     });
   }
+  const sessionLogger = options.sessionLogger;
+  if (backgroundTaskManager && sessionLogger) {
+    backgroundTaskManager.subscribe((event) =>
+      logBackgroundTaskEvent(sessionLogger, sessionId, event),
+    );
+  }
 
   let backgroundProcessToolDeps: IBackgroundProcessToolDeps | undefined;
   if (
@@ -216,7 +230,7 @@ export function createSession(options: ICreateSessionOptions): Session {
     backgroundProcessToolDeps = {
       backgroundTaskManager,
       cwd,
-      parentSessionId: options.sessionId ?? 'pending-session',
+      parentSessionId: sessionId,
     };
     tools.push(createBackgroundProcessTool(backgroundProcessToolDeps));
   }
@@ -293,7 +307,7 @@ export function createSession(options: ICreateSessionOptions): Session {
     model: options.config.provider.model,
     maxTurns: options.maxTurns,
     sessionStore: options.sessionStore,
-    sessionId: options.sessionId,
+    sessionId,
     permissionHandler: options.permissionHandler,
     onTextDelta: options.onTextDelta,
     onToolExecution: options.onToolExecution,
@@ -312,4 +326,19 @@ export function createSession(options: ICreateSessionOptions): Session {
   if (agentToolDeps) storeAgentToolDeps(session, agentToolDeps);
 
   return session;
+}
+
+function createSessionId(): string {
+  return `session_${Date.now()}_${Math.random().toString(ID_RADIX).substr(2, ID_RANDOM_LENGTH)}`;
+}
+
+function logBackgroundTaskEvent(
+  logger: ISessionLogger,
+  sessionId: string,
+  event: TBackgroundTaskEvent,
+): void {
+  logger.log(sessionId, 'background_task_event', {
+    backgroundEventType: event.type,
+    backgroundEvent: event,
+  });
 }

--- a/packages/agent-sdk/src/assembly/create-subagent-session.ts
+++ b/packages/agent-sdk/src/assembly/create-subagent-session.ts
@@ -10,7 +10,11 @@
 import type { IToolWithEventService, IHookTypeExecutor } from '@robota-sdk/agent-core';
 import type { TPermissionMode, TToolArgs } from '@robota-sdk/agent-core';
 import { Session } from '@robota-sdk/agent-sessions';
-import type { ITerminalOutput, TPermissionHandler } from '@robota-sdk/agent-sessions';
+import type {
+  ISessionLogger,
+  ITerminalOutput,
+  TPermissionHandler,
+} from '@robota-sdk/agent-sessions';
 import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import type { IResolvedConfig } from '../config/config-types.js';
 import type { ILoadedContext } from '../context/context-loader.js';
@@ -38,6 +42,10 @@ export interface ISubagentOptions {
   provider: IAIProvider;
   /** Terminal output interface. */
   terminal: ITerminalOutput;
+  /** Stable session ID for transcript files. */
+  sessionId?: string;
+  /** Optional logger for subagent transcripts. */
+  sessionLogger?: ISessionLogger;
   /** Whether this is a fork worker (uses fork suffix instead of standard). */
   isForkWorker?: boolean;
   /** Permission mode from parent (bypassPermissions, acceptEdits, etc.). */
@@ -131,6 +139,8 @@ export function createSubagentSession(options: ISubagentOptions): Session {
     provider,
     systemMessage,
     terminal,
+    ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
+    ...(options.sessionLogger !== undefined ? { sessionLogger: options.sessionLogger } : {}),
     model,
     maxTurns: agentDefinition.maxTurns,
     permissions: parentConfig.permissions,

--- a/packages/agent-sdk/src/assembly/create-tools.ts
+++ b/packages/agent-sdk/src/assembly/create-tools.ts
@@ -23,7 +23,6 @@ export const DEFAULT_TOOL_DESCRIPTIONS = [
   'Glob — find files matching a pattern',
   'Grep — search file contents with regex',
   'WebSearch — search the internet (Anthropic built-in)',
-  'Agent — launch an isolated agent for delegated work',
 ];
 
 /**

--- a/packages/agent-sdk/src/background-tasks/session-background-store.ts
+++ b/packages/agent-sdk/src/background-tasks/session-background-store.ts
@@ -1,0 +1,16 @@
+import type { IBackgroundTaskManager } from './index.js';
+
+const sessionBackgroundTaskManagers = new WeakMap<object, IBackgroundTaskManager>();
+
+export function storeSessionBackgroundTaskManager(
+  key: object,
+  manager: IBackgroundTaskManager,
+): void {
+  sessionBackgroundTaskManagers.set(key, manager);
+}
+
+export function retrieveSessionBackgroundTaskManager(
+  key: object,
+): IBackgroundTaskManager | undefined {
+  return sessionBackgroundTaskManagers.get(key);
+}

--- a/packages/agent-sdk/src/capabilities/types.ts
+++ b/packages/agent-sdk/src/capabilities/types.ts
@@ -1,0 +1,13 @@
+export type TCapabilityKind = 'builtin-command' | 'skill' | 'agent' | 'tool';
+
+export type TCapabilitySafety = 'read-only' | 'write' | 'process' | 'network' | 'background-agent';
+
+export interface ICapabilityDescriptor {
+  readonly name: string;
+  readonly kind: TCapabilityKind;
+  readonly description: string;
+  readonly userInvocable: boolean;
+  readonly modelInvocable: boolean;
+  readonly argumentHint?: string;
+  readonly safety?: TCapabilitySafety;
+}

--- a/packages/agent-sdk/src/commands/__tests__/command-registry.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/command-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { BuiltinCommandSource } from '../builtin-source.js';
+import { CommandRegistry } from '../command-registry.js';
+import type { ICommandModule } from '../command-module.js';
+
+describe('CommandRegistry capability descriptors', () => {
+  it('does not project /agent from core built-ins when the agent source is not composed', () => {
+    const registry = new CommandRegistry();
+    registry.addSource(new BuiltinCommandSource());
+
+    const descriptors = registry.getCapabilityDescriptors();
+    const agent = descriptors.find((descriptor) => descriptor.name === '/agent');
+
+    expect(agent).toBeUndefined();
+  });
+
+  it('does not expose ordinary built-ins as model-invocable commands', () => {
+    const registry = new CommandRegistry();
+    registry.addSource(new BuiltinCommandSource());
+
+    const descriptors = registry.getCapabilityDescriptors();
+    const reset = descriptors.find((descriptor) => descriptor.name === '/reset');
+
+    expect(reset?.modelInvocable).toBe(false);
+  });
+
+  it('projects capabilities from any injected command module', () => {
+    const module: ICommandModule = {
+      name: 'diagnostics-command',
+      commandSources: [
+        {
+          name: 'diagnostics',
+          getCommands: () => [
+            {
+              name: 'diagnose',
+              description: 'Run read-only diagnostics for the current workspace',
+              source: 'diagnostics',
+              modelInvocable: true,
+              argumentHint: '[scope]',
+              safety: 'read-only',
+            },
+          ],
+        },
+      ],
+    };
+    const registry = new CommandRegistry();
+
+    registry.addModule(module);
+
+    expect(registry.getCommands().map((command) => command.name)).toEqual(['diagnose']);
+    expect(registry.getCapabilityDescriptors()).toEqual([
+      {
+        name: '/diagnose',
+        kind: 'builtin-command',
+        description: 'Run read-only diagnostics for the current workspace',
+        userInvocable: true,
+        modelInvocable: true,
+        argumentHint: '[scope]',
+        safety: 'read-only',
+      },
+    ]);
+  });
+});

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SystemCommandExecutor, createSystemCommands } from '../system-command.js';
 import type { InteractiveSession } from '../../interactive/interactive-session.js';
+import type { ICommandModule } from '../command-module.js';
 
 function createMockSession(overrides?: Record<string, unknown>) {
   const underlying = {
@@ -20,6 +21,27 @@ function createMockSession(overrides?: Record<string, unknown>) {
     cancelBackgroundTask: vi.fn(),
     closeBackgroundTask: vi.fn(),
     readBackgroundTaskLog: vi.fn().mockResolvedValue({ taskId: 'agent_1', lines: [] }),
+    spawnAgentJob: vi.fn().mockResolvedValue({
+      id: 'agent_1',
+      type: 'Plan',
+      label: 'Plan',
+      parentSessionId: 'test-session-id',
+      status: 'running',
+      mode: 'background',
+      depth: 1,
+      cwd: '/workspace',
+      promptPreview: 'draft architecture',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    }),
+    waitAgentJob: vi.fn(),
+    listAgentJobs: vi.fn().mockReturnValue([]),
+    listAgentDefinitions: vi.fn().mockReturnValue([
+      { name: 'general-purpose', description: 'General-purpose task execution agent.' },
+      { name: 'Plan', description: 'Read-only planning agent.' },
+    ]),
+    sendAgentJob: vi.fn(),
+    cancelAgentJob: vi.fn(),
+    closeAgentJob: vi.fn(),
     ...overrides,
   };
 
@@ -30,6 +52,13 @@ function createMockSession(overrides?: Record<string, unknown>) {
     cancelBackgroundTask: underlying.cancelBackgroundTask,
     closeBackgroundTask: underlying.closeBackgroundTask,
     readBackgroundTaskLog: underlying.readBackgroundTaskLog,
+    spawnAgentJob: underlying.spawnAgentJob,
+    waitAgentJob: underlying.waitAgentJob,
+    listAgentJobs: underlying.listAgentJobs,
+    listAgentDefinitions: underlying.listAgentDefinitions,
+    sendAgentJob: underlying.sendAgentJob,
+    cancelAgentJob: underlying.cancelAgentJob,
+    closeAgentJob: underlying.closeAgentJob,
     _underlying: underlying,
   } as unknown as InteractiveSession;
 }
@@ -42,6 +71,15 @@ describe('SystemCommandExecutor', () => {
     expect(commands.map((c) => c.name)).toContain('help');
     expect(commands.map((c) => c.name)).toContain('clear');
     expect(commands.map((c) => c.name)).toContain('mode');
+  });
+
+  it('does not expose model-invocable commands from the core command set', () => {
+    const executor = new SystemCommandExecutor();
+    const modelCommands = executor.listModelInvocableCommands();
+
+    expect(modelCommands).toEqual([]);
+    expect(executor.isModelInvocable('agent')).toBe(false);
+    expect(executor.isModelInvocable('reset')).toBe(false);
   });
 
   it('returns null for unknown command', async () => {
@@ -221,5 +259,53 @@ describe('SystemCommandExecutor', () => {
     expect(executor.hasCommand('custom')).toBe(true);
     const result = await executor.execute('custom', createMockSession(), '');
     expect(result!.message).toBe('custom result');
+  });
+
+  it('executes arbitrary injected command modules without knowing their names in SDK core', async () => {
+    const module: ICommandModule = {
+      name: 'diagnostics-command',
+      systemCommands: [
+        {
+          name: 'diagnose',
+          description: 'Run read-only diagnostics for the current workspace',
+          modelInvocable: true,
+          safety: 'read-only',
+          execute: (_session, args) => ({
+            message: `diagnosed ${args}`,
+            success: true,
+            data: { scope: args },
+          }),
+        },
+      ],
+    };
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+
+    expect(executor.hasCommand('agent')).toBe(false);
+    expect(executor.hasCommand('diagnose')).toBe(true);
+    expect(executor.listModelInvocableCommands()).toEqual([
+      {
+        name: '/diagnose',
+        kind: 'builtin-command',
+        description: 'Run read-only diagnostics for the current workspace',
+        userInvocable: true,
+        modelInvocable: true,
+        safety: 'read-only',
+      },
+    ]);
+
+    const result = await executor.executeModelInvocable(
+      'diagnose',
+      createMockSession(),
+      'workspace',
+    );
+
+    expect(result).toEqual({
+      message: 'diagnosed workspace',
+      success: true,
+      data: { scope: 'workspace' },
+    });
   });
 });

--- a/packages/agent-sdk/src/commands/capability-descriptors.ts
+++ b/packages/agent-sdk/src/commands/capability-descriptors.ts
@@ -1,0 +1,23 @@
+import type { ICapabilityDescriptor, TCapabilityKind } from '../capabilities/types.js';
+import type { ICommand } from './types.js';
+
+function inferKind(command: ICommand): TCapabilityKind {
+  if (command.source === 'skill') return 'skill';
+  if (command.source === 'plugin' && command.skillContent) return 'skill';
+  return 'builtin-command';
+}
+
+export function commandToCapabilityDescriptor(command: ICommand): ICapabilityDescriptor {
+  const skillLike =
+    command.source === 'skill' || (command.source === 'plugin' && Boolean(command.skillContent));
+  return {
+    name: `/${command.name}`,
+    kind: inferKind(command),
+    description: command.description,
+    userInvocable: command.userInvocable !== false,
+    modelInvocable:
+      command.modelInvocable === true || (skillLike && command.disableModelInvocation !== true),
+    ...(command.argumentHint ? { argumentHint: command.argumentHint } : {}),
+    ...(command.safety ? { safety: command.safety } : {}),
+  };
+}

--- a/packages/agent-sdk/src/commands/command-module.ts
+++ b/packages/agent-sdk/src/commands/command-module.ts
@@ -1,0 +1,19 @@
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import type { ICommandSource } from './types.js';
+import type { ISystemCommand } from './system-command.js';
+
+export type TCommandModuleSessionRequirement = 'agent-runtime';
+
+/** Composable command capability module. */
+export interface ICommandModule {
+  /** Stable module id for diagnostics and duplicate handling. */
+  readonly name: string;
+  /** Slash palette/autocomplete command sources contributed by this module. */
+  readonly commandSources?: readonly ICommandSource[];
+  /** Executable system commands contributed by this module. */
+  readonly systemCommands?: readonly ISystemCommand[];
+  /** Additional model-visible descriptors not derived from executable commands. */
+  readonly commandDescriptors?: readonly ICapabilityDescriptor[];
+  /** Runtime facilities required by this module. */
+  readonly sessionRequirements?: readonly TCommandModuleSessionRequirement[];
+}

--- a/packages/agent-sdk/src/commands/command-registry.ts
+++ b/packages/agent-sdk/src/commands/command-registry.ts
@@ -1,4 +1,7 @@
 import type { ICommandSource, ICommand } from './types.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import { commandToCapabilityDescriptor } from './capability-descriptors.js';
+import type { ICommandModule } from './command-module.js';
 
 /** Aggregates commands from multiple sources */
 export class CommandRegistry {
@@ -6,6 +9,12 @@ export class CommandRegistry {
 
   addSource(source: ICommandSource): void {
     this.sources.push(source);
+  }
+
+  addModule(module: ICommandModule): void {
+    for (const source of module.commandSources ?? []) {
+      this.addSource(source);
+    }
   }
 
   /** Get all commands, optionally filtered by prefix */
@@ -39,5 +48,9 @@ export class CommandRegistry {
       }
     }
     return [];
+  }
+
+  getCapabilityDescriptors(): ICapabilityDescriptor[] {
+    return this.getCommands().map((command) => commandToCapabilityDescriptor(command));
   }
 }

--- a/packages/agent-sdk/src/commands/index.ts
+++ b/packages/agent-sdk/src/commands/index.ts
@@ -1,6 +1,8 @@
 export type { ICommand, ICommandSource } from './types.js';
+export type { ICommandModule, TCommandModuleSessionRequirement } from './command-module.js';
 export { CommandRegistry } from './command-registry.js';
 export { BuiltinCommandSource } from './builtin-source.js';
+export { commandToCapabilityDescriptor } from './capability-descriptors.js';
 export { SkillCommandSource, parseFrontmatter } from './skill-source.js';
 export { PluginCommandSource } from './plugin-source.js';
 export { SystemCommandExecutor, createSystemCommands } from './system-command.js';

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -7,6 +7,7 @@
  */
 
 import type { TPermissionMode } from '@robota-sdk/agent-core';
+import type { ICapabilityDescriptor, TCapabilitySafety } from '../capabilities/types.js';
 import type { InteractiveSession } from '../interactive/interactive-session.js';
 import { executeBackgroundCommand } from './background-command.js';
 
@@ -24,6 +25,10 @@ export interface ICommandResult {
 export interface ISystemCommand {
   name: string;
   description: string;
+  modelInvocable?: boolean;
+  userInvocable?: boolean;
+  argumentHint?: string;
+  safety?: TCapabilitySafety;
   execute(session: InteractiveSession, args: string): Promise<ICommandResult> | ICommandResult;
 }
 
@@ -263,6 +268,33 @@ export class SystemCommandExecutor {
   /** List all registered commands. */
   listCommands(): ISystemCommand[] {
     return [...this.commands.values()];
+  }
+
+  listModelInvocableCommands(): ICapabilityDescriptor[] {
+    return this.listCommands()
+      .filter((command) => command.modelInvocable === true)
+      .map((command) => ({
+        name: `/${command.name}`,
+        kind: 'builtin-command',
+        description: command.description,
+        userInvocable: command.userInvocable !== false,
+        modelInvocable: true,
+        ...(command.argumentHint ? { argumentHint: command.argumentHint } : {}),
+        ...(command.safety ? { safety: command.safety } : {}),
+      }));
+  }
+
+  isModelInvocable(name: string): boolean {
+    return this.commands.get(name)?.modelInvocable === true;
+  }
+
+  async executeModelInvocable(
+    name: string,
+    session: InteractiveSession,
+    args: string,
+  ): Promise<ICommandResult | null> {
+    if (!this.isModelInvocable(name)) return null;
+    return this.execute(name, session, args);
   }
 
   /** Check if a command exists. */

--- a/packages/agent-sdk/src/commands/types.ts
+++ b/packages/agent-sdk/src/commands/types.ts
@@ -1,3 +1,5 @@
+import type { TCapabilitySafety } from '../capabilities/types.js';
+
 /** A command entry */
 export interface ICommand {
   /** Command name without slash (e.g., "mode") */
@@ -16,8 +18,12 @@ export interface ICommand {
   argumentHint?: string;
   /** When true, models cannot invoke this skill autonomously */
   disableModelInvocation?: boolean;
+  /** When true, models may invoke this command through the command execution tool */
+  modelInvocable?: boolean;
   /** When false, users cannot invoke this skill directly */
   userInvocable?: boolean;
+  /** Safety category for model-visible capability descriptors */
+  safety?: TCapabilitySafety;
   /** List of tools this skill is allowed to use */
   allowedTools?: string[];
   /** Preferred model for executing this skill */

--- a/packages/agent-sdk/src/context/__tests__/system-prompt-composer.test.ts
+++ b/packages/agent-sdk/src/context/__tests__/system-prompt-composer.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { composeSystemPrompt } from '../system-prompt-composer.js';
+import { createCapabilitySection } from '../system-prompt-section-providers.js';
+import type { ISystemPromptSection } from '../system-prompt-types.js';
+
+describe('system prompt composer', () => {
+  it('orders and joins supplied sections without adding behavior text', () => {
+    const sections: ISystemPromptSection[] = [
+      {
+        id: 'late',
+        title: 'Late',
+        priority: 20,
+        content: 'Second',
+        source: 'runtime',
+      },
+      {
+        id: 'early',
+        title: 'Early',
+        priority: 10,
+        content: 'First',
+        source: 'framework',
+      },
+    ];
+
+    const prompt = composeSystemPrompt(sections);
+
+    expect(prompt).toBe('## Early\nFirst\n\n## Late\nSecond');
+    expect(prompt).not.toContain('coding assistant');
+    expect(prompt).not.toContain('web_search');
+    expect(prompt).not.toContain('Agent tool');
+  });
+
+  it('renders registered capabilities without composer changes', () => {
+    const section = createCapabilitySection([
+      {
+        name: '/agent',
+        kind: 'builtin-command',
+        description: 'Start, inspect, steer, stop, and close subagent jobs.',
+        userInvocable: true,
+        modelInvocable: true,
+        argumentHint: 'run <agent> --background <prompt>',
+        safety: 'background-agent',
+      },
+    ]);
+
+    const prompt = composeSystemPrompt([section]);
+
+    expect(prompt).toContain('/agent');
+    expect(prompt).toContain('Start, inspect, steer, stop, and close subagent jobs.');
+    expect(prompt).toContain('run <agent> --background <prompt>');
+  });
+});

--- a/packages/agent-sdk/src/context/__tests__/system-prompt-composer.test.ts
+++ b/packages/agent-sdk/src/context/__tests__/system-prompt-composer.test.ts
@@ -38,7 +38,7 @@ describe('system prompt composer', () => {
         description: 'Start, inspect, steer, stop, and close subagent jobs.',
         userInvocable: true,
         modelInvocable: true,
-        argumentHint: 'run <agent> --background <prompt>',
+        argumentHint: 'run AGENT_NAME --background PROMPT',
         safety: 'background-agent',
       },
     ]);
@@ -47,6 +47,6 @@ describe('system prompt composer', () => {
 
     expect(prompt).toContain('/agent');
     expect(prompt).toContain('Start, inspect, steer, stop, and close subagent jobs.');
-    expect(prompt).toContain('run <agent> --background <prompt>');
+    expect(prompt).toContain('run AGENT_NAME --background PROMPT');
   });
 });

--- a/packages/agent-sdk/src/context/system-prompt-builder.ts
+++ b/packages/agent-sdk/src/context/system-prompt-builder.ts
@@ -1,10 +1,19 @@
-/**
- * System prompt builder — assembles the system message sent to the AI model
- * from base role, project context, AGENTS.md/CLAUDE.md, tool list, and
- * permission trust level.
- */
-import type { IProjectInfo } from './project-detector.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
 import type { TTrustLevel } from '../types.js';
+import type { IProjectInfo } from './project-detector.js';
+import { composeSystemPrompt } from './system-prompt-composer.js';
+import {
+  createAgentsMdSection,
+  createCapabilitySection,
+  createClaudeMdSection,
+  createFrameworkSection,
+  createPermissionSection,
+  createProjectSection,
+  createProviderWebSearchSection,
+  createToolDescriptionSection,
+  createWorkingDirectorySection,
+} from './system-prompt-section-providers.js';
+import type { ISystemPromptSection } from './system-prompt-types.js';
 
 export interface ISystemPromptParams {
   /** Concatenated AGENTS.md content (may be empty string) */
@@ -25,155 +34,63 @@ export interface ISystemPromptParams {
   skills?: Array<{ name: string; description: string; disableModelInvocation?: boolean }>;
   /** Discovered agents to expose in the system prompt */
   agents?: Array<{ name: string; description: string }>;
+  /** Command descriptors to expose to the model */
+  commandDescriptors?: ICapabilityDescriptor[];
 }
 
-const TRUST_LEVEL_DESCRIPTIONS: Record<TTrustLevel, string> = {
-  safe: 'safe (read-only / plan mode — only read-access tools are available)',
-  moderate: 'moderate (default mode — write and bash tools require approval)',
-  full: 'full (acceptEdits mode — file writes are auto-approved; bash requires approval)',
-};
-
-function buildProjectSection(info: IProjectInfo): string {
-  const lines: string[] = ['## Current Project'];
-  if (info.name !== undefined) {
-    lines.push(`- **Name:** ${info.name}`);
-  }
-  if (info.type !== 'unknown') {
-    lines.push(`- **Type:** ${info.type}`);
-  }
-  if (info.language !== 'unknown') {
-    lines.push(`- **Language:** ${info.language}`);
-  }
-  if (info.packageManager !== undefined) {
-    lines.push(`- **Package manager:** ${info.packageManager}`);
-  }
-  return lines.join('\n');
-}
-
-function buildToolsSection(descriptions: string[]): string {
-  if (descriptions.length === 0) {
-    return '';
-  }
-  const lines = ['## Available Tools', ...descriptions.map((d) => `- ${d}`)];
-  return lines.join('\n');
-}
-
-/**
- * Assemble the full system prompt string from the provided parameters.
- */
-function buildSkillsSection(
-  skills: Array<{ name: string; description: string; disableModelInvocation?: boolean }>,
-): string {
-  const invocable = skills.filter((s) => s.disableModelInvocation !== true);
-  if (invocable.length === 0) {
-    return '';
-  }
-  const lines = [
-    '## Skills',
-    'The following skills are available:',
-    '',
-    ...invocable.map((s) => `- ${s.name}: ${s.description}`),
-  ];
-  return lines.join('\n');
-}
-
-function buildAgentsSection(agents: Array<{ name: string; description: string }>): string {
-  if (agents.length === 0) {
-    return '';
-  }
-  const lines = [
-    '## Subagents',
-    'You can launch isolated agents with the Agent tool.',
-    'Use the Agent tool when the user explicitly asks to call an agent, asks you to delegate work, or a task should run in an isolated context.',
-    'Pass the selected agent name as subagent_type and summarize the returned result for the user.',
-    '',
-    'Available agents:',
-    ...agents.map((agent) => `- ${agent.name}: ${agent.description}`),
-  ];
-  return lines.join('\n');
-}
-
-function appendSection(sections: string[], section: string): void {
-  if (section.length > 0) {
-    sections.push(section);
-  }
-}
-
-function appendModelVisibleMetadataSections(
-  sections: string[],
-  params: Pick<ISystemPromptParams, 'skills' | 'agents'>,
+function appendOptionalSection(
+  sections: ISystemPromptSection[],
+  section: ISystemPromptSection | undefined,
 ): void {
-  if (params.skills !== undefined && params.skills.length > 0) {
-    appendSection(sections, buildSkillsSection(params.skills));
-  }
-  if (params.agents !== undefined && params.agents.length > 0) {
-    appendSection(sections, buildAgentsSection(params.agents));
-  }
+  if (section !== undefined) sections.push(section);
+}
+
+function mapSkillDescriptors(
+  skills: NonNullable<ISystemPromptParams['skills']>,
+): ICapabilityDescriptor[] {
+  return skills.map((skill) => ({
+    name: skill.name,
+    kind: 'skill',
+    description: skill.description,
+    userInvocable: true,
+    modelInvocable: skill.disableModelInvocation !== true,
+  }));
+}
+
+function mapAgentDescriptors(
+  agents: NonNullable<ISystemPromptParams['agents']>,
+): ICapabilityDescriptor[] {
+  return agents.map((agent) => ({
+    name: agent.name,
+    kind: 'agent',
+    description: agent.description,
+    userInvocable: false,
+    modelInvocable: true,
+    safety: 'background-agent',
+  }));
+}
+
+function buildCapabilityDescriptors(params: ISystemPromptParams): ICapabilityDescriptor[] {
+  return [
+    ...(params.commandDescriptors ?? []),
+    ...(params.skills ? mapSkillDescriptors(params.skills) : []),
+    ...(params.agents ? mapAgentDescriptors(params.agents) : []),
+  ];
 }
 
 export function buildSystemPrompt(params: ISystemPromptParams): string {
-  const { agentsMd, claudeMd, toolDescriptions, trustLevel, projectInfo, cwd, language } = params;
-
-  const sections: string[] = [];
-
-  // Base role
-  const roleLines = [
-    '## Role',
-    'You are an AI coding assistant with access to tools that let you read and modify code.',
-    'You help developers understand, write, and improve their codebase.',
-    'Always be precise, follow existing code conventions, and prefer minimal changes.',
+  const sections: ISystemPromptSection[] = [
+    createFrameworkSection(params.language),
+    createProjectSection(params.projectInfo),
+    createPermissionSection(params.trustLevel),
+    createProviderWebSearchSection(),
   ];
-  if (language) {
-    roleLines.push(
-      `Always respond in ${language}. Use ${language} for all explanations and communications.`,
-    );
-  }
-  sections.push(roleLines.join('\n'));
 
-  // Working directory
-  if (cwd) {
-    sections.push(`## Working Directory\n\`${cwd}\``);
-  }
+  appendOptionalSection(sections, createWorkingDirectorySection(params.cwd));
+  appendOptionalSection(sections, createAgentsMdSection(params.agentsMd));
+  appendOptionalSection(sections, createClaudeMdSection(params.claudeMd));
+  appendOptionalSection(sections, createToolDescriptionSection(params.toolDescriptions));
+  appendOptionalSection(sections, createCapabilitySection(buildCapabilityDescriptors(params)));
 
-  // Project information
-  sections.push(buildProjectSection(projectInfo));
-
-  // Permission trust level
-  sections.push(
-    [
-      '## Permission Mode',
-      `Your current trust level is **${TRUST_LEVEL_DESCRIPTIONS[trustLevel]}**.`,
-    ].join('\n'),
-  );
-
-  // AGENTS.md — project/repo-level instructions
-  if (agentsMd.trim().length > 0) {
-    sections.push(['## Agent Instructions', agentsMd].join('\n'));
-  }
-
-  // CLAUDE.md — additional project notes
-  if (claudeMd.trim().length > 0) {
-    sections.push(['## Project Notes', claudeMd].join('\n'));
-  }
-
-  // Web search capability
-  sections.push(
-    [
-      '## Web Search',
-      'You have access to web search. When the user asks to search, look up, or find current/latest information,',
-      'you MUST use the web_search tool. Do NOT answer from training data when the user explicitly asks to search.',
-      'Always prefer web search for: news, latest versions, current events, live documentation.',
-    ].join('\n'),
-  );
-
-  // Tool list
-  const toolsSection = buildToolsSection(toolDescriptions);
-  if (toolsSection.length > 0) {
-    sections.push(toolsSection);
-  }
-
-  // Skills list
-  appendModelVisibleMetadataSections(sections, params);
-
-  return sections.join('\n\n');
+  return composeSystemPrompt(sections);
 }

--- a/packages/agent-sdk/src/context/system-prompt-composer.ts
+++ b/packages/agent-sdk/src/context/system-prompt-composer.ts
@@ -1,0 +1,15 @@
+import type { ISystemPromptSection } from './system-prompt-types.js';
+
+function renderSection(section: ISystemPromptSection): string {
+  const content = section.content.trim();
+  if (!section.title) return content;
+  return [`## ${section.title}`, content].join('\n');
+}
+
+export function composeSystemPrompt(sections: readonly ISystemPromptSection[]): string {
+  return [...sections]
+    .filter((section) => section.content.trim().length > 0)
+    .sort((a, b) => a.priority - b.priority || a.id.localeCompare(b.id))
+    .map((section) => renderSection(section))
+    .join('\n\n');
+}

--- a/packages/agent-sdk/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-sdk/src/context/system-prompt-section-providers.ts
@@ -1,0 +1,129 @@
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import type { TTrustLevel } from '../types.js';
+import type { IProjectInfo } from './project-detector.js';
+import type { ISystemPromptSection } from './system-prompt-types.js';
+
+const TRUST_LEVEL_DESCRIPTIONS: Record<TTrustLevel, string> = {
+  safe: 'safe (read-only / plan mode - only read-access tools are available)',
+  moderate: 'moderate (default mode - write and bash tools require approval)',
+  full: 'full (acceptEdits mode - file writes are auto-approved; bash requires approval)',
+};
+
+function createSection(
+  id: string,
+  title: string | undefined,
+  priority: number,
+  content: string,
+  source: ISystemPromptSection['source'],
+): ISystemPromptSection {
+  return { id, title, priority, content, source };
+}
+
+export function createFrameworkSection(language?: string): ISystemPromptSection {
+  const lines = [
+    'You are an AI coding assistant with access to tools that let you read and modify code.',
+    'You help developers understand, write, and improve their codebase.',
+    'Always be precise, follow existing code conventions, and prefer minimal changes.',
+  ];
+  if (language) {
+    lines.push(
+      `Always respond in ${language}. Use ${language} for all explanations and communications.`,
+    );
+  }
+  return createSection('framework-role', 'Role', 10, lines.join('\n'), 'framework');
+}
+
+export function createWorkingDirectorySection(cwd?: string): ISystemPromptSection | undefined {
+  if (!cwd) return undefined;
+  return createSection('runtime-cwd', 'Working Directory', 20, `\`${cwd}\``, 'runtime');
+}
+
+export function createProjectSection(info: IProjectInfo): ISystemPromptSection {
+  const lines: string[] = [];
+  if (info.name !== undefined) {
+    lines.push(`- **Name:** ${info.name}`);
+  }
+  if (info.type !== 'unknown') {
+    lines.push(`- **Type:** ${info.type}`);
+  }
+  if (info.language !== 'unknown') {
+    lines.push(`- **Language:** ${info.language}`);
+  }
+  if (info.packageManager !== undefined) {
+    lines.push(`- **Package manager:** ${info.packageManager}`);
+  }
+  return createSection('runtime-project', 'Current Project', 30, lines.join('\n'), 'runtime');
+}
+
+export function createPermissionSection(trustLevel: TTrustLevel): ISystemPromptSection {
+  return createSection(
+    'permission-mode',
+    'Permission Mode',
+    35,
+    `Your current trust level is **${TRUST_LEVEL_DESCRIPTIONS[trustLevel]}**.`,
+    'permissions',
+  );
+}
+
+export function createAgentsMdSection(agentsMd: string): ISystemPromptSection | undefined {
+  if (agentsMd.trim().length === 0) return undefined;
+  return createSection(
+    'project-agents-md',
+    'Agent Instructions',
+    40,
+    agentsMd,
+    'project-instructions',
+  );
+}
+
+export function createClaudeMdSection(claudeMd: string): ISystemPromptSection | undefined {
+  if (claudeMd.trim().length === 0) return undefined;
+  return createSection('project-claude-md', 'Project Notes', 41, claudeMd, 'project-instructions');
+}
+
+export function createProviderWebSearchSection(): ISystemPromptSection {
+  return createSection(
+    'provider-web-search',
+    'Web Search',
+    50,
+    [
+      'You have access to web search. When the user asks to search, look up, or find current/latest information,',
+      'you MUST use the web_search tool. Do NOT answer from training data when the user explicitly asks to search.',
+      'Always prefer web search for: news, latest versions, current events, live documentation.',
+    ].join('\n'),
+    'provider',
+  );
+}
+
+export function createToolDescriptionSection(
+  descriptions: readonly string[],
+): ISystemPromptSection | undefined {
+  if (descriptions.length === 0) return undefined;
+  return createSection(
+    'tool-descriptions',
+    'Available Tools',
+    60,
+    descriptions.map((description) => `- ${description}`).join('\n'),
+    'tool',
+  );
+}
+
+function formatCapability(descriptor: ICapabilityDescriptor): string {
+  const arg = descriptor.argumentHint ? ` ${descriptor.argumentHint}` : '';
+  return `- ${descriptor.name}${arg}: ${descriptor.description}`;
+}
+
+export function createCapabilitySection(
+  descriptors: readonly ICapabilityDescriptor[],
+): ISystemPromptSection {
+  return createSection(
+    'capability-descriptors',
+    'Capabilities',
+    70,
+    descriptors
+      .filter((descriptor) => descriptor.modelInvocable)
+      .map(formatCapability)
+      .join('\n'),
+    'command',
+  );
+}

--- a/packages/agent-sdk/src/context/system-prompt-types.ts
+++ b/packages/agent-sdk/src/context/system-prompt-types.ts
@@ -1,0 +1,18 @@
+export type TSystemPromptSectionSource =
+  | 'framework'
+  | 'project-instructions'
+  | 'runtime'
+  | 'permissions'
+  | 'provider'
+  | 'command'
+  | 'skill'
+  | 'tool'
+  | 'agent';
+
+export interface ISystemPromptSection {
+  readonly id: string;
+  readonly title?: string;
+  readonly priority: number;
+  readonly content: string;
+  readonly source: TSystemPromptSectionSource;
+}

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -26,17 +26,26 @@ export {
   BuiltinCommandSource,
   SkillCommandSource,
   PluginCommandSource,
+  SystemCommandExecutor,
+  createSystemCommands,
   parseFrontmatter,
   executeSkill,
 } from './commands/index.js';
 export type {
+  ICapabilityDescriptor,
+  TCapabilityKind,
+  TCapabilitySafety,
+} from './capabilities/types.js';
+export type {
   ICommand,
+  ICommandModule,
   ICommandSource,
   ISystemCommand,
   ICommandResult,
   IForkExecutionOptions,
   ISkillExecutionCallbacks,
   ISkillExecutionResult,
+  TCommandModuleSessionRequirement,
 } from './commands/index.js';
 
 // ── Skill prompt utilities ───────────────────────────────────
@@ -110,6 +119,8 @@ export {
 export type { ISubagentPromptOptions, ISubagentOptions } from './assembly/index.js';
 export { createAgentTool, storeAgentToolDeps, retrieveAgentToolDeps } from './tools/agent-tool.js';
 export type { IAgentToolDeps } from './tools/agent-tool.js';
+export { createCommandExecutionTool } from './tools/command-execution-tool.js';
+export type { ICommandExecutionToolDeps } from './tools/command-execution-tool.js';
 export { createBackgroundProcessTool } from './tools/background-process-tool.js';
 export type { IBackgroundProcessToolDeps } from './tools/background-process-tool.js';
 
@@ -197,6 +208,4 @@ export { runHooks } from '@robota-sdk/agent-core';
 //   createProvider()       — REMOVED (provider comes from consumer)
 //   loadConfig()           — config loading (used by InteractiveSession internally)
 //   loadContext()          — context loading (used by InteractiveSession internally)
-//   SystemCommandExecutor  — embedded in InteractiveSession
-//   createSystemCommands() — embedded in InteractiveSession
 // ──────────────────────────────────────────────────────────────

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-background-tasks.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-background-tasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { Session } from '@robota-sdk/agent-sessions';
 import { BackgroundTaskManager } from '../../background-tasks/index.js';
 import type {
@@ -15,6 +15,9 @@ import type { IAgentToolDeps } from '../../tools/agent-tool.js';
 function createSessionStub(): Session {
   return {
     getSessionId: () => 'session_parent',
+    getHistory: () => [],
+    getSystemMessage: () => 'system',
+    getToolSchemas: () => [],
     getContextState: () => ({
       usedTokens: 0,
       maxTokens: 100,
@@ -22,6 +25,16 @@ function createSessionStub(): Session {
       remainingPercentage: 100,
     }),
   } as unknown as Session;
+}
+
+function createSessionStoreStub() {
+  const records = new Map<string, unknown>();
+  return {
+    load: vi.fn((id: string) => records.get(id)),
+    save: vi.fn((record: { id: string }) => records.set(record.id, record)),
+    list: vi.fn(() => [...records.values()]),
+    delete: vi.fn((id: string) => records.delete(id)),
+  };
 }
 
 function createResolvedRunner(output: string): IBackgroundTaskRunner {
@@ -93,5 +106,49 @@ describe('InteractiveSession background task integration', () => {
     await interactiveSession.closeBackgroundTask(created.id);
 
     expect(interactiveSession.listBackgroundTasks()).toHaveLength(0);
+  });
+
+  it('persists background task snapshots while keeping streaming deltas out of session JSON', async () => {
+    const runner: IBackgroundTaskRunner = {
+      kind: 'agent',
+      start(task: IBackgroundTaskStart): IBackgroundTaskHandle {
+        task.emit?.({ type: 'background_task_text_delta', delta: 'partial ' });
+        return {
+          taskId: task.taskId,
+          transcriptPath: '/tmp/agent_1.jsonl',
+          result: Promise.resolve({ taskId: task.taskId, kind: 'agent', output: 'done' }),
+          cancel: () => Promise.resolve(),
+        };
+      },
+    };
+    const manager = new BackgroundTaskManager({ runners: [runner] });
+    const sessionStub = createSessionStub();
+    const sessionStore = createSessionStoreStub();
+    storeAgentToolDeps(sessionStub, {
+      backgroundTaskManager: manager,
+    } as unknown as IAgentToolDeps);
+    new InteractiveSession({
+      session: sessionStub,
+      sessionStore: sessionStore as never,
+    });
+
+    const created = await manager.spawn(createAgentRequest('Find files'));
+    await manager.wait(created.id);
+
+    const lastSaved = sessionStore.save.mock.calls.at(-1)?.[0] as {
+      backgroundTasks?: Array<{ id: string; status: string; transcriptPath?: string }>;
+      backgroundTaskEvents?: Array<{ type: string }>;
+    };
+    expect(lastSaved.backgroundTasks?.[0]).toMatchObject({
+      id: created.id,
+      status: 'completed',
+      transcriptPath: '/tmp/agent_1.jsonl',
+    });
+    expect(lastSaved.backgroundTaskEvents?.map((event) => event.type)).toContain(
+      'background_task_completed',
+    );
+    expect(lastSaved.backgroundTaskEvents?.map((event) => event.type)).not.toContain(
+      'background_task_text_delta',
+    );
   });
 });

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -36,6 +36,12 @@ function createMockSession(options?: {
     getPermissionMode: vi.fn().mockReturnValue('default'),
     setPermissionMode: vi.fn(),
     getSessionId: vi.fn().mockReturnValue('sess-1'),
+    getSystemMessage: vi.fn().mockReturnValue('system prompt with capabilities'),
+    getToolSchemas: vi
+      .fn()
+      .mockReturnValue([
+        { name: 'Read', description: 'Read files', parameters: { type: 'object', properties: {} } },
+      ]),
     getMessageCount: vi.fn().mockReturnValue(0),
     getSessionAllowedTools: vi.fn().mockReturnValue([]),
     compact: vi.fn(),
@@ -711,6 +717,31 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
       // Saved history must be identical to live history — no transformation
       expect(savedRecord.history).toEqual(liveHistory);
+    });
+
+    it('persists system prompt and tool schemas for session restore diagnostics', async () => {
+      const mockSessionStore = {
+        save: vi.fn(),
+        load: vi.fn().mockReturnValue(undefined),
+        list: vi.fn().mockReturnValue([]),
+        delete: vi.fn(),
+      };
+
+      const session = new InteractiveSession({
+        session: createMockSession({ runResult: 'answer' }) as never,
+        sessionStore: mockSessionStore,
+      } as never);
+
+      await session.submit('hello');
+
+      const savedRecord = mockSessionStore.save.mock.calls[0][0] as {
+        systemPrompt?: string;
+        toolSchemas?: unknown[];
+      };
+      expect(savedRecord.systemPrompt).toBe('system prompt with capabilities');
+      expect(savedRecord.toolSchemas).toEqual([
+        { name: 'Read', description: 'Read files', parameters: { type: 'object', properties: {} } },
+      ]);
     });
 
     it('multiple submits accumulate in persisted history', async () => {

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
@@ -28,6 +28,8 @@ function createMockSession(options?: {
     }),
     injectMessage: vi.fn(),
     getSessionId: vi.fn().mockReturnValue(options?.sessionId ?? 'test-session-id'),
+    getSystemMessage: vi.fn().mockReturnValue('mock system prompt'),
+    getToolSchemas: vi.fn().mockReturnValue([]),
   };
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-execution.ts
@@ -107,6 +107,8 @@ export function persistSession(
       updatedAt: new Date().toISOString(),
       messages: session.getHistory(),
       history,
+      systemPrompt: session.getSystemMessage(),
+      toolSchemas: session.getToolSchemas(),
     });
   } catch {
     // Persist failure should not break execution

--- a/packages/agent-sdk/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-execution.ts
@@ -9,6 +9,7 @@ import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-c
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { IExecutionResult, IToolSummary } from './types.js';
+import type { IBackgroundTaskState, TBackgroundTaskEvent } from '../background-tasks/index.js';
 
 /** Detect whether an error represents an abort/cancel action. */
 export function isAbortError(err: unknown): boolean {
@@ -95,6 +96,10 @@ export function persistSession(
   sessionName: string | undefined,
   cwd: string,
   history: IHistoryEntry[],
+  backgroundState?: {
+    tasks: readonly IBackgroundTaskState[];
+    events: readonly TBackgroundTaskEvent[];
+  },
 ): void {
   try {
     const sessionId = session.getSessionId();
@@ -109,6 +114,12 @@ export function persistSession(
       history,
       systemPrompt: session.getSystemMessage(),
       toolSchemas: session.getToolSchemas(),
+      ...(backgroundState
+        ? {
+            backgroundTasks: [...backgroundState.tasks],
+            backgroundTaskEvents: [...backgroundState.events],
+          }
+        : {}),
     });
   } catch {
     // Persist failure should not break execution

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -12,7 +12,11 @@ import type { Session } from '@robota-sdk/agent-sessions';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
-import type { IBackgroundTaskRunner } from '../background-tasks/index.js';
+import type {
+  IBackgroundTaskRunner,
+  IBackgroundTaskState,
+  TBackgroundTaskEvent,
+} from '../background-tasks/index.js';
 import type { TSubagentRunnerFactory } from '../subagents/index.js';
 import type { ICommandModule, ICommandResult } from '../commands/index.js';
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
@@ -225,13 +229,23 @@ export function loadSessionRecord(
   history: IHistoryEntry[];
   sessionName: string | undefined;
   pendingRestoreMessages: unknown[] | null;
+  backgroundTasks: IBackgroundTaskState[];
+  backgroundTaskEvents: TBackgroundTaskEvent[];
 } {
   const record = sessionStore.load(resumeSessionId);
   if (!record) {
-    return { history: [], sessionName: undefined, pendingRestoreMessages: null };
+    return {
+      history: [],
+      sessionName: undefined,
+      pendingRestoreMessages: null,
+      backgroundTasks: [],
+      backgroundTaskEvents: [],
+    };
   }
 
   const history = (record.history ?? []) as IHistoryEntry[];
+  const backgroundTasks = (record.backgroundTasks ?? []) as IBackgroundTaskState[];
+  const backgroundTaskEvents = (record.backgroundTaskEvents ?? []) as TBackgroundTaskEvent[];
   const sessionName = record.name;
   let pendingRestoreMessages: unknown[] | null = null;
 
@@ -247,5 +261,5 @@ export function loadSessionRecord(
     }
   }
 
-  return { history, sessionName, pendingRestoreMessages };
+  return { history, sessionName, pendingRestoreMessages, backgroundTasks, backgroundTaskEvents };
 }

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -14,6 +14,8 @@ import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { IBackgroundTaskRunner } from '../background-tasks/index.js';
 import type { TSubagentRunnerFactory } from '../subagents/index.js';
+import type { ICommandModule, ICommandResult } from '../commands/index.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
 import { projectPaths } from '../paths.js';
 import { loadConfig } from '../config/config-loader.js';
 import { loadContext } from '../context/context-loader.js';
@@ -46,6 +48,14 @@ export interface IInteractiveSessionStandardOptions {
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   /** Runtime shell override for subagent execution. */
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  /** Optional command modules composed into this session. */
+  commandModules?: readonly ICommandModule[];
+  /** Model-visible command descriptors derived from the composed command executor. */
+  commandDescriptors?: readonly ICapabilityDescriptor[];
+  /** Model command execution bridge. */
+  modelCommandExecutor?: (command: string, args: string) => Promise<ICommandResult | null>;
+  /** Predicate for commands allowed through the model command execution bridge. */
+  isModelCommandInvocable?: (command: string) => boolean;
 }
 
 /** Test/advanced construction: inject pre-built session directly. */
@@ -60,6 +70,8 @@ export interface IInteractiveSessionInjectedOptions {
   sessionName?: string;
   resumeSessionId?: string;
   forkSession?: boolean;
+  /** Optional command modules composed into this injected session. */
+  commandModules?: readonly ICommandModule[];
 }
 
 /** Union of standard and injected construction options. */
@@ -95,6 +107,14 @@ export interface IInitOptions {
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   /** Runtime shell override for subagent execution. */
   subagentRunnerFactory?: TSubagentRunnerFactory;
+  /** Optional command modules composed into this session. */
+  commandModules?: readonly ICommandModule[];
+  /** Model-visible command descriptors derived from the composed command executor. */
+  commandDescriptors?: readonly ICapabilityDescriptor[];
+  /** Model command execution bridge. */
+  modelCommandExecutor?: (command: string, args: string) => Promise<ICommandResult | null>;
+  /** Predicate for commands allowed through the model command execution bridge. */
+  isModelCommandInvocable?: (command: string) => boolean;
 }
 
 /**
@@ -159,6 +179,21 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
     appendSystemPrompt: options.appendSystemPrompt,
     backgroundTaskRunners: options.backgroundTaskRunners,
     subagentRunnerFactory: options.subagentRunnerFactory,
+    ...(options.commandModules?.some((module) =>
+      module.sessionRequirements?.includes('agent-runtime'),
+    )
+      ? { enableAgentRuntime: true }
+      : {}),
+    ...(options.commandModules || options.commandDescriptors
+      ? {
+          commandDescriptors: [
+            ...(options.commandDescriptors ?? []),
+            ...(options.commandModules?.flatMap((module) => module.commandDescriptors ?? []) ?? []),
+          ],
+        }
+      : {}),
+    modelCommandExecutor: options.modelCommandExecutor,
+    isModelCommandInvocable: options.isModelCommandInvocable,
   });
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -42,6 +42,7 @@ import type {
   IBackgroundTaskLogPage,
   IBackgroundTaskManager,
   IBackgroundTaskState,
+  TBackgroundTaskEvent,
   TBackgroundTaskIsolation,
 } from '../background-tasks/index.js';
 import type {
@@ -92,6 +93,8 @@ export class InteractiveSession {
   private sessionName?: string;
   private cwd?: string;
   private pendingRestoreMessages: unknown[] | null = null;
+  private backgroundTasks: IBackgroundTaskState[] = [];
+  private backgroundTaskEvents: TBackgroundTaskEvent[] = [];
   private resumeSessionId?: string;
   private forkSession: boolean;
   private backgroundTaskUnsubscribe: (() => void) | null = null;
@@ -126,6 +129,8 @@ export class InteractiveSession {
       );
       if (restored.history.length > 0) this.history = restored.history;
       if (restored.sessionName) this.sessionName = restored.sessionName;
+      this.backgroundTasks = restored.backgroundTasks;
+      this.backgroundTaskEvents = restored.backgroundTaskEvents;
       this.pendingRestoreMessages = restored.pendingRestoreMessages;
     }
 
@@ -496,8 +501,41 @@ export class InteractiveSession {
       retrieveAgentToolDeps(this.session)?.backgroundTaskManager;
     if (!manager) return;
     this.backgroundTaskUnsubscribe = manager.subscribe((event) => {
+      this.recordBackgroundTaskEvent(event);
       this.emit('background_task_event', event);
     });
+  }
+
+  private recordBackgroundTaskEvent(event: TBackgroundTaskEvent): void {
+    this.backgroundTasks = this.getBackgroundTaskSnapshots();
+    if (event.type !== 'background_task_text_delta') {
+      this.backgroundTaskEvents.push(event);
+      this.persistCurrentSession();
+    }
+  }
+
+  private getBackgroundTaskSnapshots(): IBackgroundTaskState[] {
+    try {
+      return this.getBackgroundTaskManagerOrThrow().list();
+    } catch {
+      return this.backgroundTasks;
+    }
+  }
+
+  private persistCurrentSession(): void {
+    if (!this.sessionStore || !this.session) return;
+    this.backgroundTasks = this.getBackgroundTaskSnapshots();
+    persistSession(
+      this.sessionStore,
+      this.session,
+      this.sessionName,
+      this.cwd ?? '',
+      this.history,
+      {
+        tasks: this.backgroundTasks,
+        events: this.backgroundTaskEvents,
+      },
+    );
   }
 
   private startForkSkillExecution(displayInput: string): void {
@@ -510,15 +548,7 @@ export class InteractiveSession {
   private finishForkSkillExecution(): void {
     this.executing = false;
     this.emit('thinking', false);
-    if (this.sessionStore && this.session) {
-      persistSession(
-        this.sessionStore,
-        this.session,
-        this.sessionName,
-        this.cwd ?? '',
-        this.history,
-      );
-    }
+    this.persistCurrentSession();
     if (this.pendingPrompt) {
       const queued = this.pendingPrompt;
       const queuedDisplay = this.pendingDisplayInput;
@@ -641,15 +671,7 @@ export class InteractiveSession {
     } finally {
       this.executing = false;
       this.emit('thinking', false);
-      if (this.sessionStore && this.session) {
-        persistSession(
-          this.sessionStore,
-          this.session,
-          this.sessionName,
-          this.cwd ?? '',
-          this.history,
-        );
-      }
+      this.persistCurrentSession();
       if (this.pendingPrompt) {
         const queued = this.pendingPrompt;
         const queuedDisplay = this.pendingDisplayInput;

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -17,7 +17,12 @@ import {
   createSystemMessage,
   messageToHistoryEntry,
 } from '@robota-sdk/agent-core';
-import type { ICommand, ISkillExecutionResult, IForkExecutionOptions } from '../commands/index.js';
+import type {
+  ICommand,
+  ICommandModule,
+  ISkillExecutionResult,
+  IForkExecutionOptions,
+} from '../commands/index.js';
 import { executeSkill } from '../commands/index.js';
 import { createSubagentSession } from '../assembly/create-subagent-session.js';
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
@@ -37,7 +42,14 @@ import type {
   IBackgroundTaskLogPage,
   IBackgroundTaskManager,
   IBackgroundTaskState,
+  TBackgroundTaskIsolation,
 } from '../background-tasks/index.js';
+import type {
+  ISubagentJobResult,
+  ISubagentJobState,
+  ISubagentManager,
+} from '../subagents/index.js';
+import { retrieveSessionBackgroundTaskManager } from '../background-tasks/session-background-store.js';
 import {
   isAbortError,
   buildResult,
@@ -83,9 +95,14 @@ export class InteractiveSession {
   private resumeSessionId?: string;
   private forkSession: boolean;
   private backgroundTaskUnsubscribe: (() => void) | null = null;
+  private readonly commandModules: readonly ICommandModule[];
 
   constructor(options: IInteractiveSessionOptions) {
-    this.commandExecutor = new SystemCommandExecutor(createSystemCommands());
+    this.commandModules = 'commandModules' in options ? (options.commandModules ?? []) : [];
+    this.commandExecutor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...this.commandModules.flatMap((module) => module.systemCommands ?? []),
+    ]);
     this.sessionStore = options.sessionStore;
     this.sessionName = options.sessionName;
     this.cwd = ('cwd' in options ? options.cwd : undefined) ?? '';
@@ -131,6 +148,14 @@ export class InteractiveSession {
       appendSystemPrompt: options.appendSystemPrompt,
       backgroundTaskRunners: options.backgroundTaskRunners,
       subagentRunnerFactory: options.subagentRunnerFactory,
+      ...(options.commandModules ? { commandModules: options.commandModules } : {}),
+      commandDescriptors: this.commandExecutor.listModelInvocableCommands(),
+      ...(this.commandExecutor.listModelInvocableCommands().length > 0
+        ? {
+            modelCommandExecutor: (command, args) => this.executeModelCommand(command, args),
+            isModelCommandInvocable: (command) => this.commandExecutor.isModelInvocable(command),
+          }
+        : {}),
     });
 
     if (this.pendingRestoreMessages) {
@@ -187,6 +212,14 @@ export class InteractiveSession {
     return this.commandExecutor.execute(name, this, args);
   }
 
+  async executeModelCommand(
+    name: string,
+    args: string,
+  ): Promise<{ message: string; success: boolean; data?: Record<string, unknown> } | null> {
+    await this.ensureInitialized();
+    return this.commandExecutor.executeModelInvocable(name, this, args);
+  }
+
   async executeSkillCommand(
     skill: ICommand,
     args: string,
@@ -221,6 +254,13 @@ export class InteractiveSession {
 
   listCommands(): Array<{ name: string; description: string }> {
     return this.commandExecutor.listCommands().map((cmd) => ({
+      name: cmd.name,
+      description: cmd.description,
+    }));
+  }
+
+  listModelInvocableCommands(): Array<{ name: string; description: string }> {
+    return this.commandExecutor.listModelInvocableCommands().map((cmd) => ({
       name: cmd.name,
       description: cmd.description,
     }));
@@ -301,6 +341,64 @@ export class InteractiveSession {
     return this.getBackgroundTaskManagerOrThrow().readLog(taskId, cursor);
   }
 
+  listAgentDefinitions(): Array<{ name: string; description: string }> {
+    const deps = retrieveAgentToolDeps(this.getSessionOrThrow());
+    return (deps?.agentDefinitions ?? []).map((agent) => ({
+      name: agent.name,
+      description: agent.description,
+    }));
+  }
+
+  listAgentJobs(): ISubagentJobState[] {
+    return this.getSubagentManagerOrThrow().list();
+  }
+
+  async spawnAgentJob(input: {
+    agentType: string;
+    label: string;
+    mode: 'foreground' | 'background';
+    prompt: string;
+    model?: string;
+    isolation?: TBackgroundTaskIsolation;
+  }): Promise<ISubagentJobState> {
+    await this.ensureInitialized();
+    const deps = this.getAgentToolDepsOrThrow();
+    const definition = this.resolveAgentDefinition(input.agentType, deps);
+    return this.getSubagentManagerOrThrow().spawn({
+      type: input.agentType,
+      label: input.label,
+      parentSessionId: this.getSessionOrThrow().getSessionId(),
+      mode: input.mode,
+      depth: (deps.subagentDepth ?? 0) + 1,
+      cwd: deps.cwd ?? this.cwd ?? process.cwd(),
+      prompt: input.prompt,
+      model: input.model ?? definition.model,
+      isolation: input.isolation,
+      allowedTools: definition.tools,
+      disallowedTools: definition.disallowedTools,
+    });
+  }
+
+  async waitAgentJob(jobId: string): Promise<ISubagentJobResult> {
+    await this.ensureInitialized();
+    return this.getSubagentManagerOrThrow().wait(jobId);
+  }
+
+  async sendAgentJob(jobId: string, prompt: string): Promise<void> {
+    await this.ensureInitialized();
+    await this.getSubagentManagerOrThrow().send(jobId, prompt);
+  }
+
+  async cancelAgentJob(jobId: string, reason?: string): Promise<void> {
+    await this.ensureInitialized();
+    await this.getSubagentManagerOrThrow().cancel(jobId, reason);
+  }
+
+  async closeAgentJob(jobId: string): Promise<void> {
+    await this.ensureInitialized();
+    await this.getSubagentManagerOrThrow().close(jobId);
+  }
+
   setName(name: string): void {
     this.sessionName = name;
     if (this.sessionStore && this.session) {
@@ -351,18 +449,53 @@ export class InteractiveSession {
   }
 
   private getBackgroundTaskManagerOrThrow(): IBackgroundTaskManager {
-    const deps = retrieveAgentToolDeps(this.getSessionOrThrow());
-    if (!deps?.backgroundTaskManager) {
+    const session = this.getSessionOrThrow();
+    const manager =
+      retrieveSessionBackgroundTaskManager(session) ??
+      retrieveAgentToolDeps(session)?.backgroundTaskManager;
+    if (!manager) {
       throw new Error('Background task manager is not available for this session.');
     }
-    return deps.backgroundTaskManager;
+    return manager;
+  }
+
+  private getAgentToolDepsOrThrow(): NonNullable<ReturnType<typeof retrieveAgentToolDeps>> {
+    const deps = retrieveAgentToolDeps(this.getSessionOrThrow());
+    if (!deps) {
+      throw new Error('Agent runtime dependencies are not available for this session.');
+    }
+    if (!deps.backgroundTaskManager) {
+      throw new Error('Background task manager is not available for this session.');
+    }
+    return deps;
+  }
+
+  private getSubagentManagerOrThrow(): ISubagentManager {
+    const deps = this.getAgentToolDepsOrThrow();
+    if (!deps.subagentManager) {
+      throw new Error('Subagent manager is not available for this session.');
+    }
+    return deps.subagentManager;
+  }
+
+  private resolveAgentDefinition(
+    agentType: string,
+    deps: NonNullable<ReturnType<typeof retrieveAgentToolDeps>>,
+  ): IAgentDefinition {
+    const definition = deps.customAgentRegistry?.(agentType);
+    if (!definition) {
+      throw new Error(`Unknown agent type: ${agentType}`);
+    }
+    return definition;
   }
 
   private subscribeBackgroundTaskEvents(): void {
     if (this.backgroundTaskUnsubscribe || !this.session) return;
-    const deps = retrieveAgentToolDeps(this.session);
-    if (!deps?.backgroundTaskManager) return;
-    this.backgroundTaskUnsubscribe = deps.backgroundTaskManager.subscribe((event) => {
+    const manager =
+      retrieveSessionBackgroundTaskManager(this.session) ??
+      retrieveAgentToolDeps(this.session)?.backgroundTaskManager;
+    if (!manager) return;
+    this.backgroundTaskUnsubscribe = manager.subscribe((event) => {
       this.emit('background_task_event', event);
     });
   }

--- a/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
@@ -123,6 +123,13 @@ describe('Agent tool', () => {
     const schema = tool.schema;
     expect(schema.name).toBe('Agent');
     expect(schema.description).toContain('subagent');
+    expect(schema.description).toContain('same assistant turn');
+    expect(schema.description).toContain('one Agent tool call per role');
+    expect(schema.description).toContain('background: true');
+    expect(schema.description).toContain('<agent');
+    expect(schema.description).toContain('choose one backlog');
+    expect(schema.description).toContain('Korean example');
+    expect(schema.description).toContain('백로그 중에 하나');
     // Verify parameters include prompt, subagent_type, model
     const props = schema.parameters.properties;
     expect(props).toHaveProperty('prompt');
@@ -130,6 +137,9 @@ describe('Agent tool', () => {
     expect(props).toHaveProperty('model');
     expect(props).toHaveProperty('background');
     expect(props).toHaveProperty('isolation');
+    expect((props.background as { description?: string }).description).toContain(
+      'Defaults to true',
+    );
   });
 
   it('should resolve built-in agent type "Explore"', async () => {
@@ -187,7 +197,7 @@ describe('Agent tool', () => {
   it('should return response with agentId', async () => {
     const tool = createAgentTool(makeDeps());
 
-    const toolResult = await tool.execute({ prompt: 'Do task' });
+    const toolResult = await tool.execute({ prompt: 'Do task', background: false });
     const result = parseToolResult(toolResult);
 
     expect(result['success']).toBe(true);
@@ -232,6 +242,7 @@ describe('Agent tool', () => {
     const toolResult = await tool.execute({
       prompt: 'Find files',
       subagent_type: 'Explore',
+      background: false,
     });
     const result = parseToolResult(toolResult);
 
@@ -297,6 +308,7 @@ describe('Agent tool', () => {
       prompt: 'Change files',
       subagent_type: 'Explore',
       isolation: 'worktree',
+      background: false,
     });
     const result = parseToolResult(toolResult);
 
@@ -320,10 +332,63 @@ describe('Agent tool', () => {
     });
   });
 
-  it('should return immediately when background mode is requested', async () => {
+  it('should default to background mode and return immediately when background is omitted', async () => {
     const subagentManager = {
       spawn: vi.fn().mockResolvedValue({
         id: 'agent_background_1',
+        type: 'Explore',
+        label: 'Explore',
+        parentSessionId: 'session_parent',
+        status: 'running',
+        mode: 'background',
+        depth: 1,
+        cwd: '/workspace',
+        promptPreview: 'Find files',
+        updatedAt: '2026-04-30T00:00:00.000Z',
+      }),
+      wait: vi.fn(),
+      list: vi.fn(),
+      get: vi.fn(),
+      cancel: vi.fn(),
+      close: vi.fn(),
+      send: vi.fn(),
+    };
+
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+      }),
+    );
+
+    const toolResult = await tool.execute({
+      prompt: 'Find files',
+      subagent_type: 'Explore',
+    });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'Explore',
+        mode: 'background',
+        prompt: 'Find files',
+      }),
+    );
+    expect(subagentManager.wait).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      background: true,
+      output: '',
+      agentId: 'agent_background_1',
+      status: 'running',
+    });
+  });
+
+  it('should return immediately when background mode is explicitly requested', async () => {
+    const subagentManager = {
+      spawn: vi.fn().mockResolvedValue({
+        id: 'agent_background_2',
         type: 'Explore',
         label: 'Explore',
         parentSessionId: 'session_parent',
@@ -369,7 +434,7 @@ describe('Agent tool', () => {
       success: true,
       background: true,
       output: '',
-      agentId: 'agent_background_1',
+      agentId: 'agent_background_2',
       status: 'running',
     });
   });
@@ -395,6 +460,7 @@ describe('Agent tool', () => {
       prompt: 'Do task',
       subagent_type: 'general-purpose',
       model: 'haiku',
+      background: false,
     });
 
     expect(createSubagentSession).toHaveBeenCalledWith(
@@ -418,7 +484,7 @@ describe('Agent tool', () => {
       }),
     );
 
-    await tool.execute({ prompt: 'Do task' });
+    await tool.execute({ prompt: 'Do task', background: false });
 
     expect(createSubagentSession).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -451,7 +517,7 @@ describe('Agent tool', () => {
 
     const tool = createAgentTool(makeDeps());
 
-    const toolResult = await tool.execute({ prompt: 'Do task' });
+    const toolResult = await tool.execute({ prompt: 'Do task', background: false });
     const result = parseToolResult(toolResult);
 
     expect(result['success']).toBe(false);
@@ -472,6 +538,7 @@ describe('Agent tool', () => {
     await tool.execute({
       prompt: 'Custom task',
       subagent_type: 'CustomWorker',
+      background: false,
     });
 
     expect(customRegistry).toHaveBeenCalledWith('CustomWorker');
@@ -501,7 +568,7 @@ describe('Agent tool', () => {
 
     const tool = createAgentTool(makeDeps());
 
-    const toolResult = await tool.execute({ prompt: 'Do task' });
+    const toolResult = await tool.execute({ prompt: 'Do task', background: false });
     const result = parseToolResult(toolResult);
 
     expect(result['success']).toBe(false);
@@ -531,6 +598,7 @@ describe('Agent tool', () => {
     await tool.execute({
       prompt: 'Do task',
       subagent_type: 'Explore',
+      background: false,
       // no model arg
     });
 
@@ -557,6 +625,7 @@ describe('Agent tool', () => {
     await tool.execute({
       prompt: 'Explore task',
       subagent_type: 'Explore',
+      background: false,
     });
 
     expect(customRegistry).toHaveBeenCalledWith('Explore');
@@ -595,7 +664,7 @@ describe('Agent tool', () => {
   it('should pass isForkWorker as undefined (not fork) to createSubagentSession', async () => {
     const tool = createAgentTool(makeDeps());
 
-    await tool.execute({ prompt: 'Do task' });
+    await tool.execute({ prompt: 'Do task', background: false });
 
     // Agent tool never sets isForkWorker (only useSubmitHandler fork runner does)
     expect(createSubagentSession).toHaveBeenCalledWith(

--- a/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
@@ -126,7 +126,9 @@ describe('Agent tool', () => {
     expect(schema.description).toContain('same assistant turn');
     expect(schema.description).toContain('one Agent tool call per role');
     expect(schema.description).toContain('background: true');
-    expect(schema.description).toContain('<agent');
+    expect(schema.description).toContain('tool-call channel');
+    expect(schema.description).not.toContain('<agent');
+    expect(schema.description).not.toContain('pseudo-tags');
     expect(schema.description).toContain('choose one backlog');
     expect(schema.description).toContain('Korean example');
     expect(schema.description).toContain('백로그 중에 하나');

--- a/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { createCommandExecutionTool } from '../command-execution-tool.js';
 
 describe('command execution tool', () => {
+  it('describes tool execution as the required path instead of assistant text', () => {
+    const tool = createCommandExecutionTool({
+      isModelInvocable: () => true,
+      execute: vi.fn(),
+    });
+
+    expect(tool.schema.description).toContain('Use this tool when command execution is required');
+    expect(tool.schema.description).toContain('pseudo-tags');
+  });
+
   it('executes only model-invocable commands through the injected command handler', async () => {
     const execute = vi.fn().mockResolvedValue({
       message: 'Started agent_1',

--- a/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
@@ -10,6 +10,8 @@ describe('command execution tool', () => {
 
     expect(tool.schema.description).toContain('Use this tool when command execution is required');
     expect(tool.schema.description).toContain('pseudo-tags');
+    expect(tool.schema.description).toContain('JSON arguments');
+    expect(tool.schema.description).toContain('"command":"agent"');
   });
 
   it('executes only model-invocable commands through the injected command handler', async () => {

--- a/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
@@ -9,7 +9,9 @@ describe('command execution tool', () => {
     });
 
     expect(tool.schema.description).toContain('Use this tool when command execution is required');
-    expect(tool.schema.description).toContain('pseudo-tags');
+    expect(tool.schema.description).toContain('assistant text does not execute');
+    expect(tool.schema.description).not.toContain('pseudo-tags');
+    expect(tool.schema.description).not.toContain('<agent');
     expect(tool.schema.description).toContain('JSON arguments');
     expect(tool.schema.description).toContain('"command":"agent"');
   });

--- a/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCommandExecutionTool } from '../command-execution-tool.js';
+
+describe('command execution tool', () => {
+  it('executes only model-invocable commands through the injected command handler', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      message: 'Started agent_1',
+      success: true,
+      data: { agentId: 'agent_1' },
+    });
+    const tool = createCommandExecutionTool({
+      isModelInvocable: (command) => command === 'agent',
+      execute,
+    });
+
+    const result = await tool.execute({
+      command: '/agent',
+      args: 'run Plan --background "draft architecture"',
+    });
+
+    expect(execute).toHaveBeenCalledWith('agent', 'run Plan --background "draft architecture"');
+    expect(String(result.data)).toContain('"agentId":"agent_1"');
+  });
+
+  it('rejects commands that are not model invocable', async () => {
+    const execute = vi.fn();
+    const tool = createCommandExecutionTool({
+      isModelInvocable: () => false,
+      execute,
+    });
+
+    const result = await tool.execute({
+      command: '/reset',
+      args: '',
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(String(result.data)).toContain('not model-invocable');
+  });
+});

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -26,6 +26,41 @@ import type {
 } from '../subagents/index.js';
 import type { IBackgroundTaskManager } from '../background-tasks/index.js';
 
+export const AGENT_TOOL_DESCRIPTION = [
+  'Launch a real subagent job for delegated work in an isolated context.',
+  'Use this tool in the same assistant turn when the user explicitly asks to create, spawn, run, delegate to, or use agents/subagents.',
+  'For multiple or parallel roles, emit one Agent tool call per role in the same assistant turn.',
+  'If the user asks to choose one backlog, task, or item, include that target-selection instruction inside each subagent prompt and start the agents instead of first replying with an inspection plan.',
+  'Korean example: "백로그 중에 하나를 분석할건데, 개발자 서브에이전트와 디자이너 서브에이전트를 만들어서 병렬로 동시에 백로그 하나를 분석해" means call Agent twice immediately, once for a general-purpose developer prompt and once for a Plan designer prompt.',
+  'Subagent jobs are background-first: omit background or set background: true unless the user explicitly asks to wait in the foreground.',
+  'Do not print XML/HTML-like <agent ... /> pseudo-tags as assistant text; pseudo-tags do not execute anything.',
+  'The result returned by the agent is not visible to the user, so summarize completed foreground results for the user when needed.',
+].join(' ');
+
+export function createAgentToolPromptDescription(
+  agentDefinitions: readonly Pick<IAgentDefinition, 'name' | 'description'>[] = [],
+): string {
+  const availableAgents =
+    agentDefinitions.length > 0
+      ? ` Available agent types: ${agentDefinitions
+          .map((agent) => `${agent.name} (${agent.description})`)
+          .join(', ')}.`
+      : '';
+  return [
+    'Agent — launch an isolated agent for delegated work.',
+    'Call the Agent tool in the same assistant turn for explicit subagent requests.',
+    'For parallel work, emit one Agent tool call per role with background: true.',
+    'If needed, choose one backlog/task/item inside the agent prompt instead of delaying launch.',
+    'Korean example: "백로그 중에 하나를 분석할건데..." means launch the requested agents now.',
+    'background defaults to true; use background: false only for explicit foreground/wait requests.',
+    'Do not print <agent ... /> pseudo-tags as assistant text.',
+    availableAgents,
+  ]
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /** Cast a Zod schema to the IZodSchema interface expected by createZodFunctionTool */
 function asZodSchema(schema: z.ZodType): IZodSchema {
   return schema as IZodSchema;
@@ -41,7 +76,9 @@ const AgentSchema = z.object({
   background: z
     .boolean()
     .optional()
-    .describe('When true, start the subagent as a background task and return immediately'),
+    .describe(
+      'Defaults to true. When true or omitted, start the subagent as a background task and return immediately. Use false only when the user explicitly asks to wait in the foreground.',
+    ),
   isolation: z
     .enum(['none', 'worktree'])
     .optional()
@@ -118,7 +155,7 @@ function createSpawnRequest(
     type: agentType,
     label: agentDef.name,
     parentSessionId: deps.parentSessionId ?? 'unknown-session',
-    mode: args.background ? 'background' : 'foreground',
+    mode: args.background === false ? 'foreground' : 'background',
     depth: deps.subagentDepth ?? 1,
     cwd: deps.cwd ?? process.cwd(),
     prompt: args.prompt,
@@ -182,7 +219,7 @@ async function runManagedAgent(
   try {
     const state = await manager.spawn(createSpawnRequest(args, agentType, agentDef, deps));
     agentId = state.id;
-    if (args.background) {
+    if (args.background !== false) {
       return stringifyBackgroundAgentStarted(state.id, state.status);
     }
     const response = await manager.wait(state.id);
@@ -203,7 +240,7 @@ export function createAgentTool(deps: IAgentToolDeps): ReturnType<typeof createZ
 
   return createZodFunctionTool(
     'Agent',
-    'Launch a subagent to handle a task in an isolated context. The subagent gets its own context window and returns a result when done. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.',
+    AGENT_TOOL_DESCRIPTION,
     asZodSchema(AgentSchema),
     async (params) => {
       return runManagedAgent(params as TAgentArgs, deps, manager);

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -59,6 +59,8 @@ export interface IAgentToolDeps extends IInProcessSubagentRunnerDeps {
   backgroundTaskManager?: IBackgroundTaskManager;
   /** Optional custom agent registry for resolving non-built-in agent types. */
   customAgentRegistry?: (name: string) => IAgentDefinition | undefined;
+  /** Model-visible and command-visible agent definitions available to this session. */
+  agentDefinitions?: IAgentDefinition[];
 }
 
 /**

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -33,7 +33,7 @@ export const AGENT_TOOL_DESCRIPTION = [
   'If the user asks to choose one backlog, task, or item, include that target-selection instruction inside each subagent prompt and start the agents instead of first replying with an inspection plan.',
   'Korean example: "백로그 중에 하나를 분석할건데, 개발자 서브에이전트와 디자이너 서브에이전트를 만들어서 병렬로 동시에 백로그 하나를 분석해" means call Agent twice immediately, once for a general-purpose developer prompt and once for a Plan designer prompt.',
   'Subagent jobs are background-first: omit background or set background: true unless the user explicitly asks to wait in the foreground.',
-  'Do not print XML/HTML-like <agent ... /> pseudo-tags as assistant text; pseudo-tags do not execute anything.',
+  'Execution requires the tool-call channel; assistant text does not start a subagent job.',
   'The result returned by the agent is not visible to the user, so summarize completed foreground results for the user when needed.',
 ].join(' ');
 
@@ -53,7 +53,7 @@ export function createAgentToolPromptDescription(
     'If needed, choose one backlog/task/item inside the agent prompt instead of delaying launch.',
     'Korean example: "백로그 중에 하나를 분석할건데..." means launch the requested agents now.',
     'background defaults to true; use background: false only for explicit foreground/wait requests.',
-    'Do not print <agent ... /> pseudo-tags as assistant text.',
+    'Execution requires the tool-call channel; assistant text alone does not start a subagent job.',
     availableAgents,
   ]
     .join(' ')

--- a/packages/agent-sdk/src/tools/command-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/command-execution-tool.ts
@@ -47,10 +47,10 @@ export function createCommandExecutionTool(
 ): ReturnType<typeof createZodFunctionTool> {
   return createZodFunctionTool(
     'ExecuteCommand',
-    'Execute a registered Robota command that has been marked model-invocable by its command module.',
+    'Execute a registered Robota command that has been marked model-invocable by its command module. Use this tool when command execution is required; writing command syntax or pseudo-tags as assistant text does not execute anything.',
     asZodSchema(CommandExecutionSchema),
     async (params) => {
-      const args = params as unknown as ICommandExecutionArgs;
+      const args: ICommandExecutionArgs = CommandExecutionSchema.parse(params);
       const command = normalizeCommand(args.command);
       if (!deps.isModelInvocable(command)) {
         return JSON.stringify({

--- a/packages/agent-sdk/src/tools/command-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/command-execution-tool.ts
@@ -47,7 +47,7 @@ export function createCommandExecutionTool(
 ): ReturnType<typeof createZodFunctionTool> {
   return createZodFunctionTool(
     'ExecuteCommand',
-    'Execute a registered Robota command that has been marked model-invocable by its command module. Use this tool when command execution is required; writing command syntax or pseudo-tags as assistant text does not execute anything.',
+    'Execute a registered Robota command that has been marked model-invocable by its command module. Use this tool when command execution is required; writing command syntax or pseudo-tags as assistant text does not execute anything. Pass valid JSON arguments such as {"command":"agent","args":"parallel developer=general-purpose:\\"analyze implementation\\" designer=Plan:\\"analyze architecture\\""} when running model-routed agent commands.',
     asZodSchema(CommandExecutionSchema),
     async (params) => {
       const args: ICommandExecutionArgs = CommandExecutionSchema.parse(params);

--- a/packages/agent-sdk/src/tools/command-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/command-execution-tool.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import { createZodFunctionTool } from '@robota-sdk/agent-tools';
+import type { IZodSchema } from '@robota-sdk/agent-tools';
+import type { ICommandResult } from '../commands/index.js';
+
+const CommandExecutionSchema = z.object({
+  command: z.string().describe('Command name to execute, with or without a leading slash'),
+  args: z.string().optional().describe('Arguments to pass to the command'),
+});
+
+interface ICommandExecutionArgs {
+  command: string;
+  args?: string;
+}
+
+export interface ICommandExecutionToolDeps {
+  isModelInvocable: (command: string) => boolean;
+  execute: (command: string, args: string) => Promise<ICommandResult | null>;
+}
+
+function asZodSchema(schema: z.ZodType): IZodSchema {
+  return schema as IZodSchema;
+}
+
+function normalizeCommand(command: string): string {
+  return command.trim().replace(/^\/+/, '').split(/\s+/)[0] ?? '';
+}
+
+function stringifyCommandResult(command: string, result: ICommandResult | null): string {
+  if (!result) {
+    return JSON.stringify({
+      success: false,
+      command,
+      error: `Unknown command: ${command}`,
+    });
+  }
+  return JSON.stringify({
+    success: result.success,
+    command,
+    message: result.message,
+    data: result.data,
+  });
+}
+
+export function createCommandExecutionTool(
+  deps: ICommandExecutionToolDeps,
+): ReturnType<typeof createZodFunctionTool> {
+  return createZodFunctionTool(
+    'ExecuteCommand',
+    'Execute a registered Robota command that has been marked model-invocable by its command module.',
+    asZodSchema(CommandExecutionSchema),
+    async (params) => {
+      const args = params as unknown as ICommandExecutionArgs;
+      const command = normalizeCommand(args.command);
+      if (!deps.isModelInvocable(command)) {
+        return JSON.stringify({
+          success: false,
+          command,
+          error: `Command is not model-invocable: ${command}`,
+        });
+      }
+      return stringifyCommandResult(command, await deps.execute(command, args.args ?? ''));
+    },
+  );
+}

--- a/packages/agent-sdk/src/tools/command-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/command-execution-tool.ts
@@ -47,7 +47,7 @@ export function createCommandExecutionTool(
 ): ReturnType<typeof createZodFunctionTool> {
   return createZodFunctionTool(
     'ExecuteCommand',
-    'Execute a registered Robota command that has been marked model-invocable by its command module. Use this tool when command execution is required; writing command syntax or pseudo-tags as assistant text does not execute anything. Pass valid JSON arguments such as {"command":"agent","args":"parallel developer=general-purpose:\\"analyze implementation\\" designer=Plan:\\"analyze architecture\\""} when running model-routed agent commands.',
+    'Execute a registered Robota command that has been marked model-invocable by its command module. Use this tool when command execution is required; assistant text does not execute commands. Pass valid JSON arguments such as {"command":"agent","args":"parallel developer=general-purpose:\\"analyze implementation\\" designer=Plan:\\"analyze architecture\\""} when running model-routed agent commands.',
     asZodSchema(CommandExecutionSchema),
     async (params) => {
       const args: ICommandExecutionArgs = CommandExecutionSchema.parse(params);

--- a/packages/agent-sessions/README.md
+++ b/packages/agent-sessions/README.md
@@ -99,7 +99,9 @@ Note: `IPermissionEnforcerOptions` is an internal type and is not exported from 
 
 ### ISessionRecord
 
-`ISessionRecord` includes a required `history` field (`IHistoryEntry[]`) that stores the full conversation timeline for session persistence, resume, and fork operations. When a session is resumed, history entries are replayed via `Session.injectMessage()`.
+`ISessionRecord` includes a required `history` field (`IHistoryEntry[]`) that stores the full conversation timeline for session persistence, resume, and fork operations. It may also include `backgroundTasks` and `backgroundTaskEvents` so background work can be restored and debugged alongside the conversation. When a session is resumed, history entries are replayed via `Session.injectMessage()`.
+
+Streaming text deltas are written to append-only JSONL session logs as `text_delta` events. Consumers should store high-frequency streaming chunks in JSONL logs/transcripts and keep session JSON focused on resumable snapshots and references.
 
 A migration script is available for upgrading session records from older formats. See the package source for details.
 

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -123,17 +123,19 @@ Types consumed from other packages (not owned here):
 
 ### ISessionRecord Fields
 
-| Field          | Type        | Required | Description                                                                                                                                                       |
-| -------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | `string`    | Yes      | Unique session identifier                                                                                                                                         |
-| `cwd`          | `string`    | Yes      | Working directory where the session was created                                                                                                                   |
-| `name`         | `string`    | No       | User-assigned session name for easy identification                                                                                                                |
-| `createdAt`    | `string`    | Yes      | ISO timestamp of session creation                                                                                                                                 |
-| `updatedAt`    | `string`    | Yes      | ISO timestamp of last update                                                                                                                                      |
-| `messages`     | `unknown[]` | Yes      | AI provider messages (TUniversalMessage[]) for context restoration. Saved from `session.getHistory()`, replayed via `session.injectMessage()` on resume.          |
-| `history`      | `unknown[]` | Yes      | Full UI timeline (IHistoryEntry[] — chat + events) for rendering restoration. Passed to TuiStateManager on resume.                                                |
-| `systemPrompt` | `string`    | No       | Exact system prompt used to create the session. Duplicates the system message in `messages` intentionally so diagnostics can inspect prompt composition directly. |
-| `toolSchemas`  | `unknown[]` | No       | Tool schemas registered for the session, including model-invocable command tools such as `ExecuteCommand`.                                                        |
+| Field                  | Type        | Required | Description                                                                                                                                                       |
+| ---------------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | `string`    | Yes      | Unique session identifier                                                                                                                                         |
+| `cwd`                  | `string`    | Yes      | Working directory where the session was created                                                                                                                   |
+| `name`                 | `string`    | No       | User-assigned session name for easy identification                                                                                                                |
+| `createdAt`            | `string`    | Yes      | ISO timestamp of session creation                                                                                                                                 |
+| `updatedAt`            | `string`    | Yes      | ISO timestamp of last update                                                                                                                                      |
+| `messages`             | `unknown[]` | Yes      | AI provider messages (TUniversalMessage[]) for context restoration. Saved from `session.getHistory()`, replayed via `session.injectMessage()` on resume.          |
+| `history`              | `unknown[]` | Yes      | Full UI timeline (IHistoryEntry[] — chat + events) for rendering restoration. Passed to TuiStateManager on resume.                                                |
+| `systemPrompt`         | `string`    | No       | Exact system prompt used to create the session. Duplicates the system message in `messages` intentionally so diagnostics can inspect prompt composition directly. |
+| `toolSchemas`          | `unknown[]` | No       | Tool schemas registered for the session, including model-invocable command tools such as `ExecuteCommand`.                                                        |
+| `backgroundTasks`      | `unknown[]` | No       | Latest persisted background task snapshots. Streaming chunks are not written here per token; snapshots point to append-only transcript/log files where available. |
+| `backgroundTaskEvents` | `unknown[]` | No       | Durable non-streaming background task lifecycle/progress events needed for resume/debugging. High-frequency text deltas belong in JSONL logs/transcripts.         |
 
 ### Session Data Migration
 
@@ -155,6 +157,7 @@ The session log records structured events to a JSONL file for diagnostics and re
 - **`session_init` event** -- Recorded when a session is constructed. Includes `systemPrompt`, `systemPromptLength`, provider/model, cwd, and registered `toolSchemas`.
 - **`server_tool` event** -- Recorded when a server-managed tool (e.g., web search) executes during streaming. Includes the tool name and query.
 - **`pre_run` event** -- Recorded at the start of each `run()` call. Includes the provider name, `webToolsEnabled` flag, full enriched input, and current message history before the model call.
+- **`text_delta` event** -- Recorded for each streaming text chunk delivered through `ISessionOptions.onTextDelta`. This is append-only JSONL data and must be available while a run is still in progress.
 - **`assistant` event** -- Recorded after each assistant response. Includes full assistant content, full post-run history, and `historyStructure`: an array with per-message metadata (role, contentLength, hasToolCalls, toolCallNames, metadata).
 - **`onServerToolUse` callback wiring** -- When session logging is enabled, the `onServerToolUse` callback from the provider is automatically wired to emit `server_tool` log events.
 

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -123,15 +123,17 @@ Types consumed from other packages (not owned here):
 
 ### ISessionRecord Fields
 
-| Field       | Type        | Required | Description                                                                                                                                              |
-| ----------- | ----------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `string`    | Yes      | Unique session identifier                                                                                                                                |
-| `cwd`       | `string`    | Yes      | Working directory where the session was created                                                                                                          |
-| `name`      | `string`    | No       | User-assigned session name for easy identification                                                                                                       |
-| `createdAt` | `string`    | Yes      | ISO timestamp of session creation                                                                                                                        |
-| `updatedAt` | `string`    | Yes      | ISO timestamp of last update                                                                                                                             |
-| `messages`  | `unknown[]` | Yes      | AI provider messages (TUniversalMessage[]) for context restoration. Saved from `session.getHistory()`, replayed via `session.injectMessage()` on resume. |
-| `history`   | `unknown[]` | Yes      | Full UI timeline (IHistoryEntry[] — chat + events) for rendering restoration. Passed to TuiStateManager on resume.                                       |
+| Field          | Type        | Required | Description                                                                                                                                                       |
+| -------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `string`    | Yes      | Unique session identifier                                                                                                                                         |
+| `cwd`          | `string`    | Yes      | Working directory where the session was created                                                                                                                   |
+| `name`         | `string`    | No       | User-assigned session name for easy identification                                                                                                                |
+| `createdAt`    | `string`    | Yes      | ISO timestamp of session creation                                                                                                                                 |
+| `updatedAt`    | `string`    | Yes      | ISO timestamp of last update                                                                                                                                      |
+| `messages`     | `unknown[]` | Yes      | AI provider messages (TUniversalMessage[]) for context restoration. Saved from `session.getHistory()`, replayed via `session.injectMessage()` on resume.          |
+| `history`      | `unknown[]` | Yes      | Full UI timeline (IHistoryEntry[] — chat + events) for rendering restoration. Passed to TuiStateManager on resume.                                                |
+| `systemPrompt` | `string`    | No       | Exact system prompt used to create the session. Duplicates the system message in `messages` intentionally so diagnostics can inspect prompt composition directly. |
+| `toolSchemas`  | `unknown[]` | No       | Tool schemas registered for the session, including model-invocable command tools such as `ExecuteCommand`.                                                        |
 
 ### Session Data Migration
 
@@ -148,11 +150,12 @@ Types consumed from other packages (not owned here):
 
 ## Session Logging
 
-The session log records structured events to a JSONL file for diagnostics and replay:
+The session log records structured events to a JSONL file for diagnostics and replay. Logs must preserve enough raw data to reconstruct what was sent to the model and what came back:
 
+- **`session_init` event** -- Recorded when a session is constructed. Includes `systemPrompt`, `systemPromptLength`, provider/model, cwd, and registered `toolSchemas`.
 - **`server_tool` event** -- Recorded when a server-managed tool (e.g., web search) executes during streaming. Includes the tool name and query.
-- **`pre_run` event** -- Recorded at the start of each `run()` call. Includes the provider name and `webToolsEnabled` flag.
-- **`assistant` event** -- Recorded after each assistant response. Includes `historyStructure`: an array with per-message metadata (role, contentLength, hasToolCalls, toolCallNames, metadata).
+- **`pre_run` event** -- Recorded at the start of each `run()` call. Includes the provider name, `webToolsEnabled` flag, full enriched input, and current message history before the model call.
+- **`assistant` event** -- Recorded after each assistant response. Includes full assistant content, full post-run history, and `historyStructure`: an array with per-message metadata (role, contentLength, hasToolCalls, toolCallNames, metadata).
 - **`onServerToolUse` callback wiring** -- When session logging is enabled, the `onServerToolUse` callback from the provider is automatically wired to emit `server_tool` log events.
 
 ## Extension Points

--- a/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
@@ -7,11 +7,12 @@
  * was loaded but never reached the API.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { Session } from '../session.js';
 
 // Capture the config passed to Robota constructor
 let capturedConfig: Record<string, unknown> | null = null;
+let mockRunResult = 'mock response';
 
 vi.mock('@robota-sdk/agent-core', async () => {
   const actual = await vi.importActual('@robota-sdk/agent-core');
@@ -20,7 +21,7 @@ vi.mock('@robota-sdk/agent-core', async () => {
     Robota: vi.fn().mockImplementation((config: Record<string, unknown>) => {
       capturedConfig = config;
       return {
-        run: vi.fn().mockResolvedValue('mock response'),
+        run: vi.fn().mockImplementation(async () => mockRunResult),
         getHistory: vi.fn().mockReturnValue([]),
         clearHistory: vi.fn(),
       };
@@ -42,13 +43,21 @@ const MOCK_PROVIDER = {
 
 const MOCK_TOOLS = [
   {
-    schema: { name: 'Bash' },
+    schema: {
+      name: 'Bash',
+      description: 'Execute shell commands',
+      parameters: { type: 'object', properties: {} },
+    },
     execute: vi.fn(),
     getName: () => 'Bash',
     setEventService: vi.fn(),
   },
   {
-    schema: { name: 'Read' },
+    schema: {
+      name: 'Read',
+      description: 'Read file contents',
+      parameters: { type: 'object', properties: {} },
+    },
     execute: vi.fn(),
     getName: () => 'Read',
     setEventService: vi.fn(),
@@ -68,6 +77,7 @@ const MOCK_TERMINAL = {
 describe('Session — system prompt delivery', () => {
   beforeEach(() => {
     capturedConfig = null;
+    mockRunResult = 'mock response';
   });
 
   it('should include AGENTS.md content in system prompt', () => {
@@ -169,5 +179,63 @@ describe('Session — system prompt delivery', () => {
 
     const topLevel = capturedConfig!['systemMessage'] as string;
     expect(topLevel).toContain('moderate');
+  });
+
+  it('logs the complete system prompt and tool schemas at session initialization', () => {
+    const systemMessage = '## Capabilities\n- /agent <prompt>: Start a background agent job';
+    const logger = { log: vi.fn() };
+
+    new Session({
+      tools: MOCK_TOOLS as never,
+      provider: MOCK_PROVIDER as never,
+      systemMessage,
+      terminal: MOCK_TERMINAL,
+      sessionLogger: logger,
+    });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.any(String),
+      'session_init',
+      expect.objectContaining({
+        systemPrompt: systemMessage,
+        systemPromptLength: systemMessage.length,
+        toolSchemas: [
+          {
+            name: 'Bash',
+            description: 'Execute shell commands',
+            parameters: { type: 'object', properties: {} },
+          },
+          {
+            name: 'Read',
+            description: 'Read file contents',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
+      }),
+    );
+  });
+
+  it('logs full assistant content without truncation', async () => {
+    const longResponse = `prefix-${'x'.repeat(700)}-suffix`;
+    mockRunResult = longResponse;
+    const logger = { log: vi.fn() };
+
+    const session = new Session({
+      tools: MOCK_TOOLS as never,
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'System prompt',
+      terminal: MOCK_TERMINAL,
+      sessionLogger: logger,
+    });
+
+    await session.run('hello');
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.any(String),
+      'assistant',
+      expect.objectContaining({
+        content: longResponse,
+      }),
+    );
   });
 });

--- a/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
@@ -13,6 +13,7 @@ import { Session } from '../session.js';
 // Capture the config passed to Robota constructor
 let capturedConfig: Record<string, unknown> | null = null;
 let mockRunResult = 'mock response';
+let mockRunDeltas: string[] = [];
 
 vi.mock('@robota-sdk/agent-core', async () => {
   const actual = await vi.importActual('@robota-sdk/agent-core');
@@ -21,7 +22,12 @@ vi.mock('@robota-sdk/agent-core', async () => {
     Robota: vi.fn().mockImplementation((config: Record<string, unknown>) => {
       capturedConfig = config;
       return {
-        run: vi.fn().mockImplementation(async () => mockRunResult),
+        run: vi.fn().mockImplementation(async (_message: string, options?: unknown) => {
+          const onTextDelta = (options as { onTextDelta?: (delta: string) => void } | undefined)
+            ?.onTextDelta;
+          for (const delta of mockRunDeltas) onTextDelta?.(delta);
+          return mockRunResult;
+        }),
         getHistory: vi.fn().mockReturnValue([]),
         clearHistory: vi.fn(),
       };
@@ -78,6 +84,7 @@ describe('Session — system prompt delivery', () => {
   beforeEach(() => {
     capturedConfig = null;
     mockRunResult = 'mock response';
+    mockRunDeltas = [];
   });
 
   it('should include AGENTS.md content in system prompt', () => {
@@ -236,6 +243,35 @@ describe('Session — system prompt delivery', () => {
       expect.objectContaining({
         content: longResponse,
       }),
+    );
+  });
+
+  it('logs streaming text deltas before forwarding them to the callback', async () => {
+    mockRunDeltas = ['hello ', 'world'];
+    const forwarded: string[] = [];
+    const logger = { log: vi.fn() };
+
+    const session = new Session({
+      tools: MOCK_TOOLS as never,
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'System prompt',
+      terminal: MOCK_TERMINAL,
+      sessionLogger: logger,
+      onTextDelta: (delta) => forwarded.push(delta),
+    });
+
+    await session.run('hello');
+
+    expect(forwarded).toEqual(['hello ', 'world']);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.any(String),
+      'text_delta',
+      expect.objectContaining({ delta: 'hello ' }),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.any(String),
+      'text_delta',
+      expect.objectContaining({ delta: 'world' }),
     );
   });
 });

--- a/packages/agent-sessions/src/session-history-ops.ts
+++ b/packages/agent-sessions/src/session-history-ops.ts
@@ -17,6 +17,7 @@ import type { SessionStore, ISessionRecord } from './session-store.js';
 import type { CompactionOrchestrator } from './compaction-orchestrator.js';
 import type { ContextWindowTracker } from './context-window-tracker.js';
 import type { TSessionLogData } from './session-logger.js';
+import type { IToolSchema } from '@robota-sdk/agent-core';
 
 /** Dependencies for compact() */
 export interface ICompactContext {
@@ -91,6 +92,8 @@ export async function compact(
 export interface IPersistContext {
   sessionId: string;
   cwd: string;
+  systemPrompt: string;
+  toolSchemas: IToolSchema[];
   sessionStore: SessionStore;
   robota: Robota;
   getFullHistory: () => Array<{
@@ -117,6 +120,8 @@ export function persistSession(ctx: IPersistContext): void {
     updatedAt: now,
     messages: history,
     history: ctx.getFullHistory(),
+    systemPrompt: ctx.systemPrompt,
+    toolSchemas: ctx.toolSchemas,
   };
 
   ctx.sessionStore.save(record);

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -111,9 +111,16 @@ export async function executeRun(
 
   let response: string;
   try {
+    const onTextDelta = ctx.onTextDelta
+      ? (delta: string): void => {
+          ctx.log('text_delta', { delta });
+          ctx.onTextDelta?.(delta);
+        }
+      : undefined;
+
     response = await ctx.robota.run(enrichedMessage, {
       signal: abortSignal,
-      ...(ctx.onTextDelta && { onTextDelta: ctx.onTextDelta }),
+      ...(onTextDelta && { onTextDelta }),
     });
 
     // If execution was interrupted (abort fired during execution),

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -101,6 +101,8 @@ export async function executeRun(
     historyLength: history.length,
     historyChars: historyJson.length,
     historyEstTokens: Math.ceil(historyJson.length / 4),
+    input: enrichedMessage,
+    history,
     model: ctx.model,
     provider: ctx.aiProvider.name,
     maxTokens: ctx.contextTracker.getContextState().maxTokens,
@@ -145,9 +147,10 @@ export async function executeRun(
     };
   });
   ctx.log('assistant', {
-    content: response.substring(0, 500),
+    content: response,
     historyLength: postHistory.length,
     estimatedChars: JSON.stringify(postHistory).length,
+    history: postHistory,
     historyStructure,
   });
 

--- a/packages/agent-sessions/src/session-store.ts
+++ b/packages/agent-sessions/src/session-store.ts
@@ -1,12 +1,14 @@
 /**
  * SessionStore — persists conversation sessions as JSON files.
  *
- * Sessions are stored at `~/.robota/sessions/{id}.json`.
+ * Sessions are stored at `~/.robota/sessions/{id}.json` by default.
+ * Consumers can inject a project-local directory such as `.robota/sessions`.
  * The store directory is created on first write if it does not exist.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, readdirSync } from 'fs';
 import { join } from 'path';
+import type { IToolSchema } from '@robota-sdk/agent-core';
 
 /** A persisted session record */
 export interface ISessionRecord {
@@ -24,6 +26,10 @@ export interface ISessionRecord {
   messages: unknown[];
   /** Full UI timeline (chat + events) for rendering restoration */
   history?: unknown[];
+  /** Exact system prompt used to create the session. */
+  systemPrompt?: string;
+  /** Tool schemas registered for the session. */
+  toolSchemas?: IToolSchema[];
 }
 
 /**

--- a/packages/agent-sessions/src/session-store.ts
+++ b/packages/agent-sessions/src/session-store.ts
@@ -30,6 +30,10 @@ export interface ISessionRecord {
   systemPrompt?: string;
   /** Tool schemas registered for the session. */
   toolSchemas?: IToolSchema[];
+  /** Latest background task snapshots for resume/debugging. */
+  backgroundTasks?: unknown[];
+  /** Durable non-streaming background task events for resume/debugging. */
+  backgroundTaskEvents?: unknown[];
 }
 
 /**

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -12,6 +12,7 @@ import { Robota, TRUST_TO_MODE } from '@robota-sdk/agent-core';
 import type {
   IAgentConfig,
   IAIProvider,
+  IToolSchema,
   TPermissionMode,
   IHookTypeExecutor,
 } from '@robota-sdk/agent-core';
@@ -51,6 +52,7 @@ export class Session {
   private readonly cwd: string;
   private readonly aiProvider: IAIProvider;
   private readonly systemMessage: string;
+  private readonly toolSchemas: IToolSchema[];
   private model: string;
   private readonly hooks?: Record<string, unknown>;
   private readonly hookTypeExecutors?: IHookTypeExecutor[];
@@ -71,6 +73,7 @@ export class Session {
     this.terminal = terminal;
     this.sessionStore = sessionStore;
     this.systemMessage = systemMessage;
+    this.toolSchemas = tools.map((tool) => tool.schema);
     this.cwd = process.cwd();
     this.sessionLogger = options.sessionLogger;
     this.hooks = options.hooks;
@@ -89,6 +92,8 @@ export class Session {
     this.log('session_init', {
       cwd: this.cwd,
       systemPromptLength: systemMessage.length,
+      systemPrompt: systemMessage,
+      toolSchemas: this.toolSchemas,
       model: this.model,
       provider: provider.name,
     });
@@ -192,6 +197,8 @@ export class Session {
     persistSession({
       sessionId: this.sessionId,
       cwd: this.cwd,
+      systemPrompt: this.systemMessage,
+      toolSchemas: this.toolSchemas,
       sessionStore: this.sessionStore,
       robota: this.robota,
       getFullHistory: () => this.getFullHistory(),
@@ -214,6 +221,16 @@ export class Session {
   /** Return the stable session identifier */
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  /** Return the exact system prompt used by this session. */
+  getSystemMessage(): string {
+    return this.systemMessage;
+  }
+
+  /** Return tool schemas registered for this session. */
+  getToolSchemas(): IToolSchema[] {
+    return this.toolSchemas;
   }
 
   /** Return the number of run() calls completed */

--- a/packages/agent-transport-headless/docs/SPEC.md
+++ b/packages/agent-transport-headless/docs/SPEC.md
@@ -25,6 +25,8 @@ Returns `{ run: (prompt: string) => Promise<number> }`.
 
 The `run` function submits the prompt to the session, writes output to `process.stdout`, and resolves with an exit code.
 
+If the prompt begins with `/`, the runner treats it as a slash command and calls `session.executeCommand(name, args)` instead of submitting the text to the model. Unknown slash commands return an explicit command error. Command availability depends on the command modules composed into the upstream `InteractiveSession`.
+
 ### IHeadlessRunnerOptions
 
 | Field          | Type                                | Description              |
@@ -91,6 +93,8 @@ When `InteractiveSession` emits `background_task_event`, `stream-json` writes it
 
 Headless transport does not expose interactive background controls. Non-interactive callers should use the emitted events plus SDK/transport-specific control surfaces outside this one-shot runner.
 
+For slash commands that start background tasks, `stream-json` subscribes to `background_task_event` before command execution so created/started events can be emitted before the final command result.
+
 ## Claude Code Field Name Compatibility
 
 JSON and stream-json output formats use field names that match Claude Code's `--output-format json` and `--output-format stream-json` (e.g., `type: 'result'`, `session_id`, `subtype`, `content_block_delta`). This is a **reference-only alignment** for user convenience — it allows reuse of `jq` pipelines and parsing scripts. Robota does NOT depend on Claude Code and will NOT track Claude Code's field name changes. The output format is independently owned and versioned by this package.
@@ -120,6 +124,7 @@ Interrupted executions (e.g., abort signal) are treated as success (exit code 0)
 createHeadlessRunner(options)
   └── run(prompt)
         ├── subscribes to InteractiveSession events
+        ├── executes leading slash commands through session.executeCommand()
         ├── writes formatted output to process.stdout
         └── resolves with exit code (0 or 1)
 ```

--- a/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
@@ -39,6 +39,7 @@ function createMockSession(behavior: 'complete' | 'interrupted' | 'error', respo
         }
       }
     }),
+    executeCommand: vi.fn().mockResolvedValue(null),
     getSession: vi.fn(() => ({ getSessionId: () => 'test-session-id' })),
   } as unknown as InteractiveSession;
 }
@@ -101,6 +102,28 @@ describe('createHeadlessRunner (text format)', () => {
     await runner.run('my prompt');
 
     expect(session.submit).toHaveBeenCalledWith('my prompt');
+  });
+
+  it('executes /agent as a command without submitting to the model', async () => {
+    const session = {
+      ...createMockSession('complete', 'unused'),
+      executeCommand: vi.fn().mockResolvedValue({
+        message: 'Started agent job: agent_1',
+        success: true,
+        data: { agentId: 'agent_1' },
+      }),
+    } as unknown as InteractiveSession;
+    const runner = createHeadlessRunner({ session, outputFormat: 'text' });
+
+    const exitCode = await runner.run('/agent run Plan --background "draft architecture"');
+
+    expect(exitCode).toBe(0);
+    expect(session.executeCommand).toHaveBeenCalledWith(
+      'agent',
+      'run Plan --background "draft architecture"',
+    );
+    expect(session.submit).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('Started agent job: agent_1\n');
   });
 });
 
@@ -286,11 +309,6 @@ describe('createHeadlessRunner (stream-json format)', () => {
   });
 
   it('stream-json emits background task events before the final result', async () => {
-    const backgroundEvent: TBackgroundTaskEvent = {
-      type: 'background_task_text_delta',
-      taskId: 'task_1',
-      delta: 'partial output',
-    };
     const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
     const session = {
       on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -298,19 +316,37 @@ describe('createHeadlessRunner (stream-json format)', () => {
         listeners.get(event)!.push(handler);
       }),
       off: vi.fn(),
-      submit: vi.fn(async () => {
+      submit: vi.fn(),
+      executeCommand: vi.fn().mockImplementation(async () => {
         for (const h of listeners.get('background_task_event') ?? []) {
-          h(backgroundEvent);
+          h({
+            type: 'background_task_created',
+            task: {
+              id: 'agent_1',
+              kind: 'agent',
+              label: 'Plan',
+              status: 'running',
+              mode: 'background',
+              parentSessionId: 'stream-session',
+              depth: 1,
+              cwd: '/workspace',
+              updatedAt: '2026-05-01T00:00:00.000Z',
+              unread: false,
+              promptPreview: 'draft architecture',
+            },
+          } satisfies TBackgroundTaskEvent);
         }
-        for (const h of listeners.get('complete') ?? []) {
-          h({ response: 'done', history: [], toolSummaries: [], contextState: {} });
-        }
+        return {
+          message: 'Started agent job: agent_1',
+          success: true,
+          data: { agentId: 'agent_1' },
+        };
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'stream-session' })),
     } as unknown as InteractiveSession;
 
     const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
-    const exitCode = await runner.run('test prompt');
+    const exitCode = await runner.run('/agent run Plan --background "draft architecture"');
 
     expect(exitCode).toBe(0);
 
@@ -320,17 +356,24 @@ describe('createHeadlessRunner (stream-json format)', () => {
     );
 
     expect(parsed).toHaveLength(2);
+    expect(session.submit).not.toHaveBeenCalled();
+    expect(session.executeCommand).toHaveBeenCalledWith(
+      'agent',
+      'run Plan --background "draft architecture"',
+    );
     expect(parsed[0]).toMatchObject({
       type: 'stream_event',
       session_id: 'stream-session',
       event: {
         type: 'background_task_event',
-        background_task_event: backgroundEvent,
+        background_task_event: {
+          type: 'background_task_created',
+        },
       },
     });
     expect(parsed[1]).toEqual({
       type: 'result',
-      result: 'done',
+      result: 'Started agent job: agent_1',
       session_id: 'stream-session',
       subtype: 'success',
     });

--- a/packages/agent-transport-headless/src/headless-runner.ts
+++ b/packages/agent-transport-headless/src/headless-runner.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type {
   InteractiveSession,
   IExecutionResult,
+  ICommandResult,
   TBackgroundTaskEvent,
 } from '@robota-sdk/agent-sdk';
 
@@ -21,6 +22,11 @@ type TStreamJsonEvent =
       type: 'background_task_event';
       background_task_event: TBackgroundTaskEvent;
     };
+
+interface ISlashCommandExecution {
+  readonly isSlashCommand: boolean;
+  readonly result: ICommandResult | null;
+}
 
 export function createHeadlessRunner(options: IHeadlessRunnerOptions): {
   run: (prompt: string) => Promise<number>;
@@ -43,6 +49,33 @@ export function createHeadlessRunner(options: IHeadlessRunnerOptions): {
 function writeJsonResult(sessionId: string, result: string, subtype: 'success' | 'error'): void {
   const output = JSON.stringify({ type: 'result', result, session_id: sessionId, subtype });
   process.stdout.write(output + '\n');
+}
+
+function parseSlashCommand(prompt: string): { name: string; args: string } | null {
+  const trimmed = prompt.trimStart();
+  if (!trimmed.startsWith('/')) return null;
+  const withoutSlash = trimmed.slice(1);
+  const [name = '', ...args] = withoutSlash.split(/\s+/);
+  if (name.length === 0) return null;
+  return { name, args: args.join(' ') };
+}
+
+async function executeSlashCommandIfPresent(
+  session: InteractiveSession,
+  prompt: string,
+): Promise<ISlashCommandExecution> {
+  const command = parseSlashCommand(prompt);
+  if (!command) return { isSlashCommand: false, result: null };
+  const result = await session.executeCommand(command.name, command.args);
+  return {
+    isSlashCommand: true,
+    result:
+      result ??
+      ({
+        message: `Unknown command "/${command.name}".`,
+        success: false,
+      } satisfies ICommandResult),
+  };
 }
 
 function getSessionId(session: InteractiveSession): string {
@@ -93,7 +126,19 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
     session.on('interrupted', onInterrupted);
     session.on('error', onError);
 
-    void session.submit(prompt);
+    void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
+      if (commandExecution.isSlashCommand && commandExecution.result) {
+        cleanup();
+        writeJsonResult(
+          getSessionId(session),
+          commandExecution.result.message,
+          commandExecution.result.success ? 'success' : 'error',
+        );
+        resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      void session.submit(prompt);
+    });
   });
 }
 
@@ -145,7 +190,19 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
     session.on('interrupted', onInterrupted);
     session.on('error', onError);
 
-    void session.submit(prompt);
+    void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
+      if (commandExecution.isSlashCommand && commandExecution.result) {
+        cleanup();
+        writeJsonResult(
+          getSessionId(session),
+          commandExecution.result.message,
+          commandExecution.result.success ? 'success' : 'error',
+        );
+        resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      void session.submit(prompt);
+    });
   });
 }
 
@@ -180,6 +237,14 @@ function runTextFormat(session: InteractiveSession, prompt: string): Promise<num
     session.on('interrupted', onInterrupted);
     session.on('error', onError);
 
-    void session.submit(prompt);
+    void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
+      if (commandExecution.isSlashCommand && commandExecution.result) {
+        cleanup();
+        process.stdout.write(commandExecution.result.message + '\n');
+        resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      void session.submit(prompt);
+    });
   });
 }

--- a/packages/agent-transport-ws/docs/SPEC.md
+++ b/packages/agent-transport-ws/docs/SPEC.md
@@ -85,6 +85,8 @@ ws.on('close', cleanup);
 | `background_task_control_result` | `{ action, taskId, success, message? }`                | cancel/close/send response               |
 | `protocol_error`                 | `{ message: string }`                                  | invalid client message                   |
 
+The `command` message is generic. Available commands depend on the `ICommandModule` instances composed into the upstream `InteractiveSession`; this transport does not know command names in advance.
+
 ## ITransportAdapter
 
 This package implements the `ITransportAdapter` interface from `@robota-sdk/agent-sdk`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
 
   packages/agent-cli:
     dependencies:
+      '@robota-sdk/agent-command-agent':
+        specifier: workspace:*
+        version: link:../agent-command-agent
       '@robota-sdk/agent-core':
         specifier: workspace:*
         version: link:../agent-core
@@ -622,6 +625,25 @@ importers:
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.9)
+
+  packages/agent-command-agent:
+    dependencies:
+      '@robota-sdk/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+    devDependencies:
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3


### PR DESCRIPTION
## Summary
- add durable session/debug logging for background subagents, including parent background task snapshots/events and per-subagent append-only JSONL transcripts
- persist exact session prompt/tool context needed for resume/debugging while keeping high-frequency stream deltas out of the main session JSON
- refine model-visible Agent and ExecuteCommand contracts so real tool calls are encouraged without exposing tag-like pseudo syntax local models may copy
- keep `/agent` as an injected command module, preserve simple natural-language `/agent` usage, and add plain usage placeholders
- add backlog for a first-class Gemma provider plus reusable OpenAI-compatible transport extraction

## Verification
- pnpm --filter @robota-sdk/agent-sessions test -- --run session-system-prompt
- pnpm --filter @robota-sdk/agent-runtime test -- --run background-task-manager subagent-manager
- pnpm --filter @robota-sdk/agent-sdk test -- --run interactive-session
- pnpm --filter @robota-sdk/agent-cli test -- --run child-process-subagent-runner
- pnpm --filter @robota-sdk/agent-sdk test -- --run agent-tool command-execution-tool create-session-new-options system-prompt-composer
- pnpm --filter @robota-sdk/agent-command-agent test -- --run agent-command
- pnpm --filter @robota-sdk/agent-sessions build
- pnpm --filter @robota-sdk/agent-runtime build
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-command-agent build
- pnpm --filter @robota-sdk/agent-cli build
- pnpm docs:build
- git diff --check
- git push hook: harness:scan:dist and harness:verify --base-ref origin/main

## Notes
- Push-time harness verification passed for changed scopes. Existing lint warnings remain warnings only; no lint errors were reported.
