### PR TITLE
feat(agent-cli): add diff row background rendering

### DIFF
--- a/.agents/backlog/completed/cli-diff-line-background-rendering.md
+++ b/.agents/backlog/completed/cli-diff-line-background-rendering.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -68,16 +68,24 @@ Recommended color policy:
 
 ## Acceptance Criteria
 
-- [ ] Added diff lines use both foreground and background color when color is enabled.
-- [ ] Removed diff lines use both foreground and background color when color is enabled.
-- [ ] Added/removed backgrounds cover each rendered row including indentation and right-side padding.
-- [ ] Color-disabled rendering remains plain readable diff text with no ANSI color sequences.
-- [ ] Assistant markdown diffs and Edit tool diff summaries use the same diff background policy.
-- [ ] Tests cover row padding/background behavior and no-color fallback.
-- [ ] CLI SPEC documents foreground-plus-background diff rendering and row-fill behavior.
+- [x] Added diff lines use both foreground and background color when color is enabled.
+- [x] Removed diff lines use both foreground and background color when color is enabled.
+- [x] Added/removed backgrounds cover each rendered row including indentation and right-side padding.
+- [x] Color-disabled rendering remains plain readable diff text with no ANSI color sequences.
+- [x] Assistant markdown diffs and Edit tool diff summaries use the same diff background policy.
+- [x] Tests cover row padding/background behavior and no-color fallback.
+- [x] CLI SPEC documents foreground-plus-background diff rendering and row-fill behavior.
 
 ## Verification Plan
 
 - `pnpm --filter @robota-sdk/agent-cli test -- render-markdown message-list-rendering streaming-indicator`
 - `pnpm --filter @robota-sdk/agent-cli typecheck`
 - `pnpm --filter @robota-sdk/agent-cli lint`
+
+## Result
+
+Implemented shared Markdown `diff` rendering with red/green foreground colors plus dark
+addition/removal backgrounds. Added and removed rows are padded before ANSI styling so the
+background covers the rendered row, and color-disabled output remains plain readable text. The CLI
+SPEC and CLI guide now document the shared foreground/background row-fill policy used by assistant
+Markdown diffs and Edit tool summaries.

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -354,7 +354,7 @@ Long tool arguments are middle-truncated, keeping the last 30 characters visible
 
 ### Edit Diff Display
 
-When the Edit tool completes, the CLI renders a `DiffBlock` showing the change. The display format consists of a file path header followed by red (`-`) lines for removals and greenBright (`+`) lines for additions. A maximum of 10 lines are displayed; larger diffs are truncated with an `... and N more lines` indicator. No-op edits (where old and new strings are identical) are suppressed entirely.
+When the Edit tool completes, the CLI renders a `DiffBlock` showing the change. The display format consists of a file path header followed by removal (`-`) rows with red foreground plus dark red background and addition (`+`) rows with green foreground plus dark green background. Diff row backgrounds fill the rendered row, including padding, so additions and removals remain scannable in dense edits. A maximum of 10 lines are displayed; larger diffs are truncated with an `... and N more lines` indicator. No-op edits (where old and new strings are identical) are suppressed entirely.
 
 ### Subagent Execution
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -991,7 +991,8 @@ Assistant responses are rendered as Markdown through `render-markdown.ts`. A fen
 **Rules:**
 
 - `render-markdown.ts` owns assistant Markdown diff rendering.
-- `diff` fenced blocks receive line-level terminal colors: removed lines red, added lines green, hunk headers cyan, diff metadata dim.
+- `diff` fenced blocks receive line-level terminal colors: removed lines use red foreground plus dark red background, added lines use green foreground plus dark green background, hunk headers use cyan foreground, and diff metadata is dim.
+- Added and removed `diff` rows are padded before ANSI styling so the background covers the full rendered row. The renderer uses an explicit code block width when supplied and otherwise falls back to the widest diff row.
 - Color is controlled by renderer options and terminal color environment. With color disabled, the same diff text remains readable without ANSI escape codes.
 - General fenced code blocks continue through `marked-terminal`; only `diff` fenced blocks take the Robota line-level path.
 - Tool execution summaries use the same Markdown diff body rendering path while keeping file path, truncation, permissions, and streaming status as structured UI metadata outside the fenced block.
@@ -1002,7 +1003,7 @@ When an Edit tool summary includes diff lines, the CLI shows a compact diff belo
 
 **Source:** `old_string` and `new_string` from the Edit tool arguments.
 
