### PR TITLE
[codex] Fix PR 144 CI and review comments

### DIFF
--- a/.changeset/preserve-atomic-write-mode.md
+++ b/.changeset/preserve-atomic-write-mode.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-tools': patch
+---
+
+Preserve existing target mode bits during atomic Write and Edit file replacements.

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -59,7 +59,7 @@ const agent = new Robota({
 
 ## Edit and Write Safety
 
-Recent file tool updates keep write/edit behavior atomic and make Edit tool results easier for higher layers to display. The Edit tool returns line metadata for changed regions, allowing the CLI to render concise context hunks instead of dumping full files or opaque summaries.
+Recent file tool updates keep write/edit behavior atomic and make Edit tool results easier for higher layers to display. Atomic replacements preserve existing target mode bits, so executable scripts remain executable after Write or Edit updates. The Edit tool returns line metadata for changed regions, allowing the CLI to render concise context hunks instead of dumping full files or opaque summaries.
 
 ## Tool Infrastructure
 

--- a/packages/agent-tools/docs/SPEC.md
+++ b/packages/agent-tools/docs/SPEC.md
@@ -93,7 +93,7 @@ Each built-in tool is an `IToolWithEventService`-compatible object with `getName
 
 **WriteTool output**: Reports actual UTF-8 byte count via `Buffer.byteLength(content, 'utf8')`, not JS `content.length` (which is character count and differs for multibyte content).
 
-**Atomic write semantics**: `Write` and `Edit` replace UTF-8 file content by writing to a temporary file in the same directory and then renaming it into place. The temporary file is removed after failed writes when possible. This keeps built-in filesystem mutations provider-agnostic while preventing partially written target files during self-hosting edit/build/verify loops.
+**Atomic write semantics**: `Write` and `Edit` replace UTF-8 file content by writing to a temporary file in the same directory and then renaming it into place. When replacing an existing target, the temporary file is assigned the target's existing mode bits before the rename so executable scripts and other permission-sensitive files keep their permissions. The temporary file is removed after failed writes when possible. This keeps built-in filesystem mutations provider-agnostic while preventing partially written target files during self-hosting edit/build/verify loops.
 
 ### TToolResult Shape
 
@@ -147,12 +147,12 @@ None. `FunctionTool` and `OpenAPITool` implement their respective interfaces dir
 
 ### Current Test Coverage
 
-| File                                      | Scope | Description                                          |
-| ----------------------------------------- | ----- | ---------------------------------------------------- |
-| `src/__tests__/atomic-file-write.test.ts` | Unit  | Atomic UTF-8 write replacement, cleanup, and handoff |
-| `src/__tests__/function-tool.test.ts`     | Unit  | FunctionTool creation, execution, schema validation  |
-| `src/__tests__/schema-converter.test.ts`  | Unit  | Zod-to-JSON-Schema conversion                        |
-| `src/__tests__/tool-registry.test.ts`     | Unit  | ToolRegistry registration, lookup, listing           |
+| File                                      | Scope | Description                                                             |
+| ----------------------------------------- | ----- | ----------------------------------------------------------------------- |
+| `src/__tests__/atomic-file-write.test.ts` | Unit  | Atomic UTF-8 write replacement, mode preservation, cleanup, and handoff |
+| `src/__tests__/function-tool.test.ts`     | Unit  | FunctionTool creation, execution, schema validation                     |
+| `src/__tests__/schema-converter.test.ts`  | Unit  | Zod-to-JSON-Schema conversion                                           |
+| `src/__tests__/tool-registry.test.ts`     | Unit  | ToolRegistry registration, lookup, listing                              |
 
 ### Gaps
 

--- a/packages/agent-tools/src/__tests__/atomic-file-write.test.ts
+++ b/packages/agent-tools/src/__tests__/atomic-file-write.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { execFile } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { mkdtemp, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -49,6 +57,19 @@ describe('atomicWriteUtf8File', () => {
 
     expect(readFileSync(filePath, 'utf8')).toBe('after');
     expect(await listRobotaTempFiles(dirname(filePath))).toEqual([]);
+  });
+
+  it('Given an executable target file When writing replacement content Then the target permissions are preserved', async () => {
+    const dir = await makeTempDir();
+    tempDirs.push(dir);
+    const filePath = join(dir, 'script.sh');
+    writeFileSync(filePath, '#!/bin/sh\necho before\n', 'utf8');
+    chmodSync(filePath, 0o755);
+
+    await atomicWriteUtf8File(filePath, '#!/bin/sh\necho after\n');
+
+    expect(readFileSync(filePath, 'utf8')).toBe('#!/bin/sh\necho after\n');
+    expect(statSync(filePath).mode & 0o777).toBe(0o755);
   });
 
   it('Given a target path that is a directory When replacement fails Then the directory remains and temp files are cleaned', async () => {

--- a/packages/agent-tools/src/builtins/atomic-file-write.ts
+++ b/packages/agent-tools/src/builtins/atomic-file-write.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from 'node:crypto';
-import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
 const TEMP_RANDOM_BYTES = 6;
+const PRESERVED_MODE_BITS = 0o7777;
+const MISSING_FILE_ERROR_CODE = 'ENOENT';
 
 function createTempFilePath(filePath: string): string {
   const dir = dirname(filePath);
@@ -11,13 +13,31 @@ function createTempFilePath(filePath: string): string {
   return join(dir, `.${name}.robota-tmp-${process.pid}-${Date.now()}-${suffix}`);
 }
 
+async function readExistingMode(filePath: string): Promise<number | undefined> {
+  try {
+    const fileStats = await stat(filePath);
+    return fileStats.mode & PRESERVED_MODE_BITS;
+  } catch (error) {
+    if (error instanceof Error && hasErrorCode(error, MISSING_FILE_ERROR_CODE)) return undefined;
+    throw error;
+  }
+}
+
+function hasErrorCode(error: Error, code: string): boolean {
+  return 'code' in error && error.code === code;
+}
+
 export async function atomicWriteUtf8File(filePath: string, content: string): Promise<void> {
   const dir = dirname(filePath);
   await mkdir(dir, { recursive: true });
 
+  const existingMode = await readExistingMode(filePath);
   const tempFilePath = createTempFilePath(filePath);
   try {
     await writeFile(tempFilePath, content, 'utf8');
+    if (existingMode !== undefined) {
+      await chmod(tempFilePath, existingMode);
+    }
     await rename(tempFilePath, filePath);
   } catch (error) {
     await rm(tempFilePath, { force: true }).catch(() => undefined);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,7 +577,7 @@ importers:
         specifier: workspace:*
         version: link:../agent-sdk
       '@robota-sdk/agent-sessions':
-        specifier: workspace:3.0.0-beta.56
+        specifier: workspace:3.0.0-beta.58
         version: link:../agent-sessions
       '@robota-sdk/agent-transport-headless':
         specifier: workspace:*
@@ -8850,12 +8850,12 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/utils': 6.21.0(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3
+      debug: 4.4.1
       eslint: 9.31.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.4
+      semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:


### PR DESCRIPTION
## What changed

- Updated `pnpm-lock.yaml` via `pnpm install` so the `@robota-sdk/agent-sessions` workspace specifier matches `3.0.0-beta.58`.
- Preserved existing target mode bits during atomic file replacement in `@robota-sdk/agent-tools`.
- Added regression coverage for executable file mode preservation.
- Updated `agent-tools` docs and added a changeset.

## Why

PR #144 was failing at `pnpm install --frozen-lockfile` because the lockfile still referenced `workspace:3.0.0-beta.56` for `@robota-sdk/agent-sessions` while the package manifest requires `workspace:3.0.0-beta.58`.

The active PR review also flagged that atomic writes replaced the target inode without preserving file permissions. The fix applies the existing target mode to the temporary file before rename, so scripts remain executable after Write/Edit operations.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run lint` (passes with existing warnings)
- `pnpm run test`
- `pnpm harness:verify:release`
- `pnpm docs:build`
- `pnpm --filter robota-blog build`
- `pnpm --filter @robota-sdk/agent-tools test -- atomic-file-write`
- `pnpm --filter @robota-sdk/agent-tools build`
- `pnpm --filter @robota-sdk/agent-tools test`
- `pnpm --filter @robota-sdk/agent-tools typecheck`
- `pnpm --filter @robota-sdk/agent-tools lint` (passes with existing warnings)
- `pnpm audit --audit-level high`
- Node 18 compat: `pnpm install --frozen-lockfile`, `pnpm run build:deps`, `pnpm --filter !@robota-sdk/agent-cli run test -- --coverage --coverage.thresholds.lines=80`

This PR targets `develop`; once merged, PR #144 (`develop` -> `main`) will pick up the CI and review fixes.