### PR TITLE
fix(cli): render edit diffs from tool summaries

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,9 +11,14 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-| File                                                                           | Topic                                                         |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
-| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
-| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
-| [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |
+| File                                                                                           | Topic                                                         |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [cli-diff-context-hunk-rendering.md](cli-diff-context-hunk-rendering.md)                       | CLI diff context-aware hunk rendering                         |
+| [cli-tui-background-work-tree-display.md](cli-tui-background-work-tree-display.md)             | CLI TUI background work tree display                          |
+| [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |
+| [cli-tui-output-visual-grammar-audit.md](cli-tui-output-visual-grammar-audit.md)               | CLI TUI output visual grammar audit                           |
+| [cli-tui-status-activity-indicator.md](cli-tui-status-activity-indicator.md)                   | CLI TUI status activity indicator                             |
+| [gemini-provider-modernization.md](gemini-provider-modernization.md)                           | Gemini API provider modernization                             |
+| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)                         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
+| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md)                 | OpenAI-compatible provider web search/fetch support           |
+| [openai-provider-modernization.md](openai-provider-modernization.md)                           | OpenAI provider modernization                                 |

--- a/.agents/backlog/cli-diff-context-hunk-rendering.md
+++ b/.agents/backlog/cli-diff-context-hunk-rendering.md
@@ -1,0 +1,67 @@
+# CLI Diff Context Hunk Rendering
+
+## Priority
+
+P0 — edit visibility is a safety-critical CLI behavior.
+
+## What
+
+Upgrade Edit diff rendering from change-only blocks to context-aware hunks that show nearby unchanged lines, group related changes, and truncate large diffs by hunk rather than only by absolute line count.
+
+## Why
+
+Showing only changed lines makes edits hard to verify, especially when reverting or modifying multiple adjacent lines. Established diff formats show context around changes so users can understand where the edit occurred and how it relates to surrounding code.
+
+## Initial Research Notes
+
+- GNU diff documentation says users usually want nearby file parts around differing lines, and calls those nearby lines context.
+- GNU diff context format defaults to three context lines when no count is specified, while `patch` typically needs at least two lines for robust application.
+- Unified/context diff formats make code review easier than isolated add/remove lines because unchanged surrounding lines orient the reader.
+
+## Research Required
+
+Before implementation, compare:
+
+- Git/GNU unified diff context defaults and hunk behavior.
+- Codex and Claude Code user-facing edit/diff displays where documented or observable.
+- Terminal readability constraints for compact inline diffs.
+
+Use documentation and product behavior observations only; do not copy source code from other projects.
+
+## Scope
+
+- Generate context-aware `IDiffLine[]` for Edit summaries:
+  - default surrounding context: propose 3 lines, confirm during implementation research;
+  - include hunk headers or equivalent compact separators when useful;
+  - merge nearby hunks when context overlaps;
+  - truncate large diffs by hunk with an omitted-lines marker.
+- Preserve markdown `diff` fenced rendering as the single colorization path.
+- Keep file path and truncation metadata outside the markdown diff body.
+- Add tests for:
+  - addition;
+  - deletion/revert;
+  - replacement;
+  - multi-line edit;
+  - multiple separated hunks;
+  - beginning/end of file;
+  - large diff truncation.
+
+## Non-Goals
+
+- Do not implement a full Git diff engine unless research shows the current approach cannot safely support context hunks.
+- Do not make assistant prose responsible for diff previews.
+- Do not lose raw tool arguments or session records when truncating the visible diff.
+
+## Acceptance Criteria
+
+- [ ] Edit tool summaries show changed lines plus surrounding context.
+- [ ] Revert/deletion edits display removed and added lines with enough context to verify location.
+- [ ] Large diffs are truncated predictably without hiding all changed lines.
+- [ ] `renderMarkdown()` remains the only line-coloring implementation for diff bodies.
+- [ ] Unit tests cover the hunk and truncation cases listed above.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-cli-diff-context-hunk-rendering.md`.
+2. Complete diff-format research before implementation.
+3. Update `agent-cli` SPEC first, then implement under TDD.

--- a/.agents/backlog/cli-tui-background-work-tree-display.md
+++ b/.agents/backlog/cli-tui-background-work-tree-display.md
@@ -1,0 +1,53 @@
+# CLI TUI Background Work Tree Display
+
+## Priority
+
+P1 — implement after the visual grammar audit, before expanding background orchestration UI.
+
+## What
+
+Redesign background job and agent progress display as a compact one-level tree that clearly separates group title, running/completed/error items, idle time, and latest trimmed output.
+
+## Why
+
+The current background display is functional but reads like raw state. Users need a concise view similar to modern coding assistants: a single activity header, visually aligned child rows, stable status markers, short labels, and optional details. This becomes more important as subagents and background processes run in parallel.
+
+## Research Required
+
+Research documentation and user-facing behavior for:
+
+- Codex CLI interactive TUI progress and subagent display.
+- Claude Code task/subagent views, focus mode, and status surfaces.
+- Common terminal UI patterns for tree-like activity lists.
+
+Use documentation and product behavior observations only; do not copy source code from other projects.
+
+## Scope
+
+- Define a one-level tree renderer for background job groups:
+  - group label: human-readable action name, not raw class/state names;
+  - child rows: status marker, agent/process label, age/idle time, trimmed latest output;
+  - terminal states: completed, failed, timeout, canceled;
+  - no stale completed items after the configured retention policy.
+- Keep background orchestration state in SDK/runtime layers.
+- Keep TUI rendering in CLI-only components.
+- Add tests for pure row formatting and Ink rendering.
+
+## Non-Goals
+
+- Do not change background execution semantics.
+- Do not introduce provider-specific labels.
+- Do not make the model write tree syntax in assistant text.
+
+## Acceptance Criteria
+
+- [ ] Running background jobs are shown as a stable one-level tree.
+- [ ] Completed/failed/timeout rows use the shared visual grammar.
+- [ ] Latest output is trimmed consistently and does not push other UI off-screen.
+- [ ] Persisted session history and live display use the same formatter where possible.
+- [ ] Unit tests cover running, completed, failed, timeout, long output, and empty-output cases.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-background-work-tree-display.md`.
+2. Implement after the visual grammar audit establishes shared markers and spacing.

