### PR TITLE
feat(qwen): support provider-side web tools

### DIFF
--- a/.agents/tasks/completed/CLI-BL-044-qwen-built-in-web-tools.md
+++ b/.agents/tasks/completed/CLI-BL-044-qwen-built-in-web-tools.md
@@ -1,7 +1,8 @@
 # CLI-BL-044 Qwen Built-in Web Tools
 
-- **Status**: backlog
+- **Status**: completed
 - **Created**: 2026-05-02
+- **Branch**: feat/qwen-built-in-web-tools
 - **Scope**: packages/agent-provider-qwen, packages/agent-provider-openai-compatible, packages/agent-core, packages/agent-cli
 - **Related**: .agents/tasks/completed/CLI-BL-038-qwen-api-provider.md
 
@@ -69,14 +70,23 @@ Do not implement `code_interpreter` in the first slice. It executes provider-hos
 
 ## Plan
 
-- [ ] Update `agent-provider-qwen` SPEC with built-in web tools ownership and Responses API boundary.
-- [ ] Define a provider-side built-in tool capability contract that generic layers can observe without provider-name branching.
-- [ ] Add Qwen Responses API request and response/event parsing for `web_search` and `web_extractor`.
-- [ ] Add provider fixtures for non-streaming and streaming Responses API output with provider-side web tool events.
-- [ ] Add session-log metadata for provider-side built-in tool usage.
-- [ ] Add CLI docs/settings guidance for enabling Qwen built-in web tools.
-- [ ] Keep `code_interpreter` documented as a future separate backlog item.
-- [ ] Run targeted Qwen provider tests, typecheck, build, lint, and harness scan.
+- [x] Update `agent-provider-qwen` SPEC with built-in web tools ownership and Responses API boundary.
+- [x] Define a provider-side built-in tool capability contract that generic layers can observe without provider-name branching.
+- [x] Add Qwen Responses API request and response/event parsing for `web_search` and `web_extractor`.
+- [x] Add provider fixtures for non-streaming and streaming Responses API output with provider-side web tool events.
+- [x] Add session-log metadata for provider-side built-in tool usage.
+- [x] Add CLI docs/settings guidance for enabling Qwen built-in web tools.
+- [x] Keep `code_interpreter` documented as a future separate backlog item.
+- [x] Run targeted Qwen provider tests, typecheck, build, lint, and harness scan.
+
+## Progress
+
+### 2026-05-02
+
+- Added provider-owned Qwen Responses API support for `web_search` and `web_extractor`.
+- Added a generic provider `options` bag through provider definitions, CLI settings, SDK config loading, and runtime serialization so provider-owned capabilities can be injected without CLI/SDK provider-name branches.
+- Added Qwen provider tests for Responses API request construction, streaming output assembly, provider-side tool provenance, and local function-tool separation.
+- Updated package specs and README guidance for enabling Qwen built-in web tools and deferring provider-hosted code interpreter support.
 
 ## Test Plan
 
@@ -103,4 +113,4 @@ None.
 
 ## Result
 
-Pending.
+Implemented Qwen provider-side WebSearch/WebFetch-equivalent support through the Alibaba Cloud Model Studio OpenAI-compatible Responses API. Generic layers preserve provider-owned options without knowing Qwen-specific settings, and Qwen provider metadata records enabled/used built-in tools separately from local Robota tool calls.

--- a/.changeset/qwen-built-in-web-tools.md
+++ b/.changeset/qwen-built-in-web-tools.md
@@ -1,0 +1,9 @@
+---
+'@robota-sdk/agent-provider-qwen': minor
+'@robota-sdk/agent-core': minor
+'@robota-sdk/agent-cli': minor
+'@robota-sdk/agent-sdk': minor
+'@robota-sdk/agent-runtime': minor
+---
+
+Add Qwen provider-owned Responses API support for built-in web search/fetch tools and pass provider-owned profile options through generic CLI/runtime configuration.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -63,6 +63,17 @@ Settings may define an active provider profile:
       "type": "openai",
       "model": "<openai-compatible-model>",
       "apiKey": "$ENV:OPENAI_API_KEY"
+    },
+    "qwen": {
+      "type": "qwen",
+      "model": "qwen3.6-plus",
+      "apiKey": "$ENV:DASHSCOPE_API_KEY",
+      "options": {
+        "builtInWebTools": {
+          "webSearch": true,
+          "webFetch": true
+        }
+      }
     }
   }
 }
@@ -76,19 +87,22 @@ Provider resolution order:
 2. Legacy `provider`
 3. Defaults supplied by the resolved provider definition
 
+Provider profiles may include `options`. The CLI passes this bag through to `definition.createProvider(config)` without interpreting provider-specific keys. Provider packages own the shape, validation, defaults, and behavior for their options.
+
 Provider definition contract:
 
-| Field            | Owner                            | CLI behavior                                             |
-| ---------------- | -------------------------------- | -------------------------------------------------------- |
-| `type`           | Provider package or CLI assembly | Match settings profile type to a definition              |
-| `aliases`        | Provider package                 | Optional compatibility names resolved by generic lookup  |
-| `displayName`    | Provider package                 | Optional human-readable provider label for setup lists   |
-| `description`    | Provider package                 | Optional provider description for setup lists and errors |
-| `defaults`       | Provider package                 | Fill omitted model/apiKey/baseURL/timeout values         |
-| `setupSteps`     | Provider package                 | Drive interactive setup prompts without type branches    |
-| `requiresApiKey` | Provider package                 | Validate profiles consistently                           |
-| `probeProfile`   | Provider package                 | Optional endpoint/profile test hook                      |
-| `createProvider` | Provider package                 | Build concrete provider instance                         |
+| Field              | Owner                            | CLI behavior                                                       |
+| ------------------ | -------------------------------- | ------------------------------------------------------------------ |
+| `type`             | Provider package or CLI assembly | Match settings profile type to a definition                        |
+| `aliases`          | Provider package                 | Optional compatibility names resolved by generic lookup            |
+| `displayName`      | Provider package                 | Optional human-readable provider label for setup lists             |
+| `description`      | Provider package                 | Optional provider description for setup lists and errors           |
+| `defaults`         | Provider package                 | Fill omitted model/apiKey/baseURL/timeout values                   |
+| `defaults.options` | Provider package                 | Optional provider-owned option defaults passed through generically |
+| `setupSteps`       | Provider package                 | Drive interactive setup prompts without type branches              |
+| `requiresApiKey`   | Provider package                 | Validate profiles consistently                                     |
+| `probeProfile`     | Provider package                 | Optional endpoint/profile test hook                                |
+| `createProvider`   | Provider package                 | Build concrete provider instance                                   |
 
 The default CLI binary assembles definitions from provider packages. Alternate embeddings can pass their own definitions into `startCli({ providerDefinitions })`. Compatibility provider names such as `google` for the canonical Gemini provider must be represented as provider-definition aliases, not as CLI provider-name branches.
 
@@ -823,14 +837,14 @@ When an Edit tool summary includes diff lines, the CLI shows a compact diff belo
 
 **Display format:**
 
-````markdown
+```markdown
 ✓ Edit(src/provider.ts)
 │ src/provider.ts
 `diff
     - 42 | const DEFAULT_MAX_TOKENS = 4096;
     + 42 | const maxTokens = getModelMaxOutput(modelId);
     `
-````
+```
 
 **Rules:**
 

--- a/packages/agent-cli/src/subagents/child-process-subagent-runner.ts
+++ b/packages/agent-cli/src/subagents/child-process-subagent-runner.ts
@@ -176,6 +176,7 @@ function createProviderProfile(
     apiKey: provider.apiKey,
     baseURL: provider.baseURL,
     timeout: provider.timeout,
+    options: provider.options,
   };
 }
 

--- a/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
@@ -126,11 +126,18 @@ vi.mock('@robota-sdk/agent-provider-qwen', () => {
         apiKey?: string;
         baseURL?: string;
         timeout?: number;
+        options?: Record<string, unknown>;
       }) =>
         new MockQwenProvider({
           apiKey: config.apiKey,
           ...(config.baseURL !== undefined && { baseURL: config.baseURL }),
           ...(config.timeout !== undefined && { timeout: config.timeout }),
+          ...(config.options?.['responsesBaseURL'] !== undefined && {
+            responsesBaseURL: config.options['responsesBaseURL'],
+          }),
+          ...(config.options?.['builtInWebTools'] !== undefined && {
+            builtInWebTools: config.options['builtInWebTools'],
+          }),
           defaultModel: config.model,
         }),
     }),
@@ -381,6 +388,54 @@ describe('provider-factory', () => {
       baseURL: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
       timeout: 45_000,
       defaultModel: 'qwen-plus',
+    });
+  });
+
+  it('passes provider-owned options through the generic provider config bag', () => {
+    writeJson(join(cwd, '.robota', 'settings.json'), {
+      currentProvider: 'qwen',
+      providers: {
+        qwen: {
+          type: 'qwen',
+          model: 'qwen3.6-plus',
+          apiKey: 'dashscope-key',
+          options: {
+            responsesBaseURL:
+              'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+            builtInWebTools: {
+              webSearch: true,
+              webFetch: true,
+              enableThinking: true,
+            },
+          },
+        },
+      },
+    });
+
+    const settings = readProviderSettings(cwd);
+    const provider = createProviderFromSettings(cwd);
+
+    expect(settings.options).toEqual({
+      responsesBaseURL:
+        'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+      builtInWebTools: {
+        webSearch: true,
+        webFetch: true,
+        enableThinking: true,
+      },
+    });
+    expect(provider.name).toBe('qwen');
+    expect(QwenProvider).toHaveBeenCalledWith({
+      apiKey: 'dashscope-key',
+      baseURL: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+      responsesBaseURL:
+        'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+      builtInWebTools: {
+        webSearch: true,
+        webFetch: true,
+        enableThinking: true,
+      },
+      defaultModel: 'qwen3.6-plus',
     });
   });
 

--- a/packages/agent-cli/src/utils/provider-factory.ts
+++ b/packages/agent-cli/src/utils/provider-factory.ts
@@ -8,7 +8,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IAIProvider, TUniversalValue } from '@robota-sdk/agent-core';
 import type { ISerializableProviderProfile } from '@robota-sdk/agent-sdk';
 import { type TProviderSettingsDocument } from './provider-settings.js';
 import { DEFAULT_PROVIDER_DEFINITIONS } from './provider-default-definitions.js';
@@ -126,6 +126,7 @@ function resolveActiveProvider(
         apiKey: profile.apiKey,
         baseURL: profile.baseURL,
         timeout: profile.timeout,
+        options: profile.options,
       },
       providerDefinitions,
     );
@@ -140,6 +141,7 @@ function resolveActiveProvider(
         apiKey: provider.apiKey,
         baseURL: provider.baseURL,
         timeout: provider.timeout,
+        options: provider.options,
       },
       providerDefinitions,
     );
@@ -155,6 +157,7 @@ function normalizeProviderConfig(
     apiKey?: string;
     baseURL?: string;
     timeout?: number;
+    options?: Record<string, TUniversalValue>;
   },
   providerDefinitions: readonly IProviderDefinition[],
 ): IProviderConfig {
@@ -164,12 +167,14 @@ function normalizeProviderConfig(
     throw new Error(`Provider ${settings.name} requires model`);
   }
   const apiKeyReference = settings.apiKey ?? defaults.apiKey;
+  const options = settings.options ?? defaults.options;
   return {
     name: settings.name,
     model,
     apiKey: apiKeyReference !== undefined ? resolveEnvReference(apiKeyReference) : undefined,
     baseURL: settings.baseURL ?? defaults.baseURL,
     timeout: settings.timeout,
+    ...(options !== undefined && { options }),
   };
 }
 
