### PR TITLE
docs(cli): track follow-up backlog items

### DIFF
--- a/.agents/tasks/CLI-BL-041-automatic-memory-capture-retrieval.md
+++ b/.agents/tasks/CLI-BL-041-automatic-memory-capture-retrieval.md
@@ -1,0 +1,106 @@
+---
+title: CLI-BL-041 Automatic Memory Capture and Retrieval
+status: backlog
+priority: high
+urgency: next
+created: 2026-05-02
+packages:
+  - agent-sdk
+  - agent-cli
+related:
+  - .agents/tasks/completed/CLI-BL-010-auto-memory-system.md
+---
+
+# CLI-BL-041 Automatic Memory Capture and Retrieval
+
+## Summary
+
+Extend the existing project memory foundation into a real automatic memory system. The current implementation provides `.robota/memory` storage, startup index injection, and `/memory list|show|add`; this follow-up adds automatic candidate extraction, approval/policy controls, relevant-topic retrieval, and session-log evidence.
+
+## Problem
+
+The completed `CLI-BL-010` work created the storage and command foundation, but it does not yet behave like automatic memory. A useful memory system must learn from repeated user feedback, project-specific facts, and durable workflow preferences without requiring the user to manually run `/memory add` every time. It also must retrieve only relevant memory instead of dumping every topic into the system prompt.
+
+## Scope
+
+- Automatic memory candidate extraction after selected session or turn boundaries.
+- Durable classification of candidates as `user`, `feedback`, `project`, or `reference`.
+- A policy layer for auto-save, approval-required save, and disabled modes.
+- Relevant memory retrieval before a new turn or session, using the memory index plus topic selection.
+- Session persistence of memory decisions, saved entries, skipped candidates, and retrieved memory references.
+- CLI/TUI surfaces for reviewing pending candidates and inspecting which memories were used.
+
+Out of scope:
+
+- Provider-specific memory behavior.
+- Model-specific prompt hacks.
+- Unbounded full-topic prompt injection.
+- Silent storage of sensitive or temporary user data without an explicit policy.
+
+## Prior Art Research Plan
+
+Before implementation, verify current behavior from product documentation, not source code:
+
+- Claude Code memory behavior: persistent project/user memory, `/memory`, scope rules, and startup loading.
+- Cursor Memories behavior: sidecar/background extraction, user approval, and project-scoped memories.
+- Codex `AGENTS.md`/project instruction behavior: static project context loading and limits.
+- OpenAI guidance for memory or stored context where applicable, focusing on safety and user control.
+
+The implementation recommendation should choose the most broadly supported pattern from those products and document tradeoffs before code changes.
+
+## Architecture Recommendation
+
+Add an SDK-owned memory pipeline above the existing `ProjectMemoryStore`:
+
+- `MemoryCandidateExtractor`: analyzes completed turns or session summaries and emits structured candidate records.
+- `MemoryPolicyEvaluator`: decides whether a candidate is saved automatically, queued for approval, skipped, or rejected.
+- `MemoryRetrievalService`: selects relevant memory topics from `.robota/memory/MEMORY.md` and `topics/*.md` for the next prompt context.
+- `MemoryAuditLog`: persists candidate, decision, save, skip, and retrieval events into `.robota` session data for resume/debugging.
+- CLI/TUI review commands remain thin adapters over SDK APIs.
+
+The SDK owns memory capture/retrieval logic because context loading, session persistence, system prompt composition, and model-invocable commands already live there. The CLI owns only interaction surfaces.
+
+## Implementation Plan
+
+1. Update package SPEC files to distinguish project memory foundation from automatic memory behavior.
+2. Add memory candidate and decision contracts in the SDK.
+3. Add a pure policy evaluator with modes: `disabled`, `approval_required`, and `auto_save`.
+4. Add an extraction seam so providers or future summarizers can produce candidates without hardcoding model behavior.
+5. Add pending-memory storage and review APIs.
+6. Add relevant-memory retrieval before prompt composition with caps and provenance metadata.
+7. Add `/memory pending`, `/memory approve`, `/memory reject`, and `/memory used` command behavior.
+8. Add TUI notices for pending memory candidates without blocking normal chat.
+9. Persist all memory capture/retrieval events in session logs.
+10. Add headless-safe behavior where memory capture can run without interactive approval only when policy allows it.
+
+## Test Plan
+
+The tests must prove the behavior at the memory pipeline boundaries: extraction, policy decision, storage, retrieval, prompt injection, command review, and session-log provenance. Unit tests should cover pure SDK decisions first; integration tests should verify CLI/headless flows without relying on a real model.
+
+### Unit Tests
+
+- Given a completed turn with durable project facts, when candidate extraction runs, then structured candidates are emitted with type, topic, text, source message ids, and confidence.
+- Given temporary or sensitive content, when policy evaluation runs, then the candidate is skipped or queued according to policy instead of silently saved.
+- Given `disabled` policy, when candidates are extracted, then no pending or saved memory entries are created.
+- Given `approval_required` policy, when candidates are extracted, then they are stored as pending and not injected into future prompts until approved.
+- Given `auto_save` policy, when a high-confidence project candidate is extracted, then it updates the memory index and topic file deterministically.
+- Given duplicate or near-duplicate candidates, when saving runs, then the memory store avoids repeated entries.
+- Given a user asks a topic-related question, when retrieval runs, then only matching memory topics are selected and their provenance is recorded.
+- Given no relevant topics exist, when retrieval runs, then no topic details are injected.
+- Given a session is resumed, when memory audit data is loaded, then pending candidates and used-memory references remain inspectable.
+- Given `/memory used`, when the current turn used retrieved memory, then the command returns topic names and paths without exposing unrelated topics.
+
+### Integration Tests
+
+- CLI interactive flow: complete a turn that produces a memory candidate, approve it, restart the CLI, and verify the approved memory is available.
+- Headless flow: run with approval-required policy and verify candidates are queued rather than saved silently.
+- Session log flow: verify candidate extraction, approval, save, and retrieval events are persisted in `.robota` session data.
+
+## Acceptance Criteria
+
+- Automatic memory capture exists as a separate SDK pipeline, not as ad hoc CLI behavior.
+- Users can inspect, approve, reject, and audit automatic memory decisions.
+- Relevant memory retrieval injects only selected memory with caps and provenance.
+- `.robota/memory` remains the storage SSOT created by `CLI-BL-010`.
+- Session logs contain enough information to debug why a memory was saved or retrieved.
+- The current `/memory list|show|add` commands continue to work.

