### PR TITLE
fix(agent-cli): remove message count from status bar

### DIFF
--- a/.agents/backlog/completed/cli-remove-message-count-status.md
+++ b/.agents/backlog/completed/cli-remove-message-count-status.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -56,12 +56,12 @@ section, simplify the layout rather than keeping an empty spacer solely for symm
 
 ## Acceptance Criteria
 
-- [ ] The status bar no longer renders `msgs: N`.
-- [ ] `messageCount` is removed from status bar props and upstream TUI plumbing if no longer used by
+- [x] The status bar no longer renders `msgs: N`.
+- [x] `messageCount` is removed from status bar props and upstream TUI plumbing if no longer used by
       the status surface.
-- [ ] Status-bar tests assert that message count is not rendered.
-- [ ] CLI SPEC and user-facing docs no longer list `msgs` as a status bar field.
-- [ ] Activity, conditional permission mode, provider/model/profile, git branch, and context usage
+- [x] Status-bar tests assert that message count is not rendered.
+- [x] CLI SPEC and user-facing docs no longer list `msgs` as a status bar field.
+- [x] Activity, conditional permission mode, provider/model/profile, git branch, and context usage
       still render correctly.
 
 ## Verification Plan
@@ -69,3 +69,12 @@ section, simplify the layout rather than keeping an empty spacer solely for symm
 - `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
 - `pnpm --filter @robota-sdk/agent-cli typecheck`
 - `pnpm --filter @robota-sdk/agent-cli lint`
+
+## Result
+
+Completed in `fix/cli-remove-message-count-status`.
+
+- Removed the visible `msgs: N` status-bar segment.
+- Removed `messageCount` from status bar props and upstream status-bar plumbing.
+- Kept message counts in saved-session picker surfaces.
+- Updated CLI SPEC, README, and interactive-mode docs to describe the slimmer status bar.

--- a/content/examples/interactive-mode.md
+++ b/content/examples/interactive-mode.md
@@ -52,7 +52,7 @@ Bash: pnpm test
 The status bar shows real-time context usage:
 
 ```
