### PR TITLE
docs(backlog): add architecture map split plan

### DIFF
--- a/.agents/backlog/architecture-map-document-tree-split.md
+++ b/.agents/backlog/architecture-map-document-tree-split.md
@@ -1,0 +1,111 @@
+# Architecture Map Document Tree Split
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-07
+
+## Priority
+
+P1 - architecture navigation and maintainability.
+
+## Problem
+
+The architecture map documents have grown too large after earlier guidance asked agents to avoid
+splitting files as much as possible. That guidance is now withdrawn for architecture maps. Keeping
+all repository structure, package relationships, contracts, layer notes, diagrams, and lessons in a
+small number of large files makes the maps harder for humans and LLM agents to scan.
+
+Architecture maps should become a routed document tree: a small entrypoint that explains how to
+navigate the map, plus grouped subdocuments that own focused architecture areas.
+
+## Current Code Confirmation
+
+- `.agents/specs/ARCHITECTURE-MAP.md` is the repository-level architecture map and is already large.
+- `packages/agent-cli/docs/ARCHITECTURE-MAP.md` is the CLI-focused architecture map and is also
+  large.
+- `.agents/project-structure.md` links to `.agents/specs/ARCHITECTURE-MAP.md` as the
+  repository-level architecture map.
+- Completed backlog and task history already tracks architecture-map creation/audit work, but not
+  a dedicated document-tree split for architecture maps.
+
+## Scope
+
+- `.agents/specs/ARCHITECTURE-MAP.md`
+- New architecture-map-only folder, recommended as `.agents/specs/architecture-map/`
+- `.agents/project-structure.md`
+- `AGENTS.md` document tree only if the routing entrypoint changes
+- `packages/*/docs/ARCHITECTURE-MAP.md` files that should be linked, moved, summarized, or folded
+  into the architecture-map tree
+- `.agents/rules/process.md` and `.agents/rules/common-mistakes.md` if rules need to describe when
+  architecture-map updates are required
+
+## Recommended Direction
+
+Create a dedicated architecture map folder and turn the current top-level map into a short router.
+The goal is not to scatter documentation excessively; it is to make architecture ownership
+explicit and keep each document small enough to be read and maintained safely.
+
+Recommended tree:
+
+```text
+.agents/specs/
+├── ARCHITECTURE-MAP.md                  # router and reading guide
+└── architecture-map/
+    ├── README.md                        # map index, update policy, diagram conventions
+    ├── repository-overview.md           # top-level package/app grouping
+    ├── dependency-direction.md          # allowed dependency flow and forbidden edges
+    ├── agent-system.md                  # agent package family and command/provider/runtime flow
+    ├── dag-system.md                    # DAG package family and orchestration flow
+    ├── apps-and-deployment.md           # apps, docs/blog, deployment paths
+    ├── cross-cutting-contracts.md       # auth, credits, storage, events, permissions
+    └── architecture-lessons.md          # durable architecture lessons and update triggers
+```
+
+Recommended migration strategy:
+
+- Keep `.agents/specs/ARCHITECTURE-MAP.md` as the stable entrypoint linked by existing docs.
+- Move detailed sections into focused files under `.agents/specs/architecture-map/`.
+- Keep each subdocument focused on one architecture slice and prefer links to owning `SPEC.md`
+  files instead of duplicating package contracts.
+- Use Mermaid diagrams only where they clarify boundaries or dependency direction.
+- Preserve an LLM-friendly tree/index in the router so an agent can choose the right subdocument
+  before reading large context.
+- Add a rule or process note that architecture-affecting changes must update the relevant
+  architecture-map subdocument, not append everything to the root map.
+
+## Constraints
+
+- The architecture map folder is allowed and expected; the previous "avoid splitting architecture
+  maps" preference is withdrawn.
+- Do not duplicate package-level SSOT details already owned by `packages/*/docs/SPEC.md`.
+- Do not make `AGENTS.md` domain-specific. It may route to the architecture map entrypoint, but
+  detailed architecture belongs under `.agents/specs/architecture-map/` and package specs.
+- Keep generated API reference content untouched.
+- Avoid excessive fragmentation: split by architecture ownership, not by every package or class.
+- Preserve existing inbound links or provide compatibility links from old entrypoints.
+
+## Acceptance Criteria
+
+- [ ] `.agents/specs/ARCHITECTURE-MAP.md` becomes a concise router and reading guide.
+- [ ] A dedicated `.agents/specs/architecture-map/` folder exists.
+- [ ] Repository overview, dependency direction, agent system, DAG system, apps/deployment,
+      cross-cutting contracts, and architecture lessons are separated into focused subdocuments.
+- [ ] Existing links from `.agents/project-structure.md`, AGENTS routing, and package docs still
+      lead to a valid architecture-map entrypoint.
+- [ ] The split reduces root-map size substantially while preserving all important architecture
+      information through links or moved sections.
+- [ ] Subdocuments link to owning package `SPEC.md` files instead of duplicating contract details.
+- [ ] Rules/process docs state that architecture-affecting changes must update the relevant
+      architecture-map subdocument.
+- [ ] A quick link-check or grep-based validation confirms no stale architecture-map links remain.
+
+## Verification Plan
+
+- `rg -n "ARCHITECTURE-MAP|architecture-map" AGENTS.md .agents packages content`
+- `pnpm harness:scan`
+- Manual review of the router to confirm each major architecture area has one clear destination.
+- Manual review that no generated `content/api-reference/**` files were edited.