--- a/.agents/tasks/CLI-BL-042-markdown-diff-tool-summary-migration.md
+++ b/.agents/tasks/CLI-BL-042-markdown-diff-tool-summary-migration.md
@@ -1,0 +1,71 @@
+# CLI-BL-042 Markdown Diff Tool Summary Migration
+
+- **Status**: backlog
+- **Created**: 2026-05-02
+- **Scope**: packages/agent-cli
+- **Related**: .agents/tasks/completed/CLI-BL-029-markdown-diff-rendering.md
+
+## Objective
+
+Migrate Robota CLI tool-summary diff presentation toward the Markdown fenced `diff` rendering path introduced by `CLI-BL-029`, while preserving the tool-summary requirements that still need structured data: file path, line numbers, truncation, permission context, and streaming state.
+
+## Problem
+
+`CLI-BL-029` completed assistant-response rendering for Markdown `diff` fenced code blocks. However, `Edit` tool summaries still use `DiffBlock` and `IDiffLine[]` through `tool-call-extractor`, `MessageList`, and `StreamingIndicator`. This keeps two diff rendering paths in the CLI:
+
+- assistant-authored diff suggestions use Markdown;
+- tool-generated edit previews use a bespoke React component and structured diff lines.
+
+The follow-up should determine how much of the tool-summary path can become Markdown diff text without losing metadata or permissions UX.
+
+## Research Plan
+
+Before implementation, verify documentation and public behavior from comparable coding assistants and Markdown/terminal renderers:
+
+- How coding CLIs present edit previews and tool-result diffs inside Markdown-like transcripts.
+- Whether terminal Markdown renderers can preserve readable diff output while surrounding metadata remains structured.
+- How permission prompts, truncation notices, and file-path headers are represented when the diff body is Markdown.
+
+Do not copy source code from other projects; use product docs and observable behavior only.
+
+## Recommended Direction
+
+Keep metadata structured, but make the diff body Markdown-owned:
+
+- Introduce a `ToolDiffSummary` view model with structured metadata plus a Markdown `diff` fenced body.
+- Convert existing `IDiffLine[]` output into a unified diff-like fenced block for rendering through `renderMarkdown()`.
+- Keep file path, truncation count, and permission labels outside the fenced block as structured UI.
+- Retire `DiffBlock` only after `MessageList` and `StreamingIndicator` tests prove equivalent output for completed and in-flight tool summaries.
+
+## Plan
+
+- [ ] Document the target tool-summary diff contract in `packages/agent-cli/docs/SPEC.md`.
+- [ ] Add RED tests for converting `IDiffLine[]` into a Markdown `diff` fenced block with file headers and line context.
+- [ ] Add component tests proving `MessageList` and `StreamingIndicator` render tool diffs through the Markdown path.
+- [ ] Preserve permission prompt and truncation metadata as structured UI outside the Markdown diff body.
+- [ ] Remove or narrow `DiffBlock` only when no production path still depends on bespoke diff rendering.
+- [ ] Run targeted `agent-cli` tests, typecheck, build, lint, and harness scan.
+
+## Test Plan
+
+- Given an `Edit` tool summary with remove/add/context lines, when the summary view model is built, then the diff body is a Markdown `diff` fenced block.
+- Given a tool summary has a file path, when rendered, then the file path remains visible outside the diff code block.
+- Given a compact diff is truncated, when rendered, then the truncation notice remains visible and is not embedded as diff source text.
+- Given color output is disabled, when a tool-summary diff renders through Markdown, then added and removed lines remain readable as plain text.
+- Given `StreamingIndicator` receives an active Edit tool, when it renders in-flight diff data, then it uses the same diff-body renderer as completed message history.
+- Given non-Edit tool summaries render, when this migration lands, then they do not gain empty diff blocks or unrelated formatting changes.
+
+## Acceptance Criteria
+
+- Tool-summary diffs and assistant Markdown diffs share the same diff body rendering path.
+- Structured tool metadata remains available for file path, truncation, permissions, and streaming status.
+- `DiffBlock` is either removed or documented as a narrow compatibility component with no duplicated diff-coloring policy.
+- Existing assistant Markdown diff rendering from `CLI-BL-029` does not regress.
+
+## Blockers
+
+None.
+
+## Result
+
+Pending.

