### PR TITLE
fix(cli): show compact command execution state

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -38,7 +38,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | [command-migration-statusline.md](command-migration-statusline.md)             | Migrate `/statusline` into a command-module owner             |
 | [compact-auto-controls.md](compact-auto-controls.md)                           | Command controls for auto-compact threshold and on/off state  |
 | [compact-command-descriptor.md](compact-command-descriptor.md)                 | Descriptor-owned compact command and auto-trigger policy      |
-| [compact-command-execution-state.md](compact-command-execution-state.md)       | Manual `/compact` should show blocking command execution      |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |

--- a/.agents/tasks/completed/compact-command-execution-state.md
+++ b/.agents/tasks/completed/compact-command-execution-state.md
@@ -1,3 +1,15 @@
+---
+title: Compact Command Execution State
+status: completed
+priority: high
+urgency: now
+created: 2026-05-03
+completed: 2026-05-03
+packages:
+  - agent-sdk
+  - agent-cli
+---
+
 # Compact Command Execution State
 
 ## What
@@ -58,3 +70,18 @@ Rationale: compaction calls the provider and rewrites session history. It has th
 1. Move to `.agents/tasks/CLI-BL-0XX-compact-command-execution-state.md`.
 2. Start with a failing CLI regression test that keeps compaction pending.
 3. Wire manual compaction into the shared execution lifecycle before changing visual copy.
+
+## Result
+
+- Confirmed `/compact` already uses the SDK blocking foreground command lifecycle.
+- Added a `/compact` regression test that keeps compaction pending, emits `thinking`, blocks a second command, and reports completion after compaction resolves.
+- Updated the generic TUI streaming indicator to render `Thinking...` when foreground work has no tools or streaming text yet, which makes model-backed compaction visibly active without adding a `/compact` special case.
+
+## Verification
+
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session.test.ts`
+- `pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/streaming-indicator.test.tsx src/ui/__tests__/status-bar.test.tsx`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-cli lint` (passes with existing warnings)
+- `pnpm --filter @robota-sdk/agent-sdk lint` (passes with existing warnings)

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -209,7 +209,11 @@ function AppInner(
         )}
         {(isThinking || activeTools.length > 0) && (
           <Box flexDirection="column" marginBottom={1}>
-            <StreamingIndicator text={streamingText} activeTools={activeTools} />
+            <StreamingIndicator
+              text={streamingText}
+              activeTools={activeTools}
+              isThinking={isThinking}
+            />
           </Box>
         )}
         <BackgroundTaskPanel tasks={backgroundTasks} />

