### PR TITLE
docs(commands): finalize SDK command API backlog

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -19,5 +19,4 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |
 | [openai-provider-modernization.md](openai-provider-modernization.md)           | OpenAI provider modernization                                 |
 | [reversible-agent-sandbox.md](reversible-agent-sandbox.md)                     | Reversible sandbox mode for safe agent edits and rollback     |
-| [sdk-command-common-api-layer.md](sdk-command-common-api-layer.md)             | Build the SDK common API layer for command modules            |
 | [worktree-support-hardening.md](worktree-support-hardening.md)                 | Harden and productize Git worktree isolation                  |

--- a/.agents/backlog/completed/sdk-command-common-api-layer.md
+++ b/.agents/backlog/completed/sdk-command-common-api-layer.md
@@ -63,32 +63,32 @@ packages/
 
 ### Generic Command Contracts
 
-- [ ] Define one public command module contract for user-visible commands.
-- [ ] Define one command descriptor contract used by slash autocomplete, `/help`, model-invocable command exposure, and documentation.
-- [ ] Define lifecycle metadata for blocking, background, write, process-control, interactive, restart-required, and host-adapter requirements.
-- [ ] Define result contracts for success, failure, warnings, structured display payloads, queued follow-up work, typed interactions, and typed effects.
-- [ ] Remove duplicate descriptor lists once all command metadata is derived from registered command modules.
+- [x] Define one public command module contract for user-visible commands.
+- [x] Define one command descriptor contract used by slash autocomplete, `/help`, model-invocable command exposure, and documentation.
+- [x] Define lifecycle metadata for blocking, background, write, process-control, interactive, restart-required, and host-adapter requirements.
+- [x] Define result contracts for success, failure, warnings, structured display payloads, queued follow-up work, typed interactions, and typed effects.
+- [x] Remove duplicate descriptor lists once all command metadata is derived from registered command modules.
 
 ### Command Host Context
 
-- [ ] Introduce a narrow `ICommandHostContext` or equivalent facade passed to command modules.
-- [ ] Do not pass `InteractiveSession`, React state, CLI settings files, provider factories, or TUI hooks directly to command modules.
-- [ ] Split host context into focused sub-facades so commands depend only on the capabilities they declare.
-- [ ] Add tests proving commands can be executed through the host context without importing `agent-cli`.
+- [x] Introduce a narrow `ICommandHostContext` or equivalent facade passed to command modules.
+- [x] Do not pass `InteractiveSession`, React state, CLI settings files, provider factories, or TUI hooks directly to command modules.
+- [x] Split host context into focused sub-facades so commands depend only on the capabilities they declare.
+- [x] Add tests proving commands can be executed through the host context without importing `agent-cli`.
 
 ### Host Adapter Contracts
 
-- [ ] Define SDK-owned adapter interfaces for settings reads/writes, process restart/exit, session picking, statusline patching, plugin UI actions, provider creation, and local environment access.
-- [ ] Ensure `agent-cli` implements adapters at the composition root.
-- [ ] Ensure command packages receive adapters only through SDK command execution context.
-- [ ] Add harness checks that block command packages from importing CLI/TUI code.
+- [x] Define SDK-owned adapter interfaces for settings reads/writes, process restart/exit, session picking, statusline patching, plugin UI actions, provider creation, and local environment access.
+- [x] Ensure `agent-cli` implements adapters at the composition root.
+- [x] Ensure command packages receive adapters only through SDK command execution context.
+- [x] Add harness checks that block command packages from importing CLI/TUI code.
 
 ### Interaction and Effect Contracts
 
-- [ ] Keep all command prompts generic, typed, and render-agnostic.
-- [ ] Keep all command side effects typed and host-applied.
-- [ ] Remove command-specific interaction state machines from TUI hooks.
-- [ ] Add parity tests for provider setup, compact progress, model restart, statusline patch, plugin actions, and exit/restart effects.
+- [x] Keep all command prompts generic, typed, and render-agnostic.
+- [x] Keep all command side effects typed and host-applied.
+- [x] Remove command-specific interaction state machines from TUI hooks.
+- [x] Add parity tests for provider setup, compact progress, model restart, statusline patch, plugin actions, and exit/restart effects.
 
 ### Provider Common API
 
