### PR TITLE
docs: refresh 48-hour release notes and package READMEs

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -99,6 +99,7 @@ robota -p "Explain this project"    # Print mode
 - **Type-Safe**: Strict TypeScript with zero `any` in production code
 - **Multi-Provider**: Anthropic Claude, OpenAI, Google — same API, seamless switching
 - **Tool Calling**: Zod-based schema validation for type-safe function calls
+- **Subagents**: Runtime-managed background jobs, transcripts, and batch Agent tool requests
 - **Plugin System**: Extensible lifecycle hooks for logging, analytics, error handling
 - **Streaming**: Real-time text delta streaming from all providers
 - **CLI Ready**: Built-in coding assistant CLI with permission system and context management
@@ -107,6 +108,7 @@ robota -p "Explain this project"    # Print mode
 
 ```
 agent-cli              ← Interactive terminal AI coding assistant
+agent-command-agent    ← /agent command module for background subagent control
 agent-transport-http   ← HTTP transport (Hono; Cloudflare Workers / Node.js / Lambda)
 agent-transport-mcp    ← MCP transport (Model Context Protocol server)
 agent-transport-ws     ← WebSocket transport (framework-agnostic)
@@ -114,8 +116,9 @@ agent-transport-ws     ← WebSocket transport (framework-agnostic)
 agent-sdk              ← Assembly layer: InteractiveSession, config, context, query()
   ↓
 agent-sessions         ← Session lifecycle: permissions, hooks, compaction
+agent-runtime          ← Background task and subagent lifecycle primitives
 agent-tools            ← Tool infrastructure + 8 built-in tools
-agent-provider-*       ← AI provider implementations (anthropic, openai, google)
+agent-provider-*       ← AI provider implementations (anthropic, openai, gemini, gemma, qwen)
   ↓ (all three depend on)
 agent-core             ← Foundation: Robota engine, abstractions, plugins
 ```
@@ -127,8 +130,12 @@ agent-core             ← Foundation: Robota engine, abstractions, plugins
 | [`@robota-sdk/agent-core`](./packages/agent-core/)                             | Core agent runtime, abstractions, and plugin system                    |
 | [`@robota-sdk/agent-tools`](./packages/agent-tools/)                           | Tool registry, FunctionTool, and 8 built-in tools                      |
 | [`@robota-sdk/agent-sessions`](./packages/agent-sessions/)                     | Session with permissions, hooks, and compaction                        |
+| [`@robota-sdk/agent-runtime`](./packages/agent-runtime/)                       | Background task and subagent lifecycle primitives                      |
 | [`@robota-sdk/agent-sdk`](./packages/agent-sdk/)                               | Assembly layer with config/context loading and query()                 |
 | [`@robota-sdk/agent-provider-anthropic`](./packages/agent-provider-anthropic/) | Anthropic Claude provider                                              |
+| [`@robota-sdk/agent-provider-gemini`](./packages/agent-provider-gemini/)       | Canonical Google Gemini provider                                       |
+| [`@robota-sdk/agent-provider-gemma`](./packages/agent-provider-gemma/)         | Gemma-family local provider for LM Studio/OpenAI-compatible endpoints  |
+| [`@robota-sdk/agent-provider-qwen`](./packages/agent-provider-qwen/)           | Qwen/DashScope provider with optional provider-side web tools          |
 | [`@robota-sdk/agent-cli`](./packages/agent-cli/)                               | Interactive terminal AI coding assistant                               |
 | [`@robota-sdk/agent-transport-http`](./packages/agent-transport-http/)         | HTTP/REST transport adapter (Hono; Cloudflare Workers / Node / Lambda) |
 | [`@robota-sdk/agent-transport-mcp`](./packages/agent-transport-mcp/)           | MCP transport adapter (Model Context Protocol server)                  |
@@ -139,6 +146,7 @@ agent-core             ← Foundation: Robota engine, abstractions, plugins
 
 - [Getting Started](./getting-started/) — Installation and first steps
 - [Guide](./guide/) — Architecture, building agents, SDK, CLI
+- [Release Notes: 2026-05-02](./guide/release-2026-05-02.md) — Latest 48-hour develop snapshot
 - [Examples](./examples/) — Working code samples
 - [Development](./development/) — Contributing and monorepo setup
 

--- a/content/guide/README.md
+++ b/content/guide/README.md
@@ -6,5 +6,6 @@
 - [Building Agents](./building-agents.md) — Creating agents with agent-core: providers, tools, plugins, streaming
 - [Using the SDK](./sdk.md) — Config loading, context discovery, sessions, and query()
 - [CLI Reference](./cli.md) — Interactive TUI, slash commands, permission modes
+- [Release Notes: 2026-05-02](./release-2026-05-02.md) — 48-hour develop snapshot covering agents, CLI, providers, and replay work
 - [Permissions and Hooks](./permissions-and-hooks.md) — Security model and lifecycle hooks
 - [Context Management](./context-management.md) — Token tracking, compaction, and streaming

