### PR TITLE
fix(harness): keep pre-push fast by default

### DIFF
--- a/.agents/rules/verification.md
+++ b/.agents/rules/verification.md
@@ -23,8 +23,10 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 
 - **NEVER push new repository content without first running the affected local checks.** Remote CI failure after a local-only fix is a preventable waste.
 - The default fast local gate is `pnpm harness:pre-push`, which resolves the branch base and runs the scoped package checks for content that is actually being pushed.
+- Default pre-push MUST verify directly changed scopes and repository checks only. Dependent scope expansion is intentionally opt-in through `HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push` or explicit `pnpm harness:verify -- --base-ref <ref>` so local push latency stays bounded.
 - Do not duplicate a stronger gate with a weaker one. If `pnpm harness:verify -- --base-ref <ref> --skip-record-check` or release-grade verification has already passed for the final diff, the pre-push hook may be treated as the final safety net rather than a separate manual command.
 - Delete-only pushes, branch cleanup after a squash-merged PR, and tree-equivalent pushes MUST NOT re-run package build/test/lint/typecheck. The pre-push hook must skip these mechanically.
+- Tree-equivalent skip is valid only when the working tree is clean. Dirty working tree changes must still be planned and verified when `pnpm harness:pre-push` is run manually.
 - If the hook skips because no repository content is being published, do not run full checks by habit.
 - If any scoped check fails, fix it locally before pushing.
 - This rule exists because both CI-only failures and repeated no-op local verification waste minutes and slow down the feedback loop.

--- a/.agents/skills/repo-change-loop/SKILL.md
+++ b/.agents/skills/repo-change-loop/SKILL.md
@@ -88,11 +88,12 @@ pnpm lint
 - Running the full workspace by habit when the affected scope is narrow and known.
 - Re-running package checks after branch deletion, squash-merge cleanup, or other no-content Git operations.
 - Running `pnpm typecheck`, `pnpm lint`, and `pnpm test` manually immediately before `pnpm harness:pre-push` when the harness will execute the same final scoped checks.
+- Treating dependent package typechecks as mandatory for every local push. Use `HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push` or explicit `pnpm harness:verify -- --base-ref <ref>` when the change risk warrants broad dependent validation.
 - Reporting success without saying what was actually verified.
 - Treating documentation reading as equivalent to verification.
 - Treating TUI-only checks as sufficient for behavior also reachable through headless CLI mode.
 
 ## Related Harness Commands
 
-- Current: `pnpm harness:verify -- --scope <packages/foo|apps/bar> [--include-scenarios]`, `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint`
+- Current: `pnpm harness:pre-push`, `HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push`, `pnpm harness:verify -- --scope <packages/foo|apps/bar> [--include-scenarios]`, `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint`
 - Current review support: `pnpm harness:review -- --scope <packages/foo|apps/bar>`

--- a/.agents/tasks/completed/harness-pre-push-fast-mode.md
+++ b/.agents/tasks/completed/harness-pre-push-fast-mode.md
@@ -1,0 +1,49 @@
+# Harness Pre-Push Fast Mode
+
+- **Status**: completed
+- **Created**: 2026-05-08
+- **Branch**: fix/harness-pre-push-fast-mode
+- **Scope**: scripts/harness, .agents/rules
+
+## Objective
+
+Reduce unnecessary pre-push latency while preserving explicit full verification paths. Pre-push should remain a local fast gate and deeper dependent verification should be opt-in or CI-owned.
+
+## Plan
+
+- [x] Inspect current harness planning and pre-push behavior.
+- [x] Add a configurable fast pre-push mode that avoids repeated broad dependent checks by default.
+- [x] Keep full verification available through an explicit mode.
+- [x] Update repository guidance and tests.
+- [x] Run targeted verification.
+
+## Progress
+
+### 2026-05-08
+
+- Started after provider setup PR #302 exposed excessive pre-push runtime.
+- Recommended defaulting pre-push to directly changed scopes and making full dependent verification explicit.
+- Found that `createVerificationPlan` always expands dependent scopes for entrypoint/public-surface changes, and `pre-push.mjs` always runs that full plan.
+- Added `--skip-dependent-scopes` to planning and verification, then made `harness:pre-push` default to fast mode while preserving `HARNESS_PRE_PUSH_MODE=full`.
+- Found and fixed an existing manual pre-push skip bug: dirty working tree changes no longer get treated as tree-equivalent to the base branch.
+- Verified the new fast path with harness plan fixtures, targeted harness unit tests, consistency/worktree scans, and actual `pnpm harness:pre-push`.
+
+## Decisions
+
+- Keep `pnpm harness:verify` broad by default for intentional manual verification.
+- Make only `pnpm harness:pre-push` fast by default because it is a push-time safety net and should not duplicate CI-grade dependent validation unless explicitly requested.
+- Treat tree-equivalent skip as valid only when the working tree is clean.
+
+## Blockers
+
+- None.
+
+## Test Plan
+
+- Run harness plan fixtures with and without `--skip-dependent-scopes` to prove fast mode removes dependent scope expansion while full mode keeps it.
+- Run harness script unit tests for option parsing, pre-push policy markers, and verification plan behavior.
+- Run worktree, consistency, and task-plan scans through `pnpm harness:pre-push` so the actual fast local gate validates this change.
+
+## Result
+
+Completed. Default pre-push now skips dependent scope expansion, full dependent validation remains explicit via `HARNESS_PRE_PUSH_MODE=full`, and manual pre-push no longer skips dirty working tree changes.

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -13,7 +13,8 @@ These scripts are the executable layer of the Robota harness.
 - `pnpm harness:scan:coverage-scripts`
 - `pnpm harness:plan -- --changed-file <path> [--changed-file <path>] [--base-ref <git-ref>]`
 - `pnpm harness:pre-push`
