### PR TITLE
docs(skills): add backlog execution orchestrator

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,5 +11,4 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-- [Backlog Execution Orchestrator Skill](backlog-execution-orchestrator-skill.md)
 - [CLI AI Workflow Reviewer and Harness Planning](cli-ai-workflow-reviewer-harness-planning.md)

--- a/.agents/backlog/completed/backlog-execution-orchestrator-skill.md
+++ b/.agents/backlog/completed/backlog-execution-orchestrator-skill.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -85,12 +85,12 @@ Create the skill as a small procedural wrapper:
 
 ## Acceptance Criteria
 
-- [ ] The skill is an orchestration wrapper, not a copy of detailed owner skills.
-- [ ] The skill requires a recommendation gate before each backlog or work unit.
-- [ ] The skill routes work to relevant existing skills by domain.
-- [ ] The skill requires one backlog or split work unit per PR.
-- [ ] The skill requires child PRs to merge into the initiative base branch.
-- [ ] The skill requires the final `develop` PR to remain unmerged for the user.
+- [x] The skill is an orchestration wrapper, not a copy of detailed owner skills.
+- [x] The skill requires a recommendation gate before each backlog or work unit.
+- [x] The skill routes work to relevant existing skills by domain.
+- [x] The skill requires one backlog or split work unit per PR.
+- [x] The skill requires child PRs to merge into the initiative base branch.
+- [x] The skill requires the final `develop` PR to remain unmerged for the user.
 
 ## Test Plan
 
@@ -106,3 +106,12 @@ Create the skill as a small procedural wrapper:
 - Document authority scan must pass when this backlog is promoted.
 - The first implementation PR must include a before/after review showing the orchestration skill did
   not duplicate owner skill responsibilities.
+
+## Result
+
+Completed by adding `.agents/skills/backlog-execution-orchestrator/SKILL.md`.
+
+- The skill owns recommendation gates, branch/PR sequencing, owner-skill routing, verification
+  checkpoints, and PR summary requirements.
+- Detailed implementation procedures remain delegated to existing owner skills.
+- The active backlog item was moved to `.agents/backlog/completed/`.

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: backlog-execution-orchestrator
+description: Use when executing backlog-driven work, multi-PR initiatives, recommendation-gated implementation, or one-backlog-per-PR workflows. Orchestrates owner skills without duplicating their detailed procedures.
+---
+
+# Backlog Execution Orchestrator
+
+## Rule Anchor
+
+- `.agents/rules/backlog-execution.md`
+- `.agents/rules/git-branch.md`
+- `.agents/rules/process.md`
+
+## Use This Skill When
+
+- The user asks to work through one or more backlog items.
+- The user requires a recommendation before implementation.
+- The work must use one PR per backlog or split work unit.
+- A multi-backlog initiative needs a base branch and child PR sequence.
+- The final initiative PR must target `develop` but remain unmerged for the user.
+
+## Scope
+
+This skill owns orchestration only:
+
+- recommendation gate enforcement;
+- branch and PR sequencing;
+- owner-skill routing;
+- verification checkpoint ordering;
+- PR summary requirements;
+- final handoff state.
+
+It does not own package architecture, test design, branch safety, SPEC authoring, commit messages,
+or implementation details.
+
+## Pipeline
+
+1. Read the target backlog and `.agents/rules/backlog-execution.md`.
+2. Present a recommendation gate before implementation:
+   - proposed approach;
+   - why it matches backlog intent;
+   - why it matches repo rules, layering, and ownership;
+   - affected scope;
+   - test and verification plan;
+   - decisions that require the user.
+3. If the recommendation is coherent with rules and architecture, proceed. If not, stop and ask.
+4. Use `branch-guard` before commits or branch changes.
+5. For multi-backlog initiatives:
+   - create or confirm the initiative base branch from `develop`;
+   - create one child branch per backlog or split work unit;
+   - open each child PR into the initiative base branch;
+   - merge each child PR after checks pass;
+   - open the final initiative PR into `develop`;
+   - do not auto-merge the final `develop` PR.
+6. Route detailed work to owner skills.
+7. Ensure every PR body records recommendation, rationale, implementation summary, tests, and
+   residual risks.
+
+## Owner Skill Routing
+
+- Branch safety and protected branches: `branch-guard`
+- Docs, backlog, ADR, or commit wording: `repo-writing`
+- Impact, verification, and residual risk loop: `repo-change-loop`
+- Contract boundary or package ownership change: `spec-first-development`
+- SPEC authoring: `spec-writing-standard`
+- SPEC/code drift after spec changes: `spec-code-conformance`
+- Tests and red-green-refactor work: `tdd-red-green-refactor`
+- Vitest strategy: `vitest-testing-strategy`
+- Architecture/layering boundary: `architecture-patterns`
+- Type contracts and trust boundaries: `type-boundary-and-ssot`
+- Post-implementation release/docs checklist: `post-implementation-checklist`
+
+Load only the owner skills needed for the current backlog or work unit.
+
+## PR Body Requirements
+
+Every child PR must include:
+
+- accepted recommendation;
+- rationale against backlog intent and architecture;
+- implementation summary;
+- tests and verification commands;
+- residual risks or skipped checks;
+- next backlog or handoff note when relevant.
+
+## Stop Conditions
+
+- No recommendation gate was presented.
+- The recommendation conflicts with rules, ownership, architecture, or backlog intent.
+- The work combines unrelated backlogs in one PR.
+- A child branch targets `develop` instead of the initiative base branch during a multi-backlog
+  initiative.
+- The final initiative PR would be auto-merged into `develop`.
+- This skill would need to duplicate detailed instructions already owned by another skill.

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -7,16 +7,17 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Process & Planning
 
