### PR TITLE
fix(cli): apply model changes to active provider

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -15,7 +15,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
 | [agent-followup-roadmap.md](agent-followup-roadmap.md)                         | Recommended sequence for agent/CLI/runtime follow-ups         |
 | [agent-package-coverage-audit.md](agent-package-coverage-audit.md)             | Current coverage baseline for all agent-\* packages           |
-| [cli-model-change-restart.md](cli-model-change-restart.md)                     | `/model` restart flow does not reliably apply selected model  |
 | [command-migration-agent.md](command-migration-agent.md)                       | Finish migration hardening for `/agent`                       |
 | [command-migration-background.md](command-migration-background.md)             | Migrate `/background` into a command-module owner             |
 | [command-migration-clear.md](command-migration-clear.md)                       | Migrate `/clear` into a command-module owner                  |

--- a/.agents/tasks/completed/cli-model-change-restart.md
+++ b/.agents/tasks/completed/cli-model-change-restart.md
@@ -1,5 +1,7 @@
 # CLI Model Change Restart Regression
 
+Status: completed on `fix/cli-model-change-restart`.
+
 ## What
 
 Fix the `/model` command flow so confirming a model change actually affects the next session after Robota says it will restart.
@@ -18,15 +20,15 @@ The CLI currently tells the user that changing the model will restart the sessio
 
 ## Scope
 
-- Reproduce the regression with the current settings shapes:
+- [x] Reproduce the regression with the current settings shapes:
   - `currentProvider` plus `providers`
   - legacy `provider`
   - provider profiles created by `/provider setup`
-- Determine whether the failure is settings persistence, config reload, process restart semantics, or active session reuse.
-- Make `/model` behavior consistent across slash routing and SDK system command routing.
-- Ensure the selected model is applied to `IResolvedConfig.provider.model` for the next session.
-- Keep provider-specific model validation in provider definitions/settings, not in generic CLI execution code.
-- Add regression tests for settings update and restart/reload behavior.
+- [x] Determine whether the failure is settings persistence, config reload, process restart semantics, or active session reuse.
+- [x] Make `/model` behavior consistent across slash routing and SDK system command routing.
+- [x] Ensure the selected model is applied to `IResolvedConfig.provider.model` for the next session.
+- [x] Keep provider-specific model validation in provider definitions/settings, not in generic CLI execution code.
+- [x] Add regression tests for settings update and restart/reload behavior.
 
 ## Non-Goals
 
@@ -37,12 +39,12 @@ The CLI currently tells the user that changing the model will restart the sessio
 
 ## Acceptance Criteria
 
-- [ ] Given a settings file with `currentProvider`, `/model <id>` updates the active provider profile's model.
-- [ ] Given a legacy settings file, `/model <id>` updates the legacy provider model without losing existing fields.
-- [ ] After confirming `/model`, the next CLI session resolves the selected model.
-- [ ] If restart is requested, the CLI either truly restarts or exits with clear behavior that the launcher handles.
-- [ ] Cancellation leaves settings unchanged.
-- [ ] Tests cover slash command routing, system command routing, settings persistence, and resolved config behavior.
+- [x] Given a settings file with `currentProvider`, `/model <id>` updates the active provider profile's model.
+- [x] Given a legacy settings file, `/model <id>` updates the legacy provider model without losing existing fields.
+- [x] After confirming `/model`, the next CLI session resolves the selected model.
+- [x] If restart is requested, the CLI either truly restarts or exits with clear behavior that the launcher handles.
+- [x] Cancellation leaves settings unchanged.
+- [x] Tests cover slash command routing, system command routing, settings persistence, and resolved config behavior.
 
 ## Test Plan
 
@@ -53,6 +55,6 @@ The CLI currently tells the user that changing the model will restart the sessio
 
 ## Promotion Path
 
