### PR TITLE
fix(sdk): remove abort test race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,16 @@ jobs:
           import { appendFileSync, readFileSync } from 'node:fs';
 
           const plan = JSON.parse(readFileSync('.agents/evals/local-metrics/ci-plan.json', 'utf8'));
-          const required = plan.scopes.some((scope) => scope.checks.includes('build'));
+          const checksRequiringPackageDist = new Set(['build', 'test', 'typecheck']);
+          const required = plan.scopes.some((scope) =>
+            scope.checks.some((check) => checksRequiringPackageDist.has(check)),
+          );
           appendFileSync(process.env.GITHUB_OUTPUT, `required=${required ? 'true' : 'false'}\n`);
 
           if (required) {
-            console.log('Package or app build checks require the root monorepo build.');
+            console.log('Package or app verification requires the root monorepo build output.');
           } else {
-            console.log('No package or app build checks required.');
+            console.log('No package or app verification requires build output.');
           }
           EOF
 
@@ -90,9 +93,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Skip monorepo build when no package build is required
+      - name: Skip monorepo build when no build output is required
         if: github.base_ref != 'main' && steps.build_requirement.outputs.required != 'true'
-        run: echo "No package or app build checks required."
+        run: echo "No package or app verification requires build output."
 
   quality:
     name: quality

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -54,8 +54,10 @@ function createControllableRun(): {
   run: () => Promise<string>;
   started: Promise<void>;
   resolve: (value: string) => void;
+  reject: (reason?: unknown) => void;
 } {
   let resolveRun: ((value: string) => void) | undefined;
+  let rejectRun: ((reason?: unknown) => void) | undefined;
   let markStarted: () => void = () => {};
   const started = new Promise<void>((resolve) => {
     markStarted = resolve;
@@ -63,14 +65,19 @@ function createControllableRun(): {
 
   return {
     run: () =>
-      new Promise<string>((resolve) => {
+      new Promise<string>((resolve, reject) => {
         resolveRun = resolve;
+        rejectRun = reject;
         markStarted();
       }),
     started,
     resolve: (value: string) => {
       if (!resolveRun) throw new Error('run has not started');
       resolveRun(value);
+    },
+    reject: (reason?: unknown) => {
+      if (!rejectRun) throw new Error('run has not started');
+      rejectRun(reason);
     },
   };
 }
@@ -182,18 +189,13 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
   it('abort clears queue and emits interrupted event', async () => {
     const abortError = new DOMException('The operation was aborted.', 'AbortError');
-    let rejectRun: (err: Error) => void;
     const abortHistory = [
       { role: 'user', content: 'test' },
       { role: 'assistant', content: 'partial answer', state: 'interrupted' },
     ];
     const mockSession = createMockSession();
-    mockSession.run.mockImplementation(
-      () =>
-        new Promise<string>((_, reject) => {
-          rejectRun = reject;
-        }),
-    );
+    const controllableRun = createControllableRun();
+    mockSession.run.mockImplementation(controllableRun.run);
     // History is empty at start, populated when abort happens
     mockSession.getHistory.mockReturnValue([]);
     // After abort, history contains the interrupted messages
@@ -213,7 +215,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     });
 
     const exec = session.submit('test');
-    await new Promise((r) => setTimeout(r, 10));
+    await controllableRun.started;
 
     await session.submit('queued');
     session.abort();
@@ -221,7 +223,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     expect(mockSession.abort).toHaveBeenCalled();
     expect(session.getPendingPrompt()).toBeNull();
 
-    rejectRun!(abortError);
+    controllableRun.reject(abortError);
     await exec;
     await new Promise((r) => setTimeout(r, 10));
 
@@ -524,14 +526,9 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
   it('abort preserves partial assistant text in messages', async () => {
     const abortError = new DOMException('The operation was aborted.', 'AbortError');
-    let rejectRun: (err: Error) => void;
     const mockSession = createMockSession();
-    mockSession.run.mockImplementation(
-      () =>
-        new Promise<string>((_, reject) => {
-          rejectRun = reject;
-        }),
-    );
+    const controllableRun = createControllableRun();
+    mockSession.run.mockImplementation(controllableRun.run);
     mockSession.getHistory.mockReturnValue([]);
     mockSession.abort.mockImplementation(() => {
       mockSession.getHistory.mockReturnValue([
@@ -545,9 +542,9 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     });
 
     const exec = session.submit('write a story');
-    await new Promise((r) => setTimeout(r, 10));
+    await controllableRun.started;
     session.abort();
-    rejectRun!(abortError);
+    controllableRun.reject(abortError);
     await exec;
     await new Promise((r) => setTimeout(r, 10));
 

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
@@ -42,8 +42,10 @@ function createControllableRun(): {
   run: () => Promise<string>;
   started: Promise<void>;
   resolve: (value: string) => void;
+  reject: (reason?: unknown) => void;
 } {
   let resolveRun: ((value: string) => void) | undefined;
+  let rejectRun: ((reason?: unknown) => void) | undefined;
   let markStarted: () => void = () => {};
   const started = new Promise<void>((resolve) => {
     markStarted = resolve;
@@ -51,14 +53,19 @@ function createControllableRun(): {
 
   return {
     run: () =>
-      new Promise<string>((resolve) => {
+      new Promise<string>((resolve, reject) => {
         resolveRun = resolve;
+        rejectRun = reject;
         markStarted();
       }),
     started,
     resolve: (value: string) => {
       if (!resolveRun) throw new Error('run has not started');
       resolveRun(value);
+    },
+    reject: (reason?: unknown) => {
+      if (!rejectRun) throw new Error('run has not started');
+      rejectRun(reason);
     },
   };
 }
@@ -315,14 +322,9 @@ describe('InteractiveSession', () => {
 
   it('abort calls session.abort and clears queue', async () => {
     const abortError = new DOMException('The operation was aborted.', 'AbortError');
-    let rejectRun: (err: Error) => void;
     const mockSession = createMockSession();
-    mockSession.run.mockImplementation(
-      () =>
-        new Promise<string>((_, reject) => {
-          rejectRun = reject;
-        }),
-    );
+    const controllableRun = createControllableRun();
+    mockSession.run.mockImplementation(controllableRun.run);
 
     const session = new InteractiveSession({
       session: mockSession as never,
@@ -334,7 +336,7 @@ describe('InteractiveSession', () => {
     });
 
     const execution = session.submit('prompt');
-    await new Promise((r) => setTimeout(r, 10));
+    await controllableRun.started;
 
     await session.submit('queued');
     session.abort();
@@ -342,7 +344,7 @@ describe('InteractiveSession', () => {
     expect(mockSession.abort).toHaveBeenCalled();
     expect(session.getPendingPrompt()).toBeNull();
 
-    rejectRun!(abortError);
+    controllableRun.reject(abortError);
     await execution;
     await new Promise((r) => setTimeout(r, 10));
 

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -113,6 +113,12 @@ describe('CI build workflow', () => {
 
     expect(content).toContain('run: pnpm build');
     expect(content).toContain('Detect build requirement');
+    expect(content).toContain(
+      "const checksRequiringPackageDist = new Set(['build', 'test', 'typecheck'])",
+    );
+    expect(content).toContain(
+      'scope.checks.some((check) => checksRequiringPackageDist.has(check))',
+    );
     expect(content).toContain("steps.build_requirement.outputs.required == 'true'");
     expect(content).toContain(
       'tar -czf package-dist.tgz packages/*/dist packages/dag-nodes/*/dist',


### PR DESCRIPTION
## Summary
- replace sleep-based abort test synchronization with a controllable run start signal
- apply the same helper to the behavior regression tests that reject an in-flight run

## Verification
- pnpm --filter @robota-sdk/agent-sdk exec vitest run src/interactive/__tests__/interactive-session.test.ts src/interactive/__tests__/interactive-session-behavior.test.ts
- volta run --node 22.14.0 pnpm --filter @robota-sdk/agent-sdk test
- pre-push harness: packages/agent-sdk test, lint, typecheck