### PR TITLE
feat(dag): add shared node orchestration state

### DIFF
--- a/.agents/tasks/completed/ORCH-BL-003-orchestration-node-state-management.md
+++ b/.agents/tasks/completed/ORCH-BL-003-orchestration-node-state-management.md
@@ -1,6 +1,6 @@
 ---
 title: 오케스트레이션 레벨 노드 공통 상태 관리
-status: backlog
+status: completed
 created: 2026-03-15
 priority: high
 urgency: later
@@ -36,6 +36,18 @@ urgency: later
 - 오케스트레이션 레벨에 `INodeStateMap` 같은 공통 상태 모델 정의
 - 각 노드의 상태를 통합 (pending operations + execution status + results)
 - dag-designer는 이 상태를 참조하여 UI 표시 및 액션 제어
+
+## 진행 기록
+
+- 2026-05-05: 기존 구현 확인 결과 `dag-designer` 내부 `nodeStateMap`이 업로드/실행 상태를 일부 통합하고 있으나, 타입과 전이 규칙이 React context에 남아 있어 공통 오케스트레이션 상태 SSOT가 없음. `dag-core`에 공통 노드 상태 타입과 순수 상태 reducer를 추가하고 `dag-designer`가 이를 소비하도록 마이그레이션한다.
+- 2026-05-05: `dag-core`에 `IDagNodeState`/`TNodeStateMap` 및 순수 reducer를 추가하고, `dag-designer`의 React context가 이를 소비하도록 마이그레이션 완료. 업로드 같은 노드 부수작업 상태와 실행 상태를 분리했고, Run 가능 여부는 `isDagNodeStateMapRunnable()`으로 판단한다.
+
+## 결과
+
+- 공통 노드 상태 SSOT: `packages/dag-core/src/types/node-state.ts`
+- 순수 상태 reducer: `packages/dag-core/src/state/dag-node-state.ts`
+- 디자이너 연동: `packages/dag-designer/src/components/dag-designer-context.tsx`
+- 검증: `pnpm build`, `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
 
 ## 검증
 

--- a/packages/dag-core/docs/SPEC.md
+++ b/packages/dag-core/docs/SPEC.md
@@ -28,6 +28,7 @@ dag-core/
     state-machines/  -- DagRun and TaskRun finite state machines
     lifecycle/       -- Node lifecycle runner, cost policy evaluator, task executor port
     services/        -- Domain services (validation, definition mgmt, cost policy)
+    state/           -- Pure DAG node state reducers for orchestration views
     registry/        -- (emptied — extracted to node authoring package)
     schemas/         -- (emptied — extracted to node authoring package)
     value-objects/   -- (emptied — extracted to node authoring package)
@@ -59,6 +60,8 @@ All types below are the canonical SSOT definitions. Other `dag-*` packages must 
 | `TAssetReference`           | `types/domain.ts`                | Discriminated union for asset-by-id or asset-by-uri references                                                                                              |
 | `TDagRunStatus`             | `types/domain.ts`                | DAG run states: `created`, `queued`, `running`, `success`, `failed`, `cancelled`                                                                            |
 | `TTaskRunStatus`            | `types/domain.ts`                | Task run states: `created`, `queued`, `running`, `success`, `failed`, `upstream_failed`, `skipped`, `cancelled`                                             |
+| `TNodeExecutionStatus`      | `types/node-state.ts`            | Designer/orchestration node execution projection states: `idle`, `running`, `success`, `failed`                                                             |
+| `TNodeOperationStatus`      | `types/node-state.ts`            | Node side-effect operation states that gate execution, currently `idle` or `uploading`                                                                      |
 | `TDagTriggerType`           | `types/domain.ts`                | Trigger types: `manual`, `scheduled`, `api`                                                                                                                 |
 | `IPortDefinition`           | `types/domain.ts`                | Port schema (key, type, required, binary constraints, list constraints)                                                                                     |
 | `INodeManifest`             | `types/domain.ts`                | Node registration manifest (type, display name, category, ports, config schema)                                                                             |
@@ -86,6 +89,9 @@ All types below are the canonical SSOT definitions. Other `dag-*` packages must 
 | `IRunCostPolicyEvaluator`   | `types/node-lifecycle.ts`        | Interface for budget enforcement                                                                                                                            |
 | `TRunProgressEvent`         | `types/run-progress.ts`          | Discriminated union of all run progress event types                                                                                                         |
 | `IRunProgressEventReporter` | `types/run-progress.ts`          | Interface for publishing progress events                                                                                                                    |
+| `IDagNodeExecutionTrace`    | `types/node-state.ts`            | Lightweight per-node execution trace projection used by orchestration views                                                                                 |
+| `IDagNodeState`             | `types/node-state.ts`            | Canonical per-node orchestration state combining side-effect status, execution status, and the latest execution trace                                       |
+| `TNodeStateMap`             | `types/node-state.ts`            | Node-id keyed map of `IDagNodeState` values                                                                                                                 |
 | `TPortValue`                | `interfaces/ports.ts`            | Union of all port value types (primitives, binary, arrays, objects)                                                                                         |
 | `TPortPayload`              | `interfaces/ports.ts`            | Key-value map of port values                                                                                                                                |
 | `IStoredAssetMetadata`      | `interfaces/asset-store-port.ts` | Asset metadata stored by infrastructure adapters, including optional `runtimeAssetId` when an orchestrator asset has been synchronized to a runtime backend |
@@ -113,6 +119,14 @@ All types below are the canonical SSOT definitions. Other `dag-*` packages must 
 | `RunCostPolicyEvaluator`                                                                                           | Class     | Evaluates whether estimated cost fits within the run budget                                                                                                   |
 | `MissingNodeLifecycleFactory`                                                                                      | Class     | Sentinel factory that always returns an error (used as default)                                                                                               |
 | `LifecycleTaskExecutorPort`                                                                                        | Class     | `ITaskExecutorPort` adapter that delegates to `NodeLifecycleRunner`                                                                                           |
+| `createDefaultDagNodeState`                                                                                        | Function  | Creates the default per-node orchestration state                                                                                                              |
+| `reconcileDagNodeStateMap`                                                                                         | Function  | Keeps a node state map aligned to a DAG definition's current node set                                                                                         |
+| `markDagNodeOperationStarted`                                                                                      | Function  | Marks a node side-effect operation, such as upload, as in progress                                                                                            |
+| `markDagNodeOperationDone`                                                                                         | Function  | Clears a node side-effect operation gate                                                                                                                      |
+| `resetDagNodeExecutionStateMap`                                                                                    | Function  | Resets execution status for a new run while preserving non-execution UI extensions at consumer boundaries                                                     |
+| `applyRunProgressEventToNodeStateMap`                                                                              | Function  | Projects run progress events into per-node execution state and traces                                                                                         |
+| `applyRunResultToNodeStateMap`                                                                                     | Function  | Projects final run traces into per-node state                                                                                                                 |
+| `isDagNodeStateMapRunnable`                                                                                        | Function  | Returns whether no node has a blocking side-effect operation or running execution                                                                             |
 | `buildValidationError`                                                                                             | Function  | Error builder for `validation` category                                                                                                                       |
 | `buildDispatchError`                                                                                               | Function  | Error builder for `dispatch` category                                                                                                                         |
 | `buildLeaseError`                                                                                                  | Function  | Error builder for `lease` category                                                                                                                            |
@@ -301,6 +315,16 @@ failed --RETRY--> queued
 ```
 
 Each transition emits a domain event with the `task.*` prefix (e.g., `task.queued`, `task.running`).
