### PR TITLE
fix(cli): isolate command effect state

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,7 +11,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-- [CLI command effect state boundary](cli-command-effect-state-boundary.md)
 - [CLI command compatibility shims retirement](cli-command-compat-shims-retirement.md)
 - [CLI runtime adapter boundary audit](cli-runtime-adapter-boundary-audit.md)
 - [SDK public surface owner audit](sdk-public-surface-owner-audit.md)

--- a/.agents/backlog/completed/cli-command-effect-state-boundary.md
+++ b/.agents/backlog/completed/cli-command-effect-state-boundary.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Backlog.
+Completed.
+
+Completed: 2026-05-05
+
+Implementation branch: fix/cli-command-effect-boundary
 
 ## Priority
 
@@ -43,13 +47,13 @@ Longer-term option:
 
 ## Acceptance Criteria
 
-- [ ] `InteractiveSession` is no longer cast to `InteractiveSession & ISideEffects` for command
+- [x] `InteractiveSession` is no longer cast to `InteractiveSession & ISideEffects` for command
       effect transport.
-- [ ] No `_pendingCommandInteraction` or `_pendingCommandEffects` fields are written to the SDK
+- [x] No `_pendingCommandInteraction` or `_pendingCommandEffects` fields are written to the SDK
       session instance.
-- [ ] Command interactions and effects remain generic and typed.
-- [ ] Existing slash routing and command effect tests are updated to assert the explicit boundary.
-- [ ] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflects the final state.
+- [x] Command interactions and effects remain generic and typed.
+- [x] Existing slash routing and command effect tests are updated to assert the explicit boundary.
+- [x] `packages/agent-cli/docs/ARCHITECTURE-MAP.md` reflects the final state.
 
 ## Verification Plan
 
@@ -57,3 +61,10 @@ Longer-term option:
 - `pnpm --filter @robota-sdk/agent-cli test -- slash-routing`
 - `pnpm --filter @robota-sdk/agent-cli test`
 - `pnpm --filter @robota-sdk/agent-cli typecheck`
+
+## Result
+
+Completed by adding `CommandEffectQueue` as the explicit CLI-owned boundary between slash routing
+and side-effect application. Command interactions and host effects are no longer stored on
+`InteractiveSession`, and command-layering harness coverage prevents the old `_pendingCommand*`
+pattern from returning.

--- a/.agents/tasks/completed/cli-command-effect-state-boundary.md
+++ b/.agents/tasks/completed/cli-command-effect-state-boundary.md
@@ -1,0 +1,61 @@
+# CLI Command Effect State Boundary
+
+- **Status**: completed
+- **Created**: 2026-05-05
+- **Branch**: fix/cli-command-effect-boundary
+- **Scope**: packages/agent-cli, packages/agent-sdk command result integration docs
+
+## Objective
+
+Remove implicit command interaction/effect transport through ad hoc fields on `InteractiveSession`.
+The CLI should keep command result state in a CLI-owned controller or React state while command
+packages continue returning typed SDK `ICommandResult` values.
+
+## Plan
+
+- [x] Characterize current slash routing effect behavior with tests.
+- [x] Introduce an explicit CLI-owned command effect boundary.
+- [x] Remove `_pendingCommandInteraction`, `_pendingCommandEffects`, and
+      `InteractiveSession & ISideEffects` casts.
+- [x] Update slash routing/effect tests for the explicit boundary.
+- [x] Update `ARCHITECTURE-MAP.md` and archive the backlog item.
+- [x] Run targeted CLI verification and harness scans.
+
+## Progress
+
+### 2026-05-05
+
+- Started from `develop` on branch `fix/cli-command-effect-boundary`.
+- Added a failing slash-routing test expectation for an explicit command effect queue.
+- Implemented `CommandEffectQueue` and wired it through `useInteractiveSession`, `useSlashRouting`,
+  `App`, and `useSideEffects`.
+- Removed command effect/interactions from the `ISideEffects` session mutation path.
+- Added command-layering harness coverage for the old `_pendingCommand*` session-state pattern.
+- Updated `ARCHITECTURE-MAP.md` and moved the backlog item to completed.
+- Verified CLI tests, CLI typecheck/build, docs build, command-layering scan, test-plan scan, and
+  harness regression tests.
+
+## Decisions
+
+- Follow the target architecture from `packages/agent-cli/docs/ARCHITECTURE-MAP.md`: command
+  result/effect state belongs to the CLI host boundary, not the SDK session instance.
+- Use a small FIFO queue rather than adding an SDK result channel because only the Ink host needs
+  this post-submit handoff today.
+
+## Blockers
+
+- None.
+
+## Test Plan
+
+- Run the existing slash routing tests first to confirm the current behavior and identify the
+  assertions that depend on `_pending*` session mutation.
+- Run targeted CLI tests after implementation, including `slash-routing-effects`.
+- Run `pnpm --filter @robota-sdk/agent-cli typecheck`, `pnpm --filter @robota-sdk/agent-cli build`,
+  and command-layer harness scans because this change touches CLI/SDK command boundaries.
+
+## Result
+
+Completed. Command results now pass from slash routing to side-effect application through an
+explicit CLI-owned queue, and the old session-mutation pattern is covered by the command-layering
+harness.