--- a/.agents/tasks/CLI-BL-043-gemini-provider-package-rename.md
+++ b/.agents/tasks/CLI-BL-043-gemini-provider-package-rename.md
@@ -1,0 +1,78 @@
+# CLI-BL-043 Gemini Provider Package Rename Compatibility Migration
+
+- **Status**: backlog
+- **Created**: 2026-05-02
+- **Scope**: packages/agent-provider-google, packages/agent-provider-gemini, packages/agent-cli, docs, publish registry
+- **Related**: .agents/tasks/completed/CLI-BL-034-google-provider-gemini-rename.md
+
+## Objective
+
+Plan and implement the package-level migration from the current `@robota-sdk/agent-provider-google` package to a canonical `@robota-sdk/agent-provider-gemini` package while preserving existing user imports and `type: "google"` provider profiles for a defined compatibility window.
+
+## Current State
+
+`CLI-BL-034` completed the compatibility-first slice:
+
+- `@robota-sdk/agent-provider-google` still owns the Gemini API implementation.
+- `createGeminiProviderDefinition()` exposes canonical provider type `gemini`.
+- `google` is accepted as a compatibility alias through the generic `IProviderDefinition.aliases` contract.
+- Direct Gemini transport uses `@google/genai`.
+- CLI composes the provider definition generically and does not branch on `gemini` or `google`.
+
+The remaining issue is package identity. The package name still says `google`, while its runtime responsibility is Gemini API behavior.
+
+## Research Plan
+
+Before implementation, verify current package migration practices from public documentation:
+
+- npm package deprecation and replacement package guidance.
+- How SDK packages communicate package rename migrations while preserving import compatibility.
+- Robota release and publish rules for adding a new publishable package with synchronized monorepo versions.
+
+## Recommended Direction
+
+Use a compatibility-wrapper migration:
+
+- Create `@robota-sdk/agent-provider-gemini` as the canonical implementation package.
+- Make `@robota-sdk/agent-provider-google` depend on and re-export from `agent-provider-gemini` for one migration window.
+- Keep provider profile `type: "gemini"` canonical and `type: "google"` as a provider-definition alias.
+- Keep `GoogleProvider` as a compatibility export if downstream code imports that class name; introduce `GeminiProvider` as the canonical class name.
+- Update CLI default provider composition to import from `agent-provider-gemini` once the new package exists.
+- Update docs and publish registry together so package identity and release policy stay consistent.
+
+## Plan
+
+- [ ] Update package specs before code changes for both canonical and compatibility packages.
+- [ ] Add `packages/agent-provider-gemini` with the canonical implementation and public exports.
+- [ ] Convert `packages/agent-provider-google` into a compatibility package that re-exports canonical behavior without duplicating implementation.
+- [ ] Preserve `GoogleProvider` compatibility export and add canonical `GeminiProvider`.
+- [ ] Keep `createGeminiProviderDefinition()` canonical and preserve `google` alias.
+- [ ] Update CLI composition root to import the canonical package without provider-name-specific branches.
+- [ ] Update project structure, publish registry, README files, and migration notes.
+- [ ] Add tests proving both old and new import paths work and resolve equivalent provider definitions.
+- [ ] Run package builds, typecheck, lint, targeted tests, publish scan, and full harness scan.
+
+## Test Plan
+
+- Given user code imports from `@robota-sdk/agent-provider-gemini`, when it creates `GeminiProvider`, then direct chat/stream behavior matches the current implementation.
+- Given user code imports from `@robota-sdk/agent-provider-google`, when it creates `GoogleProvider`, then the compatibility package reuses canonical implementation and behavior remains unchanged.
+- Given CLI default provider definitions are assembled, when provider type `gemini` is selected, then the canonical package definition is used.
+- Given an existing settings profile uses `type: "google"`, when provider resolution runs, then alias resolution still creates the Gemini provider.
+- Given package dependency checks run, when compatibility package imports canonical package, then no workspace cycle is introduced.
+- Given publish scans run, when the new package is added, then publish registry and package versions are synchronized.
+
+## Acceptance Criteria
+
+- `@robota-sdk/agent-provider-gemini` exists as the canonical package.
+- `@robota-sdk/agent-provider-google` remains functional as a compatibility import path for the documented migration window.
+- Generic CLI/SDK code remains free of provider-name branching.
+- Provider profile alias compatibility for `google` continues to work.
+- Documentation clearly states the package migration path and compatibility window.
+
+## Blockers
+
+None.
+
+## Result
+
+Pending.

