### PR TITLE
feat(commands): compose agent command by default

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -14,7 +14,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | File                                                                           | Topic                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
 | [agent-followup-roadmap.md](agent-followup-roadmap.md)                         | Recommended sequence for agent/CLI/runtime follow-ups         |
-| [command-migration-agent.md](command-migration-agent.md)                       | Finish migration hardening for `/agent`                       |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |

--- a/.agents/backlog/completed/command-migration-agent.md
+++ b/.agents/backlog/completed/command-migration-agent.md
@@ -21,13 +21,19 @@ Keep `@robota-sdk/agent-command-agent`.
 
 ## Acceptance Criteria
 
-- `/agent` remains fully supplied by `@robota-sdk/agent-command-agent`.
-- SDK imports no `agent-command-agent` implementation.
-- CLI composition root is the only default product wiring point.
-- Command-layering scan covers the invariant.
+- [x] `/agent` remains fully supplied by `@robota-sdk/agent-command-agent`.
+- [x] SDK imports no `agent-command-agent` implementation.
+- [x] CLI composition root is the only default product wiring point.
+- [x] Command-layering scan covers the invariant.
 
 ## Test Plan
 
-- Run `pnpm --filter @robota-sdk/agent-command-agent test`.
-- Run `pnpm harness:scan:commands`.
-- Add any missing contract tests for session requirements and model-invocable descriptor metadata.
+- [x] Run `pnpm --filter @robota-sdk/agent-command-agent test`.
+- [x] Run `pnpm harness:scan:commands`.
+- [x] Add any missing contract tests for session requirements and model-invocable descriptor metadata.
+
+## Result
+
+Completed in `feat/command-agent-composition`. The Robota CLI product composition now injects
+`createAgentCommandModule()` by default, while SDK and reusable TUI layers remain generic. Headless
+`/help` coverage verifies the default command list includes `/agent`.

--- a/.agents/backlog/sdk-command-common-api-layer.md
+++ b/.agents/backlog/sdk-command-common-api-layer.md
@@ -137,7 +137,7 @@ packages/
   - [x] `/plugin` migrated to `agent-command-plugin`.
   - [x] `/reload-plugins` migrated to `agent-command-plugin`.
 - [x] Generate `/help` output from registered command descriptors.
-- [ ] Ensure `/agent` keeps using the same command API and does not need special CLI routing.
+- [x] Ensure `/agent` keeps using the same command API and does not need special CLI routing.
 
 ## Package Extraction Plan
 

--- a/.agents/tasks/completed/command-migration-agent.md
+++ b/.agents/tasks/completed/command-migration-agent.md
@@ -1,0 +1,47 @@
+# Command Migration: `/agent`
+
+- **Status**: completed
+- **Created**: 2026-05-03
+- **Branch**: feat/command-agent-composition
+- **Scope**: packages/agent-cli, packages/agent-command-agent, .agents
+
+## Objective
+
+Finish `/agent` migration hardening by ensuring the Robota CLI product composition injects
+`@robota-sdk/agent-command-agent` as the command owner while SDK and reusable TUI layers stay
+generic.
+
+## Checklist
+
+- [x] Confirm `/agent` implementation already lives in `@robota-sdk/agent-command-agent`.
+- [x] Confirm SDK does not import the command implementation package.
+- [x] Compose `createAgentCommandModule()` in the CLI default command module list.
+- [x] Add regression coverage proving default CLI commands expose `/agent`.
+- [x] Update docs/backlog state.
+- [x] Run targeted verification and command layering scan.
+- [x] Create PR and merge into `develop`.
+
+## Progress
+
+### 2026-05-03
+
+- Created task record and branch.
+- Audited current ownership: `agent-command-agent` owns metadata/execution and SDK has no implementation import.
+- Found the missing product wiring: `agent-cli` depends on `agent-command-agent` but does not compose `createAgentCommandModule()` by default.
+- Composed `createAgentCommandModule()` in `agent-cli` default command modules.
+- Added headless `/help` regression coverage proving `/agent` appears in the default product command list.
+
+## Decision
+
+Use product composition only. The CLI entrypoint may import the command module to assemble the
+default Robota product, while SDK and reusable TUI code continue to consume generic command module
+contracts and remain free of `/agent` special-casing.
+
+## Test Plan
+
+Run `@robota-sdk/agent-command-agent` tests, targeted CLI headless command exposure tests, CLI
+typecheck/build, and `pnpm harness:scan:commands`.
+
+## Result
+
+Completed. `/agent` remains owned by `@robota-sdk/agent-command-agent`, and the Robota CLI product composition now includes it by default without SDK or reusable TUI special-casing.

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -273,6 +273,7 @@ When a session has a name, it appears in three places:
 | `/compact [instructions]` | Compress context window                                    |
 | `/cost`                   | Show session info                                          |
 | `/context`                | Context window details                                     |
