### PR TITLE
docs: update agent package coverage baseline

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -14,7 +14,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | File                                                                           | Topic                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
 | [agent-followup-roadmap.md](agent-followup-roadmap.md)                         | Recommended sequence for agent/CLI/runtime follow-ups         |
-| [agent-package-coverage-audit.md](agent-package-coverage-audit.md)             | Current coverage baseline for all agent-\* packages           |
 | [command-migration-agent.md](command-migration-agent.md)                       | Finish migration hardening for `/agent`                       |
 | [command-migration-background.md](command-migration-background.md)             | Migrate `/background` into a command-module owner             |
 | [command-migration-clear.md](command-migration-clear.md)                       | Migrate `/clear` into a command-module owner                  |

--- a/.agents/reports/agent-package-coverage-2026-05-03.md
+++ b/.agents/reports/agent-package-coverage-2026-05-03.md
@@ -1,69 +1,95 @@
 # Agent Package Coverage Baseline
 
 - **Date**: 2026-05-03
-- **Scope**: `packages/agent-*`
-- **Command**: `pnpm --filter "@robota-sdk/agent-*" run --if-present test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary`
-- **Notes**: The pnpm filter also dispatched app packages whose names match `@robota-sdk/agent-*`; this report includes only `packages/agent-*`.
+- **Scope**: workspace packages under `packages/agent-*` whose package name starts with `@robota-sdk/agent-`
+- **Excluded**: example packages such as `robota-agents-examples`, `robota-openai-examples`, and `robota-team-examples`
+- **Text command**: `pnpm --filter "./packages/agent-*" run --if-present test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary`
+- **Machine-readable command**: `pnpm --filter "./packages/agent-*" exec vitest run --coverage --passWithNoTests --coverage.reporter=json-summary --coverage.reporter=text-summary`
 
 ## Summary
 
-The agent package family has uneven coverage. Core, SDK, runtime, most providers, most plugins, and most transports are at or above roughly 70% line coverage. The highest-risk gaps are `agent-tools`, `agent-sessions`, `agent-tool-mcp`, `agent-playground`, and the Gemini compatibility wrapper package.
+The agent package family has uneven coverage. `agent-core`, `agent-sdk`, `agent-runtime`, most providers, most plugins, and most transports have usable line coverage. The highest-risk gaps are `agent-tools`, `agent-sessions`, `agent-tool-mcp`, `agent-cli` UI shell paths, and `agent-playground`.
 
-Do not add a global threshold yet. The current package set includes small compatibility wrappers, UI-heavy packages, and packages with intentionally sparse or no executable source. Add targeted thresholds only after high-risk packages have package-specific coverage plans.
+Do not add a global `agent-*` coverage threshold yet. The package set includes core runtime libraries, CLI/TUI code, provider wrappers, compatibility wrappers, UI-heavy packages, and packages with no executable source after intentional exclusions. Add package-owned thresholds only after the low-coverage critical packages have explicit coverage plans.
 
 ## Package Results
 