+
+### Dag Node Orchestration State
+
+`IDagNodeState` is a read-model projection for orchestration surfaces that need to show or gate node-local state before, during, and after a run. It is not persisted in DAG definitions.
+
+- `operationStatus` tracks node side-effect operations that must finish before execution, currently file uploads.
+- `executionStatus` tracks run progress for the node independently from side-effect operations.
+- `trace` stores the latest lightweight input/output projection from progress events or final run traces.
+- `isDagNodeStateMapRunnable()` is the canonical gate for Run actions: all node operations must be idle and no node may be executing.
+- The reducer functions are pure and must not depend on React, HTTP, storage, timers, or backend adapters.
 
 ## Event Architecture
 

--- a/packages/dag-core/src/__tests__/dag-node-state.test.ts
+++ b/packages/dag-core/src/__tests__/dag-node-state.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyRunProgressEventToNodeStateMap,
+  applyRunResultToNodeStateMap,
+  createDefaultDagNodeState,
+  isDagNodeStateMapRunnable,
+  markDagNodeOperationDone,
+  markDagNodeOperationStarted,
+  reconcileDagNodeStateMap,
+  resetDagNodeExecutionStateMap,
+  type IDagDefinition,
+  type IDagNodeState,
+} from '../index.js';
+
+interface IDesignerNodeState extends IDagNodeState {
+  isSelected: boolean;
+}
+
+const definition: Pick<IDagDefinition, 'nodes'> = {
+  nodes: [
+    {
+      nodeId: 'source',
+      nodeType: 'input',
+      dependsOn: [],
+      config: {},
+    },
+    {
+      nodeId: 'output',
+      nodeType: 'text-output',
+      dependsOn: ['source'],
+      config: {},
+    },
+  ],
+};
+
+function createDesignerState(nodeId: string): IDesignerNodeState {
+  return {
+    ...createDefaultDagNodeState(),
+    isSelected: nodeId === 'source',
+  };
+}
+
+describe('dag node orchestration state', () => {
+  it('reconciles state map to the current definition nodes', () => {
+    const state = reconcileDagNodeStateMap(
+      definition,
+      {
+        removed: {
+          operationStatus: 'idle',
+          executionStatus: 'success',
+          isSelected: false,
+        },
+      },
+      { createState: createDesignerState },
+    );
+
+    expect(Object.keys(state)).toEqual(['source', 'output']);
+    expect(state.source.isSelected).toBe(true);
+    expect(state.output.executionStatus).toBe('idle');
+  });
+
+  it('gates runnability while a node side-effect operation is pending', () => {
+    const initial = reconcileDagNodeStateMap(definition, {}, { createState: createDesignerState });
+    const uploading = markDagNodeOperationStarted(
+      initial,
+      'source',
+      {
+        status: 'uploading',
+        description: 'Uploading image.png...',
+      },
+      { createState: createDesignerState },
+    );
+
+    expect(uploading.source.pendingDescription).toBe('Uploading image.png...');
+    expect(isDagNodeStateMapRunnable(uploading)).toBe(false);
+
+    const done = markDagNodeOperationDone(uploading, 'source', {
+      createState: createDesignerState,
+    });
+
+    expect(done.source.operationStatus).toBe('idle');
+    expect(done.source.pendingDescription).toBeUndefined();
+    expect(isDagNodeStateMapRunnable(done)).toBe(true);
+  });
+
+  it('projects task progress events into execution state and traces', () => {
+    const initial = reconcileDagNodeStateMap(definition, {}, { createState: createDesignerState });
+    const running = applyRunProgressEventToNodeStateMap(
+      initial,
+      {
+        eventType: 'task.started',
+        dagRunId: 'run-1',
+        taskRunId: 'task-1',
+        nodeId: 'source',
+        occurredAt: '2026-05-05T00:00:00.000Z',
+        input: { prompt: 'hello' },
+      },
+      { createState: createDesignerState },
+    );
+
+    expect(running.source.executionStatus).toBe('running');
+    expect(isDagNodeStateMapRunnable(running)).toBe(false);
+
+    const completed = applyRunProgressEventToNodeStateMap(
+      running,
+      {
+        eventType: 'task.completed',
+        dagRunId: 'run-1',
+        taskRunId: 'task-1',
+        nodeId: 'source',
+        occurredAt: '2026-05-05T00:00:01.000Z',
+        output: { text: 'hello' },
+      },
+      { createState: createDesignerState },
+    );
+
+    expect(completed.source.executionStatus).toBe('success');
+    expect(completed.source.trace?.input).toEqual({ prompt: 'hello' });
+    expect(completed.source.trace?.output).toEqual({ text: 'hello' });
+    expect(isDagNodeStateMapRunnable(completed)).toBe(true);
+  });
+
+  it('resets execution state and applies final run results', () => {
+    const initial = reconcileDagNodeStateMap(definition, {}, { createState: createDesignerState });
+    const running = applyRunProgressEventToNodeStateMap(
+      initial,
+      {
+        eventType: 'task.started',
+        dagRunId: 'run-1',
+        taskRunId: 'task-1',
+        nodeId: 'source',
+        occurredAt: '2026-05-05T00:00:00.000Z',
+      },
+      { createState: createDesignerState },
+    );
+    const reset = resetDagNodeExecutionStateMap(definition, running, {
+      createState: createDesignerState,
+    });
+
+    expect(reset.source.executionStatus).toBe('idle');
+    expect(reset.source.trace).toBeUndefined();
+    expect(reset.source.isSelected).toBe(true);
+
+    const finished = applyRunResultToNodeStateMap(
+      reset,
+      {
+        dagRunId: 'run-1',
+        status: 'failed',
+        traces: [
+          {
+            nodeId: 'source',
+            nodeType: 'input',
+            input: {},
+            output: { text: 'hello' },
+            estimatedCredits: 0,
+            totalCredits: 0,
+          },
+        ],
+        nodeErrors: [
+          {
+            nodeId: 'output',
+            nodeType: 'text-output',
+            occurredAt: '2026-05-05T00:00:02.000Z',
+            error: {
+              code: 'NODE_FAILED',
+              category: 'task_execution',
+              message: 'Node failed',
+              retryable: false,
+            },
+          },
+        ],
+        totalCredits: 0,
+      },
+      { createState: createDesignerState },
+    );
+
+    expect(finished.source.executionStatus).toBe('success');
+    expect(finished.source.trace?.output).toEqual({ text: 'hello' });
+    expect(finished.output.executionStatus).toBe('failed');
+  });
+});

