### PR TITLE
fix: move CLI session store behind SDK facade

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,7 +11,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-- [CLI session store boundary cleanup](cli-session-store-boundary-cleanup.md)
 - [CLI command effect state boundary](cli-command-effect-state-boundary.md)
 - [TUI remove activity prefix from status bar](tui-remove-activity-label.md)
 - [CLI `@file` reference import](cli-at-file-reference-import.md)

--- a/.agents/backlog/completed/cli-session-store-boundary-cleanup.md
+++ b/.agents/backlog/completed/cli-session-store-boundary-cleanup.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Priority
 
@@ -41,11 +41,11 @@ Recommended shape:
 
 ## Acceptance Criteria
 
-- [ ] No production file under `packages/agent-cli/src` imports from `@robota-sdk/agent-sessions`.
-- [ ] `packages/agent-cli/package.json` no longer declares `@robota-sdk/agent-sessions`.
-- [ ] Resume, fork, continue, and session picker behavior still work through SDK-owned APIs.
-- [ ] `packages/agent-cli/docs/SPEC.md` and `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflect the final boundary.
-- [ ] Add or extend a mechanical harness/import check for this forbidden edge if feasible.
+- [x] No production file under `packages/agent-cli/src` imports from `@robota-sdk/agent-sessions`.
+- [x] `packages/agent-cli/package.json` no longer declares `@robota-sdk/agent-sessions`.
+- [x] Resume, fork, continue, and session picker behavior still work through SDK-owned APIs.
+- [x] `packages/agent-cli/docs/SPEC.md` and `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflect the final boundary.
+- [x] Add or extend a mechanical harness/import check for this forbidden edge if feasible.
 
 ## Verification Plan
 

--- a/.agents/rules/documentation-sync.md
+++ b/.agents/rules/documentation-sync.md
@@ -26,6 +26,7 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 - For every changed package, inspect and update `packages/<pkg>/README.md`.
 - For every changed package with website-visible package docs, inspect and update `packages/<pkg>/docs/README.md`.
 - For every changed package contract, update `packages/<pkg>/docs/SPEC.md`.
+- For every changed package composition, import edge, execution mode, or class/interface ownership, inspect and update any package-local `packages/<pkg>/docs/ARCHITECTURE-MAP.md`.
 - For every user-facing feature, update at least one matching robota.io source page under `content/`.
 - If no README or robota.io update is needed, the PR/task summary MUST explicitly say why the existing docs remain correct.
 

