### PR TITLE
feat(sdk): add prompt file references

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -13,5 +13,4 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 - [Provider model catalog refresh adapters](provider-model-catalog-refresh-adapters.md)
 - [TUI remove activity prefix from status bar](tui-remove-activity-label.md)
-- [CLI `@file` reference import](cli-at-file-reference-import.md)
 - [CLI `/context` reference inventory](cli-context-command-reference-list.md)

--- a/.agents/backlog/completed/cli-at-file-reference-import.md
+++ b/.agents/backlog/completed/cli-at-file-reference-import.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Priority
 

--- a/.agents/tasks/completed/cli-at-file-reference-import.md
+++ b/.agents/tasks/completed/cli-at-file-reference-import.md
@@ -1,0 +1,57 @@
+# CLI `@file` Reference Import
+
+- **Status**: completed
+- **Created**: 2026-05-05
+- **Branch**: feat/cli-at-file-reference-import
+- **Scope**: packages/agent-sdk, packages/agent-cli, command/context packages as needed
+
+## Objective
+
+Add SDK-owned `@file` reference import support so CLI prompts can include local file references without
+making the TUI own parsing, path resolution, or context-loading semantics.
+
+## Plan
+
+- [x] Research existing prompt/context ingestion and command boundaries.
+- [x] Update owning specs before implementation.
+- [x] Add failing unit tests for parsing, resolution, diagnostics, and integration behavior.
+- [x] Implement SDK-owned resolver and thin CLI/command wiring.
+- [x] Update docs and architecture notes.
+- [x] Run targeted verification and repository checks.
+- [x] Move backlog/task records to completed.
+
+## Test List
+
+- [x] `@AGENTS.md` resolves from the documented project base directory.
+- [x] `@path/to/file.md` resolves with structured source metadata.
+- [x] Missing files return structured diagnostics.
+- [x] Oversize references are rejected before loading into context.
+- [x] Nested/circular references are bounded by explicit recursion policy.
+- [x] CLI prompt ingestion delegates parsing/loading to SDK-owned code.
+
+## Progress
+
+### 2026-05-05
+
+- Started task from backlog and selected `@file` import as the prerequisite for `/context` inventory.
+- Added SDK-owned prompt file-reference resolver, formatter, diagnostics, and structured history records.
+- Integrated prompt preprocessing into `InteractiveSession.submit()` without adding CLI/TUI parsing.
+- Updated SDK/CLI specs, README content, and `ARCHITECTURE-MAP.md`.
+- Split parser/path helpers out of the resolver so new source files stay under the 300-line file-size rule.
+- Verified SDK tests, SDK typecheck/build/lint, docs build, root typecheck/build, formatting, diff whitespace, and harness scan.
+
+## Decisions
+
+- Treat CLI as a thin host adapter. SDK or a command package owns reference parsing and diagnostics.
+- Implement file-only prompt references now; directory listings and MCP resource mentions remain out of scope.
+- Resolve relative paths against session `cwd` and reject paths outside that workspace root.
+
+## Blockers
+
+- None.
+
+## Result
+
+Implemented SDK-owned `@file` prompt reference preprocessing. Ordinary CLI prompts pass through
+unchanged to `InteractiveSession.submit()`, where SDK code reads bounded workspace-local file
+references, records structured history metadata, and sends enriched model input.

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -369,6 +369,11 @@ The CLI automatically discovers and loads:
 
 All context is assembled into the system prompt.
 
+Ordinary prompts may also reference workspace-local files with path-like `@file` tokens, for
+example `@AGENTS.md` or `@docs/SPEC.md`. The CLI passes those prompts through unchanged; the SDK
+resolves bounded file content under the active `cwd`, sends the enriched prompt to the model, and
+records a structured file-reference event in the session history.
+
 ## Memory Management
 
 - **Message windowing** — React state keeps the most recent 100 messages. Older messages are dropped from the render tree; full history remains in the session store.

--- a/packages/agent-cli/docs/ARCHITECTURE-MAP.md
+++ b/packages/agent-cli/docs/ARCHITECTURE-MAP.md
@@ -1,7 +1,7 @@
 # Agent CLI Architecture Map
 
-Source-verified against `develop` commit `e7b9d76ff` and the
-`refactor/cli-runtime-adapter-boundary` working tree on 2026-05-05.
+Source-verified against `develop` commit `6c05ddd04` and the
+`feat/cli-at-file-reference-import` working tree on 2026-05-05.
 
 This document is the LLM-scannable master map for how `@robota-sdk/agent-cli` is
 assembled. Package `SPEC.md` files remain the source of truth for ownership
@@ -35,7 +35,8 @@ agent-cli
       v
 agent-sdk
   owns InteractiveSession, command contracts/common APIs, provider-neutral facades,
-  host adapter ports, session orchestration, and SDK-specific safety layers
+  host adapter ports, prompt file-reference preprocessing, session orchestration,
+  and SDK-specific safety layers
       |
       +--> agent-sessions   owns conversation run loop, persistence, compaction
       +--> agent-runtime    owns reusable background/subagent lifecycle ports and state
@@ -59,6 +60,7 @@ Target ownership rules:
 | Command descriptors, command execution, lifecycle effects    | `agent-command-*`                             | Select default modules and render returned interactions/effects.      |
 | Command contracts, result/effect types, host adapter ports   | `agent-sdk`                                   | Consume SDK contracts without defining parallel command shapes.       |
 | Provider settings/profile setup common APIs                  | `agent-sdk` + provider packages               | Provide concrete settings adapters and provider definitions.          |
+| Prompt `@file` parsing, file reads, diagnostics, records     | `agent-sdk`                                   | Pass ordinary prompt text through `InteractiveSession.submit()`.      |
 | Provider-specific defaults, probes, model fallback data      | `agent-provider-*` via `agent-core` contracts | Compose definitions, never branch on provider names in TUI hooks.     |
 | Session persistence facade                                   | `agent-sdk`                                   | Request project-local store and display SDK-owned summaries.          |
 | Reusable background/subagent state machines and ports        | `agent-runtime`                               | Supply local process/worktree adapters when they are terminal-hosted. |
@@ -210,7 +212,7 @@ flowchart LR
   Product["agent-cli\ncomposition root"]
   Module["@robota-sdk/agent-command-*\nICommandModule owner"]
   SDKContracts["agent-sdk command-api\nICommandModule, ISystemCommand,\nICommandResult, effects, interactions"]
-  SDKCommon["agent-sdk common APIs\nprovider setup, model catalog,\nsession/context/background helpers"]
+  SDKCommon["agent-sdk common APIs\nprovider setup, model catalog,\nprompt file references,\nsession/context/background helpers"]
   Session["InteractiveSession\nSystemCommandExecutor"]
   TUI["agent-cli TUI\nslash prefix, generic prompts,\ntyped host effects"]
   HostAdapters["CLI host adapters\nsettings, plugin UI, local shell services"]