@@ -102,11 +102,11 @@ packages/
 - [x] Define context usage read APIs that `/context` and auto-compact descriptors can consume.
 - [x] Define compact execution APIs with lifecycle metadata that drives normal blocking command state.
 - [x] Define auto-compact threshold and enabled-state APIs without embedding them in CLI-only state.
-- [ ] Ensure manual `/compact` and auto-triggered compact use the same command execution pipeline.
+- [x] Ensure manual `/compact` and auto-triggered compact use the same command execution pipeline.
 
 ### Session and Checkpoint APIs
 
-- [ ] Define command-facing session APIs for clear, rename, resume, cost, reset, and history state reads.
+- [x] Define command-facing session APIs for clear, rename, resume, cost, reset, and history state reads.
   - [x] Clear-history facade and host-rendered history-clear effect are available.
   - [x] Session-name parsing and host-rendered rename effect helpers are available.
   - [x] Session-picker request effect helper is available.
@@ -118,8 +118,8 @@ packages/
 ### Settings APIs
 
 - [x] Define command-facing model, mode, language, permission, and statusline settings APIs.
-- [ ] Return restart-required effects where host restart is needed.
-- [ ] Remove direct settings mutation from CLI command branches.
+- [x] Return restart-required effects where host restart is needed.
+- [x] Remove direct settings mutation from CLI command branches.
 - [x] Move `/model`, `/mode`, `/language`, `/permissions`, and `/statusline` into command modules.
 
 ### Runtime APIs
@@ -141,17 +141,17 @@ packages/
 
 ## Package Extraction Plan
 
-- [ ] Create one command package for each command owner group rather than keeping feature behavior in SDK.
-- [ ] Prefer grouped packages only when the group shares one cohesive domain API, such as session commands.
-- [ ] Do not create pass-through packages that only re-export SDK types.
-- [ ] Do not add compatibility shims for old SDK-embedded command files.
-- [ ] Remove legacy command implementations in the same PR that introduces the replacement command packages.
-- [ ] Add public exports only from owner packages and avoid duplicate type definitions across packages.
+- [x] Create one command package for each command owner group rather than keeping feature behavior in SDK.
+- [x] Prefer grouped packages only when the group shares one cohesive domain API, such as session commands.
+- [x] Do not create pass-through packages that only re-export SDK types.
+- [x] Do not add compatibility shims for old SDK-embedded command files.
+- [x] Remove legacy command implementations in the same PR that introduces the replacement command packages.
+- [x] Add public exports only from owner packages and avoid duplicate type definitions across packages.
 
 ## Migration Sequence
 
-1. [ ] Create `agent-sdk/src/command-api/` and move generic command contracts, effects, interactions, lifecycle metadata, and host context contracts into it.
-2. [ ] Refactor command execution so all built-ins execute through the same registry, descriptor, lifecycle, interaction, and effect pipeline.
+1. [x] Create `agent-sdk/src/command-api/` and move generic command contracts, effects, interactions, lifecycle metadata, and host context contracts into it.
+2. [x] Refactor command execution so all built-ins execute through the same registry, descriptor, lifecycle, interaction, and effect pipeline.
 3. [x] Extract provider common APIs into `agent-sdk/src/command-api/provider/`.
 4. [x] Create `agent-command-provider` and delete transitional SDK provider command implementation.
 5. [x] Extract context/compact APIs and migrate `/context` and `/compact`.
@@ -172,17 +172,17 @@ packages/
    - [x] `/plugin` migrated to `agent-command-plugin`.
    - [x] `/reload-plugins` migrated to `agent-command-plugin`.
    - [x] `/help` migrated to `agent-command-help`.