--- a/.agents/tasks/completed/cli-session-store-boundary-cleanup.md
+++ b/.agents/tasks/completed/cli-session-store-boundary-cleanup.md
@@ -1,0 +1,54 @@
+# CLI Session Store Boundary Cleanup
+
+- **Status**: completed
+- **Created**: 2026-05-05
+- **Branch**: fix/cli-session-store-boundary
+- **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-sessions, scripts/harness
+
+## Objective
+
+Remove the direct `agent-cli` dependency on `@robota-sdk/agent-sessions` while preserving project-local
+session persistence, continue/resume/fork flows, and the saved-session picker.
+
+## Plan
+
+- [x] Confirm the current forbidden `agent-cli -> agent-sessions` imports and manifest dependency.
+- [x] Update governing SPEC/rule docs before implementation.
+- [x] Add regression tests and harness coverage for the forbidden edge.
+- [x] Add SDK-owned session persistence facade and resumable-session summary helpers.
+- [x] Migrate CLI construction, hooks, and picker to SDK-owned types/helpers.
+- [x] Update `ARCHITECTURE-MAP.md` to remove the audit violation and show the new boundary.
+- [x] Move backlog item to completed with acceptance criteria checked.
+- [x] Run targeted package and harness verification.
+
+## Progress
+
+### 2026-05-05
+
+- Merged PR #204, refreshed `develop`, and created `fix/cli-session-store-boundary`.
+- Confirmed direct CLI imports from `@robota-sdk/agent-sessions` in `cli.ts`, `render.tsx`,
+  `App.tsx`, `SessionPicker.tsx`, and `useInteractiveSession.ts`.
+- Added SDK-owned project session store and resumable-session helpers.
+- Removed the direct CLI `agent-sessions` package dependency and migrated resume/session picker flows
+  to SDK facade types.
+- Added command-layering harness checks for forbidden CLI imports and package dependencies.
+- Updated SPEC/README/content docs and `packages/agent-cli/docs/ARCHITECTURE-MAP.md`.
+- Verified affected packages and docs build.
+
+## Decisions
+
+- Use an SDK-owned session persistence facade instead of exposing `SessionStore` to the CLI.
+- Keep the concrete JSON persistence implementation in `agent-sessions`; SDK owns the host-facing
+  facade and resumable-session summaries.
+- Add a harness check for the forbidden CLI dependency so the boundary does not regress.
+
+## Blockers
+
+- None.
+
+## Result
+
+Completed. The CLI now uses SDK-owned session persistence APIs for project-local stores, latest
+session resolution, named/id resume, and picker summaries. The concrete sessions package remains
+behind the SDK facade, and harness coverage now prevents the forbidden CLI dependency from
+regressing.

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -212,19 +212,19 @@ const session = new InteractiveSession({
 
 `InteractiveSession` provides these capabilities:
 
-| Feature                    | Description                                                                                                                                                                |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Permission enforcement** | Tool calls are gated by the permission system                                                                                                                              |
-| **Hook execution**         | PreToolUse/PostToolUse/PreCompact/PostCompact hooks fire automatically                                                                                                     |
-| **Context tracking**       | Token usage is tracked and available via `getContextState()`                                                                                                               |
-| **Auto-compaction**        | Context is compressed when usage exceeds ~83.5%                                                                                                                            |
-| **Session persistence**    | Conversations can be saved/loaded via `SessionStore`. `ISessionRecord` includes `history` (`IHistoryEntry[]`) plus background task snapshots for restoration and debugging |
-| **Session resume/fork**    | Restore a previous session with `resumeSessionId` or fork with `forkSession`. On resume, `session.injectMessage()` restores AI context from persisted history              |
-| **Session naming**         | `getName()` / `setName()` for human-friendly session identification                                                                                                        |
-| **Abort**                  | `session.abort()` cancels via AbortSignal. Partial response committed as `'interrupted'`                                                                                   |
-| **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                                           |
-| **Background work**        | Subagent jobs are tracked through runtime-owned task state, transcripts, and background task events                                                                        |
-| **Replay events**          | Session runs forward core provider/tool boundary events into append-only JSONL logs                                                                                        |
+| Feature                    | Description                                                                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Permission enforcement** | Tool calls are gated by the permission system                                                                                                                                         |
+| **Hook execution**         | PreToolUse/PostToolUse/PreCompact/PostCompact hooks fire automatically                                                                                                                |
+| **Context tracking**       | Token usage is tracked and available via `getContextState()`                                                                                                                          |
+| **Auto-compaction**        | Context is compressed when usage exceeds ~83.5%                                                                                                                                       |
+| **Session persistence**    | Conversations can be saved/loaded through SDK-owned session store facades. Records include `history` (`IHistoryEntry[]`) plus background task snapshots for restoration and debugging |
+| **Session resume/fork**    | Restore a previous session with `resumeSessionId` or fork with `forkSession`. On resume, `session.injectMessage()` restores AI context from persisted history                         |
+| **Session naming**         | `getName()` / `setName()` for human-friendly session identification                                                                                                                   |
+| **Abort**                  | `session.abort()` cancels via AbortSignal. Partial response committed as `'interrupted'`                                                                                              |
+| **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                                                      |
+| **Background work**        | Subagent jobs are tracked through runtime-owned task state, transcripts, and background task events                                                                                   |
+| **Replay events**          | Session runs forward core provider/tool boundary events into append-only JSONL logs                                                                                                   |
 
 ## Subagent Sessions
 

--- a/packages/agent-cli/docs/ARCHITECTURE-MAP.md
+++ b/packages/agent-cli/docs/ARCHITECTURE-MAP.md
@@ -1,6 +1,6 @@
 # Agent CLI Architecture Map
 
-Source-verified against `origin/develop` at `35ae9b46c0c7` on 2026-05-04.
+Source-verified against the `fix/cli-session-store-boundary` working tree on 2026-05-05.
 
 This document is the LLM-scannable master map for how `@robota-sdk/agent-cli` is
 assembled. Package `SPEC.md` files remain the source of truth for ownership
@@ -36,7 +36,6 @@ flowchart TD
   CLI --> Providers
   CLI --> Core
   CLI --> Headless
-  CLI -. "current audit violation: SessionStore" .-> Sessions
 
   Commands --> SDK
   Commands --> Core
@@ -53,17 +52,17 @@ flowchart TD
   Headless --> SDK
 ```
 
-| Edge | Status | Rule |
-| --- | --- | --- |
-| CLI -> SDK | Allowed | CLI consumes `InteractiveSession`, command registries, command contracts, and SDK path helpers. |
-| CLI -> command packages | Allowed | Product composition root selects default command modules. |
-| CLI -> provider packages | Allowed | CLI owns provider definition composition and provider instance creation. |
-| CLI -> agent-core public types | Allowed | CLI may use public provider, permission, history, and message types. |
-| CLI -> headless transport | Allowed | Print mode attaches a transport to `InteractiveSession`. |
-| CLI -> agent-sessions | Forbidden by CLI SPEC | Current code imports `SessionStore`; see audit finding `CLI-AUDIT-001`. |
-| SDK -> command packages | Forbidden | SDK owns contracts/common APIs and must not import command implementations. No source edge found. |
-| command packages -> CLI/TUI | Forbidden | Commands consume SDK contracts and host adapters only. No source edge found. |
-| provider packages -> Robota commands/TUI | Forbidden | Providers translate provider wire formats only. No source edge found in this audit. |
+| Edge                                     | Status                | Rule                                                                                                                                        |
+| ---------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLI -> SDK                               | Allowed               | CLI consumes `InteractiveSession`, command registries, command contracts, SDK path helpers, and SDK-owned session persistence facade types. |
+| CLI -> command packages                  | Allowed               | Product composition root selects default command modules.                                                                                   |
+| CLI -> provider packages                 | Allowed               | CLI owns provider definition composition and provider instance creation.                                                                    |
+| CLI -> agent-core public types           | Allowed               | CLI may use public provider, permission, history, and message types.                                                                        |
+| CLI -> headless transport                | Allowed               | Print mode attaches a transport to `InteractiveSession`.                                                                                    |
+| CLI -> agent-sessions                    | Forbidden by CLI SPEC | No production source or package dependency should exist; harness command layering scan enforces this edge.                                  |
+| SDK -> command packages                  | Forbidden             | SDK owns contracts/common APIs and must not import command implementations. No source edge found.                                           |
+| command packages -> CLI/TUI              | Forbidden             | Commands consume SDK contracts and host adapters only. No source edge found.                                                                |
+| provider packages -> Robota commands/TUI | Forbidden             | Providers translate provider wire formats only. No source edge found in this audit.                                                         |
 
 ## CLI Composition Tree
 
@@ -105,7 +104,7 @@ packages/agent-cli/src/bin.ts
    |- create runtime adapters
    |  |- managed shell background runner
    |  `- child-process subagent runner factory
-   |- create SessionStore for resume/persistence (audit violation)
+   |- createProjectSessionStore(cwd) from SDK for resume/persistence facade
    |- if -p print mode
    |  |- new InteractiveSession({ cwd, provider, commandModules, commandHostAdapters, ... })
    |  |- createHeadlessTransport({ outputFormat, prompt })
@@ -167,15 +166,15 @@ flowchart LR
   HostAdapters --> Module
 ```
 
-| Responsibility | Owner |
-| --- | --- |
-| Slash prefix detection and unknown-command rendering | `agent-cli` |
-| Command metadata, subcommands, lifecycle policy, interactions, effects | Owning `agent-command-*` package |
-| Command contracts, registry, executor, effect/interactions types | `agent-sdk` |
-| Reusable command common APIs and ports | `agent-sdk/src/command-api/*` |
-| Host persistence, local process actions, UI shell actions | `agent-cli` host adapters and TUI effect handlers |
-| Provider setup semantics for `/provider` | `agent-command-provider` consuming SDK provider common APIs |
-| Model-change request semantics for `/model` | `agent-command-model` consuming SDK model common APIs |
+| Responsibility                                                         | Owner                                                       |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Slash prefix detection and unknown-command rendering                   | `agent-cli`                                                 |
+| Command metadata, subcommands, lifecycle policy, interactions, effects | Owning `agent-command-*` package                            |
+| Command contracts, registry, executor, effect/interactions types       | `agent-sdk`                                                 |
+| Reusable command common APIs and ports                                 | `agent-sdk/src/command-api/*`                               |
+| Host persistence, local process actions, UI shell actions              | `agent-cli` host adapters and TUI effect handlers           |
+| Provider setup semantics for `/provider`                               | `agent-command-provider` consuming SDK provider common APIs |
+| Model-change request semantics for `/model`                            | `agent-command-model` consuming SDK model common APIs       |
 
 Forbidden shortcuts:
 
@@ -261,7 +260,7 @@ Interactive mode currently supports:
 - generic `ICommandInteraction` rendering;
 - typed `TCommandEffect` application;
 - skill and plugin command discovery through SDK command sources;
-- session resume/fork/name flows through a `SessionStore` created by CLI (audit violation).
+- session resume/fork/name flows through SDK-owned session persistence facade and summaries.
 
 ### Non-Interactive Print Mode
 
@@ -293,40 +292,42 @@ this section must be updated in the same PR.
 
 ## Class and Interface Inventory
 
-| Item | Owner | Layer | Inbound consumers | Outbound dependencies | Responsibility |
-| --- | --- | --- | --- | --- | --- |
-| `startCli()` | `agent-cli/src/cli.ts` | Product shell | binary entrypoint, embedders | SDK, command packages, providers, headless transport, settings I/O | Parse flags, compose providers/modules/adapters, choose interactive or print mode. |
-| `renderApp()` | `agent-cli/src/ui/render.tsx` | UI shell | `startCli()` | React, Ink, `App` | Start Ink app and process exit handling. |
-| `App` / `AppInner` | `agent-cli/src/ui/App.tsx` | UI shell | `renderApp()` | CLI hooks and components | Compose TUI state, prompts, plugin UI, session picker, status bar. |
-| `useInteractiveSession()` | `agent-cli/src/ui/hooks/useInteractiveSession.ts` | React-SDK bridge | `AppInner` | `InteractiveSession`, `CommandRegistry`, `TuiStateManager` | Create the SDK session once and subscribe SDK events to render state. |
-| `useSlashRouting()` | `agent-cli/src/ui/hooks/useSlashRouting.ts` | UI command routing | `useInteractiveSession()` | `InteractiveSession`, `CommandRegistry` | Parse leading slash, call SDK command execution, route skill/plugin fallback. |
-| `useSideEffects()` | `agent-cli/src/ui/hooks/useSideEffects.ts` | UI effect application | `AppInner` | CLI settings/UI adapters, `InteractiveSession` | Render generic interactions and apply typed command effects. |
-| `TuiStateManager` | `agent-cli/src/ui/tui-state-manager.ts` | UI state projection | `useInteractiveSession()` | agent-core history/context types | Convert SDK events into stable render state. |
-| `ICommandModule` | `agent-sdk/src/command-api/command-module.ts` | SDK command contract | command packages, CLI, SDK executor | agent-sdk command API | Module boundary for command sources, system commands, descriptors, requirements. |
-| `ICommandResult` | `agent-sdk/src/command-api/command-result.ts` | SDK command contract | command packages, SDK, CLI | command effects/interactions | Structured command output consumed by generic hosts. |
-| `TCommandEffect` | `agent-sdk/src/command-api/effects.ts` | SDK command contract | command packages, CLI effect handlers | agent-core end reason types | Typed host-side work requested by commands. |
-| `CommandRegistry` | `agent-sdk/src/commands/command-registry.ts` | SDK command infrastructure | CLI, tests | `ICommandSource` | Aggregate command palette entries from modules, skills, and plugins. |
-| `BuiltinCommandSource` | `agent-sdk/src/commands/builtin-source.ts` | SDK command infrastructure | CLI, SDK tests | SDK command API | Expose SDK-default built-ins; currently empty. |
-| `SystemCommandExecutor` | `agent-sdk/src/commands/system-command-executor.ts` | SDK command infrastructure | `InteractiveSession` | `ISystemCommand` | Execute matching system command with SDK host context. |
-| `InteractiveSession` | `agent-sdk/src/interactive/interactive-session.ts` | SDK entrypoint | CLI, command tests, SDK consumers | sessions, runtime, tools, core, command API | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence. |
-| `createInteractiveSession()` | `agent-sdk/src/interactive/interactive-session-init.ts` | SDK assembly | `InteractiveSession` | config/context, plugin hooks, `createSession()` | Load config/context/project data and construct `Session`. |
-| `createSession()` | `agent-sdk/src/assembly/create-session.ts` | SDK assembly | `createInteractiveSession()`, SDK tests | sessions, tools, runtime, core | Assemble provider, tools, system prompt, command tool, background/subagent runtime. |
-| `Session` | `agent-sessions` | Session runtime | SDK assembly | agent-core | Run conversation lifecycle, permissions, compaction, context tracking. |
-| `SessionStore` | `agent-sessions` | Session persistence | SDK and currently CLI | filesystem | Persist/resume session JSON. CLI direct use is audit debt. |
-| `IProviderDefinition` | `agent-core` | Core/provider contract | provider packages, CLI, provider command | core provider config types | Provider defaults, setup metadata, aliases, probes, factory. |
-| `createProviderFromSettings()` | `agent-cli/src/utils/provider-factory.ts` | CLI provider composition | `startCli()` | provider definitions, settings I/O | Resolve effective provider settings and instantiate provider. |
-| `createProviderCommandModule()` | `agent-command-provider` | Command package | CLI composition | SDK command and provider common APIs | Own `/provider` metadata, setup interactions, settings patches, restart effects. |
-| `createModelCommandModule()` | `agent-command-model` | Command package | CLI composition | SDK model common API | Own `/model` metadata and model-change effects. |
-| `createAgentCommandModule()` | `agent-command-agent` | Command package | CLI composition | SDK command/runtime APIs | Own `/agent` metadata and background agent command execution. |
-| `createHeadlessTransport()` | `agent-transport-headless` | Transport | CLI print mode | SDK transport contract | Drive non-interactive prompt input and output formatting. |
+| Item                            | Owner                                                   | Layer                      | Inbound consumers                        | Outbound dependencies                                              | Responsibility                                                                              |
+| ------------------------------- | ------------------------------------------------------- | -------------------------- | ---------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `startCli()`                    | `agent-cli/src/cli.ts`                                  | Product shell              | binary entrypoint, embedders             | SDK, command packages, providers, headless transport, settings I/O | Parse flags, compose providers/modules/adapters, choose interactive or print mode.          |
+| `renderApp()`                   | `agent-cli/src/ui/render.tsx`                           | UI shell                   | `startCli()`                             | React, Ink, `App`                                                  | Start Ink app and process exit handling.                                                    |
+| `App` / `AppInner`              | `agent-cli/src/ui/App.tsx`                              | UI shell                   | `renderApp()`                            | CLI hooks and components                                           | Compose TUI state, prompts, plugin UI, session picker, status bar.                          |
+| `useInteractiveSession()`       | `agent-cli/src/ui/hooks/useInteractiveSession.ts`       | React-SDK bridge           | `AppInner`                               | `InteractiveSession`, `CommandRegistry`, `TuiStateManager`         | Create the SDK session once and subscribe SDK events to render state.                       |
+| `useSlashRouting()`             | `agent-cli/src/ui/hooks/useSlashRouting.ts`             | UI command routing         | `useInteractiveSession()`                | `InteractiveSession`, `CommandRegistry`                            | Parse leading slash, call SDK command execution, route skill/plugin fallback.               |
+| `useSideEffects()`              | `agent-cli/src/ui/hooks/useSideEffects.ts`              | UI effect application      | `AppInner`                               | CLI settings/UI adapters, `InteractiveSession`                     | Render generic interactions and apply typed command effects.                                |
+| `TuiStateManager`               | `agent-cli/src/ui/tui-state-manager.ts`                 | UI state projection        | `useInteractiveSession()`                | agent-core history/context types                                   | Convert SDK events into stable render state.                                                |
+| `ICommandModule`                | `agent-sdk/src/command-api/command-module.ts`           | SDK command contract       | command packages, CLI, SDK executor      | agent-sdk command API                                              | Module boundary for command sources, system commands, descriptors, requirements.            |
+| `ICommandResult`                | `agent-sdk/src/command-api/command-result.ts`           | SDK command contract       | command packages, SDK, CLI               | command effects/interactions                                       | Structured command output consumed by generic hosts.                                        |
+| `TCommandEffect`                | `agent-sdk/src/command-api/effects.ts`                  | SDK command contract       | command packages, CLI effect handlers    | agent-core end reason types                                        | Typed host-side work requested by commands.                                                 |
+| `CommandRegistry`               | `agent-sdk/src/commands/command-registry.ts`            | SDK command infrastructure | CLI, tests                               | `ICommandSource`                                                   | Aggregate command palette entries from modules, skills, and plugins.                        |
+| `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`              | SDK command infrastructure | CLI, SDK tests                           | SDK command API                                                    | Expose SDK-default built-ins; currently empty.                                              |
+| `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`     | SDK command infrastructure | `InteractiveSession`                     | `ISystemCommand`                                                   | Execute matching system command with SDK host context.                                      |
+| `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`      | SDK entrypoint             | CLI, command tests, SDK consumers        | sessions, runtime, tools, core, command API                        | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.       |
+| `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`      | SDK facade                 | CLI, SDK consumers                       | agent-sessions, project paths                                      | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI. |
+| `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`      | SDK facade type            | CLI session picker, SDK consumers        | none                                                               | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.     |
+| `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts` | SDK assembly               | `InteractiveSession`                     | config/context, plugin hooks, `createSession()`                    | Load config/context/project data and construct `Session`.                                   |
+| `createSession()`               | `agent-sdk/src/assembly/create-session.ts`              | SDK assembly               | `createInteractiveSession()`, SDK tests  | sessions, tools, runtime, core                                     | Assemble provider, tools, system prompt, command tool, background/subagent runtime.         |
+| `Session`                       | `agent-sessions`                                        | Session runtime            | SDK assembly                             | agent-core                                                         | Run conversation lifecycle, permissions, compaction, context tracking.                      |
+| `SessionStore`                  | `agent-sessions`                                        | Session persistence        | SDK facade and generic session consumers | filesystem                                                         | Persist/resume session JSON behind `ISessionStore`. CLI must not consume it directly.       |
+| `IProviderDefinition`           | `agent-core`                                            | Core/provider contract     | provider packages, CLI, provider command | core provider config types                                         | Provider defaults, setup metadata, aliases, probes, factory.                                |
+| `createProviderFromSettings()`  | `agent-cli/src/utils/provider-factory.ts`               | CLI provider composition   | `startCli()`                             | provider definitions, settings I/O                                 | Resolve effective provider settings and instantiate provider.                               |
+| `createProviderCommandModule()` | `agent-command-provider`                                | Command package            | CLI composition                          | SDK command and provider common APIs                               | Own `/provider` metadata, setup interactions, settings patches, restart effects.            |
+| `createModelCommandModule()`    | `agent-command-model`                                   | Command package            | CLI composition                          | SDK model common API                                               | Own `/model` metadata and model-change effects.                                             |
+| `createAgentCommandModule()`    | `agent-command-agent`                                   | Command package            | CLI composition                          | SDK command/runtime APIs                                           | Own `/agent` metadata and background agent command execution.                               |
+| `createHeadlessTransport()`     | `agent-transport-headless`                              | Transport                  | CLI print mode                           | SDK transport contract                                             | Drive non-interactive prompt input and output formatting.                                   |
 
 ## Layering Audit
 
 ### CLI-AUDIT-001: CLI imports `agent-sessions` directly
 
-Status: confirmed violation.
+Status: resolved in `fix/cli-session-store-boundary`.
 
-Current files:
+Former files:
 
 - `packages/agent-cli/src/cli.ts`
 - `packages/agent-cli/src/ui/render.tsx`
@@ -340,15 +341,18 @@ Problem:
 `packages/agent-cli/docs/SPEC.md` says CLI must not import from
 `@robota-sdk/agent-sessions`, but the CLI creates and passes `SessionStore` directly.
 
-Recommended fix:
+Resolution:
 
-Move session persistence construction and the public resume/picker data contract behind an SDK-owned
-API or port. CLI should ask SDK for a project session persistence adapter or use an SDK-exported
-host-facing interface that does not expose `agent-sessions` concrete classes.
+Session persistence construction and the public resume/picker data contract now live behind
+SDK-owned APIs in `agent-sdk/src/interactive/session-persistence.ts`. CLI calls
+`createProjectSessionStore(cwd)`, `resolveLatestSessionId()`, `resolveSessionIdByIdOrName()`, and
+`listResumableSessionSummaries()` from `@robota-sdk/agent-sdk`; it does not import
+`@robota-sdk/agent-sessions` or declare it in `packages/agent-cli/package.json`.
 
-Tracked follow-up:
+Mechanical guard:
 
-- `.agents/backlog/cli-session-store-boundary-cleanup.md`
+- `scripts/harness/check-command-layering.mjs` flags production CLI imports from
+  `@robota-sdk/agent-sessions` and direct CLI package dependencies on it.
 
 ### CLI-AUDIT-002: TUI command effects are queued by mutating `InteractiveSession`
 
@@ -430,7 +434,7 @@ Before merging a CLI architecture change:
 Suggested mechanical checks from this audit:
 
 - Scan `packages/agent-cli/src` for forbidden imports from `@robota-sdk/agent-sessions` and
-  `@robota-sdk/agent-tools`.
+  `@robota-sdk/agent-tools`; the `agent-sessions` import/dependency edge is now enforced.
 - Scan `packages/agent-sdk/src` for imports from `@robota-sdk/agent-command-*`.
 - Scan `packages/agent-command-*/src` for imports from `packages/agent-cli` or
   `@robota-sdk/agent-cli`.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -47,7 +47,7 @@ The CLI is a pure TUI layer. All business logic (session lifecycle, slash comman
 1. Reads config to determine which provider profile to use.
 2. Resolves the profile `type` against an injected `IProviderDefinition[]`.
 3. Creates the provider instance by calling `definition.createProvider(config)`.
-4. Creates `InteractiveSession({ cwd, provider, commandHostAdapters })` — config and context loading happen internally inside the SDK. CLI-owned adapters expose host services such as user-settings persistence and plugin management without letting command packages import CLI files.
+4. Creates `InteractiveSession({ cwd, provider, commandHostAdapters, sessionStore })` — config and context loading happen internally inside the SDK. CLI-owned adapters expose host services such as user-settings persistence and plugin management without letting command packages import CLI files. Session persistence is passed only through SDK-owned facade types.
 5. Subscribes to `InteractiveSession` events and converts them to React state for rendering.
 
 ### Provider Profile Creation
@@ -905,7 +905,7 @@ When `--resume` is used without a value, a `ListPicker` overlay is shown with al
 
 ### Session Storage
 
-The CLI constructs `SessionStore` with the current project path `.robota/sessions`, not the generic user-level default. Every resumable session record must stay beside the project logs and must include provider messages, UI history, the exact system prompt, and registered tool schemas. This makes `/continue`, `/resume`, and local debugging inspect the same project-local `.robota` tree.
+The CLI asks `@robota-sdk/agent-sdk` for a project-local session persistence facade rooted at `.robota/sessions`, not the generic user-level default. The CLI must not import `SessionStore` or `ISessionRecord` from `@robota-sdk/agent-sessions`; it may only consume SDK-owned store and resumable-session summary types. Every resumable session record must stay beside the project logs and must include provider messages, UI history, the exact system prompt, and registered tool schemas. This makes `/continue`, `/resume`, and local debugging inspect the same project-local `.robota` tree.
 
 ## Tool Output Limits
 

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -74,7 +74,6 @@
     "@robota-sdk/agent-provider-openai": "workspace:*",
     "@robota-sdk/agent-provider-qwen": "workspace:*",
     "@robota-sdk/agent-sdk": "workspace:*",
-    "@robota-sdk/agent-sessions": "workspace:3.0.0-beta.60",
     "@robota-sdk/agent-transport-headless": "workspace:*",
     "chalk": "^5.3.0",
     "cli-highlight": "^2.1.0",

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -26,13 +26,18 @@ import { createResetCommandModule } from '@robota-sdk/agent-command-reset';
 import { createRewindCommandModule } from '@robota-sdk/agent-command-rewind';
 import { createStatusLineCommandModule } from '@robota-sdk/agent-command-statusline';
 import { createSessionCommandModule } from '@robota-sdk/agent-command-session';
-import { InteractiveSession, projectPaths } from '@robota-sdk/agent-sdk';
+import {
+  InteractiveSession,
+  createProjectSessionStore,
+  projectPaths,
+  resolveLatestSessionId,
+  resolveSessionIdByIdOrName,
+} from '@robota-sdk/agent-sdk';
 import type {
   ICommandHostAdapters,
   ICommandModule,
   TProviderSettingsDocument,
 } from '@robota-sdk/agent-sdk';
-import { SessionStore } from '@robota-sdk/agent-sessions';
 import { parseCliArgs } from './utils/cli-args.js';
 import {
   getUserSettingsPath,
@@ -255,24 +260,18 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   });
 
   // Session management
-  const sessionStore = new SessionStore(paths.sessions);
+  const sessionStore = createProjectSessionStore(cwd);
   let resumeSessionId: string | undefined;
+  let showSessionPickerOnStart = false;
 
   if (args.continueMode) {
-    const sessions = sessionStore.list().filter((s) => s.cwd === cwd);
-    if (sessions.length > 0) {
-      resumeSessionId = sessions[0]!.id;
-    }
+    resumeSessionId = resolveLatestSessionId(sessionStore, cwd);
   } else if (args.resumeId !== undefined) {
     if (args.resumeId === '') {
-      // -r without argument = show picker (handled in App.tsx)
-      resumeSessionId = '__picker__';
+      showSessionPickerOnStart = true;
     } else {
-      const sessions = sessionStore.list();
-      const match = sessions.find((s) => s.id === args.resumeId || s.name === args.resumeId);
-      if (match) {
-        resumeSessionId = match.id;
-      } else {
+      resumeSessionId = resolveSessionIdByIdOrName(sessionStore, args.resumeId);
+      if (resumeSessionId === undefined) {
         process.stderr.write(`Session not found: ${args.resumeId}\n`);
         process.exit(1);
       }
@@ -359,6 +358,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     version,
     sessionStore,
     resumeSessionId,
+    showSessionPickerOnStart,
     forkSession: args.forkSession,
     sessionName: args.sessionName,
     backgroundTaskRunners,

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -6,8 +6,10 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSessionStore,
   TSubagentRunnerFactory,
 } from '@robota-sdk/agent-sdk';
+import { listResumableSessionSummaries } from '@robota-sdk/agent-sdk';
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import { useInteractiveSession } from './hooks/useInteractiveSession.js';
 import { usePluginCallbacks } from './hooks/usePluginCallbacks.js';
@@ -26,7 +28,6 @@ import BackgroundTaskPanel from './BackgroundTaskPanel.js';
 import UpdateNotice from './UpdateNotice.js';
 import { formatCliUpdateNotice, type ICliUpdateNotice } from '../utils/update-check.js';
 import { formatModelChangeConfirmationMessage } from './hooks/model-change-side-effect.js';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 
 interface IProps {
   cwd: string;
@@ -36,8 +37,9 @@ interface IProps {
   permissionMode?: TPermissionMode;
   maxTurns?: number;
   version?: string;
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   resumeSessionId?: string;
+  showSessionPickerOnStart?: boolean;
   forkSession?: boolean;
   sessionName?: string;
   backgroundTaskRunners?: IBackgroundTaskRunner[];
@@ -49,13 +51,20 @@ interface IProps {
 
 export default function App(props: IProps): React.ReactElement {
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(props.resumeSessionId);
+  const [showInitialSessionPicker, setShowInitialSessionPicker] = useState(
+    props.showSessionPickerOnStart ?? false,
+  );
 
   return (
     <AppInner
       key={activeSessionId ?? '__new__'}
       {...props}
+      showSessionPickerOnStart={showInitialSessionPicker}
       resumeSessionId={activeSessionId}
-      onSessionSwitch={(sessionId) => setActiveSessionId(sessionId)}
+      onSessionSwitch={(sessionId) => {
+        setShowInitialSessionPicker(false);
+        setActiveSessionId(sessionId);
+      }}
     />
   );
 }
@@ -127,6 +136,7 @@ function AppInner(
     baseHandleSubmit,
     setSessionName,
     setStatusLineSettings,
+    showSessionPickerOnStart: props.showSessionPickerOnStart,
   });
 
   // Sync session name from InteractiveSession when resuming
@@ -248,8 +258,7 @@ function AppInner(
       )}
       {showSessionPicker && (
         <SessionPicker
-          sessionStore={props.sessionStore}
-          cwd={props.cwd}
+          sessions={listResumableSessionSummaries(props.sessionStore, props.cwd)}
           onSelect={(id) => {
             setShowSessionPicker(false);
             props.onSessionSwitch(id);

--- a/packages/agent-cli/src/ui/SessionPicker.tsx
+++ b/packages/agent-cli/src/ui/SessionPicker.tsx
@@ -5,44 +5,34 @@
 
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { SessionStore, ISessionRecord } from '@robota-sdk/agent-sessions';
+import type { IResumableSessionSummary } from '@robota-sdk/agent-sdk';
 import ListPicker from './ListPicker.js';
 
 const SESSION_ID_DISPLAY_LENGTH = 8;
+const SESSION_PREVIEW_DISPLAY_LENGTH = 60;
 
 interface IProps {
-  sessionStore?: SessionStore;
-  cwd: string;
+  sessions: readonly IResumableSessionSummary[];
   onSelect: (sessionId: string) => void;
   onCancel: () => void;
 }
 
 export default function SessionPicker({
-  sessionStore,
-  cwd,
+  sessions,
   onSelect,
   onCancel,
 }: IProps): React.ReactElement {
-  const sessions = (sessionStore?.list() ?? []).filter((s) => s.cwd === cwd);
-
   return (
     <Box flexDirection="column" paddingX={1} marginBottom={1}>
       <Text bold color="cyan">
         Select a session to resume (ESC to cancel):
       </Text>
-      <ListPicker<ISessionRecord>
-        items={sessions}
-        renderItem={(session: ISessionRecord, isSelected: boolean) => {
-          const lastMsg = session.messages
-            .slice()
-            .reverse()
-            .find((m) => {
-              const msg = m as { role?: string; content?: string };
-              return msg.role === 'assistant' && msg.content;
-            }) as { content?: string } | undefined;
-          const rawPreview = lastMsg?.content?.replace(/[\n\r]+/g, ' ').trim() ?? '';
-          const preview = rawPreview
-            ? rawPreview.slice(0, 60) + (rawPreview.length > 60 ? '...' : '')
+      <ListPicker<IResumableSessionSummary>
+        items={[...sessions]}
+        renderItem={(session: IResumableSessionSummary, isSelected: boolean) => {
+          const preview = session.preview
+            ? session.preview.slice(0, SESSION_PREVIEW_DISPLAY_LENGTH) +
+              (session.preview.length > SESSION_PREVIEW_DISPLAY_LENGTH ? '...' : '')
             : '';
           return (
             <Text>
@@ -58,7 +48,7 @@ export default function SessionPicker({
                 })}
               </Text>
               {'  '}
-              <Text dimColor>msgs: {session.messages.length}</Text>
+              <Text dimColor>msgs: {session.messageCount}</Text>
               {preview ? (
                 <>
                   {'\n    '}
@@ -68,7 +58,7 @@ export default function SessionPicker({
             </Text>
           );
         }}
-        onSelect={(session: ISessionRecord) => onSelect(session.id)}
+        onSelect={(session: IResumableSessionSummary) => onSelect(session.id)}
         onCancel={onCancel}
       />
     </Box>

--- a/packages/agent-cli/src/ui/hooks/side-effects-types.ts
+++ b/packages/agent-cli/src/ui/hooks/side-effects-types.ts
@@ -30,6 +30,7 @@ export interface IUseSideEffectsOptions {
   baseHandleSubmit: (input: string) => Promise<void>;
   setSessionName: (name: string) => void;
   setStatusLineSettings: (settings: IStatusLineSettings) => void;
+  showSessionPickerOnStart?: boolean;
 }
 
 export interface IUseSideEffectsResult {

--- a/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
+++ b/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
@@ -18,6 +18,7 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TPermissionResultValue,
 } from '@robota-sdk/agent-sdk';
@@ -33,14 +34,12 @@ import { TuiStateManager } from '../tui-state-manager.js';
 import { useSlashRouting } from './useSlashRouting.js';
 import { reloadPluginCommandSource } from '../../plugins/plugin-command-source-loader.js';
 
-import type { SessionStore } from '@robota-sdk/agent-sessions';
-
 export interface IInteractiveSessionProps {
   cwd: string;
   provider: IAIProvider;
   permissionMode?: TPermissionMode;
   maxTurns?: number;
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   resumeSessionId?: string;
   forkSession?: boolean;
   sessionName?: string;

--- a/packages/agent-cli/src/ui/hooks/useSideEffects.ts
+++ b/packages/agent-cli/src/ui/hooks/useSideEffects.ts
@@ -30,6 +30,7 @@ export function useSideEffects({
   baseHandleSubmit,
   setSessionName,
   setStatusLineSettings,
+  showSessionPickerOnStart,
 }: IUseSideEffectsOptions): IUseSideEffectsResult {
   const { exit } = useApp();
   const [pendingModelId, setPendingModelId] = useState<string | null>(null);
@@ -38,7 +39,7 @@ export function useSideEffects({
     useState<TInteractivePrompt | null>(null);
   const commandInteractionRef = useRef<ICommandInteraction | null>(null);
   const [showPluginTUI, setShowPluginTUI] = useState(false);
-  const [showSessionPicker, setShowSessionPicker] = useState(false);
+  const [showSessionPicker, setShowSessionPicker] = useState(showSessionPickerOnStart ?? false);
 
   const requestShutdown = useCallback(
     (reason: TSessionEndReason, message: string): void => {

--- a/packages/agent-cli/src/ui/render.tsx
+++ b/packages/agent-cli/src/ui/render.tsx
@@ -7,11 +7,11 @@ import { render } from 'ink';
 import App from './App.js';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSessionStore,
   TSubagentRunnerFactory,
 } from '@robota-sdk/agent-sdk';
 import type { ICliUpdateNotice } from '../utils/update-check.js';
@@ -25,8 +25,9 @@ export interface IRenderOptions {
   permissionMode?: TPermissionMode;
   maxTurns?: number;
   version?: string;
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   resumeSessionId?: string;
+  showSessionPickerOnStart?: boolean;
   forkSession?: boolean;
   sessionName?: string;
   backgroundTaskRunners?: IBackgroundTaskRunner[];

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -82,19 +82,22 @@ The SDK is **pure TypeScript with no React dependency**. The CLI is a thin TUI-o
 `InteractiveSession` wraps `Session` (composition over inheritance) to provide event-driven interaction for any client. It manages streaming text accumulation, tool execution state tracking, prompt queuing, abort orchestration, and message history. Logic that was previously embedded in CLI React hooks now lives here.
 
 ```typescript
-import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { InteractiveSession, createProjectSessionStore } from '@robota-sdk/agent-sdk';
 import type { IInteractiveSessionOptions } from '@robota-sdk/agent-sdk';
+
+const cwd = process.cwd();
+const sessionStore = createProjectSessionStore(cwd);
 
 const session = new InteractiveSession({
   config,
   context,
   projectInfo,
-  sessionStore, // SessionStore instance for persistence
+  sessionStore, // SDK-owned project-local persistence facade
   resumeSessionId, // Session ID to restore (optional)
   forkSession, // Session ID to fork from (optional)
   permissionMode: 'default',
   maxTurns: 10,
-  cwd: process.cwd(),
+  cwd,
   permissionHandler: async (toolName, toolArgs) => ({ allowed: true }),
 });
 
@@ -288,7 +291,7 @@ Built-in agents: `general-purpose` (full tool access), `Explore` (read-only, Hai
 
 `createAgentTool()` wraps subagent creation into a tool the AI can invoke directly. The parent session's hooks, permissions, and context are forwarded to the child.
 
-Background subagent lifecycle events are persisted through `InteractiveSession` when a `SessionStore` is configured. Streaming chunks are written to append-only JSONL logs/transcripts rather than rewriting the main session JSON per token.
+Background subagent lifecycle events are persisted through `InteractiveSession` when an SDK session persistence facade is configured. Streaming chunks are written to append-only JSONL logs/transcripts rather than rewriting the main session JSON per token.
 
 ## Hook Executors (SDK-Specific)
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -125,6 +125,7 @@ agent-sessions (generic — depends only on agent-core)
 agent-sdk (assembly layer — SDK-specific features only)
 ├── src/interactive/
 │   ├── interactive-session.ts  ← InteractiveSession: event-driven wrapper over Session
+│   ├── session-persistence.ts  ← SDK-owned session store facade and resumable-session summaries
 │   └── types.ts                ← IToolState, IExecutionResult, IInteractiveSessionEvents
 ├── src/command-api/            ← Command module contracts, host context, effects/interactions, provider/model common APIs
 │   ├── contracts.ts            ← ISystemCommand + lifecycle metadata
@@ -174,7 +175,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Package**: `agent-sessions` (generic, depends only on agent-core)
 - **Implementation**: Session accepts pre-constructed tools, provider, and system message. Internal concerns are delegated to PermissionEnforcer, ContextWindowTracker, and CompactionOrchestrator.
 - **Assembly**: `agent-sdk/assembly/` provides `createSession()` (internal — not exported) which wires tools, provider, and system prompt from config/context. Consumers use `InteractiveSession({ cwd, provider })` instead.
-- **Persistence**: `SessionStore` defaults to `~/.robota/sessions/{id}.json` for generic consumers. CLI composition injects a project-local `.robota/sessions` directory so project runs keep resumable session JSON beside project logs.
+- **Persistence**: `SessionStore` defaults to `~/.robota/sessions/{id}.json` for generic session consumers. SDK exposes `createProjectSessionStore(cwd)` and resumable-session helpers so CLI composition can use project-local `.robota/sessions` without importing `agent-sessions` directly.
 
 ### Permission System
 
@@ -259,7 +260,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued. The queued prompt auto-executes after the current one completes. Only one prompt can be queued at a time.
 - **Abort**: `abort()` clears the queue and delegates to `session.abort()`. An `interrupted` event fires when the abort completes.
 - **No-op terminal**: Uses a built-in NOOP_TERMINAL so no `ITerminalOutput` implementation is required by callers
-- **Session persistence**: When `sessionStore` is provided in options, auto-persists session state (messages, history, cwd, timestamps, system prompt, tool schemas, memory events, used memory references) to disk after each `submit()` completion. Uses `SessionStore` from `agent-sessions`. `messages` remains the replay source for context restoration; `systemPrompt` and `toolSchemas` are duplicated top-level diagnostic fields.
+- **Session persistence**: When an SDK-owned `sessionStore` facade is provided in options, auto-persists session state (messages, history, cwd, timestamps, system prompt, tool schemas, memory events, used memory references) after each `submit()` completion. The SDK facade delegates to the concrete `SessionStore` implementation from `agent-sessions` internally and exposes resumable-session summaries for hosts such as the CLI. `messages` remains the replay source for context restoration; `systemPrompt` and `toolSchemas` are duplicated top-level diagnostic fields.
 - **Session restore**: When `resumeSessionId` is provided, loads the saved session record and restores AI context. Messages are stored as `pendingRestoreMessages` and injected via `session.injectMessage()` after async initialization completes (deferred injection pattern). Memory event history and the last used memory references are restored for `/memory used` and debugging. This avoids injection failures caused by the Session not yet being fully initialized when the constructor runs.
 - **forkSession option**: `forkSession?: boolean` (default `false`). When `false` (resume), the original session ID is passed to the Session constructor so it reuses the same file. When `true` (fork), `sessionId` is omitted, generating a fresh UUID — the original session remains untouched.
 - **getName()/setName(name)**: Get or set the session's user-facing name. Persists to the session record when a store is configured.

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -22,10 +22,10 @@ import { Session } from '@robota-sdk/agent-sessions';
 import type {
   ITerminalOutput,
   ICompactEvent,
+  ISessionOptions,
   TPermissionHandler,
   ISessionLogger,
 } from '@robota-sdk/agent-sessions';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { IResolvedConfig } from '../config/config-types.js';
 import type { ILoadedContext } from '../context/context-loader.js';
 import type { IProjectInfo } from '../context/project-detector.js';
@@ -51,6 +51,7 @@ import type { IReversibleExecutionOptions } from '../reversible-execution/index.
 import { BackgroundTaskManager, SubagentManager } from '@robota-sdk/agent-runtime';
 import { createInProcessSubagentRunner } from '../subagents/in-process-subagent-runner.js';
 import type { TSubagentRunnerFactory } from '../subagents/in-process-subagent-runner.js';
+import type { IInteractiveSessionStore } from '../interactive/session-persistence.js';
 import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
 import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
@@ -67,7 +68,7 @@ const ID_RANDOM_LENGTH = 9;
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 120_000;
 
 type TAutoCompactThreshold = number | false;
-type TSessionOptionsWithAutoCompact = ConstructorParameters<typeof Session>[0] & {
+type TSessionOptionsWithAutoCompact = ISessionOptions & {
   autoCompactThreshold?: TAutoCompactThreshold;
 };
 type TSessionConstructorWithAutoCompact = new (options: TSessionOptionsWithAutoCompact) => Session;
@@ -89,7 +90,7 @@ export interface ICreateSessionOptions {
   /** Maximum number of agentic turns per run() call. Undefined = unlimited. */
   maxTurns?: number;
   /** Optional session store for persistence */
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   /** Inject a pre-constructed AI provider (used by tests to avoid real API calls) */
   provider?: IAIProvider;
   /** Custom permission handler (overrides terminal-based prompts, used by Ink UI) */

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -3,9 +3,18 @@
 
 // ── InteractiveSession (primary API) ────────────────────────
 export { InteractiveSession } from './interactive/index.js';
+export {
+  createProjectSessionStore,
+  listResumableSessionSummaries,
+  resolveLatestSessionId,
+  resolveSessionIdByIdOrName,
+} from './interactive/index.js';
 export type {
   IInteractiveSessionOptions,
   IInteractiveSessionShutdownOptions,
+  IInteractiveSessionRecord,
+  IInteractiveSessionStore,
+  IResumableSessionSummary,
   IToolState,
   IDiffLine,
   IExecutionResult,

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-memory.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-memory.test.ts
@@ -3,8 +3,8 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IAIProvider, TUniversalMessage } from '@robota-sdk/agent-core';
-import { SessionStore } from '@robota-sdk/agent-sessions';
 import { InteractiveSession } from '../interactive-session.js';
+import { createProjectSessionStore } from '../session-persistence.js';
 import { ProjectMemoryStore } from '../../memory/project-memory-store.js';
 
 const TMP_BASE = join(tmpdir(), `robota-interactive-memory-${process.pid}`);
@@ -51,7 +51,7 @@ describe('InteractiveSession memory command integration', () => {
   it('Given a memory cue When a turn completes Then no hidden pending memory is created', async () => {
     const cwd = makeProject();
     const provider = createProvider('noted');
-    const sessionStore = new SessionStore(join(cwd, '.robota', 'sessions'));
+    const sessionStore = createProjectSessionStore(cwd);
     const session = new InteractiveSession({
       cwd,
       provider,

--- a/packages/agent-sdk/src/interactive/__tests__/session-persistence.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/session-persistence.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createAssistantMessage, createUserMessage } from '@robota-sdk/agent-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createProjectSessionStore,
+  listResumableSessionSummaries,
+  resolveLatestSessionId,
+  resolveSessionIdByIdOrName,
+} from '../session-persistence.js';
+
+describe('session persistence facade', () => {
+  it('creates a project-local session store and resolves resumable summaries', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'robota-sdk-session-store-'));
+    mkdirSync(join(cwd, '.robota'), { recursive: true });
+    const store = createProjectSessionStore(cwd);
+
+    store.save({
+      id: 'session_one',
+      name: 'first',
+      cwd,
+      createdAt: '2026-05-05T00:00:00.000Z',
+      updatedAt: '2026-05-05T00:01:00.000Z',
+      messages: [createUserMessage('hello'), createAssistantMessage('first answer\nwith newline')],
+    });
+    store.save({
+      id: 'session_two',
+      cwd,
+      createdAt: '2026-05-05T00:00:00.000Z',
+      updatedAt: '2026-05-05T00:02:00.000Z',
+      messages: [createAssistantMessage('newer answer')],
+    });
+
+    expect(resolveLatestSessionId(store, cwd)).toBe('session_two');
+    expect(resolveSessionIdByIdOrName(store, 'first')).toBe('session_one');
+    expect(resolveSessionIdByIdOrName(store, 'session_two')).toBe('session_two');
+    expect(listResumableSessionSummaries(store, cwd)).toEqual([
+      {
+        id: 'session_two',
+        cwd,
+        updatedAt: '2026-05-05T00:02:00.000Z',
+        messageCount: 1,
+        preview: 'newer answer',
+      },
+      {
+        id: 'session_one',
+        name: 'first',
+        cwd,
+        updatedAt: '2026-05-05T00:01:00.000Z',
+        messageCount: 2,
+        preview: 'first answer with newline',
+      },
+    ]);
+
+    rmSync(cwd, { recursive: true, force: true });
+  });
+});

--- a/packages/agent-sdk/src/interactive/index.ts
+++ b/packages/agent-sdk/src/interactive/index.ts
@@ -1,8 +1,19 @@
 export { InteractiveSession } from './interactive-session.js';
+export {
+  createProjectSessionStore,
+  listResumableSessionSummaries,
+  resolveLatestSessionId,
+  resolveSessionIdByIdOrName,
+} from './session-persistence.js';
 export type {
   IInteractiveSessionOptions,
   IInteractiveSessionShutdownOptions,
 } from './interactive-session.js';
+export type {
+  IInteractiveSessionRecord,
+  IInteractiveSessionStore,
+  IResumableSessionSummary,
+} from './session-persistence.js';
 export type {
   IToolState,
   IDiffLine,

--- a/packages/agent-sdk/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-execution.ts
@@ -8,9 +8,9 @@ import { randomUUID } from 'node:crypto';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
 import { collectAssistantUsageMetadata } from '@robota-sdk/agent-core';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { IExecutionResult, IToolSummary, IUsageSnapshot } from './types.js';
+import type { IInteractiveSessionStore } from './session-persistence.js';
 import type {
   IBackgroundJobGroupState,
   IBackgroundTaskState,
@@ -146,7 +146,7 @@ function extractTurnUsage(
  * Silently ignores errors (persist failure must not break execution).
  */
 export function persistSession(
-  sessionStore: SessionStore,
+  sessionStore: IInteractiveSessionStore,
   session: Session,
   sessionName: string | undefined,
   cwd: string,

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -10,11 +10,11 @@ import type { ICreateSessionOptions } from '../assembly/index.js';
 import { FileSessionLogger } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { ICompactEvent } from '@robota-sdk/agent-sessions';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { IContextWindowState } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
+import type { TUniversalMessage } from '@robota-sdk/agent-core';
 import type {
   IBackgroundJobGroupState,
   IBackgroundTaskRunner,
@@ -37,6 +37,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { TInteractivePermissionHandler } from './types.js';
 import { NOOP_TERMINAL } from './interactive-session-execution.js';
+import type { IInteractiveSessionStore } from './session-persistence.js';
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
 import type { IEditCheckpointRecorder } from '../checkpoints/edit-checkpoint-types.js';
 import type { IReversibleExecutionOptions } from '../reversible-execution/index.js';
@@ -48,7 +49,7 @@ export interface IInteractiveSessionStandardOptions {
   permissionMode?: ICreateSessionOptions['permissionMode'];
   maxTurns?: number;
   permissionHandler?: TInteractivePermissionHandler;
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   sessionName?: string;
   resumeSessionId?: string;
   forkSession?: boolean;
@@ -86,7 +87,7 @@ export interface IInteractiveSessionInjectedOptions {
   permissionMode?: ICreateSessionOptions['permissionMode'];
   maxTurns?: number;
   permissionHandler?: TInteractivePermissionHandler;
-  sessionStore?: SessionStore;
+  sessionStore?: IInteractiveSessionStore;
   sessionName?: string;
   resumeSessionId?: string;
   forkSession?: boolean;
@@ -232,17 +233,15 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
 }
 
 /** Inject a saved message into a session, supporting all roles including 'tool'. */
-export function injectSavedMessage(session: Session, msg: unknown): void {
-  if (!msg || typeof msg !== 'object') return;
-  const m = msg as Record<string, unknown>;
-  if (!m.role || !m.content) return;
-  const role = m.role as string;
-  if (role === 'tool') {
-    const toolCallId = (m.toolCallId as string) ?? '';
-    const name = (m.name as string) ?? undefined;
-    session.injectMessage('tool', m.content as string, { toolCallId, name });
-  } else if (role === 'user' || role === 'assistant' || role === 'system') {
-    session.injectMessage(role, m.content as string);
+export function injectSavedMessage(session: Session, msg: TUniversalMessage): void {
+  if (typeof msg.content !== 'string') return;
+  if (msg.role === 'tool') {
+    session.injectMessage('tool', msg.content, {
+      toolCallId: msg.toolCallId,
+      ...(msg.name !== undefined ? { name: msg.name } : {}),
+    });
+  } else {
+    session.injectMessage(msg.role, msg.content);
   }
 }
 
@@ -251,14 +250,14 @@ export function injectSavedMessage(session: Session, msg: unknown): void {
  * Returns the loaded history and any pending messages that need injection once session is ready.
  */
 export function loadSessionRecord(
-  sessionStore: SessionStore,
+  sessionStore: IInteractiveSessionStore,
   resumeSessionId: string,
   forkSession: boolean,
   existingSession: Session | null,
 ): {
   history: IHistoryEntry[];
   sessionName: string | undefined;
-  pendingRestoreMessages: unknown[] | null;
+  pendingRestoreMessages: TUniversalMessage[] | null;
   backgroundTasks: IBackgroundTaskState[];
   backgroundTaskEvents: TBackgroundTaskEvent[];
   backgroundJobGroups: IBackgroundJobGroupState[];
@@ -281,21 +280,19 @@ export function loadSessionRecord(
     };
   }
 
-  const history = (record.history ?? []) as IHistoryEntry[];
-  const restoredBackgroundTasks = (record.backgroundTasks ?? []) as IBackgroundTaskState[];
-  const restoredBackgroundTaskEvents = (record.backgroundTaskEvents ??
-    []) as TBackgroundTaskEvent[];
-  const backgroundJobGroups = (record.backgroundJobGroups ?? []) as IBackgroundJobGroupState[];
-  const backgroundJobGroupEvents = (record.backgroundJobGroupEvents ??
-    []) as TBackgroundJobGroupEvent[];
-  const memoryEvents = (record.memoryEvents ?? []) as IMemoryEvent[];
-  const usedMemoryReferences = (record.usedMemoryReferences ?? []) as IMemoryReference[];
+  const history = record.history ?? [];
+  const restoredBackgroundTasks = record.backgroundTasks ?? [];
+  const restoredBackgroundTaskEvents = record.backgroundTaskEvents ?? [];
+  const backgroundJobGroups = record.backgroundJobGroups ?? [];
+  const backgroundJobGroupEvents = record.backgroundJobGroupEvents ?? [];
+  const memoryEvents = record.memoryEvents ?? [];
+  const usedMemoryReferences = record.usedMemoryReferences ?? [];
   const { backgroundTasks, backgroundTaskEvents } = reconcileRestoredBackgroundTasks(
     restoredBackgroundTasks,
     restoredBackgroundTaskEvents,
   );
   const sessionName = record.name;
-  let pendingRestoreMessages: unknown[] | null = null;
+  let pendingRestoreMessages: TUniversalMessage[] | null = null;
 
   if (!forkSession && record.messages) {
     if (existingSession) {

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -10,7 +10,6 @@
 
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { ICompactEvent } from '@robota-sdk/agent-sessions';
-import type { SessionStore } from '@robota-sdk/agent-sessions';
 import type {
   TUniversalMessage,
   IContextWindowState,
@@ -93,6 +92,7 @@ import type {
   IInteractiveSessionOptions,
   IInteractiveSessionStandardOptions,
 } from './interactive-session-init.js';
+import type { IInteractiveSessionStore } from './session-persistence.js';
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
 import { EditCheckpointStore } from '../checkpoints/edit-checkpoint-store.js';
 import type {
@@ -122,10 +122,10 @@ export class InteractiveSession {
   private pendingDisplayInput: string | undefined;
   private pendingRawInput: string | undefined;
   private history: IHistoryEntry[] = [];
-  private sessionStore?: SessionStore;
+  private sessionStore?: IInteractiveSessionStore;
   private sessionName?: string;
   private cwd?: string;
-  private pendingRestoreMessages: unknown[] | null = null;
+  private pendingRestoreMessages: TUniversalMessage[] | null = null;
   private backgroundTasks: IBackgroundTaskState[] = [];
   private backgroundTaskEvents: TBackgroundTaskEvent[] = [];
   private backgroundJobGroups: IBackgroundJobGroupState[] = [];

--- a/packages/agent-sdk/src/interactive/session-persistence.ts
+++ b/packages/agent-sdk/src/interactive/session-persistence.ts
@@ -1,0 +1,152 @@
+import type { IHistoryEntry, IToolSchema, TUniversalMessage } from '@robota-sdk/agent-core';
+import { SessionStore, type ISessionRecord } from '@robota-sdk/agent-sessions';
+import type {
+  IBackgroundJobGroupState,
+  IBackgroundTaskState,
+  TBackgroundJobGroupEvent,
+  TBackgroundTaskEvent,
+} from '../background-tasks/index.js';
+import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
+import { projectPaths } from '../paths.js';
+
+export interface IInteractiveSessionRecord {
+  id: string;
+  name?: string;
+  cwd: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: TUniversalMessage[];
+  history?: IHistoryEntry[];
+  systemPrompt?: string;
+  toolSchemas?: IToolSchema[];
+  backgroundTasks?: IBackgroundTaskState[];
+  backgroundTaskEvents?: TBackgroundTaskEvent[];
+  backgroundJobGroups?: IBackgroundJobGroupState[];
+  backgroundJobGroupEvents?: TBackgroundJobGroupEvent[];
+  memoryEvents?: IMemoryEvent[];
+  usedMemoryReferences?: IMemoryReference[];
+}
+
+export interface IInteractiveSessionStore {
+  save(session: IInteractiveSessionRecord): void;
+  load(id: string): IInteractiveSessionRecord | undefined;
+  list(): IInteractiveSessionRecord[];
+  delete(id: string): void;
+}
+
+export interface IResumableSessionSummary {
+  id: string;
+  name?: string;
+  cwd: string;
+  updatedAt: string;
+  messageCount: number;
+  preview: string;
+}
+
+export function createProjectSessionStore(cwd: string): IInteractiveSessionStore {
+  return new ProjectSessionStoreFacade(projectPaths(cwd).sessions);
+}
+
+export function listResumableSessionSummaries(
+  sessionStore: IInteractiveSessionStore | undefined,
+  cwd: string,
+): IResumableSessionSummary[] {
+  return (sessionStore?.list() ?? [])
+    .filter((session) => session.cwd === cwd)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .map((session) => ({
+      id: session.id,
+      ...(session.name !== undefined ? { name: session.name } : {}),
+      cwd: session.cwd,
+      updatedAt: session.updatedAt,
+      messageCount: session.messages.length,
+      preview: getLastAssistantPreview(session.messages),
+    }));
+}
+
+export function resolveLatestSessionId(
+  sessionStore: IInteractiveSessionStore | undefined,
+  cwd: string,
+): string | undefined {
+  return listResumableSessionSummaries(sessionStore, cwd)[0]?.id;
+}
+
+export function resolveSessionIdByIdOrName(
+  sessionStore: IInteractiveSessionStore | undefined,
+  idOrName: string,
+): string | undefined {
+  const match = (sessionStore?.list() ?? []).find(
+    (session) => session.id === idOrName || session.name === idOrName,
+  );
+  return match?.id;
+}
+
+class ProjectSessionStoreFacade implements IInteractiveSessionStore {
+  private readonly store: SessionStore;
+
+  constructor(baseDir: string) {
+    this.store = new SessionStore(baseDir);
+  }
+
+  save(session: IInteractiveSessionRecord): void {
+    this.store.save(toSessionRecord(session));
+  }
+
+  load(id: string): IInteractiveSessionRecord | undefined {
+    const session = this.store.load(id);
+    return session === undefined ? undefined : fromSessionRecord(session);
+  }
+
+  list(): IInteractiveSessionRecord[] {
+    return this.store.list().map(fromSessionRecord);
+  }
+
+  delete(id: string): void {
+    this.store.delete(id);
+  }
+}
+
+function getLastAssistantPreview(messages: readonly TUniversalMessage[]): string {
+  for (const message of [...messages].reverse()) {
+    if (message.role !== 'assistant') continue;
+    if (typeof message.content !== 'string') continue;
+    return message.content.replace(/[\n\r]+/g, ' ').trim();
+  }
+  return '';
+}
+
+function toSessionRecord(session: IInteractiveSessionRecord): ISessionRecord {
+  return { ...session };
+}
+
+function fromSessionRecord(session: ISessionRecord): IInteractiveSessionRecord {
+  return {
+    id: session.id,
+    ...(session.name !== undefined ? { name: session.name } : {}),
+    cwd: session.cwd,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    messages: session.messages as TUniversalMessage[],
+    ...(session.history !== undefined ? { history: session.history as IHistoryEntry[] } : {}),
+    ...(session.systemPrompt !== undefined ? { systemPrompt: session.systemPrompt } : {}),
+    ...(session.toolSchemas !== undefined ? { toolSchemas: session.toolSchemas } : {}),
+    ...(session.backgroundTasks !== undefined
+      ? { backgroundTasks: session.backgroundTasks as IBackgroundTaskState[] }
+      : {}),
+    ...(session.backgroundTaskEvents !== undefined
+      ? { backgroundTaskEvents: session.backgroundTaskEvents as TBackgroundTaskEvent[] }
+      : {}),
+    ...(session.backgroundJobGroups !== undefined
+      ? { backgroundJobGroups: session.backgroundJobGroups as IBackgroundJobGroupState[] }
+      : {}),
+    ...(session.backgroundJobGroupEvents !== undefined
+      ? { backgroundJobGroupEvents: session.backgroundJobGroupEvents as TBackgroundJobGroupEvent[] }
+      : {}),
+    ...(session.memoryEvents !== undefined
+      ? { memoryEvents: session.memoryEvents as IMemoryEvent[] }
+      : {}),
+    ...(session.usedMemoryReferences !== undefined
+      ? { usedMemoryReferences: session.usedMemoryReferences as IMemoryReference[] }
+      : {}),
+  };
+}

--- a/packages/agent-sessions/README.md
+++ b/packages/agent-sessions/README.md
@@ -48,22 +48,22 @@ await session.compact('Focus on the API changes');
 
 ## Key Methods
 
-| Method                                            | Description                                              |
-| ------------------------------------------------- | -------------------------------------------------------- |
-| `constructor(options)` (with `sessionId`)         | Accepts optional `sessionId` for deterministic IDs       |
-| `run(message)`                                    | Send a message, returns AI response                      |
-| `injectMessage(message)`                          | Inject a message into history without running the agent  |
-| `compact(instructions?)`                          | Compress conversation via LLM summary                    |
+| Method                                            | Description                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------ |
+| `constructor(options)` (with `sessionId`)         | Accepts optional `sessionId` for deterministic IDs                 |
+| `run(message)`                                    | Send a message, returns AI response                                |
+| `injectMessage(message)`                          | Inject a message into history without running the agent            |
+| `compact(instructions?)`                          | Compress conversation via LLM summary                              |
 | `getContextState()`                               | Effective token usage: `{ usedTokens, maxTokens, usedPercentage }` |
-| `getAutoCompactThreshold()`                       | Auto-compact threshold fraction, or `false` if disabled  |
-| `getPermissionMode()` / `setPermissionMode(mode)` | Read/change permission mode                              |
-| `getHistory()` / `clearHistory()`                 | Access or clear conversation history                     |
-| `abort()`                                         | Cancel running execution                                 |
-| `isRunning()`                                     | Returns true if a `run()` call is in progress            |
-| `getSessionId()`                                  | Returns the stable session identifier                    |
-| `getMessageCount()`                               | Returns the number of completed `run()` calls            |
-| `getSessionAllowedTools()`                        | Tools approved for this session                          |
-| `clearSessionAllowedTools()`                      | Clears all session-scoped allow rules                    |
+| `getAutoCompactThreshold()`                       | Auto-compact threshold fraction, or `false` if disabled            |
+| `getPermissionMode()` / `setPermissionMode(mode)` | Read/change permission mode                                        |
+| `getHistory()` / `clearHistory()`                 | Access or clear conversation history                               |
+| `abort()`                                         | Cancel running execution                                           |
+| `isRunning()`                                     | Returns true if a `run()` call is in progress                      |
+| `getSessionId()`                                  | Returns the stable session identifier                              |
+| `getMessageCount()`                               | Returns the number of completed `run()` calls                      |
+| `getSessionAllowedTools()`                        | Tools approved for this session                                    |
+| `clearSessionAllowedTools()`                      | Clears all session-scoped allow rules                              |
 
 ## Public API Surface
 
@@ -85,6 +85,7 @@ await session.compact('Focus on the API changes');
 | `ISessionLogger`         | Interface | Pluggable session event logger interface                     |
 | `TSessionLogData`        | Type      | Structured log event data                                    |
 | `ISessionRecord`         | Interface | Persisted session record shape (includes `history` field)    |
+| `ISessionStore`          | Interface | Minimal persistence port implemented by `SessionStore`       |
 | `IContextWindowState`    | Type      | Context window usage state (re-exported from agent-core)     |
 
 Note: `IPermissionEnforcerOptions` is an internal type and is not exported from the public API.

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -97,6 +97,7 @@ Types consumed from other packages (not owned here):
 | `ISessionLogger`                 | Interface            | Pluggable session event logger interface                                                                       |
 | `TSessionLogData`                | Type                 | Structured log event data                                                                                      |
 | `ISessionRecord`                 | Interface            | Persisted session record shape                                                                                 |
+| `ISessionStore`                  | Interface            | Minimal persistence port consumed by `Session`; implemented by `SessionStore`                                  |
 | `IContextWindowState`            | Type                 | Context window usage state (re-exported from agent-core)                                                       |
 
 ### Session Constructor — sessionId Parameter
@@ -126,7 +127,7 @@ Types consumed from other packages (not owned here):
 | `getHistory`               | `() => TUniversalMessage[]`                                          | Returns the current conversation history as `TUniversalMessage[]` (chat entries only). Unchanged.                                       |
 | `getFullHistory`           | `() => IHistoryEntry[]`                                              | Returns the full history as `IHistoryEntry[]`, including both chat messages and event entries (e.g., tool summaries).                   |
 | `addHistoryEntry`          | `(entry: IHistoryEntry) => void`                                     | Appends a pre-built `IHistoryEntry` (e.g., a tool-summary event entry) to the session history via `ConversationStore.addEntry()`.       |
-| `getContextState`          | `() => IContextWindowState`                                          | Returns real-time effective context window usage (tokens, percentage) from the shared agent-core estimator.                              |
+| `getContextState`          | `() => IContextWindowState`                                          | Returns real-time effective context window usage (tokens, percentage) from the shared agent-core estimator.                             |
 | `getAutoCompactThreshold`  | `() => TAutoCompactThreshold`                                        | Returns the configured automatic compaction threshold, or `false` when disabled.                                                        |
 | `setAutoCompactThreshold`  | `(threshold: TAutoCompactThreshold) => void`                         | Updates the automatic compaction threshold for subsequent `run()` calls.                                                                |
 | `compact`                  | `(instructions?: string) => Promise<void>`                           | Compresses conversation via LLM summary. System message is preserved across compaction (see below). Fires PreCompact/PostCompact hooks. |

--- a/packages/agent-sessions/src/index.ts
+++ b/packages/agent-sessions/src/index.ts
@@ -28,4 +28,4 @@ export type { ISessionLogger, TSessionLogData } from './session-logger.js';
 
 // Session persistence
 export { SessionStore } from './session-store.js';
-export type { ISessionRecord } from './session-store.js';
+export type { ISessionRecord, ISessionStore } from './session-store.js';

--- a/packages/agent-sessions/src/session-history-ops.ts
+++ b/packages/agent-sessions/src/session-history-ops.ts
@@ -13,7 +13,7 @@ import type {
   IHookTypeExecutor,
 } from '@robota-sdk/agent-core';
 import type { Robota } from '@robota-sdk/agent-core';
-import type { SessionStore, ISessionRecord } from './session-store.js';
+import type { ISessionRecord, ISessionStore } from './session-store.js';
 import type { CompactionOrchestrator } from './compaction-orchestrator.js';
 import type { ContextWindowTracker } from './context-window-tracker.js';
 import type { TSessionLogData } from './session-logger.js';
@@ -105,7 +105,7 @@ export interface IPersistContext {
   cwd: string;
   systemPrompt: string;
   toolSchemas: IToolSchema[];
-  sessionStore: SessionStore;
+  sessionStore: ISessionStore;
   robota: Robota;
   getFullHistory: () => Array<{
     id: string;

--- a/packages/agent-sessions/src/session-store.ts
+++ b/packages/agent-sessions/src/session-store.ts
@@ -44,6 +44,14 @@ export interface ISessionRecord {
   usedMemoryReferences?: unknown[];
 }
 
+/** Minimal persistence port consumed by Session. */
+export interface ISessionStore {
+  save(session: ISessionRecord): void;
+  load(id: string): ISessionRecord | undefined;
+  list(): ISessionRecord[];
+  delete(id: string): void;
+}
+
 /**
  * Return the current user home directory.
  * Reads process.env.HOME at call time so tests can override it.
@@ -57,7 +65,7 @@ function getHomeDir(): string {
  *
  * Construct with a custom `baseDir` to redirect storage (useful in tests).
  */
-export class SessionStore {
+export class SessionStore implements ISessionStore {
   private readonly baseDir: string;
 
   constructor(baseDir?: string) {

--- a/packages/agent-sessions/src/session-types.ts
+++ b/packages/agent-sessions/src/session-types.ts
@@ -11,7 +11,7 @@ import type {
   TToolArgs,
 } from '@robota-sdk/agent-core';
 import type { IHookTypeExecutor } from '@robota-sdk/agent-core';
-import type { SessionStore } from './session-store.js';
+import type { ISessionStore } from './session-store.js';
 import type { ISessionLogger } from './session-logger.js';
 import type { TAutoCompactThreshold } from './context-window-tracker.js';
 import type {
@@ -60,7 +60,7 @@ export interface ISessionOptions {
   /** Maximum number of agentic turns per run() call. Undefined = unlimited. */
   maxTurns?: number;
   /** Optional session store for persistence */
-  sessionStore?: SessionStore;
+  sessionStore?: ISessionStore;
   /** Override session ID (used when resuming a session to reuse the original ID) */
   sessionId?: string;
   /** Custom permission handler (overrides terminal-based prompts, used by Ink UI) */

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -17,7 +17,7 @@ import type {
   TPermissionMode,
   IHookTypeExecutor,
 } from '@robota-sdk/agent-core';
-import type { SessionStore } from './session-store.js';
+import type { ISessionStore } from './session-store.js';
 import type { ISessionLogger, TSessionLogData } from './session-logger.js';
 import { PermissionEnforcer } from './permission-enforcer.js';
 import type {
@@ -68,7 +68,7 @@ export class Session {
   private readonly sessionId: string;
   private permissionMode: TPermissionMode;
   private readonly terminal: ITerminalOutput;
-  private readonly sessionStore?: SessionStore;
+  private readonly sessionStore?: ISessionStore;
   private readonly cwd: string;
   private readonly aiProvider: IAIProvider;
   private readonly systemMessage: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,9 +624,6 @@ importers:
       '@robota-sdk/agent-sdk':
         specifier: workspace:*
         version: link:../agent-sdk
-      '@robota-sdk/agent-sessions':
-        specifier: workspace:3.0.0-beta.60
-        version: link:../agent-sessions
       '@robota-sdk/agent-transport-headless':
         specifier: workspace:*
         version: link:../agent-transport-headless

--- a/scripts/harness/__tests__/check-command-layering.test.mjs
+++ b/scripts/harness/__tests__/check-command-layering.test.mjs
@@ -104,4 +104,42 @@ describe('findCommandLayeringFindings', () => {
       },
     ]);
   });
+
+  it('flags direct CLI imports from agent-sessions', async () => {
+    const root = await createFixture({
+      'packages/agent-cli/src/cli.ts':
+        'import { SessionStore } from "@robota-sdk/agent-sessions";\n',
+      'packages/agent-sdk/package.json': '{"dependencies":{}}',
+    });
+
+    const findings = await findCommandLayeringFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'packages/agent-cli/src/cli.ts',
+        type: 'cli-agent-sessions-import',
+        detail:
+          'agent-cli must not import @robota-sdk/agent-sessions; use SDK-owned session persistence APIs.',
+      },
+    ]);
+  });
+
+  it('flags direct CLI package dependencies on agent-sessions', async () => {
+    const root = await createFixture({
+      'packages/agent-cli/package.json':
+        '{"dependencies":{"@robota-sdk/agent-sessions":"workspace:*"}}',
+      'packages/agent-sdk/package.json': '{"dependencies":{}}',
+    });
+
+    const findings = await findCommandLayeringFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'packages/agent-cli/package.json',
+        type: 'cli-agent-sessions-dependency',
+        detail:
+          'agent-cli must not depend on @robota-sdk/agent-sessions; use @robota-sdk/agent-sdk facade APIs.',
+      },
+    ]);
+  });
 });

--- a/scripts/harness/check-command-layering.mjs
+++ b/scripts/harness/check-command-layering.mjs
@@ -50,6 +50,15 @@ const CLI_UI_FORBIDDEN_PATTERNS = [
   },
 ];
 
+const CLI_FORBIDDEN_PATTERNS = [
+  {
+    type: 'cli-agent-sessions-import',
+    pattern: /from\s+['"]@robota-sdk\/agent-sessions['"]/,
+    detail:
+      'agent-cli must not import @robota-sdk/agent-sessions; use SDK-owned session persistence APIs.',
+  },
+];
+
 const CLI_SLASH_ROUTER_FORBIDDEN_PATTERNS = [
   {
     type: 'cli-command-specific-router-branch',
@@ -162,6 +171,23 @@ function findSdkPackageDependencyFindings(packageJson) {
     }));
 }
 
+function findCliPackageDependencyFindings(packageJson) {
+  const dependencies = {
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+    ...(packageJson.peerDependencies ?? {}),
+    ...(packageJson.optionalDependencies ?? {}),
+  };
+
+  return Object.keys(dependencies)
+    .filter((name) => name === '@robota-sdk/agent-sessions')
+    .map((name) => ({
+      file: 'packages/agent-cli/package.json',
+      type: 'cli-agent-sessions-dependency',
+      detail: `agent-cli must not depend on ${name}; use @robota-sdk/agent-sdk facade APIs.`,
+    }));
+}
+
 export async function findCommandLayeringFindings(root = WORKSPACE_ROOT) {
   const findings = [];
 
@@ -179,6 +205,10 @@ export async function findCommandLayeringFindings(root = WORKSPACE_ROOT) {
     findings.push(
       ...findPatternFindings(file, await readText(root, file), CLI_UI_FORBIDDEN_PATTERNS),
     );
+  }
+
+  for (const file of await walkFiles(root, 'packages/agent-cli/src')) {
+    findings.push(...findPatternFindings(file, await readText(root, file), CLI_FORBIDDEN_PATTERNS));
   }
 
   const slashRouter = 'packages/agent-cli/src/ui/hooks/useSlashRouting.ts';
@@ -201,6 +231,15 @@ export async function findCommandLayeringFindings(root = WORKSPACE_ROOT) {
     findings.push(
       ...findSdkPackageDependencyFindings(
         JSON.parse(await fs.readFile(sdkPackageJsonPath, 'utf8')),
+      ),
+    );
+  }
+
+  const cliPackageJsonPath = path.join(root, 'packages/agent-cli/package.json');
+  if (await pathExists(cliPackageJsonPath)) {
+    findings.push(
+      ...findCliPackageDependencyFindings(
+        JSON.parse(await fs.readFile(cliPackageJsonPath, 'utf8')),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- move project session persistence construction and resume lookup behind SDK-owned facade APIs
- remove direct agent-cli dependency/import edge to @robota-sdk/agent-sessions
- add harness coverage for forbidden CLI -> agent-sessions imports and package dependencies
- update SPEC/README/content docs and ARCHITECTURE-MAP.md, and archive the completed backlog/task

## Verification
- pnpm install --frozen-lockfile
- pnpm docs:build
- pnpm harness:scan
- pnpm --filter @robota-sdk/agent-sessions build
- pnpm --filter @robota-sdk/agent-sessions test
- pnpm --filter @robota-sdk/agent-sessions typecheck
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-sdk test
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-cli typecheck
- pre-push scoped harness verification passed, including root pnpm build and affected package checks

Lint exits 0 with existing warnings only.