### PR TITLE
docs(cli): define tui visual grammar

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -17,7 +17,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | [cli-provider-usage-cost-visibility.md](cli-provider-usage-cost-visibility.md)                 | CLI provider usage and cost visibility                        |
 | [cli-tui-background-work-tree-display.md](cli-tui-background-work-tree-display.md)             | CLI TUI background work tree display                          |
 | [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |
-| [cli-tui-output-visual-grammar-audit.md](cli-tui-output-visual-grammar-audit.md)               | CLI TUI output visual grammar audit                           |
 | [cli-tui-status-activity-indicator.md](cli-tui-status-activity-indicator.md)                   | CLI TUI status activity indicator                             |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)                           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)                         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |

--- a/.agents/tasks/completed/CLI-BL-047-cli-tui-output-visual-grammar-audit.md
+++ b/.agents/tasks/completed/CLI-BL-047-cli-tui-output-visual-grammar-audit.md
@@ -1,5 +1,10 @@
 # CLI TUI Output Visual Grammar Audit
 
+- **Status**: completed
+- **Created**: 2026-05-02
+- **Branch**: docs/cli-tui-visual-grammar
+- **Scope**: packages/agent-cli
+
 ## Priority
 
 P0 — umbrella audit before broad TUI changes.
@@ -44,13 +49,29 @@ Recent CLI work added background jobs, agent orchestration, markdown diff render
 
 ## Acceptance Criteria
 
-- [ ] Audit document lists every current CLI output surface and its owner.
-- [ ] Visual grammar defines plan, tool, background, command, diff, status, warning, and error presentation.
-- [ ] Each later TUI implementation task references this grammar instead of inventing local formatting.
-- [ ] Tests are identified for both pure formatting modules and Ink render snapshots.
+- [x] Audit document lists every current CLI output surface and its owner.
+- [x] Visual grammar defines plan, tool, background, command, diff, status, warning, and error presentation.
+- [x] Each later TUI implementation task references this grammar instead of inventing local formatting.
+- [x] Tests are identified for both pure formatting modules and Ink render snapshots.
 
-## Promotion Path
+## Progress
 
-1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-output-visual-grammar-audit.md`.
-2. Complete documentation-based research before implementation.
-3. Update `packages/agent-cli/docs/SPEC.md` with the approved grammar before code changes.
+### 2026-05-02
+
+- Completed documentation-based research against Codex CLI, Claude Code status/subagent/focus surfaces, and GNU diff context behavior.
+- Added the visual grammar owner contract to `packages/agent-cli/docs/SPEC.md`.
+- Converted this backlog into a completed task so implementation follow-ups can reference the package SPEC.
+
+## Decisions
+
+- Treat the CLI TUI as a renderer for structured runtime/session events, not a parser of assistant prose.
+- Use one-level tree rows, compact status markers, bounded previews, and explicit transcript/context hints as the baseline visual vocabulary.
+- Keep provider/model-specific behavior outside generic TUI formatting.
+
+## Blockers
+
+- None.
+
+## Result
+
+The visual grammar is now documented in `packages/agent-cli/docs/SPEC.md`. Follow-up CLI TUI tasks must reuse this grammar instead of inventing local formatting.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -250,6 +250,50 @@ Session name appears in three locations when set (via `--name` or `/rename`):
 | 70-89% | Yellow | Approaching limit               |
 | 90%+   | Red    | Near limit, compaction imminent |
 
+## TUI Visual Grammar
+
+The CLI TUI renders structured session/runtime data. It must not parse assistant prose to infer state, and it must not add provider/model-specific presentation branches. Rendering components may format data they receive, but ownership of the data remains in the SDK/session/runtime layer.
+
+### Output Surface Ownership
+
+| Surface                      | Owner                                 | Data Source                            | Rendering Contract                                                                |
+| ---------------------------- | ------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| Chat messages                | `MessageList`                         | `IHistoryEntry[]` chat entries         | Show stable role labels and markdown-rendered assistant content                   |
+| Tool summaries               | `MessageList`                         | structured `tool-summary` event data   | Show compact one-line tool rows plus structured details such as diffs             |
+| Streaming assistant response | `StreamingIndicator`                  | SDK text deltas                        | Show current assistant text without persisting duplicate rendered state           |
+| Live tool execution          | `StreamingIndicator`                  | SDK tool state events                  | Show current tool state using the shared status marker set                        |
+| Background work              | `BackgroundTaskPanel`                 | SDK background task events             | Show a one-level tree of running and retained terminal jobs                       |
+| Status/activity              | `StatusBar` and `SessionStatusBar`    | session state, context state, settings | Show current activity and session metadata in the primary scan path               |
+| Diff blocks                  | `ToolDiffBlock` and markdown renderer | structured diff lines                  | Render diff bodies through fenced `diff` markdown; keep metadata outside the body |
+| Setup/permission prompts     | prompt components                     | CLI flow descriptors                   | Render generic interactions only; prompt semantics remain in flow modules         |
+
+### Shared Markers
+
+| State              | Marker | Meaning                                            |
+| ------------------ | ------ | -------------------------------------------------- |
+| Running/queued     | `□`    | Work exists but is not terminal                    |
+| Completed/success  | `■`    | Work reached a successful terminal state           |
+| Failed/error       | `■`    | Work reached an error state, colored as error      |
+| Cancelled/denied   | `■`    | Work ended by user or policy decision              |
+| Omitted transcript | `...`  | Additional persisted output is hidden from preview |
+
+Colors remain renderer-owned: green for success/healthy state, yellow for warning or user-decision state, red for error/near-limit state, cyan for active assistant work, and dim text for secondary metadata.
+
+### Layout Rules
+
+- Prefer one-level trees for grouped activity: a short group label followed by aligned child rows.
+- Keep labels human-readable. Avoid raw class names, untrimmed JSON, or provider-specific implementation names in user-facing rows.
+- Keep previews bounded and whitespace-normalized. Long output must show a transcript/omitted-lines hint instead of expanding indefinitely.
+- Keep persistent raw data in session/log records even when the TUI renders a compact preview.
+- Place active state in the primary scan path. Passive metadata may remain dim or right-aligned, but model/tool/background activity must be visible without scanning the far edge of the terminal.
+- Keep code/diff colorization centralized through markdown rendering or dedicated formatting helpers, not ad hoc line coloring in each component.
+
+### Testing Requirements
+
+- Pure formatting helpers must have unit tests for status markers, truncation, omitted-line counts, and narrow-output labels.
+- Ink components must have render tests for the same states using representative structured data.
+- Changes that add a new output surface must update this section or explain why an existing surface owns the behavior.
+
 ## Context Management (CLI Layer)
 
 ### `/compact` Slash Command


### PR DESCRIPTION
## Summary
- document CLI TUI visual grammar in the agent-cli SPEC
- define output surface ownership, shared markers, layout rules, and test requirements
- archive CLI-BL-047 as completed and remove it from backlog

## Research
- OpenAI Codex CLI docs: terminal TUI, local code editing, subagents, command execution
- Claude Code docs: status line, subagent UI, focus view/tool summaries
- GNU diff docs: context/unified diff context around changed lines

## Validation
- pnpm harness:scan
- pre-push hook: pnpm harness:plan -- --base-ref origin/develop
- pre-push hook: pnpm harness:verify -- --base-ref origin/develop --skip-record-check