-| Package                                         | Lines | Branches | Functions | Statements | Risk Note                                              |
-| ----------------------------------------------- | ----: | -------: | --------: | ---------: | ------------------------------------------------------ |
-| `@robota-sdk/agent-cli`                         | 70.20 |    76.87 |     83.50 |      70.20 | UI hooks/App paths remain comparatively low            |
-| `@robota-sdk/agent-command-agent`               | 79.58 |    76.27 |     75.00 |      79.58 | Acceptable baseline                                    |
-| `@robota-sdk/agent-core`                        | 83.03 |    80.18 |     72.12 |      83.03 | Good baseline; some plugin/registry helpers low        |
-| `@robota-sdk/agent-event-service`               |   n/a |      n/a |       n/a |        n/a | No covered executable source in report                 |
-| `@robota-sdk/agent-playground`                  |  0.37 |     3.81 |      1.90 |       0.37 | Critical UI/package coverage gap                       |
-| `@robota-sdk/agent-plugin-conversation-history` | 83.90 |    75.96 |    100.00 |      83.90 | Acceptable baseline                                    |
-| `@robota-sdk/agent-plugin-error-handling`       | 93.80 |    79.10 |     88.24 |      93.80 | Good baseline                                          |
-| `@robota-sdk/agent-plugin-event-emitter`        | 88.25 |    87.50 |     75.86 |      88.25 | Good baseline                                          |
-| `@robota-sdk/agent-plugin-execution-analytics`  | 87.47 |    68.92 |     77.78 |      87.47 | Branch coverage should be improved                     |
-| `@robota-sdk/agent-plugin-limits`               | 98.09 |    93.58 |     94.12 |      98.09 | Strong baseline                                        |
-| `@robota-sdk/agent-plugin-logging`              | 91.91 |    86.82 |     85.37 |      91.91 | Strong baseline                                        |
-| `@robota-sdk/agent-plugin-performance`          | 88.11 |    77.14 |     96.00 |      88.11 | Good baseline                                          |
-| `@robota-sdk/agent-plugin-usage`                | 94.37 |    91.10 |    100.00 |      94.37 | Strong baseline                                        |
-| `@robota-sdk/agent-plugin-webhook`              | 93.76 |    72.87 |     92.11 |      93.76 | Branch coverage should be improved                     |
-| `@robota-sdk/agent-provider-anthropic`          | 80.26 |    86.59 |     84.21 |      80.26 | Good baseline                                          |
-| `@robota-sdk/agent-provider-bytedance`          | 92.48 |    91.88 |     90.91 |      92.48 | Strong baseline                                        |
-| `@robota-sdk/agent-provider-gemini`             | 95.14 |    90.87 |    100.00 |      95.14 | Strong baseline                                        |
-| `@robota-sdk/agent-provider-gemma`              | 86.42 |    74.36 |     91.01 |      86.42 | Good baseline; branch coverage should improve          |
-| `@robota-sdk/agent-provider-google`             | 39.39 |    50.00 |     50.00 |      39.39 | Compatibility wrapper needs targeted smoke coverage    |
-| `@robota-sdk/agent-provider-openai-compatible`  | 90.13 |    77.37 |     96.77 |      90.13 | Good baseline                                          |
-| `@robota-sdk/agent-provider-openai`             | 91.68 |    83.96 |     84.62 |      91.68 | Strong baseline                                        |
-| `@robota-sdk/agent-provider-qwen`               | 81.97 |    69.31 |     84.48 |      81.97 | Branch coverage should be improved                     |
-| `@robota-sdk/agent-remote-client`               | 99.32 |    92.90 |    100.00 |      99.32 | Strong baseline                                        |
-| `@robota-sdk/agent-runtime`                     | 93.31 |    74.26 |     84.69 |      93.31 | Good baseline; worktree/cancel edge cases still needed |
-| `@robota-sdk/agent-sdk`                         | 91.16 |    81.10 |     85.46 |      91.16 | Strong baseline                                        |
-| `@robota-sdk/agent-sessions`                    | 66.42 |    77.27 |     45.31 |      66.42 | High-risk runtime/session gap                          |
-| `@robota-sdk/agent-team`                        | 91.02 |    71.43 |     75.00 |      91.02 | Acceptable baseline                                    |
-| `@robota-sdk/agent-tool-mcp`                    |  0.00 |     0.00 |      0.00 |       0.00 | Critical package coverage gap                          |
-| `@robota-sdk/agent-tools`                       | 31.64 |    79.56 |     65.31 |      31.64 | Critical filesystem/shell tool coverage gap            |
-| `@robota-sdk/agent-transport-headless`          | 93.41 |    86.57 |     91.18 |      93.41 | Strong baseline                                        |
-| `@robota-sdk/agent-transport-http`              | 71.79 |    88.89 |     75.00 |      71.79 | Acceptable baseline                                    |
-| `@robota-sdk/agent-transport-mcp`               | 63.33 |    90.00 |     62.50 |      63.33 | Add transport request/response coverage                |
-| `@robota-sdk/agent-transport-ws`                | 91.26 |    86.32 |     83.78 |      91.26 | Strong baseline                                        |
+| Package                                         | Tests |  Lines | Branches | Functions | Statements | Classification                 | Risk Note                                            |
+| ----------------------------------------------- | ----: | -----: | -------: | --------: | ---------: | ------------------------------ | ---------------------------------------------------- |
+| `@robota-sdk/agent-cli`                         |    57 | 70.28% |   77.78% |    82.32% |     70.28% | tested executable source       | UI shell and process entry paths remain low          |
+| `@robota-sdk/agent-command-agent`               |     1 | 79.57% |   76.27% |    75.00% |     79.57% | tested executable source       | Acceptable baseline                                  |
+| `@robota-sdk/agent-command-compact`             |     1 | 92.00% |   77.77% |    87.50% |     92.00% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-command-context`             |     1 | 85.23% |   81.57% |    92.85% |     85.23% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-command-provider`            |     1 | 73.90% |   64.58% |    75.00% |     73.90% | tested executable source       | Provider setup branches need more coverage           |
+| `@robota-sdk/agent-core`                        |    41 | 83.03% |   80.18% |    72.12% |     83.03% | tested executable source       | Core baseline is usable; helper functions remain low |
+| `@robota-sdk/agent-event-service`               |     2 |    n/a |      n/a |       n/a |        n/a | no executable source in report | Thin re-export barrel intentionally excluded         |
+| `@robota-sdk/agent-playground`                  |     1 |  0.36% |    3.80% |     1.90% |      0.36% | tested executable source       | Critical UI/package coverage gap                     |
+| `@robota-sdk/agent-plugin-conversation-history` |     2 | 83.89% |   75.96% |   100.00% |     83.89% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-plugin-error-handling`       |     1 | 93.79% |   79.10% |    88.23% |     93.79% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-plugin-event-emitter`        |     2 | 88.25% |   87.50% |    75.86% |     88.25% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-plugin-execution-analytics`  |     1 | 87.47% |   68.91% |    77.77% |     87.47% | tested executable source       | Branch coverage should improve                       |
+| `@robota-sdk/agent-plugin-limits`               |     1 | 98.08% |   93.57% |    94.11% |     98.08% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-plugin-logging`              |     3 | 91.91% |   86.82% |    85.36% |     91.91% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-plugin-performance`          |     3 | 88.11% |   77.14% |    96.00% |     88.11% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-plugin-usage`                |     5 | 94.36% |   91.09% |   100.00% |     94.36% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-plugin-webhook`              |     1 | 93.75% |   72.86% |    92.10% |     93.75% | tested executable source       | Branch coverage should improve                       |
+| `@robota-sdk/agent-provider-anthropic`          |     3 | 80.26% |   86.58% |    84.21% |     80.26% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-provider-bytedance`          |     3 | 92.47% |   91.87% |    90.90% |     92.47% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-provider-gemini`             |     6 | 95.14% |   90.82% |   100.00% |     95.14% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-provider-gemma`              |     3 | 86.42% |   74.35% |    91.01% |     86.42% | tested executable source       | Branch coverage should improve                       |
+| `@robota-sdk/agent-provider-google`             |     1 | 39.39% |   50.00% |    50.00% |     39.39% | compatibility wrapper          | Add wrapper compatibility smoke coverage             |
+| `@robota-sdk/agent-provider-openai`             |     9 | 91.68% |   83.87% |    84.61% |     91.68% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-provider-openai-compatible`  |     4 | 90.12% |   77.37% |    96.77% |     90.12% | tested executable source       | Good baseline                                        |
+| `@robota-sdk/agent-provider-qwen`               |     2 | 81.96% |   69.31% |    84.48% |     81.96% | tested executable source       | Branch coverage should improve                       |
+| `@robota-sdk/agent-remote-client`               |     7 | 99.31% |   92.89% |   100.00% |     99.31% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-runtime`                     |     4 | 93.37% |   74.16% |    85.00% |     93.37% | tested executable source       | Add worktree/cancel edge cases before policy changes |
+| `@robota-sdk/agent-sdk`                         |    57 | 88.59% |   80.40% |    80.98% |     88.59% | tested executable source       | Good baseline; provider command helpers are low      |
+| `@robota-sdk/agent-sessions`                    |     4 | 67.59% |   79.00% |    47.82% |     67.59% | tested executable source       | High-risk runtime/session gap                        |
+| `@robota-sdk/agent-team`                        |     1 | 91.01% |   71.42% |    75.00% |     91.01% | tested executable source       | Acceptable baseline                                  |
+| `@robota-sdk/agent-tool-mcp`                    |     0 |  0.00% |    0.00% |     0.00% |      0.00% | no tests                       | Critical MCP tool coverage gap                       |
+| `@robota-sdk/agent-tools`                       |     4 | 31.64% |   79.55% |    65.30% |     31.64% | tested executable source       | Critical filesystem/shell/web tool coverage gap      |
+| `@robota-sdk/agent-transport-headless`          |     3 | 93.41% |   86.56% |    91.17% |     93.41% | tested executable source       | Strong baseline                                      |
+| `@robota-sdk/agent-transport-http`              |     2 | 71.79% |   88.88% |    75.00% |     71.79% | tested executable source       | Acceptable baseline                                  |
+| `@robota-sdk/agent-transport-mcp`               |     2 | 63.33% |   90.00% |    62.50% |     63.33% | tested executable source       | Add transport request/response coverage              |
+| `@robota-sdk/agent-transport-ws`                |     2 | 91.25% |   86.31% |    83.78% |     91.25% | tested executable source       | Strong baseline                                      |
 
