### PR TITLE
feat(sdk): add sandbox execution ports

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -7,7 +7,7 @@ packages/
 ├── agent-core/                  # Foundation contracts, engine, events, hooks, permissions
 ├── agent-runtime/               # Reusable background task and subagent lifecycle/state/ports
 ├── agent-sessions/              # Session lifecycle and persistence
-├── agent-tools/                 # Tool implementations: FunctionTool, built-ins, schema helpers
+├── agent-tools/                 # Tool implementations: FunctionTool, built-ins, schema helpers, sandbox ports
 ├── agent-tool-mcp/              # MCP tool implementations
 ├── agent-sdk/                   # SDK assembly layer: InteractiveSession, command contracts/common APIs
 ├── agent-command-agent/         # Command module that contributes /agent

--- a/.agents/tasks/completed/INFRA-BL-002-agent-sandbox-execution.md
+++ b/.agents/tasks/completed/INFRA-BL-002-agent-sandbox-execution.md
@@ -1,8 +1,8 @@
 ---
 title: Agent 샌드박스 실행 환경
-status: backlog
+status: completed
 created: 2026-03-15
-updated: 2026-04-19
+updated: 2026-05-05
 priority: medium
 urgency: later
 ---
@@ -155,6 +155,43 @@ await sandbox.kill();
 1. Open design questions 답변 후 스펙 작성
 2. E2B 통합부터 시작 (TS SDK 있음, 가장 간단)
 3. Branch: `feat/agent-sandbox-execution` (구현 시점에 생성)
+
+## Progress
+
+- [x] `ISandboxClient` owner를 `agent-tools`로 확정하고 command/file/snapshot/restore 포트를 정의
+- [x] Bash, Read, Write, Edit 도구를 sandbox-aware factory로 확장하고 기존 singleton host-local export 유지
+- [x] `agent-sdk` `InteractiveSession`/`createSession()`에 `sandboxClient` 주입 경로 추가
+- [x] `reversibleExecution`에서 sandbox 주입 시 기본 isolation을 `provider-sandbox`로 분류
+- [x] E2B-compatible structural adapter와 deterministic in-memory contract adapter 추가
+- [x] package SPEC/README/content 문서 업데이트
+- [x] 최종 검증, PR 생성, 머지 후 completed로 이동
+
+## Decisions
+
+- `ISandboxClient`는 `agent-tools`가 소유한다. 실제 command/file tool 구현이 이 패키지에 있으므로 `agent-core`에 실행-plane 세부 계약을 올리지 않는다.
+- E2B는 직접 dependency로 추가하지 않고 structural adapter로 지원한다. 애플리케이션 composition root가 `e2b` 설치와 `Sandbox.create()`를 담당하고, Robota는 해당 객체를 `E2BSandboxClient`로 감싼다.
+- sandbox가 주입된 SDK session은 Bash/Read/Write/Edit만 sandbox-aware로 전환한다. Glob/Grep은 기존 host-local 구현을 유지하며, provider-native file search가 필요하면 별도 manifest/catalog 백로그에서 확장한다.
+
+## Result
+
+- `agent-tools`에 provider-neutral `ISandboxClient` 포트, E2B-compatible structural adapter, in-memory contract adapter를 추가했다.
+- Bash/Read/Write/Edit built-in tool을 sandbox-aware factory로 확장하고 기존 singleton host-local export는 유지했다.
+- `agent-sdk`의 `createSession()`과 `InteractiveSession`이 `sandboxClient`를 받아 기본 도구를 sandbox execution plane으로 조립하도록 연결했다.
+- sandbox 주입 시 reversible execution 기본 isolation을 `provider-sandbox`로 분류하고, sandbox file mutation에는 host edit checkpoint wrapping을 적용하지 않도록 했다.
+- SPEC, README, content 문서, changeset을 갱신했고 검증을 통과했다.
+
+검증:
+
+- `pnpm --filter @robota-sdk/agent-tools test -- src/__tests__/sandbox-tools.test.ts`
+- `pnpm --filter @robota-sdk/agent-sdk test -- src/assembly/__tests__/create-tools.test.ts src/__tests__/create-session-new-options.test.ts src/reversible-execution/__tests__/reversible-execution-policy.test.ts`
+- `pnpm --filter @robota-sdk/agent-tools typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-tools lint`
+- `pnpm --filter @robota-sdk/agent-sdk lint`
+- `pnpm build`
+- `pnpm docs:build`
+- `pnpm harness:scan`
+- `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
 
 ## References
 

--- a/.changeset/agent-sandbox-execution.md
+++ b/.changeset/agent-sandbox-execution.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-tools': minor
+'@robota-sdk/agent-sdk': minor
+---
+
+Add provider-neutral sandbox execution ports, E2B-compatible sandbox adapter, and SDK sandbox injection for Bash and core file tools.

--- a/content/README.md
+++ b/content/README.md
@@ -123,7 +123,7 @@ agent-sdk              ← Assembly layer: InteractiveSession, config, context, 
   ↓
 agent-sessions         ← Session lifecycle: permissions, hooks, compaction
 agent-runtime          ← Background task and subagent lifecycle primitives
-agent-tools            ← Tool infrastructure + 8 built-in tools
+agent-tools            ← Tool infrastructure + 8 built-in tools + sandbox ports
 agent-provider-*       ← AI provider implementations (anthropic, openai, gemini, google, gemma, qwen)
   ↓
 agent-core             ← Foundation: Robota engine, abstractions, plugins
@@ -134,7 +134,7 @@ agent-core             ← Foundation: Robota engine, abstractions, plugins
 | Package                                                                                        | Description                                                            |
 | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | [`@robota-sdk/agent-core`](./packages/agent-core/)                                             | Core agent runtime, abstractions, and plugin system                    |
-| [`@robota-sdk/agent-tools`](./packages/agent-tools/)                                           | Tool registry, FunctionTool, and 8 built-in tools                      |
+| [`@robota-sdk/agent-tools`](./packages/agent-tools/)                                           | Tool registry, FunctionTool, built-in tools, and sandbox ports         |
 | [`@robota-sdk/agent-sessions`](./packages/agent-sessions/)                                     | Session with permissions, hooks, and compaction                        |
 | [`@robota-sdk/agent-runtime`](./packages/agent-runtime/)                                       | Background task and subagent lifecycle primitives                      |
 | [`@robota-sdk/agent-sdk`](./packages/agent-sdk/)                                               | Assembly layer with config/context loading and createQuery()           |

--- a/content/examples/tool-calling.md
+++ b/content/examples/tool-calling.md
@@ -94,3 +94,35 @@ const agent = new Robota({
 
 const response = await agent.run('Find all TODO comments in the project');
 ```
+
+## Sandbox-Aware Built-in Tools
+
+Use factory exports when Bash or file tools should run inside a provider sandbox instead of the host workspace:
+
+```typescript
+import {
+  E2BSandboxClient,
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+} from '@robota-sdk/agent-tools';
+import { Sandbox } from 'e2b';
+
+const sandbox = await Sandbox.create();
+const sandboxClient = new E2BSandboxClient({ sandbox });
+
+const agent = new Robota({
+  name: 'SandboxedDevAgent',
+  aiProviders: [provider],
+  defaultModel: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+  tools: [
+    createBashTool({ sandboxClient }),
+    createReadTool({ sandboxClient }),
+    createWriteTool({ sandboxClient }),
+    createEditTool({ sandboxClient }),
+  ],
+});
+```
+
+`E2BSandboxClient` is a structural adapter. Install and construct the concrete provider SDK in your application, then pass the adapter to Robota tools or `InteractiveSession`.

--- a/content/guide/permissions-and-hooks.md
+++ b/content/guide/permissions-and-hooks.md
@@ -19,6 +19,8 @@ Defined in `agent-core`, consumed by `agent-sessions`. Provides deterministic 3-
 | `acceptEdits`       | auto | auto             | approve (prompt) |
 | `bypassPermissions` | auto | auto             | auto             |
 
