### PR TITLE
fix(agent-sdk): enforce skill activation contract

### DIFF
--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -49,7 +49,7 @@ Startup checks are rate-limited by a user-level cache at `~/.robota/update-check
 
 ## Non-Interactive (Headless) Mode
 
-Print mode (`-p`) runs a single prompt without the interactive TUI and exits. It delegates to `@robota-sdk/agent-transport-headless` for output formatting.
+Print mode (`-p`) runs a single prompt without the interactive TUI and exits. It delegates to `@robota-sdk/agent-transport-headless` for output formatting. When the prompt starts with `/skill-name`, headless mode routes it through `InteractiveSession.executeUserSkillCommand()` so the SDK loads the full `SKILL.md` before the model turn.
 
 ### Output Formats
 
@@ -260,7 +260,9 @@ Use the `` !`command` `` syntax to embed shell command output into the skill bod
 
 ### Invocation Methods
 
-- **User direct**: Type `/skill-name` in the input area
+- **User direct**: Type `/skill-name` in the input area, or pass `/skill-name ...` to print/headless mode
+- **User directive**: Prompts such as `Use the repo-writing skill ...` are treated as explicit user-directed skill activations and load the matching `SKILL.md` before the model turn
+- **Skill discovery**: Use `/skills` to list registered skills and show the activation contract. Models can also call the SDK-owned `/skills` command through `ExecuteCommand` before choosing a matching skill.
 - **Model auto-invoke**: The model calls `ExecuteSkill` during a conversation when a task matches the skill description. The tool accepts only registered model-invocable skill names for the session.
 - **Model-only**: Skills with `user-invocable: false` are invisible in the `/` menu but available to the model
 

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -261,8 +261,12 @@ Use the `` !`command` `` syntax to embed shell command output into the skill bod
 ### Invocation Methods
 
 - **User direct**: Type `/skill-name` in the input area
-- **Model auto-invoke**: The model calls the Skill tool during a conversation (unless `disable-model-invocation: true`)
+- **Model auto-invoke**: The model calls `ExecuteSkill` during a conversation when a task matches the skill description. The tool accepts only registered model-invocable skill names for the session.
 - **Model-only**: Skills with `user-invocable: false` are invisible in the `/` menu but available to the model
+
+Skill descriptions are metadata only. Mentioning a skill name in ordinary assistant text does not
+activate that skill; activation is recorded only when `ExecuteSkill` or an explicit `/skill-name`
+invocation loads the full `SKILL.md`.
 
 When `context: fork` is set, the skill runs in a spawned subagent session rather than the main conversation. See [agent-sdk SPEC.md](../../packages/agent-sdk/docs/SPEC.md) for details.
 

--- a/content/guide/sdk.md
+++ b/content/guide/sdk.md
@@ -64,12 +64,12 @@ Event types include: `tool-start` (individual tool execution began), `tool-end` 
 
 The SDK owns `CommandRegistry` and the command sources used by clients:
 
-- **`BuiltinCommandSource`** — SDK-default infrastructure command metadata; currently empty because user-visible built-ins are command modules
+- **`BuiltinCommandSource`** — SDK-default infrastructure command metadata, including `/skills` for skill discovery and activation guidance
 - **Command modules** — product-composed built-ins such as `/help`, `/clear`, `/compact`, `/mode`, `/model`, `/cost`, `/context`, `/permissions`, `/memory`, `/rewind`, `/provider`, `/resume`, `/background`, `/rename`, `/plugin`, `/reload-plugins`, `/language`, `/reset`, and `/exit`
 - **`SkillCommandSource`** — project and user skills discovered from `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, and `~/.robota/skills/`
 - **`PluginCommandSource`** — commands contributed by loaded plugins
 
-Clients such as the CLI compose these sources into a registry for autocomplete. `InteractiveSession.listCommands()` returns executable system commands for transports and direct command execution, while skill commands discovered through `SkillCommandSource` are executed with `session.executeSkillCommand()`.
+Clients such as the CLI compose these sources into a registry for autocomplete. `InteractiveSession.listCommands()` returns executable system commands for transports and direct command execution, while explicit `/skill` prompts are executed with `session.executeUserSkillCommand()`.
 
 ### System Commands
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -245,6 +245,11 @@ registry.resolveQualifiedName('audit'); // "my-plugin:audit"
 - `~/.robota/skills/*/SKILL.md`
 - `<cwd>/.agents/skills/*/SKILL.md`
 
+Model-invocable skills are exposed to the model as metadata only. `createSession()` registers the
+`ExecuteSkill` tool when invocable skills exist, constrains its `skill` argument to the registered
+skill names, and loads full `SKILL.md` content only after that tool is called. Mentioning a skill in
+ordinary prose does not activate the skill.
+
 ### createQuery()
 
 ```typescript

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -149,6 +149,9 @@ await session.submit('Explain @AGENTS.md and @docs/SPEC.md');
 // Submit with display override (shown in UI) and raw input (for hook matching)
 await session.submit(fullPrompt, '/audit', '/rulebased-harness:audit');
 
+// Execute a named user-invoked skill command. Transports should use this for `/skill`.
+await session.executeUserSkillCommand('audit', 'src/index.ts', '/audit src/index.ts');
+
 // Abort current execution and clear queue
 session.abort();
 
@@ -206,7 +209,7 @@ executor.listCommands(); // ISystemCommand[]
 executor.hasCommand('mode'); // boolean
 ```
 
-Product built-ins are supplied as `agent-command-*` modules. For example, `/help` is owned by `@robota-sdk/agent-command-help`, while `/compact` is owned by `@robota-sdk/agent-command-compact`.
+SDK-owned discovery built-ins are supplied by `agent-sdk`; `/skills` lists registered skills and exposes the skill activation contract for models and users. Product built-ins are supplied as `agent-command-*` modules. For example, `/help` is owned by `@robota-sdk/agent-command-help`, while `/compact` is owned by `@robota-sdk/agent-command-compact`.
 
 Command modules may use SDK common APIs for shared provider-neutral behavior. For `/model`, the SDK
 resolves the active provider from settings, reads provider-owned fallback metadata from injected
@@ -248,7 +251,10 @@ registry.resolveQualifiedName('audit'); // "my-plugin:audit"
 Model-invocable skills are exposed to the model as metadata only. `createSession()` registers the
 `ExecuteSkill` tool when invocable skills exist, constrains its `skill` argument to the registered
 skill names, and loads full `SKILL.md` content only after that tool is called. Mentioning a skill in
