### PR TITLE
refactor(playground): split demo execution data

### DIFF
--- a/.agents/specs/ARCHITECTURE-MAP.md
+++ b/.agents/specs/ARCHITECTURE-MAP.md
@@ -1,6 +1,6 @@
 # System Architecture Map
 
-Source-verified against `develop` commit `644da21d6` on 2026-05-05.
+Source-verified against `develop` commit `ede199ac6` on 2026-05-05.
 
 This is the repository-wide master architecture map. It should contain the complete repository
 structure at a level an LLM can scan before changing package boundaries, product shells, deployment
@@ -123,6 +123,7 @@ flowchart TD
   RootEntry["agent-playground root entry\nservices + components"]
   Components["playground React components\neditor, gallery, panels, visualizers"]
   ComponentData["component data modules\ncode-editor-templates,\ntemplate-gallery-data"]
+  DemoData["demo execution data module\nscenario + timeline offsets"]
   Hooks["playground hooks\ninput, websocket, execution, stats"]
   Context["playground context + reducer"]
   Executor["PlaygroundExecutor\nbrowser execution facade"]
@@ -136,6 +137,7 @@ flowchart TD
   RootEntry --> Components
   RootEntry --> Executor
   Components --> ComponentData
+  Components --> DemoData
   Components --> Hooks
   Components --> Context
   Hooks --> Executor

--- a/.agents/tasks/DAG-BL-011-playground-monolith-decomposition.md
+++ b/.agents/tasks/DAG-BL-011-playground-monolith-decomposition.md
@@ -2,7 +2,7 @@
 
 - **Status**: in-progress
 - **Created**: 2026-03-27
-- **Branch**: refactor/agent-playground-decompose-p1
+- **Branch**: refactor/agent-playground-demo-data
 - **Scope**: packages/agent-playground
 - **Priority**: low
 
@@ -17,7 +17,9 @@ changing runtime behavior. Decompose one responsibility at a time under characte
 - [x] Split `code-editor-templates.ts` into a stable directory module.
 - [x] Add characterization tests for `template-gallery-data`.
 - [x] Split `template-gallery-data.ts` into a stable directory module.
-- [x] Update package SPEC and central architecture map for the new module boundary.
+- [x] Add characterization tests for `demo-execution-data`.
+- [x] Split `demo-execution-data.ts` into a stable directory module.
+- [x] Update package SPEC and central architecture map for the new module boundaries.
 - [ ] Continue with the remaining >300 line files in follow-up decomposition slices.
 
 ## Current >300 Line Files
@@ -52,7 +54,6 @@ changing runtime behavior. Decompose one responsibility at a time under characte
 - `project-manager.ts` (387 lines)
 - `block-tracking/block-hooks.ts` (324 lines)
 - `code-analyzer.ts` (320 lines)
-- `demo-execution-data.ts` (310 lines)
 
 ### contexts
 
@@ -67,12 +68,18 @@ changing runtime behavior. Decompose one responsibility at a time under characte
   preserving the existing import paths through directory `index.ts` modules.
 - Added characterization tests before each extraction.
 - Updated `packages/agent-playground/docs/SPEC.md` and `.agents/specs/ARCHITECTURE-MAP.md`.
+- Completed the second low-risk slice: `demo-execution-data.ts` now delegates through a same-name
+  directory module with `index.ts`, `offsets.ts`, and `scenario.ts`.
+- Added characterization coverage for demo block order, hierarchy, timeline offsets, and the
+  complex-demo wrapper behavior.
+- Updated package SPEC and the central architecture map for the demo data module.
 
 ## Decisions
 
 - Start with static data modules because they have no UI state, network, or browser side effects.
 - Preserve consumer imports (`./code-editor-templates`, `./template-gallery-data`) by replacing
   files with same-name directory modules.
+- Apply the same stable-import directory module pattern to demo execution data.
 - Keep architecture documentation centralized in `.agents/specs/ARCHITECTURE-MAP.md`; package
   SPEC only records package-local contract details.
 
@@ -90,6 +97,6 @@ changing runtime behavior. Decompose one responsibility at a time under characte
 
 ## Result
 
-This task remains open because 24 source files still exceed the guideline. The current branch
-delivers the first tested decomposition slice and establishes the repeatable pattern for follow-up
+This task remains open because 23 source files still exceed the guideline. The current branch
+delivers the second tested decomposition slice and extends the repeatable pattern for follow-up
 files.

