### PR TITLE
docs(agent): archive follow-up roadmap

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,7 +13,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 | File                                                                           | Topic                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [agent-followup-roadmap.md](agent-followup-roadmap.md)                         | Recommended sequence for agent/CLI/runtime follow-ups         |
 | [gemini-provider-modernization.md](gemini-provider-modernization.md)           | Gemini API provider modernization                             |
 | [harness-hooks-and-auto-lessons.md](harness-hooks-and-auto-lessons.md)         | Auto-lessons pipeline (Phase C) — Phase B completed in PR #92 |
 | [openai-compatible-web-search-fetch.md](openai-compatible-web-search-fetch.md) | OpenAI-compatible provider web search/fetch support           |

--- a/.agents/backlog/completed/agent-followup-roadmap.md
+++ b/.agents/backlog/completed/agent-followup-roadmap.md
@@ -41,4 +41,12 @@ The current follow-up set spans a user-facing bug, test coverage discovery, comm
 
 ## Promotion Path
 
-When these items are scheduled, promote them one at a time into `.agents/tasks/` with concrete IDs. Keep this roadmap in backlog until at least the model regression, coverage audit, and compact research/design are either completed or superseded.
+Completed in `docs/agent-followup-roadmap-close`.
+
+## Result
+
+- `/model` restart behavior was completed in `.agents/tasks/completed/cli-model-change-restart.md`.
+- Agent package coverage measurement was completed in `.agents/tasks/completed/agent-package-coverage-audit.md`.
+- Compact descriptor behavior was completed in `.agents/tasks/completed/compact-command-descriptor.md`.
+- Worktree hardening and reversible sandboxing remain tracked as their own backlog items, so this
+  roadmap no longer needs to stay active.

--- a/.agents/tasks/completed/agent-followups-implementation.md
+++ b/.agents/tasks/completed/agent-followups-implementation.md
@@ -1,6 +1,6 @@
 # Agent Follow-ups Implementation
 
-- **Status**: in-progress
+- **Status**: completed
 - **Created**: 2026-05-03
 - **Branch**: feat/agent-followups-implementation
 - **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-sessions, packages/agent-runtime, .agents
@@ -20,7 +20,7 @@ Implement the follow-up work promoted from backlog: fix the `/model` restart reg
 - [x] Harden worktree metadata, cleanup, and edge-case behavior.
 - [x] Add local-first reversible sandbox/rollback workflow built on checkpoints/worktrees.
 - [x] Run targeted verification for changed packages.
-- [ ] Prepare PR and merge into `develop`.
+- [x] Prepare PR and merge into `develop`.
 
 ## Progress
 
@@ -52,4 +52,6 @@ Run focused RED/GREEN tests for each behavior slice, then verify the affected mo
 
 ## Result
 
-Pending.
+Completed in PR #156 (`feat(agent): implement follow-up runtime fixes`). The remaining roadmap
+items with product scope are tracked independently by `worktree-support-hardening.md` and
+`reversible-agent-sandbox.md`.


### PR DESCRIPTION
## Summary
- archive the agent follow-up roadmap after its first three gating items were completed
- mark the merged follow-up implementation task as completed
- leave worktree hardening and reversible sandboxing tracked as independent backlog items

## Verification
- volta run pnpm docs:validate-structure
- git diff --check
- git push pre-push hook: pnpm harness:verify -- --base-ref origin/develop --skip-record-check (passed)