+Permissions and hooks run before tool execution regardless of whether a tool executes locally or through an injected sandbox client. A sandbox changes the execution plane for Bash and file operations; it does not bypass the permission matrix or hook pipeline.
+
 ### Pattern Syntax
 
 ```

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -225,6 +225,30 @@ const session = new InteractiveSession({
 | **Universal history**      | `getFullHistory()` returns `IHistoryEntry[]` — the unified chat + event timeline                                                                                                      |
 | **Background work**        | Subagent jobs are tracked through runtime-owned task state, transcripts, and background task events                                                                                   |
 | **Replay events**          | Session runs forward core provider/tool boundary events into append-only JSONL logs                                                                                                   |
+| **Sandbox execution**      | Optional sandbox clients route Bash and core file tools through an injected execution plane                                                                                           |
+
+## Sandbox Execution
+
+`InteractiveSession` accepts `sandboxClient?: ISandboxClient`. When present, the SDK creates sandbox-aware Bash, Read, Write, and Edit tools. This keeps the CLI/TUI thin: hosts choose whether to supply a sandbox, while tool command/file behavior remains in `agent-tools`.
+
+```typescript
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { E2BSandboxClient } from '@robota-sdk/agent-tools';
+import { Sandbox } from 'e2b';
+
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
+const sandbox = await Sandbox.create();
+
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
+  sandboxClient: new E2BSandboxClient({ sandbox }),
+  reversibleExecution: { mode: 'local-first' },
+});
+```
+
+`E2BSandboxClient` adapts E2B-compatible objects from its owning package, `agent-tools`, but does not require `agent-sdk` or `agent-tools` to depend on the `e2b` package. Applications install provider SDKs at their composition root and pass the adapted client into the SDK.
 
 ## Subagent Sessions
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -45,6 +45,7 @@ const detailedResponse = await queryWithOptions('Analyze the code');
 - **createQuery()** — Provider-bound factory for one-shot AI agent interactions with streaming support
 - **Session assembly** — Internal factory wires tools, provider, config, and context for `InteractiveSession`
 - **Built-in Tools** — Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch are assembled for SDK sessions; direct tool usage imports from `@robota-sdk/agent-tools`
+- **Sandbox Execution** — Optional `sandboxClient` injection routes Bash and core file tools through a provider-backed execution plane
 - **Agent Tool** — Sub-agent session creation for multi-agent workflows
 - **Permissions** — 3-step evaluation (deny list, allow list, mode policy) with four modes: `plan`, `default`, `acceptEdits`, `bypassPermissions`
 - **Hooks** — `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SessionStart`, `UserPromptSubmit`, `Stop` events with shell command execution
@@ -288,6 +289,29 @@ import {
   writeTool,
 } from '@robota-sdk/agent-tools';
 ```
+
+### Sandbox Execution
+
+SDK sessions can receive a provider-neutral sandbox client. When provided, Bash, Read, Write, and Edit use the sandbox execution plane instead of the host process/filesystem:
+
+```typescript
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { E2BSandboxClient } from '@robota-sdk/agent-tools';
+import { Sandbox } from 'e2b';
+
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
+const sandbox = await Sandbox.create();
+
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  provider,
+  sandboxClient: new E2BSandboxClient({ sandbox }),
+  reversibleExecution: { mode: 'local-first' },
+});
+```
+
+`E2BSandboxClient` is a structural adapter owned by `agent-tools`, and it does not make `e2b` a dependency of `agent-sdk`. Install and create the concrete provider SDK in the application layer, then pass the adapter into `InteractiveSession`.
 
 ## Subagent Sessions
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -33,6 +33,7 @@ agent-sdk            ← InteractiveSession (single entry point)
   ├── optional: Agent tool + AgentDefinitionLoader when a module requests agent-runtime
   ├── composed: agent-runtime BackgroundTaskManager, SubagentManager, runner ports
   ├── internal: createSession(), createDefaultTools(), loadConfig(), loadContext()
+  ├── optional: sandboxClient injection for sandbox-aware built-in tool execution
   ├── exposed: createQuery({ provider }) → (prompt) => result
   └── NO provider dependency (provider-neutral)
 
@@ -90,7 +91,7 @@ The SDK layer has **no React dependency** and **no provider dependency**. The CL
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | **agent-core**        | Robota engine, execution loop, provider abstraction, permissions, hooks                                                                  | General             |
 | **agent-runtime**     | Background task and subagent lifecycle primitives, runner ports, worktree runner decorator                                               | General             |
-| **agent-tools**       | Tool creation infrastructure + 8 built-in tools                                                                                          | General             |
+| **agent-tools**       | Tool creation infrastructure, sandbox execution ports, and 8 built-in tools                                                              | General             |
 | **agent-sessions**    | Generic Session class, SessionStore (persistence)                                                                                        | General             |
 | **agent-sdk**         | Assembly layer: InteractiveSession (single entry point), command contracts/common APIs, createQuery(), config, context                   | SDK-specific        |
 | **agent-command-\***  | Built-in/optional command modules that consume SDK command interfaces/common APIs and can be selected by composition roots               | Command-specific    |
@@ -111,6 +112,7 @@ agent-runtime (reusable runtime primitives — depends only on agent-core)
 
 agent-tools
 ├── src/builtins/             ← bash, read, write, edit, glob, grep, web-fetch, web-search tools
+├── src/sandbox/              ← ISandboxClient, E2B structural adapter, and in-memory contract adapter
 ├── src/types/tool-result.ts  ← TToolResult
 └── (existing) FunctionTool, createZodFunctionTool, schema conversion
 
@@ -205,6 +207,14 @@ agent-cli (Ink TUI — CLI-specific)
 - **Agent tool**: `agent-sdk/tools/agent-tool.ts` — sub-agent Session creation (SDK-specific). Registered only when the composed command modules request agent runtime support. The tool description is the owner-provided model contract for direct subagent delegation: explicit user requests to create, run, spawn, delegate to, or use agents/subagents should start `Agent` tool calls immediately unless impossible or unsafe; one `Agent` tool call creates one background subagent job and waits for terminal completed/failed/timed-out result data before returning to the parent conversation.
 - **Edit checkpoint wrapper**: `agent-sdk/checkpoints/edit-checkpoint-tools.ts` wraps `Write` and `Edit` at SDK session assembly time. The underlying tool package stays generic; the SDK wrapper snapshots the target file before the first mutation in each prompt turn.
 - **Tool result type**: `TToolResult` in `agent-tools/types/tool-result.ts`
+
+### Sandbox Execution
+
+- **Port owner**: `agent-tools/sandbox/` owns `ISandboxClient`, `ISandboxRunOptions`, and `ISandboxRunResult`.
+- **Adapter owner**: `agent-tools` owns structural sandbox adapters such as `E2BSandboxClient` and `InMemorySandboxClient`. It does not install provider SDKs; application composition roots may install `e2b` or another provider and wrap its sandbox object.
+- **SDK assembly**: `createSession()` and `InteractiveSession` accept `sandboxClient?: ISandboxClient`. When present, SDK-created Bash, Read, Write, and Edit tools are created through sandbox-aware factories and route command/filesystem operations through the injected client.
+- **Reversible execution**: If `reversibleExecution.mode` is enabled and no explicit isolation is set, a supplied `sandboxClient` makes the SDK classify Bash and sandbox-routed file mutations as `provider-sandbox` isolated instead of host checkpoint-backed mutations.
+- **Boundary**: `agent-cli` and other hosts only decide whether to provide a sandbox client. They must not implement sandbox command/file algorithms or provider-specific restore behavior in UI code.
 
 ### Edit Checkpointing
 

--- a/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
+++ b/packages/agent-sdk/src/__tests__/create-session-new-options.test.ts
@@ -11,6 +11,9 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IResolvedConfig } from '../config/config-types.js';
+import { InMemorySandboxClient } from '@robota-sdk/agent-tools';
+import type { IToolWithEventService } from '@robota-sdk/agent-core';
+import type { TToolResult } from '@robota-sdk/agent-tools';
 
 // Capture all Session constructor calls to inspect the options passed
 const sessionCtorCalls: Array<Record<string, unknown>> = [];
@@ -308,6 +311,84 @@ describe('createSession — provider timeout option', () => {
     });
 
     expect(sessionCtorCalls[0]!['providerTimeout']).toBe(120000);
+  });
+});
+
+describe('createSession — sandbox client option', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('assembles sandbox-aware default tools when sandboxClient is provided', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+    const sandboxClient = new InMemorySandboxClient({
+      runHandler: () => ({ stdout: 'from sandbox', stderr: '', exitCode: 0 }),
+    });
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      sandboxClient,
+    });
+
+    const tools = sessionCtorCalls[0]!['tools'] as IToolWithEventService[];
+    const bashTool = tools.find((tool) => tool.getName() === 'Bash');
+    expect(bashTool).toBeDefined();
+
+    const rawResult = await bashTool!.execute(
+      { command: 'echo host should not run' },
+      { toolName: 'Bash', parameters: { command: 'echo host should not run' } },
+    );
+    const result = JSON.parse(rawResult.data as string) as TToolResult;
+    expect(result.output).toBe('from sandbox');
+  });
+
+  it('treats reversible execution as provider-sandbox isolated when sandboxClient is present', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+    const sandboxClient = new InMemorySandboxClient({
+      runHandler: () => ({ stdout: 'isolated', stderr: '', exitCode: 0 }),
+    });
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', claudeMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      sandboxClient,
+      reversibleExecution: { mode: 'local-first' },
+    });
+
+    const tools = sessionCtorCalls[0]!['tools'] as IToolWithEventService[];
+    const bashTool = tools.find((tool) => tool.getName() === 'Bash');
+    const writeTool = tools.find((tool) => tool.getName() === 'Write');
+    const rawResult = await bashTool!.execute(
+      { command: 'touch isolated.txt' },
+      { toolName: 'Bash', parameters: { command: 'touch isolated.txt' } },
+    );
+    const result = JSON.parse(rawResult.data as string) as TToolResult;
+    const rawWriteResult = await writeTool!.execute(
+      { filePath: '/workspace/generated.ts', content: 'export const isolated = true;\n' },
+      {
+        toolName: 'Write',
+        parameters: {
+          filePath: '/workspace/generated.ts',
+          content: 'export const isolated = true;\n',
+        },
+      },
+    );
+    const writeResult = JSON.parse(rawWriteResult.data as string) as TToolResult;
+
+    expect(result).toMatchObject({
+      success: true,
+      output: 'isolated',
+      exitCode: 0,
+    });
+    expect(writeResult.success).toBe(true);
+    expect(sandboxClient.getFile('/workspace/generated.ts')).toBe(
+      'export const isolated = true;\n',
+    );
   });
 });
 

