### PR TITLE
fix(agent-cli): clean up status bar indicators

### DIFF
--- a/.agents/backlog/completed/cli-hide-default-permission-mode-status.md
+++ b/.agents/backlog/completed/cli-hide-default-permission-mode-status.md
@@ -1,0 +1,84 @@
+# CLI Hide Default Permission Mode In Status Bar
+
+## Status
+
+Completed.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P2 - TUI clarity cleanup.
+
+## Problem
+
+`packages/agent-cli/src/ui/StatusBar.tsx` renders `Mode: <permissionMode>` in the primary status
+line. In practice this looks like a model performance mode or provider capability mode, but the
+value is actually the SDK permission mode. This is confusing because users cannot use it to select a
+provider-level "fast" or "smart" model behavior, and provider/model capabilities differ too much for
+the CLI to present a generic mode label honestly.
+
+The status bar already has several high-value fields: activity, session/profile/model identity, git
+branch, context, and message count. Rendering `Mode: default` permanently adds visual noise because
+`default` is the normal baseline. Non-default permission modes are operationally important and should
+remain visible.
+
+## Code Confirmation
+
+- `StatusBar.tsx` renders `Mode:` through `ModeText({ permissionMode })`.
+- `App.tsx` passes `session.getPermissionMode()` into `SessionStatusBar`.
+- `agent-command-mode` implements `/mode` by reading/writing SDK permission mode.
+- `TPermissionMode` is `plan | default | acceptEdits | bypassPermissions`; it is not a provider
+  speed tier, model quality tier, or generic fast/smart mode.
+
+## Scope
+
+- `packages/agent-cli/src/ui/StatusBar.tsx`
+- `packages/agent-cli/src/ui/SessionStatusBar.tsx`
+- `packages/agent-cli/src/ui/App.tsx` and render prop plumbing only if `permissionMode` becomes
+  unused by the status surface
+- `packages/agent-cli/src/ui/__tests__/status-bar.test.tsx`
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-cli/docs/ARCHITECTURE-MAP.md` if diagrams/examples describe unconditional `Mode:`
+
+## Constraints
+
+- Do not remove the SDK permission-mode runtime contract in this task.
+- Do not remove `/mode` or `--permission-mode`.
+- Keep permission enforcement behavior unchanged.
+- Keep provider/model/profile identity visible in the status bar.
+- Keep activity state as the first primary scan-path item.
+- Keep non-default permission modes visible because they affect tool approval behavior.
+
+## Recommended Direction
+
+Render permission mode conditionally:
+
+- `default`: hide the mode segment.
+- `plan`: show `Mode: plan`.
+- `acceptEdits`: show `Mode: acceptEdits`.
+- `bypassPermissions`: show `Mode: bypassPermissions`.
+
+Treat `default` as the baseline state and non-default modes as explicit operational overrides.
+
+## Acceptance Criteria
+
+- [x] The status bar does not render `Mode: default`.
+- [x] The status bar still renders `Mode: plan`, `Mode: acceptEdits`, and
+      `Mode: bypassPermissions`.
+- [x] Activity, provider profile/model, git branch, context usage, and message count remain visible.
+- [x] Status-bar tests cover both hidden default mode and visible non-default modes.
+- [x] CLI SPEC status examples describe permission mode as conditional status metadata.
+- [x] Permission-mode CLI flags, commands, and SDK behavior remain unchanged.
+
+## Result
+
+Changed the status bar permission mode segment to render only for non-default modes. `default` is
+treated as the baseline and hidden; `plan`, `acceptEdits`, and `bypassPermissions` remain visible.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`

