### PR TITLE
chore: publish provider packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,8 @@
       "@robota-sdk/agent-tools",
       "@robota-sdk/agent-provider-anthropic",
       "@robota-sdk/agent-provider-openai",
+      "@robota-sdk/agent-provider-openai-compatible",
+      "@robota-sdk/agent-provider-gemma",
       "@robota-sdk/agent-provider-google",
       "@robota-sdk/agent-provider-bytedance",
       "@robota-sdk/agent-transport-http",

--- a/packages/agent-provider-gemma/package.json
+++ b/packages/agent-provider-gemma/package.json
@@ -80,6 +80,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": true
+  }
 }

--- a/packages/agent-provider-openai-compatible/package.json
+++ b/packages/agent-provider-openai-compatible/package.json
@@ -78,6 +78,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": true
+  }
 }

--- a/packages/agent-provider-openai/package.json
+++ b/packages/agent-provider-openai/package.json
@@ -108,6 +108,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
## Summary
- make @robota-sdk/agent-provider-openai, @robota-sdk/agent-provider-openai-compatible, and @robota-sdk/agent-provider-gemma publishable
- add openai-compatible and gemma providers to the changeset fixed version group
- ensure public packages no longer depend on private workspace packages

## Verification
- pnpm build
- pnpm test (rerun with network/process permissions after sandbox EPERM on local listen)
- pnpm --filter @robota-sdk/agent-provider-openai-compatible --filter @robota-sdk/agent-provider-openai --filter @robota-sdk/agent-provider-gemma --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-provider-openai-compatible --filter @robota-sdk/agent-provider-openai --filter @robota-sdk/agent-provider-gemma --filter @robota-sdk/agent-cli test
- pnpm publish -r --no-git-checks --dry-run