-- `pnpm harness:verify -- --scope <packages/foo|apps/bar> [--include-scenarios] [--base-ref <git-ref>]`
+- `HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push`
+- `pnpm harness:verify -- --scope <packages/foo|apps/bar> [--include-scenarios] [--base-ref <git-ref>] [--skip-dependent-scopes]`
 - `pnpm harness:verify:release`
 - `pnpm harness:record -- --scope <packages/foo|apps/bar> [--base-ref <git-ref>]`
 - `pnpm harness:review -- --scope <packages/foo|apps/bar> [--report-file <path>] [--report-format markdown|json] [--base-ref <git-ref>]`
@@ -92,8 +93,11 @@ These scripts are the executable layer of the Robota harness.
 - reads Git pre-push ref updates from stdin
 - skips verification for delete-only pushes because no repository content is being published
 - skips verification when the pushed tree already matches the resolved base, such as cleanup after a squash-merged PR
+- does not use the tree-equivalent skip when the local working tree is dirty
 - prints the scoped verification plan
-- runs `harness:verify` for affected scopes and executable repository checks
+- defaults to fast mode, which verifies directly changed scopes and executable repository checks
+- uses `--skip-dependent-scopes` in fast mode so local push latency does not explode on shared package entrypoint changes
+- supports `HARNESS_PRE_PUSH_MODE=full` when dependent scope typechecks should run locally before publishing
 - leaves release-grade verification as an explicit `pnpm harness:verify:release` command
 
 ### `verify-change.mjs`
@@ -101,6 +105,8 @@ These scripts are the executable layer of the Robota harness.
 - resolves workspace scopes from changed files or `--scope`
 - falls back to `git diff <base-ref>...HEAD` when the working tree is clean
 - runs build, test, lint, and typecheck for the relevant scope
+- includes dependent scopes by default for public entrypoint, dependency manifest, and public-surface manifest changes
+- supports `--skip-dependent-scopes` for fast local gates that intentionally avoid broad dependent checks
 - runs owner-registered scenario verification when scenario-like changes, source/config changes in scenario-owning scopes, or `--include-scenarios` are present
 - fails if authoritative scenario records are missing, invalid, duplicated, or do not match the owner command set
 - compares scenario verification output against the owner `*.record.json` artifact and fails on drift

--- a/scripts/harness/__tests__/check-plan.test.mjs
+++ b/scripts/harness/__tests__/check-plan.test.mjs
@@ -46,6 +46,12 @@ describe('parsePlanArgs', () => {
     ]);
   });
 
+  it('parses --skip-dependent-scopes', () => {
+    const result = parsePlanArgs(['--skip-dependent-scopes']);
+
+    expect(result.skipDependentScopes).toBe(true);
+  });
+
   it('throws when --changed-file has no value', () => {
     expect(() => parsePlanArgs(['--changed-file'])).toThrow('--changed-file requires a value');
   });
