### PR TITLE
feat(cli): collapse command output transcripts

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,10 +11,9 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-| File                                                                                           | Topic                                                         |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [cli-tui-command-output-transcript-collapse.md](cli-tui-command-output-transcript-collapse.md) | CLI TUI command output transcript collapse                    |
-| [gemini-provider-modernization.md](gemini-provider-modernization.md)                           | Gemini API provider modernization                             |
-| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)                         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
-| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md)                 | OpenAI-compatible provider web search/fetch support           |
-| [openai-provider-modernization.md](openai-provider-modernization.md)                           | OpenAI provider modernization                                 |
+| File                                                                           | Topic                                                         |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
+| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
+| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
+| [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |

--- a/.agents/tasks/completed/CLI-BL-052-cli-tui-command-output-transcript-collapse.md
+++ b/.agents/tasks/completed/CLI-BL-052-cli-tui-command-output-transcript-collapse.md
@@ -1,5 +1,10 @@
 # CLI TUI Command Output Transcript Collapse
 
+Status: completed
+Created: 2026-05-02
+Branch: feat/cli-command-transcript-collapse
+Scope: packages/agent-cli, packages/agent-sdk
+
 ## Priority
 
 P1 — implement after the visual grammar audit.
@@ -42,13 +47,30 @@ Use documentation and product behavior observations only; do not copy source cod
 
 ## Acceptance Criteria
 
-- [ ] Short command output renders inline without unnecessary decoration.
-- [ ] Long output renders a bounded preview plus omitted-line transcript hint.
-- [ ] Failed commands remain visually distinct from successful commands.
-- [ ] The full transcript remains available from persisted session/log data.
-- [ ] Formatting is tested independently from Ink component rendering.
+- [x] Short command output renders inline without unnecessary decoration.
+- [x] Long output renders a bounded preview plus omitted-line transcript hint.
+- [x] Failed commands remain visually distinct from successful commands.
+- [x] The full transcript remains available from persisted session/log data.
+- [x] Formatting is tested independently from Ink component rendering.
 
 ## Promotion Path
 
 1. Move to `.agents/tasks/CLI-BL-0XX-cli-tui-command-output-transcript-collapse.md`.
 2. Implement after the visual grammar audit defines shared output labels and truncation copy.
+
+## Research Result
+
+- Codex-style terminal output favors a compact command row followed by a bounded transcript preview and an explicit hint when additional output is omitted.
+- Claude-style tool displays keep tool execution separate from model prose, so Robota should derive command previews from structured tool result data rather than asking the model to summarize command output.
+- Terminal log preview patterns work best when the raw transcript remains persisted and the visible TUI output only presents a bounded projection.
+
+## Implementation Notes
+
+- Added `formatCommandOutputSummary` as a pure CLI formatter for command-like tools.
+- Extended SDK `IToolState` and `tool-summary` metadata with `toolResultData` so the CLI can render persisted command previews after completion and resume.
+- Kept output collapse scoped to command tools (`Bash`, `BackgroundProcess`) to avoid rendering large non-command tool payloads such as file reads.
+
+## Verification
+
+- `pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/command-output-summary.test.ts src/ui/__tests__/message-list-rendering.test.tsx`
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-streaming.test.ts`

--- a/.changeset/collapse-command-transcripts.md
+++ b/.changeset/collapse-command-transcripts.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-cli': patch
+'@robota-sdk/agent-sdk': patch
+---
+
+Render command tool output as bounded transcript previews and persist tool result metadata in SDK tool summaries.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -269,7 +269,7 @@ The CLI TUI renders structured session/runtime data. It must not parse assistant
 | Surface                      | Owner                                 | Data Source                            | Rendering Contract                                                                |
 | ---------------------------- | ------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
 | Chat messages                | `MessageList`                         | `IHistoryEntry[]` chat entries         | Show stable role labels and markdown-rendered assistant content                   |
-| Tool summaries               | `MessageList`                         | structured `tool-summary` event data   | Show compact one-line tool rows plus structured details such as diffs             |
+| Tool summaries               | `MessageList`                         | structured `tool-summary` event data   | Show compact one-line tool rows plus structured details such as diffs/output      |
 | Streaming assistant response | `StreamingIndicator`                  | SDK text deltas                        | Show current assistant text without persisting duplicate rendered state           |
 | Live tool execution          | `StreamingIndicator`                  | SDK tool state events                  | Show current tool state using the shared status marker set                        |
 | Background work              | `BackgroundTaskPanel`                 | SDK background task events             | Show a one-level tree of running and retained terminal jobs                       |
@@ -303,6 +303,18 @@ Colors remain renderer-owned: green for success/healthy state, yellow for warnin
 - Pure formatting helpers must have unit tests for status markers, truncation, omitted-line counts, and narrow-output labels.
 - Ink components must have render tests for the same states using representative structured data.
 - Changes that add a new output surface must update this section or explain why an existing surface owns the behavior.
+
+### Command Output Summary Rendering
+
+Command-like tool summaries render a compact command row plus a bounded output preview. The contract is:
+
+- Applies only to command execution tools (`Bash`, `BackgroundProcess`) that provide `toolResultData`.
+- The visible preview shows at most four output lines.
+- If output has additional lines, render `... +N lines (full output in session transcript)`.
+- Non-zero command `exitCode`, `success=false`, or tool `result=error` renders the tool row as failed even when the tool transport itself completed.
+- Structured `stdout` and `stderr` are kept distinct; stderr preview lines are prefixed with `[stderr]`.
+- Empty successful output shows only the compact command row.
+- Full result data remains in SDK/session records; the TUI renders only the bounded projection.
 
 ### Edit Diff Hunk Rendering
 

--- a/packages/agent-cli/src/ui/MessageList.tsx
+++ b/packages/agent-cli/src/ui/MessageList.tsx
@@ -6,6 +6,8 @@ import { renderMarkdown } from './render-markdown.js';
 import type { IToolCallSummary } from '../utils/tool-call-extractor.js';
 import ToolDiffBlock from './ToolDiffBlock.js';
 import UsageSummaryEntry from './UsageSummaryEntry.js';
+import { formatCommandOutputSummary } from './command-output-summary.js';
+import ToolCommandOutput from './ToolCommandOutput.js';
 
 interface IProps {
   history: IHistoryEntry[];
@@ -18,13 +20,21 @@ type TToolSummaryItem = {
   result?: string;
   diffLines?: IToolCallSummary['diffLines'];
   diffFile?: string;
+  toolResultData?: string;
 };
 
 function getToolSummaryStatus(tool: TToolSummaryItem): string {
+  if (formatCommandOutputSummary(tool)?.status === 'error') return '✗';
   if (tool.isRunning) return '⟳';
   if (tool.result === 'error') return '✗';
   if (tool.result === 'denied') return '⊘';
   return '✓';
+}
+
+function getToolSummaryColor(tool: TToolSummaryItem): string {
+  if (formatCommandOutputSummary(tool)?.status === 'error' || tool.result === 'error') return 'red';
+  if (tool.isRunning || tool.result === 'denied') return 'yellow';
+  return 'green';
 }
 
 function getToolSummaryLabel(tool: TToolSummaryItem): string {
@@ -182,10 +192,11 @@ function ToolSummaryEntry({ entry }: { entry: IHistoryEntry }): React.ReactEleme
         <Text> </Text>
         {tools.map((tool, i) => (
           <Box key={i} flexDirection="column">
-            <Text color="green">
+            <Text color={getToolSummaryColor(tool)}>
               {'  '}
               {getToolSummaryLabel(tool)}
             </Text>
+            <ToolCommandOutput tool={tool} />
             {tool.diffLines && tool.diffLines.length > 0 && (
               <ToolDiffBlock file={tool.diffFile} lines={tool.diffLines} />
             )}

--- a/packages/agent-cli/src/ui/ToolCommandOutput.tsx
+++ b/packages/agent-cli/src/ui/ToolCommandOutput.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { ICommandOutputInput } from './command-output-summary.js';
+import { formatCommandOutputSummary } from './command-output-summary.js';
+
+interface IProps {
+  tool: ICommandOutputInput;
+}
+
+export default function ToolCommandOutput({ tool }: IProps): React.ReactElement | null {
+  const summary = formatCommandOutputSummary(tool);
+  if (!summary) return null;
+  if (
+    summary.statusLabel === 'ok' &&
+    summary.previewLines.length === 0 &&
+    !summary.transcriptHint
+  ) {
+    return null;
+  }
+  const color = summary.status === 'error' ? 'red' : 'white';
+
+  return (
+    <Box flexDirection="column" marginLeft={4}>
+      {summary.statusLabel !== 'ok' && (
+        <Text color={color} dimColor>
+          {summary.statusLabel}
+        </Text>
+      )}
+      {summary.previewLines.map((line, index) => (
+        <Text key={`${line}-${index}`} color={color} dimColor>
+          {line}
+        </Text>
+      ))}
+      {summary.transcriptHint && <Text dimColor>{summary.transcriptHint}</Text>}
+    </Box>
+  );
+}

--- a/packages/agent-cli/src/ui/__tests__/command-output-summary.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/command-output-summary.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { formatCommandOutputSummary } from '../command-output-summary.js';
+
+describe('formatCommandOutputSummary', () => {
+  it('renders short command output inline without transcript decoration', () => {
+    const summary = formatCommandOutputSummary({
+      toolName: 'Bash',
+      firstArg: 'echo hello',
+      isRunning: false,
+      result: 'success',
+      toolResultData: JSON.stringify({ success: true, output: 'hello\n', exitCode: 0 }),
+    });
+
+    expect(summary).toMatchObject({
+      status: 'success',
+      statusLabel: 'ok',
+      previewLines: ['hello'],
+      omittedLineCount: 0,
+      transcriptHint: undefined,
+    });
+  });
+
+  it('renders long command output with a bounded preview and transcript hint', () => {
+    const output = Array.from({ length: 8 }, (_, index) => `line-${index + 1}`).join('\n');
+    const summary = formatCommandOutputSummary({
+      toolName: 'Bash',
+      firstArg: 'pnpm test',
+      isRunning: false,
+      result: 'success',
+      toolResultData: JSON.stringify({ success: true, output, exitCode: 0 }),
+    });
+
+    expect(summary?.previewLines).toEqual(['line-1', 'line-2', 'line-3', 'line-4']);
+    expect(summary?.omittedLineCount).toBe(4);
+    expect(summary?.transcriptHint).toBe('... +4 lines (full output in session transcript)');
+  });
+
+  it('keeps stderr distinct when stdout and stderr are structured separately', () => {
+    const summary = formatCommandOutputSummary({
+      toolName: 'Bash',
+      firstArg: 'node script.js',
+      isRunning: false,
+      result: 'success',
+      toolResultData: JSON.stringify({
+        success: true,
+        stdout: 'ok',
+        stderr: 'warn',
+        exitCode: 0,
+      }),
+    });
+
+    expect(summary?.previewLines).toEqual(['ok', '[stderr] warn']);
+  });
+
+  it('marks non-zero exit codes as failed even when the tool transport succeeded', () => {
+    const summary = formatCommandOutputSummary({
+      toolName: 'Bash',
+      firstArg: 'exit 42',
+      isRunning: false,
+      result: 'success',
+      toolResultData: JSON.stringify({ success: true, output: '', exitCode: 42 }),
+    });
+
+    expect(summary?.status).toBe('error');
+    expect(summary?.statusLabel).toBe('exit 42');
+    expect(summary?.previewLines).toEqual([]);
+  });
+
+  it('renders no-output commands without dangling transcript hints', () => {
+    const summary = formatCommandOutputSummary({
+      toolName: 'Bash',
+      firstArg: 'true',
+      isRunning: false,
+      result: 'success',
+      toolResultData: JSON.stringify({ success: true, output: '', exitCode: 0 }),
+    });
+
+    expect(summary?.status).toBe('success');
+    expect(summary?.previewLines).toEqual([]);
+    expect(summary?.omittedLineCount).toBe(0);
+    expect(summary?.transcriptHint).toBeUndefined();
+  });
+
+  it('ignores non-command tools', () => {
+    const summary = formatCommandOutputSummary({
+      toolName: 'Read',
+      firstArg: 'file.ts',
+      isRunning: false,
+      result: 'success',
+      toolResultData: 'large file content',
+    });
+
+    expect(summary).toBeUndefined();
+  });
+});

--- a/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/message-list-rendering.test.tsx
@@ -183,6 +183,72 @@ describe('MessageList rendering', () => {
     expect(output).toContain('+ 1 | const original = true;');
   });
 
+  it('tool-summary event collapses long command output with transcript hint', () => {
+    const commandOutput = Array.from({ length: 7 }, (_, index) => `line-${index + 1}`).join('\n');
+    const history: IHistoryEntry[] = [
+      {
+        id: 'summary_command_long',
+        timestamp: new Date(),
+        category: 'event',
+        type: 'tool-summary',
+        data: {
+          tools: [
+            {
+              toolName: 'Bash',
+              firstArg: 'pnpm test',
+              isRunning: false,
+              result: 'success',
+              toolResultData: JSON.stringify({
+                success: true,
+                output: commandOutput,
+                exitCode: 0,
+              }),
+            },
+          ],
+          summary: '✓ Bash(pnpm test)',
+        },
+      },
+    ];
+
+    const { lastFrame } = render(<MessageList history={history} />);
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('✓ Bash(pnpm test)');
+    expect(output).toContain('line-1');
+    expect(output).toContain('line-4');
+    expect(output).not.toContain('line-5');
+    expect(output).toContain('... +3 lines (full output in session transcript)');
+  });
+
+  it('tool-summary event marks non-zero command exits as failed', () => {
+    const history: IHistoryEntry[] = [
+      {
+        id: 'summary_command_failed',
+        timestamp: new Date(),
+        category: 'event',
+        type: 'tool-summary',
+        data: {
+          tools: [
+            {
+              toolName: 'Bash',
+              firstArg: 'exit 42',
+              isRunning: false,
+              result: 'success',
+              toolResultData: JSON.stringify({ success: true, output: '', exitCode: 42 }),
+            },
+          ],
+          summary: '✓ Bash(exit 42)',
+        },
+      },
+    ];
+
+    const { lastFrame } = render(<MessageList history={history} />);
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('✗ Bash(exit 42)');
+    expect(output).toContain('exit 42');
+  });
+
   it('usage-summary event renders compact token and cost visibility', () => {
     const history: IHistoryEntry[] = [
       {

--- a/packages/agent-cli/src/ui/command-output-summary.ts
+++ b/packages/agent-cli/src/ui/command-output-summary.ts
@@ -1,0 +1,122 @@
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+
+const MAX_PREVIEW_LINES = 4;
+const SUCCESS_EXIT_CODE = 0;
+const COMMAND_TOOL_NAMES = new Set(['Bash', 'BackgroundProcess']);
+
+export interface ICommandOutputInput {
+  toolName: string;
+  firstArg?: string;
+  isRunning?: boolean;
+  result?: string;
+  toolResultData?: string;
+}
+
+export interface ICommandOutputSummary {
+  status: 'success' | 'error';
+  statusLabel: string;
+  previewLines: string[];
+  omittedLineCount: number;
+  transcriptHint?: string;
+}
+
+export function formatCommandOutputSummary(
+  tool: ICommandOutputInput,
+): ICommandOutputSummary | undefined {
+  if (!COMMAND_TOOL_NAMES.has(tool.toolName) || !tool.toolResultData) return undefined;
+
+  const parsed = parseToolResultData(tool.toolResultData);
+  const exitCode = getNumberValue(parsed, 'exitCode');
+  const successValue = getBooleanValue(parsed, 'success');
+  const output = buildOutputText(tool.toolResultData, parsed);
+  const lines = trimTrailingBlankLines(splitOutputLines(output));
+  const previewLines = lines.slice(0, MAX_PREVIEW_LINES);
+  const omittedLineCount = Math.max(0, lines.length - previewLines.length);
+  const isFailed =
+    tool.result === 'error' ||
+    successValue === false ||
+    (exitCode !== undefined && exitCode !== SUCCESS_EXIT_CODE);
+
+  return {
+    status: isFailed ? 'error' : 'success',
+    statusLabel: formatStatusLabel(isFailed, exitCode),
+    previewLines,
+    omittedLineCount,
+    transcriptHint:
+      omittedLineCount > 0
+        ? `... +${omittedLineCount} lines (full output in session transcript)`
+        : undefined,
+  };
+}
+
+function parseToolResultData(value: string): TUniversalValue {
+  try {
+    return JSON.parse(value) as TUniversalValue;
+  } catch {
+    return value;
+  }
+}
+
+function buildOutputText(raw: string, parsed: TUniversalValue): string {
+  if (!isUniversalObject(parsed)) return raw;
+
+  const output = getStringValue(parsed, 'output');
+  if (output !== undefined) return output;
+
+  const stdout = getStringValue(parsed, 'stdout');
+  const stderr = getStringValue(parsed, 'stderr');
+  const error = getStringValue(parsed, 'error');
+  const lines: string[] = [];
+  if (stdout) lines.push(stdout);
+  if (stderr) lines.push(prefixLines(stderr, '[stderr] '));
+  if (!stdout && !stderr && error) lines.push(error);
+  return lines.join('\n');
+}
+
+function formatStatusLabel(isFailed: boolean, exitCode: number | undefined): string {
+  if (exitCode !== undefined && exitCode !== SUCCESS_EXIT_CODE) return `exit ${exitCode}`;
+  return isFailed ? 'error' : 'ok';
+}
+
+function splitOutputLines(output: string): string[] {
+  if (!output) return [];
+  return output.replace(/\r\n/g, '\n').split('\n');
+}
+
+function trimTrailingBlankLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1]!.trim().length === 0) {
+    end -= 1;
+  }
+  return lines.slice(0, end);
+}
+
+function prefixLines(value: string, prefix: string): string {
+  return splitOutputLines(value)
+    .map((line) => `${prefix}${line}`)
+    .join('\n');
+}
+
+function isUniversalObject(value: TUniversalValue): value is Record<string, TUniversalValue> {
+  return (
+    typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)
+  );
+}
+
+function getStringValue(source: TUniversalValue, key: string): string | undefined {
+  if (!isUniversalObject(source)) return undefined;
+  const value = source[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumberValue(source: TUniversalValue, key: string): number | undefined {
+  if (!isUniversalObject(source)) return undefined;
+  const value = source[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getBooleanValue(source: TUniversalValue, key: string): boolean | undefined {
+  if (!isUniversalObject(source)) return undefined;
+  const value = source[key];
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -226,7 +226,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Pattern**: Composition over Session (holds a `Session` instance, does not extend it)
 - **Constructor**: Accepts `{ cwd, provider }` plus optional composition inputs such as `commandModules`. Config and context are loaded internally from `cwd`.
 - **Responsibility**: Streaming accumulation, tool state tracking, prompt queue (max 1), abort orchestration, full history management (`IHistoryEntry[]`), embedded command execution
-- **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. For completed Edit tools, `IToolState` also carries `diffFile` and `diffLines` derived from the Edit tool arguments plus the tool result `startLine`. The `tool-summary` entry (aggregated) is still pushed at execution completion and preserves the same per-tool metadata for persisted UI rendering.
+- **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. For completed Edit tools, `IToolState` also carries `diffFile` and `diffLines` derived from the Edit tool arguments plus the tool result `startLine`. For completed command tools, `IToolState` carries `toolResultData` so transports can render bounded command output previews while raw tool messages remain persisted. The `tool-summary` entry (aggregated) is still pushed at execution completion and preserves the same per-tool metadata for persisted UI rendering.
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
 - **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Core commands are always present; additional command modules may contribute more commands.
@@ -482,10 +482,11 @@ interface IToolState {
   result?: 'success' | 'error' | 'denied';
   diffLines?: IDiffLine[];
   diffFile?: string;
+  toolResultData?: string;
 }
 ```
 
-`diffLines` is structured Edit tool display metadata. For completed Edit tools, `InteractiveSession` derives it from the Edit arguments, tool result `startLine`, and the modified file contents when readable. Diff lines may include `type: 'hunk'`, `context`, `remove`, and `add`. The SDK persists this metadata so all transports can replay the same edit summary; CLI owns visual rendering only.
+`diffLines` is structured Edit tool display metadata. For completed Edit tools, `InteractiveSession` derives it from the Edit arguments, tool result `startLine`, and the modified file contents when readable. Diff lines may include `type: 'hunk'`, `context`, `remove`, and `add`. `toolResultData` is the already-truncated tool result payload emitted by the permission/session layer; transports may derive bounded previews from it, but SDK/session records remain the source for full transcript recovery. The SDK persists this metadata so all transports can replay the same tool summary; CLI owns visual rendering only.
 
 **IExecutionResult:**
 
@@ -677,6 +678,7 @@ Exported subagent runtime types:
       result?: 'success' | 'error' | 'denied';
       diffLines?: IDiffLine[];
       diffFile?: string;
+      toolResultData?: string;
     }>;
   }
 }

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-streaming.test.ts
@@ -101,4 +101,37 @@ describe('interactive-session-streaming edit diffs', () => {
       ],
     });
   });