--- a/packages/agent-playground/docs/SPEC.md
+++ b/packages/agent-playground/docs/SPEC.md
@@ -7,13 +7,14 @@ Owns the Robota Playground UI package: React components, hooks, executor logic, 
 ## Boundaries
 
 - Does not own core agent contracts (`IExecutor`, `IAIProvider`, `TUniversalMessage`); imports from `@robota-sdk/agent-core`.
-- Does not own remote transport contracts; imports `RemoteExecutor` from `@robota-sdk/agent-remote`.
-- Does not own WebSocket message types; imports `IPlaygroundWebSocketMessage` from `@robota-sdk/agent-remote`.
+- Does not own remote transport contracts; imports `RemoteExecutor` from `@robota-sdk/agent-remote-client`.
+- Does not own WebSocket transport hosting; playground WebSocket message types are local UI
+  contracts in `src/lib/playground/types.ts`.
 - Does not define deployment or hosting behavior; that belongs to `apps/agent-web`.
 
 ## Architecture Overview
 
-Facade-pattern executor (`PlaygroundExecutor`) wraps Robota agent instances for browser-based execution. AI providers are constructed with a `RemoteExecutor` so API keys stay server-side. Two plugins (`PlaygroundHistoryPlugin`, `PlaygroundStatisticsPlugin`) are standalone classes that collect conversation events and UX metrics. React hooks (`usePlaygroundBoot`, `usePlaygroundData`, `useRobotaExecution`, etc.) provide state management; these hooks are used internally by the React components and are not part of the public package API. A `PlaygroundWebSocketClient` enables real-time communication with the API server. Block-tracking layer (`PlaygroundBlockCollector`, `LLMTracker`, `PlaygroundBlockVisualizationSubscriber`) handles execution block collection and real-time visualization data. Tool catalog (`ToolRegistry`) provides built-in playground tools created via factory functions; it is used internally and is not exported from the public entry point. Static component catalogs such as code editor examples and template gallery entries are directory modules under `src/components/playground/*-data/`; their `index.ts` files preserve the previous component import paths while keeping large data payloads out of one monolithic file.
+Facade-pattern executor (`PlaygroundExecutor`) wraps Robota agent instances for browser-based execution. AI providers are constructed with a `RemoteExecutor` so API keys stay server-side. Two plugins (`PlaygroundHistoryPlugin`, `PlaygroundStatisticsPlugin`) are standalone classes that collect conversation events and UX metrics. React hooks (`usePlaygroundBoot`, `usePlaygroundData`, `useRobotaExecution`, etc.) provide state management; these hooks are used internally by the React components and are not part of the public package API. A `PlaygroundWebSocketClient` enables real-time communication with the API server. Block-tracking layer (`PlaygroundBlockCollector`, `LLMTracker`, `PlaygroundBlockVisualizationSubscriber`) handles execution block collection and real-time visualization data. Tool catalog (`ToolRegistry`) provides built-in playground tools created via factory functions; it is used internally and is not exported from the public entry point. Static component catalogs such as code editor examples and template gallery entries are directory modules under `src/components/playground/*-data/`; their `index.ts` files preserve the previous component import paths while keeping large data payloads out of one monolithic file. Demo execution data is a directory module under `src/lib/playground/demo-execution-data/` with the public generator functions in `index.ts` and the large scenario payload isolated in `scenario.ts`.
 
 ## Type Ownership
 
@@ -79,14 +80,16 @@ None. `PlaygroundStatisticsPlugin` and `PlaygroundHistoryPlugin` are standalone 
 | -------------------------------------- | --------------------------- | ---------------------------------------- |
 | `Robota` (agent-core)                  | `PlaygroundExecutor`        | `src/lib/playground/robota-executor.ts`  |
 | `FunctionTool` (agent-tools)           | Tool factory functions      | `src/tools/`                             |
