### PR TITLE
feat(sdk): add edit checkpointing

### DIFF
--- a/.agents/tasks/completed/CLI-BL-011-edit-checkpointing.md
+++ b/.agents/tasks/completed/CLI-BL-011-edit-checkpointing.md
@@ -1,6 +1,6 @@
 ---
 title: Edit Checkpointing — 파일 편집 전 스냅샷 + 되돌리기
-status: backlog
+status: completed
 priority: high
 urgency: soon
 created: 2026-03-26
@@ -32,11 +32,17 @@ packages:
 - Composer 패널에서 "Restore Checkpoint" 버튼
 - 1턴의 모든 변경을 하나의 논리 단위로 묶음
 
+## 리서치 재검증 (2026-05-02)
+
+- Claude Code 공식 문서: 사용자 프롬프트 단위 체크포인트, `Esc Esc` 또는 `/rewind`, 코드/대화 복원 옵션을 계속 안내한다. <https://docs.claude.com/en/docs/claude-code/checkpointing>
+- Claude Code Agent SDK 공식 문서: 파일 체크포인트는 옵션으로 활성화하고, 응답 스트림에서 checkpoint UUID를 받아 파일 복원을 호출하는 API 형태도 제공한다. <https://code.claude.com/docs/en/agent-sdk/file-checkpointing>
+- Cursor 공식 문서: Agent 변경 후 자동 checkpoint를 만들고 이전 요청에서 Restore Checkpoint를 제공한다. <https://docs.cursor.com/en/agent/chat/checkpoints>
+
 ### 구현 설계
 
 **저장:**
 
-- 프롬프트(턴) 단위로 체크포인트 디렉토리 생성: `~/.robota/checkpoints/{session-id}/{turn-N}/`
+- 프롬프트(턴) 단위로 체크포인트 디렉토리 생성: `.robota/checkpoints/{session-id}/{turn-N}/`
 - 각 파일은 그 턴에서 **처음 수정될 때 1회만** 원본 복사 (같은 턴에서 같은 파일 재수정 시 복사 안 함)
 - Edit/Write 도구 내부에서 "첫 수정 시 복사" 훅 실행
 
@@ -80,8 +86,17 @@ packages:
 
 - 완전 독립. git의 보완재 (커밋 전 안전망)
 
+## 구현 결과 (2026-05-02)
+
+- SDK에 `EditCheckpointStore`와 `Write`/`Edit` 도구 래퍼를 추가했다.
+- `InteractiveSession.submit()`의 각 프롬프트 턴마다 체크포인트를 시작하고, 도구가 파일을 처음 수정하기 전에 pre-image를 1회 저장한다.
+- `.robota/checkpoints/{session-id}/{turn-id}/manifest.json`과 `files/` 스냅샷을 사용한다.
+- `/rewind list`, `/rewind restore <checkpoint-id>`, `/rewind code <checkpoint-id>` 시스템 명령을 추가했다.
+- 복원은 선택한 체크포인트 이후 턴을 역순으로 되돌리고, 이후 체크포인트 디렉토리를 제거한다.
+- 현재 범위는 `Write`/`Edit` 도구 변경 추적이다. Bash 내부의 `rm`, `mv` 등 셸 파일 조작 추적은 별도 후속 과제로 다룰 수 있다.
+
 ## 검증
 
-- 구현 완료 후 관련 패키지 빌드 성공 확인
-- 연관 유닛 테스트 통과 확인
-- typecheck 및 lint 에러 없음 확인
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/checkpoints/__tests__/edit-checkpoint-store.test.ts src/checkpoints/__tests__/edit-checkpoint-tools.test.ts src/interactive/__tests__/interactive-session-checkpoints.test.ts src/commands/__tests__/system-command.test.ts`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk lint` (기존 warning만 존재)

--- a/.changeset/edit-checkpointing.md
+++ b/.changeset/edit-checkpointing.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-sdk': minor
+'@robota-sdk/agent-cli': patch
+---
+
+Add SDK-owned edit checkpointing for Write/Edit tool mutations with `/rewind` list and code restore commands.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -12,6 +12,7 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 - Does NOT own permissions/hooks — public types imported from `@robota-sdk/agent-core`; permission callback type (`TInteractivePermissionHandler`) owned by `@robota-sdk/agent-sdk`
 - Does NOT own config/context loading — loaded internally by `InteractiveSession` constructor
 - Does NOT own automatic project memory capture, retrieval, approval policy, or memory storage — handled by `@robota-sdk/agent-sdk`; CLI/TUI may only render command output and notices
+- Does NOT own edit checkpoint capture, storage, or restore algorithms — handled by `@robota-sdk/agent-sdk`; CLI/TUI may only route `/rewind`, render command output, and later provide picker chrome over SDK data
 - OWNS: Provider composition (receives provider definitions, reads config, selects an injected definition, creates instance, passes to `InteractiveSession`)
 - Does NOT own `InteractiveSession` — imported from `@robota-sdk/agent-sdk`
 - Does NOT own `CommandRegistry`, `BuiltinCommandSource`, `SkillCommandSource` — all imported from `@robota-sdk/agent-sdk`
@@ -322,6 +323,9 @@ Tool: [5 tools]
 | `/cost`                   | Show session info                                             |
 | `/context`                | Context window info                                           |
 | `/permissions`            | Permission rules                                              |
+| `/memory`                 | Route project memory commands to SDK                          |
+| `/rewind`                 | Route edit checkpoint list/restore commands to SDK            |
+| `/background`             | Route background task controls to SDK                         |
 | `/plugin [subcommand]`    | Plugin management                                             |
 | `/resume`                 | Show session picker to resume a saved session                 |
 | `/rename <name>`          | Rename the current session (name displayed in StatusBar)      |
@@ -1106,6 +1110,20 @@ Supported SDK-owned project memory commands exposed through the CLI:
 | `/memory used`         | Render SDK-reported memory references used in the latest turn   |
 
 Pending-memory notices emitted into `InteractiveSession` history are presentation data only. TUI components may style or position them, but must not infer candidate IDs or mutate memory state outside SDK commands.
