### PR TITLE
feat(cli): surface status activity in primary scan path

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -14,7 +14,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | File                                                                                           | Topic                                                         |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |
-| [cli-tui-status-activity-indicator.md](cli-tui-status-activity-indicator.md)                   | CLI TUI status activity indicator                             |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)                           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)                         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md)                 | OpenAI-compatible provider web search/fetch support           |

--- a/.agents/tasks/completed/CLI-BL-051-cli-tui-status-activity-indicator.md
+++ b/.agents/tasks/completed/CLI-BL-051-cli-tui-status-activity-indicator.md
@@ -1,5 +1,10 @@
 # CLI TUI Status Activity Indicator
 
+Status: completed
+Created: 2026-05-02
+Branch: feat/cli-status-activity-indicator
+Scope: packages/agent-cli
+
 ## Priority
 
 P1 — implement after the visual grammar audit.
@@ -37,12 +42,23 @@ The current `Thinking` indicator can be too subtle when placed on the right. Use
 
 ## Acceptance Criteria
 
-- [ ] Active model waiting state is visible in the primary scan path.
-- [ ] Running tool/background states have deterministic priority.
-- [ ] Status remains readable on narrow terminals.
-- [ ] Tests cover state priority and width-constrained rendering.
+- [x] Active model waiting state is visible in the primary scan path.
+- [x] Running tool/background states have deterministic priority.
+- [x] Status remains readable on narrow terminals.
+- [x] Tests cover state priority and width-constrained rendering.
 
 ## Promotion Path
 
 1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-status-activity-indicator.md`.
 2. Implement after visual grammar audit and before broader fullscreen renderer work.
+
+## Implementation Notes
+
+- Added a pure `formatStatusActivity` helper with deterministic priority:
+  active tools, model thinking, active background work, queued prompt, idle.
+- Moved the visible activity label into the left side of `StatusBar` before mode/model metadata.
+- Kept the TUI as a renderer boundary: `App` derives counts from CLI view state and `StatusBar` renders only display props.
+
+## Verification
+
+- `pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/status-activity.test.ts src/ui/__tests__/status-bar.test.tsx`

--- a/.changeset/bright-status-activity.md
+++ b/.changeset/bright-status-activity.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-cli': patch
+---
+
+Move the active status indicator into the primary status-bar scan path with deterministic tool, thinking, background, queued, and idle priority.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -178,7 +178,7 @@ bin.ts → cli.ts (arg parsing + provider definition composition)
                     ├── MessageList.tsx        (renders IHistoryEntry[]; EntryItem dispatches on category)
                     ├── InputArea.tsx          (bottom input area, slash detection)
                     ├── SessionStatusBar.tsx   (connects statusline settings + git branch to renderer)
-                    ├── StatusBar.tsx          (pure status bar renderer, shows "Thinking..." during run())
+                    ├── StatusBar.tsx          (pure status bar renderer, shows primary activity state)
                     ├── PermissionPrompt.tsx   (arrow-key selection)
                     └── SlashAutocomplete.tsx  (command popup with scroll)
 ```
@@ -199,7 +199,7 @@ The StatusBar shows real-time session information:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ Mode: default  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  |  msgs: 12 │
+│ Activity: Thinking  |  Mode: default  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  |  msgs: 12 │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -211,7 +211,17 @@ The StatusBar shows real-time session information:
 | Context  | `session.getContextState().usedPercentage` | Context usage with K/M formatting (e.g., "90K/1M")    |
 | msgs     | message count                              | Number of messages in conversation                    |
 | Session  | `session.getName()`                        | Session name (shown only when a name is set)          |
-| Thinking | isThinking state                           | Shown during `session.run()` execution                |
+| Activity | CLI-derived display state                  | Left-side primary activity label                      |
+
+Activity priority is deterministic and renderer-owned:
+
+1. active tool calls (`Tools xN`)
+2. foreground model waiting (`Thinking`)
+3. active background work (`Background xN`)
+4. queued prompt (`Queued`)
+5. idle (`Idle`)
+
+When a prompt is queued behind foreground work, the activity row keeps the active work as primary and appends `queued` as secondary metadata. SDK session state remains the source of truth; `StatusBar` receives derived display counts and does not infer provider or execution semantics.
 
 ### `/statusline` Slash Command
 

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -24,7 +24,6 @@ import SessionPicker from './SessionPicker.js';
 import BackgroundTaskPanel from './BackgroundTaskPanel.js';
 import UpdateNotice from './UpdateNotice.js';
 import { formatCliUpdateNotice, type ICliUpdateNotice } from '../utils/update-check.js';