-Thinking | Model: claude-sonnet-4-6 | Context: 45% | msgs: 12
+Thinking | Model: claude-sonnet-4-6 | Context: 45%
 ```
 
 `default` permission mode is hidden because it is the baseline. Non-default permission modes such as

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -106,7 +106,7 @@ The TUI (built with React + Ink) provides:
 
 - **Message list** — Conversation history with markdown rendering
 - **Input area** — Text input with slash command autocomplete
-- **Status bar** — Permission mode, model, context usage %, message count, and activity state
+- **Status bar** — Permission mode, model, context usage %, and activity state
 - **Permission prompts** — Arrow-key Allow/Deny selection for tool calls
 - **Streaming** — Real-time text output as the model responds
 - **Usage summaries** — Provider usage and cost metadata when available

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -416,7 +416,7 @@ bin.ts → cli.ts (arg parsing)
                     ├── plugin-hooks-merger.ts (merges plugin hooks into SDK config)
                     ├── MessageList.tsx
                     ├── InputArea.tsx          (CjkTextInput, bracketed paste, slash detection)
-                    ├── StatusBar.tsx          (activity, conditional mode, model, context %, message count)
+                    ├── StatusBar.tsx          (activity, conditional mode, model, context %)
                     ├── PermissionPrompt.tsx   (arrow-key Allow/Deny)
                     ├── SlashAutocomplete.tsx  (command popup with scroll)
                     ├── DiffBlock.tsx          (Edit tool diff display)

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -243,7 +243,7 @@ The StatusBar shows real-time session information:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ Thinking  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K)  msgs: 12 │
+│ Thinking  |  my-session  |  git: feat/x  |  Claude Sonnet 4.6  |  Context: 45% (90K/200K) │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -253,7 +253,6 @@ The StatusBar shows real-time session information:
 | Model    | `getModelName(config.provider.model)`      | Human-readable model name (e.g., "Claude Sonnet 4.6")  |
 | Git      | `resolveGitBranch(cwd)`                    | Current git branch when available and enabled          |
 | Context  | `session.getContextState().usedPercentage` | Context usage with K/M formatting (e.g., "90K/1M")     |
-| msgs     | message count                              | Number of messages in conversation                     |
 | Session  | `session.getName()`                        | Session name (shown only when a name is set)           |
 | Activity | CLI-derived display state                  | Left-side primary activity text without a field prefix |
 
@@ -265,7 +264,7 @@ Activity priority is deterministic and renderer-owned:
 4. queued prompt (`Queued`)
 5. idle (`Idle`)
 
-When a prompt is queued behind foreground work, the activity row keeps the active work as primary and appends `queued` as secondary metadata. `default` permission mode is the baseline and is hidden; non-default permission modes (`plan`, `acceptEdits`, `bypassPermissions`) are rendered as `Mode: <mode>`. SDK session state remains the source of truth; `StatusBar` receives derived display counts and does not infer provider or execution semantics.
+When a prompt is queued behind foreground work, the activity row keeps the active work as primary and appends `queued` as secondary metadata. `default` permission mode is the baseline and is hidden; non-default permission modes (`plan`, `acceptEdits`, `bypassPermissions`) are rendered as `Mode: <mode>`. SDK session state remains the source of truth; `StatusBar` receives derived display values and does not infer provider or execution semantics.
 
 ### `/statusline` Slash Command
 
@@ -804,7 +803,7 @@ src/
     ├── MessageList.tsx              ← Renders IHistoryEntry[] via EntryItem (dispatches on category)
     ├── InputArea.tsx                ← Bottom fixed input (CjkTextInput), slash detection
     ├── SessionStatusBar.tsx         ← Statusline settings + git branch adapter
-    ├── StatusBar.tsx                ← Activity, conditional mode, model, git branch, context %, message count
+    ├── StatusBar.tsx                ← Activity, conditional mode, model, git branch, context %
     ├── PermissionPrompt.tsx         ← Allow/Deny arrow-key selection (useInput)
     ├── StreamingIndicator.tsx       ← Real-time Tools:/Robota: display during run()
     ├── SlashAutocomplete.tsx        ← Command autocomplete popup (scroll, highlight)

--- a/packages/agent-cli/src/ui/App.tsx
+++ b/packages/agent-cli/src/ui/App.tsx
@@ -280,7 +280,6 @@ function AppInner(
         providerProfileName={props.providerProfileName}
         providerType={props.providerType}
         sessionId={sessionId}
-        messageCount={history.length}
         isThinking={isThinking}
         activeToolCount={activeTools.length}
         activeBackgroundTaskCount={activeBackgroundTaskCount}

--- a/packages/agent-cli/src/ui/SessionStatusBar.tsx
+++ b/packages/agent-cli/src/ui/SessionStatusBar.tsx
@@ -12,7 +12,6 @@ interface IProps {
   providerProfileName?: string | undefined;
   providerType?: string | undefined;
   sessionId: string;
-  messageCount: number;
   isThinking: boolean;
   activeToolCount: number;
   activeBackgroundTaskCount: number;
@@ -29,7 +28,6 @@ export default function SessionStatusBar({
   providerProfileName,
   providerType,
   sessionId,
-  messageCount,
   isThinking,
   activeToolCount,
   activeBackgroundTaskCount,
@@ -48,7 +46,6 @@ export default function SessionStatusBar({
       providerProfileName={providerProfileName}
       providerType={providerType}
       sessionId={sessionId}
-      messageCount={messageCount}
       isThinking={isThinking}
       activeToolCount={activeToolCount}
       activeBackgroundTaskCount={activeBackgroundTaskCount}

--- a/packages/agent-cli/src/ui/StatusBar.tsx
+++ b/packages/agent-cli/src/ui/StatusBar.tsx
@@ -14,7 +14,6 @@ interface IProps {
   providerProfileName?: string | undefined;
   providerType?: string | undefined;
   sessionId: string;
-  messageCount: number;
   isThinking: boolean;
   activeToolCount?: number;
   activeBackgroundTaskCount?: number;
@@ -171,21 +170,12 @@ function StatusLeft(props: IStatusLeftProps): React.ReactElement {
   );
 }
 
-function StatusRight({ messageCount }: { messageCount: number }): React.ReactElement {
-  return (
-    <Text>
-      <Text dimColor>msgs: {messageCount}</Text>
-    </Text>
-  );
-}
-
 export default function StatusBar({
   permissionMode,
   modelName,
   providerProfileName,
   providerType,
   sessionId: _sessionId,
-  messageCount,
   isThinking,
   activeToolCount = 0,
   activeBackgroundTaskCount = 0,
@@ -221,7 +211,6 @@ export default function StatusBar({
         gitBranch={gitBranch}
         showGitBranch={showGitBranch}
       />
-      <StatusRight messageCount={messageCount} />
     </Box>
   );
 }

--- a/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
+++ b/packages/agent-cli/src/ui/__tests__/status-bar.test.tsx
@@ -8,7 +8,6 @@ describe('StatusBar', () => {
     permissionMode: 'default' as const,
     modelName: 'test-model',
     sessionId: 'sess-1',
-    messageCount: 5,
     isThinking: false,
     activeToolCount: 0,
     activeBackgroundTaskCount: 0,
@@ -73,10 +72,10 @@ describe('StatusBar', () => {
     expect(frame).toContain('test-model');
   });
 
-  it('renders message count', () => {
+  it('does not render message count in the status bar', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} />);
     const frame = lastFrame()!;
-    expect(frame).toContain('msgs: 5');
+    expect(frame).not.toContain('msgs:');
   });
 
   it('shows thinking indicator when isThinking is true', () => {
@@ -87,12 +86,12 @@ describe('StatusBar', () => {
     expect(frame.indexOf('Thinking')).toBeLessThan(frame.indexOf('test-model'));
   });
 
-  it('does not duplicate thinking state next to the message count', () => {
+  it('does not duplicate thinking state in secondary status text', () => {
     const { lastFrame } = render(<StatusBar {...baseProps} isThinking={true} />);
     const frame = lastFrame()!;
     expect(frame).toContain('Thinking');
     expect(frame).not.toContain('thinking...');
-    expect(frame).toContain('msgs: 5');
+    expect(frame).not.toContain('msgs:');
   });
 
   it('hides the lower-right prompt-processing indicator while idle', () => {


### PR DESCRIPTION
## Summary

- remove the `msgs: N` segment from the always-visible agent-cli status bar
- remove unused message-count status props from StatusBar, SessionStatusBar, and App wiring
- update CLI docs and website examples to describe the slimmer status bar
- archive the completed backlog item

## Recommendation Applied

The status bar should stay focused on actionable scan-path metadata: activity, non-default permission mode, session/profile/model identity, git branch, and context usage. Message counts remain available in saved-session picker/debug surfaces, but are no longer always visible.

## Verification

- `pnpm --filter @robota-sdk/agent-cli test -- status-bar`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli lint` (existing warnings only, exit 0)
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm docs:build`
- pre-push scoped verification: monorepo `pnpm build`, full `agent-cli` test/lint/typecheck