+
+  it('persists command tool result data for collapsed transcript rendering', () => {
+    const state = createState();
+    applyToolStart(state, {
+      toolName: 'Bash',
+      toolArgs: { command: 'pnpm test' },
+    });
+
+    const toolResultData = JSON.stringify({
+      success: true,
+      output: 'line-1\nline-2',
+      exitCode: 0,
+    });
+    const finished = applyToolEnd(state, {
+      type: 'end',
+      toolName: 'Bash',
+      toolArgs: { command: 'pnpm test' },
+      success: true,
+      toolResultData,
+    });
+
+    expect(finished?.toolResultData).toBe(toolResultData);
+    pushToolSummaryToHistory(state);
+    expect(state.history[2]?.data).toMatchObject({
+      tools: [
+        {
+          toolName: 'Bash',
+          firstArg: 'pnpm test',
+          toolResultData,
+        },
+      ],
+    });
+  });
 });

--- a/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-streaming.ts
@@ -174,6 +174,7 @@ export function pushToolSummaryToHistory(state: IStreamingState): void {
         result: t.result,
         diffFile: t.diffFile,
         diffLines: t.diffLines,
+        toolResultData: t.toolResultData,
       })),
       summary,
     },
@@ -232,6 +233,7 @@ export function applyToolEnd(state: IStreamingState, event: IToolEndEvent): IToo
     ...buildEditDiffState(event),
     isRunning: false,
     result,