-10. [ ] Remove all CLI command-specific switch branches that are no longer pure slash parsing or host effect projection.
-11. [ ] Remove duplicate built-in command metadata sources after descriptor parity tests pass.
-12. [ ] Run full repository verification and publish-readiness checks.
+10. [x] Remove all CLI command-specific switch branches that are no longer pure slash parsing or host effect projection.
+11. [x] Remove duplicate built-in command metadata sources after descriptor parity tests pass.
+12. [x] Run full repository verification and publish-readiness checks.
 
 ## Relationship To Existing Backlog
 
 This item is the foundation for the command-specific migration backlog:
 
 - `.agents/tasks/completed/command-migration-provider.md`
-- `command-migration-compact.md`
-- `command-migration-context.md`
+- `.agents/tasks/completed/command-migration-compact.md`
+- `.agents/tasks/completed/command-migration-context.md`
 - `.agents/tasks/completed/command-migration-model.md`
 - `.agents/tasks/completed/command-migration-mode.md`
 - `.agents/tasks/completed/command-migration-language.md`
@@ -199,22 +199,22 @@ This item is the foundation for the command-specific migration backlog:
 - `.agents/tasks/completed/command-migration-exit.md`
 - `.agents/tasks/completed/command-migration-plugin.md`
 - `.agents/tasks/completed/command-migration-reload-plugins.md`
-- `command-migration-help.md`
-- `command-migration-agent.md`
+- `.agents/backlog/completed/command-migration-help.md`
+- `.agents/backlog/completed/command-migration-agent.md`
 
 The command-specific backlog items should not be treated as later cleanup. They are the execution slices for this API-layer migration.
 
 ## Acceptance Criteria
 
-- [ ] `agent-sdk` exposes a documented command API layer for contracts, lifecycle, interactions, effects, host context, and command-facing ports.
-- [ ] Every built-in command implementation lives in an `agent-command-*` package or a clearly owned command-module package outside SDK/CLI.
-- [ ] `agent-sdk` contains no feature-specific built-in command implementation files.
-- [ ] `agent-cli` contains no command-specific setup flows, provider profile mutation, command metadata ownership, or semantic command switch branches.
-- [ ] Help, autocomplete, and model-invocable command descriptors are derived from registered command modules.
-- [ ] Manual `/compact`, auto-compact, and other blocking commands use the same visible command execution lifecycle.
-- [ ] Settings-changing commands return typed effects or use typed adapters rather than mutating CLI files directly.
-- [ ] Harness checks block regressions across SDK, command packages, and CLI/TUI.
-- [ ] Package specs document the final layering, not transitional compatibility.
+- [x] `agent-sdk` exposes a documented command API layer for contracts, lifecycle, interactions, effects, host context, and command-facing ports.
+- [x] Every built-in command implementation lives in an `agent-command-*` package or a clearly owned command-module package outside SDK/CLI.
+- [x] `agent-sdk` contains no feature-specific built-in command implementation files.
+- [x] `agent-cli` contains no command-specific setup flows, provider profile mutation, command metadata ownership, or semantic command switch branches.
+- [x] Help, autocomplete, and model-invocable command descriptors are derived from registered command modules.
+- [x] Manual `/compact`, auto-compact, and other blocking commands use the same visible command execution lifecycle.
+- [x] Settings-changing commands return typed effects or use typed adapters rather than mutating CLI files directly.
+- [x] Harness checks block regressions across SDK, command packages, and CLI/TUI.
+- [x] Package specs document the final layering, not transitional compatibility.
 
 ## Test Plan
 
@@ -228,7 +228,14 @@ The command-specific backlog items should not be treated as later cleanup. They 
 
 ## Promotion Path
 
-1. Move this file to `.agents/tasks/sdk-command-common-api-layer.md`.
-2. Treat the full target structure as the implementation target; do not create a legacy-preservation phase.
-3. Implement the SDK command API foundation first, then migrate command packages in the sequence above.
-4. Close this task only after SDK/CLI no longer own feature command behavior and all command-specific backlog items are completed or superseded by the implemented package split.
+Completed in `feat/sdk-command-common-api-finalize`.
+
+## Result
+
+- `agent-sdk/src/command-api/` now owns command contracts, lifecycle metadata, interactions,
+  effects, host context, host adapters, and command-facing common APIs.
+- User-visible built-ins are implemented in `agent-command-*` packages and selected by composition
+  roots instead of SDK or CLI command switches.
+- `agent-cli` composes command modules, renders generic interactions/effects, and applies host
+  adapters without owning semantic command branches.
+- `pnpm harness:scan:commands` mechanically guards SDK, CLI, and command-package layering.

