### PR TITLE
docs: sync content docs for beta 59

### DIFF
--- a/.agents/tasks/content-docs-beta-59-sync.md
+++ b/.agents/tasks/content-docs-beta-59-sync.md
@@ -1,0 +1,134 @@
+# Content Docs Beta 59 Sync
+
+- **Status**: completed
+- **Created**: 2026-05-03
+- **Branch**: docs/content-beta-59-sync
+- **Scope**: content docs, website documentation source
+
+## Objective
+
+Audit robota.io source documents under `content/` against the current `3.0.0-beta.59` repository state, then update stale handwritten content so the next main deployment publishes accurate documentation.
+
+## Constraints
+
+- Do not edit `content/api-reference/**` directly. It is generated from JSDoc and generator inputs.
+- Do not edit `content/v2.0.0/**`. It is legacy frozen content.
+- Do not edit generated outputs under `apps/docs/.temp/**` or `apps/docs/.vitepress/dist/**`.
+- If API reference content is stale, update source JSDoc or generator inputs in a separate scoped step.
+
+## Checklist
+
+### Baseline and Source Map
+
+- [x] Confirm branch and working tree state.
+- [x] Identify latest release/version state from `package.json`, npm tags, and merged PRs.
+- [x] List handwritten `content/` files that are in scope.
+- [x] List generated/frozen content paths that must remain read-only.
+
+### Home and Navigation
+
+- [x] Audit `content/README.md` for package list, installation commands, feature summary, and release note links.
+- [x] Update `content/README.md` where stale.
+- [x] Audit `content/getting-started/README.md` for install/setup/API examples.
+- [x] Update `content/getting-started/README.md` where stale.
+- [x] Audit `content/guide/README.md` navigation and release-note summary.
+- [x] Update `content/guide/README.md` where stale.
+
+### Guide Pages
+
+- [x] Audit `content/guide/building-agents.md`.
+- [x] Update `content/guide/building-agents.md` where stale.
+- [x] Audit `content/guide/sdk.md`.
+- [x] Update `content/guide/sdk.md` where stale.
+- [x] Audit `content/guide/cli.md`.
+- [x] Update `content/guide/cli.md` where stale.
+- [x] Audit `content/guide/architecture.md`.
+- [x] Update `content/guide/architecture.md` where stale.
+- [x] Audit `content/guide/permissions-and-hooks.md`.
+- [x] Update `content/guide/permissions-and-hooks.md` where stale.
+- [x] Audit `content/guide/context-management.md`.
+- [x] Update `content/guide/context-management.md` where stale.
+- [x] Audit `content/guide/release-2026-05-02.md`.
+- [x] Update `content/guide/release-2026-05-02.md` for beta.58/beta.59, CI/deploy, publish, and dist-tag state.
+
+### Examples
+
+- [x] Audit `content/examples/README.md`.
+- [x] Update `content/examples/README.md` where stale.
+- [x] Audit `content/examples/basic-conversation.md`.
+- [x] Update `content/examples/basic-conversation.md` where stale.
+- [x] Audit `content/examples/streaming.md`.
+- [x] Update `content/examples/streaming.md` where stale.
+- [x] Audit `content/examples/tool-calling.md`.
+- [x] Update `content/examples/tool-calling.md` where stale.
+- [x] Audit `content/examples/session-management.md`.
+- [x] Update `content/examples/session-management.md` where stale.
+- [x] Audit `content/examples/multi-provider.md`.
+- [x] Update `content/examples/multi-provider.md` where stale.
+- [x] Audit `content/examples/one-shot-query.md`.
+- [x] Update `content/examples/one-shot-query.md` where stale.
+- [x] Audit `content/examples/print-mode.md`.
+- [x] Update `content/examples/print-mode.md` where stale.
+- [x] Audit `content/examples/interactive-mode.md`.
+- [x] Update `content/examples/interactive-mode.md` where stale.
+- [x] Audit `content/examples/http-transport.md`.
+- [x] Update `content/examples/http-transport.md` where stale.
+- [x] Audit `content/examples/ws-transport.md`.
+- [x] Update `content/examples/ws-transport.md` where stale.
+- [x] Audit `content/examples/mcp-transport.md`.
+- [x] Update `content/examples/mcp-transport.md` where stale.
+
+### Generated and Frozen Content
+
+- [x] Confirm `content/api-reference/**` was not manually edited.
+- [x] Confirm `content/v2.0.0/**` was not edited.
+- [x] If generated API reference is stale, record source/JSDoc follow-up instead of editing generated files.
+
+### Verification
+
+- [x] Run docs structure validation.
+- [x] Run docs build.
+- [x] Run formatting/check commands needed for changed markdown.
+- [x] Review final diff for accidental generated/frozen edits.
+- [x] Summarize remaining risks and deployment path.
+
+## Progress
+
+### 2026-05-03
+
+- Created the task checklist before auditing or editing content.
+- Created `docs/content-beta-59-sync` from `develop`.
+- Confirmed latest coordinated publishable package version is `3.0.0-beta.59`; 18 `@robota-sdk/*` packages are publishable.
+- Identified 23 handwritten in-scope content markdown files.
+- Marked `content/api-reference/**` and `content/v2.0.0/**` read-only for this task.
+- Updated home, getting-started, guide, development, and example pages for beta.59 package/public API state.
+- Replaced stale `createSession`/internal SDK examples with public `InteractiveSession` and `createQuery` usage.
+- Replaced stale object-style `createZodFunctionTool` examples with the current positional API.
+- Refreshed release notes through the 2026-05-03 02:09 KST main promotion and confirmed npm `latest`/`beta` tags for all 18 publishable packages.
+- Audited unchanged example/guide pages and left them unchanged where they still matched the current API.
+- Passed `pnpm docs:validate-structure`.
+- Passed `pnpm docs:build`.
+- Passed Prettier check and `git diff --check`.
+- Confirmed no diff under `content/api-reference/**`, `content/v2.0.0/**`, `apps/docs/.temp/**`, or `apps/docs/.vitepress/dist/**`.
+
+## Decisions
+
+- Treat `content/api-reference/**` as generated JSDoc output and read-only.
+- Treat `content/v2.0.0/**` as frozen legacy content and read-only.
+- Use `2ccaecd8e` (PR #148 docs refresh) through current `develop` as the stale-doc comparison range.
+- No generated API reference source/JSDoc follow-up was opened because this task found stale content only in handwritten pages.
+
+## Blockers
+
+- None.
+
+## Test Plan
+
+- Run `pnpm docs:validate-structure` to verify package documentation structure after the content sync.
+- Run `pnpm docs:build` to verify the robota.io source pages copy into the docs app and build successfully with VitePress.
+- Run Prettier checks and `git diff --check` to confirm markdown formatting and whitespace are clean.
+- Confirm `content/api-reference/**`, `content/v2.0.0/**`, `apps/docs/.temp/**`, and `apps/docs/.vitepress/dist/**` have no final diff.
+
+## Result
+
+Completed. Handwritten `content/` docs are updated for the `3.0.0-beta.59` state, and verification passed. The changed docs are ready to merge through the normal PR path; after merge to `main`, the docs site deployment path can publish the regenerated site output. No generated API reference or frozen v2.0.0 content was edited.

--- a/content/README.md
+++ b/content/README.md
@@ -49,20 +49,23 @@ console.log(response);
 
 ```typescript
 import { Robota } from '@robota-sdk/agent-core';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import { z } from 'zod';
 
-const calculatorTool = createZodFunctionTool({
-  name: 'calculator',
-  description: 'Perform arithmetic calculations',
-  schema: z.object({
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const calculatorTool = createZodFunctionTool(
+  'calculator',
+  'Perform arithmetic calculations',
+  z.object({
     expression: z.string().describe('Math expression to evaluate'),
   }),
-  handler: async ({ expression }) => {
+  async ({ expression }) => {
     // WARNING: eval() is used here for brevity only. Do not use in production.
     return { data: String(eval(expression)) }; // eslint-disable-line no-eval
   },
-});
+);
 
 const agent = new Robota({
   name: 'ToolAgent',
@@ -112,41 +115,46 @@ agent-command-agent    ← /agent command module for background subagent control
 agent-transport-http   ← HTTP transport (Hono; Cloudflare Workers / Node.js / Lambda)
 agent-transport-mcp    ← MCP transport (Model Context Protocol server)
 agent-transport-ws     ← WebSocket transport (framework-agnostic)
-  ↓ (all four consume)
-agent-sdk              ← Assembly layer: InteractiveSession, config, context, query()
+agent-transport-headless ← Non-interactive transport for text/json/stream-json output
+  ↓ (all five consume)
+agent-sdk              ← Assembly layer: InteractiveSession, config, context, createQuery()
   ↓
 agent-sessions         ← Session lifecycle: permissions, hooks, compaction
 agent-runtime          ← Background task and subagent lifecycle primitives
 agent-tools            ← Tool infrastructure + 8 built-in tools
-agent-provider-*       ← AI provider implementations (anthropic, openai, gemini, gemma, qwen)
-  ↓ (all three depend on)
+agent-provider-*       ← AI provider implementations (anthropic, openai, gemini, google, gemma, qwen)
+  ↓
 agent-core             ← Foundation: Robota engine, abstractions, plugins
 ```
 
 ## Packages
 
-| Package                                                                        | Description                                                            |
-| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| [`@robota-sdk/agent-core`](./packages/agent-core/)                             | Core agent runtime, abstractions, and plugin system                    |
-| [`@robota-sdk/agent-tools`](./packages/agent-tools/)                           | Tool registry, FunctionTool, and 8 built-in tools                      |
-| [`@robota-sdk/agent-sessions`](./packages/agent-sessions/)                     | Session with permissions, hooks, and compaction                        |
-| [`@robota-sdk/agent-runtime`](./packages/agent-runtime/)                       | Background task and subagent lifecycle primitives                      |
-| [`@robota-sdk/agent-sdk`](./packages/agent-sdk/)                               | Assembly layer with config/context loading and query()                 |
-| [`@robota-sdk/agent-provider-anthropic`](./packages/agent-provider-anthropic/) | Anthropic Claude provider                                              |
-| [`@robota-sdk/agent-provider-gemini`](./packages/agent-provider-gemini/)       | Canonical Google Gemini provider                                       |
-| [`@robota-sdk/agent-provider-gemma`](./packages/agent-provider-gemma/)         | Gemma-family local provider for LM Studio/OpenAI-compatible endpoints  |
-| [`@robota-sdk/agent-provider-qwen`](./packages/agent-provider-qwen/)           | Qwen/DashScope provider with optional provider-side web tools          |
-| [`@robota-sdk/agent-cli`](./packages/agent-cli/)                               | Interactive terminal AI coding assistant                               |
-| [`@robota-sdk/agent-transport-http`](./packages/agent-transport-http/)         | HTTP/REST transport adapter (Hono; Cloudflare Workers / Node / Lambda) |
-| [`@robota-sdk/agent-transport-mcp`](./packages/agent-transport-mcp/)           | MCP transport adapter (Model Context Protocol server)                  |
-| [`@robota-sdk/agent-transport-ws`](./packages/agent-transport-ws/)             | WebSocket transport adapter (framework-agnostic)                       |
-| [`@robota-sdk/agent-remote-client`](./packages/agent-remote-client/)           | HTTP client for calling a remote agent over HTTP                       |
+| Package                                                                                        | Description                                                            |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`@robota-sdk/agent-core`](./packages/agent-core/)                                             | Core agent runtime, abstractions, and plugin system                    |
+| [`@robota-sdk/agent-tools`](./packages/agent-tools/)                                           | Tool registry, FunctionTool, and 8 built-in tools                      |
+| [`@robota-sdk/agent-sessions`](./packages/agent-sessions/)                                     | Session with permissions, hooks, and compaction                        |
+| [`@robota-sdk/agent-runtime`](./packages/agent-runtime/)                                       | Background task and subagent lifecycle primitives                      |
+| [`@robota-sdk/agent-sdk`](./packages/agent-sdk/)                                               | Assembly layer with config/context loading and createQuery()           |
+| [`@robota-sdk/agent-command-agent`](./packages/agent-command-agent/)                           | `/agent` command module for background subagent jobs                   |
+| [`@robota-sdk/agent-provider-anthropic`](./packages/agent-provider-anthropic/)                 | Anthropic Claude provider                                              |
+| [`@robota-sdk/agent-provider-openai`](./packages/agent-provider-openai/)                       | OpenAI provider                                                        |
+| [`@robota-sdk/agent-provider-gemini`](./packages/agent-provider-gemini/)                       | Canonical Google Gemini provider                                       |
+| [`@robota-sdk/agent-provider-google`](./packages/agent-provider-google/)                       | Gemini compatibility wrapper for legacy Google imports/settings        |
+| [`@robota-sdk/agent-provider-gemma`](./packages/agent-provider-gemma/)                         | Gemma-family local provider for LM Studio/OpenAI-compatible endpoints  |
+| [`@robota-sdk/agent-provider-openai-compatible`](./packages/agent-provider-openai-compatible/) | Reusable OpenAI-compatible transport primitives                        |
+| [`@robota-sdk/agent-provider-qwen`](./packages/agent-provider-qwen/)                           | Qwen/DashScope provider with optional provider-side web tools          |
+| [`@robota-sdk/agent-cli`](./packages/agent-cli/)                                               | Interactive terminal AI coding assistant                               |
+| [`@robota-sdk/agent-transport-headless`](./packages/agent-transport-headless/)                 | Non-interactive text/json/stream-json transport                        |
+| [`@robota-sdk/agent-transport-http`](./packages/agent-transport-http/)                         | HTTP/REST transport adapter (Hono; Cloudflare Workers / Node / Lambda) |
+| [`@robota-sdk/agent-transport-mcp`](./packages/agent-transport-mcp/)                           | MCP transport adapter (Model Context Protocol server)                  |
+| [`@robota-sdk/agent-transport-ws`](./packages/agent-transport-ws/)                             | WebSocket transport adapter (framework-agnostic)                       |
 
 ## Documentation
 
 - [Getting Started](./getting-started/) — Installation and first steps
 - [Guide](./guide/) — Architecture, building agents, SDK, CLI