+    toolResultData: event.toolResultData,
   };
   state.activeTools[idx] = finished;
   state.activeTools = trimCompletedTools(state.activeTools);
@@ -246,6 +248,7 @@ export function applyToolEnd(state: IStreamingState, event: IToolEndEvent): IToo
       firstArg: finished.firstArg,
       isRunning: false,
       result,
+      toolResultData: event.toolResultData,
     },
   });
 

--- a/packages/agent-sdk/src/interactive/types.ts
+++ b/packages/agent-sdk/src/interactive/types.ts
@@ -17,6 +17,7 @@ export interface IToolState {
   result?: 'success' | 'error' | 'denied';
   diffLines?: IDiffLine[];
   diffFile?: string;
+  toolResultData?: string;
 }
 
 /** A single diff line for Edit tool display. */


### PR DESCRIPTION
## Summary
- Render Bash/BackgroundProcess tool output as bounded transcript previews instead of dumping long command output inline.
- Persist SDK toolResultData into tool states and tool-summary history so resumed sessions can replay command output summaries.
- Mark CLI-BL-052 complete and document the CLI/SDK rendering contract.

## Verification
- pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/command-output-summary.test.ts src/ui/__tests__/message-list-rendering.test.tsx
- pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session-streaming.test.ts
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-sdk lint
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-cli build
- git diff --check
- pnpm harness:scan
- pre-push scoped verification for agent-cli and agent-sdk
