### PR TITLE
fix(cli): render edit diffs as context hunks

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,7 +13,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 | File                                                                                           | Topic                                                         |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [cli-diff-context-hunk-rendering.md](cli-diff-context-hunk-rendering.md)                       | CLI diff context-aware hunk rendering                         |
 | [cli-provider-usage-cost-visibility.md](cli-provider-usage-cost-visibility.md)                 | CLI provider usage and cost visibility                        |
 | [cli-tui-background-work-tree-display.md](cli-tui-background-work-tree-display.md)             | CLI TUI background work tree display                          |
 | [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |

--- a/.agents/tasks/completed/CLI-BL-048-cli-diff-context-hunk-rendering.md
+++ b/.agents/tasks/completed/CLI-BL-048-cli-diff-context-hunk-rendering.md
@@ -1,5 +1,10 @@
 # CLI Diff Context Hunk Rendering
 
+- **Status**: completed
+- **Created**: 2026-05-02
+- **Branch**: feat/cli-diff-context-hunks
+- **Scope**: packages/agent-cli, packages/agent-sdk
+
 ## Priority
 
 P0 — edit visibility is a safety-critical CLI behavior.
@@ -54,14 +59,32 @@ Use documentation and product behavior observations only; do not copy source cod
 
 ## Acceptance Criteria
 
-- [ ] Edit tool summaries show changed lines plus surrounding context.
-- [ ] Revert/deletion edits display removed and added lines with enough context to verify location.
-- [ ] Large diffs are truncated predictably without hiding all changed lines.
-- [ ] `renderMarkdown()` remains the only line-coloring implementation for diff bodies.
-- [ ] Unit tests cover the hunk and truncation cases listed above.
+- [x] Edit tool summaries show changed lines plus surrounding context.
+- [x] Revert/deletion edits display removed and added lines with enough context to verify location.
+- [x] Large diffs are truncated predictably without hiding all changed lines.
+- [x] `renderMarkdown()` remains the only line-coloring implementation for diff bodies.
+- [x] Unit tests cover the hunk and truncation cases listed above.
 
-## Promotion Path
+## Progress
 
-1. Move to `.agents/tasks/CLI-BL-0XX-cli-diff-context-hunk-rendering.md`.
-2. Complete diff-format research before implementation.
-3. Update `agent-cli` SPEC first, then implement under TDD.
+### 2026-05-02
+
+- Researched GNU diff context/unified defaults and current Codex/Claude compact tool-summary behavior.
+- Updated `agent-cli` SPEC with context-hunk rendering behavior.
+- Added failing tests for three-line context, hunk headers, SDK-persisted context lines, and hunk-aware truncation.
+- Implemented context-aware edit diff generation and hunk-aware markdown summary rendering.
+
+## Decisions
+
+- Use three context lines by default, matching common unified diff behavior.
+- Keep diff colorization through fenced `diff` markdown only.
+- Keep file path and truncation metadata outside the fenced diff body.
+- Let SDK-persisted tool summaries include context when the edited file can be read; CLI legacy extraction follows the same display behavior.
+
+## Blockers
+
+- None.
+
+## Result
+
+Edit tool summaries now include a compact hunk header, surrounding context lines where available, and deterministic hunk-aware truncation metadata.

--- a/.changeset/fix-cli-diff-context-hunks.md
+++ b/.changeset/fix-cli-diff-context-hunks.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-cli': patch
+'@robota-sdk/agent-sdk': patch
+---
+
+Render Edit tool summaries as context-aware diff hunks with structured truncation metadata.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -294,6 +294,17 @@ Colors remain renderer-owned: green for success/healthy state, yellow for warnin
 - Ink components must have render tests for the same states using representative structured data.
 - Changes that add a new output surface must update this section or explain why an existing surface owns the behavior.
 
+### Edit Diff Hunk Rendering
+
+Edit tool summaries render context-aware hunks rather than isolated changed lines. The rendering contract is:
+
+- Default context is three unchanged lines before and after the edited span when the modified file can be read.
+- Diff bodies are fenced as `diff` markdown and rendered through the shared markdown renderer.
+- Hunk headers, context lines, additions, and removals are represented as structured diff line data before rendering.
+- File path, truncation state, and omitted-line counts remain outside the markdown body.
+- If file context is unavailable, the renderer falls back to changed lines only rather than failing the tool summary.
+- Large diffs are truncated by visible hunk groups when possible, preserving the first changed hunk before omitting additional lines.
+
 ## Context Management (CLI Layer)
 
 ### `/compact` Slash Command

--- a/packages/agent-cli/src/utils/__tests__/edit-diff.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/edit-diff.test.ts
@@ -221,7 +221,7 @@ describe('generateDiffLinesWithContext', () => {
     return filePath;
   }
 
-  it('should include 2 context lines before the change', () => {
+  it('should include 3 context lines before the change', () => {
     // 10-line file, edit line 5 (replaced already in file)
     const fileLines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
     // Simulate: line5 was replaced with lineNEW
@@ -231,14 +231,15 @@ describe('generateDiffLinesWithContext', () => {
 
     const result = generateDiffLinesWithContext('line5', 'lineNEW', 5, filePath);
 
-    // Context before: line3 (lineNumber=3) and line4 (lineNumber=4)
+    // Context before: line2, line3, line4
     const contextBefore = result.filter((l) => l.type === 'context' && l.lineNumber < 5);
-    expect(contextBefore).toHaveLength(2);
-    expect(contextBefore[0]).toEqual({ type: 'context', text: 'line3', lineNumber: 3 });
-    expect(contextBefore[1]).toEqual({ type: 'context', text: 'line4', lineNumber: 4 });
+    expect(contextBefore).toHaveLength(3);
+    expect(contextBefore[0]).toEqual({ type: 'context', text: 'line2', lineNumber: 2 });
+    expect(contextBefore[1]).toEqual({ type: 'context', text: 'line3', lineNumber: 3 });
+    expect(contextBefore[2]).toEqual({ type: 'context', text: 'line4', lineNumber: 4 });
   });
 
-  it('should include 2 context lines after the change', () => {
+  it('should include 3 context lines after the change', () => {
     const fileLines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
     const modifiedLines = [...fileLines];
     modifiedLines[4] = 'lineNEW';
@@ -246,11 +247,12 @@ describe('generateDiffLinesWithContext', () => {
 
     const result = generateDiffLinesWithContext('line5', 'lineNEW', 5, filePath);
 
-    // Context after: line6 (lineNumber=6) and line7 (lineNumber=7)
+    // Context after: line6, line7, line8
     const contextAfter = result.filter((l) => l.type === 'context' && l.lineNumber > 5);
-    expect(contextAfter).toHaveLength(2);
+    expect(contextAfter).toHaveLength(3);
     expect(contextAfter[0]).toEqual({ type: 'context', text: 'line6', lineNumber: 6 });
     expect(contextAfter[1]).toEqual({ type: 'context', text: 'line7', lineNumber: 7 });
+    expect(contextAfter[2]).toEqual({ type: 'context', text: 'line8', lineNumber: 8 });
   });
 
   it('should handle edit at start of file (no lines before)', () => {
@@ -264,11 +266,12 @@ describe('generateDiffLinesWithContext', () => {
     const contextBefore = result.filter((l) => l.type === 'context' && l.lineNumber < 1);
     expect(contextBefore).toHaveLength(0);
 
-    // Context after: line2, line3
+    // Context after: line2, line3, line4
     const contextAfter = result.filter((l) => l.type === 'context' && l.lineNumber > 1);
-    expect(contextAfter).toHaveLength(2);
+    expect(contextAfter).toHaveLength(3);
     expect(contextAfter[0]).toEqual({ type: 'context', text: 'line2', lineNumber: 2 });
     expect(contextAfter[1]).toEqual({ type: 'context', text: 'line3', lineNumber: 3 });
+    expect(contextAfter[2]).toEqual({ type: 'context', text: 'line4', lineNumber: 4 });
   });
 
   it('should handle edit at end of file (no lines after)', () => {
@@ -279,9 +282,9 @@ describe('generateDiffLinesWithContext', () => {
 
     const result = generateDiffLinesWithContext('line5', 'lineNEW', 5, filePath);
 
-    // Context before: line3, line4
+    // Context before: line2, line3, line4
     const contextBefore = result.filter((l) => l.type === 'context' && l.lineNumber < 5);
-    expect(contextBefore).toHaveLength(2);
+    expect(contextBefore).toHaveLength(3);
 
     // Context after: none (line5 is the last line)
     const contextAfter = result.filter((l) => l.type === 'context' && l.lineNumber > 5);
@@ -301,6 +304,21 @@ describe('generateDiffLinesWithContext', () => {
     for (const line of contextLines) {
       expect(line.type).toBe('context');
     }
+  });
+
+  it('starts readable context diffs with a hunk header', () => {
+    const fileLines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`);
+    const modifiedLines = [...fileLines];
+    modifiedLines[4] = 'lineNEW';
+    const filePath = makeTempFile(modifiedLines.join('\n'));
+
+    const result = generateDiffLinesWithContext('line5', 'lineNEW', 5, filePath);
+
+    expect(result[0]).toEqual({
+      type: 'hunk',
+      text: '@@ -2,7 +2,7 @@',
+      lineNumber: 2,
+    });
   });
 
   it('all lines should have absolute lineNumber', () => {

--- a/packages/agent-cli/src/utils/__tests__/tool-diff-summary.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/tool-diff-summary.test.ts
@@ -5,6 +5,7 @@ import type { IDiffLine } from '../edit-diff.js';
 describe('buildToolDiffSummary', () => {
   it('builds a markdown diff fenced body while preserving file metadata', () => {
     const lines: IDiffLine[] = [
+      { type: 'hunk', lineNumber: 10, text: '@@ -10,2 +10,2 @@' },
       { type: 'context', lineNumber: 10, text: 'const before = true;' },
       { type: 'remove', lineNumber: 11, text: 'const value = false;' },
       { type: 'add', lineNumber: 11, text: 'const value = true;' },
@@ -18,6 +19,7 @@ describe('buildToolDiffSummary', () => {
     expect(summary.markdown).toBe(
       [
         '```diff',
+        '@@ -10,2 +10,2 @@',
         '  10 | const before = true;',
         '- 11 | const value = false;',
         '+ 11 | const value = true;',
@@ -44,5 +46,34 @@ describe('buildToolDiffSummary', () => {
     expect(summary.markdown).toContain('+ 10 | line 10');
     expect(summary.markdown).not.toContain('line 11');
     expect(summary.markdown).not.toContain('more lines');
+  });
+
+  it('preserves the first hunk when truncating multi-hunk diffs', () => {
+    const lines: IDiffLine[] = [
+      { type: 'hunk', lineNumber: 1, text: '@@ -1,4 +1,4 @@' },
+      { type: 'context', lineNumber: 1, text: 'one' },
+      { type: 'remove', lineNumber: 2, text: 'two-old' },
+      { type: 'add', lineNumber: 2, text: 'two-new' },
+      { type: 'context', lineNumber: 3, text: 'three' },
+      { type: 'hunk', lineNumber: 20, text: '@@ -20,4 +20,4 @@' },
+      { type: 'context', lineNumber: 20, text: 'twenty' },
+      { type: 'remove', lineNumber: 21, text: 'twenty-one-old' },
+      { type: 'add', lineNumber: 21, text: 'twenty-one-new' },
+      { type: 'context', lineNumber: 22, text: 'twenty-two' },
+      { type: 'hunk', lineNumber: 40, text: '@@ -40,4 +40,4 @@' },
+      { type: 'context', lineNumber: 40, text: 'forty' },
+      { type: 'remove', lineNumber: 41, text: 'forty-one-old' },
+      { type: 'add', lineNumber: 41, text: 'forty-one-new' },
+      { type: 'context', lineNumber: 42, text: 'forty-two' },
+    ];
+
+    const summary = buildToolDiffSummary({ lines });
+
+    expect(summary.truncated).toBe(true);
+    expect(summary.remainingLineCount).toBe(5);
+    expect(summary.markdown).toContain('@@ -1,4 +1,4 @@');
+    expect(summary.markdown).toContain('two-new');
+    expect(summary.markdown).toContain('@@ -20,4 +20,4 @@');
+    expect(summary.markdown).not.toContain('@@ -40,4 +40,4 @@');
   });
 });

--- a/packages/agent-cli/src/utils/edit-diff.ts
+++ b/packages/agent-cli/src/utils/edit-diff.ts
@@ -6,14 +6,14 @@
 import { readFileSync } from 'node:fs';
 
 export interface IDiffLine {
-  type: 'add' | 'remove' | 'context';
+  type: 'add' | 'remove' | 'context' | 'hunk';
   text: string;
   /** Absolute line number in the file */
   lineNumber: number;
 }
 
 /** Number of context lines to show before and after the change */
-const CONTEXT_LINES = 2;
+const CONTEXT_LINES = 3;
 
 /**
  * Generate diff lines from old and new strings with absolute line numbers.
@@ -65,29 +65,45 @@ export function generateDiffLinesWithContext(
     return diffLines; // Can't read file — return without context
   }
 
-  const result: IDiffLine[] = [];
-
   // Context BEFORE: lines before startLine in the file
   const contextStart = Math.max(0, startLine - 1 - CONTEXT_LINES);
+  const beforeContext: IDiffLine[] = [];
   for (let i = contextStart; i < startLine - 1; i++) {
     if (i < fileLines.length) {
-      result.push({ type: 'context', text: fileLines[i], lineNumber: i + 1 });
+      beforeContext.push({ type: 'context', text: fileLines[i], lineNumber: i + 1 });
     }
   }
-
-  // The diff lines (remove + add)
-  result.push(...diffLines);
 
   // Context AFTER: lines after the new content in the modified file
   const newLineCount = newStr.split('\n').length;
   const afterStart = startLine - 1 + newLineCount;
+  const afterContext: IDiffLine[] = [];
   for (let i = afterStart; i < afterStart + CONTEXT_LINES; i++) {
     if (i < fileLines.length) {
-      result.push({ type: 'context', text: fileLines[i], lineNumber: i + 1 });
+      afterContext.push({ type: 'context', text: fileLines[i], lineNumber: i + 1 });
     }
   }
 
-  return result;
+  const hunkStart =
+    beforeContext[0]?.lineNumber ??
+    diffLines[0]?.lineNumber ??
+    afterContext[0]?.lineNumber ??
+    startLine;
+  const oldLineCount = oldStr.split('\n').length;
+  const newLineCountInHunk = newStr.split('\n').length;
+  const oldHunkLineCount = beforeContext.length + oldLineCount + afterContext.length;
+  const newHunkLineCount = beforeContext.length + newLineCountInHunk + afterContext.length;
+
+  return [
+    {
+      type: 'hunk',
+      text: `@@ -${hunkStart},${oldHunkLineCount} +${hunkStart},${newHunkLineCount} @@`,
+      lineNumber: hunkStart,
+    },
+    ...beforeContext,
+    ...diffLines,
+    ...afterContext,
+  ];
 }
 
 /**

--- a/packages/agent-cli/src/utils/tool-diff-summary.ts
+++ b/packages/agent-cli/src/utils/tool-diff-summary.ts
@@ -17,7 +17,7 @@ export interface IToolDiffSummary {
 
 export function buildToolDiffSummary(input: IToolDiffSummaryInput): IToolDiffSummary {
   const visibleLines =
-    input.lines.length > MAX_DIFF_LINES ? input.lines.slice(0, TRUNCATED_SHOW) : input.lines;
+    input.lines.length > MAX_DIFF_LINES ? selectVisibleDiffLines(input.lines) : input.lines;
   const lineNumberWidth = Math.max(...visibleLines.map((line) => line.lineNumber), 0).toString()
     .length;
   const body = visibleLines.map((line) => formatDiffLine(line, lineNumberWidth));
@@ -32,8 +32,44 @@ export function buildToolDiffSummary(input: IToolDiffSummaryInput): IToolDiffSum
 }
 
 function formatDiffLine(line: IDiffLine, lineNumberWidth: number): string {
+  if (line.type === 'hunk') return line.text;
   const lineNumber = line.lineNumber.toString().padStart(lineNumberWidth, ' ');
   if (line.type === 'remove') return `- ${lineNumber} | ${line.text}`;
   if (line.type === 'add') return `+ ${lineNumber} | ${line.text}`;
   return `  ${lineNumber} | ${line.text}`;
+}
+
+function selectVisibleDiffLines(lines: readonly IDiffLine[]): readonly IDiffLine[] {
+  const groups = groupByHunk(lines);
+  const visible: IDiffLine[] = [];
+
+  for (const group of groups) {
+    if (visible.length === 0 && group.length > TRUNCATED_SHOW) {
+      return group.slice(0, TRUNCATED_SHOW);
+    }
+    if (visible.length + group.length > TRUNCATED_SHOW) break;
+    visible.push(...group);
+  }
+
+  return visible.length > 0 ? visible : lines.slice(0, TRUNCATED_SHOW);
+}
+
+function groupByHunk(lines: readonly IDiffLine[]): IDiffLine[][] {
+  const groups: IDiffLine[][] = [];
+  let current: IDiffLine[] = [];
+
+  for (const line of lines) {
+    if (line.type === 'hunk' && current.length > 0) {
+      groups.push(current);
+      current = [line];
+      continue;
+    }
+    current.push(line);
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
 }

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -485,6 +485,8 @@ interface IToolState {
 }
 ```
 
+`diffLines` is structured Edit tool display metadata. For completed Edit tools, `InteractiveSession` derives it from the Edit arguments, tool result `startLine`, and the modified file contents when readable. Diff lines may include `type: 'hunk'`, `context`, `remove`, and `add`. The SDK persists this metadata so all transports can replay the same edit summary; CLI owns visual rendering only.
+
 **IExecutionResult:**
 
 ```typescript

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   applyToolEnd,
   applyToolStart,
@@ -14,12 +17,31 @@ function createState(): IStreamingState {
 }
 
 describe('interactive-session-streaming edit diffs', () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  function makeTempFile(content: string): string {
+    tmpDir = mkdtempSync(join(tmpdir(), 'interactive-diff-test-'));
+    const filePath = join(tmpDir, 'example.md');
+    writeFileSync(filePath, content, 'utf8');
+    return filePath;
+  }
+
   it('attaches diff metadata when an Edit tool completes', () => {
+    const filePath = makeTempFile(
+      ['line four', 'line five', 'line six', 'line one', 'line eight', 'line nine'].join('\n'),
+    );
     const state = createState();
     applyToolStart(state, {
       toolName: 'Edit',
       toolArgs: {
-        filePath: '/tmp/example.md',
+        filePath,
         oldString: 'line one\nline two\nline three',
         newString: 'line one',
       },
@@ -29,7 +51,7 @@ describe('interactive-session-streaming edit diffs', () => {
       type: 'end',
       toolName: 'Edit',
       toolArgs: {
-        filePath: '/tmp/example.md',
+        filePath,
         oldString: 'line one\nline two\nline three',
         newString: 'line one',
       },
@@ -37,13 +59,16 @@ describe('interactive-session-streaming edit diffs', () => {
       toolResultData: JSON.stringify({ success: true, startLine: 7 }),
     });
 
-    expect(finished?.diffFile).toBe('/tmp/example.md');
-    expect(finished?.diffLines).toEqual([
-      { type: 'remove', text: 'line one', lineNumber: 7 },
-      { type: 'remove', text: 'line two', lineNumber: 8 },
-      { type: 'remove', text: 'line three', lineNumber: 9 },
-      { type: 'add', text: 'line one', lineNumber: 7 },
-    ]);
+    expect(finished?.diffFile).toBe(filePath);
+    expect(finished?.diffLines).toEqual(
+      expect.arrayContaining([
+        { type: 'hunk', text: '@@ -4,6 +4,4 @@', lineNumber: 4 },
+        { type: 'remove', text: 'line one', lineNumber: 7 },
+        { type: 'remove', text: 'line two', lineNumber: 8 },
+        { type: 'remove', text: 'line three', lineNumber: 9 },
+        { type: 'add', text: 'line one', lineNumber: 7 },
+      ]),
+    );
   });
 
   it('persists tool-summary diff metadata for later TUI rendering', () => {

--- a/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
@@ -6,9 +6,10 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
-import type { IToolState } from './types.js';
+import type { IDiffLine, IToolState } from './types.js';
 
 /** Max chars to display from first tool argument. */
 export const TOOL_ARG_DISPLAY_MAX = 80;
@@ -18,6 +19,7 @@ export const MAX_COMPLETED_TOOLS = 50;
 /** Streaming text flush interval (ms) — ~60fps. */
 export const STREAMING_FLUSH_INTERVAL_MS = 16;
 const DEFAULT_START_LINE = 1;
+const EDIT_DIFF_CONTEXT_LINES = 3;
 
 /** Extract a short display string from the first tool argument. */
 export function extractFirstArg(toolArgs?: TToolArgs): string {
@@ -71,19 +73,76 @@ function buildEditDiffState(event: IToolEndEvent): Pick<IToolState, 'diffFile' |
   const startLine = parseStartLine(event.toolResultData);
   return {
     diffFile: filePath,
-    diffLines: [
-      ...oldString.split('\n').map((text, index) => ({
-        type: 'remove' as const,
-        text,
-        lineNumber: startLine + index,
-      })),
-      ...newString.split('\n').map((text, index) => ({
-        type: 'add' as const,
-        text,
-        lineNumber: startLine + index,
-      })),
-    ],
+    diffLines: buildEditDiffLinesWithContext(oldString, newString, startLine, filePath),
   };
+}
+
+function buildEditDiffLines(oldString: string, newString: string, startLine: number): IDiffLine[] {
+  return [
+    ...oldString.split('\n').map((text, index) => ({
+      type: 'remove' as const,
+      text,
+      lineNumber: startLine + index,
+    })),
+    ...newString.split('\n').map((text, index) => ({
+      type: 'add' as const,
+      text,
+      lineNumber: startLine + index,
+    })),
+  ];
+}
+
+function buildEditDiffLinesWithContext(
+  oldString: string,
+  newString: string,
+  startLine: number,
+  filePath: string,
+): IDiffLine[] {
+  const diffLines = buildEditDiffLines(oldString, newString, startLine);
+
+  let fileLines: string[];
+  try {
+    fileLines = readFileSync(filePath, 'utf8').split('\n');
+  } catch {
+    return diffLines;
+  }
+
+  const beforeContext: IDiffLine[] = [];
+  const contextStart = Math.max(0, startLine - 1 - EDIT_DIFF_CONTEXT_LINES);
+  for (let index = contextStart; index < startLine - 1; index++) {
+    if (index < fileLines.length) {
+      beforeContext.push({ type: 'context', text: fileLines[index], lineNumber: index + 1 });
+    }
+  }
+
+  const afterContext: IDiffLine[] = [];
+  const afterStart = startLine - 1 + newString.split('\n').length;
+  for (let index = afterStart; index < afterStart + EDIT_DIFF_CONTEXT_LINES; index++) {
+    if (index < fileLines.length) {
+      afterContext.push({ type: 'context', text: fileLines[index], lineNumber: index + 1 });
+    }
+  }
+
+  const hunkStart =
+    beforeContext[0]?.lineNumber ??
+    diffLines[0]?.lineNumber ??
+    afterContext[0]?.lineNumber ??
+    startLine;
+  const oldLineCount = oldString.split('\n').length;
+  const newLineCount = newString.split('\n').length;
+  const oldHunkLineCount = beforeContext.length + oldLineCount + afterContext.length;
+  const newHunkLineCount = beforeContext.length + newLineCount + afterContext.length;
+
+  return [
+    {
+      type: 'hunk',
+      text: `@@ -${hunkStart},${oldHunkLineCount} +${hunkStart},${newHunkLineCount} @@`,
+      lineNumber: hunkStart,
+    },
+    ...beforeContext,
+    ...diffLines,
+    ...afterContext,
+  ];
 }
 
 /** Build a tool-summary history entry from current active tools and push it into history. */

--- a/packages/agent-sdk/src/interactive/types.ts
+++ b/packages/agent-sdk/src/interactive/types.ts
@@ -21,7 +21,7 @@ export interface IToolState {
 
 /** A single diff line for Edit tool display. */
 export interface IDiffLine {
-  type: 'add' | 'remove' | 'context';
+  type: 'add' | 'remove' | 'context' | 'hunk';
   text: string;
   lineNumber: number;
 }


### PR DESCRIPTION
## Summary
- render Edit tool summaries as markdown diff hunks with three lines of surrounding context when the edited file can be read
- persist structured hunk/context/add/remove diff metadata from the SDK so transports replay the same summary
- complete CLI-BL-048 and document the CLI/SDK diff contract

## Research
- GNU diff unified output convention uses context hunks; this change follows that shape for terminal reviewability.
- Commercial coding CLIs generally show compact tool summaries with enough surrounding context rather than only isolated changed lines.

## Verification
- pnpm --filter @robota-sdk/agent-cli test -- src/utils/__tests__/edit-diff.test.ts src/utils/__tests__/tool-diff-summary.test.ts src/ui/__tests__/message-list-rendering.test.tsx src/ui/__tests__/streaming-indicator.test.tsx
- pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-streaming.test.ts src/interactive/__tests__/interactive-session-behavior.test.ts
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-sdk lint
- git diff --check
- pnpm harness:scan
- pre-push scoped harness verification for agent-cli and agent-sdk