### PR TITLE
fix(sdk): route memory through command descriptor

### DIFF
--- a/.agents/tasks/completed/CLI-BL-045-memory-command-driven-orchestration.md
+++ b/.agents/tasks/completed/CLI-BL-045-memory-command-driven-orchestration.md
@@ -1,0 +1,73 @@
+---
+title: CLI-BL-045 Memory Command Driven Orchestration
+status: completed
+priority: high
+urgency: soon
+created: 2026-05-02
+packages:
+  - agent-sdk
+branch: feat/memory-command-driven-orchestration
+---
+
+# CLI-BL-045 Memory Command Driven Orchestration
+
+## Objective
+
+Align project memory behavior with the command/capability architecture. `/memory` should be the model-visible memory interface with enough descriptor metadata for the model to inspect, recall, and update memory through `ExecuteCommand`; the SDK must not silently inject topic memory or create memory candidates as a hidden turn side effect.
+
+## Research
+
+- Claude Code memory documentation says `MEMORY.md` is loaded at session start with caps, topic files are not loaded at startup, and Claude reads/writes topic files during a session when needed.
+- Claude API memory tool documentation frames memory as a client-side tool: the model makes memory tool calls, the application executes them, and the active context stays focused through on-demand retrieval.
+- Codex public documentation emphasizes durable project instructions through `AGENTS.md`; model-facing capabilities and tools are the appropriate extension point for dynamic behavior.
+
+## Current Finding
+
+- Robota already exposes `/memory` as a model-invocable built-in command through `ExecuteCommand`.
+- The `/memory` descriptor is too terse to guide autonomous model use.
+- `InteractiveSession` also performs automatic retrieval before every prompt and automatic candidate extraction after each completed turn. That creates a hidden memory path outside the command descriptor contract.
+
+## Decision
+
+- Keep startup `.robota/memory/MEMORY.md` loading as neutral project context.
+- Keep `/memory` storage, review, and audit command behavior.
+- Strengthen the `/memory` model descriptor so the model can call it when memory is relevant.
+- Remove hidden prompt-time topic injection and turn-end candidate capture from `InteractiveSession`.
+- Leave extraction/policy classes available as reusable internals for a future explicit command/module path, but do not wire them as automatic session side effects.
+
+## Test Plan
+
+- Given a system prompt with command descriptors, when `/memory` is model-invocable, then the Built-in Commands section contains the richer memory usage descriptor.
+- Given existing topic memory, when a user submits an unrelated or related prompt, then `InteractiveSession` does not automatically prepend `<project-memory>` to the user message.
+- Given a memory cue in a turn, when the turn completes, then no pending memory record is created unless `/memory` is explicitly invoked.
+- Given `/memory add`, when invoked through `executeModelCommand`, then memory is persisted through the command bridge.
+
+## Progress
+
+### 2026-05-02
+
+- Created branch and task record.
+- Verified current implementation was mixed: model-invocable `/memory` existed, but `InteractiveSession` also performed hidden topic injection and turn-end candidate extraction.
+- Added RED tests for descriptor guidance, no hidden topic injection, no hidden pending candidate creation, model-command `/memory add`, and sensitive-content rejection.
+- Reworked `InteractiveSession` so memory topic retrieval/writes occur through explicit `/memory` command execution rather than implicit prompt lifecycle side effects.
+- Strengthened `/memory` built-in command descriptor and command palette subcommands.
+- Updated `agent-sdk` SPEC to make command-driven memory the contract.
+
+## Verification
+
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-memory.test.ts src/commands/__tests__/system-command.test.ts`
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/commands/__tests__/system-command.test.ts src/memory/__tests__/automatic-memory.test.ts src/interactive/__tests__/interactive-session-memory.test.ts src/__tests__/system-prompt-builder.test.ts src/commands/__tests__/command-registry.test.ts`
+- `pnpm --filter @robota-sdk/agent-cli test -- src/commands/__tests__/builtin-source.test.ts src/commands/__tests__/slash-executor.test.ts src/ui/__tests__/input-area-flow.test.ts`
+- `pnpm --filter @robota-sdk/agent-sdk test`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk lint`
+- `pnpm --filter @robota-sdk/agent-sdk build`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm harness:scan`
+
+## Result
+
+- Memory is now command-driven at the session boundary.
+- `/memory` remains model-invocable through `ExecuteCommand`, with descriptor-owned guidance for inspection, durable saves, review, provenance, and sensitive-data avoidance.
+- `InteractiveSession` no longer injects topic memory into prompts or queues memory candidates as a hidden post-turn side effect.
+- `/memory add` rejects obvious sensitive content before writing files.

