### PR TITLE
fix(dag): stabilize Node 18 route tests

### DIFF
--- a/apps/dag-orchestrator-server/docs/SPEC.md
+++ b/apps/dag-orchestrator-server/docs/SPEC.md
@@ -342,6 +342,11 @@ ComfyUI proxy endpoints (`/prompt`, `/queue`, `/history`, etc.) use the backend'
 
 ### Current Coverage
 
+The app test runner uses a 30s per-test timeout because route integration tests exercise Express,
+HTTP fetch, WebSocket, and multipart boundaries under coverage. The timeout protects Node 18
+compatibility CI from false negatives caused by parallel coverage overhead while still failing real
+hangs within a bounded interval.
+
 | Test File                                            | Scope                                 | Tests                                                                                                                                          |
 | ---------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/__tests__/comfyui-event-translator.test.ts`     | `translateComfyUiEvent` pure function | ComfyUI message type mapping, prompt_id filtering, terminal events                                                                             |

--- a/apps/dag-orchestrator-server/vitest.config.ts
+++ b/apps/dag-orchestrator-server/vitest.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-    test: {
-        include: [
-            'src/**/*.{test,spec}.{ts,tsx}',
-            'src/**/__tests__/**/*.{test,spec}.{ts,tsx}',
-        ],
-        environment: 'node',
-        testTimeout: 10000,
-    },
+  test: {
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'src/**/__tests__/**/*.{test,spec}.{ts,tsx}'],
+    environment: 'node',
+    testTimeout: 30000,
+  },
 });


### PR DESCRIPTION
## Summary
- raise dag-orchestrator-server Vitest per-test timeout for route integration tests under Node 18 CI
- document the bounded timeout in the package SPEC test strategy

## Verification
- pnpm --filter @robota-sdk/dag-orchestrator-server run test -- --coverage --coverage.thresholds.lines=80
- volta run --node 18.20.8 pnpm --filter @robota-sdk/dag-orchestrator-server run test -- --coverage --coverage.thresholds.lines=80