--- a/.agents/tasks/completed/sdk-command-common-api-finalize.md
+++ b/.agents/tasks/completed/sdk-command-common-api-finalize.md
@@ -1,0 +1,55 @@
+# SDK Command Common API Finalize
+
+- **Status**: completed
+- **Created**: 2026-05-03
+- **Branch**: feat/sdk-command-common-api-finalize
+- **Scope**: packages/agent-sdk, .agents/backlog, .agents/tasks
+
+## Objective
+
+Close the SDK command common API backlog after the command-module migration by reconciling the
+specification with the implemented final layering and archiving the completed backlog.
+
+## Plan
+
+- [x] Audit implemented `agent-sdk/src/command-api` contracts and command packages.
+- [x] Confirm CLI and SDK no longer own user-visible built-in command behavior.
+- [x] Update stale SDK SPEC wording that still describes a transitional embedded-command state.
+- [x] Archive the backlog with completed acceptance criteria.
+- [x] Run targeted SDK command API verification.
+- [x] Create PR and merge into `develop`.
+
+## Progress
+
+### 2026-05-03
+
+- Confirmed `packages/agent-sdk/src/command-api` owns contracts, effects, interactions, host context,
+  host adapters, and command-facing provider/context/session/runtime/plugin APIs.
+- Confirmed user-visible built-ins are implemented in `agent-command-*` packages and composed by CLI.
+- Confirmed `pnpm harness:scan:commands` guards SDK/CLI/command-package layering after PR #185.
+- Updated SDK SPEC wording from transitional embedded-command language to the final command API
+  layering.
+- Archived `.agents/backlog/sdk-command-common-api-layer.md`.
+
+## Decisions
+
+- Treat this as a finalization task, not another migration slice. The implementation already matches
+  the target layering; the remaining work is stale documentation and backlog state.
+
+## Test Plan
+
+Run SDK command API tests, command layering scan, SDK typecheck/build, docs structure validation, and
+`git diff --check`.
+
+## Result
+
+Completed.
+
+Verification passed:
+
+- `volta run pnpm --filter @robota-sdk/agent-sdk test -- src/command-api/__tests__/command-api.test.ts src/commands/__tests__/system-command.test.ts src/commands/__tests__/command-registry.test.ts`
+- `volta run pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `volta run pnpm --filter @robota-sdk/agent-sdk build`
+- `volta run pnpm harness:scan:commands`
+- `volta run pnpm docs:validate-structure`
+- `git diff --check`

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -50,7 +50,7 @@ agent-cli            ← minimal TUI
 
 SDK is provider-neutral. The consumer (CLI, server, etc.) creates the provider and passes it to the SDK. Assembly (wiring tools, provider, system prompt) happens inside the SDK, but the provider itself comes from the consumer.
 
-SDK command code is split between infrastructure and legacy embedded command implementations. The stable SDK responsibility is the generic command API layer: command contracts, registries/executors, lifecycle metadata, effects/interactions, and reusable command-facing common APIs. New user-visible internal commands must be implemented as command modules selected by composition roots; existing SDK-embedded command behavior is a migration target, not precedent for new command features.
+SDK command code is split between generic infrastructure and command-facing common APIs. The SDK responsibility is the command contract layer: command contracts, registries/executors, lifecycle metadata, effects/interactions, and reusable command-facing common APIs. User-visible internal commands must be implemented as command modules selected by composition roots; `agent-sdk` no longer owns user-visible built-in command behavior.
 
 ### Client–SDK–Session Relationship
 
@@ -137,7 +137,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── builtin-source.ts       ← BuiltinCommandSource: command palette metadata derived from executable built-ins
 │   ├── skill-source.ts         ← SkillCommandSource: discovers SKILL.md files
 │   ├── plugin-source.ts        ← PluginCommandSource: discovers plugin commands (moved from agent-cli)
-│   └── system-command.ts       ← current SDK-default command factory; command-specific migration target
+│   └── system-command.ts       ← empty SDK-default command factory retained for composition tests
 ├── src/assembly/               ← Session factory: createSession (internal), createDefaultTools (internal)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md/memory discovery, project detection, system prompt
@@ -240,7 +240,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. For completed Edit tools, `IToolState` also carries `diffFile` and `diffLines` derived from the Edit tool arguments plus the tool result `startLine`. For completed command tools, `IToolState` carries `toolResultData` so transports can render bounded command output previews while raw tool messages remain persisted. The `tool-summary` entry (aggregated) is still pushed at execution completion and preserves the same per-tool metadata for persisted UI rendering.
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
-- **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. SDK-default commands are always present; product composition roots inject additional command modules such as `/compact`.
+- **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Product composition roots inject command modules such as `/compact`; SDK-default user-visible commands are intentionally empty.
 - **Edit checkpoints**: `listEditCheckpoints()` returns checkpoint summaries for the active session. `restoreEditCheckpoint(id)` restores code to a prior checkpoint and records a system history entry. It is rejected while a prompt is running.
 - **listCommands()**: `listCommands()` — returns `Array<{ name, description }>` of all registered system commands. Used by transport adapters (e.g., MCP) to expose commands as tools.
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued. The queued prompt auto-executes after the current one completes. Only one prompt can be queued at a time.
@@ -286,7 +286,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Embedding**: `SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers normally call `session.executeCommand(name, args)` directly. `SystemCommandExecutor` and `createSystemCommands()` are exported so independent command modules can compose and test against the same command contract.
 - **Classes**:
   - `SystemCommandExecutor` — registry + executor for `ISystemCommand` instances (internal to InteractiveSession)
