### PR TITLE
fix(agents): add api spec skill frontmatter

### DIFF
--- a/.agents/skills/api-spec-management/SKILL.md
+++ b/.agents/skills/api-spec-management/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: api-spec-management
+description: Manage API specifications for apps with external HTTP, WebSocket, gRPC, or other API endpoints, including endpoint additions, request or response shape changes, OpenAPI documentation, and schema synchronization.
+---
+
 # api-spec-management
 
 API specification management for applications with external endpoints.


### PR DESCRIPTION
## Summary
- Add required YAML frontmatter to the api-spec-management skill
- Restore skill loader compatibility for the skill metadata scan

## Verification
- pnpm harness:scan:consistency
- pnpm harness:scan:test-plans
- pnpm harness:scan was attempted earlier but stopped on existing missing dist/ artifacts unrelated to this docs-only change