### PR TITLE
docs(backlog): add provider profile switching research

### DIFF
--- a/.agents/backlog/cli-provider-profile-naming-research.md
+++ b/.agents/backlog/cli-provider-profile-naming-research.md
@@ -1,0 +1,102 @@
+# CLI Provider Profile Naming Research
+
+## Status
+
+Backlog.
+
+## Priority
+
+P1 - blocks a low-friction provider profile setup flow.
+
+## Problem
+
+Provider profiles need stable user-facing names because profile identity must not be derived from
+provider type or model. Users may create multiple profiles with the same provider type and model when
+they use different API keys, accounts, organizations, billing contexts, base URLs, or operational
+defaults.
+
+The setup flow should make profile registration easy. Requiring a name before every setup may add
+friction, but silently generating names can create confusing profile lists if the generated names are
+not readable or easy to rename.
+
+## Research Questions
+
+The current requirements are not contradictory if the research keeps three surfaces separate:
+persistent default selection, one-shot invocation override, and interactive profile management.
+
+- Should setup require users to enter a profile name, or should it propose one that can be accepted
+  with Enter?
+- When the interactive CLI starts with no configured profiles, what setup path gets users to a usable
+  first profile with the fewest decisions?
+- What default naming pattern is easiest to scan in `/provider list`?
+- How should duplicate names be disambiguated when provider type and model are the same?
+- Should generated names include provider type, model, credential hint, organization, endpoint, or a
+  numeric suffix?
+- How can the CLI avoid exposing sensitive credential details while still helping users distinguish
+  profiles?
+- Should temporary/generated names be explicitly marked until renamed?
+- What rename/edit flow is needed if users accept a generated name during setup?
+- How should headless setup flags support explicit names and generated defaults?
+- Where should profile switching live for easiest access: startup prompt, `/provider`, `/model`,
+  status bar action, command palette, CLI flag, or another command surface?
+- How should the UX distinguish persistent profile switching from one-shot headless invocation with a
+  specific profile?
+- What headless command should change the persisted default profile without launching an agent
+  session, and how should it differ from one-shot `--profile` startup?
+- Should there be a headless command that opens an interactive profile switcher/manager TUI?
+- Can the first-run setup TUI and explicit profile switcher TUI share the same profile management
+  implementation?
+- How complete does first-run profile management need to be if it becomes the reusable profile
+  management surface?
+
+## Candidate Directions To Evaluate
+
+- Prompt with an editable default name, such as `claude-sonnet-4-6`, and append `-2`, `-3`, etc. for
+  duplicates.
+- Generate a readable name from provider type and model, then show non-sensitive metadata separately
+  in profile lists, such as account label, org id, base URL host, or key fingerprint.
+- Ask for a short user label only when a duplicate provider/model pair already exists.
+- Let users optionally add a display label while keeping an internal stable profile key.
+- Create temporary names such as `anthropic-1` only when necessary, then surface a rename prompt after
+  setup succeeds.
+- Keep persistent switching in `/provider` or a dedicated profile command, while headless startup uses
+  a one-shot `--profile <name>`-style override that does not mutate the default selected profile.
+- Add a separate non-session command, such as a profile/default command, for changing the persisted
+  default profile in headless workflows.
+- Provide an explicit command that opens profile management UI without starting a normal agent
+  session, if interactive switching is important outside first-run setup.
+- Expose the active profile in the status area and make the switch action discoverable from there, if
+  the TUI command architecture supports it without moving profile semantics into rendering code.
+
+## Acceptance Criteria
+
+- [ ] Research compares at least three naming UX options for interactive setup.
+- [ ] Recommendation covers same provider/model duplicates with different credentials.
+- [ ] Recommendation defines what profile list rows show so users can distinguish profiles safely.
+- [ ] Recommendation covers explicit naming flags for non-interactive setup.
+- [ ] Recommendation defines rename/edit behavior for generated or temporary names.
+- [ ] Recommendation identifies the easiest persistent switch surface for interactive users.
+- [ ] Recommendation distinguishes persistent default selection from one-shot invocation overrides.
+- [ ] Recommendation distinguishes one-shot headless startup, headless default-profile update, and
+      headless-launched profile management TUI.
+- [ ] Recommendation defines whether first-run setup and profile management TUI share one component
+      or workflow.
+- [ ] Recommendation identifies any required config shape changes, such as separating profile key from
+      display label.
+- [ ] Recommendation keeps profile management semantics in SDK-owned APIs consumed by agent-cli.
+
+## Verification Plan
+
+- Review existing provider setup and listing command behavior.
+- Add proposed UX examples for:
+  - first Anthropic Sonnet profile;
+  - first CLI startup with no profiles;
+  - second Anthropic Sonnet profile with a different API key;
+  - Anthropic Opus profile;
+  - OpenAI-compatible local profile with a base URL;
+  - headless setup with explicit profile name;
+  - headless startup using a profile without changing the persisted default;
+  - headless command changing the persisted default without launching a session;
+  - headless command opening profile switcher/manager TUI.
+- Validate the recommendation against repository rules for secret handling and provider-neutral CLI
+  behavior.

