### PR TITLE
feat(agent): implement follow-up runtime fixes

### DIFF
--- a/.agents/reports/agent-package-coverage-2026-05-03.md
+++ b/.agents/reports/agent-package-coverage-2026-05-03.md
@@ -1,0 +1,69 @@
+# Agent Package Coverage Baseline
+
+- **Date**: 2026-05-03
+- **Scope**: `packages/agent-*`
+- **Command**: `pnpm --filter "@robota-sdk/agent-*" run --if-present test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary`
+- **Notes**: The pnpm filter also dispatched app packages whose names match `@robota-sdk/agent-*`; this report includes only `packages/agent-*`.
+
+## Summary
+
+The agent package family has uneven coverage. Core, SDK, runtime, most providers, most plugins, and most transports are at or above roughly 70% line coverage. The highest-risk gaps are `agent-tools`, `agent-sessions`, `agent-tool-mcp`, `agent-playground`, and the Gemini compatibility wrapper package.
+
+Do not add a global threshold yet. The current package set includes small compatibility wrappers, UI-heavy packages, and packages with intentionally sparse or no executable source. Add targeted thresholds only after high-risk packages have package-specific coverage plans.
+
+## Package Results
+
+| Package                                         | Lines | Branches | Functions | Statements | Risk Note                                              |
+| ----------------------------------------------- | ----: | -------: | --------: | ---------: | ------------------------------------------------------ |
+| `@robota-sdk/agent-cli`                         | 70.20 |    76.87 |     83.50 |      70.20 | UI hooks/App paths remain comparatively low            |
+| `@robota-sdk/agent-command-agent`               | 79.58 |    76.27 |     75.00 |      79.58 | Acceptable baseline                                    |
+| `@robota-sdk/agent-core`                        | 83.03 |    80.18 |     72.12 |      83.03 | Good baseline; some plugin/registry helpers low        |
+| `@robota-sdk/agent-event-service`               |   n/a |      n/a |       n/a |        n/a | No covered executable source in report                 |
+| `@robota-sdk/agent-playground`                  |  0.37 |     3.81 |      1.90 |       0.37 | Critical UI/package coverage gap                       |
+| `@robota-sdk/agent-plugin-conversation-history` | 83.90 |    75.96 |    100.00 |      83.90 | Acceptable baseline                                    |
+| `@robota-sdk/agent-plugin-error-handling`       | 93.80 |    79.10 |     88.24 |      93.80 | Good baseline                                          |
+| `@robota-sdk/agent-plugin-event-emitter`        | 88.25 |    87.50 |     75.86 |      88.25 | Good baseline                                          |
+| `@robota-sdk/agent-plugin-execution-analytics`  | 87.47 |    68.92 |     77.78 |      87.47 | Branch coverage should be improved                     |
+| `@robota-sdk/agent-plugin-limits`               | 98.09 |    93.58 |     94.12 |      98.09 | Strong baseline                                        |
+| `@robota-sdk/agent-plugin-logging`              | 91.91 |    86.82 |     85.37 |      91.91 | Strong baseline                                        |
+| `@robota-sdk/agent-plugin-performance`          | 88.11 |    77.14 |     96.00 |      88.11 | Good baseline                                          |
+| `@robota-sdk/agent-plugin-usage`                | 94.37 |    91.10 |    100.00 |      94.37 | Strong baseline                                        |
+| `@robota-sdk/agent-plugin-webhook`              | 93.76 |    72.87 |     92.11 |      93.76 | Branch coverage should be improved                     |
+| `@robota-sdk/agent-provider-anthropic`          | 80.26 |    86.59 |     84.21 |      80.26 | Good baseline                                          |
+| `@robota-sdk/agent-provider-bytedance`          | 92.48 |    91.88 |     90.91 |      92.48 | Strong baseline                                        |
+| `@robota-sdk/agent-provider-gemini`             | 95.14 |    90.87 |    100.00 |      95.14 | Strong baseline                                        |
+| `@robota-sdk/agent-provider-gemma`              | 86.42 |    74.36 |     91.01 |      86.42 | Good baseline; branch coverage should improve          |
+| `@robota-sdk/agent-provider-google`             | 39.39 |    50.00 |     50.00 |      39.39 | Compatibility wrapper needs targeted smoke coverage    |
+| `@robota-sdk/agent-provider-openai-compatible`  | 90.13 |    77.37 |     96.77 |      90.13 | Good baseline                                          |
+| `@robota-sdk/agent-provider-openai`             | 91.68 |    83.96 |     84.62 |      91.68 | Strong baseline                                        |
+| `@robota-sdk/agent-provider-qwen`               | 81.97 |    69.31 |     84.48 |      81.97 | Branch coverage should be improved                     |
+| `@robota-sdk/agent-remote-client`               | 99.32 |    92.90 |    100.00 |      99.32 | Strong baseline                                        |
+| `@robota-sdk/agent-runtime`                     | 93.31 |    74.26 |     84.69 |      93.31 | Good baseline; worktree/cancel edge cases still needed |
+| `@robota-sdk/agent-sdk`                         | 91.16 |    81.10 |     85.46 |      91.16 | Strong baseline                                        |
+| `@robota-sdk/agent-sessions`                    | 66.42 |    77.27 |     45.31 |      66.42 | High-risk runtime/session gap                          |
+| `@robota-sdk/agent-team`                        | 91.02 |    71.43 |     75.00 |      91.02 | Acceptable baseline                                    |
+| `@robota-sdk/agent-tool-mcp`                    |  0.00 |     0.00 |      0.00 |       0.00 | Critical package coverage gap                          |
+| `@robota-sdk/agent-tools`                       | 31.64 |    79.56 |     65.31 |      31.64 | Critical filesystem/shell tool coverage gap            |
+| `@robota-sdk/agent-transport-headless`          | 93.41 |    86.57 |     91.18 |      93.41 | Strong baseline                                        |
+| `@robota-sdk/agent-transport-http`              | 71.79 |    88.89 |     75.00 |      71.79 | Acceptable baseline                                    |
+| `@robota-sdk/agent-transport-mcp`               | 63.33 |    90.00 |     62.50 |      63.33 | Add transport request/response coverage                |
+| `@robota-sdk/agent-transport-ws`                | 91.26 |    86.32 |     83.78 |      91.26 | Strong baseline                                        |
+
+## Recommended Follow-ups
+
+1. **agent-tools**: add characterization tests for Bash, Read, Write, Edit, Glob, Grep, WebFetch, and WebSearch behavior before sandbox/refactor work.
+2. **agent-sessions**: add tests for lifecycle hooks, compaction orchestration, session persistence, abort/timeout, and context reconciliation paths.
+3. **agent-tool-mcp**: add basic protocol/tool wrapper tests or explicitly document why the package should be excluded from coverage gates.
+4. **agent-playground**: decide whether UI-heavy package coverage belongs in component tests, integration tests, or a separate app-level coverage plan.
+5. **agent-provider-google**: add wrapper compatibility tests that prove legacy imports/settings still route to canonical Gemini behavior.
+6. **agent-runtime**: add the worktree hardening edge-case tests before changing default worktree isolation policy.
+
+## Threshold Recommendation
+
+Do not introduce one global threshold for `agent-*` packages now.
+
+Recommended staged policy:
+
+- Start with package-owned thresholds only for packages already above 80% and not UI-heavy.
+- Require targeted regression tests for new code in low-coverage packages.
+- After `agent-tools`, `agent-sessions`, and `agent-tool-mcp` improve, consider a release-grade coverage threshold for critical runtime packages only.

