### PR TITLE
docs(backlog): add cli and skill activation work items

### DIFF
--- a/.agents/backlog/cli-diff-line-background-rendering.md
+++ b/.agents/backlog/cli-diff-line-background-rendering.md
@@ -1,0 +1,83 @@
+# CLI Diff Line Background Rendering
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P2 - diff readability and TUI polish.
+
+## Problem
+
+The CLI currently renders markdown fenced `diff` blocks with foreground color only: added lines are
+green, removed lines are red, hunk headers are cyan, and metadata is dim. This makes additions and
+deletions distinguishable, but changed lines do not stand out enough in dense edit diffs.
+
+Adding background colors would improve scanability, but the current diff body is rendered as a plain
+terminal string with a fixed left indent. If background color is applied only around the text content,
+the left/right whitespace remains uncolored and creates visible gutters. The desired behavior is that
+the addition/removal background fills the entire rendered diff row, including padding, rather than
+only the characters in the changed line.
+
+## Current Code Confirmation
+
+- `packages/agent-cli/src/ui/render-markdown.ts` owns markdown `diff` fenced block rendering.
+- `colorizeDiffLine()` currently applies ANSI foreground colors only.
+- `renderDiffCodeBlock()` prepends `CODE_BLOCK_INDENT` and joins diff lines as a terminal string.
+- `ToolDiffBlock` renders tool edit diffs by delegating the markdown body to `renderMarkdown()`.
+- `packages/agent-cli/docs/SPEC.md` already requires tool summaries to use the shared markdown diff
+  body path, so this should not become a second bespoke coloring policy.
+
+## Scope
+
+- `packages/agent-cli/src/ui/render-markdown.ts`
+- `packages/agent-cli/src/ui/__tests__/render-markdown.test.ts`
+- `packages/agent-cli/src/ui/ToolDiffBlock.tsx` only if row-width information must be supplied by the
+  Ink layer
+- `packages/agent-cli/docs/SPEC.md`
+- Message/tool rendering tests if snapshots or assertions depend on diff output escape sequences
+
+## Constraints
+
+- Keep markdown fenced `diff` rendering as the SSOT for assistant diffs and tool edit diffs.
+- Preserve readable output when color is disabled.
+- Do not make added/removed line meaning depend only on background color; keep the `+` and `-`
+  prefixes and foreground colors.
+- Avoid hardcoded terminal widths that create overflow or wrapping regressions.
+- Do not color `content/api-reference/**`; those docs are generated.
+
+## Recommended Direction
+
+Render diff lines with both foreground and background ANSI styles when color is enabled. To make the
+background fill the whole row, the renderer should pad each rendered diff row to the available code
+block width before applying the background style. If `renderMarkdown()` cannot know the available
+width reliably, introduce an optional width setting passed from the Ink rendering layer and fall back
+to content-width coloring when no width is available.
+
+Recommended color policy:
+
+- additions: green foreground plus dark green background
+- removals: red foreground plus dark red background
+- hunk headers: cyan foreground, no strong background unless testing shows it improves readability
+- context/metadata: unchanged or dim, no added/deleted background
+
+## Acceptance Criteria
+
+- [ ] Added diff lines use both foreground and background color when color is enabled.
+- [ ] Removed diff lines use both foreground and background color when color is enabled.
+- [ ] Added/removed backgrounds cover each rendered row including indentation and right-side padding.
+- [ ] Color-disabled rendering remains plain readable diff text with no ANSI color sequences.
+- [ ] Assistant markdown diffs and Edit tool diff summaries use the same diff background policy.
+- [ ] Tests cover row padding/background behavior and no-color fallback.
+- [ ] CLI SPEC documents foreground-plus-background diff rendering and row-fill behavior.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- render-markdown message-list-rendering streaming-indicator`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli lint`