--- a/.agents/backlog/cli-tui-command-output-transcript-collapse.md
+++ b/.agents/backlog/cli-tui-command-output-transcript-collapse.md
@@ -1,0 +1,54 @@
+# CLI TUI Command Output Transcript Collapse
+
+## Priority
+
+P1 — implement after the visual grammar audit.
+
+## What
+
+Render command execution output as a concise command row plus a bounded output preview, with an explicit transcript hint when output is longer than the visible preview.
+
+## Why
+
+Long command output can dominate the terminal and hide the important result. Modern coding assistant CLIs tend to show the command, a short result/output excerpt, and a way to inspect the full transcript. Robota already persists session data, so the TUI should summarize command output without losing the underlying record.
+
+## Research Required
+
+Research documentation and observed behavior for:
+
+- Codex CLI command execution display and transcript access patterns.
+- Claude Code focus view and tool-call summary behavior.
+- Terminal UX patterns for collapsed command output and log previews.
+
+Use documentation and product behavior observations only; do not copy source code from other projects.
+
+## Scope
+
+- Define a command output summary shape:
+  - command line;
+  - exit/status marker;
+  - bounded stdout/stderr preview;
+  - omitted line count;
+  - transcript/session reference hint.
+- Keep raw output persistence in session/logging layers.
+- Keep truncation and transcript metadata structured, not embedded in assistant prose.
+- Add tests for short output, long output, stderr, failed command, no output, and multiline output.
+
+## Non-Goals
+
+- Do not remove full command output from session persistence.
+- Do not rely on model-generated summaries for command output.
+- Do not implement interactive transcript browsing until the summary contract is stable.
+
+## Acceptance Criteria
+
+- [ ] Short command output renders inline without unnecessary decoration.
+- [ ] Long output renders a bounded preview plus omitted-line transcript hint.
+- [ ] Failed commands remain visually distinct from successful commands.
+- [ ] The full transcript remains available from persisted session/log data.
+- [ ] Formatting is tested independently from Ink component rendering.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-command-output-transcript-collapse.md`.
+2. Implement after the visual grammar audit defines shared output labels and truncation copy.

--- a/.agents/backlog/cli-tui-output-visual-grammar-audit.md
+++ b/.agents/backlog/cli-tui-output-visual-grammar-audit.md
@@ -1,0 +1,56 @@
+# CLI TUI Output Visual Grammar Audit
+
+## Priority
+
+P0 — umbrella audit before broad TUI changes.
+
+## What
+
+Define a consistent visual grammar for Robota CLI output across plans, background jobs, tool execution, command output, streaming text, status indicators, and persisted history entries.
+
+## Why
+
+Recent CLI work added background jobs, agent orchestration, markdown diff rendering, command summaries, and status indicators incrementally. The output now works functionally, but it needs a coherent terminal presentation model so users can scan current activity, completed work, failures, and expandable details without reading noisy raw output.
+
+## Initial Research Notes
+
+- OpenAI Codex CLI is documented as an interactive terminal UI that can read, change, and run local code, with separate workflows for subagents, web search, code review, cloud tasks, and approval modes. Robota should treat TUI display as a first-class shell for structured runtime events, not as feature logic.
+- Claude Code documents focus view as showing the last prompt, a one-line tool-call summary with edit diffstats, and the final response. This supports concise summaries with details available on demand.
+- Claude Code status line documentation emphasizes configurable, color-coded, multi-line session/status information that can refresh on events and while background subagents change repository state.
+- Claude Code supports configurable TUI renderers, including a fullscreen renderer. This supports separating visual renderer concerns from command/session semantics.
+
+## Scope
+
+- Audit all current CLI output surfaces:
+  - `StreamingIndicator`
+  - `MessageList`
+  - `StatusBar`
+  - background task panel
+  - command/tool output summaries
+  - markdown/diff rendering
+  - permission and setup prompts
+- Define a shared vocabulary for status icons, indentation, tree connectors, truncation labels, transcript hints, and activity labels.
+- Define which layer owns each piece of data:
+  - SDK/session/runtime owns structured events and state.
+  - CLI TUI owns display grammar only.
+  - Provider packages own provider wire-format adaptation only.
+- Produce follow-up task breakdowns for individual implementation PRs.
+
+## Non-Goals
+
+- Do not add behavior instructions to prompts to force prettier output.
+- Do not make TUI parse assistant prose as structured state.
+- Do not couple TUI components to provider names, agent model names, or command-specific business logic.
+
+## Acceptance Criteria
+
+- [ ] Audit document lists every current CLI output surface and its owner.
+- [ ] Visual grammar defines plan, tool, background, command, diff, status, warning, and error presentation.
+- [ ] Each later TUI implementation task references this grammar instead of inventing local formatting.
+- [ ] Tests are identified for both pure formatting modules and Ink render snapshots.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-output-visual-grammar-audit.md`.
+2. Complete documentation-based research before implementation.
+3. Update `packages/agent-cli/docs/SPEC.md` with the approved grammar before code changes.

