### PR TITLE
docs(rules): add backlog execution gates

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,4 +11,5 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
+- [Backlog Execution Orchestrator Skill](backlog-execution-orchestrator-skill.md)
 - [CLI AI Workflow Reviewer and Harness Planning](cli-ai-workflow-reviewer-harness-planning.md)

--- a/.agents/backlog/backlog-execution-orchestrator-skill.md
+++ b/.agents/backlog/backlog-execution-orchestrator-skill.md
@@ -1,0 +1,108 @@
+# Backlog Execution Orchestrator Skill
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - process automation prerequisite for multi-backlog initiatives.
+
+## Request
+
+Create an orchestration skill that manages backlog-driven implementation as a pipeline while
+delegating detailed work to existing owner skills.
+
+The skill must help the agent follow the backlog execution rule:
+
+> For each backlog or work unit, present a recommendation gate, proceed only when the recommendation
+> is coherent with repository rules and architecture, create one PR per backlog, merge each child PR
+> into an initiative base branch, and leave the final `develop` PR unmerged for the user.
+
+## Non-Negotiable Product Principles
+
+- **Orchestration only.** The skill manages gates, sequence, branch flow, PR flow, and verification
+  checkpoints. It must not own implementation details.
+- **Delegate to owner skills.** It must invoke or route to `branch-guard`, `repo-writing`,
+  `repo-change-loop`, `spec-first-development`, `tdd-red-green-refactor`,
+  `architecture-patterns`, `vitest-testing-strategy`, and `post-implementation-checklist` when
+  those domains apply.
+- **Recommendation gate first.** The skill must require a recommendation with rationale before each
+  backlog or work unit starts.
+- **One backlog, one PR.** The skill must keep unrelated backlogs out of the same PR.
+- **Final PR is user-controlled.** The skill must not auto-merge the final initiative PR into
+  `develop`.
+
+## Expected Outcomes
+
+- Multi-backlog initiatives become predictable and auditable.
+- The agent consistently explains why a recommendation is valid before acting.
+- Existing skills keep their detailed responsibilities instead of being copied into a large process
+  skill.
+- PR descriptions consistently capture recommendation, rationale, implementation summary, tests,
+  and residual risks.
+- The final `develop` merge remains an explicit user decision.
+
+## Architecture Ownership Rule
+
+The orchestration skill owns only workflow sequencing:
+
+- recommendation gate enforcement;
+- branch and PR sequencing;
+- skill selection and handoff;
+- verification checkpoint ordering;
+- status/handoff summary shape.
+
+It does not own:
+
+- package architecture;
+- test design details;
+- branch safety rules;
+- commit message rules;
+- SPEC authoring rules;
+- implementation details of any package.
+
+Those responsibilities remain with existing rules and skills.
+
+## Recommended First Slice
+
+Create the skill as a small procedural wrapper:
+
+1. Add `.agents/skills/backlog-execution-orchestrator/SKILL.md`.
+2. Define trigger conditions for backlog-driven implementation, multi-PR initiatives, and
+   recommendation-gated work.
+3. Define the pipeline:
+   recommendation gate -> branch setup -> owner-skill routing -> implementation loop -> tests ->
+   PR description -> child PR merge -> next backlog -> final unmerged develop PR.
+4. Keep the skill body concise and reference existing owner skills by name instead of copying their
+   details.
+5. Update `.agents/skills/index.md`.
+6. Add a small governance check or document scan later if repeated drift appears.
+
+## Acceptance Criteria
+
+- [ ] The skill is an orchestration wrapper, not a copy of detailed owner skills.
+- [ ] The skill requires a recommendation gate before each backlog or work unit.
+- [ ] The skill routes work to relevant existing skills by domain.
+- [ ] The skill requires one backlog or split work unit per PR.
+- [ ] The skill requires child PRs to merge into the initiative base branch.
+- [ ] The skill requires the final `develop` PR to remain unmerged for the user.
+
+## Test Plan
+
+- Add a document/governance check only if the rule starts drifting or the skill is repeatedly
+  misused.
+- Manually verify the skill body references owner skills instead of duplicating their detailed
+  workflows.
+- Run `pnpm harness:scan`.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Document authority scan must pass when this backlog is promoted.
+- The first implementation PR must include a before/after review showing the orchestration skill did
+  not duplicate owner skill responsibilities.

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -1,0 +1,87 @@
+# Backlog Execution Rules
+
+Mandatory rules for executing backlog-driven work through recommendation gates and focused PRs.
+Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
+
+## Recommendation Gate
+
+Before starting each backlog or meaningful work unit inside a backlog, present a recommendation with
+the reasoning needed to judge whether it should proceed.
+
+The recommendation must include:
+
+- the proposed implementation or documentation approach;
+- why it matches the backlog intent;
+- why it matches repository rules, layering, ownership, and architecture boundaries;
+- affected packages, docs, or commands;
+- the expected test and verification plan;
+- any decisions that require the user instead of agent autonomy.
+
+If the recommendation is coherent with repository rules, layering, architecture, and the backlog
+intent, the agent may proceed with that recommendation. If the recommendation is weak, conflicts
+with rules, changes ownership boundaries, introduces new dependency direction, or requires product
+judgment, stop and ask the user for a decision.
+
+## PR Unit Rule
+
+- Treat one backlog as one PR by default.
+- If a backlog is too large, split it into explicitly named work units before implementation; each
+  work unit must have its own recommendation gate.
+- Do not combine unrelated backlogs in one PR.
+- Every PR description must include the accepted recommendation, rationale, implementation summary,
+  tests run, and residual risks.
+
+## Base Branch Workflow
+
+For a multi-backlog initiative:
+
+1. Create an initiative base branch from `develop`.
+2. For each backlog, create a child branch from the initiative base branch.
+3. Open a PR from the child branch into the initiative base branch.
+4. After checks pass and the PR content matches its recommendation gate, merge that PR into the
+   initiative base branch.
+5. Repeat until all backlog PRs are merged into the initiative base branch.
+6. Open a final PR from the initiative base branch into `develop`.
+7. Do not auto-merge the final PR into `develop`; leave that decision to the user.
+
+## Layering Rule
+
+Backlog implementation must preserve owner boundaries:
+
+- `agent-cli` owns UI/TUI rendering, prompt intake, keyboard navigation, and local host adapter
+  wiring.
+- SDK/runtime or other lower owner packages own reusable contracts, lifecycle, state machines,
+  storage policy, command behavior, and process/task semantics.
+- Command packages expose user-visible commands through SDK/runtime contracts.
+- Skills may orchestrate workflows, but they must not absorb detailed behavior owned by the skills
+  or packages they invoke.
+
+## Orchestration Skill Rule
+
+An orchestration skill may coordinate other skills as a pipeline, but it must stay thin:
+
+- It may select and sequence skills.
+- It may enforce gates, PR order, and verification checkpoints.
+- It may record status and handoff points.
+- It must not duplicate the detailed procedures of invoked skills.
+- It must not redefine mandatory rules.
+- It must delegate package-specific, testing, branch, writing, architecture, and verification work
+  to the relevant owner skills.
+
+## Stop Conditions
+
+- No recommendation gate was presented for the backlog or work unit.
+- The recommendation conflicts with repo rules, layering, package ownership, or backlog intent.
+- The work would combine unrelated backlogs into one PR.
+- The final initiative PR would be auto-merged into `develop`.
+- An orchestration skill duplicates implementation details from invoked skills instead of only
+  coordinating them.
+
+## Checklist
+
+- [ ] Recommendation gate presented before work begins.
+- [ ] Recommendation includes rationale, ownership, affected scope, tests, and open decisions.
+- [ ] PR scope maps to exactly one backlog or explicitly split work unit.
+- [ ] Child PR targets the initiative base branch.
+- [ ] Final initiative PR targets `develop` and is not auto-merged.
+- [ ] PR description records the accepted recommendation and verification evidence.

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -25,5 +25,6 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 | [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gates, publish flow |
 | [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates   |
 | [research.md](research.md)                     | Research-first implementation and recommendation authority         |
+| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, one-backlog PRs, initiative branches |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation            |
 | [learning-loop.md](learning-loop.md)           | Lesson capture and mechanical enforcement preference               |

--- a/.agents/rules/process.md
+++ b/.agents/rules/process.md
@@ -14,5 +14,6 @@ This file routes to detailed rule documents. Each linked file contains the full 
 | [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gate discipline, publish boundary                           |
 | [documentation-sync.md](documentation-sync.md) | Document role sync, package README, and robota.io source update requirements                               |
 | [research.md](research.md)                     | Research-first implementation, documentation-only prior art, recommendation authority                      |
+| [backlog-execution.md](backlog-execution.md)   | Recommendation gates, one-backlog PRs, initiative branch workflow, orchestration skill boundary            |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation                                                    |
 | [learning-loop.md](learning-loop.md)           | Convert repeated lessons into rules, hooks, harness checks, or tested automation                           |


### PR DESCRIPTION
## Recommendation Gate

Recommendation: add a dedicated backlog execution rule document and a follow-up backlog for an orchestration skill before implementing the remaining backlog series.

Rationale:
- The requested workflow is cross-cutting process behavior, so it belongs in .agents/rules/ rather than inside a package SPEC or a single backlog.
- process.md is a routing document, so the detailed policy lives in .agents/rules/backlog-execution.md and is linked from process.md and rules/index.md.
- The proposed orchestration skill should be backloged before implementation because it must coordinate existing owner skills without duplicating their detailed responsibilities.
- This preserves repo layering: rules define mandatory gates, skills handle procedural workflows, and package specs continue to own package contracts.

## Changes

- Added .agents/rules/backlog-execution.md with recommendation gates, one-backlog PR scope, initiative base branch workflow, layering rules, and final develop PR no-auto-merge rule.
- Linked the new rule from .agents/rules/process.md and .agents/rules/index.md.
- Added .agents/backlog/backlog-execution-orchestrator-skill.md as the first backlog for creating a thin orchestration skill.
- Added the skill backlog to .agents/backlog/README.md.

## Tests

- pnpm harness:scan
- pre-push fast verification:
  - pnpm harness:scan:consistency
  - pnpm harness:scan:test-plans

## Residual Risk

- The orchestration skill itself is not implemented in this PR. It is intentionally captured as the next focused backlog so its boundaries can be reviewed before creation.