-
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 
 interface IProps {
@@ -45,9 +44,6 @@ interface IProps {
   startupUpdateNoticePromise?: Promise<ICliUpdateNotice | undefined>;
 }
 
-/**
- * Outer wrapper that manages session switching via React key remounting.
- */
 export default function App(props: IProps): React.ReactElement {
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(props.resumeSessionId);
 
@@ -105,6 +101,9 @@ function AppInner(
   const [sessionName, setSessionName] = useState<string | undefined>(props.sessionName);
   const [updateNotice, setUpdateNotice] = useState<ICliUpdateNotice | undefined>();
   const [statusLineSettings, setStatusLineSettings] = useStatusLineSettings();
+  const activeBackgroundTaskCount = backgroundTasks.filter(
+    (task) => task.status === 'queued' || task.status === 'running',
+  ).length;
 
   const {
     handleSubmit,
@@ -269,6 +268,9 @@ function AppInner(
         sessionId={sessionId}
         messageCount={history.length}
         isThinking={isThinking}
+        activeToolCount={activeTools.length}
+        activeBackgroundTaskCount={activeBackgroundTaskCount}
+        hasPendingPrompt={pendingPrompt !== null}
         contextState={contextState}
         sessionName={sessionName}
         settings={statusLineSettings}

--- a/packages/agent-cli/src/ui/SessionStatusBar.tsx
+++ b/packages/agent-cli/src/ui/SessionStatusBar.tsx
@@ -12,6 +12,9 @@ interface IProps {
   sessionId: string;
   messageCount: number;
   isThinking: boolean;
+  activeToolCount: number;
+  activeBackgroundTaskCount: number;
+  hasPendingPrompt: boolean;
   contextState: { percentage: number; usedTokens: number; maxTokens: number };
   sessionName?: string;
   settings: IStatusLineSettings;
@@ -24,6 +27,9 @@ export default function SessionStatusBar({
   sessionId,
   messageCount,
   isThinking,
+  activeToolCount,
+  activeBackgroundTaskCount,
+  hasPendingPrompt,
   contextState,
   sessionName,
   settings,
@@ -38,6 +44,9 @@ export default function SessionStatusBar({
       sessionId={sessionId}
       messageCount={messageCount}
       isThinking={isThinking}
+      activeToolCount={activeToolCount}
+      activeBackgroundTaskCount={activeBackgroundTaskCount}
+      hasPendingPrompt={hasPendingPrompt}
       contextPercentage={contextState.percentage}
       contextUsedTokens={contextState.usedTokens}
       contextMaxTokens={contextState.maxTokens}

--- a/packages/agent-cli/src/ui/StatusBar.tsx
+++ b/packages/agent-cli/src/ui/StatusBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
 import { formatTokenCount } from '@robota-sdk/agent-core';
+import { formatStatusActivity } from './status-activity.js';
 
 /** Threshold boundaries for context percentage color coding */
 const CONTEXT_YELLOW_THRESHOLD = 70;
@@ -13,12 +14,30 @@ interface IProps {
   sessionId: string;
   messageCount: number;
   isThinking: boolean;
+  activeToolCount?: number;
+  activeBackgroundTaskCount?: number;
+  hasPendingPrompt?: boolean;
   contextPercentage: number;
   contextUsedTokens: number;
   contextMaxTokens: number;
   sessionName?: string;
   gitBranch?: string;
   showGitBranch?: boolean;
+}
+
+interface IStatusLeftProps {
+  permissionMode: TPermissionMode;
+  modelName: string;
+  isThinking: boolean;
+  activeToolCount: number;
+  activeBackgroundTaskCount: number;
+  hasPendingPrompt: boolean;
+  contextPercentage: number;
+  contextUsedTokens: number;
+  contextMaxTokens: number;
+  sessionName?: string;
+  gitBranch?: string;
+  showGitBranch: boolean;
 }
 
 /** Return the color for the context percentage indicator */
@@ -28,12 +47,120 @@ function getContextColor(percentage: number): string {
   return 'green';
 }
 
+function StatusActivityText({
+  isThinking,
+  activeToolCount,
+  activeBackgroundTaskCount,
+  hasPendingPrompt,
+}: Pick<
+  IStatusLeftProps,
+  'isThinking' | 'activeToolCount' | 'activeBackgroundTaskCount' | 'hasPendingPrompt'
+>): React.ReactElement {
+  const activity = formatStatusActivity({
+    isThinking,
+    activeToolCount,
+    activeBackgroundTaskCount,
+    hasPendingPrompt,
+  });
+
+  return (
+    <>
+      <Text color="cyan" bold>
+        Activity:
+      </Text>{' '}
+      <Text color={activity.color} bold={activity.kind !== 'idle'}>
+        {activity.text}
+      </Text>
+    </>
+  );
+}
+
+function ContextText({
+  percentage,
+  usedTokens,
+  maxTokens,
+}: {
+  percentage: number;
+  usedTokens: number;
+  maxTokens: number;
+}): React.ReactElement {
+  return (
+    <Text color={getContextColor(percentage)}>
+      Context: {Math.round(percentage)}% ({formatTokenCount(usedTokens)}/
+      {formatTokenCount(maxTokens)})
+    </Text>
+  );
+}
+
+function ModeText({ permissionMode }: { permissionMode: TPermissionMode }): React.ReactElement {
+  return (
+    <>
+      <Text color="cyan" bold>
+        Mode:
+      </Text>{' '}
+      <Text>{permissionMode}</Text>
+    </>
+  );
+}
+
+function StatusLeft({
+  permissionMode,
+  modelName,
+  isThinking,
+  activeToolCount,
+  activeBackgroundTaskCount,
+  hasPendingPrompt,
+  contextPercentage,
+  contextUsedTokens,
+  contextMaxTokens,
+  sessionName,
+  gitBranch,
+  showGitBranch,
+}: IStatusLeftProps): React.ReactElement {
+  const shouldShowGitBranch = showGitBranch && gitBranch !== undefined && gitBranch.length > 0;
+  return (
+    <Text>
+      <StatusActivityText
+        isThinking={isThinking}
+        activeToolCount={activeToolCount}
+        activeBackgroundTaskCount={activeBackgroundTaskCount}
+        hasPendingPrompt={hasPendingPrompt}
+      />
+      {'  |  '}
+      <ModeText permissionMode={permissionMode} />
+      {sessionName && (
+        <>
+          {'  |  '}
+          <Text color="magenta">{sessionName}</Text>
+        </>
+      )}
+      {shouldShowGitBranch && (
+        <>
+          {'  |  '}
+          <Text dimColor>git: {gitBranch}</Text>
+        </>
+      )}
+      {'  |  '}
+      <Text dimColor>{modelName}</Text>
+      {'  |  '}
+      <ContextText
+        percentage={contextPercentage}
+        usedTokens={contextUsedTokens}
+        maxTokens={contextMaxTokens}
+      />
+    </Text>
+  );
+}
+
 export default function StatusBar({
   permissionMode,
   modelName,
   sessionId: _sessionId,
   messageCount,
   isThinking,
+  activeToolCount = 0,
+  activeBackgroundTaskCount = 0,
+  hasPendingPrompt = false,
   contextPercentage,
   contextUsedTokens,
   contextMaxTokens,
@@ -41,9 +168,6 @@ export default function StatusBar({
   gitBranch,
   showGitBranch = true,
 }: IProps): React.ReactElement {
-  const contextColor = getContextColor(contextPercentage);
-  const shouldShowGitBranch = showGitBranch && gitBranch !== undefined && gitBranch.length > 0;
-
   return (
     <Box
       borderStyle="single"
@@ -52,33 +176,21 @@ export default function StatusBar({
       paddingRight={1}
       justifyContent="space-between"
     >
+      <StatusLeft
+        permissionMode={permissionMode}
+        modelName={modelName}
+        isThinking={isThinking}
+        activeToolCount={activeToolCount}
+        activeBackgroundTaskCount={activeBackgroundTaskCount}
+        hasPendingPrompt={hasPendingPrompt}
+        contextPercentage={contextPercentage}
+        contextUsedTokens={contextUsedTokens}
+        contextMaxTokens={contextMaxTokens}
+        sessionName={sessionName}
+        gitBranch={gitBranch}
+        showGitBranch={showGitBranch}
+      />
       <Text>
-        <Text color="cyan" bold>
-          Mode:
-        </Text>{' '}
-        <Text>{permissionMode}</Text>
-        {sessionName && (
-          <>
-            {'  |  '}
-            <Text color="magenta">{sessionName}</Text>
-          </>
-        )}
-        {shouldShowGitBranch && (
-          <>
-            {'  |  '}
-            <Text dimColor>git: {gitBranch}</Text>
-          </>
-        )}
-        {'  |  '}
-        <Text dimColor>{modelName}</Text>
-        {'  |  '}
-        <Text color={contextColor}>
-          Context: {Math.round(contextPercentage)}% ({formatTokenCount(contextUsedTokens)}/
-          {formatTokenCount(contextMaxTokens)})
-        </Text>
-      </Text>
-      <Text>
-        {isThinking && <Text color="yellow">Thinking... </Text>}
         <Text dimColor>msgs: {messageCount}</Text>
       </Text>
     </Box>

--- a/packages/agent-cli/src/ui/__tests__/status-activity.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/status-activity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { formatStatusActivity } from '../status-activity.js';
+
+describe('formatStatusActivity', () => {
+  it('prioritizes running tools over thinking, background work, and queued prompts', () => {
+    const activity = formatStatusActivity({
+      isThinking: true,
+      activeToolCount: 2,
+      activeBackgroundTaskCount: 3,
+      hasPendingPrompt: true,
+    });
+
+    expect(activity.kind).toBe('tools');
+    expect(activity.label).toBe('Tools x2');
+    expect(activity.color).toBe('cyan');
+    expect(activity.segments).toEqual(['queued']);
+    expect(activity.text).toBe('Tools x2 · queued');
+  });
+
+  it('shows thinking as the primary model waiting state', () => {
+    const activity = formatStatusActivity({
+      isThinking: true,
+      activeToolCount: 0,
+      activeBackgroundTaskCount: 0,
+      hasPendingPrompt: false,
+    });
+
+    expect(activity.kind).toBe('thinking');
+    expect(activity.label).toBe('Thinking');
+    expect(activity.segments).toEqual([]);
+  });
+
+  it('shows background activity when foreground work is idle', () => {
+    const activity = formatStatusActivity({
+      isThinking: false,
+      activeToolCount: 0,
+      activeBackgroundTaskCount: 1,
+      hasPendingPrompt: false,
+    });
+
+    expect(activity.kind).toBe('background');
+    expect(activity.label).toBe('Background x1');
+    expect(activity.color).toBe('cyan');
+  });
+
+  it('shows queued prompt before idle when no work is active', () => {
+    const activity = formatStatusActivity({
+      isThinking: false,
+      activeToolCount: 0,
+      activeBackgroundTaskCount: 0,
+      hasPendingPrompt: true,
+    });
+
+    expect(activity.kind).toBe('queued');
+    expect(activity.label).toBe('Queued');
+    expect(activity.color).toBe('yellow');
+  });
+
+  it('keeps idle compact and dim', () => {
+    const activity = formatStatusActivity({
+      isThinking: false,
+      activeToolCount: 0,
+      activeBackgroundTaskCount: 0,
+      hasPendingPrompt: false,
+    });
+
+    expect(activity.kind).toBe('idle');
+    expect(activity.text).toBe('Idle');
+    expect(activity.color).toBe('gray');
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
@@ -10,6 +10,9 @@ describe('StatusBar', () => {
     sessionId: 'sess-1',
     messageCount: 5,
     isThinking: false,
+    activeToolCount: 0,
+    activeBackgroundTaskCount: 0,
+    hasPendingPrompt: false,
     contextPercentage: 10,
     contextUsedTokens: 1000,
     contextMaxTokens: 200000,
@@ -50,7 +53,52 @@ describe('StatusBar', () => {
   it('shows thinking indicator when isThinking is true', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} isThinking={true} />);
     const frame = lastFrame()!;
+    expect(frame).toContain('Activity:');
     expect(frame).toContain('Thinking');
+    expect(frame.indexOf('Activity:')).toBeLessThan(frame.indexOf('Mode:'));
+  });
+
+  it('prioritizes tool activity in the primary scan path', () => {
+    const { lastFrame } = render(
+      <StatusBar
+        {...baseProps}
+        isThinking={true}
+        activeToolCount={2}
+        activeBackgroundTaskCount={1}
+        hasPendingPrompt={true}
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Activity:');
+    expect(frame).toContain('Tools x2');
+    expect(frame).toContain('queued');
+    expect(frame.indexOf('Tools x2')).toBeLessThan(frame.indexOf('Mode:'));
+    expect(frame).not.toContain('Thinking...');
+  });
+
+  it('shows background activity when no foreground execution is active', () => {
+    const { lastFrame } = render(<StatusBar {...baseProps} activeBackgroundTaskCount={3} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain('Background x3');
+    expect(frame.indexOf('Background x3')).toBeLessThan(frame.indexOf('Mode:'));
+  });
+
+  it('keeps the activity segment compact for narrow terminals', () => {
+    const { lastFrame } = render(
+      <StatusBar
+        {...baseProps}
+        isThinking={true}
+        activeToolCount={12}
+        activeBackgroundTaskCount={9}
+        hasPendingPrompt={true}
+      />,
+    );
+    const frame = lastFrame()!;
+    const firstLine = frame.split('\n')[1] ?? '';
+    const activityEnd = firstLine.indexOf('Mode:');
+    const activitySegment = firstLine.slice(0, activityEnd);
+    expect(activitySegment).toContain('Tools x12');
+    expect(activitySegment.length).toBeLessThanOrEqual(40);
   });
 
   it('renders git branch when provided', () => {

--- a/packages/agent-cli/src/ui/status-activity.ts
+++ b/packages/agent-cli/src/ui/status-activity.ts
@@ -1,0 +1,63 @@
+export type TStatusActivityKind = 'tools' | 'thinking' | 'background' | 'queued' | 'idle';
+
+export interface IStatusActivityInput {
+  isThinking: boolean;
+  activeToolCount: number;
+  activeBackgroundTaskCount: number;
+  hasPendingPrompt: boolean;
+}
+
+export interface IStatusActivity {
+  kind: TStatusActivityKind;
+  label: string;
+  color: string;
+  segments: string[];
+  text: string;
+}
+
+const NO_ACTIVE_ITEMS = 0;
+
+export function formatStatusActivity(input: IStatusActivityInput): IStatusActivity {
+  const base = getPrimaryActivity(input);
+  const segments = input.hasPendingPrompt && base.kind !== 'queued' ? ['queued'] : [];
+  const text = [base.label, ...segments].join(' · ');
+  return { ...base, segments, text };
+}
+
+function getPrimaryActivity(
+  input: IStatusActivityInput,
+): Omit<IStatusActivity, 'segments' | 'text'> {
+  if (input.activeToolCount > NO_ACTIVE_ITEMS) {
+    return {
+      kind: 'tools',
+      label: `Tools x${input.activeToolCount}`,
+      color: 'cyan',
+    };
+  }
+  if (input.isThinking) {
+    return {
+      kind: 'thinking',
+      label: 'Thinking',
+      color: 'yellow',
+    };
+  }
+  if (input.activeBackgroundTaskCount > NO_ACTIVE_ITEMS) {
+    return {
+      kind: 'background',
+      label: `Background x${input.activeBackgroundTaskCount}`,
+      color: 'cyan',
+    };
+  }
+  if (input.hasPendingPrompt) {
+    return {
+      kind: 'queued',
+      label: 'Queued',
+      color: 'yellow',
+    };
+  }
+  return {
+    kind: 'idle',
+    label: 'Idle',
+    color: 'gray',
+  };
+}


### PR DESCRIPTION
## Summary
- Add a pure status activity formatter with deterministic priority for tools, thinking, background work, queued prompts, and idle.
- Move the visible activity label into the left side of the StatusBar before passive session metadata.
- Keep TUI as renderer-only by passing derived display counts from App/SessionStatusBar and marking CLI-BL-051 complete.

## Research
- Claude Code statusline docs emphasize a persistent at-a-glance row for context/status and note refresh needs for background subagents while the main session is idle.
- Ink terminal rendering conventions favor short status/spinner text beside activity indicators, so the implementation keeps the activity segment compact and bounded.

## Verification
- pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/status-activity.test.ts src/ui/__tests__/status-bar.test.tsx
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint (existing warnings only; warning count reduced to 47)
- pnpm --filter @robota-sdk/agent-cli build
- git diff --check
- pnpm harness:scan
- pre-push scoped verification: packages/agent-cli build, test, lint, typecheck