### PR TITLE
docs(backlog): add session replay and agent parallel items

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,9 +11,11 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-| File                                                                           | Topic                                                         |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
-| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
-| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
-| [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |
+| File                                                                                 | Topic                                                         |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [agent-parallel-invocation-reliability.md](agent-parallel-invocation-reliability.md) | Reliable model-invoked parallel subagent starts               |
+| [gemini-provider-modernization.md](gemini-provider-modernization.md)                 | Gemini API provider modernization                             |
+| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)               | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
+| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md)       | OpenAI-compatible provider web search/fetch support           |
+| [openai-provider-modernization.md](openai-provider-modernization.md)                 | OpenAI provider modernization                                 |
+| [session-event-log-replay.md](session-event-log-replay.md)                           | Replay-grade append-only session event logs for `/resume`     |

--- a/.agents/backlog/agent-parallel-invocation-reliability.md
+++ b/.agents/backlog/agent-parallel-invocation-reliability.md
@@ -1,0 +1,76 @@
+# Agent Parallel Invocation Reliability
+
+## What
+
+Make explicit multi-agent and parallel-agent requests reliably start the requested number of subagent jobs in the same parent turn.
+
+## Why
+
+A recent CLI session showed the assistant saying it would run agents in parallel while the session history recorded only one `Agent` tool call per round. When challenged, it continued adding one `Agent` call at a time, waiting for each result before starting the next. This breaks the user-visible contract for explicit parallel delegation and makes the current `Agent` tool path unreliable for parallel work.
+
+This backlog item is separate from replay-grade session logging. Better logs should prove what happened, but the runtime and model-invocable surfaces should also make the correct parallel behavior easy and robust.
+
+## Observed Evidence
+
+In `.robota/logs/session_1777720835221_ak6mqwr7b.jsonl` and `.robota/sessions/session_1777720835221_ak6mqwr7b.json`:
+
+- The user requested designer and developer agents to review a document in parallel.
+- The assistant said it would run them in parallel.
+- The normalized assistant message contained one `Agent` tool call, then a later round contained the second `Agent` tool call.
+- The user later asked why four agents were not created after the assistant said it would use four parallel agents.
+- Follow-up rounds again contained one `Agent` tool call per round instead of a single parallel batch.
+
+Because raw provider responses are not currently logged, this evidence proves the persisted normalized history and actual tool execution were not parallel. It does not prove whether the provider raw output originally contained one or multiple tool calls.
+
+## Current Gap
+
+Robota has two different parallel-capable paths:
+
+- `/agent parallel ...` command path: parses multiple jobs and starts them with `Promise.all`.
+- Direct `Agent` tool path: one `Agent` tool call creates one subagent job.
+
+The model-visible instructions say that for multiple or parallel agents, the model should create one `Agent` tool call per requested role in the current turn. In practice, this is not reliable enough. The model may call only one `Agent` tool and narrate that it started several.
+
+## Scope
+
+- Decide the canonical model-invocable path for explicit parallel subagent requests.
+- Make that path robust when the model emits only one tool call.
+- Consider adding a batch-capable `Agent` tool input, for example `jobs: [...]`, while preserving the existing single-job contract.
+- Consider routing explicit parallel requests through `ExecuteCommand(command: "agent", args: "parallel ...")` only if the command surface can be made reliable and testable.
+- Ensure parent-turn behavior starts all requested jobs before waiting for terminal summaries.
+- Ensure subagent jobs have distinct labels, prompts, agent types, and provenance metadata.
+- Add tests covering explicit requests for two, four, and named-role parallel agents.
+- Add session-log assertions once replay-grade event logging exists.
+
+## Non-Goals
+
+- Do not rely only on prompt wording to fix this.
+- Do not remove the existing single-job `Agent` tool behavior.
+- Do not make subagents recursively spawn subagents.
+- Do not hide partial failures; if one requested job cannot start, the parent response should report which jobs started and which failed.
+
+## Acceptance Criteria
+
+- [ ] An explicit request for N parallel agents starts N subagent jobs before waiting for their results.
+- [ ] The runtime supports a deterministic batch path that does not depend on the model emitting N separate tool calls.
+- [ ] The parent turn records one group/provenance object tying the requested jobs together.
+- [ ] The user-facing response does not claim parallel execution unless the jobs were actually started.
+- [ ] Tests cover direct `Agent` tool batch behavior or `/agent parallel` model-invocation behavior, whichever becomes canonical.
+- [ ] Tests cover the regression where the assistant says "4 parallel agents" but only one job is created.
+- [ ] Session logs can distinguish: provider emitted one batch tool call, provider emitted N direct tool calls, or runtime expanded one request into N jobs.
+
+## Risks & Mitigations
+
+| Risk                                            | Mitigation                                                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Batch input complicates the `Agent` tool schema | Keep single-job fields backwards compatible and add an explicit `jobs` array contract                              |
+| Model still narrates unsupported behavior       | Add runtime-side validation and response metadata so the final response can be checked against actual started jobs |
+| `/agent parallel` and `Agent` batch diverge     | Share parser/request-building logic between both paths                                                             |
+| Partial startup failure leaves unclear state    | Return structured per-job startup results and group metadata                                                       |
+
+## Promotion Path
+
+1. Assign a backlog ID, for example `SDK-BL-0XX-agent-parallel-invocation-reliability`.
+2. Move this file to `.agents/tasks/<ID>-agent-parallel-invocation-reliability.md`.
+3. Update `packages/agent-sdk/docs/SPEC.md`, `packages/agent-command-agent/docs/SPEC.md`, and relevant session logging specs before implementation.
+4. Implement with TDD around two-agent and four-agent explicit parallel requests.

