### PR TITLE
feat(agent-cli): make permissions own mode changes

### DIFF
--- a/.agents/backlog/completed/cli-permissions-command-owns-mode-setting.md
+++ b/.agents/backlog/completed/cli-permissions-command-owns-mode-setting.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -78,14 +78,14 @@ Recommended `/mode` handling:
 
 ## Acceptance Criteria
 
-- [ ] `/permissions` with no args shows current permission state.
-- [ ] `/permissions <mode>` changes permission mode through SDK command common APIs.
-- [ ] `/permissions` autocomplete/subcommands list all supported permission modes.
-- [ ] `/mode` is removed from default visible command listings, or is explicitly implemented as a
+- [x] `/permissions` with no args shows current permission state.
+- [x] `/permissions <mode>` changes permission mode through SDK command common APIs.
+- [x] `/permissions` autocomplete/subcommands list all supported permission modes.
+- [x] `/mode` is removed from default visible command listings, or is explicitly implemented as a
       temporary hidden migration alias with tests.
-- [ ] Docs describe `/permissions [mode]` as the canonical permission mode command.
-- [ ] Docs no longer present `/mode` as the primary way to set permission mode.
-- [ ] Tests cover valid mode changes, invalid mode errors, no-arg state display, and `/mode`
+- [x] Docs describe `/permissions [mode]` as the canonical permission mode command.
+- [x] Docs no longer present `/mode` as the primary way to set permission mode.
+- [x] Tests cover valid mode changes, invalid mode errors, no-arg state display, and `/mode`
       retirement/alias behavior.
 
 ## Verification Plan
@@ -95,3 +95,11 @@ Recommended `/mode` handling:
 - `pnpm --filter @robota-sdk/agent-cli test -- slash command`
 - `pnpm --filter @robota-sdk/agent-command-permissions typecheck`
 - `pnpm --filter @robota-sdk/agent-cli typecheck`
+
+## Result
+
+Implemented `/permissions [mode]` as the canonical permission-mode command. `/permissions` now uses
+SDK permission common APIs for validation, subcommand metadata, state reads, formatting, and mode
+updates. The default Robota CLI composition no longer includes the legacy `/mode` module, while
+`@robota-sdk/agent-command-mode` remains available as an optional legacy command module for
+applications that explicitly compose it. Docs and headless command coverage were updated.

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -148,12 +148,11 @@ The available command list is built from composed command modules such as `agent
 | ------------------------- | --------------------------------------- |
 | `/help`                   | Show available commands                 |
 | `/clear`                  | Clear conversation history              |
-| `/mode [mode]`            | Show or change permission mode          |
 | `/model [model]`          | Show or change AI model                 |
 | `/compact [instructions]` | Compress context window                 |
 | `/cost`                   | Show session info                       |
 | `/context`                | Context window details                  |
-| `/permissions`            | Show permission rules                   |
+| `/permissions [mode]`     | Show permission rules or change mode    |
 | `/memory`                 | Inspect and manage project memory       |
 | `/rewind`                 | List and restore edit checkpoints       |
 | `/provider`               | Manage provider profiles                |
@@ -169,7 +168,7 @@ The available command list is built from composed command modules such as `agent
 | `/statusline`             | Show, hide, or reset status line fields |
 | `/reset`                  | Delete settings and exit                |
 
-`/mode` and `/model` show nested submenus for selection.
+`/permissions` and `/model` show nested submenus for selection.
 
 ### Plugin Management
 

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -180,12 +180,12 @@ Every tool call passes through a three-step permission gate:
 
 ### Changing Mode at Runtime
 
-Use the `/mode` slash command:
+Use the `/permissions` slash command:
 
 ```
-> /mode                    # Show current mode
-> /mode plan               # Switch to plan (read-only)
-> /mode bypassPermissions  # Skip all prompts
+> /permissions                    # Show current mode and session-approved tools
+> /permissions plan               # Switch to plan (read-only)
+> /permissions bypassPermissions  # Skip all prompts
 ```
 
 Or set it at startup:
@@ -272,20 +272,19 @@ When a session has a name, it appears in three places:
 | ------------------------- | ---------------------------------------------------------------------- |
 | `/help`                   | Show available commands                                                |
 | `/clear`                  | Clear conversation history                                             |
-| `/mode [mode]`            | Show or change permission mode                                         |
 | `/model [model]`          | Select AI model (confirmation prompt, CLI restarts)                    |
 | `/language [lang]`        | Set response language (ko, en, ja, zh), saves and restarts             |
 | `/compact [instructions]` | Compress context window                                                |
 | `/cost`                   | Show session info                                                      |
 | `/context`                | Context window details, reference inventory, and auto-compact controls |
 | `/agent`                  | Run and manage background subagent jobs                                |
-| `/permissions`            | Show permission rules                                                  |
+| `/permissions [mode]`     | Show permission rules or change permission mode                        |
 | `/plugin [subcommand]`    | Plugin management                                                      |
 | `/resume`                 | List recent sessions and resume one                                    |
 | `/rename <name>`          | Rename the current session                                             |
 | `/exit`                   | Exit CLI                                                               |
 