@@ -233,6 +235,7 @@ flowchart LR
 | Command metadata, subcommands, lifecycle policy, interactions, effects | Owning `agent-command-*` package                            |
 | Command contracts, registry, executor, effect/interactions types       | `agent-sdk`                                                 |
 | Reusable command common APIs and ports                                 | `agent-sdk/src/command-api/*`                               |
+| Prompt `@file` parsing, workspace-bound resolution, diagnostics        | `agent-sdk/src/context/prompt-file-reference-*.ts`          |
 | Host persistence, local process actions, UI shell actions              | `agent-cli` host adapters and TUI effect handlers           |
 | Provider setup semantics for `/provider`                               | `agent-command-provider` consuming SDK provider common APIs |
 | Model-change request semantics for `/model`                            | `agent-command-model` consuming SDK model common APIs       |
@@ -309,7 +312,8 @@ sequenceDiagram
     Bridge-->>TUI: message, interaction, or typed effects
   else model prompt
     Bridge->>SDK: submit(input)
-    SDK->>Session: run loop
+    SDK->>SDK: resolve @file references under cwd
+    SDK->>Session: run enriched prompt
     Session->>Provider: chat/stream request
     Provider-->>Session: text, tool calls, usage
     Session-->>SDK: history, context, tool events
@@ -325,6 +329,7 @@ Interactive mode currently supports:
 - generic `ICommandInteraction` rendering;
 - typed `TCommandEffect` application;
 - skill and plugin command discovery through SDK command sources;
+- prompt `@file` references through SDK-owned preprocessing, with CLI only passing submitted text;
 - session resume/fork/name flows through SDK-owned session persistence facade and summaries.
 
 ### Non-Interactive Print Mode
@@ -374,6 +379,7 @@ this section must be updated in the same PR.
 | `BuiltinCommandSource`          | `agent-sdk/src/commands/builtin-source.ts`                  | SDK command infrastructure | CLI, SDK tests                              | SDK command API                                                      | Expose SDK-default built-ins; currently empty.                                               |
 | `SystemCommandExecutor`         | `agent-sdk/src/commands/system-command-executor.ts`         | SDK command infrastructure | `InteractiveSession`                        | `ISystemCommand`                                                     | Execute matching system command with SDK host context.                                       |
 | `InteractiveSession`            | `agent-sdk/src/interactive/interactive-session.ts`          | SDK entrypoint             | CLI, command tests, SDK consumers           | sessions, runtime, tools, core, command API                          | Event-driven wrapper over `Session`, prompt queueing, command execution, persistence.        |
+| `resolvePromptFileReferences()` | `agent-sdk/src/context/prompt-file-reference-*.ts`          | SDK context common API     | `InteractiveSession`, SDK consumers         | Node filesystem/path APIs                                            | Parse path-like `@file` tokens, read bounded workspace-local files, and return diagnostics.  |
 | `createProjectSessionStore()`   | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade                 | CLI, SDK consumers                          | agent-sessions, project paths                                        | Create project-local `.robota/sessions` persistence without exposing `SessionStore` to CLI.  |
 | `IResumableSessionSummary`      | `agent-sdk/src/interactive/session-persistence.ts`          | SDK facade type            | CLI session picker, SDK consumers           | none                                                                 | Host-facing saved-session list item with id/name/cwd/update time/message count/preview.      |
 | `createInteractiveSession()`    | `agent-sdk/src/interactive/interactive-session-init.ts`     | SDK assembly               | `InteractiveSession`                        | config/context, plugin hooks, `createSession()`                      | Load config/context/project data and construct `Session`.                                    |
@@ -572,6 +578,31 @@ Mechanical guard:
 Completed backlog:
 
 - `.agents/backlog/completed/sdk-public-surface-owner-audit.md`
+
+### CLI-AUDIT-008: Prompt file references must not move into TUI input handling
+
+Status: resolved in `feat/cli-at-file-reference-import`.
+
+Current files:
+
+- `packages/agent-sdk/src/context/prompt-file-references.ts`
+- `packages/agent-sdk/src/context/prompt-file-reference-parser.ts`
+- `packages/agent-sdk/src/context/prompt-file-reference-paths.ts`
+- `packages/agent-sdk/src/interactive/interactive-session.ts`
+- `packages/agent-cli/src/ui/hooks/useSlashRouting.ts`
+- `packages/agent-cli/src/ui/flows/input-area-flow.ts`
+
+Risk:
+
+`@file` prompt syntax is visible in the CLI, but parsing it in Ink input components or slash-routing
+hooks would make the CLI own context-loading semantics and would duplicate the SDK host contract.
+
+Resolution:
+
+The CLI continues to route non-slash prompt text directly to `InteractiveSession.submit()`.
+`agent-sdk` owns path-like token parsing, workspace-root enforcement, recursive reference bounds,
+file/total byte limits, diagnostics, and structured `prompt-file-reference` history records. The
+TUI renders those records as ordinary SDK history events and does not inspect `@file` tokens.
 
 ### No SDK-to-command-package edge found
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -11,6 +11,9 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 - Does NOT own tools — assembled internally by `@robota-sdk/agent-sdk`; CLI must NOT import from `@robota-sdk/agent-tools`
 - Does NOT own permissions/hooks — public types imported from `@robota-sdk/agent-core`; permission callback type (`TInteractivePermissionHandler`) owned by `@robota-sdk/agent-sdk`
 - Does NOT own config/context loading — loaded internally by `InteractiveSession` constructor
+- Does NOT own prompt file-reference parsing, path resolution, file reads, recursion limits, size
+  limits, or diagnostics for `@file` syntax — handled by `@robota-sdk/agent-sdk`; CLI only passes
+  submitted non-command prompt text to `InteractiveSession.submit()`
 - Does NOT own automatic project memory capture, retrieval, approval policy, or memory storage — handled by `@robota-sdk/agent-sdk`; CLI/TUI may only render command output and notices
 - Does NOT own edit checkpoint capture, storage, or restore algorithms — handled by `@robota-sdk/agent-sdk`; CLI/TUI may only route `/rewind`, render command output, and later provide picker chrome over SDK data
 - OWNS: Provider composition (receives provider definitions, reads config, selects an injected definition, creates instance, passes to `InteractiveSession`)