--- a/packages/dag-core/src/index.ts
+++ b/packages/dag-core/src/index.ts
@@ -6,11 +6,13 @@ export * from './types/node-lifecycle.js';
 export * from './types/error.js';
 export * from './types/result.js';
 export * from './types/run-progress.js';
+export * from './types/node-state.js';
 export * from './interfaces/ports.js';
 export * from './constants/status.js';
 export * from './constants/events.js';
 export * from './state-machines/dag-run-state-machine.js';
 export * from './state-machines/task-run-state-machine.js';
+export * from './state/dag-node-state.js';
 export * from './services/definition-validator.js';
 export * from './services/definition-service.js';
 export * from './services/time-semantics.js';
@@ -18,21 +20,32 @@ export * from './services/node-lifecycle-runner.js';
 export * from './services/lifecycle-task-executor-port.js';
 export * from './utils/error-builders.js';
 export type {
-    TPrompt, IPromptNodeDef, TPromptInputValue, TPromptLink,
-    IPromptRequest, IPromptResponse,
-    IQueueStatus, IQueueAction,
-    IHistoryEntry, THistory, IOutputAsset,
-    INodeObjectInfo, TObjectInfo, TInputTypeSpec,
-    ISystemStats, IWorkflowJson, INodeError,
+  TPrompt,
+  IPromptNodeDef,
+  TPromptInputValue,
+  TPromptLink,
+  IPromptRequest,
+  IPromptResponse,
+  IQueueStatus,
+  IQueueAction,
+  IHistoryEntry,
+  THistory,
+  IOutputAsset,
+  INodeObjectInfo,
+  TObjectInfo,
+  TInputTypeSpec,
+  ISystemStats,
+  IWorkflowJson,
+  INodeError,
 } from './types/prompt-types.js';
 export { isPromptLink } from './types/prompt-types.js';
 export type { IPromptBackendPort } from './interfaces/prompt-backend-port.js';
 export type {
-    IAssetStore,
-    IStoredAssetMetadata,
-    ICreateAssetInput,
-    ICreateAssetReferenceInput,
-    IAssetContentResult
+  IAssetStore,
+  IStoredAssetMetadata,
+  ICreateAssetInput,
+  ICreateAssetReferenceInput,
+  IAssetContentResult,
 } from './interfaces/asset-store-port.js';
 export * from './types/run-result.js';
 