--- a/content/guide/architecture.md
+++ b/content/guide/architecture.md
@@ -6,6 +6,7 @@ Robota SDK follows a strict bottom-up layered assembly model. Each layer builds 
 
 ```
 agent-cli                ← TUI layer: Ink TUI, useInteractiveSession hook, permission prompts
+agent-command-agent      ← Optional /agent command module for subagent job control
 agent-transport-http     ← HTTP transport: Hono-based REST adapter (Cloudflare Workers / Node.js / Lambda)
 agent-transport-mcp      ← MCP transport: Model Context Protocol server adapter
 agent-transport-ws       ← WebSocket transport: framework-agnostic real-time adapter
@@ -13,11 +14,12 @@ agent-transport-headless ← Headless transport: non-interactive execution with 
   ↓ (all five consume)
 agent-sdk                ← Assembly layer: InteractiveSession, SystemCommandExecutor,
   │                          CommandRegistry, BuiltinCommandSource, SkillCommandSource,
-  │                          config, context, session factory, query()
+  │                          config, context, session factory, query(), Agent tool
   ↓
-agent-sessions    ← Session lifecycle: permissions, hooks, compaction, persistence
+agent-sessions    ← Session lifecycle: permissions, hooks, compaction, persistence, replay events
+agent-runtime     ← Background task and subagent lifecycle primitives
 agent-tools       ← Tool infrastructure + 8 built-in CLI tools
-agent-providers   ← AI provider implementations (Anthropic, OpenAI-compatible, Google)
+agent-providers   ← AI provider implementations (Anthropic, OpenAI, Gemini, Gemma, Qwen)
   ↓
 agent-core        ← Foundation: Robota engine, abstractions, DI, events, plugins
 ```
@@ -29,7 +31,9 @@ agent-core        ← Foundation: Robota engine, abstractions, DI, events, plugi
 | **agent-core**               | Robota engine, execution loop, provider abstraction, permissions, hooks, plugin system, model definitions (SSOT)                                           | Foundation   |
 | **agent-tools**              | ToolRegistry, FunctionTool, createZodFunctionTool, 8 built-in CLI tools                                                                                    | General      |
 | **agent-sessions**           | Session class with permission enforcement, context tracking, compaction                                                                                    | General      |
+| **agent-runtime**            | Background task state machines, subagent manager contracts, task snapshots, watchdogs, transcript references                                               | General      |
 | **agent-providers**          | Provider packages for Anthropic, OpenAI/OpenAI-compatible model families, Qwen, Google, and future integrations                                            | General      |
+| **agent-command-agent**      | Optional `/agent` command module for user-invoked subagent job control                                                                                     | SDK-specific |
 | **agent-sdk**                | Assembly: InteractiveSession, SystemCommandExecutor, CommandRegistry, BuiltinCommandSource, SkillCommandSource, config loading, context discovery, query() | SDK-specific |
 | **agent-cli**                | Ink TUI: useInteractiveSession hook bridges SDK events → React state, permission prompts                                                                   | Transport    |
 | **agent-transport-http**     | Hono-based HTTP/REST adapter — exposes InteractiveSession over HTTP (Cloudflare Workers, Node.js, AWS Lambda)                                              | Transport    |
@@ -42,10 +46,11 @@ agent-core        ← Foundation: Robota engine, abstractions, DI, events, plugi
 
 ```
 agent-cli              ─→ agent-sdk ─→ agent-sessions ─→ agent-core
+agent-command-agent    ─→ agent-runtime
 agent-transport-http   ─→ agent-sdk    ├─→ agent-tools ────────────→ agent-core
-agent-transport-mcp    ─→ agent-sdk    ├─→ agent-provider-anthropic → agent-core
-agent-transport-ws     ─→ agent-sdk    └─────────────────────────→ agent-core
-agent-transport-headless ─→ agent-sdk
+agent-transport-mcp    ─→ agent-sdk    ├─→ agent-runtime
+agent-transport-ws     ─→ agent-sdk    ├─→ agent-provider-anthropic → agent-core
+agent-transport-headless ─→ agent-sdk  └─────────────────────────→ agent-core
 agent-remote-client                    (HTTP client, no agent-sdk dependency)
 ```
 
@@ -54,6 +59,8 @@ agent-remote-client                    (HTTP client, no agent-sdk dependency)
 `InteractiveSession` maintains history as `IHistoryEntry[]` — a universal timeline that includes both chat messages (user/assistant turns) and session events (tool calls, system events, status changes). This is the single source of truth for display and persistence.
 
 Background tasks are tracked alongside the session through runtime snapshots and append-only JSONL event/transcript streams. High-frequency streaming output is stored in logs/transcripts, while session JSON stores resumable task state and references.