-## Recommended Follow-ups
+## Notable Uncovered Public Surfaces
 
-1. **agent-tools**: add characterization tests for Bash, Read, Write, Edit, Glob, Grep, WebFetch, and WebSearch behavior before sandbox/refactor work.
-2. **agent-sessions**: add tests for lifecycle hooks, compaction orchestration, session persistence, abort/timeout, and context reconciliation paths.
-3. **agent-tool-mcp**: add basic protocol/tool wrapper tests or explicitly document why the package should be excluded from coverage gates.
-4. **agent-playground**: decide whether UI-heavy package coverage belongs in component tests, integration tests, or a separate app-level coverage plan.
-5. **agent-provider-google**: add wrapper compatibility tests that prove legacy imports/settings still route to canonical Gemini behavior.
-6. **agent-runtime**: add the worktree hardening edge-case tests before changing default worktree isolation policy.
+- `agent-tools`: built-in Bash, Read, Write, Edit, Glob, Grep, WebFetch, and WebSearch tools are at 0% in this run even though the package has registry/schema tests.
+- `agent-tool-mcp`: `mcp-tool.ts`, `relay-mcp-tool.ts`, and protocol glue have no tests.
+- `agent-sessions`: `session-store.ts`, `session-logger.ts`, `tool-hook-helpers.ts`, `permission-enforcer.ts`, and lifecycle branches are low or uncovered.
+- `agent-cli`: `App.tsx`, `InputArea.tsx`, `useSideEffects.ts`, `useInteractiveSession.ts`, process entry files, and child worker entry files are low or uncovered.
+- `agent-sdk`: provider command common APIs such as `provider-command-probe.ts`, `provider-setup-flow.ts`, provider env-ref/settings helpers, and permission prompt paths are the main remaining low spots.
+- `agent-playground`: only `button.tsx` has meaningful coverage; most app/component/playground execution code is uncovered.
+- `agent-provider-google`: the compatibility wrapper mostly re-exports Gemini behavior; add smoke tests for legacy import surfaces rather than treating it like a full provider.
+
+## Prioritized Coverage Plan
+
+1. **agent-tools**: add characterization tests for shell/file edit/read/write/search/fetch tool behavior before sandbox or rollback work.
+2. **agent-sessions**: add lifecycle, persistence, permission, compaction, abort, timeout, and context reconciliation tests before worktree/sandbox semantics change.
+3. **agent-tool-mcp**: add basic MCP protocol and relay tool tests, or explicitly mark the package excluded from thresholds until the MCP boundary is redesigned.
+4. **agent-cli**: add tests around thin TUI side-effect bridges before migrating more hardcoded slash commands into built-in command packages.
+5. **agent-sdk**: cover provider command common API helpers before moving more provider setup/model command logic behind built-in commands.
+6. **agent-playground**: decide whether this private UI package needs component/integration coverage or should be tracked under an app-specific coverage plan.
+7. **agent-transport-mcp/http**: add request/response and error-path tests for transport edge cases.
 
 ## Threshold Recommendation
 