+
+## Edit Checkpointing
+
+Edit checkpoint behavior is SDK-owned. The CLI and TUI must not snapshot files, restore files, inspect checkpoint manifests directly, or decide rollback ordering. They route `/rewind` commands through `session.executeCommand()` and render returned messages/data.
+
+Supported SDK-owned edit checkpoint commands exposed through the CLI:
+
+| Command                        | CLI responsibility                                    |
+| ------------------------------ | ----------------------------------------------------- |
+| `/rewind list`                 | Render checkpoint summaries returned by the SDK       |
+| `/rewind restore <checkpoint>` | Pass the selected checkpoint ID to the SDK            |
+| `/rewind code <checkpoint>`    | Alias for SDK code restore; render the restore result |
+
+Future Esc Esc or picker UI is terminal chrome only. The picker must call SDK APIs or commands; it must not duplicate checkpoint storage or restore algorithms.
 
 ### Message Windowing
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -131,6 +131,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md/memory discovery, project detection, system prompt
 ├── src/memory/                 ← project memory store, automatic capture policy, retrieval services
+├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
 ├── src/subagents/              ← SDK in-process runner + explicit compatibility exports from agent-runtime
 ├── src/background-tasks/       ← explicit compatibility exports from agent-runtime
@@ -181,7 +182,18 @@ agent-cli (Ink TUI — CLI-specific)
 - **Infrastructure**: `agent-tools` (createZodFunctionTool, FunctionTool, Zod→JSON conversion)
 - **Built-in tools**: `agent-tools/builtins/` — Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
 - **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific). Registered only when the composed command modules request agent runtime support. The tool description is the owner-provided model contract for direct subagent delegation: explicit user requests to create, run, spawn, delegate to, or use agents/subagents should start `Agent` tool calls immediately unless impossible or unsafe; one `Agent` tool call creates one background subagent job and waits for terminal completed/failed/timed-out result data before returning to the parent conversation.
+- **Edit checkpoint wrapper**: `agent-sdk/checkpoints/edit-checkpoint-tools.ts` wraps `Write` and `Edit` at SDK session assembly time. The underlying tool package stays generic; the SDK wrapper snapshots the target file before the first mutation in each prompt turn.
 - **Tool result type**: `TToolResult` in `agent-tools/types/tool-result.ts`
+
+### Edit Checkpointing
+
+- **Package**: `agent-sdk/checkpoints/` (SDK-specific session safety layer)
+- **Storage**: Project-local `.robota/checkpoints/{session-id}/{turn-id}/manifest.json` plus copied pre-image files under `files/`.
+- **Turn model**: Every `InteractiveSession.submit()` prompt starts a turn-level checkpoint. The checkpoint is finalized after the run finishes, even when no file was edited, so prompt turns can be listed consistently.
+- **Capture model**: `Write` and `Edit` tools are wrapped during `createSession()` assembly when an `IEditCheckpointRecorder` is present. A file is captured once per turn before the first tool mutation. Repeated edits to the same file in the same turn reuse the first pre-image.
+- **Restore model**: `restoreToCheckpoint(sessionId, checkpointId)` rolls back later checkpoints in reverse sequence order, restores copied pre-images, deletes files that did not exist at capture time, and removes later checkpoint directories. This provides code-only rewind to the selected prompt turn.
+- **Boundary**: `agent-tools` does not know about sessions, prompts, `.robota`, or checkpoints. CLI/TUI does not implement checkpoint algorithms; it only exposes SDK command output and future picker UI.
+- **Current scope**: `Write` and `Edit` mutations are tracked. Shell-side filesystem changes from `Bash` are not tracked by this layer.
 
 ### Web Search
 
@@ -206,6 +218,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
 - **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Core commands are always present; additional command modules may contribute more commands.
+- **Edit checkpoints**: `listEditCheckpoints()` returns checkpoint summaries for the active session. `restoreEditCheckpoint(id)` restores code to a prior checkpoint and records a system history entry. It is rejected while a prompt is running.
 - **listCommands()**: `listCommands()` — returns `Array<{ name, description }>` of all registered system commands. Used by transport adapters (e.g., MCP) to expose commands as tools.
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued. The queued prompt auto-executes after the current one completes. Only one prompt can be queued at a time.
 - **Abort**: `abort()` clears the queue and delegates to `session.abort()`. An `interrupted` event fires when the abort completes.
@@ -226,8 +239,9 @@ agent-cli (Ink TUI — CLI-specific)
   - `SystemCommandExecutor` — registry + executor for `ISystemCommand` instances (internal to InteractiveSession)
   - `createSystemCommands()` — factory for all built-in commands (internal)
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional `data`. Side effects that require caller context (file I/O for `reset`, model switching for `model`) are signaled via `data` — the caller applies them.
-- **Core built-in commands**: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `memory`, `resume`, `rename`, `reset`
+- **Core built-in commands**: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `memory`, `rewind`, `resume`, `rename`, `reset`
 - **Model-invocable built-ins**: `/memory` is exposed through command descriptors so explicit user/model requests can persist project memory via the generic command execution bridge. The descriptor owns usage metadata; the system prompt composer must not add separate behavior instructions.
+- **`/rewind`**: User-invocable code checkpoint command. `rewind list` lists prompt-turn checkpoints; `rewind restore <checkpoint-id>` and `rewind code <checkpoint-id>` restore files to the selected checkpoint. It is not model-invocable by default.
 - **Command modules**: Optional `ICommandModule` instances may contribute `ICommandSource` palette metadata, `ISystemCommand` handlers, model-visible descriptors, and session requirements. The SDK does not know command names contributed by modules in advance.
 
 ### Slash Command Registry (SDK-Specific)