+
+Session logs also receive provider/tool execution boundary events from `agent-core`: provider request envelopes, normalized provider responses, assistant commits, tool batch starts, tool execution requests, and tool execution results. These events are a replay-provenance layer, not yet the full deterministic `/resume` replay engine.
 
 ```
 User input

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -105,11 +105,23 @@ The TUI (built with React + Ink) provides:
 
 - **Message list** — Conversation history with markdown rendering
 - **Input area** — Text input with slash command autocomplete
-- **Status bar** — Permission mode, model, context usage %, message count
+- **Status bar** — Permission mode, model, context usage %, message count, and activity state
 - **Permission prompts** — Arrow-key Allow/Deny selection for tool calls
 - **Streaming** — Real-time text output as the model responds
+- **Usage summaries** — Provider usage and cost metadata when available
+- **Background work tree** — Running and completed background jobs grouped for quick scanning
 - **ESC abort** — Press ESC during streaming to cancel. Partial response is saved with interrupted state
 - **History SSOT** — Renders from `IHistoryEntry[]` — the universal timeline of chat messages and session events
+
+### Recent TUI Behavior
+
+The CLI is intentionally a thin TUI over SDK-owned session state. Recent updates focus on making long agentic runs readable:
+
+- Command output transcripts collapse automatically so long shell output does not dominate the conversation.
+- Edit tool results render as context hunks with markdown-friendly diff blocks.
+- Provider usage summaries appear in the primary scan path when token/cost metadata is present.
+- Background subagent work renders as tree rows with status activity instead of a flat list.
+- Print/headless mode skips startup update checks so scripted stdout/stderr remain deterministic.
 
 ### useInteractiveSession Hook
 
@@ -326,9 +338,13 @@ When the Edit tool completes, the CLI renders a `DiffBlock` showing the change. 
 
 The AI can spawn subagents via the **Agent** tool to handle complex subtasks (e.g., exploring the codebase, planning multi-step changes). Subagents run in isolated sessions with their own tool access and inherit the parent session's hooks and permissions. Built-in agent types include `Explore`, `Plan`, and a general-purpose agent.
 
+For explicit multi-agent or parallel-agent requests, the model-visible Agent tool now supports a `jobs` array. A single batch tool call starts all valid jobs before waiting for terminal summaries and returns structured per-job results with a shared group identifier. The older single-job `prompt` shape remains supported.
+
 ## Session Logging
 
 Events are logged to `.robota/logs/{sessionId}.jsonl` in JSONL format. Events include `session_init`, `pre_run`, `text_delta`, `assistant`, `server_tool`, `context`, and `background_task_event`.
+
+The session log also records execution-boundary events emitted by the core run loop: `provider_request`, `provider_response_normalized`, `assistant_message_committed`, `tool_batch_started`, `tool_execution_request`, and `tool_execution_result`. These events are the first replay-grade provenance layer; raw provider payload storage and deterministic `/resume` reconstruction remain active follow-up work.
 
 Background subagents write append-only transcripts to `.robota/logs/{sessionId}/subagents/{agentId}.jsonl`. These transcripts include streaming deltas, tool calls/results, final output, and errors as they occur. The resumable `.robota/sessions/{sessionId}.json` file stores background task snapshots and transcript paths, not every token chunk.
 

--- a/content/guide/release-2026-05-02.md
+++ b/content/guide/release-2026-05-02.md
@@ -1,0 +1,141 @@
+# Release Notes: 48-Hour Develop Snapshot
+
+This document summarizes the final develop-branch state after the 48-hour work window ending on 2026-05-02. It covers the merged PR range from the subagent runtime work through session replay events and Agent batch jobs.
+
+## Scope
+
+- Time window: 2026-04-30 23:01 KST through 2026-05-02 22:40 KST
+- Develop range: `d2c351652^..ac996fac3`
+- PR range: #100 through #147
+- Published baseline inside the range: `3.0.0-beta.56`
+- Current develop head after the window: `ac996fac3`
+
+## Release Intent
+
+The work turns Robota from a basic interactive coding assistant into a more complete agent runtime:
+
+- Subagents are real background jobs with runtime-owned state, transcripts, watchdogs, and command surfaces.
+- The CLI is a TUI shell over SDK-owned session state, with richer status, usage, diff, and background-work displays.
+- Provider composition is now definition-driven, allowing Qwen, Gemma, Gemini, Anthropic, OpenAI, and OpenAI-compatible endpoints to be configured without CLI-specific branches.
+- Session logs now begin moving toward replay-grade provenance by recording provider/tool execution boundary events.
+- The Agent tool now has a deterministic batch path for explicit multi-agent and parallel-agent requests.
+- The repository harness now performs scoped verification and release-safety checks before push and publish.
+
+## Highlights
+
+### Agent Runtime and Subagents
+
+Merged PRs: #100, #101, #103, #106, #108, #122, #123, #124, #131, #132, #146, #147
+
+- Added `@robota-sdk/agent-runtime` as the shared owner of background task and subagent lifecycle contracts.
+- Added background agent jobs with real process/session execution rather than display-only placeholders.
+- Added subagent manager state, background task snapshots, transcripts, watchdogs, and terminal visibility rules.
+- Added command-level `/agent` orchestration through `@robota-sdk/agent-command-agent`.
+- Added active task context injection so agents can see current `.agents/tasks` work items in system prompt context.
+- Added self-hosting verification helpers for agent-driven development loops.
+- Added replay-grade session event plumbing for provider requests, normalized responses, assistant commits, tool batches, tool requests, and tool results.
+- Added deterministic batch `Agent` tool calls via `jobs`, so explicit parallel requests can spawn all valid jobs before waiting.
+
+### CLI and TUI
+
+Merged PRs: #102, #112, #114, #115, #118, #119, #120, #121, #126, #133, #136, #138, #139, #140, #141, #142, #143
+
+- Updated the CLI to Ink 7 and moved more interaction logic into tested TypeScript state managers and hooks.
+- Added provider setup UI generated from provider definitions.
+- Added npm update checks while keeping print/headless mode deterministic.
+- Added project memory commands and then routed memory through command descriptors instead of public automatic memory APIs.
+- Added status line settings, prompt history navigation, queue handling, and CJK input flow improvements.
+- Added markdown rendering for tool diff blocks and context hunk rendering for edit diffs.
+- Added provider usage summaries and status activity indicators.
+- Added tree-row display for background work and collapsed command-output transcripts for scannable long sessions.
+
+### Providers
+
+Merged PRs: #107, #110, #113, #117, #127, #128, #134, #135
+
+- Added Gemma provider transport for LM Studio/OpenAI-compatible local endpoints.
+- Added Gemma serving-template projection for reasoning markers and native tool-call text.
+- Added Qwen provider support through Alibaba Cloud Model Studio/DashScope.
+- Added Qwen provider-side web tools via Responses API `web_search` and `web_extractor`.
+- Modernized Gemini transport on `@google/genai`.
+- Added canonical `@robota-sdk/agent-provider-gemini`; `agent-provider-google` remains a compatibility wrapper.
+- Clarified OpenAI-compatible transport boundaries so model-family behavior lives in provider packages.
+- Kept provider setup branch-free through provider definition metadata.
+
+### SDK, Sessions, Memory, and Checkpoints
+
+Merged PRs: #129, #130, #132, #134, #135, #146, #147
+
+- Added automatic memory capture/retrieval internals, then narrowed the public surface so memory is controlled through command descriptors.
+- Added edit checkpointing and rewind support for safer file-edit workflows.
+- Added context injection from active task files.
+- Added session-log evidence for execution boundaries through `onExecutionEvent`.
+- Added batch `Agent` tool schema and structured per-job results with `groupId`, `agentIds`, ordered job output, and partial failure reporting.
+- Kept unresolved replay work explicit: raw provider payloads/chunks, payload references, redaction policy, deterministic `/resume` replay, history mutation events, and validator commands remain active task scope.
+
+### Harness, Release, and Governance
+
+Merged PRs: #111, #116, #137, #145
+
+- Added scoped verification planning and pre-push verification hooks.
+- Added package coverage commands.
+- Added release dist freshness scanning that builds before checking dist output.
+- Added backlog tracking for provider usage visibility and later session replay/parallel-agent reliability work.
+- Added learning-loop and operational rule updates so repeated failures become repository guidance.
+
+## User-Facing Changes
+
+### CLI
+
+- `robota --check-update` checks npm for newer CLI versions.
+- `robota --disable-update-check` skips interactive startup update checks for one run.
+- `robota -p` remains deterministic and does not perform startup update checks.
+- Provider setup is now driven by provider definitions, including Anthropic, OpenAI-compatible, Gemma, and Qwen in the default CLI build.
+- TUI output now gives clearer edit diffs, provider usage summaries, command-output collapse, background job tree rows, and status activity.
+- Slash-command behavior is increasingly SDK-owned; the CLI renders and routes commands rather than owning session logic.
+
+### SDK
+
+- `InteractiveSession` remains the primary assembly API for interactive clients.
+- Agent definitions and active tasks are included in prompt composition when enabled.
+- System commands, skills, memory, checkpointing, and background jobs are SDK-level capabilities that CLI and transports can consume.
+- `Agent` tool supports `jobs` for batch subagent execution.
+- Session logs include more execution-boundary events, but full deterministic replay is still an active task.
+
+### Providers
+
+- Use `@robota-sdk/agent-provider-gemini` for Gemini API work.
+- Use `@robota-sdk/agent-provider-google` only as a compatibility wrapper.
+- Use `@robota-sdk/agent-provider-gemma` for Gemma-family local models served through LM Studio/OpenAI-compatible endpoints.
+- Use `@robota-sdk/agent-provider-qwen` for DashScope/Qwen, including optional provider-side web search/fetch.
+- Use `@robota-sdk/agent-provider-openai-compatible` as reusable transport infrastructure, not as the model-family owner.
+
+## Compatibility Notes
+
+- The provider profile type for Gemini is `gemini`; `google` remains accepted as an alias during migration.
+- Qwen provider-side web tools are separate from Robota local tools and do not bypass local permission checks.
+- Gemma local models should use the Gemma provider rather than the generic OpenAI provider so reasoning markers and native tool-call text are projected correctly.
+- The Agent tool remains backwards-compatible with single-job `prompt` calls; batch jobs are additive.
+- Existing session JSON snapshots still exist, but replay-grade restoration is not complete until raw payload storage and replay validation are implemented.
+
+## Verification Notes
+
+The final PR in this window passed scoped pre-push verification for:
+
+- `packages/agent-core`: build, test, lint, typecheck, scenario verification
+- `packages/agent-sdk`: build, test, lint, typecheck
+- `packages/agent-sessions`: build, test, lint, typecheck, scenario verification
+
+Release-grade verification remains explicit:
+
+```bash
+pnpm harness:verify:release
+```
+
+## Follow-Up Work
+
+- Complete deterministic `/resume` replay from append-only event logs.
+- Add raw provider response/chunk logging with redaction and payload-reference policy.
+- Add replay validators for unmatched tool calls/results and non-replayable payload references.
+- Add four-agent batch scenario coverage and final-response claim validation.
+- Continue converging `/agent parallel` and model-invoked `Agent({ jobs })` behavior.

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -207,6 +207,8 @@ const systemMessage = buildSystemPrompt({
 | **Session naming**         | `getName()` / `setName()` for human-friendly session identification                                                                                                        |
 | **Abort**                  | `session.abort()` cancels via AbortSignal. Partial response committed as `'interrupted'`                                                                                   |
 | **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                                           |
+| **Background work**        | Subagent jobs are tracked through runtime-owned task state, transcripts, and background task events                                                                        |
+| **Replay events**          | Session runs forward core provider/tool boundary events into append-only JSONL logs                                                                                        |
 
 ## Subagent Sessions
 
@@ -223,6 +225,21 @@ const subSession = createSubagentSession({
 
 const result = await subSession.run();
 ```