--- a/.agents/backlog/session-event-log-replay.md
+++ b/.agents/backlog/session-event-log-replay.md
@@ -1,0 +1,108 @@
+# Session Event Log Replay
+
+## What
+
+Make `.robota/logs/*.jsonl` the append-only source of truth for session replay so `/resume` can reconstruct a session from raw execution events without relying on incomplete snapshots or inferred state.
+
+## Why
+
+Recent agent parallel-call investigation showed that the current logs preserve normalized history and some tool execution observations, but they do not preserve every raw boundary needed to answer what actually happened:
+
+- what request payload was sent to the provider;
+- what raw provider response or stream chunks came back;
+- how provider output was normalized into `TUniversalMessage`;
+- which tool execution requests were derived from assistant tool calls;
+- which tool invocations actually ran and what raw results they returned;
+- which history mutations were committed for replay.
+
+This makes root-cause analysis depend on inference. It also conflicts with the stronger requirement that session logs are not merely diagnostics: they are durable replay data for 100% session restoration.
+
+## Current Gap
+
+`packages/agent-sessions/docs/SPEC.md` says session logs must preserve enough raw data to reconstruct what was sent to the model and what came back. Current implementation only partially satisfies that contract:
+
+- `pre_run` logs enriched input and pre-run history.
+- `text_delta` logs streamed visible text deltas.
+- `assistant` logs final response text, post-run history, and `historyStructure`.
+- `tool_call` logs the actual wrapped tool invocation name and args.
+- `tool_result` logs success and size metadata, but not the full raw result payload.
+
+Missing raw provenance:
+
+- provider request options and tool schemas as actually passed to the provider call;
+- raw provider non-streaming response payloads;
+- raw provider streaming chunks, including tool-call deltas;
+- normalized provider response immediately after adapter parsing;
+- execution-round assistant message before and after history commit;
+- tool execution batch metadata, request index, batch mode, and parsed arguments;
+- full tool result payload or a deterministic external reference when too large;
+- append-only history mutation events suitable for deterministic replay.
+
+## Scope
+
+- Define a canonical event-log schema for replay-grade session logs.
+- Update specs for `agent-sessions`, `agent-core`, and `agent-sdk` to distinguish:
+  - diagnostic display logs;
+  - raw provider/tool provenance;
+  - replay events;
+  - snapshot persistence.
+- Add event logging at provider-call boundaries in `agent-core` without adding provider-specific branches.
+- Add event logging at tool batch/request/result boundaries, including parallel execution metadata.
+- Preserve large payloads through bounded inline data plus content-addressed file references or another deterministic storage strategy.
+- Make `/resume` able to rebuild session state from append-only replay events, with session JSON snapshots used only as acceleration/cache.
+- Add validation tooling that checks a session log has no unmatched assistant tool calls, tool requests, or tool results.
+- Add regression coverage for multi-tool and multi-agent tool-call turns.
+
+## Non-Goals
+
+- Do not add provider-specific logic to `agent-core`.
+- Do not rely on final `history` snapshots as the only source of replay truth.
+- Do not silently omit raw payloads because they are large; use references when inline storage is too expensive.
+- Do not store secrets in plaintext logs. Define redaction rules for provider requests and tool args/results that may contain credentials.
+- Do not make high-frequency streaming writes rewrite the main session JSON file.
+
+## Proposed Event Families
+
+The exact schema should be finalized in the spec before implementation, but the replay model should include at least:
+
+| Event                          | Purpose                                                              |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `provider_request`             | Exact provider-neutral request envelope before adapter/provider call |
+| `provider_response_raw`        | Raw non-streaming provider response or reference                     |
+| `provider_stream_raw_delta`    | Raw streaming provider chunk or reference                            |
+| `provider_response_normalized` | Parsed `TUniversalMessage` returned by provider adapter              |
+| `assistant_message_committed`  | Assistant message appended to canonical history                      |
+| `tool_batch_started`           | Tool batch mode, concurrency, request count, round/execution IDs     |
+| `tool_execution_request`       | Tool name, toolCallId, parsed args, batch index, owner path          |
+| `tool_execution_result`        | Full raw tool result or reference, success/error metadata            |
+| `tool_message_committed`       | Tool message appended to canonical history                           |
+| `history_mutation`             | Append-only canonical history mutation for replay                    |
+
+## Acceptance Criteria
+
+- [ ] Specs define replay-grade event log ownership, event ordering, redaction, payload reference policy, and compatibility with existing session JSON records.
+- [ ] Every provider turn logs the exact request envelope and the raw provider response/chunks before normalization.
+- [ ] Every provider response logs the normalized assistant message, including all tool calls and provider-supplied tool call IDs.
+- [ ] Every tool batch logs batch mode (`parallel` or `sequential`), concurrency, ordered requests, and terminal results.
+- [ ] Full tool results are recoverable from the log stream or referenced payload files.
+- [ ] `/resume` can rebuild messages, full UI history, background task state, and subagent provenance from replay events.
+- [ ] Tests prove a turn with multiple assistant tool calls can be replayed without losing or inventing calls.
+- [ ] Tests prove an `Agent` parallel/delegation turn records whether the provider emitted one tool call or several.
+- [ ] A validator command reports missing raw provider responses, unmatched tool calls/results, and non-replayable payload references.
+
+## Risks & Mitigations
+
+| Risk                                       | Mitigation                                                                         |
+| ------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Logs grow too large                        | Use append-only JSONL plus content-addressed payload files for large raw data      |
+| Secrets leak into durable logs             | Apply explicit redaction at provider request and tool boundary before persistence  |
+| Replay schema drifts from runtime behavior | Add contract tests that replay logs generated by real execution paths              |
+| Existing sessions cannot replay fully      | Mark legacy logs as snapshot-only and migrate only what can be proven              |
+| Core gains provider-specific behavior      | Log provider-neutral envelopes in core and raw provider-owned payloads in adapters |
+
+## Promotion Path
+
+1. Assign a backlog ID, for example `SDK-BL-0XX-session-event-log-replay`.
+2. Move this file to `.agents/tasks/<ID>-session-event-log-replay.md`.
+3. Update `packages/agent-sessions/docs/SPEC.md`, `packages/agent-core/docs/SPEC.md`, and `packages/agent-sdk/docs/SPEC.md` before code changes.
+4. Implement with TDD around replay, multi-tool turns, and parallel `Agent` tool-call provenance.


### PR DESCRIPTION
## Summary
- Add backlog item for replay-grade append-only session event logs for /resume
- Add backlog item for reliable model-invoked parallel subagent starts
- Update backlog index

## Verification
- pre-push harness ran repository-review; no package/app scope detected for docs-only changes