--- a/packages/agent-cli/src/ui/StreamingIndicator.tsx
+++ b/packages/agent-cli/src/ui/StreamingIndicator.tsx
@@ -23,40 +23,58 @@ function getToolStyle(t: IToolState): {
 interface IProps {
   text: string;
   activeTools: IToolState[];
+  isThinking?: boolean;
 }
 
-export default function StreamingIndicator({ text, activeTools }: IProps): React.ReactElement {
+function renderThinkingFallback(isThinking: boolean): React.ReactElement {
+  if (!isThinking) return <></>;
+  return (
+    <Box marginBottom={1}>
+      <Text color="yellow">Thinking...</Text>
+    </Box>
+  );
+}
+
+function renderTools(activeTools: IToolState[]): React.ReactElement {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color="white" bold>
+        Tools:
+      </Text>
+      <Text> </Text>
+      {activeTools.map((t, i) => {
+        const { color, icon, strikethrough } = getToolStyle(t);
+        return (
+          <Box key={`${t.toolName}-${i}`} flexDirection="column">
+            <Text color={color} strikethrough={strikethrough}>
+              {'  '}
+              {icon} {t.toolName}({t.firstArg})
+            </Text>
+            {t.diffLines && t.diffLines.length > 0 && (
+              <ToolDiffBlock file={t.diffFile} lines={t.diffLines} />
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default function StreamingIndicator({
+  text,
+  activeTools,
+  isThinking = false,
+}: IProps): React.ReactElement {
   const hasTools = activeTools.length > 0;
   const hasText = text.length > 0;
 
   if (!hasTools && !hasText) {
-    return <></>;
+    return renderThinkingFallback(isThinking);
   }
 
   return (
     <Box flexDirection="column">
-      {hasTools && (
-        <Box flexDirection="column" marginBottom={1}>
-          <Text color="white" bold>
-            Tools:
-          </Text>
-          <Text> </Text>
-          {activeTools.map((t, i) => {
-            const { color, icon, strikethrough } = getToolStyle(t);
-            return (
-              <Box key={`${t.toolName}-${i}`} flexDirection="column">
-                <Text color={color} strikethrough={strikethrough}>
-                  {'  '}
-                  {icon} {t.toolName}({t.firstArg})
-                </Text>
-                {t.diffLines && t.diffLines.length > 0 && (
-                  <ToolDiffBlock file={t.diffFile} lines={t.diffLines} />
-                )}
-              </Box>
-            );
-          })}
-        </Box>
-      )}
+      {hasTools && renderTools(activeTools)}
       {hasText && (
         <Box flexDirection="column" marginBottom={1}>
           <Text color="cyan" bold>

--- a/packages/agent-cli/src/ui/__tests__/streaming-indicator.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/streaming-indicator.test.tsx
@@ -9,6 +9,12 @@ describe('StreamingIndicator', () => {
     expect(lastFrame()).not.toContain('Thinking');
   });
 
+  it('shows a generic thinking state when foreground work has no text or tools yet', () => {
+    const { lastFrame } = render(<StreamingIndicator text="" activeTools={[]} isThinking={true} />);
+
+    expect(lastFrame()).toContain('Thinking...');
+  });
+
   it('shows Tools: section with running tool', () => {
     const { lastFrame } = render(
       <StreamingIndicator
@@ -77,7 +83,9 @@ describe('StreamingIndicator', () => {
   });
 
   it('does not show Thinking... when text is present', () => {
-    const { lastFrame } = render(<StreamingIndicator text="Some response" activeTools={[]} />);
+    const { lastFrame } = render(
+      <StreamingIndicator text="Some response" activeTools={[]} isThinking={true} />,
+    );
     expect(lastFrame()).not.toContain('Thinking...');
   });
 

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
@@ -27,6 +27,7 @@ function createMockSession(options?: {
       usedTokens: 1000,
       maxTokens: 10000,
     }),
+    compact: vi.fn().mockResolvedValue(undefined),
     injectMessage: vi.fn(),
     getSessionId: vi.fn().mockReturnValue(options?.sessionId ?? 'test-session-id'),
     getSystemMessage: vi.fn().mockReturnValue('mock system prompt'),
@@ -192,6 +193,40 @@ describe('InteractiveSession', () => {
 
     resolveCommand!({ message: 'done', success: true });
     await pending;
+  });
+
+  it('runs compact through the foreground thinking lifecycle', async () => {
+    let resolveCompact: () => void;
+    const mockSession = createMockSession();
+    mockSession.compact.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCompact = resolve;
+        }),
+    );
+    const session = new InteractiveSession({
+      session: mockSession as never,
+    });
+    const thinkingStates: boolean[] = [];
+    session.on('thinking', (isThinking) => thinkingStates.push(isThinking));
+
+    const pending = session.executeCommand('compact', 'focus on tests');
+    await new Promise((r) => setTimeout(r, 10));
+    const blocked = await session.executeCommand('context', '');
+
+    expect(session.isExecuting()).toBe(true);
+    expect(thinkingStates).toEqual([true]);
+    expect(blocked?.success).toBe(false);
+    expect(blocked?.message).toContain('already running');
+    expect(mockSession.compact).toHaveBeenCalledWith('focus on tests');
+
+    resolveCompact!();
+    const result = await pending;
+
+    expect(result?.success).toBe(true);
+    expect(result?.message).toContain('Context compacted: 10% -> 10%');
+    expect(session.isExecuting()).toBe(false);
+    expect(thinkingStates).toEqual([true, false]);
   });
 
   it('cancelQueue clears pending without aborting', async () => {


### PR DESCRIPTION
## Summary
- show a generic Thinking state while blocking built-in commands such as /compact are running without streamed text or tools
- cover /compact foreground execution lifecycle so concurrent commands are blocked while compaction runs
- mark the compact command execution-state backlog complete

## Verification
- pnpm --filter @robota-sdk/agent-sdk test -- src/interactive/__tests__/interactive-session.test.ts
- pnpm --filter @robota-sdk/agent-cli test -- src/ui/__tests__/streaming-indicator.test.tsx src/ui/__tests__/status-bar.test.tsx
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-sdk lint
- pnpm docs:validate-structure
- pnpm harness:scan:test-plans
- git diff --check
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-cli build
- pre-push scoped verification