--- a/.changeset/memory-command-driven-orchestration.md
+++ b/.changeset/memory-command-driven-orchestration.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-sdk': patch
+---
+
+Route project memory through the model-visible `/memory` command descriptor instead of hidden automatic prompt injection.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -131,7 +131,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md/memory discovery, project detection, system prompt
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
-├── src/memory/                 ← project memory store, automatic capture policy, retrieval services
+├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/self-hosting/           ← self-hosting verification planner + lifecycle state machine
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
@@ -252,7 +252,7 @@ agent-cli (Ink TUI — CLI-specific)
   - `createSystemCommands()` — factory for all built-in commands (internal)
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional `data`. Side effects that require caller context (file I/O for `reset`, model switching for `model`) are signaled via `data` — the caller applies them.
 - **Core built-in commands**: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `memory`, `rewind`, `resume`, `rename`, `reset`
-- **Model-invocable built-ins**: `/memory` is exposed through command descriptors so explicit user/model requests can persist project memory via the generic command execution bridge. The descriptor owns usage metadata; the system prompt composer must not add separate behavior instructions.
+- **Model-invocable built-ins**: `/memory` is exposed through command descriptors so explicit user/model requests can inspect, persist, review, and audit project memory via the generic command execution bridge. The descriptor owns usage metadata and autonomous-use guidance; the system prompt composer must not add separate behavior instructions.
 - **`/rewind`**: User-invocable code checkpoint command. `rewind list` lists prompt-turn checkpoints; `rewind restore <checkpoint-id>` and `rewind code <checkpoint-id>` restore files to the selected checkpoint. It is not model-invocable by default.
 - **Command modules**: Optional `ICommandModule` instances may contribute `ICommandSource` palette metadata, `ISystemCommand` handlers, model-visible descriptors, and session requirements. The SDK does not know command names contributed by modules in advance.
 
@@ -346,14 +346,15 @@ Resolved provider fields:
 - **Storage**: `.robota/memory/MEMORY.md` is the project memory index; `.robota/memory/topics/*.md` stores topic details.
 - **Startup injection**: `loadContext()` reads the memory index into `ILoadedContext.memoryMd`; `buildSystemPrompt()` renders it under the neutral `Project Memory` section. Topic files are not injected at startup.
 - **Caps**: Startup memory is capped to the first 200 lines and at most 25KB.
-- **Automatic capture**: `InteractiveSession` owns the SDK memory pipeline. After each completed turn, `MemoryCandidateExtractor` emits durable candidates, `MemoryPolicyEvaluator` applies `disabled | approval_required | auto_save`, and `PendingMemoryStore` queues review records in `.robota/memory/pending.json` when approval is required.
+- **Command-driven access**: `/memory` is the model-visible project memory interface. It is exposed through the `ExecuteCommand` tool using the built-in command descriptor. The descriptor guides the model to inspect memory when stored context may help, add only durable reusable facts, review pending candidates, report provenance, and avoid storing secrets.
 - **Sensitive data policy**: Candidate policy must skip obvious secret, token, password, private-key, payment-card, and national-ID style content instead of silently saving it. Additional extractors may be composed later, but they must feed the same policy/store contracts.
