### PR TITLE
docs(backlog): add agent follow-up items

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,6 +13,7 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 | File                                                                           | Topic                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [agent-followup-roadmap.md](agent-followup-roadmap.md)                         | Recommended sequence for agent/CLI/runtime follow-ups         |
 | [agent-package-coverage-audit.md](agent-package-coverage-audit.md)             | Current coverage baseline for all agent-\* packages           |
 | [cli-model-change-restart.md](cli-model-change-restart.md)                     | `/model` restart flow does not reliably apply selected model  |
 | [compact-command-descriptor.md](compact-command-descriptor.md)                 | Descriptor-owned compact command and auto-trigger policy      |

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,7 +13,12 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 | File                                                                           | Topic                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| [agent-package-coverage-audit.md](agent-package-coverage-audit.md)             | Current coverage baseline for all agent-\* packages           |
+| [cli-model-change-restart.md](cli-model-change-restart.md)                     | `/model` restart flow does not reliably apply selected model  |
+| [compact-command-descriptor.md](compact-command-descriptor.md)                 | Descriptor-owned compact command and auto-trigger policy      |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
 | [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |
+| [reversible-agent-sandbox.md](reversible-agent-sandbox.md)                     | Reversible sandbox mode for safe agent edits and rollback     |
+| [worktree-support-hardening.md](worktree-support-hardening.md)                 | Harden and productize Git worktree isolation                  |

--- a/.agents/backlog/agent-followup-roadmap.md
+++ b/.agents/backlog/agent-followup-roadmap.md
@@ -1,0 +1,44 @@
+# Agent Follow-up Roadmap
+
+## What
+
+Coordinate the next agent/CLI/runtime backlog items into a practical execution order with the main recommendations called out explicitly.
+
+## Why
+
+The current follow-up set spans a user-facing bug, test coverage discovery, command architecture, worktree isolation, and reversible sandboxing. These should not be implemented in a random order because some items reduce risk for later items.
+
+## Recommended Order
+
+1. **Fix `/model` restart behavior** (`cli-model-change-restart.md`)
+   - Reason: this is a direct user-facing regression with a bounded surface.
+   - It does not depend on broader architecture work.
+   - The first implementation step should be a failing regression test around settings persistence and resolved model config.
+
+2. **Measure agent package coverage** (`agent-package-coverage-audit.md`)
+   - Reason: this gives a baseline before changing command/runtime/sandbox boundaries.
+   - Do not add thresholds yet; measure first, then choose targeted coverage work.
+
+3. **Research and design compact descriptor behavior** (`compact-command-descriptor.md`)
+   - Reason: compaction touches command routing, session runtime, context telemetry, and UI.
+   - Recommendation: unify manual `/compact` routing before changing auto-trigger behavior.
+
+4. **Harden worktree support** (`worktree-support-hardening.md`)
+   - Reason: worktree isolation is already partially implemented and is the local foundation for safer write-capable agent work.
+   - Recommendation: improve metadata/reporting/cleanup before making worktree isolation the default for write-capable jobs.
+
+5. **Implement reversible sandbox mode** (`reversible-agent-sandbox.md`)
+   - Reason: reversible sandboxing depends on clear checkpoint and worktree semantics.
+   - Recommendation: ship a local-first reversible mode before provider-backed sandbox snapshots.
+
+## Cross-Item Recommendations
+
+- Treat `/model` and coverage audit as early, independent work.
+- Treat compact descriptor work as a command architecture task, not just a CLI command cleanup.
+- Treat worktree hardening as the prerequisite for local reversible agent edits.
+- Treat provider-backed sandboxing as a later extension after local rollback guarantees are explicit.
+- Do not add CI coverage thresholds or default worktree isolation until measurement and reporting are trustworthy.
+
+## Promotion Path
+
+When these items are scheduled, promote them one at a time into `.agents/tasks/` with concrete IDs. Keep this roadmap in backlog until at least the model regression, coverage audit, and compact research/design are either completed or superseded.

--- a/.agents/backlog/agent-package-coverage-audit.md
+++ b/.agents/backlog/agent-package-coverage-audit.md
@@ -1,0 +1,58 @@
+# Agent Package Test Coverage Audit
+
+## What
+
+Measure and publish the current test coverage for every `@robota-sdk/agent-*` package, then turn the result into a prioritized coverage improvement plan.
+
+## Why
+
+The repository now exposes package-level coverage commands, but there is no current, package-by-package view of actual coverage for the agent package family. Without a baseline, it is hard to decide which packages need characterization tests before refactors, which packages can accept coverage gates, and which packages intentionally have little executable code.
+
+## Current Signals
+
+- Root commands exist:
+  - `pnpm test:coverage`
+  - `pnpm test:coverage:packages`
+  - `pnpm --filter "./packages/**" run --if-present test:coverage`
+- `INFRA-BL-011-package-test-coverage-commands` added consistent coverage scripts and a static harness scan for script presence.
+- CI currently keeps broad coverage out of normal PR checks and reserves broader verification for release-grade paths.
+- Older completed tasks mention previous low coverage, but those numbers are stale and should not be used as the current baseline.
+
+## Scope
+
+- Enumerate every package whose name starts with `@robota-sdk/agent-`.
+- Run each package's `test:coverage` command or a filtered batch strategy that preserves per-package reports.
+- Capture line, branch, function, and statement coverage for each package.
+- Distinguish packages with no source, no tests, generated-only code, or intentional pass-with-no-tests behavior.
+- Produce a repository-owned report, for example `.agents/reports/agent-package-coverage.md`.
+- Identify the top coverage gaps by risk, not only by lowest percentage.
+- Recommend whether package-specific thresholds should be added now, deferred, or limited to critical packages.
+
+## Non-Goals
+
+- Do not add or raise CI coverage thresholds before the baseline is measured.
+- Do not treat partial affected-test coverage as a full package coverage signal.
+- Do not rewrite test architecture as part of the audit.
+- Do not include `dag-*` packages unless the task is explicitly expanded.
+
+## Acceptance Criteria
+
+- [ ] Every `@robota-sdk/agent-*` package has a recorded coverage result or an explicit exclusion reason.
+- [ ] The report includes package name, test command, coverage percentages, and notable uncovered public surfaces.
+- [ ] The report separates "no tests" from "no executable source" packages.
+- [ ] The report identifies high-risk gaps in CLI, SDK, sessions, core, providers, transports, runtime, and tools.
+- [ ] The follow-up plan ranks coverage work by public API risk and refactor risk.
+- [ ] The audit documents whether current coverage scripts are reliable enough for recurring measurement.
+
+## Test Plan
+
+- Run the package coverage commands from a clean checkout.
+- Verify generated coverage artifacts are either ignored or cleaned up after reporting.
+- Re-run at least one high-risk package coverage command independently to confirm the collected number.
+- Run `pnpm harness:scan:coverage-scripts` to confirm the command surface still matches policy.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/INFRA-BL-0XX-agent-package-coverage-audit.md` when prioritized.
+2. Create the coverage report as a task artifact.
+3. Open follow-up backlog/tasks for targeted coverage expansion after the baseline is accepted.

--- a/.agents/backlog/cli-model-change-restart.md
+++ b/.agents/backlog/cli-model-change-restart.md
@@ -1,0 +1,58 @@
+# CLI Model Change Restart Regression
+
+## What
+
+Fix the `/model` command flow so confirming a model change actually affects the next session after Robota says it will restart.
+
+## Why
+
+The CLI currently tells the user that changing the model will restart the session, but the selected model is not reliably applied after that restart. This is a user-facing configuration bug: the command confirms an action, exits the current session, and then the next session can still use the old model.
+
+## Current Signals
+
+- `packages/agent-sdk/src/commands/system-command.ts` returns `data.modelId` for the `model` system command and leaves application to the caller.
+- `packages/agent-cli/src/ui/hooks/useSlashRouting.ts` maps `data.modelId` to `_pendingModelId`.
+- `packages/agent-cli/src/ui/hooks/useSideEffects.ts` confirms the model change, calls `updateModelInSettings()`, and requests shutdown.
+- `packages/agent-cli/src/utils/settings-io.ts` updates either `providers[currentProvider].model` or legacy `provider.model`.
+- The UI copy says "This will restart the session" and "Model changed ... Restarting...", so the observable contract is already established.
+
+## Scope
+
+- Reproduce the regression with the current settings shapes:
+  - `currentProvider` plus `providers`
+  - legacy `provider`
+  - provider profiles created by `/provider setup`
+- Determine whether the failure is settings persistence, config reload, process restart semantics, or active session reuse.
+- Make `/model` behavior consistent across slash routing and SDK system command routing.
+- Ensure the selected model is applied to `IResolvedConfig.provider.model` for the next session.
+- Keep provider-specific model validation in provider definitions/settings, not in generic CLI execution code.
+- Add regression tests for settings update and restart/reload behavior.
+
+## Non-Goals
+
+- Do not add provider-specific model-name branches to CLI, SDK, or core.
+- Do not change provider profile selection semantics.
+- Do not introduce a hidden fallback model if the requested model is invalid.
+- Do not make model changes mutate an already-running provider unless that behavior is explicitly designed.
+
+## Acceptance Criteria
+
+- [ ] Given a settings file with `currentProvider`, `/model <id>` updates the active provider profile's model.
+- [ ] Given a legacy settings file, `/model <id>` updates the legacy provider model without losing existing fields.
+- [ ] After confirming `/model`, the next CLI session resolves the selected model.
+- [ ] If restart is requested, the CLI either truly restarts or exits with clear behavior that the launcher handles.
+- [ ] Cancellation leaves settings unchanged.
+- [ ] Tests cover slash command routing, system command routing, settings persistence, and resolved config behavior.
+
+## Test Plan
+
+- Add unit tests for `updateModelInSettings()` covering current and legacy settings.
+- Add a config-resolution test proving the updated settings produce the selected model.
+- Add a CLI/TUI side-effect test for confirmed and cancelled model changes.
+- Add a PTY or process-level smoke test if restart semantics need end-to-end coverage.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-model-change-restart.md`.
+2. Start with a failing regression test that reproduces the user's report.
+3. Fix the smallest owner boundary that makes the confirmed model visible to the next session.

--- a/.agents/backlog/compact-command-descriptor.md
+++ b/.agents/backlog/compact-command-descriptor.md
@@ -1,0 +1,67 @@
+# Compact Command Descriptor and Auto-Trigger Policy
+
+## What
+
+Make context compaction a descriptor-owned built-in command with an explicit auto-trigger policy instead of a CLI-owned special case.
+
+## Why
+
+Compaction currently exists in multiple paths. The SDK has a `compact` system command, while the CLI slash executor also implements `/compact` directly. Auto-compaction is embedded in session execution through a hardcoded threshold. This makes compaction less composable than `/agent`, harder to expose consistently to model-invocable command routing, and harder to tune or explain to users.
+
+## Current Signals
+
+- `packages/agent-sdk/src/commands/system-command.ts` defines a `compact` system command.
+- `packages/agent-cli/src/commands/slash-executor.ts` directly handles `/compact`.
+- `packages/agent-sessions/src/context-window-tracker.ts` hardcodes `AUTO_COMPACT_THRESHOLD = 0.835`.
+- `packages/agent-sessions/src/session-run.ts` auto-compacts at the start of `run()` when the tracker exceeds the threshold.
+- `agent-invocation-router.md` already describes command descriptors and model-invocable command execution as the direction for built-in commands such as `/agent`.
+
+## Research Required
+
+Before implementation, research how context usage and compaction are exposed in comparable coding agents and SDKs. Confirm:
+
+- whether users should see context usage every prompt, only in the status bar, or only near threshold;
+- whether auto-compaction should happen before a prompt, after a response, or after tool results;
+- how to avoid compacting while streaming or while a tool call is in flight;
+- whether the model should be able to invoke compaction through the generic command tool;
+- how threshold, cooldown, and "ask before compact" settings should be represented;
+- how exact provider token usage and estimated token usage should be labelled.
+
+## Scope
+
+- Define a command descriptor for compact that includes user-visible metadata, model-invocable policy, and optional auto-trigger metadata.
+- Route CLI `/compact` through the same command execution path as SDK/system commands.
+- Move hardcoded threshold policy behind configuration with a default equivalent to the current behavior.
+- Decide whether the status bar is sufficient for per-prompt context percentage or whether each prompt/turn needs an explicit usage row.
+- Ensure auto-compaction emits enough events for CLI, headless, and logs to explain what happened.
+- Preserve system prompt/project context across compaction.
+- Add tests for manual compaction, threshold-based auto-triggering, disabled auto-triggering, and CLI routing.
+
+## Non-Goals
+
+- Do not remove manual `/compact`.
+- Do not compact by prompt text injection or hidden assistant messages outside the session compaction contract.
+- Do not make compaction provider-specific.
+- Do not dump large command bodies into startup context; descriptors should stay concise.
+
+## Acceptance Criteria
+
+- [ ] `compact` has a descriptor-owned command module or equivalent registry entry.
+- [ ] CLI slash input, SDK command execution, and model-invocable command routing use the same compact handler.
+- [ ] Auto-compact threshold is configurable with a documented default.
+- [ ] Context usage visibility is explicitly designed and tested for prompt submission and post-response reconciliation.
+- [ ] Auto-compaction produces user-visible/log-visible events with before/after context percentages.
+- [ ] Tests prove compaction does not stream summary text into the normal answer path.
+
+## Test Plan
+
+- Add command registry tests proving `compact` metadata is projected correctly.
+- Add CLI slash-routing tests proving `/compact` no longer has a separate behavior path.
+- Add session tests for default threshold, custom threshold, disabled threshold, and no compaction below threshold.
+- Add UI/view-model tests for context percentage visibility and auto-compact notifications.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/SDK-BL-0XX-compact-command-descriptor.md`.
+2. Complete research before finalizing the descriptor shape.
+3. Implement descriptor routing first, then migrate auto-trigger policy.

--- a/.agents/backlog/compact-command-descriptor.md
+++ b/.agents/backlog/compact-command-descriptor.md
@@ -27,6 +27,22 @@ Before implementation, research how context usage and compaction are exposed in 
 - how threshold, cooldown, and "ask before compact" settings should be represented;
 - how exact provider token usage and estimated token usage should be labelled.
 
+## Recommendation
+
+Start with descriptor unification, then move auto-trigger policy behind configuration.
+
+The recommended default is:
+
+- keep manual `/compact` user-invocable;
+- route CLI slash input through the SDK command registry instead of the CLI-specific compact handler;
+- let the session runtime consume descriptor/config metadata for auto-compact thresholds;
+- keep the current default threshold behavior until research proves a better value;
+- show context percentage in the status bar continuously, with explicit warning/notification only near the threshold or when auto-compaction runs;
+- label context state as exact or estimated when that signal is available;
+- do not rely on the model to decide routine auto-compaction.
+
+Rationale: compaction is a runtime safety policy. The model may request compaction through a command later, but the default auto-trigger should be deterministic and observable rather than a hidden model decision.
+
 ## Scope
 
 - Define a command descriptor for compact that includes user-visible metadata, model-invocable policy, and optional auto-trigger metadata.

--- a/.agents/backlog/reversible-agent-sandbox.md
+++ b/.agents/backlog/reversible-agent-sandbox.md
@@ -1,0 +1,60 @@
+# Reversible Agent Sandbox
+
+## What
+
+Implement a sandbox-backed execution mode that lets Robota make file changes and run commands while preserving a reliable way to inspect, accept, or roll back those changes.
+
+## Why
+
+Robota can already create edit checkpoints for file mutations, but users need stronger safety: even if the agent edits files or runs commands, the work should remain recoverable. A sandbox/reversible workspace layer should make "try changes, verify them, and revert if needed" a first-class capability instead of relying only on manual Git cleanup.
+
+## Relationship to Existing Work
+
+- `.agents/tasks/INFRA-BL-002-agent-sandbox-execution.md` tracks provider-backed sandbox execution.
+- `.agents/tasks/INFRA-BL-003-agent-workspace-manifest.md` tracks declarative workspace setup.
+- `.agents/tasks/INFRA-BL-004-agent-snapshot-hydration.md` tracks provider snapshot/restore.
+- `.agents/specs/self-hosting-loop-verification.md` defines checkpoint, atomic edit, verify, and recover behavior for self-hosting loops.
+- `packages/agent-sdk/src/checkpoints` already owns edit checkpoint storage and `/rewind` restore behavior.
+
+## Scope
+
+- Decide the first reversible layer:
+  - local edit checkpoints only;
+  - Git worktree or branch isolation;
+  - provider sandbox snapshot/restore;
+  - or a composed local-first strategy.
+- Define a clear lifecycle: create checkpoint, apply edits, run commands, verify, accept, rollback, cleanup.
+- Keep filesystem mutation semantics in tool/SDK-owned contracts, not CLI renderer code.
+- Ensure Bash/process side effects are either isolated or explicitly marked as not checkpoint-restorable.
+- Integrate with `/rewind` or a successor command so users can list and restore safe points.
+- Record enough metadata to explain which files changed, which commands ran, and what can be rolled back.
+- Define how sandbox mode interacts with permissions, worktrees, and session resume.
+
+## Non-Goals
+
+- Do not claim host-level shell side effects are reversible unless they are actually isolated.
+- Do not put sandbox provider SDKs into `agent-core`.
+- Do not make the CLI own checkpoint storage or restore ordering.
+- Do not remove direct local execution until sandbox behavior is proven and migration is planned.
+
+## Acceptance Criteria
+
+- [ ] A documented reversible execution mode exists with clear guarantees and limitations.
+- [ ] Before the first file mutation in a turn, Robota creates a recoverable checkpoint or isolated workspace.
+- [ ] Users can inspect pending changes before accepting or rolling back.
+- [ ] Rollback restores tracked file edits deterministically.
+- [ ] Non-reversible side effects are prevented by sandbox isolation or surfaced clearly before execution.
+- [ ] Tests cover successful rollback, failed rollback, command side effects, and cleanup behavior.
+
+## Test Plan
+
+- Add contract tests for checkpoint creation, restore, and cleanup.
+- Add integration tests that mutate multiple files, run verification, and restore the previous state.
+- Add tests that prove Bash side effects are isolated or explicitly rejected in reversible mode.
+- Run affected package tests, build, and `pnpm harness:scan` before implementation promotion.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/INFRA-BL-0XX-reversible-agent-sandbox.md`.
+2. Reconcile with `INFRA-BL-002`, `INFRA-BL-003`, `INFRA-BL-004`, and `self-hosting-loop-verification.md`.
+3. Ship a local-first reversible mode before adding provider-backed snapshot hydration.

--- a/.agents/backlog/reversible-agent-sandbox.md
+++ b/.agents/backlog/reversible-agent-sandbox.md
@@ -30,6 +30,20 @@ Robota can already create edit checkpoints for file mutations, but users need st
 - Record enough metadata to explain which files changed, which commands ran, and what can be rolled back.
 - Define how sandbox mode interacts with permissions, worktrees, and session resume.
 
+## Recommendation
+
+Use a local-first reversible mode before adding provider-backed sandbox snapshots.
+
+Recommended first slice:
+
+1. Create an SDK-owned edit checkpoint before the first file mutation in a turn.
+2. Run write-capable agent jobs in a Git worktree when worktree support is available and hardened.
+3. Treat file edits as rollback-capable through checkpoints.
+4. Treat shell/process side effects as rollback-capable only when they are contained inside an isolated worktree or sandbox.
+5. Surface a clear "accept / rollback / preserve workspace" result after verification.
+
+Rationale: the repository already has edit checkpoint storage and initial worktree isolation. Provider sandboxes add external lifecycle, billing, and snapshot semantics, so they should follow after the local guarantees are clear and testable.
+
 ## Non-Goals
 
 - Do not claim host-level shell side effects are reversible unless they are actually isolated.

--- a/.agents/backlog/worktree-support-hardening.md
+++ b/.agents/backlog/worktree-support-hardening.md
@@ -26,6 +26,21 @@ Worktree isolation exists, but it needs to behave like a reliable product featur
 - Handle branch-name collisions, nested repositories, non-Git directories, detached HEAD, and uncommitted parent changes.
 - Ensure cancellation and failed worker startup clean up or preserve worktrees according to the same policy.
 
+## Recommendation
+
+Keep worktree isolation explicit until reporting and cleanup are hardened, then make it the default for write-capable background agent jobs when the current directory is a supported Git repository.
+
+Recommended policy after hardening:
+
+- read-only jobs may continue without worktree isolation;
+- write-capable `/agent` and model-invoked `Agent` jobs default to worktree isolation;
+- unsupported Git states fail with an actionable message unless the user explicitly requests non-isolated execution;
+- dirty worktrees are preserved and reported;
+- clean worktrees are removed automatically;
+- dirty parent checkouts are allowed only if the worktree branch point and risk are surfaced clearly.
+
+Rationale: default isolation is valuable, but silent fallback or poor handoff metadata would be worse than explicit local execution. Productize observability first, then change defaults.
+
 ## Non-Goals
 
 - Do not make `agent-runtime` call Git directly.

--- a/.agents/backlog/worktree-support-hardening.md
+++ b/.agents/backlog/worktree-support-hardening.md
@@ -1,0 +1,56 @@
+# Worktree Support Hardening
+
+## What
+
+Harden Robota's Git worktree support so write-capable agent work can run in isolated worktrees predictably, expose useful handoff metadata, and clean up safely.
+
+## Why
+
+Worktree isolation exists, but it needs to behave like a reliable product feature. Users need to know when a worker ran in a worktree, where changes were left, how to review them, when cleanup happened, and how worktree mode interacts with background jobs, `/agent`, permissions, and rollback.
+
+## Current Signals
+
+- `packages/agent-runtime/src/subagents/worktree-subagent-runner.ts` owns runner decoration and cleanup decisions through an injected worktree adapter.
+- `packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts` owns concrete local Git worktree operations.
+- `packages/agent-cli/docs/SPEC.md` documents worktree isolation and dirty worktree preservation.
+- `.agents/specs/agent-invocation-router.md` says background write-capable agent work should default to worktree isolation when available.
+- Completed `CLI-BL-013-subagent-worktree-isolation` implemented the first slice; this backlog is for hardening and productizing the behavior.
+
+## Scope
+
+- Audit current worktree behavior across `/agent`, model-invoked `Agent` tool calls, and background task views.
+- Decide default isolation policy for write-capable agent jobs.
+- Ensure clean worktrees are removed and dirty worktrees are preserved with clear metadata.
+- Surface preserved `worktreePath` and `branchName` in CLI/TUI/headless results.
+- Add commands or documented workflows for reviewing, merging, diffing, and deleting preserved worktrees.
+- Handle branch-name collisions, nested repositories, non-Git directories, detached HEAD, and uncommitted parent changes.
+- Ensure cancellation and failed worker startup clean up or preserve worktrees according to the same policy.
+
+## Non-Goals
+
+- Do not make `agent-runtime` call Git directly.
+- Do not silently merge worktree changes into the parent checkout.
+- Do not delete dirty worktrees without an explicit user action or documented cleanup policy.
+- Do not require worktree isolation for read-only background jobs unless the policy explicitly chooses that later.
+
+## Acceptance Criteria
+
+- [ ] Worktree isolation has a documented default policy for `/agent` and model-invoked agent jobs.
+- [ ] Dirty worktrees are preserved and reported with path, branch, status, and next action.
+- [ ] Clean worktrees are removed consistently on success, failure, and cancellation.
+- [ ] Non-Git or unsupported contexts fail with actionable messages or fall back only when explicitly allowed.
+- [ ] CLI/TUI/headless surfaces can list or link preserved worktrees.
+- [ ] Tests cover branch collisions, parent dirty state, nested repo detection, cancellation, startup failure, clean cleanup, and dirty preservation.
+
+## Test Plan
+
+- Extend `GitWorktreeIsolationAdapter` tests for Git edge cases.
+- Extend `WorktreeSubagentRunner` tests for cancellation and startup-failure cleanup.
+- Add CLI/TUI view-model tests for preserved worktree metadata.
+- Add integration smoke tests in a temporary Git repository with real `git worktree` commands.
+
+## Promotion Path
+
+1. Move to `.agents/tasks/CLI-BL-0XX-worktree-support-hardening.md`.
+2. Start with an audit of current behavior against the documented SPEC.
+3. Implement metadata/reporting improvements before changing default isolation policy.


### PR DESCRIPTION
## Summary

- Add backlog items for the `/model` restart regression, agent package coverage audit, compact command descriptor work, reversible sandbox mode, and worktree hardening.
- Add a roadmap that recommends the execution order and calls out key architecture recommendations.
- Update the backlog index with the new items.

## Validation

- `pnpm exec prettier --check ...`
- `git diff --check`
- pre-push `pnpm harness:plan -- --base-ref origin/develop`
- pre-push `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