-Typing `/` triggers an autocomplete popup with arrow-key navigation and Esc to dismiss. Tab inserts the highlighted command into the input field without executing — continue typing args or press Enter to execute. Enter selects and executes immediately. Commands with subcommands (e.g., `/mode`, `/model`) show a nested submenu. Skill commands discovered from `.agents/skills/` and `.claude/commands/` appear alongside built-in commands.
+Typing `/` triggers an autocomplete popup with arrow-key navigation and Esc to dismiss. Tab inserts the highlighted command into the input field without executing — continue typing args or press Enter to execute. Enter selects and executes immediately. Commands with subcommands (e.g., `/permissions`, `/model`) show a nested submenu. Skill commands discovered from `.agents/skills/` and `.claude/commands/` appear alongside built-in commands.
 
 ## Plugin Management
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -458,14 +458,13 @@ Tool: [5 tools]
 | ------------------------- | -------------------------------------------------------------------------- |
 | `/help`                   | Show available commands                                                    |
 | `/clear`                  | Clear conversation history through the session module                      |
-| `/mode [mode]`            | Show/change permission mode                                                |
 | `/model [model]`          | Select AI model through the injected model command module                  |
 | `/language [lang]`        | Set response language (ko, en, ja, zh), saves and restarts                 |
 | `/compact [instructions]` | Compress context window                                                    |
 | `/cost`                   | Show session info through the session command module                       |
 | `/context`                | Context window info, reference inventory, and `/context auto ...` controls |
 | `/agent`                  | Run and manage background subagent jobs                                    |
-| `/permissions`            | Permission rules                                                           |
+| `/permissions [mode]`     | Permission rules and permission mode changes                               |
 | `/memory`                 | Route project memory commands to the memory command module                 |
 | `/rewind`                 | Route edit checkpoint list/restore commands to SDK                         |
 | `/background`             | Route background task controls to the background command module            |
@@ -488,10 +487,10 @@ Typing `/` as the first character in the input triggers an autocomplete popup. T
 
 **Subcommand Navigation:**
 
-Commands with subcommands (e.g., `/mode`, `/model`) show a nested submenu when selected:
+Commands with subcommands (e.g., `/permissions`, `/model`) show a nested submenu when selected:
 
 ```
-> /mode
+> /permissions
 +-------------------------------------+
 |   plan                              |
 |   default                           |
@@ -508,9 +507,7 @@ Commands are grouped by source with separators: built-in commands appear first, 
 
 The `/model` command is provided by the `@robota-sdk/agent-command-model` module that the Robota binary composes into `InteractiveSession`. The command lists available models for the effective active provider when provider-owned catalog metadata is available. Model definitions come through the SDK model command common API and injected provider definitions; the CLI/TUI must not show Claude-only subcommands while another provider is active.
 
-The `/mode` command is provided by the `@robota-sdk/agent-command-mode` module that the Robota binary composes into `InteractiveSession`. The CLI slash router does not mutate permission mode directly; it routes `/mode` into the generic command execution path, and the command module uses SDK permission-mode common APIs.
-
-The `/permissions` command is provided by the `@robota-sdk/agent-command-permissions` module that the Robota binary composes into `InteractiveSession`. The CLI slash router does not inspect permission state directly; it routes `/permissions` into the generic command execution path, and the command module uses SDK permission common APIs.
+The `/permissions` command is provided by the `@robota-sdk/agent-command-permissions` module that the Robota binary composes into `InteractiveSession`. The CLI slash router does not inspect or mutate permission state directly; it routes `/permissions [mode]` into the generic command execution path, and the command module uses SDK permission common APIs. The default Robota CLI does not compose `/mode`; permission-mode changes belong under `/permissions`.
 
 The `/language` command is provided by the `@robota-sdk/agent-command-language` module that the Robota binary composes into `InteractiveSession`. The command module emits `language-change-requested`; the CLI applies settings persistence and restart through the generic command effect handler.
 
@@ -1359,9 +1356,8 @@ Tool messages use the `isToolMessage(msg)` type guard for safe access to `msg.na
 | `@robota-sdk/agent-command-exit`        | Default `/exit` command module composed by the Robota binary                                                                         |
 | `@robota-sdk/agent-command-help`        | Default `/help` command module composed by the Robota binary                                                                         |
 | `@robota-sdk/agent-command-language`    | Default `/language` command module composed by the Robota binary                                                                     |
-| `@robota-sdk/agent-command-mode`        | Default `/mode` command module composed by the Robota binary                                                                         |
 | `@robota-sdk/agent-command-model`       | Default `/model` command module composed by the Robota binary                                                                        |
-| `@robota-sdk/agent-command-permissions` | Default `/permissions` command module composed by the Robota binary                                                                  |
+| `@robota-sdk/agent-command-permissions` | Default `/permissions [mode]` command module composed by the Robota binary                                                           |
 | `@robota-sdk/agent-command-provider`    | Default `/provider` command module composed by the Robota binary                                                                     |
 | `@robota-sdk/agent-command-rewind`      | Default `/rewind` command module composed by the Robota binary                                                                       |
 | `@robota-sdk/agent-command-session`     | Default session command module composed by the Robota binary, currently owning `/clear`, `/rename`, `/resume`, and `/cost`           |

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -58,7 +58,6 @@
     "@robota-sdk/agent-command-help": "workspace:*",
     "@robota-sdk/agent-command-language": "workspace:*",
     "@robota-sdk/agent-command-memory": "workspace:*",
