### PR TITLE
[codex] Use root monorepo build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,31 +10,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip duplicate build for main PR
+        if: github.base_ref == 'main'
+        run: echo "build is covered by release-grade verification"
+
       - uses: actions/checkout@v4
+        if: github.base_ref != 'main'
         with:
           fetch-depth: 50
 
       - name: Install pnpm
+        if: github.base_ref != 'main'
         uses: pnpm/action-setup@v2
         with:
           version: 8.15.4
 
       - name: Use Node.js 22.x
+        if: github.base_ref != 'main'
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: github.base_ref != 'main'
         run: pnpm install --frozen-lockfile
 
       - name: Fetch base branch
+        if: github.base_ref != 'main'
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Show verification plan
+        if: github.base_ref != 'main'
         run: pnpm harness:plan -- --base-ref origin/${{ github.base_ref }} --report-file .agents/evals/local-metrics/ci-plan.json
 
       - name: Upload verification plan
+        if: github.base_ref != 'main'
         uses: actions/upload-artifact@v4
         with:
           name: verification-plan
@@ -42,36 +53,69 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Build affected scopes
-        run: pnpm harness:verify -- --base-ref origin/${{ github.base_ref }} --skip-tests --skip-lint --skip-typecheck --skip-record-check --skip-repository-checks
+      - name: Detect build requirement
+        id: build_requirement
+        if: github.base_ref != 'main'
+        run: |
+          node --input-type=module <<'EOF'
+          import { appendFileSync, readFileSync } from 'node:fs';
+
+          const plan = JSON.parse(readFileSync('.agents/evals/local-metrics/ci-plan.json', 'utf8'));
+          const required = plan.scopes.some((scope) => scope.checks.includes('build'));
+          appendFileSync(process.env.GITHUB_OUTPUT, `required=${required ? 'true' : 'false'}\n`);
+
+          if (required) {
+            console.log('Package or app build checks require the root monorepo build.');
+          } else {
+            console.log('No package or app build checks required.');
+          }
+          EOF
+
+      - name: Build monorepo
+        if: github.base_ref != 'main' && steps.build_requirement.outputs.required == 'true'
+        run: pnpm build
+
+      - name: Skip monorepo build when no package build is required
+        if: github.base_ref != 'main' && steps.build_requirement.outputs.required != 'true'
+        run: echo "No package or app build checks required."
 
   quality:
     name: quality
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip duplicate quality checks for main PR
+        if: github.base_ref == 'main'
+        run: echo "quality is covered by release-grade verification"
+
       - uses: actions/checkout@v4
+        if: github.base_ref != 'main'
         with:
           fetch-depth: 50
 
       - name: Install pnpm
+        if: github.base_ref != 'main'
         uses: pnpm/action-setup@v2
         with:
           version: 8.15.4
 
       - name: Use Node.js 22.x
+        if: github.base_ref != 'main'
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: github.base_ref != 'main'
         run: pnpm install --frozen-lockfile
 
       - name: Fetch base branch
+        if: github.base_ref != 'main'
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Verify affected quality checks
+        if: github.base_ref != 'main'
         run: pnpm harness:verify -- --base-ref origin/${{ github.base_ref }} --skip-build --skip-record-check
 
   security-audit:
@@ -79,35 +123,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip duplicate audit for main PR
+        if: github.base_ref == 'main'
+        run: echo "security audit is covered by release-grade verification"
+
       - uses: actions/checkout@v4
+        if: github.base_ref != 'main'
         with:
           fetch-depth: 50
 
+      - name: Fetch base branch
+        if: github.base_ref != 'main'
+        run: git fetch origin ${{ github.base_ref }} --depth=50
+
+      - name: Detect dependency graph changes
+        id: dependency_changes
+        if: github.base_ref != 'main'
+        run: |
+          changed_files="$(git diff --name-only --diff-filter=ACMRD origin/${{ github.base_ref }}...HEAD)"
+          if printf '%s\n' "$changed_files" | grep -Eq '(^pnpm-lock.yaml$|(^|/)package.json$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No package manifest or lockfile changes; skipping pnpm audit."
+          fi
+
       - name: Install pnpm
+        if: github.base_ref != 'main' && steps.dependency_changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v2
         with:
           version: 8.15.4
 
       - name: Use Node.js 22.x