--- a/.agents/tasks/agent-followups-implementation.md
+++ b/.agents/tasks/agent-followups-implementation.md
@@ -1,0 +1,55 @@
+# Agent Follow-ups Implementation
+
+- **Status**: in-progress
+- **Created**: 2026-05-03
+- **Branch**: feat/agent-followups-implementation
+- **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-sessions, packages/agent-runtime, .agents
+
+## Objective
+
+Implement the follow-up work promoted from backlog: fix the `/model` restart regression, measure `agent-*` package coverage, unify compact command routing and policy, harden worktree support, and add a local-first reversible sandbox/rollback workflow.
+
+## Plan
+
+- [x] Fix `/model` restart behavior with regression tests.
+- [x] Measure `agent-*` package coverage and write a report.
+- [x] Unify `/compact` around descriptor/system command routing and expose auto-trigger policy.
+  - [x] Route CLI legacy `/compact` fallback to SDK system command instead of duplicating execution.
+  - [x] Add compact command descriptor metadata.
+  - [x] Add configurable/disable-able auto compact threshold.
+- [x] Harden worktree metadata, cleanup, and edge-case behavior.
+- [x] Add local-first reversible sandbox/rollback workflow built on checkpoints/worktrees.
+- [x] Run targeted verification for changed packages.
+- [ ] Prepare PR and merge into `develop`.
+
+## Progress
+
+### 2026-05-03
+
+- Created task record and implementation branch.
+- Fixed `/model` model persistence so the active highest-precedence provider profile is updated instead of always writing to the user-global settings file.
+- Verified targeted agent-cli provider/settings tests, typecheck, and build.
+- Ran `agent-*` package coverage and added `.agents/reports/agent-package-coverage-2026-05-03.md`.
+- Unified `/compact` through SDK system command routing, added descriptor metadata, exposed `autoCompactThreshold`, and updated context output with the active policy.
+- Added dirty worktree handoff metadata (`worktreeStatus`, `worktreeNextAction`) and Git adapter status reporting.
+- Added inclusive checkpoint rollback via `/rewind rollback <checkpoint-id>` for local-first reversible edit recovery.
+- Verified targeted tests, root typecheck, root build, root lint, and harness verification against `origin/develop`.
+
+## Decisions
+
+- Follow the backlog roadmap order: model regression, coverage audit, compact descriptor, worktree hardening, reversible sandbox.
+- Use TDD for behavior changes where existing tests can express the regression.
+- Do not add global `agent-*` coverage thresholds yet; the baseline shows package categories differ too much for one fair threshold.
+- Keep `/rewind restore` semantics as "restore to the state after the selected checkpoint"; add `/rewind rollback` for inclusive rollback through the selected checkpoint.
+
+## Test Plan
+
+Run focused RED/GREEN tests for each behavior slice, then verify the affected monorepo surface with root commands. Targeted tests cover provider settings precedence, legacy slash routing, SDK system commands, session compaction thresholds, worktree handoff metadata, Git worktree status reporting, checkpoint store rollback, and interactive checkpoint rollback. Final checks use root `pnpm typecheck`, root `pnpm build`, root `pnpm lint`, and harness verification against `origin/develop` with build skipped after the root build has already produced package artifacts.
+
+## Blockers
+
+- None.
+
+## Result
+
+Pending.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -1149,14 +1149,14 @@ The runtime worktree runner owns worktree lifecycle orchestration:
 - delegate non-worktree requests unchanged
 - run isolated workers with `cwd` set to the prepared worktree path
 - remove clean worktrees on success or worker failure
-- preserve dirty worktrees and return `worktreePath` plus `branchName` in result metadata
+- preserve dirty worktrees and return `worktreePath`, `branchName`, `worktreeStatus`, and `worktreeNextAction` in result metadata
 - fire SDK hook notifications for `WorktreeCreate` and `WorktreeRemove` when configured
 
 The CLI-owned Git adapter implements only local Git/filesystem I/O:
 
 - create a temporary branch and worktree before the worker starts
 - remove the worktree and branch when the worktree remains clean
-- report whether the worktree has local edits
+- report whether the worktree has local edits and expose `git status --porcelain` output for preserved worktree handoff
 
 When a user invokes a skill slash command with `context: fork`, the CLI must call `interactiveSession.executeSkillCommand(...)`. The CLI may render a `skill-invocation` event, but it must not convert fork skills into plain prompt injection. This keeps fork execution deterministic and preserves the CLI as a thin TUI shell.
 
@@ -1205,11 +1205,12 @@ Edit checkpoint behavior is SDK-owned. The CLI and TUI must not snapshot files, 
 
 Supported SDK-owned edit checkpoint commands exposed through the CLI:
 
-| Command                        | CLI responsibility                                    |
-| ------------------------------ | ----------------------------------------------------- |
-| `/rewind list`                 | Render checkpoint summaries returned by the SDK       |
-| `/rewind restore <checkpoint>` | Pass the selected checkpoint ID to the SDK            |
-| `/rewind code <checkpoint>`    | Alias for SDK code restore; render the restore result |
+| Command                         | CLI responsibility                                        |
+| ------------------------------- | --------------------------------------------------------- |
+| `/rewind list`                  | Render checkpoint summaries returned by the SDK           |
+| `/rewind restore <checkpoint>`  | Pass the selected checkpoint ID to the SDK                |
+| `/rewind code <checkpoint>`     | Alias for SDK code restore; render the restore result     |
+| `/rewind rollback <checkpoint>` | Pass the selected checkpoint ID to SDK inclusive rollback |
 
 Future Esc Esc or picker UI is terminal chrome only. The picker must call SDK APIs or commands; it must not duplicate checkpoint storage or restore algorithms.
 

--- a/packages/agent-cli/src/commands/__tests__/slash-executor.test.ts
+++ b/packages/agent-cli/src/commands/__tests__/slash-executor.test.ts
@@ -8,7 +8,6 @@ import {
   handlePermissions,
   handleContext,
   handleReset,
-  handleCompact,
   executeSlashCommand,
   HELP_TEXT,
 } from '../slash-executor.js';
@@ -165,26 +164,6 @@ describe('handleReset', () => {
   });
 });
 
-describe('handleCompact', () => {
-  it('calls session.compact and shows before/after', async () => {
-    const { addMessage, messages } = createMockAddMessage();
-    let callCount = 0;
-    const session = createMockSession({
-      getContextState: () => {
-        callCount++;
-        return callCount === 1
-          ? { usedTokens: 170000, maxTokens: 200000, usedPercentage: 85 }
-          : { usedTokens: 60000, maxTokens: 200000, usedPercentage: 30 };
-      },
-      compact: vi.fn(),
-    });
-    await handleCompact('focus on API', session, addMessage);
-    expect(session.compact).toHaveBeenCalledWith('focus on API');
-    expect(messages[1].content).toContain('85%');
-    expect(messages[1].content).toContain('30%');
-  });
-});
-
 function emptyRegistry(): CommandRegistry {
   return new CommandRegistry();
 }