--- a/packages/dag-core/src/state/dag-node-state.ts
+++ b/packages/dag-core/src/state/dag-node-state.ts
@@ -1,0 +1,189 @@
+import { TASK_PROGRESS_EVENTS } from '../constants/events.js';
+import type { IDagDefinition } from '../types/domain.js';
+import type { IRunResult } from '../types/run-result.js';
+import type { TRunProgressEvent } from '../types/run-progress.js';
+import type {
+  IDagNodeExecutionTrace,
+  IDagNodeState,
+  TNodeOperationStatus,
+} from '../types/node-state.js';
+
+export interface IDagNodeOperationInput {
+  status: Exclude<TNodeOperationStatus, 'idle'>;
+  description: string;
+}
+
+export interface INodeStateReducerOptions<TState extends IDagNodeState> {
+  createState?: (nodeId: string) => TState;
+}
+
+export function createDefaultDagNodeState(): IDagNodeState {
+  return {
+    operationStatus: 'idle',
+    executionStatus: 'idle',
+  };
+}
+
+export function reconcileDagNodeStateMap<TState extends IDagNodeState>(
+  definition: Pick<IDagDefinition, 'nodes'>,
+  currentState: Record<string, TState>,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  const nextState: Record<string, TState> = {};
+  for (const node of definition.nodes) {
+    nextState[node.nodeId] = getStateOrDefault(currentState, node.nodeId, options);
+  }
+  return nextState;
+}
+
+export function markDagNodeOperationStarted<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+  nodeId: string,
+  operation: IDagNodeOperationInput,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  const existing = getStateOrDefault(currentState, nodeId, options);
+  return {
+    ...currentState,
+    [nodeId]: {
+      ...existing,
+      operationStatus: operation.status,
+      pendingDescription: operation.description,
+    },
+  };
+}
+
+export function markDagNodeOperationDone<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+  nodeId: string,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  const existing = getStateOrDefault(currentState, nodeId, options);
+  return {
+    ...currentState,
+    [nodeId]: {
+      ...existing,
+      operationStatus: 'idle',
+      pendingDescription: undefined,
+    },
+  };
+}
+
+export function resetDagNodeExecutionStateMap<TState extends IDagNodeState>(
+  definition: Pick<IDagDefinition, 'nodes'>,
+  currentState: Record<string, TState>,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  const reconciled = reconcileDagNodeStateMap(definition, currentState, {
+    createState: options?.createState,
+  });
+  const nextState: Record<string, TState> = {};
+  for (const [nodeId, state] of Object.entries(reconciled)) {
+    nextState[nodeId] = {
+      ...state,
+      executionStatus: 'idle',
+      trace: undefined,
+    };
+  }
+  return nextState;
+}
+
+export function applyRunProgressEventToNodeStateMap<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+  event: TRunProgressEvent,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  if (!isTaskProgressEvent(event)) {
+    return currentState;
+  }
+  const existing = getStateOrDefault(currentState, event.nodeId, options);
+  const nextTrace: IDagNodeExecutionTrace = {
+    nodeId: event.nodeId,
+    input: event.input ?? existing.trace?.input,
+    output: event.output ?? existing.trace?.output,
+  };
+  return {
+    ...currentState,
+    [event.nodeId]: {
+      ...existing,
+      executionStatus: eventToExecutionStatus(event),
+      trace: nextTrace,
+    },
+  };
+}
+
+export function applyRunResultToNodeStateMap<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+  result: IRunResult,
+  options?: INodeStateReducerOptions<TState>,
+): Record<string, TState> {
+  let nextState = currentState;
+  for (const trace of result.traces) {
+    const existing = getStateOrDefault(nextState, trace.nodeId, options);
+    nextState = {
+      ...nextState,
+      [trace.nodeId]: {
+        ...existing,
+        executionStatus: 'success',
+        trace: {
+          nodeId: trace.nodeId,
+          input: trace.input,
+          output: trace.output,
+        },
+      },
+    };
+  }
+  for (const nodeError of result.nodeErrors) {
+    const existing = getStateOrDefault(nextState, nodeError.nodeId, options);
+    nextState = {
+      ...nextState,
+      [nodeError.nodeId]: {
+        ...existing,
+        executionStatus: 'failed',
+      },
+    };
+  }
+  return nextState;
+}
+
+export function isDagNodeStateMapRunnable<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+): boolean {
+  return Object.values(currentState).every(
+    (state) => state.operationStatus === 'idle' && state.executionStatus !== 'running',
+  );
+}
+
+function getStateOrDefault<TState extends IDagNodeState>(
+  currentState: Record<string, TState>,
+  nodeId: string,
+  options?: INodeStateReducerOptions<TState>,
+): TState {
+  return (
+    currentState[nodeId] ??
+    options?.createState?.(nodeId) ??
+    (createDefaultDagNodeState() as TState)
+  );
+}
+
+function isTaskProgressEvent(
+  event: TRunProgressEvent,
+): event is Extract<TRunProgressEvent, { nodeId: string }> {
+  return (
+    event.eventType === TASK_PROGRESS_EVENTS.STARTED ||
+    event.eventType === TASK_PROGRESS_EVENTS.COMPLETED ||
+    event.eventType === TASK_PROGRESS_EVENTS.FAILED
+  );
+}
+
+function eventToExecutionStatus(
+  event: Extract<TRunProgressEvent, { nodeId: string }>,
+): IDagNodeState['executionStatus'] {
+  if (event.eventType === TASK_PROGRESS_EVENTS.STARTED) {
+    return 'running';
+  }
+  if (event.eventType === TASK_PROGRESS_EVENTS.COMPLETED) {
+    return 'success';
+  }
+  return 'failed';
+}