-| Skill                                                                   | Description                                                     |
-| ----------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [spec-first-development](spec-first-development/SKILL.md)               | Enforce spec-first workflow before touching contract boundaries |
-| [spec-writing-standard](spec-writing-standard/SKILL.md)                 | Required sections and quality gates for SPEC.md authoring       |
-| [spec-code-conformance](spec-code-conformance/SKILL.md)                 | Verification loop to align code with spec after spec changes    |
-| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)               | Kent Beck TDD cycle: Red → Green → Refactor                     |
-| [task-tracking](task-tracking/SKILL.md)                                 | Create and update task files in `.agents/tasks/`                |
-| [post-implementation-checklist](post-implementation-checklist/SKILL.md) | Mandatory checklist after completing implementation work        |
-| [repo-change-loop](repo-change-loop/SKILL.md)                           | Standard change loop: impact → build → verify → summarize       |
-| [version-management](version-management/SKILL.md)                       | Coordinated version bumps with changesets across all packages   |
+| Skill                                                                     | Description                                                     |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries |
+| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring       |
+| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes    |
+| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                     |
+| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                |
+| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Recommendation-gated backlog PR pipeline                        |
+| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work        |
+| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize       |
+| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages   |
 
 ## Code Quality & Architecture
 


### PR DESCRIPTION
## Recommendation Gate

Recommendation: implement the Backlog Execution Orchestrator Skill as a thin procedural wrapper and archive the completed backlog item.

Rationale:
- The backlog asks for an orchestration skill, not a detailed implementation skill.
- The skill keeps orchestration responsibilities limited to recommendation gates, branch and PR sequencing, owner-skill routing, verification checkpoint ordering, and PR summary requirements.
- Detailed behavior remains delegated to existing owner skills such as branch-guard, repo-writing, repo-change-loop, spec-first-development, tdd-red-green-refactor, architecture-patterns, and post-implementation-checklist.
- This matches the repository layering rule: rules define mandatory process, skills orchestrate procedure, and package SPEC files own package contracts.

## Changes

- Added .agents/skills/backlog-execution-orchestrator/SKILL.md.
- Updated .agents/skills/index.md.
- Moved .agents/backlog/backlog-execution-orchestrator-skill.md to .agents/backlog/completed/ and marked acceptance criteria complete.
- Removed the completed backlog from .agents/backlog/README.md.

## Tests

- pnpm harness:scan
- pre-push fast verification:
  - pnpm harness:scan:consistency
  - pnpm harness:scan:test-plans

## Residual Risk

- No runtime code changed. The remaining risk is procedural drift, which can be handled later with a governance scan if the new skill is misused.