-Do not introduce one global threshold for `agent-*` packages now.
+Do not introduce one global threshold now.
 
 Recommended staged policy:
 
-- Start with package-owned thresholds only for packages already above 80% and not UI-heavy.
+- Add package-owned thresholds only to stable packages already above 80% line coverage and not UI-heavy.
 - Require targeted regression tests for new code in low-coverage packages.
-- After `agent-tools`, `agent-sessions`, and `agent-tool-mcp` improve, consider a release-grade coverage threshold for critical runtime packages only.
+- Keep broad coverage out of normal PR checks until `agent-tools`, `agent-sessions`, and `agent-tool-mcp` have improved.
+- Consider release-grade thresholds only for critical runtime packages after the staged gaps above are addressed.
+
+## Coverage Script Reliability
+
+Current package scripts are good enough for manual text coverage, but not sufficient for recurring machine-readable audits. Passing reporter flags through the filtered `pnpm run test:coverage` path did not create `coverage-summary.json` consistently in this run, so the machine-readable baseline used direct `vitest` execution through `pnpm --filter ... exec`.
+
+Recommended follow-up:
+
+- Add a dedicated root command such as `pnpm test:coverage:agent-packages:json`.
+- Standardize package coverage reporters to include `json-summary`.
+- Keep generated `coverage/` directories ignored and uncommitted.

