### PR TITLE
docs(dag): document pending operation run gate

### DIFF
--- a/.agents/tasks/completed/DAG-BL-009-node-pending-operation-gate.md
+++ b/.agents/tasks/completed/DAG-BL-009-node-pending-operation-gate.md
@@ -1,6 +1,6 @@
 ---
 title: 노드 부수작업 진행 중 Run 차단 + 업로드 프로그레스 표시
-status: backlog
+status: completed
 created: 2026-03-15
 priority: high
 urgency: later
@@ -29,3 +29,16 @@ urgency: later
 - 구현 완료 후 관련 패키지 빌드 성공 확인
 - 연관 유닛 테스트 통과 확인
 - typecheck 및 lint 에러 없음 확인
+
+## 진행
+
+### 2026-05-05
+
+- 현재 구현을 점검했고, `dag-designer` context가 `nodeStateMap`의 `operationStatus: 'uploading'`, `pendingDescription`, `isRunnable` 파생 상태를 이미 제공함을 확인했다.
+- `ComfyFileUploadField`가 업로드 시작/종료 시 context action을 호출하고, `dag-studio` Run 버튼이 `context.isRunnable`이 false일 때 비활성화되는 것을 확인했다.
+- 누락된 계약 설명을 `packages/dag-designer/docs/SPEC.md`와 `apps/dag-studio/docs/SPEC.md`에 추가했다.
+
+## 결과
+
+- 노드 부수작업 진행 중 Run 차단 및 업로드 진행 표시 계약을 SPEC에 명시했다.
+- 검증: `pnpm --filter @robota-sdk/dag-designer test`, `build`, `typecheck`, `lint`, `pnpm --filter @robota-sdk/dag-studio typecheck`, `lint`, `pnpm harness:scan:specs`.

--- a/apps/dag-studio/docs/SPEC.md
+++ b/apps/dag-studio/docs/SPEC.md
@@ -23,6 +23,8 @@ Next.js App Router application with the following route structure:
 
 The app composes workspace packages as React components and configures API access via `API_CONFIG` (versioned base URL, timeout, retry, rate limiting). Client-side caching is provided by `src/lib/cache.ts`.
 
+The DAG Designer editor header reads `@robota-sdk/dag-designer` context state for action gating. Save/Publish are blocked by binding validation errors, and Run is additionally blocked while `context.isRunnable` is false, for example while an asset upload is still in progress.
+
 ## Type Ownership
 
 This app is SSOT for:

--- a/packages/dag-designer/docs/SPEC.md
+++ b/packages/dag-designer/docs/SPEC.md
@@ -57,6 +57,7 @@ Run client contract: `createRun -> startRun -> getRunResult`.
 - `INodeManifest` is retained for backward compatibility in component props where existing consumers pass manifests directly.
 - Config form rendering uses ComfyUI `TInputTypeSpec` (from `/object_info`), not Zod schemas.
 - Persisted DAG JSON must not store runtime-owned `inputs`/`outputs`. The designer may enrich definitions in memory from `objectInfo` or manifests, but every mutation emitted through `onDefinitionChange` strips node-local port definitions.
+- Node side effects such as file uploads are represented in `nodeStateMap` with `operationStatus: 'uploading'` and a `pendingDescription`; `isRunnable` is false while any node has an upload operation in progress.
 
 ## Type Ownership
 
@@ -133,6 +134,14 @@ Mutation paths (`addNodeFromManifest`, `addNodeFromObjectInfo`, `updateNode`, `u
 Rendering, edge editing, binding validation, list-handle compaction, and port display must use `definitionWithRuntimePorts`. Runtime catalog data is the SSOT for ports; node-local ports in loaded legacy definitions are ignored when a current catalog entry exists.
 
 `createNodeFromManifest()` and `createNodeFromObjectInfo()` create nodes with only node identity, type, position, dependencies, and config. They must not copy manifest or object-info ports into the node.
+
+## Node Operation Gate
+
+`DagDesignerRoot` owns node-local operation state in `nodeStateMap`. Long-running node side effects that must complete before execution, currently asset uploads, call `setNodeUploading(nodeId, description)` when they start and `setNodeUploadDone(nodeId)` in completion/failure cleanup.
+
+`isRunnable` is derived from `nodeStateMap`; it is false while any node has `operationStatus: 'uploading'`. Host UIs must use this flag to disable Run actions. The selected node inspector receives `pendingOperationDescription` so users can see which selected node is still processing.
+
+Run progress events may also mark nodes as `running`, `success`, or `failed`, but those states describe server execution. They do not replace the pre-run operation gate for upload and other designer-side side effects.
 
 ## List Port Handle Behavior
 


### PR DESCRIPTION
## Summary
- document dag-designer node operation gate semantics for upload pending state and isRunnable
- document dag-studio Run action gating against context.isRunnable
- archive DAG-BL-009 as completed

## Verification
- pnpm --filter @robota-sdk/dag-designer test
- pnpm --filter @robota-sdk/dag-designer build
- pnpm --filter @robota-sdk/dag-designer typecheck
- pnpm --filter @robota-sdk/dag-designer lint
- pnpm --filter @robota-sdk/dag-studio typecheck
- pnpm --filter @robota-sdk/dag-studio lint
- pnpm harness:scan:specs
- git diff --check
- pre-push pnpm harness:verify -- --base-ref origin/develop --skip-record-check