--- a/.agents/backlog/cli-tui-status-activity-indicator.md
+++ b/.agents/backlog/cli-tui-status-activity-indicator.md
@@ -1,0 +1,48 @@
+# CLI TUI Status Activity Indicator
+
+## Priority
+
+P1 — implement after the visual grammar audit.
+
+## What
+
+Make active thinking/waiting/status indicators more visible by moving or duplicating the current activity state into the left side of the status area or another consistently scanned location.
+
+## Why
+
+The current `Thinking` indicator can be too subtle when placed on the right. Users need an obvious signal when Robota is waiting on the model, running tools, processing background jobs, or idle. The activity indicator should be glanceable without becoming noisy.
+
+## Initial Research Notes
+
+- Claude Code status line documentation supports multi-line, color-coded, event-refreshed status output and notes that background subagent state can matter while the main session is idle.
+- Claude Code command documentation includes configurable TUI renderers, suggesting status placement should be renderer-owned and not tied to session semantics.
+
+## Scope
+
+- Audit current `StatusBar` fields and reading order.
+- Define left-side activity slots for:
+  - thinking/waiting for model;
+  - running tools;
+  - background jobs active;
+  - queued prompt;
+  - idle.
+- Keep model/session state in SDK and render only derived display state in CLI.
+- Add tests for status priority when multiple states are true.
+
+## Non-Goals
+
+- Do not change model execution state semantics.
+- Do not create provider-specific status strings.
+- Do not add flashing or high-noise animations without accessibility review.
+
+## Acceptance Criteria
+
+- [ ] Active model waiting state is visible in the primary scan path.
+- [ ] Running tool/background states have deterministic priority.
+- [ ] Status remains readable on narrow terminals.
+- [ ] Tests cover state priority and width-constrained rendering.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-status-activity-indicator.md`.
+2. Implement after visual grammar audit and before broader fullscreen renderer work.

--- a/.changeset/fix-edit-diff-summary.md
+++ b/.changeset/fix-edit-diff-summary.md
@@ -1,0 +1,7 @@
+---
+'@robota-sdk/agent-cli': patch
+'@robota-sdk/agent-sdk': patch
+'@robota-sdk/agent-sessions': patch
+---
+
+Preserve and render Edit tool diff metadata in persisted CLI tool summaries.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -860,6 +860,7 @@ When an Edit tool summary includes diff lines, the CLI shows a compact diff belo
 - Truncation is structured metadata outside the Markdown diff body: **max display lines: 12**. If the diff exceeds 12 lines, render the first 10 lines plus `... and N more lines`.
 - If `old_string` and `new_string` are identical (no-op edit), show nothing.
 - Diff is shown in both the real-time streaming indicator (after tool completes) and the post-execution summary.
+- Post-execution `tool-summary` entries must render from structured `data.tools` when present so persisted `diffFile` and `diffLines` are not lost. The plain `summary` string is a fallback for legacy entries only.
 
 **Permission prompt integration (future):**
 

--- a/packages/agent-cli/src/ui/MessageList.tsx
+++ b/packages/agent-cli/src/ui/MessageList.tsx
@@ -10,6 +10,26 @@ interface IProps {
   history: IHistoryEntry[];
 }
 
+type TToolSummaryItem = {
+  toolName: string;
+  firstArg?: string;
+  isRunning?: boolean;
+  result?: string;
+  diffLines?: IToolCallSummary['diffLines'];
+  diffFile?: string;
+};
+
+function getToolSummaryStatus(tool: TToolSummaryItem): string {
+  if (tool.isRunning) return '⟳';
+  if (tool.result === 'error') return '✗';
+  if (tool.result === 'denied') return '⊘';
+  return '✓';
+}
+
+function getToolSummaryLabel(tool: TToolSummaryItem): string {
+  return `${getToolSummaryStatus(tool)} ${tool.toolName}${tool.firstArg ? `(${tool.firstArg})` : ''}`;
+}
+
 function RoleLabel({ role }: { role: TUniversalMessage['role'] }): React.ReactElement {
   switch (role) {
     case 'user':
@@ -144,15 +164,35 @@ function ToolSummaryEntry({ entry }: { entry: IHistoryEntry }): React.ReactEleme
   const data = entry.data as
     | {
         summary?: string;
-        tools?: Array<{
-          toolName: string;
-          firstArg?: string;
-          isRunning?: boolean;
-          result?: string;
-        }>;
+        tools?: TToolSummaryItem[];
       }
     | undefined;
+  const tools = data?.tools;
   const lines = data?.summary?.split('\n') ?? [];
+
+  if (tools && tools.length > 0) {
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Box>
+          <Text color="white" bold>
+            Tool:{' '}
+          </Text>
+        </Box>
+        <Text> </Text>
+        {tools.map((tool, i) => (
+          <Box key={i} flexDirection="column">
+            <Text color="green">
+              {'  '}
+              {getToolSummaryLabel(tool)}
+            </Text>
+            {tool.diffLines && tool.diffLines.length > 0 && (
+              <ToolDiffBlock file={tool.diffFile} lines={tool.diffLines} />
+            )}
+          </Box>
+        ))}
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" marginBottom={1}>

--- a/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
@@ -149,6 +149,40 @@ describe('MessageList rendering', () => {
     expect(output).not.toContain('│ 1 - const oldValue = true;');
   });
 
+  it('tool-summary event renders persisted edit diff metadata', () => {
+    const history: IHistoryEntry[] = [
+      {
+        id: 'summary_1',
+        timestamp: new Date(),
+        category: 'event',
+        type: 'tool-summary',
+        data: {
+          tools: [
+            {
+              toolName: 'Edit',
+              firstArg: '/src/index.ts',
+              isRunning: false,
+              result: 'success',
+              diffFile: '/src/index.ts',
+              diffLines: [
+                { type: 'remove', lineNumber: 1, text: 'const temporary = true;' },
+                { type: 'add', lineNumber: 1, text: 'const original = true;' },
+              ],
+            },
+          ],
+          summary: '✓ Edit(/src/index.ts)',
+        },
+      },
+    ];
+
+    const { lastFrame } = render(<MessageList history={history} />);
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('/src/index.ts');
+    expect(output).toContain('- 1 | const temporary = true;');
+    expect(output).toContain('+ 1 | const original = true;');
+  });
+
   it('system message renders with "System:" label', () => {
     const history: IHistoryEntry[] = [
       messageToHistoryEntry(createSystemMessage('Interrupted by user.')),

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -226,7 +226,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Pattern**: Composition over Session (holds a `Session` instance, does not extend it)
 - **Constructor**: Accepts `{ cwd, provider }` plus optional composition inputs such as `commandModules`. Config and context are loaded internally from `cwd`.
 - **Responsibility**: Streaming accumulation, tool state tracking, prompt queue (max 1), abort orchestration, full history management (`IHistoryEntry[]`), embedded command execution
-- **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. The `tool-summary` entry (aggregated) is still pushed at execution completion for backward compatibility.
+- **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. For completed Edit tools, `IToolState` also carries `diffFile` and `diffLines` derived from the Edit tool arguments plus the tool result `startLine`. The `tool-summary` entry (aggregated) is still pushed at execution completion and preserves the same per-tool metadata for persisted UI rendering.
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
 - **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Core commands are always present; additional command modules may contribute more commands.
@@ -647,7 +647,17 @@ Exported subagent runtime types:
   timestamp: Date;
   category: 'event';
   type: 'tool-summary';
-  data: { toolSummaries: IToolSummary[] };
+  data: {
+    summary: string;
+    tools: Array<{
+      toolName: string;
+      firstArg: string;
+      isRunning: boolean;
+      result?: 'success' | 'error' | 'denied';
+      diffLines?: IDiffLine[];
+      diffFile?: string;
+    }>;
+  }
 }
 ```
 

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -102,6 +102,8 @@ export interface ICreateSessionOptions {
     toolName: string;
     toolArgs?: TToolArgs;
     success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
   }) => void;
   /** Callback when context is compacted */
   onCompact?: (summary: string) => void;