--- a/.agents/tasks/CLI-BL-044-qwen-built-in-web-tools.md
+++ b/.agents/tasks/CLI-BL-044-qwen-built-in-web-tools.md
@@ -1,0 +1,106 @@
+# CLI-BL-044 Qwen Built-in Web Tools
+
+- **Status**: backlog
+- **Created**: 2026-05-02
+- **Scope**: packages/agent-provider-qwen, packages/agent-provider-openai-compatible, packages/agent-core, packages/agent-cli
+- **Related**: .agents/tasks/completed/CLI-BL-038-qwen-api-provider.md
+
+## Objective
+
+Add a narrowly scoped Qwen built-in web tools capability for Robota, focused first on WebSearch/WebFetch-equivalent behavior through Alibaba Cloud Model Studio Qwen APIs, without attempting to support every Qwen built-in tool.
+
+## Problem
+
+`CLI-BL-038` implemented Qwen through OpenAI-compatible Chat Completions. That path supports normal chat, streaming, and user-defined function/tool calling, but Alibaba Cloud documents richer Qwen built-in tools through OpenAI-compatible Responses API and DashScope-specific parameters.
+
+Robota should not mix provider/server-side built-in tools with local Robota tools as if they had the same execution semantics. Qwen built-in tools are executed by the provider service, have provider-specific billing/provenance behavior, and return provider-specific response items. Robota needs a provider-owned capability layer before exposing them as user-facing WebSearch/WebFetch equivalents.
+
+## Research Findings
+
+Official Alibaba Cloud Model Studio documentation separates Qwen API surfaces:
+
+- OpenAI Chat Completions: mature migration path for chat, streaming, and user-defined function calling.
+- OpenAI Responses: supports built-in web search, code interpreter, web extractor, file search, image search, and MCP-style tools depending on model/region.
+- DashScope: native API surface with the broadest Qwen feature coverage.
+
+Relevant sources:
+
+- Qwen API interfaces: <https://www.alibabacloud.com/help/en/model-studio/qwen-api-reference/>
+- Qwen Responses API built-in tools: <https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-responses>
+- Web search: <https://www.alibabacloud.com/help/en/model-studio/web-search>
+- Web extractor: <https://www.alibabacloud.com/help/en/model-studio/web-extractor>
+- Code interpreter: <https://www.alibabacloud.com/help/en/model-studio/qwen-code-interpreter>
+- qwen3.6-plus Token Plan built-in tools overview: <https://www.alibabacloud.com/help/en/model-studio/token-plan-tool>
+
+## Terminology
+
+- `web_search`: Provider-side web search. This is closest to Robota's `WebSearch` intent: retrieve up-to-date web information and let the model answer from search results.
+- `web_extractor`: Provider-side web page extraction. This is closest to Robota's `WebFetch` intent: fetch a specific URL or page content and provide extracted content to the model. Alibaba documentation notes that Responses API usage adds both `web_search` and `web_extractor` to `tools`.
+- `code_interpreter`: Provider-side sandboxed Python execution for math, data analysis, or code-aided reasoning. This is not equivalent to Robota local shell/process tools and must not be treated as local command execution.
+
+## Recommended Direction
+
+Implement only provider-side web tools first:
+
+- Add a Qwen-owned Responses API transport capability instead of overloading the existing Chat Completions provider path.
+- Expose a Qwen provider option or provider definition capability for enabling built-in web tools.
+- Map Robota WebSearch/WebFetch intent to Qwen `web_search` and `web_extractor` only inside `agent-provider-qwen`.
+- Preserve local Robota tools as separate tools with separate permissions, logs, and execution ownership.
+- Persist provider-side tool usage metadata in session logs so users can audit when Qwen used built-in web tools.
+
+Do not implement `code_interpreter` in the first slice. It executes provider-hosted Python in a sandbox and needs separate safety, billing, output-shape, and provenance design.
+
+## Scope
+
+- Qwen Responses API request/stream parsing required for `web_search` and `web_extractor`.
+- Provider-owned capability metadata that says Qwen can provide web-search/web-fetch behavior.
+- Session-log provenance for provider-side built-in tool invocations and final response text.
+- CLI configuration documentation for enabling Qwen built-in web tools.
+- Tests using provider-owned fixtures for Responses API events and completed responses.
+
+## Non-Goals
+
+- No first-slice support for `code_interpreter`.
+- No first-slice support for `file_search`, `web_search_image`, `image_search`, or MCP tools.
+- No native DashScope transport implementation unless Responses API cannot satisfy WebSearch/WebFetch.
+- No generic CLI/SDK branches for Qwen model names or provider type names.
+- No replacement of Robota local tools with provider-side built-in tools.
+- No hidden provider-side network access without configuration and session-log evidence.
+
+## Plan
+
+- [ ] Update `agent-provider-qwen` SPEC with built-in web tools ownership and Responses API boundary.
+- [ ] Define a provider-side built-in tool capability contract that generic layers can observe without provider-name branching.
+- [ ] Add Qwen Responses API request and response/event parsing for `web_search` and `web_extractor`.
+- [ ] Add provider fixtures for non-streaming and streaming Responses API output with provider-side web tool events.
+- [ ] Add session-log metadata for provider-side built-in tool usage.
+- [ ] Add CLI docs/settings guidance for enabling Qwen built-in web tools.
+- [ ] Keep `code_interpreter` documented as a future separate backlog item.
+- [ ] Run targeted Qwen provider tests, typecheck, build, lint, and harness scan.
+
+## Test Plan
+
+- Given Qwen built-in web tools are disabled, when a normal Qwen chat request runs, then it uses the existing Chat Completions path and sends no Responses API built-in tools.
+- Given built-in web search is enabled, when the provider sends a Responses API request, then the request includes `web_search`.
+- Given built-in web fetch/extraction is enabled, when the provider sends a Responses API request, then the request includes `web_search` and `web_extractor` as required by Qwen documentation.
+- Given a streamed Responses API event contains `response.output_text.delta`, when parsed, then Robota emits normal visible text deltas.
+- Given a streamed Responses API event reports a `web_extractor_call` or web-search tool completion, when parsed, then Robota records provider-side tool provenance without exposing it as a local Robota tool execution.
+- Given provider-side tool usage exists, when session logs are inspected, then the logs show which Qwen built-in tools were enabled and used.
+- Given a user-defined Robota `WebSearch` or `WebFetch` tool is also available, when the model calls a local tool, then Robota local permission/logging semantics remain unchanged.
+- Given `code_interpreter` appears in provider output fixtures, when first-slice parsing runs, then Robota treats it as unsupported provider-side metadata and does not execute or emulate it locally.
+
+## Acceptance Criteria
+
+- Qwen WebSearch/WebFetch-equivalent support is provider-owned and does not add Qwen-specific branches to generic CLI/SDK layers.
+- First implementation scope is limited to `web_search` and `web_extractor`.
+- Provider-side built-in tool usage is auditable in session logs.
+- Local Robota tools and provider-side built-in tools remain distinct in permissions, lifecycle, and provenance.
+- `code_interpreter` and other built-in tools are explicitly deferred with documented reasons.
+
+## Blockers
+
+None.
+
+## Result
+
+Pending.