-ordinary prose does not activate the skill.
+ordinary prose does not activate the skill, but explicit user directives such as
+`Use the repo-writing skill ...` are routed through the same SDK skill loader before the model turn.
+The SDK-owned `/skills` command is exposed through `ExecuteCommand` with a registered-command enum
+and returns the current skill list plus activation guidance.
 
 ### createQuery()
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -1216,15 +1216,17 @@ Bundle plugins package reusable extensions (tools, hooks, permissions, system pr
 ## System Prompt Skill and Agent Injection
 
 Skills discovered from skill directories are exposed to the system prompt by metadata only: name and
-description. Full `SKILL.md` content is loaded only when a skill is invoked through the SDK skill
-activation path. Skills with `disable-model-invocation: true` are omitted from model-visible
-metadata.
+description. The `## Skills` section includes the shared activation contract that metadata is not
+active skill content and that the model must call `ExecuteSkill` before following a skill workflow.
+Full `SKILL.md` content is loaded only when a skill is invoked through the SDK skill activation path.
+Skills with `disable-model-invocation: true` are omitted from model-visible metadata.
 
 When at least one model-invocable skill exists, `createSession()` registers an `ExecuteSkill` tool.
-The tool is the only deterministic model-side skill activation path. It accepts a skill name and
-arguments, validates `disable-model-invocation`, loads the full `SKILL.md`, emits
-`skill_activation`, and returns either the processed in-session skill prompt (`mode: inject`) or the
-fork result (`mode: fork`). A model mentioning a skill in ordinary prose is not a skill activation.
+The tool is the only deterministic model-side skill activation path. Its `skill` parameter schema is
+constrained to the registered model-invocable skill names for the session. It accepts arguments,
+validates `disable-model-invocation`, loads the full `SKILL.md`, emits `skill_activation`, and returns
+either the processed in-session skill prompt (`mode: inject`) or the fork result (`mode: fork`). A
+model mentioning a skill in ordinary prose is not a skill activation.
 
 Agent definitions are exposed to the system prompt by metadata only when an injected command module requests `agent-runtime`. Without that session requirement, `Agent` tool registration, agent definitions, and model-visible agent metadata are omitted.
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -54,7 +54,7 @@ agent-cli            ← minimal TUI
 
 SDK is provider-neutral. The consumer (CLI, server, etc.) creates the provider and passes it to the SDK. Assembly (wiring tools, provider, system prompt) happens inside the SDK, but the provider itself comes from the consumer.
 
-SDK command code is split between generic infrastructure and command-facing common APIs. The SDK responsibility is the command contract layer: command contracts, registries/executors, lifecycle metadata, effects/interactions, and reusable command-facing common APIs. User-visible internal commands must be implemented as command modules selected by composition roots; `agent-sdk` no longer owns user-visible built-in command behavior.
+SDK command code is split between generic infrastructure, command-facing common APIs, and SDK-owned discovery commands. The SDK responsibility is the command contract layer: command contracts, registries/executors, lifecycle metadata, effects/interactions, reusable command-facing common APIs, and session capability discovery such as `/skills`. Product-specific user-visible internal commands must be implemented as command modules selected by composition roots.
 
 Model command common APIs are provider-aware but provider-neutral. They resolve the effective active provider profile from the provider settings document, read model catalog fallback metadata from injected `IProviderDefinition` records, can explicitly invoke provider-owned catalog refresh hooks, and produce command descriptors without hardcoding CLI/TUI provider branches. If a live refresh fails or a provider does not expose catalog metadata, `/model` remains manually invocable and the command result must surface stale/unavailable catalog state rather than showing another provider's models.
 
@@ -69,6 +69,7 @@ Any client (CLI, web, API server, worker)
     ↓
 InteractiveSession  (agent-sdk — pure TypeScript, no React)
     │  submit(input, displayInput?, rawInput?)
+    │  executeUserSkillCommand(name, args, displayInput?, rawInput?)
     │  executeSkillCommand(skill, args, displayInput?, rawInput?)
     │  executeCommand(name, args)
     │  abort() / cancelQueue()
@@ -146,7 +147,8 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── builtin-source.ts       ← BuiltinCommandSource: command palette metadata derived from executable built-ins
 │   ├── skill-source.ts         ← SkillCommandSource: discovers SKILL.md files
 │   ├── plugin-source.ts        ← PluginCommandSource: discovers plugin commands (moved from agent-cli)
-│   └── system-command.ts       ← empty SDK-default command factory retained for composition tests
+│   ├── skill-system-command.ts ← /skills discovery command and activation contract output
+│   └── system-command.ts       ← SDK-default command factory
 ├── src/assembly/               ← Session factory: createSession (internal), createDefaultTools (internal)
 ├── src/config/                 ← settings.json loading (6-layer merge, $ENV substitution)
 ├── src/context/                ← AGENTS.md/CLAUDE.md/memory discovery, project detection, system prompt
@@ -321,12 +323,13 @@ agent-cli (Ink TUI — CLI-specific)
 - **Embedding**: `SystemCommandExecutor` is embedded inside `InteractiveSession`. Consumers normally call `session.executeCommand(name, args)` directly. `SystemCommandExecutor` and `createSystemCommands()` are exported so independent command modules can compose and test against the same command contract.
 - **Classes**:
   - `SystemCommandExecutor` — registry + executor for `ISystemCommand` instances (internal to InteractiveSession)
-  - `createSystemCommands()` — empty SDK-default executable command factory retained for composition tests
+  - `createSystemCommands()` — SDK-default executable command factory for SDK-owned discovery commands
   - `createBuiltinCommandModule()` — SDK-default command module that exposes the same executable commands as palette/autocomplete metadata
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional SDK-owned `effects` and `interaction` contracts. `data` remains available for command-specific diagnostic payloads, but callers must not invent command-specific side-effect keys. User-facing follow-up prompts are represented by `ICommandInteraction`, and host actions such as restart, shutdown, plugin UI, plugin registry reload, session picker, model/language changes, session rename, and status-line updates are represented by typed `TCommandEffect` values.
 - **Single owner rule**: SDK-default built-in command metadata is derived from executable `ISystemCommand` records. A built-in command must not be added to autocomplete/help metadata without an executable owner module.
 - **Lifecycle policy**: `ISystemCommand` may declare command lifecycle metadata. Blocking foreground commands share the same `InteractiveSession` execution guard and `thinking` events as prompt execution. Inline commands execute immediately and must not call model-backed long-running operations.
-- **SDK-default built-in commands**: none. User-visible internal commands are provided by product-composed command modules.
+- **SDK-default built-in commands**: `/skills` is SDK-owned because skill discovery, metadata, and activation events are SDK concerns. It is user- and model-invocable, read-only, and returns registered skill metadata plus the activation contract: descriptions are selection metadata only, and matching skill workflows must be activated with `ExecuteSkill`.
+- **Product-specific built-in commands**: User-visible internal commands outside SDK-owned discovery are provided by product-composed command modules.
 - **Product-composed built-in command modules**: `/help` is provided by `@robota-sdk/agent-command-help` and renders the composed command list through SDK help common APIs.
 - **Product-composed built-in command modules**: `/model` is provided by `@robota-sdk/agent-command-model`, reuses SDK model-command common APIs for subcommand metadata, and emits `model-change-requested` effects for host application.
 - **Product-composed built-in command modules**: `/mode` is provided by `@robota-sdk/agent-command-mode`, reuses SDK permission-mode common APIs for validation/subcommand metadata, and updates permission mode through the command host adapter facade.
@@ -342,7 +345,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Product-composed built-in command modules**: `/compact` is provided by `@robota-sdk/agent-command-compact`, declares blocking lifecycle metadata through the same `ISystemCommand` contract, and is exposed as a model-invocable `write` capability. Auto-compaction remains a deterministic session policy and emits structured compaction events instead of relying on the model to decide routine compaction.
 - **Product-composed built-in command modules**: `/exit` is provided by `@robota-sdk/agent-command-exit`. It reuses the SDK session-exit effect helper, stays user-invocable only, and leaves concrete shutdown/process exit to the host effect handler.
 - **Product-composed built-in command modules**: `/plugin` and `/reload-plugins` are provided by `@robota-sdk/agent-command-plugin`. They reuse SDK plugin command common APIs, send host UI opening through `plugin-tui-requested`, refresh host plugin command sources through `plugin-registry-reload-requested`, and perform install/uninstall/enable/disable/marketplace/reload operations through a host-provided `ICommandPluginAdapter`.
-- **Model-invocable built-ins**: Product-composed command modules such as `/memory` and `/compact` expose descriptors so explicit user/model requests can execute through the generic command execution bridge. The descriptor owns usage metadata and autonomous-use guidance; the system prompt composer must not add separate behavior instructions.
+- **Model-invocable built-ins**: SDK-owned `/skills` and product-composed command modules such as `/memory` and `/compact` expose descriptors so explicit user/model requests can execute through the generic command execution bridge. The descriptor owns usage metadata and autonomous-use guidance; the system prompt composer must not add separate behavior instructions.
 - **`/rewind`**: User-invocable product-composed code checkpoint command. `rewind list` lists prompt-turn checkpoints; `rewind inspect <checkpoint-id>` shows captured files plus restore/rollback ranges; `rewind restore <checkpoint-id>` and `rewind code <checkpoint-id>` restore files to the selected checkpoint. It is not model-invocable by default.
 - **Command modules**: Optional `ICommandModule` instances may contribute `ICommandSource` palette metadata, `ISystemCommand` handlers, model-visible descriptors, and session requirements. The SDK does not know command names contributed by modules in advance. Product assemblies can inject host-owned built-ins such as plugin and product-composed command packages such as exit and statusline without adding CLI-specific code to SDK core.
 
@@ -351,7 +354,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Package**: `agent-sdk/commands/` — SSOT owner; agent-cli re-exports from here
 - **Classes**:
   - `CommandRegistry` — aggregates multiple `ICommandSource` instances; filters by prefix; resolves plugin-qualified names
-  - `BuiltinCommandSource` — provides palette/autocomplete metadata derived from SDK-default executable slash commands; currently empty because user-visible built-ins are product-composed modules
+  - `BuiltinCommandSource` — provides palette/autocomplete metadata derived from SDK-default executable slash commands such as `/skills`
   - `SkillCommandSource` — discovers SKILL.md files from project and user directories; parses YAML frontmatter; lazy-caches results
   - `PluginCommandSource` — discovers commands exposed by installed bundle plugins (moved from agent-cli to agent-sdk)
 - **Migration note**: These classes were previously in `agent-cli/src/commands/`. They were moved to `agent-sdk` so any client can use slash command discovery without a TUI dependency. `PluginCommandSource` was also moved from `agent-cli` to `agent-sdk` as part of the scope redesign.
@@ -492,9 +495,12 @@ session.on('skill_activation', (event: ISkillActivationEvent) => { /* skill acti
 // rawInput: passed to Session.run() for hook matching
 await session.submit(input, displayInput?, rawInput?);
 
-// Execute a discovered user-invoked skill command. Non-fork skills submit into the current session.
-// `context: fork` skills run through an isolated subagent session. Each real invocation emits a
-// skill_activation event; prompt-only references to skill names do not.
+// Execute a named user-invoked skill command. Transports should use this path for `/skill`.
+await session.executeUserSkillCommand(name, args, displayInput?, rawInput?);
+
+// Execute a discovered user-invoked skill command object. Non-fork skills submit into the current
+// session. `context: fork` skills run through an isolated subagent session. Each real invocation
+// emits a skill_activation event; prompt-only references to skill names do not.
 await session.executeSkillCommand(skillCommand, args, displayInput?, rawInput?);
 
 // Execute a named system command (embedded SystemCommandExecutor)
@@ -815,7 +821,7 @@ Exported subagent runtime types:
   data: {
     skillName: string;
     source: 'skill' | 'plugin';
-    invocation: 'user-slash' | 'model-tool';
+    invocation: 'user-slash' | 'user-directive' | 'model-tool';
     mode: 'inject' | 'fork';
     status: 'started' | 'completed' | 'failed';
     message: string;
@@ -1216,10 +1222,11 @@ Bundle plugins package reusable extensions (tools, hooks, permissions, system pr
 ## System Prompt Skill and Agent Injection
 
 Skills discovered from skill directories are exposed to the system prompt by metadata only: name and
-description. The `## Skills` section includes the shared activation contract that metadata is not
-active skill content and that the model must call `ExecuteSkill` before following a skill workflow.
-Full `SKILL.md` content is loaded only when a skill is invoked through the SDK skill activation path.
-Skills with `disable-model-invocation: true` are omitted from model-visible metadata.
+description. The `## Skills` section must not include extra hardcoded behavior instructions; the
+SDK-owned `/skills` built-in command descriptor and command result own the skill discovery and
+activation guidance. Full `SKILL.md` content is loaded only when a skill is invoked through the SDK
+skill activation path. Skills with `disable-model-invocation: true` are omitted from model-visible
+metadata.
 
 When at least one model-invocable skill exists, `createSession()` registers an `ExecuteSkill` tool.
 The tool is the only deterministic model-side skill activation path. Its `skill` parameter schema is
@@ -1227,6 +1234,17 @@ constrained to the registered model-invocable skill names for the session. It ac
 validates `disable-model-invocation`, loads the full `SKILL.md`, emits `skill_activation`, and returns
 either the processed in-session skill prompt (`mode: inject`) or the fork result (`mode: fork`). A
 model mentioning a skill in ordinary prose is not a skill activation.
+
+For user prompts, `InteractiveSession.submit()` treats explicit registered skill directives such as
+`Use the repo-writing skill ...` or `repo-writing 스킬대로 ...` as deterministic user-directed
+activations. These prompts load the matching `SKILL.md` before the model turn and record
+`invocation: 'user-directive'`. Incidental prose that merely mentions a skill name without an
+activation directive remains a normal prompt.
+
+When at least one model-invocable command exists, `createSession()` registers an `ExecuteCommand`
+tool. Its `command` parameter schema is constrained to the registered model-invocable command names
+for the session. `/skills` is included by default so models can inspect registered skills before
+choosing a matching `ExecuteSkill` call.
 
 Agent definitions are exposed to the system prompt by metadata only when an injected command module requests `agent-runtime`. Without that session requirement, `Agent` tool registration, agent definitions, and model-visible agent metadata are omitted.
 
@@ -1238,7 +1256,13 @@ The direct `Agent` tool always sets `mode: 'background'`, emits lifecycle update
 
 ### Skill Execution Semantics
 
-`InteractiveSession.executeSkillCommand(skill, args, displayInput?, rawInput?)` is the SDK-owned skill execution path.
+`InteractiveSession.executeUserSkillCommand(name, args, displayInput?, rawInput?)` is the
+transport-facing SDK skill execution path for explicit user slash invocations such as `/audit`.
+It resolves the named skill from SDK-owned skill sources, loads the full `SKILL.md`, emits
+`skill_activation`, and then delegates to the same execution semantics as discovered skill commands.
+
+`InteractiveSession.executeSkillCommand(skill, args, displayInput?, rawInput?)` is the lower-level
+SDK-owned skill execution path for already discovered skill command objects.
 
 `InteractiveSession.executeModelSkillCommand(name, args)` is the SDK-owned model-tool execution
 path used by `ExecuteSkill`. It must not submit a second user turn for inject-mode skills; instead,
@@ -1261,7 +1285,7 @@ interface ISkillActivationEvent {
   readonly type: 'skill-activation';
   readonly skillName: string;
   readonly source: 'skill' | 'plugin';
-  readonly invocation: 'user-slash' | 'model-tool';
+  readonly invocation: 'user-slash' | 'user-directive' | 'model-tool';
   readonly mode: 'inject' | 'fork';
   readonly status: 'started' | 'completed' | 'failed';
   readonly timestamp: string;

--- a/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
@@ -143,6 +143,11 @@ describe('buildSystemPrompt', () => {
 
       expect(result).toContain('## Skills');
       expect(result).toContain('my-skill: Does useful things');
+      expect(result).toContain('Skills are metadata only until activated.');
+      expect(result).toContain('call ExecuteSkill with the skill name');
+      expect(result).toContain(
+        'Do not treat a plain-text skill reference or descriptor as activated skill content.',
+      );
       expect(result).not.toContain('hidden');
     });
 

--- a/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-sdk/src/__tests__/system-prompt-builder.test.ts
@@ -143,11 +143,7 @@ describe('buildSystemPrompt', () => {
 
       expect(result).toContain('## Skills');
       expect(result).toContain('my-skill: Does useful things');
-      expect(result).toContain('Skills are metadata only until activated.');
-      expect(result).toContain('call ExecuteSkill with the skill name');
-      expect(result).toContain(
-        'Do not treat a plain-text skill reference or descriptor as activated skill content.',
-      );
+      expect(result).not.toContain('Skills are metadata only until activated.');
       expect(result).not.toContain('hidden');
     });
 

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -76,6 +76,22 @@ type TSessionOptionsWithAutoCompact = ISessionOptions & {
 };
 type TSessionConstructorWithAutoCompact = new (options: TSessionOptionsWithAutoCompact) => Session;
 
+function normalizeCapabilityCommandName(name: string): string {
+  return name.trim().replace(/^\/+/, '').split(/\s+/)[0] ?? '';
+}
+
+function getModelInvocableCommandNames(
+  descriptors: readonly ICapabilityDescriptor[] | undefined,
+): string[] {
+  const names = new Set<string>();
+  for (const descriptor of descriptors ?? []) {
+    if (!descriptor.modelInvocable || descriptor.kind !== 'builtin-command') continue;
+    const name = normalizeCapabilityCommandName(descriptor.name);
+    if (name.length > 0) names.add(name);
+  }
+  return [...names];
+}
+
 /** Options for the createSession factory */
 export interface ICreateSessionOptions {
   /** Resolved CLI configuration (model, API key, permissions) */
@@ -215,6 +231,7 @@ export function createSession(options: ICreateSessionOptions): Session {
       createCommandExecutionTool({
         execute: options.modelCommandExecutor,
         isModelInvocable: options.isModelCommandInvocable,
+        commandNames: getModelInvocableCommandNames(options.commandDescriptors),
       }),
     );
   }

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -227,6 +227,7 @@ export function createSession(options: ICreateSessionOptions): Session {
       createSkillExecutionTool({
         execute: options.modelSkillExecutor,
         isModelInvocable: options.isModelSkillInvocable,
+        skillNames: modelInvocableSkills.map((skill) => skill.name),
       }),
     );
   }

--- a/packages/agent-sdk/src/command-api/host-context.ts
+++ b/packages/agent-sdk/src/command-api/host-context.ts
@@ -26,6 +26,17 @@ export interface ICommandListEntry {
   description: string;
 }
 
+export interface ICommandSkillListEntry {
+  readonly name: string;
+  readonly description: string;
+  readonly source: string;
+  readonly modelInvocable: boolean;
+  readonly userInvocable: boolean;
+  readonly argumentHint?: string;
+  readonly context?: string;
+  readonly agent?: string;
+}
+
 export type TAutoCompactThresholdSource = 'default' | 'settings' | 'session';
 
 export interface ICommandSessionRuntime {
@@ -66,6 +77,7 @@ export interface ICommandHostContext {
   clearContextReferences?(): IContextReferenceClearResult;
   getCwd(): string;
   listCommands?(): ICommandListEntry[];
+  listSkills?(): ICommandSkillListEntry[];
   listEditCheckpoints(): IEditCheckpointSummary[];
   inspectEditCheckpoint?(checkpointId: string): IEditCheckpointInspection;
   restoreEditCheckpoint(checkpointId: string): Promise<IEditCheckpointRestoreResult>;

--- a/packages/agent-sdk/src/command-api/index.ts
+++ b/packages/agent-sdk/src/command-api/index.ts
@@ -13,6 +13,7 @@ export type {
   ICommandListEntry,
   ICommandSessionReplayValidationReport,
   ICommandSessionRuntime,
+  ICommandSkillListEntry,
   TAutoCompactThresholdSource,
 } from './host-context.js';
 export type {

--- a/packages/agent-sdk/src/commands/__tests__/builtin-source.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/builtin-source.test.ts
@@ -11,7 +11,7 @@ describe('BuiltinCommandSource', () => {
 
   it('returns expected built-in commands', () => {
     const names = commands.map((c) => c.name);
-    expect(names).toEqual([]);
+    expect(names).toEqual(['skills']);
     expect(names).not.toContain('memory');
     expect(names).not.toContain('cost');
     expect(names).not.toContain('clear');

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -75,10 +75,10 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
 }
 
 describe('SystemCommandExecutor', () => {
-  it('keeps SDK core built-in commands empty by default', () => {
+  it('keeps SDK core built-in commands limited to SDK-owned discovery commands', () => {
     const executor = new SystemCommandExecutor();
     const commands = executor.listCommands();
-    expect(commands).toEqual([]);
+    expect(commands.map((c) => c.name)).toEqual(['skills']);
     expect(commands.map((c) => c.name)).not.toContain('background');
     expect(commands.map((c) => c.name)).not.toContain('memory');
     expect(commands.map((c) => c.name)).not.toContain('cost');
@@ -95,15 +95,46 @@ describe('SystemCommandExecutor', () => {
     expect(commands.map((c) => c.name)).not.toContain('rewind');
   });
 
-  it('exposes no model-invocable SDK core commands', () => {
+  it('exposes /skills as the SDK core model-invocable discovery command', () => {
     const executor = new SystemCommandExecutor();
     const modelCommands = executor.listModelInvocableCommands();
 
-    expect(modelCommands.map((command) => command.name)).toEqual([]);
+    expect(modelCommands.map((command) => command.name)).toEqual(['/skills']);
+    expect(executor.isModelInvocable('skills')).toBe(true);
     expect(executor.isModelInvocable('memory')).toBe(false);
     expect(executor.isModelInvocable('agent')).toBe(false);
     expect(executor.isModelInvocable('reset')).toBe(false);
     expect(executor.isModelInvocable('rewind')).toBe(false);
+  });
+
+  it('returns registered skill metadata and activation guidance from /skills', async () => {
+    const executor = new SystemCommandExecutor();
+    const result = await executor.execute(
+      'skills',
+      createMockSession({
+        listSkills: vi.fn().mockReturnValue([
+          {
+            name: 'repo-writing',
+            description: 'Repository writing rules',
+            source: 'skill',
+            modelInvocable: true,
+            userInvocable: true,
+          },
+        ]),
+      }),
+      '',
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      message: expect.stringContaining('Registered skills:'),
+    });
+    expect(result?.message).toContain('repo-writing: Repository writing rules');
+    expect(result?.message).toContain('Use ExecuteSkill with the exact skill name');
+    expect(result?.data?.['activationContract']).toMatchObject({
+      activateWith: 'ExecuteSkill',
+      activationRequiredBeforeWorkflow: true,
+    });
   });
 
   it('returns null for unknown command', async () => {
@@ -184,6 +215,11 @@ describe('SystemCommandExecutor', () => {
     expect(executor.hasCommand('agent')).toBe(false);
     expect(executor.hasCommand('diagnose')).toBe(true);
     expect(executor.listModelInvocableCommands()).toEqual([
+      expect.objectContaining({
+        name: '/skills',
+        kind: 'builtin-command',
+        modelInvocable: true,
+      }),
       {
         name: '/diagnose',
         kind: 'builtin-command',

--- a/packages/agent-sdk/src/commands/index.ts
+++ b/packages/agent-sdk/src/commands/index.ts
@@ -15,6 +15,7 @@ export type {
   ICommandSessionRuntime,
   ICommandSettingsAdapter,
   ICommandSettingsDocument,
+  ICommandSkillListEntry,
   ICommandSource,
   ISystemCommand,
   TAutoCompactThresholdSource,
@@ -34,6 +35,11 @@ export { commandToCapabilityDescriptor } from './capability-descriptors.js';
 export { SkillCommandSource, parseFrontmatter } from './skill-source.js';
 export { PluginCommandSource } from './plugin-source.js';
 export { SystemCommandExecutor, createSystemCommands } from './system-command.js';
+export {
+  createSkillsSystemCommand,
+  executeSkillsCommand,
+  SKILLS_COMMAND_DESCRIPTION,
+} from './skill-system-command.js';
 export type {
   IProviderCommandModuleOptions,
   IProviderCommandSettingsAdapter,

--- a/packages/agent-sdk/src/commands/skill-activation-events.ts
+++ b/packages/agent-sdk/src/commands/skill-activation-events.ts
@@ -1,7 +1,7 @@
 import type { ICommand } from '../command-api/types.js';
 
 export type TSkillActivationSource = 'skill' | 'plugin';
-export type TSkillActivationInvocation = 'user-slash' | 'model-tool';
+export type TSkillActivationInvocation = 'user-slash' | 'user-directive' | 'model-tool';
 export type TSkillActivationMode = 'inject' | 'fork';
 export type TSkillActivationStatus = 'started' | 'completed' | 'failed';
 

--- a/packages/agent-sdk/src/commands/skill-system-command.ts
+++ b/packages/agent-sdk/src/commands/skill-system-command.ts
@@ -1,0 +1,71 @@
+import type {
+  ICommandHostContext,
+  ICommandResult,
+  ICommandSkillListEntry,
+  ISystemCommand,
+} from '../command-api/index.js';
+
+export const SKILLS_COMMAND_DESCRIPTION =
+  'Mandatory skill gate. When the user mentions a skill or the task may match a registered skill, call /skills first, then call ExecuteSkill with the exact skill name before answering; never imitate skill behavior from metadata.';
+
+function formatSkillFlags(skill: ICommandSkillListEntry): string {
+  const flags: string[] = [];
+  if (!skill.modelInvocable) flags.push('model-disabled');
+  if (!skill.userInvocable) flags.push('model-only');
+  if (skill.context) flags.push(`context:${skill.context}`);
+  if (skill.agent) flags.push(`agent:${skill.agent}`);
+  return flags.length > 0 ? ` [${flags.join(', ')}]` : '';
+}
+
+function formatSkillLine(skill: ICommandSkillListEntry): string {
+  const hint = skill.argumentHint ? ` ${skill.argumentHint}` : '';
+  return `- ${skill.name}${hint}: ${skill.description}${formatSkillFlags(skill)}`;
+}
+
+function formatSkillsMessage(skills: readonly ICommandSkillListEntry[]): string {
+  if (skills.length === 0) {
+    return [
+      'No skills are registered for this session.',
+      '',
+      'Skills are metadata until activated. Do not invent or imitate a skill workflow when no matching registered skill exists.',
+    ].join('\n');
+  }
+
+  return [
+    'Registered skills:',
+    ...skills.map(formatSkillLine),
+    '',
+    'Activation contract:',
+    '- Use ExecuteSkill with the exact skill name before following a matching skill workflow.',
+    '- Treat descriptions as selection metadata only, not as loaded SKILL.md content.',
+    '- If no listed skill matches the task, continue without claiming a skill was activated.',
+  ].join('\n');
+}
+
+export function executeSkillsCommand(context: ICommandHostContext): ICommandResult {
+  const skills = context.listSkills?.() ?? [];
+  return {
+    success: true,
+    message: formatSkillsMessage(skills),
+    data: {
+      skills,
+      activationContract: {
+        activateWith: 'ExecuteSkill',
+        activationRequiredBeforeWorkflow: true,
+        metadataIsNotSkillContent: true,
+      },
+    },
+  };
+}
+
+export function createSkillsSystemCommand(): ISystemCommand {
+  return {
+    name: 'skills',
+    description: SKILLS_COMMAND_DESCRIPTION,
+    userInvocable: true,
+    modelInvocable: true,
+    safety: 'read-only',
+    lifecycle: 'inline',
+    execute: executeSkillsCommand,
+  };
+}

--- a/packages/agent-sdk/src/commands/system-command.ts
+++ b/packages/agent-sdk/src/commands/system-command.ts
@@ -1,4 +1,5 @@
 import type { ISystemCommand } from '../command-api/index.js';
+import { createSkillsSystemCommand } from './skill-system-command.js';
 export { SystemCommandExecutor } from './system-command-executor.js';
 export type {
   ICommandInteraction,
@@ -12,5 +13,5 @@ export type { ISystemCommand, TSystemCommandLifecycle } from '../command-api/ind
 
 /** Built-in system commands. */
 export function createSystemCommands(): ISystemCommand[] {
-  return [];
+  return [createSkillsSystemCommand()];
 }

--- a/packages/agent-sdk/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-sdk/src/context/system-prompt-section-providers.ts
@@ -10,6 +10,11 @@ const TRUST_LEVEL_LABELS: Record<TTrustLevel, string> = {
 };
 const PROJECT_MEMORY_PRIORITY = Number('25');
 const TASK_CONTEXT_PRIORITY = Number('27');
+const SKILL_ACTIVATION_CONTRACT = [
+  'Skills are metadata only until activated.',
+  'When a task matches a skill description, call ExecuteSkill with the skill name before following the workflow.',
+  'Do not treat a plain-text skill reference or descriptor as activated skill content.',
+].join('\n');
 
 function createSection(
   id: string,
@@ -121,11 +126,14 @@ function createCapabilityKindSection(
   source: ISystemPromptSection['source'],
   descriptors: readonly ICapabilityDescriptor[],
 ): ISystemPromptSection | undefined {
-  const content = descriptors
+  const formattedDescriptors = descriptors
     .filter((descriptor) => descriptor.modelInvocable && descriptor.kind === kind)
-    .map(formatCapability)
-    .join('\n');
-  if (content.trim().length === 0) return undefined;
+    .map(formatCapability);
+  if (formattedDescriptors.length === 0) return undefined;
+  const content =
+    kind === 'skill'
+      ? [SKILL_ACTIVATION_CONTRACT, '', ...formattedDescriptors].join('\n')
+      : formattedDescriptors.join('\n');
   return createSection(`capability-${kind}`, title, priority, content, source);
 }
 

--- a/packages/agent-sdk/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-sdk/src/context/system-prompt-section-providers.ts
@@ -10,11 +10,6 @@ const TRUST_LEVEL_LABELS: Record<TTrustLevel, string> = {
 };
 const PROJECT_MEMORY_PRIORITY = Number('25');
 const TASK_CONTEXT_PRIORITY = Number('27');
-const SKILL_ACTIVATION_CONTRACT = [
-  'Skills are metadata only until activated.',
-  'When a task matches a skill description, call ExecuteSkill with the skill name before following the workflow.',
-  'Do not treat a plain-text skill reference or descriptor as activated skill content.',
-].join('\n');
 
 function createSection(
   id: string,
@@ -130,11 +125,13 @@ function createCapabilityKindSection(
     .filter((descriptor) => descriptor.modelInvocable && descriptor.kind === kind)
     .map(formatCapability);
   if (formattedDescriptors.length === 0) return undefined;
-  const content =
-    kind === 'skill'
-      ? [SKILL_ACTIVATION_CONTRACT, '', ...formattedDescriptors].join('\n')
-      : formattedDescriptors.join('\n');
-  return createSection(`capability-${kind}`, title, priority, content, source);
+  return createSection(
+    `capability-${kind}`,
+    title,
+    priority,
+    formattedDescriptors.join('\n'),
+    source,
+  );
 }
 
 export function createCapabilitySections(

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -41,6 +41,9 @@ export {
   PluginCommandSource,
   SystemCommandExecutor,
   createSystemCommands,
+  createSkillsSystemCommand,
+  executeSkillsCommand,
+  SKILLS_COMMAND_DESCRIPTION,
   parseFrontmatter,
   executeSkill,
 } from './commands/index.js';
@@ -62,6 +65,7 @@ export type {
   ICommandSessionRuntime,
   ICommandSettingsAdapter,
   ICommandSettingsDocument,
+  ICommandSkillListEntry,
   ISystemCommand,
   ICommandResult,
   ICommandInteraction,

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-skill-command.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-skill-command.test.ts
@@ -168,13 +168,69 @@ describe('InteractiveSession.executeSkillCommand', () => {
     ]);
   });
 
+  it('executes named user skills through the SDK path', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-user-skill-'));
+    createTempSkill(cwd);
+    const parentSession = makeParentSession();
+    const session = new InteractiveSession({ session: parentSession as never, cwd });
+
+    const result = await session.executeUserSkillCommand(
+      'audit',
+      'src/index.ts',
+      '/audit src/index.ts',
+      '/audit src/index.ts',
+    );
+
+    expect(result).toEqual({
+      mode: 'inject',
+      prompt: expect.stringContaining('Audit src/index.ts'),
+    });
+    expect(parentSession.run).toHaveBeenCalledWith(
+      expect.stringContaining('Audit src/index.ts'),
+      '/audit src/index.ts',
+    );
+    expect(session.getSkillActivationEvents().map((event) => event.invocation)).toEqual([
+      'user-slash',
+      'user-slash',
+    ]);
+  });
+
+  it('returns null for unknown named user skills', async () => {
+    const parentSession = makeParentSession();
+    const session = new InteractiveSession({ session: parentSession as never });
+
+    const result = await session.executeUserSkillCommand('missing', '');
+
+    expect(result).toBeNull();
+    expect(parentSession.run).not.toHaveBeenCalled();
+    expect(session.getSkillActivationEvents()).toEqual([]);
+  });
+
+  it('activates an explicitly named skill directive before the model turn', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-user-directive-skill-'));
+    createTempSkill(cwd);
+    const parentSession = makeParentSession();
+    const session = new InteractiveSession({ session: parentSession as never, cwd });
+
+    await session.submit('Use the audit skill to inspect src/index.ts.');
+
+    expect(parentSession.run).toHaveBeenCalledWith(
+      expect.stringContaining('Audit Use the audit skill to inspect src/index.ts.'),
+      'Use the audit skill to inspect src/index.ts.',
+    );
+    expect(session.getSkillActivationEvents().map((event) => event.invocation)).toEqual([
+      'user-directive',
+      'user-directive',
+    ]);
+  });
+
   it('does not record skill activation for prompt-only skill references', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-prompt-only-skill-'));
     createTempSkill(cwd);
     const parentSession = makeParentSession();
     const session = new InteractiveSession({ session: parentSession as never, cwd });
 
-    await session.submit('Use the audit skill by following the workflow in prose.');
+    await session.submit('The audit skill exists in this repository.');
 
     expect(parentSession.run).toHaveBeenCalledOnce();
     expect(session.getSkillActivationEvents()).toEqual([]);

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -29,6 +29,7 @@ import type {
   ICommandHostAdapters,
   ICommandModule,
   ICommandResult,
+  ICommandSkillListEntry,
   ISystemCommand,
   ISkillExecutionResult,
   IForkExecutionOptions,
@@ -133,6 +134,20 @@ export interface IInteractiveSessionShutdownOptions {
 
 function normalizeSkillName(name: string): string {
   return name.trim().replace(/^\/+/, '').split(/\s+/)[0] ?? '';
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasExplicitSkillDirective(input: string, skillName: string): boolean {
+  const escapedName = escapeRegExp(skillName);
+  const englishDirective = new RegExp(
+    `\\b(?:use|using|with)\\s+(?:the\\s+)?${escapedName}\\s+skill\\b`,
+    'i',
+  );
+  const koreanDirective = new RegExp(`${escapedName}\\s*스킬(?:을|를|로|으로|대로)?`, 'i');
+  return englishDirective.test(input) || koreanDirective.test(input);
 }
 
 function getQualifiedSkillName(rawInput?: string): string | undefined {
@@ -345,6 +360,17 @@ export class InteractiveSession {
       this.pendingRawInput = rawInput;
       return;
     }
+    const directiveSkill = this.findExplicitUserSkillDirective(input);
+    if (directiveSkill) {
+      await this.executeUserResolvedSkillCommand(
+        directiveSkill,
+        input,
+        displayInput ?? input,
+        rawInput ?? input,
+        'user-directive',
+      );
+      return;
+    }
     await this.executePrompt(input, displayInput, rawInput);
   }
 
@@ -384,11 +410,33 @@ export class InteractiveSession {
     return this.executeSkillWithActivation(skill, args, 'model-tool');
   }
 
+  async executeUserSkillCommand(
+    name: string,
+    args: string,
+    displayInput?: string,
+    rawInput?: string,
+  ): Promise<ISkillExecutionResult | null> {
+    await this.ensureInitialized();
+    const skill = this.findSkillCommand(name);
+    if (!skill) return null;
+    return this.executeUserResolvedSkillCommand(skill, args, displayInput, rawInput, 'user-slash');
+  }
+
   async executeSkillCommand(
     skill: ICommand,
     args: string,
     displayInput?: string,
     rawInput?: string,
+  ): Promise<ISkillExecutionResult> {
+    return this.executeUserResolvedSkillCommand(skill, args, displayInput, rawInput, 'user-slash');
+  }
+
+  private async executeUserResolvedSkillCommand(
+    skill: ICommand,
+    args: string,
+    displayInput: string | undefined,
+    rawInput: string | undefined,
+    invocation: ISkillActivationEvent['invocation'],
   ): Promise<ISkillExecutionResult> {
     await this.ensureInitialized();
     if (skill.userInvocable === false) {
@@ -398,10 +446,10 @@ export class InteractiveSession {
     const qualifiedName = getQualifiedSkillName(rawInput);
 
     if (skill.context === 'fork') {
-      return this.executeForkSkillCommand(skill, args, displayInput, qualifiedName);
+      return this.executeForkSkillCommand(skill, args, displayInput, qualifiedName, invocation);
     }
 
-    const result = await this.executeSkillWithActivation(skill, args, 'user-slash', qualifiedName);
+    const result = await this.executeSkillWithActivation(skill, args, invocation, qualifiedName);
 
     if (result.mode === 'inject') {
       if (result.prompt) {
@@ -418,6 +466,19 @@ export class InteractiveSession {
     return this.commandExecutor.listCommands().map((cmd) => ({
       name: cmd.name,
       description: cmd.description,
+    }));
+  }
+
+  listSkills(): ICommandSkillListEntry[] {
+    return this.skillCommandSource.getCommands().map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      source: skill.source,
+      modelInvocable: skill.disableModelInvocation !== true,
+      userInvocable: skill.userInvocable !== false,
+      ...(skill.argumentHint !== undefined ? { argumentHint: skill.argumentHint } : {}),
+      ...(skill.context !== undefined ? { context: skill.context } : {}),
+      ...(skill.agent !== undefined ? { agent: skill.agent } : {}),
     }));
   }
 
@@ -441,6 +502,14 @@ export class InteractiveSession {
     return this.skillCommandSource
       .getCommands()
       .find((skill) => skill.name.toLowerCase() === normalizedName.toLowerCase());
+  }
+
+  private findExplicitUserSkillDirective(input: string): ICommand | undefined {
+    const trimmed = input.trimStart();
+    if (trimmed.startsWith('/') || trimmed.startsWith('<skill ')) return undefined;
+    return this.skillCommandSource
+      .getUserInvocableSkills()
+      .find((skill) => hasExplicitSkillDirective(input, skill.name));
   }
 
   abort(): void {
@@ -822,6 +891,7 @@ export class InteractiveSession {
     args: string,
     displayInput?: string,
     qualifiedName?: string,
+    invocation: ISkillActivationEvent['invocation'] = 'user-slash',
   ): Promise<ISkillExecutionResult> {
     if (this.executing) {
       throw new Error('Cannot execute fork skill while another prompt is running.');
@@ -830,12 +900,7 @@ export class InteractiveSession {
     this.startForkSkillExecution(displayInput ?? `/${skill.name}`);
 
     try {
-      const result = await this.executeSkillWithActivation(
-        skill,
-        args,
-        'user-slash',
-        qualifiedName,
-      );
+      const result = await this.executeSkillWithActivation(skill, args, invocation, qualifiedName);
       await this.applyForkSkillResult(result.result ?? '(empty response)');
       return result;
     } catch (err) {
@@ -1012,7 +1077,7 @@ export class InteractiveSession {
       const queuedDisplay = this.pendingDisplayInput;
       const queuedRaw = this.pendingRawInput;
       this.clearPendingQueue();
-      setTimeout(() => this.executePrompt(queued, queuedDisplay, queuedRaw), 0);
+      setTimeout(() => void this.submit(queued, queuedDisplay, queuedRaw), 0);
     }
   }
 
@@ -1104,7 +1169,7 @@ export class InteractiveSession {
         const queuedDisplay = this.pendingDisplayInput;
         const queuedRaw = this.pendingRawInput;
         this.clearPendingQueue();
-        setTimeout(() => this.executePrompt(queued, queuedDisplay, queuedRaw), 0);
+        setTimeout(() => void this.submit(queued, queuedDisplay, queuedRaw), 0);
       }
     }
   }
@@ -1188,7 +1253,7 @@ export class InteractiveSession {
         const queuedDisplay = this.pendingDisplayInput;
         const queuedRaw = this.pendingRawInput;
         this.clearPendingQueue();
-        setTimeout(() => this.executePrompt(queued, queuedDisplay, queuedRaw), 0);
+        setTimeout(() => void this.submit(queued, queuedDisplay, queuedRaw), 0);
       }
     }
   }

--- a/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/command-execution-tool.test.ts
@@ -36,6 +36,17 @@ describe('command execution tool', () => {
     expect(String(result.data)).toContain('"agentId":"agent_1"');
   });
 
+  it('constrains command schema to registered model-invocable commands when provided', () => {
+    const tool = createCommandExecutionTool({
+      isModelInvocable: () => true,
+      execute: vi.fn(),
+      commandNames: ['skills', 'compact'],
+    });
+
+    const commandEnum = tool.schema.parameters.properties['command']?.enum;
+    expect(commandEnum).toEqual(['skills', 'compact']);
+  });
+
   it('rejects commands that are not model invocable', async () => {
     const execute = vi.fn();
     const tool = createCommandExecutionTool({

--- a/packages/agent-sdk/src/tools/__tests__/skill-execution-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/skill-execution-tool.test.ts
@@ -13,6 +13,16 @@ describe('skill execution tool', () => {
     expect(tool.schema.description).toContain('plain text references do not activate skills');
   });
 
+  it('constrains model skill activation to registered skill names when provided', () => {
+    const tool = createSkillExecutionTool({
+      skillNames: ['audit', 'review'],
+      isModelInvocable: () => true,
+      execute: vi.fn(),
+    });
+
+    expect(tool.schema.parameters.properties['skill']?.enum).toEqual(['audit', 'review']);
+  });
+
   it('executes only model-invocable skills through the injected skill handler', async () => {
     const execute = vi.fn().mockResolvedValue({
       mode: 'inject',

--- a/packages/agent-sdk/src/tools/command-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/command-execution-tool.ts
@@ -3,11 +3,6 @@ import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import type { IZodSchema } from '@robota-sdk/agent-tools';
 import type { ICommandResult } from '../commands/index.js';
 
-const CommandExecutionSchema = z.object({
-  command: z.string().describe('Command name to execute, with or without a leading slash'),
-  args: z.string().optional().describe('Arguments to pass to the command'),
-});
-
 interface ICommandExecutionArgs {
   command: string;
   args?: string;
@@ -16,10 +11,35 @@ interface ICommandExecutionArgs {
 export interface ICommandExecutionToolDeps {
   isModelInvocable: (command: string) => boolean;
   execute: (command: string, args: string) => Promise<ICommandResult | null>;
+  commandNames?: readonly string[];
 }
 
 function asZodSchema(schema: z.ZodType): IZodSchema {
   return schema as IZodSchema;
+}
+
+function toNonEmptyCommandNames(
+  commandNames?: readonly string[],
+): [string, ...string[]] | undefined {
+  if (!commandNames || commandNames.length === 0) return undefined;
+  const [first, ...rest] = commandNames;
+  if (first === undefined) return undefined;
+  return [first, ...rest];
+}
+
+function createCommandExecutionSchema(
+  commandNames?: readonly string[],
+): z.ZodType<ICommandExecutionArgs> {
+  const validCommandNames = toNonEmptyCommandNames(commandNames);
+  const commandSchema =
+    validCommandNames !== undefined
+      ? z.enum(validCommandNames).describe('Registered model-invocable command name to execute')
+      : z.string().describe('Command name to execute, with or without a leading slash');
+
+  return z.object({
+    command: commandSchema,
+    args: z.string().optional().describe('Arguments to pass to the command'),
+  });
 }
 
 function normalizeCommand(command: string): string {
@@ -45,12 +65,13 @@ function stringifyCommandResult(command: string, result: ICommandResult | null):
 export function createCommandExecutionTool(
   deps: ICommandExecutionToolDeps,
 ): ReturnType<typeof createZodFunctionTool> {
+  const commandExecutionSchema = createCommandExecutionSchema(deps.commandNames);
   return createZodFunctionTool(
     'ExecuteCommand',
     'Executes a registered model-invocable Robota command through the command registry. Accepted command names and argument grammar come from registered command descriptors.',
-    asZodSchema(CommandExecutionSchema),
+    asZodSchema(commandExecutionSchema),
     async (params) => {
-      const args: ICommandExecutionArgs = CommandExecutionSchema.parse(params);
+      const args: ICommandExecutionArgs = commandExecutionSchema.parse(params);
       const command = normalizeCommand(args.command);
       if (!deps.isModelInvocable(command)) {
         return JSON.stringify({

--- a/packages/agent-sdk/src/tools/skill-execution-tool.ts
+++ b/packages/agent-sdk/src/tools/skill-execution-tool.ts
@@ -3,11 +3,6 @@ import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import type { IZodSchema } from '@robota-sdk/agent-tools';
 import type { ISkillExecutionResult } from '../commands/skill-executor.js';
 
-const SkillExecutionSchema = z.object({
-  skill: z.string().describe('Skill name to activate, with or without a leading slash'),
-  args: z.string().optional().describe('Arguments to pass to the skill'),
-});
-
 interface ISkillExecutionArgs {
   skill: string;
   args?: string;
@@ -16,10 +11,33 @@ interface ISkillExecutionArgs {
 export interface ISkillExecutionToolDeps {
   isModelInvocable: (skillName: string) => boolean;
   execute: (skillName: string, args: string) => Promise<ISkillExecutionResult | null>;
+  skillNames?: readonly string[];
 }
 
 function asZodSchema(schema: z.ZodType): IZodSchema {
   return schema as IZodSchema;
+}
+
+function toNonEmptySkillNames(skillNames?: readonly string[]): [string, ...string[]] | undefined {
+  if (!skillNames || skillNames.length === 0) return undefined;
+  const [first, ...rest] = skillNames;
+  if (first === undefined) return undefined;
+  return [first, ...rest];
+}
+
+function createSkillExecutionSchema(
+  skillNames?: readonly string[],
+): z.ZodType<ISkillExecutionArgs> {
+  const validSkillNames = toNonEmptySkillNames(skillNames);
+  const skillSchema =
+    validSkillNames !== undefined
+      ? z.enum(validSkillNames).describe('Registered model-invocable skill name to activate')
+      : z.string().describe('Skill name to activate, with or without a leading slash');
+
+  return z.object({
+    skill: skillSchema,
+    args: z.string().optional().describe('Arguments to pass to the skill'),
+  });
 }
 
 function normalizeSkillName(skill: string): string {
@@ -46,12 +64,13 @@ function stringifySkillResult(skill: string, result: ISkillExecutionResult | nul
 export function createSkillExecutionTool(
   deps: ISkillExecutionToolDeps,
 ): ReturnType<typeof createZodFunctionTool> {
+  const skillExecutionSchema = createSkillExecutionSchema(deps.skillNames);
   return createZodFunctionTool(
     'ExecuteSkill',
     'Activates a registered model-invocable Robota skill through the skill registry. Use this tool before applying a skill; plain text references do not activate skills.',
-    asZodSchema(SkillExecutionSchema),
+    asZodSchema(skillExecutionSchema),
     async (params) => {
-      const args: ISkillExecutionArgs = SkillExecutionSchema.parse(params);
+      const args: ISkillExecutionArgs = skillExecutionSchema.parse(params);
       const skill = normalizeSkillName(args.skill);
       if (!deps.isModelInvocable(skill)) {
         return JSON.stringify({

--- a/packages/agent-transport-headless/README.md
+++ b/packages/agent-transport-headless/README.md
@@ -19,7 +19,10 @@ Plain text output, suitable for piping:
 ```bash
 robota -p "Explain this error"
 robota -p "List all TypeScript files" | head -20
+robota -p "/repo-writing backlog markdown format"
 ```
+
+Prompts that start with `/skill-name` are routed through `InteractiveSession.executeUserSkillCommand()`, so the SDK loads the full skill file before the model turn.
 
 ### JSON
 

--- a/packages/agent-transport-headless/docs/SPEC.md
+++ b/packages/agent-transport-headless/docs/SPEC.md
@@ -25,7 +25,7 @@ Returns `{ run: (prompt: string) => Promise<number> }`.
 
 The `run` function submits the prompt to the session, writes output to `process.stdout`, and resolves with an exit code.
 
-If the prompt begins with `/`, the runner treats it as a slash command and calls `session.executeCommand(name, args)` instead of submitting the text to the model. Unknown slash commands return an explicit command error. Command availability depends on the command modules composed into the upstream `InteractiveSession`.
+If the prompt begins with `/`, the runner treats it as a slash command. It first calls `session.executeCommand(name, args)` for SDK-owned system commands. If no system command matches, it calls `session.executeUserSkillCommand(name, args, prompt, prompt)` so explicit `/skill` prompts load full `SKILL.md` content through the SDK before the model turn. Unknown slash commands return an explicit command error. Command and skill availability depends on the command modules and skill sources composed into the upstream `InteractiveSession`.
 
 ### IHeadlessRunnerOptions
 
@@ -126,7 +126,8 @@ Interrupted executions (e.g., abort signal) are treated as success (exit code 0)
 createHeadlessRunner(options)
   └── run(prompt)
         ├── subscribes to InteractiveSession events
-        ├── executes leading slash commands through session.executeCommand()
+        ├── executes leading slash system commands through session.executeCommand()
+        ├── executes leading slash skills through session.executeUserSkillCommand()
         ├── writes formatted output to process.stdout
         └── resolves with exit code (0 or 1)
 ```

--- a/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
@@ -5,6 +5,10 @@ import type { TBackgroundJobGroupEvent } from '@robota-sdk/agent-sdk';
 import type { TBackgroundTaskEvent } from '@robota-sdk/agent-sdk';
 import { createHeadlessRunner } from '../headless-runner.js';
 
+interface IUserSkillCommandTestSession {
+  executeUserSkillCommand: ReturnType<typeof vi.fn>;
+}
+
 function createMockSession(behavior: 'complete' | 'interrupted' | 'error', response = '') {
   const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
   return {
@@ -41,6 +45,7 @@ function createMockSession(behavior: 'complete' | 'interrupted' | 'error', respo
       }
     }),
     executeCommand: vi.fn().mockResolvedValue(null),
+    executeUserSkillCommand: vi.fn().mockResolvedValue(null),
     getSession: vi.fn(() => ({ getSessionId: () => 'test-session-id' })),
   } as unknown as InteractiveSession;
 }
@@ -125,6 +130,43 @@ describe('createHeadlessRunner (text format)', () => {
     );
     expect(session.submit).not.toHaveBeenCalled();
     expect(stdoutWriteSpy).toHaveBeenCalledWith('Started agent job: agent_1\n');
+  });
+
+  it('executes /skill through the session skill API without submitting the raw slash prompt', async () => {
+    const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    const session = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event)!.push(handler);
+      }),
+      off: vi.fn(),
+      submit: vi.fn(),
+      executeCommand: vi.fn().mockResolvedValue(null),
+      executeUserSkillCommand: vi.fn().mockImplementation(async () => {
+        const result: IExecutionResult = {
+          response: 'Skill response',
+          history: [],
+          toolSummaries: [],
+          contextState: {} as IExecutionResult['contextState'],
+        };
+        for (const handler of listeners.get('complete') ?? []) {
+          handler(result);
+        }
+        return { mode: 'inject', prompt: 'Rendered skill prompt' };
+      }),
+      getSession: vi.fn(() => ({ getSessionId: () => 'test-session-id' })),
+    } as unknown as InteractiveSession;
+    const runner = createHeadlessRunner({ session, outputFormat: 'text' });
+
+    const exitCode = await runner.run('/audit src/index.ts');
+
+    expect(exitCode).toBe(0);
+    expect(session.executeCommand).toHaveBeenCalledWith('audit', 'src/index.ts');
+    expect(
+      (session as InteractiveSession & IUserSkillCommandTestSession).executeUserSkillCommand,
+    ).toHaveBeenCalledWith('audit', 'src/index.ts', '/audit src/index.ts', '/audit src/index.ts');
+    expect(session.submit).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('Skill response\n');
   });
 });
 

--- a/packages/agent-transport-headless/src/__tests__/headless-skill-activation.integration.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-skill-activation.integration.test.ts
@@ -19,8 +19,15 @@ interface IObservedProvider {
   provider: TTestProvider;
   getChatCallCount(): number;
   getFirstCallToolNames(): string[];
+  getFirstCallExecuteCommandEnum(): string[] | undefined;
   getFirstCallExecuteSkillEnum(): string[] | undefined;
   getToolResultContent(): string;
+}
+
+interface IObservedPromptProvider {
+  provider: TTestProvider;
+  getChatCallCount(): number;
+  getPromptContent(): string;
 }
 
 function createTempSkill(cwd: string): void {
@@ -67,6 +74,7 @@ function assistantMessage(content: string | null, toolCalls?: TToolCalls): TChat
 function createSkillToolCallingProvider(): IObservedProvider {
   let chatCallCount = 0;
   let firstCallToolNames: string[] = [];
+  let firstCallExecuteCommandEnum: string[] | undefined;
   let firstCallExecuteSkillEnum: string[] | undefined;
   let toolResultContent = '';
 
@@ -78,6 +86,11 @@ function createSkillToolCallingProvider(): IObservedProvider {
 
       if (chatCallCount === 1) {
         firstCallToolNames = options?.tools?.map((tool) => tool.name) ?? [];
+        const executeCommandSchema = options?.tools?.find((tool) => tool.name === 'ExecuteCommand');
+        const commandEnum = executeCommandSchema?.parameters.properties['command']?.enum;
+        firstCallExecuteCommandEnum = Array.isArray(commandEnum)
+          ? commandEnum.map((value) => String(value))
+          : undefined;
         const executeSkillSchema = options?.tools?.find((tool) => tool.name === 'ExecuteSkill');
         const skillEnum = executeSkillSchema?.parameters.properties['skill']?.enum;
         firstCallExecuteSkillEnum = Array.isArray(skillEnum)
@@ -116,8 +129,39 @@ function createSkillToolCallingProvider(): IObservedProvider {
     provider,
     getChatCallCount: () => chatCallCount,
     getFirstCallToolNames: () => firstCallToolNames,
+    getFirstCallExecuteCommandEnum: () => firstCallExecuteCommandEnum,
     getFirstCallExecuteSkillEnum: () => firstCallExecuteSkillEnum,
     getToolResultContent: () => toolResultContent,
+  };
+}
+
+function createPromptObservingProvider(response: string): IObservedPromptProvider {
+  let chatCallCount = 0;
+  let promptContent = '';
+
+  const provider: TTestProvider = {
+    name: 'headless-test-provider',
+    version: '1.0.0',
+    async chat(messages) {
+      chatCallCount += 1;
+      promptContent = messages.map((message) => message.content).join('\n');
+      return assistantMessage(response);
+    },
+    async generateResponse() {
+      return { content: 'unused' };
+    },
+    supportsTools() {
+      return true;
+    },
+    validateConfig() {
+      return true;
+    },
+  };
+
+  return {
+    provider,
+    getChatCallCount: () => chatCallCount,
+    getPromptContent: () => promptContent,
   };
 }
 
@@ -172,7 +216,7 @@ describe('headless transport skill activation integration', () => {
     try {
       const transport = createHeadlessTransport({
         outputFormat: 'json',
-        prompt: 'Use the audit skill for src/index.ts',
+        prompt: 'Audit src/index.ts',
       });
 
       session.attachTransport(transport);
@@ -188,6 +232,7 @@ describe('headless transport skill activation integration', () => {
       expect(output['session_id']).toBeTypeOf('string');
       expect(observed.getChatCallCount()).toBe(2);
       expect(observed.getFirstCallToolNames()).toContain('ExecuteSkill');
+      expect(observed.getFirstCallExecuteCommandEnum()).toContain('skills');
       expect(observed.getFirstCallExecuteSkillEnum()).toEqual(['audit']);
       expect(observed.getToolResultContent()).toContain('"success":true');
       expect(observed.getToolResultContent()).toContain('<skill name=\\"audit\\">');
@@ -204,6 +249,57 @@ describe('headless transport skill activation integration', () => {
       await session.shutdown({
         reason: 'prompt_input_exit',
         message: 'Headless skill activation test complete',
+      });
+    }
+  });
+
+  it('executes explicit slash skills through SDK skill loading in a headless session', async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'robota-headless-slash-skill-'));
+    createTempSkill(cwd);
+    const observed = createPromptObservingProvider('Headless slash skill activated');
+    const session = new InteractiveSession({
+      cwd,
+      provider: observed.provider,
+      config: createConfig(),
+      permissionMode: 'bypassPermissions',
+      bare: true,
+    });
+    const stdout = captureStdout();
+
+    try {
+      const transport = createHeadlessTransport({
+        outputFormat: 'json',
+        prompt: '/audit src/index.ts',
+      });
+
+      session.attachTransport(transport);
+      await transport.start();
+
+      const output = parseJsonObject(stdout.writes.join('').trim());
+      expect(transport.getExitCode()).toBe(0);
+      expect(output).toMatchObject({
+        type: 'result',
+        result: 'Headless slash skill activated',
+        subtype: 'success',
+      });
+      expect(observed.getChatCallCount()).toBe(1);
+      expect(observed.getPromptContent()).toContain(
+        'Audit this file with the real skill runtime: src/index.ts',
+      );
+      expect(observed.getPromptContent()).toContain('<skill name="audit">');
+      expect(session.getSkillActivationEvents().map((event) => event.invocation)).toEqual([
+        'user-slash',
+        'user-slash',
+      ]);
+      expect(session.getSkillActivationEvents().map((event) => event.status)).toEqual([
+        'started',
+        'completed',
+      ]);
+    } finally {
+      stdout.restore();
+      await session.shutdown({
+        reason: 'prompt_input_exit',
+        message: 'Headless slash skill activation test complete',
       });
     }
   });

--- a/packages/agent-transport-headless/src/__tests__/headless-skill-activation.integration.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-skill-activation.integration.test.ts
@@ -19,6 +19,7 @@ interface IObservedProvider {
   provider: TTestProvider;
   getChatCallCount(): number;
   getFirstCallToolNames(): string[];
+  getFirstCallExecuteSkillEnum(): string[] | undefined;
   getToolResultContent(): string;
 }
 
@@ -66,6 +67,7 @@ function assistantMessage(content: string | null, toolCalls?: TToolCalls): TChat
 function createSkillToolCallingProvider(): IObservedProvider {
   let chatCallCount = 0;
   let firstCallToolNames: string[] = [];
+  let firstCallExecuteSkillEnum: string[] | undefined;
   let toolResultContent = '';
 
   const provider: TTestProvider = {
@@ -76,6 +78,11 @@ function createSkillToolCallingProvider(): IObservedProvider {
 
       if (chatCallCount === 1) {
         firstCallToolNames = options?.tools?.map((tool) => tool.name) ?? [];
+        const executeSkillSchema = options?.tools?.find((tool) => tool.name === 'ExecuteSkill');
+        const skillEnum = executeSkillSchema?.parameters.properties['skill']?.enum;
+        firstCallExecuteSkillEnum = Array.isArray(skillEnum)
+          ? skillEnum.map((value) => String(value))
+          : undefined;
         return assistantMessage(null, [
           {
             id: 'call_execute_skill',
@@ -109,6 +116,7 @@ function createSkillToolCallingProvider(): IObservedProvider {
     provider,
     getChatCallCount: () => chatCallCount,
     getFirstCallToolNames: () => firstCallToolNames,
+    getFirstCallExecuteSkillEnum: () => firstCallExecuteSkillEnum,
     getToolResultContent: () => toolResultContent,
   };
 }
@@ -180,6 +188,7 @@ describe('headless transport skill activation integration', () => {
       expect(output['session_id']).toBeTypeOf('string');
       expect(observed.getChatCallCount()).toBe(2);
       expect(observed.getFirstCallToolNames()).toContain('ExecuteSkill');
+      expect(observed.getFirstCallExecuteSkillEnum()).toEqual(['audit']);
       expect(observed.getToolResultContent()).toContain('"success":true');
       expect(observed.getToolResultContent()).toContain('<skill name=\\"audit\\">');
       expect(session.getSkillActivationEvents().map((event) => event.invocation)).toEqual([

--- a/packages/agent-transport-headless/src/headless-runner.ts
+++ b/packages/agent-transport-headless/src/headless-runner.ts
@@ -3,6 +3,7 @@ import type {
   InteractiveSession,
   IExecutionResult,
   ICommandResult,
+  ISkillExecutionResult,
   TBackgroundJobGroupEvent,
   TBackgroundTaskEvent,
 } from '@robota-sdk/agent-sdk';
@@ -12,6 +13,15 @@ export type TOutputFormat = 'text' | 'json' | 'stream-json';
 export interface IHeadlessRunnerOptions {
   session: InteractiveSession;
   outputFormat: TOutputFormat;
+}
+
+interface IUserSkillCommandSession {
+  executeUserSkillCommand(
+    name: string,
+    args: string,
+    displayInput?: string,
+    rawInput?: string,
+  ): Promise<ISkillExecutionResult | null>;
 }
 
 type TStreamJsonEvent =
@@ -28,10 +38,17 @@ type TStreamJsonEvent =
       background_job_group_event: TBackgroundJobGroupEvent;
     };
 
-interface ISlashCommandExecution {
-  readonly isSlashCommand: boolean;
-  readonly result: ICommandResult | null;
-}
+type TSlashCommandExecution =
+  | {
+      readonly kind: 'not-slash';
+    }
+  | {
+      readonly kind: 'command-result';
+      readonly result: ICommandResult;
+    }
+  | {
+      readonly kind: 'session-execution';
+    };
 
 export function createHeadlessRunner(options: IHeadlessRunnerOptions): {
   run: (prompt: string) => Promise<number>;
@@ -65,21 +82,35 @@ function parseSlashCommand(prompt: string): { name: string; args: string } | nul
   return { name, args: args.join(' ') };
 }
 
+function getUserSkillCommandSession(session: InteractiveSession): IUserSkillCommandSession | null {
+  const candidate = session as InteractiveSession & Partial<IUserSkillCommandSession>;
+  return typeof candidate.executeUserSkillCommand === 'function'
+    ? (candidate as IUserSkillCommandSession)
+    : null;
+}
+
 async function executeSlashCommandIfPresent(
   session: InteractiveSession,
   prompt: string,
-): Promise<ISlashCommandExecution> {
+): Promise<TSlashCommandExecution> {
   const command = parseSlashCommand(prompt);
-  if (!command) return { isSlashCommand: false, result: null };
+  if (!command) return { kind: 'not-slash' };
+
   const result = await session.executeCommand(command.name, command.args);
+  if (result) return { kind: 'command-result', result };
+
+  const skillSession = getUserSkillCommandSession(session);
+  const skillResult = skillSession
+    ? await skillSession.executeUserSkillCommand(command.name, command.args, prompt, prompt)
+    : null;
+  if (skillResult) return { kind: 'session-execution' };
+
   return {
-    isSlashCommand: true,
-    result:
-      result ??
-      ({
-        message: `Unknown command "/${command.name}".`,
-        success: false,
-      } satisfies ICommandResult),
+    kind: 'command-result',
+    result: {
+      message: `Unknown command "/${command.name}".`,
+      success: false,
+    },
   };
 }
 
@@ -132,7 +163,7 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
     session.on('error', onError);
 
     void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
-      if (commandExecution.isSlashCommand && commandExecution.result) {
+      if (commandExecution.kind === 'command-result') {
         cleanup();
         writeJsonResult(
           getSessionId(session),
@@ -140,6 +171,9 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
           commandExecution.result.success ? 'success' : 'error',
         );
         resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      if (commandExecution.kind === 'session-execution') {
         return;
       }
       void session.submit(prompt);
@@ -152,7 +186,7 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
     const cleanup = subscribeStreamJsonEvents(session, resolve);
 
     void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
-      if (commandExecution.isSlashCommand && commandExecution.result) {
+      if (commandExecution.kind === 'command-result') {
         cleanup();
         writeJsonResult(
           getSessionId(session),
@@ -160,6 +194,9 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
           commandExecution.result.success ? 'success' : 'error',
         );
         resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      if (commandExecution.kind === 'session-execution') {
         return;
       }
       void session.submit(prompt);
@@ -276,10 +313,13 @@ function runTextFormat(session: InteractiveSession, prompt: string): Promise<num
     session.on('error', onError);
 
     void executeSlashCommandIfPresent(session, prompt).then((commandExecution) => {
-      if (commandExecution.isSlashCommand && commandExecution.result) {
+      if (commandExecution.kind === 'command-result') {
         cleanup();
         process.stdout.write(commandExecution.result.message + '\n');
         resolve(commandExecution.result.success ? 0 : 1);
+        return;
+      }
+      if (commandExecution.kind === 'session-execution') {
         return;
       }
       void session.submit(prompt);


### PR DESCRIPTION
## Summary
- Add SDK-owned `/skills` as a model/user-invocable built-in discovery command with skill activation guidance.
- Keep `## Skills` as metadata only; move behavioral guidance into command/tool descriptors and `/skills` command output.
- Constrain `ExecuteSkill.skill` and `ExecuteCommand.command` schemas to registered enum values for the current session.
- Add deterministic SDK routing for explicit user skill directives such as `Use the repo-writing skill ...`, recording `user-directive` activation events.
- Make headless print mode route explicit `/skill` prompts through the SDK skill loader before the model turn.

## Behavioral Verification
- `pnpm exec tsx --conditions=source packages/agent-cli/src/bin.ts -p --output-format json --max-turns 2 --permission-mode bypassPermissions "/skills"`
- `pnpm exec tsx --conditions=source packages/agent-cli/src/bin.ts -p --output-format json --max-turns 4 --permission-mode bypassPermissions "/repo-writing backlog markdown format, answer one sentence without editing files"`
- `pnpm exec tsx --conditions=source packages/agent-cli/src/bin.ts -p --output-format json --max-turns 8 --permission-mode bypassPermissions "I am preparing a documentation edit. Use the repo-writing skill to answer without modifying files or running shell commands: what repository writing rule should I follow for a markdown backlog document? Keep the answer to one sentence."`
- Verified session `session_1778081181124_vlx8swxrx` recorded `skillActivationEvents` with `invocation: user-directive` and loaded `<skill name="repo-writing">` before the model response.

## Automated Verification
- `pnpm --filter @robota-sdk/agent-sdk test`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-sdk lint` (passes with existing warnings)
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-transport-headless test`
- `pnpm --filter @robota-sdk/agent-transport-headless typecheck`
- `pnpm --filter @robota-sdk/agent-transport-headless lint`
- `pnpm --filter @robota-sdk/agent-transport-headless build`
- `pnpm docs:build`