@@ -226,6 +231,7 @@ export function createProviderFromProfile(
         apiKey: resolveProfileApiKey(profile),
         baseURL: profile.baseURL,
         timeout: profile.timeout,
+        options: profile.options,
       },
       providerDefinitions,
     ),

--- a/packages/agent-cli/src/utils/provider-settings.ts
+++ b/packages/agent-cli/src/utils/provider-settings.ts
@@ -9,6 +9,7 @@ export interface IProviderProfileSettings {
   apiKey?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export interface ILegacyProviderSettings {
@@ -18,6 +19,7 @@ export interface ILegacyProviderSettings {
   apiKey?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export type TProviderSettingsDocument = Record<string, TUniversalValue> & {

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -80,7 +80,7 @@ This package is the single source of truth (SSOT) for the following types:
 | `IAgentConfig`              | `interfaces/agent.ts`               | Agent configuration contract                                                                                                                                                                                          |
 | `IAIProvider`               | `interfaces/provider.ts`            | Provider integration contract                                                                                                                                                                                         |
 | `IProviderDefinition`       | `interfaces/provider-definition.ts` | Provider assembly contract. Provider packages expose definitions with display metadata, compatibility aliases, defaults, setup prompts, validation requirements, probe hooks, and `createProvider()` factories.       |
-| `IProviderConfig`           | `interfaces/provider-definition.ts` | Normalized provider configuration consumed by provider definitions.                                                                                                                                                   |
+| `IProviderConfig`           | `interfaces/provider-definition.ts` | Normalized provider configuration consumed by provider definitions, including a provider-owned `options` bag that generic layers pass through without interpreting.                                                   |
 | `IProviderProbeResult`      | `interfaces/provider-definition.ts` | Generic provider profile probe result used by CLI and setup flows without provider-specific branching.                                                                                                                |
 | `TMessageFormatConverter`   | `utils/message-converter.ts`        | Optional injected provider message conversion function. Concrete message conversion belongs to provider packages, not core.                                                                                           |
 | `TMessageConverterRegistry` | `utils/message-converter.ts`        | Optional converter registry keyed by caller-owned identifiers. Core treats all keys uniformly and never recognizes provider names internally.                                                                         |
@@ -128,18 +128,18 @@ Provider packages import these types. They must not re-declare them.
 
 ### Core
 
-| Export                         | Kind           | Description                                                                                       |
-| ------------------------------ | -------------- | ------------------------------------------------------------------------------------------------- |
-| `Robota`                       | class          | Main agent facade                                                                                 |
-| `AbstractAgent`                | abstract class | Base agent lifecycle                                                                              |
-| `AbstractAIProvider`           | abstract class | Base for provider implementations                                                                 |
-| `AbstractPlugin`               | abstract class | Base for plugin extensions                                                                        |
-| `AbstractTool`                 | abstract class | Base for tool implementations                                                                     |
-| `AbstractExecutor`             | abstract class | Base for execution strategies                                                                     |
-| `LocalExecutor`                | class          | Local provider execution                                                                          |
-| `IProviderDefinition`          | interface      | Provider assembly definition, including optional setup display metadata and compatibility aliases |
-| `findProviderDefinition`       | function       | Resolve an injected provider definition by canonical type or alias                                |
-| `formatSupportedProviderTypes` | function       | Format injected provider types and aliases for generic errors                                     |
+| Export                         | Kind           | Description                                                                                                                          |
+| ------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `Robota`                       | class          | Main agent facade                                                                                                                    |
+| `AbstractAgent`                | abstract class | Base agent lifecycle                                                                                                                 |
+| `AbstractAIProvider`           | abstract class | Base for provider implementations                                                                                                    |
+| `AbstractPlugin`               | abstract class | Base for plugin extensions                                                                                                           |
+| `AbstractTool`                 | abstract class | Base for tool implementations                                                                                                        |
+| `AbstractExecutor`             | abstract class | Base for execution strategies                                                                                                        |
+| `LocalExecutor`                | class          | Local provider execution                                                                                                             |
+| `IProviderDefinition`          | interface      | Provider assembly definition, including optional setup display metadata, compatibility aliases, defaults, and provider-owned options |
+| `findProviderDefinition`       | function       | Resolve an injected provider definition by canonical type or alias                                                                   |
+| `formatSupportedProviderTypes` | function       | Format injected provider types and aliases for generic errors                                                                        |
 
 ### Tools
 

--- a/packages/agent-core/src/interfaces/provider-definition.ts
+++ b/packages/agent-core/src/interfaces/provider-definition.ts
@@ -1,4 +1,5 @@
 import type { IAIProvider } from './provider';
+import type { TUniversalValue } from './types';
 
 export interface IProviderConfig {
   name: string;
@@ -6,6 +7,7 @@ export interface IProviderConfig {
   apiKey?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export interface IProviderProfileDefaults {
@@ -13,6 +15,7 @@ export interface IProviderProfileDefaults {
   apiKey?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export interface IProviderProfileConfig {
@@ -21,6 +24,7 @@ export interface IProviderProfileConfig {
   apiKey?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export interface IProviderProbeResult {

--- a/packages/agent-provider-qwen/README.md
+++ b/packages/agent-provider-qwen/README.md
@@ -1,8 +1,8 @@
 # @robota-sdk/agent-provider-qwen
 
-Qwen provider for Robota using Alibaba Cloud Model Studio / DashScope OpenAI-compatible Chat Completions.
+Qwen provider for Robota using Alibaba Cloud Model Studio / DashScope OpenAI-compatible APIs.
 
-This provider owns Qwen/DashScope defaults and error framing while reusing the shared OpenAI-compatible transport primitives. It does not implement native DashScope or OpenAI Responses API behavior.
+This provider owns Qwen/DashScope defaults and error framing while reusing the shared OpenAI-compatible Chat Completions primitives for normal chat. It also owns a narrow Qwen Responses API path for provider-side `web_search` and `web_extractor`.
 
 ```ts
 import { QwenProvider } from '@robota-sdk/agent-provider-qwen';
@@ -12,6 +12,44 @@ const provider = new QwenProvider({
   baseURL: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
   defaultModel: 'qwen-plus',
 });
+```
+
+Provider-side web search/fetch can be enabled without adding Qwen branches to CLI or SDK composition:
+
+```ts
+const provider = new QwenProvider({
+  apiKey: process.env.DASHSCOPE_API_KEY,
+  defaultModel: 'qwen3.6-plus',
+  builtInWebTools: {
+    webSearch: true,
+    webFetch: true,
+    enableThinking: true,
+  },
+});
+```
+
+When `webFetch` is enabled, the provider sends both `web_search` and `web_extractor` to Qwen Responses API and records provider-side tool provenance in assistant-message metadata. These provider-side tools are separate from Robota local tools and do not bypass local tool permissions.
+
+CLI settings can pass Qwen-owned options through the generic provider profile `options` bag:
+
+```json
+{
+  "currentProvider": "qwen",
+  "providers": {
+    "qwen": {
+      "type": "qwen",
+      "model": "qwen3.6-plus",
+      "apiKey": "$ENV:DASHSCOPE_API_KEY",
+      "options": {
+        "builtInWebTools": {
+          "webSearch": true,
+          "webFetch": true,
+          "enableThinking": true
+        }
+      }
+    }
+  }
+}
 ```
 
 See [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-provider-qwen/docs/SPEC.md
+++ b/packages/agent-provider-qwen/docs/SPEC.md
@@ -2,19 +2,19 @@
 
 ## Scope
 
-This package owns Qwen provider behavior for Robota when Qwen models are served through Alibaba Cloud Model Studio / DashScope OpenAI-compatible Chat Completions endpoints. It composes `agent-provider-openai-compatible` for message conversion, tool conversion, response parsing, streaming assembly, and endpoint probing while owning Qwen/DashScope defaults, setup labels, and error framing.
+This package owns Qwen provider behavior for Robota when Qwen models are served through Alibaba Cloud Model Studio / DashScope OpenAI-compatible endpoints. It composes `agent-provider-openai-compatible` for Chat Completions message conversion, tool conversion, response parsing, streaming assembly, and endpoint probing while owning Qwen/DashScope defaults, setup labels, Responses API built-in web tools, and error framing.
 
 ## Boundaries
 
 - Does not own generic OpenAI-compatible transport conversion, parser behavior, stream assembly, or endpoint probing. Those belong to `agent-provider-openai-compatible`.
 - Does not own OpenAI-branded account semantics or OpenAI default models. Those belong to `agent-provider-openai`.
 - Does not own Google Gemini/Gemma marker projection. That behavior belongs to provider packages for those model families.
-- Does not own native DashScope or OpenAI Responses API behavior. Those require separate transport contracts and are future work.
+- Owns the Qwen Responses API slice for provider-side `web_search` and `web_extractor`. Broader native DashScope behavior and non-web Responses built-in tools remain future work.
 - Does not own CLI routing, session persistence, tool execution, or SDK orchestration.
 
 ## Research
 
-Official Qwen / Alibaba Cloud Model Studio documentation describes OpenAI-compatible Chat Completions as the mature migration path for Qwen chat, streaming, and tool-calling integration. The documented base URLs are region-specific, and API keys are region-bound. This package therefore defaults to the international Singapore compatible endpoint and exposes base URL setup through the common provider-definition contract instead of adding CLI branches.
+Official Qwen / Alibaba Cloud Model Studio documentation describes OpenAI-compatible Chat Completions as the mature migration path for Qwen chat, streaming, and tool-calling integration. It separately documents OpenAI-compatible Responses API support for built-in tools, including `web_search` and `web_extractor`. Web extractor documentation recommends Responses API for new integrations and says it exposes intermediate tool execution status. The documented base URLs are region-specific, and API keys are region-bound. This package therefore defaults to the international Singapore compatible endpoints and exposes provider-specific Responses options through the generic provider-definition `options` bag instead of adding CLI branches.
 
 Sources:
 
@@ -33,10 +33,12 @@ src/
   defaults.ts             # Qwen documented defaults and region base URLs
   provider.ts             # QwenProvider
   provider-definition.ts  # provider definition for CLI/runtime composition
+  responses-converter.ts  # Qwen Responses API input/tool conversion
+  responses-parser.ts     # Qwen Responses API response/event parsing
   types.ts                # provider options and option value types
 ```
 
-`QwenProvider` is a thin provider shell over OpenAI-compatible Chat Completions. It creates or receives an OpenAI SDK client, builds OpenAI-compatible request parameters, delegates conversion/parsing/stream assembly to `agent-provider-openai-compatible`, and wraps failures with Qwen-owned error messages. `createQwenProviderDefinition()` returns an `IProviderDefinition` so CLI and SDK composition can inject Qwen without provider-specific branches.
+`QwenProvider` is a provider shell over OpenAI-compatible Chat Completions plus a Qwen-owned Responses API path. Normal chat uses `agent-provider-openai-compatible`. When `builtInWebTools.webSearch` or `builtInWebTools.webFetch` is enabled, the provider switches to Responses API, sends provider-side built-in tool declarations, parses provider-side tool events, and records provenance in assistant-message metadata. `createQwenProviderDefinition()` returns an `IProviderDefinition` so CLI and SDK composition can inject Qwen without provider-specific branches.
 
 ## Type Ownership
 
@@ -45,7 +47,10 @@ src/
 | `IQwenProviderOptions`                    | `src/types.ts`    | Constructor options for `QwenProvider`.                     |
 | `TQwenProviderOptionValue`                | `src/types.ts`    | Valid provider option value union.                          |
 | `TQwenProviderRegion`                     | `src/defaults.ts` | Supported documented Qwen OpenAI-compatible regions.        |
+| `TQwenProviderResponsesRegion`            | `src/defaults.ts` | Supported documented Qwen Responses API regions.            |
 | `QWEN_PROVIDER_BASE_URLS`                 | `src/defaults.ts` | Region to base URL map owned by this package.               |
+| `QWEN_PROVIDER_RESPONSES_BASE_URLS`       | `src/defaults.ts` | Region to Responses API base URL map owned by this package. |
+| `IQwenBuiltInWebToolsOptions`             | `src/types.ts`    | Qwen-owned switch for provider-side web search/fetch tools. |
 | `DEFAULT_QWEN_PROVIDER_MODEL`             | `src/defaults.ts` | Package-owned default Qwen model for setup definition.      |
 | `DEFAULT_QWEN_PROVIDER_API_KEY_ENV`       | `src/defaults.ts` | Package-owned default API-key environment variable name.    |
 | `DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE` | `src/defaults.ts` | `$ENV:` provider profile reference for the default API key. |
@@ -53,26 +58,40 @@ src/
 
 ## Public API Surface
 
-| Export                                    | Kind       | Description                                                               |
-| ----------------------------------------- | ---------- | ------------------------------------------------------------------------- |
-| `QwenProvider`                            | class      | Primary provider class; extends `AbstractAIProvider`.                     |
-| `createQwenProviderDefinition`            | function   | Returns an `IProviderDefinition` for branch-free CLI/runtime composition. |
-| `QWEN_PROVIDER_BASE_URLS`                 | constant   | Documented Qwen OpenAI-compatible base URLs by region.                    |
-| `DEFAULT_QWEN_PROVIDER_MODEL`             | constant   | Default setup model owned by this package.                                |
-| `DEFAULT_QWEN_PROVIDER_API_KEY_ENV`       | constant   | Default API-key environment variable name.                                |
-| `DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE` | constant   | Default `$ENV:` API-key reference for settings.                           |
-| `DEFAULT_QWEN_PROVIDER_BASE_URL`          | constant   | Default setup base URL owned by this package.                             |
-| `IQwenProviderOptions`                    | interface  | Provider constructor options.                                             |
-| `TQwenProviderOptionValue`                | type alias | Valid provider option values.                                             |
-| `TQwenProviderRegion`                     | type alias | Supported region keys for `QWEN_PROVIDER_BASE_URLS`.                      |
+| Export                                     | Kind       | Description                                                               |
+| ------------------------------------------ | ---------- | ------------------------------------------------------------------------- |
+| `QwenProvider`                             | class      | Primary provider class; extends `AbstractAIProvider`.                     |
+| `createQwenProviderDefinition`             | function   | Returns an `IProviderDefinition` for branch-free CLI/runtime composition. |
+| `QWEN_PROVIDER_BASE_URLS`                  | constant   | Documented Qwen OpenAI-compatible base URLs by region.                    |
+| `QWEN_PROVIDER_RESPONSES_BASE_URLS`        | constant   | Documented Qwen Responses API base URLs by region.                        |
+| `DEFAULT_QWEN_PROVIDER_MODEL`              | constant   | Default setup model owned by this package.                                |
+| `DEFAULT_QWEN_PROVIDER_API_KEY_ENV`        | constant   | Default API-key environment variable name.                                |
+| `DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE`  | constant   | Default `$ENV:` API-key reference for settings.                           |
+| `DEFAULT_QWEN_PROVIDER_BASE_URL`           | constant   | Default setup base URL owned by this package.                             |
+| `DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL` | constant   | Default Responses API base URL owned by this package.                     |
+| `IQwenBuiltInWebToolsOptions`              | interface  | Provider-side web search/fetch configuration.                             |
+| `IQwenProviderOptions`                     | interface  | Provider constructor options.                                             |
+| `TQwenProviderOptionValue`                 | type alias | Valid provider option values.                                             |
+| `TQwenProviderRegion`                      | type alias | Supported region keys for `QWEN_PROVIDER_BASE_URLS`.                      |
 
 ## Extension Points
 
 - Consumers can provide a preconfigured OpenAI SDK `client` for custom Qwen-compatible endpoint behavior.
-- Consumers can provide `apiKey`, `baseURL`, `timeout`, and `defaultModel`.
+- Consumers can provide `apiKey`, `baseURL`, `responsesBaseURL`, `timeout`, `defaultModel`, and `builtInWebTools`.
 - Consumers can provide an executor to delegate provider execution without direct API calls.
 - Consumers such as `agent-cli` can inject `createQwenProviderDefinition()` alongside other provider definitions. The CLI and SDK must not special-case Qwen by type string or model name.
-- Future native DashScope or Responses API support must be added as explicit Qwen-owned transport capability, not as generic CLI/SDK branches.
+- Future native DashScope or non-web Responses API support must be added as explicit Qwen-owned transport capability, not as generic CLI/SDK branches.
+
+### Built-in Web Tools
+
+Qwen built-in web tools are provider-side capabilities, not Robota local tools. When enabled:
+
+- `builtInWebTools.webSearch: true` sends `web_search`.
+- `builtInWebTools.webFetch: true` sends both `web_search` and `web_extractor`, matching Alibaba's Responses API web extractor guidance.
+- `builtInWebTools.enableThinking` maps to Qwen's `enable_thinking` request field.
+- Provider-side tool usage is recorded in assistant metadata as `providerToolMode`, `providerBuiltInToolsEnabled`, `providerBuiltInToolsUsed`, `qwenWebSearchCalls`, and `qwenWebExtractorCalls`.
+
+`code_interpreter` is intentionally unsupported in this package slice. If Qwen returns unsupported provider-side tool metadata, the parser records it as `qwenUnsupportedProviderToolTypes`; it does not execute or emulate that tool locally.
 
 ## Error Taxonomy
 
@@ -82,8 +101,10 @@ src/
 | Missing API key in provider setup    | `Provider qwen requires apiKey`                       | `provider-definition.ts`  |
 | Missing model                        | `Qwen chat/stream failed: Model is required...`       | `provider.ts`             |
 | Client unavailable                   | `Qwen client not available...`                        | `provider.ts`             |
+| Responses client unavailable         | `Qwen Responses client not available...`              | `provider.ts`             |
 | Chat failure                         | `Qwen chat failed: <message>`                         | `provider.ts`             |
 | Streaming failure                    | `Qwen stream failed: <message>`                       | `provider.ts`             |
+| Responses failure                    | `Qwen responses failed: <message>`                    | `provider.ts`             |
 
 ## Test Strategy
 
@@ -92,8 +113,12 @@ src/
 - Unit tests verify non-streaming chat sends OpenAI-compatible messages/tools and parses native tool calls into universal assistant messages.
 - Unit tests verify streaming assembly emits `onTextDelta` values and returns the final assembled assistant response.
 - Unit tests verify direct `chatStream` yields universal assistant stream chunks.
+- Unit tests verify Responses API requests include `web_search` and `web_extractor` according to provider options.
+- Unit tests verify streamed `response.output_text.delta` events emit visible deltas and final metadata records provider-side tool provenance.
+- Unit tests verify Responses API `function_call` output remains a local Robota tool call and is not logged as provider-side built-in tool execution.
 - Unit tests verify upstream chat and streaming failures are wrapped with Qwen-owned error messages.
 - CLI tests verify Qwen is available through injected default provider definitions without CLI provider-specific branches.
+- CLI tests verify provider-owned `options` are passed through the generic provider config bag.
 
 ## Class Contract Registry
 
@@ -116,3 +141,4 @@ None.
 | `TUniversalMessage` (agent-core)       | `QwenProvider`                 | `src/provider.ts`            |
 | OpenAI-compatible transport primitives | `QwenProvider`                 | `src/provider.ts`            |
 | OpenAI-compatible endpoint probe       | `createQwenProviderDefinition` | `src/provider-definition.ts` |
+| Qwen Responses API conversion/parsing  | `QwenProvider`                 | `src/responses-*.ts`         |

--- a/packages/agent-provider-qwen/src/defaults.ts
+++ b/packages/agent-provider-qwen/src/defaults.ts
@@ -7,7 +7,16 @@ export const QWEN_PROVIDER_BASE_URLS = {
 
 export type TQwenProviderRegion = keyof typeof QWEN_PROVIDER_BASE_URLS;
 
+export const QWEN_PROVIDER_RESPONSES_BASE_URLS = {
+  singapore: 'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+  usVirginia: 'https://dashscope-us.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+  beijing: 'https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+} as const;
+
+export type TQwenProviderResponsesRegion = keyof typeof QWEN_PROVIDER_RESPONSES_BASE_URLS;
+
 export const DEFAULT_QWEN_PROVIDER_MODEL = 'qwen-plus';
 export const DEFAULT_QWEN_PROVIDER_API_KEY_ENV = 'DASHSCOPE_API_KEY';
 export const DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE = `$ENV:${DEFAULT_QWEN_PROVIDER_API_KEY_ENV}`;
 export const DEFAULT_QWEN_PROVIDER_BASE_URL = QWEN_PROVIDER_BASE_URLS.singapore;
+export const DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL = QWEN_PROVIDER_RESPONSES_BASE_URLS.singapore;

--- a/packages/agent-provider-qwen/src/provider-definition.test.ts
+++ b/packages/agent-provider-qwen/src/provider-definition.test.ts
@@ -5,7 +5,9 @@ import {
   DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE,
   DEFAULT_QWEN_PROVIDER_BASE_URL,
   DEFAULT_QWEN_PROVIDER_MODEL,
+  DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
   QWEN_PROVIDER_BASE_URLS,
+  QWEN_PROVIDER_RESPONSES_BASE_URLS,
   QwenProvider,
 } from './index';
 
@@ -15,6 +17,9 @@ vi.mock('openai', () => {
       completions: {
         create: vi.fn(),
       },
+    },
+    responses: {
+      create: vi.fn(),
     },
   }));
   return { default: MockOpenAI };
@@ -42,6 +47,14 @@ describe('createQwenProviderDefinition', () => {
       usVirginia: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1',
       beijing: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
       hongKong: 'https://cn-hongkong.dashscope.aliyuncs.com/compatible-mode/v1',
+    });
+    expect(DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL).toBe(
+      'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+    );
+    expect(QWEN_PROVIDER_RESPONSES_BASE_URLS).toMatchObject({
+      singapore: 'https://dashscope-intl.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+      usVirginia: 'https://dashscope-us.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
+      beijing: 'https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1',
     });
     expect(definition.setupSteps).toEqual([
       {
@@ -76,6 +89,32 @@ describe('createQwenProviderDefinition', () => {
 
     expect(provider).toBeInstanceOf(QwenProvider);
     expect(provider.name).toBe('qwen');
+  });
+
+  it('passes Qwen-owned Responses API options from the generic provider options bag', () => {
+    const definition = createQwenProviderDefinition();
+
+    const provider = definition.createProvider({
+      name: 'qwen',
+      model: 'qwen3.6-plus',
+      apiKey: 'dashscope-key',
+      options: {
+        responsesBaseURL: QWEN_PROVIDER_RESPONSES_BASE_URLS.usVirginia,
+        builtInWebTools: {
+          webSearch: true,
+          webFetch: true,
+          enableThinking: true,
+        },
+      },
+    });
+
+    const options = (provider as unknown as { options: Record<string, unknown> }).options;
+    expect(options['responsesBaseURL']).toBe(QWEN_PROVIDER_RESPONSES_BASE_URLS.usVirginia);
+    expect(options['builtInWebTools']).toEqual({
+      webSearch: true,
+      webFetch: true,
+      enableThinking: true,
+    });
   });
 
   it('rejects provider creation without an API key', () => {

--- a/packages/agent-provider-qwen/src/provider-definition.ts
+++ b/packages/agent-provider-qwen/src/provider-definition.ts
@@ -1,4 +1,5 @@
 import type { IProviderDefinition } from '@robota-sdk/agent-core';
+import type { TUniversalValue } from '@robota-sdk/agent-core';
 import { probeOpenAICompatibleProfile } from '@robota-sdk/agent-provider-openai-compatible';
 import { QwenProvider } from './provider';
 import {
@@ -6,15 +7,18 @@ import {
   DEFAULT_QWEN_PROVIDER_BASE_URL,
   DEFAULT_QWEN_PROVIDER_MODEL,
 } from './defaults';
+import type { IQwenBuiltInWebToolsOptions } from './types';
 
 export {
   DEFAULT_QWEN_PROVIDER_API_KEY_ENV,
   DEFAULT_QWEN_PROVIDER_API_KEY_REFERENCE,
   DEFAULT_QWEN_PROVIDER_BASE_URL,
   DEFAULT_QWEN_PROVIDER_MODEL,
+  DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
   QWEN_PROVIDER_BASE_URLS,
+  QWEN_PROVIDER_RESPONSES_BASE_URLS,
 } from './defaults';
-export type { TQwenProviderRegion } from './defaults';
+export type { TQwenProviderRegion, TQwenProviderResponsesRegion } from './defaults';
 
 export function createQwenProviderDefinition(): IProviderDefinition {
   return {
@@ -46,13 +50,21 @@ export function createQwenProviderDefinition(): IProviderDefinition {
     ],
     requiresApiKey: true,
     probeProfile: probeOpenAICompatibleProfile,
-    createProvider: (config) =>
-      new QwenProvider({
+    createProvider: (config) => {
+      const qwenOptions = parseQwenProviderOptions(config.options);
+      return new QwenProvider({
         apiKey: requireApiKey(config.apiKey),
         ...(config.baseURL !== undefined && { baseURL: config.baseURL }),
+        ...(qwenOptions.responsesBaseURL !== undefined && {
+          responsesBaseURL: qwenOptions.responsesBaseURL,
+        }),
         ...(config.timeout !== undefined && { timeout: config.timeout }),
+        ...(qwenOptions.builtInWebTools !== undefined && {
+          builtInWebTools: qwenOptions.builtInWebTools,
+        }),
         defaultModel: config.model,
-      }),
+      });
+    },
   };
 }
 
@@ -61,4 +73,50 @@ function requireApiKey(apiKey: string | undefined): string {
     throw new Error('Provider qwen requires apiKey');
   }
   return apiKey;
+}
+
+function parseQwenProviderOptions(options: Record<string, TUniversalValue> | undefined): {
+  responsesBaseURL?: string;
+  builtInWebTools?: IQwenBuiltInWebToolsOptions;
+} {
+  const builtInWebTools = parseBuiltInWebTools(asRecord(options?.['builtInWebTools']));
+  const responsesBaseURL = asString(options?.['responsesBaseURL']);
+  return {
+    ...(responsesBaseURL !== undefined && { responsesBaseURL }),
+    ...(builtInWebTools !== undefined && { builtInWebTools }),
+  };
+}
+
+function parseBuiltInWebTools(
+  options: Record<string, TUniversalValue> | undefined,
+): IQwenBuiltInWebToolsOptions | undefined {
+  if (options === undefined) {
+    return undefined;
+  }
+  return {
+    ...(asBoolean(options['webSearch']) !== undefined && {
+      webSearch: asBoolean(options['webSearch']),
+    }),
+    ...(asBoolean(options['webFetch']) !== undefined && {
+      webFetch: asBoolean(options['webFetch']),
+    }),
+    ...(asBoolean(options['enableThinking']) !== undefined && {
+      enableThinking: asBoolean(options['enableThinking']),
+    }),
+  };
+}
+
+function asRecord(value: TUniversalValue | undefined): Record<string, TUniversalValue> | undefined {
+  if (value === null || value === undefined || value instanceof Date || Array.isArray(value)) {
+    return undefined;
+  }
+  return typeof value === 'object' ? value : undefined;
+}
+
+function asBoolean(value: TUniversalValue | undefined): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function asString(value: TUniversalValue | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/packages/agent-provider-qwen/src/provider.test.ts
+++ b/packages/agent-provider-qwen/src/provider.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type OpenAI from 'openai';
 import type { IToolSchema, TUniversalMessage } from '@robota-sdk/agent-core';
-import { DEFAULT_QWEN_PROVIDER_BASE_URL, QwenProvider } from './index';
+import {
+  DEFAULT_QWEN_PROVIDER_BASE_URL,
+  DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
+  QwenProvider,
+} from './index';
 
 vi.mock('openai', () => {
   const MockOpenAI = vi.fn().mockImplementation(() => ({
@@ -9,6 +13,9 @@ vi.mock('openai', () => {
       completions: {
         create: vi.fn(),
       },
+    },
+    responses: {
+      create: vi.fn(),
     },
   }));
   return { default: MockOpenAI };
@@ -22,10 +29,17 @@ interface IOpenAIClientMock {
       create: ReturnType<typeof vi.fn>;
     };
   };
+  responses: {
+    create: ReturnType<typeof vi.fn>;
+  };
 }
 
 function getClient(provider: QwenProvider): IOpenAIClientMock {
   return (provider as unknown as { client: IOpenAIClientMock }).client;
+}
+
+function getResponsesClient(provider: QwenProvider): IOpenAIClientMock {
+  return (provider as unknown as { responsesClient: IOpenAIClientMock }).responsesClient;
 }
 
 function createUserMessage(content: string): TUniversalMessage {
@@ -112,6 +126,21 @@ describe('QwenProvider', () => {
     expect(OpenAIConstructor).toHaveBeenCalledWith({
       apiKey: 'dashscope-key',
       baseURL: DEFAULT_QWEN_PROVIDER_BASE_URL,
+    });
+  });
+
+  it('creates a Responses API client when provider-side web tools are configured', async () => {
+    const OpenAIModule = await import('openai');
+    const OpenAIConstructor = vi.mocked(OpenAIModule.default);
+
+    new QwenProvider({
+      apiKey: 'dashscope-key',
+      builtInWebTools: { webSearch: true },
+    });
+
+    expect(OpenAIConstructor).toHaveBeenCalledWith({
+      apiKey: 'dashscope-key',
+      baseURL: DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
     });
   });
 
@@ -224,6 +253,214 @@ describe('QwenProvider', () => {
     expect(result.content).toBe('Hello from Qwen');
     expect(result.metadata?.['model']).toBe('qwen-plus');
     expect(result.metadata?.['finishReason']).toBe('stop');
+  });
+
+  it('uses Qwen Responses API with web_search when built-in web search is enabled', async () => {
+    const provider = new QwenProvider({
+      apiKey: 'dashscope-key',
+      builtInWebTools: { webSearch: true, enableThinking: true },
+    });
+    const client = getResponsesClient(provider);
+    client.responses.create.mockResolvedValue({
+      id: 'resp_1',
+      model: 'qwen3.6-plus',
+      output_text: 'Search-backed answer',
+      status: 'completed',
+      output: [
+        { type: 'web_search_call', id: 'ws_1', status: 'completed' },
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Search-backed answer' }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 4,
+        total_tokens: 14,
+        x_tools: { web_search: { count: 1 } },
+      },
+    });
+
+    const result = await provider.chat([createUserMessage('Latest Qwen news')], {
+      model: 'qwen3.6-plus',
+    });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      {
+        model: 'qwen3.6-plus',
+        input: [{ role: 'user', content: 'Latest Qwen news' }],
+        tools: [{ type: 'web_search' }],
+        enable_thinking: true,
+      },
+      undefined,
+    );
+    expect(result.content).toBe('Search-backed answer');
+    expect(result.metadata?.['providerToolMode']).toBe('qwen_responses');
+    expect(result.metadata?.['providerBuiltInToolsEnabled']).toEqual(['web_search']);
+    expect(result.metadata?.['providerBuiltInToolsUsed']).toEqual(['web_search']);
+    expect(result.metadata?.['qwenWebSearchCalls']).toBe(1);
+  });
+
+  it('adds web_search and web_extractor when built-in web fetch is enabled', async () => {
+    const provider = new QwenProvider({
+      apiKey: 'dashscope-key',
+      builtInWebTools: { webFetch: true },
+    });
+    const client = getResponsesClient(provider);
+    client.responses.create.mockResolvedValue({
+      output_text: 'Fetched answer',
+      output: [
+        {
+          type: 'web_extractor_call',
+          id: 'wx_1',
+          status: 'completed',
+          goal: 'fetch a page',
+          output: 'page text',
+        },
+      ],
+      usage: {
+        input_tokens: 5,
+        output_tokens: 3,
+        total_tokens: 8,
+        x_tools: { web_search: { count: 1 }, web_extractor: { count: 1 } },
+      },
+    });
+
+    const result = await provider.chat([createUserMessage('Fetch https://example.com')], {
+      model: 'qwen3.6-plus',
+    });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      {
+        model: 'qwen3.6-plus',
+        input: [{ role: 'user', content: 'Fetch https://example.com' }],
+        tools: [{ type: 'web_search' }, { type: 'web_extractor' }],
+      },
+      undefined,
+    );
+    expect(result.metadata?.['providerBuiltInToolsEnabled']).toEqual([
+      'web_search',
+      'web_extractor',
+    ]);
+    expect(result.metadata?.['qwenWebExtractorCalls']).toBe(1);
+  });
+
+  it('streams Qwen Responses API text deltas and records provider-side tool provenance', async () => {
+    const provider = new QwenProvider({
+      apiKey: 'dashscope-key',
+      builtInWebTools: { webFetch: true },
+    });
+    const client = getResponsesClient(provider);
+    client.responses.create.mockResolvedValue(
+      asyncIterableFrom([
+        { type: 'response.output_text.delta', delta: 'Hello ' },
+        {
+          type: 'response.output_item.done',
+          item: {
+            type: 'web_extractor_call',
+            id: 'wx_1',
+            status: 'completed',
+            goal: 'extract page',
+            output: 'content',
+          },
+        },
+        { type: 'response.output_text.delta', delta: 'world' },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_1',
+            model: 'qwen3.6-plus',
+            status: 'completed',
+            output_text: 'Hello world',
+            output: [],
+            usage: {
+              input_tokens: 12,
+              output_tokens: 2,
+              total_tokens: 14,
+              x_tools: { web_search: { count: 1 }, web_extractor: { count: 1 } },
+            },
+          },
+        },
+      ]),
+    );
+    const onTextDelta = vi.fn();
+
+    const result = await provider.chat([createUserMessage('Fetch example')], {
+      model: 'qwen3.6-plus',
+      onTextDelta,
+    });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      {
+        model: 'qwen3.6-plus',
+        input: [{ role: 'user', content: 'Fetch example' }],
+        tools: [{ type: 'web_search' }, { type: 'web_extractor' }],
+        stream: true,
+      },
+      undefined,
+    );
+    expect(onTextDelta).toHaveBeenNthCalledWith(1, 'Hello ');
+    expect(onTextDelta).toHaveBeenNthCalledWith(2, 'world');
+    expect(result.content).toBe('Hello world');
+    expect(result.metadata?.['providerBuiltInToolsUsed']).toEqual(['web_search', 'web_extractor']);
+  });
+
+  it('keeps local function tools distinct from provider-side built-in tools', async () => {
+    const provider = new QwenProvider({
+      apiKey: 'dashscope-key',
+      builtInWebTools: { webSearch: true },
+    });
+    const client = getResponsesClient(provider);
+    client.responses.create.mockResolvedValue({
+      output_text: '',
+      output: [
+        {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'inspect_file',
+          arguments: '{"path":"README.md"}',
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 4,
+        total_tokens: 14,
+      },
+    });
+
+    const result = await provider.chat([createUserMessage('Inspect README')], {
+      model: 'qwen3.6-plus',
+      tools: [createToolSchema()],
+    });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      {
+        model: 'qwen3.6-plus',
+        input: [{ role: 'user', content: 'Inspect README' }],
+        tools: [
+          { type: 'web_search' },
+          {
+            type: 'function',
+            name: 'inspect_file',
+            description: 'Inspect a file',
+            parameters: createToolSchema().parameters,
+          },
+        ],
+      },
+      undefined,
+    );
+    if (result.role !== 'assistant') throw new Error('Expected assistant message');
+    expect(result.toolCalls).toEqual([
+      {
+        id: 'call_1',
+        type: 'function',
+        function: {
+          name: 'inspect_file',
+          arguments: '{"path":"README.md"}',
+        },
+      },
+    ]);
+    expect(result.metadata?.['providerBuiltInToolsUsed']).toBeUndefined();
   });
 
   it('yields universal assistant messages from direct chatStream chunks', async () => {

--- a/packages/agent-provider-qwen/src/provider.ts
+++ b/packages/agent-provider-qwen/src/provider.ts
@@ -1,11 +1,6 @@
 import OpenAI from 'openai';
 import { AbstractAIProvider, SilentLogger } from '@robota-sdk/agent-core';
-import type {
-  IAssistantMessage,
-  IChatOptions,
-  TTextDeltaCallback,
-  TUniversalMessage,
-} from '@robota-sdk/agent-core';
+import type { IChatOptions, TTextDeltaCallback, TUniversalMessage } from '@robota-sdk/agent-core';
 import {
   assembleOpenAICompatibleStream,
   convertToOpenAICompatibleMessages,
@@ -13,7 +8,12 @@ import {
   OpenAICompatibleResponseParser,
 } from '@robota-sdk/agent-provider-openai-compatible';
 import type { IOpenAICompatibleError } from '@robota-sdk/agent-provider-openai-compatible';
-import { DEFAULT_QWEN_PROVIDER_BASE_URL } from './defaults';
+import {
+  DEFAULT_QWEN_PROVIDER_BASE_URL,
+  DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
+} from './defaults';
+import { hasQwenBuiltInWebTools } from './responses-converter';
+import { chatStreamWithQwenResponsesApi, chatWithQwenResponsesApi } from './responses-chat';
 import type { IQwenProviderOptions } from './types';
 
 export class QwenProvider extends AbstractAIProvider {
@@ -21,6 +21,7 @@ export class QwenProvider extends AbstractAIProvider {
   override readonly version = '1.0.0';
 
   private readonly client?: OpenAI;
+  private readonly responsesClient?: OpenAI;
   private readonly options: IQwenProviderOptions;
   private readonly responseParser: OpenAICompatibleResponseParser;
 
@@ -37,10 +38,16 @@ export class QwenProvider extends AbstractAIProvider {
     if (!this.executor) {
       if (options.client) {
         this.client = options.client;
+        this.responsesClient = options.client;
       } else if (options.apiKey) {
         this.client = new OpenAI({
           apiKey: options.apiKey,
           baseURL: options.baseURL ?? DEFAULT_QWEN_PROVIDER_BASE_URL,
+          ...(options.timeout !== undefined && { timeout: options.timeout }),
+        });
+        this.responsesClient = new OpenAI({
+          apiKey: options.apiKey,
+          baseURL: options.responsesBaseURL ?? DEFAULT_QWEN_PROVIDER_RESPONSES_BASE_URL,
           ...(options.timeout !== undefined && { timeout: options.timeout }),
         });
       } else {
@@ -58,40 +65,63 @@ export class QwenProvider extends AbstractAIProvider {
     this.validateMessages(messages);
 
     if (this.executor) {
-      try {
-        return await this.executeViaExecutorOrDirect(messages, options);
-      } catch (error) {
-        this.logger.error(
-          'Qwen Provider executor chat error:',
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      }
+      return this.chatViaExecutor(messages, options);
     }
 
-    if (!this.client) {
-      throw new Error(
-        'Qwen client not available. Either provide a client/apiKey or use an executor.',
+    if (this.shouldUseResponsesApi()) {
+      return this.chatViaResponsesApi(messages, options, this.getResponsesClient());
+    }
+
+    return this.chatViaChatCompletions(messages, options, this.getClient());
+  }
+
+  private async chatViaExecutor(
+    messages: TUniversalMessage[],
+    options: IChatOptions | undefined,
+  ): Promise<TUniversalMessage> {
+    try {
+      return await this.executeViaExecutorOrDirect(messages, options);
+    } catch (error) {
+      this.logger.error(
+        'Qwen Provider executor chat error:',
+        error instanceof Error ? error.message : String(error),
       );
+      throw error;
     }
+  }
 
+  private async chatViaResponsesApi(
+    messages: TUniversalMessage[],
+    options: IChatOptions | undefined,
+    client: OpenAI,
+  ): Promise<TUniversalMessage> {
+    this.validateTools(options?.tools);
+    return chatWithQwenResponsesApi({
+      client,
+      messages,
+      chatOptions: options,
+      defaultModel: this.options.defaultModel,
+      builtInWebTools: this.options.builtInWebTools,
+      onTextDelta: this.onTextDelta,
+    });
+  }
+
+  private async chatViaChatCompletions(
+    messages: TUniversalMessage[],
+    options: IChatOptions | undefined,
+    client: OpenAI,
+  ): Promise<TUniversalMessage> {
     try {
       const requestParams = this.buildRequestParams(messages, options);
       const textDeltaCb = options?.onTextDelta ?? this.onTextDelta;
       if (textDeltaCb) {
         return await this.chatWithStreamingAssembly(
-          {
-            ...requestParams,
-            stream: true,
-          },
-          {
-            ...options,
-            onTextDelta: textDeltaCb,
-          },
+          { ...requestParams, stream: true },
+          { ...options, onTextDelta: textDeltaCb },
         );
       }
 
-      const response = await this.client.chat.completions.create(requestParams);
+      const response = await client.chat.completions.create(requestParams);
       return this.responseParser.parseResponse(response);
     } catch (error) {
       const qwenError = error as IOpenAICompatibleError;
@@ -125,6 +155,19 @@ export class QwenProvider extends AbstractAIProvider {
       );
     }
 
+    if (this.shouldUseResponsesApi()) {
+      this.validateTools(options?.tools);
+      yield* chatStreamWithQwenResponsesApi({
+        client: this.responsesClient,
+        messages,
+        chatOptions: options,
+        defaultModel: this.options.defaultModel,
+        builtInWebTools: this.options.builtInWebTools,
+        onTextDelta: this.onTextDelta,
+      });
+      return;
+    }
+
     try {
       const requestParams = this.buildStreamingRequestParams(messages, options);
       const stream = await this.client.chat.completions.create(requestParams);
@@ -147,28 +190,13 @@ export class QwenProvider extends AbstractAIProvider {
   }
 
   override validateConfig(): boolean {
-    return !!this.client && !!this.options;
+    return (
+      !!this.client && !!this.options && (!this.shouldUseResponsesApi() || !!this.responsesClient)
+    );
   }
 
   override async dispose(): Promise<void> {
     // OpenAI-compatible Qwen clients do not need explicit cleanup.
-  }
-
-  protected override validateMessages(messages: TUniversalMessage[]): void {
-    super.validateMessages(messages);
-
-    for (const message of messages) {
-      if (message.role === 'assistant') {
-        const assistantMsg = message as IAssistantMessage;
-        if (
-          assistantMsg.toolCalls &&
-          assistantMsg.toolCalls.length > 0 &&
-          assistantMsg.content === ''
-        ) {
-          continue;
-        }
-      }
-    }
   }
 
   private buildRequestParams(
@@ -205,6 +233,28 @@ export class QwenProvider extends AbstractAIProvider {
       ...this.buildRequestParams(messages, options),
       stream: true,
     } as OpenAI.Chat.ChatCompletionCreateParamsStreaming;
+  }
+
+  private shouldUseResponsesApi(): boolean {
+    return hasQwenBuiltInWebTools(this.options.builtInWebTools);
+  }
+
+  private getClient(): OpenAI {
+    if (!this.client) {
+      throw new Error(
+        'Qwen client not available. Either provide a client/apiKey or use an executor.',
+      );
+    }
+
+    return this.client;
+  }
+
+  private getResponsesClient(): OpenAI {
+    if (!this.responsesClient) {
+      throw new Error('Qwen Responses client not available for built-in web tools.');
+    }
+
+    return this.responsesClient;
   }
 
   private async chatWithStreamingAssembly(

--- a/packages/agent-provider-qwen/src/responses-chat.ts
+++ b/packages/agent-provider-qwen/src/responses-chat.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto';
+import type OpenAI from 'openai';
+import type { IChatOptions, TTextDeltaCallback, TUniversalMessage } from '@robota-sdk/agent-core';
+import type { IOpenAICompatibleError } from '@robota-sdk/agent-provider-openai-compatible';
+import {
+  buildQwenResponsesTools,
+  convertToQwenResponsesInput,
+  getQwenBuiltInWebToolNames,
+} from './responses-converter';
+import { assembleQwenResponsesStream, parseQwenResponsesResponse } from './responses-parser';
+import type {
+  IQwenBuiltInWebToolsOptions,
+  IQwenResponsesRequestNonStreaming,
+  IQwenResponsesRequestStreaming,
+  TQwenResponsesStreamEvent,
+} from './types';
+
+export interface IQwenResponsesChatOptions {
+  client?: OpenAI;
+  messages: TUniversalMessage[];
+  chatOptions?: IChatOptions;
+  defaultModel?: string;
+  builtInWebTools?: IQwenBuiltInWebToolsOptions;
+  onTextDelta?: TTextDeltaCallback;
+}
+
+export async function chatWithQwenResponsesApi(
+  input: IQwenResponsesChatOptions,
+): Promise<TUniversalMessage> {
+  const textDeltaCb = input.chatOptions?.onTextDelta ?? input.onTextDelta;
+  if (textDeltaCb) {
+    return chatWithQwenResponsesStreamingAssembly({
+      ...input,
+      chatOptions: {
+        ...input.chatOptions,
+        onTextDelta: textDeltaCb,
+      },
+    });
+  }
+
+  if (!input.client) {
+    throw new Error('Qwen Responses client not available for built-in web tools.');
+  }
+
+  try {
+    const requestParams = buildResponsesRequestParams(input);
+    const response = await input.client.responses.create(
+      requestParams as OpenAI.Responses.ResponseCreateParamsNonStreaming,
+      input.chatOptions?.signal ? { signal: input.chatOptions.signal } : undefined,
+    );
+    return parseQwenResponsesResponse(response, {
+      enabledBuiltInTools: getQwenBuiltInWebToolNames(input.builtInWebTools),
+    });
+  } catch (error) {
+    const qwenError = error as IOpenAICompatibleError;
+    const errorMessage = qwenError.message || 'Qwen Responses API request failed';
+    throw new Error(`Qwen responses failed: ${errorMessage}`);
+  }
+}
+
+export async function* chatStreamWithQwenResponsesApi(
+  input: IQwenResponsesChatOptions,
+): AsyncIterable<TUniversalMessage> {
+  const deltas: TUniversalMessage[] = [];
+  const result = await chatWithQwenResponsesStreamingAssembly({
+    ...input,
+    chatOptions: {
+      ...input.chatOptions,
+      onTextDelta: (delta) => {
+        input.chatOptions?.onTextDelta?.(delta);
+        deltas.push(createStreamDeltaMessage(delta));
+      },
+    },
+  });
+
+  for (const delta of deltas) {
+    yield delta;
+  }
+  yield {
+    ...result,
+    content: '',
+    metadata: {
+      ...result.metadata,
+      isStreamChunk: true,
+      isComplete: true,
+    },
+  };
+}
+
+async function chatWithQwenResponsesStreamingAssembly(
+  input: IQwenResponsesChatOptions,
+): Promise<TUniversalMessage> {
+  if (!input.client) {
+    throw new Error('Qwen Responses client not available for built-in web tools.');
+  }
+
+  try {
+    const requestParams = buildResponsesStreamingRequestParams(input);
+    const stream = await input.client.responses.create(
+      requestParams as OpenAI.Responses.ResponseCreateParamsStreaming,
+      input.chatOptions?.signal ? { signal: input.chatOptions.signal } : undefined,
+    );
+    return assembleQwenResponsesStream({
+      stream: stream as AsyncIterable<TQwenResponsesStreamEvent>,
+      enabledBuiltInTools: getQwenBuiltInWebToolNames(input.builtInWebTools),
+      onTextDelta: input.chatOptions?.onTextDelta,
+      signal: input.chatOptions?.signal,
+    });
+  } catch (error) {
+    const qwenError = error as IOpenAICompatibleError;
+    const errorMessage = qwenError.message || 'Qwen Responses streaming request failed';
+    throw new Error(`Qwen responses stream failed: ${errorMessage}`);
+  }
+}
+
+function buildResponsesRequestParams(
+  input: IQwenResponsesChatOptions,
+): IQwenResponsesRequestNonStreaming {
+  const model = input.chatOptions?.model ?? input.defaultModel;
+  if (!model) {
+    throw new Error(
+      'Model is required in chat options. Please specify a model in defaultModel configuration.',
+    );
+  }
+
+  const enabledBuiltInTools = getQwenBuiltInWebToolNames(input.builtInWebTools);
+  const tools = buildQwenResponsesTools(enabledBuiltInTools, input.chatOptions?.tools);
+
+  return {
+    model,
+    input: convertToQwenResponsesInput(input.messages),
+    ...(tools !== undefined && { tools }),
+    ...(input.chatOptions?.temperature !== undefined && {
+      temperature: input.chatOptions.temperature,
+    }),
+    ...(input.chatOptions?.maxTokens !== undefined && {
+      max_output_tokens: input.chatOptions.maxTokens,
+    }),
+    ...(input.builtInWebTools?.enableThinking !== undefined && {
+      enable_thinking: input.builtInWebTools.enableThinking,
+    }),
+  };
+}
+
+function buildResponsesStreamingRequestParams(
+  input: IQwenResponsesChatOptions,
+): IQwenResponsesRequestStreaming {
+  return {
+    ...buildResponsesRequestParams(input),
+    stream: true,
+  };
+}
+
+function createStreamDeltaMessage(delta: string): TUniversalMessage {
+  return {
+    id: randomUUID(),
+    role: 'assistant',
+    content: delta,
+    state: 'complete',
+    timestamp: new Date(),
+    metadata: {
+      isStreamChunk: true,
+      isComplete: false,
+    },
+  };
+}

--- a/packages/agent-provider-qwen/src/responses-converter.ts
+++ b/packages/agent-provider-qwen/src/responses-converter.ts
@@ -1,0 +1,104 @@
+import type { IAssistantMessage, IToolSchema, TUniversalMessage } from '@robota-sdk/agent-core';
+import type {
+  IQwenBuiltInWebToolsOptions,
+  IQwenResponsesFunctionTool,
+  IQwenResponsesMessageInput,
+  TQwenBuiltInWebToolName,
+  TQwenResponsesInputItem,
+  TQwenResponsesTool,
+} from './types';
+
+export function getQwenBuiltInWebToolNames(
+  options: IQwenBuiltInWebToolsOptions | undefined,
+): TQwenBuiltInWebToolName[] {
+  const tools: TQwenBuiltInWebToolName[] = [];
+  if (options?.webSearch === true || options?.webFetch === true) {
+    tools.push('web_search');
+  }
+  if (options?.webFetch === true) {
+    tools.push('web_extractor');
+  }
+  return tools;
+}
+
+export function hasQwenBuiltInWebTools(options: IQwenBuiltInWebToolsOptions | undefined): boolean {
+  return getQwenBuiltInWebToolNames(options).length > 0;
+}
+
+export function convertToQwenResponsesInput(
+  messages: TUniversalMessage[],
+): TQwenResponsesInputItem[] {
+  return messages.flatMap((message) => convertMessage(message));
+}
+
+export function buildQwenResponsesTools(
+  builtInWebTools: readonly TQwenBuiltInWebToolName[],
+  localTools: IToolSchema[] | undefined,
+): TQwenResponsesTool[] | undefined {
+  const tools: TQwenResponsesTool[] = [
+    ...builtInWebTools.map((type) => ({ type })),
+    ...convertToQwenResponsesFunctionTools(localTools),
+  ];
+  return tools.length > 0 ? tools : undefined;
+}
+
+function convertToQwenResponsesFunctionTools(
+  tools: IToolSchema[] | undefined,
+): IQwenResponsesFunctionTool[] {
+  return (
+    tools?.map((tool) => ({
+      type: 'function',
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    })) ?? []
+  );
+}
+
+function convertMessage(message: TUniversalMessage): TQwenResponsesInputItem[] {
+  if (message.role === 'user') {
+    return [createMessageInput('user', message.content)];
+  }
+  if (message.role === 'system') {
+    return [createMessageInput('system', message.content)];
+  }
+  if (message.role === 'tool') {
+    return [
+      {
+        type: 'function_call_output',
+        call_id: message.toolCallId,
+        output: message.content || '',
+      },
+    ];
+  }
+  return convertAssistantMessage(message);
+}
+
+function convertAssistantMessage(message: IAssistantMessage): TQwenResponsesInputItem[] {
+  const items: TQwenResponsesInputItem[] = [];
+  if (message.content && message.content.length > 0) {
+    items.push(createMessageInput('assistant', message.content));
+  }
+  for (const toolCall of message.toolCalls ?? []) {
+    items.push({
+      type: 'function_call',
+      call_id: toolCall.id,
+      name: toolCall.function.name,
+      arguments: toolCall.function.arguments,
+    });
+  }
+  if (items.length === 0) {
+    items.push(createMessageInput('assistant', ''));
+  }
+  return items;
+}
+
+function createMessageInput(
+  role: IQwenResponsesMessageInput['role'],
+  content: string | null,
+): IQwenResponsesMessageInput {
+  return {
+    role,
+    content: content ?? '',
+  };
+}

--- a/packages/agent-provider-qwen/src/responses-parser.ts
+++ b/packages/agent-provider-qwen/src/responses-parser.ts
@@ -1,0 +1,299 @@
+import { randomUUID } from 'node:crypto';
+import type { IToolCall, TTextDeltaCallback, TUniversalMessage } from '@robota-sdk/agent-core';
+import type {
+  IQwenResponsesFunctionCallOutputItem,
+  IQwenResponsesErrorEvent,
+  IQwenResponsesResponse,
+  IQwenResponsesUsage,
+  TQwenBuiltInWebToolName,
+  TQwenResponsesOutputItem,
+  TQwenResponsesStreamEvent,
+} from './types';
+import { streamWithAbort } from './responses-stream-utils';
+
+interface IQwenResponsesParseOptions {
+  enabledBuiltInTools: readonly TQwenBuiltInWebToolName[];
+}
+
+interface IQwenResponsesStreamAssemblyOptions extends IQwenResponsesParseOptions {
+  stream: AsyncIterable<TQwenResponsesStreamEvent>;
+  onTextDelta?: TTextDeltaCallback;
+  signal?: AbortSignal;
+}
+
+interface IQwenProviderToolUsage {
+  webSearchCalls: number;
+  webExtractorCalls: number;
+  unsupportedToolTypes: Set<string>;
+}
+
+interface IQwenResponsesStreamState {
+  textParts: string[];
+  toolCalls: IToolCall[];
+  completedResponse?: IQwenResponsesResponse;
+  usage: IQwenProviderToolUsage;
+}
+
+export function parseQwenResponsesResponse(
+  response: IQwenResponsesResponse,
+  options: IQwenResponsesParseOptions,
+): TUniversalMessage {
+  const output = response.output ?? [];
+  const usage = collectProviderToolUsage(output, response.usage);
+  const toolCalls = extractFunctionToolCalls(output);
+  const content = response.output_text ?? extractMessageText(output);
+
+  return buildAssistantMessage({
+    content,
+    toolCalls,
+    response,
+    usage,
+    enabledBuiltInTools: options.enabledBuiltInTools,
+  });
+}
+
+export async function assembleQwenResponsesStream(
+  options: IQwenResponsesStreamAssemblyOptions,
+): Promise<TUniversalMessage> {
+  const state: IQwenResponsesStreamState = {
+    textParts: [],
+    toolCalls: [],
+    usage: createEmptyToolUsage(),
+  };
+
+  for await (const event of streamWithAbort(options.stream, options.signal)) {
+    applyStreamEvent(state, event, options.onTextDelta);
+  }
+
+  if (state.completedResponse !== undefined) {
+    return buildMessageFromCompletedResponse(state, options.enabledBuiltInTools);
+  }
+
+  return buildAssistantMessage({
+    content: state.textParts.join(''),
+    toolCalls: state.toolCalls,
+    usage: state.usage,
+    enabledBuiltInTools: options.enabledBuiltInTools,
+  });
+}
+
+function applyStreamEvent(
+  state: IQwenResponsesStreamState,
+  event: TQwenResponsesStreamEvent,
+  onTextDelta: TTextDeltaCallback | undefined,
+): void {
+  if (event.type === 'response.output_text.delta') {
+    state.textParts.push(event.delta);
+    onTextDelta?.(event.delta);
+    return;
+  }
+
+  if (event.type === 'response.completed') {
+    state.completedResponse = event.response;
+    mergeToolUsage(
+      state.usage,
+      collectProviderToolUsage(event.response.output ?? [], event.response.usage),
+    );
+    return;
+  }
+
+  if (event.type === 'response.output_item.done') {
+    applyOutputItem(state, event.item);
+    return;
+  }
+
+  if (event.type === 'response.web_search_call.completed') {
+    state.usage.webSearchCalls += 1;
+    return;
+  }
+
+  if (event.type === 'response.error' || event.type === 'response.failed') {
+    throw new Error(`Qwen Responses API failed: ${extractErrorMessage(event)}`);
+  }
+}
+
+function buildMessageFromCompletedResponse(
+  state: IQwenResponsesStreamState,
+  enabledBuiltInTools: readonly TQwenBuiltInWebToolName[],
+): TUniversalMessage {
+  const response = state.completedResponse;
+  if (response === undefined) {
+    throw new Error('Qwen Responses stream completed without response metadata');
+  }
+
+  const output = response.output ?? [];
+  const responseToolCalls = extractFunctionToolCalls(output);
+  const content =
+    state.textParts.length > 0
+      ? state.textParts.join('')
+      : (response.output_text ?? extractMessageText(output));
+  const usage = collectProviderToolUsage(output, response.usage);
+  mergeToolUsage(usage, state.usage);
+
+  return buildAssistantMessage({
+    content,
+    toolCalls: responseToolCalls.length > 0 ? responseToolCalls : state.toolCalls,
+    response,
+    usage,
+    enabledBuiltInTools,
+  });
+}
+
+function applyOutputItem(state: IQwenResponsesStreamState, item: TQwenResponsesOutputItem): void {
+  if (item.type === 'function_call') {
+    if (isFunctionCallOutputItem(item)) {
+      state.toolCalls.push(convertFunctionCall(item));
+    }
+    return;
+  }
+  mergeToolUsage(state.usage, collectProviderToolUsage([item], undefined));
+}
+
+function buildAssistantMessage(input: {
+  content: string;
+  toolCalls: IToolCall[];
+  response?: IQwenResponsesResponse;
+  usage: IQwenProviderToolUsage;
+  enabledBuiltInTools: readonly TQwenBuiltInWebToolName[];
+}): TUniversalMessage {
+  return {
+    id: randomUUID(),
+    role: 'assistant',
+    content: input.content,
+    state: 'complete',
+    timestamp: new Date(),
+    ...(input.toolCalls.length > 0 && { toolCalls: input.toolCalls }),
+    ...(input.response?.usage !== undefined && {
+      usage: {
+        promptTokens: input.response.usage.input_tokens ?? 0,
+        completionTokens: input.response.usage.output_tokens ?? 0,
+        totalTokens: input.response.usage.total_tokens ?? 0,
+      },
+    }),
+    metadata: buildProviderToolMetadata(input.enabledBuiltInTools, input.usage, input.response),
+  };
+}
+
+function buildProviderToolMetadata(
+  enabledBuiltInTools: readonly TQwenBuiltInWebToolName[],
+  usage: IQwenProviderToolUsage,
+  response: IQwenResponsesResponse | undefined,
+): NonNullable<TUniversalMessage['metadata']> {
+  const usedTools = collectUsedToolNames(usage);
+  return {
+    providerToolMode: 'qwen_responses',
+    providerBuiltInToolsEnabled: [...enabledBuiltInTools],
+    ...(usedTools.length > 0 && { providerBuiltInToolsUsed: usedTools }),
+    qwenWebSearchCalls: usage.webSearchCalls,
+    qwenWebExtractorCalls: usage.webExtractorCalls,
+    ...(usage.unsupportedToolTypes.size > 0 && {
+      qwenUnsupportedProviderToolTypes: [...usage.unsupportedToolTypes].sort(),
+    }),
+    ...(response?.id !== undefined && { responseId: response.id }),
+    ...(response?.model !== undefined && { model: response.model }),
+    ...(response?.status !== undefined && { finishReason: response.status }),
+  };
+}
+
+function collectUsedToolNames(usage: IQwenProviderToolUsage): TQwenBuiltInWebToolName[] {
+  const used: TQwenBuiltInWebToolName[] = [];
+  if (usage.webSearchCalls > 0) {
+    used.push('web_search');
+  }
+  if (usage.webExtractorCalls > 0) {
+    used.push('web_extractor');
+  }
+  return used;
+}
+
+function collectProviderToolUsage(
+  output: readonly TQwenResponsesOutputItem[],
+  responseUsage: IQwenResponsesUsage | undefined,
+): IQwenProviderToolUsage {
+  const usage = createEmptyToolUsage();
+  for (const item of output) {
+    if (item.type === 'web_search_call') {
+      usage.webSearchCalls += 1;
+    } else if (item.type === 'web_extractor_call') {
+      usage.webExtractorCalls += 1;
+    } else if (isProviderToolOutput(item.type)) {
+      usage.unsupportedToolTypes.add(item.type);
+    }
+  }
+  applyUsageCounts(usage, responseUsage);
+  return usage;
+}
+
+function applyUsageCounts(
+  usage: IQwenProviderToolUsage,
+  responseUsage: IQwenResponsesUsage | undefined,
+): void {
+  const xTools = responseUsage?.x_tools;
+  if (xTools === undefined) {
+    return;
+  }
+  usage.webSearchCalls = Math.max(usage.webSearchCalls, xTools['web_search']?.count ?? 0);
+  usage.webExtractorCalls = Math.max(usage.webExtractorCalls, xTools['web_extractor']?.count ?? 0);
+  for (const toolName of Object.keys(xTools)) {
+    if (toolName !== 'web_search' && toolName !== 'web_extractor') {
+      usage.unsupportedToolTypes.add(toolName);
+    }
+  }
+}
+
+function mergeToolUsage(target: IQwenProviderToolUsage, source: IQwenProviderToolUsage): void {
+  target.webSearchCalls = Math.max(target.webSearchCalls, source.webSearchCalls);
+  target.webExtractorCalls = Math.max(target.webExtractorCalls, source.webExtractorCalls);
+  for (const toolType of source.unsupportedToolTypes) {
+    target.unsupportedToolTypes.add(toolType);
+  }
+}
+
+function createEmptyToolUsage(): IQwenProviderToolUsage {
+  return {
+    webSearchCalls: 0,
+    webExtractorCalls: 0,
+    unsupportedToolTypes: new Set(),
+  };
+}
+
+function isProviderToolOutput(type: string): boolean {
+  return type.endsWith('_call') && type !== 'function_call';
+}
+
+function extractFunctionToolCalls(output: readonly TQwenResponsesOutputItem[]): IToolCall[] {
+  return output.filter(isFunctionCallOutputItem).map((item) => convertFunctionCall(item));
+}
+
+function isFunctionCallOutputItem(
+  item: TQwenResponsesOutputItem,
+): item is IQwenResponsesFunctionCallOutputItem {
+  return (
+    item.type === 'function_call' && 'call_id' in item && 'name' in item && 'arguments' in item
+  );
+}
+
+function convertFunctionCall(item: IQwenResponsesFunctionCallOutputItem): IToolCall {
+  return {
+    id: item.call_id,
+    type: 'function',
+    function: {
+      name: item.name,
+      arguments: item.arguments,
+    },
+  };
+}
+
+function extractMessageText(output: readonly TQwenResponsesOutputItem[]): string {
+  return output
+    .filter((item): item is Extract<TQwenResponsesOutputItem, { type: 'message' }> => {
+      return item.type === 'message';
+    })
+    .flatMap((item) => item.content)
+    .map((part) => part.text)
+    .join('');
+}
+
+function extractErrorMessage(event: IQwenResponsesErrorEvent): string {
+  return event.message ?? event.error?.message ?? event.response?.error?.message ?? 'unknown error';
+}

--- a/packages/agent-provider-qwen/src/responses-stream-utils.ts
+++ b/packages/agent-provider-qwen/src/responses-stream-utils.ts
@@ -1,0 +1,38 @@
+export async function* streamWithAbort<T>(
+  source: AsyncIterable<T>,
+  signal?: AbortSignal,
+): AsyncGenerator<T> {
+  const iterator = source[Symbol.asyncIterator]();
+  try {
+    while (!signal?.aborted) {
+      const item = await nextStreamItem(iterator, signal);
+      if (item.done) break;
+      if (signal?.aborted) break;
+      yield item.value;
+    }
+  } finally {
+    if (signal?.aborted) {
+      await iterator.return?.();
+    }
+  }
+}
+
+async function nextStreamItem<T>(
+  iterator: AsyncIterator<T>,
+  signal?: AbortSignal,
+): Promise<IteratorResult<T>> {
+  if (!signal) return iterator.next();
+  if (signal.aborted) return { done: true, value: undefined as T };
+
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<IteratorResult<T>>((resolve) => {
+    abortListener = (): void => resolve({ done: true, value: undefined as T });
+    signal.addEventListener('abort', abortListener, { once: true });
+  });
+
+  try {
+    return await Promise.race([iterator.next(), aborted]);
+  } finally {
+    if (abortListener) signal.removeEventListener('abort', abortListener);
+  }
+}

--- a/packages/agent-provider-qwen/src/types.ts
+++ b/packages/agent-provider-qwen/src/types.ts
@@ -1,5 +1,203 @@
 import type OpenAI from 'openai';
-import type { IExecutor, ILogger, TProviderOptionValueBase } from '@robota-sdk/agent-core';
+import type {
+  IExecutor,
+  ILogger,
+  IToolSchema,
+  TProviderOptionValueBase,
+  TUniversalMessage,
+} from '@robota-sdk/agent-core';
+
+export type TQwenBuiltInWebToolName = 'web_search' | 'web_extractor';
+
+export interface IQwenBuiltInWebToolsOptions {
+  webSearch?: boolean;
+  webFetch?: boolean;
+  enableThinking?: boolean;
+}
+
+export interface IQwenResponsesWebSearchTool {
+  type: 'web_search';
+}
+
+export interface IQwenResponsesWebExtractorTool {
+  type: 'web_extractor';
+}
+
+export interface IQwenResponsesFunctionTool {
+  type: 'function';
+  name: string;
+  description?: string;
+  parameters: IToolSchema['parameters'];
+}
+
+export type TQwenResponsesTool =
+  | IQwenResponsesWebSearchTool
+  | IQwenResponsesWebExtractorTool
+  | IQwenResponsesFunctionTool;
+
+export interface IQwenResponsesMessageInput {
+  type?: 'message';
+  role: 'user' | 'assistant' | 'system' | 'developer';
+  content: string;
+}
+
+export interface IQwenResponsesFunctionCallInput {
+  type: 'function_call';
+  call_id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface IQwenResponsesFunctionCallOutputInput {
+  type: 'function_call_output';
+  call_id: string;
+  output: string;
+}
+
+export type TQwenResponsesInputItem =
+  | IQwenResponsesMessageInput
+  | IQwenResponsesFunctionCallInput
+  | IQwenResponsesFunctionCallOutputInput;
+
+export interface IQwenResponsesRequestBase {
+  model: string;
+  input: TQwenResponsesInputItem[];
+  tools?: TQwenResponsesTool[];
+  temperature?: number;
+  max_output_tokens?: number;
+  enable_thinking?: boolean;
+}
+
+export interface IQwenResponsesRequestNonStreaming extends IQwenResponsesRequestBase {
+  stream?: false;
+}
+
+export interface IQwenResponsesRequestStreaming extends IQwenResponsesRequestBase {
+  stream: true;
+}
+
+export interface IQwenResponsesTextContent {
+  type: 'output_text' | 'text' | 'input_text';
+  text: string;
+}
+
+export interface IQwenResponsesMessageOutputItem {
+  type: 'message';
+  content: IQwenResponsesTextContent[];
+}
+
+export interface IQwenResponsesFunctionCallOutputItem {
+  type: 'function_call';
+  call_id: string;
+  name: string;
+  arguments: string;
+  id?: string;
+  status?: string;
+}
+
+export interface IQwenResponsesWebSearchAction {
+  query?: string;
+}
+
+export interface IQwenResponsesWebSearchOutputItem {
+  type: 'web_search_call';
+  id?: string;
+  status?: string;
+  action?: IQwenResponsesWebSearchAction;
+}
+
+export interface IQwenResponsesWebExtractorOutputItem {
+  type: 'web_extractor_call';
+  id?: string;
+  status?: string;
+  goal?: string;
+  output?: string;
+}
+
+export interface IQwenResponsesGenericOutputItem {
+  type: string;
+  id?: string;
+  status?: string;
+}
+
+export type TQwenResponsesOutputItem =
+  | IQwenResponsesMessageOutputItem
+  | IQwenResponsesFunctionCallOutputItem
+  | IQwenResponsesWebSearchOutputItem
+  | IQwenResponsesWebExtractorOutputItem
+  | IQwenResponsesGenericOutputItem;
+
+export interface IQwenResponsesToolUsageCount {
+  count?: number;
+}
+
+export interface IQwenResponsesUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  x_tools?: Record<string, IQwenResponsesToolUsageCount>;
+}
+
+export interface IQwenResponsesResponse {
+  id?: string;
+  model?: string;
+  output_text?: string;
+  output?: TQwenResponsesOutputItem[];
+  usage?: IQwenResponsesUsage;
+  status?: string;
+}
+
+export interface IQwenResponsesTextDeltaEvent {
+  type: 'response.output_text.delta';
+  delta: string;
+}
+
+export interface IQwenResponsesCompletedEvent {
+  type: 'response.completed';
+  response: IQwenResponsesResponse;
+}
+
+export interface IQwenResponsesOutputItemDoneEvent {
+  type: 'response.output_item.done';
+  item: TQwenResponsesOutputItem;
+}
+
+export interface IQwenResponsesErrorEvent {
+  type: 'response.error' | 'response.failed';
+  message?: string;
+  error?: {
+    message?: string;
+  };
+  response?: {
+    error?: {
+      message?: string;
+    };
+  };
+}
+
+export interface IQwenResponsesWebSearchEvent {
+  type:
+    | 'response.web_search_call.in_progress'
+    | 'response.web_search_call.searching'
+    | 'response.web_search_call.completed';
+}
+
+export interface IQwenResponsesGenericEvent {
+  type: string;
+  item?: TQwenResponsesOutputItem;
+  response?: IQwenResponsesResponse;
+}
+
+export type TQwenResponsesStreamEvent =
+  | IQwenResponsesTextDeltaEvent
+  | IQwenResponsesCompletedEvent
+  | IQwenResponsesOutputItemDoneEvent
+  | IQwenResponsesErrorEvent
+  | IQwenResponsesWebSearchEvent;
+
+export type TQwenMessagesToResponsesInput = (
+  messages: TUniversalMessage[],
+) => TQwenResponsesInputItem[];
 
 export type TQwenProviderOptionValue =
   | string
@@ -7,6 +205,7 @@ export type TQwenProviderOptionValue =
   | boolean
   | undefined
   | null
+  | IQwenBuiltInWebToolsOptions
   | OpenAI
   | ILogger
   | IExecutor
@@ -19,8 +218,10 @@ export interface IQwenProviderOptions {
 
   apiKey?: string;
   baseURL?: string;
+  responsesBaseURL?: string;
   timeout?: number;
   defaultModel?: string;
+  builtInWebTools?: IQwenBuiltInWebToolsOptions;
   client?: OpenAI;
   executor?: IExecutor;
   logger?: ILogger;

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -42,22 +42,23 @@ Design rules:
 
 ## Type Ownership
 
-| Type                           | Location                                    | Purpose                                 |
-| ------------------------------ | ------------------------------------------- | --------------------------------------- |
-| `IBackgroundTaskManager`       | `src/background-tasks/types.ts`             | Generic background task registry API    |
-| `IBackgroundTaskRunner`        | `src/background-tasks/types.ts`             | Port for executing one task kind        |
-| `IBackgroundTaskState`         | `src/background-tasks/types.ts`             | Immutable task state snapshot shape     |
-| `IBackgroundTaskRequest`       | `src/background-tasks/types.ts`             | Agent/process task request union        |
-| `IBackgroundTaskResult`        | `src/background-tasks/types.ts`             | Completed task output and metadata      |
-| `TBackgroundTaskEvent`         | `src/background-tasks/types.ts`             | Lifecycle/progress event union          |
-| `TBackgroundTaskTimeoutReason` | `src/background-tasks/types.ts`             | Watchdog terminal reason union          |
-| `ISubagentManager`             | `src/subagents/types.ts`                    | Subagent job compatibility facade       |
-| `ISubagentRunner`              | `src/subagents/types.ts`                    | Port for executing one subagent job     |
-| `ISubagentSpawnRequest`        | `src/subagents/types.ts`                    | Subagent spawn request                  |
-| `ISubagentJobState`            | `src/subagents/types.ts`                    | Subagent job state projection           |
-| `ISubagentJobResult`           | `src/subagents/types.ts`                    | Subagent completion output and metadata |
-| `ISubagentWorktreeAdapter`     | `src/subagents/worktree-subagent-runner.ts` | Port for concrete worktree I/O          |
-| `IPreparedSubagentWorktree`    | `src/subagents/worktree-subagent-runner.ts` | Prepared worktree handoff data          |
+| Type                           | Location                                    | Purpose                                                                             |
+| ------------------------------ | ------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `IBackgroundTaskManager`       | `src/background-tasks/types.ts`             | Generic background task registry API                                                |
+| `IBackgroundTaskRunner`        | `src/background-tasks/types.ts`             | Port for executing one task kind                                                    |
+| `IBackgroundTaskState`         | `src/background-tasks/types.ts`             | Immutable task state snapshot shape                                                 |
+| `IBackgroundTaskRequest`       | `src/background-tasks/types.ts`             | Agent/process task request union                                                    |
+| `IBackgroundTaskResult`        | `src/background-tasks/types.ts`             | Completed task output and metadata                                                  |
+| `TBackgroundTaskEvent`         | `src/background-tasks/types.ts`             | Lifecycle/progress event union                                                      |
+| `TBackgroundTaskTimeoutReason` | `src/background-tasks/types.ts`             | Watchdog terminal reason union                                                      |
+| `ISerializableProviderProfile` | `src/background-tasks/types.ts`             | Provider profile handoff for background workers, including provider-owned `options` |
+| `ISubagentManager`             | `src/subagents/types.ts`                    | Subagent job compatibility facade                                                   |
+| `ISubagentRunner`              | `src/subagents/types.ts`                    | Port for executing one subagent job                                                 |
+| `ISubagentSpawnRequest`        | `src/subagents/types.ts`                    | Subagent spawn request                                                              |
+| `ISubagentJobState`            | `src/subagents/types.ts`                    | Subagent job state projection                                                       |
+| `ISubagentJobResult`           | `src/subagents/types.ts`                    | Subagent completion output and metadata                                             |
+| `ISubagentWorktreeAdapter`     | `src/subagents/worktree-subagent-runner.ts` | Port for concrete worktree I/O                                                      |
+| `IPreparedSubagentWorktree`    | `src/subagents/worktree-subagent-runner.ts` | Prepared worktree handoff data                                                      |
 
 Hook event types and hook execution are owned by `agent-core`.
 

--- a/packages/agent-runtime/src/background-tasks/types.ts
+++ b/packages/agent-runtime/src/background-tasks/types.ts
@@ -1,3 +1,5 @@
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+
 export type TBackgroundTaskKind = 'agent' | 'process';
 
 export type TBackgroundTaskMode = 'foreground' | 'background';
@@ -59,6 +61,7 @@ export interface ISerializableProviderProfile {
   apiKeyEnv?: string;
   baseURL?: string;
   timeout?: number;
+  options?: Record<string, TUniversalValue>;
 }
 
 export interface IBaseBackgroundTaskRequest {

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -264,12 +264,25 @@ Provider profile shape:
       "type": "openai",
       "model": "<openai-compatible-model>",
       "apiKey": "$ENV:OPENAI_API_KEY"
+    },
+    "qwen": {
+      "type": "qwen",
+      "model": "qwen3.6-plus",
+      "apiKey": "$ENV:DASHSCOPE_API_KEY",
+      "options": {
+        "builtInWebTools": {
+          "webSearch": true,
+          "webFetch": true
+        }
+      }
     }
   }
 }
 ```
 
 Gemma-family local models should be configured through `type: "gemma"` so provider-specific stream projection is applied. `type: "openai"` remains a model-family neutral OpenAI-compatible transport profile.
+
+Provider profile `options` are preserved as provider-owned data. SDK config loading validates that the value is universal/JSON-like and passes it through; SDK code must not interpret provider-specific option keys.
 
 Resolved provider fields:
 
@@ -280,6 +293,7 @@ Resolved provider fields:
 | `apiKey`  | API key or local placeholder token                                                                  |
 | `baseURL` | Optional OpenAI-compatible endpoint override                                                        |
 | `timeout` | Optional provider idle timeout in milliseconds. Also passed to provider construction when supported |
+| `options` | Optional provider-owned options bag preserved for CLI/provider composition                          |
 
 ### Context Loading (SDK-Specific)
 

--- a/packages/agent-sdk/src/__tests__/config-loader.test.ts
+++ b/packages/agent-sdk/src/__tests__/config-loader.test.ts
@@ -157,6 +157,36 @@ describe('loadConfig', () => {
     });
   });
 
+  it('preserves provider-owned options in active provider profiles', async () => {
+    writeJson(join(projectDir, 'settings.json'), {
+      currentProvider: 'qwen',
+      providers: {
+        qwen: {
+          type: 'qwen',
+          model: 'qwen3.6-plus',
+          apiKey: 'dashscope-key',
+          options: {
+            builtInWebTools: {
+              webSearch: true,
+              webFetch: true,
+              enableThinking: true,
+            },
+          },
+        },
+      },
+    });
+
+    const config = await loadConfig(cwd);
+
+    expect(config.provider.options).toEqual({
+      builtInWebTools: {
+        webSearch: true,
+        webFetch: true,
+        enableThinking: true,
+      },
+    });
+  });
+
   it('resolves $ENV: prefix in active provider profile apiKey', async () => {
     process.env.TEST_OPENAI_COMPAT_KEY = 'sk-profile-value';
     writeJson(join(projectDir, 'settings.json'), {

--- a/packages/agent-sdk/src/config/config-loader.ts
+++ b/packages/agent-sdk/src/config/config-loader.ts
@@ -172,6 +172,7 @@ function resolveProvider(merged: TSettings): IResolvedConfig['provider'] {
       apiKey: profile.apiKey ?? DEFAULTS.provider.apiKey,
       ...(profile.baseURL !== undefined && { baseURL: profile.baseURL }),
       ...(profile.timeout !== undefined && { timeout: profile.timeout }),
+      ...(profile.options !== undefined && { options: profile.options }),
     };
   }
 
@@ -181,6 +182,7 @@ function resolveProvider(merged: TSettings): IResolvedConfig['provider'] {
     apiKey: merged.provider?.apiKey ?? DEFAULTS.provider.apiKey,
     ...(merged.provider?.baseURL !== undefined && { baseURL: merged.provider.baseURL }),
     ...(merged.provider?.timeout !== undefined && { timeout: merged.provider.timeout }),
+    ...(merged.provider?.options !== undefined && { options: merged.provider.options }),
   };
 }
 

--- a/packages/agent-sdk/src/config/config-types.ts
+++ b/packages/agent-sdk/src/config/config-types.ts
@@ -3,6 +3,20 @@
  */
 import { z } from 'zod';
 import type { THooksConfig } from '@robota-sdk/agent-core';
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+
+const UniversalValueSchema: z.ZodType<TUniversalValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.undefined(),
+    z.date(),
+    z.array(UniversalValueSchema),
+    z.record(UniversalValueSchema),
+  ]),
+);
 
 const ProviderSchema = z.object({
   name: z.string().optional(),
@@ -10,6 +24,7 @@ const ProviderSchema = z.object({
   apiKey: z.string().optional(),
   baseURL: z.string().optional(),
   timeout: z.number().optional(),
+  options: z.record(UniversalValueSchema).optional(),
 });
 
 const ProviderProfileSchema = z.object({
@@ -18,6 +33,7 @@ const ProviderProfileSchema = z.object({
   apiKey: z.string().optional(),
   baseURL: z.string().optional(),
   timeout: z.number().optional(),
+  options: z.record(UniversalValueSchema).optional(),
 });
 
 const PermissionsSchema = z.object({
@@ -145,6 +161,7 @@ export interface IResolvedConfig {
     apiKey: string | undefined;
     baseURL?: string;
     timeout?: number;
+    options?: Record<string, TUniversalValue>;
   };
   permissions: {
     allow: string[];


### PR DESCRIPTION
## Summary
- add Qwen Responses API transport for provider-side web_search and web_extractor
- preserve provider-owned options through core, SDK, runtime, and CLI config layers without provider-name branching
- record Qwen built-in tool provenance separately from local Robota tool calls

## Verification
- pnpm --filter @robota-sdk/agent-provider-qwen test
- pnpm --filter @robota-sdk/agent-provider-qwen typecheck
- pnpm --filter @robota-sdk/agent-provider-qwen lint
- pnpm --filter @robota-sdk/agent-provider-qwen build
- pnpm --filter @robota-sdk/agent-cli test -- provider-factory
- pnpm --filter @robota-sdk/agent-sdk test -- config-loader
- pnpm harness:scan
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check

## Notes
- code_interpreter and other Qwen built-in tools remain deferred by design.