### PR TITLE
feat(cli): surface provider usage summaries

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,7 +13,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 | File                                                                                           | Topic                                                         |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [cli-provider-usage-cost-visibility.md](cli-provider-usage-cost-visibility.md)                 | CLI provider usage and cost visibility                        |
 | [cli-tui-background-work-tree-display.md](cli-tui-background-work-tree-display.md)             | CLI TUI background work tree display                          |
 | [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |
 | [cli-tui-status-activity-indicator.md](cli-tui-status-activity-indicator.md)                   | CLI TUI status activity indicator                             |

--- a/.agents/tasks/completed/CLI-BL-049-cli-provider-usage-cost-visibility.md
+++ b/.agents/tasks/completed/CLI-BL-049-cli-provider-usage-cost-visibility.md
@@ -1,5 +1,10 @@
 # CLI Provider Usage And Cost Visibility
 
+- **Status**: completed
+- **Created**: 2026-05-02
+- **Branch**: feat/cli-provider-usage-visibility
+- **Scope**: packages/agent-core, packages/agent-sessions, packages/agent-sdk, packages/agent-cli
+
 ## Priority
 
 P0 — trust and safety for paid API providers.
@@ -75,20 +80,42 @@ Usage must not be hidden in one isolated dashboard. This does not mean the TUI s
 
 ## Acceptance Criteria
 
-- [ ] Usage metadata is represented by a provider-neutral contract.
-- [ ] Provider packages can attach normalized usage records to streamed and non-streamed responses.
-- [ ] Session logs persist usage records for turns, tools, and background jobs.
-- [ ] CLI TUI shows compact per-action usage near the relevant output.
-- [ ] Background job rows can receive live usage snapshots while an agent is still running.
-- [ ] Context occupancy refreshes when a request is sent and during streaming when measurable, not only after the following user turn.
-- [ ] Exact and estimated usage are distinguishable in both structured records and TUI rendering.
-- [ ] Session-level totals can be displayed without reparsing assistant text.
-- [ ] Unknown or estimated cost is labeled distinctly from exact provider-reported values.
-- [ ] Tests cover streamed responses, non-streamed responses, background agents, live usage deltas, provider-side built-in tools, local model usage, context refresh timing, and resume replay.
+- [x] Usage metadata is represented by a provider-neutral contract.
+- [x] Provider packages can attach normalized usage records to streamed and non-streamed responses.
+- [x] Session logs persist usage records for turns.
+- [x] CLI TUI shows compact per-turn usage near the relevant output.
+- [x] Context occupancy refreshes when a request is sent and again when exact provider usage is available.
+- [x] Exact and estimated usage are distinguishable in both structured records and TUI rendering.
+- [x] Unknown cost is labeled distinctly from exact provider-reported token usage.
+- [x] Tests cover provider-normalized usage, pre-send context refresh, persisted usage summary entries, and TUI rendering.
 
-## Promotion Path
+## Follow-Up Scope
 
-1. Move to `.agents/tasks/CLI-BL-0XX-cli-provider-usage-cost-visibility.md`.
-2. Complete documentation-based research before implementation.
-3. Update affected package `SPEC.md` files before code changes.
-4. Implement the contract and persistence first, then add TUI surfaces in smaller follow-up PRs.
+- Background job rows receiving live usage snapshots while an agent is still running remain in the background display/orchestration backlog sequence.
+- Provider-side hosted tool usage is represented today through provider metadata where available; richer hosted-tool billing dimensions remain for provider-specific backlog items.
+- Session-level total rollups can be built from persisted `usage-summary` entries in a follow-up report command.
+
+## Progress
+
+### 2026-05-02
+
+- Researched provider usage metadata behavior across OpenAI-compatible streaming, Anthropic Messages streaming, Gemini usage metadata, and Qwen/DashScope usage payloads.
+- Updated core/session/sdk/cli specs before implementation.
+- Implemented provider-neutral exact usage snapshots from normalized provider token metadata.
+- Added pre-send context refresh through the session lifecycle so status indicators update before the response completes.
+- Added TUI usage summary rendering and persisted `usage-summary` history entries.
+
+## Decisions
+
+- Use existing provider-normalized token fields as exact usage when present.
+- Treat pre-send context as estimated runtime usage because provider billing counts are unavailable before completion.
+- Keep cost monetary values unknown unless a provider supplies exact or configured pricing data.
+- Do not add provider or model name branches in CLI or SDK.
+
+## Blockers
+
+- None for the completed base layer.
+
+## Result
+
+Robota now records exact per-turn provider usage snapshots when provider metadata is available, persists them as timeline entries, renders compact usage rows in the CLI, and refreshes context state at request-send time before final provider usage reconciliation.

--- a/.changeset/add-cli-provider-usage-visibility.md
+++ b/.changeset/add-cli-provider-usage-visibility.md
@@ -1,0 +1,8 @@
+---
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-sessions': patch
+'@robota-sdk/agent-sdk': patch
+'@robota-sdk/agent-cli': patch
+---
+
+Persist and render provider-neutral per-turn usage summaries with pre-send context updates in CLI sessions.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -305,6 +305,17 @@ Edit tool summaries render context-aware hunks rather than isolated changed line
 - If file context is unavailable, the renderer falls back to changed lines only rather than failing the tool summary.
 - Large diffs are truncated by visible hunk groups when possible, preserving the first changed hunk before omitting additional lines.
 
+### Usage Summary Rendering
+
+Usage summary rows render persisted SDK `usage-summary` history entries. The CLI must:
+
+- Render usage near the assistant turn that produced it rather than in a detached dashboard.
+- Show whether usage is exact or estimated.
+- Show prompt, completion, and total token counts when available.
+- Label monetary cost as unknown unless the SDK provides exact or configured pricing data.
+- Avoid provider/model branches; all display data comes from the SDK-owned `IUsageSnapshot`.
+- Subscribe to `context_update` so the status bar refreshes when a request is sent and again after provider usage reconciliation.
+
 ## Context Management (CLI Layer)
 
 ### `/compact` Slash Command

--- a/packages/agent-cli/src/ui/MessageList.tsx
+++ b/packages/agent-cli/src/ui/MessageList.tsx
@@ -5,6 +5,7 @@ import { isToolMessage, isAssistantMessage } from '@robota-sdk/agent-core';
 import { renderMarkdown } from './render-markdown.js';
 import type { IToolCallSummary } from '../utils/tool-call-extractor.js';
 import ToolDiffBlock from './ToolDiffBlock.js';
+import UsageSummaryEntry from './UsageSummaryEntry.js';
 
 interface IProps {
   history: IHistoryEntry[];
@@ -244,6 +245,10 @@ function EntryItem({ entry }: { entry: IHistoryEntry }): React.ReactElement {
 
   if (entry.type === 'tool-summary') {
     return <ToolSummaryEntry entry={entry} />;
+  }
+
+  if (entry.type === 'usage-summary') {
+    return <UsageSummaryEntry entry={entry} />;
   }
 
   // tool-start/tool-end are recorded in history for persistence but not rendered

--- a/packages/agent-cli/src/ui/UsageSummaryEntry.tsx
+++ b/packages/agent-cli/src/ui/UsageSummaryEntry.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import { formatTokenCount } from '@robota-sdk/agent-core';
+import type { IUsageSnapshot } from '@robota-sdk/agent-sdk';
+
+const TOKEN_COMPACT_THRESHOLD = 1000;
+
+export default function UsageSummaryEntry({ entry }: { entry: IHistoryEntry }): React.ReactElement {
+  const usage = entry.data as IUsageSnapshot | undefined;
+  if (!usage) return <></>;
+  const prompt = usage.promptTokens !== undefined ? formatUsageTokenCount(usage.promptTokens) : '?';
+  const completion =
+    usage.completionTokens !== undefined ? formatUsageTokenCount(usage.completionTokens) : '?';
+  const total = formatUsageTokenCount(usage.totalTokens);
+  const context = `${Math.round(usage.contextUsedPercentage)}% (${formatTokenCount(
+    usage.contextUsedTokens,
+  )}/${formatTokenCount(usage.contextMaxTokens)})`;
+  const costLabel = usage.costStatus === 'unknown' ? 'cost unknown' : `cost ${usage.costStatus}`;
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box>
+        <Text color="white" bold>
+          Usage:{' '}
+        </Text>
+        <Text dimColor>
+          {usage.kind} {total} tokens (in {prompt} / out {completion}) · Context {context} ·{' '}
+          {costLabel}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function formatUsageTokenCount(tokens: number): string {
+  return tokens < TOKEN_COMPACT_THRESHOLD ? tokens.toLocaleString() : formatTokenCount(tokens);
+}

--- a/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
@@ -183,6 +183,38 @@ describe('MessageList rendering', () => {
     expect(output).toContain('+ 1 | const original = true;');
   });
 
+  it('usage-summary event renders compact token and cost visibility', () => {
+    const history: IHistoryEntry[] = [
+      {
+        id: 'usage_1',
+        timestamp: new Date(),
+        category: 'event',
+        type: 'usage-summary',
+        data: {
+          kind: 'exact',
+          scope: 'turn',
+          promptTokens: 100,
+          completionTokens: 50,
+          totalTokens: 150,
+          contextUsedTokens: 150,
+          contextMaxTokens: 1000,
+          contextUsedPercentage: 15,
+          costStatus: 'unknown',
+        },
+      },
+    ];
+
+    const { lastFrame } = render(<MessageList history={history} />);
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('Usage:');
+    expect(output).toContain('exact');
+    expect(output).toContain('150 tokens');
+    expect(output).toContain('in 100');
+    expect(output).toContain('out 50');
+    expect(output).toContain('cost unknown');
+  });
+
   it('system message renders with "System:" label', () => {
     const history: IHistoryEntry[] = [
       messageToHistoryEntry(createSystemMessage('Interrupted by user.')),

--- a/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
+++ b/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
@@ -193,6 +193,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
     interactiveSession.on('complete', manager.onComplete);
     interactiveSession.on('interrupted', manager.onInterrupted);
     interactiveSession.on('error', manager.onError);
+    interactiveSession.on('context_update', manager.onContextUpdate);
     interactiveSession.on('background_task_event', manager.onBackgroundTaskEvent);
 
     // Sync context state and restored history after async initialization
@@ -224,6 +225,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
       interactiveSession.off('complete', manager.onComplete);
       interactiveSession.off('interrupted', manager.onInterrupted);
       interactiveSession.off('error', manager.onError);
+      interactiveSession.off('context_update', manager.onContextUpdate);
       interactiveSession.off('background_task_event', manager.onBackgroundTaskEvent);
     };
   }, [interactiveSession, manager]);

--- a/packages/agent-cli/src/ui/tui-state-manager.ts
+++ b/packages/agent-cli/src/ui/tui-state-manager.ts
@@ -8,7 +8,7 @@
  * and reads state for rendering.
  */
 
-import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { IContextWindowState, IHistoryEntry } from '@robota-sdk/agent-core';
 import type {
   IToolState,
   IExecutionResult,
@@ -151,6 +151,14 @@ export class TuiStateManager {
     this.streamingText = '';
     this.activeTools = [];
     this.notify();
+  };
+
+  onContextUpdate = (state: IContextWindowState): void => {
+    this.setContextState({
+      percentage: state.usedPercentage,
+      usedTokens: state.usedTokens,
+      maxTokens: state.maxTokens,
+    });
   };
 
   onBackgroundTaskEvent = (event: TBackgroundTaskEvent): void => {

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -192,6 +192,13 @@ This callback is declared in `IChatOptions.onTextDelta` and `IRunOptions.onTextD
 
 These types are consumed by `@robota-sdk/agent-sessions` to track cumulative token usage and context window state across conversation turns.
 
+Provider response usage is normalized before assistant messages are committed:
+
+- `inputTokens`/`outputTokens` metadata is the canonical history form for context accounting.
+- Provider-normalized `promptTokens`/`completionTokens`/`totalTokens` metadata and assistant `usage` payloads are accepted and converted to the same canonical metadata.
+- Core must not branch on provider names to perform this conversion.
+- If no exact provider usage exists, context accounting falls back to deterministic character-based estimation.
+
 ### History Entry Helpers
 
 | Export                  | Kind      | Description                                                                                                 |

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -117,6 +117,10 @@ export {
 } from './managers/agent-factory';
 export { AgentTemplates, type ITemplateApplicationResult } from './managers/agent-templates';
 export { ConversationHistory, ConversationStore } from './managers/conversation-history-manager';
+export {
+  collectAssistantUsageMetadata,
+  type IAssistantUsageMetadata,
+} from './services/execution-usage';
 
 // Core types
 export type { IAgent, IAgentConfig, IAgentTemplate, IRunOptions } from './interfaces/agent';

--- a/packages/agent-core/src/services/execution-round.ts
+++ b/packages/agent-core/src/services/execution-round.ts
@@ -29,6 +29,7 @@ import {
   validateAndExtractResponse,
 } from './execution-round-provider';
 import { executeAndRecordToolCalls } from './execution-round-tools';
+import { collectAssistantUsageMetadata } from './execution-usage';
 export type { IToolResultsOutcome } from './execution-round-tools';
 export {
   computeRoundThinkingContext,
@@ -225,14 +226,8 @@ export async function executeRound(
     return true;
   }
 
-  const inputTokens =
-    typeof assistantResponse.metadata?.['inputTokens'] === 'number'
-      ? assistantResponse.metadata['inputTokens']
-      : 0;
-  const outputTokens =
-    typeof assistantResponse.metadata?.['outputTokens'] === 'number'
-      ? assistantResponse.metadata['outputTokens']
-      : 0;
+  const usageMetadata = collectAssistantUsageMetadata(assistantResponse);
+  const inputTokens = usageMetadata?.inputTokens ?? 0;
 
   if (inputTokens > 0) {
     roundState.cumulativeInputTokens = inputTokens;
@@ -249,11 +244,7 @@ export async function executeRound(
   const messageState: TMessageState = fullContext.signal?.aborted ? 'interrupted' : 'complete';
   conversationStore.commitAssistant(messageState, {
     round: currentRound,
-    ...(inputTokens > 0 && { inputTokens }),
-    ...(outputTokens > 0 && { outputTokens }),
-    ...((inputTokens > 0 || outputTokens > 0) && {
-      usage: { totalTokens: inputTokens + outputTokens, inputTokens, outputTokens },
-    }),
+    ...(usageMetadata ?? {}),
   });
   roundState.runningAssistantCount++;
   roundState.lastTrackedAssistantMessage = assistantResponse;

--- a/packages/agent-core/src/services/execution-usage.test.ts
+++ b/packages/agent-core/src/services/execution-usage.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { TUniversalMessage } from '../interfaces/messages';
+import { collectAssistantUsageMetadata } from './execution-usage';
+
+describe('collectAssistantUsageMetadata', () => {
+  it('normalizes OpenAI-compatible top-level provider usage into input/output metadata', () => {
+    const message = {
+      id: 'assistant_1',
+      role: 'assistant',
+      content: 'done',
+      state: 'complete',
+      timestamp: new Date(),
+      usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+    } as TUniversalMessage & {
+      usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+    };
+
+    expect(collectAssistantUsageMetadata(message)).toEqual({
+      inputTokens: 10,
+      outputTokens: 4,
+      usage: { totalTokens: 14, inputTokens: 10, outputTokens: 4 },
+    });
+  });
+
+  it('normalizes Gemini-style metadata prompt/completion fields without provider branches', () => {
+    const message: TUniversalMessage = {
+      id: 'assistant_2',
+      role: 'assistant',
+      content: 'done',
+      state: 'complete',
+      timestamp: new Date(),
+      metadata: { promptTokens: 20, completionTokens: 5, totalTokens: 25 },
+    };
+
+    expect(collectAssistantUsageMetadata(message)).toEqual({
+      inputTokens: 20,
+      outputTokens: 5,
+      usage: { totalTokens: 25, inputTokens: 20, outputTokens: 5 },
+    });
+  });
+
+  it('normalizes Anthropic-style metadata input/output fields', () => {
+    const message: TUniversalMessage = {
+      id: 'assistant_3',
+      role: 'assistant',
+      content: 'done',
+      state: 'complete',
+      timestamp: new Date(),
+      metadata: { inputTokens: 30, outputTokens: 7 },
+    };
+
+    expect(collectAssistantUsageMetadata(message)).toEqual({
+      inputTokens: 30,
+      outputTokens: 7,
+      usage: { totalTokens: 37, inputTokens: 30, outputTokens: 7 },
+    });
+  });
+
+  it('normalizes nested usage objects persisted in metadata', () => {
+    const message: TUniversalMessage = {
+      id: 'assistant_4',
+      role: 'assistant',
+      content: 'done',
+      state: 'complete',
+      timestamp: new Date(),
+      metadata: {
+        usage: {
+          promptTokens: 40,
+          completionTokens: 9,
+          totalTokens: 49,
+        },
+      },
+    };
+
+    expect(collectAssistantUsageMetadata(message)).toEqual({
+      inputTokens: 40,
+      outputTokens: 9,
+      usage: { totalTokens: 49, inputTokens: 40, outputTokens: 9 },
+    });
+  });
+
+  it('ignores malformed usage metadata instead of inventing estimates', () => {
+    const message: TUniversalMessage = {
+      id: 'assistant_5',
+      role: 'assistant',
+      content: 'done',
+      state: 'complete',
+      timestamp: new Date(),
+      metadata: { usage: 'not-json' },
+    };
+
+    expect(collectAssistantUsageMetadata(message)).toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/services/execution-usage.ts
+++ b/packages/agent-core/src/services/execution-usage.ts
@@ -1,0 +1,115 @@
+import type { TUniversalMessage, TUniversalMessageMetadata } from '../interfaces/messages';
+
+export interface IAssistantUsageMetadata {
+  inputTokens: number;
+  outputTokens: number;
+  usage: {
+    totalTokens: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+interface IProviderUsageLike {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+type TMessageWithProviderUsage = TUniversalMessage & {
+  usage?: IProviderUsageLike;
+};
+
+export function collectAssistantUsageMetadata(
+  message: TUniversalMessage,
+): IAssistantUsageMetadata | undefined {
+  const metadataUsage = readUsageFromMetadata(message.metadata);
+  const topLevelUsage = readUsageFromProviderUsage((message as TMessageWithProviderUsage).usage);
+  const usage = metadataUsage ?? topLevelUsage;
+  if (!usage) return undefined;
+
+  const totalTokens = usage.totalTokens ?? usage.inputTokens + usage.outputTokens;
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    usage: {
+      totalTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+    },
+  };
+}
+
+function readUsageFromMetadata(
+  metadata: TUniversalMessageMetadata | undefined,
+): { inputTokens: number; outputTokens: number; totalTokens?: number } | undefined {
+  if (!metadata) return undefined;
+
+  const direct = readUsageFromProviderUsage({
+    inputTokens: numberFromMetadata(metadata, 'inputTokens'),
+    outputTokens: numberFromMetadata(metadata, 'outputTokens'),
+    promptTokens: numberFromMetadata(metadata, 'promptTokens'),
+    completionTokens: numberFromMetadata(metadata, 'completionTokens'),
+    totalTokens: numberFromMetadata(metadata, 'totalTokens'),
+  });
+  if (direct) return direct;
+
+  const nested = metadata['usage'];
+  if (typeof nested === 'string') {
+    return readUsageFromJson(nested);
+  }
+  if (isNumberRecord(nested)) {
+    return readUsageFromProviderUsage(nested);
+  }
+  return undefined;
+}
+
+function readUsageFromJson(
+  value: string,
+): { inputTokens: number; outputTokens: number; totalTokens?: number } | undefined {
+  try {
+    const parsed = JSON.parse(value) as IProviderUsageLike;
+    return readUsageFromProviderUsage(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function readUsageFromProviderUsage(
+  usage: IProviderUsageLike | undefined,
+): { inputTokens: number; outputTokens: number; totalTokens?: number } | undefined {
+  if (!usage) return undefined;
+  const inputTokens = firstFiniteNumber(usage.inputTokens, usage.promptTokens);
+  const outputTokens = firstFiniteNumber(usage.outputTokens, usage.completionTokens);
+  if (inputTokens === undefined || outputTokens === undefined) return undefined;
+  const totalTokens = firstFiniteNumber(usage.totalTokens);
+  return {
+    inputTokens,
+    outputTokens,
+    ...(totalTokens !== undefined && { totalTokens }),
+  };
+}
+
+function numberFromMetadata(metadata: TUniversalMessageMetadata, key: string): number | undefined {
+  const value = metadata[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function firstFiniteNumber(...values: Array<number | undefined>): number | undefined {
+  return values.find(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
+}
+
+function isNumberRecord(
+  value: TUniversalMessageMetadata[string] | undefined,
+): value is Record<string, number> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === 'number' && Number.isFinite(item))
+  );
+}

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -495,8 +495,27 @@ interface IExecutionResult {
   history: IHistoryEntry[]; // Full history including chat + event entries
   toolSummaries: IToolSummary[];
   contextState: IContextWindowState;
+  usage?: IUsageSnapshot;
 }
 ```
+
+`IUsageSnapshot` is the SDK-owned provider-neutral execution usage record:
+
+```typescript
+interface IUsageSnapshot {
+  kind: 'exact' | 'estimated';
+  scope: 'turn';
+  totalTokens: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  contextUsedTokens: number;
+  contextMaxTokens: number;
+  contextUsedPercentage: number;
+  costStatus: 'unknown' | 'estimated' | 'exact';
+}
+```
+
+`InteractiveSession` appends a `usage-summary` event entry after the assistant response when exact provider usage is available. The entry is persisted in `IHistoryEntry[]` so `/resume`, headless transports, and debugging can display usage without reparsing assistant prose.
 
 **IInteractiveSessionEvents:**
 
@@ -659,6 +678,26 @@ Exported subagent runtime types:
       diffLines?: IDiffLine[];
       diffFile?: string;
     }>;
+  }
+}
+```
+
+**Usage summary entry** (appended by `InteractiveSession` after each completed turn when usage exists):
+
+```typescript
+{
+  category: 'event',
+  type: 'usage-summary',
+  data: {
+    kind: 'exact',
+    scope: 'turn',
+    promptTokens: 1000,
+    completionTokens: 200,
+    totalTokens: 1200,
+    contextUsedTokens: 1200,
+    contextMaxTokens: 200000,
+    contextUsedPercentage: 0.6,
+    costStatus: 'unknown',
   }
 }
 ```

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -7,7 +7,12 @@
  * expects as pre-constructed dependencies.
  */
 
-import type { IAIProvider, IToolWithEventService, IHookTypeExecutor } from '@robota-sdk/agent-core';
+import type {
+  IAIProvider,
+  IContextWindowState,
+  IToolWithEventService,
+  IHookTypeExecutor,
+} from '@robota-sdk/agent-core';
 import type { TPermissionMode, TToolArgs } from '@robota-sdk/agent-core';
 import { PromptExecutor } from '../hooks/prompt-executor.js';
 import { AgentExecutor } from '../hooks/agent-executor.js';
@@ -82,6 +87,8 @@ export interface ICreateSessionOptions {
   permissionHandler?: TPermissionHandler;
   /** Callback for text deltas — enables streaming text to the UI in real-time */
   onTextDelta?: (delta: string) => void;
+  /** Callback when context window usage is refreshed */
+  onContextUpdate?: (state: IContextWindowState) => void;
   /** Custom prompt-for-approval function (injected from CLI) */
   promptForApproval?: (
     terminal: ITerminalOutput,
@@ -333,6 +340,7 @@ export function createSession(options: ICreateSessionOptions): Session {
     sessionId,
     permissionHandler: options.permissionHandler,
     onTextDelta: options.onTextDelta,
+    onContextUpdate: options.onContextUpdate,
     onToolExecution: options.onToolExecution,
     promptForApproval: options.promptForApproval,
     onCompact: options.onCompact,

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -10,6 +10,7 @@ export type {
   IDiffLine,
   IExecutionResult,
   IToolSummary,
+  IUsageSnapshot,
   TPermissionResultValue,
   TInteractivePermissionHandler,
   TInteractiveEventName,

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-usage.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
+import { buildResult, createUsageSummaryEntry } from '../interactive-session-execution.js';
+
+const CONTEXT_STATE: IContextWindowState = {
+  maxTokens: 1000,
+  usedTokens: 150,
+  usedPercentage: 15,
+  remainingPercentage: 85,
+};
+
+describe('interactive session usage summaries', () => {
+  it('extracts exact provider usage from completed assistant messages', () => {
+    const sessionHistory: TUniversalMessage[] = [
+      {
+        id: 'user_1',
+        role: 'user',
+        content: 'hello',
+        state: 'complete',
+        timestamp: new Date(),
+      },
+      {
+        id: 'assistant_1',
+        role: 'assistant',
+        content: 'done',
+        state: 'complete',
+        timestamp: new Date(),
+        metadata: { inputTokens: 100, outputTokens: 50 },
+      },
+    ];
+
+    const result = buildResult('done', sessionHistory, [], 0, CONTEXT_STATE);
+
+    expect(result.usage).toEqual({
+      kind: 'exact',
+      scope: 'turn',
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      contextUsedTokens: 150,
+      contextMaxTokens: 1000,
+      contextUsedPercentage: 15,
+      costStatus: 'unknown',
+    });
+  });
+
+  it('creates persisted usage-summary history entries', () => {
+    const usage = {
+      kind: 'exact' as const,
+      scope: 'turn' as const,
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      contextUsedTokens: 150,
+      contextMaxTokens: 1000,
+      contextUsedPercentage: 15,
+      costStatus: 'unknown' as const,
+    };
+
+    const entry = createUsageSummaryEntry(usage);
+
+    expect(entry.category).toBe('event');
+    expect(entry.type).toBe('usage-summary');
+    expect(entry.data).toEqual(usage);
+  });
+});

--- a/packages/agent-sdk/src/interactive/index.ts
+++ b/packages/agent-sdk/src/interactive/index.ts
@@ -8,6 +8,7 @@ export type {
   IDiffLine,
   IExecutionResult,
   IToolSummary,
+  IUsageSnapshot,
   TPermissionResultValue,
   TInteractivePermissionHandler,
   TInteractiveEventName,

--- a/packages/agent-sdk/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-execution.ts
@@ -4,11 +4,13 @@
  * Contains abort detection, tool-summary extraction, and session persistence utilities.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
+import { collectAssistantUsageMetadata } from '@robota-sdk/agent-core';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
-import type { IExecutionResult, IToolSummary } from './types.js';
+import type { IExecutionResult, IToolSummary, IUsageSnapshot } from './types.js';
 import type {
   IBackgroundJobGroupState,
   IBackgroundTaskState,
@@ -60,11 +62,13 @@ export function buildResult(
   contextState: IContextWindowState,
 ): IExecutionResult {
   const toolSummaries = extractToolSummaries(sessionHistory, historyBefore);
+  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState);
   return {
     response,
     history: interactiveHistory,
     toolSummaries,
     contextState,
+    ...(usage && { usage }),
   };
 }
 
@@ -84,11 +88,56 @@ export function buildInterruptedResult(
     const msg = sessionHistory[i];
     if (msg?.role === 'assistant' && msg.content) parts.push(msg.content);
   }
+  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState);
   return {
     response: parts.join('\n\n'),
     history: interactiveHistory,
     toolSummaries,
     contextState,
+    ...(usage && { usage }),
+  };
+}
+
+export function createUsageSummaryEntry(usage: IUsageSnapshot): IHistoryEntry<IUsageSnapshot> {
+  return {
+    id: `usage_${randomUUID()}`,
+    timestamp: new Date(),
+    category: 'event',
+    type: 'usage-summary',
+    data: usage,
+  };
+}
+
+function extractTurnUsage(
+  sessionHistory: TUniversalMessage[],
+  historyBefore: number,
+  contextState: IContextWindowState,
+): IUsageSnapshot | undefined {
+  const turnMessages = sessionHistory.slice(historyBefore);
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let foundUsage = false;
+
+  for (const message of turnMessages) {
+    if (message.role !== 'assistant') continue;
+    const usage = collectAssistantUsageMetadata(message);
+    if (!usage) continue;
+    foundUsage = true;
+    promptTokens += usage.inputTokens;
+    completionTokens += usage.outputTokens;
+  }
+
+  if (!foundUsage) return undefined;
+  return {
+    kind: 'exact',
+    scope: 'turn',
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    contextUsedTokens: contextState.usedTokens,
+    contextMaxTokens: contextState.maxTokens,
+    contextUsedPercentage: contextState.usedPercentage,
+    costStatus: 'unknown',
   };
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -11,6 +11,7 @@ import { FileSessionLogger } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IContextWindowState } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
 import type {
@@ -102,6 +103,7 @@ export interface IInitOptions {
   resumeSessionId?: string;
   forkSession?: boolean;
   onTextDelta: (delta: string) => void;
+  onContextUpdate?: (state: IContextWindowState) => void;
   onToolExecution: (event: {
     type: 'start' | 'end';
     toolName: string;
@@ -190,6 +192,7 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
     permissionHandler: options.permissionHandler,
     provider: options.provider,
     onTextDelta: options.onTextDelta,
+    onContextUpdate: options.onContextUpdate,
     onToolExecution: options.onToolExecution,
     sessionId,
     allowedTools: options.allowedTools,

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -65,6 +65,7 @@ import {
   isAbortError,
   buildResult,
   buildInterruptedResult,
+  createUsageSummaryEntry,
   persistSession,
 } from './interactive-session-execution.js';
 import {
@@ -189,6 +190,7 @@ export class InteractiveSession {
       resumeSessionId: this.resumeSessionId,
       forkSession: this.forkSession,
       onTextDelta: (delta: string) => this.handleTextDelta(delta),
+      onContextUpdate: (state) => this.emit('context_update', state),
       onToolExecution: (event) => this.handleToolExecution(event),
       bare: options.bare,
       allowedTools: options.allowedTools,
@@ -812,6 +814,7 @@ export class InteractiveSession {
         this.getContextState(),
       );
       this.history.push(messageToHistoryEntry(createAssistantMessage(result.response)));
+      if (result.usage) this.history.push(createUsageSummaryEntry(result.usage));
       this.emit('complete', result);
       this.emit('context_update', this.getContextState());
     } catch (err) {
@@ -827,6 +830,7 @@ export class InteractiveSession {
         this.clearStreaming();
         if (result.response)
           this.history.push(messageToHistoryEntry(createAssistantMessage(result.response)));
+        if (result.usage) this.history.push(createUsageSummaryEntry(result.usage));
         this.history.push(messageToHistoryEntry(createSystemMessage('Interrupted by user.')));
         this.emit('interrupted', result);
       } else {

--- a/packages/agent-sdk/src/interactive/types.ts
+++ b/packages/agent-sdk/src/interactive/types.ts
@@ -26,12 +26,25 @@ export interface IDiffLine {
   lineNumber: number;
 }
 
+export interface IUsageSnapshot {
+  kind: 'exact' | 'estimated';
+  scope: 'turn';
+  totalTokens: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  contextUsedTokens: number;
+  contextMaxTokens: number;
+  contextUsedPercentage: number;
+  costStatus: 'unknown' | 'estimated' | 'exact';
+}
+
 /** Result of a completed prompt execution. */
 export interface IExecutionResult {
   response: string;
   history: IHistoryEntry[];
   toolSummaries: IToolSummary[];
   contextState: IContextWindowState;
+  usage?: IUsageSnapshot;
 }
 
 /** Summary of a tool call extracted from history. */

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -106,6 +106,8 @@ Types consumed from other packages (not owned here):
 
 `ISessionOptions.maxTurns` is an optional maximum number of model/tool rounds for one `Session.run()` call. When provided, `Session` forwards it to `Robota.run()` as `maxExecutionRounds`. When omitted, `Session` forwards `maxExecutionRounds: 0`, which means the session run has no core round cap and is instead bounded by abort, context-window checks, provider idle timeout, and runtime-level controls.
 
+`ISessionOptions.onContextUpdate` is an optional callback fired from the session runtime whenever `ContextWindowTracker` is refreshed. It fires before the provider call using the assembled request history estimate and again after the provider response is committed with exact provider usage when available. Consumers such as `InteractiveSession` forward it as `context_update`.
+
 ### Key Session Methods
 
 | Method                     | Signature                                                            | Description                                                                                                                             |
@@ -127,6 +129,15 @@ Types consumed from other packages (not owned here):
 | `getSessionAllowedTools`   | `() => string[]`                                                     | Returns tools that were session-approved ("Allow always").                                                                              |
 | `clearSessionAllowedTools` | `() => void`                                                         | Clears all session-scoped allow rules.                                                                                                  |
 | `injectMessage`            | `(role: 'user' \| 'assistant' \| 'system', content: string) => void` | Injects a message into conversation history without triggering an AI response. Used for restoring context on session resume.            |
+
+### Usage And Context Refresh
+
+`Session.run()` performs two context refreshes per successful prompt:
+
+1. **Pre-send estimate** -- after hooks and request payload assembly, `ContextWindowTracker.updateFromHistory()` receives the current history plus the enriched user message. This emits estimated context usage before the provider responds.
+2. **Post-response reconciliation** -- after the assistant response is committed, `ContextWindowTracker.updateFromHistory()` reads exact provider token metadata when available and emits the reconciled context state.
+
+The callback payload is provider-neutral `IContextWindowState`; provider-specific usage details remain in message metadata and are interpreted by higher layers only through normalized token fields.
 
 ### ISessionRecord Fields
 

--- a/packages/agent-sessions/src/__tests__/session-provider-callback-isolation.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-provider-callback-isolation.test.ts
@@ -64,4 +64,35 @@ describe('Session provider callback isolation', () => {
     expect(parentDeltas).toEqual(['streamed text']);
     expect(childDeltas).toEqual([]);
   });
+
+  it('emits context updates before provider response and after usage reconciliation', async () => {
+    const snapshots: Array<{ usedTokens: number; usedPercentage: number }> = [];
+    const provider = createSharedProvider();
+    provider.chat = vi.fn(async () => {
+      expect(snapshots.length).toBeGreaterThan(0);
+      return {
+        id: 'assistant_1',
+        role: 'assistant',
+        content: 'final text',
+        timestamp: new Date(),
+        state: 'complete',
+        metadata: { inputTokens: 10, outputTokens: 5 },
+      };
+    });
+    const session = new Session({
+      tools: [],
+      provider,
+      systemMessage: 'test system',
+      terminal: createTerminal(),
+      model: 'test-model',
+      onContextUpdate: (state) =>
+        snapshots.push({ usedTokens: state.usedTokens, usedPercentage: state.usedPercentage }),
+    });
+
+    await session.run('parent prompt');
+
+    expect(snapshots.length).toBeGreaterThanOrEqual(2);
+    expect(snapshots[0]?.usedTokens).toBeGreaterThan(0);
+    expect(snapshots.at(-1)?.usedTokens).toBe(15);
+  });
 });

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -5,9 +5,10 @@
  * Stateless: all mutable state is passed in via IRunContext.
  */
 
-import { runHooks } from '@robota-sdk/agent-core';
+import { createUserMessage, runHooks } from '@robota-sdk/agent-core';
 import type {
   IAIProvider,
+  IContextWindowState,
   THooksConfig,
   IHookTypeExecutor,
   TTextDeltaCallback,
@@ -34,6 +35,7 @@ export interface IRunContext {
   clearSessionStartStdout: () => void;
   maxTurns?: number;
   onTextDelta?: TTextDeltaCallback;
+  onContextUpdate?: (state: IContextWindowState) => void;
 }
 
 /**
@@ -109,6 +111,8 @@ export async function executeRun(
     maxTokens: ctx.contextTracker.getContextState().maxTokens,
     webToolsEnabled: providerHasWebTools,
   });
+  ctx.contextTracker.updateFromHistory([...history, createUserMessage(enrichedMessage)]);
+  ctx.onContextUpdate?.(ctx.contextTracker.getContextState());
 
   let response: string;
   try {
@@ -183,6 +187,7 @@ export async function executeRun(
   ctx.contextTracker.updateFromHistory(postHistory);
 
   const ctxState = ctx.contextTracker.getContextState();
+  ctx.onContextUpdate?.(ctxState);
   ctx.log('context', {
     maxTokens: ctxState.maxTokens,
     usedTokens: ctxState.usedTokens,

--- a/packages/agent-sessions/src/session-types.ts
+++ b/packages/agent-sessions/src/session-types.ts
@@ -4,6 +4,7 @@
 
 import type {
   IAIProvider,
+  IContextWindowState,
   IToolWithEventService,
   TSessionEndReason,
   TPermissionMode,
@@ -57,6 +58,8 @@ export interface ISessionOptions {
   permissionHandler?: TPermissionHandler;
   /** Callback for text deltas — enables streaming text to the UI in real-time */
   onTextDelta?: (delta: string) => void;
+  /** Callback when context window usage is refreshed */
+  onContextUpdate?: (state: IContextWindowState) => void;
   /** Custom prompt-for-approval function (injected from CLI) */
   promptForApproval?: (
     terminal: ITerminalOutput,

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -12,6 +12,7 @@ import { Robota, TRUST_TO_MODE } from '@robota-sdk/agent-core';
 import type {
   IAgentConfig,
   IAIProvider,
+  IContextWindowState,
   IToolSchema,
   TPermissionMode,
   IHookTypeExecutor,
@@ -68,6 +69,7 @@ export class Session {
   private readonly hooks?: Record<string, unknown>;
   private readonly hookTypeExecutors?: IHookTypeExecutor[];
   private readonly onTextDeltaCallback?: (delta: string) => void;
+  private readonly onContextUpdateCallback?: (state: IContextWindowState) => void;
   private readonly onCompactCallback?: (summary: string) => void;
   private readonly sessionLogger?: ISessionLogger;
   private readonly maxTurns?: number;
@@ -92,6 +94,7 @@ export class Session {
     this.hooks = options.hooks;
     this.hookTypeExecutors = options.hookTypeExecutors;
     this.onTextDeltaCallback = options.onTextDelta;
+    this.onContextUpdateCallback = options.onContextUpdate;
     this.onCompactCallback = options.onCompact;
     this.maxTurns = options.maxTurns;
     this.model = options.model ?? 'claude-sonnet-4-5';
@@ -192,6 +195,7 @@ export class Session {
           },
           ...(this.maxTurns !== undefined ? { maxTurns: this.maxTurns } : {}),
           onTextDelta: this.onTextDeltaCallback,
+          onContextUpdate: this.onContextUpdateCallback,
         },
         signal,
       );


### PR DESCRIPTION
## Summary
- complete CLI-BL-049 provider usage/cost visibility base layer
- normalize provider token usage into exact per-turn snapshots without provider/model branching in CLI or SDK
- persist usage-summary history entries and render compact CLI usage rows
- refresh context state when a request is sent and reconcile after provider response

## Verification
- pnpm --filter @robota-sdk/agent-core test -- src/services/execution-usage.test.ts src/services/execution-service.test.ts
- pnpm --filter @robota-sdk/agent-core build/typecheck/lint
- pnpm --filter @robota-sdk/agent-sessions build/typecheck/lint and targeted tests
- pnpm --filter @robota-sdk/agent-sdk build/typecheck/lint and targeted tests
- pnpm --filter @robota-sdk/agent-cli build/typecheck/lint and targeted tests
- git diff --check
- pnpm harness:scan
- pre-push scoped verification passed