### PR TITLE
feat(sdk): add auth and credits contract packages

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -2,6 +2,8 @@
 
 ```text
 packages/
+├── auth/                        # Auth contracts, verifier ports, scope policy
+├── credits/                     # Credit account, reservation, and settlement contracts
 ├── agent-core/                  # Foundation contracts, engine, events, hooks, permissions
 ├── agent-runtime/               # Reusable background task and subagent lifecycle/state/ports
 ├── agent-sessions/              # Session lifecycle and persistence
@@ -75,10 +77,10 @@ apps/
 
 ## Related Documents
 
-| Document                                                   | Content                                   |
-| ---------------------------------------------------------- | ----------------------------------------- |
-| [publish-registry.md](publish-registry.md)                 | npm publish rules, package registry table |
-| [dag-dependency-direction.md](dag-dependency-direction.md) | DAG package dependency flow and rules     |
+| Document                                                                                         | Content                                   |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| [publish-registry.md](publish-registry.md)                                                       | npm publish rules, package registry table |
+| [dag-dependency-direction.md](dag-dependency-direction.md)                                       | DAG package dependency flow and rules     |
 | [../packages/agent-cli/docs/ARCHITECTURE-MAP.md](../packages/agent-cli/docs/ARCHITECTURE-MAP.md) | CLI composition map and layer audit       |
 
 ## Command Package Rule

--- a/.agents/publish-registry.md
+++ b/.agents/publish-registry.md
@@ -6,6 +6,8 @@ Packages marked **publish** are published to npm under `@robota-sdk/` scope. All
 
 | Package                          | Publish | npm tag | Notes                              |
 | -------------------------------- | ------- | ------- | ---------------------------------- |
+| auth                             | no      | —       | private: true, beta contracts      |
+| credits                          | no      | —       | private: true, beta contracts      |
 | agent-core                       | yes     | beta    | Foundation — zero @robota-sdk deps |
 | agent-runtime                    | yes     | beta    | Runtime lifecycle/ports for SDK    |
 | agent-sessions                   | yes     | beta    | Session management                 |

--- a/.agents/tasks/completed/SDK-BL-001-auth-and-credits-package-design.md
+++ b/.agents/tasks/completed/SDK-BL-001-auth-and-credits-package-design.md
@@ -1,6 +1,6 @@
 ---
 title: 인증 + 크레딧 시스템 패키지 설계
-status: backlog
+status: completed
 created: 2026-03-15
 priority: high
 urgency: later
@@ -85,3 +85,18 @@ billing → credits (추후)
 - 구현 완료 후 관련 패키지 빌드 성공 확인
 - 연관 유닛 테스트 통과 확인
 - typecheck 및 lint 에러 없음 확인
+
+## 계획
+
+- [x] 인증/크레딧/결제 패키지 경계 ADR 작성
+- [x] `@robota-sdk/auth` private package 스캐폴드 및 인증 포트/스코프 정책 구현
+- [x] `@robota-sdk/credits` private package 스캐폴드 및 크레딧 예약/정산 순수 정책 구현
+- [x] package SPEC, docs index, project structure, publish registry 갱신
+- [x] 타깃 package test/typecheck/lint/build 및 workspace 검증 실행
+- [x] 완료 후 task를 completed로 이동
+
+## 진행 기록
+
+- 2026-05-05: published workflow API 후속 기반으로 인증/크레딧 경계를 먼저 고정한다. `billing`은 payment provider가 정해지기 전까지 빈 패키지를 만들지 않고 ADR의 후속 독립 패키지로 남긴다.
+- 2026-05-05: ADR-002를 추가하고 `@robota-sdk/auth`, `@robota-sdk/credits` private package의 SPEC, 포트, 순수 정책 함수, 단위 테스트를 추가했다.
+- 2026-05-05: `pnpm install`, 타깃 패키지 test/typecheck/lint/build, `pnpm harness:scan:specs`, `pnpm build`, `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`, `git diff --check`가 모두 통과했다.

--- a/.design/decisions/ADR-002-auth-credits-package-boundaries.md
+++ b/.design/decisions/ADR-002-auth-credits-package-boundaries.md
@@ -1,0 +1,51 @@
+# ADR-002: Auth and Credits Package Boundaries
+
+## Status
+
+accepted
+
+## Context
+
+Published DAG execution introduces external callers, API keys, user ownership, and credit checks before a workflow can run. The monorepo already has `dag-cost` for CEL-based cost estimation, but it does not own identity, account balance, reservations, settlement, or billing provider integration. Those concerns need stable package boundaries before route middleware and orchestrator policy checks are added.
+
+The immediate beta need is to make the contracts composable without binding them to Express, a payment provider, or a specific DAG execution path.
+
+## Alternatives Considered
+
+1. **Put auth and credits inside `dag-orchestrator-server`**
+   - Pros: fastest route-level integration.
+   - Cons: makes authentication and credit policy app-specific, blocks reuse by SDK, CLI, remote execution, or other servers.
+
+2. **Put credits inside `dag-cost` and auth inside `dag-orchestrator`**
+   - Pros: fewer packages.
+   - Cons: `dag-cost` would mix formula evaluation with account state, reservations, and settlement. `dag-orchestrator` would gain identity concerns unrelated to run translation.
+
+3. **Create neutral `@robota-sdk/auth` and `@robota-sdk/credits` packages; defer `billing` until payment provider selection**
+   - Pros: keeps identity and credit ledger/reservation contracts reusable, testable, and independent from DAG execution. Keeps `dag-cost` focused on cost formulas.
+   - Cons: route integration requires explicit composition and adapter wiring later.
+
+## Decision
+
+Use neutral private packages:
+
+- `@robota-sdk/auth` owns credential, principal, auth context, verifier port, and scope policy contracts.
+- `@robota-sdk/credits` owns credit account, reservation, ledger entry, store ports, and pure reservation/settlement policy.
+- `@robota-sdk/dag-cost` remains the cost formula evaluator. It does not store balances or decide account authorization.
+- `@robota-sdk/billing` is not created yet. Billing must become a separate package when a concrete payment provider or invoice lifecycle is selected.
+
+The DAG orchestrator server will later compose these packages at its HTTP/API boundary: verify caller, estimate cost with `dag-cost`, reserve credits with `credits`, run the workflow, then settle or release credits based on execution result.
+
+## Consequences
+
+- Auth and credit logic can be tested without Express, ComfyUI, or DAG runtime dependencies.
+- Published workflow routes can add middleware later without changing the core package contracts.
+- Credit reservation uses integer credit units to avoid floating-point balance drift.
+- Billing remains an explicit future boundary instead of a placeholder package with unstable contracts.
+- A later adapter package or application layer must provide concrete auth verifiers and credit stores.
+
+## References
+
+- `.agents/project-structure.md`
+- `.agents/rules/code-quality.md`
+- `.agents/tasks/SDK-BL-001-auth-and-credits-package-design.md`
+- `.agents/tasks/DAG-BL-006-dag-publish-api-endpoint.md`

--- a/packages/auth/.eslintrc.json
+++ b/packages/auth/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @robota-sdk/auth
+
+## 3.0.0-beta.60
+
+- Initial private package with auth contracts and scope policy helpers.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/auth
+
+Authentication contracts and pure policy helpers for Robota runtimes.
+
+See [docs/SPEC.md](docs/SPEC.md) for ownership, boundaries, and verification.

--- a/packages/auth/docs/README.md
+++ b/packages/auth/docs/README.md
@@ -1,0 +1,3 @@
+# @robota-sdk/auth Docs
+
+- [SPEC.md](SPEC.md)

--- a/packages/auth/docs/SPEC.md
+++ b/packages/auth/docs/SPEC.md
@@ -1,0 +1,79 @@
+# Auth Specification
+
+## Scope
+
+`@robota-sdk/auth` owns authentication contracts and pure authorization policy helpers for Robota runtimes. It defines credential, principal, auth context, verifier port, error, and scope policy types.
+
+## Boundaries
+
+| Responsibility                 | Owner                        | Not This Package                                 |
+| ------------------------------ | ---------------------------- | ------------------------------------------------ |
+| Credential/principal contracts | `auth`                       | Does not store users or sessions                 |
+| Scope policy evaluation        | `auth`                       | Does not define product-specific permissions     |
+| HTTP middleware wiring         | Application packages         | Does not import Express or web framework objects |
+| API key/session persistence    | Adapter/application packages | Does not implement storage                       |
+| Credit balances                | `credits`                    | Does not own account or ledger state             |
+
+## Architecture Overview
+
+`auth` is a functional-core package. It exposes pure scope policy functions and port interfaces. Concrete credential verification, user stores, token parsing, and HTTP middleware belong in adapters or app composition roots.
+
+```text
+auth
+├── types.ts          # credential, principal, context, verifier port
+└── scope-policy.ts   # pure scope checks and auth error helper
+```
+
+## Type Ownership
+
+| Type                    | Location       | Purpose                                             |
+| ----------------------- | -------------- | --------------------------------------------------- |
+| `IAuthCredential`       | `src/types.ts` | Credential presented by a caller                    |
+| `IAuthPrincipal`        | `src/types.ts` | Authenticated caller identity and scopes            |
+| `IAuthContext`          | `src/types.ts` | Verified auth state passed to application use cases |
+| `IAuthVerifierPort`     | `src/types.ts` | Adapter port for credential verification            |
+| `IRequiredScopesPolicy` | `src/types.ts` | Scope requirement contract                          |
+| `IScopeDecision`        | `src/types.ts` | Pure scope evaluation result                        |
+| `IAuthError`            | `src/types.ts` | Auth failure contract                               |
+| `TAuthResult`           | `src/types.ts` | Auth operation result union                         |
+
+## Public API Surface
+
+| Export              | Kind             | Description                                           |
+| ------------------- | ---------------- | ----------------------------------------------------- |
+| `createAuthError`   | Function         | Builds a typed auth error                             |
+| `hasScope`          | Function         | Checks whether a principal has one scope              |
+| `evaluateScopes`    | Function         | Evaluates all/any scope policy without throwing       |
+| `requireScopes`     | Function         | Returns `TAuthResult` for scope policy enforcement    |
+| `IAuthVerifierPort` | Interface        | Verifier adapter contract                             |
+| Auth type exports   | Types/interfaces | Credential, principal, context, errors, policy shapes |
+
+## Extension Points
+
+Consumers implement `IAuthVerifierPort` for API key, bearer token, session token, or external IdP verification. Applications compose verifier adapters into HTTP middleware or command/session boundaries.
+
+## Error Taxonomy
+
+| Code                        | Retryable | Context                         |
+| --------------------------- | --------- | ------------------------------- |
+| `AUTH_CREDENTIAL_MISSING`   | false     | No credential was provided      |
+| `AUTH_CREDENTIAL_INVALID`   | false     | Credential failed verification  |
+| `AUTH_CREDENTIAL_EXPIRED`   | false     | Credential is expired           |
+| `AUTH_SCOPE_DENIED`         | false     | Principal lacks required scope  |
+| `AUTH_VERIFIER_UNAVAILABLE` | true      | Verifier backend is unavailable |
+
+## Test Strategy
+
+| Test File                            | Scope                                           |
+| ------------------------------------ | ----------------------------------------------- |
+| `src/__tests__/scope-policy.test.ts` | Scope policy all/any behavior and denied result |
+
+Coverage gaps: concrete verifier adapters and HTTP middleware do not exist yet and must be tested in their owner packages.
+
+## Class Contract Registry
+
+No classes are implemented. `IAuthVerifierPort` is a port interface implemented by future adapter/application packages.
+
+## Dependencies
+
+This package has no production dependencies.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@robota-sdk/auth",
+  "version": "3.0.0-beta.60",
+  "description": "Authentication contracts and policy helpers for Robota runtimes",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
+    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "private": true
+}

--- a/packages/auth/src/__tests__/scope-policy.test.ts
+++ b/packages/auth/src/__tests__/scope-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { IAuthPrincipal } from '../types.js';
+import { evaluateScopes, requireScopes } from '../scope-policy.js';
+
+function createPrincipal(scopes: readonly string[]): IAuthPrincipal {
+  return {
+    principalId: 'principal-1',
+    kind: 'service',
+    subject: 'svc:test',
+    scopes,
+  };
+}
+
+describe('auth scope policy', () => {
+  it('allows a principal with every required scope by default', () => {
+    const decision = evaluateScopes(createPrincipal(['workflow:run', 'asset:read']), {
+      requiredScopes: ['workflow:run'],
+    });
+
+    expect(decision).toEqual({ allowed: true, missingScopes: [] });
+  });
+
+  it('denies a principal missing a required scope in all mode', () => {
+    const result = requireScopes(createPrincipal(['asset:read']), {
+      requiredScopes: ['workflow:run', 'asset:read'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('AUTH_SCOPE_DENIED');
+    }
+  });
+
+  it('allows a principal with at least one required scope in any mode', () => {
+    const decision = evaluateScopes(createPrincipal(['asset:read']), {
+      requiredScopes: ['workflow:run', 'asset:read'],
+      mode: 'any',
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.missingScopes).toEqual(['workflow:run']);
+  });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './scope-policy.js';

--- a/packages/auth/src/scope-policy.ts
+++ b/packages/auth/src/scope-policy.ts
@@ -1,0 +1,59 @@
+import type {
+  IAuthError,
+  IAuthPrincipal,
+  IRequiredScopesPolicy,
+  IScopeDecision,
+  TAuthResult,
+} from './types.js';
+
+export function createAuthError(
+  code: IAuthError['code'],
+  message: string,
+  retryable = false,
+): IAuthError {
+  return { code, message, retryable };
+}
+
+export function hasScope(principal: IAuthPrincipal, requiredScope: string): boolean {
+  return principal.scopes.includes(requiredScope);
+}
+
+export function evaluateScopes(
+  principal: IAuthPrincipal,
+  policy: IRequiredScopesPolicy,
+): IScopeDecision {
+  if (policy.requiredScopes.length === 0) {
+    return { allowed: true, missingScopes: [] };
+  }
+
+  const missingScopes = policy.requiredScopes.filter((scope) => !hasScope(principal, scope));
+  const mode = policy.mode ?? 'all';
+  if (mode === 'any') {
+    return {
+      allowed: missingScopes.length < policy.requiredScopes.length,
+      missingScopes,
+    };
+  }
+
+  return {
+    allowed: missingScopes.length === 0,
+    missingScopes,
+  };
+}
+
+export function requireScopes(
+  principal: IAuthPrincipal,
+  policy: IRequiredScopesPolicy,
+): TAuthResult<IScopeDecision> {
+  const decision = evaluateScopes(principal, policy);
+  if (decision.allowed) {
+    return { ok: true, value: decision };
+  }
+  return {
+    ok: false,
+    error: createAuthError(
+      'AUTH_SCOPE_DENIED',
+      `Principal ${principal.principalId} does not satisfy required scopes`,
+    ),
+  };
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,0 +1,68 @@
+export type TAuthCredentialKind = 'api-key' | 'bearer-token' | 'session-token';
+
+export type TAuthPrincipalKind = 'user' | 'service' | 'anonymous';
+
+export type TAuthScopeMode = 'all' | 'any';
+
+export type TAuthMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | IAuthMetadata
+  | TAuthMetadataValue[];
+
+export interface IAuthMetadata {
+  [key: string]: TAuthMetadataValue | undefined;
+}
+
+export interface IAuthCredential {
+  kind: TAuthCredentialKind;
+  value: string;
+  issuer?: string;
+}
+
+export interface IAuthPrincipal {
+  principalId: string;
+  kind: TAuthPrincipalKind;
+  subject: string;
+  scopes: readonly string[];
+  metadata?: IAuthMetadata;
+}
+
+export interface IAuthContext {
+  principal: IAuthPrincipal;
+  credentialKind: TAuthCredentialKind;
+  authenticatedAt: string;
+  expiresAt?: string;
+}
+
+export type TAuthErrorCode =
+  | 'AUTH_CREDENTIAL_MISSING'
+  | 'AUTH_CREDENTIAL_INVALID'
+  | 'AUTH_CREDENTIAL_EXPIRED'
+  | 'AUTH_SCOPE_DENIED'
+  | 'AUTH_VERIFIER_UNAVAILABLE';
+
+export interface IAuthError {
+  code: TAuthErrorCode;
+  message: string;
+  retryable: boolean;
+  metadata?: IAuthMetadata;
+}
+
+export type TAuthResult<TValue> = { ok: true; value: TValue } | { ok: false; error: IAuthError };
+
+export interface IAuthVerifierPort {
+  verifyCredential(credential: IAuthCredential): Promise<TAuthResult<IAuthContext>>;
+}
+
+export interface IRequiredScopesPolicy {
+  requiredScopes: readonly string[];
+  mode?: TAuthScopeMode;
+}
+
+export interface IScopeDecision {
+  allowed: boolean;
+  missingScopes: readonly string[];
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/credits/.eslintrc.json
+++ b/packages/credits/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/packages/credits/CHANGELOG.md
+++ b/packages/credits/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @robota-sdk/credits
+
+## 3.0.0-beta.60
+
+- Initial private package with credit account, reservation, ledger, and policy contracts.

--- a/packages/credits/README.md
+++ b/packages/credits/README.md
@@ -1,0 +1,5 @@
+# @robota-sdk/credits
+
+Credit account, reservation, and settlement contracts for Robota runtimes.
+
+See [docs/SPEC.md](docs/SPEC.md) for ownership, boundaries, and verification.

--- a/packages/credits/docs/README.md
+++ b/packages/credits/docs/README.md
@@ -1,0 +1,3 @@
+# @robota-sdk/credits Docs
+
+- [SPEC.md](SPEC.md)

--- a/packages/credits/docs/SPEC.md
+++ b/packages/credits/docs/SPEC.md
@@ -1,0 +1,82 @@
+# Credits Specification
+
+## Scope
+
+`@robota-sdk/credits` owns credit account, reservation, ledger, and settlement contracts for Robota runtimes. It provides pure policy helpers for reservation, release, and settlement decisions using integer credit units.
+
+## Boundaries
+
+| Responsibility                       | Owner                        | Not This Package            |
+| ------------------------------------ | ---------------------------- | --------------------------- |
+| Account/reservation/ledger contracts | `credits`                    | Does not estimate DAG costs |
+| Reservation and settlement policy    | `credits`                    | Does not execute workflows  |
+| Cost formula evaluation              | `dag-cost`                   | Not duplicated here         |
+| Auth principal verification          | `auth`                       | Does not verify credentials |
+| Payment provider integration         | Future `billing` package     | Not implemented here        |
+| Persistence adapters                 | Adapter/application packages | Does not implement storage  |
+
+## Architecture Overview
+
+`credits` is a functional-core package with ports. It exposes account/reservation/ledger contracts, storage port interfaces, and pure functions for credit reservation lifecycle decisions.
+
+```text
+credits
+├── types.ts                # account, reservation, ledger, store ports
+└── reservation-policy.ts   # pure reservation/release/settlement rules
+```
+
+## Type Ownership
+
+| Type                          | Location       | Purpose                                    |
+| ----------------------------- | -------------- | ------------------------------------------ |
+| `ICreditAccount`              | `src/types.ts` | Account balance and held reservation state |
+| `ICreditReservation`          | `src/types.ts` | Reserved credit hold for one operation     |
+| `ICreditLedgerEntry`          | `src/types.ts` | Ledger event for audit and reconciliation  |
+| `ICreditAccountStorePort`     | `src/types.ts` | Account persistence adapter port           |
+| `ICreditReservationStorePort` | `src/types.ts` | Reservation persistence adapter port       |
+| `ICreditReservationDecision`  | `src/types.ts` | Pure reservation eligibility result        |
+| `ICreditError`                | `src/types.ts` | Credit failure contract                    |
+| `TCreditResult`               | `src/types.ts` | Credit operation result union              |
+
+## Public API Surface
+
+| Export                    | Kind             | Description                                          |
+| ------------------------- | ---------------- | ---------------------------------------------------- |
+| `createCreditError`       | Function         | Builds a typed credit error                          |
+| `getAvailableCreditUnits` | Function         | Computes `balanceUnits - reservedUnits`              |
+| `canReserveCredits`       | Function         | Evaluates reservation eligibility                    |
+| `reserveCredits`          | Function         | Applies a reserved hold to an account snapshot       |
+| `releaseReservation`      | Function         | Releases a reservation hold without charging         |
+| `settleReservation`       | Function         | Charges actual units and clears the reservation hold |
+| Credit type exports       | Types/interfaces | Account, reservation, ledger, ports, errors          |
+
+## Extension Points
+
+Consumers implement `ICreditAccountStorePort` and `ICreditReservationStorePort`. Applications compose those adapters with `dag-cost` estimates and auth principals to enforce execution policy.
+
+## Error Taxonomy
+
+| Code                                    | Retryable | Context                                  |
+| --------------------------------------- | --------- | ---------------------------------------- |
+| `CREDIT_AMOUNT_INVALID`                 | false     | Credit units are not valid integers      |
+| `CREDIT_ACCOUNT_NOT_ACTIVE`             | false     | Account is suspended or closed           |
+| `CREDIT_BALANCE_INSUFFICIENT`           | false     | Available units are below required units |
+| `CREDIT_RESERVATION_NOT_ACTIVE`         | false     | Reservation is not in `reserved` state   |
+| `CREDIT_SETTLEMENT_EXCEEDS_RESERVATION` | false     | Actual charge exceeds the reservation    |
+| `CREDIT_STORE_UNAVAILABLE`              | true      | Future adapter storage failure           |
+
+## Test Strategy
+
+| Test File                                  | Scope                                                     |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `src/__tests__/reservation-policy.test.ts` | Available balance, reserve, release, settle, denial cases |
+
+Coverage gaps: store adapters, idempotent ledger writes, and concurrent reservation locking belong in future adapter/application packages.
+
+## Class Contract Registry
+
+No classes are implemented. Store interfaces are ports implemented by future adapter/application packages.
+
+## Dependencies
+
+This package has no production dependencies.

--- a/packages/credits/package.json
+++ b/packages/credits/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@robota-sdk/credits",
+  "version": "3.0.0-beta.60",
+  "description": "Credit account, reservation, and settlement contracts for Robota runtimes",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
+    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "private": true
+}

--- a/packages/credits/src/__tests__/reservation-policy.test.ts
+++ b/packages/credits/src/__tests__/reservation-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { ICreditAccount, ICreditReservation } from '../types.js';
+import {
+  canReserveCredits,
+  getAvailableCreditUnits,
+  releaseReservation,
+  reserveCredits,
+  settleReservation,
+} from '../reservation-policy.js';
+
+function createAccount(overrides: Partial<ICreditAccount> = {}): ICreditAccount {
+  return {
+    accountId: 'account-1',
+    ownerPrincipalId: 'principal-1',
+    balanceUnits: 100,
+    reservedUnits: 10,
+    status: 'active',
+    updatedAt: '2026-05-05T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createReservation(overrides: Partial<ICreditReservation> = {}): ICreditReservation {
+  return {
+    reservationId: 'reservation-1',
+    accountId: 'account-1',
+    units: 25,
+    status: 'reserved',
+    reason: 'workflow-run',
+    createdAt: '2026-05-05T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('credit reservation policy', () => {
+  it('calculates available units from balance minus active reservations', () => {
+    expect(getAvailableCreditUnits(createAccount())).toBe(90);
+  });
+
+  it('allows reservations when the account is active and balance is sufficient', () => {
+    const decision = canReserveCredits(createAccount(), 40);
+
+    expect(decision).toEqual({ allowed: true, availableUnits: 90, requiredUnits: 40 });
+  });
+
+  it('denies reservations that exceed available units', () => {
+    const decision = canReserveCredits(createAccount(), 120);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('CREDIT_BALANCE_INSUFFICIENT');
+  });
+
+  it('adds reserved units when a reservation is accepted', () => {
+    const result = reserveCredits(createAccount(), createReservation({ units: 25 }));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.reservedUnits).toBe(35);
+    }
+  });
+
+  it('settles a reservation by decrementing balance and clearing the reservation hold', () => {
+    const result = settleReservation(createAccount(), createReservation({ units: 25 }), 20);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.balanceUnits).toBe(80);
+      expect(result.value.reservedUnits).toBe(0);
+    }
+  });
+
+  it('rejects settlement above reserved units', () => {
+    const result = settleReservation(createAccount(), createReservation({ units: 25 }), 30);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('CREDIT_SETTLEMENT_EXCEEDS_RESERVATION');
+    }
+  });
+
+  it('releases a reservation without decrementing balance', () => {
+    const result = releaseReservation(createAccount(), createReservation({ units: 25 }));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.balanceUnits).toBe(100);
+      expect(result.value.reservedUnits).toBe(0);
+    }
+  });
+});

--- a/packages/credits/src/index.ts
+++ b/packages/credits/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './reservation-policy.js';

--- a/packages/credits/src/reservation-policy.ts
+++ b/packages/credits/src/reservation-policy.ts
@@ -1,0 +1,144 @@
+import type {
+  ICreditAccount,
+  ICreditError,
+  ICreditReservation,
+  ICreditReservationDecision,
+  TCreditResult,
+} from './types.js';
+
+export function createCreditError(
+  code: ICreditError['code'],
+  message: string,
+  retryable = false,
+): ICreditError {
+  return { code, message, retryable };
+}
+
+export function getAvailableCreditUnits(account: ICreditAccount): number {
+  return account.balanceUnits - account.reservedUnits;
+}
+
+export function canReserveCredits(
+  account: ICreditAccount,
+  requiredUnits: number,
+): ICreditReservationDecision {
+  const availableUnits = getAvailableCreditUnits(account);
+  if (!Number.isSafeInteger(requiredUnits) || requiredUnits <= 0) {
+    return {
+      allowed: false,
+      availableUnits,
+      requiredUnits,
+      reason: 'CREDIT_AMOUNT_INVALID',
+    };
+  }
+  if (account.status !== 'active') {
+    return {
+      allowed: false,
+      availableUnits,
+      requiredUnits,
+      reason: 'CREDIT_ACCOUNT_NOT_ACTIVE',
+    };
+  }
+  if (availableUnits < requiredUnits) {
+    return {
+      allowed: false,
+      availableUnits,
+      requiredUnits,
+      reason: 'CREDIT_BALANCE_INSUFFICIENT',
+    };
+  }
+  return { allowed: true, availableUnits, requiredUnits };
+}
+
+export function reserveCredits(
+  account: ICreditAccount,
+  reservation: ICreditReservation,
+): TCreditResult<ICreditAccount> {
+  const decision = canReserveCredits(account, reservation.units);
+  if (!decision.allowed) {
+    return {
+      ok: false,
+      error: createCreditError(
+        decision.reason ?? 'CREDIT_BALANCE_INSUFFICIENT',
+        `Account ${account.accountId} cannot reserve ${reservation.units} credit units`,
+      ),
+    };
+  }
+  if (reservation.status !== 'reserved') {
+    return {
+      ok: false,
+      error: createCreditError(
+        'CREDIT_RESERVATION_NOT_ACTIVE',
+        `Reservation ${reservation.reservationId} is not active`,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      ...account,
+      reservedUnits: account.reservedUnits + reservation.units,
+    },
+  };
+}
+
+export function releaseReservation(
+  account: ICreditAccount,
+  reservation: ICreditReservation,
+): TCreditResult<ICreditAccount> {
+  if (reservation.status !== 'reserved') {
+    return {
+      ok: false,
+      error: createCreditError(
+        'CREDIT_RESERVATION_NOT_ACTIVE',
+        `Reservation ${reservation.reservationId} is not active`,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      ...account,
+      reservedUnits: Math.max(0, account.reservedUnits - reservation.units),
+    },
+  };
+}
+
+export function settleReservation(
+  account: ICreditAccount,
+  reservation: ICreditReservation,
+  actualUnits: number,
+): TCreditResult<ICreditAccount> {
+  if (reservation.status !== 'reserved') {
+    return {
+      ok: false,
+      error: createCreditError(
+        'CREDIT_RESERVATION_NOT_ACTIVE',
+        `Reservation ${reservation.reservationId} is not active`,
+      ),
+    };
+  }
+  if (!Number.isSafeInteger(actualUnits) || actualUnits < 0) {
+    return {
+      ok: false,
+      error: createCreditError('CREDIT_AMOUNT_INVALID', 'Settlement units must be non-negative'),
+    };
+  }
+  if (actualUnits > reservation.units) {
+    return {
+      ok: false,
+      error: createCreditError(
+        'CREDIT_SETTLEMENT_EXCEEDS_RESERVATION',
+        'Settlement units must not exceed reserved units',
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      ...account,
+      balanceUnits: account.balanceUnits - actualUnits,
+      reservedUnits: Math.max(0, account.reservedUnits - reservation.units),
+    },
+  };
+}

--- a/packages/credits/src/types.ts
+++ b/packages/credits/src/types.ts
@@ -1,0 +1,90 @@
+export type TCreditAccountStatus = 'active' | 'suspended' | 'closed';
+
+export type TCreditReservationStatus = 'reserved' | 'settled' | 'released';
+
+export type TCreditLedgerEntryKind =
+  | 'grant'
+  | 'debit'
+  | 'credit'
+  | 'reservation'
+  | 'release'
+  | 'settlement';
+
+export type TCreditMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ICreditMetadata
+  | TCreditMetadataValue[];
+
+export interface ICreditMetadata {
+  [key: string]: TCreditMetadataValue | undefined;
+}
+
+export interface ICreditAccount {
+  accountId: string;
+  ownerPrincipalId: string;
+  balanceUnits: number;
+  reservedUnits: number;
+  status: TCreditAccountStatus;
+  updatedAt: string;
+}
+
+export interface ICreditReservation {
+  reservationId: string;
+  accountId: string;
+  units: number;
+  status: TCreditReservationStatus;
+  reason: string;
+  createdAt: string;
+  expiresAt?: string;
+  metadata?: ICreditMetadata;
+}
+
+export interface ICreditLedgerEntry {
+  entryId: string;
+  accountId: string;
+  kind: TCreditLedgerEntryKind;
+  units: number;
+  reservationId?: string;
+  createdAt: string;
+  metadata?: ICreditMetadata;
+}
+
+export type TCreditErrorCode =
+  | 'CREDIT_AMOUNT_INVALID'
+  | 'CREDIT_ACCOUNT_NOT_ACTIVE'
+  | 'CREDIT_BALANCE_INSUFFICIENT'
+  | 'CREDIT_RESERVATION_NOT_ACTIVE'
+  | 'CREDIT_SETTLEMENT_EXCEEDS_RESERVATION'
+  | 'CREDIT_STORE_UNAVAILABLE';
+
+export interface ICreditError {
+  code: TCreditErrorCode;
+  message: string;
+  retryable: boolean;
+  metadata?: ICreditMetadata;
+}
+
+export type TCreditResult<TValue> =
+  | { ok: true; value: TValue }
+  | { ok: false; error: ICreditError };
+
+export interface ICreditAccountStorePort {
+  getAccount(accountId: string): Promise<ICreditAccount | undefined>;
+  saveAccount(account: ICreditAccount): Promise<void>;
+  appendLedgerEntry(entry: ICreditLedgerEntry): Promise<void>;
+}
+
+export interface ICreditReservationStorePort {
+  getReservation(reservationId: string): Promise<ICreditReservation | undefined>;
+  saveReservation(reservation: ICreditReservation): Promise<void>;
+}
+
+export interface ICreditReservationDecision {
+  allowed: boolean;
+  availableUnits: number;
+  requiredUnits: number;
+  reason?: TCreditErrorCode;
+}

--- a/packages/credits/tsconfig.json
+++ b/packages/credits/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1910,6 +1910,36 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.9)
 
+  packages/auth:
+    devDependencies:
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.9)
+
+  packages/credits:
+    devDependencies:
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.9)
+
   packages/dag-adapters-local:
     dependencies:
       '@robota-sdk/dag-core':


### PR DESCRIPTION
## Summary
- Add ADR-002 for auth, credits, dag-cost, and future billing package boundaries
- Add private @robota-sdk/auth package with credential/principal/verifier contracts and pure scope policy helpers
- Add private @robota-sdk/credits package with account/reservation/ledger contracts and pure reservation lifecycle helpers
- Update project structure, publish registry, and move SDK-BL-001 to completed

## Verification
- pnpm --filter @robota-sdk/auth test
- pnpm --filter @robota-sdk/auth typecheck
- pnpm --filter @robota-sdk/auth lint
- pnpm --filter @robota-sdk/auth build
- pnpm --filter @robota-sdk/credits test
- pnpm --filter @robota-sdk/credits typecheck
- pnpm --filter @robota-sdk/credits lint
- pnpm --filter @robota-sdk/credits build
- pnpm harness:scan:specs
- pnpm build
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check
- git diff --check
- pre-push scoped verification