### PR TITLE
fix(agent-cli): improve diff foreground contrast

### DIFF
--- a/.agents/backlog/completed/cli-diff-foreground-contrast.md
+++ b/.agents/backlog/completed/cli-diff-foreground-contrast.md
@@ -1,0 +1,67 @@
+# CLI Diff Foreground Contrast
+
+## Status
+
+Completed.
+
+## Priority
+
+P1 - markdown diff readability affects code review and edit approval in the TUI.
+
+## Problem
+
+The CLI recently added full-row background colors for fenced `diff` markdown blocks. The row-fill
+behavior was correct, but the foreground colors had weak contrast against the added/removed line
+backgrounds in some terminals.
+
+Current added/removed rows combined dark backgrounds with standard ANSI red/green foregrounds. On
+terminals with muted palettes, `31` red on dark red and `32` green on dark green could make changed
+content harder to read than the previous foreground-only rendering.
+
+## Research
+
+- W3C WCAG contrast guidance treats foreground/background contrast as the readable signal for text,
+  not just hue. It recommends at least 4.5:1 contrast for normal text and 3:1 for larger text.
+- Robota already uses 256-color ANSI background escapes for diff rows, so using 256-color light
+  foreground escapes keeps the policy deterministic instead of depending on terminal-specific
+  standard ANSI red/green palettes.
+
+Sources:
+
+- <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum>
+
+## Recommended Direction
+
+Keep the full-row background behavior, but increase foreground contrast for changed diff rows.
+
+Implemented color policy:
+
+- removed rows: dark red background plus light red foreground
+- added rows: dark green background plus light green foreground
+- hunk headers and metadata remain unchanged
+- color-disabled rendering remains plain text with no ANSI escape sequences
+
+## Acceptance Criteria
+
+- [x] Added diff rows use a higher-contrast foreground color over the existing green background.
+- [x] Removed diff rows use a higher-contrast foreground color over the existing red background.
+- [x] Added/removed backgrounds still cover the full rendered row including indentation and
+      right-side padding.
+- [x] Color-disabled diff rendering remains unchanged and contains no ANSI color sequences.
+- [x] Assistant markdown diffs and Edit tool diff summaries use the same updated contrast policy.
+- [x] Tests assert the new contrast color constants and preserve row-fill coverage.
+- [x] CLI SPEC documents the higher-contrast foreground policy.
+
+## Result
+
+`render-markdown.ts` now uses 256-color light red/light green foreground escapes for changed diff
+rows while preserving the existing dark red/dark green full-row backgrounds. The markdown renderer
+test coverage and CLI SPEC were updated to match the shared policy used by assistant markdown diffs
+and edit tool summaries.
+
+## Verification Plan
+
+- `pnpm --filter @robota-sdk/agent-cli test -- render-markdown`
+- `pnpm --filter @robota-sdk/agent-cli test -- message-list-rendering streaming-indicator`
+- `pnpm --filter @robota-sdk/agent-cli typecheck`
+- `pnpm --filter @robota-sdk/agent-cli lint`

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -990,7 +990,7 @@ Assistant responses are rendered as Markdown through `render-markdown.ts`. A fen
 **Rules:**
 
 - `render-markdown.ts` owns assistant Markdown diff rendering.
-- `diff` fenced blocks receive line-level terminal colors: removed lines use red foreground plus dark red background, added lines use green foreground plus dark green background, hunk headers use cyan foreground, and diff metadata is dim.
+- `diff` fenced blocks receive line-level terminal colors: removed lines use high-contrast light red foreground plus dark red background, added lines use high-contrast light green foreground plus dark green background, hunk headers use cyan foreground, and diff metadata is dim.
 - Added and removed `diff` rows are padded before ANSI styling so the background covers the full rendered row. The renderer uses an explicit code block width when supplied and otherwise falls back to the widest diff row.
 - Color is controlled by renderer options and terminal color environment. With color disabled, the same diff text remains readable without ANSI escape codes.
 - General fenced code blocks continue through `marked-terminal`; only `diff` fenced blocks take the Robota line-level path.

--- a/packages/agent-cli/src/ui/__tests__/render-markdown.test.ts
+++ b/packages/agent-cli/src/ui/__tests__/render-markdown.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { renderMarkdown } from '../render-markdown.js';
 
-const ANSI_RED = '\u001b[31m';
-const ANSI_GREEN = '\u001b[32m';
+const ANSI_LIGHT_RED = '\u001b[38;5;210m';
+const ANSI_LIGHT_GREEN = '\u001b[38;5;120m';
 const ANSI_DARK_RED_BACKGROUND = '\u001b[48;5;52m';
 const ANSI_DARK_GREEN_BACKGROUND = '\u001b[48;5;22m';
 const ANSI_RESET = '\u001b[0m';
@@ -17,9 +17,9 @@ describe('renderMarkdown', () => {
       { color: true },
     );
 
-    expect(output).toContain(`${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}`);
+    expect(output).toContain(`${ANSI_DARK_RED_BACKGROUND}${ANSI_LIGHT_RED}`);
     expect(output).toContain(`${CODE_BLOCK_INDENT}- const oldValue = true;`);
-    expect(output).toContain(`${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}`);
+    expect(output).toContain(`${ANSI_DARK_GREEN_BACKGROUND}${ANSI_LIGHT_GREEN}`);
     expect(output).toContain(`${CODE_BLOCK_INDENT}+ const newValue = true;`);
   });
 