--- a/.agents/tasks/completed/agent-package-coverage-audit.md
+++ b/.agents/tasks/completed/agent-package-coverage-audit.md
@@ -1,5 +1,7 @@
 # Agent Package Test Coverage Audit
 
+Status: completed on `chore/agent-package-coverage-audit`.
+
 ## What
 
 Measure and publish the current test coverage for every `@robota-sdk/agent-*` package, then turn the result into a prioritized coverage improvement plan.
@@ -20,13 +22,13 @@ The repository now exposes package-level coverage commands, but there is no curr
 
 ## Scope
 
-- Enumerate every package whose name starts with `@robota-sdk/agent-`.
-- Run each package's `test:coverage` command or a filtered batch strategy that preserves per-package reports.
-- Capture line, branch, function, and statement coverage for each package.
-- Distinguish packages with no source, no tests, generated-only code, or intentional pass-with-no-tests behavior.
-- Produce a repository-owned report, for example `.agents/reports/agent-package-coverage.md`.
-- Identify the top coverage gaps by risk, not only by lowest percentage.
-- Recommend whether package-specific thresholds should be added now, deferred, or limited to critical packages.
+- [x] Enumerate every package whose name starts with `@robota-sdk/agent-`.
+- [x] Run each package's `test:coverage` command or a filtered batch strategy that preserves per-package reports.
+- [x] Capture line, branch, function, and statement coverage for each package.
+- [x] Distinguish packages with no source, no tests, generated-only code, or intentional pass-with-no-tests behavior.
+- [x] Produce a repository-owned report, for example `.agents/reports/agent-package-coverage.md`.
+- [x] Identify the top coverage gaps by risk, not only by lowest percentage.
+- [x] Recommend whether package-specific thresholds should be added now, deferred, or limited to critical packages.
 
 ## Non-Goals
 
@@ -37,12 +39,12 @@ The repository now exposes package-level coverage commands, but there is no curr
 
 ## Acceptance Criteria
 
-- [ ] Every `@robota-sdk/agent-*` package has a recorded coverage result or an explicit exclusion reason.
-- [ ] The report includes package name, test command, coverage percentages, and notable uncovered public surfaces.
-- [ ] The report separates "no tests" from "no executable source" packages.
-- [ ] The report identifies high-risk gaps in CLI, SDK, sessions, core, providers, transports, runtime, and tools.
-- [ ] The follow-up plan ranks coverage work by public API risk and refactor risk.
-- [ ] The audit documents whether current coverage scripts are reliable enough for recurring measurement.
+- [x] Every `@robota-sdk/agent-*` package has a recorded coverage result or an explicit exclusion reason.
+- [x] The report includes package name, test command, coverage percentages, and notable uncovered public surfaces.
+- [x] The report separates "no tests" from "no executable source" packages.
+- [x] The report identifies high-risk gaps in CLI, SDK, sessions, core, providers, transports, runtime, and tools.
+- [x] The follow-up plan ranks coverage work by public API risk and refactor risk.
+- [x] The audit documents whether current coverage scripts are reliable enough for recurring measurement.
 
 ## Test Plan
 
@@ -53,6 +55,6 @@ The repository now exposes package-level coverage commands, but there is no curr
 
 ## Promotion Path
 
-1. Move to `.agents/tasks/INFRA-BL-0XX-agent-package-coverage-audit.md` when prioritized.
-2. Create the coverage report as a task artifact.
-3. Open follow-up backlog/tasks for targeted coverage expansion after the baseline is accepted.
+1. [x] Move to `.agents/tasks/agent-package-coverage-audit.md` when prioritized.
+2. [x] Create the coverage report as a task artifact.
+3. [x] Capture targeted coverage expansion recommendations in the report.


### PR DESCRIPTION
## Summary
- update the agent package coverage baseline report with current package-by-package metrics
- classify no-test and no-executable-source cases separately
- record prioritized coverage follow-ups and threshold recommendations
- archive the completed coverage audit backlog

## Verification
- pnpm --filter "./packages/agent-*" run --if-present test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text-summary
- pnpm --filter "./packages/agent-*" exec vitest run --coverage --passWithNoTests --coverage.reporter=json-summary --coverage.reporter=text-summary
- pnpm harness:scan:coverage-scripts
- pnpm docs:validate-structure
- pnpm harness:scan:test-plans
- git diff --check
- pre-push scoped verification