--- a/.agents/backlog/completed/cli-remove-duplicate-thinking-status.md
+++ b/.agents/backlog/completed/cli-remove-duplicate-thinking-status.md
@@ -1,0 +1,62 @@
+# CLI Remove Duplicate Thinking Status
+
+## Status
+
+Completed.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P2 - small TUI cleanup that removes redundant execution state.
+
+## Problem
+
+`packages/agent-cli/src/ui/StatusBar.tsx` now shows foreground execution state in the primary
+status scan path through `StatusActivityText`. The same `isThinking` state is also rendered by
+`StatusRight` as a lower-right `thinking...` label next to the message count. This duplicates the
+same state in two places and makes the status area noisier than necessary.
+
+## Scope
+
+- `packages/agent-cli/src/ui/StatusBar.tsx`
+- `packages/agent-cli/src/ui/__tests__/status-bar.test.tsx`
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-cli/docs/ARCHITECTURE-MAP.md` only if it still documents or illustrates the
+  lower-right thinking indicator
+
+## Constraints
+
+- Keep `StatusActivityText` and `formatStatusActivity()` as the SSOT for visible primary activity
+  state.
+- Do not change SDK thinking events or execution lifecycle semantics.
+- Do not remove `StreamingIndicator` fallback behavior in this task unless tests prove it is part of
+  the same duplicate status surface.
+- Keep the message count visible on the right side.
+
+## Recommended Direction
+
+Remove the lower-right `thinking...` rendering from `StatusRight` and make `StatusRight` responsible
+only for passive metadata such as `msgs: N`. Update tests and CLI SPEC text/examples so `Thinking`
+appears only in the primary activity segment.
+
+## Acceptance Criteria
+
+- [x] `StatusBar` renders `Thinking` in the primary activity segment when `isThinking` is true.
+- [x] `StatusBar` no longer renders lower-right `thinking...` next to `msgs: N`.
+- [x] Message count rendering remains unchanged.
+- [x] Tests assert that only one visible status-bar thinking label is present.
+- [x] CLI SPEC no longer describes the lower-right thinking indicator as active behavior.
+
+## Result
+
+Removed the right-side `thinking...` status text from `StatusRight`. The status bar now presents
+foreground model waiting only through the primary activity segment while keeping `msgs: N` visible
+on the right.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`

--- a/.agents/tasks/completed/cli-status-bar-cleanup.md
+++ b/.agents/tasks/completed/cli-status-bar-cleanup.md
@@ -1,0 +1,52 @@
+# CLI Status Bar Cleanup
+
+- **Status**: completed
+- **Created**: 2026-05-06
+- **Branch**: feat/cli-status-bar-cleanup
+- **Scope**: packages/agent-cli
+
+## Objective
+
+Implement the two status bar backlog items as one grouped change: remove the duplicate lower-right
+thinking indicator and hide the default permission mode while keeping non-default permission modes
+visible.
+
+## Plan
+
+- [x] Update status bar tests to capture the new display policy.
+- [x] Implement conditional permission mode rendering and remove duplicate right-side thinking text.
+- [x] Update CLI docs and backlog checklists.
+- [x] Run targeted verification for `agent-cli`.
+- [x] Prepare one grouped PR-ready change for the status bar cleanup.
+
+## Progress
+
+### 2026-05-06
+
+- Started grouped implementation for the two status bar backlog items.
+- Added red status-bar tests, implemented the renderer changes, updated docs/content/changeset, and
+  completed local verification.
+
+## Decisions
+
+- Treat both backlog items as one PR because they modify the same status surface and tests.
+
+## Blockers
+
+- None.
+
+## 검증
+
+- `pnpm --filter @robota-sdk/agent-cli build`
+- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli lint`
+- `pnpm harness:scan`
+- `pnpm docs:build`
+- `pnpm harness:verify -- --scope packages/agent-cli --skip-record-check`
+
+## Result
+
+Implemented the grouped status bar cleanup. `default` permission mode is now hidden in the status
+bar, non-default permission modes remain visible, and the duplicate right-side `thinking...` text was
+removed while preserving the message count.

--- a/.changeset/cli-status-bar-cleanup.md
+++ b/.changeset/cli-status-bar-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-cli': patch
+---
+
+Clean up the CLI status bar by hiding the baseline default permission mode and removing the duplicate right-side thinking indicator.

--- a/content/examples/interactive-mode.md
+++ b/content/examples/interactive-mode.md
@@ -52,8 +52,11 @@ Bash: pnpm test
 The status bar shows real-time context usage:
 
 ```