-- [Release Notes: 2026-05-02](./guide/release-2026-05-02.md) — Latest 48-hour develop snapshot
+- [Release Notes: 2026-05-02](./guide/release-2026-05-02.md) — Beta.59 snapshot, CI/deploy build reuse, and npm dist-tag status
 - [Examples](./examples/) — Working code samples
 - [Development](./development/) — Contributing and monorepo setup
 
@@ -160,6 +168,7 @@ npm install @robota-sdk/agent-core
 npm install @robota-sdk/agent-provider-anthropic @anthropic-ai/sdk
 npm install @robota-sdk/agent-provider-openai openai
 npm install @robota-sdk/agent-provider-gemini @google/genai
+npm install @robota-sdk/agent-provider-google @google/genai
 npm install @robota-sdk/agent-provider-qwen
 npm install @robota-sdk/agent-provider-gemma
 npm install @robota-sdk/agent-provider-openai-compatible
@@ -167,8 +176,17 @@ npm install @robota-sdk/agent-provider-openai-compatible
 # Tools — FunctionTool, Zod tools, built-in CLI tools
 npm install @robota-sdk/agent-tools
 
-# SDK — assembly layer with query() and createSession()
+# SDK — assembly layer with createQuery() and InteractiveSession
 npm install @robota-sdk/agent-sdk
+
+# Command module — /agent background jobs
+npm install @robota-sdk/agent-command-agent
+
+# Transports
+npm install @robota-sdk/agent-transport-headless
+npm install @robota-sdk/agent-transport-http
+npm install @robota-sdk/agent-transport-mcp
+npm install @robota-sdk/agent-transport-ws
 
 # CLI — terminal AI coding assistant
 npm install -g @robota-sdk/agent-cli

--- a/content/development/README.md
+++ b/content/development/README.md
@@ -21,7 +21,7 @@ pnpm test
 ## Commands
 
 ```bash
-pnpm build              # Build all packages
+pnpm build              # Build the package workspace once from the repo root
 pnpm test               # Run all tests
 pnpm typecheck          # TypeScript strict check
 pnpm lint               # ESLint
@@ -50,9 +50,9 @@ packages/
 ├── agent-provider-google/      ← Gemini compatibility wrapper
 ├── agent-provider-gemma/       ← Gemma local model provider
 ├── agent-provider-qwen/        ← Qwen/DashScope provider
-├── agent-plugin-*/             ← 8 extracted plugins
+├── agent-plugin-*/             ← 9 extracted plugins
 ├── agent-team/                 ← Multi-agent task assignment
-├── agent-remote/               ← Remote execution
+├── agent-remote-client/        ← HTTP client for remote agents
 ├── agent-tool-mcp/             ← MCP tool protocol
 └── dag-*/                      ← DAG workflow (separate domain)
 ```