--- a/.agents/backlog/cli-provider-profile-management-tui.md
+++ b/.agents/backlog/cli-provider-profile-management-tui.md
@@ -1,0 +1,128 @@
+# CLI Provider Profile Management TUI
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-07
+
+## Priority
+
+P1 - provider setup and switching usability.
+
+## Problem
+
+The provider command can list configured profiles and can switch profiles when the user already
+knows the exact command syntax. However, the current TUI experience is still command-instruction
+oriented rather than interaction oriented:
+
+- `/provider list` shows profile names and metadata, but does not let the user select a profile.
+- `/provider use <profile>` can switch after confirmation, but users must type the target profile
+  manually.
+- Provider setup exists, but profile management actions are spread across command syntax and
+  startup setup flows.
+- There is no first-class TUI flow for editing or deleting provider profiles.
+
+Provider profile management should feel like a normal interactive CLI workflow: show available
+profiles, let the user choose one, then offer safe actions such as switch, edit, test, duplicate,
+or delete.
+
+## Current Code Confirmation
+
+- `packages/agent-command-provider/src/provider-command-module.ts` exposes `/provider` with
+  `current | list | use <profile> | add [type] | test [profile]`.
+- `packages/agent-command-provider/src/provider-command-execution.ts` formats provider lists as
+  text and returns a confirmation interaction only after `use <profile>` receives an explicit
+  profile argument.
+- `packages/agent-sdk/src/command-api/provider/**` owns provider settings, profile validation,
+  setup-flow primitives, env references, and profile probing.
+- `packages/agent-cli/src/ui/**` already has generic UI primitives such as `MenuSelect`,
+  `ListPicker`, `ConfirmPrompt`, `TextPrompt`, and command-effect handling.
+- `packages/agent-cli/src/utils/provider-setup.ts` contains startup/configuration setup flows, but
+  the TUI runtime should remain a thin interaction renderer rather than owning provider business
+  logic.
+
+## Scope
+
+- `packages/agent-command-provider/src/provider-command-execution.ts`
+- `packages/agent-command-provider/src/provider-command-module.ts`
+- `packages/agent-command-provider/src/__tests__/provider-command-module.test.ts`
+- `packages/agent-command-provider/docs/SPEC.md`
+- `packages/agent-sdk/src/command-api/provider/**`
+- `packages/agent-sdk/docs/SPEC.md`
+- `packages/agent-cli/src/ui/hooks/command-effect-handler.ts`
+- `packages/agent-cli/src/ui/hooks/useSideEffects.ts`
+- `packages/agent-cli/src/ui/MenuSelect.tsx`, `ListPicker.tsx`, `TextPrompt.tsx`,
+  `ConfirmPrompt.tsx`, or a small shared profile-management flow component if needed
+- `packages/agent-cli/src/ui/__tests__/**` for provider interaction and headless/TUI flow coverage
+- `packages/agent-cli/docs/SPEC.md`
+- `packages/agent-cli/README.md`
+- `content/guide/cli.md`
+
+## Recommended Direction
+
+Extend the provider command module so `/provider` and `/provider list` can return structured
+interaction requests instead of only prose. The command package should own the provider-management
+state machine and settings mutations; the CLI TUI should only render generic interaction prompts and
+submit selected values back to the command interaction API.
+
+Recommended UX:
+
+- `/provider` opens a provider profile picker.
+- `/provider list` displays profiles and allows keyboard selection in TUI mode.
+- Selecting a profile opens an action menu: `switch`, `edit`, `test`, `duplicate`, `delete`,
+  `cancel`.
+- `switch` confirms restart and persists `currentProvider` through the existing settings adapter.
+- `edit` uses provider-definition setup metadata and SDK provider common APIs to update fields for
+  the selected profile.
+- `delete` requires confirmation, blocks deleting the only usable profile unless a replacement is
+  selected, and handles deleting the active provider by requiring a new active profile.
+- `test` runs the existing provider probe path and shows the result without mutating settings.
+- Headless or non-interactive mode should keep deterministic text output and command syntax; it
+  must not require a TUI.
+
+## Constraints
+
+- `agent-cli` must stay a thin UI layer. It may render pickers, prompts, and confirmations, but it
+  must not own provider profile mutation rules.
+- Provider settings ownership remains in SDK provider common APIs and the provider command package.
+- Provider packages must remain domain-neutral; do not add TUI/profile-management behavior to
+  concrete provider packages.
+- Do not expose secrets in list, edit summaries, logs, or session transcripts.
+- Deleting or editing profiles must target the settings document that will win after merge
+  precedence is applied.
+- Keep existing explicit command forms working: `/provider current`, `/provider list`,
+  `/provider use <profile>`, `/provider add <type>`, and `/provider test [profile]`.
+- Do not edit generated `content/api-reference/**` files directly.
+
+## Acceptance Criteria
+
+- [ ] `/provider` opens an interactive provider profile picker in TUI mode.
+- [ ] `/provider list` supports selecting a listed profile in TUI mode while preserving plain text
+      output in headless/non-interactive mode.
+- [ ] Selecting a profile presents an action menu with switch, edit, test, duplicate, delete, and
+      cancel.
+- [ ] Switching through the picker uses the same confirmation and restart effect as
+      `/provider use <profile>`.
+- [ ] Editing a profile uses provider-definition setup metadata and SDK provider common APIs rather
+      than CLI-specific provider branches.
+- [ ] Deleting a profile is confirmed, does not expose secrets, and handles active/last-profile
+      edge cases explicitly.
+- [ ] Provider test results are shown from the existing probe path without mutating settings.
+- [ ] TUI tests cover picker navigation, action selection, switch confirmation, edit prompt flow,
+      delete confirmation, and cancel paths.
+- [ ] Headless tests prove provider commands still return deterministic text and do not block on
+      TUI-only interactions.
+- [ ] SPEC/README/content docs describe the interactive provider-management flow.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-command-provider test`
+- `pnpm --filter @robota-sdk/agent-command-provider typecheck`
+- `pnpm --filter @robota-sdk/agent-cli test -- provider`
+- `pnpm --filter @robota-sdk/agent-cli test -- selection-flow command-effect-handler`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- Headless CLI smoke test for `/provider list` and `/provider test [profile]`
+- TUI/headless verification evidence for selecting a profile and cancelling without mutation


### PR DESCRIPTION
## Summary\n- Add backlog for splitting architecture maps into a routed document tree\n- Add backlog for interactive provider profile management TUI\n\n## Verification\n- Documentation-only backlog additions\n- lint-staged prettier ran during commit