-    "@robota-sdk/agent-command-mode": "workspace:*",
     "@robota-sdk/agent-command-model": "workspace:*",
     "@robota-sdk/agent-command-permissions": "workspace:*",
     "@robota-sdk/agent-command-plugin": "workspace:*",

--- a/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type {
+  IAIProvider,
+  IChatOptions,
+  IProviderRequest,
+  IRawProviderResponse,
+  TUniversalMessage,
+} from '@robota-sdk/agent-core';
+import { CommandRegistry, InteractiveSession } from '@robota-sdk/agent-sdk';
+import { createHeadlessTransport } from '@robota-sdk/agent-transport-headless';
+import { createDefaultCliCommandModules } from '../cli.js';
+
+function createFakeProvider(): IAIProvider {
+  return {
+    name: 'fake',
+    version: 'test',
+    async chat(
+      _messages: TUniversalMessage[],
+      _options?: IChatOptions,
+    ): Promise<TUniversalMessage> {
+      return {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'unused',
+        timestamp: new Date(),
+        state: 'complete',
+      };
+    },
+    async generateResponse(_payload: IProviderRequest): Promise<IRawProviderResponse> {
+      return { content: 'unused' };
+    },
+    supportsTools: () => false,
+    validateConfig: () => true,
+  };
+}
+
+function parseJsonObject(output: string): Record<string, unknown> {
+  const parsed = JSON.parse(output) as unknown;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Expected JSON object output');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+describe('default CLI command composition', () => {
+  it('exposes permissions mode subcommands without composing legacy mode', () => {
+    const registry = new CommandRegistry();
+
+    for (const module of createDefaultCliCommandModules({
+      cwd: '/workspace',
+      providerDefinitions: [],
+    })) {
+      registry.addModule(module);
+    }
+
+    expect(registry.getCommands().map((command) => command.name)).not.toContain('mode');
+    expect(registry.getSubcommands('permissions').map((command) => command.name)).toEqual([
+      'plan',
+      'default',
+      'acceptEdits',
+      'bypassPermissions',
+    ]);
+  });
+
+  it('runs permissions mode changes through headless slash-command execution', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-headless-permissions-'));
+    const session = new InteractiveSession({
+      cwd,
+      provider: createFakeProvider(),
+      config: {
+        defaultTrustLevel: 'moderate',
+        language: 'en',
+        provider: {
+          name: 'fake',
+          model: 'fake-model',
+          apiKey: 'test-key',
+        },
+        permissions: { allow: [], deny: [] },
+        env: {},
+      },
+      bare: true,
+      permissionMode: 'default',
+      commandModules: createDefaultCliCommandModules({
+        cwd,
+        providerDefinitions: [],
+      }),
+    });
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const transport = createHeadlessTransport({
+        outputFormat: 'json',
+        prompt: '/permissions plan',
+      });
+
+      session.attachTransport(transport);
+      await transport.start();
+
+      expect(transport.getExitCode()).toBe(0);
+      expect(session.getSession().getPermissionMode()).toBe('plan');
+      expect(parseJsonObject(writes.join('').trim())).toMatchObject({
+        type: 'result',
+        result: 'Permission mode set to: plan\nPermission mode: plan\nNo session-approved tools.',
+        subtype: 'success',
+      });
+    } finally {
+      process.stdout.write = originalWrite;
+      await session.shutdown({ reason: 'prompt_input_exit' });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -18,7 +18,6 @@ import { createExitCommandModule } from '@robota-sdk/agent-command-exit';
 import { createHelpCommandModule } from '@robota-sdk/agent-command-help';
 import { createLanguageCommandModule } from '@robota-sdk/agent-command-language';
 import { createMemoryCommandModule } from '@robota-sdk/agent-command-memory';
-import { createModeCommandModule } from '@robota-sdk/agent-command-mode';
 import { createModelCommandModule } from '@robota-sdk/agent-command-model';
 import { createPermissionsCommandModule } from '@robota-sdk/agent-command-permissions';
 import { createPluginCommandModule } from '@robota-sdk/agent-command-plugin';
@@ -158,6 +157,50 @@ export interface IStartCliOptions {
   providerDefinitions?: readonly IProviderDefinition[];
 }
 
+export interface ICreateDefaultCliCommandModulesOptions {
+  cwd: string;
+  providerDefinitions: readonly IProviderDefinition[];
+}
+
+export function createDefaultCliCommandModules({
+  cwd,
+  providerDefinitions,
+}: ICreateDefaultCliCommandModulesOptions): readonly ICommandModule[] {
+  return [
+    createSkillsCommandModule({ cwd }),
+    createHelpCommandModule(),
+    createAgentCommandModule(),
+    createModelCommandModule({
+      providerDefinitions,
+      settings: {
+        readMergedSettings: () => readMergedProviderSettings(cwd),
+      },
+    }),
+    createPermissionsCommandModule(),
+    createLanguageCommandModule(),
+    createBackgroundCommandModule(),
+    createMemoryCommandModule(),
+    createCompactCommandModule(),
+    createContextCommandModule(),
+    createExitCommandModule(),
+    createSessionCommandModule(),
+    createResetCommandModule(),
+    createRewindCommandModule(),
+    createStatusLineCommandModule(),
+    createPluginCommandModule(),
+    createProviderCommandModule({
+      providerDefinitions,
+      settings: {
+        readMergedSettings: () => readMergedProviderSettings(cwd),
+        readTargetSettings: () =>
+          readSettings(resolveProviderSettingsWriteTargetPath(cwd)) as TProviderSettingsDocument,
+        writeTargetSettings: (settings) =>
+          writeSettings(resolveProviderSettingsWriteTargetPath(cwd), settings),
+      },
+    }),
+  ];
+}
+
 export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const args = parseCliArgs();
   const version = readVersion();
@@ -193,38 +236,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   };
   const providerDefinitions = options.providerDefinitions ?? DEFAULT_PROVIDER_DEFINITIONS;
   const commandModules: readonly ICommandModule[] = [
-    createSkillsCommandModule({ cwd }),
-    createHelpCommandModule(),
-    createAgentCommandModule(),
-    createModelCommandModule({
-      providerDefinitions,
-      settings: {
-        readMergedSettings: () => readMergedProviderSettings(cwd),
-      },
-    }),
-    createModeCommandModule(),
-    createPermissionsCommandModule(),
-    createLanguageCommandModule(),
-    createBackgroundCommandModule(),
-    createMemoryCommandModule(),
-    createCompactCommandModule(),
-    createContextCommandModule(),
-    createExitCommandModule(),
-    createSessionCommandModule(),
-    createResetCommandModule(),
-    createRewindCommandModule(),
-    createStatusLineCommandModule(),
-    createPluginCommandModule(),
-    createProviderCommandModule({
-      providerDefinitions,
-      settings: {
-        readMergedSettings: () => readMergedProviderSettings(cwd),
-        readTargetSettings: () =>
-          readSettings(resolveProviderSettingsWriteTargetPath(cwd)) as TProviderSettingsDocument,
-        writeTargetSettings: (settings) =>
-          writeSettings(resolveProviderSettingsWriteTargetPath(cwd), settings),
-      },
-    }),
+    ...createDefaultCliCommandModules({ cwd, providerDefinitions }),
     ...(options.commandModules ?? []),
   ];
   const startupUpdateNoticePromise = shouldRunStartupCliUpdateCheck(args)

--- a/packages/agent-command-mode/README.md
+++ b/packages/agent-command-mode/README.md
@@ -1,3 +1,4 @@
 # @robota-sdk/agent-command-mode
 
-Composable `/mode` command module for Robota sessions.
+Optional legacy `/mode` command module for Robota sessions. Product CLIs should prefer the
+canonical `/permissions [mode]` command.

--- a/packages/agent-command-mode/docs/SPEC.md
+++ b/packages/agent-command-mode/docs/SPEC.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Own the user-visible `/mode` command as a composable command module. The package supplies command metadata and execution together, while consuming SDK command common APIs as an external module.
+Own the legacy `/mode` command as an optional composable command module. The package supplies command metadata and execution together, while consuming SDK command common APIs as an external module. The default Robota CLI composition does not include this module; `/permissions` is the canonical permission-mode command.
 
 ## Ownership
 
-- Owns `/mode` descriptor metadata, permission-mode subcommands, validation, and execution.
+- Owns optional `/mode` descriptor metadata, permission-mode subcommands, validation, and execution.
 - Does not own permission storage, TUI rendering, or direct session internals.
 - Uses `@robota-sdk/agent-sdk` command contracts and permission mode common APIs.
 
@@ -24,7 +24,8 @@ Own the user-visible `/mode` command as a composable command module. The package
 - `/mode` with no argument reports the current permission mode.
 - `/mode plan`, `/mode default`, `/mode acceptEdits`, and `/mode bypassPermissions` update the permission mode.
 - Invalid arguments fail with the SDK common valid-mode list.
-- The command is user-invocable and not model-invocable.
+- The command is user-invocable and not model-invocable when an application explicitly composes the module.
+- Product CLIs should prefer `/permissions [mode]` and avoid composing `/mode` as a visible default command.
 
 ## Dependency Rules
 

--- a/packages/agent-command-mode/package.json
+++ b/packages/agent-command-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robota-sdk/agent-command-mode",
   "version": "3.0.0-beta.60",
-  "description": "Composable /mode command module for Robota sessions",
+  "description": "Optional legacy /mode command module for Robota sessions",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",

--- a/packages/agent-command-permissions/README.md
+++ b/packages/agent-command-permissions/README.md
@@ -1,3 +1,4 @@
 # @robota-sdk/agent-command-permissions
 
-Composable `/permissions` command module for Robota sessions.
+Composable `/permissions` command module for Robota sessions. It shows permission state and owns
+permission-mode changes such as `/permissions plan`.

--- a/packages/agent-command-permissions/docs/SPEC.md
+++ b/packages/agent-command-permissions/docs/SPEC.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Own the user-visible `/permissions` command as a composable command module. The package supplies command metadata and execution together, while consuming SDK permission command common APIs as an external module.
+Own the user-visible `/permissions` command as a composable command module. The package supplies command metadata and execution together, while consuming SDK permission command common APIs as an external module. `/permissions` is the canonical command for viewing permission state and changing permission mode.
 
 ## Ownership
 
-- Owns `/permissions` descriptor metadata and read-only execution.
+- Owns `/permissions` descriptor metadata, permission-mode subcommands, validation, and execution.
 - Does not own permission storage, permission prompts, TUI rendering, or direct session internals.
 - Uses `@robota-sdk/agent-sdk` command contracts and permission command common APIs.
 
@@ -22,6 +22,8 @@ Own the user-visible `/permissions` command as a composable command module. The 
 ## Behavior
 
 - `/permissions` reports the current permission mode.
+- `/permissions plan`, `/permissions default`, `/permissions acceptEdits`, and `/permissions bypassPermissions` update the permission mode.
+- Invalid arguments fail with the SDK common valid-mode list.
 - `/permissions` reports session-approved tools when present.
 - `/permissions` reports that there are no session-approved tools when the session allowlist is empty.
 - The command is user-invocable and not model-invocable.
@@ -30,10 +32,13 @@ Own the user-visible `/permissions` command as a composable command module. The 
 
 - May import `@robota-sdk/agent-sdk`.
 - Must not import `@robota-sdk/agent-cli`.
-- Must not duplicate permission-state formatting owned by the SDK command API.
+- Must not duplicate permission-state formatting or permission-mode constants owned by the SDK command API.
 
 ## Test Plan
 
 - Module metadata and user-only descriptor policy.
+- Descriptor subcommands.
 - Empty session-approved tool list.
 - Non-empty session-approved tool list.
+- Valid mode updates.
+- Invalid mode rejection.

--- a/packages/agent-command-permissions/package.json
+++ b/packages/agent-command-permissions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robota-sdk/agent-command-permissions",
   "version": "3.0.0-beta.60",
-  "description": "Composable /permissions command module for Robota sessions",
+  "description": "Composable /permissions command module for permission state and mode changes",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",

--- a/packages/agent-command-permissions/src/__tests__/permissions-command-module.test.ts
+++ b/packages/agent-command-permissions/src/__tests__/permissions-command-module.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ICommandHostContext, IEditCheckpointRestoreResult } from '@robota-sdk/agent-sdk';
 import { SystemCommandExecutor } from '@robota-sdk/agent-sdk';
 import { createPermissionsCommandModule } from '../permissions-command-module.js';
 
 type TPermissionModeName = 'plan' | 'default' | 'acceptEdits' | 'bypassPermissions';