-| `RemoteExecutor` (remote)              | `PlaygroundExecutor`        | `src/lib/playground/robota-executor.ts`  |
-| `IPlaygroundWebSocketMessage` (remote) | `PlaygroundWebSocketClient` | `src/lib/playground/websocket-client.ts` |
+| `RemoteExecutor` (agent-remote-client) | `PlaygroundExecutor`        | `src/lib/playground/robota-executor.ts`  |
+| `IPlaygroundWebSocketMessage` (local)  | `PlaygroundWebSocketClient` | `src/lib/playground/websocket-client.ts` |
 
 ## Test Strategy
 
 - `components/ui/__tests__/button.test.tsx` covers the shared button primitive.
 - `components/playground/__tests__/code-editor-templates.test.ts` characterizes the public code editor template keys, default template, and required metadata.
 - `components/playground/__tests__/template-gallery-data.test.ts` characterizes curated gallery template ids, display-map alignment, and required metadata.
+- `lib/playground/__tests__/demo-execution-data.test.ts` characterizes the demo block sequence,
+  timing offsets, and complex-demo wrapper behavior.
 - Statistics types and plugin logic have no unit test coverage.
 - React components and hooks have no behavioral test coverage.
 - Recommended: unit tests for `PlaygroundExecutor` methods, `toPlaygroundUiError` classification, statistics plugin recording, and hook-level state transitions before further decomposition.

--- a/packages/agent-playground/src/lib/playground/__tests__/demo-execution-data.test.ts
+++ b/packages/agent-playground/src/lib/playground/__tests__/demo-execution-data.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IPlaygroundBlockCollector } from '../block-tracking/block-collector';
+import type { IBlockMessage, IBlockTreeNode } from '../block-tracking/types';
+import { generateComplexDemoData, generateDemoExecutionData } from '../demo-execution-data';
+
+function createCollector(): {
+  collector: IPlaygroundBlockCollector;
+  collected: IBlockMessage[];
+  clearCount: () => number;
+} {
+  const collected: IBlockMessage[] = [];
+  let clears = 0;
+
+  const collector: IPlaygroundBlockCollector = {
+    collectBlock(message: IBlockMessage): void {
+      collected.push(message);
+    },
+    updateBlock(): void {
+      // Not used by demo data generation.
+    },
+    updateRealTimeBlock(): void {
+      // Not used by demo data generation.
+    },
+    getBlocks(): IBlockMessage[] {
+      return collected;
+    },
+    getBlocksByParent(): IBlockMessage[] {
+      return [];
+    },
+    getBlock(): IBlockMessage | undefined {
+      return undefined;
+    },
+    getBlockTree(): IBlockTreeNode[] {
+      return [];
+    },
+    clearBlocks(): void {
+      clears += 1;
+      collected.length = 0;
+    },
+    generateBlockId(): string {
+      return 'block_test';
+    },
+    createGroupBlock(): IBlockMessage {
+      throw new Error('createGroupBlock is not used by demo data generation');
+    },
+    removeBlock(): void {
+      // Not used by demo data generation.
+    },
+    getStats() {
+      return {
+        total: collected.length,
+        byType: {},
+        byState: {},
+        rootBlocks: 0,
+      };
+    },
+    addListener(): void {
+      // Not used by demo data generation.
+    },
+    removeListener(): void {
+      // Not used by demo data generation.
+    },
+  };
+
+  return {
+    collector,
+    collected,
+    clearCount: () => clears,
+  };
+}
+
+describe('demo execution data', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('generates the stable demo block sequence and hierarchy', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'));
+
+    const { collector, collected, clearCount } = createCollector();
+
+    generateDemoExecutionData(collector);
+
+    expect(clearCount()).toBe(1);
+    expect(collected.map((block) => block.blockMetadata.id)).toEqual([
+      'user_001',
+      'team_001',
+      'agent_001',
+      'tool_001',
+      'tool_002',
+      'llm_response_001',
+    ]);
+    expect(collected.map((block) => block.role)).toEqual([
+      'user',
+      'system',
+      'assistant',
+      'tool',
+      'tool',
+      'assistant',
+    ]);
+    expect(collected[2]?.blockMetadata.children).toEqual(['tool_001', 'tool_002']);
+    expect(collected[5]?.blockMetadata.parentId).toBe('agent_001');
+  });
+
+  it('uses deterministic offsets from the generation time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'));
+
+    const { collector, collected } = createCollector();
+
+    generateDemoExecutionData(collector);
+
+    expect(collected[0]?.timestamp?.toISOString()).toBe('2026-01-02T03:04:05.000Z');
+    expect(collected[1]?.timestamp?.toISOString()).toBe('2026-01-02T03:04:05.200Z');
+    expect(collected[3]?.timestamp?.toISOString()).toBe('2026-01-02T03:04:06.000Z');
+    expect(collected[5]?.timestamp?.toISOString()).toBe('2026-01-02T03:04:18.000Z');
+  });
+
+  it('keeps complex demo generation behavior aligned with the regular demo', () => {
+    const { collector, collected, clearCount } = createCollector();
+
+    generateComplexDemoData(collector);
+
+    expect(clearCount()).toBe(2);
+    expect(collected).toHaveLength(6);
+    expect(collected[0]?.blockMetadata.id).toBe('user_001');
+  });
+});