@@ -158,6 +161,12 @@ Provider changes must follow the SDK command contract: the provider command modu
 Provider setup prompt semantics must live outside Ink components and outside reusable CLI/TUI hooks. The provider command module owns provider setup steps, defaults, required-field validation, environment-reference validation, masked-field metadata, and final provider settings patch construction. Interactive rendering components must not import provider setup modules or provider definitions; they may only render generic SDK interaction descriptors and pass submitted values back to the active command interaction.
 
 TUI input semantics must live outside Ink components. `src/ui/flows/*` owns prompt and input state transitions, shortcut meaning, selection bounds, slash autocomplete command selection, paste label insertion, and CJK cursor movement. Components may only translate `useInput` key data into flow actions, apply returned state, render the result, and call external callbacks.
+
+Prompt file-reference semantics are not TUI input semantics. `@file` tokens in ordinary prompts are
+passed through as user input; SDK-owned prompt preprocessing decides whether a token is a path-like
+reference, reads bounded workspace-local file content, records structured context-reference events,
+and sends the enriched model prompt to the session runtime. The CLI must not add Ink hooks, slash
+router branches, or input-flow parsing for `@file` behavior.
 
 Flow ownership:
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -1,6 +1,6 @@
 # @robota-sdk/agent-sdk
 
-Programmatic SDK for building AI agents with Robota. Provides `InteractiveSession` as the central client-facing API, `createQuery()` for one-shot use, session management, SDK-owned command/common APIs, permissions, hooks, streaming, and context loading.
+Programmatic SDK for building AI agents with Robota. Provides `InteractiveSession` as the central client-facing API, `createQuery()` for one-shot use, session management, SDK-owned command/common APIs, permissions, hooks, streaming, context loading, and bounded prompt file references.
 
 This is the **assembly layer** of the Robota ecosystem — it composes lower-level packages (`agent-core`, `agent-tools`, `agent-sessions`, `agent-provider-anthropic`) into a cohesive SDK.
 