@@ -215,6 +194,24 @@ describe('executeSlashCommand', () => {
       emptyRegistry(),
     );
     expect(result.exitRequested).toBe(true);
+  });
+
+  it('routes /compact through the SDK system command instead of legacy CLI handling', async () => {
+    const { addMessage, messages } = createMockAddMessage();
+    const session = createMockSession({ compact: vi.fn() });
+
+    const result = await executeSlashCommand(
+      'compact',
+      'focus on API',
+      session,
+      addMessage,
+      vi.fn(),
+      emptyRegistry(),
+    );
+
+    expect(result.handled).toBe(false);
+    expect(session.compact).not.toHaveBeenCalled();
+    expect(messages).toHaveLength(0);
   });
 
   it('returns handled=false for skill command', async () => {

--- a/packages/agent-cli/src/commands/slash-executor.ts
+++ b/packages/agent-cli/src/commands/slash-executor.ts
@@ -100,23 +100,6 @@ export function handleClear(
   return { handled: true };
 }
 
-export async function handleCompact(
-  args: string,
-  session: ISlashSession,
-  addMessage: TAddMessage,
-): Promise<ISlashResult> {
-  const instructions = args.trim() || undefined;
-  const before = session.getContextState().usedPercentage;
-  addMessage({ role: 'system', content: 'Compacting context...' });
-  await session.compact(instructions);
-  const after = session.getContextState().usedPercentage;
-  addMessage({
-    role: 'system',
-    content: `Context compacted: ${Math.round(before)}% -> ${Math.round(after)}%`,
-  });
-  return { handled: true };
-}
-
 export function handleMode(
   arg: string | undefined,
   session: ISlashSession,
@@ -211,7 +194,7 @@ export async function executeSlashCommand(
     case 'clear':
       return handleClear(addMessage, clearMessages, session);
     case 'compact':
-      return handleCompact(args, session, addMessage);
+      return { handled: false }; // Route to SDK system command (context compaction)
     case 'mode':
       return handleMode(args.split(/\s+/)[0] || undefined, session, addMessage);
     case 'model':

--- a/packages/agent-cli/src/subagents/__tests__/git-worktree-isolation-adapter.test.ts
+++ b/packages/agent-cli/src/subagents/__tests__/git-worktree-isolation-adapter.test.ts
@@ -62,6 +62,7 @@ describe('GitWorktreeIsolationAdapter', () => {
       writeFileSync(join(worktree.worktreePath, 'dirty.txt'), 'dirty\n');
 
       expect(adapter.isClean(worktree)).toBe(false);
+      expect(adapter.getStatus(worktree)).toContain('?? dirty.txt');
     },
     TEST_TIMEOUT_MS,
   );

--- a/packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts
+++ b/packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts
@@ -46,7 +46,11 @@ export class GitWorktreeIsolationAdapter implements ISubagentWorktreeAdapter {
   }
 
   isClean(worktree: IPreparedSubagentWorktree): boolean {
-    return runGit(worktree.worktreePath, ['status', '--porcelain']).trim().length === 0;
+    return this.getStatus(worktree).trim().length === 0;
+  }
+
+  getStatus(worktree: IPreparedSubagentWorktree): string {
+    return runGit(worktree.worktreePath, ['status', '--porcelain']);
   }
 
   remove(worktree: IPreparedSubagentWorktree): void {

--- a/packages/agent-cli/src/ui/hooks/useSideEffects.ts
+++ b/packages/agent-cli/src/ui/hooks/useSideEffects.ts
@@ -5,12 +5,12 @@ import { createSystemMessage, messageToHistoryEntry, getModelName } from '@robot
 import type { TSessionEndReason } from '@robota-sdk/agent-core';
 import {
   getUserSettingsPath,
-  updateModelInSettings,
   deleteSettings,
   readSettings,
   writeSettings,
 } from '../../utils/settings-io.js';
 import {
+  applyActiveModelChange,
   applyProviderConfiguration,
   applyProviderSwitch,
 } from '../../utils/provider-configuration.js';
@@ -168,8 +168,7 @@ export function useSideEffects({
       pendingModelChangeRef.current = null;
       if (index === 0 && modelId) {
         try {
-          const settingsPath = getUserSettingsPath();
-          updateModelInSettings(settingsPath, modelId);
+          applyActiveModelChange(cwd, modelId);
           addEntry(
             messageToHistoryEntry(
               createSystemMessage(`Model changed to ${getModelName(modelId)}. Restarting...`),
@@ -187,7 +186,7 @@ export function useSideEffects({
         addEntry(messageToHistoryEntry(createSystemMessage('Model change cancelled.')));
       }
     },
-    [addEntry, requestShutdown],
+    [cwd, addEntry, requestShutdown],
   );
 
   const handleProviderConfirm = useCallback(

--- a/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { applyProviderConfiguration, applyProviderSwitch } from '../provider-configuration.js';
+import {
+  applyActiveModelChange,
+  applyProviderConfiguration,
+  applyProviderSwitch,
+} from '../provider-configuration.js';
 
 const TMP_BASE = join(tmpdir(), `robota-provider-configuration-test-${process.pid}`);
 
@@ -101,5 +105,46 @@ describe('provider configuration writes', () => {
     const settings = readJson(settingsPath);
     expect(settings.currentProvider).toBe('openai');
     expect(settings.providers).toBeUndefined();
+  });
+
+  it('updates the highest-precedence active provider profile model', () => {
+    const userPath = join(TMP_BASE, '.robota', 'settings.json');
+    const projectPath = join(TMP_BASE, 'project', '.robota', 'settings.local.json');
+    mkdirSync(join(TMP_BASE, '.robota'), { recursive: true });
+    mkdirSync(join(TMP_BASE, 'project', '.robota'), { recursive: true });
+    writeFileSync(
+      userPath,
+      JSON.stringify({
+        currentProvider: 'anthropic',
+        providers: {
+          anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+        },
+      }),
+      'utf8',
+    );
+    writeFileSync(
+      projectPath,
+      JSON.stringify({
+        currentProvider: 'qwen',
+        providers: {
+          qwen: { type: 'qwen', model: 'qwen3.6-plus-2026-04-02', apiKey: 'sk-qwen' },
+        },
+      }),
+      'utf8',
+    );
+
+    const result = applyActiveModelChange(join(TMP_BASE, 'project'), 'qwen-plus', {
+      settingsPaths: [userPath, projectPath],
+    });
+
+    expect(result.settingsPath).toBe(projectPath);
+    const userSettings = readJson(userPath);
+    const projectSettings = readJson(projectPath);
+    expect(
+      (userSettings.providers as Record<string, Record<string, unknown>>).anthropic?.model,
+    ).toBe('claude-sonnet-4-6');
+    expect((projectSettings.providers as Record<string, Record<string, unknown>>).qwen?.model).toBe(
+      'qwen-plus',
+    );
   });
 });

--- a/packages/agent-cli/src/utils/provider-configuration.ts
+++ b/packages/agent-cli/src/utils/provider-configuration.ts
@@ -1,5 +1,9 @@
 import { readSettings, writeSettings } from './settings-io.js';
 import {
+  getProviderSettingsPaths,
+  readMergedProviderSettingsFromPaths,
+} from './provider-factory.js';
+import {
   buildProviderSetupPatch,
   mergeProviderPatch,
   setCurrentProvider,
@@ -11,6 +15,17 @@ import {
 
 export interface IProviderSwitchOptions {
   knownProviders?: Record<string, IProviderProfileSettings>;
+}
+
+export interface IActiveModelChangeOptions {
+  settingsPaths?: readonly string[];
+}
+
+export interface IActiveModelChangeResult {
+  settingsPath: string;
+  settings: TProviderSettingsDocument;
+  profileName?: string;
+  legacyProvider?: boolean;
 }
 
 function readProviderDocument(settingsPath: string): TProviderSettingsDocument {
@@ -43,4 +58,91 @@ export function applyProviderSwitch(
       : setCurrentProvider(settings, profileName);
   writeSettings(settingsPath, next);
   return next;
+}
+
+export function applyActiveModelChange(
+  cwd: string,
+  modelId: string,
+  options: IActiveModelChangeOptions = {},
+): IActiveModelChangeResult {
+  const settingsPaths = options.settingsPaths ?? getProviderSettingsPaths(cwd);
+  const merged = readMergedProviderSettingsFromPaths(settingsPaths);
+
+  if (typeof merged.currentProvider === 'string') {
+    return updateActiveProviderProfileModel(settingsPaths, merged.currentProvider, modelId);
+  }
+
+  return updateLegacyProviderModel(settingsPaths, modelId);
+}
+
+function updateActiveProviderProfileModel(
+  settingsPaths: readonly string[],
+  profileName: string,
+  modelId: string,
+): IActiveModelChangeResult {
+  const settingsPath =
+    findLastPathWithProviderProfile(settingsPaths, profileName) ?? settingsPaths[0];
+  if (settingsPath === undefined) {
+    throw new Error('No settings path available for model update');
+  }
+
+  const settings = readProviderDocument(settingsPath);
+  const providers = settings.providers ?? {};
+  const existing = providers[profileName] ?? {};
+  const next: TProviderSettingsDocument = {
+    ...settings,
+    providers: {
+      ...providers,
+      [profileName]: {
+        ...existing,
+        model: modelId,
+      },
+    },
+  };
+  writeSettings(settingsPath, next);
+  return { settingsPath, settings: next, profileName };
+}
+
+function updateLegacyProviderModel(
+  settingsPaths: readonly string[],
+  modelId: string,
+): IActiveModelChangeResult {
+  const settingsPath = findLastPathWithLegacyProvider(settingsPaths) ?? settingsPaths[0];
+  if (settingsPath === undefined) {
+    throw new Error('No settings path available for model update');
+  }
+
+  const settings = readProviderDocument(settingsPath);
+  const next: TProviderSettingsDocument = {
+    ...settings,
+    provider: {
+      ...(settings.provider ?? {}),
+      model: modelId,
+    },
+  };
+  writeSettings(settingsPath, next);
+  return { settingsPath, settings: next, legacyProvider: true };
+}
+
+function findLastPathWithProviderProfile(
+  settingsPaths: readonly string[],
+  profileName: string,
+): string | undefined {
+  for (let index = settingsPaths.length - 1; index >= 0; index -= 1) {
+    const settingsPath = settingsPaths[index];
+    if (settingsPath === undefined) continue;
+    const settings = readProviderDocument(settingsPath);
+    if (settings.providers?.[profileName] !== undefined) return settingsPath;
+  }
+  return undefined;
+}
+
+function findLastPathWithLegacyProvider(settingsPaths: readonly string[]): string | undefined {
+  for (let index = settingsPaths.length - 1; index >= 0; index -= 1) {
+    const settingsPath = settingsPaths[index];
+    if (settingsPath === undefined) continue;
+    const settings = readProviderDocument(settingsPath);
+    if (settings.provider !== undefined) return settingsPath;
+  }
+  return undefined;
 }

--- a/packages/agent-cli/src/utils/provider-factory.ts
+++ b/packages/agent-cli/src/utils/provider-factory.ts
@@ -46,7 +46,11 @@ export function readProviderSettings(
 }
 
 export function readMergedProviderSettings(cwd: string): TProviderSettingsDocument {
-  const paths = [
+  return readMergedProviderSettingsFromPaths(getProviderSettingsPaths(cwd));
+}
+
+export function getProviderSettingsPaths(cwd: string): string[] {
+  return [
     join(homedir(), '.robota', 'settings.json'),
     join(homedir(), '.claude', 'settings.json'),
     join(cwd, '.robota', 'settings.json'),
@@ -54,7 +58,11 @@ export function readMergedProviderSettings(cwd: string): TProviderSettingsDocume
     join(cwd, '.claude', 'settings.json'),
     join(cwd, '.claude', 'settings.local.json'),
   ];
+}
 
+export function readMergedProviderSettingsFromPaths(
+  paths: readonly string[],
+): TProviderSettingsDocument {
   return paths.reduce<TProviderSettingsDocument>((settings, filePath) => {
     const parsed = readSettingsFile(filePath);
     if (parsed === undefined) {

--- a/packages/agent-runtime/src/subagents/__tests__/worktree-subagent-runner.test.ts
+++ b/packages/agent-runtime/src/subagents/__tests__/worktree-subagent-runner.test.ts
@@ -15,6 +15,7 @@ interface ICapturedRunner {
 
 interface IFakeWorktreeAdapter extends ISubagentWorktreeAdapter {
   removed: IPreparedSubagentWorktree[];
+  status: string;
 }
 
 const TEST_WORKTREE: IPreparedSubagentWorktree = {
@@ -61,11 +62,15 @@ function createCapturedRunner(onStart?: (job: ISubagentJobStart) => void): ICapt
   };
 }
 
-function createAdapter(clean: boolean): IFakeWorktreeAdapter {
+function createAdapter(clean: boolean, status = '?? dirty.txt'): IFakeWorktreeAdapter {
   return {
     removed: [],
+    status,
     prepare: () => TEST_WORKTREE,
     isClean: () => clean,
+    getStatus() {
+      return this.status;
+    },
     remove(worktree) {
       this.removed.push(worktree);
     },
@@ -112,6 +117,10 @@ describe('WorktreeSubagentRunner', () => {
     expect(adapter.removed).toEqual([]);
     expect(getStringMetadata(metadata, 'worktreePath')).toBe(TEST_WORKTREE.worktreePath);
     expect(getStringMetadata(metadata, 'branchName')).toBe(TEST_WORKTREE.branchName);
+    expect(metadata.worktreeRemoved).toBe(false);
+    expect(getStringMetadata(metadata, 'worktreeStatus')).toBe('?? dirty.txt');
+    expect(getStringMetadata(metadata, 'worktreeNextAction')).toContain(TEST_WORKTREE.worktreePath);
+    expect(getStringMetadata(metadata, 'worktreeNextAction')).toContain(TEST_WORKTREE.branchName);
   });
 
   it('removes a clean worktree when the delegated job fails', async () => {

--- a/packages/agent-runtime/src/subagents/worktree-subagent-runner.ts
+++ b/packages/agent-runtime/src/subagents/worktree-subagent-runner.ts
@@ -27,6 +27,7 @@ export interface IPreparedSubagentWorktree {
 export interface ISubagentWorktreeAdapter {
   prepare(request: ISubagentWorktreePrepareRequest): IPreparedSubagentWorktree;
   isClean(worktree: IPreparedSubagentWorktree): boolean;
+  getStatus?(worktree: IPreparedSubagentWorktree): string;
   remove(worktree: IPreparedSubagentWorktree): void;
 }
 
@@ -130,8 +131,11 @@ function finalizeWorktreeResult(
     ...result,
     metadata: mergeMetadata(result.metadata, {
       isolation: 'worktree',
+      worktreeRemoved: false,
       worktreePath: worktree.worktreePath,
       branchName: worktree.branchName,
+      worktreeStatus: getWorktreeStatus(options, worktree),
+      worktreeNextAction: formatWorktreeNextAction(worktree),
     }),
   };
 }
@@ -145,6 +149,17 @@ function cleanupCleanWorktree(
   options.worktreeAdapter.remove(worktree);
   fireWorktreeHook(options, 'WorktreeRemove', job, worktree, true);
   return true;
+}
+
+function getWorktreeStatus(
+  options: IWorktreeSubagentRunnerOptions,
+  worktree: IPreparedSubagentWorktree,
+): string {
+  return options.worktreeAdapter.getStatus?.(worktree).trim() || '(dirty worktree)';
+}
+
+function formatWorktreeNextAction(worktree: IPreparedSubagentWorktree): string {
+  return `Review ${worktree.worktreePath}, then merge or delete branch ${worktree.branchName}.`;
 }
 
 function mergeMetadata(

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -32,7 +32,7 @@ const response = await query('Analyze the code', {
 ## Features
 
 - **InteractiveSession** — Event-driven session wrapper (composition over Session). Central client-facing API for CLI, web, API server, or any other client
-- **SystemCommandExecutor + ISystemCommand** — SDK-level command execution. Built-in commands: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `reset`
+- **SystemCommandExecutor + ISystemCommand** — SDK-level command execution. Built-in commands: `help`, `clear`, `compact`, `mode`, `model`, `language`, `cost`, `context`, `permissions`, `memory`, `rewind`, `background`, `reset`
 - **CommandRegistry, BuiltinCommandSource, SkillCommandSource** — Slash command registry and discovery (owned by SDK; agent-cli re-exports `CommandRegistry` from here)
 - **query()** — Single entry point for one-shot AI agent interactions with streaming support
 - **createSession()** — Assembly factory: wires tools, provider, config, and context into a Session
@@ -43,7 +43,7 @@ const response = await query('Analyze the code', {
 - **Streaming** — Real-time text delta callbacks via `onTextDelta`
 - **Context Loading** — AGENTS.md / CLAUDE.md walk-up discovery and system prompt assembly
 - **Config Loading** — 6-file settings merge with provider profiles, legacy provider compatibility, and `$ENV:VAR` substitution for provider API keys
-- **Context Window Management** — Token tracking, auto-compaction at ~83.5%, manual `session.compact()`
+- **Context Window Management** — Token tracking, configurable auto-compaction (default ~83.5%), manual `session.compact()`
 - **Background Jobs** — Runtime-managed subagent tasks with transcripts and task snapshots
 - **Agent Batch Jobs** — `Agent({ jobs: [...] })` starts explicit parallel subagent requests deterministically
 - **Edit Checkpoints** — Checkpoint/rewind support for safer edit workflows
@@ -190,18 +190,19 @@ executor.hasCommand('mode'); // boolean
 
 Built-in commands:
 
-| Command       | Description                                             |
-| ------------- | ------------------------------------------------------- |
-| `help`        | Show available commands                                 |
-| `clear`       | Clear conversation history                              |
-| `compact`     | Compress context window (optional focus instructions)   |
-| `mode [m]`    | Show or change permission mode                          |
-| `model <id>`  | Change AI model                                         |
-| `language`    | Set response language (ko, en, ja, zh)                  |
-| `cost`        | Show session info (session ID, message count)           |
-| `context`     | Context window token usage                              |
-| `permissions` | Show current permission mode and session-approved tools |
-| `reset`       | Delete settings (caller handles file I/O and exit)      |
+| Command       | Description                                                             |
+| ------------- | ----------------------------------------------------------------------- |
+| `help`        | Show available commands                                                 |
+| `clear`       | Clear conversation history                                              |
+| `compact`     | Compress context window (optional focus instructions)                   |
+| `mode [m]`    | Show or change permission mode                                          |
+| `model <id>`  | Change AI model                                                         |
+| `language`    | Set response language (ko, en, ja, zh)                                  |
+| `cost`        | Show session info (session ID, message count)                           |
+| `context`     | Context window token usage                                              |
+| `permissions` | Show current permission mode and session-approved tools                 |
+| `rewind`      | List checkpoints, restore later edits, or rollback through a checkpoint |
+| `reset`       | Delete settings (caller handles file I/O and exit)                      |
 
 ### CommandRegistry, BuiltinCommandSource, SkillCommandSource
 
@@ -242,6 +243,7 @@ const response = await query('Analyze the code', {
   cwd: '/path/to/project',
   permissionMode: 'acceptEdits',
   maxTurns: 10,
+  autoCompactThreshold: 0.75,
   onTextDelta: (delta) => process.stdout.write(delta),
   onCompact: () => console.log('Context compacted'),
 });

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -360,7 +360,7 @@ Resolved provider fields:
 
 - **Token tracking**: `agent-sessions` Session tracks cumulative input tokens from provider response metadata
 - **Usage state**: `session.getContextState()` returns `IContextWindowState` (usedTokens, maxTokens, usedPercentage)
-- **Auto-compaction**: Triggers at ~83.5% of model context window (configurable per model)
+- **Auto-compaction**: Triggers at the configured context-window threshold, defaults to ~83.5%, and can be disabled per session
 - **Manual compaction**: `session.compact(instructions?)` generates LLM summary, replaces history
 - **Model sizes**: Lookup table per model (200K for Sonnet/Haiku, 1M for Opus)
 - **Compact Instructions**: Extracted from CLAUDE.md "Compact Instructions" section, passed to summary prompt
@@ -752,6 +752,7 @@ const result: ICommandResult | null = await session.executeCommand('context', ''
 | `context`     | Token usage: used / max / percentage                                                  |
 | `permissions` | Current mode and session-approved tools                                               |
 | `memory`      | List/show/add/review project memory and report used memory references                 |
+| `rewind`      | List edit checkpoints, restore later edits, or rollback through a checkpoint          |
 | `reset`       | Returns `data.resetRequested: true` — caller handles exit                             |
 | `resume`      | Returns `data.triggerResumePicker: true` — caller shows session picker overlay        |
 | `rename`      | Returns `data.name: '<name>'` — caller applies via `interactiveSession.setName(name)` |

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -63,6 +63,12 @@ const ID_RADIX = 36;
 const ID_RANDOM_LENGTH = 9;
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 120_000;
 
+type TAutoCompactThreshold = number | false;
+type TSessionOptionsWithAutoCompact = ConstructorParameters<typeof Session>[0] & {
+  autoCompactThreshold?: TAutoCompactThreshold;
+};
+type TSessionConstructorWithAutoCompact = new (options: TSessionOptionsWithAutoCompact) => Session;
+
 /** Options for the createSession factory */
 export interface ICreateSessionOptions {
   /** Resolved CLI configuration (model, API key, permissions) */
@@ -116,6 +122,8 @@ export interface ICreateSessionOptions {
   onCompact?: (summary: string) => void;
   /** Instructions to include in the compaction prompt (e.g. from CLAUDE.md) */
   compactInstructions?: string;
+  /** Auto-compact threshold as a 0-1 fraction. Set false to disable automatic compaction. */
+  autoCompactThreshold?: TAutoCompactThreshold;
   /** Custom system prompt builder function */
   systemPromptBuilder?: (params: ISystemPromptParams) => string;
   /** Custom tool descriptions for the system prompt */
@@ -324,7 +332,8 @@ export function createSession(options: ICreateSessionOptions): Session {
     deny: options.config.permissions.deny ?? [],
   };
 
-  const session = new Session({
+  const SessionWithAutoCompact = Session as TSessionConstructorWithAutoCompact;
+  const session = new SessionWithAutoCompact({
     tools,
     provider,
     systemMessage: finalSystemMessage,
@@ -345,6 +354,7 @@ export function createSession(options: ICreateSessionOptions): Session {
     promptForApproval: options.promptForApproval,
     onCompact: options.onCompact,
     compactInstructions: options.compactInstructions ?? options.context.compactInstructions,
+    autoCompactThreshold: options.autoCompactThreshold,
     sessionLogger: options.sessionLogger,
     hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
   });

--- a/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
+++ b/packages/agent-sdk/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
@@ -61,6 +61,31 @@ describe('EditCheckpointStore', () => {
     expect(result.restoredFileCount).toBe(1);
   });
 
+  it('Given edited turns When rolling back through a checkpoint Then the selected turn and later turns are reverted', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'src', 'example.ts');
+    mkdirSync(join(cwd, 'src'), { recursive: true });
+    writeFileSync(filePath, 'version 1', 'utf8');
+    const store = new EditCheckpointStore({ cwd });
+
+    const first = await store.beginTurn({ sessionId: 'session_1', prompt: 'first edit' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'version 2', 'utf8');
+    await store.finalizeTurn();
+
+    await store.beginTurn({ sessionId: 'session_1', prompt: 'second edit' });
+    await store.captureFile(filePath);
+    writeFileSync(filePath, 'version 3', 'utf8');
+    await store.finalizeTurn();
+
+    const result = await store.rollbackThroughCheckpoint('session_1', first.id);
+
+    expect(readFileSync(filePath, 'utf8')).toBe('version 1');
+    expect(result.restoredCheckpointCount).toBe(2);
+    expect(result.restoredFileCount).toBe(2);
+    expect(store.list('session_1')).toEqual([]);
+  });
+
   it('Given the same file is captured twice in one turn When finalizing Then only the first pre-image is stored', async () => {
     const cwd = makeProject();
     const filePath = join(cwd, 'same.txt');

--- a/packages/agent-sdk/src/checkpoints/edit-checkpoint-store.ts
+++ b/packages/agent-sdk/src/checkpoints/edit-checkpoint-store.ts
@@ -127,6 +127,40 @@ export class EditCheckpointStore {
     };
   }
 
+  async rollbackThroughCheckpoint(
+    sessionId: string,
+    checkpointId: string,
+  ): Promise<IEditCheckpointRestoreResult> {
+    const manifests = this.loadManifests(sessionId);
+    const target = manifests.find((manifest) => manifest.id === checkpointId);
+    if (!target) {
+      throw new Error(`Unknown edit checkpoint: ${checkpointId}`);
+    }
+
+    const rollbackRange = manifests
+      .filter((manifest) => manifest.sequence >= target.sequence)
+      .sort((a, b) => b.sequence - a.sequence);
+
+    let restoredFileCount = 0;
+    for (const manifest of rollbackRange) {
+      for (const file of manifest.files) {
+        await this.restoreFile(sessionId, manifest.id, file);
+        restoredFileCount += 1;
+      }
+    }
+
+    for (const manifest of rollbackRange) {
+      await rm(this.checkpointDir(sessionId, manifest.id), { recursive: true, force: true });
+    }
+
+    return {
+      target: toSummary(target),
+      restoredCheckpointCount: rollbackRange.length,
+      restoredFileCount,
+      removedCheckpointCount: rollbackRange.length,
+    };
+  }
+
   private async createFileRecord(
     originalPath: string,
     active: IActiveEditCheckpointTurn,

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -32,6 +32,7 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
       maxTokens: 200000,
       usedPercentage: 2.5,
     }),
+    getAutoCompactThreshold: vi.fn().mockReturnValue(0.835),
     compact: vi.fn(),
     listBackgroundTasks: vi.fn().mockReturnValue([]),
     cancelBackgroundTask: vi.fn(),
@@ -57,6 +58,7 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
     ]),
     listEditCheckpoints: vi.fn().mockReturnValue([]),
     restoreEditCheckpoint: vi.fn(),
+    rollbackEditCheckpoint: vi.fn(),
     sendAgentJob: vi.fn(),
     cancelAgentJob: vi.fn(),
     closeAgentJob: vi.fn(),
@@ -76,6 +78,7 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
     listAgentDefinitions: underlying.listAgentDefinitions,
     listEditCheckpoints: underlying.listEditCheckpoints,
     restoreEditCheckpoint: underlying.restoreEditCheckpoint,
+    rollbackEditCheckpoint: underlying.rollbackEditCheckpoint,
     sendAgentJob: underlying.sendAgentJob,
     cancelAgentJob: underlying.cancelAgentJob,
     closeAgentJob: underlying.closeAgentJob,
@@ -178,6 +181,18 @@ describe('SystemCommandExecutor', () => {
     expect(result!.data?.usedTokens).toBe(5000);
   });
 
+  it('context reports the auto-compact policy when exposed by the session', async () => {
+    const executor = new SystemCommandExecutor();
+    const result = await executor.execute(
+      'context',
+      createMockSession({ getAutoCompactThreshold: vi.fn().mockReturnValue(0.75) }),
+      '',
+    );
+
+    expect(result!.message).toContain('Auto compact: 75%');
+    expect(result!.data?.autoCompactThreshold).toBe(0.75);
+  });
+
   it('compact calls session.compact', async () => {
     const executor = new SystemCommandExecutor();
     const session = createMockSession();
@@ -187,6 +202,18 @@ describe('SystemCommandExecutor', () => {
       (session as unknown as { _underlying: { compact: ReturnType<typeof vi.fn> } })._underlying
         .compact,
     ).toHaveBeenCalledWith('focus on tests');
+  });
+
+  it('compact exposes descriptor metadata for SDK-owned slash routing', () => {
+    const compact = createSystemCommands().find((command) => command.name === 'compact');
+
+    expect(compact).toEqual(
+      expect.objectContaining({
+        name: 'compact',
+        description: 'Compress context window',
+        argumentHint: '[instructions]',
+      }),
+    );
   });
 
   it('resume returns triggerResumePicker in data', async () => {
@@ -243,6 +270,31 @@ describe('SystemCommandExecutor', () => {
     expect(result!.success).toBe(true);
     expect(restoreEditCheckpoint).toHaveBeenCalledWith('turn-0001');
     expect(result!.data?.restoredFileCount).toBe(3);
+  });
+
+  it('rewind rollback delegates inclusive code rollback to the interactive session', async () => {
+    const executor = new SystemCommandExecutor();
+    const rollbackEditCheckpoint = vi.fn().mockResolvedValue({
+      target: {
+        id: 'turn-0001',
+        sessionId: 'test-session-id',
+        sequence: 1,
+        prompt: 'change files',
+        createdAt: '2026-05-02T00:00:00.000Z',
+        fileCount: 1,
+      },
+      restoredCheckpointCount: 1,
+      restoredFileCount: 1,
+      removedCheckpointCount: 1,
+    });
+    const session = createMockSession({ rollbackEditCheckpoint });
+
+    const result = await executor.execute('rewind', session, 'rollback turn-0001');
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(true);
+    expect(rollbackEditCheckpoint).toHaveBeenCalledWith('turn-0001');
+    expect(result!.message).toContain('Rolled back code through turn-0001.');
   });
 
   it('background list returns task summaries', async () => {

--- a/packages/agent-sdk/src/commands/builtin-source.ts
+++ b/packages/agent-sdk/src/commands/builtin-source.ts
@@ -40,6 +40,7 @@ function buildRewindSubcommands(): ICommand[] {
     { name: 'list', description: 'List edit checkpoints', source: 'builtin' },
     { name: 'restore', description: 'Restore code to a checkpoint', source: 'builtin' },
     { name: 'code', description: 'Restore code to a checkpoint', source: 'builtin' },
+    { name: 'rollback', description: 'Rollback code through a checkpoint', source: 'builtin' },
   ];
 }
 

--- a/packages/agent-sdk/src/commands/rewind-command.ts
+++ b/packages/agent-sdk/src/commands/rewind-command.ts
@@ -9,7 +9,8 @@ const ELLIPSIS_LENGTH = 3;
 
 function usage(): ICommandResult {
   return {
-    message: 'Usage: rewind [list] | rewind restore <checkpoint-id> | rewind code <checkpoint-id>',
+    message:
+      'Usage: rewind [list] | rewind restore <checkpoint-id> | rewind code <checkpoint-id> | rewind rollback <checkpoint-id>',
     success: false,
   };
 }
@@ -64,6 +65,32 @@ async function restore(session: InteractiveSession, checkpointId: string | undef
   }
 }
 
+async function rollback(session: InteractiveSession, checkpointId: string | undefined) {
+  if (!checkpointId) return usage();
+  try {
+    const result = await session.rollbackEditCheckpoint(checkpointId);
+    return {
+      message: [
+        `Rolled back code through ${result.target.id}.`,
+        `Restored files: ${result.restoredFileCount}`,
+        `Removed checkpoints: ${result.removedCheckpointCount}`,
+      ].join('\n'),
+      success: true,
+      data: {
+        target: result.target,
+        restoredCheckpointCount: result.restoredCheckpointCount,
+        restoredFileCount: result.restoredFileCount,
+        removedCheckpointCount: result.removedCheckpointCount,
+      },
+    };
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
 export async function executeRewindCommand(
   session: InteractiveSession,
   rawArgs: string,
@@ -77,6 +104,10 @@ export async function executeRewindCommand(
 
   if (subcommand === 'restore' || subcommand === 'code') {
     return restore(session, args[CHECKPOINT_ID_INDEX]);
+  }
+
+  if (subcommand === 'rollback') {
+    return rollback(session, args[CHECKPOINT_ID_INDEX]);
   }
 
   return usage();

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -36,6 +36,8 @@ export interface ISystemCommand {
 }
 
 const VALID_MODES: TPermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions'];
+const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.835;
+const PERCENT = 100;
 const MEMORY_COMMAND_DESCRIPTION =
   'Project memory command. Use it to inspect project memory when stored context may help, save durable preferences, project conventions, feedback, or references worth reusing across sessions, review pending candidates, and report memory provenance. Do not store secrets, credentials, or transient facts.';
 const MEMORY_COMMAND_ARGUMENT_HINT =
@@ -82,6 +84,7 @@ export function createSystemCommands(): ISystemCommand[] {
     {
       name: 'compact',
       description: 'Compress context window',
+      argumentHint: '[instructions]',
       execute: async (session, args) => {
         const underlying = session.getSession();
         const instructions = args.trim() || undefined;
@@ -172,13 +175,22 @@ export function createSystemCommands(): ISystemCommand[] {
       description: 'Context window info',
       execute: (session, _args) => {
         const ctx = session.getContextState();
+        const autoCompactThreshold = getAutoCompactThreshold(session);
+        const autoCompactLine =
+          autoCompactThreshold === false
+            ? 'Auto compact: disabled'
+            : `Auto compact: ${Math.round(autoCompactThreshold * PERCENT)}%`;
         return {
-          message: `Context: ${ctx.usedTokens.toLocaleString()} / ${ctx.maxTokens.toLocaleString()} tokens (${Math.round(ctx.usedPercentage)}%)`,
+          message: [
+            `Context: ${ctx.usedTokens.toLocaleString()} / ${ctx.maxTokens.toLocaleString()} tokens (${Math.round(ctx.usedPercentage)}%)`,
+            autoCompactLine,
+          ].join('\n'),
           success: true,
           data: {
             usedTokens: ctx.usedTokens,
             maxTokens: ctx.maxTokens,
             percentage: ctx.usedPercentage,
+            autoCompactThreshold,
           },
         };
       },
@@ -214,7 +226,7 @@ export function createSystemCommands(): ISystemCommand[] {
     {
       name: 'rewind',
       description: 'List edit checkpoints or restore code to a previous checkpoint.',
-      argumentHint: 'list | restore CHECKPOINT_ID | code CHECKPOINT_ID',
+      argumentHint: 'list | restore CHECKPOINT_ID | code CHECKPOINT_ID | rollback CHECKPOINT_ID',
       safety: 'write',
       execute: executeRewindCommand,
     },
@@ -260,4 +272,9 @@ export function createSystemCommands(): ISystemCommand[] {
       },
     },
   ];
+}
+
+function getAutoCompactThreshold(session: InteractiveSession): number | false {
+  const candidate = session.getSession() as { getAutoCompactThreshold?: () => number | false };
+  return candidate.getAutoCompactThreshold?.() ?? DEFAULT_AUTO_COMPACT_THRESHOLD;
 }

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-checkpoints.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-checkpoints.test.ts
@@ -92,4 +92,40 @@ describe('InteractiveSession edit checkpointing', () => {
       firstCheckpoint!.id,
     ]);
   });
+
+  it('Given the model edits a file When rolling back the checkpoint Then the selected turn is reverted', async () => {
+    const cwd = makeProject();
+    const filePath = join(cwd, 'example.txt');
+    writeFileSync(filePath, 'initial', 'utf8');
+    const provider = createProvider([
+      assistantMessage('', [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'Write',
+            arguments: JSON.stringify({ filePath, content: 'first edit' }),
+          },
+        },
+      ]),
+      assistantMessage('first done'),
+    ]);
+    const session = new InteractiveSession({
+      cwd,
+      provider,
+      bare: true,
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Write'],
+    });
+
+    await session.submit('write first version');
+    const [firstCheckpoint] = session.listEditCheckpoints();
+
+    expect(readFileSync(filePath, 'utf8')).toBe('first edit');
+
+    await session.rollbackEditCheckpoint(firstCheckpoint!.id);
+
+    expect(readFileSync(filePath, 'utf8')).toBe('initial');
+    expect(session.listEditCheckpoints()).toEqual([]);
+  });
 });

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -408,6 +408,22 @@ export class InteractiveSession {
     return result;
   }
 
+  async rollbackEditCheckpoint(checkpointId: string): Promise<IEditCheckpointRestoreResult> {
+    await this.ensureInitialized();
+    if (this.executing) {
+      throw new Error('Cannot rollback edit checkpoint while a prompt is running.');
+    }
+    const result = await this.getEditCheckpointStore().rollbackThroughCheckpoint(
+      this.getSessionOrThrow().getSessionId(),
+      checkpointId,
+    );
+    this.history.push(
+      messageToHistoryEntry(createSystemMessage(`Rolled back edit checkpoint: ${checkpointId}`)),
+    );
+    this.persistCurrentSession();
+    return result;
+  }
+
   getUsedMemoryReferences(): IMemoryReference[] {
     return [...this.usedMemoryReferences];
   }

--- a/packages/agent-sessions/README.md
+++ b/packages/agent-sessions/README.md
@@ -19,6 +19,7 @@ const session = new Session({
   systemMessage: 'You are a helpful assistant.',
   terminal,
   permissions: { allow: ['Read(*)'], deny: [] },
+  autoCompactThreshold: 0.75,
 });
 
 const response = await session.run('Hello!');
@@ -37,7 +38,7 @@ await session.compact('Focus on the API changes');
 | -------------------------- | ------------------------------------------------------------------------------------------------------ |
 | **Permission enforcement** | Tool calls gated by 3-step policy (deny list, allow list, mode policy)                                 |
 | **Hook execution**         | PreToolUse, PostToolUse, PreCompact, PostCompact, SessionStart, Stop                                   |
-| **Context tracking**       | Token usage from provider metadata, auto-compact at ~83.5%                                             |
+| **Context tracking**       | Token usage from provider metadata, configurable auto-compact threshold (default ~83.5%)               |
 | **Compaction**             | LLM-generated conversation summary to free context space                                               |
 | **Persistence**            | `SessionStore` for JSON file-based session save/load                                                   |
 | **Abort**                  | Cancel via `session.abort()` — propagates AbortSignal to `robota.run()`, throws `AbortError` to caller |
@@ -53,6 +54,7 @@ await session.compact('Focus on the API changes');
 | `injectMessage(message)`                          | Inject a message into history without running the agent  |
 | `compact(instructions?)`                          | Compress conversation via LLM summary                    |
 | `getContextState()`                               | Token usage: `{ usedTokens, maxTokens, usedPercentage }` |
+| `getAutoCompactThreshold()`                       | Auto-compact threshold fraction, or `false` if disabled  |
 | `getPermissionMode()` / `setPermissionMode(mode)` | Read/change permission mode                              |
 | `getHistory()` / `clearHistory()`                 | Access or clear conversation history                     |
 | `abort()`                                         | Cancel running execution                                 |
@@ -74,6 +76,7 @@ await session.compact('Focus on the API changes');
 | `FileSessionLogger`      | Class     | JSONL file-based session event logger                        |
 | `SilentSessionLogger`    | Class     | No-op session logger                                         |
 | `ISessionOptions`        | Interface | Constructor options for Session                              |
+| `TAutoCompactThreshold`  | Type      | Auto-compact threshold fraction, or `false` to disable       |
 | `TPermissionHandler`     | Type      | Custom permission approval callback                          |
 | `TPermissionResult`      | Type      | Permission decision result (`boolean \| 'allow-session'`)    |
 | `ITerminalOutput`        | Interface | Terminal I/O abstraction (write, prompt, select, spinner)    |

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -88,6 +88,7 @@ Types consumed from other packages (not owned here):
 | `SilentSessionLogger`            | Class                | No-op session logger                                                                                           |
 | `ISessionOptions`                | Interface            | Constructor options for Session                                                                                |
 | `ISessionShutdownOptions`        | Interface            | Graceful shutdown options for `Session.shutdown()`                                                             |
+| `TAutoCompactThreshold`          | Type                 | Auto-compact threshold fraction, or `false` to disable automatic compaction                                    |
 | `TPermissionHandler`             | Type                 | Custom permission approval callback                                                                            |
 | `TPermissionResult`              | Type                 | Permission decision result                                                                                     |
 | `ITerminalOutput`                | Interface            | Terminal I/O abstraction                                                                                       |
@@ -108,6 +109,8 @@ Types consumed from other packages (not owned here):
 
 `ISessionOptions.onContextUpdate` is an optional callback fired from the session runtime whenever `ContextWindowTracker` is refreshed. It fires before the provider call using the assembled request history estimate and again after the provider response is committed with exact provider usage when available. Consumers such as `InteractiveSession` forward it as `context_update`.
 
+`ISessionOptions.autoCompactThreshold` controls the automatic compaction trigger as a `0 < value <= 1` fraction. The default is `0.835`. Set it to `false` when an embedding runtime manages compaction externally.
+
 ### Key Session Methods
 
 | Method                     | Signature                                                            | Description                                                                                                                             |
@@ -122,6 +125,7 @@ Types consumed from other packages (not owned here):
 | `getFullHistory`           | `() => IHistoryEntry[]`                                              | Returns the full history as `IHistoryEntry[]`, including both chat messages and event entries (e.g., tool summaries).                   |
 | `addHistoryEntry`          | `(entry: IHistoryEntry) => void`                                     | Appends a pre-built `IHistoryEntry` (e.g., a tool-summary event entry) to the session history via `ConversationStore.addEntry()`.       |
 | `getContextState`          | `() => IContextWindowState`                                          | Returns real-time context window usage (tokens, percentage).                                                                            |
+| `getAutoCompactThreshold`  | `() => TAutoCompactThreshold`                                        | Returns the configured automatic compaction threshold, or `false` when disabled.                                                        |
 | `compact`                  | `(instructions?: string) => Promise<void>`                           | Compresses conversation via LLM summary. System message is preserved across compaction (see below). Fires PreCompact/PostCompact hooks. |
 | `abort`                    | `() => void`                                                         | Cancels the currently running `run()` call. No-op if not running.                                                                       |
 | `shutdown`                 | `(options?: ISessionShutdownOptions) => Promise<void>`               | Aborts active work, persists the session when a store exists, logs shutdown, and fires `SessionEnd` exactly once.                       |
@@ -223,7 +227,9 @@ The session log records structured events to a JSONL file for diagnostics and re
 
 11. **`ISessionOptions.maxTurns`** -- Optional model/tool round cap passed to the underlying Robota run. Omitted means unlimited for the session layer.
 
-12. **`SessionStore` constructor** -- Accept a custom `baseDir` to redirect storage location (useful in tests).
+12. **`ISessionOptions.autoCompactThreshold`** -- Optional automatic compaction threshold. A number is interpreted as a fraction of the context window; `false` disables automatic compaction.
+
+13. **`SessionStore` constructor** -- Accept a custom `baseDir` to redirect storage location (useful in tests).
 
 ## Abort Behavior
 
@@ -265,7 +271,7 @@ This ensures the AI retains project context (working directory, coding rules, av
 
 ### Auto-Compaction
 
-Auto-compaction triggers at the **start** of `run()` (before processing the user message) when `ContextWindowTracker.shouldAutoCompact()` returns true. This prevents compaction from interfering with the current response stream.
+Auto-compaction triggers at the **start** of `run()` (before processing the user message) when `ContextWindowTracker.shouldAutoCompact()` returns true. This prevents compaction from interfering with the current response stream. The trigger defaults to 83.5% of the context window and can be configured per session or disabled with `autoCompactThreshold: false`.
 
 ## Error Taxonomy
 

--- a/packages/agent-sessions/src/__tests__/session-compaction.test.ts
+++ b/packages/agent-sessions/src/__tests__/session-compaction.test.ts
@@ -215,6 +215,35 @@ describe('Session compaction', () => {
     expect(mockRunCalls).toContain('next question');
   });
 
+  it('auto-compact uses a configured threshold', async () => {
+    const session = createSession({ contextMaxTokens: 100, autoCompactThreshold: 0.5 });
+
+    mockHistory = [
+      { role: 'user', content: 'hello', metadata: { inputTokens: 40, outputTokens: 20 } },
+    ];
+
+    await session.run('next question');
+
+    expect(mockClearCount).toBeGreaterThanOrEqual(1);
+    expect(mockInjectCalls[1].content).toContain('[Context Summary]');
+    expect(mockRunCalls).toContain('next question');
+  });
+
+  it('auto-compact can be disabled for sessions that manage compaction externally', async () => {
+    const session = createSession({ contextMaxTokens: 100, autoCompactThreshold: false });
+
+    mockHistory = [
+      { role: 'user', content: 'hello', metadata: { inputTokens: 90, outputTokens: 10 } },
+      { role: 'assistant', content: 'response', metadata: { inputTokens: 90, outputTokens: 10 } },
+    ];
+
+    await session.run('next question');
+
+    expect(mockClearCount).toBe(0);
+    expect(mockInjectCalls).toHaveLength(0);
+    expect(mockRunCalls).toContain('next question');
+  });
+
   it('run() logs error and re-throws when robota.run() fails', async () => {
     // Create a session with a provider whose chat will work for compaction
     const session = createSession();

--- a/packages/agent-sessions/src/context-window-tracker.ts
+++ b/packages/agent-sessions/src/context-window-tracker.ts
@@ -13,12 +13,20 @@ const PERCENT = 100;
 /** Auto-compact when context usage reaches this fraction */
 export const AUTO_COMPACT_THRESHOLD = 0.835;
 
+export type TAutoCompactThreshold = number | false;
+
 export class ContextWindowTracker {
   private contextUsedTokens = 0;
   private readonly contextMaxTokens: number;
+  private readonly autoCompactThreshold: TAutoCompactThreshold;
 
-  constructor(model: string, contextMaxTokens?: number) {
+  constructor(
+    model: string,
+    contextMaxTokens?: number,
+    autoCompactThreshold?: TAutoCompactThreshold,
+  ) {
     this.contextMaxTokens = contextMaxTokens ?? getModelContextWindow(model);
+    this.autoCompactThreshold = normalizeAutoCompactThreshold(autoCompactThreshold);
   }
 
   /** Get current context window state */
@@ -37,7 +45,15 @@ export class ContextWindowTracker {
 
   /** Whether auto-compaction threshold has been exceeded */
   shouldAutoCompact(): boolean {
-    return this.getContextState().usedPercentage >= AUTO_COMPACT_THRESHOLD * PERCENT;
+    if (this.autoCompactThreshold === false) {
+      return false;
+    }
+    return this.getContextState().usedPercentage >= this.autoCompactThreshold * PERCENT;
+  }
+
+  /** The auto-compaction policy for this tracker. */
+  getAutoCompactThreshold(): TAutoCompactThreshold {
+    return this.autoCompactThreshold;
   }
 
   /**
@@ -81,4 +97,23 @@ export class ContextWindowTracker {
   reset(): void {
     this.contextUsedTokens = 0;
   }
+}
+
+function normalizeAutoCompactThreshold(
+  autoCompactThreshold: TAutoCompactThreshold | undefined,
+): TAutoCompactThreshold {
+  if (autoCompactThreshold === undefined) {
+    return AUTO_COMPACT_THRESHOLD;
+  }
+  if (autoCompactThreshold === false) {
+    return false;
+  }
+  if (
+    !Number.isFinite(autoCompactThreshold) ||
+    autoCompactThreshold <= 0 ||
+    autoCompactThreshold > 1
+  ) {
+    throw new RangeError('autoCompactThreshold must be a number greater than 0 and at most 1.');
+  }
+  return autoCompactThreshold;
 }

--- a/packages/agent-sessions/src/index.ts
+++ b/packages/agent-sessions/src/index.ts
@@ -5,6 +5,7 @@ export { Session } from './session.js';
 export type {
   ISessionOptions,
   ISessionShutdownOptions,
+  TAutoCompactThreshold,
   TPermissionHandler,
   TPermissionResult,
   ITerminalOutput,

--- a/packages/agent-sessions/src/session-types.ts
+++ b/packages/agent-sessions/src/session-types.ts
@@ -13,6 +13,7 @@ import type {
 import type { IHookTypeExecutor } from '@robota-sdk/agent-core';
 import type { SessionStore } from './session-store.js';
 import type { ISessionLogger } from './session-logger.js';
+import type { TAutoCompactThreshold } from './context-window-tracker.js';
 import type {
   TPermissionHandler,
   TPermissionResult,
@@ -81,6 +82,8 @@ export interface ISessionOptions {
   compactInstructions?: string;
   /** Override context max tokens (otherwise derived from model name) */
   contextMaxTokens?: number;
+  /** Auto-compact threshold as a 0-1 fraction. Set false to disable automatic compaction. */
+  autoCompactThreshold?: TAutoCompactThreshold;
   /** Session logger — injected for pluggable session event logging. */
   sessionLogger?: ISessionLogger;
   /** Additional hook type executors (e.g. prompt, agent) beyond the core defaults. */

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -45,6 +45,7 @@ export type {
   ISessionOptions,
   ISessionShutdownOptions,
 };
+export type { TAutoCompactThreshold } from './context-window-tracker.js';
 
 const ID_RADIX = 36;
 const ID_RANDOM_LENGTH = 9;
@@ -132,7 +133,11 @@ export class Session {
       hookTypeExecutors: options.hookTypeExecutors,
     });
 
-    this.contextTracker = new ContextWindowTracker(this.model, options.contextMaxTokens);
+    this.contextTracker = new ContextWindowTracker(
+      this.model,
+      options.contextMaxTokens,
+      options.autoCompactThreshold,
+    );
     this.compactionOrchestrator = new CompactionOrchestrator({
       sessionId: this.sessionId,
       cwd: this.cwd,
@@ -303,6 +308,11 @@ export class Session {
   /** Get current context window state */
   getContextState() {
     return this.contextTracker.getContextState();
+  }
+
+  /** Get this session's automatic context compaction threshold policy. */
+  getAutoCompactThreshold() {
+    return this.contextTracker.getAutoCompactThreshold();
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix `/model` changes so the active provider profile is updated before the session restart path runs.
- Move `/compact` through the SDK system-command descriptor path and add context-window auto-compact threshold reporting/configuration.
- Add reversible rollback-through-checkpoint support via `/rewind rollback`, plus worktree dirty-state metadata for subagent runs.
- Add an agent package coverage audit report and update package docs/SPEC files for the new runtime behavior.

## Verification

- `pnpm --filter @robota-sdk/agent-cli test -- slash-executor git-worktree-isolation-adapter provider-configuration settings-io provider-factory`
- `pnpm --filter @robota-sdk/agent-sdk test -- system-command edit-checkpoint-store edit-checkpoint-tools interactive-session-checkpoints agent-tool`
- `pnpm --filter @robota-sdk/agent-sessions test -- session-compaction`
- `pnpm --filter @robota-sdk/agent-runtime test -- worktree-subagent-runner`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (warnings only)
- `pnpm harness:verify -- --base-ref origin/develop --skip-build --skip-record-check`
- pre-push `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`