-Mode: default | Model: claude-sonnet-4-6 | Context: 45% | msgs: 12
+Thinking | Model: claude-sonnet-4-6 | Context: 45% | msgs: 12
 ```
+
+`default` permission mode is hidden because it is the baseline. Non-default permission modes such as
+`plan`, `acceptEdits`, and `bypassPermissions` are shown as `Mode: <mode>`.
 
 Colors: green (0-69%), yellow (70-89%), red (90%+).
 

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -296,6 +296,9 @@ When a session has a name, it is displayed in the input area border, the termina
 
 When a tool requires approval, the TUI shows a permission prompt with arrow-key selection.
 
+The status bar hides `default` permission mode because it is the baseline. Non-default permission
+modes remain visible as `Mode: plan`, `Mode: acceptEdits`, or `Mode: bypassPermissions`.
+
 ## Context Window
 
 The status bar shows context usage with color coding:

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -264,7 +264,7 @@ When a session has a name, it appears in three places:
 
 - **Input border** — session name shown in the input area border
 - **Terminal title** — updated via ANSI escape sequences
-- **StatusBar** — displayed alongside mode, model, and context usage
+- **StatusBar** — displayed alongside activity, model, and context usage
 
 ## Slash Commands
 
@@ -416,7 +416,7 @@ bin.ts → cli.ts (arg parsing)
                     ├── plugin-hooks-merger.ts (merges plugin hooks into SDK config)
                     ├── MessageList.tsx
                     ├── InputArea.tsx          (CjkTextInput, bracketed paste, slash detection)
-                    ├── StatusBar.tsx          (mode, model, context %, message count)
+                    ├── StatusBar.tsx          (activity, conditional mode, model, context %, message count)
                     ├── PermissionPrompt.tsx   (arrow-key Allow/Deny)
                     ├── SlashAutocomplete.tsx  (command popup with scroll)
                     ├── DiffBlock.tsx          (Edit tool diff display)

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -244,20 +244,19 @@ The StatusBar shows real-time session information:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ Thinking  |  Mode: default  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  thinking... msgs: 12 │
+│ Thinking  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  msgs: 12 │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
 | Field    | Source                                     | Description                                            |
 | -------- | ------------------------------------------ | ------------------------------------------------------ |
-| Mode     | `session.getPermissionMode()`              | Current permission mode                                |
+| Mode     | `session.getPermissionMode()`              | Current permission mode, shown only when not `default` |
 | Model    | `getModelName(config.provider.model)`      | Human-readable model name (e.g., "Claude Sonnet 4.6")  |
 | Git      | `resolveGitBranch(cwd)`                    | Current git branch when available and enabled          |
 | Context  | `session.getContextState().usedPercentage` | Context usage with K/M formatting (e.g., "90K/1M")     |
 | msgs     | message count                              | Number of messages in conversation                     |
 | Session  | `session.getName()`                        | Session name (shown only when a name is set)           |
 | Activity | CLI-derived display state                  | Left-side primary activity text without a field prefix |
-| thinking | `isThinking`                               | Lower-right prompt-processing indicator                |
 
 Activity priority is deterministic and renderer-owned:
 
@@ -267,7 +266,7 @@ Activity priority is deterministic and renderer-owned:
 4. queued prompt (`Queued`)
 5. idle (`Idle`)
 
-When a prompt is queued behind foreground work, the activity row keeps the active work as primary and appends `queued` as secondary metadata. While `isThinking` is true, `StatusBar` also renders a compact lower-right `thinking...` indicator next to the message count. SDK session state remains the source of truth; `StatusBar` receives derived display counts and does not infer provider or execution semantics.
+When a prompt is queued behind foreground work, the activity row keeps the active work as primary and appends `queued` as secondary metadata. `default` permission mode is the baseline and is hidden; non-default permission modes (`plan`, `acceptEdits`, `bypassPermissions`) are rendered as `Mode: <mode>`. SDK session state remains the source of truth; `StatusBar` receives derived display counts and does not infer provider or execution semantics.
 
 ### `/statusline` Slash Command
 
@@ -437,7 +436,7 @@ Robota:
 - Format: `ToolName(firstArgValue)` — first argument truncated to 80 chars, matching post-run summary style
 - Completed tools remain visible until `session.run()` finishes (not removed on `end`)
 - `Tools:` and `Robota:` sections each have a blank line below the label and between sections
-- When no tools and no streaming text, renders nothing (empty fragment); "Thinking..." is shown by `StatusBar`
+- When no tools and no streaming text, renders the `Thinking...` fallback while the model is active
 
 ### Post-Run Tool Summary
 
@@ -805,7 +804,7 @@ src/
     ├── MessageList.tsx              ← Renders IHistoryEntry[] via EntryItem (dispatches on category)
     ├── InputArea.tsx                ← Bottom fixed input (CjkTextInput), slash detection
     ├── SessionStatusBar.tsx         ← Statusline settings + git branch adapter
-    ├── StatusBar.tsx                ← Mode, model, git branch, context %, message count, Thinking
+    ├── StatusBar.tsx                ← Activity, conditional mode, model, git branch, context %, message count
     ├── PermissionPrompt.tsx         ← Allow/Deny arrow-key selection (useInput)
     ├── StreamingIndicator.tsx       ← Real-time Tools:/Robota: display during run()
     ├── SlashAutocomplete.tsx        ← Command autocomplete popup (scroll, highlight)

--- a/packages/agent-cli/src/ui/StatusBar.tsx
+++ b/packages/agent-cli/src/ui/StatusBar.tsx
@@ -102,6 +102,10 @@ function ModeText({ permissionMode }: { permissionMode: TPermissionMode }): Reac
   );
 }
 
+function shouldShowPermissionMode(permissionMode: TPermissionMode): boolean {
+  return permissionMode !== 'default';
+}
+
 function ProviderText({
   modelName,
   providerProfileName,
@@ -124,6 +128,7 @@ function ProviderText({
 function StatusLeft(props: IStatusLeftProps): React.ReactElement {
   const shouldShowGitBranch =
     props.showGitBranch && props.gitBranch !== undefined && props.gitBranch.length > 0;
+  const showPermissionMode = shouldShowPermissionMode(props.permissionMode);
   return (
     <Text>
       <StatusActivityText
@@ -132,8 +137,12 @@ function StatusLeft(props: IStatusLeftProps): React.ReactElement {
         activeBackgroundTaskCount={props.activeBackgroundTaskCount}
         hasPendingPrompt={props.hasPendingPrompt}
       />
-      {'  |  '}
-      <ModeText permissionMode={props.permissionMode} />
+      {showPermissionMode && (
+        <>
+          {'  |  '}
+          <ModeText permissionMode={props.permissionMode} />
+        </>
+      )}
       {props.sessionName && (
         <>
           {'  |  '}
@@ -162,20 +171,9 @@ function StatusLeft(props: IStatusLeftProps): React.ReactElement {
   );
 }
 
-function StatusRight({
-  isThinking,
-  messageCount,
-}: {
-  isThinking: boolean;
-  messageCount: number;
-}): React.ReactElement {
+function StatusRight({ messageCount }: { messageCount: number }): React.ReactElement {
   return (
     <Text>
-      {isThinking && (
-        <>
-          <Text color="yellow">thinking...</Text>{' '}
-        </>
-      )}
       <Text dimColor>msgs: {messageCount}</Text>
     </Text>
   );
@@ -223,7 +221,7 @@ export default function StatusBar({
         gitBranch={gitBranch}
         showGitBranch={showGitBranch}
       />
-      <StatusRight isThinking={isThinking} messageCount={messageCount} />
+      <StatusRight messageCount={messageCount} />
     </Box>
   );
 }

--- a/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
@@ -21,8 +21,27 @@ describe('StatusBar', () => {
   it('renders without session name', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} />);
     const frame = lastFrame()!;
-    expect(frame).toContain('Mode:');
-    expect(frame).toContain('default');
+    expect(frame).toContain('test-model');
+    expect(frame).not.toContain('Mode: default');
+  });
+
+  it('hides default permission mode', () => {
+    const { lastFrame } = render(<StatusBar {...baseProps} permissionMode="default" />);
+    const frame = lastFrame()!;
+    expect(frame).not.toContain('Mode:');
+    expect(frame).not.toContain('default');
+  });
+
+  it('shows non-default permission modes', () => {
+    for (const permissionMode of ['plan', 'acceptEdits', 'bypassPermissions'] as const) {
+      const { lastFrame, unmount } = render(
+        <StatusBar {...baseProps} permissionMode={permissionMode} />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Mode:');
+      expect(frame).toContain(permissionMode);
+      unmount();
+    }
   });
 
   it('renders session name when provided', () => {
@@ -65,14 +84,15 @@ describe('StatusBar', () => {
     const frame = lastFrame()!;
     expect(frame).not.toContain('Activity:');
     expect(frame).toContain('Thinking');
-    expect(frame.indexOf('Thinking')).toBeLessThan(frame.indexOf('Mode:'));
+    expect(frame.indexOf('Thinking')).toBeLessThan(frame.indexOf('test-model'));
   });
 
-  it('restores the lower-right prompt-processing indicator while thinking', () => {
+  it('does not duplicate thinking state next to the message count', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} isThinking={true} />);
     const frame = lastFrame()!;
-    expect(frame).toContain('thinking...');
-    expect(frame.indexOf('thinking...')).toBeGreaterThan(frame.indexOf('Context:'));
+    expect(frame).toContain('Thinking');
+    expect(frame).not.toContain('thinking...');
+    expect(frame).toContain('msgs: 5');
   });
 
   it('hides the lower-right prompt-processing indicator while idle', () => {
@@ -95,8 +115,8 @@ describe('StatusBar', () => {
     expect(frame).not.toContain('Activity:');
     expect(frame).toContain('Tools x2');
     expect(frame).toContain('queued');
-    expect(frame).toContain('thinking...');
-    expect(frame.indexOf('Tools x2')).toBeLessThan(frame.indexOf('Mode:'));
+    expect(frame).not.toContain('thinking...');
+    expect(frame.indexOf('Tools x2')).toBeLessThan(frame.indexOf('test-model'));
     expect(frame).not.toContain('Thinking...');
   });
 
@@ -104,7 +124,7 @@ describe('StatusBar', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} activeBackgroundTaskCount={3} />);
     const frame = lastFrame()!;
     expect(frame).toContain('Background x3');
-    expect(frame.indexOf('Background x3')).toBeLessThan(frame.indexOf('Mode:'));
+    expect(frame.indexOf('Background x3')).toBeLessThan(frame.indexOf('test-model'));
   });
 
   it('keeps the activity segment compact for narrow terminals', () => {
@@ -119,7 +139,7 @@ describe('StatusBar', () => {
     );
     const frame = lastFrame()!;
     const firstLine = frame.split('\n')[1] ?? '';
-    const activityEnd = firstLine.indexOf('Mode:');
+    const activityEnd = firstLine.indexOf('test-model');
     const activitySegment = firstLine.slice(0, activityEnd);
     expect(activitySegment).toContain('Tools x12');
     expect(activitySegment.length).toBeLessThanOrEqual(40);


### PR DESCRIPTION
## Summary
- hide the baseline default permission mode in the CLI status bar while keeping non-default modes visible
- remove the duplicate right-side thinking indicator and keep Thinking in the primary activity segment
- update CLI SPEC, README, content docs, changeset, and completed backlog records

## Verification
- pnpm --filter @robota-sdk/agent-cli build
- pnpm --filter @robota-sdk/agent-cli test -- status-bar
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm docs:build
- pnpm harness:scan
- pnpm harness:verify -- --scope packages/agent-cli --skip-record-check