### PR TITLE
docs: complete agent invocation router backlog

### DIFF
--- a/.agents/specs/agent-invocation-router.md
+++ b/.agents/specs/agent-invocation-router.md
@@ -1,7 +1,8 @@
 # Agent Command Invocation Specification
 
-Status: Proposed
+Status: Implemented
 Created: 2026-05-01
+Implemented: 2026-05-01 through PRs #106 and #108
 Related specs:
 
 - `.agents/specs/background-task-layer.md`

--- a/.agents/tasks/CLI-BL-036-background-agent-result-orchestration.md
+++ b/.agents/tasks/CLI-BL-036-background-agent-result-orchestration.md
@@ -13,7 +13,7 @@ packages:
   - agent-transport-ws
 related:
   - .agents/tasks/completed/CLI-BL-030-background-agent-jobs.md
-  - .agents/tasks/CLI-BL-032-agent-invocation-router.md
+  - .agents/tasks/completed/CLI-BL-032-agent-invocation-router.md
   - .agents/tasks/CLI-BL-035-background-agent-watchdogs.md
 ---
 

--- a/.agents/tasks/completed/CLI-BL-032-agent-invocation-router.md
+++ b/.agents/tasks/completed/CLI-BL-032-agent-invocation-router.md
@@ -1,6 +1,6 @@
 ---
 title: CLI-BL-032 Agent Invocation Router
-status: backlog
+status: completed
 priority: high
 urgency: next
 created: 2026-05-01
@@ -11,6 +11,10 @@ packages:
   - agent-transport-headless
   - agent-transport-ws
 spec: .agents/specs/agent-invocation-router.md
+merged_prs:
+  - 105
+  - 106
+  - 108
 ---
 
 ## Summary
@@ -111,9 +115,18 @@ pnpm harness:scan
 
 ## Acceptance Criteria
 
-- `system-prompt-builder` does not own operational guidance; prompt content comes from owner-provided sections and descriptors.
-- `/agent` is model-visible through injected descriptors and user-invocable through command parsing when the agent command module is composed.
-- SDK core can run without the agent command module.
-- Explicit `/agent` requests and model command tool calls create real runtime jobs.
-- Parallel background agent execution returns job IDs immediately.
-- Robota-owned execution status is backed by runtime evidence.
+- [x] `system-prompt-builder` does not own operational guidance; prompt content comes from owner-provided sections and descriptors.
+- [x] `/agent` is model-visible through injected descriptors and user-invocable through command parsing when the agent command module is composed.
+- [x] SDK core can run without the agent command module.
+- [x] Explicit `/agent` requests and model command tool calls create real runtime jobs.
+- [x] Parallel background agent execution returns job IDs and, by default, a wait_all group summary for same-turn consolidation.
+- [x] Robota-owned execution status is backed by runtime evidence.
+
+## Completion Notes
+
+### 2026-05-02
+
+- Confirmed the specification was introduced by PR #105.
+- Confirmed the composable `/agent` command module and model-visible command descriptor path were implemented through PR #106.
+- Confirmed background group orchestration and default `/agent parallel` consolidation were completed by PR #108.
+- Archived this backlog item because the implementation is present on `develop` and package specs now describe the command-module, background-task, and group-orchestration contracts.


### PR DESCRIPTION
## Summary
- archive CLI-BL-032 after confirming the implementation is already merged
- mark the agent invocation router spec as implemented
- update CLI-BL-036 related-task links to the archived CLI-BL-032 task

## Verification
- pnpm harness:scan:test-plans
- pnpm harness:scan:specs
- pre-push: pnpm harness:verify -- --base-ref origin/develop --skip-record-check
