### PR TITLE
[codex] Reuse root package build in deploy workflow

### DIFF
--- a/.changeset/reuse-deploy-root-build.md
+++ b/.changeset/reuse-deploy-root-build.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-playground': minor
+---
+
+Add a browser-safe agent-playground client subpath for the deployed web app and reuse root package build output in the deploy workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    outputs:
+      package_dist_required: ${{ steps.build_requirement.outputs.required }}
 
     steps:
       - name: Skip duplicate build for main PR
@@ -75,6 +77,19 @@ jobs:
         if: github.base_ref != 'main' && steps.build_requirement.outputs.required == 'true'
         run: pnpm build
 
+      - name: Archive package build output
+        if: github.base_ref != 'main' && steps.build_requirement.outputs.required == 'true'
+        run: tar -czf package-dist.tgz packages/*/dist packages/dag-nodes/*/dist
+
+      - name: Upload package build output
+        if: github.base_ref != 'main' && steps.build_requirement.outputs.required == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: package-dist.tgz
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Skip monorepo build when no package build is required
         if: github.base_ref != 'main' && steps.build_requirement.outputs.required != 'true'
         run: echo "No package or app build checks required."
@@ -82,6 +97,7 @@ jobs:
   quality:
     name: quality
     runs-on: ubuntu-latest
+    needs: build
 
     steps:
       - name: Skip duplicate quality checks for main PR
@@ -113,6 +129,17 @@ jobs:
       - name: Fetch base branch
         if: github.base_ref != 'main'
         run: git fetch origin ${{ github.base_ref }} --depth=50
+
+      - name: Download package build output
+        if: github.base_ref != 'main' && needs.build.outputs.package_dist_required == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+          path: .artifacts/package-dist
+
+      - name: Restore package build output
+        if: github.base_ref != 'main' && needs.build.outputs.package_dist_required == 'true'
+        run: tar -xzf .artifacts/package-dist/package-dist.tgz
 
       - name: Verify affected quality checks
         if: github.base_ref != 'main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,15 +32,26 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build SDK packages (for type declarations)
-        run: pnpm --filter @robota-sdk/agent-playground... build
+      - name: Build package workspace
+        run: pnpm build
+
+      - name: Archive package build output
+        run: tar -czf package-dist.tgz packages/*/dist packages/dag-nodes/*/dist
+
+      - name: Upload package build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: package-dist.tgz
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Run linting
         run: pnpm --filter @robota-sdk/agent-web run lint
@@ -51,7 +62,7 @@ jobs:
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3
         with:
-          file: apps/web/coverage/lcov.info
+          file: apps/agent-web/coverage/lcov.info
           flags: web
           fail_ci_if_error: false
 
@@ -77,15 +88,21 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build SDK packages (for type declarations)
-        run: pnpm --filter @robota-sdk/agent-playground... build
+      - name: Download package build output
+        uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+          path: .artifacts/package-dist
+
+      - name: Restore package build output
+        run: tar -xzf .artifacts/package-dist/package-dist.tgz
 
       - name: Build application
         run: pnpm --filter @robota-sdk/agent-web run build
@@ -101,7 +118,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-args: '--prod'
-          working-directory: apps/web
+          working-directory: apps/agent-web
 
       - name: Deploy to Vercel (Staging)
         if: github.event.inputs.environment == 'staging'
@@ -110,7 +127,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_STAGING }}
-          working-directory: apps/web
+          working-directory: apps/agent-web
 
   security:
     name: Security Scan
@@ -129,12 +146,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run security audit
         run: pnpm audit --audit-level high

--- a/apps/agent-web/docs/SPEC.md
+++ b/apps/agent-web/docs/SPEC.md
@@ -2,11 +2,11 @@
 
 ## Scope
 
-Owns the Robota web application. A Next.js 15 host that serves the Playground UI (`@robota-sdk/agent-playground`), the DAG Designer (`@robota-sdk/dag-designer`), and provides the browser runtime composition layer. The root route redirects to `/dag-designer`.
+Owns the Robota web application. A Next.js 15 host that serves the Playground UI (`@robota-sdk/agent-playground/client`), the DAG Designer (`@robota-sdk/dag-designer`), and provides the browser runtime composition layer. The root route redirects to `/dag-designer`.
 
 ## Boundaries
 