--- a/packages/dag-core/src/types/node-state.ts
+++ b/packages/dag-core/src/types/node-state.ts
@@ -1,0 +1,25 @@
+import type { TPortPayload } from '../interfaces/ports.js';
+
+/** Node-local side-effect status that can block a DAG run before execution starts. */
+export type TNodeOperationStatus = 'idle' | 'uploading';
+
+/** Node execution status projected from run progress events and final run results. */
+export type TNodeExecutionStatus = 'idle' | 'running' | 'success' | 'failed';
+
+/** Lightweight execution trace suitable for orchestration and designer views. */
+export interface IDagNodeExecutionTrace {
+  nodeId: string;
+  input?: TPortPayload;
+  output?: TPortPayload;
+}
+
+/** Canonical per-node orchestration state. This state is not persisted in DAG definitions. */
+export interface IDagNodeState {
+  operationStatus: TNodeOperationStatus;
+  executionStatus: TNodeExecutionStatus;
+  pendingDescription?: string;
+  trace?: IDagNodeExecutionTrace;
+}
+
+/** Node-id keyed orchestration state map. */
+export type TNodeStateMap = Record<string, IDagNodeState>;

--- a/packages/dag-designer/docs/SPEC.md
+++ b/packages/dag-designer/docs/SPEC.md
@@ -57,7 +57,7 @@ Run client contract: `createRun -> startRun -> getRunResult`.
 - `INodeManifest` is retained for backward compatibility in component props where existing consumers pass manifests directly.
 - Config form rendering uses ComfyUI `TInputTypeSpec` (from `/object_info`), not Zod schemas.
 - Persisted DAG JSON must not store runtime-owned `inputs`/`outputs`. The designer may enrich definitions in memory from `objectInfo` or manifests, but every mutation emitted through `onDefinitionChange` strips node-local port definitions.
-- Node side effects such as file uploads are represented in `nodeStateMap` with `operationStatus: 'uploading'` and a `pendingDescription`; `isRunnable` is false while any node has an upload operation in progress. Upload fields call `POST /v1/dag/assets` and only write an asset reference into node config after the server has stored the asset locally and synchronized it to the runtime backend.
+- Node side effects such as file uploads are represented in `nodeStateMap` using the canonical `IDagNodeState` projection from `dag-core`; `isRunnable` is false while any node has a blocking operation or execution in progress. Upload fields call `POST /v1/dag/assets` and only write an asset reference into node config after the server has stored the asset locally and synchronized it to the runtime backend.
 
 ## Type Ownership
 