+| `/agent`                  | Run and manage background subagent jobs                    |
 | `/permissions`            | Show permission rules                                      |
 | `/plugin [subcommand]`    | Plugin management                                          |
 | `/resume`                 | List recent sessions and resume one                        |

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -162,6 +162,7 @@ Flow ownership:
 
 ```
 bin.ts → cli.ts (arg parsing + provider definition composition)
+              ├── createAgentCommandModule()      (from @robota-sdk/agent-command-agent)
               ├── createModelCommandModule()      (from @robota-sdk/agent-command-model)
               ├── createModeCommandModule()       (from @robota-sdk/agent-command-mode)
               ├── createLanguageCommandModule()   (from @robota-sdk/agent-command-language)
@@ -431,6 +432,7 @@ Tool: [5 tools]
 | `/compact [instructions]` | Compress context window                                         |
 | `/cost`                   | Show session info through the session command module            |
 | `/context`                | Context window info and `/context auto ...` controls            |
+| `/agent`                  | Run and manage background subagent jobs                         |
 | `/permissions`            | Permission rules                                                |
 | `/memory`                 | Route project memory commands to the memory command module      |
 | `/rewind`                 | Route edit checkpoint list/restore commands to SDK              |
@@ -1180,7 +1182,7 @@ The CLI also injects `createChildProcessSubagentRunnerFactory()` into `Interacti
 
 `child-process-subagent-runner-result.ts` owns child-worker result orchestration for the adapter: IPC message validation, timeout timer cleanup, early-exit errors, and transcript metadata projection. `child-process-subagent-runner.ts` remains the process factory and payload composer.
 
-Agent command behavior is not owned by the TUI. The Robota binary can compose `@robota-sdk/agent-command-agent` as a default command module, but reusable CLI UI code only handles generic command modules.
+Agent command behavior is not owned by the TUI. The Robota binary composes `@robota-sdk/agent-command-agent` as a default command module, but reusable CLI UI code only handles generic command modules.
 
 Child-process subagent runner responsibilities:
 
@@ -1313,7 +1315,7 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 
 | Package                                 | Purpose                                                                                                                              |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `@robota-sdk/agent-command-agent`       | Optional default `/agent` command module composed by the Robota binary                                                               |
+| `@robota-sdk/agent-command-agent`       | Default `/agent` command module composed by the Robota binary                                                                        |
 | `@robota-sdk/agent-command-compact`     | Default `/compact` command module composed by the Robota binary                                                                      |
 | `@robota-sdk/agent-command-context`     | Default `/context` command module composed by the Robota binary                                                                      |
 | `@robota-sdk/agent-command-exit`        | Default `/exit` command module composed by the Robota binary                                                                         |

--- a/packages/agent-cli/src/__tests__/cli-update-check.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-update-check.test.ts
@@ -148,6 +148,7 @@ describe('CLI update check command', () => {
       expect(fetchImpl).not.toHaveBeenCalled();
       const stdoutText = stdout.mock.calls.join('');
       expect(stdoutText).toContain('Available commands:');
+      expect(stdoutText).toContain('agent');
       expect(stdoutText).not.toContain('Robota update available');
       expect(stderr.mock.calls.join('')).toBe('');
       expect(existsSync(join(home, '.robota', 'update-check.json'))).toBe(false);

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -9,6 +9,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
+import { createAgentCommandModule } from '@robota-sdk/agent-command-agent';
 import { createBackgroundCommandModule } from '@robota-sdk/agent-command-background';
 import { createProviderCommandModule } from '@robota-sdk/agent-command-provider';
 import { createCompactCommandModule } from '@robota-sdk/agent-command-compact';
@@ -177,6 +178,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const providerDefinitions = options.providerDefinitions ?? DEFAULT_PROVIDER_DEFINITIONS;
   const commandModules: readonly ICommandModule[] = [
     createHelpCommandModule(),
+    createAgentCommandModule(),
     createModelCommandModule(),
     createModeCommandModule(),
     createPermissionsCommandModule(),


### PR DESCRIPTION
## Summary
- compose @robota-sdk/agent-command-agent in the default Robota CLI command module list
- add headless /help regression coverage proving /agent is exposed by the default product composition
- archive the /agent migration backlog and mark the SDK command API checklist item complete

## Verification
- volta run pnpm --filter @robota-sdk/agent-command-agent test
- volta run pnpm --filter @robota-sdk/agent-command-agent typecheck
- volta run pnpm --filter @robota-sdk/agent-command-agent build
- volta run pnpm --filter @robota-sdk/agent-command-agent lint
- volta run pnpm --filter @robota-sdk/agent-cli test -- src/__tests__/cli-update-check.test.ts
- volta run pnpm --filter @robota-sdk/agent-cli typecheck
- volta run pnpm --filter @robota-sdk/agent-cli build
- volta run pnpm --filter @robota-sdk/agent-cli lint
- volta run pnpm harness:scan:commands
- volta run pnpm docs:validate-structure
- git diff --check
- pre-push harness verification