### PR TITLE
feat(agent): add session replay events and agent batch jobs

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,11 +11,9 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-| File                                                                                 | Topic                                                         |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [agent-parallel-invocation-reliability.md](agent-parallel-invocation-reliability.md) | Reliable model-invoked parallel subagent starts               |
-| [gemini-provider-modernization.md](gemini-provider-modernization.md)                 | Gemini API provider modernization                             |
-| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)               | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
-| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md)       | OpenAI-compatible provider web search/fetch support           |
-| [openai-provider-modernization.md](openai-provider-modernization.md)                 | OpenAI provider modernization                                 |
-| [session-event-log-replay.md](session-event-log-replay.md)                           | Replay-grade append-only session event logs for `/resume`     |
+| File                                                                           | Topic                                                         |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
+| [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
+| [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
+| [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |

--- a/.agents/tasks/SDK-BL-005-session-event-log-replay.md
+++ b/.agents/tasks/SDK-BL-005-session-event-log-replay.md
@@ -1,5 +1,10 @@
 # Session Event Log Replay
 
+- **Status**: in-progress
+- **Created**: 2026-05-02
+- **Branch**: feat/session-replay-agent-parallel
+- **Scope**: packages/agent-sessions, packages/agent-core, packages/agent-sdk
+
 ## What
 
 Make `.robota/logs/*.jsonl` the append-only source of truth for session replay so `/resume` can reconstruct a session from raw execution events without relying on incomplete snapshots or inferred state.
@@ -100,9 +105,29 @@ The exact schema should be finalized in the spec before implementation, but the 
 | Existing sessions cannot replay fully      | Mark legacy logs as snapshot-only and migrate only what can be proven              |
 | Core gains provider-specific behavior      | Log provider-neutral envelopes in core and raw provider-owned payloads in adapters |
 
+## Test Plan
+
+- Add unit coverage for `agent-sessions` forwarding core execution boundary events into the append-only session logger.
+- Add targeted `agent-core` coverage for provider request/response and tool batch/request/result event ordering as the replay schema expands.
+- Add replay fixture tests for multi-tool and Agent batch turns before marking this task complete.
+- Run affected `agent-core`, `agent-sessions`, and `agent-sdk` typecheck/build targets after each replay-event contract change.
+
 ## Promotion Path
 
 1. Assign a backlog ID, for example `SDK-BL-0XX-session-event-log-replay`.
 2. Move this file to `.agents/tasks/<ID>-session-event-log-replay.md`.
 3. Update `packages/agent-sessions/docs/SPEC.md`, `packages/agent-core/docs/SPEC.md`, and `packages/agent-sdk/docs/SPEC.md` before code changes.
 4. Implement with TDD around replay, multi-tool turns, and parallel `Agent` tool-call provenance.
+
+## Progress
+
+### 2026-05-02
+
+- Promoted from backlog to active task as `SDK-BL-005`.
+- Started on branch `feat/session-replay-agent-parallel`.
+- Updated `agent-sessions`, `agent-core`, and `agent-sdk` specs with replay-grade execution boundary events.
+- Added `IRunOptions.onExecutionEvent` / `IExecutionContext.onExecutionEvent` so core execution can emit append-only session events without depending on session storage.
+- Added core event emission for provider request envelopes, normalized provider responses, assistant commits, tool batch starts, tool execution requests, and tool execution results.
+- Wired `agent-sessions` run execution to persist core execution events through the existing session log path.
+- Added session test coverage for forwarding core execution boundary events into session logs.
+- Remaining work: raw provider responses/stream chunks, content-addressed payload references, redaction policy, deterministic `/resume` replay, history mutation events, validator command.

--- a/.agents/tasks/SDK-BL-006-agent-parallel-invocation-reliability.md
+++ b/.agents/tasks/SDK-BL-006-agent-parallel-invocation-reliability.md
@@ -1,5 +1,10 @@
 # Agent Parallel Invocation Reliability
 
+- **Status**: in-progress
+- **Created**: 2026-05-02
+- **Branch**: feat/session-replay-agent-parallel
+- **Scope**: packages/agent-sdk, packages/agent-command-agent, packages/agent-sessions
+
 ## What
 
 Make explicit multi-agent and parallel-agent requests reliably start the requested number of subagent jobs in the same parent turn.
@@ -68,9 +73,29 @@ The model-visible instructions say that for multiple or parallel agents, the mod
 | `/agent parallel` and `Agent` batch diverge     | Share parser/request-building logic between both paths                                                             |
 | Partial startup failure leaves unclear state    | Return structured per-job startup results and group metadata                                                       |
 
+## Test Plan
+
+- Add unit coverage for direct batch `Agent` tool calls with two and four requested jobs.
+- Assert all valid jobs are spawned before the first wait begins, and partial startup failures remain visible per job.
+- Add session-log assertions after replay-grade events can distinguish one batch call from N direct tool calls.
+- Run affected `agent-sdk` tests, typecheck, and build after changing the model-visible Agent tool contract.
+
 ## Promotion Path
 
 1. Assign a backlog ID, for example `SDK-BL-0XX-agent-parallel-invocation-reliability`.
 2. Move this file to `.agents/tasks/<ID>-agent-parallel-invocation-reliability.md`.
 3. Update `packages/agent-sdk/docs/SPEC.md`, `packages/agent-command-agent/docs/SPEC.md`, and relevant session logging specs before implementation.
 4. Implement with TDD around two-agent and four-agent explicit parallel requests.
+
+## Progress
+
+### 2026-05-02
+
+- Promoted from backlog to active task as `SDK-BL-006`.
+- Started on branch `feat/session-replay-agent-parallel`.
+- Updated `agent-sdk` spec to make one batch `Agent` tool call with `jobs` the canonical model path for explicit parallel subagent requests.
+- Added backwards-compatible `jobs` support to the `Agent` tool schema while preserving the single-job `prompt` contract.
+- Implemented batch execution so all valid jobs are spawned before any wait begins, with shared `groupId`, ordered per-job results, `agentIds`, and partial failure reporting.
+- Updated model-visible Agent tool instructions to prefer `jobs` for explicit multi-agent and parallel-agent requests.
+- Added regression coverage proving a batch `Agent` call can start multiple jobs before waiting, including the model-friendly `jobs`-only shape.
+- Remaining work: four-agent scenario coverage, user-facing claim validation, command-path convergence, and session-log assertions that distinguish one batch call from N direct calls.

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -376,20 +376,22 @@ The execution loop supports cooperative cancellation via the standard `AbortSign
 
 ### Interface Changes
 
-| Interface                    | Field                              | Description                                                          |
-| ---------------------------- | ---------------------------------- | -------------------------------------------------------------------- |
-| `IRunOptions`                | `signal?: AbortSignal`             | Allows callers to cancel execution of `Robota.run()`                 |
-| `IRunOptions`                | `onTextDelta?: TTextDeltaCallback` | Per-run streaming callback forwarded through execution context       |
-| `IRunOptions`                | `maxExecutionRounds?: number`      | Maximum model/tool rounds for one run. `0` means unlimited.          |
-| `IChatOptions`               | `signal?: AbortSignal`             | Passed to provider `chat()` / `chatStream()` for cancelling calls    |
-| `IAgentConfig`               | `timeout?: number`                 | Provider idle timeout in milliseconds for a model call               |
-| `IAgentConfig`               | `maxExecutionRounds?: number`      | Default maximum model/tool rounds for each run. `0` means unlimited. |
-| `IExecutionContext`          | `signal?: AbortSignal`             | Threaded through the execution context for round-level checks        |
-| `IExecutionContext`          | `onTextDelta?: TTextDeltaCallback` | Run-scoped callback used before provider-level callback fallback     |
-| `IExecutionContext`          | `maxExecutionRounds?: number`      | Run-scoped override for execution round limit                        |
-| `IExecutionResult`           | `interrupted?: boolean`            | Indicates the execution was aborted before natural completion        |
-| `IToolExecutionBatchContext` | `signal?: AbortSignal`             | Allows skipping queued tool executions when abort is signalled       |
-| `IToolExecutionBatchContext` | `maxConcurrency?: number`          | Bounds active tool executions when batch mode is `parallel`          |
+| Interface                    | Field                                        | Description                                                          |
+| ---------------------------- | -------------------------------------------- | -------------------------------------------------------------------- |
+| `IRunOptions`                | `signal?: AbortSignal`                       | Allows callers to cancel execution of `Robota.run()`                 |
+| `IRunOptions`                | `onTextDelta?: TTextDeltaCallback`           | Per-run streaming callback forwarded through execution context       |
+| `IRunOptions`                | `onExecutionEvent?: TExecutionEventCallback` | Per-run replay event callback for provider/tool boundaries           |
+| `IRunOptions`                | `maxExecutionRounds?: number`                | Maximum model/tool rounds for one run. `0` means unlimited.          |
+| `IChatOptions`               | `signal?: AbortSignal`                       | Passed to provider `chat()` / `chatStream()` for cancelling calls    |
+| `IAgentConfig`               | `timeout?: number`                           | Provider idle timeout in milliseconds for a model call               |
+| `IAgentConfig`               | `maxExecutionRounds?: number`                | Default maximum model/tool rounds for each run. `0` means unlimited. |
+| `IExecutionContext`          | `signal?: AbortSignal`                       | Threaded through the execution context for round-level checks        |
+| `IExecutionContext`          | `onTextDelta?: TTextDeltaCallback`           | Run-scoped callback used before provider-level callback fallback     |
+| `IExecutionContext`          | `onExecutionEvent?: TExecutionEventCallback` | Internal replay event callback forwarded to provider/tool rounds     |
+| `IExecutionContext`          | `maxExecutionRounds?: number`                | Run-scoped override for execution round limit                        |
+| `IExecutionResult`           | `interrupted?: boolean`                      | Indicates the execution was aborted before natural completion        |
+| `IToolExecutionBatchContext` | `signal?: AbortSignal`                       | Allows skipping queued tool executions when abort is signalled       |
+| `IToolExecutionBatchContext` | `maxConcurrency?: number`                    | Bounds active tool executions when batch mode is `parallel`          |
 
 ### Signal Propagation
 

--- a/packages/agent-core/src/core/robota-execution.ts
+++ b/packages/agent-core/src/core/robota-execution.ts
@@ -31,6 +31,7 @@ function buildRunContext(
     ...(options.metadata && { metadata: options.metadata }),
     ...(options.signal && { signal: options.signal }),
     ...(options.onTextDelta && { onTextDelta: options.onTextDelta }),
+    ...(options.onExecutionEvent && { onExecutionEvent: options.onExecutionEvent }),
     ...(options.maxExecutionRounds !== undefined && {
       maxExecutionRounds: options.maxExecutionRounds,
     }),

--- a/packages/agent-core/src/interfaces/agent.ts
+++ b/packages/agent-core/src/interfaces/agent.ts
@@ -167,12 +167,18 @@ export interface IRunOptions {
   signal?: AbortSignal;
   /** Per-run streaming text callback. Prefer this over mutating provider callback state. */
   onTextDelta?: TTextDeltaCallback;
+  /** Per-run replay event callback for provider/tool execution boundaries. */
+  onExecutionEvent?: TExecutionEventCallback;
   /**
    * Maximum model/tool rounds for this run.
    * Use 0 for no core round cap.
    */
   maxExecutionRounds?: number;
 }
+
+export type TExecutionEventData = Record<string, unknown>;
+
+export type TExecutionEventCallback = (event: string, data: TExecutionEventData) => void;
 
 /**
  * Generic agent interface with type parameters for enhanced type safety

--- a/packages/agent-core/src/services/execution-round-tools.ts
+++ b/packages/agent-core/src/services/execution-round-tools.ts
@@ -3,7 +3,11 @@
  * Extracted from execution-round.ts for single-responsibility.
  */
 
-import type { IAgentConfig } from '../interfaces/agent';
+import type {
+  IAgentConfig,
+  TExecutionEventCallback,
+  TExecutionEventData,
+} from '../interfaces/agent';
 import type { IToolCall } from '../interfaces/messages';
 import type { IToolExecutionBatchContext } from './tool-execution-service';
 import type { ILogger } from '../utils/logger';
@@ -36,6 +40,7 @@ export async function executeAndRecordToolCalls(
   deps: IRoundDependencies,
   config?: IAgentConfig,
   signal?: AbortSignal,
+  onExecutionEvent?: TExecutionEventCallback,
 ): Promise<IToolResultsOutcome> {
   const { toolExecutionService, logger, eventEmitter } = deps;
 
@@ -85,7 +90,46 @@ export async function executeAndRecordToolCalls(
     signal,
   };
 
+  onExecutionEvent?.('tool_batch_started', {
+    executionId,
+    conversationId,
+    round: currentRound,
+    batchId,
+    mode: toolContext.mode,
+    maxConcurrency: toolContext.maxConcurrency,
+    requestCount: toolRequests.length,
+    tools: toolRequests.map((request) => request.toolName),
+  } as TExecutionEventData);
+  toolRequests.forEach((request, index) => {
+    onExecutionEvent?.('tool_execution_request', {
+      executionId,
+      conversationId,
+      round: currentRound,
+      batchId,
+      index,
+      toolName: request.toolName,
+      toolCallId: request.executionId,
+      parameters: request.parameters,
+      ownerPath: request.ownerPath,
+    } as TExecutionEventData);
+  });
+
   const toolSummary = await toolExecutionService.executeTools(toolContext);
+
+  toolSummary.results.forEach((result, index) => {
+    onExecutionEvent?.('tool_execution_result', {
+      executionId,
+      conversationId,
+      round: currentRound,
+      batchId,
+      index,
+      toolName: result.toolName,
+      toolCallId: result.executionId,
+      success: result.success,
+      result: result.result,
+      error: result.error,
+    } as TExecutionEventData);
+  });
 
   roundState.toolsExecuted.push(
     ...toolSummary.results.map((r) => {

--- a/packages/agent-core/src/services/execution-round.ts
+++ b/packages/agent-core/src/services/execution-round.ts
@@ -4,7 +4,7 @@
  * Tool recording → execution-round-tools.ts
  */
 
-import type { IAgentConfig } from '../interfaces/agent';
+import type { IAgentConfig, TExecutionEventData } from '../interfaces/agent';
 import type { TUniversalMessage, TMessageState } from '../interfaces/messages';
 import type { ToolExecutionService } from './tool-execution-service';
 import type { ILogger } from '../utils/logger';
@@ -175,10 +175,29 @@ export async function executeRound(
 
   let response: TUniversalMessage;
   try {
+    fullContext.onExecutionEvent?.('provider_request', {
+      executionId,
+      conversationId: fullContext.conversationId,
+      round: currentRound,
+      provider: resolved.currentInfo.provider,
+      model: config.defaultModel.model,
+      messages: conversationMessages,
+      tools: resolved.availableTools,
+    } as TExecutionEventData);
     response = await callProviderWithCache(conversationMessages, config, resolved, cacheService, {
       signal: fullContext.signal,
       onTextDelta: wrappedOnTextDelta,
     });
+    fullContext.onExecutionEvent?.('provider_response_normalized', {
+      executionId,
+      conversationId: fullContext.conversationId,
+      round: currentRound,
+      response,
+      toolCallsCount:
+        response.role === 'assistant' && Array.isArray(response.toolCalls)
+          ? response.toolCalls.length
+          : 0,
+    } as TExecutionEventData);
   } catch (providerError) {
     const isAbortError =
       providerError instanceof Error &&
@@ -246,6 +265,12 @@ export async function executeRound(
     round: currentRound,
     ...(usageMetadata ?? {}),
   });
+  fullContext.onExecutionEvent?.('assistant_message_committed', {
+    executionId,
+    conversationId: fullContext.conversationId,
+    round: currentRound,
+    message: assistantResponse,
+  } as TExecutionEventData);
   roundState.runningAssistantCount++;
   roundState.lastTrackedAssistantMessage = assistantResponse;
 
@@ -276,6 +301,7 @@ export async function executeRound(
     deps,
     config,
     fullContext.signal,
+    fullContext.onExecutionEvent,
   );
 
   if (toolOutcome.contextOverflowed) {

--- a/packages/agent-core/src/services/execution-service.ts
+++ b/packages/agent-core/src/services/execution-service.ts
@@ -49,6 +49,7 @@ function buildFullExecutionContext(
     ...(context?.metadata && { metadata: context.metadata }),
     ...(context?.signal && { signal: context.signal }),
     ...(context?.onTextDelta && { onTextDelta: context.onTextDelta }),
+    ...(context?.onExecutionEvent && { onExecutionEvent: context.onExecutionEvent }),
     ...(context?.maxExecutionRounds !== undefined && {
       maxExecutionRounds: context.maxExecutionRounds,
     }),

--- a/packages/agent-core/src/services/execution-types.ts
+++ b/packages/agent-core/src/services/execution-types.ts
@@ -1,4 +1,4 @@
-import type { IAgentConfig, IAssistantMessage } from '../interfaces/agent';
+import type { IAgentConfig, IAssistantMessage, TExecutionEventCallback } from '../interfaces/agent';
 import type { TMetadata } from '../interfaces/types';
 import type { IAIProviderManager } from '../interfaces/manager';
 import type { IToolManager } from '../interfaces/manager';
@@ -105,6 +105,8 @@ export interface IExecutionContext {
   signal?: AbortSignal;
   /** Per-run streaming text callback. */
   onTextDelta?: TTextDeltaCallback;
+  /** Per-run replay event callback for provider/tool execution boundaries. */
+  onExecutionEvent?: TExecutionEventCallback;
   /** Per-run model/tool round limit. Use 0 for no core round cap. */
   maxExecutionRounds?: number;
 }

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -1250,10 +1250,13 @@ The parent session exposes an `Agent` function tool with parameters:
 | `subagent_type` | `string`               | No       | Agent name. Defaults to `general-purpose` when omitted  |
 | `model`         | `string`               | No       | Optional model override for this invocation             |
 | `isolation`     | `'none' \| 'worktree'` | No       | Run in the parent cwd or a runtime-managed Git worktree |
+| `jobs`          | `AgentJob[]`           | No       | Batch of subagent jobs to start in one tool call        |
+
+When `jobs` is present and non-empty, the Agent tool runs in batch mode. Each `AgentJob` contains `prompt` plus optional `subagent_type`, `model`, and `isolation`. Batch mode starts all valid jobs before waiting for terminal results, returns one structured result per requested job, and includes a shared `groupId`/`agentIds` provenance envelope. The single-job fields remain supported for backwards compatibility.
 
 Unknown extra tool-call arguments are tolerated by the Agent tool runtime for provider compatibility, but they are not part of the public Agent parameter contract.
 
-The parent model may call this tool when the user asks for an agent to be called or asks for delegation. The tool result is private to the model; the parent model must summarize the returned output for the user.
+The parent model may call this tool when the user asks for an agent to be called or asks for delegation. For explicit multi-agent or parallel-agent requests, the canonical model-invocable path is one batch `Agent` tool call with `jobs`. The tool result is private to the model; the parent model must summarize the returned output for the user and must not claim that parallel execution happened unless the batch result shows the jobs were started.
 
 When `isolation: 'worktree'` is requested, a runtime shell that supports worktree isolation must compose `WorktreeSubagentRunner` with a concrete `ISubagentWorktreeAdapter`. The runtime runner handles lifecycle, cleanup, handoff metadata, and `WorktreeCreate` / `WorktreeRemove` hook notifications; the shell adapter handles Git/filesystem I/O.
 

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -264,8 +264,10 @@ describe('createSession — appendSystemPrompt option', () => {
 
       const opts = sessionCtorCalls[0]!;
       const systemMessage = opts.systemMessage as string;
-      expect(systemMessage).toContain('Agent — creates one isolated subagent job');
-      expect(systemMessage).toContain('One Agent tool call corresponds to one subagent job');
+      expect(systemMessage).toContain('Agent — creates isolated subagent jobs');
+      expect(systemMessage).toContain(
+        'For explicit multi-agent or parallel-agent requests, use one Agent tool call with jobs',
+      );
       expect(systemMessage).toContain('The tool returns terminal result data');
       expect(systemMessage).not.toContain('<agent');
       expect(systemMessage).toContain('- reviewer: Reviews code for risks and missing tests');

--- a/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/agent-tool.test.ts
@@ -129,7 +129,7 @@ describe('Agent tool', () => {
     expect(schema.description).toContain('When the user explicitly asks');
     expect(schema.description).toContain('start the requested subagent job immediately');
     expect(schema.description).toContain('Do not ask a follow-up question');
-    expect(schema.description).toContain('one Agent tool call per requested role');
+    expect(schema.description).toContain('one Agent tool call with jobs');
     expect(schema.description).not.toContain('<agent');
     expect(schema.description).not.toContain('pseudo-tags');
     // Verify parameters include prompt, subagent_type, model
@@ -645,6 +645,87 @@ describe('Agent tool', () => {
     expect(timedOut['success']).toBe(false);
     expect(timedOut['agentId']).toBe('agent_parallel_3');
     expect(timedOut['error']).toContain('Background agent produced no activity');
+  });
+
+  it('should start all jobs in one batch Agent tool call before waiting', async () => {
+    const subagentManager = {
+      spawn: vi
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'agent_batch_1',
+          type: 'Explore',
+          label: 'Explore',
+          parentSessionId: 'session_parent',
+          status: 'running',
+          mode: 'background',
+          depth: 1,
+          cwd: '/workspace',
+          promptPreview: 'Developer analysis',
+          updatedAt: '2026-04-30T00:00:00.000Z',
+        })
+        .mockResolvedValueOnce({
+          id: 'agent_batch_2',
+          type: 'Plan',
+          label: 'Plan',
+          parentSessionId: 'session_parent',
+          status: 'running',
+          mode: 'background',
+          depth: 1,
+          cwd: '/workspace',
+          promptPreview: 'Designer analysis',
+          updatedAt: '2026-04-30T00:00:00.000Z',
+        }),
+      wait: vi
+        .fn()
+        .mockResolvedValueOnce({ jobId: 'agent_batch_1', output: 'developer complete' })
+        .mockResolvedValueOnce({ jobId: 'agent_batch_2', output: 'designer complete' }),
+      list: vi.fn(),
+      get: vi.fn(),
+      cancel: vi.fn(),
+      close: vi.fn(),
+      send: vi.fn(),
+      shutdown: vi.fn(),
+    };
+
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+      }),
+    );
+
+    const toolResult = await tool.execute({
+      jobs: [
+        { prompt: 'Developer analysis', subagent_type: 'Explore' },
+        { prompt: 'Designer analysis', subagent_type: 'Plan' },
+      ],
+    });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).toHaveBeenCalledTimes(2);
+    expect(subagentManager.wait).toHaveBeenCalledTimes(2);
+    expect(subagentManager.spawn.mock.invocationCallOrder[1]).toBeLessThan(
+      subagentManager.wait.mock.invocationCallOrder[0]!,
+    );
+    expect(result['success']).toBe(true);
+    expect(result['agentIds']).toEqual(['agent_batch_1', 'agent_batch_2']);
+    expect(result['jobs']).toEqual([
+      expect.objectContaining({
+        index: 0,
+        success: true,
+        agentId: 'agent_batch_1',
+        subagent_type: 'Explore',
+        output: 'developer complete',
+      }),
+      expect.objectContaining({
+        index: 1,
+        success: true,
+        agentId: 'agent_batch_2',
+        subagent_type: 'Plan',
+        output: 'designer complete',
+      }),
+    ]);
   });
 
   it('should ignore undeclared model-emitted orchestration hints without changing single-call execution', async () => {

--- a/packages/agent-sdk/src/tools/agent-tool.ts
+++ b/packages/agent-sdk/src/tools/agent-tool.ts
@@ -27,11 +27,11 @@ import type {
 import type { IBackgroundTaskManager } from '../background-tasks/index.js';
 
 export const AGENT_TOOL_DESCRIPTION = [
-  'Creates one subagent job for delegated work in an isolated context.',
-  'One tool call creates one subagent job.',
+  'Creates delegated subagent jobs in isolated contexts.',
+  'Without jobs, one tool call creates one subagent job from prompt.',
+  'For explicit multi-agent or parallel-agent requests, use one Agent tool call with jobs containing one entry per requested role.',
   'When the user explicitly asks to create, run, spawn, delegate to, or use agents/subagents, start the requested subagent job immediately.',
   'Do not ask a follow-up question unless execution is impossible or unsafe.',
-  'For multiple or parallel agents, create one Agent tool call per requested role in the current turn.',
   'Subagent jobs run as background tasks by default.',
   'The tool waits for a terminal result and returns completed, failed, or timed-out outcome data to the parent conversation.',
   'Execution is represented by a real tool call and runtime background task event.',
@@ -47,11 +47,11 @@ export function createAgentToolPromptDescription(
           .join(', ')}.`
       : '';
   return [
-    'Agent — creates one isolated subagent job.',
-    'One Agent tool call corresponds to one subagent job.',
+    'Agent — creates isolated subagent jobs.',
+    'Without jobs, one Agent tool call corresponds to one subagent job.',
+    'For explicit multi-agent or parallel-agent requests, use one Agent tool call with jobs containing one entry per requested role.',
     'When the user explicitly asks to create, run, spawn, delegate to, or use agents/subagents, start the requested subagent job immediately.',
     'Do not ask a follow-up question unless execution is impossible or unsafe.',
-    'For multiple or parallel agents, create one Agent tool call per requested role in the current turn.',
     'The tool returns terminal result data.',
     'Runtime mode is background.',
     availableAgents,
@@ -68,7 +68,10 @@ function asZodSchema(schema: z.ZodType): IZodSchema {
 
 const AgentSchema = z
   .object({
-    prompt: z.string().describe('The task for the subagent to perform'),
+    prompt: z
+      .string()
+      .optional()
+      .describe('The task for a single subagent to perform. Required when jobs is omitted.'),
     subagent_type: z
       .string()
       .optional()
@@ -78,10 +81,25 @@ const AgentSchema = z
       .enum(['none', 'worktree'])
       .optional()
       .describe('Optional runtime isolation mode. "worktree" runs in a Git worktree.'),
+    jobs: z
+      .array(
+        z
+          .object({
+            prompt: z.string().describe('The task for this subagent to perform'),
+            subagent_type: z.string().optional().describe('Agent type for this job'),
+            model: z.string().optional().describe('Optional model override for this job'),
+            isolation: z.enum(['none', 'worktree']).optional().describe('Isolation for this job'),
+          })
+          .passthrough(),
+      )
+      .optional()
+      .describe('Batch of subagent jobs to start in one Agent tool call'),
   })
   .passthrough();
 
 type TAgentArgs = z.infer<typeof AgentSchema>;
+type TAgentJobArgs = NonNullable<TAgentArgs['jobs']>[number];
+type TSingleAgentArgs = TAgentArgs & { prompt: string };
 
 /** Dependencies injected at creation time via createAgentTool factory */
 export interface IAgentToolDeps extends IInProcessSubagentRunnerDeps {
@@ -142,7 +160,7 @@ function createSubagentManager(deps: IAgentToolDeps): ISubagentManager {
 }
 
 function createSpawnRequest(
-  args: TAgentArgs,
+  args: TSingleAgentArgs | TAgentJobArgs,
   agentType: string,
   agentDef: IAgentDefinition,
   deps: IAgentToolDeps,
@@ -190,11 +208,44 @@ function stringifyAgentError(message: string, agentId?: string): string {
   });
 }
 
+function stringifyAgentBatchResult(input: {
+  groupId: string;
+  jobs: Array<{
+    index: number;
+    success: boolean;
+    agentId?: string;
+    subagent_type: string;
+    output?: string;
+    error?: string;
+    metadata?: ISubagentJobResult['metadata'];
+  }>;
+}): string {
+  const successfulJobs = input.jobs.filter((job) => job.success);
+  const agentIds = input.jobs
+    .map((job) => job.agentId)
+    .filter((agentId): agentId is string => typeof agentId === 'string' && agentId.length > 0);
+  return JSON.stringify({
+    success: input.jobs.every((job) => job.success),
+    output: successfulJobs
+      .map((job) => job.output ?? '')
+      .filter(Boolean)
+      .join('\n\n'),
+    groupId: input.groupId,
+    agentIds,
+    jobs: input.jobs,
+  });
+}
+
 async function runManagedAgent(
   args: TAgentArgs,
   deps: IAgentToolDeps,
   manager: ISubagentManager,
 ): Promise<string> {
+  if (typeof args.prompt !== 'string' || args.prompt.length === 0) {
+    return stringifyAgentError('prompt is required when jobs is omitted');
+  }
+
+  const singleArgs: TSingleAgentArgs = { ...args, prompt: args.prompt };
   const agentType = args.subagent_type ?? 'general-purpose';
   const agentDef = resolveAgentDefinition(agentType, deps.customAgentRegistry);
   if (!agentDef) {
@@ -203,7 +254,7 @@ async function runManagedAgent(
 
   let agentId: string | undefined;
   try {
-    const state = await manager.spawn(createSpawnRequest(args, agentType, agentDef, deps));
+    const state = await manager.spawn(createSpawnRequest(singleArgs, agentType, agentDef, deps));
     agentId = state.id;
     const response = await manager.wait(state.id);
     return stringifyAgentSuccess(response);
@@ -211,6 +262,88 @@ async function runManagedAgent(
     const message = err instanceof Error ? err.message : String(err);
     return stringifyAgentError(message, agentId);
   }
+}
+
+function createBatchGroupId(): string {
+  return `agent_group_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function runManagedAgentBatch(
+  jobs: TAgentJobArgs[],
+  deps: IAgentToolDeps,
+  manager: ISubagentManager,
+): Promise<string> {
+  const groupId = createBatchGroupId();
+  const resolvedJobs = jobs.map((job, index) => {
+    const agentType = job.subagent_type ?? 'general-purpose';
+    const agentDef = resolveAgentDefinition(agentType, deps.customAgentRegistry);
+    return { index, job, agentType, agentDef };
+  });
+
+  const invalidJobs = resolvedJobs
+    .filter((job) => job.agentDef === undefined)
+    .map((job) => ({
+      index: job.index,
+      success: false,
+      subagent_type: job.agentType,
+      error: `Unknown agent type: ${job.agentType}`,
+    }));
+
+  const validJobs = resolvedJobs.filter(
+    (job): job is typeof job & { agentDef: IAgentDefinition } => job.agentDef !== undefined,
+  );
+
+  const startedJobs = await Promise.all(
+    validJobs.map(async (job) => {
+      try {
+        const state = await manager.spawn(
+          createSpawnRequest(job.job, job.agentType, job.agentDef, deps),
+        );
+        return { ...job, agentId: state.id, spawnError: undefined };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { ...job, agentId: undefined, spawnError: message };
+      }
+    }),
+  );
+
+  const terminalJobs = await Promise.all(
+    startedJobs.map(async (job) => {
+      if (job.spawnError || !job.agentId) {
+        return {
+          index: job.index,
+          success: false,
+          subagent_type: job.agentType,
+          error: `Sub-agent error: ${job.spawnError ?? 'missing agent id'}`,
+        };
+      }
+      try {
+        const result = await manager.wait(job.agentId);
+        return {
+          index: job.index,
+          success: true,
+          agentId: result.jobId,
+          subagent_type: job.agentType,
+          output: result.output,
+          metadata: result.metadata,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          index: job.index,
+          success: false,
+          agentId: job.agentId,
+          subagent_type: job.agentType,
+          error: `Sub-agent error: ${message}`,
+        };
+      }
+    }),
+  );
+
+  const batchJobs = [...invalidJobs, ...terminalJobs].sort(
+    (left, right) => left.index - right.index,
+  );
+  return stringifyAgentBatchResult({ groupId, jobs: batchJobs });
 }
 
 /**
@@ -227,6 +360,9 @@ export function createAgentTool(deps: IAgentToolDeps): ReturnType<typeof createZ
     asZodSchema(AgentSchema),
     async (params) => {
       const args = params as TAgentArgs;
+      if (Array.isArray(args.jobs) && args.jobs.length > 0) {
+        return runManagedAgentBatch(args.jobs, deps, manager);
+      }
       return runManagedAgent(
         {
           prompt: args.prompt,

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -179,6 +179,11 @@ The session log records structured events to a JSONL file for diagnostics and re
 - **`session_init` event** -- Recorded when a session is constructed. Includes `systemPrompt`, `systemPromptLength`, provider/model, cwd, and registered `toolSchemas`.
 - **`server_tool` event** -- Recorded when a server-managed tool (e.g., web search) executes during streaming. Includes the tool name and query.
 - **`pre_run` event** -- Recorded at the start of each `run()` call. Includes the provider name, `webToolsEnabled` flag, full enriched input, and current message history before the model call.
+- **`provider_request` event** -- Recorded before each provider call. Includes the provider-neutral request envelope: provider, model, messages, tool schemas/options, round, and execution identifiers.
+- **`provider_response_normalized` event** -- Recorded immediately after the provider adapter returns a `TUniversalMessage`. Includes the normalized assistant message, tool call count, provider/model metadata, round, and execution identifiers.
+- **`tool_batch_started` event** -- Recorded before a tool batch executes. Includes batch mode, max concurrency, request count, ordered tool names, round, and execution identifiers.
+- **`tool_execution_request` event** -- Recorded for each parsed tool request. Includes tool name, toolCallId/executionId, parsed parameters, batch index, owner path, round, and execution identifiers.
+- **`tool_execution_result` event** -- Recorded for each terminal tool result. Includes tool name, toolCallId/executionId, success/error, result payload when available, batch index, round, and execution identifiers.
 - **`text_delta` event** -- Recorded for each streaming text chunk delivered through `ISessionOptions.onTextDelta`. This is append-only JSONL data and must be available while a run is still in progress.
 - **`assistant` event** -- Recorded after each assistant response. Includes full assistant content, full post-run history, and `historyStructure`: an array with per-message metadata (role, contentLength, hasToolCalls, toolCallNames, metadata).
 - **`session_shutdown` event** -- Recorded once when `Session.shutdown()` begins. Includes the Claude-compatible shutdown reason.

--- a/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-system-prompt.test.ts
@@ -317,4 +317,36 @@ describe('Session — system prompt delivery', () => {
       expect.objectContaining({ delta: 'world' }),
     );
   });
+
+  it('logs execution boundary events emitted by the core run loop', async () => {
+    const logger = { log: vi.fn() };
+
+    mockRunResult = 'done';
+    const session = new Session({
+      tools: MOCK_TOOLS as never,
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'System prompt',
+      terminal: MOCK_TERMINAL,
+      sessionLogger: logger,
+    });
+
+    await session.run('hello');
+
+    const options = mockRunOptions[0] as {
+      onExecutionEvent?: (event: string, data: Record<string, string>) => void;
+    };
+    options.onExecutionEvent?.('provider_response_normalized', {
+      executionId: 'exec-1',
+      round: '1',
+    });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.any(String),
+      'provider_response_normalized',
+      expect.objectContaining({
+        executionId: 'exec-1',
+        round: '1',
+      }),
+    );
+  });
 });

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -126,6 +126,7 @@ export async function executeRun(
     response = await ctx.robota.run(enrichedMessage, {
       signal: abortSignal,
       maxExecutionRounds: ctx.maxTurns ?? 0,
+      onExecutionEvent: (event, data) => ctx.log(event, data as TSessionLogData),
       ...(onTextDelta && { onTextDelta }),
     });
 


### PR DESCRIPTION
## Summary
- promote the two backlog items into active task docs with test plans and progress notes
- add execution-boundary session events from agent-core into agent-sessions logs
- add batch jobs support to the Agent tool so explicit parallel requests can start all jobs before waiting

## Verification
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check
- pre-push scoped verification passed for agent-core, agent-sdk, and agent-sessions