@@ -137,11 +137,13 @@ Rendering, edge editing, binding validation, list-handle compaction, and port di
 
 ## Node Operation Gate
 
-`DagDesignerRoot` owns node-local operation state in `nodeStateMap`. Long-running node side effects that must complete before execution, currently asset uploads, call `setNodeUploading(nodeId, description)` when they start and `setNodeUploadDone(nodeId)` in completion/failure cleanup.
+`dag-core` owns the node orchestration state contract and pure reducers (`IDagNodeState`, `TNodeStateMap`, `reconcileDagNodeStateMap`, `markDagNodeOperationStarted`, `markDagNodeOperationDone`, `applyRunProgressEventToNodeStateMap`, `applyRunResultToNodeStateMap`, `isDagNodeStateMapRunnable`). `DagDesignerRoot` owns only the React state container and UI-only extensions such as selected-node marking.
 
-`isRunnable` is derived from `nodeStateMap`; it is false while any node has `operationStatus: 'uploading'`. Host UIs must use this flag to disable Run actions. The selected node inspector receives `pendingOperationDescription` so users can see which selected node is still processing.
+Long-running node side effects that must complete before execution, currently asset uploads, call `setNodeUploading(nodeId, description)` when they start and `setNodeUploadDone(nodeId)` in completion/failure cleanup.
 
-Run progress events may also mark nodes as `running`, `success`, or `failed`, but those states describe server execution. They do not replace the pre-run operation gate for upload and other designer-side side effects.
+`isRunnable` is derived from `isDagNodeStateMapRunnable(nodeStateMap)`; it is false while any node has `operationStatus: 'uploading'` or `executionStatus: 'running'`. Host UIs must use this flag to disable Run actions. The selected node inspector receives `pendingOperationDescription` so users can see which selected node is still processing.
+
+Run progress events mark `executionStatus` as `running`, `success`, or `failed`. These states describe server execution and are separate from the pre-run operation gate for upload and other designer-side side effects.
 
 Upload success means the orchestrator returned a valid asset reference after runtime synchronization completed. The designer stores the returned orchestrator `assetId` in config; runtime-specific upload IDs are server metadata and must not be written directly into DAG JSON.
 

--- a/packages/dag-designer/src/components/canvas-utils.ts
+++ b/packages/dag-designer/src/components/canvas-utils.ts
@@ -7,13 +7,14 @@ import {
   type INodeManifest,
   type INodeObjectInfo,
   type IPortDefinition,
+  type TNodeExecutionStatus,
   type TObjectInfo,
   type TPortValueType,
 } from '@robota-sdk/dag-core';
 import type { Edge, Node, XYPosition } from '@xyflow/react';
 import type { IDagNodeIoTrace, IDagNodeViewData, TDagCanvasNode } from './dag-node-view.js';
 import type { IDagBindingEdgeData } from './dag-binding-edge.js';