+type TSetPermissionModeSpy = ReturnType<typeof vi.fn<[nextMode: TPermissionModeName], void>>;
 
 function createCheckpointResult(): IEditCheckpointRestoreResult {
   return {
@@ -24,15 +25,20 @@ function createCheckpointResult(): IEditCheckpointRestoreResult {
 function createCommandHostContext(options?: {
   mode?: TPermissionModeName;
   sessionAllowed?: readonly string[];
-}): ICommandHostContext {
+}): ICommandHostContext & { setPermissionMode: TSetPermissionModeSpy } {
+  let mode = options?.mode ?? 'default';
+  const setPermissionMode = vi.fn((nextMode: TPermissionModeName) => {
+    mode = nextMode;
+  });
+
   return {
     getSession: () => {
       throw new Error('permissions command should use the permission mode adapter');
     },
     getCommandHostAdapters: () => ({
       permissionMode: {
-        getPermissionMode: () => options?.mode ?? 'default',
-        setPermissionMode: () => undefined,
+        getPermissionMode: () => mode,
+        setPermissionMode,
         listSessionAllowedTools: () => options?.sessionAllowed ?? [],
       },
     }),
@@ -54,6 +60,7 @@ function createCommandHostContext(options?: {
     readBackgroundTaskLog: async () => ({ taskId: 'task_1', lines: [] }),
     cancelBackgroundTask: async () => undefined,
     closeBackgroundTask: async () => undefined,
+    setPermissionMode,
   };
 }
 
@@ -67,19 +74,28 @@ describe('createPermissionsCommandModule', () => {
     expect(entry).toEqual(
       expect.objectContaining({
         name: 'permissions',
-        description: 'Show permission rules',
+        description: 'Show/change permission mode and permission rules',
+        argumentHint: 'plan | default | acceptEdits | bypassPermissions',
         source: 'permissions',
         modelInvocable: false,
       }),
     );
+    expect(entry?.subcommands?.map((subcommand) => subcommand.name)).toEqual([
+      'plan',
+      'default',
+      'acceptEdits',
+      'bypassPermissions',
+    ]);
     expect(command).toEqual(
       expect.objectContaining({
         name: 'permissions',
-        description: 'Show permission rules',
+        description: 'Show/change permission mode and permission rules',
+        argumentHint: 'plan | default | acceptEdits | bypassPermissions',
         lifecycle: 'inline',
         modelInvocable: false,
       }),
     );
+    expect(command?.subcommands).toEqual(entry?.subcommands);
   });
 
   it('reports no session-approved tools when the command allowlist is empty', async () => {
@@ -110,5 +126,36 @@ describe('createPermissionsCommandModule', () => {
       'Permission mode: acceptEdits\nSession-approved tools: Bash, Read',
     );
     expect(result?.data).toEqual({ mode: 'acceptEdits', sessionAllowed: ['Bash', 'Read'] });
+  });
+
+  it('updates valid permission modes through the SDK command adapter', async () => {
+    const executor = new SystemCommandExecutor([
+      ...(createPermissionsCommandModule().systemCommands ?? []),
+    ]);
+    const context = createCommandHostContext();
+
+    const result = await executor.execute('permissions', context, 'plan');
+
+    expect(result?.success).toBe(true);
+    expect(result?.message).toBe(
+      'Permission mode set to: plan\nPermission mode: plan\nNo session-approved tools.',
+    );
+    expect(result?.data).toEqual({ mode: 'plan', sessionAllowed: [] });
+    expect(context.setPermissionMode).toHaveBeenCalledWith('plan');
+  });
+
+  it('rejects invalid permission modes without writing state', async () => {
+    const executor = new SystemCommandExecutor([
+      ...(createPermissionsCommandModule().systemCommands ?? []),
+    ]);
+    const context = createCommandHostContext();
+
+    const result = await executor.execute('permissions', context, 'invalid');
+
+    expect(result?.success).toBe(false);
+    expect(result?.message).toBe(
+      'Invalid mode. Valid: plan | default | acceptEdits | bypassPermissions',
+    );
+    expect(context.setPermissionMode).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-command-permissions/src/permissions-command-module.ts
+++ b/packages/agent-command-permissions/src/permissions-command-module.ts
@@ -4,7 +4,11 @@ import type {
   ICommandSource,
   ISystemCommand,
 } from '@robota-sdk/agent-sdk';
-import { PERMISSIONS_COMMAND_DESCRIPTION } from '@robota-sdk/agent-sdk';
+import {
+  buildPermissionModeSubcommands,
+  PERMISSION_MODE_ARGUMENT_HINT,
+  PERMISSIONS_COMMAND_DESCRIPTION,
+} from '@robota-sdk/agent-sdk';
 import { executePermissionsCommand } from './permissions-command.js';
 
 export function createPermissionsCommandEntry(): ICommand {
@@ -12,6 +16,8 @@ export function createPermissionsCommandEntry(): ICommand {
     name: 'permissions',
     description: PERMISSIONS_COMMAND_DESCRIPTION,
     source: 'permissions',
+    argumentHint: PERMISSION_MODE_ARGUMENT_HINT,
+    subcommands: buildPermissionModeSubcommands('permissions'),
     modelInvocable: false,
   };
 }
@@ -23,6 +29,8 @@ function createPermissionsSystemCommand(): ISystemCommand {
     description: entry.description,
     userInvocable: true,
     modelInvocable: false,
+    argumentHint: entry.argumentHint,
+    subcommands: entry.subcommands,
     lifecycle: 'inline',
     execute: executePermissionsCommand,
   };

--- a/packages/agent-command-permissions/src/permissions-command.ts
+++ b/packages/agent-command-permissions/src/permissions-command.ts
@@ -1,13 +1,38 @@
 import type { ICommandHostContext, ICommandResult } from '@robota-sdk/agent-sdk';
 import {
   formatCommandPermissionsMessage,
+  formatInvalidPermissionModeMessage,
+  isPermissionMode,
+  parsePermissionModeArgument,
   readCommandPermissionsState,
+  writeCommandPermissionMode,
 } from '@robota-sdk/agent-sdk';
 
 export function executePermissionsCommand(
   context: ICommandHostContext,
-  _args: string,
+  args: string,
 ): ICommandResult {
+  const arg = parsePermissionModeArgument(args);
+  if (arg !== undefined) {
+    if (!isPermissionMode(arg)) {
+      return {
+        message: formatInvalidPermissionModeMessage(),
+        success: false,
+      };
+    }
+
+    writeCommandPermissionMode(context, arg);
+    const state = readCommandPermissionsState(context);
+    return {
+      message: `Permission mode set to: ${arg}\n${formatCommandPermissionsMessage(state)}`,
+      success: true,
+      data: {
+        mode: state.mode,
+        sessionAllowed: state.sessionAllowed,
+      },
+    };
+  }
+
   const state = readCommandPermissionsState(context);
   return {
     message: formatCommandPermissionsMessage(state),

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -207,7 +207,7 @@ executor.register({
 
 // List all commands
 executor.listCommands(); // ISystemCommand[]
-executor.hasCommand('mode'); // boolean
+executor.hasCommand('permissions'); // boolean
 ```
 
 SDK core does not own user-visible built-in commands. Product built-ins are supplied as `agent-command-*` modules. SDK command identity is slash-free (`skills`, `help`, `compact`); UI shells render and parse those commands as slash syntax such as `/skills`, `/help`, and `/compact`.
@@ -216,6 +216,10 @@ Command modules may use SDK common APIs for shared provider-neutral behavior. Fo
 resolves the active provider from settings, reads provider-owned fallback metadata from injected
 `IProviderDefinition` records, and can invoke provider-owned catalog refresh hooks. The CLI/TUI must
 only render command results and must not own provider model lists.
+
+For `/permissions`, the SDK owns permission-mode constants, subcommand descriptors, validation,
+state formatting, and command-host adapter access. The command module owns user-visible behavior and
+keeps permission-mode changes under `/permissions [mode]`.
 
 For `/validate-session`, the session command module calls SDK session command APIs to locate and
 validate the current JSONL session log. Hosts may override `validateCurrentSessionReplayLog()` in

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -305,7 +305,7 @@ agent-cli (Ink TUI — CLI-specific)
 - **Memory common APIs**: `agent-sdk/command-api/memory/` owns memory-command metadata constants, subcommand projection helpers, project/pending memory store facades, sensitive-content checks, used-memory reference reads, and memory-event recording helpers. `memory` command behavior lives in `@robota-sdk/agent-command-memory` and consumes these APIs as an external command module.
 - **Background common APIs**: `agent-sdk/command-api/background/` owns background-command metadata constants, subcommand projection helpers, task-list/log formatting helpers, and list/read/cancel/close facades over `ICommandHostContext`. `background` command behavior lives in `@robota-sdk/agent-command-background` and consumes these APIs as an external command module.
 - **Help common APIs**: `agent-sdk/command-api/help/` owns help-command metadata constants and generic command-list formatting. `help` command behavior lives in `@robota-sdk/agent-command-help` and consumes this API as an external command module.
-- **Permission common APIs**: `agent-sdk/command-api/permissions/` owns permission-mode constants, descriptor subcommands, validation, permission-state reads, permission-state formatting, and command-facing adapter resolution. `mode` command behavior lives in `@robota-sdk/agent-command-mode`; `permissions` command behavior lives in `@robota-sdk/agent-command-permissions`. Both consume these APIs as external command modules.
+- **Permission common APIs**: `agent-sdk/command-api/permissions/` owns permission-mode constants, descriptor subcommands, validation, permission-state reads, permission-state formatting, and command-facing adapter resolution. Canonical permission command behavior lives in `@robota-sdk/agent-command-permissions`, which owns `/permissions [mode]`. Legacy `/mode` behavior lives in `@robota-sdk/agent-command-mode` only for applications that explicitly compose that optional module. Both consume these APIs as external command modules.
 - **Statusline common APIs**: `agent-sdk/command-api/statusline/` owns statusline command metadata constants, subcommand projection helpers, default settings shape, typed settings patch contracts, and patch validation. `statusline` command behavior lives in `@robota-sdk/agent-command-statusline` and emits typed host-applied effects instead of importing CLI settings utilities.
 - **Plugin common APIs**: `agent-sdk/command-api/plugin/` owns plugin command metadata constants, subcommand projection helpers, `ICommandPluginAdapter`, reload result contracts, and plugin host effect factories. `plugin` and `reload-plugins` command behavior lives in `@robota-sdk/agent-command-plugin` and consumes these APIs as an external command module while hosts keep concrete plugin storage/UI wiring.
 - **Session common APIs**: `agent-sdk/command-api/session/` owns command-facing session-history helpers, session-name parsing, session-info reads, and effect factories for host-rendered history/name/picker/exit state. `clear`, `rename`, `resume`, and `cost` command behavior lives in `@robota-sdk/agent-command-session`; `exit` command behavior lives in `@robota-sdk/agent-command-exit`. Both consume these APIs as external command modules.
@@ -331,8 +331,8 @@ agent-cli (Ink TUI — CLI-specific)
 - **Product-composed built-in command modules**: `skills` is provided by `@robota-sdk/agent-command-skills`. It is user- and model-invocable, lists registered skill metadata, and activates a skill through `ICommandHostContext.executeSkillCommandByName()`. Model-side activation uses the standard `ExecuteCommand` route with `command: "skills"` and skill arguments in `args`.
 - **Product-composed built-in command modules**: `help` is provided by `@robota-sdk/agent-command-help` and renders the composed command list through SDK help common APIs.
 - **Product-composed built-in command modules**: `model` is provided by `@robota-sdk/agent-command-model`, reuses SDK model-command common APIs for subcommand metadata, and emits `model-change-requested` effects for host application.
-- **Product-composed built-in command modules**: `mode` is provided by `@robota-sdk/agent-command-mode`, reuses SDK permission-mode common APIs for validation/subcommand metadata, and updates permission mode through the command host adapter facade.
-- **Product-composed built-in command modules**: `permissions` is provided by `@robota-sdk/agent-command-permissions`, reuses SDK permission common APIs for state reads/formatting, and stays user-invocable only.
+- **Product-composed built-in command modules**: `permissions` is provided by `@robota-sdk/agent-command-permissions`, reuses SDK permission common APIs for validation/subcommand metadata, state reads/formatting, and permission-mode updates through the command host adapter facade, and stays user-invocable only.
+- **Optional legacy command modules**: `mode` is provided by `@robota-sdk/agent-command-mode` only when an application explicitly composes that module. Product CLIs should prefer the canonical `permissions` command for permission-mode changes.
 - **Product-composed built-in command modules**: `language` is provided by `@robota-sdk/agent-command-language`, reuses SDK language command common APIs for usage/subcommand metadata, and emits `language-change-requested` effects for host application.
 - **Product-composed built-in command modules**: `statusline` is provided by `@robota-sdk/agent-command-statusline`, reuses SDK statusline common APIs for subcommand metadata and typed patch effects, and leaves status bar rendering/settings persistence to the host.
 - **Product-composed built-in command modules**: `clear`, `rename`, `resume`, and `cost` are provided by `@robota-sdk/agent-command-session`. `clear` reuses SDK session command common APIs to clear SDK session history and emits `conversation-history-cleared` so hosts clear rendered history through their own UI state. `rename` reuses SDK session command common APIs to normalize the requested name and emits `session-renamed` so hosts update title/status/persistence through their own adapters. `resume` emits `session-picker-requested` so hosts display saved-session picker UI through their own adapters. `cost` reads session id and message count through SDK session command common APIs.
@@ -846,23 +846,22 @@ const result: ICommandResult | null = await session.executeCommand('context', ''
 
 **Product-composed command modules:**
 
-| Command       | Description                                                                  |
-| ------------- | ---------------------------------------------------------------------------- |
-| `help`        | Command module for rendering registered commands                             |
-| `clear`       | Optional command module for clearing conversation and rendered host history  |
-| `compact`     | Compress context window (optional focus instructions)                        |
-| `mode [m]`    | Show or change permission mode                                               |
-| `language`    | Request response language update through `language-change-requested` effect  |
-| `cost`        | Optional session command module for session ID and message count             |
-| `context`     | Token usage: used / max / percentage                                         |
-| `permissions` | Current mode and session-approved tools                                      |
-| `statusline`  | Optional command module for statusline visibility and git branch patch flows |
-| `memory`      | List/show/add/review project memory and report used memory references        |
-| `rewind`      | List edit checkpoints, restore later edits, or rollback through a checkpoint |
-| `reset`       | Requests settings reset through `settings-reset-requested` effect            |
-| `resume`      | Optional command module for requesting session picker through effect         |
-| `rename`      | Optional command module for requesting session rename through effect         |
-| `provider`    | Optional command module for provider current/list/use/add/test flows         |
+| Command              | Description                                                                  |
+| -------------------- | ---------------------------------------------------------------------------- |
+| `help`               | Command module for rendering registered commands                             |
+| `clear`              | Optional command module for clearing conversation and rendered host history  |
+| `compact`            | Compress context window (optional focus instructions)                        |
+| `language`           | Request response language update through `language-change-requested` effect  |
+| `cost`               | Optional session command module for session ID and message count             |
+| `context`            | Token usage: used / max / percentage                                         |
+| `permissions [mode]` | Current mode, session-approved tools, and permission mode changes            |
+| `statusline`         | Optional command module for statusline visibility and git branch patch flows |
+| `memory`             | List/show/add/review project memory and report used memory references        |
+| `rewind`             | List edit checkpoints, restore later edits, or rollback through a checkpoint |
+| `reset`              | Requests settings reset through `settings-reset-requested` effect            |
+| `resume`             | Optional command module for requesting session picker through effect         |
+| `rename`             | Optional command module for requesting session rename through effect         |
+| `provider`           | Optional command module for provider current/list/use/add/test flows         |
 
 **ISystemCommand:**
 

--- a/packages/agent-sdk/src/command-api/permissions/permission-mode-command-api.ts
+++ b/packages/agent-sdk/src/command-api/permissions/permission-mode-command-api.ts
@@ -5,7 +5,7 @@ import type { ICommandPermissionModeAdapter } from '../host-adapters.js';
 
 export const PERMISSION_MODE_COMMAND_DESCRIPTION = 'Show/change permission mode';
 export const PERMISSION_MODE_ARGUMENT_HINT = 'plan | default | acceptEdits | bypassPermissions';
-export const PERMISSIONS_COMMAND_DESCRIPTION = 'Show permission rules';
+export const PERMISSIONS_COMMAND_DESCRIPTION = 'Show/change permission mode and permission rules';
 
 export interface IPermissionsCommandState {
   readonly mode: TPermissionMode;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,9 +585,6 @@ importers:
       '@robota-sdk/agent-command-memory':
         specifier: workspace:*
         version: link:../agent-command-memory
-      '@robota-sdk/agent-command-mode':
-        specifier: workspace:*
-        version: link:../agent-command-mode
       '@robota-sdk/agent-command-model':
         specifier: workspace:*
         version: link:../agent-command-model


### PR DESCRIPTION
## Summary
- make `/permissions [mode]` the canonical permission mode command
- remove legacy `/mode` from default Robota CLI composition and package dependency
- keep `agent-command-mode` as an optional legacy module for explicit external composition
- add command module tests and headless slash-command verification

## Verification
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-command-permissions build`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm --filter @robota-sdk/agent-command-permissions test`
- `pnpm --filter @robota-sdk/agent-command-mode test`
- `pnpm --filter @robota-sdk/agent-sdk test -- command-api`
- `pnpm --filter @robota-sdk/agent-cli test -- cli-command-composition slash-routing-effects`
- `pnpm --filter @robota-sdk/agent-command-permissions typecheck`
- `pnpm --filter @robota-sdk/agent-command-mode typecheck`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-command-permissions lint`
- `pnpm --filter @robota-sdk/agent-command-mode lint`
- `pnpm --filter @robota-sdk/agent-sdk lint` (passes with existing warnings)
- `pnpm --filter @robota-sdk/agent-cli lint` (passes with existing warnings)
- `pnpm docs:build`
- pre-push: `pnpm harness:verify -- --base-ref origin/develop --skip-record-check`