+        if: github.base_ref != 'main' && steps.dependency_changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: Install dependencies for audit
+        if: github.base_ref != 'main' && steps.dependency_changes.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }} --depth=50
-
       - name: Run audit only for dependency graph changes
-        run: |
-          changed_files="$(git diff --name-only --diff-filter=ACMRD origin/${{ github.base_ref }}...HEAD)"
-          if printf '%s\n' "$changed_files" | grep -Eq '(^pnpm-lock.yaml$|(^|/)package.json$)'; then
-            pnpm audit --audit-level high
-          else
-            echo "No package manifest or lockfile changes; skipping pnpm audit."
-          fi
+        if: github.base_ref != 'main' && steps.dependency_changes.outputs.changed == 'true'
+        run: pnpm audit --audit-level high
 
   release-grade-verify:
     name: release-grade verification

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -5,7 +5,6 @@ import {
   parseScopeArgs,
   classifyScopeChanges,
   classifyPackageManifestChange,
-  createWorkspaceDependencyBuildArgs,
   mapFilesToScopes,
   resolveBaseRef,
   resolveRequestedScopes,
@@ -95,25 +94,49 @@ describe('parseScopeArgs', () => {
 });
 
 // ---------------------------------------------------------------------------
-// createWorkspaceDependencyBuildArgs
+// CI build shape
 // ---------------------------------------------------------------------------
-describe('createWorkspaceDependencyBuildArgs', () => {
-  it('renders a pnpm dependency-only filter for clean scoped verification', () => {
-    const result = createWorkspaceDependencyBuildArgs({
-      workspaceName: '@robota-sdk/agent-cli',
-      workspaceDependencies: ['@robota-sdk/agent-command-agent'],
-    });
+describe('CI build workflow', () => {
+  it('runs the monorepo root build once instead of per-scope package builds', () => {
+    const content = readFileSync('.github/workflows/ci.yml', 'utf8');
 
-    expect(result).toEqual(['--filter', '@robota-sdk/agent-cli^...', '--if-present', 'build']);
+    expect(content).toContain('run: pnpm build');
+    expect(content).toContain('Detect build requirement');
+    expect(content).toContain("steps.build_requirement.outputs.required == 'true'");
+    expect(content).not.toContain('Build affected scopes');
+    expect(content).not.toContain('--skip-tests --skip-lint --skip-typecheck');
+    expect(content).not.toContain('<scope>^...');
   });
 
-  it('returns null when a scope has no workspace dependencies', () => {
-    const result = createWorkspaceDependencyBuildArgs({
-      workspaceName: '@robota-sdk/agent-core',
-      workspaceDependencies: [],
-    });
+  it('keeps main PR duplicate jobs as fast successful no-ops', () => {
+    const content = readFileSync('.github/workflows/ci.yml', 'utf8');
 
-    expect(result).toBeNull();
+    expect(content).toContain("github.base_ref == 'main'");
+    expect(content).toContain('covered by release-grade verification');
+  });
+
+  it('checks dependency graph changes before installing for security audit', () => {
+    const content = readFileSync('.github/workflows/ci.yml', 'utf8');
+    const diffIndex = content.indexOf('Detect dependency graph changes');
+    const installIndex = content.indexOf('Install dependencies for audit');
+
+    expect(diffIndex).toBeGreaterThanOrEqual(0);
+    expect(installIndex).toBeGreaterThan(diffIndex);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify-change build flow
+// ---------------------------------------------------------------------------
+describe('verify-change build flow', () => {
+  it('uses one root build for scoped build checks instead of dependency package builds', () => {
+    const content = readFileSync('scripts/harness/verify-change.mjs', 'utf8');
+
+    expect(content).toContain('[verify] monorepo build');
+    expect(content).toContain("runCommand('pnpm', ['build'], WORKSPACE_ROOT");
+    expect(content).not.toContain('createWorkspaceDependencyBuildArgs');
+    expect(content).not.toContain('shouldPrepareWorkspaceDependencies');
+    expect(content).not.toContain("runCommand('pnpm', ['build'], workdir");
   });
 });
 

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -280,14 +280,6 @@ export function parseScopeArgs(argv) {
   return options;
 }
 
-export function createWorkspaceDependencyBuildArgs(scope) {
-  if ((scope.workspaceDependencies ?? []).length === 0) {
-    return null;
-  }
-
-  return ['--filter', `${scope.workspaceName}^...`, '--if-present', 'build'];
-}
-
 export function runCommand(command, args, workdir, dryRun, envOverrides = {}) {
   const rendered = [command, ...args].join(' ');
   process.stdout.write(`> (${path.relative(WORKSPACE_ROOT, workdir) || '.'}) ${rendered}\n`);

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -17,7 +17,6 @@ import {
   WORKSPACE_ROOT,
   classifyScopeChanges,
   collectPackageManifestChanges,
-  createWorkspaceDependencyBuildArgs,
   detectChangedFiles,
   listWorkspaceScopes,
   parseScopeArgs,
@@ -76,19 +75,6 @@ function runRepositoryCheck(check, dryRun) {
   }
 }
 
-function shouldPrepareWorkspaceDependencies(scope, plannedChecks, options) {
-  if ((scope.workspaceDependencies ?? []).length === 0) {
-    return false;
-  }
-
-  return (
-    (!options.skipBuild && plannedChecks.has('build')) ||
-    (!options.skipTests && plannedChecks.has('test')) ||
-    (!options.skipLint && plannedChecks.has('lint')) ||
-    (!options.skipTypecheck && plannedChecks.has('typecheck'))
-  );
-}
-
 async function main() {
   const options = parseScopeArgs(process.argv.slice(2));
   const scopes = await listWorkspaceScopes();
@@ -118,6 +104,13 @@ async function main() {
     process.stdout.write('No package or app scope detected from changed files.\n');
     process.stdout.write('Use --scope <packages/foo|apps/bar> to run explicit verification.\n');
     return;
+  }
+
+  const needsRootBuild =
+    !options.skipBuild && plan.scopes.some((planScope) => planScope.checks.includes('build'));
+  if (needsRootBuild) {
+    process.stdout.write('\n[verify] monorepo build\n');
+    runCommand('pnpm', ['build'], WORKSPACE_ROOT, options.dryRun);
   }
 
   const summary = [];
@@ -155,28 +148,9 @@ async function main() {
       scenarios: 'not-applicable',
     };
 
-    if (shouldPrepareWorkspaceDependencies(scope, plannedChecks, options)) {
-      const dependencyBuildArgs = createWorkspaceDependencyBuildArgs(scope);
-      if (dependencyBuildArgs) {
-        try {
-          runCommand('pnpm', dependencyBuildArgs, WORKSPACE_ROOT, options.dryRun);
-          notes.push('workspace dependencies built before scoped checks');
-        } catch (error) {
-          allPassed = false;
-          throw error;
-        }
-      }
-    }
-
     if (!options.skipBuild && plannedChecks.has('build')) {
-      try {
-        runCommand('pnpm', ['build'], workdir, options.dryRun);
-        stepResults.build = 'pass';
-      } catch (error) {
-        stepResults.build = 'fail';
-        allPassed = false;
-        throw error;
-      }
+      stepResults.build = 'pass';
+      notes.push('monorepo root build completed before scoped checks');
     }
 
     if (!options.skipTests && plannedChecks.has('test')) {


### PR DESCRIPTION
## Summary

- Replace the CI build job's per-scope harness build loop with a plan-gated root `pnpm build`.
- Update `harness:verify` so scoped build checks share one root monorepo build instead of rebuilding workspace dependencies per scope.
- Keep duplicate `main` PR build/quality/audit jobs as fast successful no-ops because `release-grade verification` covers them there.
- Skip security audit dependency installation when neither `pnpm-lock.yaml` nor `package.json` changed.

## Validation

- `pnpm exec prettier --check .github/workflows/ci.yml scripts/harness/shared.mjs scripts/harness/verify-change.mjs scripts/harness/__tests__/harness-scripts.test.mjs`
- `pnpm exec vitest run scripts/harness/__tests__/harness-scripts.test.mjs scripts/harness/__tests__/check-plan.test.mjs scripts/harness/__tests__/scan-test-plan.test.mjs scripts/harness/__tests__/harness-smoke.test.mjs`
- `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
- `pnpm build`
- `pnpm harness:verify:release`
- `pnpm audit --audit-level high`
- pre-push `pnpm harness:pre-push` via `git push -u origin fix/ci-root-build`
