### PR TITLE
fix(cli): validate merged active provider config

### DIFF
--- a/.changeset/cli-active-provider-validation.md
+++ b/.changeset/cli-active-provider-validation.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-cli': patch
+---
+
+Validate the merged active provider profile during CLI startup so higher-priority provider selections with missing API keys are not masked by unrelated valid settings files.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -129,6 +129,8 @@ Supported setup flags:
 
 First-run setup must offer the injected provider definitions as a selectable list when stdin/stdout are TTYs. The list is generated from `IProviderDefinition[]` and may render `displayName`, `type`, and `description`, but it must not branch on concrete provider names. Selecting a provider starts the same provider setup flow used by runtime provider setup.
 
+Startup setup validation must evaluate the merged settings document and the provider selected for this invocation. A valid lower-priority legacy `provider` entry or another valid settings file must not mask an unusable `currentProvider` profile from a higher-priority layer or `--provider` override.
+
 Non-interactive print/headless execution must not prompt. Missing provider config must produce an actionable error generated from the injected provider definitions, pointing to `robota --configure` and `robota --configure-provider` without hardcoded provider-specific examples.
 
 Environment-variable API key references use the `$ENV:NAME` form. If a required provider API key resolves to an unset environment variable, setup validation or provider construction must fail with a clear error before any provider request is sent. A literal unresolved `$ENV:NAME` string must never be sent as an API key.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -129,7 +129,7 @@ Supported setup flags:
 
 First-run setup must offer the injected provider definitions as a selectable list when stdin/stdout are TTYs. The list is generated from `IProviderDefinition[]` and may render `displayName`, `type`, and `description`, but it must not branch on concrete provider names. Selecting a provider starts the same provider setup flow used by runtime provider setup.
 
-Startup setup validation must evaluate the merged settings document and the provider selected for this invocation. A valid lower-priority legacy `provider` entry or another valid settings file must not mask an unusable `currentProvider` profile from a higher-priority layer or `--provider` override.
+Startup setup validation must evaluate the merged settings document and the provider selected for this invocation. A valid lower-priority legacy `provider` entry or another valid settings file must not mask an unusable `currentProvider` profile from a higher-priority layer or `--provider` override. When interactive startup setup is opened because a project `.robota` file already selects an unusable provider, the setup write target must be project-local settings so the new selection actually wins in the merged configuration.
 
 Non-interactive print/headless execution must not prompt. Missing provider config must produce an actionable error generated from the injected provider definitions, pointing to `robota --configure` and `robota --configure-provider` without hardcoded provider-specific examples.
 

--- a/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-factory.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import {
   createProviderFromProfile,
   createProviderFromSettings,
+  getProviderSettingsPaths,
   readProviderSettings,
 } from '../provider-factory.js';
 import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