--- a/packages/agent-playground/src/lib/playground/demo-execution-data/index.ts
+++ b/packages/agent-playground/src/lib/playground/demo-execution-data/index.ts
@@ -1,0 +1,24 @@
+import type { IPlaygroundBlockCollector } from '../block-tracking/block-collector';
+import { WebLogger } from '../../web-logger';
+import { createDemoExecutionBlocks } from './scenario';
+
+export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollector): void {
+  WebLogger.debug('Generating demo execution data');
+
+  blockCollector.clearBlocks();
+
+  createDemoExecutionBlocks(new Date()).forEach((block) => {
+    blockCollector.collectBlock(block);
+  });
+
+  WebLogger.debug('Demo execution data generated successfully', { blockCount: 6 });
+}
+
+export function generateComplexDemoData(blockCollector: IPlaygroundBlockCollector): void {
+  WebLogger.debug('Generating complex demo execution data');
+
+  blockCollector.clearBlocks();
+  generateDemoExecutionData(blockCollector);
+
+  WebLogger.debug('Complex demo data generation complete');
+}

--- a/packages/agent-playground/src/lib/playground/demo-execution-data/offsets.ts
+++ b/packages/agent-playground/src/lib/playground/demo-execution-data/offsets.ts
@@ -1,0 +1,13 @@
+export const DEMO_TIMELINE_OFFSETS_MS = {
+  userEnd: 100,
+  teamStart: 200,
+  teamEnd: 15000,
+  agentStart: 500,
+  agentEnd: 14500,
+  tool1Start: 1000,
+  tool1End: 6000,
+  tool2Start: 7000,
+  tool2End: 12000,
+  llmStart: 13000,
+  llmEnd: 14500,
+} as const;

--- a/packages/agent-playground/src/lib/playground/demo-execution-data/scenario.ts
+++ b/packages/agent-playground/src/lib/playground/demo-execution-data/scenario.ts
@@ -1,32 +1,7 @@
-import type { IPlaygroundBlockCollector } from './block-tracking/block-collector';
-import type { IRealTimeBlockMessage, IRealTimeBlockMetadata } from './block-tracking/types';
-import { WebLogger } from '../web-logger';
+import type { IRealTimeBlockMessage } from '../block-tracking/types';
+import { DEMO_TIMELINE_OFFSETS_MS } from './offsets';
 
-// Demo timeline offsets in milliseconds
-const OFFSET_USER_END = 100;
-const OFFSET_TEAM_START = 200;
-const OFFSET_TEAM_END = 15000;
-const OFFSET_AGENT_START = 500;
-const OFFSET_AGENT_END = 14500;
-const OFFSET_TOOL1_START = 1000;
-const OFFSET_TOOL1_END = 6000;
-const OFFSET_TOOL2_START = 7000;
-const OFFSET_TOOL2_END = 12000;
-const OFFSET_LLM_START = 13000;
-const OFFSET_LLM_END = 14500;
-
-/**
- * Generate demo execution data for testing the tree visualization
- */
-export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollector): void {
-  WebLogger.debug('Generating demo execution data');
-
-  const now = new Date();
-
-  // Clear existing blocks
-  blockCollector.clearBlocks();
-
-  // 1. Root level - User message
+export function createDemoExecutionBlocks(now: Date): IRealTimeBlockMessage[] {
   const userMessage: IRealTimeBlockMessage = {
     role: 'user',
     content: 'Compare React vs Vue for a new project and search for recent performance benchmarks',
@@ -40,19 +15,18 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       isExpanded: true,
       visualState: 'completed',
       startTime: new Date(now.getTime()),
-      endTime: new Date(now.getTime() + OFFSET_USER_END),
-      actualDuration: OFFSET_USER_END,
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.userEnd),
+      actualDuration: DEMO_TIMELINE_OFFSETS_MS.userEnd,
       executionContext: {
         timestamp: new Date(now.getTime()),
       },
     },
   };
 