+
+### Agent Tool Batch Jobs
+
+The model-visible `Agent` tool supports both the existing single-job shape and a batch `jobs` shape for explicit parallel requests:
+
+```typescript
+{
+  jobs: [
+    { prompt: 'Review the API contract', subagent_type: 'Plan' },
+    { prompt: 'Inspect implementation risks', subagent_type: 'Explore' },
+  ],
+}
+```
+
+When `jobs` is present, the Agent tool starts every valid job before waiting for results. The returned JSON includes `success`, `groupId`, `agentIds`, and ordered per-job results. This gives the runtime a deterministic path for requests such as "run two agents in parallel" even when the model emits only one tool call.
 
 ### Tool Filtering
 
@@ -263,6 +280,12 @@ The SDK appends a framework suffix to the subagent's system prompt to shape its 
 ### Subagent Transcript
 
 Subagent execution is logged to `{logsDir}/{parentSessionId}/subagents/{agentId}.jsonl` for debugging and audit purposes. Streaming text deltas are appended to this transcript while the provider request is still running. The parent session JSON stores the background task snapshot and transcript path; it does not rewrite the whole session file for every token chunk.
+
+## Replay-Grade Session Events
+
+`Session.run()` now forwards core execution events through the session logger. Current events include provider request envelopes, normalized provider responses, assistant message commits, tool batch starts, tool execution requests, and tool execution results.
+
+These events are append-only provenance for debugging and future `/resume` replay. Full deterministic replay still requires raw provider response/chunk storage, payload reference handling, redaction rules, history mutation events, and a replay validator.
 
 ## Always-Streaming Policy
 

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -2,8 +2,6 @@
 
 AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for project context and provides a tool-calling REPL with Claude Code-compatible permission modes.
 