@@ -188,6 +194,25 @@ describe('createVerificationPlan', () => {
         files: [],
         checks: ['typecheck'],
         notes: ['dependent-of:packages/agent-core'],
+      },
+    ]);
+  });
+
+  it('can skip dependent scopes for fast local pre-push verification', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['packages/agent-core/src/index.ts'],
+      scopeTokens: [],
+      includeDependentScopes: false,
+    });
+
+    expect(plan.scopes).toEqual([
+      {
+        scope: 'packages/agent-core',
+        workspaceName: '@robota-sdk/agent-core',
+        files: ['packages/agent-core/src/index.ts'],
+        checks: ['build', 'test', 'lint', 'typecheck'],
+        notes: [],
       },
     ]);
   });

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -54,6 +54,11 @@ describe('parseScopeArgs', () => {
     expect(result.skipRepositoryChecks).toBe(true);
   });
 
+  it('parses --skip-dependent-scopes flag', () => {
+    const result = parseScopeArgs(['--skip-dependent-scopes']);
+    expect(result.skipDependentScopes).toBe(true);
+  });
+
   it('parses --report-file path and --report-format json', () => {
     const result = parseScopeArgs(['--report-file', 'output.json', '--report-format', 'json']);
     expect(result.reportFile).toBe('output.json');
@@ -91,6 +96,7 @@ describe('parseScopeArgs', () => {
       includeScenarios: false,
       skipRecordCheck: false,
       skipRepositoryChecks: false,
+      skipDependentScopes: false,
       reportFile: null,
       reportFormat: null,
       baseRef: null,
@@ -354,6 +360,21 @@ describe('pre-push hook', () => {
     expect(content).toContain('pnpm harness:pre-push');
     expect(content).not.toContain('origin/main');
     expect(content).not.toContain('harness:scan:dist');
+  });
+
+  it('keeps dependent scope expansion opt-in for pre-push', () => {
+    const content = readFileSync('scripts/harness/pre-push.mjs', 'utf8');
+
+    expect(content).toContain('HARNESS_PRE_PUSH_MODE');
+    expect(content).toContain('--skip-dependent-scopes');
+    expect(content).toContain('HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push');
+  });
+
+  it('does not skip dirty working tree changes as tree-equivalent pushes', () => {
+    const content = readFileSync('scripts/harness/pre-push.mjs', 'utf8');
+
+    expect(content).toContain('hasWorkingTreeChanges');
+    expect(content).toContain('baseRef && !hasWorkingTreeChanges()');
   });
 
   it('parses Git pre-push update lines', () => {

--- a/scripts/harness/check-plan.mjs
+++ b/scripts/harness/check-plan.mjs
@@ -15,6 +15,7 @@ export function parsePlanArgs(argv) {
     baseRef: null,
     reportFile: null,
     reportFormat: null,
+    skipDependentScopes: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -53,6 +54,9 @@ export function parsePlanArgs(argv) {
         index += 1;
         break;
       }
+      case '--skip-dependent-scopes':
+        options.skipDependentScopes = true;
+        break;
       default:
         throw new Error(`Unknown argument: ${token}`);
     }
@@ -187,6 +191,7 @@ export function createVerificationPlan({
   changedFiles,
   scopeTokens = [],
   manifestChangesByScope = new Map(),
+  includeDependentScopes = true,
 }) {
   const scopeFiles = mapFilesToScopes(changedFiles, scopes);
   const initialSelectedScopes =
@@ -209,7 +214,7 @@ export function createVerificationPlan({
       notes: listNotes(classification),
     });
 
-    if (needsDependentChecks(classification)) {
+    if (includeDependentScopes && needsDependentChecks(classification)) {
       for (const dependentScope of findDependentScopes(scopes, scope)) {
         if (scopePlans.has(dependentScope.relativeDir)) {
           continue;

--- a/scripts/harness/plan-change.mjs
+++ b/scripts/harness/plan-change.mjs
@@ -49,6 +49,7 @@ async function main() {
     changedFiles,
     scopeTokens: options.scopeTokens,
     manifestChangesByScope,
+    includeDependentScopes: !options.skipDependentScopes,
   });
 
   process.stdout.write(renderPlanSummary(plan));

--- a/scripts/harness/pre-push.mjs
+++ b/scripts/harness/pre-push.mjs
@@ -29,6 +29,17 @@ function runGitQuiet(args) {
   );
 }
 
+function hasWorkingTreeChanges() {
+  const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    cwd: WORKSPACE_ROOT,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    return true;
+  }
+  return result.stdout.trim().length > 0;
+}
+
 function readPrePushInput() {
   if (process.stdin.isTTY) {
     return '';
@@ -41,10 +52,23 @@ function readPrePushInput() {
   }
 }
 
+function resolvePrePushMode(value) {
+  const mode = value?.trim() || 'fast';
+  if (mode !== 'fast' && mode !== 'full') {
+    throw new Error('HARNESS_PRE_PUSH_MODE must be one of: fast, full');
+  }
+  return mode;
+}
+
 const baseRef = resolveGitBaseRef(process.env.HARNESS_BASE_REF ?? null);
 const baseArgs = baseRef ? ['--base-ref', baseRef] : [];
+const prePushMode = resolvePrePushMode(process.env.HARNESS_PRE_PUSH_MODE);
+const scopeExpansionArgs = prePushMode === 'fast' ? ['--skip-dependent-scopes'] : [];
 const updates = parsePrePushUpdates(readPrePushInput());
-const treeMatchesBase = baseRef ? runGitQuiet(['diff', '--quiet', baseRef, 'HEAD', '--']) : false;
+const treeMatchesBase =
+  baseRef && !hasWorkingTreeChanges()
+    ? runGitQuiet(['diff', '--quiet', baseRef, 'HEAD', '--'])
+    : false;
 const prePushDecision = decidePrePushVerification({
   updates,
   baseRef,
@@ -56,15 +80,20 @@ if (!prePushDecision.shouldRun) {
   process.exit(0);
 }
 
-process.stdout.write('▶ scoped pre-push verification\n');
+process.stdout.write(`▶ scoped pre-push verification (${prePushMode})\n`);
 if (baseRef) {
   process.stdout.write(`base: ${baseRef}\n`);
 } else {
   process.stdout.write('base: unresolved; using working-tree changes only\n');
 }
 
-run('pnpm', ['harness:plan', '--', ...baseArgs]);
-run('pnpm', ['harness:verify', '--', ...baseArgs, '--skip-record-check']);
+if (prePushMode === 'fast') {
+  process.stdout.write('dependent scope expansion: skipped; use HARNESS_PRE_PUSH_MODE=full\n');
+}
+
+run('pnpm', ['harness:plan', '--', ...baseArgs, ...scopeExpansionArgs]);
+run('pnpm', ['harness:verify', '--', ...baseArgs, ...scopeExpansionArgs, '--skip-record-check']);
 
 process.stdout.write('\nRelease-grade verification remains explicit:\n');
+process.stdout.write('  HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push\n');
 process.stdout.write('  pnpm harness:verify:release\n');

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -199,6 +199,7 @@ export function parseScopeArgs(argv) {
     includeScenarios: false,
     skipRecordCheck: false,
     skipRepositoryChecks: false,
+    skipDependentScopes: false,
     reportFile: null,
     reportFormat: null,
     baseRef: null,
@@ -241,6 +242,9 @@ export function parseScopeArgs(argv) {
         break;
       case '--skip-repository-checks':
         options.skipRepositoryChecks = true;
+        break;
+      case '--skip-dependent-scopes':
+        options.skipDependentScopes = true;
         break;
       case '--report-file': {
         const value = argv[index + 1];

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -93,6 +93,7 @@ async function main() {
     changedFiles,
     scopeTokens: options.scopeTokens,
     manifestChangesByScope,
+    includeDependentScopes: !options.skipDependentScopes,
   });
 
   if (plan.repositoryChecks.length > 0 && !options.skipRepositoryChecks) {


### PR DESCRIPTION
## Summary
- Make pre-push default to fast mode by skipping dependent scope expansion
- Keep full dependent validation available with HARNESS_PRE_PUSH_MODE=full
- Add --skip-dependent-scopes to harness plan/verify for explicit fast gates
- Prevent manual pre-push from skipping dirty working tree changes as tree-equivalent

## Verification
- pnpm exec vitest run scripts/harness/__tests__/check-plan.test.mjs scripts/harness/__tests__/harness-scripts.test.mjs
- pnpm harness:plan -- --changed-file packages/agent-core/src/index.ts --skip-dependent-scopes
- pnpm harness:plan -- --changed-file packages/agent-core/src/index.ts
- pnpm harness:scan:worktrees
- pnpm harness:scan:consistency
- pnpm harness:scan:test-plans
- pnpm harness:pre-push
- git push pre-push hook passed