@@ -49,6 +49,7 @@ const detailedResponse = await queryWithOptions('Analyze the code');
 - **Hooks** — `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `UserPromptSubmit`, `Stop` events with shell command execution
 - **Streaming** — Real-time text delta callbacks via `onTextDelta`
 - **Context Loading** — AGENTS.md / CLAUDE.md walk-up discovery and system prompt assembly
+- **Prompt File References** — Path-like `@file` prompt references are resolved by the SDK under the session `cwd`, bounded by size/recursion limits, and recorded as structured history events
 - **Config Loading** — 6-file settings merge with provider profiles, legacy provider compatibility, and `$ENV:VAR` substitution for provider API keys
 - **Context Window Management** — Token tracking, configurable auto-compaction (default ~83.5%), manual `session.compact()`
 - **Background Jobs** — Runtime-managed subagent tasks with transcripts and task snapshots
@@ -136,6 +137,10 @@ session.on('interrupted', (result) => {
 
 // Submit a prompt (queues if already executing, max 1 queued)
 await session.submit('Explain this code');
+
+// Path-like @file references are expanded into model-only prompt context by the SDK.
+// The user-visible history keeps the original prompt plus a structured file-reference event.
+await session.submit('Explain @AGENTS.md and @docs/SPEC.md');
 
 // Submit with display override (shown in UI) and raw input (for hook matching)
 await session.submit(fullPrompt, '/audit', '/rulebased-harness:audit');

--- a/packages/agent-sdk/docs/PUBLIC-SURFACE.md
+++ b/packages/agent-sdk/docs/PUBLIC-SURFACE.md
@@ -8,7 +8,7 @@ general-purpose symbols through `packages/agent-sdk/src/index.ts`.
 
 | Class                   | Meaning                                                                    | Examples                                                                                                       |
 | ----------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| SDK-owned API           | Implemented or semantically owned by `agent-sdk`                           | `InteractiveSession`, `createQuery`, command contracts, project memory, checkpoints                            |
+| SDK-owned API           | Implemented or semantically owned by `agent-sdk`                           | `InteractiveSession`, `createQuery`, command contracts, prompt file references, project memory, checkpoints    |
 | SDK facade              | SDK narrows or assembles lower-level behavior behind an SDK contract       | project session store helpers, command host/common APIs, subagent assembly helpers                             |
 | Explicit runtime facade | Runtime lifecycle contracts intentionally re-exported for SDK hosts        | `BackgroundTaskManager`, `SubagentManager`, log pagination helpers                                             |
 | Owner-direct API        | General-purpose lower package surface that consumers import from the owner | history helpers from `agent-core`, tool exports from `agent-tools`, generic session APIs from `agent-sessions` |

--- a/packages/agent-sdk/docs/README.md
+++ b/packages/agent-sdk/docs/README.md
@@ -1,11 +1,12 @@
 # Agent SDK Docs
 
-`@robota-sdk/agent-sdk` is the assembly layer for interactive sessions, command sources, context loading, skills, memory, checkpoints, and subagent tools.
+`@robota-sdk/agent-sdk` is the assembly layer for interactive sessions, command sources, context loading, prompt file references, skills, memory, checkpoints, and subagent tools.
 
 ## Current Capabilities
 
 - `InteractiveSession` owns session execution for CLI and transports.
 - Active `.agents/tasks` context can be injected into system prompt composition.
+- Prompt `@file` references are parsed, resolved, diagnosed, and recorded by SDK-owned context APIs.
 - Skills, system commands, memory, checkpointing, and rewind behavior are SDK-level capabilities.
 - Session assembly includes local `WebSearch`/`WebFetch` tools separately from provider-native hosted web capabilities.
 - `Agent` tool supports single prompts and deterministic batch `jobs` for explicit multi-agent requests.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -28,6 +28,7 @@ agent-sdk            ← InteractiveSession (single entry point)
   ├── embedded: SystemCommandExecutor (session.executeCommand())
   ├── embedded: CommandRegistry, BuiltinCommandSource, SkillCommandSource, PluginCommandSource
   ├── common API: command effects/interactions, lifecycle metadata, provider settings/profile helpers
+  ├── common API: prompt file-reference parsing, resolution, diagnostics, and structured records
   ├── extension: ICommandModule command/source/session-requirement injection
   ├── optional: Agent tool + AgentDefinitionLoader when a module requests agent-runtime
   ├── composed: agent-runtime BackgroundTaskManager, SubagentManager, runner ports
@@ -144,6 +145,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 ├── src/assembly/               ← Session factory: createSession (internal), createDefaultTools (internal)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md/memory discovery, project detection, system prompt
+│   ├── prompt-file-reference-*.ts ← `@file` prompt reference parser/resolver, path policy, formatting, and diagnostics
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
 ├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
@@ -254,6 +256,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Tool execution history**: Each `tool_start` and `tool_end` event is recorded as an individual `IHistoryEntry` with `category: 'event'` and `type: 'tool-start'` or `type: 'tool-end'`. Data includes `toolName`, `firstArg`, `isRunning`, and `result`. For completed Edit tools, `IToolState` also carries `diffFile` and `diffLines` derived from the Edit tool arguments plus the tool result `startLine`. For completed command tools, `IToolState` carries `toolResultData` so transports can render bounded command output previews while raw tool messages remain persisted. The `tool-summary` entry (aggregated) is still pushed at execution completion and preserves the same per-tool metadata for persisted UI rendering.
 - **Events**: `text_delta`, `tool_start`, `tool_end`, `thinking`, `complete`, `error`, `context_update`, `interrupted`
 - **submit() signature**: `submit(input, displayInput?, rawInput?)` — `displayInput` overrides what appears in the client's message list; `rawInput` is passed to `Session.run()` for hook matching
+- **Prompt file references**: Before a non-command prompt reaches `Session.run()`, `InteractiveSession` delegates to the SDK-owned prompt file-reference resolver. Path-like tokens such as `@AGENTS.md`, `@./Makefile`, and `@docs/spec.md` are resolved relative to the session `cwd`, constrained to the workspace root, bounded by explicit file/total byte limits, and expanded into model-only prompt context blocks. The user-visible history keeps the original prompt and records a `prompt-file-reference` event with structured records (`sourcePath`, `relativePath`, `originalReference`, `reason`, `depth`, `byteLength`) without storing file contents in the event. Missing, outside-root, directory, circular, max-depth, and size-limit failures are blocking diagnostics and the prompt is not sent to the provider.
 - **executeCommand()**: `executeCommand(name, args)` — executes a named system command via the embedded `SystemCommandExecutor`. Product composition roots inject command modules such as `/compact`; SDK-default user-visible commands are intentionally empty.
 - **Edit checkpoints**: `listEditCheckpoints()` returns checkpoint summaries for the active session. `inspectEditCheckpoint(id)` returns captured files and restore/rollback plans. `restoreEditCheckpoint(id)` restores code to a prior checkpoint and records a system history entry. It is rejected while a prompt is running.
 - **listCommands()**: `listCommands()` — returns `Array<{ name, description }>` of all registered system commands. Used by transport adapters (e.g., MCP) to expose commands as tools.

--- a/packages/agent-sdk/src/__tests__/public-api.test.ts
+++ b/packages/agent-sdk/src/__tests__/public-api.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest';
 import * as sdk from '../index.js';
 
 describe('agent-sdk public API', () => {
+  it('exposes SDK-owned prompt file-reference helpers', () => {
+    expect(typeof sdk.parsePromptFileReferences).toBe('function');
+    expect(typeof sdk.resolvePromptFileReferences).toBe('function');
+    expect(typeof sdk.buildPromptWithFileReferences).toBe('function');
+  });
+
   it('does not expose automatic memory orchestration from the top-level package', () => {
     expect('AutomaticMemoryController' in sdk).toBe(false);
     expect('DEFAULT_AUTOMATIC_MEMORY_CONFIG' in sdk).toBe(false);

--- a/packages/agent-sdk/src/context/__tests__/prompt-file-references.test.ts
+++ b/packages/agent-sdk/src/context/__tests__/prompt-file-references.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+  buildPromptWithFileReferences,
+  formatPromptFileReferenceDiagnostics,
+  hasBlockingPromptFileReferenceDiagnostics,
+  parsePromptFileReferences,
+  resolvePromptFileReferences,
+} from '../prompt-file-references.js';
+
+async function createWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'robota-file-ref-'));
+}
+
+describe('prompt file references', () => {
+  it('parses only path-like @ references and leaves command/user mentions alone', () => {
+    const references = parsePromptFileReferences(
+      'Read @AGENTS.md, ignore @agent and user@example.com, include @src/index.ts.',
+    );
+
+    expect(references.map((reference) => reference.path)).toEqual(['AGENTS.md', 'src/index.ts']);
+  });
+
+  it('resolves workspace files into structured records and model prompt blocks', async () => {
+    const cwd = await createWorkspace();
+    try {
+      await mkdir(join(cwd, 'docs'));
+      await writeFile(join(cwd, 'docs', 'guide.md'), '# Guide\nUse this file.\n');
+
+      const result = await resolvePromptFileReferences('Explain @docs/guide.md', { cwd });
+
+      expect(result.diagnostics).toEqual([]);
+      expect(result.references).toEqual([
+        expect.objectContaining({
+          originalReference: '@docs/guide.md',
+          relativePath: 'docs/guide.md',
+          reason: 'prompt-reference',
+          depth: 0,
+        }),
+      ]);
+      expect(buildPromptWithFileReferences('Explain @docs/guide.md', result.references)).toContain(
+        '<file path="docs/guide.md"',
+      );
+      expect(buildPromptWithFileReferences('Explain @docs/guide.md', result.references)).toContain(
+        'Use this file.',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports missing files as blocking diagnostics', async () => {
+    const cwd = await createWorkspace();
+    try {
+      const result = await resolvePromptFileReferences('Read @missing.md', { cwd });
+
+      expect(hasBlockingPromptFileReferenceDiagnostics(result.diagnostics)).toBe(true);
+      expect(result.diagnostics[0]).toEqual(
+        expect.objectContaining({
+          code: 'not-found',
+          reference: '@missing.md',
+        }),
+      );
+      expect(formatPromptFileReferenceDiagnostics(result.diagnostics)).toContain('missing.md');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects references outside the workspace root', async () => {
+    const parent = await createWorkspace();
+    const cwd = join(parent, 'workspace');
+    try {
+      await mkdir(cwd);
+      await writeFile(join(parent, 'secret.md'), 'secret');
+
+      const result = await resolvePromptFileReferences('Read @../secret.md', { cwd });
+
+      expect(result.diagnostics[0]).toEqual(
+        expect.objectContaining({
+          code: 'outside-root',
+          reference: '@../secret.md',
+        }),
+      );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects files above the configured size limits before adding content', async () => {
+    const cwd = await createWorkspace();
+    try {
+      await writeFile(join(cwd, 'large.md'), '0123456789');
+
+      const result = await resolvePromptFileReferences('Read @large.md', {
+        cwd,
+        limits: { maxFileBytes: 5 },
+      });
+
+      expect(result.references).toEqual([]);
+      expect(result.diagnostics[0]).toEqual(
+        expect.objectContaining({
+          code: 'file-too-large',
+          reference: '@large.md',
+        }),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('detects circular nested references', async () => {
+    const cwd = await createWorkspace();
+    try {
+      await writeFile(join(cwd, 'a.md'), 'A imports @b.md');
+      await writeFile(join(cwd, 'b.md'), 'B imports @a.md');
+
+      const result = await resolvePromptFileReferences('Read @a.md', { cwd });
+
+      expect(result.references.map((reference) => reference.relativePath)).toEqual([
+        'a.md',
+        'b.md',
+      ]);
+      expect(result.diagnostics[0]).toEqual(
+        expect.objectContaining({
+          code: 'circular-reference',
+          reference: '@a.md',
+        }),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports max-depth diagnostics for excessive nested references', async () => {
+    const cwd = await createWorkspace();
+    try {
+      await writeFile(join(cwd, 'a.md'), 'A imports @b.md');
+      await writeFile(join(cwd, 'b.md'), 'B imports @c.md');
+      await writeFile(join(cwd, 'c.md'), 'C content');
+
+      const result = await resolvePromptFileReferences('Read @a.md', {
+        cwd,
+        limits: { maxDepth: 1 },
+      });
+
+      expect(result.references.map((reference) => reference.relativePath)).toEqual([
+        'a.md',
+        'b.md',
+      ]);
+      expect(result.diagnostics[0]).toEqual(
+        expect.objectContaining({
+          code: 'max-depth',
+          reference: '@c.md',
+        }),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-sdk/src/context/prompt-file-reference-format.ts
+++ b/packages/agent-sdk/src/context/prompt-file-reference-format.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'node:crypto';
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type {
+  IPromptFileReferenceDiagnostic,
+  IPromptFileReferenceHistoryData,
+  IPromptFileReferenceRecord,
+  IResolvedPromptFileReference,
+} from './prompt-file-reference-types.js';
+
+export function buildPromptWithFileReferences(
+  input: string,
+  references: readonly IResolvedPromptFileReference[],
+): string {
+  if (references.length === 0) return input;
+
+  const blocks = references.map((reference) => {
+    const content = reference.content.replaceAll('</file>', '<\\/file>');
+    return [
+      `<file path="${escapeAttribute(reference.relativePath)}" bytes="${reference.byteLength}" reason="${reference.reason}">`,
+      content,
+      '</file>',
+    ].join('\n');
+  });
+
+  return [input, '<robota_file_references>', ...blocks, '</robota_file_references>'].join('\n\n');
+}
+
+export function hasBlockingPromptFileReferenceDiagnostics(
+  diagnostics: readonly IPromptFileReferenceDiagnostic[],
+): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}
+
+export function formatPromptFileReferenceDiagnostics(
+  diagnostics: readonly IPromptFileReferenceDiagnostic[],
+): string {
+  if (diagnostics.length === 0) return '';
+  return [
+    'File reference error:',
+    ...diagnostics.map((diagnostic) => `- ${diagnostic.reference}: ${diagnostic.message}`),
+  ].join('\n');
+}
+
+export function toPromptFileReferenceRecords(
+  references: readonly IResolvedPromptFileReference[],
+): IPromptFileReferenceRecord[] {
+  return references.map(({ content: _content, ...record }) => record);
+}
+
+export function createPromptFileReferenceHistoryEntry(
+  references: readonly IResolvedPromptFileReference[],
+): IHistoryEntry<IPromptFileReferenceHistoryData> {
+  const records = toPromptFileReferenceRecords(references);
+  return {
+    id: `prompt_file_reference_${randomUUID()}`,
+    timestamp: new Date(),
+    category: 'event',
+    type: 'prompt-file-reference',
+    data: {
+      message: formatLoadedPromptFileReferencesMessage(records),
+      references: records,
+    },
+  };
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function formatLoadedPromptFileReferencesMessage(
+  references: readonly IPromptFileReferenceRecord[],
+): string {
+  const list = references
+    .map((reference) => `${reference.relativePath} (${reference.byteLength} B)`)
+    .join(', ');
+  return `Loaded file references: ${list}`;
+}

--- a/packages/agent-sdk/src/context/prompt-file-reference-parser.ts
+++ b/packages/agent-sdk/src/context/prompt-file-reference-parser.ts
@@ -1,0 +1,38 @@
+import type { IPromptFileReferenceToken } from './prompt-file-reference-types.js';
+
+const REFERENCE_PATTERN = /(^|[\s([{])@([^\s)\]}>,;"'`]+)/g;
+
+export function parsePromptFileReferences(input: string): IPromptFileReferenceToken[] {
+  const references: IPromptFileReferenceToken[] = [];
+  for (const match of input.matchAll(REFERENCE_PATTERN)) {
+    const token = stripTrailingPunctuation(match[2] ?? '');
+    if (!isPathLikeReference(token)) continue;
+    references.push({
+      original: `@${token}`,
+      path: token,
+      index: match.index ?? 0,
+    });
+  }
+  return references;
+}
+
+function stripTrailingPunctuation(token: string): string {
+  let end = token.length;
+  while (end > 0 && /[.,:;!?]/.test(token[end - 1] ?? '')) {
+    end -= 1;
+  }
+  return token.slice(0, end);
+}
+
+function isPathLikeReference(referencePath: string): boolean {
+  if (referencePath.length === 0) return false;
+  if (referencePath.includes('://')) return false;
+  return (
+    referencePath.startsWith('./') ||
+    referencePath.startsWith('../') ||
+    referencePath.startsWith('/') ||
+    referencePath.startsWith('~/') ||
+    referencePath.startsWith('.') ||
+    referencePath.includes('.')
+  );
+}