--- a/packages/agent-sdk/src/assembly/create-subagent-session.ts
+++ b/packages/agent-sdk/src/assembly/create-subagent-session.ts
@@ -64,6 +64,8 @@ export interface ISubagentOptions {
     toolName: string;
     toolArgs?: TToolArgs;
     success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
   }) => void;
 }
 

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyToolEnd,
+  applyToolStart,
+  pushToolSummaryToHistory,
+} from '../interactive-session-streaming.js';
+import type { IStreamingState } from '../interactive-session-streaming.js';
+
+function createState(): IStreamingState {
+  return {
+    activeTools: [],
+    history: [],
+  };
+}
+
+describe('interactive-session-streaming edit diffs', () => {
+  it('attaches diff metadata when an Edit tool completes', () => {
+    const state = createState();
+    applyToolStart(state, {
+      toolName: 'Edit',
+      toolArgs: {
+        filePath: '/tmp/example.md',
+        oldString: 'line one\nline two\nline three',
+        newString: 'line one',
+      },
+    });
+
+    const finished = applyToolEnd(state, {
+      type: 'end',
+      toolName: 'Edit',
+      toolArgs: {
+        filePath: '/tmp/example.md',
+        oldString: 'line one\nline two\nline three',
+        newString: 'line one',
+      },
+      success: true,
+      toolResultData: JSON.stringify({ success: true, startLine: 7 }),
+    });
+
+    expect(finished?.diffFile).toBe('/tmp/example.md');
+    expect(finished?.diffLines).toEqual([
+      { type: 'remove', text: 'line one', lineNumber: 7 },
+      { type: 'remove', text: 'line two', lineNumber: 8 },
+      { type: 'remove', text: 'line three', lineNumber: 9 },
+      { type: 'add', text: 'line one', lineNumber: 7 },
+    ]);
+  });
+
+  it('persists tool-summary diff metadata for later TUI rendering', () => {
+    const state = createState();
+    state.activeTools.push({
+      toolName: 'Edit',
+      firstArg: '/tmp/example.md',
+      isRunning: false,
+      result: 'success',
+      diffFile: '/tmp/example.md',
+      diffLines: [
+        { type: 'remove', text: 'temporary line', lineNumber: 2 },
+        { type: 'add', text: 'original line', lineNumber: 2 },
+      ],
+    });
+
+    pushToolSummaryToHistory(state);
+
+    expect(state.history[0]?.type).toBe('tool-summary');
+    expect(state.history[0]?.data).toMatchObject({
+      tools: [
+        {
+          toolName: 'Edit',
+          diffFile: '/tmp/example.md',
+          diffLines: [
+            { type: 'remove', text: 'temporary line', lineNumber: 2 },
+            { type: 'add', text: 'original line', lineNumber: 2 },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -12,6 +12,7 @@ import type { Session } from '@robota-sdk/agent-sessions';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { TToolArgs } from '@robota-sdk/agent-core';
 import type {
   IBackgroundJobGroupState,
   IBackgroundTaskRunner,
@@ -104,7 +105,7 @@ export interface IInitOptions {
   onToolExecution: (event: {
     type: 'start' | 'end';
     toolName: string;
-    toolArgs?: Record<string, unknown>;
+    toolArgs?: TToolArgs;
     success?: boolean;
     denied?: boolean;
     toolResultData?: string;

--- a/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
@@ -7,6 +7,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { TToolArgs } from '@robota-sdk/agent-core';
 import type { IToolState } from './types.js';
 
 /** Max chars to display from first tool argument. */
@@ -16,9 +17,10 @@ const TAIL_KEEP = 30;
 export const MAX_COMPLETED_TOOLS = 50;
 /** Streaming text flush interval (ms) — ~60fps. */
 export const STREAMING_FLUSH_INTERVAL_MS = 16;
+const DEFAULT_START_LINE = 1;
 
 /** Extract a short display string from the first tool argument. */
-export function extractFirstArg(toolArgs?: Record<string, unknown>): string {
+export function extractFirstArg(toolArgs?: TToolArgs): string {
   if (!toolArgs) return '';
   const firstVal = Object.values(toolArgs)[0];
   const raw = typeof firstVal === 'string' ? firstVal : JSON.stringify(firstVal ?? '');
@@ -31,6 +33,57 @@ export function extractFirstArg(toolArgs?: Record<string, unknown>): string {
 export interface IStreamingState {
   activeTools: IToolState[];
   history: IHistoryEntry[];
+}
+
+interface IToolEndEvent {
+  type?: 'start' | 'end';
+  toolName: string;
+  toolArgs?: TToolArgs;
+  success?: boolean;
+  denied?: boolean;
+  toolResultData?: string;
+}
+
+function getStringArg(args: TToolArgs | undefined, snake: string, camel: string): string | null {
+  const value = args?.[snake] ?? args?.[camel];
+  return typeof value === 'string' ? value : null;
+}
+
+function parseStartLine(toolResultData: string | undefined): number {
+  if (!toolResultData) return DEFAULT_START_LINE;
+  try {
+    const parsed = JSON.parse(toolResultData) as Partial<{ startLine: number }>;
+    return typeof parsed.startLine === 'number' && Number.isFinite(parsed.startLine)
+      ? parsed.startLine
+      : DEFAULT_START_LINE;
+  } catch {
+    return DEFAULT_START_LINE;
+  }
+}
+
+function buildEditDiffState(event: IToolEndEvent): Pick<IToolState, 'diffFile' | 'diffLines'> {
+  if (event.toolName !== 'Edit') return {};
+  const filePath = getStringArg(event.toolArgs, 'file_path', 'filePath');
+  const oldString = getStringArg(event.toolArgs, 'old_string', 'oldString');
+  const newString = getStringArg(event.toolArgs, 'new_string', 'newString');
+  if (!filePath || oldString === null || newString === null || oldString === newString) return {};
+
+  const startLine = parseStartLine(event.toolResultData);
+  return {
+    diffFile: filePath,
+    diffLines: [
+      ...oldString.split('\n').map((text, index) => ({
+        type: 'remove' as const,
+        text,
+        lineNumber: startLine + index,
+      })),
+      ...newString.split('\n').map((text, index) => ({
+        type: 'add' as const,
+        text,
+        lineNumber: startLine + index,
+      })),
+    ],
+  };
 }
 
 /** Build a tool-summary history entry from current active tools and push it into history. */
@@ -60,6 +113,8 @@ export function pushToolSummaryToHistory(state: IStreamingState): void {
         firstArg: t.firstArg,
         isRunning: t.isRunning,
         result: t.result,
+        diffFile: t.diffFile,
+        diffLines: t.diffLines,
       })),
       summary,
     },
@@ -85,7 +140,7 @@ export function trimCompletedTools(activeTools: IToolState[]): IToolState[] {
 /** Process a tool-start event: add to activeTools and push to history. */
 export function applyToolStart(
   state: IStreamingState,
-  event: { toolName: string; toolArgs?: Record<string, unknown> },
+  event: { toolName: string; toolArgs?: TToolArgs },
 ): IToolState {
   const firstArg = extractFirstArg(event.toolArgs);
   const toolState: IToolState = { toolName: event.toolName, firstArg, isRunning: true };
@@ -103,14 +158,7 @@ export function applyToolStart(
 }
 
 /** Process a tool-end event: mark the tool finished and push to history. Returns updated tool or null. */
-export function applyToolEnd(
-  state: IStreamingState,
-  event: {
-    toolName: string;
-    success?: boolean;
-    denied?: boolean;
-  },
-): IToolState | null {
+export function applyToolEnd(state: IStreamingState, event: IToolEndEvent): IToolState | null {
   const result: IToolState['result'] = event.denied
     ? 'denied'
     : event.success === false
@@ -120,7 +168,12 @@ export function applyToolEnd(
   const idx = state.activeTools.findIndex((t) => t.toolName === event.toolName && t.isRunning);
   if (idx === -1) return null;
 
-  const finished: IToolState = { ...state.activeTools[idx]!, isRunning: false, result };
+  const finished: IToolState = {
+    ...state.activeTools[idx]!,
+    ...buildEditDiffState(event),
+    isRunning: false,
+    result,
+  };
   state.activeTools[idx] = finished;
   state.activeTools = trimCompletedTools(state.activeTools);
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -15,6 +15,7 @@ import type {
   IContextWindowState,
   IHistoryEntry,
   TSessionEndReason,
+  TToolArgs,
 } from '@robota-sdk/agent-core';
 import {
   createUserMessage,
@@ -891,7 +892,7 @@ export class InteractiveSession {
   private handleToolExecution(event: {
     type: 'start' | 'end';
     toolName: string;
-    toolArgs?: Record<string, unknown>;
+    toolArgs?: TToolArgs;
     success?: boolean;
     denied?: boolean;
     toolResultData?: string;

--- a/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
@@ -38,6 +38,8 @@ export interface IInProcessSubagentRunnerDeps {
     toolName: string;
     toolArgs?: TToolArgs;
     success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
   }) => void;
   customAgentRegistry?: (name: string) => IAgentDefinition | undefined;
 }

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -199,7 +199,7 @@ The session log records structured events to a JSONL file for diagnostics and re
 
 7. **`ISessionOptions.onTextDelta`** -- Streaming callback for real-time text output to the UI. `Session` stores this callback and passes it to `Robota.run()` as a per-run option; it MUST NOT mutate provider-level `onTextDelta` state because parent/subagent sessions may share the same provider instance.
 
-8. **`ISessionOptions.onToolExecution`** -- Callback for real-time tool execution events. Fires `{ type: 'start', toolName }` when a tool begins and `{ type: 'end', toolName, success }` when it completes. Wired through `PermissionEnforcer.wrapToolWithPermission()`.
+8. **`ISessionOptions.onToolExecution`** -- Callback for real-time tool execution events. Fires `{ type: 'start', toolName, toolArgs }` when a tool begins and `{ type: 'end', toolName, toolArgs, success, denied?, toolResultData? }` when it completes. `toolResultData` is the serialized, possibly truncated tool result payload used by higher layers for display metadata such as Edit start lines. Wired through `PermissionEnforcer.wrapToolWithPermission()`.
 
 9. **`ISessionOptions.onCompact`** -- Callback invoked when compaction occurs (auto or manual), receives the generated summary string.
 

--- a/packages/agent-sessions/src/session-types.ts
+++ b/packages/agent-sessions/src/session-types.ts
@@ -69,6 +69,8 @@ export interface ISessionOptions {
     toolName: string;
     toolArgs?: TToolArgs;
     success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
   }) => void;
   /** Callback when context is compacted */
   onCompact?: (summary: string) => void;


### PR DESCRIPTION
## Summary
- persist structured edit diff metadata in SDK tool summaries so session history can replay actual edit/revert diffs
- render structured tool summary diffs in the CLI message list before falling back to legacy summary text
- add follow-up backlog items for TUI visual grammar, background tree display, command transcript collapse, status activity placement, and context-aware diff hunks

## Validation
- pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-streaming.test.ts src/interactive/__tests__/interactive-session-behavior.test.ts
- pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/message-list-rendering.test.tsx src/ui/__tests__/streaming-indicator.test.tsx src/ui/__tests__/render-markdown.test.ts src/utils/__tests__/tool-diff-summary.test.ts
- pnpm --filter @robota-sdk/agent-sessions test
- pnpm --filter @robota-sdk/agent-sdk test
- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-sessions build
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-sessions exec tsc -p tsconfig.json --noEmit
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm harness:scan
- pre-push hook: pnpm harness:plan -- --base-ref origin/develop
- pre-push hook: pnpm harness:verify -- --base-ref origin/develop --skip-record-check