-**Ownership:** `tool-diff-summary.ts` converts structured `IDiffLine[]` data into a Markdown fenced `diff` body. `ToolDiffBlock.tsx` renders structured metadata around that body and delegates the diff body itself to `renderMarkdown()`. There must not be a second bespoke diff-coloring policy for tool summaries.
+**Ownership:** `tool-diff-summary.ts` converts structured `IDiffLine[]` data into a Markdown fenced `diff` body. `ToolDiffBlock.tsx` renders structured metadata around that body and delegates the diff body itself to `renderMarkdown()`. There must not be a second bespoke diff-coloring policy for tool summaries; edit diffs use the same foreground, background, and row-fill policy as assistant Markdown diffs.
 
 **Display format:**
 

--- a/packages/agent-cli/src/ui/__tests__/render-markdown.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/render-markdown.test.ts
@@ -3,6 +3,10 @@ import { renderMarkdown } from '../render-markdown.js';
 
 const ANSI_RED = '\u001b[31m';
 const ANSI_GREEN = '\u001b[32m';
+const ANSI_DARK_RED_BACKGROUND = '\u001b[48;5;52m';
+const ANSI_DARK_GREEN_BACKGROUND = '\u001b[48;5;22m';
+const ANSI_RESET = '\u001b[0m';
+const CODE_BLOCK_INDENT = '    ';
 
 describe('renderMarkdown', () => {
   it('renders diff fenced code blocks with addition and removal colors', () => {
@@ -13,8 +17,23 @@ describe('renderMarkdown', () => {
       { color: true },
     );
 
-    expect(output).toContain(`${ANSI_RED}- const oldValue = true;`);
-    expect(output).toContain(`${ANSI_GREEN}+ const newValue = true;`);
+    expect(output).toContain(`${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}`);
+    expect(output).toContain(`${CODE_BLOCK_INDENT}- const oldValue = true;`);
+    expect(output).toContain(`${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}`);
+    expect(output).toContain(`${CODE_BLOCK_INDENT}+ const newValue = true;`);
+  });
+
+  it('pads added and removed diff rows before applying background colors', () => {
+    const codeBlockWidth = 24;
+    const removedRow = `${CODE_BLOCK_INDENT}- removed`.padEnd(codeBlockWidth);
+    const addedRow = `${CODE_BLOCK_INDENT}+ added`.padEnd(codeBlockWidth);
+    const output = renderMarkdown(['```diff', '- removed', '+ added', '```'].join('\n'), {
+      color: true,
+      codeBlockWidth,
+    });
+
+    expect(output).toContain(`${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}${removedRow}${ANSI_RESET}`);
+    expect(output).toContain(`${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}${addedRow}${ANSI_RESET}`);
   });
 
   it('keeps diff fenced code block content readable when color is disabled', () => {
@@ -28,6 +47,8 @@ describe('renderMarkdown', () => {
     expect(output).toContain(' unchanged line');
     expect(output).not.toContain(ANSI_RED);
     expect(output).not.toContain(ANSI_GREEN);
+    expect(output).not.toContain(ANSI_DARK_RED_BACKGROUND);
+    expect(output).not.toContain(ANSI_DARK_GREEN_BACKGROUND);
   });
 
   it('keeps regular fenced code blocks as code output', () => {

--- a/packages/agent-cli/src/ui/render-markdown.ts
+++ b/packages/agent-cli/src/ui/render-markdown.ts
@@ -7,12 +7,15 @@ const ANSI_RED = '\u001b[31m';
 const ANSI_GREEN = '\u001b[32m';
 const ANSI_CYAN = '\u001b[36m';
 const ANSI_DIM = '\u001b[2m';
+const ANSI_DARK_RED_BACKGROUND = '\u001b[48;5;52m';
+const ANSI_DARK_GREEN_BACKGROUND = '\u001b[48;5;22m';
 const ANSI_RESET = '\u001b[0m';
 const CODE_BLOCK_INDENT = '    ';
 const ZERO_COLOR = '0';
 
 interface IRenderMarkdownOptions {
   color?: boolean;
+  codeBlockWidth?: number;
 }
 
 interface ITerminalRendererOptions {
@@ -47,40 +50,66 @@ function isDiffLanguage(language: string | undefined): boolean {
   return language?.trim().toLowerCase() === 'diff';
 }
 
-function colorizeDiffLine(line: string, color: boolean): string {
+function styleAddedOrRemovedDiffRow(line: string, rowWidth: number, color: boolean): string {
+  const row = `${CODE_BLOCK_INDENT}${line}`.padEnd(rowWidth);
   if (!color) {
-    return line;
+    return row.trimEnd();
   }
   if (line.startsWith('+')) {
-    return `${ANSI_GREEN}${line}${ANSI_RESET}`;
+    return `${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}${row}${ANSI_RESET}`;
   }
   if (line.startsWith('-')) {
-    return `${ANSI_RED}${line}${ANSI_RESET}`;
+    return `${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}${row}${ANSI_RESET}`;
   }
-  if (line.startsWith('@@')) {
-    return `${ANSI_CYAN}${line}${ANSI_RESET}`;
-  }
-  if (line.startsWith('diff ') || line.startsWith('index ')) {
-    return `${ANSI_DIM}${line}${ANSI_RESET}`;
-  }
-  return line;
+  return row.trimEnd();
 }
 
-function renderDiffCodeBlock(code: string, color: boolean): string {
-  const body = code
-    .split('\n')
-    .map((line) => `${CODE_BLOCK_INDENT}${colorizeDiffLine(line, color)}`)
-    .join('\n');
+function colorizeDiffLine(line: string, color: boolean, rowWidth: number): string {
+  if (line.startsWith('+') || line.startsWith('-')) {
+    return styleAddedOrRemovedDiffRow(line, rowWidth, color);
+  }
+  const row = `${CODE_BLOCK_INDENT}${line}`;
+  if (!color) {
+    return row;
+  }
+  if (line.startsWith('@@')) {
+    return `${ANSI_CYAN}${row}${ANSI_RESET}`;
+  }
+  if (line.startsWith('diff ') || line.startsWith('index ')) {
+    return `${ANSI_DIM}${row}${ANSI_RESET}`;
+  }
+  return row;
+}
+
+function resolveDiffRowWidth(lines: readonly string[], requestedWidth: number | undefined): number {
+  const minimumWidth = lines.reduce(
+    (maxWidth, line) => Math.max(maxWidth, CODE_BLOCK_INDENT.length + line.length),
+    0,
+  );
+  if (requestedWidth === undefined) {
+    return minimumWidth;
+  }
+  return Math.max(minimumWidth, requestedWidth);
+}
+
+function renderDiffCodeBlock(
+  code: string,
+  color: boolean,
+  codeBlockWidth: number | undefined,
+): string {
+  const lines = code.split('\n');
+  const rowWidth = resolveDiffRowWidth(lines, codeBlockWidth);
+  const body = lines.map((line) => colorizeDiffLine(line, color, rowWidth)).join('\n');
   return `${body}\n\n`;
 }
 
-function createTerminalRenderer(color: boolean): Renderer {
+function createTerminalRenderer(color: boolean, codeBlockWidth: number | undefined): Renderer {
   const renderer = new TerminalRendererConstructor(undefined, { ignoreIllegals: true });
   const renderCode = renderer.code.bind(renderer);
 
   renderer.code = (code: string, language: string | undefined, escaped: boolean): string => {
     if (isDiffLanguage(language)) {
-      return renderDiffCodeBlock(code, color);
+      return renderDiffCodeBlock(code, color, codeBlockWidth);
     }
     return renderCode(code, language, escaped);
   };
@@ -94,7 +123,7 @@ function createTerminalRenderer(color: boolean): Renderer {
  */
 export function renderMarkdown(md: string, options: IRenderMarkdownOptions = {}): string {
   const result = marked.parse(md, {
-    renderer: createTerminalRenderer(shouldUseColor(options.color)),
+    renderer: createTerminalRenderer(shouldUseColor(options.color), options.codeBlockWidth),
   });
   return typeof result === 'string' ? result.trimEnd() : md;
 }


### PR DESCRIPTION
## Summary
- add shared Markdown `diff` rendering with red/green foreground plus dark row backgrounds
- pad added/removed diff rows before styling so backgrounds fill the rendered row
- document the shared assistant/Edit diff policy and move the backlog to completed

## Verification
- `pnpm --filter @robota-sdk/agent-cli test -- render-markdown message-list-rendering streaming-indicator`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm --filter @robota-sdk/agent-cli lint` (passes with existing warnings)
- `pnpm docs:build`
- pre-push: `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`