-**Version**: 3.0.0-beta.40
-
 ## Installation
 
 Requires Node.js 22+.
@@ -148,6 +146,15 @@ The AI agent can invoke 6 tools:
 | `Edit`  | Replace a string in a file           | `filePath`       |
 | `Glob`  | Find files matching a pattern        | `pattern`        |
 | `Grep`  | Search file contents with regex      | `pattern`        |
+
+## Recent TUI Capabilities
+
+- Provider setup is generated from provider definitions, so the default CLI build can configure Anthropic, OpenAI-compatible, Gemma, and Qwen profiles without provider-specific UI branches.
+- Interactive startup can check npm for newer CLI versions; print/headless mode skips startup update checks to keep scripted output deterministic.
+- Long-running sessions show provider usage summaries, status activity, background job tree rows, and collapsed command-output transcripts.
+- Edit results render as context hunks with markdown-friendly diff blocks.
+- Background subagents are real runtime jobs with transcripts and resumable task snapshots.
+- Explicit multi-agent requests can use the Agent tool `jobs` batch path through the SDK runtime.
 
 ## Permission System
 

--- a/packages/agent-command-agent/README.md
+++ b/packages/agent-command-agent/README.md
@@ -3,3 +3,14 @@
 Composable `/agent` command module for Robota sessions.
 
 This package contributes command metadata and execution for agent job control. It is intentionally outside `@robota-sdk/agent-sdk` so SDK consumers can choose whether to compose the command.
+
+## Scope
+
+- Parses `/agent` command input into job-control operations.
+- Provides command metadata for SDK/CLI command registries.
+- Delegates lifecycle work to runtime/SDK subagent managers instead of owning process execution directly.
+- Complements the model-visible Agent tool: slash commands are user-invoked control flow, while `Agent({ jobs })` is the deterministic model-invoked batch path for explicit parallel requests.
+
+## Typical Composition
+
+`@robota-sdk/agent-sdk` can compose this module into an `InteractiveSession` command registry. The CLI renders it like any other SDK command and does not need package-specific command ownership.

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -45,6 +45,7 @@ console.log(response);
 - **Model definitions**: Central `CLAUDE_MODELS` registry with context windows, output limits, and human-readable names
 - **callProviderWithCache**: Accepts `Partial<IChatOptions>` overrides for per-call configuration
 - **AbortSignal propagation**: Signal flows through the entire execution chain (Session -> Robota -> Provider)
+- **Execution boundary events**: `Robota.run()` can emit provider/tool provenance events through `onExecutionEvent`
 - **Type safety**: Strict TypeScript, zero `any` in production code
 
 ## Robota API
@@ -62,6 +63,19 @@ agent.clearHistory();
 // Switch provider/model mid-conversation
 agent.setModel({ provider: 'openai', model: 'gpt-4o' });
 ```
+
+### Execution Boundary Events
+
+`run()` accepts `onExecutionEvent` in run options. The execution loop emits provider-neutral events that higher layers can persist as append-only session provenance:
+
+- `provider_request`
+- `provider_response_normalized`
+- `assistant_message_committed`
+- `tool_batch_started`
+- `tool_execution_request`
+- `tool_execution_result`
+
+Raw provider payload/chunk storage remains provider/session logging follow-up work so `agent-core` does not gain provider-specific branches.
 
 ## IAgentConfig
 

--- a/packages/agent-plugin-conversation-history/README.md
+++ b/packages/agent-plugin-conversation-history/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-conversation-history
+
+Conversation history plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-error-handling/README.md
+++ b/packages/agent-plugin-error-handling/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-error-handling
+
+Error handling plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-event-emitter/README.md
+++ b/packages/agent-plugin-event-emitter/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-event-emitter
+
+Event emitter plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-execution-analytics/README.md
+++ b/packages/agent-plugin-execution-analytics/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-execution-analytics
+
+Execution analytics plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-limits/README.md
+++ b/packages/agent-plugin-limits/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-limits
+
+Execution limits plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-logging/README.md
+++ b/packages/agent-plugin-logging/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-logging
+
+Logging plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-performance/README.md
+++ b/packages/agent-plugin-performance/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-performance
+
+Performance plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-usage/README.md
+++ b/packages/agent-plugin-usage/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-usage
+
+Usage tracking plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-plugin-webhook/README.md
+++ b/packages/agent-plugin-webhook/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-plugin-webhook
+
+Webhook plugin package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-provider-anthropic/README.md
+++ b/packages/agent-provider-anthropic/README.md
@@ -64,6 +64,10 @@ provider.onServerToolUse = (name, input) => {
 
 Tool calls are handled automatically by the Robota execution loop. The provider converts between the universal message format and Anthropic's `input_schema`-based tool format.
 
+### Provider Definition
+
+`createAnthropicProviderDefinition()` exposes setup metadata for branch-free CLI and SDK provider composition. Consumers can configure Anthropic alongside OpenAI-compatible, Gemma, Qwen, and Gemini providers without adding Anthropic-specific UI branches.
+
 ## Configuration
 
 ```typescript