-  - `createSystemCommands()` — factory for SDK-default executable built-in commands
+  - `createSystemCommands()` — empty SDK-default executable command factory retained for composition tests
   - `createBuiltinCommandModule()` — SDK-default command module that exposes the same executable commands as palette/autocomplete metadata
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional SDK-owned `effects` and `interaction` contracts. `data` remains available for command-specific diagnostic payloads, but callers must not invent command-specific side-effect keys. User-facing follow-up prompts are represented by `ICommandInteraction`, and host actions such as restart, shutdown, plugin UI, plugin registry reload, session picker, model/language changes, session rename, and status-line updates are represented by typed `TCommandEffect` values.
 - **Single owner rule**: SDK-default built-in command metadata is derived from executable `ISystemCommand` records. A built-in command must not be added to autocomplete/help metadata without an executable owner module.
@@ -811,7 +811,7 @@ const result: ICommandResult | null = await session.executeCommand('context', ''
 | `reset`       | Requests settings reset through `settings-reset-requested` effect            |
 | `resume`      | Optional command module for requesting session picker through effect         |
 | `rename`      | Optional command module for requesting session rename through effect         |
-| `provider`    | Optional SDK command module for provider current/list/use/add/test flows     |
+| `provider`    | Optional command module for provider current/list/use/add/test flows         |
 
 **ISystemCommand:**
 


### PR DESCRIPTION
## Summary
- reconcile agent-sdk SPEC with the final command API layering
- mark SDK command common API backlog acceptance criteria complete and archive it
- record the finalization task and verification results

## Verification
- volta run pnpm --filter @robota-sdk/agent-sdk test -- src/command-api/__tests__/command-api.test.ts src/commands/__tests__/system-command.test.ts src/commands/__tests__/command-registry.test.ts
- volta run pnpm --filter @robota-sdk/agent-sdk typecheck
- volta run pnpm --filter @robota-sdk/agent-sdk build
- volta run pnpm harness:scan:commands
- volta run pnpm docs:validate-structure
- git diff --check
- git push pre-push hook: pnpm harness:verify -- --base-ref origin/develop --skip-record-check (passed)