--- a/.agents/tasks/completed/CLI-BL-034-google-provider-gemini-rename.md
+++ b/.agents/tasks/completed/CLI-BL-034-google-provider-gemini-rename.md
@@ -1,9 +1,10 @@
 # CLI-BL-034 Gemini Provider Modernization and Google Compatibility
 
-- **Status**: in-progress
+- **Status**: completed
 - **Created**: 2026-05-01
 - **Branch**: feat/gemini-provider-modernization
-- **Scope**: packages/agent-provider-google, packages/agent-provider-gemini, packages/agent-cli, docs
+- **Merged PR**: #117
+- **Scope**: packages/agent-provider-google, packages/agent-core, packages/agent-cli, docs
 
 ## Objective
 
@@ -36,13 +37,14 @@ Renaming directly would affect imports, package documentation, CLI provider type
 - Gemini structured outputs support JSON schema and streaming partial JSON.
   - Source: <https://ai.google.dev/gemini-api/docs/structured-output>
 
-## Current Slice Decision
+## Completed Slice Decision
 
 - Do not create `agent-provider-gemini` in this slice. Creating a new canonical package and turning `agent-provider-google` into a compatibility wrapper requires a publish and semver migration plan.
 - Add a provider-definition alias mechanism in the shared provider-definition contract so compatibility names are resolved generically.
 - Export a Gemini provider definition from the current Google/Gemini provider package with canonical `type: "gemini"` and compatibility alias `google`.
 - Add the Gemini provider definition to the CLI composition root. CLI may import and inject the provider definition, but generic provider resolution must not branch on `gemini` or `google`.
 - Migrate the direct Gemini transport from legacy `@google/generative-ai` to the official GA `@google/genai` SDK after provider-type compatibility is covered by tests.