-  // 2. Team level execution
   const teamExecution: IRealTimeBlockMessage = {
     role: 'system',
     content: 'Team execution started - Processing comparison request',
-    timestamp: new Date(now.getTime() + OFFSET_TEAM_START),
+    timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.teamStart),
     blockMetadata: {
       id: 'team_001',
       type: 'group',
@@ -61,8 +35,8 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       children: ['agent_001'],
       isExpanded: true,
       visualState: 'completed',
-      startTime: new Date(now.getTime() + OFFSET_TEAM_START),
-      endTime: new Date(now.getTime() + OFFSET_TEAM_END),
+      startTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.teamStart),
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.teamEnd),
       actualDuration: 14800,
       executionHierarchy: {
         level: 0,
@@ -71,16 +45,15 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       },
       executionContext: {
         executionId: 'team_001',
-        timestamp: new Date(now.getTime() + OFFSET_TEAM_START),
+        timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.teamStart),
       },
     },
   };
 
-  // 3. Agent level execution
   const agentExecution: IRealTimeBlockMessage = {
     role: 'assistant',
     content: 'Agent processing: I need to research both frameworks and find recent benchmarks',
-    timestamp: new Date(now.getTime() + OFFSET_AGENT_START),
+    timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.agentStart),
     blockMetadata: {
       id: 'agent_001',
       type: 'assistant',
@@ -89,8 +62,8 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       children: ['tool_001', 'tool_002'],
       isExpanded: true,
       visualState: 'completed',
-      startTime: new Date(now.getTime() + OFFSET_AGENT_START),
-      endTime: new Date(now.getTime() + OFFSET_AGENT_END),
+      startTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.agentStart),
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.agentEnd),
       actualDuration: 14000,
       executionHierarchy: {
         parentExecutionId: 'team_001',
@@ -101,16 +74,15 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       executionContext: {
         agentId: 'research_agent',
         executionId: 'agent_001',
-        timestamp: new Date(now.getTime() + OFFSET_AGENT_START),
+        timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.agentStart),
       },
     },
   };
 
-  // 4. First tool - Web search for React vs Vue
   const webSearchTool: IRealTimeBlockMessage = {
     role: 'tool',
     content: 'Executing webSearch tool for React vs Vue comparison',
-    timestamp: new Date(now.getTime() + OFFSET_TOOL1_START),
+    timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool1Start),
     blockMetadata: {
       id: 'tool_001',
       type: 'tool_call',
@@ -119,8 +91,8 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       children: ['tool_result_001'],
       isExpanded: true,
       visualState: 'completed',
-      startTime: new Date(now.getTime() + OFFSET_TOOL1_START),
-      endTime: new Date(now.getTime() + OFFSET_TOOL1_END),
+      startTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool1Start),
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool1End),
       actualDuration: 5000,
       toolParameters: {
         query: 'React vs Vue 2024 performance comparison',
@@ -142,7 +114,7 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       executionContext: {
         toolName: 'webSearch',
         executionId: 'tool_001',
-        timestamp: new Date(now.getTime() + OFFSET_TOOL1_START),
+        timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool1Start),
         duration: 5000,
       },
       renderData: {
@@ -164,11 +136,10 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
     },
   };
 
-  // 5. Second tool - Performance benchmarks search
   const benchmarkSearchTool: IRealTimeBlockMessage = {
     role: 'tool',
     content: 'Executing webSearch tool for performance benchmarks',
-    timestamp: new Date(now.getTime() + OFFSET_TOOL2_START),
+    timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool2Start),
     blockMetadata: {
       id: 'tool_002',
       type: 'tool_call',
@@ -177,8 +148,8 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       children: ['tool_result_002'],
       isExpanded: true,
       visualState: 'completed',
-      startTime: new Date(now.getTime() + OFFSET_TOOL2_START),
-      endTime: new Date(now.getTime() + OFFSET_TOOL2_END),
+      startTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool2Start),
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool2End),
       actualDuration: 5000,
       toolParameters: {
         query: 'JavaScript framework performance benchmarks 2024',
@@ -200,7 +171,7 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
       executionContext: {
         toolName: 'webSearch',
         executionId: 'tool_002',
-        timestamp: new Date(now.getTime() + OFFSET_TOOL2_START),
+        timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.tool2Start),
         duration: 5000,
       },
       renderData: {
@@ -222,7 +193,6 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
     },
   };
 