--- a/.agents/backlog/cli-provider-profile-switching.md
+++ b/.agents/backlog/cli-provider-profile-switching.md
@@ -1,0 +1,165 @@
+# CLI Provider Profile Switching
+
+## Status
+
+Backlog.
+
+## Priority
+
+P1 - improves daily CLI ergonomics and creates the foundation for profile-aware agent invocation.
+
+## Problem
+
+The CLI already supports provider profiles, `currentProvider`, and provider/model commands, but the
+interactive switching experience is still centered on changing a provider and then changing a model
+inside that provider. That makes model identity feel nested under a provider type instead of being a
+first-class selectable runtime profile.
+
+The target behavior is that a user can keep multiple named profiles and start `agent-cli` with one
+selected profile by default. Switching the selected profile should persist, so later CLI sessions keep
+using the last selected profile until the user changes it again.
+
+On first startup, if no profile exists, the interactive CLI should guide the user through profile
+creation instead of failing with a dead-end error. Later startups should use the persisted selected
+profile automatically.
+
+Profiles must be model-specific, not only provider-specific. For example:
+
+- `claude-sonnet-4-6`
+- `claude-opus-4-6`
+- `claude-sonnet-4-5`
+
+These profiles may all have provider type `anthropic`, but each profile can carry its own model,
+API key, base URL, timeout, and other provider settings. The same pattern should work for OpenAI,
+Qwen, Gemini, Gemma, OpenAI-compatible local models, and future provider types.
+
+Profiles must also allow duplicates with the same provider type and model. Two profiles may both use
+the same model but represent different accounts, API keys, organizations, billing contexts, base URLs,
+or operational defaults. This means uniqueness cannot be defined by `(provider type, model)`.
+
+## Scope
+
+- `packages/agent-cli`
+- `packages/agent-sdk` profile/settings services and command common APIs
+- `packages/agent-command-provider`
+- `packages/agent-command-model`
+- package docs/specs that define provider profile persistence and command behavior
+
+## Recommended Direction
+
+Promote provider profiles to the primary user-facing selection unit.
+
+## Consolidated Requirements
+
+The requirements are consistent if profile operations are split into three explicit modes:
+
+1. **Persistent default selection**
+   - Changes the stored selected profile.
+   - Affects later interactive CLI startups.
+   - Can be triggered from interactive profile management or from a headless command that only updates
+     the default profile.
+
+2. **One-shot invocation override**
+   - Selects a profile for a single headless or non-interactive run.
+   - Does not mutate the persisted default profile.
+   - Is suitable for scripts, CI, or explicit per-run agent invocation.
+
+3. **Interactive profile management**
+   - Lets users create, list, select, rename, edit, test, and delete profiles.
+   - Should be available when the CLI first starts with no profiles.
+   - May also be opened explicitly from a headless command that launches only the profile management
+     TUI, without starting a normal agent session.
+
+Profile identity must be independent from provider type and model. Multiple profiles may share the
+same provider type and model when they represent different credentials, accounts, organizations,
+endpoints, billing contexts, or operational defaults.
+
+Profile management semantics should be SDK-owned. `agent-cli` should host rendering, input, and
+process-level effects, while the SDK owns profile persistence, default selection, one-shot override
+resolution, validation, and command/common APIs.
+
+Recommended design:
+
+- Treat profile management as an SDK-owned capability that `agent-cli` consumes through injected
+  services or command common APIs. CLI/TUI code should host interaction and rendering, not own profile
+  persistence semantics.
+- Treat a profile as a complete runtime provider configuration: provider type, model, credentials,
+  endpoint options, timeout, and provider-specific options.
+- Keep `currentProvider` or its successor as the selected profile key, not merely the selected
+  provider type.
+- Let setup create multiple profiles for the same provider type when the selected model or credential
+  set differs.
+- Let setup create multiple profiles even when provider type and model are identical, when the user
+  wants separate credentials, endpoints, or operational defaults.
+- Decide whether duplicate-profile creation requires a user-provided name up front or can create a
+  temporary/generated name that the user may rename later.
+- Research profile naming and registration UX before implementation. See
+  `.agents/backlog/cli-provider-profile-naming-research.md`.
+- Make `/provider` focus on profile selection, listing, creation, editing, testing, and deletion.
+- Make `/model` operate on the active profile by default, with clear behavior when changing the model
+  should update the current profile versus create a new profile.
+- Persist profile switches in the effective settings scope that will win on next startup.
+- Support headless startup with an explicit profile key. This should select the runtime profile for
+  that invocation without changing the persisted default profile.
+- Support a separate headless command for changing the persisted default profile without starting an
+  agent session. This must be distinct from one-shot headless startup profile selection.
+- Consider a headless-invoked interactive profile switcher TUI for selecting or managing profiles.
+  This TUI may need to share implementation with the first-run setup flow.
+- Treat the first-run setup TUI as a real profile management surface, not only a minimal wizard,
+  because the same surface may later be reused for profile switching, default selection, and profile
+  maintenance.
+- Surface the active profile name, provider type, and model in startup/status output so users can
+  verify which account/model is active.
+- Leave room for future agent invocation APIs to accept an explicit profile key per invocation,
+  without requiring global CLI state mutation.
+
+## Acceptance Criteria
+
+- [ ] Users can list all configured profiles, including multiple profiles with the same provider type.
+- [ ] Users can create multiple profiles with the same provider type and model.
+- [ ] Users can select a profile and have that selection persist across CLI restarts.
+- [ ] Interactive first startup prompts the user to create a profile when none exists.
+- [ ] CLI startup uses the selected profile by default.
+- [ ] Headless startup can select a profile for that process without mutating the persisted default
+      selected profile.
+- [ ] A separate headless command can change the persisted default profile without starting an agent
+      session.
+- [ ] One-shot headless profile selection and persisted default profile switching have distinct
+      command surfaces and tests.
+- [ ] A reusable interactive profile management TUI exists or is designed for first-run setup and
+      explicit profile switching.
+- [ ] First-run profile setup supports enough profile management behavior that it can evolve into the
+      shared profile management TUI.
+- [ ] A profile can own its own model and provider settings, including API key references and base URL.
+- [ ] Profile persistence, selection, and invocation override semantics are owned by SDK APIs, not
+      agent-cli rendering code.
+- [ ] Profile identity is based on the profile key/name, not on provider type or model uniqueness.
+- [ ] Duplicate-profile naming policy is explicit: either require a user-provided name or generate a
+      temporary name with a supported rename path.
+- [ ] `/provider` and `/model` no longer create ambiguous state when provider type stays the same but
+      model/profile changes.
+- [ ] The active profile display includes profile name, provider type, and model.
+- [ ] Switching from `claude-sonnet-4-6` to `claude-opus-4-6` does not mutate the Sonnet profile.
+- [ ] Switching between profiles writes to the same effective settings scope used by next startup.
+- [ ] Agent invocation APIs can later accept an explicit profile key without depending on TUI-only
+      state.
+
+## Verification Plan
+
+- Add SDK command API tests for listing, selecting, creating, and updating same-type profiles.
+- Add duplicate-profile tests where provider type and model match but API key references differ.
+- Add command package tests for `/provider` profile selection and persisted restart behavior.
+- Add startup tests for no-profile interactive setup and selected-profile restart behavior.
+- Add headless startup tests proving explicit profile selection does not update the default profile.
+- Add headless default-switch tests proving the selected default changes without launching a session.
+- Add command-surface tests proving one-shot profile override and default profile switch are not
+  conflated.
+- Add `/model` tests proving model changes update the intended profile or explicitly create a new
+  profile when that flow exists.
+- Add CLI startup/status projection tests for active profile name, provider type, and model.
+- Run:
+  - `pnpm --filter @robota-sdk/agent-sdk test -- provider`
+  - `pnpm --filter @robota-sdk/agent-command-provider test`
+  - `pnpm --filter @robota-sdk/agent-command-model test`
+  - `pnpm --filter @robota-sdk/agent-cli test`
+  - `pnpm harness:verify -- --scope packages/agent-cli`


### PR DESCRIPTION
## Summary
- Add a consolidated backlog item for provider profile switching semantics
- Add a research backlog for profile naming, registration, and switch UX
- Distinguish persistent default selection, one-shot invocation override, and interactive profile management

## Verification
- pre-push scoped verification ran via git push
- harness plan selected repository-review; no executable fast-path check was required for backlog-only files