--- a/packages/agent-sdk/src/__tests__/paths.test.ts
+++ b/packages/agent-sdk/src/__tests__/paths.test.ts
@@ -9,5 +9,6 @@ describe('projectPaths', () => {
     expect(projectPaths(cwd).logs).toBe(join(cwd, '.robota', 'logs'));
     expect(projectPaths(cwd).sessions).toBe(join(cwd, '.robota', 'sessions'));
     expect(projectPaths(cwd).memory).toBe(join(cwd, '.robota', 'memory'));
+    expect(projectPaths(cwd).checkpoints).toBe(join(cwd, '.robota', 'checkpoints'));
   });
 });

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -38,6 +38,8 @@ import type { IBackgroundProcessToolDeps } from '../tools/background-process-too
 import { createCommandExecutionTool } from '../tools/command-execution-tool.js';
 import type { ICommandResult } from '../commands/system-command.js';
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import { wrapEditCheckpointTools } from '../checkpoints/edit-checkpoint-tools.js';
+import type { IEditCheckpointRecorder } from '../checkpoints/edit-checkpoint-types.js';
 import { BackgroundTaskManager, SubagentManager } from '@robota-sdk/agent-runtime';
 import { createInProcessSubagentRunner } from '../subagents/in-process-subagent-runner.js';
 import type { TSubagentRunnerFactory } from '../subagents/in-process-subagent-runner.js';