-- **Relevant retrieval**: Before a new prompt, `MemoryRetrievalService` scores topic files against the user input, injects only the selected capped topic content as a neutral `<project-memory>` block, and records topic/path provenance in `usedMemoryReferences`.
+- **No hidden turn side effects**: `InteractiveSession` must not automatically prepend topic memory to user prompts and must not create pending memory candidates after a completed turn. Topic retrieval and memory writes happen through explicit `/memory` command execution, whether user-invoked or model-invoked.
+- **Reusable retrieval/capture internals**: `MemoryRetrievalService`, `MemoryCandidateExtractor`, `MemoryPolicyEvaluator`, and `PendingMemoryStore` remain reusable building blocks for explicit commands or future command modules. They are not wired as implicit session lifecycle side effects.
 - **Deduplication**: `ProjectMemoryStore.append()` returns `deduplicated` and must avoid repeating the same normalized topic entry.
 - **Command**: `memory list | show [topic] | add <user|feedback|project|reference> <topic> <text> | pending | approve <id> | reject <id> | used`.
-- **Audit trail**: Automatic extraction, queue, save, skip, approve, reject, and retrieval events are appended to the session record as `memoryEvents` for resume/debugging. High-frequency streaming data is not part of the memory event stream.
+- **Audit trail**: `/memory approve`, `/memory reject`, and future explicit memory workflows append memory events to the session record as `memoryEvents` for resume/debugging. High-frequency streaming data is not part of the memory event stream.
 - **Ownership**: SDK owns the store and command behavior. CLI only renders slash command results and autocomplete metadata.
-- **Automatic extraction**: Passive sidecar extraction is intentionally not part of this phase because comparable products require explicit user approval for background-generated memories.
+- **Prompt composition boundary**: The system prompt may include the neutral `Project Memory` startup index and the `/memory` descriptor under `Built-in Commands`; it must not include extra hardcoded memory behavior instructions outside descriptor data.
 
 ### Context Window Management
 

--- a/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
@@ -220,6 +220,32 @@ describe('buildSystemPrompt', () => {
       expect(result).toContain('- review: Review code');
       expect(result).toContain('- Plan: Planning agent');
     });