-- Does not own package-level runtime contracts; imports from `@robota-sdk/agent-core`, `@robota-sdk/agent-playground`, `@robota-sdk/dag-core`, and `@robota-sdk/dag-designer`.
+- Does not own package-level runtime contracts; imports browser-safe components from `@robota-sdk/agent-playground/client` and shared contracts/components from `@robota-sdk/agent-core`, `@robota-sdk/dag-core`, and `@robota-sdk/dag-designer`.
 - Does not own API server behavior; that belongs to `apps/agent-server`.
 - Keeps deployment, auth configuration, and frontend integration behavior within this app.
 - Styling uses Tailwind CSS v4 utility classes only.
@@ -21,7 +21,7 @@ Next.js App Router application with the following route structure:
 - `/playground` -- Playground main page.
 - `/playground/demo` -- Playground demo mode.
 
-The app composes workspace packages as React components and configures API access via `API_CONFIG` (versioned base URL, timeout, retry, rate limiting). Client-side caching is provided by `src/lib/cache.ts`.
+The app composes workspace packages as React components and configures API access via `API_CONFIG` (versioned base URL, timeout, retry, rate limiting). Client-side caching is provided by `src/lib/cache.ts`. Browser builds explicitly disable Node builtin polyfills in `next.config.ts` so Node-only optional exports from workspace packages do not enter the client bundle.
 
 ## Type Ownership
 
@@ -74,10 +74,10 @@ None.
 
 ### Cross-Package Port Consumers
 
-| Port (Owner)                              | Consumer    | Location                |
-| ----------------------------------------- | ----------- | ----------------------- |
-| `@robota-sdk/agent-playground` components | Page routes | `src/app/playground/`   |
-| `@robota-sdk/dag-designer` components     | Page routes | `src/app/dag-designer/` |
+| Port (Owner)                                     | Consumer    | Location                |
+| ------------------------------------------------ | ----------- | ----------------------- |
+| `@robota-sdk/agent-playground/client` components | Page routes | `src/app/playground/`   |
+| `@robota-sdk/dag-designer` components            | Page routes | `src/app/dag-designer/` |
 
 ## Test Strategy
 

--- a/apps/agent-web/next.config.ts
+++ b/apps/agent-web/next.config.ts
@@ -77,8 +77,22 @@ const nextConfig: NextConfig = {
     removeConsole: false,
   },
 
-  // Remove complex webpack configuration
-  // Next.js should handle server/client separation automatically
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve = config.resolve ?? {};
+      config.resolve.fallback = {
+        ...(config.resolve.fallback ?? {}),
+        child_process: false,
+        fs: false,
+        module: false,
+        net: false,
+        tls: false,
+        worker_threads: false,
+      };
+    }
+
+    return config;
+  },
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/apps/agent-web/src/app/playground/demo/page.tsx
+++ b/apps/agent-web/src/app/playground/demo/page.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 
 const PlaygroundDemo = dynamic(
-  () => import('@robota-sdk/agent-playground').then((m) => ({ default: m.PlaygroundDemo })),
+  () => import('@robota-sdk/agent-playground/client').then((m) => ({ default: m.PlaygroundDemo })),
   { ssr: false, loading: () => <div className="p-6 text-sm text-gray-500">Loading Demo...</div> },
 );
 