-  // 6. Final LLM response
   const finalResponse: IRealTimeBlockMessage = {
     role: 'assistant',
     content: `Based on my research, here's a comprehensive comparison of React vs Vue for 2024:
@@ -245,7 +215,7 @@ export function generateDemoExecutionData(blockCollector: IPlaygroundBlockCollec
 - React performs better in complex state management scenarios
 
 I recommend React for larger teams and complex applications, Vue for smaller projects and teams preferring simplicity.`,
-    timestamp: new Date(now.getTime() + OFFSET_LLM_START),
+    timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.llmStart),
     blockMetadata: {
       id: 'llm_response_001',
       type: 'assistant',
@@ -254,8 +224,8 @@ I recommend React for larger teams and complex applications, Vue for smaller pro
       children: [],
       isExpanded: true,
       visualState: 'completed',
-      startTime: new Date(now.getTime() + OFFSET_LLM_START),
-      endTime: new Date(now.getTime() + OFFSET_LLM_END),
+      startTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.llmStart),
+      endTime: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.llmEnd),
       actualDuration: 1500,
       executionHierarchy: {
         parentExecutionId: 'agent_001',
@@ -266,7 +236,7 @@ I recommend React for larger teams and complex applications, Vue for smaller pro
       executionContext: {
         agentId: 'research_agent',
         executionId: 'llm_response_001',
-        timestamp: new Date(now.getTime() + OFFSET_LLM_START),
+        timestamp: new Date(now.getTime() + DEMO_TIMELINE_OFFSETS_MS.llmStart),
         duration: 1500,
       },
       renderData: {
@@ -279,32 +249,12 @@ I recommend React for larger teams and complex applications, Vue for smaller pro
     },
   };
 
-  // Add all blocks to collector
-  [
+  return [
     userMessage,
     teamExecution,
     agentExecution,
     webSearchTool,
     benchmarkSearchTool,
     finalResponse,
-  ].forEach((block) => {
-    blockCollector.collectBlock(block);
-  });
-
-  WebLogger.debug('Demo execution data generated successfully', { blockCount: 6 });
-}
-
-/**
- * Generate a second demo scenario - Complex multi-tool execution
- */
-export function generateComplexDemoData(blockCollector: IPlaygroundBlockCollector): void {
-  WebLogger.debug('Generating complex demo execution data');
-
-  const now = new Date();
-  blockCollector.clearBlocks();
-
-  // Simple implementation for now - just call the regular demo
-  generateDemoExecutionData(blockCollector);
-
-  WebLogger.debug('Complex demo data generation complete');
+  ];
 }


### PR DESCRIPTION
## Summary
- Add characterization tests for demo execution data generation.
- Split `demo-execution-data.ts` into a same-path directory module with public generators in `index.ts`, timeline offsets in `offsets.ts`, and scenario payload in `scenario.ts`.
- Update `agent-playground` SPEC, the central architecture map, and DAG-BL-011 progress.

## Decision
- Continue DAG-BL-011 with a low-risk data-generation module that has no network or UI state side effects.
- Preserve existing imports via the same directory `index.ts` pattern used in the previous slice.
- Keep architecture updates in `.agents/specs/ARCHITECTURE-MAP.md` without adding companion docs.

## Verification
- `pnpm --filter @robota-sdk/agent-playground test`
- `pnpm --filter @robota-sdk/agent-playground typecheck`
- `pnpm --filter @robota-sdk/agent-playground lint` (0 errors, existing warnings remain)
- `pnpm --filter @robota-sdk/agent-playground build`
- `pnpm docs:build`
- `pnpm harness:scan:specs`
- `pnpm harness:scan:test-plans`
- `git diff --check`
- `pnpm harness:verify -- --scope packages/agent-playground --base-ref origin/develop --skip-record-check`
- pre-push harness verification

## Follow-up
- DAG-BL-011 remains in progress; this PR removes `demo-execution-data.ts` from the >300-line file set and leaves 23 files for follow-up slices.