-1. Move to `.agents/tasks/CLI-BL-0XX-model-change-restart.md`.
-2. Start with a failing regression test that reproduces the user's report.
-3. Fix the smallest owner boundary that makes the confirmed model visible to the next session.
+1. [x] Move to `.agents/tasks/cli-model-change-restart.md`.
+2. [x] Start with a failing regression test that reproduces the user's report.
+3. [x] Fix the smallest owner boundary that makes the confirmed model visible to the next session.

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -300,6 +300,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   renderApp({
     cwd,
     provider,
+    providerOverride: args.provider,
     modelId,
     language: args.language,
     permissionMode: args.permissionMode,

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -8,7 +8,7 @@ import type {
   ICommandModule,
   TSubagentRunnerFactory,
 } from '@robota-sdk/agent-sdk';
-import { getModelName, createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
+import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import { useInteractiveSession } from './hooks/useInteractiveSession.js';
 import { usePluginCallbacks } from './hooks/usePluginCallbacks.js';
 import { useSideEffects } from './hooks/useSideEffects.js';
@@ -25,11 +25,13 @@ import SessionPicker from './SessionPicker.js';
 import BackgroundTaskPanel from './BackgroundTaskPanel.js';
 import UpdateNotice from './UpdateNotice.js';
 import { formatCliUpdateNotice, type ICliUpdateNotice } from '../utils/update-check.js';
+import { formatModelChangeConfirmationMessage } from './hooks/model-change-side-effect.js';
 import type { SessionStore } from '@robota-sdk/agent-sessions';
 
 interface IProps {
   cwd: string;
   provider: IAIProvider;
+  providerOverride?: string | undefined;
   modelId?: string;
   permissionMode?: TPermissionMode;
   maxTurns?: number;
@@ -118,6 +120,7 @@ function AppInner(
     handleInteractionCancel,
   } = useSideEffects({
     cwd,
+    providerOverride: props.providerOverride,
     interactiveSession,
     addEntry,
     baseHandleSubmit,
@@ -224,7 +227,7 @@ function AppInner(
       {permissionRequest && <PermissionPrompt request={permissionRequest} />}
       {pendingModelId && (
         <ConfirmPrompt
-          message={`Change model to ${getModelName(pendingModelId)}? This will restart the session.`}
+          message={formatModelChangeConfirmationMessage(pendingModelId)}
           onSelect={handleModelConfirm}
         />
       )}

--- a/packages/agent-cli/src/ui/__tests__/model-change-side-effect.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/model-change-side-effect.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { IHistoryEntry, TSessionEndReason } from '@robota-sdk/agent-core';
+import type {
+  IActiveModelChangeOptions,
+  IActiveModelChangeResult,
+} from '../../utils/provider-configuration.js';
+import {
+  addModelChangeCancelledMessage,
+  applyConfirmedModelChange,
+  formatModelChangeConfirmationMessage,
+} from '../hooks/model-change-side-effect.js';
+
+interface IShutdownCall {
+  reason: TSessionEndReason;
+  message: string;
+}
+
+interface IModelChangeCall {
+  cwd: string;
+  modelId: string;
+  options?: IActiveModelChangeOptions;
+}
+
+function entryContent(entry: IHistoryEntry): string {
+  return (entry.data as { content: string }).content;
+}
+
+describe('model change side effect', () => {
+  it('persists the selected model for the active provider override before exiting', () => {
+    const entries: IHistoryEntry[] = [];
+    const shutdowns: IShutdownCall[] = [];
+    const calls: IModelChangeCall[] = [];
+    const applyModelChange = (
+      cwd: string,
+      modelId: string,
+      options?: IActiveModelChangeOptions,
+    ): IActiveModelChangeResult => {
+      calls.push({ cwd, modelId, ...(options !== undefined && { options }) });
+      return { settingsPath: 'settings.json', settings: {}, profileName: 'openai' };
+    };
+
+    applyConfirmedModelChange({
+      cwd: '/tmp/project',
+      modelId: 'gpt-4.1',
+      providerOverride: 'openai',
+      addEntry: (entry) => entries.push(entry),
+      requestShutdown: (reason, message) => shutdowns.push({ reason, message }),
+      applyModelChange,
+    });
+
+    expect(calls).toEqual([
+      {
+        cwd: '/tmp/project',
+        modelId: 'gpt-4.1',
+        options: { providerOverride: 'openai' },
+      },
+    ]);
+    expect(entryContent(entries[0]!)).toBe(
+      'Model changed to gpt-4.1. Exiting so the next session uses it.',
+    );
+    expect(shutdowns).toEqual([{ reason: 'other', message: 'Model change applied' }]);
+  });
+
+  it('does not exit when persistence fails', () => {
+    const entries: IHistoryEntry[] = [];
+    const shutdowns: IShutdownCall[] = [];
+
+    applyConfirmedModelChange({
+      cwd: '/tmp/project',
+      modelId: 'gpt-4.1',
+      addEntry: (entry) => entries.push(entry),
+      requestShutdown: (reason, message) => shutdowns.push({ reason, message }),
+      applyModelChange: () => {
+        throw new Error('settings write failed');
+      },
+    });
+
+    expect(entryContent(entries[0]!)).toBe('Failed: settings write failed');
+    expect(shutdowns).toEqual([]);
+  });
+
+  it('reports cancellation without applying settings or exiting', () => {
+    const entries: IHistoryEntry[] = [];
+
+    addModelChangeCancelledMessage((entry) => entries.push(entry));
+
+    expect(entryContent(entries[0]!)).toBe('Model change cancelled.');
+  });
+
+  it('describes model changes as an exit for the next session', () => {
+    expect(formatModelChangeConfirmationMessage('gpt-4.1')).toBe(
+      'Change model to gpt-4.1? This will exit the current session so the next session uses it.',
+    );
+  });
+});

--- a/packages/agent-cli/src/ui/hooks/model-change-side-effect.ts
+++ b/packages/agent-cli/src/ui/hooks/model-change-side-effect.ts
@@ -1,0 +1,59 @@
+import {
+  createSystemMessage,
+  getModelName,
+  messageToHistoryEntry,
+  type IHistoryEntry,
+  type TSessionEndReason,
+} from '@robota-sdk/agent-core';
+import {
+  applyActiveModelChange,
+  type IActiveModelChangeOptions,
+  type IActiveModelChangeResult,
+} from '../../utils/provider-configuration.js';
+
+type TApplyModelChange = (
+  cwd: string,
+  modelId: string,
+  options?: IActiveModelChangeOptions,
+) => IActiveModelChangeResult;
+
+export interface IApplyConfirmedModelChangeDeps {
+  cwd: string;
+  modelId: string;
+  providerOverride?: string | undefined;
+  addEntry: (entry: IHistoryEntry) => void;
+  requestShutdown: (reason: TSessionEndReason, message: string) => void;
+  applyModelChange?: TApplyModelChange;
+}
+
+export function formatModelChangeConfirmationMessage(modelId: string): string {
+  return `Change model to ${getModelName(modelId)}? This will exit the current session so the next session uses it.`;
+}
+
+export function formatModelChangeExitMessage(modelId: string): string {
+  return `Model changed to ${getModelName(modelId)}. Exiting so the next session uses it.`;
+}
+
+export function applyConfirmedModelChange(deps: IApplyConfirmedModelChangeDeps): void {
+  const applyModelChange = deps.applyModelChange ?? applyActiveModelChange;
+  const options =
+    deps.providerOverride !== undefined ? { providerOverride: deps.providerOverride } : undefined;
+
+  try {
+    applyModelChange(deps.cwd, deps.modelId, options);
+    deps.addEntry(
+      messageToHistoryEntry(createSystemMessage(formatModelChangeExitMessage(deps.modelId))),
+    );
+    deps.requestShutdown('other', 'Model change applied');
+  } catch (error) {
+    deps.addEntry(
+      messageToHistoryEntry(
+        createSystemMessage(`Failed: ${error instanceof Error ? error.message : String(error)}`),
+      ),
+    );
+  }
+}
+
+export function addModelChangeCancelledMessage(addEntry: (entry: IHistoryEntry) => void): void {
+  addEntry(messageToHistoryEntry(createSystemMessage('Model change cancelled.')));
+}

--- a/packages/agent-cli/src/ui/hooks/side-effects-types.ts
+++ b/packages/agent-cli/src/ui/hooks/side-effects-types.ts
@@ -26,6 +26,7 @@ export interface ISideEffects {
 
 export interface IUseSideEffectsOptions {
   cwd: string;
+  providerOverride?: string | undefined;
   interactiveSession: InteractiveSession;
   addEntry: (entry: IHistoryEntry) => void;
   baseHandleSubmit: (input: string) => Promise<void>;

--- a/packages/agent-cli/src/ui/hooks/useSideEffects.ts
+++ b/packages/agent-cli/src/ui/hooks/useSideEffects.ts
@@ -5,9 +5,8 @@ import type {
   ICommandResult,
   InteractiveSession,
 } from '@robota-sdk/agent-sdk';
-import { createSystemMessage, messageToHistoryEntry, getModelName } from '@robota-sdk/agent-core';
+import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import type { TSessionEndReason } from '@robota-sdk/agent-core';
-import { applyActiveModelChange } from '../../utils/provider-configuration.js';
 import type { TInteractivePrompt } from '../../utils/interactive-prompt.js';
 import type {
   ISideEffects,
@@ -16,11 +15,16 @@ import type {
 } from './side-effects-types.js';
 import { applyPendingStatusLinePatch } from './statusline-side-effect.js';
 import { applyCommandEffects } from './command-effect-handler.js';
+import {
+  addModelChangeCancelledMessage,
+  applyConfirmedModelChange,
+} from './model-change-side-effect.js';
 
 const EXIT_DELAY_MS = 500;
 
 export function useSideEffects({
   cwd,
+  providerOverride,
   interactiveSession,
   addEntry,
   baseHandleSubmit,
@@ -174,26 +178,18 @@ export function useSideEffects({
       setPendingModelId(null);
       pendingModelChangeRef.current = null;
       if (index === 0 && modelId) {
-        try {
-          applyActiveModelChange(cwd, modelId);
-          addEntry(
-            messageToHistoryEntry(
-              createSystemMessage(`Model changed to ${getModelName(modelId)}. Restarting...`),
-            ),
-          );
-          requestShutdown('other', 'Model change restart');
-        } catch (err) {
-          addEntry(
-            messageToHistoryEntry(
-              createSystemMessage(`Failed: ${err instanceof Error ? err.message : String(err)}`),
-            ),
-          );
-        }
+        applyConfirmedModelChange({
+          cwd,
+          modelId,
+          providerOverride,
+          addEntry,
+          requestShutdown,
+        });
       } else {
-        addEntry(messageToHistoryEntry(createSystemMessage('Model change cancelled.')));
+        addModelChangeCancelledMessage(addEntry);
       }
     },
-    [cwd, addEntry, requestShutdown],
+    [cwd, providerOverride, addEntry, requestShutdown],
   );
 
   const handleInteractionSubmit = useCallback(

--- a/packages/agent-cli/src/ui/render.tsx
+++ b/packages/agent-cli/src/ui/render.tsx
@@ -19,6 +19,7 @@ import type { ICliUpdateNotice } from '../utils/update-check.js';
 export interface IRenderOptions {
   cwd: string;
   provider: IAIProvider;
+  providerOverride?: string | undefined;
   modelId?: string;
   language?: string;
   permissionMode?: TPermissionMode;

--- a/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-configuration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -7,15 +7,22 @@ import {
   applyProviderConfiguration,
   applyProviderSwitch,
 } from '../provider-configuration.js';
+import { readProviderSettings } from '../provider-factory.js';
 
 const TMP_BASE = join(tmpdir(), `robota-provider-configuration-test-${process.pid}`);
+const ORIGINAL_HOME = process.env.HOME;
 
 function readJson(path: string): Record<string, unknown> {
   return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
 }
 
 describe('provider configuration writes', () => {
+  beforeEach(() => {
+    process.env.HOME = join(TMP_BASE, 'home');
+  });
+
   afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
     rmSync(TMP_BASE, { recursive: true, force: true });
   });
 
@@ -146,5 +153,87 @@ describe('provider configuration writes', () => {
     expect((projectSettings.providers as Record<string, Record<string, unknown>>).qwen?.model).toBe(
       'qwen-plus',
     );
+  });
+
+  it('updates the provider override profile model resolved by the next session', () => {
+    const cwd = join(TMP_BASE, 'project');
+    const settingsPath = join(cwd, '.robota', 'settings.json');
+    mkdirSync(join(cwd, '.robota'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        currentProvider: 'anthropic',
+        providers: {
+          anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+          openai: {
+            type: 'openai',
+            model: 'gpt-4.1-mini',
+            apiKey: 'lm-studio',
+            baseURL: 'http://localhost:1234/v1',
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    const result = applyActiveModelChange(cwd, 'gpt-4.1', {
+      providerOverride: 'openai',
+    });
+
+    const settings = readJson(settingsPath);
+    const providers = settings.providers as Record<string, Record<string, unknown>>;
+    expect(result.profileName).toBe('openai');
+    expect(providers.anthropic?.model).toBe('claude-sonnet-4-6');
+    expect(providers.openai?.model).toBe('gpt-4.1');
+    expect(readProviderSettings(cwd, { providerOverride: 'openai' }).model).toBe('gpt-4.1');
+  });
+
+  it('updates the current provider profile model resolved by the next session', () => {
+    const cwd = join(TMP_BASE, 'project');
+    const settingsPath = join(cwd, '.robota', 'settings.json');
+    mkdirSync(join(cwd, '.robota'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        currentProvider: 'anthropic',
+        providers: {
+          anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6', apiKey: 'sk-ant' },
+        },
+      }),
+      'utf8',
+    );
+
+    applyActiveModelChange(cwd, 'claude-opus-4-6');
+
+    expect(readProviderSettings(cwd).model).toBe('claude-opus-4-6');
+  });
+
+  it('updates the legacy provider model resolved by the next session without losing fields', () => {
+    const cwd = join(TMP_BASE, 'project');
+    const settingsPath = join(cwd, '.robota', 'settings.json');
+    mkdirSync(join(cwd, '.robota'), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        provider: {
+          name: 'openai',
+          model: 'gpt-4.1-mini',
+          apiKey: 'lm-studio',
+          baseURL: 'http://localhost:1234/v1',
+        },
+      }),
+      'utf8',
+    );
+
+    applyActiveModelChange(cwd, 'gpt-4.1');
+
+    const settings = readJson(settingsPath);
+    expect(settings.provider).toMatchObject({
+      name: 'openai',
+      model: 'gpt-4.1',
+      apiKey: 'lm-studio',
+      baseURL: 'http://localhost:1234/v1',
+    });
+    expect(readProviderSettings(cwd).model).toBe('gpt-4.1');
   });
 });

--- a/packages/agent-cli/src/utils/provider-configuration.ts
+++ b/packages/agent-cli/src/utils/provider-configuration.ts
@@ -19,6 +19,7 @@ export interface IProviderSwitchOptions {
 
 export interface IActiveModelChangeOptions {
   settingsPaths?: readonly string[];
+  providerOverride?: string | undefined;
 }
 
 export interface IActiveModelChangeResult {
@@ -67,9 +68,10 @@ export function applyActiveModelChange(
 ): IActiveModelChangeResult {
   const settingsPaths = options.settingsPaths ?? getProviderSettingsPaths(cwd);
   const merged = readMergedProviderSettingsFromPaths(settingsPaths);
+  const activeProfileName = options.providerOverride ?? merged.currentProvider;
 
-  if (typeof merged.currentProvider === 'string') {
-    return updateActiveProviderProfileModel(settingsPaths, merged.currentProvider, modelId);
+  if (typeof activeProfileName === 'string') {
+    return updateActiveProviderProfileModel(settingsPaths, activeProfileName, modelId);
   }
 
   return updateLegacyProviderModel(settingsPaths, modelId);


### PR DESCRIPTION
## Summary
- apply /model changes to the active provider override when the CLI was launched with --provider
- make model-change confirmation/exit copy describe the actual next-session behavior
- add regression coverage for provider override, currentProvider, legacy provider settings, and TUI model-change side effects

## Verification
- pnpm --filter @robota-sdk/agent-cli test -- src/utils/__tests__/provider-configuration.test.ts src/ui/__tests__/model-change-side-effect.test.ts src/ui/__tests__/slash-routing-effects.test.ts
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-cli test
- pnpm build
- pnpm docs:validate-structure
- pnpm harness:scan:commands
- pre-push scoped verification