### PR TITLE
fix(harness): build before release dist scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "harness:plan": "node scripts/harness/plan-change.mjs",
     "harness:pre-push": "node scripts/harness/pre-push.mjs",
     "harness:verify": "node scripts/harness/verify-change.mjs",
-    "harness:verify:release": "pnpm harness:scan && pnpm build:deps && pnpm test && pnpm typecheck && pnpm lint",
+    "harness:verify:release": "pnpm build:deps && pnpm harness:scan && pnpm test && pnpm typecheck && pnpm lint",
     "harness:record": "node scripts/harness/record-change.mjs",
     "harness:review": "node scripts/harness/review-change.mjs",
     "harness:self-check": "node scripts/harness/self-check.mjs",

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -131,6 +131,22 @@ describe('pre-push hook', () => {
 });
 
 // ---------------------------------------------------------------------------
+// release verification
+// ---------------------------------------------------------------------------
+describe('release verification script', () => {
+  it('builds before running harness:scan so dist freshness has artifacts in clean CI', () => {
+    const rootPackage = JSON.parse(readFileSync('package.json', 'utf8'));
+    const releaseScript = rootPackage.scripts['harness:verify:release'];
+
+    expect(releaseScript).toContain('pnpm build:deps');
+    expect(releaseScript).toContain('pnpm harness:scan');
+    expect(releaseScript.indexOf('pnpm build:deps')).toBeLessThan(
+      releaseScript.indexOf('pnpm harness:scan'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // resolveBaseRef
 // ---------------------------------------------------------------------------
 describe('resolveBaseRef', () => {


### PR DESCRIPTION
## Summary
- Fix release-grade verification order so clean CI builds packages before running the dist freshness scan.
- Add a harness regression test that locks the build-before-scan ordering.

## Verification
- pnpm exec vitest run scripts/harness/__tests__/harness-scripts.test.mjs
- pnpm harness:scan
- pre-push scoped harness verification
