### PR TITLE
feat(dag): add published workflow run endpoint

### DIFF
--- a/.agents/tasks/completed/DAG-BL-006-dag-publish-api-endpoint.md
+++ b/.agents/tasks/completed/DAG-BL-006-dag-publish-api-endpoint.md
@@ -1,6 +1,6 @@
 ---
 title: DAG Publish → API Endpoint 생성 + 외부 서비스 연동
-status: backlog
+status: completed
 created: 2026-03-15
 priority: high
 urgency: later
@@ -61,3 +61,26 @@ dag-designer에서 Publish 버튼을 누르면 해당 DAG에 대한 API endpoint
 - 구현 완료 후 관련 패키지 빌드 성공 확인
 - 연관 유닛 테스트 통과 확인
 - typecheck 및 lint 에러 없음 확인
+
+## 계획
+
+- [x] published workflow HTTP 계약을 `dag-orchestrator-server` SPEC에 명시
+- [x] published definition 조회, 버전 선택, draft 차단, override 검증 테스트 추가
+- [x] `/v1/dag/workflows/:dagId/runs` 라우트 구현 및 서버 등록
+- [x] runtime asset 동기화와 기존 run service 실행 경로 재사용 확인
+- [x] 타깃 테스트/typecheck/lint/build 및 workspace 검증 실행
+- [x] 완료 후 task를 completed로 이동
+
+## 진행 기록
+
+- 2026-05-05: 우선 published DAG를 서버가 저장소에서 조회해 외부 API로 실행하는 최소 안정 계약을 구현한다. Input Schema 자동 생성은 별도 메타 모델이 필요하므로 초기 구현에서는 명시적 `input`과 `overrides` 요청 계약으로 고정한다.
+- 2026-05-05: 외부 API 경로는 기존 Robota DAG 네임스페이스와 맞춰 `POST /v1/dag/workflows/:dagId/runs`로 둔다. `?version=`이 없으면 최신 published 버전을 실행하고, body는 `{ input?, overrides? }`만 받는다.
+- 2026-05-05: published workflow route contract 테스트를 추가하고 RED를 확인한 뒤 라우트 구현, 서버 등록, runtime asset 동기화 재사용까지 완료했다.
+- 2026-05-05: 서버 패키지 test/typecheck/lint/build, `pnpm harness:scan:specs`, `pnpm build`, `pnpm harness:verify -- --base-ref origin/develop --skip-record-check` 통과를 확인했다.
+
+## 결과
+
+- `POST /v1/dag/workflows/:dagId/runs` endpoint를 추가해 published DAG definition을 외부 API로 즉시 실행할 수 있게 했다.
+- `?version=`이 없으면 최신 published definition을 실행하고, 특정 version 요청은 published 상태만 허용한다.
+- 실행 body는 `{ input?, overrides? }`로 고정하고, node config override는 요청 단위 shallow merge만 수행하며 저장된 definition은 변경하지 않는다.
+- input schema 자동 생성, 인증, 크레딧, rate limiting, webhook은 별도 설계가 필요한 후속 범위로 남긴다.