--- a/packages/agent-sdk/src/assembly/__tests__/create-tools.test.ts
+++ b/packages/agent-sdk/src/assembly/__tests__/create-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from '../create-tools';
+import { InMemorySandboxClient } from '@robota-sdk/agent-tools';
 
 describe('createDefaultTools', () => {
   it('assembles all default local tools and describes web tools as local tools', () => {
@@ -18,5 +19,20 @@ describe('createDefaultTools', () => {
     expect(DEFAULT_TOOL_DESCRIPTIONS).toContain(
       'WebSearch — search the internet through the configured local tool',
     );
+  });
+
+  it('accepts a sandbox client while preserving the default tool list', () => {
+    const sandboxClient = new InMemorySandboxClient();
+
+    expect(createDefaultTools({ sandboxClient }).map((tool) => tool.getName())).toEqual([
+      'Bash',
+      'Read',
+      'Write',
+      'Edit',
+      'Glob',
+      'Grep',
+      'WebFetch',
+      'WebSearch',
+    ]);
   });
 });

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -32,6 +32,7 @@ import type { IProjectInfo } from '../context/project-detector.js';
 import { buildSystemPrompt } from '../context/system-prompt-builder.js';
 import type { ISystemPromptParams } from '../context/system-prompt-builder.js';
 import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
+import type { ISandboxClient } from '@robota-sdk/agent-tools';
 
 import {
   createAgentTool,
@@ -158,6 +159,8 @@ export interface ICreateSessionOptions {
   editCheckpointRecorder?: IEditCheckpointRecorder;
   /** Opt-in local-first reversible execution policy for write/shell tools. */
   reversibleExecution?: IReversibleExecutionOptions;
+  /** Optional provider sandbox client used by sandbox-aware built-in tools. */
+  sandboxClient?: ISandboxClient;
 }
 
 /**
@@ -176,14 +179,26 @@ export function createSession(options: ICreateSessionOptions): Session {
   const cwd = options.cwd ?? process.cwd();
   const sessionId = options.sessionId ?? createSessionId();
 
-  const defaultTools = options.editCheckpointRecorder
-    ? wrapEditCheckpointTools(createDefaultTools(), options.editCheckpointRecorder)
-    : createDefaultTools();
+  const baseDefaultTools = createDefaultTools({ sandboxClient: options.sandboxClient });
+  const shouldWrapHostEditCheckpoints =
+    options.editCheckpointRecorder !== undefined && options.sandboxClient === undefined;
+  const defaultTools =
+    shouldWrapHostEditCheckpoints && options.editCheckpointRecorder
+      ? wrapEditCheckpointTools(baseDefaultTools, options.editCheckpointRecorder)
+      : baseDefaultTools;
   const assembledTools = [...defaultTools, ...(options.additionalTools ?? [])];
-  const tools = options.reversibleExecution
-    ? wrapReversibleExecutionTools(assembledTools, {
+  const reversibleExecution = options.reversibleExecution
+    ? {
         ...options.reversibleExecution,
-        checkpointAvailable: options.editCheckpointRecorder !== undefined,
+        isolation:
+          options.reversibleExecution.isolation ??
+          (options.sandboxClient ? ('provider-sandbox' as const) : undefined),
+      }
+    : undefined;
+  const tools = reversibleExecution
+    ? wrapReversibleExecutionTools(assembledTools, {
+        ...reversibleExecution,
+        checkpointAvailable: shouldWrapHostEditCheckpoints,
       })
     : assembledTools;
   if (options.modelCommandExecutor && options.isModelCommandInvocable) {

--- a/packages/agent-sdk/src/assembly/create-tools.ts
+++ b/packages/agent-sdk/src/assembly/create-tools.ts
@@ -4,15 +4,16 @@
 
 import type { IToolWithEventService } from '@robota-sdk/agent-core';
 import {
-  bashTool,
-  readTool,
-  writeTool,
-  editTool,
+  createBashTool,
+  createReadTool,
+  createWriteTool,
+  createEditTool,
   globTool,
   grepTool,
   webFetchTool,
   webSearchTool,
 } from '@robota-sdk/agent-tools';
+import type { ISandboxClient } from '@robota-sdk/agent-tools';
 
 /** Human-readable descriptions of the built-in tools (for system prompt) */
 export const DEFAULT_TOOL_DESCRIPTIONS = [
@@ -30,12 +31,18 @@ export const DEFAULT_TOOL_DESCRIPTIONS = [
  * Create the default set of CLI tools.
  * Returns the 8 standard tools as IToolWithEventService[].
  */
-export function createDefaultTools(): IToolWithEventService[] {
+export interface ICreateDefaultToolsOptions {
+  sandboxClient?: ISandboxClient;
+}
+
+export function createDefaultTools(
+  options: ICreateDefaultToolsOptions = {},
+): IToolWithEventService[] {
   return [
-    bashTool as IToolWithEventService,
-    readTool as IToolWithEventService,
-    writeTool as IToolWithEventService,
-    editTool as IToolWithEventService,
+    createBashTool(options) as IToolWithEventService,
+    createReadTool(options) as IToolWithEventService,
+    createWriteTool(options) as IToolWithEventService,
+    createEditTool(options) as IToolWithEventService,
     globTool as IToolWithEventService,
     grepTool as IToolWithEventService,
     webFetchTool as IToolWithEventService,

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -42,6 +42,7 @@ import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-
 import type { IContextReferenceItem } from '../context/context-reference-inventory.js';
 import type { IEditCheckpointRecorder } from '../checkpoints/edit-checkpoint-types.js';
 import type { IReversibleExecutionOptions } from '../reversible-execution/index.js';
+import type { ISandboxClient } from '@robota-sdk/agent-tools';
 
 /** Standard construction: cwd + provider. Config/context loaded internally. */
 export interface IInteractiveSessionStandardOptions {
@@ -78,6 +79,8 @@ export interface IInteractiveSessionStandardOptions {
   config?: IResolvedConfig;
   /** Opt-in local-first reversible execution policy for write/shell tools. */
   reversibleExecution?: IReversibleExecutionOptions;
+  /** Optional provider sandbox client used by sandbox-aware built-in tools. */
+  sandboxClient?: ISandboxClient;
 }
 
 /** Test/advanced construction: inject pre-built session directly. */
@@ -147,6 +150,8 @@ export interface IInitOptions {
   editCheckpointRecorder?: IEditCheckpointRecorder;
   /** Opt-in local-first reversible execution policy for write/shell tools. */
   reversibleExecution?: IReversibleExecutionOptions;
+  /** Optional provider sandbox client used by sandbox-aware built-in tools. */
+  sandboxClient?: ISandboxClient;
 }
 
 /**
@@ -230,6 +235,7 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
     isModelCommandInvocable: options.isModelCommandInvocable,
     editCheckpointRecorder: options.editCheckpointRecorder,
     reversibleExecution: options.reversibleExecution,
+    sandboxClient: options.sandboxClient,
   });
 }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -239,6 +239,7 @@ export class InteractiveSession {
       ...(options.commandModules ? { commandModules: options.commandModules } : {}),
       editCheckpointRecorder: this.editCheckpointStore,
       ...(options.reversibleExecution ? { reversibleExecution: options.reversibleExecution } : {}),
+      ...(options.sandboxClient ? { sandboxClient: options.sandboxClient } : {}),
       commandDescriptors: this.commandExecutor.listModelInvocableCommands(),
       ...(this.commandExecutor.listModelInvocableCommands().length > 0
         ? {

--- a/packages/agent-sdk/src/reversible-execution/__tests__/reversible-execution-policy.test.ts
+++ b/packages/agent-sdk/src/reversible-execution/__tests__/reversible-execution-policy.test.ts
@@ -61,6 +61,21 @@ describe('reversible execution policy', () => {
     });
   });
 
+  it('classifies provider-sandbox file mutations as reversible without host checkpoints', () => {
+    const report = evaluateReversibleToolSafety({
+      toolName: 'Write',
+      toolArgs: { filePath: '/workspace/generated.ts' },
+      context: { checkpointAvailable: false, isolation: 'provider-sandbox' },
+    });
+
+    expect(report).toMatchObject({
+      reversible: true,
+      sideEffect: 'file-mutation',
+      rollbackLayer: 'provider-sandbox',
+      status: 'reversible',
+    });
+  });
+
   it('treats worktree-isolated Agent jobs as reversible through the worktree layer', () => {
     const report = evaluateReversibleToolSafety({
       toolName: 'Agent',

--- a/packages/agent-sdk/src/reversible-execution/reversible-execution-policy.ts
+++ b/packages/agent-sdk/src/reversible-execution/reversible-execution-policy.ts
@@ -78,6 +78,9 @@ export function evaluateReversibleToolSafety(
   }
 
   if (FILE_MUTATION_TOOLS.has(toolName)) {
+    if (input.context.isolation === 'worktree' || input.context.isolation === 'provider-sandbox') {
+      return evaluateIsolatedSideEffect(toolName, 'file-mutation', input.context);
+    }
     if (input.context.checkpointAvailable) {
       return {
         toolName,

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -1,6 +1,6 @@
 # @robota-sdk/agent-tools
 
-Tool registry, tool creation infrastructure, and 8 built-in CLI tools for the Robota SDK.
+Tool registry, tool creation infrastructure, 8 built-in CLI tools, and sandbox execution ports for the Robota SDK.
 
 ## Installation
 
@@ -46,16 +46,35 @@ const agent = new Robota({
 
 ## Built-in Tools (8)
 
-| Export          | Tool Name | Description                                      |
-| --------------- | --------- | ------------------------------------------------ |
-| `bashTool`      | Bash      | Execute shell commands via `child_process.spawn` |
-| `readTool`      | Read      | Read file contents with line numbers (cat -n)    |
-| `writeTool`     | Write     | Write content to a file (creates parent dirs)    |
-| `editTool`      | Edit      | Replace a specific string in a file              |
-| `globTool`      | Glob      | Find files matching a glob pattern (fast-glob)   |
-| `grepTool`      | Grep      | Search file contents with regex patterns         |
-| `webFetchTool`  | WebFetch  | Fetch URL content (HTML-to-text conversion)      |
-| `webSearchTool` | WebSearch | Web search via Brave Search API                  |
+| Export          | Tool Name | Description                                               |
+| --------------- | --------- | --------------------------------------------------------- |
+| `bashTool`      | Bash      | Execute shell commands via host process or sandbox client |
+| `readTool`      | Read      | Read file contents with line numbers (cat -n)             |
+| `writeTool`     | Write     | Write content to a file (creates parent dirs)             |
+| `editTool`      | Edit      | Replace a specific string in a file                       |
+| `globTool`      | Glob      | Find files matching a glob pattern (fast-glob)            |
+| `grepTool`      | Grep      | Search file contents with regex patterns                  |
+| `webFetchTool`  | WebFetch  | Fetch URL content (HTML-to-text conversion)               |
+| `webSearchTool` | WebSearch | Web search via Brave Search API                           |
+
+Factory exports (`createBashTool`, `createReadTool`, `createWriteTool`, `createEditTool`) accept an optional `sandboxClient`. The default singleton exports keep host-local behavior.
+
+## Sandbox Execution
+
+`ISandboxClient` is the provider-neutral execution-plane port used by sandbox-aware built-in tools:
+
+```typescript
+import { E2BSandboxClient, createBashTool, createReadTool } from '@robota-sdk/agent-tools';
+import { Sandbox } from 'e2b';
+
+const e2b = await Sandbox.create();
+const sandboxClient = new E2BSandboxClient({ sandbox: e2b });
+
+const bashTool = createBashTool({ sandboxClient });
+const readTool = createReadTool({ sandboxClient });
+```
+
+The package does not depend on E2B directly. `E2BSandboxClient` adapts an E2B-compatible object with `commands.run`, `files.read`, `files.write`, and optional `pause`/`connect` methods, so applications can choose whether to install the provider SDK. `InMemorySandboxClient` is available for deterministic tests and contract verification.
 
 ## Edit and Write Safety
 
@@ -73,6 +92,9 @@ Recent file tool updates keep write/edit behavior atomic and make Edit tool resu
 | `createOpenAPITool`     | Factory for creating OpenAPI tools                     |
 | `zodToJsonSchema`       | Converts Zod schemas to JSON Schema format             |
 | `TToolResult`           | Result type for built-in CLI tool invocations          |
+| `ISandboxClient`        | Provider-neutral sandbox execution port                |
+| `E2BSandboxClient`      | Adapter for E2B-compatible sandbox instances           |
+| `InMemorySandboxClient` | Deterministic sandbox client for tests                 |
 
 ## TToolResult Shape
 

--- a/packages/agent-tools/docs/SPEC.md
+++ b/packages/agent-tools/docs/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Owns the tool registry, tool implementations, and tool result types for the Robota SDK. This package provides both the infrastructure for defining and managing tools (`ToolRegistry`, `FunctionTool`, `createZodFunctionTool`) and a set of 8 built-in CLI tools (`bash`, `read`, `write`, `edit`, `glob`, `grep`, `webFetch`, `webSearch`) used by the agent CLI.
+Owns the tool registry, tool implementations, tool result types, and sandbox execution ports for the Robota SDK. This package provides both the infrastructure for defining and managing tools (`ToolRegistry`, `FunctionTool`, `createZodFunctionTool`) and a set of 8 built-in CLI tools (`bash`, `read`, `write`, `edit`, `glob`, `grep`, `webFetch`, `webSearch`) used by the agent CLI.
 
 ## Boundaries
 
@@ -10,6 +10,7 @@ Owns the tool registry, tool implementations, and tool result types for the Robo
 - Does not own permission evaluation or hook execution. Tool permission wrapping is performed by consumers (e.g., `@robota-sdk/agent-sessions`).
 - Does not own MCP tool protocol. MCP tools live in `@robota-sdk/agent-tool-mcp`.
 - Does not own provider-specific behavior. Tools are provider-agnostic.
+- Does not own provider SDK installation. Provider sandbox adapters are structural adapters; applications decide whether to install concrete provider SDKs such as E2B.
 
 ## Architecture Overview
 
@@ -25,6 +26,10 @@ implementations/
   openapi-tool.ts       -- OpenAPITool: tool generated from OpenAPI spec
 types/
   tool-result.ts        -- TToolResult: result type for CLI tool invocations
+sandbox/
+  types.ts                       -- ISandboxClient and command/file contracts
+  in-memory-sandbox-client.ts    -- deterministic contract-test adapter
+  e2b-sandbox-client.ts          -- structural adapter for E2B-compatible sandboxes
 builtins/
   index.ts              -- Re-exports all 8 built-in CLI tools
   atomic-file-write.ts  -- Same-directory temp write + atomic rename helper for UTF-8 file replacement
@@ -42,7 +47,8 @@ builtins/
 
 - **Registry** -- `ToolRegistry` provides central tool registration, lookup, and schema management.
 - **Factory** -- `createFunctionTool` and `createZodFunctionTool` provide ergonomic tool construction.
-- **Adapter** -- `zodToJsonSchema` adapts Zod schemas into the JSON Schema format expected by AI providers.
+- **Adapter** -- `zodToJsonSchema` adapts Zod schemas into the JSON Schema format expected by AI providers; `E2BSandboxClient` adapts E2B-compatible sandbox instances to `ISandboxClient`.
+- **Ports and adapters** -- `ISandboxClient` separates tool execution intent from the concrete execution plane.
 
 **Dependency direction:** `@robota-sdk/agent-tools` has a peer dependency on `@robota-sdk/agent-core`. No reverse dependency exists.
 
@@ -60,36 +66,48 @@ Types owned by this package (SSOT):
 | `ISchemaConversionOptions`       | Interface | `implementations/function-tool/types.ts` | Options for Zod-to-JSON-Schema conversion        |
 | `IFunctionToolExecutionMetadata` | Interface | `implementations/function-tool/types.ts` | Metadata returned by function tool execution     |
 | `IFunctionToolResult`            | Interface | `implementations/function-tool/types.ts` | Extended result type for function tool execution |
+| `ISandboxClient`                 | Interface | `sandbox/types.ts`                       | Provider-neutral command and file sandbox port   |
+| `ISandboxRunOptions`             | Interface | `sandbox/types.ts`                       | Sandbox command execution options                |
+| `ISandboxRunResult`              | Interface | `sandbox/types.ts`                       | Sandbox command execution result                 |
+| `ISandboxToolOptions`            | Interface | `sandbox/types.ts`                       | Built-in tool factory options for sandbox use    |
+| `IE2BSandboxAdapter`             | Interface | `sandbox/e2b-sandbox-client.ts`          | Structural E2B-compatible adapter input          |
+| `IE2BSandboxClientOptions`       | Interface | `sandbox/e2b-sandbox-client.ts`          | E2B adapter construction options                 |
+| `IInMemorySandboxClientOptions`  | Interface | `sandbox/in-memory-sandbox-client.ts`    | In-memory sandbox construction options           |
 
 ## Public API Surface
 
 ### Tool Infrastructure
 
-| Export                  | Kind     | Description                                 |
-| ----------------------- | -------- | ------------------------------------------- |
-| `ToolRegistry`          | Class    | Central tool registration and schema lookup |
-| `FunctionTool`          | Class    | JS function tool with Zod schema validation |
-| `createFunctionTool`    | Function | Factory for creating function tools         |
-| `createZodFunctionTool` | Function | Factory with Zod validation and conversion  |
-| `OpenAPITool`           | Class    | Tool generated from OpenAPI specification   |
-| `createOpenAPITool`     | Function | Factory for creating OpenAPI tools          |
-| `zodToJsonSchema`       | Function | Converts Zod schemas to JSON Schema format  |
-| `TToolResult`           | Type     | Result shape for CLI tool invocations       |
+| Export                  | Kind     | Description                                  |
+| ----------------------- | -------- | -------------------------------------------- |
+| `ToolRegistry`          | Class    | Central tool registration and schema lookup  |
+| `FunctionTool`          | Class    | JS function tool with Zod schema validation  |
+| `createFunctionTool`    | Function | Factory for creating function tools          |
+| `createZodFunctionTool` | Function | Factory with Zod validation and conversion   |
+| `OpenAPITool`           | Class    | Tool generated from OpenAPI specification    |
+| `createOpenAPITool`     | Function | Factory for creating OpenAPI tools           |
+| `zodToJsonSchema`       | Function | Converts Zod schemas to JSON Schema format   |
+| `TToolResult`           | Type     | Result shape for CLI tool invocations        |
+| `E2BSandboxClient`      | Class    | Adapter for E2B-compatible sandbox instances |
+| `InMemorySandboxClient` | Class    | Deterministic sandbox client for tests       |
+| `ISandboxClient`        | Type     | Provider-neutral sandbox execution port      |
 
 ### Built-in CLI Tools
 
-| Export          | Kind   | Tool Name   | Description                                      |
-| --------------- | ------ | ----------- | ------------------------------------------------ |
-| `bashTool`      | Object | `Bash`      | Execute shell commands via `child_process.spawn` |
-| `readTool`      | Object | `Read`      | Read file contents with line numbers (cat -n)    |
-| `writeTool`     | Object | `Write`     | Write content to a file (creates parent dirs)    |
-| `editTool`      | Object | `Edit`      | Replace a specific string in a file              |
-| `globTool`      | Object | `Glob`      | Find files matching a glob pattern (fast-glob)   |
-| `grepTool`      | Object | `Grep`      | Search file contents with regex patterns         |
-| `webFetchTool`  | Object | `WebFetch`  | Fetch URL content with HTML-to-text conversion   |
-| `webSearchTool` | Object | `WebSearch` | Web search via Brave Search API                  |
+| Export          | Kind   | Tool Name   | Description                                        |
+| --------------- | ------ | ----------- | -------------------------------------------------- |
+| `bashTool`      | Object | `Bash`      | Execute shell commands via host process by default |
+| `readTool`      | Object | `Read`      | Read file contents with line numbers (cat -n)      |
+| `writeTool`     | Object | `Write`     | Write content to a file (creates parent dirs)      |
+| `editTool`      | Object | `Edit`      | Replace a specific string in a file                |
+| `globTool`      | Object | `Glob`      | Find files matching a glob pattern (fast-glob)     |
+| `grepTool`      | Object | `Grep`      | Search file contents with regex patterns           |
+| `webFetchTool`  | Object | `WebFetch`  | Fetch URL content with HTML-to-text conversion     |
+| `webSearchTool` | Object | `WebSearch` | Web search via Brave Search API                    |
 
 Each built-in tool is an `IToolWithEventService`-compatible object with `getName()`, `getDescription()`, `getSchema()`, and `execute()` methods.
+
+`createBashTool`, `createReadTool`, `createWriteTool`, and `createEditTool` create sandbox-aware tool instances. When an `ISandboxClient` is supplied, Bash command execution plus Read/Write/Edit filesystem operations are routed through the sandbox client. When no sandbox client is supplied, the singleton exports keep existing host-local behavior.
 
 **WriteTool output**: Reports actual UTF-8 byte count via `Buffer.byteLength(content, 'utf8')`, not JS `content.length` (which is character count and differs for multibyte content).
 
@@ -117,6 +135,8 @@ This is the inner result type used by built-in tools. It is serialized to JSON a
 
 3. **OpenAPITool / createOpenAPITool** -- Consumers create tools from OpenAPI specifications for API integration.
 
+4. **ISandboxClient** -- Consumers inject provider-backed execution planes into sandbox-aware built-in tool factories. `E2BSandboxClient` adapts E2B-compatible objects without adding an `e2b` package dependency to `agent-tools`; `InMemorySandboxClient` supports deterministic contract tests.
+
 ## Error Taxonomy
 
 This package does not define a custom error hierarchy. Built-in tools return errors via the `TToolResult.error` field rather than throwing. Schema conversion errors from `zodToJsonSchema` are thrown as standard `Error` instances.
@@ -125,11 +145,13 @@ This package does not define a custom error hierarchy. Built-in tools return err
 
 ### Interface Implementations
 
-| Interface                    | Implementor    | Kind       | Location                               |
-| ---------------------------- | -------------- | ---------- | -------------------------------------- |
-| `IFunctionTool` (agent-core) | `FunctionTool` | production | `src/implementations/function-tool.ts` |
-| `ITool` (agent-core)         | `OpenAPITool`  | production | `src/implementations/openapi-tool.ts`  |
-| `IToolRegistry` (agent-core) | `ToolRegistry` | production | `src/registry/tool-registry.ts`        |
+| Interface                      | Implementor             | Kind         | Location                                  |
+| ------------------------------ | ----------------------- | ------------ | ----------------------------------------- |
+| `IFunctionTool` (agent-core)   | `FunctionTool`          | production   | `src/implementations/function-tool.ts`    |
+| `ITool` (agent-core)           | `OpenAPITool`           | production   | `src/implementations/openapi-tool.ts`     |
+| `IToolRegistry` (agent-core)   | `ToolRegistry`          | production   | `src/registry/tool-registry.ts`           |
+| `ISandboxClient` (agent-tools) | `E2BSandboxClient`      | production   | `src/sandbox/e2b-sandbox-client.ts`       |
+| `ISandboxClient` (agent-tools) | `InMemorySandboxClient` | test/utility | `src/sandbox/in-memory-sandbox-client.ts` |
 
 ### Inheritance Chains
 
@@ -137,11 +159,12 @@ None. `FunctionTool` and `OpenAPITool` implement their respective interfaces dir
 
 ### Cross-Package Port Consumers
 
-| Port (Owner)                  | Consumer           | Location                               |
-| ----------------------------- | ------------------ | -------------------------------------- |
-| `IFunctionTool` (agent-core)  | `FunctionTool`     | `src/implementations/function-tool.ts` |
-| `ITool` (agent-core)          | `OpenAPITool`      | `src/implementations/openapi-tool.ts`  |
-| `IToolWithEventService` shape | Built-in CLI tools | `src/builtins/*.ts`                    |
+| Port (Owner)                   | Consumer                    | Location                                                                     |
+| ------------------------------ | --------------------------- | ---------------------------------------------------------------------------- |
+| `IFunctionTool` (agent-core)   | `FunctionTool`              | `src/implementations/function-tool.ts`                                       |
+| `ITool` (agent-core)           | `OpenAPITool`               | `src/implementations/openapi-tool.ts`                                        |
+| `IToolWithEventService` shape  | Built-in CLI tools          | `src/builtins/*.ts`                                                          |
+| `ISandboxClient` (agent-tools) | Built-in CLI tool factories | `src/builtins/bash-tool.ts`, `read-tool.ts`, `write-tool.ts`, `edit-tool.ts` |
 
 ## Test Strategy
 
@@ -150,13 +173,14 @@ None. `FunctionTool` and `OpenAPITool` implement their respective interfaces dir
 | File                                      | Scope | Description                                                             |
 | ----------------------------------------- | ----- | ----------------------------------------------------------------------- |
 | `src/__tests__/atomic-file-write.test.ts` | Unit  | Atomic UTF-8 write replacement, mode preservation, cleanup, and handoff |
+| `src/__tests__/sandbox-tools.test.ts`     | Unit  | Sandbox client contracts, sandbox-aware tools, and E2B adapter behavior |
 | `src/__tests__/function-tool.test.ts`     | Unit  | FunctionTool creation, execution, schema validation                     |
 | `src/__tests__/schema-converter.test.ts`  | Unit  | Zod-to-JSON-Schema conversion                                           |
 | `src/__tests__/tool-registry.test.ts`     | Unit  | ToolRegistry registration, lookup, listing                              |
 
 ### Gaps
 
-- **Built-in tools** -- No unit tests for `bashTool`, `readTool`, `globTool`, or `grepTool`.
+- **Built-in tools** -- `globTool` and `grepTool` still need dedicated unit coverage beyond provider-agnostic composition tests.
 - **OpenAPITool** -- No unit tests for OpenAPI tool creation or execution.
 - **TToolResult** -- No tests verifying the result shape contract.
 

--- a/packages/agent-tools/src/__tests__/sandbox-tools.test.ts
+++ b/packages/agent-tools/src/__tests__/sandbox-tools.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { IToolWithEventService, TToolParameters } from '@robota-sdk/agent-core';
+import {
+  E2BSandboxClient,
+  InMemorySandboxClient,
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+} from '../index.js';
+import type { ISandboxRunOptions, TToolResult } from '../index.js';
+
+async function executeTool(
+  tool: IToolWithEventService,
+  parameters: TToolParameters,
+): Promise<TToolResult> {
+  const rawResult = await tool.execute(parameters, { toolName: tool.getName(), parameters });
+  return JSON.parse(rawResult.data as string) as TToolResult;
+}
+
+describe('sandbox-aware built-in tools', () => {
+  it('routes Bash through the injected sandbox client', async () => {
+    let observedCommand = '';
+    let observedOptions: ISandboxRunOptions | undefined;
+    const sandboxClient = new InMemorySandboxClient({
+      runHandler: (command, options) => {
+        observedCommand = command;
+        observedOptions = options;
+        return { stdout: 'sandbox stdout', stderr: 'sandbox stderr', exitCode: 7 };
+      },
+    });
+
+    const result = await executeTool(createBashTool({ sandboxClient }), {
+      command: 'npm test',
+      timeout: 1234,
+      workingDirectory: '/workspace',
+    });
+
+    expect(observedCommand).toBe('npm test');
+    expect(observedOptions).toEqual({ timeoutMs: 1234, workingDirectory: '/workspace' });
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 7,
+    });
+    expect(result.output).toContain('sandbox stdout');
+    expect(result.output).toContain('sandbox stderr');
+  });
+
+  it('routes Read, Write, and Edit through the injected sandbox filesystem', async () => {
+    const sandboxClient = new InMemorySandboxClient({
+      files: {
+        '/workspace/source.ts': 'const value = 1;\n',
+      },
+    });
+
+    const readResult = await executeTool(createReadTool({ sandboxClient }), {
+      filePath: '/workspace/source.ts',
+    });
+    expect(readResult.success).toBe(true);
+    expect(readResult.output).toContain('1\tconst value = 1;');
+
+    const editResult = await executeTool(createEditTool({ sandboxClient }), {
+      filePath: '/workspace/source.ts',
+      oldString: 'const value = 1;',
+      newString: 'const value = 2;',
+    });
+    expect(editResult.success).toBe(true);
+    expect(sandboxClient.getFile('/workspace/source.ts')).toBe('const value = 2;\n');
+
+    const writeResult = await executeTool(createWriteTool({ sandboxClient }), {
+      filePath: '/workspace/generated.ts',
+      content: 'export const generated = true;\n',
+    });
+    expect(writeResult.success).toBe(true);
+    expect(sandboxClient.getFile('/workspace/generated.ts')).toBe(
+      'export const generated = true;\n',
+    );
+  });
+
+  it('supports snapshot and restore contracts for sandbox adapters', async () => {
+    const sandboxClient = new InMemorySandboxClient({
+      files: {
+        '/workspace/state.txt': 'before',
+      },
+    });
+
+    const snapshotId = await sandboxClient.snapshot();
+    await sandboxClient.writeFile('/workspace/state.txt', 'after');
+    await sandboxClient.restore(snapshotId);
+
+    await expect(sandboxClient.readFile('/workspace/state.txt')).resolves.toBe('before');
+  });
+
+  it('adapts E2B-compatible sandboxes without importing the provider SDK', async () => {
+    const commandCalls: Array<{ command: string; cwd?: string; timeoutMs?: number }> = [];
+    let paused = false;
+    let restored = false;
+    const e2bSandbox = {
+      sandboxId: 'sandbox_1',
+      commands: {
+        run: async (command: string, options?: { cwd?: string; timeoutMs?: number }) => {
+          commandCalls.push({ command, cwd: options?.cwd, timeoutMs: options?.timeoutMs });
+          return { stdout: 'ok', stderr: '', exitCode: 0 };
+        },
+      },
+      files: {
+        read: async () => 'file content',
+        write: async () => undefined,
+      },
+      pause: async () => {
+        paused = true;
+      },
+      connect: async () => {
+        restored = true;
+        return e2bSandbox;
+      },
+    };
+    const sandboxClient = new E2BSandboxClient({ sandbox: e2bSandbox });
+
+    await expect(
+      sandboxClient.run('pnpm test', { workingDirectory: '/workspace', timeoutMs: 5000 }),
+    ).resolves.toEqual({ stdout: 'ok', stderr: '', exitCode: 0 });
+    await expect(sandboxClient.readFile('/workspace/file.txt')).resolves.toBe('file content');
+    await expect(sandboxClient.snapshot()).resolves.toBe('sandbox_1');
+    await sandboxClient.restore('sandbox_1');
+
+    expect(commandCalls).toEqual([{ command: 'pnpm test', cwd: '/workspace', timeoutMs: 5000 }]);
+    expect(paused).toBe(true);
+    expect(restored).toBe(true);
+  });
+});

--- a/packages/agent-tools/src/builtins/bash-tool.ts
+++ b/packages/agent-tools/src/builtins/bash-tool.ts
@@ -10,6 +10,7 @@ import { spawn } from 'node:child_process';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
 import type { IZodSchema } from '../implementations/function-tool/types';
+import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 
 const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
@@ -32,8 +33,32 @@ type TBashArgs = z.infer<typeof BashSchema>;
  * Run a shell command and return stdout + stderr.
  * Resolves with the TToolResult JSON string.
  */
-async function runBash(args: TBashArgs): Promise<string> {
+async function runBash(args: TBashArgs, options: ISandboxToolOptions = {}): Promise<string> {
   const { command, timeout = DEFAULT_TIMEOUT_MS, workingDirectory } = args;
+  if (options.sandboxClient) {
+    try {
+      const sandboxResult = await options.sandboxClient.run(command, {
+        timeoutMs: timeout,
+        workingDirectory,
+      });
+      const output = sandboxResult.stderr
+        ? `${sandboxResult.stdout}\nstderr:\n${sandboxResult.stderr}`
+        : sandboxResult.stdout;
+      const result: TToolResult = {
+        success: true,
+        output,
+        exitCode: sandboxResult.exitCode,
+      };
+      return JSON.stringify(result);
+    } catch (err) {
+      const result: TToolResult = {
+        success: false,
+        output: '',
+        error: err instanceof Error ? err.message : String(err),
+      };
+      return JSON.stringify(result);
+    }
+  }
 
   return new Promise<string>((resolve) => {
     const stdoutChunks: Buffer[] = [];
@@ -110,14 +135,21 @@ async function runBash(args: TBashArgs): Promise<string> {
 }
 
 /**
+ * Create a BashTool instance — register with Robota agent tools registry.
+ */
+export function createBashTool(options: ISandboxToolOptions = {}) {
+  return createZodFunctionTool(
+    'Bash',
+    'Executes a given bash command and returns its output.\n\nThe working directory persists between commands, but shell state does not.\n\nIMPORTANT: Avoid using this tool to run `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands. Instead, use the appropriate dedicated tool:\n - File search: Use Glob (NOT find or ls)\n - Content search: Use Grep (NOT grep or rg)\n - Read files: Use Read (NOT cat/head/tail)\n - Edit files: Use Edit (NOT sed/awk)\n\nFor simple commands, keep the description brief (5-10 words). For complex commands, include enough context to clarify what the command does.\n\nOutput is limited to 30,000 characters. Longer output will be middle-truncated.',
+    BashSchema as unknown as IZodSchema,
+    async (params) => {
+      // createZodFunctionTool passes validated params; cast is safe
+      return runBash(params as TBashArgs, options);
+    },
+  );
+}
+
+/**
  * BashTool instance — register with Robota agent tools registry.
  */
-export const bashTool = createZodFunctionTool(
-  'Bash',
-  'Executes a given bash command and returns its output.\n\nThe working directory persists between commands, but shell state does not.\n\nIMPORTANT: Avoid using this tool to run `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands. Instead, use the appropriate dedicated tool:\n - File search: Use Glob (NOT find or ls)\n - Content search: Use Grep (NOT grep or rg)\n - Read files: Use Read (NOT cat/head/tail)\n - Edit files: Use Edit (NOT sed/awk)\n\nFor simple commands, keep the description brief (5-10 words). For complex commands, include enough context to clarify what the command does.\n\nOutput is limited to 30,000 characters. Longer output will be middle-truncated.',
-  BashSchema as unknown as IZodSchema,
-  async (params) => {
-    // createZodFunctionTool passes validated params; cast is safe
-    return runBash(params as TBashArgs);
-  },
-);
+export const bashTool = createBashTool();

--- a/packages/agent-tools/src/builtins/edit-tool.ts
+++ b/packages/agent-tools/src/builtins/edit-tool.ts
@@ -9,6 +9,7 @@ import { readFile } from 'node:fs/promises';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
 import type { IZodSchema } from '../implementations/function-tool/types';
+import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 import { atomicWriteUtf8File } from './atomic-file-write.js';
 
@@ -28,12 +29,14 @@ const EditSchema = z.object({
 
 type TEditArgs = z.infer<typeof EditSchema>;
 
-async function editFileTool(args: TEditArgs): Promise<string> {
+async function editFileTool(args: TEditArgs, options: ISandboxToolOptions = {}): Promise<string> {
   const { filePath, oldString, newString, replaceAll = false } = args;
 
   let content: string;
   try {
-    content = await readFile(filePath, 'utf8');
+    content = options.sandboxClient
+      ? await options.sandboxClient.readFile(filePath)
+      : await readFile(filePath, 'utf8');
   } catch (err) {
     const result: TToolResult = {
       success: false,
@@ -76,7 +79,11 @@ async function editFileTool(args: TEditArgs): Promise<string> {
       content.slice(content.indexOf(oldString) + oldString.length);
 
   try {
-    await atomicWriteUtf8File(filePath, updated);
+    if (options.sandboxClient) {
+      await options.sandboxClient.writeFile(filePath, updated);
+    } else {
+      await atomicWriteUtf8File(filePath, updated);
+    }
   } catch (err) {
     const result: TToolResult = {
       success: false,
@@ -99,13 +106,20 @@ async function editFileTool(args: TEditArgs): Promise<string> {
 }
 
 /**
+ * Create an EditTool instance — register with Robota agent tools registry.
+ */
+export function createEditTool(options: ISandboxToolOptions = {}) {
+  return createZodFunctionTool(
+    'Edit',
+    'Performs exact string replacements in files.\n\nYou must use the Read tool at least once before editing. When editing text from Read output, preserve the exact indentation.\n\nThe edit will FAIL if old_string is not unique in the file. Either provide more surrounding context to make it unique, or use replace_all to change every instance.\n\nALWAYS prefer editing existing files over creating new ones.',
+    EditSchema as unknown as IZodSchema,
+    async (params) => {
+      return editFileTool(params as TEditArgs, options);
+    },
+  );
+}
+
+/**
  * EditTool instance — register with Robota agent tools registry.
  */
-export const editTool = createZodFunctionTool(
-  'Edit',
-  'Performs exact string replacements in files.\n\nYou must use the Read tool at least once before editing. When editing text from Read output, preserve the exact indentation.\n\nThe edit will FAIL if old_string is not unique in the file. Either provide more surrounding context to make it unique, or use replace_all to change every instance.\n\nALWAYS prefer editing existing files over creating new ones.',
-  EditSchema as unknown as IZodSchema,
-  async (params) => {
-    return editFileTool(params as TEditArgs);
-  },
-);
+export const editTool = createEditTool();

--- a/packages/agent-tools/src/builtins/index.ts
+++ b/packages/agent-tools/src/builtins/index.ts
@@ -1,8 +1,8 @@
 // Built-in CLI tools
-export { bashTool } from './bash-tool.js';
-export { readTool } from './read-tool.js';
-export { writeTool } from './write-tool.js';
-export { editTool } from './edit-tool.js';
+export { bashTool, createBashTool } from './bash-tool.js';
+export { readTool, createReadTool } from './read-tool.js';
+export { writeTool, createWriteTool } from './write-tool.js';
+export { editTool, createEditTool } from './edit-tool.js';
 export { globTool } from './glob-tool.js';
 export { grepTool } from './grep-tool.js';
 export { webFetchTool } from './web-fetch-tool.js';

--- a/packages/agent-tools/src/builtins/read-tool.ts
+++ b/packages/agent-tools/src/builtins/read-tool.ts
@@ -9,6 +9,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
 import type { IZodSchema } from '../implementations/function-tool/types';
+import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 
 const DEFAULT_LIMIT = 2000;
@@ -57,9 +58,55 @@ function formatWithLineNumbers(lines: string[], startLine: number): string {
     .join('\n');
 }
 
-async function readFileTool(args: TReadArgs): Promise<string> {
+function formatReadResult(
+  filePath: string,
+  content: string,
+  startLine: number,
+  limit: number,
+): string {
+  const allLines = content.split('\n');
+
+  // Remove trailing empty line if file ends with newline (common in Unix files)
+  if (allLines[allLines.length - 1] === '') {
+    allLines.pop();
+  }
+
+  const zeroBasedStart = startLine - 1;
+  const selectedLines = allLines.slice(zeroBasedStart, zeroBasedStart + limit);
+
+  const output = formatWithLineNumbers(selectedLines, startLine);
+
+  const totalLines = allLines.length;
+  const returnedLines = selectedLines.length;
+  const header =
+    returnedLines < totalLines
+      ? `[File: ${filePath} (lines ${startLine}-${startLine + returnedLines - 1} of ${totalLines})]\n`
+      : `[File: ${filePath} (${totalLines} lines)]\n`;
+
+  const result: TToolResult = {
+    success: true,
+    output: header + output,
+  };
+  return JSON.stringify(result);
+}
+
+async function readFileTool(args: TReadArgs, options: ISandboxToolOptions = {}): Promise<string> {
   const { filePath, offset, limit = DEFAULT_LIMIT } = args;
   const startLine = offset !== undefined && offset > 0 ? offset : 1;
+
+  if (options.sandboxClient) {
+    try {
+      const content = await options.sandboxClient.readFile(filePath);
+      return formatReadResult(filePath, content, startLine, limit);
+    } catch (err) {
+      const result: TToolResult = {
+        success: false,
+        output: '',
+        error: err instanceof Error ? err.message : String(err),
+      };
+      return JSON.stringify(result);
+    }
+  }
 
   let fileStats: Awaited<ReturnType<typeof stat>> | undefined;
   try {
@@ -104,40 +151,24 @@ async function readFileTool(args: TReadArgs): Promise<string> {
   }
 
   const content = buffer.toString('utf8');
-  const allLines = content.split('\n');
+  return formatReadResult(filePath, content, startLine, limit);
+}
 
-  // Remove trailing empty line if file ends with newline (common in Unix files)
-  if (allLines[allLines.length - 1] === '') {
-    allLines.pop();
-  }
-
-  const zeroBasedStart = startLine - 1;
-  const selectedLines = allLines.slice(zeroBasedStart, zeroBasedStart + limit);
-
-  const output = formatWithLineNumbers(selectedLines, startLine);
-
-  const totalLines = allLines.length;
-  const returnedLines = selectedLines.length;
-  const header =
-    returnedLines < totalLines
-      ? `[File: ${filePath} (lines ${startLine}-${startLine + returnedLines - 1} of ${totalLines})]\n`
-      : `[File: ${filePath} (${totalLines} lines)]\n`;
-
-  const result: TToolResult = {
-    success: true,
-    output: header + output,
-  };
-  return JSON.stringify(result);
+/**
+ * Create a ReadTool instance — register with Robota agent tools registry.
+ */
+export function createReadTool(options: ISandboxToolOptions = {}) {
+  return createZodFunctionTool(
+    'Read',
+    'Reads a file from the local filesystem.\n\nBy default, reads up to 2000 lines from the beginning of the file. You can optionally specify offset and limit for partial reads.\n\nResults are returned using cat -n format, with line numbers starting at 1.\n\nThe file_path parameter must be an absolute path, not a relative path.',
+    ReadSchema as unknown as IZodSchema,
+    async (params) => {
+      return readFileTool(params as TReadArgs, options);
+    },
+  );
 }
 
 /**
  * ReadTool instance — register with Robota agent tools registry.
  */
-export const readTool = createZodFunctionTool(
-  'Read',
-  'Reads a file from the local filesystem.\n\nBy default, reads up to 2000 lines from the beginning of the file. You can optionally specify offset and limit for partial reads.\n\nResults are returned using cat -n format, with line numbers starting at 1.\n\nThe file_path parameter must be an absolute path, not a relative path.',
-  ReadSchema as unknown as IZodSchema,
-  async (params) => {
-    return readFileTool(params as TReadArgs);
-  },
-);
+export const readTool = createReadTool();

--- a/packages/agent-tools/src/builtins/write-tool.ts
+++ b/packages/agent-tools/src/builtins/write-tool.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
 import type { IZodSchema } from '../implementations/function-tool/types';
+import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 import { atomicWriteUtf8File } from './atomic-file-write.js';
 
@@ -15,11 +16,15 @@ const WriteSchema = z.object({
 
 type TWriteArgs = z.infer<typeof WriteSchema>;
 
-async function writeFileTool(args: TWriteArgs): Promise<string> {
+async function writeFileTool(args: TWriteArgs, options: ISandboxToolOptions = {}): Promise<string> {
   const { filePath, content } = args;
 
   try {
-    await atomicWriteUtf8File(filePath, content);
+    if (options.sandboxClient) {
+      await options.sandboxClient.writeFile(filePath, content);
+    } else {
+      await atomicWriteUtf8File(filePath, content);
+    }
 
     const result: TToolResult = {
       success: true,
@@ -37,13 +42,20 @@ async function writeFileTool(args: TWriteArgs): Promise<string> {
 }
 
 /**
+ * Create a WriteTool instance — register with Robota agent tools registry.
+ */
+export function createWriteTool(options: ISandboxToolOptions = {}) {
+  return createZodFunctionTool(
+    'Write',
+    'Writes a file to the local filesystem. This will overwrite an existing file if one exists.\n\nALWAYS prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.\n\nNEVER create documentation files (*.md) or README files unless explicitly requested by the user.',
+    WriteSchema as unknown as IZodSchema,
+    async (params) => {
+      return writeFileTool(params as TWriteArgs, options);
+    },
+  );
+}
+
+/**
  * WriteTool instance — register with Robota agent tools registry.
  */
-export const writeTool = createZodFunctionTool(
-  'Write',
-  'Writes a file to the local filesystem. This will overwrite an existing file if one exists.\n\nALWAYS prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.\n\nNEVER create documentation files (*.md) or README files unless explicitly requested by the user.',
-  WriteSchema as unknown as IZodSchema,
-  async (params) => {
-    return writeFileTool(params as TWriteArgs);
-  },
-);
+export const writeTool = createWriteTool();

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -2,6 +2,17 @@
 
 // Tool result type
 export type { TToolResult } from './types/tool-result';
+export { E2BSandboxClient, InMemorySandboxClient } from './sandbox/index';
+export type {
+  IE2BSandboxAdapter,
+  IE2BSandboxClientOptions,
+  ISandboxClient,
+  ISandboxRunOptions,
+  ISandboxRunResult,
+  ISandboxToolOptions,
+  IInMemorySandboxClientOptions,
+  TInMemorySandboxRunHandler,
+} from './sandbox/index';
 
 export { ToolRegistry } from './registry/tool-registry';
 export {
@@ -22,10 +33,10 @@ export type {
 } from './implementations/function-tool/types';
 
 // Built-in CLI tools
-export { bashTool } from './builtins/bash-tool';
-export { readTool } from './builtins/read-tool';
-export { writeTool } from './builtins/write-tool';
-export { editTool } from './builtins/edit-tool';
+export { bashTool, createBashTool } from './builtins/bash-tool';
+export { readTool, createReadTool } from './builtins/read-tool';
+export { writeTool, createWriteTool } from './builtins/write-tool';
+export { editTool, createEditTool } from './builtins/edit-tool';
 export { globTool } from './builtins/glob-tool';
 export { grepTool } from './builtins/grep-tool';
 export { webFetchTool } from './builtins/web-fetch-tool';

--- a/packages/agent-tools/src/sandbox/e2b-sandbox-client.ts
+++ b/packages/agent-tools/src/sandbox/e2b-sandbox-client.ts
@@ -1,0 +1,95 @@
+import type { ISandboxClient, ISandboxRunOptions, ISandboxRunResult } from './types.js';
+
+interface IE2BCommandStartOptions {
+  timeoutMs?: number;
+  cwd?: string;
+  background?: false;
+}
+
+interface IE2BCommandResult {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  exit_code?: number;
+}
+
+interface IE2BCommands {
+  run(command: string, options?: IE2BCommandStartOptions): Promise<IE2BCommandResult>;
+}
+
+interface IE2BFiles {
+  read(path: string): Promise<string | Uint8Array>;
+  write(path: string, content: string): Promise<void>;
+}
+
+export interface IE2BSandboxAdapter {
+  sandboxId?: string;
+  commands: IE2BCommands;
+  files: IE2BFiles;
+  pause?(): Promise<boolean | string | void>;
+  connect?(): Promise<IE2BSandboxAdapter>;
+}
+
+export interface IE2BSandboxClientOptions {
+  sandbox: IE2BSandboxAdapter;
+  connectSandbox?: (sandboxId: string) => Promise<IE2BSandboxAdapter>;
+}
+
+export class E2BSandboxClient implements ISandboxClient {
+  private sandbox: IE2BSandboxAdapter;
+  private readonly connectSandbox?: (sandboxId: string) => Promise<IE2BSandboxAdapter>;
+
+  constructor(options: IE2BSandboxClientOptions) {
+    this.sandbox = options.sandbox;
+    this.connectSandbox = options.connectSandbox;
+  }
+
+  async run(command: string, options?: ISandboxRunOptions): Promise<ISandboxRunResult> {
+    const result = await this.sandbox.commands.run(command, {
+      background: false,
+      timeoutMs: options?.timeoutMs,
+      cwd: options?.workingDirectory,
+    });
+
+    return {
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.exitCode ?? result.exit_code ?? 0,
+    };
+  }
+
+  async readFile(path: string): Promise<string> {
+    const content = await this.sandbox.files.read(path);
+    return typeof content === 'string' ? content : Buffer.from(content).toString('utf8');
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await this.sandbox.files.write(path, content);
+  }
+
+  async snapshot(): Promise<string> {
+    const sandboxId = this.sandbox.sandboxId;
+    if (!sandboxId) {
+      throw new Error('E2B sandboxId is required to create a resumable sandbox snapshot.');
+    }
+    if (!this.sandbox.pause) {
+      throw new Error('E2B sandbox adapter does not expose pause().');
+    }
+    await this.sandbox.pause();
+    return sandboxId;
+  }
+
+  async restore(snapshotId: string): Promise<void> {
+    if (this.connectSandbox) {
+      this.sandbox = await this.connectSandbox(snapshotId);
+      return;
+    }
+    if (this.sandbox.sandboxId === snapshotId && this.sandbox.connect) {
+      this.sandbox = await this.sandbox.connect();
+      return;
+    }
+    throw new Error(
+      'E2B sandbox restore requires connectSandbox(snapshotId) or sandbox.connect().',
+    );
+  }
+}

--- a/packages/agent-tools/src/sandbox/in-memory-sandbox-client.ts
+++ b/packages/agent-tools/src/sandbox/in-memory-sandbox-client.ts
@@ -1,0 +1,66 @@
+import type { ISandboxClient, ISandboxRunOptions, ISandboxRunResult } from './types.js';
+
+export type TInMemorySandboxRunHandler = (
+  command: string,
+  options: ISandboxRunOptions | undefined,
+  files: ReadonlyMap<string, string>,
+) => Promise<ISandboxRunResult> | ISandboxRunResult;
+
+export interface IInMemorySandboxClientOptions {
+  files?: Record<string, string>;
+  runHandler?: TInMemorySandboxRunHandler;
+}
+
+export class InMemorySandboxClient implements ISandboxClient {
+  private readonly files = new Map<string, string>();
+  private readonly snapshots = new Map<string, Map<string, string>>();
+  private readonly runHandler?: TInMemorySandboxRunHandler;
+  private snapshotSequence = 0;
+
+  constructor(options: IInMemorySandboxClientOptions = {}) {
+    for (const [path, content] of Object.entries(options.files ?? {})) {
+      this.files.set(path, content);
+    }
+    this.runHandler = options.runHandler;
+  }
+
+  async run(command: string, options?: ISandboxRunOptions): Promise<ISandboxRunResult> {
+    if (this.runHandler) {
+      return this.runHandler(command, options, this.files);
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
+
+  async readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw new Error(`Sandbox file not found: ${path}`);
+    }
+    return content;
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async snapshot(): Promise<string> {
+    const snapshotId = `snapshot-${++this.snapshotSequence}`;
+    this.snapshots.set(snapshotId, new Map(this.files));
+    return snapshotId;
+  }
+
+  async restore(snapshotId: string): Promise<void> {
+    const snapshot = this.snapshots.get(snapshotId);
+    if (!snapshot) {
+      throw new Error(`Sandbox snapshot not found: ${snapshotId}`);
+    }
+    this.files.clear();
+    for (const [path, content] of snapshot.entries()) {
+      this.files.set(path, content);
+    }
+  }
+
+  getFile(path: string): string | undefined {
+    return this.files.get(path);
+  }
+}

--- a/packages/agent-tools/src/sandbox/index.ts
+++ b/packages/agent-tools/src/sandbox/index.ts
@@ -1,0 +1,13 @@
+export { E2BSandboxClient } from './e2b-sandbox-client.js';
+export type { IE2BSandboxAdapter, IE2BSandboxClientOptions } from './e2b-sandbox-client.js';
+export { InMemorySandboxClient } from './in-memory-sandbox-client.js';
+export type {
+  IInMemorySandboxClientOptions,
+  TInMemorySandboxRunHandler,
+} from './in-memory-sandbox-client.js';
+export type {
+  ISandboxClient,
+  ISandboxRunOptions,
+  ISandboxRunResult,
+  ISandboxToolOptions,
+} from './types.js';

--- a/packages/agent-tools/src/sandbox/types.ts
+++ b/packages/agent-tools/src/sandbox/types.ts
@@ -1,0 +1,22 @@
+export interface ISandboxRunOptions {
+  timeoutMs?: number;
+  workingDirectory?: string;
+}
+
+export interface ISandboxRunResult {
+  stdout: string;
+  stderr?: string;
+  exitCode: number;
+}
+
+export interface ISandboxClient {
+  run(command: string, options?: ISandboxRunOptions): Promise<ISandboxRunResult>;
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, content: string): Promise<void>;
+  snapshot?(): Promise<string>;
+  restore?(snapshotId: string): Promise<void>;
+}
+
+export interface ISandboxToolOptions {
+  sandboxClient?: ISandboxClient;
+}


### PR DESCRIPTION
## Summary
- add provider-neutral sandbox execution ports and E2B-compatible structural adapter in agent-tools
- route Bash, Read, Write, and Edit through sandbox-aware factories when a sandbox client is provided
- wire agent-sdk session assembly and reversible execution defaults for provider-sandbox isolation
- update specs, README/content docs, changeset, and move the sandbox backlog item to completed

## Verification
- pnpm --filter @robota-sdk/agent-tools test -- src/__tests__/sandbox-tools.test.ts
- pnpm --filter @robota-sdk/agent-sdk test -- src/assembly/__tests__/create-tools.test.ts src/__tests__/create-session-new-options.test.ts src/reversible-execution/__tests__/reversible-execution-policy.test.ts
- pnpm --filter @robota-sdk/agent-tools typecheck
- pnpm --filter @robota-sdk/agent-sdk typecheck
- pnpm --filter @robota-sdk/agent-tools lint
- pnpm --filter @robota-sdk/agent-sdk lint
- pnpm build
- pnpm docs:build
- pnpm harness:scan
- pnpm harness:verify -- --base-ref origin/develop --skip-record-check
- pre-push scoped verification