--- a/apps/agent-web/src/app/playground/page.tsx
+++ b/apps/agent-web/src/app/playground/page.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 
 const PlaygroundApp = dynamic(
-  () => import('@robota-sdk/agent-playground').then((m) => ({ default: m.PlaygroundApp })),
+  () => import('@robota-sdk/agent-playground/client').then((m) => ({ default: m.PlaygroundApp })),
   {
     ssr: false,
     loading: () => <div className="p-6 text-sm text-gray-500">Loading Playground...</div>,

--- a/packages/agent-playground/docs/SPEC.md
+++ b/packages/agent-playground/docs/SPEC.md
@@ -2,14 +2,14 @@
 
 ## Scope
 
-Owns the Robota Playground UI package: React components, hooks, executor logic, plugins, and tool catalog for interactive agent experimentation in the browser. Provides `PlaygroundApp` and `PlaygroundDemo` components, `PlaygroundExecutor` for managing Robota agents via `RemoteExecutor`, and statistics/history plugins for real-time visualization.
+Owns the Robota Playground UI package: React components, hooks, executor logic, plugins, and tool catalog for interactive agent experimentation in the browser. Provides `PlaygroundApp` and `PlaygroundDemo` components, a browser-safe `@robota-sdk/agent-playground/client` component entry, `PlaygroundExecutor` for managing Robota agents via `RemoteExecutor`, and statistics/history plugins for real-time visualization.
 
 ## Boundaries
 
 - Does not own core agent contracts (`IExecutor`, `IAIProvider`, `TUniversalMessage`); imports from `@robota-sdk/agent-core`.
 - Does not own remote transport contracts; imports `RemoteExecutor` from `@robota-sdk/agent-remote`.
 - Does not own WebSocket message types; imports `IPlaygroundWebSocketMessage` from `@robota-sdk/agent-remote`.
-- Does not define deployment or hosting behavior; that belongs to `apps/web`.
+- Does not define deployment or hosting behavior; that belongs to `apps/agent-web`.
 
 ## Architecture Overview
 
@@ -38,6 +38,8 @@ This package is SSOT for:
 | `PlaygroundDemo`        | React component | Demo-mode playground                                             |
 | `PlaygroundExecutor`    | class           | Agent lifecycle and execution facade (re-exported from services) |
 | ~~`usePlaygroundBoot`~~ | hook (internal) | Boot state management — not exported from package entry          |
+
+Browser consumers that only render the React playground must import `PlaygroundApp` and `PlaygroundDemo` from `@robota-sdk/agent-playground/client`. The root entry also exports service-layer APIs for server/runtime consumers and must not be used as the browser page entry.
 
 Note: `usePlaygroundData`, `useRobotaExecution`, `useChatInput`, and `ToolRegistry` are used internally by the package's own components and are not exported from the public entry point (`src/index.ts → src/playground/index.ts`).
 

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -20,6 +20,11 @@
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs"
       }
+    },
+    "./client": {
+      "types": "./dist/browser/client.d.ts",
+      "import": "./dist/browser/client.js",
+      "default": "./dist/browser/client.js"
     }
   },
   "files": [

--- a/packages/agent-playground/src/client.ts
+++ b/packages/agent-playground/src/client.ts
@@ -1,0 +1,2 @@
+export { PlaygroundApp } from './playground/components/PlaygroundApp';
+export { PlaygroundDemo } from './playground/components/PlaygroundDemo';

--- a/packages/agent-playground/tsup.config.ts
+++ b/packages/agent-playground/tsup.config.ts
@@ -13,7 +13,7 @@ const baseConfig = {
   clean: true,
   treeshake: true,
   minify: true,
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/client.ts'],
   external: [
     /^@robota-sdk\/.*/,
     'react',

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -103,9 +103,27 @@ describe('CI build workflow', () => {
     expect(content).toContain('run: pnpm build');
     expect(content).toContain('Detect build requirement');
     expect(content).toContain("steps.build_requirement.outputs.required == 'true'");
+    expect(content).toContain(
+      'tar -czf package-dist.tgz packages/*/dist packages/dag-nodes/*/dist',
+    );
+    expect(content).toContain(
+      'package_dist_required: ${{ steps.build_requirement.outputs.required }}',
+    );
     expect(content).not.toContain('Build affected scopes');
     expect(content).not.toContain('--skip-tests --skip-lint --skip-typecheck');
     expect(content).not.toContain('<scope>^...');
+  });
+
+  it('restores root build output before skip-build quality verification', () => {
+    const content = readFileSync('.github/workflows/ci.yml', 'utf8');
+    const restoreIndex = content.indexOf('Restore package build output');
+    const verifyIndex = content.indexOf('Verify affected quality checks');
+
+    expect(content).toContain('needs: build');
+    expect(content).toContain("needs.build.outputs.package_dist_required == 'true'");
+    expect(content).toContain('tar -xzf .artifacts/package-dist/package-dist.tgz');
+    expect(restoreIndex).toBeGreaterThanOrEqual(0);
+    expect(verifyIndex).toBeGreaterThan(restoreIndex);
   });
 
   it('keeps main PR duplicate jobs as fast successful no-ops', () => {
@@ -122,6 +140,64 @@ describe('CI build workflow', () => {
 
     expect(diffIndex).toBeGreaterThanOrEqual(0);
     expect(installIndex).toBeGreaterThan(diffIndex);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deploy workflow build shape
+// ---------------------------------------------------------------------------
+describe('deploy workflow', () => {
+  it('uses one root package build and reuses package dist artifacts for Vercel deploys', () => {
+    const content = readFileSync('.github/workflows/deploy.yml', 'utf8');
+
+    expect(content).toContain('run: pnpm build');
+    expect(content).toContain('package-dist.tgz');
+    expect(content).toContain(
+      'tar -czf package-dist.tgz packages/*/dist packages/dag-nodes/*/dist',
+    );
+    expect(content).toContain('tar -xzf .artifacts/package-dist/package-dist.tgz');
+    expect(content).not.toContain('@robota-sdk/agent-playground... build');
+  });
+
+  it('points deploy artifacts and Vercel working directories at apps/agent-web', () => {
+    const content = readFileSync('.github/workflows/deploy.yml', 'utf8');
+
+    expect(content).toContain('apps/agent-web/coverage/lcov.info');
+    expect(content).toContain('working-directory: apps/agent-web');
+    expect(content).not.toContain('apps/web');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agent-web deploy import shape
+// ---------------------------------------------------------------------------
+describe('agent-web deploy imports', () => {
+  it('uses the browser-safe agent-playground client entry in playground routes', () => {
+    const playgroundPage = readFileSync('apps/agent-web/src/app/playground/page.tsx', 'utf8');
+    const demoPage = readFileSync('apps/agent-web/src/app/playground/demo/page.tsx', 'utf8');
+
+    expect(playgroundPage).toContain('@robota-sdk/agent-playground/client');
+    expect(demoPage).toContain('@robota-sdk/agent-playground/client');
+    expect(playgroundPage).not.toContain("import('@robota-sdk/agent-playground')");
+    expect(demoPage).not.toContain("import('@robota-sdk/agent-playground')");
+  });
+
+  it('declares an agent-playground client subpath export', () => {
+    const packageJson = JSON.parse(readFileSync('packages/agent-playground/package.json', 'utf8'));
+
+    expect(packageJson.exports['./client']).toMatchObject({
+      types: './dist/browser/client.d.ts',
+      import: './dist/browser/client.js',
+      default: './dist/browser/client.js',
+    });
+  });
+
+  it('blocks Node builtin polyfills from the agent-web browser bundle', () => {
+    const content = readFileSync('apps/agent-web/next.config.ts', 'utf8');
+
+    expect(content).toContain('if (!isServer)');
+    expect(content).toContain('fs: false');
+    expect(content).toContain('child_process: false');
   });
 });
 


### PR DESCRIPTION
## Summary
- Build workspace packages once with the root `pnpm build` command in CI/deploy workflows.
- Upload package `dist` output and restore it in downstream jobs instead of rebuilding package filters.
- Add `@robota-sdk/agent-playground/client` as a browser-safe entry for the web playground routes and document the contract.
- Add harness tests covering CI/deploy workflow shape, artifact reuse, and browser import paths.

## Why
The deploy workflow rebuilt `@robota-sdk/agent-playground...` in multiple jobs. In this monorepo, package builds should run through the root package build once and then be reused. CI quality checks also run on fresh runners with `--skip-build`, so they need the root build artifact restored before typechecking dependent apps. The web build also needed a browser-facing playground entry so the deployed Next.js app does not pull Node-only optional modules through the page import.

## Validation
- `pnpm exec prettier --check ...`
- `pnpm exec vitest run scripts/harness/__tests__/harness-scripts.test.mjs scripts/harness/__tests__/check-plan.test.mjs`
- `pnpm build`
- `pnpm --filter @robota-sdk/agent-web run build`
- `pnpm --filter @robota-sdk/agent-web run lint`
- `pnpm --filter @robota-sdk/agent-web run test:ci`
- `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
- pre-push `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`