@@ -71,20 +71,20 @@ See [AGENTS.md](https://github.com/woojubb/robota/blob/main/AGENTS.md) for the c
 
 ## Publishing
 
-Robota publishes every non-private package together with one coordinated version.
+Robota publishes every non-private package together with one coordinated version. The current beta.59 package set has 18 publishable `@robota-sdk/*` packages; private app, plugin, DAG, and internal packages are not published by the beta script.
 
 ```bash
 pnpm harness:verify:release
 pnpm publish:beta
 ```
 
-`pnpm publish:beta` runs the npm authentication preflight first, performs a recursive dry-run, then prompts for OTP only after the dry-run succeeds. If npm authentication fails, run:
+`pnpm harness:verify:release` uses the root monorepo build instead of rebuilding each package independently. `pnpm publish:beta` runs the npm authentication preflight first, performs one recursive dry-run, prompts for OTP only after the dry-run succeeds, publishes all non-private packages with `pnpm publish -r`, syncs the `beta` dist-tag to the same version, and verifies both `latest` and `beta` dist-tags. If npm authentication fails, run:
 
 ```bash
 npm login --registry https://registry.npmjs.org/
 ```
 
-Never publish individual packages with `--filter`. Always use `pnpm publish:beta`; it resolves `workspace:*` dependencies correctly and keeps the monorepo package set on one version.
+Never publish individual packages with `--filter`. Always use `pnpm publish:beta`; it resolves `workspace:*` dependencies correctly, avoids sequential per-package publishes, and keeps the monorepo package set on one version.
 
 ## Documentation Sync
 

--- a/content/examples/README.md
+++ b/content/examples/README.md
@@ -6,13 +6,13 @@ Working code samples for common Robota SDK use cases.
 
 - [Basic Conversation](./basic-conversation.md) — Simple agent with conversation history
 - [Tool Calling](./tool-calling.md) — Agents that call functions
-- [Multi-Provider](./multi-provider.md) — Switching between Anthropic, OpenAI, Google
+- [Multi-Provider](./multi-provider.md) — Switching between Anthropic, OpenAI, Gemini, Gemma, and Qwen
 - [Streaming](./streaming.md) — Real-time text output
 
 ## SDK
 
-- [One-Shot Query](./one-shot-query.md) — Using `query()` for single-turn interactions
-- [Session Management](./session-management.md) — Multi-turn sessions with `createSession()`
+- [One-Shot Query](./one-shot-query.md) — Using `createQuery()` for single-turn interactions
+- [Session Management](./session-management.md) — Multi-turn sessions with `InteractiveSession`
 
 ## CLI
 

--- a/content/examples/http-transport.md
+++ b/content/examples/http-transport.md
@@ -6,9 +6,11 @@ Expose InteractiveSession over REST API using Hono.
 
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { createHttpTransport } from '@robota-sdk/agent-transport-http';
 import { serve } from '@hono/node-server';
 
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 const session = new InteractiveSession({ cwd: process.cwd(), provider });
 
 const transport = createHttpTransport();

--- a/content/examples/interactive-mode.md
+++ b/content/examples/interactive-mode.md
@@ -27,6 +27,12 @@ Type `/` to see all available commands. The autocomplete popup filters as you ty
 /clear        Clear history and start fresh
 /resume       Resume a previous session
 /rename name  Rename the current session
+/provider     Manage provider profiles
+/memory       Inspect and manage project memory
+/rewind       Restore an edit checkpoint
+/background   List and control background tasks
+/agent        Run or manage background subagent jobs
+/statusline   Show, hide, or reset status line fields
 /reload-plugins  Reload all plugins
 ```
 

--- a/content/examples/mcp-transport.md
+++ b/content/examples/mcp-transport.md
@@ -6,9 +6,11 @@ Expose InteractiveSession as a Model Context Protocol server.
 
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { createMcpTransport } from '@robota-sdk/agent-transport-mcp';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 const session = new InteractiveSession({ cwd: process.cwd(), provider });
 
 const transport = createMcpTransport({
@@ -25,7 +27,7 @@ await transport.getServer().connect(new StdioServerTransport());
 
 ## MCP Tools
 
-The server exposes these tools to MCP clients:
+The server exposes `submit` plus one `command_<name>` MCP tool for each command returned by `session.listCommands()`:
 
 | Tool            | Input                | Description                        |
 | --------------- | -------------------- | ---------------------------------- |
@@ -36,8 +38,10 @@ The server exposes these tools to MCP clients:
 | command_mode    | `{ args?: string }`  | Show/change permission mode        |
 | command_model   | `{ args?: string }`  | Change AI model                    |
 | command_context | `{ args?: string }`  | Context window info                |
+| command_resume  | `{ args?: string }`  | Resume a previous session          |
+| command_rename  | `{ args?: string }`  | Rename the current session         |
 
-System commands are auto-discovered via `session.listCommands()`.
+Other auto-discovered commands, such as `memory`, `rewind`, `provider`, `background`, `plugin`, `reload-plugins`, and command-module entries like `agent`, are exposed the same way when they are available on the session.
 
 ## Advanced: Direct MCP Server
 

--- a/content/examples/multi-provider.md
+++ b/content/examples/multi-provider.md
@@ -7,6 +7,8 @@ import { Robota } from '@robota-sdk/agent-core';
 import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
 import { GeminiProvider } from '@robota-sdk/agent-provider-gemini';
+import { GemmaProvider } from '@robota-sdk/agent-provider-gemma';
+import { QwenProvider } from '@robota-sdk/agent-provider-qwen';
 
 const agent = new Robota({
   name: 'MultiAgent',
@@ -14,6 +16,15 @@ const agent = new Robota({
     new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY }),
     new OpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
     new GeminiProvider({ apiKey: process.env.GEMINI_API_KEY }),
+    new GemmaProvider({
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+      defaultModel: 'gemma-local-model',
+    }),
+    new QwenProvider({
+      apiKey: process.env.DASHSCOPE_API_KEY,
+      defaultModel: 'qwen-plus',
+    }),
   ],
   defaultModel: {
     provider: 'anthropic',
@@ -35,6 +46,16 @@ console.log('GPT-4:', response);
 agent.setModel({ provider: 'gemini', model: 'gemini-2.5-pro' });
 response = await agent.run('And now?');
 console.log('Gemini:', response);
+
+// Switch to local Gemma
+agent.setModel({ provider: 'gemma', model: 'gemma-local-model' });
+response = await agent.run('Summarize the conversation locally.');
+console.log('Gemma:', response);
+
+// Switch to Qwen/DashScope
+agent.setModel({ provider: 'qwen', model: 'qwen-plus' });
+response = await agent.run('Give one closing recommendation.');
+console.log('Qwen:', response);
 ```
 
 Conversation history is preserved across provider switches. The new provider sees the full context.

--- a/content/examples/print-mode.md
+++ b/content/examples/print-mode.md
@@ -62,14 +62,14 @@ robota -p "Explain recursion" --output-format stream-json
 robota -p "query" --output-format json | jq -r '.result'
 ```
 
-## System Prompt
+## System Prompt Append
 
 ```bash
-# Replace system prompt
-robota -p "Review this code" --system-prompt "You are a security auditor"
-
 # Append to default system prompt
 robota -p "Fix the bug" --append-system-prompt "Focus on error handling"
+
+# Require JSON output matching a schema
+robota -p "Describe this package" --json-schema '{"type":"object"}'
 ```
 
 ## Exit Codes

--- a/content/examples/session-management.md
+++ b/content/examples/session-management.md
@@ -7,8 +7,10 @@ Multi-turn sessions with permissions, context tracking, and compaction.
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 
 const sessionStore = new SessionStore();
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 const session = new InteractiveSession({
   cwd: process.cwd(),
@@ -43,32 +45,33 @@ const forked = new InteractiveSession({
 });
 ```
 
-## Using Session Directly (Advanced)
+## Using InteractiveSession Events
 
 ```typescript
-import { createSession, loadConfig, loadContext, detectProject } from '@robota-sdk/agent-sdk';
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 
-const cwd = process.cwd();
-const [config, context, projectInfo] = await Promise.all([
-  loadConfig(cwd),
-  loadContext(cwd),
-  detectProject(cwd),
-]);
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-const session = createSession({
-  config,
-  context,
-  terminal,
-  projectInfo,
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
   permissionMode: 'default',
-  onTextDelta: (delta) => process.stdout.write(delta),
-  onCompact: (summary) => console.log('\n[Context compacted]'),
 });
 
-// Multi-turn conversation
-await session.run('What is the architecture of this project?');
-await session.run('Show me the main entry point.');
-await session.run('What tests exist?');
+session.on('text_delta', (delta) => process.stdout.write(delta));
+session.on('context_update', (state) => {
+  console.log(`Context: ${state.usedPercentage.toFixed(1)}% used`);
+});
+session.on('complete', ({ response }) => {
+  console.log('\n--- Complete response ---');
+  console.log(response);
+});
+
+// Multi-turn conversation. submit() queues automatically if a run is active.
+await session.submit('What is the architecture of this project?');
+await session.submit('Show me the main entry point.');
+await session.submit('What tests exist?');
 
 // Check context usage
 const state = session.getContextState();
@@ -76,16 +79,15 @@ console.log(`Context: ${state.usedPercentage.toFixed(1)}% used`);
 
 // Manual compaction with focus
 if (state.usedPercentage > 70) {
-  await session.compact('Focus on the architecture discussion');
+  await session.executeCommand('compact', 'Focus on the architecture discussion');
 }
 
 // Session metadata
-console.log(`Session: ${session.getSessionId()}`);
-console.log(`Messages: ${session.getMessageCount()}`);
-console.log(`Mode: ${session.getPermissionMode()}`);
+console.log(`Messages: ${session.getFullHistory().length}`);
+console.log(`Mode: ${session.getSession().getPermissionMode()}`);
 
 // Change permission mode
-session.setPermissionMode('acceptEdits');
+session.getSession().setPermissionMode('acceptEdits');
 
 // Abort a long-running request
 setTimeout(() => session.abort(), 30000);
@@ -94,19 +96,21 @@ setTimeout(() => session.abort(), 30000);
 ## Session Persistence
 
 ```typescript
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { SessionStore } from '@robota-sdk/agent-sessions';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 
 const store = new SessionStore();
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 // Sessions auto-persist when a store is provided
-const session = createSession({
-  config,
-  context,
-  terminal,
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
   sessionStore: store,
 });
 
-await session.run('Hello');
+await session.submit('Hello');
 
 // Later — list and resume sessions
 const sessions = store.list();
@@ -121,10 +125,10 @@ robota -c
 
 # Resume specific session (by name or ID)
 robota -r my-feature
-robota --resume
 
 # Fork from existing session (new ID, same context)
 robota -c --fork-session
+robota -r my-feature --fork-session
 
 # Name a session
 robota --name "auth-refactor"

--- a/content/examples/streaming.md
+++ b/content/examples/streaming.md
@@ -35,16 +35,15 @@ console.log(response);
 ## With Sessions (SDK)
 
 ```typescript
-import { createSession, loadConfig, loadContext } from '@robota-sdk/agent-sdk';
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
 
-const session = createSession({
-  config: await loadConfig(process.cwd()),
-  context: await loadContext(process.cwd()),
-  terminal,
-  onTextDelta: (delta) => process.stdout.write(delta),
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
 });
 
-await session.run('Explain the architecture of this project');
+session.on('text_delta', (delta) => process.stdout.write(delta));
+await session.submit('Explain the architecture of this project');
 ```
 
-The `onTextDelta` option on `createSession()` is wired to the provider automatically.
+The `text_delta` event streams output from the underlying provider while `submit()` is running.

--- a/content/examples/tool-calling.md
+++ b/content/examples/tool-calling.md
@@ -14,16 +14,16 @@ const provider = new AnthropicProvider({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-const calculatorTool = createZodFunctionTool({
-  name: 'calculator',
-  description: 'Evaluate a math expression',
-  schema: z.object({
+const calculatorTool = createZodFunctionTool(
+  'calculator',
+  'Evaluate a math expression',
+  z.object({
     expression: z.string().describe('The math expression to evaluate'),
   }),
-  handler: async ({ expression }) => ({
+  async ({ expression }) => ({
     data: String(eval(expression)),
   }),
-});
+);
 
 const agent = new Robota({
   name: 'MathAgent',
@@ -44,30 +44,30 @@ console.log(response);
 ## Multiple Tools
 
 ```typescript
-const fileSearchTool = createZodFunctionTool({
-  name: 'search_files',
-  description: 'Search for files by name pattern',
-  schema: z.object({
+const fileSearchTool = createZodFunctionTool(
+  'search_files',
+  'Search for files by name pattern',
+  z.object({
     pattern: z.string().describe('Glob pattern'),
   }),
-  handler: async ({ pattern }) => {
+  async ({ pattern }) => {
     const { glob } = await import('fast-glob');
     const files = await glob(pattern);
     return { data: JSON.stringify(files) };
   },
-});
+);
 
-const readFileTool = createZodFunctionTool({
-  name: 'read_file',
-  description: 'Read the contents of a file',
-  schema: z.object({
+const readFileTool = createZodFunctionTool(
+  'read_file',
+  'Read the contents of a file',
+  z.object({
     path: z.string().describe('File path to read'),
   }),
-  handler: async ({ path }) => {
+  async ({ path }) => {
     const { readFileSync } = await import('fs');
     return { data: readFileSync(path, 'utf-8') };
   },
-});
+);
 
 const agent = new Robota({
   name: 'FileAgent',

--- a/content/examples/ws-transport.md
+++ b/content/examples/ws-transport.md
@@ -6,12 +6,14 @@ Real-time bidirectional communication with InteractiveSession.
 
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { createWsTransport } from '@robota-sdk/agent-transport-ws';
 import { WebSocketServer } from 'ws';
 
 const wss = new WebSocketServer({ port: 8080 });
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-wss.on('connection', (ws) => {
+wss.on('connection', async (ws) => {
   const session = new InteractiveSession({ cwd: process.cwd(), provider });
   const transport = createWsTransport({
     send: (msg) => ws.send(JSON.stringify(msg)),

--- a/content/getting-started/README.md
+++ b/content/getting-started/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Node.js**: 18.0.0 or higher (recommended: 22.14.0)
-- **AI Provider API key**: Anthropic, OpenAI, or Google
+- **AI Provider API key**: Anthropic, OpenAI, Gemini, Qwen, or another configured provider
 
 ## Installation
 
@@ -67,16 +67,16 @@ const provider = new AnthropicProvider({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-const weatherTool = createZodFunctionTool({
-  name: 'get_weather',
-  description: 'Get current weather for a city',
-  schema: z.object({
+const weatherTool = createZodFunctionTool(
+  'get_weather',
+  'Get current weather for a city',
+  z.object({
     city: z.string().describe('City name'),
   }),
-  handler: async ({ city }) => ({
+  async ({ city }) => ({
     data: JSON.stringify({ city, temperature: 22, condition: 'sunny' }),
   }),
-});
+);
 
 const agent = new Robota({
   name: 'WeatherBot',
@@ -123,25 +123,29 @@ response = await agent.run('Continue our conversation.');
 ### 4. Use the SDK for project-aware sessions
 
 ```typescript
-import { createSession, loadConfig, loadContext, detectProject } from '@robota-sdk/agent-sdk';
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 
-const cwd = process.cwd();
-const [config, context, projectInfo] = await Promise.all([
-  loadConfig(cwd),
-  loadContext(cwd),
-  detectProject(cwd),
-]);
-
-// createSession assembles provider, tools, and system prompt automatically
-const session = createSession({
-  config,
-  context,
-  terminal,
-  projectInfo,
+const provider = new AnthropicProvider({
+  apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-// Session provides permissions, hooks, compaction, and persistence
-const response = await session.run('Explain the architecture of this project');
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
+  permissionMode: 'default',
+});
+
+session.on('text_delta', (delta) => process.stdout.write(delta));
+
+session.on('complete', ({ response }) => {
+  console.log('\n--- Complete response ---');
+  console.log(response);
+});
+
+// InteractiveSession loads project context and settings, then provides
+// permissions, hooks, compaction, commands, persistence, and transports.
+await session.submit('Explain the architecture of this project');
 ```
 
 ### 5. Use the CLI
@@ -160,6 +164,6 @@ robota --model claude-opus-4-6
 ## What's Next
 
 - [Building Agents](../guide/building-agents.md) — Agent patterns with agent-core
-- [Using the SDK](../guide/sdk.md) — Config, context, sessions, query()
+- [Using the SDK](../guide/sdk.md) — InteractiveSession, transports, sessions, createQuery()
 - [CLI Reference](../guide/cli.md) — Full CLI usage guide
 - [Architecture](../guide/architecture.md) — Package layers and design

--- a/content/guide/README.md
+++ b/content/guide/README.md
@@ -4,8 +4,8 @@
 
 - [Architecture](./architecture.md) — Layered package design and dependency flow
 - [Building Agents](./building-agents.md) — Creating agents with agent-core: providers, tools, plugins, streaming
-- [Using the SDK](./sdk.md) — Config loading, context discovery, sessions, and query()
-- [CLI Reference](./cli.md) — Interactive TUI, slash commands, permission modes
-- [Release Notes: 2026-05-02](./release-2026-05-02.md) — 48-hour develop snapshot covering agents, CLI, providers, and replay work
+- [Using the SDK](./sdk.md) — InteractiveSession, transports, sessions, and createQuery()
+- [CLI Reference](./cli.md) — Interactive TUI, slash commands, providers, permission modes
+- [Release Notes: 2026-05-02](./release-2026-05-02.md) — Beta.59 snapshot covering agents, CLI, providers, CI/deploy, publish, and replay work
 - [Permissions and Hooks](./permissions-and-hooks.md) — Security model and lifecycle hooks
 - [Context Management](./context-management.md) — Token tracking, compaction, and streaming

--- a/content/guide/architecture.md
+++ b/content/guide/architecture.md
@@ -14,33 +14,33 @@ agent-transport-headless ← Headless transport: non-interactive execution with 
   ↓ (all five consume)
 agent-sdk                ← Assembly layer: InteractiveSession, SystemCommandExecutor,
   │                          CommandRegistry, BuiltinCommandSource, SkillCommandSource,
-  │                          config, context, session factory, query(), Agent tool
+  │                          config, context, createQuery(), Agent tool
   ↓
 agent-sessions    ← Session lifecycle: permissions, hooks, compaction, persistence, replay events
 agent-runtime     ← Background task and subagent lifecycle primitives
 agent-tools       ← Tool infrastructure + 8 built-in CLI tools
-agent-providers   ← AI provider implementations (Anthropic, OpenAI, Gemini, Gemma, Qwen)
+agent-providers   ← AI provider implementations (Anthropic, OpenAI, Gemini, Google compatibility, Gemma, Qwen)
   ↓
 agent-core        ← Foundation: Robota engine, abstractions, DI, events, plugins
 ```
 
 ## Package Roles
 
-| Package                      | Role                                                                                                                                                       | Layer        |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| **agent-core**               | Robota engine, execution loop, provider abstraction, permissions, hooks, plugin system, model definitions (SSOT)                                           | Foundation   |
-| **agent-tools**              | ToolRegistry, FunctionTool, createZodFunctionTool, 8 built-in CLI tools                                                                                    | General      |
-| **agent-sessions**           | Session class with permission enforcement, context tracking, compaction                                                                                    | General      |
-| **agent-runtime**            | Background task state machines, subagent manager contracts, task snapshots, watchdogs, transcript references                                               | General      |
-| **agent-providers**          | Provider packages for Anthropic, OpenAI/OpenAI-compatible model families, Qwen, Google, and future integrations                                            | General      |
-| **agent-command-agent**      | Optional `/agent` command module for user-invoked subagent job control                                                                                     | SDK-specific |
-| **agent-sdk**                | Assembly: InteractiveSession, SystemCommandExecutor, CommandRegistry, BuiltinCommandSource, SkillCommandSource, config loading, context discovery, query() | SDK-specific |
-| **agent-cli**                | Ink TUI: useInteractiveSession hook bridges SDK events → React state, permission prompts                                                                   | Transport    |
-| **agent-transport-http**     | Hono-based HTTP/REST adapter — exposes InteractiveSession over HTTP (Cloudflare Workers, Node.js, AWS Lambda)                                              | Transport    |
-| **agent-transport-mcp**      | Model Context Protocol adapter — exposes InteractiveSession as an MCP server for Claude and other MCP clients                                              | Transport    |
-| **agent-transport-ws**       | Framework-agnostic WebSocket adapter — exposes InteractiveSession over real-time connections (works with any WS library)                                   | Transport    |
-| **agent-transport-headless** | Non-interactive headless adapter — runs InteractiveSession without a terminal, outputting text, JSON, or stream-JSON                                       | Transport    |
-| **agent-remote-client**      | HTTP client for calling a remote Robota agent exposed via agent-transport-http                                                                             | Client       |
+| Package                      | Role                                                                                                                                                             | Layer        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| **agent-core**               | Robota engine, execution loop, provider abstraction, permissions, hooks, plugin system, model definitions (SSOT)                                                 | Foundation   |
+| **agent-tools**              | ToolRegistry, FunctionTool, createZodFunctionTool, 8 built-in CLI tools                                                                                          | General      |
+| **agent-sessions**           | Session class with permission enforcement, context tracking, compaction                                                                                          | General      |
+| **agent-runtime**            | Background task state machines, subagent manager contracts, task snapshots, watchdogs, transcript references                                                     | General      |
+| **agent-providers**          | Provider packages for Anthropic, OpenAI, OpenAI-compatible primitives, Gemini, Google compatibility, Gemma, Qwen, and future integrations                        | General      |
+| **agent-command-agent**      | Optional `/agent` command module for user-invoked subagent job control                                                                                           | SDK-specific |
+| **agent-sdk**                | Assembly: InteractiveSession, SystemCommandExecutor, CommandRegistry, BuiltinCommandSource, SkillCommandSource, config loading, context discovery, createQuery() | SDK-specific |
+| **agent-cli**                | Ink TUI: useInteractiveSession hook bridges SDK events → React state, permission prompts                                                                         | Transport    |
+| **agent-transport-http**     | Hono-based HTTP/REST adapter — exposes InteractiveSession over HTTP (Cloudflare Workers, Node.js, AWS Lambda)                                                    | Transport    |
+| **agent-transport-mcp**      | Model Context Protocol adapter — exposes InteractiveSession as an MCP server for Claude and other MCP clients                                                    | Transport    |
+| **agent-transport-ws**       | Framework-agnostic WebSocket adapter — exposes InteractiveSession over real-time connections (works with any WS library)                                         | Transport    |
+| **agent-transport-headless** | Non-interactive headless adapter — runs InteractiveSession without a terminal, outputting text, JSON, or stream-JSON                                             | Transport    |
+| **agent-remote-client**      | HTTP client for calling a remote Robota agent exposed via agent-transport-http                                                                                   | Client       |
 
 ## Dependency Flow
 
@@ -123,7 +123,7 @@ Key responsibilities:
 | **Event emission**        | Emits typed events (`text_delta`, `tool_start`, `tool_end`, `thinking`, `context_update`, `error`) consumed by clients                  |
 | **Universal history**     | Maintains `IHistoryEntry[]` — unified timeline of chat messages and session events; `getFullHistory()` returns the complete list        |
 | **SystemCommandExecutor** | Embedded inside `InteractiveSession`. Intercepts built-in system commands (help, clear, compact, mode, model, etc.) before any LLM call |
-| **CommandRegistry**       | Aggregates `BuiltinCommandSource` and `SkillCommandSource` for slash-command discovery                                                  |
+| **CommandRegistry**       | SDK-owned utility used by clients to aggregate built-in, skill, plugin, and command-module sources for slash-command discovery          |
 
 The CLI's `useInteractiveSession` hook subscribes to these events and translates them into React state via `TuiStateManager`. `InteractiveSession` itself has no React dependency.
 

--- a/content/guide/building-agents.md
+++ b/content/guide/building-agents.md
@@ -81,18 +81,47 @@ const provider = new GeminiProvider({
 });
 ```
 
+### Gemma
+
+```typescript
+import { GemmaProvider } from '@robota-sdk/agent-provider-gemma';
+
+const provider = new GemmaProvider({
+  apiKey: 'lm-studio',
+  baseURL: 'http://localhost:1234/v1',
+  defaultModel: 'gemma-local-model',
+});
+```
+
+Use the Gemma provider for Gemma-family local models served through LM Studio or another OpenAI-compatible endpoint. It owns Gemma-specific reasoning marker filtering and native tool-call text projection.
+
+### Qwen
+
+```typescript
+import { QwenProvider } from '@robota-sdk/agent-provider-qwen';
+
+const provider = new QwenProvider({
+  apiKey: process.env.DASHSCOPE_API_KEY,
+  defaultModel: 'qwen-plus',
+});
+```
+
+Qwen can also enable provider-side hosted web search and extraction through `builtInWebTools`; those tools are separate from Robota local tools and do not bypass local permission checks.
+
 ### Switching Providers
 
 ```typescript
 const agent = new Robota({
   name: 'FlexAgent',
-  aiProviders: [anthropicProvider, openaiProvider, geminiProvider],
+  aiProviders: [anthropicProvider, openaiProvider, geminiProvider, gemmaProvider, qwenProvider],
   defaultModel: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
 });
 
 // Switch at any time
 agent.setModel({ provider: 'openai', model: 'gpt-4o' });
 agent.setModel({ provider: 'gemini', model: 'gemini-2.5-pro' });
+agent.setModel({ provider: 'gemma', model: 'gemma-local-model' });
+agent.setModel({ provider: 'qwen', model: 'qwen-plus' });
 ```
 
 ## Tools
@@ -317,13 +346,13 @@ try {
 
 ## Changes from v2.0.0
 
-| v2.0.0                                     | v3.0.0                                                    |
-| ------------------------------------------ | --------------------------------------------------------- |
-| Plugins built into `agent-core`            | 9 plugins extracted to `agent-plugin-*` packages          |
-| `FunctionTool` in `agent-core`             | Moved to `@robota-sdk/agent-tools`                        |
-| `ToolRegistry` in `agent-core`             | Moved to `@robota-sdk/agent-tools`                        |
-| `MCPTool` / `RelayMcpTool` in `agent-core` | Moved to `@robota-sdk/agent-tool-mcp`                     |
-| No permission/hook system                  | Permission evaluation + shell hook system in `agent-core` |
-| No session management                      | `Session` class in `agent-sessions` with compaction       |
-| No CLI                                     | `agent-cli` with Ink TUI                                  |
-| No SDK layer                               | `agent-sdk` with config/context loading and `query()`     |
+| v2.0.0                                     | v3.0.0                                                      |
+| ------------------------------------------ | ----------------------------------------------------------- |
+| Plugins built into `agent-core`            | 9 plugins extracted to `agent-plugin-*` packages            |
+| `FunctionTool` in `agent-core`             | Moved to `@robota-sdk/agent-tools`                          |
+| `ToolRegistry` in `agent-core`             | Moved to `@robota-sdk/agent-tools`                          |
+| `MCPTool` / `RelayMcpTool` in `agent-core` | Moved to `@robota-sdk/agent-tool-mcp`                       |
+| No permission/hook system                  | Permission evaluation + shell hook system in `agent-core`   |
+| No session management                      | `Session` class in `agent-sessions` with compaction         |
+| No CLI                                     | `agent-cli` with Ink TUI                                    |
+| No SDK layer                               | `agent-sdk` with config/context loading and `createQuery()` |

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -22,8 +22,9 @@ robota --model claude-opus-4-6      # Model override
 robota --permission-mode plan       # Permission mode override
 robota --max-turns 10               # Limit agentic turns
 robota --output-format json         # Output format (text/json/stream-json)
-robota --system-prompt "..."        # Replace system prompt
 robota --append-system-prompt "..." # Append to system prompt
+robota --configure                  # Interactive provider setup
+robota --provider qwen              # Run with a configured provider profile
 robota --reset                      # Delete user settings and exit
 robota --check-update               # Check npm for a newer CLI version and exit
 robota --disable-update-check        # Skip startup update check for this run
@@ -85,11 +86,11 @@ cat error.log | robota -p "What went wrong?"
 git diff | robota -p "Review this diff" --output-format json
 ```
 
-### System Prompt Overrides
+### System Prompt Append
 
 ```bash
-robota -p "query" --system-prompt "You are a code reviewer"
 robota -p "query" --append-system-prompt "Focus on security issues"
+robota -p "query" --json-schema '{"type":"object"}'
 ```
 
 ### Exit Codes
@@ -135,28 +136,37 @@ The state shape exposed to components includes `history: IHistoryEntry[]` — th
 
 `TuiStateManager` is a pure TypeScript class with no React dependency. It can be instantiated and tested independently of the component tree, making state transition logic fully unit-testable.
 
-The CLI contains no session management logic beyond this hook. The old `useSession`, `useSubmitHandler`, `useSlashCommands`, `useCommandRegistry`, and `useMessages` hooks have been removed and their responsibilities moved to `InteractiveSession` in the SDK.
+The CLI contains no session management logic beyond this hook. The old `useSession`, `useSubmitHandler`, `useSlashCommands`, `useCommandRegistry`, and `useMessages` hooks have been removed; session execution lives in `InteractiveSession`, and command discovery uses SDK-owned command registry/source classes.
 
 ## Slash Commands
 
 Type `/` to trigger the autocomplete popup. Arrow keys to navigate, Tab to insert into input (without executing), Enter to execute immediately.
 
-The available command list is provided by `InteractiveSession.getCommands()`, which aggregates `BuiltinCommandSource` and `SkillCommandSource`. The CLI renders this list but does not own it.
+The available command list is built from SDK-owned command sources: `BuiltinCommandSource`, `SkillCommandSource`, `PluginCommandSource`, and command modules such as `agent-command-agent`. The CLI renders this list but does not own the command definitions.
 
-| Command                   | Description                      |
-| ------------------------- | -------------------------------- |
-| `/help`                   | Show available commands          |
-| `/clear`                  | Clear conversation history       |
-| `/mode [mode]`            | Show or change permission mode   |
-| `/model [model]`          | Show or change AI model          |
-| `/compact [instructions]` | Compress context window          |
-| `/cost`                   | Show session info                |
-| `/context`                | Context window details           |
-| `/permissions`            | Show permission rules            |
-| `/exit`                   | Exit CLI                         |
-| `/plugin`                 | Plugin manager (interactive TUI) |
-| `/reload-plugins`         | Reload all plugins               |
-| `/language [lang]`        | Show or change UI language       |
+| Command                   | Description                             |
+| ------------------------- | --------------------------------------- |
+| `/help`                   | Show available commands                 |
+| `/clear`                  | Clear conversation history              |
+| `/mode [mode]`            | Show or change permission mode          |
+| `/model [model]`          | Show or change AI model                 |
+| `/compact [instructions]` | Compress context window                 |
+| `/cost`                   | Show session info                       |
+| `/context`                | Context window details                  |
+| `/permissions`            | Show permission rules                   |
+| `/memory`                 | Inspect and manage project memory       |
+| `/rewind`                 | List and restore edit checkpoints       |
+| `/provider`               | Manage provider profiles                |
+| `/resume`                 | Resume a previous session               |
+| `/background`             | List and control background tasks       |
+| `/agent`                  | Run and manage background subagent jobs |
+| `/rename`                 | Rename the current session              |
+| `/exit`                   | Exit CLI                                |
+| `/plugin`                 | Plugin manager (interactive TUI)        |
+| `/reload-plugins`         | Reload all plugins                      |
+| `/language [lang]`        | Show or change UI language              |
+| `/statusline`             | Show, hide, or reset status line fields |
+| `/reset`                  | Delete settings and exit                |
 
 `/mode` and `/model` show nested submenus for selection.
 
@@ -262,7 +272,7 @@ The CLI supports continuing, resuming, forking, and naming sessions for workflow
 ```bash
 robota -c                    # Continue the most recent session
 robota -r <session-id>       # Resume a specific session by ID
-robota --fork-session <id>   # Fork a session (new session with copied history)
+robota -r <session-id> --fork-session # Fork a session (new session with copied history)
 robota --name "my-task"      # Assign a name to the session at startup
 ```
 

--- a/content/guide/context-management.md
+++ b/content/guide/context-management.md
@@ -45,29 +45,30 @@ CLAUDE.md can define a "Compact Instructions" section. These instructions are au
 
 ## Streaming
 
-The `onTextDelta` callback provides real-time text as the model generates it:
+The `text_delta` event provides real-time text as the model generates it:
 
 ```typescript
-const session = createSession({
-  config,
-  context,
-  terminal,
-  onTextDelta: (delta) => process.stdout.write(delta),
-});
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const session = new InteractiveSession({ cwd: process.cwd(), provider });
+session.on('text_delta', (delta) => process.stdout.write(delta));
 ```
 
-The completed response is returned by `session.run()` after streaming finishes.
+The `complete` event carries the final response after streaming finishes.
 
 ### Web Search
 
-The Anthropic provider supports server-side web search (`web_search_20250305`). When `enableWebTools` is set on the provider instance, the model can search the web during response generation. The `onServerToolUse` callback fires when search executes.
+Provider-side web tools are distinct from Robota local tools. Anthropic supports server-side web search (`web_search_20250305`) when `enableWebTools` is set on the provider instance, and `onServerToolUse` fires when search executes. Qwen supports provider-side `web_search` and `web_extractor` through `builtInWebTools`; those hosted tools record provenance in assistant-message metadata and do not bypass local Robota permission checks.
 
 ## Abort
 
-Cancel a running `session.run()` via AbortSignal:
+Cancel a running `InteractiveSession.submit()` via AbortSignal:
 
 ```typescript
 session.abort(); // Triggers AbortSignal, cancels streaming
 ```
 
-The AbortSignal flows through the entire execution chain: `Session.run()` passes the signal to `Robota.run()`, which passes it to the provider. `AbstractAIProvider.streamWithAbort()` provides a standard streaming wrapper that all providers use to handle abort — when the signal fires, the provider returns partial content with `stopReason: 'aborted'`. The partial response is committed to history with `state: 'interrupted'`.
+The AbortSignal flows through the entire execution chain: `InteractiveSession` calls `Session.run()`, `Session.run()` passes the signal to `Robota.run()`, and `Robota.run()` passes it to the provider. `AbstractAIProvider.streamWithAbort()` provides a standard streaming wrapper that all providers use to handle abort — when the signal fires, the provider returns partial content with `stopReason: 'aborted'`. The partial response is committed to history with `state: 'interrupted'`.

--- a/content/guide/release-2026-05-02.md
+++ b/content/guide/release-2026-05-02.md
@@ -1,25 +1,25 @@
-# Release Notes: 48-Hour Develop Snapshot
+# Release Notes: 2026-05-02 Beta 59 Snapshot
 
-This document summarizes the final develop-branch state after the 48-hour work window ending on 2026-05-02. It covers the merged PR range from the subagent runtime work through session replay events and Agent batch jobs.
+This document summarizes the develop-branch work window that was promoted to `main` by PR #144 on 2026-05-03 02:09 KST. It covers the runtime, CLI, provider, CI, deployment, and publishing process state now represented by the `3.0.0-beta.59` npm release.
 
 ## Scope
 
-- Time window: 2026-04-30 23:01 KST through 2026-05-02 23:20 KST
-- Develop range: `d2c351652^..76564c16d`
-- PR range: #100 through #147
-- Published releases inside the range: `3.0.0-beta.56`, `3.0.0-beta.57`
-- Process baseline before this documentation refresh: `76564c16d`
+- Time window: 2026-04-30 23:01 KST through 2026-05-03 02:09 KST
+- Develop range: `d2c351652^..59d0d42a8`
+- Main promotion: `b9d9b9d9c` (`Merge pull request #144 from woojubb/develop`)
+- Published releases inside the range: `3.0.0-beta.56`, `3.0.0-beta.57`, `3.0.0-beta.58`, `3.0.0-beta.59`
+- Current npm state: all 18 publishable `@robota-sdk/*` packages have both `latest` and `beta` dist-tags on `3.0.0-beta.59`
 
 ## Release Intent
 
 The work turns Robota from a basic interactive coding assistant into a more complete agent runtime:
 
 - Subagents are real background jobs with runtime-owned state, transcripts, watchdogs, and command surfaces.
-- The CLI is a TUI shell over SDK-owned session state, with richer status, usage, diff, and background-work displays.
-- Provider composition is now definition-driven, allowing Qwen, Gemma, Gemini, Anthropic, OpenAI, and OpenAI-compatible endpoints to be configured without CLI-specific branches.
-- Session logs now begin moving toward replay-grade provenance by recording provider/tool execution boundary events.
-- The Agent tool now has a deterministic batch path for explicit multi-agent and parallel-agent requests.
-- The repository harness now performs scoped verification and release-safety checks before push and publish.
+- The CLI is a TUI shell over SDK-owned session state, with richer status, usage, diff, checkpoint, memory, and background-work displays.
+- Provider composition is definition-driven, allowing Qwen, Gemma, Gemini, Anthropic, OpenAI, and OpenAI-compatible endpoints without CLI-specific provider branches.
+- Session logs now record provider/tool execution-boundary events as replay-grade provenance.
+- The Agent tool has a deterministic batch path for explicit multi-agent and parallel-agent requests.
+- CI, deployment, and beta publishing now avoid per-package rebuild/publish loops and reuse the monorepo root build path.
 
 ## Highlights
 
@@ -73,18 +73,19 @@ Merged PRs: #129, #130, #132, #134, #135, #146, #147
 - Added batch `Agent` tool schema and structured per-job results with `groupId`, `agentIds`, ordered job output, and partial failure reporting.
 - Kept unresolved replay work explicit: raw provider payloads/chunks, payload references, redaction policy, deterministic `/resume` replay, history mutation events, and validator commands remain active task scope.
 
-### Harness, Release, and Governance
+### Harness, CI, Deploy, and Publish
 
-Merged PRs: #111, #116, #137, #145 plus direct release governance commits
+Merged PRs and release commits: #111, #116, #137, #145, #149, #150, #151, plus beta.57-beta.59 release governance commits
 
 - Added scoped verification planning and pre-push verification hooks.
 - Added package coverage commands.
 - Added release dist freshness scanning that builds before checking dist output.
-- Added backlog tracking for provider usage visibility and later session replay/parallel-agent reliability work.
-- Added learning-loop and operational rule updates so repeated failures become repository guidance.
-- Published the coordinated `3.0.0-beta.57` npm release for all non-private packages.
-- Added npm authentication preflight to `pnpm publish:beta`; the script now fails before dry-run and OTP if `npm whoami` is not valid.
 - Added documentation-sync rules requiring package READMEs, package docs pages, and robota.io source pages to stay current with package changes.
+- Fixed atomic Write/Edit internals to preserve existing file mode bits during atomic replacement.
+- Changed PR CI to run the root monorepo package build once when affected scopes require build output, then reuse the archived `dist` artifact for quality verification.
+- Changed Vercel deploy verification to run the root package build once, archive package dist output, and reuse it during the app build/deploy job.
+- Hardened beta publishing so `pnpm publish:beta` runs npm auth preflight, performs one recursive dry-run, prompts for OTP only after dry-run succeeds, publishes all non-private packages with `pnpm publish -r`, syncs the `beta` dist-tag, and verifies both `latest` and `beta`.
+- Confirmed lockfile updates are produced through `pnpm install`; generated lockfile content is not manually edited.
 
 ## User-Facing Changes
 
@@ -93,17 +94,18 @@ Merged PRs: #111, #116, #137, #145 plus direct release governance commits
 - `robota --check-update` checks npm for newer CLI versions.
 - `robota --disable-update-check` skips interactive startup update checks for one run.
 - `robota -p` remains deterministic and does not perform startup update checks.
-- Provider setup is now driven by provider definitions, including Anthropic, OpenAI-compatible, Gemma, and Qwen in the default CLI build.
+- Provider setup is now driven by provider definitions, including Anthropic, OpenAI-compatible, Gemma, Gemini, and Qwen in the default CLI build.
 - TUI output now gives clearer edit diffs, provider usage summaries, command-output collapse, background job tree rows, and status activity.
 - Slash-command behavior is increasingly SDK-owned; the CLI renders and routes commands rather than owning session logic.
 
 ### SDK
 
-- `InteractiveSession` remains the primary assembly API for interactive clients.
+- `InteractiveSession` is the primary assembly API for interactive clients.
+- Consumers pass a provider instance to `InteractiveSession` or `createQuery()`; the SDK remains provider-neutral.
 - Agent definitions and active tasks are included in prompt composition when enabled.
 - System commands, skills, memory, checkpointing, and background jobs are SDK-level capabilities that CLI and transports can consume.
 - `Agent` tool supports `jobs` for batch subagent execution.
-- Session logs include more execution-boundary events, but full deterministic replay is still an active task.
+- Session logs include more execution-boundary events, but full deterministic replay is still active follow-up work.
 
 ### Providers
 
@@ -123,19 +125,16 @@ Merged PRs: #111, #116, #137, #145 plus direct release governance commits
 
 ## Verification Notes
 
-The final feature PR in this window passed scoped pre-push verification for:
-
-- `packages/agent-core`: build, test, lint, typecheck, scenario verification
-- `packages/agent-sdk`: build, test, lint, typecheck
-- `packages/agent-sessions`: build, test, lint, typecheck, scenario verification
-
-Release-grade verification remains explicit:
+Release-grade verification for main PRs now runs:
 
 ```bash
 pnpm harness:verify:release
+pnpm audit --audit-level high
 ```
 
-The `3.0.0-beta.57` release preparation ran `pnpm harness:verify:release` before publishing. Post-release process updates passed harness consistency and task-plan scans through the pre-push hook.
+The Node 18 compatibility job runs the root package build through `pnpm run build:deps` and then runs coverage for packages that support Node 18. Develop PR CI uses the affected-scope plan, but package/app build output is produced once at the root and reused by later jobs.
+
+The `3.0.0-beta.59` beta publish completed for 18 publishable packages. npm registry checks confirmed `latest=3.0.0-beta.59` and `beta=3.0.0-beta.59` for every publishable `@robota-sdk/*` package in the beta set.
 
 ## Follow-Up Work
 

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -1,6 +1,6 @@
 # Using the SDK
 
-`@robota-sdk/agent-sdk` is the assembly layer that composes `agent-core`, `agent-tools`, `agent-sessions`, and `agent-provider-anthropic` into a cohesive experience. It provides configuration loading, project context discovery, and the `InteractiveSession` primary entry point along with the `query()` convenience API.
+`@robota-sdk/agent-sdk` is the provider-neutral assembly layer that composes `agent-core`, `agent-tools`, `agent-sessions`, runtime services, commands, context loading, and transports into a cohesive experience. It exposes `InteractiveSession` as the primary entry point and `createQuery()` as the one-shot convenience API. Consumers create the provider instance and pass it in.
 
 ## InteractiveSession — Primary Entry Point
 
@@ -8,15 +8,22 @@
 
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+
+const provider = new AnthropicProvider({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+});
 
 const session = new InteractiveSession({
   cwd: process.cwd(),
+  provider,
   permissionMode: 'default',
-  onTextDelta: (delta) => process.stdout.write(delta),
 });
 
+session.on('text_delta', (delta) => process.stdout.write(delta));
+
 // Submit a prompt (queued automatically if a run is in progress)
-session.submit('Refactor the auth module');
+await session.submit('Refactor the auth module');
 
 // Abort the in-flight run (partial response saved as 'interrupted')
 session.abort();
@@ -55,35 +62,38 @@ Event types include: `tool-start` (individual tool execution began), `tool-end` 
 
 ### Command Discovery
 
-`InteractiveSession` integrates a `CommandRegistry` that aggregates two sources:
+The SDK owns `CommandRegistry` and the command sources used by clients:
 
-- **`BuiltinCommandSource`** — built-in slash commands: `/help`, `/clear`, `/compact`, `/mode`, `/model`, `/cost`, `/context`, `/permissions`, `/exit`, `/plugin`, `/reload-plugins`, `/language`, `/resume`, `/rename`
+- **`BuiltinCommandSource`** — built-in slash commands: `/help`, `/clear`, `/compact`, `/mode`, `/model`, `/cost`, `/context`, `/permissions`, `/memory`, `/rewind`, `/provider`, `/resume`, `/background`, `/rename`, `/plugin`, `/reload-plugins`, `/language`, `/reset`, `/exit`
 - **`SkillCommandSource`** — project and user skills discovered from `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, and `~/.robota/skills/`
+- **`PluginCommandSource`** — commands contributed by loaded plugins
 
-Calling `session.getCommands()` returns the merged list for autocomplete.
+Clients such as the CLI compose these sources into a registry for autocomplete. `InteractiveSession.listCommands()` returns executable system commands for transports and direct command execution, while skill commands discovered through `SkillCommandSource` are executed with `session.executeSkillCommand()`.
 
 ### System Commands
 
 `SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers access commands through `session.executeCommand(name, args)` and `session.listCommands()` — the executor is not independently exported.
 
-Before each submitted prompt, the session checks whether the input matches a built-in system command. If it does, the command is executed directly (e.g., clearing history, switching model, running compaction) and no LLM call is made. Unrecognized inputs are forwarded to the session's `run()`.
+Before each submitted prompt, the session checks whether the input matches a built-in system command. If it does, the command is executed directly (e.g., clearing history, switching model, running compaction) and no LLM call is made. Unrecognized inputs are forwarded to the underlying `Session.run()`.
 
 Transport adapters (HTTP, WS, MCP) use `session.listCommands()` to discover available commands and `session.executeCommand()` to execute them.
 
 ## createQuery() — Convenience API
 
-`createQuery({ provider })` is a lightweight factory that builds a one-shot query function pre-configured for a specific provider. Use it when you want `query()`-style simplicity but need to reuse a configured instance across multiple calls.
+`createQuery({ provider })` is a lightweight factory that builds a one-shot query function pre-configured for a specific provider. Use it when you want simple prompt-in/response-out calls but need to reuse a configured provider instance across multiple calls.
 
 ```typescript
 import { createQuery } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 
-const ask = createQuery({ provider: 'anthropic' });
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY! });
+const ask = createQuery({ provider });
 const response = await ask('List all TypeScript files in this project');
 ```
 
-## query() — One-Shot API
+## One-Shot Usage
 
-The simplest way to interact with Robota. Handles config, context, session creation, and cleanup automatically.
+The simplest way to interact with Robota is to create a query function and call it with a prompt. `createQuery()` builds an `InteractiveSession` internally, loads settings and project context from the working directory, and cleans up after each prompt.
 
 ```typescript
 import { createQuery } from '@robota-sdk/agent-sdk';
@@ -159,36 +169,36 @@ The `.claude/` paths take higher runtime priority so that Claude Code settings o
 }
 ```
 
-`currentProvider` selects the active profile from `providers`. The active profile is normalized into the resolved `provider` object with `name`, `model`, `apiKey`, optional `baseURL`, and optional `timeout`. Qwen Model Studio uses `type: "qwen"` plus the documented DashScope OpenAI-compatible `baseURL`; generic OpenAI-compatible endpoints use `type: "openai"` plus `baseURL`. The legacy single `provider` object remains supported when no active profile is configured.
+`InteractiveSession` loads these settings for permissions, hooks, project context, skills, and session behavior. Provider profile resolution is performed by the consumer shell before creating the SDK session; the CLI uses `currentProvider` and `providers` to construct the active provider instance, then passes that instance to `InteractiveSession`. Qwen Model Studio uses `type: "qwen"` plus the documented DashScope OpenAI-compatible `baseURL`; generic OpenAI-compatible endpoints use `type: "openai"` plus `baseURL`. The legacy single `provider` object remains supported by CLI/provider-settings compatibility code when no active profile is configured.
 
 The `$ENV:` prefix resolves environment variables at load time.
 
 ## Context Discovery
 
-`loadContext()` walks up from the working directory to find project context:
+`InteractiveSession` walks up from the working directory to find project context during initialization:
 
 - **AGENTS.md** — Project-level agent instructions and rules
 - **CLAUDE.md** — Additional agent instructions (Claude Code compatible)
 - **Compact Instructions** — Extracted from CLAUDE.md for use during context compaction
 
 ```typescript
-const context = await loadContext('/path/to/project');
-// { agentsMd: string, claudeMd: string, compactInstructions?: string }
+const session = new InteractiveSession({
+  cwd: '/path/to/project',
+  provider,
+});
 ```
+
+Use `bare: true` when you need a session without AGENTS.md/CLAUDE.md loading or plugin discovery.
 
 ## System Prompt
 
-`buildSystemPrompt()` assembles the system prompt from context, tools, and trust level:
+The SDK assembles the system prompt internally from loaded project context, tool descriptions, command descriptors, trust level, active task context, and optional appended instructions.
 
 ```typescript
-import { buildSystemPrompt } from '@robota-sdk/agent-sdk';
-
-const systemMessage = buildSystemPrompt({
-  agentsMd: context.agentsMd,
-  claudeMd: context.claudeMd,
-  toolDescriptions: ['Bash — execute shell commands', 'Read — read file contents'],
-  trustLevel: 'moderate',
-  projectInfo: { type: 'node', language: 'typescript' },
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
+  appendSystemPrompt: 'Prefer concise responses.',
 });
 ```
 
@@ -318,12 +328,12 @@ All transport adapters implement the `ITransportAdapter` interface (exported fro
 
 ## Assembly vs Direct Usage
 
-| Use case                       | Approach                                                           |
-| ------------------------------ | ------------------------------------------------------------------ |
-| Quick one-shot                 | `query()` / `createQuery({ provider })` — handles everything       |
-| Interactive CLI / web / server | `InteractiveSession` — event-driven, queuing, command handling     |
-| Expose over HTTP / MCP / WS    | `agent-transport-{http,mcp,ws}` wrapping `InteractiveSession`      |
-| Non-interactive / headless     | `agent-transport-headless` — text, JSON, or stream-JSON output     |
-| Call a remote agent over HTTP  | `agent-remote-client` — standalone HTTP client                     |
-| Custom agent (no SDK)          | `new Robota()` from `agent-core` directly                          |
-| Custom session (no SDK)        | `new Session()` from `agent-sessions` with your own tools/provider |
+| Use case                       | Approach                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| Quick one-shot                 | `createQuery({ provider })` — creates an `InteractiveSession` internally |
+| Interactive CLI / web / server | `InteractiveSession` — event-driven, queuing, command handling           |
+| Expose over HTTP / MCP / WS    | `agent-transport-{http,mcp,ws}` wrapping `InteractiveSession`            |
+| Non-interactive / headless     | `agent-transport-headless` — text, JSON, or stream-JSON output           |
+| Call a remote agent over HTTP  | `agent-remote-client` — standalone HTTP client                           |
+| Custom agent (no SDK)          | `new Robota()` from `agent-core` directly                                |
+| Custom session (no SDK)        | `new Session()` from `agent-sessions` with your own tools/provider       |


### PR DESCRIPTION
## Summary

- Sync handwritten robota.io `content/` docs with the `3.0.0-beta.59` repository and npm state.
- Update public examples to use the current `InteractiveSession`, `createQuery()`, and positional `createZodFunctionTool()` APIs.
- Refresh release, CI, deploy, and publish documentation, including root build reuse and npm `latest`/`beta` dist-tag verification.
- Add a task checklist documenting the audit scope and generated/frozen docs constraints.

## Generated docs policy

- Did not edit `content/api-reference/**` directly.
- Did not edit `content/v2.0.0/**`.
- Confirmed no final diff under generated docs outputs.

## Validation

- `pnpm docs:validate-structure`
- `pnpm docs:build`
- `pnpm exec prettier --check ...`
- `git diff --check`
- pre-push scoped verification (`pnpm harness:verify -- --base-ref origin/develop --skip-record-check`)