+- Track the package-level rename to a future `@robota-sdk/agent-provider-gemini` package separately in `CLI-BL-043`, because it affects package names, publish policy, compatibility imports, and semver.
 
 ## Plan
 
@@ -103,11 +105,20 @@ Renaming directly would affect imports, package documentation, CLI provider type
 - Split Gemini tool schema conversion into `tool-schema-converter.ts` after harness file-size scan showed `message-converter.ts` exceeded the 300-line limit.
 - Verified `pnpm harness:scan`; file-size warnings returned to the pre-existing 55-file set and no new oversized file remains from this slice.
 
+### Post-Merge Current State
+
+- PR #117 merged the compatibility-first Gemini modernization into `develop`.
+- The workspace still contains `@robota-sdk/agent-provider-google`; no `packages/agent-provider-gemini` package exists yet.
+- `createGeminiProviderDefinition()` is exported from `@robota-sdk/agent-provider-google` with canonical `type: "gemini"` and compatibility alias `google`.
+- CLI default provider composition injects the Gemini provider definition through the generic provider-definition contract.
+- Direct Gemini transport now uses `@google/genai`; the legacy `@google/generative-ai` transport is no longer the implementation path.
+- The remaining rename/compatibility-package work is tracked as `CLI-BL-043 Gemini Provider Package Rename Compatibility Migration`.
+
 ## Blockers
 
-- Full package rename to `agent-provider-gemini` still needs a semver and publish strategy.
-- Package rename remains separate; direct SDK migration is now in progress in this branch.
+- None for this completed modernization slice.
+- Full package rename to `agent-provider-gemini` remains future work and is tracked separately.
 
 ## Result
 
-In progress. Completed the compatibility-first provider type slice and the direct transport migration to `@google/genai` on `feat/gemini-provider-modernization`. Remaining work is the package-level rename/compatibility strategy for a future `agent-provider-gemini` package.
+Completed and merged through PR #117. This slice made `gemini` the canonical provider type, kept `google` as a compatibility alias, moved direct Gemini transport to `@google/genai`, and kept generic CLI/SDK layers branch-free through provider definitions. The package-level rename to a future `@robota-sdk/agent-provider-gemini` package is intentionally deferred to `CLI-BL-043`.


### PR DESCRIPTION
## Summary
- mark the Gemini provider modernization backlog as completed after PR #117
- add follow-up backlog items for automatic memory, markdown diff tool summaries, Gemini package rename, and Qwen built-in web tools
- scope Qwen built-in tools to WebSearch/WebFetch-equivalent behavior first

## Verification
- pnpm harness:scan
- pnpm harness:scan:test-plans
- pre-push scoped verification