--- a/packages/agent-provider-gemini/README.md
+++ b/packages/agent-provider-gemini/README.md
@@ -150,6 +150,10 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 Google's current documentation recommends `@google/genai` for new Gemini API work. This package uses `@google/genai` for direct Gemini transport while preserving the existing `GeminiProvider` public class and `google` compatibility alias.
 
+## Migration Note
+
+New code should use the `gemini` provider profile type and import from `@robota-sdk/agent-provider-gemini`. The legacy `@robota-sdk/agent-provider-google` package remains a compatibility wrapper for existing imports and settings that still reference `google`.
+
 ## License
 
 MIT

--- a/packages/agent-provider-gemma/README.md
+++ b/packages/agent-provider-gemma/README.md
@@ -6,4 +6,18 @@ This provider is separate from Gemini API support. Gemini API behavior belongs t
 
 The provider owns Gemma/LM Studio serving-template projection. It filters Gemma reasoning-channel markers from user-visible text and converts documented native tool-call text emitted by the Gemma/LM Studio template into Robota universal `toolCalls` when the referenced tool was declared in the request.
 
+## Usage
+
+```ts
+import { GemmaProvider } from '@robota-sdk/agent-provider-gemma';
+
+const provider = new GemmaProvider({
+  apiKey: 'lm-studio',
+  baseURL: 'http://localhost:1234/v1',
+  defaultModel: 'gemma-local-model',
+});
+```
+
+Use this package instead of the generic OpenAI provider for Gemma-family local models. The Gemma provider owns reasoning marker filtering and native tool-call text projection; the shared OpenAI-compatible transport does not infer model-family syntax.
+
 See [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-provider-google/README.md
+++ b/packages/agent-provider-google/README.md
@@ -13,3 +13,9 @@ const provider = new GoogleProvider({
 ```
 
 The provider profile type remains `gemini`; existing settings that use `type: "google"` continue through the provider-definition alias.
+
+## Migration Guidance
+
+- Prefer `@robota-sdk/agent-provider-gemini` for all new code.
+- Keep this package only for existing `GoogleProvider` imports during the migration window.
+- Use `type: "gemini"` in new provider profiles; `type: "google"` remains accepted as an alias.

--- a/packages/agent-provider-openai-compatible/README.md
+++ b/packages/agent-provider-openai-compatible/README.md
@@ -6,4 +6,13 @@ This package is a building block. End-user provider packages such as `agent-prov
 
 Provider packages may inject text projectors for documented model-family output, including native tool-call text projection. This package only calls injected strategies and does not infer model names, prompt directives, or provider-specific syntax.
 
+## Boundary
+
+- Owns shared OpenAI-compatible Chat Completions request/response and stream assembly utilities.
+- Does not own product-specific setup defaults, model-family prompt directives, or provider profile metadata.
+- Does not infer Gemma, Qwen, OpenAI, or local-model behavior from model names.
+- Allows provider packages to inject explicit projection strategies when a model family documents native text forms for tool calls or reasoning channels.
+
+End-user code usually imports a concrete provider package such as `agent-provider-openai`, `agent-provider-gemma`, or `agent-provider-qwen`.
+
 See [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-provider-openai/README.md
+++ b/packages/agent-provider-openai/README.md
@@ -77,6 +77,8 @@ Gemma-family local models should use `@robota-sdk/agent-provider-gemma` instead 
 OpenAI provider so Gemma chat-template channel markers are projected out of user-facing
 streamed text.
 
+For provider packages that share OpenAI-compatible transport code, the reusable primitives live in `@robota-sdk/agent-provider-openai-compatible`. This package owns OpenAI product semantics and generic OpenAI-compatible endpoint usage; model-family behavior such as Gemma reasoning/tool-call projection belongs in that model-family provider.
+
 ### Streaming Responses
 
 ```typescript

--- a/packages/agent-provider-qwen/README.md
+++ b/packages/agent-provider-qwen/README.md
@@ -30,6 +30,10 @@ const provider = new QwenProvider({
 
 When `webFetch` is enabled, the provider sends both `web_search` and `web_extractor` to Qwen Responses API and records provider-side tool provenance in assistant-message metadata. These provider-side tools are separate from Robota local tools and do not bypass local tool permissions.
 
+## Provider Definition
+
+`createQwenProviderDefinition()` exposes setup metadata so CLI and SDK composition can configure Qwen profiles without adding Qwen-specific branches. The default CLI build can prompt for the DashScope API key, model, and base URL using this provider definition.
+
 CLI settings can pass Qwen-owned options through the generic provider profile `options` bag:
 
 ```json

--- a/packages/agent-runtime/README.md
+++ b/packages/agent-runtime/README.md
@@ -5,3 +5,14 @@ Composable runtime primitives for Robota background tasks and subagent orchestra
 This package owns lifecycle/state/port contracts that are reused by SDK assembly, transports, and runtime shells. It does not create providers, sessions, child processes, Git worktrees, or UI state directly.
 
 Background task handles may expose `logPath` and `transcriptPath` for append-only diagnostic streams. The runtime projects those paths into task state so SDK/CLI layers can persist resumable snapshots while high-frequency output stays in JSONL logs.
+
+## Current Responsibilities
+
+- Own background task state transitions, terminal status, watchdog behavior, and task snapshots.
+- Own subagent manager contracts used by SDK Agent tool execution and CLI background work display.
+- Keep process execution, provider calls, Git worktree I/O, and UI rendering outside the runtime boundary.
+- Surface `logPath` and `transcriptPath` so session records can store resumable references while logs remain append-only.
+
+## Subagent Orchestration
+
+The SDK composes these runtime primitives to spawn subagent jobs for the model-visible Agent tool and `/agent` command flows. A parent session can track running, completed, failed, and timed-out work without coupling the runtime to React, Ink, provider SDKs, or filesystem-specific worktree code.

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -4,8 +4,6 @@ Programmatic SDK for building AI agents with Robota. Provides `InteractiveSessio
 
 This is the **assembly layer** of the Robota ecosystem — it composes lower-level packages (`agent-core`, `agent-tools`, `agent-sessions`, `agent-provider-anthropic`) into a cohesive SDK.
 
-**Version**: 3.0.0-beta.33
-
 ## Installation
 
 ```bash
@@ -46,6 +44,11 @@ const response = await query('Analyze the code', {
 - **Context Loading** — AGENTS.md / CLAUDE.md walk-up discovery and system prompt assembly
 - **Config Loading** — 6-file settings merge with provider profiles, legacy provider compatibility, and `$ENV:VAR` substitution for provider API keys
 - **Context Window Management** — Token tracking, auto-compaction at ~83.5%, manual `session.compact()`
+- **Background Jobs** — Runtime-managed subagent tasks with transcripts and task snapshots
+- **Agent Batch Jobs** — `Agent({ jobs: [...] })` starts explicit parallel subagent requests deterministically
+- **Edit Checkpoints** — Checkpoint/rewind support for safer edit workflows
+- **Project Memory** — Command-driven memory capture and retrieval surfaces
+- **Replay Events** — Session execution can forward provider/tool boundary events into append-only logs
 - **Bundle Plugin System** — Install and manage reusable extensions packaged as bundle plugins
 
 ## Architecture
@@ -56,6 +59,8 @@ agent-sdk (assembly layer)
   │     └── Session       ← generic session (agent-sessions)
   ├── SystemCommandExecutor ← SDK-level command execution
   ├── CommandRegistry / BuiltinCommandSource / SkillCommandSource
+  ├── Agent tool batch jobs and background orchestration
+  ├── Edit checkpoints and command-driven memory
   ├── query()             ← one-shot entry point
   ├── createSession()     ← assembly factory
   └── deps:

--- a/packages/agent-sessions/README.md
+++ b/packages/agent-sessions/README.md
@@ -42,6 +42,7 @@ await session.compact('Focus on the API changes');
 | **Persistence**            | `SessionStore` for JSON file-based session save/load                                                   |
 | **Abort**                  | Cancel via `session.abort()` — propagates AbortSignal to `robota.run()`, throws `AbortError` to caller |
 | **Session logging**        | `FileSessionLogger` writes JSONL event logs                                                            |
+| **Replay events**          | Provider/tool execution boundary events are forwarded from core into append-only session logs          |
 
 ## Key Methods
 
@@ -102,6 +103,19 @@ Note: `IPermissionEnforcerOptions` is an internal type and is not exported from 
 `ISessionRecord` includes a required `history` field (`IHistoryEntry[]`) that stores the full conversation timeline for session persistence, resume, and fork operations. It may also include `backgroundTasks` and `backgroundTaskEvents` so background work can be restored and debugged alongside the conversation. When a session is resumed, history entries are replayed via `Session.injectMessage()`.
 
 Streaming text deltas are written to append-only JSONL session logs as `text_delta` events. Consumers should store high-frequency streaming chunks in JSONL logs/transcripts and keep session JSON focused on resumable snapshots and references.
+
+### Replay-Oriented JSONL Events
+
+`Session.run()` forwards core execution events into the session logger through `onExecutionEvent`. Current events include:
+
+- `provider_request`
+- `provider_response_normalized`
+- `assistant_message_committed`
+- `tool_batch_started`
+- `tool_execution_request`
+- `tool_execution_result`
+
+These events provide provenance for debugging and future deterministic `/resume` replay. Full replay still requires raw provider payload/chunk storage, redaction rules, content-addressed payload references, history mutation events, and validator tooling.
 
 A migration script is available for upgrading session records from older formats. See the package source for details.
 

--- a/packages/agent-team/README.md
+++ b/packages/agent-team/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-team
+
+Team collaboration package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-tool-mcp/README.md
+++ b/packages/agent-tool-mcp/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/agent-tool-mcp
+
+MCP tool integration package for Robota.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -57,6 +57,10 @@ const agent = new Robota({
 | `webFetchTool`  | WebFetch  | Fetch URL content (HTML-to-text conversion)      |
 | `webSearchTool` | WebSearch | Web search via Brave Search API                  |
 
+## Edit and Write Safety
+
+Recent file tool updates keep write/edit behavior atomic and make Edit tool results easier for higher layers to display. The Edit tool returns line metadata for changed regions, allowing the CLI to render concise context hunks instead of dumping full files or opaque summaries.
+
 ## Tool Infrastructure
 
 | Export                  | Description                                            |

--- a/packages/agent-transport-headless/README.md
+++ b/packages/agent-transport-headless/README.md
@@ -10,7 +10,7 @@ npm install @robota-sdk/agent-transport-headless
 
 ## Usage
 
-The headless runner is invoked via the CLI's print mode flag (`-p`). Three output formats are supported:
+The headless runner is invoked via the CLI's print mode flag (`-p`). It does not perform interactive startup update checks, so stdout/stderr remain deterministic for scripts and CI jobs. Three output formats are supported:
 
 ### Text (default)
 

--- a/packages/agent-transport-ws/README.md
+++ b/packages/agent-transport-ws/README.md
@@ -47,21 +47,22 @@ All messages are JSON-encoded objects with a `type` field.
 
 ### Server to Client (pushed events)
 
-| type             | payload                             | source                   |
-| ---------------- | ----------------------------------- | ------------------------ |
-| `text_delta`     | `{ delta: string }`                 | InteractiveSession event |
-| `tool_start`     | `{ state: IToolState }`             | InteractiveSession event |
-| `tool_end`       | `{ state: IToolState }`             | InteractiveSession event |
-| `thinking`       | `{ isThinking: boolean }`           | InteractiveSession event |
-| `complete`       | `{ result: IExecutionResult }`      | InteractiveSession event |
-| `interrupted`    | `{ result: IExecutionResult }`      | InteractiveSession event |
-| `error`          | `{ message: string }`               | InteractiveSession event |
-| `command_result` | `{ name, message, success, data? }` | command response         |
-| `messages`       | `{ messages: TUniversalMessage[] }` | get-messages response    |
-| `context`        | `{ state: IContextWindowState }`    | get-context response     |
-| `executing`      | `{ executing: boolean }`            | get-executing response   |
-| `pending`        | `{ pending: string\|null }`         | get-pending response     |
-| `protocol_error` | `{ message: string }`               | invalid client message   |
+| type                    | payload                             | source                                   |
+| ----------------------- | ----------------------------------- | ---------------------------------------- |
+| `text_delta`            | `{ delta: string }`                 | InteractiveSession event                 |
+| `tool_start`            | `{ state: IToolState }`             | InteractiveSession event                 |
+| `tool_end`              | `{ state: IToolState }`             | InteractiveSession event                 |
+| `background_task_event` | `{ event: TBackgroundTaskEvent }`   | InteractiveSession background task event |
+| `thinking`              | `{ isThinking: boolean }`           | InteractiveSession event                 |
+| `complete`              | `{ result: IExecutionResult }`      | InteractiveSession event                 |
+| `interrupted`           | `{ result: IExecutionResult }`      | InteractiveSession event                 |
+| `error`                 | `{ message: string }`               | InteractiveSession event                 |
+| `command_result`        | `{ name, message, success, data? }` | command response                         |
+| `messages`              | `{ messages: TUniversalMessage[] }` | get-messages response                    |
+| `context`               | `{ state: IContextWindowState }`    | get-context response                     |
+| `executing`             | `{ executing: boolean }`            | get-executing response                   |
+| `pending`               | `{ pending: string\|null }`         | get-pending response                     |
+| `protocol_error`        | `{ message: string }`               | invalid client message                   |
 
 ## ITransportAdapter
 
@@ -87,3 +88,7 @@ ws.on('close', () => transport.stop());
 
 - `@robota-sdk/agent-sdk` — `InteractiveSession`
 - No WebSocket library dependency (framework-agnostic)
+
+## Background Work
+
+When the attached `InteractiveSession` emits background task updates, the WebSocket transport forwards them as protocol messages so clients can render subagent jobs, transcript references, and terminal states without polling session JSON.

--- a/packages/dag-adapters-local/README.md
+++ b/packages/dag-adapters-local/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-adapters-local
+
+Local adapter package for DAG testing and development.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-api/README.md
+++ b/packages/dag-api/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-api
+
+DAG API contract package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-core/README.md
+++ b/packages/dag-core/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-core
+
+Core DAG domain contract package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-cost/README.md
+++ b/packages/dag-cost/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-cost
+
+DAG cost estimation package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-designer/README.md
+++ b/packages/dag-designer/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-designer
+
+DAG designer package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-node/README.md
+++ b/packages/dag-node/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-node
+
+DAG node authoring package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-nodes/README.md
+++ b/packages/dag-nodes/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-nodes
+
+DAG node implementations package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-orchestrator/README.md
+++ b/packages/dag-orchestrator/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-orchestrator
+
+DAG orchestration package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-projection/README.md
+++ b/packages/dag-projection/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-projection
+
+DAG projection/read-model package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-runtime/README.md
+++ b/packages/dag-runtime/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-runtime
+
+DAG runtime package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-scheduler/README.md
+++ b/packages/dag-scheduler/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-scheduler
+
+DAG scheduler package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.

--- a/packages/dag-worker/README.md
+++ b/packages/dag-worker/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/dag-worker
+
+DAG worker package.
+
+See [docs/README.md](docs/README.md) and [docs/SPEC.md](docs/SPEC.md) for the package contract.


### PR DESCRIPTION
## Summary
- add a 48-hour develop snapshot release note covering PRs #100-#147
- update guide pages for agents, CLI, providers, session replay events, and Agent batch jobs
- refresh package README coverage and add missing package-root READMEs so README validation passes

## Verification
- pnpm readme:validate
- pnpm docs:validate-structure
- pnpm docs:build
- pre-push scoped verification passed