--- a/apps/dag-orchestrator-server/docs/SPEC.md
+++ b/apps/dag-orchestrator-server/docs/SPEC.md
@@ -25,6 +25,7 @@ Express Application (http.Server)
 ├── Robota API Routes (/v1/dag/*)
 │   ├── definition-routes  → DagDesignController (dag-api)
 │   ├── run-routes         → OrchestratorRunService (dag-orchestrator)
+│   ├── published-workflow-routes → IStoragePort + OrchestratorRunService
 │   ├── asset-routes       → IAssetStore (dag-core)
 │   ├── admin-routes       → DagDesignController (dag-api)
 │   └── ws-routes          → WebSocket bridge to ComfyUI backend
@@ -53,10 +54,12 @@ Express Application (http.Server)
 
 This application does not define SSOT domain types. All domain types are imported from upstream packages.
 
-| Type                       | Source                                         | Purpose                                         |
-| -------------------------- | ---------------------------------------------- | ----------------------------------------------- |
-| `IComfyUiWsMessage`        | Local (`services/comfyui-event-translator.ts`) | ComfyUI WebSocket message shape for translation |
-| `TVersionQueryParseResult` | Local (`routes/route-utils.ts`)                | Version query parameter parse result union      |
+| Type                       | Source                                             | Purpose                                         |
+| -------------------------- | -------------------------------------------------- | ----------------------------------------------- |
+| `IComfyUiWsMessage`        | Local (`services/comfyui-event-translator.ts`)     | ComfyUI WebSocket message shape for translation |
+| `TVersionQueryParseResult` | Local (`routes/route-utils.ts`)                    | Version query parameter parse result union      |
+| `IWorkflowOverrideMap`     | Local (`routes/published-workflow-route-utils.ts`) | Request-local node config override map          |
+| `IWorkflowRunRequestBody`  | Local (`routes/published-workflow-route-utils.ts`) | Parsed published workflow run request body      |
 
 Helper functions and HTTP status constants in `route-utils.ts` are locally defined but not exported as SSOT types.
 
@@ -89,6 +92,22 @@ All Robota endpoints use a standard response envelope:
 | `/v1/dag/runs/:id/start`  | POST   | Start run execution | None                     | `202 { ok, data: { dagRunId, preparationId } }` |
 | `/v1/dag/runs/:id/result` | GET    | Get run result      | None                     | `200 { ok, data: { run } }`                     |
 | `/v1/dag/runs/:id`        | GET    | Get run status      | None                     | `200 { ok, data: { dagRunId, status } }`        |
+
+#### Published Workflow Routes
+
+| Endpoint                        | Method | Purpose                          | Request Body             | Success Response                                                |
+| ------------------------------- | ------ | -------------------------------- | ------------------------ | --------------------------------------------------------------- |
+| `/v1/dag/workflows/:dagId/runs` | POST   | Start a published definition run | `{ input?, overrides? }` | `202 { ok, data: { dagRunId, preparationId, dagId, version } }` |
+
+**Published workflow execution contract:**
+
+1. The route executes only persisted definitions whose `status` is `published`.
+2. `?version=<positive-int>` selects an exact published version. Without `version`, the route selects `IStoragePort.getLatestPublishedDefinition(dagId)`.
+3. `input` must be an object when provided and is forwarded as the run input payload.
+4. `overrides` must be an object keyed by `nodeId`. Each value must be an object and is shallow-merged into that node's `config` for this single run only.
+5. Unknown override node IDs are rejected. Overrides never mutate or persist the stored definition.
+6. Asset references are validated after overrides and before prompt translation. Runtime asset synchronization uses the same `resolvePromptAssetsForRuntime` path as `/v1/dag/runs/:id/start`.
+7. Published workflow runs are asynchronous. A successful request means the run was accepted by the runtime and returns identifiers for status/result polling.
 
 #### Asset Routes
 
@@ -192,29 +211,35 @@ Error objects follow RFC 7807 (IProblemDetails) structure where applicable:
 
 ### Error Code to HTTP Status Mapping
 
-| Error Code                                                    | HTTP Status | Context                                                     |
-| ------------------------------------------------------------- | ----------- | ----------------------------------------------------------- |
-| `DAG_VALIDATION_DEFINITION_REQUIRED`                          | 400         | Missing definition in request body                          |
-| `DAG_VALIDATION_VERSION_QUERY_INVALID`                        | 400         | Invalid version query parameter                             |
-| `DAG_VALIDATION_ASSET_FILENAME_REQUIRED`                      | 400         | Missing fileName in asset upload                            |
-| `DAG_VALIDATION_ASSET_MEDIATYPE_REQUIRED`                     | 400         | Missing mediaType in asset upload                           |
-| `DAG_VALIDATION_ASSET_BASE64_REQUIRED`                        | 400         | Missing base64Data in asset upload                          |
-| `DAG_VALIDATION_ASSET_EMPTY_CONTENT`                          | 400         | Decoded base64 content is empty                             |
-| `DAG_VALIDATION_ASSET_BASE64_INVALID`                         | 400         | Invalid base64 encoding                                     |
-| `DAG_RUNTIME_ASSET_UPLOAD_FAILED`                             | 502         | Runtime rejected or could not receive an asset upload       |
-| `DAG_RUNTIME_ASSET_RESPONSE_INVALID`                          | 502         | Runtime upload response did not contain a usable asset name |
-| `DAG_VALIDATION_ASSET_REFERENCE_OBJECT_REQUIRED`              | 400         | config.asset must be a media reference object               |
-| `DAG_VALIDATION_ASSET_REFERENCE_TYPE_INVALID`                 | 400         | referenceType must be asset or uri                          |
-| `DAG_VALIDATION_ASSET_REFERENCE_XOR_REQUIRED`                 | 400         | Exactly one of assetId or uri required                      |
-| `DAG_VALIDATION_ASSET_REFERENCE_TYPE_ASSET_REQUIRES_ASSET_ID` | 400         | referenceType asset requires assetId                        |
-| `DAG_VALIDATION_ASSET_REFERENCE_NOT_FOUND`                    | 400         | Referenced assetId does not exist                           |
-| `DAG_VALIDATION_RUN_DEFINITION_REQUIRED`                      | 400         | Missing definition in run create request                    |
-| `DAG_VALIDATION_RUN_INPUT_INVALID`                            | 400         | input must be an object when provided                       |
-| `DAG_ASSET_NOT_FOUND`                                         | 404         | Asset not found by assetId                                  |
-| `ORCHESTRATOR_RUN_NOT_FOUND`                                  | 404         | Run not found by dagRunId                                   |
-| `ORCHESTRATOR_RUN_NOT_COMPLETED`                              | 409         | Run result requested before completion                      |
-| `WS_BRIDGE_ERROR`                                             | N/A (WS)    | WebSocket bridge failure (sent as WS event)                 |
-| `COMFYUI_EXECUTION_ERROR`                                     | N/A (WS)    | ComfyUI execution error (sent as WS event)                  |
+| Error Code                                                    | HTTP Status | Context                                                          |
+| ------------------------------------------------------------- | ----------- | ---------------------------------------------------------------- |
+| `DAG_VALIDATION_DEFINITION_REQUIRED`                          | 400         | Missing definition in request body                               |
+| `DAG_VALIDATION_VERSION_QUERY_INVALID`                        | 400         | Invalid version query parameter                                  |
+| `DAG_VALIDATION_ASSET_FILENAME_REQUIRED`                      | 400         | Missing fileName in asset upload                                 |
+| `DAG_VALIDATION_ASSET_MEDIATYPE_REQUIRED`                     | 400         | Missing mediaType in asset upload                                |
+| `DAG_VALIDATION_ASSET_BASE64_REQUIRED`                        | 400         | Missing base64Data in asset upload                               |
+| `DAG_VALIDATION_ASSET_EMPTY_CONTENT`                          | 400         | Decoded base64 content is empty                                  |
+| `DAG_VALIDATION_ASSET_BASE64_INVALID`                         | 400         | Invalid base64 encoding                                          |
+| `DAG_RUNTIME_ASSET_UPLOAD_FAILED`                             | 502         | Runtime rejected or could not receive an asset upload            |
+| `DAG_RUNTIME_ASSET_RESPONSE_INVALID`                          | 502         | Runtime upload response did not contain a usable asset name      |
+| `DAG_VALIDATION_ASSET_REFERENCE_OBJECT_REQUIRED`              | 400         | config.asset must be a media reference object                    |
+| `DAG_VALIDATION_ASSET_REFERENCE_TYPE_INVALID`                 | 400         | referenceType must be asset or uri                               |
+| `DAG_VALIDATION_ASSET_REFERENCE_XOR_REQUIRED`                 | 400         | Exactly one of assetId or uri required                           |
+| `DAG_VALIDATION_ASSET_REFERENCE_TYPE_ASSET_REQUIRES_ASSET_ID` | 400         | referenceType asset requires assetId                             |
+| `DAG_VALIDATION_ASSET_REFERENCE_NOT_FOUND`                    | 400         | Referenced assetId does not exist                                |
+| `DAG_VALIDATION_RUN_DEFINITION_REQUIRED`                      | 400         | Missing definition in run create request                         |
+| `DAG_VALIDATION_RUN_INPUT_INVALID`                            | 400         | input must be an object when provided                            |
+| `DAG_PUBLISHED_DEFINITION_NOT_FOUND`                          | 404         | Published workflow endpoint could not find a runnable definition |
+| `DAG_PUBLISHED_DEFINITION_STATUS_INVALID`                     | 409         | Requested workflow version exists but is not published           |
+| `DAG_VALIDATION_WORKFLOW_REQUEST_INVALID`                     | 400         | Published workflow request body must be an object                |
+| `DAG_VALIDATION_WORKFLOW_INPUT_INVALID`                       | 400         | Published workflow input must be an object when provided         |
+| `DAG_VALIDATION_WORKFLOW_OVERRIDES_INVALID`                   | 400         | Published workflow overrides must be an object map               |
+| `DAG_VALIDATION_WORKFLOW_OVERRIDE_NODE_NOT_FOUND`             | 400         | Override references a node ID absent from the definition         |
+| `DAG_ASSET_NOT_FOUND`                                         | 404         | Asset not found by assetId                                       |
+| `ORCHESTRATOR_RUN_NOT_FOUND`                                  | 404         | Run not found by dagRunId                                        |
+| `ORCHESTRATOR_RUN_NOT_COMPLETED`                              | 409         | Run result requested before completion                           |
+| `WS_BRIDGE_ERROR`                                             | N/A (WS)    | WebSocket bridge failure (sent as WS event)                      |
+| `COMFYUI_EXECUTION_ERROR`                                     | N/A (WS)    | ComfyUI execution error (sent as WS event)                       |
 
 ### ComfyUI Proxy Error Format
 
@@ -227,10 +252,11 @@ ComfyUI proxy endpoints (`/prompt`, `/queue`, `/history`, etc.) use the backend'
 
 ### Current Coverage
 
-| Test File                                        | Scope                                 | Tests                                                                                 |
-| ------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------- |
-| `src/__tests__/comfyui-event-translator.test.ts` | `translateComfyUiEvent` pure function | ComfyUI message type mapping, prompt_id filtering, terminal events                    |
-| `src/__tests__/endpoint-contract.test.ts`        | Run route endpoint contracts          | Response envelope shapes, preparationId/dagRunId flow, error format (IProblemDetails) |
+| Test File                                         | Scope                                 | Tests                                                                                 |
+| ------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/__tests__/comfyui-event-translator.test.ts`  | `translateComfyUiEvent` pure function | ComfyUI message type mapping, prompt_id filtering, terminal events                    |
+| `src/__tests__/endpoint-contract.test.ts`         | Run route endpoint contracts          | Response envelope shapes, preparationId/dagRunId flow, error format (IProblemDetails) |
+| `src/__tests__/published-workflow-routes.test.ts` | Published workflow routes             | Latest/exact published selection, draft rejection, override validation                |
 
 ### Coverage Gaps
 
@@ -254,15 +280,16 @@ ComfyUI proxy endpoints (`/prompt`, `/queue`, `/history`, etc.) use the backend'
 
 ### Route Registration Functions
 
-| Function                     | Module                           | Dependencies                                              |
-| ---------------------------- | -------------------------------- | --------------------------------------------------------- |
-| `registerDefinitionRoutes`   | `routes/definition-routes.ts`    | `DagDesignController`, `IAssetStore`                      |
-| `registerRunRoutes`          | `routes/run-routes.ts`           | `OrchestratorRunService`, `IAssetStore`                   |
-| `registerAssetRoutes`        | `routes/asset-routes.ts`         | `IAssetStore`                                             |
-| `registerAdminRoutes`        | `routes/admin-routes.ts`         | `DagDesignController`                                     |
-| `registerRuntimeAssetRoutes` | `routes/runtime-asset-routes.ts` | `backendUrl`                                              |
-| `registerCostMetaRoutes`     | `routes/cost-meta-routes.ts`     | `ICostMetaStoragePort`, `CelCostEvaluator`                |
-| `registerWsRoutes`           | `routes/ws-routes.ts`            | `http.Server`, `OrchestratorRunService`, `backendBaseUrl` |
+| Function                          | Module                                | Dependencies                                              |
+| --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
+| `registerDefinitionRoutes`        | `routes/definition-routes.ts`         | `DagDesignController`, `IAssetStore`                      |
+| `registerRunRoutes`               | `routes/run-routes.ts`                | `OrchestratorRunService`, `IAssetStore`                   |
+| `registerPublishedWorkflowRoutes` | `routes/published-workflow-routes.ts` | `IStoragePort`, `OrchestratorRunService`, `IAssetStore`   |
+| `registerAssetRoutes`             | `routes/asset-routes.ts`              | `IAssetStore`                                             |
+| `registerAdminRoutes`             | `routes/admin-routes.ts`              | `DagDesignController`                                     |
+| `registerRuntimeAssetRoutes`      | `routes/runtime-asset-routes.ts`      | `backendUrl`                                              |
+| `registerCostMetaRoutes`          | `routes/cost-meta-routes.ts`          | `ICostMetaStoragePort`, `CelCostEvaluator`                |
+| `registerWsRoutes`                | `routes/ws-routes.ts`                 | `http.Server`, `OrchestratorRunService`, `backendBaseUrl` |
 
 ### Utility Functions (route-utils.ts)
 

--- a/apps/dag-orchestrator-server/src/__tests__/published-workflow-routes.test.ts
+++ b/apps/dag-orchestrator-server/src/__tests__/published-workflow-routes.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { FileStoragePort } from '@robota-sdk/dag-adapters-local';
+import type {
+  IDagDefinition,
+  IAssetContentResult,
+  IAssetStore,
+  ICreateAssetInput,
+  ICreateAssetReferenceInput,
+  IPromptRequest,
+  IStoredAssetMetadata,
+  TPortPayload,
+} from '@robota-sdk/dag-core';
+import type { OrchestratorRunService } from '@robota-sdk/dag-orchestrator';
+import { registerPublishedWorkflowRoutes } from '../routes/published-workflow-routes.js';
+
+class StubAssetStore implements IAssetStore {
+  async save(_input: ICreateAssetInput): Promise<IStoredAssetMetadata> {
+    return createAssetMetadata('asset-1');
+  }
+
+  async saveReference(_input: ICreateAssetReferenceInput): Promise<IStoredAssetMetadata> {
+    return createAssetMetadata('asset-1');
+  }
+
+  async getMetadata(assetId: string): Promise<IStoredAssetMetadata | undefined> {
+    return createAssetMetadata(assetId);
+  }
+
+  async getContent(_assetId: string): Promise<IAssetContentResult | undefined> {
+    return { data: Buffer.from('test'), mediaType: 'image/png' };
+  }
+}
+
+class StubRunService {
+  public createdDefinition: IDagDefinition | undefined;
+  public createdInput: TPortPayload | undefined;
+  public startedPreparationId: string | undefined;
+
+  async createRun(definition: IDagDefinition, input: TPortPayload) {
+    this.createdDefinition = definition;
+    this.createdInput = input;
+    return { ok: true as const, value: { preparationId: 'prep-1' } };
+  }
+
+  getPendingPromptRequest(_preparationId: string): IPromptRequest | undefined {
+    return { prompt: {} };
+  }
+
+  async startRun(preparationId: string) {
+    this.startedPreparationId = preparationId;
+    return { ok: true as const, value: { dagRunId: 'dag-run-1', preparationId } };
+  }
+}
+
+interface ITestServer {
+  baseUrl: string;
+  close(): Promise<void>;
+  runService: StubRunService;
+  storage: FileStoragePort;
+}
+
+const openServers: ITestServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(openServers.splice(0).map((server) => server.close()));
+});
+
+function createAssetMetadata(assetId: string): IStoredAssetMetadata {
+  return {
+    assetId,
+    fileName: 'test.png',
+    mediaType: 'image/png',
+    sizeBytes: 100,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function createDefinition(
+  version: number,
+  status: IDagDefinition['status'],
+  config: Record<string, string | number>,
+): IDagDefinition {
+  return {
+    dagId: 'published-dag',
+    version,
+    status,
+    nodes: [
+      {
+        nodeId: 'text-1',
+        nodeType: 'text-template',
+        dependsOn: [],
+        config,
+      },
+    ],
+    edges: [],
+  };
+}
+
+async function createTestServer(definitions: IDagDefinition[]): Promise<ITestServer> {
+  const storageRoot = await mkdtemp(path.join(os.tmpdir(), 'robota-published-workflow-'));
+  const storage = new FileStoragePort(storageRoot);
+  for (const definition of definitions) {
+    await storage.saveDefinition(definition);
+  }
+
+  const app = express();
+  app.use(express.json());
+
+  const runService = new StubRunService();
+  const router = express.Router();
+  registerPublishedWorkflowRoutes(
+    router,
+    storage,
+    runService as unknown as OrchestratorRunService,
+    new StubAssetStore(),
+    'http://127.0.0.1:8188',
+  );
+  app.use(router);
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('Server did not bind to a port');
+  }
+
+  const testServer: ITestServer = {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    runService,
+    storage,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+      await rm(storageRoot, { recursive: true, force: true });
+    },
+  };
+  openServers.push(testServer);
+  return testServer;
+}
+
+async function post(
+  pathname: string,
+  payload?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  const server = openServers[openServers.length - 1];
+  if (!server) {
+    throw new Error('No open test server');
+  }
+  const response = await fetch(`${server.baseUrl}${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof payload === 'undefined' ? undefined : JSON.stringify(payload),
+  });
+  const body: unknown = await response.json();
+  return { status: response.status, body };
+}
+
+describe('published workflow routes', () => {
+  it('starts the latest published definition and applies per-run overrides without persisting them', async () => {
+    const server = await createTestServer([
+      createDefinition(1, 'published', { template: 'published-v1', seed: 1 }),
+      createDefinition(2, 'draft', { template: 'draft-v2', seed: 2 }),
+      createDefinition(3, 'published', { template: 'published-v3', seed: 3 }),
+    ]);
+
+    const { status, body } = await post('/v1/dag/workflows/published-dag/runs', {
+      input: { prompt: 'from-api' },
+      overrides: {
+        'text-1': { template: 'override-template' },
+      },
+    });
+
+    expect(status).toBe(202);
+    const envelope = body as {
+      ok: boolean;
+      status: number;
+      data: { dagRunId: string; preparationId: string; dagId: string; version: number };
+    };
+    expect(envelope.ok).toBe(true);
+    expect(envelope.status).toBe(202);
+    expect(envelope.data).toEqual({
+      dagRunId: 'dag-run-1',
+      preparationId: 'prep-1',
+      dagId: 'published-dag',
+      version: 3,
+    });
+
+    expect(server.runService.createdInput).toEqual({ prompt: 'from-api' });
+    expect(server.runService.createdDefinition?.version).toBe(3);
+    expect(server.runService.createdDefinition?.nodes[0]?.config).toEqual({
+      template: 'override-template',
+      seed: 3,
+    });
+    expect(server.runService.startedPreparationId).toBe('prep-1');
+
+    const persistedDefinition = await server.storage.getDefinition('published-dag', 3);
+    expect(persistedDefinition?.nodes[0]?.config).toEqual({
+      template: 'published-v3',
+      seed: 3,
+    });
+  });
+
+  it('rejects an exact version that is not published', async () => {
+    const server = await createTestServer([
+      createDefinition(1, 'draft', { template: 'draft-v1', seed: 1 }),
+    ]);
+
+    const { status, body } = await post('/v1/dag/workflows/published-dag/runs?version=1', {});
+
+    expect(status).toBe(409);
+    const envelope = body as { ok: boolean; errors: Array<{ code: string }> };
+    expect(envelope.ok).toBe(false);
+    expect(envelope.errors[0]?.code).toBe('DAG_PUBLISHED_DEFINITION_STATUS_INVALID');
+    expect(server.runService.createdDefinition).toBeUndefined();
+  });
+
+  it('returns 404 when no published definition exists', async () => {
+    await createTestServer([]);
+
+    const { status, body } = await post('/v1/dag/workflows/published-dag/runs', {});
+
+    expect(status).toBe(404);
+    const envelope = body as { ok: boolean; errors: Array<{ code: string }> };
+    expect(envelope.ok).toBe(false);
+    expect(envelope.errors[0]?.code).toBe('DAG_PUBLISHED_DEFINITION_NOT_FOUND');
+  });
+
+  it('rejects overrides for unknown node IDs', async () => {
+    const server = await createTestServer([
+      createDefinition(1, 'published', { template: 'published-v1', seed: 1 }),
+    ]);
+
+    const { status, body } = await post('/v1/dag/workflows/published-dag/runs', {
+      overrides: {
+        missing: { template: 'override-template' },
+      },
+    });
+
+    expect(status).toBe(400);
+    const envelope = body as { ok: boolean; errors: Array<{ code: string }> };
+    expect(envelope.ok).toBe(false);
+    expect(envelope.errors[0]?.code).toBe('DAG_VALIDATION_WORKFLOW_OVERRIDE_NODE_NOT_FOUND');
+    expect(server.runService.createdDefinition).toBeUndefined();
+  });
+});

--- a/apps/dag-orchestrator-server/src/routes/published-workflow-route-utils.ts
+++ b/apps/dag-orchestrator-server/src/routes/published-workflow-route-utils.ts
@@ -1,0 +1,246 @@
+import type {
+  IDagDefinition,
+  IStoragePort,
+  TNodeConfigRecord,
+  TNodeConfigValue,
+  TPortPayload,
+} from '@robota-sdk/dag-core';
+import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from './route-utils.js';
+
+export type TWorkflowRequestValue =
+  | string
+  | number
+  | boolean
+  | null
+  | IWorkflowRequestObject
+  | TWorkflowRequestValue[];
+
+export interface IWorkflowRequestObject {
+  [key: string]: TWorkflowRequestValue | undefined;
+}
+
+export interface IWorkflowOverrideMap {
+  [nodeId: string]: TNodeConfigRecord;
+}
+
+export interface IWorkflowRunRequestBody {
+  input?: TPortPayload;
+  overrides?: IWorkflowOverrideMap;
+}
+
+export interface IWorkflowValidationError {
+  code: string;
+  detail: string;
+  retryable: false;
+}
+
+export type TDefinitionLookupResult =
+  | { ok: true; definition: IDagDefinition }
+  | { ok: false; status: number; error: IWorkflowValidationError };
+
+export type TOverrideResult =
+  | { ok: true; definition: IDagDefinition }
+  | { ok: false; error: IWorkflowValidationError };
+
+function isRecord(value: TWorkflowRequestValue | undefined): value is IWorkflowRequestObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeConfigValue(value: TWorkflowRequestValue | undefined): value is TNodeConfigValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every((item) => isNodeConfigValue(item));
+  }
+  if (isRecord(value)) {
+    return Object.values(value).every((item) => isNodeConfigValue(item));
+  }
+  return false;
+}
+
+function isNodeConfigRecord(value: TWorkflowRequestValue | undefined): value is TNodeConfigRecord {
+  return isRecord(value) && Object.values(value).every((item) => isNodeConfigValue(item));
+}
+
+export function toWorkflowProblemDetails(
+  error: IWorkflowValidationError,
+  status: number,
+  instance: string,
+): {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance: string;
+  code: string;
+  retryable: boolean;
+} {
+  const title =
+    status === HTTP_NOT_FOUND
+      ? 'Published workflow not found'
+      : status === HTTP_CONFLICT
+        ? 'Published workflow unavailable'
+        : 'DAG validation failed';
+  const problemType =
+    status === HTTP_BAD_REQUEST
+      ? 'urn:robota:problems:dag:validation'
+      : 'urn:robota:problems:dag:published-workflow';
+  return {
+    type: problemType,
+    title,
+    status,
+    detail: error.detail,
+    instance,
+    code: error.code,
+    retryable: error.retryable,
+  };
+}
+
+export function readWorkflowRunRequestBody(
+  rawBody: TWorkflowRequestValue | undefined,
+): IWorkflowRunRequestBody | IWorkflowValidationError {
+  if (typeof rawBody === 'undefined') {
+    return {};
+  }
+  if (!isRecord(rawBody)) {
+    return {
+      code: 'DAG_VALIDATION_WORKFLOW_REQUEST_INVALID',
+      detail: 'request body must be an object when provided',
+      retryable: false,
+    };
+  }
+
+  const input = rawBody.input;
+  if (typeof input !== 'undefined' && !isRecord(input)) {
+    return {
+      code: 'DAG_VALIDATION_WORKFLOW_INPUT_INVALID',
+      detail: 'input must be an object when provided',
+      retryable: false,
+    };
+  }
+
+  const overrides = rawBody.overrides;
+  if (typeof overrides === 'undefined') {
+    return { input: (input ?? {}) as TPortPayload };
+  }
+  if (!isRecord(overrides)) {
+    return {
+      code: 'DAG_VALIDATION_WORKFLOW_OVERRIDES_INVALID',
+      detail: 'overrides must be an object keyed by nodeId when provided',
+      retryable: false,
+    };
+  }
+
+  const parsedOverrides: IWorkflowOverrideMap = {};
+  for (const [nodeId, override] of Object.entries(overrides)) {
+    if (!isNodeConfigRecord(override)) {
+      return {
+        code: 'DAG_VALIDATION_WORKFLOW_OVERRIDES_INVALID',
+        detail: `overrides.${nodeId} must be a node config object`,
+        retryable: false,
+      };
+    }
+    parsedOverrides[nodeId] = override;
+  }
+
+  return {
+    input: (input ?? {}) as TPortPayload,
+    overrides: parsedOverrides,
+  };
+}
+
+export async function resolvePublishedDefinition(
+  storage: IStoragePort,
+  dagId: string,
+  version: number | undefined,
+): Promise<TDefinitionLookupResult> {
+  if (typeof version === 'number') {
+    const exactDefinition = await storage.getDefinition(dagId, version);
+    if (!exactDefinition) {
+      return {
+        ok: false,
+        status: HTTP_NOT_FOUND,
+        error: {
+          code: 'DAG_PUBLISHED_DEFINITION_NOT_FOUND',
+          detail: `Published definition not found for dagId ${dagId} version ${version}`,
+          retryable: false,
+        },
+      };
+    }
+    if (exactDefinition.status !== 'published') {
+      return {
+        ok: false,
+        status: HTTP_CONFLICT,
+        error: {
+          code: 'DAG_PUBLISHED_DEFINITION_STATUS_INVALID',
+          detail: `Definition ${dagId} version ${version} is not published`,
+          retryable: false,
+        },
+      };
+    }
+    return { ok: true, definition: exactDefinition };
+  }
+
+  const latestDefinition = await storage.getLatestPublishedDefinition(dagId);
+  if (!latestDefinition) {
+    return {
+      ok: false,
+      status: HTTP_NOT_FOUND,
+      error: {
+        code: 'DAG_PUBLISHED_DEFINITION_NOT_FOUND',
+        detail: `Published definition not found for dagId ${dagId}`,
+        retryable: false,
+      },
+    };
+  }
+  return { ok: true, definition: latestDefinition };
+}
+
+export function applyWorkflowOverrides(
+  definition: IDagDefinition,
+  overrides: IWorkflowOverrideMap | undefined,
+): TOverrideResult {
+  if (typeof overrides === 'undefined' || Object.keys(overrides).length === 0) {
+    return { ok: true, definition };
+  }
+
+  const nodeIds = new Set(definition.nodes.map((node) => node.nodeId));
+  for (const nodeId of Object.keys(overrides)) {
+    if (!nodeIds.has(nodeId)) {
+      return {
+        ok: false,
+        error: {
+          code: 'DAG_VALIDATION_WORKFLOW_OVERRIDE_NODE_NOT_FOUND',
+          detail: `Override references unknown nodeId: ${nodeId}`,
+          retryable: false,
+        },
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    definition: {
+      ...definition,
+      nodes: definition.nodes.map((node) => {
+        const override = overrides[node.nodeId];
+        if (typeof override === 'undefined') {
+          return node;
+        }
+        return {
+          ...node,
+          config: {
+            ...node.config,
+            ...override,
+          },
+        };
+      }),
+    },
+  };
+}

--- a/apps/dag-orchestrator-server/src/routes/published-workflow-routes.ts
+++ b/apps/dag-orchestrator-server/src/routes/published-workflow-routes.ts
@@ -1,0 +1,265 @@
+import type { Request, Response, Router } from 'express';
+import { toProblemDetails, type IProblemDetails } from '@robota-sdk/dag-api';
+import type { IDagDefinition, IAssetStore, IStoragePort, TPortPayload } from '@robota-sdk/dag-core';
+import type { OrchestratorRunService } from '@robota-sdk/dag-orchestrator';
+import {
+  HTTP_ACCEPTED,
+  HTTP_BAD_REQUEST,
+  HTTP_NOT_FOUND,
+  parseOptionalPositiveIntegerQuery,
+  toRunProblemDetails,
+  toRuntimeAssetProblemDetails,
+  validateAssetReferences,
+} from './route-utils.js';
+import { resolvePromptAssetsForRuntime } from './runtime-asset-upload.js';
+import {
+  applyWorkflowOverrides,
+  readWorkflowRunRequestBody,
+  resolvePublishedDefinition,
+  toWorkflowProblemDetails,
+  type TWorkflowRequestValue,
+} from './published-workflow-route-utils.js';
+
+interface IPublishedWorkflowRouteDependencies {
+  storage: IStoragePort;
+  runService: OrchestratorRunService;
+  assetStore: IAssetStore;
+  backendUrl: string;
+}
+
+interface IWorkflowRunRouteContext {
+  dagId: string;
+  instance: string;
+  versionQuery: string | undefined;
+  body: TWorkflowRequestValue | undefined;
+}
+
+interface IWorkflowRouteSuccess {
+  ok: true;
+  status: number;
+  data: {
+    dagRunId: string;
+    preparationId: string;
+    dagId: string;
+    version: number;
+  };
+}
+
+interface IWorkflowRouteFailure {
+  ok: false;
+  status: number;
+  errors: IProblemDetails[];
+}
+
+type TWorkflowRouteResult = IWorkflowRouteSuccess | IWorkflowRouteFailure;
+type TPreparedWorkflowRunDefinition =
+  | { ok: true; definition: IDagDefinition; input: TPortPayload }
+  | IWorkflowRouteFailure;
+type TPreparedRunResult = { ok: true; preparationId: string } | IWorkflowRouteFailure;
+type TStartedRunResult =
+  | { ok: true; dagRunId: string; preparationId: string }
+  | IWorkflowRouteFailure;
+
+function toFailure(status: number, errors: IProblemDetails[]): IWorkflowRouteFailure {
+  return { ok: false, status, errors };
+}
+
+async function validateDefinitionAssets(
+  definition: IDagDefinition,
+  deps: IPublishedWorkflowRouteDependencies,
+  instance: string,
+): Promise<IWorkflowRouteFailure | undefined> {
+  const assetErrors = await validateAssetReferences(definition, deps.assetStore);
+  if (assetErrors.length === 0) {
+    return undefined;
+  }
+  return toFailure(
+    HTTP_BAD_REQUEST,
+    assetErrors.map((error) => toRunProblemDetails(error, instance)),
+  );
+}
+
+async function createPreparedRun(
+  definition: IDagDefinition,
+  input: TPortPayload,
+  deps: IPublishedWorkflowRouteDependencies,
+  instance: string,
+): Promise<TPreparedRunResult> {
+  const createResult = await deps.runService.createRun(definition, input);
+  if (!createResult.ok) {
+    return toFailure(HTTP_BAD_REQUEST, [toProblemDetails(createResult.error, instance)]);
+  }
+  return { ok: true, preparationId: createResult.value.preparationId };
+}
+
+async function syncRuntimeAssets(
+  preparationId: string,
+  deps: IPublishedWorkflowRouteDependencies,
+  instance: string,
+): Promise<IWorkflowRouteFailure | undefined> {
+  const promptRequest = deps.runService.getPendingPromptRequest(preparationId);
+  if (!promptRequest) {
+    return undefined;
+  }
+  const assetResolution = await resolvePromptAssetsForRuntime(
+    promptRequest,
+    deps.assetStore,
+    deps.backendUrl,
+  );
+  if (assetResolution.ok) {
+    return undefined;
+  }
+  return toFailure(assetResolution.status, [
+    toRuntimeAssetProblemDetails(assetResolution, instance),
+  ]);
+}
+
+async function startPreparedRun(
+  preparationId: string,
+  deps: IPublishedWorkflowRouteDependencies,
+  instance: string,
+): Promise<TStartedRunResult> {
+  const startResult = await deps.runService.startRun(preparationId);
+  if (!startResult.ok) {
+    const statusCode =
+      startResult.error.code === 'ORCHESTRATOR_RUN_NOT_FOUND' ? HTTP_NOT_FOUND : HTTP_BAD_REQUEST;
+    return toFailure(statusCode, [toProblemDetails(startResult.error, instance)]);
+  }
+  return {
+    ok: true,
+    dagRunId: startResult.value.dagRunId,
+    preparationId: startResult.value.preparationId,
+  };
+}
+
+async function prepareWorkflowRunDefinition(
+  context: IWorkflowRunRouteContext,
+  deps: IPublishedWorkflowRouteDependencies,
+): Promise<TPreparedWorkflowRunDefinition> {
+  const parsedVersion = parseOptionalPositiveIntegerQuery(context.versionQuery);
+  if (!parsedVersion.ok) {
+    return toFailure(HTTP_BAD_REQUEST, [
+      toRunProblemDetails(parsedVersion.error, context.instance),
+    ]);
+  }
+
+  const requestBody = readWorkflowRunRequestBody(context.body);
+  if ('code' in requestBody) {
+    return toFailure(HTTP_BAD_REQUEST, [
+      toWorkflowProblemDetails(requestBody, HTTP_BAD_REQUEST, context.instance),
+    ]);
+  }
+
+  const lookupResult = await resolvePublishedDefinition(
+    deps.storage,
+    context.dagId,
+    parsedVersion.value,
+  );
+  if (!lookupResult.ok) {
+    return toFailure(lookupResult.status, [
+      toWorkflowProblemDetails(lookupResult.error, lookupResult.status, context.instance),
+    ]);
+  }
+
+  const overrideResult = applyWorkflowOverrides(lookupResult.definition, requestBody.overrides);
+  if (!overrideResult.ok) {
+    return toFailure(HTTP_BAD_REQUEST, [
+      toWorkflowProblemDetails(overrideResult.error, HTTP_BAD_REQUEST, context.instance),
+    ]);
+  }
+
+  const assetFailure = await validateDefinitionAssets(
+    overrideResult.definition,
+    deps,
+    context.instance,
+  );
+  if (assetFailure) {
+    return assetFailure;
+  }
+
+  return {
+    ok: true,
+    definition: overrideResult.definition,
+    input: requestBody.input ?? {},
+  };
+}
+
+async function startWorkflowRun(
+  preparedDefinition: { definition: IDagDefinition; input: TPortPayload },
+  context: IWorkflowRunRouteContext,
+  deps: IPublishedWorkflowRouteDependencies,
+): Promise<TWorkflowRouteResult> {
+  const preparedRun = await createPreparedRun(
+    preparedDefinition.definition,
+    preparedDefinition.input,
+    deps,
+    context.instance,
+  );
+  if (!preparedRun.ok) {
+    return preparedRun;
+  }
+
+  const assetSyncFailure = await syncRuntimeAssets(
+    preparedRun.preparationId,
+    deps,
+    context.instance,
+  );
+  if (assetSyncFailure) {
+    return assetSyncFailure;
+  }
+
+  const startedRun = await startPreparedRun(preparedRun.preparationId, deps, context.instance);
+  if (!startedRun.ok) {
+    return startedRun;
+  }
+
+  return {
+    ok: true,
+    status: HTTP_ACCEPTED,
+    data: {
+      dagRunId: startedRun.dagRunId,
+      preparationId: startedRun.preparationId,
+      dagId: preparedDefinition.definition.dagId,
+      version: preparedDefinition.definition.version,
+    },
+  };
+}
+
+async function runPublishedWorkflow(
+  context: IWorkflowRunRouteContext,
+  deps: IPublishedWorkflowRouteDependencies,
+): Promise<TWorkflowRouteResult> {
+  const preparedDefinition = await prepareWorkflowRunDefinition(context, deps);
+  if (!preparedDefinition.ok) {
+    return preparedDefinition;
+  }
+  return startWorkflowRun(preparedDefinition, context, deps);
+}
+
+function createPublishedWorkflowRunHandler(deps: IPublishedWorkflowRouteDependencies) {
+  return async (req: Request<{ dagId: string }>, res: Response): Promise<void> => {
+    const result = await runPublishedWorkflow(
+      {
+        dagId: req.params.dagId,
+        instance: `/v1/dag/workflows/${req.params.dagId}/runs`,
+        versionQuery: req.query.version as string | undefined,
+        body: req.body as TWorkflowRequestValue | undefined,
+      },
+      deps,
+    );
+    res.status(result.status).json(result);
+  };
+}
+
+export function registerPublishedWorkflowRoutes(
+  router: Router,
+  storage: IStoragePort,
+  runService: OrchestratorRunService,
+  assetStore: IAssetStore,
+  backendUrl: string,
+): void {
+  router.post(
+    '/v1/dag/workflows/:dagId/runs',
+    createPublishedWorkflowRunHandler({ storage, runService, assetStore, backendUrl }),
+  );
+}

--- a/apps/dag-orchestrator-server/src/routes/route-utils.ts
+++ b/apps/dag-orchestrator-server/src/routes/route-utils.ts
@@ -1,5 +1,6 @@
 import type { IDagDefinition, TPortPayload } from '@robota-sdk/dag-core';
 import type { IAssetStore } from '@robota-sdk/dag-core';
+import type { IRuntimeAssetUploadError } from './runtime-asset-upload.js';
 
 export const HTTP_BAD_REQUEST = 400;
 export const HTTP_NOT_FOUND = 404;
@@ -161,6 +162,29 @@ export function toRunProblemDetails(
     type: 'urn:robota:problems:dag:validation',
     title: 'DAG validation failed',
     status: HTTP_BAD_REQUEST,
+    detail: error.detail,
+    instance,
+    code: error.code,
+    retryable: error.retryable,
+  };
+}
+
+export function toRuntimeAssetProblemDetails(
+  error: IRuntimeAssetUploadError,
+  instance: string,
+): {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance: string;
+  code: string;
+  retryable: boolean;
+} {
+  return {
+    type: 'urn:robota:problems:dag:runtime-asset',
+    title: 'Runtime asset upload failed',
+    status: error.status,
     detail: error.detail,
     instance,
     code: error.code,

--- a/apps/dag-orchestrator-server/src/routes/run-routes.ts
+++ b/apps/dag-orchestrator-server/src/routes/run-routes.ts
@@ -11,34 +11,9 @@ import {
   HTTP_ACCEPTED,
   HTTP_OK,
   HTTP_CONFLICT,
+  toRuntimeAssetProblemDetails,
 } from './route-utils.js';
-import {
-  resolvePromptAssetsForRuntime,
-  type IRuntimeAssetUploadError,
-} from './runtime-asset-upload.js';
-
-function toRuntimeAssetProblemDetails(
-  error: IRuntimeAssetUploadError,
-  instance: string,
-): {
-  type: string;
-  title: string;
-  status: number;
-  detail: string;
-  instance: string;
-  code: string;
-  retryable: boolean;
-} {
-  return {
-    type: 'urn:robota:problems:dag:runtime-asset',
-    title: 'Runtime asset upload failed',
-    status: error.status,
-    detail: error.detail,
-    instance,
-    code: error.code,
-    retryable: error.retryable,
-  };
-}
+import { resolvePromptAssetsForRuntime } from './runtime-asset-upload.js';
 
 export function registerRunRoutes(
   router: Router,

--- a/apps/dag-orchestrator-server/src/server.ts
+++ b/apps/dag-orchestrator-server/src/server.ts
@@ -24,6 +24,7 @@ import { LocalFsAssetStore } from './services/local-fs-asset-store.js';
 
 import { registerDefinitionRoutes } from './routes/definition-routes.js';
 import { registerRunRoutes } from './routes/run-routes.js';
+import { registerPublishedWorkflowRoutes } from './routes/published-workflow-routes.js';
 import { registerAssetRoutes } from './routes/asset-routes.js';
 import { registerWsRoutes } from './routes/ws-routes.js';
 import { registerAdminRoutes } from './routes/admin-routes.js';
@@ -152,6 +153,7 @@ async function bootstrapOrchestratorServer(): Promise<void> {
   // Robota API routes
   registerDefinitionRoutes(app, controllers.design, assetStore);
   registerRunRoutes(app, runService, assetStore, backendUrl);
+  registerPublishedWorkflowRoutes(app, storage, runService, assetStore, backendUrl);
   registerAssetRoutes(app, assetStore, backendUrl);
   registerWsRoutes(server, runService, backendUrl);
   registerAdminRoutes(app, controllers.design);


### PR DESCRIPTION
## Summary
- Add POST /v1/dag/workflows/:dagId/runs for running persisted published DAG definitions
- Support latest published selection, exact version validation, per-run input and shallow node config overrides
- Reuse run preparation/start and runtime asset synchronization paths
- Archive DAG-BL-006 as completed

## Verification
- pnpm --filter @robota-sdk/dag-orchestrator-server test
- pnpm --filter @robota-sdk/dag-orchestrator-server typecheck
- pnpm --filter @robota-sdk/dag-orchestrator-server lint (existing warnings only)
- pnpm --filter @robota-sdk/dag-orchestrator-server build
- pnpm harness:scan:specs
- pnpm build
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check
- pre-push hook passed