### PR TITLE
docs: define CLI architecture target plan

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,8 +11,11 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-- [CLI architecture map system refactor plan](cli-architecture-map-system-refactor-plan.md)
 - [CLI command effect state boundary](cli-command-effect-state-boundary.md)
+- [CLI command compatibility shims retirement](cli-command-compat-shims-retirement.md)
+- [CLI runtime adapter boundary audit](cli-runtime-adapter-boundary-audit.md)
+- [SDK public surface owner audit](sdk-public-surface-owner-audit.md)
+- [Provider model catalog refresh adapters](provider-model-catalog-refresh-adapters.md)
 - [TUI remove activity prefix from status bar](tui-remove-activity-label.md)
 - [CLI `@file` reference import](cli-at-file-reference-import.md)
 - [CLI `/context` reference inventory](cli-context-command-reference-list.md)

--- a/.agents/backlog/cli-command-compat-shims-retirement.md
+++ b/.agents/backlog/cli-command-compat-shims-retirement.md
@@ -1,0 +1,65 @@
+# CLI Command Compatibility Shims Retirement
+
+## Status
+
+Backlog.
+
+## Priority
+
+P1 - removes a misleading CLI command ownership surface before the beta API shape hardens.
+
+## Problem
+
+`packages/agent-cli/src/commands/` still contains compatibility shims that re-export SDK-owned
+command infrastructure:
+
+- `packages/agent-cli/src/commands/command-registry.ts`
+- `packages/agent-cli/src/commands/builtin-source.ts`
+- `packages/agent-cli/src/commands/skill-source.ts`
+- `packages/agent-cli/src/commands/types.ts`
+
+The CLI does not own `CommandRegistry`, `BuiltinCommandSource`, `SkillCommandSource`, or command
+contracts. Keeping these public-looking files makes it easy for new code to import command
+infrastructure from the wrong package and weakens the built-in command layer boundary.
+
+`packages/agent-cli/src/commands/skill-executor.ts` is different: it contains real skill execution
+logic for legacy CLI skill paths. It needs an owner decision instead of being treated as a simple
+re-export shim.
+
+## Recommended Direction
+
+Remove the compatibility re-export shims and update imports to use the owning package directly.
+
+Recommended sequence:
+
+1. Search for imports from `packages/agent-cli/src/commands/*` and
+   `@robota-sdk/agent-cli/dist/commands/*`.
+2. Update CLI internals and tests to import SDK-owned command infrastructure from
+   `@robota-sdk/agent-sdk`.
+3. Decide `skill-executor.ts` ownership:
+   - keep only terminal-host-specific glue in `agent-cli`; or
+   - move reusable skill prompt execution into the SDK command/skill API.
+4. Remove unused shim tests that only prove re-export behavior.
+5. Add a harness check if there is a stable import pattern to forbid.
+
+The beta is not required to preserve the CLI command shim surface.
+
+## Acceptance Criteria
+
+- [ ] No production code imports command infrastructure through `packages/agent-cli/src/commands/*`
+      or `@robota-sdk/agent-cli`.
+- [ ] `CommandRegistry`, `BuiltinCommandSource`, `SkillCommandSource`, and command contract types
+      are imported from `@robota-sdk/agent-sdk` or the owning package.
+- [ ] `skill-executor.ts` is either moved to an owning SDK command/skill API or explicitly kept as a
+      CLI-private host adapter with no public-looking compatibility barrel.
+- [ ] Re-export-only tests are deleted or replaced with owner-package tests.
+- [ ] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflects the final command ownership state.
+- [ ] A mechanical harness guard exists when the forbidden import pattern can be detected reliably.
+
+## Verification Plan
+
+- `rg -n "from ['\\\"](\\./commands|\\.\\./commands|@robota-sdk/agent-cli)" packages -g '!**/dist/**'`
+- `pnpm harness:scan:commands`
+- `pnpm --filter @robota-sdk/agent-cli test`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli build`

--- a/.agents/backlog/cli-runtime-adapter-boundary-audit.md
+++ b/.agents/backlog/cli-runtime-adapter-boundary-audit.md
@@ -1,0 +1,68 @@
+# CLI Runtime Adapter Boundary Audit
+
+## Status
+
+Backlog.
+
+## Priority
+
+P1 - keeps reusable background, subagent, and worktree behavior out of the thin TUI layer.
+
+## Problem
+
+`agent-cli` currently owns concrete local runtime adapters for background processes, child-process
+subagents, IPC, and Git worktree isolation:
+
+- `packages/agent-cli/src/background/managed-shell-process-runner.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-runner.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-transport.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-ipc.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-worker.ts`
+- `packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts`
+
+Concrete terminal process spawning can belong to the CLI shell. Reusable lifecycle rules, runner
+ports, worktree contracts, serializable provider profile handling, and child-process result
+semantics should belong to `agent-runtime` or SDK-owned ports so non-CLI hosts can use the same
+architecture without importing TUI code.
+
+## Recommended Direction
+
+Classify each local runtime file as one of:
+
+- **CLI adapter**: terminal-host-specific process spawning, executable resolution, Ink-facing
+  lifecycle handling, or local settings integration.
+- **SDK facade/port**: provider-neutral host contract needed by command modules or
+  `InteractiveSession`.
+- **Runtime primitive**: reusable background/subagent/worktree state, transitions, result envelope,
+  and runner interfaces.
+
+Then move reusable contracts/logic to the owning package and leave only concrete host adapters in
+`agent-cli`.
+
+Recommended first implementation:
+
+1. Add characterization tests around the current child-process subagent and worktree behavior.
+2. Move reusable type contracts into `agent-runtime` when they are pure lifecycle/worktree concepts.
+3. Expose only provider-neutral SDK facades needed by `InteractiveSession` and command modules.
+4. Keep Node child-process spawning and local executable path resolution in `agent-cli`.
+5. Update `ARCHITECTURE-MAP.md`, package specs, and harness dependency checks.
+
+## Acceptance Criteria
+
+- [ ] Every file under `packages/agent-cli/src/background` and `packages/agent-cli/src/subagents`
+      is classified as CLI adapter, SDK facade/port, or runtime primitive.
+- [ ] Reusable lifecycle/worktree contracts are owned outside `agent-cli`.
+- [ ] `agent-command-*` packages do not import `agent-cli` for runtime behavior.
+- [ ] Non-CLI hosts can depend on SDK/runtime contracts without pulling in React/Ink or CLI code.
+- [ ] Existing background/subagent/worktree behavior has regression coverage before extraction.
+- [ ] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` and affected package `SPEC.md` files reflect
+      the final ownership.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- subagent`
+- `pnpm --filter @robota-sdk/agent-cli test -- managed-shell`
+- `pnpm --filter @robota-sdk/agent-runtime test`
+- `pnpm --filter @robota-sdk/agent-sdk test`
+- `pnpm harness:scan:deps`
+- `pnpm harness:scan:commands`

--- a/.agents/backlog/completed/cli-architecture-map-system-refactor-plan.md
+++ b/.agents/backlog/completed/cli-architecture-map-system-refactor-plan.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Backlog.
+Completed.
+
+Completed: 2026-05-05
+
+Implementation branch: docs/cli-architecture-target-plan
 
 ## Priority
 
@@ -59,16 +63,16 @@ Recommended work sequence:
 
 ## Acceptance Criteria
 
-- [ ] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` is re-verified against current source and
+- [x] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` is re-verified against current source and
       package specs.
-- [ ] The audit explicitly evaluates actual architecture quality, not document organization.
-- [ ] All confirmed contradictions are recorded with source file references and owner package.
-- [ ] A target architecture is documented with allowed dependency edges and contract ownership.
-- [ ] Each recommended structural change is split into an actionable backlog item.
-- [ ] Recommendations distinguish immediate beta refactors from optional polish.
-- [ ] Any mechanically enforceable boundary has either a harness check or a follow-up backlog for
+- [x] The audit explicitly evaluates actual architecture quality, not document organization.
+- [x] All confirmed contradictions are recorded with source file references and owner package.
+- [x] A target architecture is documented with allowed dependency edges and contract ownership.
+- [x] Each recommended structural change is split into an actionable backlog item.
+- [x] Recommendations distinguish immediate beta refactors from optional polish.
+- [x] Any mechanically enforceable boundary has either a harness check or a follow-up backlog for
       adding one.
-- [ ] Repository rules or common-mistakes guidance are updated only for durable lessons that apply
+- [x] Repository rules or common-mistakes guidance are updated only for durable lessons that apply
       beyond this one package.
 
 ## Verification Plan
@@ -81,3 +85,19 @@ Recommended work sequence:
 
 If the audit leads to code changes, run the affected package build/test/typecheck commands for every
 changed package.
+
+## Result
+
+Completed via `docs/cli-architecture-target-plan`. `ARCHITECTURE-MAP.md` now separates the verified
+current CLI composition from the recommended target architecture, records source-backed structural
+debts, and links each confirmed refactor to a dedicated backlog item:
+
+- `.agents/backlog/cli-command-effect-state-boundary.md`
+- `.agents/backlog/cli-command-compat-shims-retirement.md`
+- `.agents/backlog/cli-runtime-adapter-boundary-audit.md`
+- `.agents/backlog/provider-model-catalog-refresh-adapters.md`
+- `.agents/backlog/sdk-public-surface-owner-audit.md`
+
+No repository rule change was needed in this task because architecture-map update requirements were
+already present in `.agents/rules/spec-workflow.md`, `.agents/rules/documentation-sync.md`, and
+`.agents/rules/common-mistakes.md`.

--- a/.agents/backlog/provider-model-catalog-refresh-adapters.md
+++ b/.agents/backlog/provider-model-catalog-refresh-adapters.md
@@ -1,0 +1,61 @@
+# Provider Model Catalog Refresh Adapters
+
+## Status
+
+Backlog.
+
+## Priority
+
+P2 - improves provider/model correctness for volatile provider catalogs without making the CLI own
+model lists.
+
+## Problem
+
+The active-provider model list now uses provider-owned fallback metadata through
+`IProviderDefinition.modelCatalog`, and `/model` no longer falls back to Claude-only choices for
+other providers. That solves the CLI beta state-drift path.
+
+The remaining architecture gap is volatility. Provider model IDs, context windows, lifecycle state,
+and capabilities can change outside this repository. The current fallback catalog contract includes
+status, source URL, and verification timestamps, but there is no provider-owned live/generated
+refresh adapter yet.
+
+The CLI/TUI must not solve this by hardcoding model lists or branching on provider names.
+
+## Recommended Direction
+
+Add a provider catalog adapter layer owned by provider packages and consumed through SDK
+provider/model common APIs.
+
+Recommended design:
+
+- Provider packages may expose an optional catalog refresh/probe function next to
+  `IProviderDefinition.modelCatalog`.
+- The SDK common API resolves catalog state in this order:
+  1. live provider API discovery when available and explicitly requested or cacheable;
+  2. generated/cache metadata refreshed by repository scripts;
+  3. built-in fallback catalog metadata already present on provider definitions;
+  4. `unavailable` state with a clear manual-input message.
+- Startup and `/model` must remain usable when refresh fails. The command result should surface
+  stale/unavailable state without blocking manual model input.
+- Static or generated entries must include source metadata and `lastVerifiedAt`.
+
+## Acceptance Criteria
+
+- [ ] Provider model catalog refresh is represented by a provider-owned public contract or SDK common
+      API extension, not a CLI constant.
+- [ ] At least one provider has a live or generated refresh adapter covered by tests.
+- [ ] `/model` exposes catalog freshness state when available.
+- [ ] Refresh failure does not block CLI startup or manual model input.
+- [ ] Fallback metadata remains source-stamped and provider-owned.
+- [ ] Package specs identify the owner of live discovery, generated metadata, fallback metadata, and
+      stale-data policy.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-core test`
+- `pnpm --filter @robota-sdk/agent-sdk test -- model`
+- `pnpm --filter @robota-sdk/agent-command-model test`
+- affected provider package tests
+- `pnpm harness:scan:commands`
+- `pnpm docs:build`