-import type { INodeState, TNodeExecutionStatus } from './dag-designer-context.js';
+import type { INodeState } from './dag-designer-context.js';
 
 export function toNode(
   nodeDefinition: IDagNode,
@@ -45,10 +46,7 @@ export function toNode(
       nodeType: nodeDefinition.nodeType,
       inputs,
       outputs,
-      executionStatus:
-        nodeState?.operationStatus === 'uploading'
-          ? 'idle'
-          : ((nodeState?.operationStatus ?? 'idle') as TNodeExecutionStatus),
+      executionStatus: nodeState?.executionStatus ?? 'idle',
       isSelected: nodeState?.isSelected ?? false,
       latestTrace,
       assetBaseUrl,

--- a/packages/dag-designer/src/components/dag-designer-context.tsx
+++ b/packages/dag-designer/src/components/dag-designer-context.tsx
@@ -12,15 +12,25 @@ import {
 import {
   EXECUTION_PROGRESS_EVENTS,
   TASK_PROGRESS_EVENTS,
+  applyRunProgressEventToNodeStateMap,
+  applyRunResultToNodeStateMap,
+  createDefaultDagNodeState,
+  isDagNodeStateMapRunnable,
+  markDagNodeOperationDone,
+  markDagNodeOperationStarted,
+  reconcileDagNodeStateMap,
+  resetDagNodeExecutionStateMap,
   type IDagDefinition,
   type IDagEdgeDefinition,
   type IDagError,
   type IDagNode,
+  type IDagNodeState,
   type INodeManifest,
   type INodeObjectInfo,
   type IRunResult,
   type TObjectInfo,
   type TRunProgressEvent,
+  type TNodeExecutionStatus,
   type TPortPayload,
   type TResult,
 } from '@robota-sdk/dag-core';
@@ -37,13 +47,9 @@ import {
   stripDefinitionNodePortDefinitions,
 } from './canvas-utils.js';
 
-export type TNodeExecutionStatus = 'idle' | 'running' | 'success' | 'failed';
+export type { TNodeExecutionStatus, TNodeOperationStatus } from '@robota-sdk/dag-core';
 
-export type TNodeOperationStatus = 'idle' | 'uploading' | 'running' | 'success' | 'failed';
-
-export interface INodeState {
-  operationStatus: TNodeOperationStatus;
-  pendingDescription?: string;
+export interface INodeState extends IDagNodeState {
   trace?: IDagNodeIoTrace;
   isSelected: boolean;
 }
@@ -54,10 +60,11 @@ export interface INodeUiState {
   isSelected: boolean;
 }
 
-const DEFAULT_NODE_STATE: INodeState = { operationStatus: 'idle', isSelected: false };
-
-function getNodeStateOrDefault(map: Record<string, INodeState>, nodeId: string): INodeState {
-  return map[nodeId] ?? DEFAULT_NODE_STATE;
+function createDesignerNodeState(): INodeState {
+  return {
+    ...createDefaultDagNodeState(),
+    isSelected: false,
+  };
 }
 
 export interface IRunProgressState {
@@ -250,12 +257,9 @@ export function DagDesignerRoot(props: IDagDesignerRootProps): ReactElement {
   const [runProgress, setRunProgress] = useState<IRunProgressState>(INITIAL_RUN_PROGRESS_STATE);
   useEffect(() => {
     setNodeStateMap((currentState) => {
-      const nextState: Record<string, INodeState> = {};
-      for (const node of props.definition.nodes) {
-        const existingState = currentState[node.nodeId];
-        nextState[node.nodeId] = existingState ?? DEFAULT_NODE_STATE;
-      }
-      return nextState;
+      return reconcileDagNodeStateMap({ nodes: props.definition.nodes }, currentState, {
+        createState: createDesignerNodeState,
+      });
     });
     setSelectedNodeIdState((currentNodeId) => {
       if (!currentNodeId) {
@@ -278,31 +282,26 @@ export function DagDesignerRoot(props: IDagDesignerRootProps): ReactElement {
   );
 
   const setNodeUploading = useCallback((nodeId: string, description: string): void => {
-    setNodeStateMap((prev) => ({
-      ...prev,
-      [nodeId]: {
-        ...getNodeStateOrDefault(prev, nodeId),
-        operationStatus: 'uploading',
-        pendingDescription: description,
-      },
-    }));
+    setNodeStateMap((prev) =>
+      markDagNodeOperationStarted(
+        prev,
+        nodeId,
+        {
+          status: 'uploading',
+          description,
+        },
+        { createState: createDesignerNodeState },
+      ),
+    );
   }, []);
 
   const setNodeUploadDone = useCallback((nodeId: string): void => {
-    setNodeStateMap((prev) => ({
-      ...prev,
-      [nodeId]: {
-        ...getNodeStateOrDefault(prev, nodeId),
-        operationStatus: 'idle',
-        pendingDescription: undefined,
-      },
-    }));
+    setNodeStateMap((prev) =>
+      markDagNodeOperationDone(prev, nodeId, { createState: createDesignerNodeState }),
+    );
   }, []);
 
-  const isRunnable = useMemo(
-    () => Object.values(nodeStateMap).every((s) => s.operationStatus !== 'uploading'),
-    [nodeStateMap],
-  );
+  const isRunnable = useMemo(() => isDagNodeStateMapRunnable(nodeStateMap), [nodeStateMap]);
 
   const clearPendingStatusTimers = useCallback((): void => {
     for (const timerId of pendingStatusTimersRef.current.values()) {
@@ -319,24 +318,13 @@ export function DagDesignerRoot(props: IDagDesignerRootProps): ReactElement {
   }, [clearPendingStatusTimers]);
 
   useEffect(() => {
-    const traces = runResult?.traces ?? [];
-    if (traces.length === 0) {
+    if (!runResult) {
       return;
     }
     setNodeStateMap((currentState) => {
-      const nextState: Record<string, INodeState> = { ...currentState };
-      for (const trace of traces) {
-        const existing = getNodeStateOrDefault(nextState, trace.nodeId);
-        nextState[trace.nodeId] = {
-          ...existing,
-          trace: {
-            nodeId: trace.nodeId,
-            input: trace.input,
-            output: trace.output,
-          },
-        };
-      }
-      return nextState;
+      return applyRunResultToNodeStateMap(currentState, runResult, {
+        createState: createDesignerNodeState,
+      });
     });
   }, [runResult]);
 
@@ -369,15 +357,9 @@ export function DagDesignerRoot(props: IDagDesignerRootProps): ReactElement {
       clearPendingStatusTimers();
       nodeRunningSinceRef.current.clear();
       setNodeStateMap((currentState) => {
-        const nextState: Record<string, INodeState> = {};
-        for (const node of definitionRef.current.nodes) {
-          const existingState = currentState[node.nodeId];
-          nextState[node.nodeId] = {
-            operationStatus: 'idle',
-            isSelected: existingState?.isSelected ?? false,
-          };
-        }
-        return nextState;
+        return resetDagNodeExecutionStateMap({ nodes: definitionRef.current.nodes }, currentState, {
+          createState: createDesignerNodeState,
+        });
       });
       setRunProgress({
         activeDagRunId: dagRunId,
@@ -394,28 +376,10 @@ export function DagDesignerRoot(props: IDagDesignerRootProps): ReactElement {
       event.eventType === TASK_PROGRESS_EVENTS.COMPLETED ||
       event.eventType === TASK_PROGRESS_EVENTS.FAILED
     ) {
-      const operationStatus: TNodeOperationStatus =
-        event.eventType === TASK_PROGRESS_EVENTS.STARTED
-          ? 'running'
-          : event.eventType === TASK_PROGRESS_EVENTS.COMPLETED
-            ? 'success'
-            : 'failed';
       setNodeStateMap((currentState) => {
-        const existing = getNodeStateOrDefault(currentState, event.nodeId);
-        const currentTrace = existing.trace;
-        const nextTrace: IDagNodeIoTrace = {
-          nodeId: event.nodeId,
-          input: event.input ?? currentTrace?.input,
-          output: event.output ?? currentTrace?.output,
-        };
-        return {
-          ...currentState,
-          [event.nodeId]: {
-            ...existing,
-            operationStatus,
-            trace: nextTrace,
-          },
-        };
+        return applyRunProgressEventToNodeStateMap(currentState, event, {
+          createState: createDesignerNodeState,
+        });
       });
     }
     setRunProgress((currentState) => {

--- a/packages/dag-designer/src/components/dag-designer-panels.tsx
+++ b/packages/dag-designer/src/components/dag-designer-panels.tsx
@@ -3,7 +3,7 @@ import { NodeConfigPanel } from './node-config-panel.js';
 import { NodeIoTracePanel } from './node-io-trace-panel.js';
 import { NodeExplorerPanel } from './node-explorer-panel.js';
 import { EdgeInspectorPanel } from './edge-inspector-panel.js';
-import { useDagDesignerContext, type TNodeExecutionStatus } from './dag-designer-context.js';
+import { useDagDesignerContext } from './dag-designer-context.js';
 import type { IDagNodeIoTrace } from './dag-node-view.js';
 
 export interface IDagDesignerNodeExplorerProps {
@@ -120,10 +120,7 @@ export function DagDesignerNodeIoTrace(props: IDagDesignerNodeIoTraceProps): Rea
   const selectedNodeState = context.selectedNodeId
     ? context.nodeStateMap[context.selectedNodeId]
     : undefined;
-  const selectedExecutionStatus =
-    selectedNodeState?.operationStatus === 'uploading'
-      ? ('idle' as const)
-      : ((selectedNodeState?.operationStatus ?? 'idle') as TNodeExecutionStatus);
+  const selectedExecutionStatus = selectedNodeState?.executionStatus ?? 'idle';
   return (
     <div className={props.className ?? ''}>
       <NodeIoTracePanel
@@ -145,9 +142,9 @@ export function DagDesignerRunProgressSummary(
     let failed = 0;
     let success = 0;
     for (const nodeState of Object.values(context.nodeStateMap)) {
-      if (nodeState.operationStatus === 'running') running++;
-      else if (nodeState.operationStatus === 'failed') failed++;
-      else if (nodeState.operationStatus === 'success') success++;
+      if (nodeState.executionStatus === 'running') running++;
+      else if (nodeState.executionStatus === 'failed') failed++;
+      else if (nodeState.executionStatus === 'success') success++;
     }
     return { runningNodeCount: running, failedNodeCount: failed, successNodeCount: success };
   }, [context.nodeStateMap]);


### PR DESCRIPTION
## Summary
- add canonical dag-core node orchestration state types and pure reducers
- migrate dag-designer nodeStateMap to consume the shared reducer layer
- split node side-effect operation status from execution status for run gating
- move ORCH-BL-003 to completed

## Verification
- pnpm --filter @robota-sdk/dag-core test
- pnpm --filter @robota-sdk/dag-core typecheck
- pnpm --filter @robota-sdk/dag-core lint
- pnpm --filter @robota-sdk/dag-core build
- pnpm --filter @robota-sdk/dag-designer test
- pnpm --filter @robota-sdk/dag-designer typecheck
- pnpm --filter @robota-sdk/dag-designer lint
- pnpm --filter @robota-sdk/dag-designer build
- pnpm harness:scan:specs
- pnpm build
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check