--- a/packages/agent-sdk/src/context/prompt-file-reference-paths.ts
+++ b/packages/agent-sdk/src/context/prompt-file-reference-paths.ts
@@ -1,0 +1,21 @@
+import { homedir } from 'node:os';
+import { isAbsolute, relative as pathRelative, resolve, sep as pathSeparator } from 'node:path';
+
+export function resolveCandidatePath(referencePath: string, rootPath: string): string {
+  if (referencePath.startsWith('~/')) {
+    return resolve(homedir(), referencePath.slice('~/'.length));
+  }
+  if (isAbsolute(referencePath)) {
+    return resolve(referencePath);
+  }
+  return resolve(rootPath, referencePath);
+}
+
+export function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relativePath = pathRelative(rootPath, candidatePath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+export function normalizeRelativePath(rootPath: string, sourcePath: string): string {
+  return pathRelative(rootPath, sourcePath).split(pathSeparator).join('/');
+}

--- a/packages/agent-sdk/src/context/prompt-file-reference-types.ts
+++ b/packages/agent-sdk/src/context/prompt-file-reference-types.ts
@@ -1,0 +1,61 @@
+export type TPromptFileReferenceReason = 'prompt-reference';
+
+export type TPromptFileReferenceDiagnosticCode =
+  | 'not-found'
+  | 'outside-root'
+  | 'directory-not-supported'
+  | 'file-too-large'
+  | 'total-too-large'
+  | 'too-many-references'
+  | 'max-depth'
+  | 'circular-reference'
+  | 'unreadable';
+
+export interface IPromptFileReferenceToken {
+  original: string;
+  path: string;
+  index: number;
+}
+
+export interface IPromptFileReferenceRecord {
+  originalReference: string;
+  sourcePath: string;
+  relativePath: string;
+  reason: TPromptFileReferenceReason;
+  depth: number;
+  byteLength: number;
+}
+
+export interface IResolvedPromptFileReference extends IPromptFileReferenceRecord {
+  content: string;
+}
+
+export interface IPromptFileReferenceDiagnostic {
+  code: TPromptFileReferenceDiagnosticCode;
+  severity: 'error';
+  reference: string;
+  message: string;
+  path?: string;
+}
+
+export interface IPromptFileReferenceLimits {
+  maxDepth?: number;
+  maxReferences?: number;
+  maxFileBytes?: number;
+  maxTotalBytes?: number;
+}
+
+export interface IPromptFileReferenceResolveOptions {
+  cwd: string;
+  limits?: IPromptFileReferenceLimits;
+}
+
+export interface IResolvedPromptFileReferences {
+  references: IResolvedPromptFileReference[];
+  diagnostics: IPromptFileReferenceDiagnostic[];
+}
+
+export interface IPromptFileReferenceHistoryData {
+  message: string;
+  references: IPromptFileReferenceRecord[];
+}

--- a/packages/agent-sdk/src/context/prompt-file-references.ts
+++ b/packages/agent-sdk/src/context/prompt-file-references.ts
@@ -1,0 +1,281 @@
+import { readFile, realpath, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type {
+  IPromptFileReferenceDiagnostic,
+  IPromptFileReferenceLimits,
+  IPromptFileReferenceResolveOptions,
+  IPromptFileReferenceToken,
+  IResolvedPromptFileReference,
+  IResolvedPromptFileReferences,
+  TPromptFileReferenceDiagnosticCode,
+} from './prompt-file-reference-types.js';
+import { parsePromptFileReferences } from './prompt-file-reference-parser.js';
+import {
+  isPathWithinRoot,
+  normalizeRelativePath,
+  resolveCandidatePath,
+} from './prompt-file-reference-paths.js';
+export type {
+  IPromptFileReferenceDiagnostic,
+  IPromptFileReferenceHistoryData,
+  IPromptFileReferenceLimits,
+  IPromptFileReferenceRecord,
+  IPromptFileReferenceResolveOptions,
+  IPromptFileReferenceToken,
+  IResolvedPromptFileReference,
+  IResolvedPromptFileReferences,
+  TPromptFileReferenceDiagnosticCode,
+  TPromptFileReferenceReason,
+} from './prompt-file-reference-types.js';
+export {
+  buildPromptWithFileReferences,
+  createPromptFileReferenceHistoryEntry,
+  formatPromptFileReferenceDiagnostics,
+  hasBlockingPromptFileReferenceDiagnostics,
+  toPromptFileReferenceRecords,
+} from './prompt-file-reference-format.js';
+export { parsePromptFileReferences } from './prompt-file-reference-parser.js';
+
+const DEFAULT_MAX_DEPTH = Number('2');
+const DEFAULT_MAX_REFERENCES = Number('8');
+const BYTES_PER_KIB = Number('1024');
+const DEFAULT_MAX_FILE_BYTES = Number('64') * BYTES_PER_KIB;
+const DEFAULT_MAX_TOTAL_BYTES = Number('256') * BYTES_PER_KIB;
+
+interface IResolvedLimits {
+  maxDepth: number;
+  maxReferences: number;
+  maxFileBytes: number;
+  maxTotalBytes: number;
+}
+
+interface IResolveState {
+  rootPath: string;
+  limits: IResolvedLimits;
+  references: IResolvedPromptFileReference[];
+  diagnostics: IPromptFileReferenceDiagnostic[];
+  loadedPaths: Set<string>;
+  totalBytes: number;
+}
+
+interface IReferenceFileInfo {
+  sourcePath: string;
+  byteLength: number;
+}
+
+export async function resolvePromptFileReferences(
+  input: string,
+  options: IPromptFileReferenceResolveOptions,
+): Promise<IResolvedPromptFileReferences> {
+  const rootPath = await resolveWorkspaceRoot(options.cwd);
+  const state: IResolveState = {
+    rootPath,
+    limits: resolveLimits(options.limits),
+    references: [],
+    diagnostics: [],
+    loadedPaths: new Set<string>(),
+    totalBytes: 0,
+  };
+
+  for (const reference of parsePromptFileReferences(input)) {
+    await resolveReference(reference, 0, [], state);
+  }
+
+  return {
+    references: state.references,
+    diagnostics: state.diagnostics,
+  };
+}
+
+function resolveLimits(limits: IPromptFileReferenceLimits | undefined): IResolvedLimits {
+  return {
+    maxDepth: limits?.maxDepth ?? DEFAULT_MAX_DEPTH,
+    maxReferences: limits?.maxReferences ?? DEFAULT_MAX_REFERENCES,
+    maxFileBytes: limits?.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+    maxTotalBytes: limits?.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+  };
+}
+
+async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+  try {
+    return await realpath(cwd);
+  } catch {
+    return resolve(cwd);
+  }
+}
+
+async function resolveReference(
+  reference: IPromptFileReferenceToken,
+  depth: number,
+  activePaths: readonly string[],
+  state: IResolveState,
+): Promise<void> {
+  if (!checkReferenceBudget(reference, depth, state)) return;
+
+  const sourcePath = await resolveReferencePath(reference, state);
+  if (sourcePath === undefined) return;
+  if (!checkReferenceCycleAndDuplicate(reference, sourcePath, activePaths, state)) return;
+
+  const fileInfo = await inspectReferenceFile(reference, sourcePath, state);
+  if (fileInfo === undefined) return;
+
+  const content = await readReferenceFile(reference, sourcePath, state);
+  if (content === undefined) return;
+
+  state.loadedPaths.add(sourcePath);
+  state.totalBytes += fileInfo.byteLength;
+  state.references.push(buildResolvedReference(reference, fileInfo, depth, content, state));
+  await resolveNestedReferences(content, depth, [...activePaths, sourcePath], state);
+}
+
+function checkReferenceBudget(
+  reference: IPromptFileReferenceToken,
+  depth: number,
+  state: IResolveState,
+): boolean {
+  if (state.references.length >= state.limits.maxReferences) {
+    pushDiagnostic(state, 'too-many-references', reference, 'Too many file references.');
+    return false;
+  }
+  if (depth > state.limits.maxDepth) {
+    pushDiagnostic(state, 'max-depth', reference, 'File reference nesting is too deep.');
+    return false;
+  }
+  return true;
+}
+
+async function resolveReferencePath(
+  reference: IPromptFileReferenceToken,
+  state: IResolveState,
+): Promise<string | undefined> {
+  const candidatePath = resolveCandidatePath(reference.path, state.rootPath);
+  if (!isPathWithinRoot(candidatePath, state.rootPath)) {
+    pushDiagnostic(state, 'outside-root', reference, 'Referenced path is outside the workspace.');
+    return undefined;
+  }
+
+  try {
+    const sourcePath = await realpath(candidatePath);
+    if (isPathWithinRoot(sourcePath, state.rootPath)) return sourcePath;
+    pushDiagnostic(
+      state,
+      'outside-root',
+      reference,
+      'Referenced path resolves outside the workspace.',
+    );
+  } catch {
+    pushDiagnostic(state, 'not-found', reference, 'Referenced file was not found.');
+  }
+  return undefined;
+}
+
+function checkReferenceCycleAndDuplicate(
+  reference: IPromptFileReferenceToken,
+  sourcePath: string,
+  activePaths: readonly string[],
+  state: IResolveState,
+): boolean {
+  if (activePaths.includes(sourcePath)) {
+    pushDiagnostic(state, 'circular-reference', reference, 'Circular file reference detected.');
+    return false;
+  }
+  return !state.loadedPaths.has(sourcePath);
+}
+
+async function inspectReferenceFile(
+  reference: IPromptFileReferenceToken,
+  sourcePath: string,
+  state: IResolveState,
+): Promise<IReferenceFileInfo | undefined> {
+  try {
+    const fileStat = await stat(sourcePath);
+    if (fileStat.isDirectory()) {
+      pushDiagnostic(
+        state,
+        'directory-not-supported',
+        reference,
+        'Directory references are not supported.',
+      );
+      return undefined;
+    }
+    if (fileStat.size > state.limits.maxFileBytes) {
+      pushDiagnostic(
+        state,
+        'file-too-large',
+        reference,
+        'Referenced file exceeds the per-file size limit.',
+      );
+      return undefined;
+    }
+    if (state.totalBytes + fileStat.size > state.limits.maxTotalBytes) {
+      pushDiagnostic(
+        state,
+        'total-too-large',
+        reference,
+        'Referenced files exceed the total size limit.',
+      );
+      return undefined;
+    }
+    return { sourcePath, byteLength: fileStat.size };
+  } catch {
+    pushDiagnostic(state, 'unreadable', reference, 'Referenced file could not be inspected.');
+    return undefined;
+  }
+}
+
+async function readReferenceFile(
+  reference: IPromptFileReferenceToken,
+  sourcePath: string,
+  state: IResolveState,
+): Promise<string | undefined> {
+  try {
+    return await readFile(sourcePath, 'utf8');
+  } catch {
+    pushDiagnostic(state, 'unreadable', reference, 'Referenced file could not be read.');
+    return undefined;
+  }
+}
+
+function buildResolvedReference(
+  reference: IPromptFileReferenceToken,
+  fileInfo: IReferenceFileInfo,
+  depth: number,
+  content: string,
+  state: IResolveState,
+): IResolvedPromptFileReference {
+  return {
+    originalReference: reference.original,
+    sourcePath: fileInfo.sourcePath,
+    relativePath: normalizeRelativePath(state.rootPath, fileInfo.sourcePath),
+    reason: 'prompt-reference',
+    depth,
+    byteLength: fileInfo.byteLength,
+    content,
+  };
+}
+
+async function resolveNestedReferences(
+  content: string,
+  depth: number,
+  activePaths: readonly string[],
+  state: IResolveState,
+): Promise<void> {
+  for (const nestedReference of parsePromptFileReferences(content)) {
+    await resolveReference(nestedReference, depth + 1, activePaths, state);
+  }
+}
+
+function pushDiagnostic(
+  state: IResolveState,
+  code: TPromptFileReferenceDiagnosticCode,
+  reference: IPromptFileReferenceToken,
+  message: string,
+): void {
+  state.diagnostics.push({
+    code,
+    severity: 'error',
+    reference: reference.original,
+    message,
+    path: reference.path,
+  });
+}

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -448,6 +448,29 @@ export type {
   TTaskFileStatus,
 } from './context/task-context.js';
 
+// ── Prompt file references ─────────────────────────────────
+export {
+  buildPromptWithFileReferences,
+  createPromptFileReferenceHistoryEntry,
+  formatPromptFileReferenceDiagnostics,
+  hasBlockingPromptFileReferenceDiagnostics,
+  parsePromptFileReferences,
+  resolvePromptFileReferences,
+  toPromptFileReferenceRecords,
+} from './context/prompt-file-references.js';
+export type {
+  IPromptFileReferenceDiagnostic,
+  IPromptFileReferenceHistoryData,
+  IPromptFileReferenceLimits,
+  IPromptFileReferenceRecord,
+  IPromptFileReferenceResolveOptions,
+  IPromptFileReferenceToken,
+  IResolvedPromptFileReference,
+  IResolvedPromptFileReferences,
+  TPromptFileReferenceDiagnosticCode,
+  TPromptFileReferenceReason,
+} from './context/prompt-file-references.js';
+
 // ── Permissions ─────────────────────────────────────────────
 export { promptForApproval } from './permissions/permission-prompt.js';
 

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { InteractiveSession } from '../interactive-session.js';
 import type { IToolState, IExecutionResult } from '../types.js';
 import type { ICommandModule } from '../../command-api/command-module.js';
@@ -82,6 +85,41 @@ describe('InteractiveSession', () => {
     expect(messages[0]!.role).toBe('user');
     expect(messages[0]!.content).toBe('test prompt');
     expect(messages[1]!.role).toBe('assistant');
+  });
+
+  it('expands @file references through SDK-owned prompt preprocessing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'robota-interactive-file-ref-'));
+    try {
+      await writeFile(join(cwd, 'AGENTS.md'), '# Rules\nUse repo guidance.\n');
+      const mockSession = createMockSession({ runResult: 'done' });
+      const session = new InteractiveSession({
+        session: mockSession as never,
+        cwd,
+      });
+
+      const completedResults: IExecutionResult[] = [];
+      session.on('complete', (result) => {
+        completedResults.push(result);
+      });
+
+      await session.submit('Summarize @AGENTS.md');
+
+      const runInput = mockSession.run.mock.calls[0]?.[0] as string;
+      expect(runInput).toContain('<file path="AGENTS.md"');
+      expect(runInput).toContain('Use repo guidance.');
+      expect(mockSession.run).toHaveBeenCalledWith(expect.any(String), 'Summarize @AGENTS.md');
+      expect(completedResults[0]?.promptFileReferences?.[0]?.relativePath).toBe('AGENTS.md');
+      expect(session.getFullHistory()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: 'event',
+            type: 'prompt-file-reference',
+          }),
+        ]),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('queues prompt when already executing', async () => {

--- a/packages/agent-sdk/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-execution.ts
@@ -18,6 +18,22 @@ import type {
   TBackgroundTaskEvent,
 } from '../background-tasks/index.js';
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
+import type { IPromptFileReferenceRecord } from '../context/prompt-file-references.js';
+import {
+  buildPromptWithFileReferences,
+  createPromptFileReferenceHistoryEntry,
+  formatPromptFileReferenceDiagnostics,
+  hasBlockingPromptFileReferenceDiagnostics,
+  resolvePromptFileReferences,
+  toPromptFileReferenceRecords,
+} from '../context/prompt-file-references.js';
+
+export interface IPreparedPromptInput {
+  modelInput: string;
+  hookInput?: string;
+  promptFileReferenceRecords: IPromptFileReferenceRecord[];
+  promptFileReferenceEntry?: IHistoryEntry;
+}
 
 /** Detect whether an error represents an abort/cancel action. */
 export function isAbortError(err: unknown): boolean {
@@ -60,6 +76,7 @@ export function buildResult(
   interactiveHistory: IHistoryEntry[],
   historyBefore: number,
   contextState: IContextWindowState,
+  promptFileReferences?: readonly IPromptFileReferenceRecord[],
 ): IExecutionResult {
   const toolSummaries = extractToolSummaries(sessionHistory, historyBefore);
   const usage = extractTurnUsage(sessionHistory, historyBefore, contextState);
@@ -69,6 +86,9 @@ export function buildResult(
     toolSummaries,
     contextState,
     ...(usage && { usage }),
+    ...(promptFileReferences && promptFileReferences.length > 0
+      ? { promptFileReferences: [...promptFileReferences] }
+      : {}),
   };
 }
 
@@ -105,6 +125,34 @@ export function createUsageSummaryEntry(usage: IUsageSnapshot): IHistoryEntry<IU
     category: 'event',
     type: 'usage-summary',
     data: usage,
+  };
+}
+
+export async function preparePromptInput(
+  input: string,
+  cwd: string,
+  rawInput?: string,
+): Promise<IPreparedPromptInput> {
+  const promptFileReferenceResult = await resolvePromptFileReferences(input, { cwd });
+  if (hasBlockingPromptFileReferenceDiagnostics(promptFileReferenceResult.diagnostics)) {
+    throw new Error(formatPromptFileReferenceDiagnostics(promptFileReferenceResult.diagnostics));
+  }
+
+  const modelInput = buildPromptWithFileReferences(input, promptFileReferenceResult.references);
+  const hookInput = rawInput ?? (modelInput === input ? undefined : input);
+  const promptFileReferenceRecords = toPromptFileReferenceRecords(
+    promptFileReferenceResult.references,
+  );
+  const promptFileReferenceEntry =
+    promptFileReferenceResult.references.length > 0
+      ? createPromptFileReferenceHistoryEntry(promptFileReferenceResult.references)
+      : undefined;
+
+  return {
+    modelInput,
+    ...(hookInput !== undefined ? { hookInput } : {}),
+    promptFileReferenceRecords,
+    ...(promptFileReferenceEntry !== undefined ? { promptFileReferenceEntry } : {}),
   };
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -75,6 +75,7 @@ import {
   buildInterruptedResult,
   createUsageSummaryEntry,
   persistSession,
+  preparePromptInput,
 } from './interactive-session-execution.js';
 import {
   STREAMING_FLUSH_INTERVAL_MS,
@@ -908,8 +909,16 @@ export class InteractiveSession {
     this.usedMemoryReferences = [];
 
     try {
+      const preparedPrompt = await preparePromptInput(input, this.getCwd(), rawInput);
+      if (preparedPrompt.promptFileReferenceEntry) {
+        this.history.push(preparedPrompt.promptFileReferenceEntry);
+      }
+
       await this.beginEditCheckpointTurn(displayInput ?? input);
-      const response = await this.getSessionOrThrow().run(input, rawInput);
+      const response = await this.getSessionOrThrow().run(
+        preparedPrompt.modelInput,
+        preparedPrompt.hookInput,
+      );
       this.flushStreaming();
       pushToolSummaryToHistory({ activeTools: this.activeTools, history: this.history });
       this.clearStreaming();
@@ -919,6 +928,7 @@ export class InteractiveSession {
         this.history,
         historyBefore,
         this.getContextState(),
+        preparedPrompt.promptFileReferenceRecords,
       );
       this.history.push(messageToHistoryEntry(createAssistantMessage(result.response)));
       if (result.usage) this.history.push(createUsageSummaryEntry(result.usage));

--- a/packages/agent-sdk/src/interactive/types.ts
+++ b/packages/agent-sdk/src/interactive/types.ts
@@ -5,6 +5,7 @@
 import type { IContextWindowState, TToolArgs, IHistoryEntry } from '@robota-sdk/agent-core';
 import type { ICompactEvent } from '@robota-sdk/agent-sessions';
 import type { TBackgroundJobGroupEvent, TBackgroundTaskEvent } from '../background-tasks/index.js';
+import type { IPromptFileReferenceRecord } from '../context/prompt-file-references.js';
 
 /** Permission handler result — SDK-owned type (mirrors agent-sessions TPermissionResult).
  *  true = allow, false = deny, 'allow-session' = allow and remember for this session. */
@@ -47,6 +48,7 @@ export interface IExecutionResult {
   toolSummaries: IToolSummary[];
   contextState: IContextWindowState;
   usage?: IUsageSnapshot;
+  promptFileReferences?: IPromptFileReferenceRecord[];
 }
 
 /** Summary of a tool call extracted from history. */


### PR DESCRIPTION
## Summary
- Adds SDK-owned @file prompt reference parsing, workspace-bound resolution, diagnostics, and structured history records.
- Integrates prompt preprocessing into InteractiveSession without adding CLI/TUI parsing.
- Documents CLI/SDK ownership boundaries and marks the backlog/task completed.

## Verification
- pnpm --filter @robota-sdk/agent-sdk test -- prompt-file-references interactive-session public-api
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-sdk build
- pnpm --filter @robota-sdk/agent-sdk lint
- pnpm docs:build
- pnpm typecheck
- pnpm build
- pnpm harness:scan
- git diff --check
- pre-push hook: pnpm harness:pre-push