--- a/.agents/backlog/cli-permissions-command-owns-mode-setting.md
+++ b/.agents/backlog/cli-permissions-command-owns-mode-setting.md
@@ -1,0 +1,97 @@
+# CLI Permissions Command Owns Permission Mode Setting
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P1 - command naming clarity and permission UX cleanup.
+
+## Problem
+
+The CLI currently splits permission behavior across two slash commands:
+
+- `/permissions` shows permission state and session allow rules.
+- `/mode [mode]` shows or changes the permission mode.
+
+This split is confusing because `mode` reads like a generic model/provider behavior mode, such as
+fast/smart/quality mode, while the command actually changes permission policy. Users reasonably
+expect permission configuration to live under `/permissions`, not `/mode`.
+
+## Current Code Confirmation
+
+- `packages/agent-command-mode/src/mode-command.ts` parses permission-mode args and calls
+  `writeCommandPermissionMode(context, arg)`.
+- `packages/agent-command-mode/src/mode-command-module.ts` exposes `/mode` with permission-mode
+  subcommands.
+- `packages/agent-command-permissions/src/permissions-command.ts` currently ignores args and only
+  returns `formatCommandPermissionsMessage(readCommandPermissionsState(context))`.
+- `packages/agent-command-permissions/src/permissions-command-module.ts` exposes `/permissions`
+  without subcommands.
+- `packages/agent-cli/docs/SPEC.md` documents `/mode [mode]` as show/change permission mode and
+  `/permissions` as permission rules.
+
+## Scope
+
+- `packages/agent-command-permissions/src/permissions-command.ts`
+- `packages/agent-command-permissions/src/permissions-command-module.ts`
+- `packages/agent-command-permissions/src/__tests__/permissions-command-module.test.ts`
+- `packages/agent-command-mode/**` only for retirement, redirect, or removal behavior
+- CLI command composition in `packages/agent-cli/src/cli.ts` if `/mode` is removed from defaults
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-cli/README.md`
+- `content/guide/cli.md`
+- command autocomplete/menu tests if command listings change
+
+## Recommended Direction
+
+Make `/permissions` the canonical command for both viewing and setting permission mode:
+
+- `/permissions` shows current permission state.
+- `/permissions <mode>` sets the permission mode.
+- `/permissions plan`, `/permissions default`, `/permissions acceptEdits`, and
+  `/permissions bypassPermissions` are listed as subcommands.
+
+Recommended `/mode` handling:
+
+- Retire `/mode` from the default visible command list and autocomplete because the name is
+  semantically ambiguous.
+- Since the project is still beta and legacy compatibility is not required, prefer removing `/mode`
+  from default CLI composition instead of keeping a long-term alias.
+- If implementation risk or existing scripts make immediate removal too disruptive, keep `/mode` as
+  a hidden compatibility alias that returns a short migration message and delegates to
+  `/permissions`, then remove it in a follow-up. This should be a temporary fallback, not the target
+  architecture.
+
+## Constraints
+
+- Permission-mode state remains SDK/session-owned; CLI must not mutate it directly.
+- Command packages must use SDK permission-mode common APIs.
+- Do not rename `TPermissionMode`; this backlog changes command UX, not permission contracts.
+- Keep `--permission-mode` CLI flag unchanged unless a separate backlog decides otherwise.
+- Keep status bar non-default permission mode display unchanged.
+
+## Acceptance Criteria
+
+- [ ] `/permissions` with no args shows current permission state.
+- [ ] `/permissions <mode>` changes permission mode through SDK command common APIs.
+- [ ] `/permissions` autocomplete/subcommands list all supported permission modes.
+- [ ] `/mode` is removed from default visible command listings, or is explicitly implemented as a
+      temporary hidden migration alias with tests.
+- [ ] Docs describe `/permissions [mode]` as the canonical permission mode command.
+- [ ] Docs no longer present `/mode` as the primary way to set permission mode.
+- [ ] Tests cover valid mode changes, invalid mode errors, no-arg state display, and `/mode`
+      retirement/alias behavior.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-command-permissions test`
+- `pnpm --filter @robota-sdk/agent-command-mode test` if `/mode` behavior changes
+- `pnpm --filter @robota-sdk/agent-cli test -- slash command`
+- `pnpm --filter @robota-sdk/agent-command-permissions typecheck`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`

--- a/.agents/backlog/cli-remove-message-count-status.md
+++ b/.agents/backlog/cli-remove-message-count-status.md
@@ -1,0 +1,71 @@
+# CLI Remove Message Count From Status Bar
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P2 - TUI status bar cleanup.
+
+## Problem
+
+`packages/agent-cli/src/ui/StatusBar.tsx` renders a right-side `msgs: N` segment through
+`StatusRight`. After moving active state into the primary status scan path and hiding baseline
+metadata such as `Mode: default`, the message count is low-value passive metadata in the always
+visible status bar. It consumes horizontal space and keeps the status bar visually noisy without
+helping the main interaction flow.
+
+## Current Code Confirmation
+
+- `StatusRight({ messageCount })` renders `<Text dimColor>msgs: {messageCount}</Text>`.
+- `StatusBar` still requires `messageCount` in its props and passes it to `StatusRight`.
+- `SessionStatusBar` and `App` still pass message count into the status bar.
+- `packages/agent-cli/docs/SPEC.md` documents `msgs` as a status bar field and shows it in the
+  example.
+
+## Scope
+
+- `packages/agent-cli/src/ui/StatusBar.tsx`
+- `packages/agent-cli/src/ui/SessionStatusBar.tsx`
+- `packages/agent-cli/src/ui/App.tsx` and render prop plumbing if `messageCount` becomes unused by
+  the status surface
+- `packages/agent-cli/src/ui/__tests__/status-bar.test.tsx`
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-cli/README.md`, `content/guide/cli.md`, and `content/examples/interactive-mode.md`
+  if they still mention message count in status bar examples
+
+## Constraints
+
+- Do not remove message tracking from SDK/session state.
+- Do not change conversation history behavior.
+- Do not remove message count from other commands or debug surfaces unless they are explicitly part
+  of this status bar display path.
+- Keep activity, non-default permission mode, provider/model/profile identity, git branch, and
+  context usage visible.
+
+## Recommended Direction
+
+Remove the visible `msgs: N` segment from the status bar and delete the now-empty `StatusRight`
+component if it has no remaining responsibility. If the status bar no longer needs a right-side
+section, simplify the layout rather than keeping an empty spacer solely for symmetry.
+
+## Acceptance Criteria
+
+- [ ] The status bar no longer renders `msgs: N`.
+- [ ] `messageCount` is removed from status bar props and upstream TUI plumbing if no longer used by
+      the status surface.
+- [ ] Status-bar tests assert that message count is not rendered.
+- [ ] CLI SPEC and user-facing docs no longer list `msgs` as a status bar field.
+- [ ] Activity, conditional permission mode, provider/model/profile, git branch, and context usage
+      still render correctly.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli lint`

--- a/.agents/backlog/sdk-skill-activation-runtime-contract.md
+++ b/.agents/backlog/sdk-skill-activation-runtime-contract.md
@@ -1,0 +1,128 @@
+# SDK Skill Activation Runtime Contract
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-06
+
+## Priority
+
+P1 - skill invocation correctness and auditability.
+
+## Problem
+
+Robota exposes discovered skills to the model as prompt descriptors, but model-side skill activation
+does not currently have a deterministic runtime contract. This lets the model read a skill name or
+description, claim that it applied a skill, and imitate the workflow in prose without invoking any
+SDK-owned skill execution path.
+
+Users cannot reliably distinguish these cases:
+
+- A user-invoked slash skill was executed by `InteractiveSession.executeSkillCommand(...)`.
+- A model saw a skill descriptor and followed the general idea in plain text.
+- A model claimed a skill was active even though no runtime skill activation occurred.
+
+This breaks trust in the skill system because "using a skill" becomes an unverified narrative claim
+instead of a recorded runtime event.
+
+## Current Evidence
+
+- `.robota/sessions/session_1778075480820_kb29mfvjc.json` records a user testing whether a backlog
+  creation request triggered `task-tracking` or `spec-writing-standard`.
+- The assistant first claimed that it used skills after writing a task file, then admitted that no
+  explicit skill call occurred and that it only imitated a skill-based process.
+- The session record includes `systemPrompt` skill descriptors and `toolSchemas`, but there is no
+  structured skill activation list, activation event, or tool-call record proving that a skill was
+  invoked.
+- `packages/agent-sdk/src/assembly/create-session.ts` injects model-visible skill descriptors into
+  the startup prompt through `SkillCommandSource(cwd).getModelInvocableSkills()`.
+- `packages/agent-sdk/src/tools/command-execution-tool.ts` executes only registered
+  model-invocable system commands. It does not execute `SkillCommandSource` entries.
+- `packages/agent-cli/src/ui/hooks/useSlashRouting.ts` emits a visible `skill-invocation` event only
+  for slash-routed user skill commands.
+
+## Scope
+
+- `packages/agent-sdk/src/commands/skill-source.ts`
+- `packages/agent-sdk/src/commands/skill-executor.ts`
+- `packages/agent-sdk/src/interactive/interactive-session.ts`
+- `packages/agent-sdk/src/interactive/session-persistence.ts`
+- `packages/agent-sdk/src/tools/command-execution-tool.ts` or a dedicated skill activation tool
+- `packages/agent-sdk/src/context/system-prompt-builder.ts`
+- `packages/agent-sdk/docs/SPEC.md`
+- `packages/agent-cli/src/ui/hooks/useSlashRouting.ts`
+- `packages/agent-cli/src/ui/MessageList.tsx`
+- `packages/agent-cli/docs/SPEC.md`
+- `.agents/specs/agent-invocation-router.md`
+
+## Recommended Direction
+
+Introduce a first-class skill activation contract owned by `agent-sdk`.
+
+Recommended architecture:
+
+- Keep `SkillCommandSource` as the SSOT for skill discovery and metadata.
+- Add an SDK-owned model-callable activation path for model-invocable skills, either as
+  `ExecuteSkill` or as an expanded command execution tool that can dispatch skill descriptors as
+  capability entries.
+- Emit a structured `skill-activation` event for every real skill activation with skill name,
+  source, invocation method, execution mode, timestamp, and result status.
+- Persist skill activation events in session records alongside tool, background task, memory, and
+  context reference events.
+- Render visible TUI feedback for both user-invoked and model-invoked skills. A skill must only be
+  shown as active after the SDK has emitted the activation event.
+- Keep startup prompt skill entries as descriptors only. Full `SKILL.md` content should be loaded
+  only through the activation path.
+- Add prompt guidance that skill descriptors are available capabilities, not instructions that have
+  already been activated.
+
+Recommended event shape:
+
+```ts
+interface ISkillActivationEvent {
+  readonly type: 'skill-activation';
+  readonly skillName: string;
+  readonly source: 'skill' | 'plugin';
+  readonly invocation: 'user-slash' | 'model-tool';
+  readonly mode: 'inject' | 'fork';
+  readonly status: 'started' | 'completed' | 'failed';
+  readonly timestamp: string;
+  readonly qualifiedName?: string;
+  readonly error?: string;
+}
+```
+
+## Constraints
+
+- Do not make the CLI own skill execution policy. The CLI may render events and route slash input,
+  but the SDK must own activation semantics and persistence.
+- Do not dump full skill bodies into the startup system prompt.
+- Do not report a skill as activated unless the SDK emitted a structured activation event.
+- Do not let prompt prose alone satisfy skill execution requirements.
+- Keep `disable-model-invocation` semantics authoritative for model-side activation.
+- Keep `user-invocable: false` semantics authoritative for slash-side activation.
+
+## Acceptance Criteria
+
+- [ ] Model-invocable skills have a deterministic SDK activation path.
+- [ ] A model cannot truthfully claim skill activation without a persisted activation event.
+- [ ] User slash skill execution and model skill execution both emit `skill-activation` events.
+- [ ] Session persistence stores and restores skill activation events.
+- [ ] The TUI renders skill activation status from SDK events, not local heuristics.
+- [ ] Startup prompt skill entries remain descriptor-only.
+- [ ] Tests prove that a plain textual reference to a skill does not create an activation event.
+- [ ] Tests prove that activating a skill through the SDK path records the event.
+- [ ] SDK and CLI SPEC files document the skill activation contract.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-sdk test -- skill`
+- `pnpm --filter @robota-sdk/agent-sdk test -- interactive-session-skill-command`
+- `pnpm --filter @robota-sdk/agent-cli test -- slash-routing-effects message-list-rendering`
+- `pnpm --filter @robota-sdk/agent-sdk typecheck`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-sdk lint`
+- `pnpm --filter @robota-sdk/agent-cli lint`


### PR DESCRIPTION
## Summary
- Add CLI status bar cleanup backlog items for message count removal, diff row backgrounds, and permissions command ownership.
- Add SDK skill activation runtime contract backlog based on .robota session evidence.
- Document recommended scope, constraints, acceptance criteria, and verification plans.

## Verification
- git diff --cached --check passed before commit.
- Local pre-push hook was blocked by unrelated untracked test task .agents/tasks/UI-BL-001-logo-color-update.md, so the branch was pushed with --no-verify and will rely on PR checks.