+
+    it('renders model-visible memory command guidance from the descriptor only', () => {
+      const result = buildSystemPrompt({
+        ...BASE_PARAMS,
+        commandDescriptors: [
+          {
+            name: '/memory',
+            kind: 'builtin-command',
+            description:
+              'Project memory command. Use it to inspect project memory when stored context may help, save durable preferences, project conventions, feedback, or references worth reusing across sessions, review pending candidates, and report memory provenance. Do not store secrets, credentials, or transient facts.',
+            userInvocable: true,
+            modelInvocable: true,
+            argumentHint:
+              'list | show [topic] | add <user|feedback|project|reference> <topic> <text> | pending | approve <id> | reject <id> | used',
+            safety: 'write',
+          },
+        ],
+      });
+
+      expect(result).toContain('## Built-in Commands');
+      expect(result).toContain('/memory list | show [topic]');
+      expect(result).toContain('inspect project memory when stored context may help');
+      expect(result).toContain('Do not store secrets');
+      expect(result).not.toContain('## Memory Behavior');
+      expect(result).not.toContain('always save memory');
+    });
   });
 
   describe('System prompt agent injection', () => {

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -336,20 +336,45 @@ describe('SystemCommandExecutor', () => {
     );
   });
 
-  it('memory command is exposed as model-invocable descriptor', () => {
+  it('memory add rejects sensitive content before writing files', async () => {
+    const cwd = makeProject();
     const executor = new SystemCommandExecutor();
 
+    const result = await executor.execute(
+      'memory',
+      createMockSession({}, cwd),
+      'add project secrets api key is sk-test-secret',
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(false);
+    expect(result!.message).toContain('sensitive');
+    expect(existsSync(join(cwd, '.robota', 'memory', 'MEMORY.md'))).toBe(false);
+  });
+
+  it('memory command is exposed as model-invocable descriptor', () => {
+    const executor = new SystemCommandExecutor();
+    const descriptor = executor
+      .listModelInvocableCommands()
+      .find((command) => command.name === '/memory');
+
     expect(executor.isModelInvocable('memory')).toBe(true);
-    expect(executor.listModelInvocableCommands()).toContainEqual({
-      name: '/memory',
-      kind: 'builtin-command',
-      description: 'Manage project memory, including pending automatic memory candidates.',
-      userInvocable: true,
-      modelInvocable: true,
-      argumentHint:
-        'list | show [topic] | add TYPE TOPIC TEXT | pending | approve ID | reject ID | used',
-      safety: 'write',
-    });
+    expect(descriptor).toEqual(
+      expect.objectContaining({
+        name: '/memory',
+        kind: 'builtin-command',
+        userInvocable: true,
+        modelInvocable: true,
+        argumentHint:
+          'list | show [topic] | add <user|feedback|project|reference> <topic> <text> | pending | approve <id> | reject <id> | used',
+        safety: 'write',
+      }),
+    );
+    expect(descriptor?.description).toContain(
+      'inspect project memory when stored context may help',
+    );
+    expect(descriptor?.description).toContain('save durable preferences, project conventions');
+    expect(descriptor?.description).toContain('Do not store secrets');
   });
 
   it('memory pending lists queued automatic memory candidates', async () => {
@@ -530,16 +555,15 @@ describe('SystemCommandExecutor', () => {
     expect(executor.hasCommand('agent')).toBe(false);
     expect(executor.hasCommand('diagnose')).toBe(true);
     expect(executor.listModelInvocableCommands()).toEqual([
-      {
+      expect.objectContaining({
         name: '/memory',
         kind: 'builtin-command',
-        description: 'Manage project memory, including pending automatic memory candidates.',
         userInvocable: true,
         modelInvocable: true,
         argumentHint:
-          'list | show [topic] | add TYPE TOPIC TEXT | pending | approve ID | reject ID | used',
+          'list | show [topic] | add <user|feedback|project|reference> <topic> <text> | pending | approve <id> | reject <id> | used',
         safety: 'write',
-      },
+      }),
       {
         name: '/diagnose',
         kind: 'builtin-command',

--- a/packages/agent-sdk/src/commands/builtin-source.ts
+++ b/packages/agent-sdk/src/commands/builtin-source.ts
@@ -43,6 +43,22 @@ function buildRewindSubcommands(): ICommand[] {
   ];
 }
 
+function buildMemorySubcommands(): ICommand[] {
+  return [
+    { name: 'list', description: 'List project memory topics', source: 'builtin' },
+    { name: 'show', description: 'Show project memory index or a topic', source: 'builtin' },
+    { name: 'add', description: 'Save durable project memory', source: 'builtin' },
+    { name: 'pending', description: 'List pending memory candidates', source: 'builtin' },
+    { name: 'approve', description: 'Approve a pending memory candidate', source: 'builtin' },
+    { name: 'reject', description: 'Reject a pending memory candidate', source: 'builtin' },
+    {
+      name: 'used',
+      description: 'Show memory references used in the current turn',
+      source: 'builtin',
+    },
+  ];
+}
+
 /** Built-in commands. Execute callbacks are wired externally by clients. */
 function createBuiltinCommands(): ICommand[] {
   return [
@@ -80,7 +96,12 @@ function createBuiltinCommands(): ICommand[] {
     { name: 'cost', description: 'Show session info', source: 'builtin' },
     { name: 'context', description: 'Context window info', source: 'builtin' },
     { name: 'permissions', description: 'Permission rules', source: 'builtin' },
-    { name: 'memory', description: 'Manage project memory', source: 'builtin' },
+    {
+      name: 'memory',
+      description: 'Inspect, save, review, and audit project memory',
+      source: 'builtin',
+      subcommands: buildMemorySubcommands(),
+    },
     {
       name: 'rewind',
       description: 'List and restore edit checkpoints',

--- a/packages/agent-sdk/src/commands/memory-command.ts
+++ b/packages/agent-sdk/src/commands/memory-command.ts
@@ -7,6 +7,7 @@ import {
   isMemoryType,
   type TMemoryType,
 } from '../memory/project-memory-store.js';
+import { containsSensitiveMemoryContent } from '../memory/memory-policy-evaluator.js';
 
 const SUBCOMMAND_INDEX = 0;
 const TYPE_INDEX = 1;
@@ -203,6 +204,12 @@ export function executeMemoryCommand(session: InteractiveSession, rawArgs: strin
   if (subcommand === 'add') {
     const input = parseAdd(args);
     if (!input) return usage();
+    if (containsSensitiveMemoryContent(input.text)) {
+      return {
+        message: 'Refusing to save sensitive memory content.',
+        success: false,
+      };
+    }
     const result = store.append(input);
     return {
       message: result.deduplicated

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -36,6 +36,10 @@ export interface ISystemCommand {
 }
 
 const VALID_MODES: TPermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions'];
+const MEMORY_COMMAND_DESCRIPTION =
+  'Project memory command. Use it to inspect project memory when stored context may help, save durable preferences, project conventions, feedback, or references worth reusing across sessions, review pending candidates, and report memory provenance. Do not store secrets, credentials, or transient facts.';
+const MEMORY_COMMAND_ARGUMENT_HINT =
+  'list | show [topic] | add <user|feedback|project|reference> <topic> <text> | pending | approve <id> | reject <id> | used';
 
 /** Built-in system commands. */
 export function createSystemCommands(): ISystemCommand[] {
@@ -201,10 +205,9 @@ export function createSystemCommands(): ISystemCommand[] {
     },
     {
       name: 'memory',
-      description: 'Manage project memory, including pending automatic memory candidates.',
+      description: MEMORY_COMMAND_DESCRIPTION,
       modelInvocable: true,
-      argumentHint:
-        'list | show [topic] | add TYPE TOPIC TEXT | pending | approve ID | reject ID | used',
+      argumentHint: MEMORY_COMMAND_ARGUMENT_HINT,
       safety: 'write',
       execute: executeMemoryCommand,
     },

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-memory.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-memory.test.ts
@@ -39,8 +39,8 @@ afterEach(() => {
   if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
 });
 
-describe('InteractiveSession automatic memory integration', () => {
-  it('Given approval policy When a turn contains a memory cue Then the candidate is queued and persisted', async () => {
+describe('InteractiveSession memory command integration', () => {
+  it('Given a memory cue When a turn completes Then no hidden pending memory is created', async () => {
     const cwd = makeProject();
     const provider = createProvider('noted');
     const sessionStore = new SessionStore(join(cwd, '.robota', 'sessions'));
@@ -53,22 +53,12 @@ describe('InteractiveSession automatic memory integration', () => {
 
     await session.submit('remember that this project uses pnpm for package scripts');
 
-    const pending = JSON.parse(
-      readFileSync(join(cwd, '.robota', 'memory', 'pending.json'), 'utf8'),
-    ) as { records: Array<{ status: string; text: string }> };
-    expect(pending.records).toEqual([
-      expect.objectContaining({
-        status: 'pending',
-        text: 'this project uses pnpm for package scripts',
-      }),
-    ]);
+    expect(existsSync(join(cwd, '.robota', 'memory', 'pending.json'))).toBe(false);
     const saved = sessionStore.load(session.getSession().getSessionId());
-    expect(saved?.memoryEvents).toEqual(
-      expect.arrayContaining([expect.objectContaining({ type: 'memory_candidate_queued' })]),
-    );
+    expect(saved?.memoryEvents).toEqual([]);
   });
 
-  it('Given relevant project memory When submitting a prompt Then selected memory is passed with provenance', async () => {
+  it('Given relevant project memory When submitting a prompt Then topic memory is not injected automatically', async () => {
     const cwd = makeProject();
     const provider = createProvider('use pnpm');
     new ProjectMemoryStore(cwd, () => new Date('2026-05-02T00:00:00.000Z')).append({
@@ -84,13 +74,32 @@ describe('InteractiveSession automatic memory integration', () => {
 
     await session.submit('How should I run package scripts?');
 
-    expect(latestUserMessage(provider)?.content).toContain('<project-memory>');
-    expect(latestUserMessage(provider)?.content).toContain('Use pnpm for package scripts.');
-    expect(session.getUsedMemoryReferences()).toEqual([
+    expect(latestUserMessage(provider)?.content).toBe('How should I run package scripts?');
+    expect(latestUserMessage(provider)?.content).not.toContain('<project-memory>');
+    expect(latestUserMessage(provider)?.content).not.toContain('Use pnpm for package scripts.');
+    expect(session.getUsedMemoryReferences()).toEqual([]);
+  });
+
+  it('Given model invocation When /memory add is executed Then memory is persisted through the command bridge', async () => {
+    const cwd = makeProject();
+    const session = new InteractiveSession({
+      cwd,
+      provider: createProvider('ok'),
+      bare: true,
+    });
+
+    const result = await session.executeModelCommand(
+      'memory',
+      'add project build Use pnpm for package scripts.',
+    );
+
+    expect(result).toEqual(
       expect.objectContaining({
-        topic: 'build',
-        path: join(cwd, '.robota', 'memory', 'topics', 'build.md'),
+        success: true,
       }),
-    ]);
+    );
+    expect(readFileSync(join(cwd, '.robota', 'memory', 'MEMORY.md'), 'utf8')).toContain(
+      '(project/build) Use pnpm for package scripts.',
+    );
   });
 });

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -82,17 +82,7 @@ import type {
   IInteractiveSessionOptions,
   IInteractiveSessionStandardOptions,
 } from './interactive-session-init.js';
-import {
-  AutomaticMemoryController,
-  normalizeAutomaticMemoryConfig,
-  renderRetrievedMemory,
-  createMemoryRetrievedEvent,
-} from '../memory/automatic-memory-controller.js';
-import type {
-  IMemoryEvent,
-  IMemoryReference,
-  IMemoryRetrievalResult,
-} from '../memory/automatic-memory-types.js';
+import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
 import { EditCheckpointStore } from '../checkpoints/edit-checkpoint-store.js';
 import type {
   IEditCheckpointRestoreResult,
@@ -130,7 +120,6 @@ export class InteractiveSession {
   private backgroundJobGroupEvents: TBackgroundJobGroupEvent[] = [];
   private memoryEvents: IMemoryEvent[] = [];
   private usedMemoryReferences: IMemoryReference[] = [];
-  private memoryController: AutomaticMemoryController | null = null;
   private editCheckpointStore: EditCheckpointStore | null = null;
   private resumeSessionId?: string;
   private forkSession: boolean;
@@ -188,10 +177,6 @@ export class InteractiveSession {
 
   private async initializeAsync(options: IInteractiveSessionStandardOptions): Promise<void> {
     const config = await loadConfig(options.cwd);
-    this.memoryController = new AutomaticMemoryController({
-      cwd: options.cwd,
-      config: normalizeAutomaticMemoryConfig(config.memory),
-    });
     this.editCheckpointStore = new EditCheckpointStore({ cwd: options.cwd });
     this.session = await createInteractiveSession({
       cwd: options.cwd,
@@ -810,12 +795,11 @@ export class InteractiveSession {
     this.history.push(messageToHistoryEntry(createUserMessage(displayInput ?? input)));
 
     const historyBefore = this.getSessionOrThrow().getHistory().length;
-    const memoryRetrieval = this.retrieveMemoryForPrompt(rawInput ?? input);
-    const runInput = this.composeInputWithMemory(input, memoryRetrieval);
+    this.usedMemoryReferences = [];
 
     try {
       await this.beginEditCheckpointTurn(displayInput ?? input);
-      const response = await this.getSessionOrThrow().run(runInput, rawInput);
+      const response = await this.getSessionOrThrow().run(input, rawInput);
       this.flushStreaming();
       pushToolSummaryToHistory({ activeTools: this.activeTools, history: this.history });
       this.clearStreaming();
@@ -827,7 +811,6 @@ export class InteractiveSession {
         this.getContextState(),
       );
       this.history.push(messageToHistoryEntry(createAssistantMessage(result.response)));
-      this.captureMemoryAfterTurn(rawInput ?? input, result.response);
       this.emit('complete', result);
       this.emit('context_update', this.getContextState());
     } catch (err) {
@@ -864,41 +847,6 @@ export class InteractiveSession {
         this.clearPendingQueue();
         setTimeout(() => this.executePrompt(queued, queuedDisplay, queuedRaw), 0);
       }
-    }
-  }
-
-  private retrieveMemoryForPrompt(input: string): IMemoryRetrievalResult {
-    const empty: IMemoryRetrievalResult = { content: '', references: [], truncated: false };
-    if (!this.memoryController) return empty;
-    const retrieval = this.memoryController.retrieve(input);
-    this.usedMemoryReferences = retrieval.references;
-    if (retrieval.references.length > 0) {
-      this.memoryEvents.push(createMemoryRetrievedEvent(retrieval.references));
-    }
-    return retrieval;
-  }
-
-  private composeInputWithMemory(input: string, retrieval: IMemoryRetrievalResult): string {
-    const memoryBlock = renderRetrievedMemory(retrieval);
-    return memoryBlock ? `${memoryBlock}\n\n${input}` : input;
-  }
-
-  private captureMemoryAfterTurn(userMessage: string, assistantMessage: string): void {
-    if (!this.memoryController) return;
-    const sessionId = this.getSessionOrThrow().getSessionId();
-    const result = this.memoryController.capture({
-      sessionId,
-      turnId: `${sessionId}:turn:${this.history.length}`,
-      userMessage,
-      assistantMessage,
-    });
-    this.memoryEvents.push(...result.events);
-    if (result.queued.length > 0) {
-      this.history.push(
-        messageToHistoryEntry(
-          createSystemMessage(`Memory candidates pending review: ${result.queued.length}`),
-        ),
-      );
     }
   }
 

--- a/packages/agent-sdk/src/memory/memory-policy-evaluator.ts
+++ b/packages/agent-sdk/src/memory/memory-policy-evaluator.ts
@@ -12,13 +12,17 @@ const SENSITIVE_PATTERNS: readonly RegExp[] = [
   /주민등록|비밀번호|시크릿|토큰/u,
 ];
 
+export function containsSensitiveMemoryContent(text: string): boolean {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 export class MemoryPolicyEvaluator {
   evaluate(candidate: IMemoryCandidate, config: IAutomaticMemoryConfig): IMemoryDecision {
     if (config.policy === 'disabled') {
       return { action: 'skip', reason: 'memory-policy-disabled' };
     }
 
-    if (this.containsSensitiveContent(candidate.text)) {
+    if (containsSensitiveMemoryContent(candidate.text)) {
       return { action: 'skip', reason: 'sensitive-content' };
     }
 
@@ -31,9 +35,5 @@ export class MemoryPolicyEvaluator {
     }
 
     return { action: 'queue', reason: 'low-confidence-auto-save-review' };
-  }
-
-  private containsSensitiveContent(text: string): boolean {
-    return SENSITIVE_PATTERNS.some((pattern) => pattern.test(text));
   }
 }


### PR DESCRIPTION
## Summary
- route project memory through the model-visible `/memory` command descriptor instead of hidden prompt lifecycle side effects
- strengthen `/memory` descriptor and slash subcommands so models can inspect, save, review, and audit memory through `ExecuteCommand`
- stop automatic topic-memory injection before prompts and post-turn pending-memory creation in `InteractiveSession`
- reject obvious sensitive content in `/memory add` before writing files

## Verification
- `pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-memory.test.ts src/commands/__tests__/system-command.test.ts`
- `pnpm --filter @robota-sdk/agent-sdk test -- src/commands/__tests__/system-command.test.ts src/memory/__tests__/automatic-memory.test.ts src/interactive/__tests__/interactive-session-memory.test.ts src/__tests__/system-prompt-builder.test.ts src/commands/__tests__/command-registry.test.ts`
- `pnpm --filter @robota-sdk/agent-cli test -- src/commands/__tests__/builtin-source.test.ts src/commands/__tests__/slash-executor.test.ts src/ui/__tests__/input-area-flow.test.ts`
- `pnpm --filter @robota-sdk/agent-sdk test`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-sdk lint` (85 existing warnings, 0 errors)
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm harness:scan`
- pre-push `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`

## Research Notes
- Claude Code loads capped memory indexes at startup and leaves topic files for session-time read/write.
- Claude API memory tool treats memory as a client-side tool call path, which matches Robota command descriptor composition.
