### PR TITLE
fix(cli): remove activity prefix from status bar

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -10,5 +10,3 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 3. When done, archive to `.agents/tasks/completed/`.
 
 ## Items
-
-- [TUI remove activity prefix from status bar](tui-remove-activity-label.md)

--- a/.agents/backlog/completed/tui-remove-activity-label.md
+++ b/.agents/backlog/completed/tui-remove-activity-label.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Priority
 
@@ -35,11 +35,16 @@ such as `Idle`, `Thinking`, `Tools xN`, `Background xN`, or `Queued`.
 
 ## Acceptance Criteria
 
-- [ ] The status bar renders activity state without the `Activity:` prefix.
-- [ ] Existing activity state text and colors remain unchanged.
-- [ ] Narrow-width status bar behavior does not regress.
-- [ ] Tests no longer assert the prefix.
-- [ ] CLI SPEC examples are updated if they still show the prefix.
+- [x] The status bar renders activity state without the `Activity:` prefix.
+- [x] Existing activity state text and colors remain unchanged.
+- [x] Narrow-width status bar behavior does not regress.
+- [x] Tests no longer assert the prefix.
+- [x] CLI SPEC examples are updated if they still show the prefix.
+
+## Result
+
+Removed the renderer-owned `Activity:` prefix from `StatusBar` while leaving the activity formatter
+unchanged. Tests and CLI SPEC examples now assert/show the compact activity text directly.
 
 ## Verification Plan
 

--- a/.agents/tasks/completed/tui-remove-activity-label.md
+++ b/.agents/tasks/completed/tui-remove-activity-label.md
@@ -1,0 +1,41 @@
+# TUI Remove Activity Label
+
+- **Status**: completed
+- **Created**: 2026-05-05
+- **Branch**: fix/tui-status-activity-label
+- **Scope**: packages/agent-cli
+
+## Objective
+
+Remove the visible `Activity:` prefix from the CLI status bar while preserving existing activity text,
+colors, and status-line behavior.
+
+## Plan
+
+- [x] Update status bar tests to assert activity text without the prefix.
+- [x] Remove the renderer-owned `Activity:` prefix from `StatusBar`.
+- [x] Update CLI docs/spec examples that show the prefix.
+- [x] Run targeted CLI verification.
+- [x] Move backlog/task records to completed.
+
+## Progress
+
+### 2026-05-05
+
+- Started from develop on `fix/tui-status-activity-label`.
+- Removed the status bar `Activity:` prefix in the renderer and updated tests/docs.
+- Verified status bar tests, CLI typecheck, CLI lint, CLI build, spec scan, and docs build.
+
+## Decisions
+
+- Keep `status-activity.ts` unchanged because it owns activity labels such as `Idle`, `Thinking`,
+  and `Tools xN`; the removable prefix is only in the renderer.
+
+## Blockers
+
+- None.
+
+## Result
+
+Completed. The status bar now renders compact activity text (`Idle`, `Thinking`, `Tools xN`, etc.)
+without a separate `Activity:` field prefix.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -231,20 +231,20 @@ The StatusBar shows real-time session information:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ Activity: Thinking  |  Mode: default  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  thinking... msgs: 12 │
+│ Thinking  |  Mode: default  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  thinking... msgs: 12 │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-| Field    | Source                                     | Description                                           |
-| -------- | ------------------------------------------ | ----------------------------------------------------- |
-| Mode     | `session.getPermissionMode()`              | Current permission mode                               |
-| Model    | `getModelName(config.provider.model)`      | Human-readable model name (e.g., "Claude Sonnet 4.6") |
-| Git      | `resolveGitBranch(cwd)`                    | Current git branch when available and enabled         |
-| Context  | `session.getContextState().usedPercentage` | Context usage with K/M formatting (e.g., "90K/1M")    |
-| msgs     | message count                              | Number of messages in conversation                    |
-| Session  | `session.getName()`                        | Session name (shown only when a name is set)          |
-| Activity | CLI-derived display state                  | Left-side primary activity label                      |
-| thinking | `isThinking`                               | Lower-right prompt-processing indicator               |
+| Field    | Source                                     | Description                                            |
+| -------- | ------------------------------------------ | ------------------------------------------------------ |
+| Mode     | `session.getPermissionMode()`              | Current permission mode                                |
+| Model    | `getModelName(config.provider.model)`      | Human-readable model name (e.g., "Claude Sonnet 4.6")  |
+| Git      | `resolveGitBranch(cwd)`                    | Current git branch when available and enabled          |
+| Context  | `session.getContextState().usedPercentage` | Context usage with K/M formatting (e.g., "90K/1M")     |
+| msgs     | message count                              | Number of messages in conversation                     |
+| Session  | `session.getName()`                        | Session name (shown only when a name is set)           |
+| Activity | CLI-derived display state                  | Left-side primary activity text without a field prefix |
+| thinking | `isThinking`                               | Lower-right prompt-processing indicator                |
 
 Activity priority is deterministic and renderer-owned:
 

--- a/packages/agent-cli/src/ui/StatusBar.tsx
+++ b/packages/agent-cli/src/ui/StatusBar.tsx
@@ -64,14 +64,9 @@ function StatusActivityText({
   });
 
   return (
-    <>
-      <Text color="cyan" bold>
-        Activity:
-      </Text>{' '}
-      <Text color={activity.color} bold={activity.kind !== 'idle'}>
-        {activity.text}
-      </Text>
-    </>
+    <Text color={activity.color} bold={activity.kind !== 'idle'}>
+      {activity.text}
+    </Text>
   );
 }
 

--- a/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
@@ -53,9 +53,9 @@ describe('StatusBar', () => {
   it('shows thinking indicator when isThinking is true', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} isThinking={true} />);
     const frame = lastFrame()!;
-    expect(frame).toContain('Activity:');
+    expect(frame).not.toContain('Activity:');
     expect(frame).toContain('Thinking');
-    expect(frame.indexOf('Activity:')).toBeLessThan(frame.indexOf('Mode:'));
+    expect(frame.indexOf('Thinking')).toBeLessThan(frame.indexOf('Mode:'));
   });
 
   it('restores the lower-right prompt-processing indicator while thinking', () => {
@@ -82,7 +82,7 @@ describe('StatusBar', () => {
       />,
     );
     const frame = lastFrame()!;
-    expect(frame).toContain('Activity:');
+    expect(frame).not.toContain('Activity:');
     expect(frame).toContain('Tools x2');
     expect(frame).toContain('queued');
     expect(frame).toContain('thinking...');


### PR DESCRIPTION
## Summary
- remove the renderer-owned `Activity:` prefix from the CLI status bar
- keep the status activity text and mode separation intact
- archive the completed backlog and task records

## Verification
- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli lint` (0 errors, existing warnings)
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm harness:scan:specs`
- `pnpm docs:build`
- pre-push `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`