@@ -32,8 +32,12 @@ describe('renderMarkdown', () => {
       codeBlockWidth,
     });
 
-    expect(output).toContain(`${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}${removedRow}${ANSI_RESET}`);
-    expect(output).toContain(`${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}${addedRow}${ANSI_RESET}`);
+    expect(output).toContain(
+      `${ANSI_DARK_RED_BACKGROUND}${ANSI_LIGHT_RED}${removedRow}${ANSI_RESET}`,
+    );
+    expect(output).toContain(
+      `${ANSI_DARK_GREEN_BACKGROUND}${ANSI_LIGHT_GREEN}${addedRow}${ANSI_RESET}`,
+    );
   });
 
   it('keeps diff fenced code block content readable when color is disabled', () => {
@@ -45,8 +49,8 @@ describe('renderMarkdown', () => {
     expect(output).toContain('- removed line');
     expect(output).toContain('+ added line');
     expect(output).toContain(' unchanged line');
-    expect(output).not.toContain(ANSI_RED);
-    expect(output).not.toContain(ANSI_GREEN);
+    expect(output).not.toContain(ANSI_LIGHT_RED);
+    expect(output).not.toContain(ANSI_LIGHT_GREEN);
     expect(output).not.toContain(ANSI_DARK_RED_BACKGROUND);
     expect(output).not.toContain(ANSI_DARK_GREEN_BACKGROUND);
   });

--- a/packages/agent-cli/src/ui/render-markdown.ts
+++ b/packages/agent-cli/src/ui/render-markdown.ts
@@ -3,8 +3,8 @@ import type { Renderer } from 'marked';
 // @ts-expect-error — marked-terminal has no type declarations
 import TerminalRenderer from 'marked-terminal';
 
-const ANSI_RED = '\u001b[31m';
-const ANSI_GREEN = '\u001b[32m';
+const ANSI_LIGHT_RED = '\u001b[38;5;210m';
+const ANSI_LIGHT_GREEN = '\u001b[38;5;120m';
 const ANSI_CYAN = '\u001b[36m';
 const ANSI_DIM = '\u001b[2m';
 const ANSI_DARK_RED_BACKGROUND = '\u001b[48;5;52m';
@@ -56,10 +56,10 @@ function styleAddedOrRemovedDiffRow(line: string, rowWidth: number, color: boole
     return row.trimEnd();
   }
   if (line.startsWith('+')) {
-    return `${ANSI_DARK_GREEN_BACKGROUND}${ANSI_GREEN}${row}${ANSI_RESET}`;
+    return `${ANSI_DARK_GREEN_BACKGROUND}${ANSI_LIGHT_GREEN}${row}${ANSI_RESET}`;
   }
   if (line.startsWith('-')) {
-    return `${ANSI_DARK_RED_BACKGROUND}${ANSI_RED}${row}${ANSI_RESET}`;
+    return `${ANSI_DARK_RED_BACKGROUND}${ANSI_LIGHT_RED}${row}${ANSI_RESET}`;
   }
   return row.trimEnd();
 }

--- a/packages/agent-command-compact/src/__tests__/compact-command-module.test.ts
+++ b/packages/agent-command-compact/src/__tests__/compact-command-module.test.ts
@@ -97,7 +97,7 @@ describe('createCompactCommandModule', () => {
 
     expect(executor.listModelInvocableCommands()).toEqual([
       {
-        name: '/compact',
+        name: 'compact',
         kind: 'builtin-command',
         description: 'Compress context window',
         userInvocable: true,

--- a/packages/agent-command-memory/src/__tests__/memory-command-module.test.ts
+++ b/packages/agent-command-memory/src/__tests__/memory-command-module.test.ts
@@ -112,12 +112,12 @@ describe('createMemoryCommandModule', () => {
     ]);
     const descriptor = executor
       .listModelInvocableCommands()
-      .find((command) => command.name === '/memory');
+      .find((command) => command.name === 'memory');
 
     expect(executor.isModelInvocable('memory')).toBe(true);
     expect(descriptor).toEqual(
       expect.objectContaining({
-        name: '/memory',
+        name: 'memory',
         kind: 'builtin-command',
         userInvocable: true,
         modelInvocable: true,


### PR DESCRIPTION
## Summary
- Use high-contrast 256-color light red/green foregrounds for markdown diff added/removed rows while preserving full-row dark backgrounds.
- Update agent-cli SPEC and completed backlog note.
- Align compact/memory descriptor tests with the repo rule that SDK command identities are slash-free.

## Research
- W3C WCAG contrast guidance: foreground/background contrast should be explicit; the previous standard ANSI red/green over dark red/green backgrounds could be hard to read.
- Repo common-mistakes rule 49: SDK command names are slash-free; slash syntax belongs to the UI layer.

## Verification
- pnpm --filter @robota-sdk/agent-cli test -- render-markdown
- pnpm --filter @robota-sdk/agent-cli typecheck
- pnpm --filter @robota-sdk/agent-cli lint
- pnpm --filter @robota-sdk/agent-command-compact test
- pnpm --filter @robota-sdk/agent-command-compact build
- pnpm --filter @robota-sdk/agent-command-memory test
- pnpm --filter @robota-sdk/agent-command-memory build
- pnpm build
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pre-push harness verification