--- a/.agents/backlog/sdk-public-surface-owner-audit.md
+++ b/.agents/backlog/sdk-public-surface-owner-audit.md
@@ -1,0 +1,63 @@
+# SDK Public Surface Owner Audit
+
+## Status
+
+Backlog.
+
+## Priority
+
+P1 - hardens the beta SDK API before compatibility surfaces become accidental contracts.
+
+## Problem
+
+`packages/agent-sdk/src/index.ts` intentionally exposes `InteractiveSession`, command contracts,
+SDK common APIs, SDK facades, and SDK-specific safety layers. It also exposes selected symbols from
+lower-level owner packages for convenience or compatibility.
+
+Current files to audit:
+
+- `packages/agent-sdk/src/index.ts`
+- `packages/agent-sdk/src/types.ts`
+- `packages/agent-sdk/src/background-tasks/index.ts`
+- `packages/agent-sdk/src/subagents/index.ts`
+
+Some of these exports are legitimate SDK facades. Others may be pass-through surfaces that make
+consumers import through the SDK instead of the true owner package, which conflicts with the
+repository rule against hiding package ownership.
+
+## Recommended Direction
+
+Classify every SDK public export into one of:
+
+- **SDK-owned API**: implemented or semantically owned by `agent-sdk`.
+- **SDK facade**: intentionally narrows or adapts a lower-level package for SDK consumers.
+- **Compatibility re-export**: exposed only because earlier code imported it through the SDK.
+- **Wrong-owner export**: should be imported from the owning package directly.
+
+Recommended sequence:
+
+1. Generate an export inventory for `packages/agent-sdk/src/index.ts` and nested barrels.
+2. Compare each export against `packages/agent-sdk/docs/SPEC.md` and owner package specs.
+3. Remove wrong-owner exports in beta instead of preserving compatibility.
+4. Namespace or document intentional facades so ownership is visible.
+5. Add a harness check for broad `export *` pass-throughs and other high-signal owner drift.
+
+## Acceptance Criteria
+
+- [ ] SDK public exports are classified as SDK-owned API, SDK facade, compatibility re-export, or
+      wrong-owner export.
+- [ ] Wrong-owner exports are removed or moved behind an explicit SDK-owned facade.
+- [ ] `packages/agent-sdk/docs/SPEC.md` describes the resulting public surface ownership.
+- [ ] Consumers in this monorepo import lower-package contracts from their owner unless an SDK facade
+      is intentionally documented.
+- [ ] A mechanical check prevents broad pass-through export drift where feasible.
+- [ ] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflects the final SDK public surface boundary.
+
+## Verification Plan
+
+- `rg -n "export \\* from '@robota-sdk|export \\* from" packages/agent-sdk/src`
+- `pnpm --filter @robota-sdk/agent-sdk test`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-cli test`
+- `pnpm harness:scan:deps`
+- `pnpm docs:build`

--- a/.agents/tasks/completed/cli-architecture-map-system-refactor-plan.md
+++ b/.agents/tasks/completed/cli-architecture-map-system-refactor-plan.md
@@ -1,0 +1,58 @@
+# CLI Architecture Map System Refactor Plan
+
+- **Status**: completed
+- **Created**: 2026-05-05
+- **Branch**: docs/cli-architecture-target-plan
+- **Scope**: packages/agent-cli, packages/agent-sdk, packages/agent-command-\*, .agents/backlog
+
+## Objective
+
+Use `packages/agent-cli/docs/ARCHITECTURE-MAP.md` as a source-backed architecture audit input, then
+document the target CLI architecture and split confirmed structural work into actionable refactor
+backlogs.
+
+## Plan
+
+- [x] Verify current architecture map against source imports, manifests, and package specs.
+- [x] Identify architecture contradictions and owner-package mismatches.
+- [x] Document the recommended target architecture and migration direction in `ARCHITECTURE-MAP.md`.
+- [x] Create concrete follow-up backlogs for each structural refactor.
+- [x] Mark the original backlog completed and archive this task.
+- [x] Run documentation and harness verification.
+
+## Progress
+
+### 2026-05-05
+
+- Started from `develop` on branch `docs/cli-architecture-target-plan`.
+- Re-verified CLI/SDK/command/provider boundaries against package specs, manifests, and source
+  imports.
+- Updated `ARCHITECTURE-MAP.md` with target architecture, migration order, and source-backed audit
+  findings.
+- Split confirmed structural work into command effect, command shim, runtime adapter, provider
+  catalog refresh, and SDK public surface backlog items.
+- Archived the source backlog item under `.agents/backlog/completed/`.
+- Verified docs build and architecture/backlog harness scans.
+
+## Decisions
+
+- Treat this as an architecture audit and refactor planning task, not a documentation-format cleanup.
+- No new rule update is needed in this task; architecture-map sync is already covered by
+  `spec-workflow.md`, `documentation-sync.md`, and `common-mistakes.md`.
+
+## Blockers
+
+- None.
+
+## Test Plan
+
+- Run `pnpm docs:build` because the architecture map is copied into the docs site.
+- Run `pnpm harness:scan:commands`, `pnpm harness:scan:deps`, `pnpm harness:scan:specs`,
+  `pnpm harness:scan:test-plans`, and `pnpm harness:scan:consistency` because this task changes
+  architecture, backlog, and task-tracking documents.
+- Run `git diff --check` to catch whitespace and patch formatting issues.
+
+## Result
+
+Completed. The CLI architecture map now documents the recommended target architecture, identifies
+source-backed structural debts, and points each confirmed refactor to a dedicated backlog item.

--- a/packages/agent-cli/docs/ARCHITECTURE-MAP.md
+++ b/packages/agent-cli/docs/ARCHITECTURE-MAP.md
@@ -1,6 +1,7 @@
 # Agent CLI Architecture Map
 
-Source-verified against the `fix/cli-session-store-boundary` working tree on 2026-05-05.
+Source-verified against `develop` commit `5bc9244a3` and the
+`docs/cli-architecture-target-plan` working tree on 2026-05-05.
 
 This document is the LLM-scannable master map for how `@robota-sdk/agent-cli` is
 assembled. Package `SPEC.md` files remain the source of truth for ownership
@@ -14,8 +15,67 @@ findings that should be fixed in follow-up work.
 3. Use [Built-in Command Layer](#built-in-command-layer) before changing any slash command.
 4. Use [Provider and Model State Flow](#provider-and-model-state-flow) before changing setup,
    `/provider`, or `/model`.
-5. Use [Layering Audit](#layering-audit) before deciding whether a concern belongs in CLI, SDK,
+5. Use [Target Architecture](#target-architecture) before adding a new package edge, facade,
+   adapter, or command host contract.
+6. Use [Layering Audit](#layering-audit) before deciding whether a concern belongs in CLI, SDK,
    a command package, provider package, runtime, sessions, or core.
+
+## Target Architecture
+
+The CLI target is a thin product shell around SDK-hosted session orchestration and command
+contracts. `agent-cli` may compose product defaults and own terminal-specific adapters, but reusable
+runtime behavior, command behavior, provider semantics, and persistence contracts must be owned by
+the package whose public API describes that behavior.
+
+```text
+agent-cli
+  owns terminal input/rendering, CLI flags, provider definition composition,
+  product-default command module selection, and concrete local host adapters
+      |
+      v
+agent-sdk
+  owns InteractiveSession, command contracts/common APIs, provider-neutral facades,
+  host adapter ports, session orchestration, and SDK-specific safety layers
+      |
+      +--> agent-sessions   owns conversation run loop, persistence, compaction
+      +--> agent-runtime    owns reusable background/subagent lifecycle ports and state
+      +--> agent-tools      owns generic tools and tool schemas
+      +--> agent-core       owns provider, history, permission, hook, and model catalog contracts
+
+agent-command-*
+  owns user-visible command descriptors and execution; consumes SDK contracts as a third-party
+  command module would
+
+agent-provider-*
+  owns provider definitions, defaults, setup metadata, fallback model catalogs, probes, transport
+  translation, and provider-specific options
+```
+
+Target ownership rules:
+
+| Concern                                                      | Target owner                                  | CLI role                                                              |
+| ------------------------------------------------------------ | --------------------------------------------- | --------------------------------------------------------------------- |
+| Slash prefix detection, command autocomplete, prompt UI      | `agent-cli`                                   | Render and route generic command requests.                            |
+| Command descriptors, command execution, lifecycle effects    | `agent-command-*`                             | Select default modules and render returned interactions/effects.      |
+| Command contracts, result/effect types, host adapter ports   | `agent-sdk`                                   | Consume SDK contracts without defining parallel command shapes.       |
+| Provider settings/profile setup common APIs                  | `agent-sdk` + provider packages               | Provide concrete settings adapters and provider definitions.          |
+| Provider-specific defaults, probes, model fallback data      | `agent-provider-*` via `agent-core` contracts | Compose definitions, never branch on provider names in TUI hooks.     |
+| Session persistence facade                                   | `agent-sdk`                                   | Request project-local store and display SDK-owned summaries.          |
+| Reusable background/subagent state machines and ports        | `agent-runtime`                               | Supply local process/worktree adapters when they are terminal-hosted. |
+| Terminal process spawning, Ink rendering, local settings I/O | `agent-cli`                                   | Keep concrete I/O at the outer shell.                                 |
+| Core provider/history/permission/model contracts             | `agent-core`                                  | Import public contracts only.                                         |
+
+Target migration order:
+
+1. Remove implicit command effect transport through mutable `InteractiveSession` fields.
+2. Retire CLI command compatibility shims so consumers import command infrastructure from the SDK
+   owner directly.
+3. Audit local runtime adapters and move reusable lifecycle/process/worktree contracts behind
+   SDK/runtime-owned ports where they are not terminal-specific.
+4. Add provider model catalog live/generated refresh adapters on top of the existing provider-owned
+   fallback catalog contract.
+5. Audit the SDK public export surface so owned APIs and compatibility re-exports are explicit and
+   do not hide package ownership.
 
 ## Package Dependency Graph
 
@@ -220,8 +280,12 @@ Current model catalog state:
 
 - `/model` is supplied by `@robota-sdk/agent-command-model`.
 - The command consumes SDK model command common APIs.
-- On current `develop`, the model catalog is still Claude-oriented through the SDK/core Claude registry.
-- Provider-aware model catalog SSOT is already tracked by `tui-provider-model-state-drift.md` and should not be solved inside this map task.
+- Active-provider model choices resolve through `IProviderDefinition.modelCatalog` metadata owned by
+  provider packages and the SDK model command common API.
+- Provider definitions include conservative fallback catalog metadata with source URLs and
+  verification timestamps where the provider has known defaults.
+- Live/generated catalog refresh adapters are not implemented yet; that is a follow-up architecture
+  task, not a TUI concern.
 
 ## Execution Modes
 
@@ -292,40 +356,44 @@ this section must be updated in the same PR.
 
 ## Class and Interface Inventory
 
-| Item                            | Owner                                                   | Layer                      | Inbound consumers                        | Outbound dependencies                                              | Responsibility                                                                              |
-| ------------------------------- | ------------------------------------------------------- | -------------------------- | ---------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `startCli()`                    | `agent-cli/src/cli.ts`                                  | Product shell              | binary entrypoint, embedders             | SDK, command packages, providers, headless transport, settings I/O | Parse flags, compose providers/modules/adapters, choose interactive or print mode.          |
-| `renderApp()`                   | `agent-cli/src/ui/render.tsx`                           | UI shell                   | `startCli()`                             | React, Ink, `App`                                                  | Start Ink app and process exit handling.                                                    |
-| `App` / `AppInner`              | `agent-cli/src/ui/App.tsx`                              | UI shell                   | `renderApp()`                            | CLI hooks and components                                           | Compose TUI state, prompts, plugin UI, session picker, status bar.                          |
-| `useInteractiveSession()`       | `agent-cli/src/ui/hooks/useInteractiveSession.ts`       | React-SDK bridge           | `AppInner`                               | `InteractiveSession`, `CommandRegistry`, `TuiStateManager`         | Create the SDK session once and subscribe SDK events to render state.                       |
-| `useSlashRouting()`             | `agent-cli/src/ui/hooks/useSlashRouting.ts`             | UI command routing         | `useInteractiveSession()`                | `InteractiveSession`, `CommandRegistry`                            | Parse leading slash, call SDK command execution, route skill/plugin fallback.               |
-| `useSideEffects()`              | `agent-cli/src/ui/hooks/useSideEffects.ts`              | UI effect application      | `AppInner`                               | CLI settings/UI adapters, `InteractiveSession`                     | Render generic interactions and apply typed command effects.                                |
-| `TuiStateManager`               | `agent-cli/src/ui/tui-state-manager.ts`                 | UI state projection        | `useInteractiveSession()`                | agent-core history/context types                                   | Convert SDK events into stable render state.                                                |
-| `ICommandModule`                | `agent-sdk/src/command-api/command-module.ts`           | SDK command contract       | command packages, CLI, SDK executor      | agent-sdk command API                                              | Module boundary for command sources, system commands, descriptors, requirements.            |
-| `ICommandResult`                | `agent-sdk/src/command-api/command-result.ts`           | SDK command contract       | command packages, SDK, CLI               | command effects/interactions                                       | Structured command output consumed by generic hosts.                                        |
-| `TCommandEffect`                | `agent-sdk/src/command-api/effects.ts`                  | SDK command contract       | command packages, CLI effect handlers    | agent-core end reason types                                        | Typed host-side work requested by commands.                                                 |
-| `CommandRegistry`               | `agent-sdk/src/commands/command-registry.ts`            | SDK command infrastructure | CLI, tests                               | `ICommandSource`                                                   | Aggregate command palette entries from modules, skills, and plugins.                        |
-| `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`              | SDK command infrastructure | CLI, SDK tests                           | SDK command API                                                    | Expose SDK-default built-ins; currently empty.                                              |
-| `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`     | SDK command infrastructure | `InteractiveSession`                     | `ISystemCommand`                                                   | Execute matching system command with SDK host context.                                      |
-| `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`      | SDK entrypoint             | CLI, command tests, SDK consumers        | sessions, runtime, tools, core, command API                        | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.       |
-| `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`      | SDK facade                 | CLI, SDK consumers                       | agent-sessions, project paths                                      | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI. |
-| `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`      | SDK facade type            | CLI session picker, SDK consumers        | none                                                               | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.     |
-| `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts` | SDK assembly               | `InteractiveSession`                     | config/context, plugin hooks, `createSession()`                    | Load config/context/project data and construct `Session`.                                   |
-| `createSession()`               | `agent-sdk/src/assembly/create-session.ts`              | SDK assembly               | `createInteractiveSession()`, SDK tests  | sessions, tools, runtime, core                                     | Assemble provider, tools, system prompt, command tool, background/subagent runtime.         |
-| `Session`                       | `agent-sessions`                                        | Session runtime            | SDK assembly                             | agent-core                                                         | Run conversation lifecycle, permissions, compaction, context tracking.                      |
-| `SessionStore`                  | `agent-sessions`                                        | Session persistence        | SDK facade and generic session consumers | filesystem                                                         | Persist/resume session JSON behind `ISessionStore`. CLI must not consume it directly.       |
-| `IProviderDefinition`           | `agent-core`                                            | Core/provider contract     | provider packages, CLI, provider command | core provider config types                                         | Provider defaults, setup metadata, aliases, probes, factory.                                |
-| `createProviderFromSettings()`  | `agent-cli/src/utils/provider-factory.ts`               | CLI provider composition   | `startCli()`                             | provider definitions, settings I/O                                 | Resolve effective provider settings and instantiate provider.                               |
-| `createProviderCommandModule()` | `agent-command-provider`                                | Command package            | CLI composition                          | SDK command and provider common APIs                               | Own `/provider` metadata, setup interactions, settings patches, restart effects.            |
-| `createModelCommandModule()`    | `agent-command-model`                                   | Command package            | CLI composition                          | SDK model common API                                               | Own `/model` metadata and model-change effects.                                             |
-| `createAgentCommandModule()`    | `agent-command-agent`                                   | Command package            | CLI composition                          | SDK command/runtime APIs                                           | Own `/agent` metadata and background agent command execution.                               |
-| `createHeadlessTransport()`     | `agent-transport-headless`                              | Transport                  | CLI print mode                           | SDK transport contract                                             | Drive non-interactive prompt input and output formatting.                                   |
+| Item                            | Owner                                                       | Layer                      | Inbound consumers                           | Outbound dependencies                                              | Responsibility                                                                              |
+| ------------------------------- | ----------------------------------------------------------- | -------------------------- | ------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `startCli()`                    | `agent-cli/src/cli.ts`                                      | Product shell              | binary entrypoint, embedders                | SDK, command packages, providers, headless transport, settings I/O | Parse flags, compose providers/modules/adapters, choose interactive or print mode.          |
+| `renderApp()`                   | `agent-cli/src/ui/render.tsx`                               | UI shell                   | `startCli()`                                | React, Ink, `App`                                                  | Start Ink app and process exit handling.                                                    |
+| `App` / `AppInner`              | `agent-cli/src/ui/App.tsx`                                  | UI shell                   | `renderApp()`                               | CLI hooks and components                                           | Compose TUI state, prompts, plugin UI, session picker, status bar.                          |
+| `useInteractiveSession()`       | `agent-cli/src/ui/hooks/useInteractiveSession.ts`           | React-SDK bridge           | `AppInner`                                  | `InteractiveSession`, `CommandRegistry`, `TuiStateManager`         | Create the SDK session once and subscribe SDK events to render state.                       |
+| `useSlashRouting()`             | `agent-cli/src/ui/hooks/useSlashRouting.ts`                 | UI command routing         | `useInteractiveSession()`                   | `InteractiveSession`, `CommandRegistry`                            | Parse leading slash, call SDK command execution, route skill/plugin fallback.               |
+| `useSideEffects()`              | `agent-cli/src/ui/hooks/useSideEffects.ts`                  | UI effect application      | `AppInner`                                  | CLI settings/UI adapters, `InteractiveSession`                     | Render generic interactions and apply typed command effects.                                |
+| `TuiStateManager`               | `agent-cli/src/ui/tui-state-manager.ts`                     | UI state projection        | `useInteractiveSession()`                   | agent-core history/context types                                   | Convert SDK events into stable render state.                                                |
+| `ICommandModule`                | `agent-sdk/src/command-api/command-module.ts`               | SDK command contract       | command packages, CLI, SDK executor         | agent-sdk command API                                              | Module boundary for command sources, system commands, descriptors, requirements.            |
+| `ICommandResult`                | `agent-sdk/src/command-api/command-result.ts`               | SDK command contract       | command packages, SDK, CLI                  | command effects/interactions                                       | Structured command output consumed by generic hosts.                                        |
+| `TCommandEffect`                | `agent-sdk/src/command-api/effects.ts`                      | SDK command contract       | command packages, CLI effect handlers       | agent-core end reason types                                        | Typed host-side work requested by commands.                                                 |
+| `CommandRegistry`               | `agent-sdk/src/commands/command-registry.ts`                | SDK command infrastructure | CLI, tests                                  | `ICommandSource`                                                   | Aggregate command palette entries from modules, skills, and plugins.                        |
+| `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`                  | SDK command infrastructure | CLI, SDK tests                              | SDK command API                                                    | Expose SDK-default built-ins; currently empty.                                              |
+| `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`         | SDK command infrastructure | `InteractiveSession`                        | `ISystemCommand`                                                   | Execute matching system command with SDK host context.                                      |
+| `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`          | SDK entrypoint             | CLI, command tests, SDK consumers           | sessions, runtime, tools, core, command API                        | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.       |
+| `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade                 | CLI, SDK consumers                          | agent-sessions, project paths                                      | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI. |
+| `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade type            | CLI session picker, SDK consumers           | none                                                               | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.     |
+| `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts`     | SDK assembly               | `InteractiveSession`                        | config/context, plugin hooks, `createSession()`                    | Load config/context/project data and construct `Session`.                                   |
+| `createSession()`               | `agent-sdk/src/assembly/create-session.ts`                  | SDK assembly               | `createInteractiveSession()`, SDK tests     | sessions, tools, runtime, core                                     | Assemble provider, tools, system prompt, command tool, background/subagent runtime.         |
+| `Session`                       | `agent-sessions`                                            | Session runtime            | SDK assembly                                | agent-core                                                         | Run conversation lifecycle, permissions, compaction, context tracking.                      |
+| `SessionStore`                  | `agent-sessions`                                            | Session persistence        | SDK facade and generic session consumers    | filesystem                                                         | Persist/resume session JSON behind `ISessionStore`. CLI must not consume it directly.       |
+| `IProviderDefinition`           | `agent-core`                                                | Core/provider contract     | provider packages, CLI, provider command    | core provider config types                                         | Provider defaults, setup metadata, aliases, probes, factory.                                |
+| `createProviderFromSettings()`  | `agent-cli/src/utils/provider-factory.ts`                   | CLI provider composition   | `startCli()`                                | provider definitions, settings I/O                                 | Resolve effective provider settings and instantiate provider.                               |
+| `createProviderCommandModule()` | `agent-command-provider`                                    | Command package            | CLI composition                             | SDK command and provider common APIs                               | Own `/provider` metadata, setup interactions, settings patches, restart effects.            |
+| `createModelCommandModule()`    | `agent-command-model`                                       | Command package            | CLI composition                             | SDK model common API                                               | Own `/model` metadata and model-change effects.                                             |
+| `createAgentCommandModule()`    | `agent-command-agent`                                       | Command package            | CLI composition                             | SDK command/runtime APIs                                           | Own `/agent` metadata and background agent command execution.                               |
+| `executeSkill()`                | `agent-cli/src/commands/skill-executor.ts`                  | CLI compatibility helper   | `useSlashRouting()`, CLI tests              | SDK skill prompt utilities                                         | Process skill prompts for legacy CLI skill execution paths; target owner needs audit.       |
+| `ManagedShellProcessRunner`     | `agent-cli/src/background/managed-shell-process-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | Node child process APIs, SDK/runtime background ports              | Terminal-hosted background process runner implementation.                                   |
+| `ChildProcessSubagentRunner`    | `agent-cli/src/subagents/child-process-subagent-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | CLI IPC/transport/worker helpers, SDK subagent contracts           | Spawn isolated child-process subagent jobs for the CLI host.                                |
+| `GitWorktreeIsolationAdapter`   | `agent-cli/src/subagents/git-worktree-isolation-adapter.ts` | Local runtime adapter      | child-process subagent runner tests/runtime | Git CLI, filesystem                                                | Prepare and clean worktree isolation for local subagent execution.                          |
+| `createHeadlessTransport()`     | `agent-transport-headless`                                  | Transport                  | CLI print mode                              | SDK transport contract                                             | Drive non-interactive prompt input and output formatting.                                   |
 
 ## Layering Audit
 
 ### CLI-AUDIT-001: CLI imports `agent-sessions` directly
 
-Status: resolved in `fix/cli-session-store-boundary`.
+Status: resolved in PR #205.
 
 Former files:
 
@@ -381,19 +449,28 @@ Tracked follow-up:
 
 - `.agents/backlog/cli-command-effect-state-boundary.md`
 
-### CLI-AUDIT-003: Provider-aware model catalog is incomplete
+### CLI-AUDIT-003: Provider model catalog refresh layer is incomplete
 
-Status: already tracked.
+Status: confirmed design debt.
 
 Current state:
 
 - `/model` is a command module, which is the correct layer.
-- The model list remains Claude-oriented through the SDK/core Claude model registry.
-- Provider-specific model catalog SSOT and provider/model state consistency are tracked separately.
+- The command reads active-provider catalog metadata through SDK model common APIs.
+- Provider packages own fallback `IProviderDefinition.modelCatalog` data with source URLs and
+  verification timestamps.
+- The current contract models `live`, `generated`, `fallback`, and `unavailable` catalog states,
+  but there is no provider-owned live/generated refresh adapter yet.
+
+Problem:
+
+Static fallback catalog data is staleable by design. The CLI/TUI should not compensate for that by
+hardcoding model lists or provider branches. The missing work is a provider/SDK catalog adapter
+layer that can refresh, cache, and surface stale/unavailable status without blocking startup.
 
 Tracked follow-up:
 
-- `.agents/backlog/tui-provider-model-state-drift.md`
+- `.agents/backlog/provider-model-catalog-refresh-adapters.md`
 
 ### CLI-AUDIT-004: Legacy assembly architecture doc was stale
 
@@ -402,6 +479,94 @@ Status: resolved by this documentation change.
 `packages/agent-cli/docs/ASSEMBLY-ARCHITECTURE.md` described an older `createSession()`-centric CLI
 assembly path and direct `FileSessionLogger` setup that no longer matches current source. It now
 redirects to this master map so future readers do not treat stale architecture text as current.
+
+### CLI-AUDIT-005: CLI command compatibility shims blur command ownership
+
+Status: confirmed design debt.
+
+Current files:
+
+- `packages/agent-cli/src/commands/command-registry.ts`
+- `packages/agent-cli/src/commands/builtin-source.ts`
+- `packages/agent-cli/src/commands/skill-source.ts`
+- `packages/agent-cli/src/commands/types.ts`
+- `packages/agent-cli/src/commands/skill-executor.ts`
+
+Problem:
+
+Most files under `agent-cli/src/commands/` are compatibility re-export shims for SDK-owned command
+infrastructure. That keeps imports working but makes the CLI look like it owns command contracts it
+does not own. `skill-executor.ts` is the remaining non-trivial CLI skill execution helper and needs
+an ownership decision: keep it as a CLI-private host adapter, or move reusable skill execution into
+the SDK command/skill API.
+
+Recommended fix:
+
+Remove public CLI command compatibility imports and update internal imports/tests to the owning SDK
+or command package. Audit `skill-executor.ts` separately from the re-export shims and keep only
+terminal-host-specific behavior in `agent-cli`.
+
+Tracked follow-up:
+
+- `.agents/backlog/cli-command-compat-shims-retirement.md`
+
+### CLI-AUDIT-006: Local runtime adapters need an owner boundary audit
+
+Status: confirmed design debt.
+
+Current files:
+
+- `packages/agent-cli/src/background/managed-shell-process-runner.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-runner.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-transport.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-ipc.ts`
+- `packages/agent-cli/src/subagents/child-process-subagent-worker.ts`
+- `packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts`
+
+Problem:
+
+`agent-cli` is allowed to own concrete terminal-host adapters, but reusable background/subagent
+state, runner ports, worktree contracts, and process lifecycle semantics belong in `agent-runtime`
+or SDK-owned ports. The current local adapter set mixes concrete process spawning with behavior that
+may be reusable by non-CLI hosts.
+
+Recommended fix:
+
+Classify every local runtime file as either terminal-host adapter or reusable runtime contract.
+Move reusable contracts/logic behind SDK/runtime-owned public APIs and leave only concrete process
+I/O, executable resolution, and terminal lifecycle wiring in `agent-cli`.
+
+Tracked follow-up:
+
+- `.agents/backlog/cli-runtime-adapter-boundary-audit.md`
+
+### CLI-AUDIT-007: SDK public exports hide some package ownership
+
+Status: confirmed design debt.
+
+Current files:
+
+- `packages/agent-sdk/src/index.ts`
+- `packages/agent-sdk/src/types.ts`
+- `packages/agent-sdk/src/background-tasks/index.ts`
+- `packages/agent-sdk/src/subagents/index.ts`
+
+Problem:
+
+The SDK entrypoint intentionally exposes SDK-owned facades and command APIs, but it also re-exports
+selected lower-package symbols for compatibility and host convenience. Some exports are legitimate
+SDK facades; others may be pass-through surfaces that make consumers import through the SDK instead
+of the actual owner package.
+
+Recommended fix:
+
+Classify the SDK public surface into owned SDK APIs, explicit facades, and compatibility
+re-exports. Remove or namespace compatibility exports that hide owner packages, update specs, and
+add harness coverage for broad pass-through exports where feasible.
+
+Tracked follow-up:
+
+- `.agents/backlog/sdk-public-surface-owner-audit.md`
 
 ### No SDK-to-command-package edge found
 
@@ -438,3 +603,10 @@ Suggested mechanical checks from this audit:
 - Scan `packages/agent-sdk/src` for imports from `@robota-sdk/agent-command-*`.
 - Scan `packages/agent-command-*/src` for imports from `packages/agent-cli` or
   `@robota-sdk/agent-cli`.
+- Add a check for `_pendingCommandInteraction`, `_pendingCommandEffects`, or other CLI-owned
+  command effect state stored on `InteractiveSession` after the explicit effect boundary is
+  implemented.
+- Add a check for public imports from `@robota-sdk/agent-cli/src/commands/*` after the command
+  compatibility shims are retired.
+- Add a public-surface audit for SDK exports that are pure pass-throughs from lower-level owner
+  packages.


### PR DESCRIPTION
## Summary
- add a target architecture section to the CLI architecture map
- record source-backed CLI layering audit findings and migration order
- split confirmed structural work into dedicated backlog items and archive the completed audit backlog/task

## Verification
- pnpm docs:build
- pnpm harness:scan
- git diff --check
- pre-push: pnpm harness:verify -- --base-ref origin/develop --skip-record-check