@@ -194,6 +195,17 @@ describe('provider-factory', () => {
     delete process.env.ROBOTA_TEST_ANTHROPIC_API_KEY;
     delete process.env.DASHSCOPE_API_KEY;
     rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it('resolves user settings paths from HOME for test and runtime isolation', () => {
+    const paths = getProviderSettingsPaths(cwd);
+    const home = process.env.HOME;
+    if (home === undefined) {
+      throw new Error('HOME is required for this test');
+    }
+
+    expect(paths[0]).toBe(join(home, '.robota', 'settings.json'));
+    expect(paths[1]).toBe(join(home, '.claude', 'settings.json'));
   });
 
   it('reads active OpenAI-compatible provider profile', () => {

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { rmSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { rmSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IParsedCliArgs } from '../cli-args.js';
 import {
@@ -125,6 +125,11 @@ function readUserSettings(home: string): Record<string, unknown> {
   >;
 }
 
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf8');
+}
+
 describe('provider setup', () => {
   afterEach(() => {
     process.env.HOME = ORIGINAL_HOME;
@@ -209,8 +214,44 @@ describe('provider setup', () => {
       return '';
     };
 
+    const args = { ...baseArgs(), provider: 'missing-profile' };
     await expect(
-      ensureConfig(join(TMP_BASE, 'project'), baseArgs(), promptInput, providerDefinitions),
+      ensureConfig(join(TMP_BASE, 'project'), args, promptInput, providerDefinitions),
+    ).rejects.toThrow('No provider configuration found');
+    expect(prompted).toBe(false);
+  });
+
+  it('validates the merged active provider instead of any individually valid settings file', async () => {
+    const home = join(TMP_BASE, 'home-merged-active');
+    const project = join(TMP_BASE, 'project-merged-active');
+    process.env.HOME = home;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    writeJson(join(home, '.robota', 'settings.json'), {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-ant-test',
+      },
+    });
+    writeJson(join(project, '.robota', 'settings.local.json'), {
+      currentProvider: 'qwen',
+      providers: {
+        qwen: {
+          type: 'qwen',
+          model: 'qwen-plus',
+          apiKey: '$ENV:DASHSCOPE_API_KEY',
+        },
+      },
+    });
+    let prompted = false;
+    const promptInput = async (): Promise<string> => {
+      prompted = true;
+      return '';
+    };
+
+    await expect(
+      ensureConfig(project, baseArgs(), promptInput, providerDefinitions),
     ).rejects.toThrow('No provider configuration found');
     expect(prompted).toBe(false);
   });

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -256,6 +256,54 @@ describe('provider setup', () => {
     expect(prompted).toBe(false);
   });
 
+  it('writes startup setup to project-local settings when project currentProvider masks user settings', async () => {
+    const home = join(TMP_BASE, 'home-project-active');
+    const project = join(TMP_BASE, 'project-active');
+    process.env.HOME = home;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    writeJson(join(home, '.robota', 'settings.json'), {
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-ant-user',
+      },
+    });
+    writeJson(join(project, '.robota', 'settings.local.json'), {
+      currentProvider: 'qwen',
+      providers: {
+        qwen: {
+          type: 'qwen',
+          model: 'qwen-plus',
+          apiKey: '$ENV:DASHSCOPE_API_KEY',
+        },
+      },
+    });
+    const answers = ['1', 'sk-ant-project', '', 'ko'];
+    const promptInput = async (): Promise<string> => answers.shift() ?? '';
+
+    await ensureConfig(project, baseArgs(), promptInput, providerDefinitions);
+
+    const settings = JSON.parse(
+      readFileSync(join(project, '.robota', 'settings.local.json'), 'utf8'),
+    ) as {
+      currentProvider?: string;
+      language?: string;
+      providers?: Record<string, Record<string, unknown>>;
+    };
+    expect(settings.currentProvider).toBe('anthropic');
+    expect(settings.language).toBe('ko');
+    expect(settings.providers?.anthropic).toMatchObject({
+      type: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-ant-project',
+    });
+    expect(settings.providers?.qwen).toMatchObject({
+      type: 'qwen',
+      model: 'qwen-plus',
+    });
+  });
+
   it('formats missing-config guidance from injected provider definitions', () => {
     const message = formatMissingProviderConfigMessage(providerDefinitions);
 

--- a/packages/agent-cli/src/utils/__tests__/settings-check.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/settings-check.test.ts
@@ -119,6 +119,28 @@ describe('checkSettingsFile', () => {
     expect(checkSettingsFile(path, providerDefinitions)).toBe('incomplete');
   });
 
+  it('does not let legacy provider config mask an unusable active provider profile', () => {
+    mkdirSync(TMP_BASE, { recursive: true });
+    const path = join(TMP_BASE, 'settings.json');
+    writeJson(path, {
+      currentProvider: 'qwen',
+      providers: {
+        qwen: {
+          type: 'qwen',
+          model: 'qwen-plus',
+          apiKey: '$ENV:DASHSCOPE_API_KEY',
+        },
+      },
+      provider: {
+        name: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-ant-test',
+      },
+    });
+
+    expect(checkSettingsFile(path, providerDefinitions)).toBe('incomplete');
+  });
+
   it('returns incomplete when a required API key environment reference is unset', () => {
     mkdirSync(TMP_BASE, { recursive: true });
     const path = join(TMP_BASE, 'settings.json');

--- a/packages/agent-cli/src/utils/provider-factory.ts
+++ b/packages/agent-cli/src/utils/provider-factory.ts
@@ -7,7 +7,6 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import type { IAIProvider, TUniversalValue } from '@robota-sdk/agent-core';
 import type { ISerializableProviderProfile } from '@robota-sdk/agent-sdk';
 import { type TProviderSettingsDocument } from './provider-settings.js';
@@ -50,14 +49,19 @@ export function readMergedProviderSettings(cwd: string): TProviderSettingsDocume
 }
 
 export function getProviderSettingsPaths(cwd: string): string[] {
+  const userHome = getUserHome();
   return [
-    join(homedir(), '.robota', 'settings.json'),
-    join(homedir(), '.claude', 'settings.json'),
+    join(userHome, '.robota', 'settings.json'),
+    join(userHome, '.claude', 'settings.json'),
     join(cwd, '.robota', 'settings.json'),
     join(cwd, '.robota', 'settings.local.json'),
     join(cwd, '.claude', 'settings.json'),
     join(cwd, '.claude', 'settings.local.json'),
   ];
+}
+
+function getUserHome(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? '/';
 }
 
 export function readMergedProviderSettingsFromPaths(

--- a/packages/agent-cli/src/utils/provider-setup.ts
+++ b/packages/agent-cli/src/utils/provider-setup.ts
@@ -4,7 +4,7 @@ import type { IParsedCliArgs } from './cli-args.js';
 import { checkSettingsDocument } from './settings-check.js';
 import { getUserSettingsPath, readSettings, writeSettings } from './settings-io.js';
 import { applyProviderConfiguration, applyProviderSwitch } from './provider-configuration.js';
-import { readMergedProviderSettings } from './provider-factory.js';
+import { getProviderSettingsPaths, readMergedProviderSettings } from './provider-factory.js';
 import { DEFAULT_PROVIDER_DEFINITIONS } from './provider-default-definitions.js';
 import { type IProviderSetupInput } from './provider-settings.js';
 import {
@@ -62,7 +62,18 @@ export async function ensureConfig(
   if (!isInteractiveTerminal()) {
     throw new Error(formatMissingProviderConfigMessage(providerDefinitions));
   }
-  await runInteractiveProviderSetup(cwd, args, promptInput, providerDefinitions);
+  await runInteractiveProviderSetup(
+    cwd,
+    selectStartupSetupArgs(cwd, args),
+    promptInput,
+    providerDefinitions,
+  );
+  const updated = readMergedProviderSettings(cwd);
+  const updatedSettings =
+    args.provider !== undefined ? { ...updated, currentProvider: args.provider } : updated;
+  if (checkSettingsDocument(updatedSettings, providerDefinitions) !== 'valid') {
+    throw new Error(formatMissingProviderConfigMessage(providerDefinitions));
+  }
 }
 
 export async function runInteractiveProviderSetup(
@@ -101,6 +112,42 @@ function buildSetupInputFromArgs(args: IParsedCliArgs): IProviderSetupInput {
     ...(args.baseURL !== undefined && { baseURL: args.baseURL }),
     setCurrent: args.setCurrent,
   };
+}
+
+function selectStartupSetupArgs(cwd: string, args: IParsedCliArgs): IParsedCliArgs {
+  if (args.settingsScope !== undefined || args.provider !== undefined) {
+    return args;
+  }
+
+  const currentProviderPath = findHighestPriorityCurrentProviderPath(getProviderSettingsPaths(cwd));
+  if (currentProviderPath === undefined) {
+    return args;
+  }
+
+  const projectSettingsPath = join(cwd, '.robota', 'settings.json');
+  const projectLocalSettingsPath = join(cwd, '.robota', 'settings.local.json');
+  if (
+    currentProviderPath === projectSettingsPath ||
+    currentProviderPath === projectLocalSettingsPath
+  ) {
+    return { ...args, settingsScope: 'project-local' };
+  }
+
+  return args;
+}
+
+function findHighestPriorityCurrentProviderPath(
+  settingsPaths: readonly string[],
+): string | undefined {
+  for (let index = settingsPaths.length - 1; index >= 0; index -= 1) {
+    const settingsPath = settingsPaths[index];
+    if (settingsPath === undefined) continue;
+    const settings = readSettings(settingsPath);
+    if (typeof settings.currentProvider === 'string') {
+      return settingsPath;
+    }
+  }
+  return undefined;
 }
 
 function isInteractiveTerminal(): boolean {

--- a/packages/agent-cli/src/utils/provider-setup.ts
+++ b/packages/agent-cli/src/utils/provider-setup.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { formatSupportedProviderTypes, type IProviderDefinition } from './provider-definition.js';
 import type { IParsedCliArgs } from './cli-args.js';
-import { checkSettingsFile } from './settings-check.js';
+import { checkSettingsDocument } from './settings-check.js';
 import { getUserSettingsPath, readSettings, writeSettings } from './settings-io.js';
 import { applyProviderConfiguration, applyProviderSwitch } from './provider-configuration.js';
 import { readMergedProviderSettings } from './provider-factory.js';
@@ -54,11 +53,10 @@ export async function ensureConfig(
   promptInput: TPromptInput,
   providerDefinitions: readonly IProviderDefinition[] = DEFAULT_PROVIDER_DEFINITIONS,
 ): Promise<void> {
-  const checks = getSettingsCheckPaths(cwd).map((path) => ({
-    path,
-    status: checkSettingsFile(path, providerDefinitions),
-  }));
-  if (checks.some((check) => check.status === 'valid')) {
+  const merged = readMergedProviderSettings(cwd);
+  const selectedSettings =
+    args.provider !== undefined ? { ...merged, currentProvider: args.provider } : merged;
+  if (checkSettingsDocument(selectedSettings, providerDefinitions) === 'valid') {
     return;
   }
   if (!isInteractiveTerminal()) {
@@ -103,17 +101,6 @@ function buildSetupInputFromArgs(args: IParsedCliArgs): IProviderSetupInput {
     ...(args.baseURL !== undefined && { baseURL: args.baseURL }),
     setCurrent: args.setCurrent,
   };
-}
-
-function getSettingsCheckPaths(cwd: string): string[] {
-  return [
-    getUserSettingsPath(),
-    join(homedir(), '.claude', 'settings.json'),
-    join(cwd, '.robota', 'settings.json'),
-    join(cwd, '.robota', 'settings.local.json'),
-    join(cwd, '.claude', 'settings.json'),
-    join(cwd, '.claude', 'settings.local.json'),
-  ];
 }
 
 function isInteractiveTerminal(): boolean {

--- a/packages/agent-cli/src/utils/settings-check.ts
+++ b/packages/agent-cli/src/utils/settings-check.ts
@@ -28,21 +28,29 @@ export function checkSettingsFile(
   }
 }
 
+/** Check a parsed settings document for a usable active provider. */
+export function checkSettingsDocument(
+  settings: IProviderSettingsShape,
+  providerDefinitions: readonly IProviderDefinition[] = [],
+): TSettingsCheck {
+  return hasUsableProviderConfig(settings, providerDefinitions) ? 'valid' : 'incomplete';
+}
+
 function hasUsableProviderConfig(
   settings: IProviderSettingsShape,
   providerDefinitions: readonly IProviderDefinition[],
 ): boolean {
+  if (typeof settings.currentProvider === 'string') {
+    const profile = settings.providers?.[settings.currentProvider];
+    return isUsableProviderProfile(profile?.type, profile, providerDefinitions);
+  }
   if (
     settings.provider &&
     isUsableProviderProfile(settings.provider.name, settings.provider, providerDefinitions)
   ) {
     return true;
   }
-  if (typeof settings.currentProvider !== 'string') {
-    return false;
-  }
-  const profile = settings.providers?.[settings.currentProvider];
-  return isUsableProviderProfile(profile?.type, profile, providerDefinitions);
+  return false;
 }
 
 function isUsableProviderProfile(


### PR DESCRIPTION
## Summary
- validate CLI startup against the merged active provider profile instead of any individually valid settings file
- prevent a lower-priority legacy provider from masking a higher-priority currentProvider with an unset API key env reference
- when project-local settings select an unusable provider, persist interactive startup setup back into project-local scope so the effective config changes immediately
- isolate provider settings path resolution from the real OS home in tests by using HOME/USERPROFILE consistently
- document the startup validation rule and add a patch changeset for agent-cli

## Notes
- The earlier qwen apiKey crash was a settings precedence/write-scope bug.
- A later Anthropic `401 invalid x-api-key` means the new Anthropic config was applied and the request reached Anthropic, but the saved key itself was rejected.

## Verification
- env -u DASHSCOPE_API_KEY pnpm run cli:dev
- pnpm --filter @robota-sdk/agent-cli exec vitest run src/utils/__tests__/provider-configuration.test.ts src/utils/__tests__/provider-factory.test.ts src/utils/__tests__/provider-setup.test.ts src/utils/__tests__/settings-check.test.ts
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint (0 errors, existing warnings)
- pnpm harness:verify -- --scope packages/agent-cli
- pre-push scoped verification