--- a/packages/agent-cli/docs/ARCHITECTURE-MAP.md
+++ b/packages/agent-cli/docs/ARCHITECTURE-MAP.md
@@ -176,6 +176,7 @@ packages/agent-cli/src/bin.ts
             |- useInteractiveSession()
             |  |- new InteractiveSession({ cwd, provider, commandModules, commandHostAdapters, ... })
             |  |- CommandRegistry
+            |  |- CommandEffectQueue
             |  |- createBuiltinCommandModule()
             |  |- register injected command modules
             |  |- SkillCommandSource
@@ -356,38 +357,39 @@ this section must be updated in the same PR.
 
 ## Class and Interface Inventory
 
-| Item                            | Owner                                                       | Layer                      | Inbound consumers                           | Outbound dependencies                                              | Responsibility                                                                              |
-| ------------------------------- | ----------------------------------------------------------- | -------------------------- | ------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `startCli()`                    | `agent-cli/src/cli.ts`                                      | Product shell              | binary entrypoint, embedders                | SDK, command packages, providers, headless transport, settings I/O | Parse flags, compose providers/modules/adapters, choose interactive or print mode.          |
-| `renderApp()`                   | `agent-cli/src/ui/render.tsx`                               | UI shell                   | `startCli()`                                | React, Ink, `App`                                                  | Start Ink app and process exit handling.                                                    |
-| `App` / `AppInner`              | `agent-cli/src/ui/App.tsx`                                  | UI shell                   | `renderApp()`                               | CLI hooks and components                                           | Compose TUI state, prompts, plugin UI, session picker, status bar.                          |
-| `useInteractiveSession()`       | `agent-cli/src/ui/hooks/useInteractiveSession.ts`           | React-SDK bridge           | `AppInner`                                  | `InteractiveSession`, `CommandRegistry`, `TuiStateManager`         | Create the SDK session once and subscribe SDK events to render state.                       |
-| `useSlashRouting()`             | `agent-cli/src/ui/hooks/useSlashRouting.ts`                 | UI command routing         | `useInteractiveSession()`                   | `InteractiveSession`, `CommandRegistry`                            | Parse leading slash, call SDK command execution, route skill/plugin fallback.               |
-| `useSideEffects()`              | `agent-cli/src/ui/hooks/useSideEffects.ts`                  | UI effect application      | `AppInner`                                  | CLI settings/UI adapters, `InteractiveSession`                     | Render generic interactions and apply typed command effects.                                |
-| `TuiStateManager`               | `agent-cli/src/ui/tui-state-manager.ts`                     | UI state projection        | `useInteractiveSession()`                   | agent-core history/context types                                   | Convert SDK events into stable render state.                                                |
-| `ICommandModule`                | `agent-sdk/src/command-api/command-module.ts`               | SDK command contract       | command packages, CLI, SDK executor         | agent-sdk command API                                              | Module boundary for command sources, system commands, descriptors, requirements.            |
-| `ICommandResult`                | `agent-sdk/src/command-api/command-result.ts`               | SDK command contract       | command packages, SDK, CLI                  | command effects/interactions                                       | Structured command output consumed by generic hosts.                                        |
-| `TCommandEffect`                | `agent-sdk/src/command-api/effects.ts`                      | SDK command contract       | command packages, CLI effect handlers       | agent-core end reason types                                        | Typed host-side work requested by commands.                                                 |
-| `CommandRegistry`               | `agent-sdk/src/commands/command-registry.ts`                | SDK command infrastructure | CLI, tests                                  | `ICommandSource`                                                   | Aggregate command palette entries from modules, skills, and plugins.                        |
-| `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`                  | SDK command infrastructure | CLI, SDK tests                              | SDK command API                                                    | Expose SDK-default built-ins; currently empty.                                              |
-| `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`         | SDK command infrastructure | `InteractiveSession`                        | `ISystemCommand`                                                   | Execute matching system command with SDK host context.                                      |
-| `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`          | SDK entrypoint             | CLI, command tests, SDK consumers           | sessions, runtime, tools, core, command API                        | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.       |
-| `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade                 | CLI, SDK consumers                          | agent-sessions, project paths                                      | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI. |
-| `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade type            | CLI session picker, SDK consumers           | none                                                               | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.     |
-| `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts`     | SDK assembly               | `InteractiveSession`                        | config/context, plugin hooks, `createSession()`                    | Load config/context/project data and construct `Session`.                                   |
-| `createSession()`               | `agent-sdk/src/assembly/create-session.ts`                  | SDK assembly               | `createInteractiveSession()`, SDK tests     | sessions, tools, runtime, core                                     | Assemble provider, tools, system prompt, command tool, background/subagent runtime.         |
-| `Session`                       | `agent-sessions`                                            | Session runtime            | SDK assembly                                | agent-core                                                         | Run conversation lifecycle, permissions, compaction, context tracking.                      |
-| `SessionStore`                  | `agent-sessions`                                            | Session persistence        | SDK facade and generic session consumers    | filesystem                                                         | Persist/resume session JSON behind `ISessionStore`. CLI must not consume it directly.       |
-| `IProviderDefinition`           | `agent-core`                                                | Core/provider contract     | provider packages, CLI, provider command    | core provider config types                                         | Provider defaults, setup metadata, aliases, probes, factory.                                |
-| `createProviderFromSettings()`  | `agent-cli/src/utils/provider-factory.ts`                   | CLI provider composition   | `startCli()`                                | provider definitions, settings I/O                                 | Resolve effective provider settings and instantiate provider.                               |
-| `createProviderCommandModule()` | `agent-command-provider`                                    | Command package            | CLI composition                             | SDK command and provider common APIs                               | Own `/provider` metadata, setup interactions, settings patches, restart effects.            |
-| `createModelCommandModule()`    | `agent-command-model`                                       | Command package            | CLI composition                             | SDK model common API                                               | Own `/model` metadata and model-change effects.                                             |
-| `createAgentCommandModule()`    | `agent-command-agent`                                       | Command package            | CLI composition                             | SDK command/runtime APIs                                           | Own `/agent` metadata and background agent command execution.                               |
-| `executeSkill()`                | `agent-cli/src/commands/skill-executor.ts`                  | CLI compatibility helper   | `useSlashRouting()`, CLI tests              | SDK skill prompt utilities                                         | Process skill prompts for legacy CLI skill execution paths; target owner needs audit.       |
-| `ManagedShellProcessRunner`     | `agent-cli/src/background/managed-shell-process-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | Node child process APIs, SDK/runtime background ports              | Terminal-hosted background process runner implementation.                                   |
-| `ChildProcessSubagentRunner`    | `agent-cli/src/subagents/child-process-subagent-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | CLI IPC/transport/worker helpers, SDK subagent contracts           | Spawn isolated child-process subagent jobs for the CLI host.                                |
-| `GitWorktreeIsolationAdapter`   | `agent-cli/src/subagents/git-worktree-isolation-adapter.ts` | Local runtime adapter      | child-process subagent runner tests/runtime | Git CLI, filesystem                                                | Prepare and clean worktree isolation for local subagent execution.                          |
-| `createHeadlessTransport()`     | `agent-transport-headless`                                  | Transport                  | CLI print mode                              | SDK transport contract                                             | Drive non-interactive prompt input and output formatting.                                   |
+| Item                            | Owner                                                       | Layer                      | Inbound consumers                           | Outbound dependencies                                                | Responsibility                                                                               |
+| ------------------------------- | ----------------------------------------------------------- | -------------------------- | ------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `startCli()`                    | `agent-cli/src/cli.ts`                                      | Product shell              | binary entrypoint, embedders                | SDK, command packages, providers, headless transport, settings I/O   | Parse flags, compose providers/modules/adapters, choose interactive or print mode.           |
+| `renderApp()`                   | `agent-cli/src/ui/render.tsx`                               | UI shell                   | `startCli()`                                | React, Ink, `App`                                                    | Start Ink app and process exit handling.                                                     |
+| `App` / `AppInner`              | `agent-cli/src/ui/App.tsx`                                  | UI shell                   | `renderApp()`                               | CLI hooks and components                                             | Compose TUI state, prompts, plugin UI, session picker, status bar.                           |
+| `useInteractiveSession()`       | `agent-cli/src/ui/hooks/useInteractiveSession.ts`           | React-SDK bridge           | `AppInner`                                  | `InteractiveSession`, `CommandRegistry`, `TuiStateManager`           | Create the SDK session once and subscribe SDK events to render state.                        |
+| `useSlashRouting()`             | `agent-cli/src/ui/hooks/useSlashRouting.ts`                 | UI command routing         | `useInteractiveSession()`                   | `InteractiveSession`, `CommandRegistry`                              | Parse leading slash, call SDK command execution, route skill/plugin fallback.                |
+| `useSideEffects()`              | `agent-cli/src/ui/hooks/useSideEffects.ts`                  | UI effect application      | `AppInner`                                  | CLI settings/UI adapters, `InteractiveSession`, `CommandEffectQueue` | Render generic interactions and apply typed command effects.                                 |
+| `CommandEffectQueue`            | `agent-cli/src/ui/hooks/command-effect-queue.ts`            | UI command result boundary | `useSlashRouting()`, `useSideEffects()`     | SDK command interaction/effect types                                 | Explicit CLI-owned queue for command interactions and host effects returned by SDK commands. |
+| `TuiStateManager`               | `agent-cli/src/ui/tui-state-manager.ts`                     | UI state projection        | `useInteractiveSession()`                   | agent-core history/context types                                     | Convert SDK events into stable render state.                                                 |
+| `ICommandModule`                | `agent-sdk/src/command-api/command-module.ts`               | SDK command contract       | command packages, CLI, SDK executor         | agent-sdk command API                                                | Module boundary for command sources, system commands, descriptors, requirements.             |
+| `ICommandResult`                | `agent-sdk/src/command-api/command-result.ts`               | SDK command contract       | command packages, SDK, CLI                  | command effects/interactions                                         | Structured command output consumed by generic hosts.                                         |
+| `TCommandEffect`                | `agent-sdk/src/command-api/effects.ts`                      | SDK command contract       | command packages, CLI effect handlers       | agent-core end reason types                                          | Typed host-side work requested by commands.                                                  |
+| `CommandRegistry`               | `agent-sdk/src/commands/command-registry.ts`                | SDK command infrastructure | CLI, tests                                  | `ICommandSource`                                                     | Aggregate command palette entries from modules, skills, and plugins.                         |
+| `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`                  | SDK command infrastructure | CLI, SDK tests                              | SDK command API                                                      | Expose SDK-default built-ins; currently empty.                                               |
+| `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`         | SDK command infrastructure | `InteractiveSession`                        | `ISystemCommand`                                                     | Execute matching system command with SDK host context.                                       |
+| `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`          | SDK entrypoint             | CLI, command tests, SDK consumers           | sessions, runtime, tools, core, command API                          | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.        |
+| `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade                 | CLI, SDK consumers                          | agent-sessions, project paths                                        | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI.  |
+| `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade type            | CLI session picker, SDK consumers           | none                                                                 | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.      |
+| `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts`     | SDK assembly               | `InteractiveSession`                        | config/context, plugin hooks, `createSession()`                      | Load config/context/project data and construct `Session`.                                    |
+| `createSession()`               | `agent-sdk/src/assembly/create-session.ts`                  | SDK assembly               | `createInteractiveSession()`, SDK tests     | sessions, tools, runtime, core                                       | Assemble provider, tools, system prompt, command tool, background/subagent runtime.          |
+| `Session`                       | `agent-sessions`                                            | Session runtime            | SDK assembly                                | agent-core                                                           | Run conversation lifecycle, permissions, compaction, context tracking.                       |
+| `SessionStore`                  | `agent-sessions`                                            | Session persistence        | SDK facade and generic session consumers    | filesystem                                                           | Persist/resume session JSON behind `ISessionStore`. CLI must not consume it directly.        |
+| `IProviderDefinition`           | `agent-core`                                                | Core/provider contract     | provider packages, CLI, provider command    | core provider config types                                           | Provider defaults, setup metadata, aliases, probes, factory.                                 |
+| `createProviderFromSettings()`  | `agent-cli/src/utils/provider-factory.ts`                   | CLI provider composition   | `startCli()`                                | provider definitions, settings I/O                                   | Resolve effective provider settings and instantiate provider.                                |
+| `createProviderCommandModule()` | `agent-command-provider`                                    | Command package            | CLI composition                             | SDK command and provider common APIs                                 | Own `/provider` metadata, setup interactions, settings patches, restart effects.             |
+| `createModelCommandModule()`    | `agent-command-model`                                       | Command package            | CLI composition                             | SDK model common API                                                 | Own `/model` metadata and model-change effects.                                              |
+| `createAgentCommandModule()`    | `agent-command-agent`                                       | Command package            | CLI composition                             | SDK command/runtime APIs                                             | Own `/agent` metadata and background agent command execution.                                |
+| `executeSkill()`                | `agent-cli/src/commands/skill-executor.ts`                  | CLI compatibility helper   | `useSlashRouting()`, CLI tests              | SDK skill prompt utilities                                           | Process skill prompts for legacy CLI skill execution paths; target owner needs audit.        |
+| `ManagedShellProcessRunner`     | `agent-cli/src/background/managed-shell-process-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | Node child process APIs, SDK/runtime background ports                | Terminal-hosted background process runner implementation.                                    |
+| `ChildProcessSubagentRunner`    | `agent-cli/src/subagents/child-process-subagent-runner.ts`  | Local runtime adapter      | `startCli()` runtime composition            | CLI IPC/transport/worker helpers, SDK subagent contracts             | Spawn isolated child-process subagent jobs for the CLI host.                                 |
+| `GitWorktreeIsolationAdapter`   | `agent-cli/src/subagents/git-worktree-isolation-adapter.ts` | Local runtime adapter      | child-process subagent runner tests/runtime | Git CLI, filesystem                                                  | Prepare and clean worktree isolation for local subagent execution.                           |
+| `createHeadlessTransport()`     | `agent-transport-headless`                                  | Transport                  | CLI print mode                              | SDK transport contract                                               | Drive non-interactive prompt input and output formatting.                                    |
 
 ## Layering Audit
 
@@ -422,9 +424,9 @@ Mechanical guard:
 - `scripts/harness/check-command-layering.mjs` flags production CLI imports from
   `@robota-sdk/agent-sessions` and direct CLI package dependencies on it.
 
-### CLI-AUDIT-002: TUI command effects are queued by mutating `InteractiveSession`
+### CLI-AUDIT-002: TUI command effects were queued by mutating `InteractiveSession`
 
-Status: confirmed design debt.
+Status: resolved in `fix/cli-command-effect-boundary`.
 
 Current files:
 
@@ -433,21 +435,24 @@ Current files:
 - `packages/agent-cli/src/ui/hooks/side-effects-types.ts`
 - `packages/agent-cli/src/ui/__tests__/slash-routing-effects.test.ts`
 
-Problem:
+Former problem:
 
 The TUI casts `InteractiveSession` to an `ISideEffects` intersection and stores fields such as
 `_pendingCommandInteraction` and `_pendingCommandEffects` on the SDK session object. This keeps the
 SDK type clean only at compile time and makes command-effect transport implicit.
 
-Recommended fix:
+Resolution:
 
-Introduce an explicit CLI-owned command effect queue or an SDK-owned typed result channel. The TUI
-should pass command results between hooks through owned React state or a small local controller
-instead of attaching ad hoc properties to `InteractiveSession`.
+`agent-cli/src/ui/hooks/command-effect-queue.ts` now owns an explicit `CommandEffectQueue`. Slash
+routing enqueues generic `ICommandInteraction` and pending `TCommandEffect[]` values into that
+queue, and `useSideEffects()` drains the queue after the base submit path. The SDK
+`InteractiveSession` instance is no longer used as the transport for command interactions or
+effects.
 
-Tracked follow-up:
+Mechanical guard:
 
-- `.agents/backlog/cli-command-effect-state-boundary.md`
+- `scripts/harness/check-command-layering.mjs` flags `_pendingCommandInteraction`,
+  `_pendingCommandEffects`, and `InteractiveSession & ISideEffects` usage in CLI/TUI source.
 
 ### CLI-AUDIT-003: Provider model catalog refresh layer is incomplete
 
@@ -603,9 +608,8 @@ Suggested mechanical checks from this audit:
 - Scan `packages/agent-sdk/src` for imports from `@robota-sdk/agent-command-*`.
 - Scan `packages/agent-command-*/src` for imports from `packages/agent-cli` or
   `@robota-sdk/agent-cli`.
-- Add a check for `_pendingCommandInteraction`, `_pendingCommandEffects`, or other CLI-owned
-  command effect state stored on `InteractiveSession` after the explicit effect boundary is
-  implemented.
+- Command effect state on `InteractiveSession` is now mechanically blocked by
+  `scripts/harness/check-command-layering.mjs`.
 - Add a check for public imports from `@robota-sdk/agent-cli/src/commands/*` after the command
   compatibility shims are retired.
 - Add a public-surface audit for SDK exports that are pure pass-throughs from lower-level owner

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -77,6 +77,7 @@ function AppInner(
   const {
     interactiveSession,
     registry,
+    commandEffectQueue,
     history,
     addEntry,
     streamingText,
@@ -132,6 +133,7 @@ function AppInner(
     cwd,
     providerOverride: props.providerOverride,
     interactiveSession,
+    commandEffectQueue,
     addEntry,
     baseHandleSubmit,
     setSessionName,

--- a/packages/agent-cli/src/ui/__tests__/PluginTUI.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/PluginTUI.test.tsx
@@ -163,5 +163,5 @@ describe('PluginTUI', () => {
     stdin.write('\r'); // User scope
     await new Promise((r) => setTimeout(r, 100));
     expect(cbs.install).toHaveBeenCalledWith('new-plugin@test-mp', 'user');
-  });
+  }, 15000);
 });

--- a/packages/agent-cli/src/ui/__tests__/slash-routing-effects.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/slash-routing-effects.test.ts
@@ -7,7 +7,7 @@ import { CommandRegistry } from '@robota-sdk/agent-sdk';
 import type { ICommandInteraction, InteractiveSession } from '@robota-sdk/agent-sdk';
 import { TuiStateManager } from '../tui-state-manager.js';
 import { applySystemCommandResult } from '../hooks/useSlashRouting.js';
-import type { ISideEffects } from '../hooks/side-effects-types.js';
+import { CommandEffectQueue } from '../hooks/command-effect-queue.js';
 
 describe('applySystemCommandResult', () => {
   afterEach(() => {
@@ -18,11 +18,16 @@ describe('applySystemCommandResult', () => {
     return new CommandRegistry();
   }
 
+  function legacyCommandField(suffix: 'Interaction' | 'Effects'): string {
+    return `_pendingCommand${suffix}`;
+  }
+
   it('stores statusline settings patch as a CLI side effect', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession & ISideEffects;
+    } as unknown as InteractiveSession;
     const manager = new TuiStateManager();
+    const queue = new CommandEffectQueue();
 
     applySystemCommandResult(
       {
@@ -33,18 +38,22 @@ describe('applySystemCommandResult', () => {
       session,
       createRegistry(),
       manager,
+      queue,
     );
 
-    expect(session._pendingCommandEffects).toEqual([
-      { type: 'statusline-settings-patch', patch: { enabled: false } },
-    ]);
+    expect(queue.drain()).toEqual({
+      type: 'effects',
+      effects: [{ type: 'statusline-settings-patch', patch: { enabled: false } }],
+    });
+    expect(Object.hasOwn(session, legacyCommandField('Effects'))).toBe(false);
   });
 
   it('stores generic command interactions without interpreting command-specific data', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession & ISideEffects;
+    } as unknown as InteractiveSession;
     const manager = new TuiStateManager();
+    const queue = new CommandEffectQueue();
     const interaction: ICommandInteraction = {
       prompt: {
         kind: 'choice',
@@ -66,16 +75,19 @@ describe('applySystemCommandResult', () => {
       session,
       createRegistry(),
       manager,
+      queue,
     );
 
-    expect(session._pendingCommandInteraction).toBe(interaction);
+    expect(queue.drain()).toEqual({ type: 'interaction', interaction });
+    expect(Object.hasOwn(session, legacyCommandField('Interaction'))).toBe(false);
   });
 
   it('stores host command side effects', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession & ISideEffects;
+    } as unknown as InteractiveSession;
     const manager = new TuiStateManager();
+    const queue = new CommandEffectQueue();
 
     applySystemCommandResult(
       {
@@ -86,16 +98,22 @@ describe('applySystemCommandResult', () => {
       session,
       createRegistry(),
       manager,
+      queue,
     );
 
-    expect(session._pendingCommandEffects).toEqual([{ type: 'plugin-tui-requested' }]);
+    expect(queue.drain()).toEqual({
+      type: 'effects',
+      effects: [{ type: 'plugin-tui-requested' }],
+    });
+    expect(Object.hasOwn(session, legacyCommandField('Effects'))).toBe(false);
   });
 
   it('applies conversation history clearing immediately before adding the command result', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession & ISideEffects;
+    } as unknown as InteractiveSession;
     const manager = new TuiStateManager();
+    const queue = new CommandEffectQueue();
     manager.addEntry({
       id: 'old',
       timestamp: new Date('2026-05-03T00:00:00.000Z'),
@@ -113,12 +131,14 @@ describe('applySystemCommandResult', () => {
       session,
       createRegistry(),
       manager,
+      queue,
     );
 
     expect(manager.history).toHaveLength(1);
     expect(manager.history[0]?.type).toBe('system');
     expect(manager.history[0]?.data).toMatchObject({ content: 'Conversation cleared.' });
-    expect(session._pendingCommandEffects).toBeUndefined();
+    expect(queue.drain()).toBeUndefined();
+    expect(Object.hasOwn(session, legacyCommandField('Effects'))).toBe(false);
   });
 
   it('reloads plugin command source immediately when requested', () => {
@@ -152,8 +172,9 @@ describe('applySystemCommandResult', () => {
     vi.stubEnv('HOME', home);
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession & ISideEffects;
+    } as unknown as InteractiveSession;
     const registry = createRegistry();
+    const queue = new CommandEffectQueue();
     registry.addSource({
       name: 'plugin',
       getCommands: () => [{ name: 'stale-skill', description: 'Stale', source: 'plugin' }],
@@ -169,9 +190,11 @@ describe('applySystemCommandResult', () => {
       session,
       registry,
       manager,
+      queue,
     );
 
     expect(registry.getCommands().map((command) => command.name)).toEqual(['fresh-skill']);
-    expect(session._pendingCommandEffects).toBeUndefined();
+    expect(queue.drain()).toBeUndefined();
+    expect(Object.hasOwn(session, legacyCommandField('Effects'))).toBe(false);
   });
 });

--- a/packages/agent-cli/src/ui/hooks/command-effect-queue.ts
+++ b/packages/agent-cli/src/ui/hooks/command-effect-queue.ts
@@ -1,0 +1,39 @@
+import type { ICommandInteraction, TCommandEffect } from '@robota-sdk/agent-sdk';
+
+export type TQueuedCommandState =
+  | {
+      type: 'interaction';
+      interaction: ICommandInteraction;
+    }
+  | {
+      type: 'effects';
+      effects: readonly TCommandEffect[];
+    };
+
+export interface ICommandEffectQueue {
+  enqueueInteraction(interaction: ICommandInteraction): void;
+  enqueueEffects(effects: readonly TCommandEffect[]): void;
+  drain(): TQueuedCommandState | undefined;
+  clear(): void;
+}
+
+export class CommandEffectQueue implements ICommandEffectQueue {
+  private readonly queue: TQueuedCommandState[] = [];
+
+  enqueueInteraction(interaction: ICommandInteraction): void {
+    this.queue.push({ type: 'interaction', interaction });
+  }
+
+  enqueueEffects(effects: readonly TCommandEffect[]): void {
+    if (effects.length === 0) return;
+    this.queue.push({ type: 'effects', effects: [...effects] });
+  }
+
+  drain(): TQueuedCommandState | undefined {
+    return this.queue.shift();
+  }
+
+  clear(): void {
+    this.queue.length = 0;
+  }
+}

--- a/packages/agent-cli/src/ui/hooks/side-effects-types.ts
+++ b/packages/agent-cli/src/ui/hooks/side-effects-types.ts
@@ -1,14 +1,11 @@
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
-import type {
-  ICommandInteraction,
-  InteractiveSession,
-  TCommandEffect,
-} from '@robota-sdk/agent-sdk';
+import type { InteractiveSession } from '@robota-sdk/agent-sdk';
 import type { TInteractivePrompt } from '../../utils/interactive-prompt.js';
 import type {
   IStatusLineSettings,
   TStatusLineSettingsPatch,
 } from '../../utils/statusline-settings.js';
+import type { ICommandEffectQueue } from './command-effect-queue.js';
 
 /** Side-effect flags for TUI-specific actions */
 export interface ISideEffects {
@@ -17,8 +14,6 @@ export interface ISideEffects {
   _exitRequested?: boolean;
   _triggerResumePicker?: boolean;
   _sessionName?: string;
-  _pendingCommandInteraction?: ICommandInteraction;
-  _pendingCommandEffects?: readonly TCommandEffect[];
   _statusLinePatch?: TStatusLineSettingsPatch;
 }
 
@@ -26,6 +21,7 @@ export interface IUseSideEffectsOptions {
   cwd: string;
   providerOverride?: string | undefined;
   interactiveSession: InteractiveSession;
+  commandEffectQueue: ICommandEffectQueue;
   addEntry: (entry: IHistoryEntry) => void;
   baseHandleSubmit: (input: string) => Promise<void>;
   setSessionName: (name: string) => void;

--- a/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
+++ b/packages/agent-cli/src/ui/hooks/useInteractiveSession.ts
@@ -32,6 +32,7 @@ import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-co
 import type { IPermissionRequest } from '../types.js';
 import { TuiStateManager } from '../tui-state-manager.js';
 import { useSlashRouting } from './useSlashRouting.js';
+import { CommandEffectQueue, type ICommandEffectQueue } from './command-effect-queue.js';
 import { reloadPluginCommandSource } from '../../plugins/plugin-command-source-loader.js';
 
 export interface IInteractiveSessionProps {
@@ -52,6 +53,7 @@ export interface IInteractiveSessionProps {
 export interface IInteractiveSessionState {
   interactiveSession: InteractiveSession;
   registry: CommandRegistry;
+  commandEffectQueue: ICommandEffectQueue;
   history: IHistoryEntry[];
   addEntry: (entry: IHistoryEntry) => void;
   streamingText: string;
@@ -72,6 +74,7 @@ export interface IInteractiveSessionState {
 interface IInitState {
   interactiveSession: InteractiveSession;
   registry: CommandRegistry;
+  commandEffectQueue: ICommandEffectQueue;
   manager: TuiStateManager;
 }
 
@@ -120,8 +123,9 @@ function initializeSession(
   reloadPluginCommandSource(registry);
 
   const manager = new TuiStateManager();
+  const commandEffectQueue = new CommandEffectQueue();
 
-  return { interactiveSession, registry, manager };
+  return { interactiveSession, registry, manager, commandEffectQueue };
 }
 
 export function useInteractiveSession(props: IInteractiveSessionProps): IInteractiveSessionState {
@@ -174,7 +178,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   if (stateRef.current === null) {
     stateRef.current = initializeSession(props, permissionHandler);
   }
-  const { interactiveSession, registry, manager } = stateRef.current;
+  const { interactiveSession, registry, manager, commandEffectQueue } = stateRef.current;
 
   // Connect TuiStateManager to React re-renders
   manager.onChange = () => forceRender((n) => n + 1);
@@ -248,7 +252,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   }, [manager.isThinking, interactiveSession, manager]);
 
   // Slash command routing (delegated to useSlashRouting)
-  const handleSubmit = useSlashRouting(interactiveSession, registry, manager);
+  const handleSubmit = useSlashRouting(interactiveSession, registry, manager, commandEffectQueue);
 
   const handleAbort = useCallback(() => {
     manager.setAborting(true);
@@ -273,6 +277,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   return {
     interactiveSession,
     registry,
+    commandEffectQueue,
     history: manager.history,
     addEntry: (entry: IHistoryEntry) => manager.addEntry(entry),
     streamingText: manager.streamingText,

--- a/packages/agent-cli/src/ui/hooks/useSideEffects.ts
+++ b/packages/agent-cli/src/ui/hooks/useSideEffects.ts
@@ -26,6 +26,7 @@ export function useSideEffects({
   cwd,
   providerOverride,
   interactiveSession,
+  commandEffectQueue,
   addEntry,
   baseHandleSubmit,
   setSessionName,
@@ -84,36 +85,34 @@ export function useSideEffects({
       commandInteractionRef.current = null;
       setPendingInteractionPrompt(null);
       if (result.effects !== undefined && result.effects.length > 0) {
-        applyEffects(result.effects, interactiveSession as InteractiveSession & ISideEffects);
+        applyEffects(result.effects, getHostSideEffects(interactiveSession));
       }
     },
     [addEntry, applyEffects, interactiveSession],
   );
 
   const applyQueuedCommandState = useCallback(
-    (sideEffects: InteractiveSession & ISideEffects): boolean => {
-      if (sideEffects._pendingCommandInteraction !== undefined) {
-        const interaction = sideEffects._pendingCommandInteraction;
-        delete sideEffects._pendingCommandInteraction;
+    (sideEffects: ISideEffects): boolean => {
+      const queued = commandEffectQueue.drain();
+      if (queued === undefined) {
+        return false;
+      }
+      if (queued.type === 'interaction') {
+        const { interaction } = queued;
         commandInteractionRef.current = interaction;
         setPendingInteractionPrompt(interaction.prompt);
         return true;
       }
-      if (sideEffects._pendingCommandEffects !== undefined) {
-        const effects = sideEffects._pendingCommandEffects;
-        delete sideEffects._pendingCommandEffects;
-        return applyEffects(effects, sideEffects);
-      }
-      return false;
+      return applyEffects(queued.effects, sideEffects);
     },
-    [applyEffects],
+    [applyEffects, commandEffectQueue],
   );
 
   const handleSubmit = useCallback(
     async (input: string): Promise<void> => {
       await baseHandleSubmit(input);
 
-      const sideEffects = interactiveSession as InteractiveSession & ISideEffects;
+      const sideEffects = getHostSideEffects(interactiveSession);
       if (applyQueuedCommandState(sideEffects)) return;
 
       if (sideEffects._pendingModelId) {
@@ -235,4 +234,8 @@ export function useSideEffects({
     handleInteractionSubmit,
     handleInteractionCancel,
   };
+}
+
+function getHostSideEffects(interactiveSession: InteractiveSession): ISideEffects {
+  return interactiveSession as unknown as ISideEffects;
 }

--- a/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
+++ b/packages/agent-cli/src/ui/hooks/useSlashRouting.ts
@@ -13,15 +13,14 @@ import type {
 } from '@robota-sdk/agent-sdk';
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import type { TuiStateManager } from '../tui-state-manager.js';
-import type { ISideEffects } from './side-effects-types.js';
+import type { ICommandEffectQueue } from './command-effect-queue.js';
 import { reloadPluginCommandSource } from '../../plugins/plugin-command-source-loader.js';
-
-type TSessionWithEffects = InteractiveSession & ISideEffects;
 
 export function useSlashRouting(
   interactiveSession: InteractiveSession,
   registry: CommandRegistry,
   manager: TuiStateManager,
+  commandEffectQueue: ICommandEffectQueue,
 ): (input: string) => Promise<void> {
   return useCallback(
     async (input: string) => {
@@ -40,7 +39,7 @@ export function useSlashRouting(
       // Try system command first
       const result = await interactiveSession.executeCommand(cmd, args);
       if (result) {
-        applySystemCommandResult(result, interactiveSession, registry, manager);
+        applySystemCommandResult(result, interactiveSession, registry, manager, commandEffectQueue);
         return;
       }
 
@@ -55,7 +54,7 @@ export function useSlashRouting(
         ),
       );
     },
-    [interactiveSession, registry, manager],
+    [interactiveSession, registry, manager, commandEffectQueue],
   );
 }
 
@@ -64,16 +63,16 @@ export function applySystemCommandResult(
   interactiveSession: InteractiveSession,
   registry: CommandRegistry,
   manager: TuiStateManager,
+  commandEffectQueue: ICommandEffectQueue,
 ): void {
   const pendingEffects = applyImmediateCommandEffects(result.effects, registry, manager);
   manager.addEntry(messageToHistoryEntry(createSystemMessage(result.message)));
-  const effects = getEffects(interactiveSession);
 
   if (result.interaction !== undefined) {
-    effects._pendingCommandInteraction = result.interaction;
+    commandEffectQueue.enqueueInteraction(result.interaction);
   }
   if (pendingEffects.length > 0) {
-    effects._pendingCommandEffects = pendingEffects;
+    commandEffectQueue.enqueueEffects(pendingEffects);
   }
 
   const ctx = interactiveSession.getContextState();
@@ -137,8 +136,4 @@ async function routeSkillCommand(
   await interactiveSession.executeSkillCommand(skillCmd, args, input, hookInput);
   manager.setPendingPrompt(interactiveSession.getPendingPrompt());
   return true;
-}
-
-function getEffects(interactiveSession: InteractiveSession): TSessionWithEffects {
-  return interactiveSession as TSessionWithEffects;
 }

--- a/scripts/harness/__tests__/check-command-layering.test.mjs
+++ b/scripts/harness/__tests__/check-command-layering.test.mjs
@@ -49,6 +49,25 @@ describe('findCommandLayeringFindings', () => {
     expect(findings.map((finding) => finding.type)).toContain('cli-command-specific-router-branch');
   });
 
+  it('flags command effect state stored on InteractiveSession', async () => {
+    const root = await createFixture({
+      'packages/agent-cli/src/ui/hooks/useSideEffects.ts':
+        'const effects = interactiveSession as InteractiveSession & ISideEffects;\neffects._pendingCommandEffects = [];\n',
+      'packages/agent-sdk/package.json': '{"dependencies":{}}',
+    });
+
+    const findings = await findCommandLayeringFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'packages/agent-cli/src/ui/hooks/useSideEffects.ts',
+        type: 'cli-command-effect-session-state',
+        detail:
+          'CLI/TUI command effect transport must use an explicit CLI-owned queue, not ad hoc fields on InteractiveSession.',
+      },
+    ]);
+  });
+
   it('flags the legacy CLI slash executor file', async () => {
     const root = await createFixture({
       'packages/agent-cli/src/commands/slash-executor.ts':

--- a/scripts/harness/check-command-layering.mjs
+++ b/scripts/harness/check-command-layering.mjs
@@ -48,6 +48,12 @@ const CLI_UI_FORBIDDEN_PATTERNS = [
     detail:
       'CLI/TUI rendering code must not import provider setup/command helpers; render generic SDK prompts instead.',
   },
+  {
+    type: 'cli-command-effect-session-state',
+    pattern: /(_pendingCommand(?:Interaction|Effects)|InteractiveSession\s*&\s*ISideEffects)/,
+    detail:
+      'CLI/TUI command effect transport must use an explicit CLI-owned queue, not ad hoc fields on InteractiveSession.',
+  },
 ];
 
 const CLI_FORBIDDEN_PATTERNS = [


### PR DESCRIPTION
## Summary
- add an explicit CLI-owned CommandEffectQueue for command interactions/effects
- stop storing command effect state on InteractiveSession
- add command-layering harness coverage and update the CLI architecture map/backlog records
- stabilize the slow PluginTUI install-flow regression test timeout

## Verification
- pnpm --filter @robota-sdk/agent-cli test
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli build
- pnpm docs:build
- pnpm harness:scan:commands
- pnpm harness:scan:test-plans
- pnpm exec vitest run scripts/harness/__tests__/check-command-layering.test.mjs
- git diff --check