@@ -129,6 +131,8 @@ export interface ICreateSessionOptions {
   isModelCommandInvocable?: (command: string) => boolean;
   /** Model-visible command descriptors. */
   commandDescriptors?: ICapabilityDescriptor[];
+  /** Recorder used to snapshot files before Write/Edit tools mutate them. */
+  editCheckpointRecorder?: IEditCheckpointRecorder;
 }
 
 /**
@@ -147,7 +151,9 @@ export function createSession(options: ICreateSessionOptions): Session {
   const cwd = options.cwd ?? process.cwd();
   const sessionId = options.sessionId ?? createSessionId();
 
-  const defaultTools = createDefaultTools();
+  const defaultTools = options.editCheckpointRecorder
+    ? wrapEditCheckpointTools(createDefaultTools(), options.editCheckpointRecorder)
+    : createDefaultTools();
   const tools = [...defaultTools, ...(options.additionalTools ?? [])];
   if (options.modelCommandExecutor && options.isModelCommandInvocable) {
     tools.push(

--- a/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
+++ b/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { EditCheckpointStore } from '../edit-checkpoint-store.js';
+
+const TMP_BASE = join(tmpdir(), `robota-edit-checkpoint-store-${process.pid}`);
+
+function makeProject(): string {
+  const dir = join(TMP_BASE, Math.random().toString(36).slice(2));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+afterEach(() => {
+  if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+});
+
+describe('EditCheckpointStore', () => {
+  it('Given two edited turns When restoring to the first turn Then later file changes are reverted in reverse order', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'src', 'example.ts');
+    mkdirSync(join(cwd, 'src'), { recursive: true });
+    writeFileSync(filePath, 'version 1', 'utf8');
+    const store = new EditCheckpointStore({ cwd });
+
+    const first = await store.beginTurn({ sessionId: 'session_1', prompt: 'first edit' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'version 2', 'utf8');
+    await store.finalizeTurn();
+
+    await store.beginTurn({ sessionId: 'session_1', prompt: 'second edit' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'version 3', 'utf8');
+    await store.finalizeTurn();
+
+    const result = await store.restoreToCheckpoint('session_1', first.id);
+
+    expect(readFileSync(filePath, 'utf8')).toBe('version 2');
+    expect(result.restoredCheckpointCount).toBe(1);
+    expect(result.restoredFileCount).toBe(1);
+    expect(store.list('session_1').map((checkpoint) => checkpoint.id)).toEqual([first.id]);
+  });
+
+  it('Given a file created after a checkpoint When restoring to that checkpoint Then the created file is removed', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'created.txt');
+    const store = new EditCheckpointStore({ cwd });
+
+    const first = await store.beginTurn({ sessionId: 'session_1', prompt: 'baseline' });
+    await store.finalizeTurn();
+
+    await store.beginTurn({ sessionId: 'session_1', prompt: 'create file' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'new content', 'utf8');
+    await store.finalizeTurn();
+
+    const result = await store.restoreToCheckpoint('session_1', first.id);
+
+    expect(existsSync(filePath)).toBe(false);
+    expect(result.restoredFileCount).toBe(1);
+  });
+
+  it('Given the same file is captured twice in one turn When finalizing Then only the first pre-image is stored', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'same.txt');
+    writeFileSync(filePath, 'before', 'utf8');
+    const store = new EditCheckpointStore({ cwd });
+
+    await store.beginTurn({ sessionId: 'session_1', prompt: 'duplicate capture' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'during', 'utf8');
+    await store.captureFile(filePath);
+    const summary = await store.finalizeTurn();
+
+    expect(summary?.fileCount).toBe(1);
+    expect(store.list('session_1')[0]?.fileCount).toBe(1);
+  });
+});

--- a/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
+++ b/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeTool } from '@robota-sdk/agent-tools';
+import { wrapEditCheckpointTools } from '../edit-checkpoint-tools.js';
+import type { IEditCheckpointRecorder } from '../edit-checkpoint-types.js';
+
+const TMP_BASE = join(tmpdir(), `robota-edit-checkpoint-tools-${process.pid}`);
+
+function makeProject(): string {
+  const dir = join(TMP_BASE, Math.random().toString(36).slice(2));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+afterEach(() => {
+  if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+});
+
+describe('wrapEditCheckpointTools', () => {
+  it('Given a Write tool wrapper When the tool writes a file Then it captures the pre-image before writing', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'output.txt');
+    const recorder: IEditCheckpointRecorder = {
+      captureFile: vi.fn(async (target) => {
+        expect(target).toBe(filePath);
+        expect(existsSync(filePath)).toBe(false);
+      }),
+    };
+    const [tool] = wrapEditCheckpointTools([writeTool], recorder);
+
+    await tool?.execute(
+      { filePath, content: 'written' },
+      { toolName: 'Write', parameters: { filePath, content: 'written' } },
+    );
+
+    expect(recorder.captureFile).toHaveBeenCalledTimes(1);
+    expect(readFileSync(filePath, 'utf8')).toBe('written');
+  });
+});

--- a/packages/agent-sdk/src/checkpoints/edit-checkpoint-store.ts
+++ b/packages/agent-sdk/src/checkpoints/edit-checkpoint-store.ts
@@ -1,0 +1,248 @@
+import { access, copyFile, mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { constants, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { projectPaths } from '../paths.js';
+import type {
+  IEditCheckpointFileRecord,
+  IEditCheckpointManifest,
+  IEditCheckpointRestoreResult,
+  IEditCheckpointSummary,
+  IEditCheckpointTurnInput,
+} from './edit-checkpoint-types.js';
+
+const MANIFEST_FILE = 'manifest.json';
+const SNAPSHOT_DIR = 'files';
+const ID_PAD = 4;
+const SNAPSHOT_PAD = 6;
+
+interface IActiveEditCheckpointTurn {
+  manifest: IEditCheckpointManifest;
+  dir: string;
+  capturedPaths: Set<string>;
+}
+
+interface IEditCheckpointStoreOptions {
+  cwd: string;
+  now?: () => Date;
+}
+
+export class EditCheckpointStore {
+  private readonly cwd: string;
+  private readonly rootDir: string;
+  private readonly now: () => Date;
+  private activeTurn: IActiveEditCheckpointTurn | null = null;
+
+  constructor(options: IEditCheckpointStoreOptions) {
+    this.cwd = resolve(options.cwd);
+    this.rootDir = projectPaths(this.cwd).checkpoints;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async beginTurn(input: IEditCheckpointTurnInput): Promise<IEditCheckpointSummary> {
+    if (this.activeTurn) {
+      await this.finalizeTurn();
+    }
+
+    const nextSequence = this.nextSequence(input.sessionId);
+    const id = `turn-${String(nextSequence).padStart(ID_PAD, '0')}`;
+    const dir = join(this.sessionDir(input.sessionId), id);
+    await mkdir(join(dir, SNAPSHOT_DIR), { recursive: true });
+
+    const manifest: IEditCheckpointManifest = {
+      version: 1,
+      id,
+      sessionId: input.sessionId,
+      sequence: nextSequence,
+      prompt: input.prompt,
+      createdAt: this.now().toISOString(),
+      fileCount: 0,
+      files: [],
+    };
+
+    this.activeTurn = {
+      manifest,
+      dir,
+      capturedPaths: new Set<string>(),
+    };
+
+    return toSummary(manifest);
+  }
+
+  async captureFile(filePath: string): Promise<void> {
+    if (!this.activeTurn) return;
+
+    const originalPath = resolve(this.cwd, filePath);
+    if (this.activeTurn.capturedPaths.has(originalPath)) return;
+    if (isInside(this.rootDir, originalPath)) return;
+
+    const record = await this.createFileRecord(originalPath, this.activeTurn);
+    this.activeTurn.manifest.files.push(record);
+    this.activeTurn.manifest.fileCount = this.activeTurn.manifest.files.length;
+    this.activeTurn.capturedPaths.add(originalPath);
+  }
+
+  async finalizeTurn(): Promise<IEditCheckpointSummary | undefined> {
+    if (!this.activeTurn) return undefined;
+    const active = this.activeTurn;
+    this.activeTurn = null;
+    await this.writeManifest(active.dir, active.manifest);
+    return toSummary(active.manifest);
+  }
+
+  list(sessionId: string): IEditCheckpointSummary[] {
+    return this.loadManifests(sessionId).map(toSummary);
+  }
+
+  async restoreToCheckpoint(
+    sessionId: string,
+    checkpointId: string,
+  ): Promise<IEditCheckpointRestoreResult> {
+    const manifests = this.loadManifests(sessionId);
+    const target = manifests.find((manifest) => manifest.id === checkpointId);
+    if (!target) {
+      throw new Error(`Unknown edit checkpoint: ${checkpointId}`);
+    }
+
+    const later = manifests
+      .filter((manifest) => manifest.sequence > target.sequence)
+      .sort((a, b) => b.sequence - a.sequence);
+
+    let restoredFileCount = 0;
+    for (const manifest of later) {
+      for (const file of manifest.files) {
+        await this.restoreFile(sessionId, manifest.id, file);
+        restoredFileCount += 1;
+      }
+    }
+
+    for (const manifest of later) {
+      await rm(this.checkpointDir(sessionId, manifest.id), { recursive: true, force: true });
+    }
+
+    return {
+      target: toSummary(target),
+      restoredCheckpointCount: later.length,
+      restoredFileCount,
+      removedCheckpointCount: later.length,
+    };
+  }
+
+  private async createFileRecord(
+    originalPath: string,
+    active: IActiveEditCheckpointTurn,
+  ): Promise<IEditCheckpointFileRecord> {
+    const existed = await pathExists(originalPath);
+    if (!existed) {
+      return {
+        originalPath,
+        existed: false,
+      };
+    }
+
+    const snapshotFile = join(
+      SNAPSHOT_DIR,
+      `${String(active.manifest.files.length + 1).padStart(SNAPSHOT_PAD, '0')}.content`,
+    );
+    await copyFile(originalPath, join(active.dir, snapshotFile));
+    return {
+      originalPath,
+      existed: true,
+      snapshotFile,
+    };
+  }
+
+  private async restoreFile(
+    sessionId: string,
+    checkpointId: string,
+    record: IEditCheckpointFileRecord,
+  ): Promise<void> {
+    if (!record.existed) {
+      await rm(record.originalPath, { force: true });
+      return;
+    }
+    if (!record.snapshotFile) {
+      throw new Error(`Checkpoint file record is missing a snapshot: ${record.originalPath}`);
+    }
+    await mkdir(dirname(record.originalPath), { recursive: true });
+    await copyFile(
+      join(this.checkpointDir(sessionId, checkpointId), record.snapshotFile),
+      record.originalPath,
+    );
+  }
+
+  private loadManifests(sessionId: string): IEditCheckpointManifest[] {
+    const dir = this.sessionDir(sessionId);
+    return readDirSyncSafe(dir)
+      .map((entry) => join(dir, entry, MANIFEST_FILE))
+      .map((manifestPath) => readJsonManifest(manifestPath))
+      .filter((manifest): manifest is IEditCheckpointManifest => manifest !== undefined)
+      .sort((a, b) => a.sequence - b.sequence);
+  }
+
+  private nextSequence(sessionId: string): number {
+    const last = this.list(sessionId).at(-1);
+    return (last?.sequence ?? 0) + 1;
+  }
+
+  private async writeManifest(dir: string, manifest: IEditCheckpointManifest): Promise<void> {
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, MANIFEST_FILE);
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, JSON.stringify(manifest, null, 2), 'utf8');
+    await rename(tmp, path);
+  }
+
+  private sessionDir(sessionId: string): string {
+    return join(this.rootDir, safePathSegment(sessionId));
+  }
+
+  private checkpointDir(sessionId: string, checkpointId: string): string {
+    return join(this.sessionDir(sessionId), safePathSegment(checkpointId));
+  }
+}
+
+function toSummary(manifest: IEditCheckpointManifest): IEditCheckpointSummary {
+  return {
+    id: manifest.id,
+    sessionId: manifest.sessionId,
+    sequence: manifest.sequence,
+    prompt: manifest.prompt,
+    createdAt: manifest.createdAt,
+    fileCount: manifest.fileCount,
+  };
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function isInside(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel.length === 0 || (!rel.startsWith('..') && !rel.startsWith('/'));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readDirSyncSafe(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function readJsonManifest(path: string): IEditCheckpointManifest | undefined {
+  try {
+    const raw = readFileSync(path, 'utf8');
+    return JSON.parse(raw) as IEditCheckpointManifest;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/agent-sdk/src/checkpoints/edit-checkpoint-tools.ts
+++ b/packages/agent-sdk/src/checkpoints/edit-checkpoint-tools.ts
@@ -1,0 +1,68 @@
+import type {
+  IEventService,
+  IParameterValidationResult,
+  IToolExecutionContext,
+  IToolResult,
+  IToolSchema,
+  IToolWithEventService,
+  TToolParameters,
+} from '@robota-sdk/agent-core';
+import type { IEditCheckpointRecorder } from './edit-checkpoint-types.js';
+
+const CHECKPOINTED_TOOL_NAMES = new Set(['Write', 'Edit']);
+
+export function wrapEditCheckpointTools(
+  tools: readonly IToolWithEventService[],
+  recorder: IEditCheckpointRecorder,
+): IToolWithEventService[] {
+  return tools.map((tool) =>
+    CHECKPOINTED_TOOL_NAMES.has(tool.getName())
+      ? new EditCheckpointToolWrapper(tool, recorder)
+      : tool,
+  );
+}
+
+class EditCheckpointToolWrapper implements IToolWithEventService {
+  readonly schema: IToolSchema;
+
+  constructor(
+    private readonly delegate: IToolWithEventService,
+    private readonly recorder: IEditCheckpointRecorder,
+  ) {
+    this.schema = delegate.schema;
+  }
+
+  setEventService(eventService: IEventService | undefined): void {
+    this.delegate.setEventService(eventService);
+  }
+
+  async execute(parameters: TToolParameters, context: IToolExecutionContext): Promise<IToolResult> {
+    const filePath = extractFilePath(parameters);
+    if (filePath) {
+      await this.recorder.captureFile(filePath);
+    }
+    return this.delegate.execute(parameters, context);
+  }
+
+  validate(parameters: TToolParameters): boolean {
+    return this.delegate.validate(parameters);
+  }
+
+  validateParameters(parameters: TToolParameters): IParameterValidationResult {
+    return this.delegate.validateParameters(parameters);
+  }
+
+  getDescription(): string {
+    return this.delegate.getDescription();
+  }
+
+  getName(): string {
+    return this.delegate.getName();
+  }
+}
+
+function extractFilePath(parameters: TToolParameters): string | undefined {
+  if (!parameters || typeof parameters !== 'object') return undefined;
+  const value = parameters.filePath;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/agent-sdk/src/checkpoints/edit-checkpoint-types.ts
+++ b/packages/agent-sdk/src/checkpoints/edit-checkpoint-types.ts
@@ -1,0 +1,35 @@
+export interface IEditCheckpointRecorder {
+  captureFile(filePath: string): Promise<void> | void;
+}
+
+export interface IEditCheckpointTurnInput {
+  sessionId: string;
+  prompt: string;
+}
+
+export interface IEditCheckpointSummary {
+  id: string;
+  sessionId: string;
+  sequence: number;
+  prompt: string;
+  createdAt: string;
+  fileCount: number;
+}
+
+export interface IEditCheckpointFileRecord {
+  originalPath: string;
+  existed: boolean;
+  snapshotFile?: string;
+}
+
+export interface IEditCheckpointManifest extends IEditCheckpointSummary {
+  version: 1;
+  files: IEditCheckpointFileRecord[];
+}
+
+export interface IEditCheckpointRestoreResult {
+  target: IEditCheckpointSummary;
+  restoredCheckpointCount: number;
+  restoredFileCount: number;
+  removedCheckpointCount: number;
+}

--- a/packages/agent-sdk/src/checkpoints/index.ts
+++ b/packages/agent-sdk/src/checkpoints/index.ts
@@ -1,0 +1,10 @@
+export { EditCheckpointStore } from './edit-checkpoint-store.js';
+export { wrapEditCheckpointTools } from './edit-checkpoint-tools.js';
+export type {
+  IEditCheckpointFileRecord,
+  IEditCheckpointManifest,
+  IEditCheckpointRecorder,
+  IEditCheckpointRestoreResult,
+  IEditCheckpointSummary,
+  IEditCheckpointTurnInput,
+} from './edit-checkpoint-types.js';

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -55,6 +55,8 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
       { name: 'general-purpose', description: 'General-purpose task execution agent.' },
       { name: 'Plan', description: 'Read-only planning agent.' },
     ]),
+    listEditCheckpoints: vi.fn().mockReturnValue([]),
+    restoreEditCheckpoint: vi.fn(),
     sendAgentJob: vi.fn(),
     cancelAgentJob: vi.fn(),
     closeAgentJob: vi.fn(),
@@ -72,6 +74,8 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
     waitAgentJob: underlying.waitAgentJob,
     listAgentJobs: underlying.listAgentJobs,
     listAgentDefinitions: underlying.listAgentDefinitions,
+    listEditCheckpoints: underlying.listEditCheckpoints,
+    restoreEditCheckpoint: underlying.restoreEditCheckpoint,
     sendAgentJob: underlying.sendAgentJob,
     cancelAgentJob: underlying.cancelAgentJob,
     closeAgentJob: underlying.closeAgentJob,
@@ -191,6 +195,54 @@ describe('SystemCommandExecutor', () => {
     expect(result).not.toBeNull();
     expect(result!.success).toBe(true);
     expect(result!.data?.triggerResumePicker).toBe(true);
+  });
+
+  it('rewind list returns edit checkpoints', async () => {
+    const executor = new SystemCommandExecutor();
+    const session = createMockSession({
+      listEditCheckpoints: vi.fn().mockReturnValue([
+        {
+          id: 'turn-0001',
+          sessionId: 'test-session-id',
+          sequence: 1,
+          prompt: 'change files',
+          createdAt: '2026-05-02T00:00:00.000Z',
+          fileCount: 2,
+        },
+      ]),
+    });
+
+    const result = await executor.execute('rewind', session, 'list');
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(true);
+    expect(result!.message).toContain('turn-0001');
+    expect(result!.data?.count).toBe(1);
+  });
+
+  it('rewind restore delegates code restoration to the interactive session', async () => {
+    const executor = new SystemCommandExecutor();
+    const restoreEditCheckpoint = vi.fn().mockResolvedValue({
+      target: {
+        id: 'turn-0001',
+        sessionId: 'test-session-id',
+        sequence: 1,
+        prompt: 'change files',
+        createdAt: '2026-05-02T00:00:00.000Z',
+        fileCount: 1,
+      },
+      restoredCheckpointCount: 2,
+      restoredFileCount: 3,
+      removedCheckpointCount: 2,
+    });
+    const session = createMockSession({ restoreEditCheckpoint });
+
+    const result = await executor.execute('rewind', session, 'restore turn-0001');
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(true);
+    expect(restoreEditCheckpoint).toHaveBeenCalledWith('turn-0001');
+    expect(result!.data?.restoredFileCount).toBe(3);
   });
 
   it('background list returns task summaries', async () => {

--- a/packages/agent-sdk/src/commands/builtin-source.ts
+++ b/packages/agent-sdk/src/commands/builtin-source.ts
@@ -35,6 +35,14 @@ function buildBackgroundSubcommands(): ICommand[] {
   ];
 }
 
+function buildRewindSubcommands(): ICommand[] {
+  return [
+    { name: 'list', description: 'List edit checkpoints', source: 'builtin' },
+    { name: 'restore', description: 'Restore code to a checkpoint', source: 'builtin' },
+    { name: 'code', description: 'Restore code to a checkpoint', source: 'builtin' },
+  ];
+}
+
 /** Built-in commands. Execute callbacks are wired externally by clients. */
 function createBuiltinCommands(): ICommand[] {
   return [
@@ -73,6 +81,12 @@ function createBuiltinCommands(): ICommand[] {
     { name: 'context', description: 'Context window info', source: 'builtin' },
     { name: 'permissions', description: 'Permission rules', source: 'builtin' },
     { name: 'memory', description: 'Manage project memory', source: 'builtin' },
+    {
+      name: 'rewind',
+      description: 'List and restore edit checkpoints',
+      source: 'builtin',
+      subcommands: buildRewindSubcommands(),
+    },
     {
       name: 'provider',
       description: 'Manage provider profiles',

--- a/packages/agent-sdk/src/commands/rewind-command.ts
+++ b/packages/agent-sdk/src/commands/rewind-command.ts
@@ -1,0 +1,83 @@
+import type { ICommandResult } from './system-command.js';
+import type { InteractiveSession } from '../interactive/interactive-session.js';
+import type { IEditCheckpointSummary } from '../checkpoints/edit-checkpoint-types.js';
+
+const SUBCOMMAND_INDEX = 0;
+const CHECKPOINT_ID_INDEX = 1;
+const PROMPT_PREVIEW_LENGTH = 120;
+const ELLIPSIS_LENGTH = 3;
+
+function usage(): ICommandResult {
+  return {
+    message: 'Usage: rewind [list] | rewind restore <checkpoint-id> | rewind code <checkpoint-id>',
+    success: false,
+  };
+}
+
+function formatPrompt(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, ' ').trim();
+  if (compact.length <= PROMPT_PREVIEW_LENGTH) return compact;
+  return `${compact.slice(0, PROMPT_PREVIEW_LENGTH - ELLIPSIS_LENGTH)}...`;
+}
+
+function formatList(checkpoints: readonly IEditCheckpointSummary[]): ICommandResult {
+  const lines =
+    checkpoints.length > 0
+      ? checkpoints.map(
+          (checkpoint) =>
+            `- ${checkpoint.id} files=${checkpoint.fileCount} ${checkpoint.createdAt} ${formatPrompt(
+              checkpoint.prompt,
+            )}`,
+        )
+      : ['(no edit checkpoints)'];
+
+  return {
+    message: ['Edit checkpoints:', ...lines].join('\n'),
+    success: true,
+    data: { count: checkpoints.length, checkpoints: [...checkpoints] },
+  };
+}
+
+async function restore(session: InteractiveSession, checkpointId: string | undefined) {
+  if (!checkpointId) return usage();
+  try {
+    const result = await session.restoreEditCheckpoint(checkpointId);
+    return {
+      message: [
+        `Restored code to ${result.target.id}.`,
+        `Restored files: ${result.restoredFileCount}`,
+        `Rolled back checkpoints: ${result.restoredCheckpointCount}`,
+      ].join('\n'),
+      success: true,
+      data: {
+        target: result.target,
+        restoredCheckpointCount: result.restoredCheckpointCount,
+        restoredFileCount: result.restoredFileCount,
+        removedCheckpointCount: result.removedCheckpointCount,
+      },
+    };
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+export async function executeRewindCommand(
+  session: InteractiveSession,
+  rawArgs: string,
+): Promise<ICommandResult> {
+  const args = rawArgs.trim().split(/\s+/).filter(Boolean);
+  const subcommand = args[SUBCOMMAND_INDEX] ?? 'list';
+
+  if (subcommand === 'list') {
+    return formatList(session.listEditCheckpoints());
+  }
+
+  if (subcommand === 'restore' || subcommand === 'code') {
+    return restore(session, args[CHECKPOINT_ID_INDEX]);
+  }
+
+  return usage();
+}

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -11,6 +11,7 @@ import type { TCapabilitySafety } from '../capabilities/types.js';
 import type { InteractiveSession } from '../interactive/interactive-session.js';
 import { executeBackgroundCommand } from './background-command.js';
 import { executeMemoryCommand } from './memory-command.js';
+import { executeRewindCommand } from './rewind-command.js';
 export { SystemCommandExecutor } from './system-command-executor.js';
 
 /** Result of a system command execution. */
@@ -55,6 +56,7 @@ export function createSystemCommands(): ISystemCommand[] {
           '  context           — Context window info',
           '  permissions       — Permission rules',
           '  memory            — Manage project memory and pending candidates',
+          '  rewind            — List or restore edit checkpoints',
           '  provider          — Provider profile status and switching',
           '  resume            — Resume a previous session',
           '  background        — List/cancel/close background tasks',
@@ -205,6 +207,13 @@ export function createSystemCommands(): ISystemCommand[] {
         'list | show [topic] | add TYPE TOPIC TEXT | pending | approve ID | reject ID | used',
       safety: 'write',
       execute: executeMemoryCommand,
+    },
+    {
+      name: 'rewind',
+      description: 'List edit checkpoints or restore code to a previous checkpoint.',
+      argumentHint: 'list | restore CHECKPOINT_ID | code CHECKPOINT_ID',
+      safety: 'write',
+      execute: executeRewindCommand,
     },
     {
       name: 'resume',

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -108,6 +108,17 @@ export type {
   TMemoryPolicyMode,
 } from './memory/automatic-memory-types.js';
 
+// ── Edit checkpointing ─────────────────────────────────────
+export { EditCheckpointStore, wrapEditCheckpointTools } from './checkpoints/index.js';
+export type {
+  IEditCheckpointFileRecord,
+  IEditCheckpointManifest,
+  IEditCheckpointRecorder,
+  IEditCheckpointRestoreResult,
+  IEditCheckpointSummary,
+  IEditCheckpointTurnInput,
+} from './checkpoints/index.js';
+
 // ── Plugin management ───────────────────────────────────────
 export { PluginSettingsStore } from './plugins/index.js';
 export type { IPluginSettings } from './plugins/index.js';

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-checkpoints.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-checkpoints.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IAIProvider, IAssistantMessage, TUniversalMessage } from '@robota-sdk/agent-core';
+import { InteractiveSession } from '../interactive-session.js';
+
+const TMP_BASE = join(tmpdir(), `robota-interactive-checkpoints-${process.pid}`);
+
+function makeProject(): string {
+  const dir = join(TMP_BASE, Math.random().toString(36).slice(2));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function assistantMessage(
+  content: string,
+  toolCalls?: NonNullable<IAssistantMessage['toolCalls']>,
+): TUniversalMessage {
+  return {
+    role: 'assistant',
+    content,
+    state: 'complete',
+    timestamp: new Date('2026-05-02T00:00:00.000Z'),
+    ...(toolCalls ? { toolCalls, finishReason: 'tool_calls' } : {}),
+  } as TUniversalMessage;
+}
+
+function createProvider(responses: TUniversalMessage[]): IAIProvider {
+  return {
+    name: 'mock',
+    version: 'test',
+    chat: vi.fn(async () => responses.shift() ?? assistantMessage('done')),
+    generateResponse: vi.fn(),
+    supportsTools: () => true,
+    validateConfig: () => true,
+  } as unknown as IAIProvider;
+}
+
+afterEach(() => {
+  if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+});
+
+describe('InteractiveSession edit checkpointing', () => {
+  it('Given the model edits a file When the turn completes Then a checkpoint can restore a later edit', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'example.txt');
+    writeFileSync(filePath, 'initial', 'utf8');
+    const provider = createProvider([
+      assistantMessage('', [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'Write',
+            arguments: JSON.stringify({ filePath, content: 'first edit' }),
+          },
+        },
+      ]),
+      assistantMessage('first done'),
+      assistantMessage('', [
+        {
+          id: 'call_2',
+          type: 'function',
+          function: {
+            name: 'Write',
+            arguments: JSON.stringify({ filePath, content: 'second edit' }),
+          },
+        },
+      ]),
+      assistantMessage('second done'),
+    ]);
+    const session = new InteractiveSession({
+      cwd,
+      provider,
+      bare: true,
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Write'],
+    });
+
+    await session.submit('write first version');
+    const [firstCheckpoint] = session.listEditCheckpoints();
+    await session.submit('write second version');
+
+    expect(readFileSync(filePath, 'utf8')).toBe('second edit');
+    expect(firstCheckpoint?.fileCount).toBe(1);
+
+    await session.restoreEditCheckpoint(firstCheckpoint!.id);
+
+    expect(readFileSync(filePath, 'utf8')).toBe('first edit');
+    expect(session.listEditCheckpoints().map((checkpoint) => checkpoint.id)).toEqual([
+      firstCheckpoint!.id,
+    ]);
+  });
+});

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -35,6 +35,7 @@ import { join } from 'node:path';
 import type { TInteractivePermissionHandler } from './types.js';
 import { NOOP_TERMINAL } from './interactive-session-execution.js';
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
+import type { IEditCheckpointRecorder } from '../checkpoints/edit-checkpoint-types.js';
 
 /** Standard construction: cwd + provider. Config/context loaded internally. */
 export interface IInteractiveSessionStandardOptions {
@@ -128,6 +129,8 @@ export interface IInitOptions {
   isModelCommandInvocable?: (command: string) => boolean;
   /** Preloaded config to avoid duplicate discovery when caller needs it too. */
   config?: IResolvedConfig;
+  /** Recorder used to snapshot files before Write/Edit tools mutate them. */
+  editCheckpointRecorder?: IEditCheckpointRecorder;
 }
 
 /**
@@ -207,6 +210,7 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
       : {}),
     modelCommandExecutor: options.modelCommandExecutor,
     isModelCommandInvocable: options.isModelCommandInvocable,
+    editCheckpointRecorder: options.editCheckpointRecorder,
   });
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -93,6 +93,11 @@ import type {
   IMemoryReference,
   IMemoryRetrievalResult,
 } from '../memory/automatic-memory-types.js';
+import { EditCheckpointStore } from '../checkpoints/edit-checkpoint-store.js';
+import type {
+  IEditCheckpointRestoreResult,
+  IEditCheckpointSummary,
+} from '../checkpoints/edit-checkpoint-types.js';
 export type { IInteractiveSessionOptions } from './interactive-session-init.js';
 
 export interface IInteractiveSessionShutdownOptions {
@@ -126,6 +131,7 @@ export class InteractiveSession {
   private memoryEvents: IMemoryEvent[] = [];
   private usedMemoryReferences: IMemoryReference[] = [];
   private memoryController: AutomaticMemoryController | null = null;
+  private editCheckpointStore: EditCheckpointStore | null = null;
   private resumeSessionId?: string;
   private forkSession: boolean;
   private backgroundTaskUnsubscribe: (() => void) | null = null;
@@ -144,6 +150,9 @@ export class InteractiveSession {
     this.sessionStore = options.sessionStore;
     this.sessionName = options.sessionName;
     this.cwd = ('cwd' in options ? options.cwd : undefined) ?? '';
+    if ('session' in options && options.session && this.cwd) {
+      this.editCheckpointStore = new EditCheckpointStore({ cwd: this.cwd });
+    }
     this.resumeSessionId = options.resumeSessionId;
     this.forkSession = options.forkSession ?? false;
 
@@ -183,6 +192,7 @@ export class InteractiveSession {
       cwd: options.cwd,
       config: normalizeAutomaticMemoryConfig(config.memory),
     });
+    this.editCheckpointStore = new EditCheckpointStore({ cwd: options.cwd });
     this.session = await createInteractiveSession({
       cwd: options.cwd,
       provider: options.provider,
@@ -200,6 +210,7 @@ export class InteractiveSession {
       backgroundTaskRunners: options.backgroundTaskRunners,
       subagentRunnerFactory: options.subagentRunnerFactory,
       ...(options.commandModules ? { commandModules: options.commandModules } : {}),
+      editCheckpointRecorder: this.editCheckpointStore,
       commandDescriptors: this.commandExecutor.listModelInvocableCommands(),
       ...(this.commandExecutor.listModelInvocableCommands().length > 0
         ? {
@@ -386,6 +397,27 @@ export class InteractiveSession {
   }
   getSession(): Session {
     return this.getSessionOrThrow();
+  }
+
+  listEditCheckpoints(): IEditCheckpointSummary[] {
+    const sessionId = this.getSessionOrThrow().getSessionId();
+    return this.getEditCheckpointStore().list(sessionId);
+  }
+
+  async restoreEditCheckpoint(checkpointId: string): Promise<IEditCheckpointRestoreResult> {
+    await this.ensureInitialized();
+    if (this.executing) {
+      throw new Error('Cannot restore edit checkpoint while a prompt is running.');
+    }
+    const result = await this.getEditCheckpointStore().restoreToCheckpoint(
+      this.getSessionOrThrow().getSessionId(),
+      checkpointId,
+    );
+    this.history.push(
+      messageToHistoryEntry(createSystemMessage(`Restored edit checkpoint: ${checkpointId}`)),
+    );
+    this.persistCurrentSession();
+    return result;
   }
 
   getUsedMemoryReferences(): IMemoryReference[] {
@@ -782,6 +814,7 @@ export class InteractiveSession {
     const runInput = this.composeInputWithMemory(input, memoryRetrieval);
 
     try {
+      await this.beginEditCheckpointTurn(displayInput ?? input);
       const response = await this.getSessionOrThrow().run(runInput, rawInput);
       this.flushStreaming();
       pushToolSummaryToHistory({ activeTools: this.activeTools, history: this.history });
@@ -820,6 +853,7 @@ export class InteractiveSession {
         this.emit('error', err instanceof Error ? err : new Error(errMsg));
       }
     } finally {
+      await this.finalizeEditCheckpointTurn();
       this.executing = false;
       this.emit('thinking', false);
       this.persistCurrentSession();
@@ -865,6 +899,33 @@ export class InteractiveSession {
           createSystemMessage(`Memory candidates pending review: ${result.queued.length}`),
         ),
       );
+    }
+  }
+
+  private getEditCheckpointStore(): EditCheckpointStore {
+    if (!this.editCheckpointStore) {
+      this.editCheckpointStore = new EditCheckpointStore({ cwd: this.getCwd() });
+    }
+    return this.editCheckpointStore;
+  }
+
+  private async beginEditCheckpointTurn(prompt: string): Promise<void> {
+    await this.getEditCheckpointStore().beginTurn({
+      sessionId: this.getSessionOrThrow().getSessionId(),
+      prompt,
+    });
+  }
+
+  private async finalizeEditCheckpointTurn(): Promise<void> {
+    if (!this.editCheckpointStore) return;
+    try {
+      await this.editCheckpointStore.finalizeTurn();
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.history.push(
+        messageToHistoryEntry(createSystemMessage(`Checkpoint error: ${err.message}`)),
+      );
+      this.emit('error', err);
     }
   }
 

--- a/packages/agent-sdk/src/paths.ts
+++ b/packages/agent-sdk/src/paths.ts
@@ -15,6 +15,7 @@ export function projectPaths(cwd: string): {
   logs: string;
   sessions: string;
   memory: string;
+  checkpoints: string;
 } {
   const base = join(cwd, '.robota');
   return {
@@ -23,6 +24,7 @@ export function projectPaths(cwd: string): {
     logs: join(base, 'logs'),
     sessions: join(base, 'sessions'),
     memory: join(base, 'memory'),
+    checkpoints: join(base, 'checkpoints'),
   };
 }
 


### PR DESCRIPTION
## Summary
- add SDK-owned edit checkpoint storage and Write/Edit tool snapshot wrapper
- add /rewind list/restore/code command support
- update SDK/CLI specs and complete CLI-BL-011

## Verification
- pnpm --filter @robota-sdk/agent-sdk test
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-sdk lint (0 errors, existing warnings)
- pnpm harness:scan
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check