### PR TITLE
docs(backlog): split transparent workflow planning

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,4 +11,10 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Items
 
-- [CLI AI Workflow Reviewer and Harness Planning](cli-ai-workflow-reviewer-harness-planning.md)
+- [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
+- [Transparent Workflow Contract for agent-cli](cli-transparent-workflow-contract.md)
+- [User-Local Storage Foundation for agent-cli](cli-user-local-storage-foundation.md)
+- [Transparent Process Execution for agent-cli](cli-transparent-process-execution.md)
+- [Background Work State Management for agent-cli](cli-background-work-state-management.md)
+- [User-Local Memory Transparency for agent-cli](cli-user-local-memory-transparency.md)
+- [Repository Situational Awareness for agent-cli](cli-repository-situational-awareness.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -1,4 +1,4 @@
-# CLI AI Workflow Reviewer and Harness Planning
+# Transparent Repo-Agnostic Workflow Client Planning for agent-cli
 
 ## Status
 
@@ -10,22 +10,42 @@ Backlog.
 
 ## Priority
 
-P0 - strategic planning for making `agent-cli` a complete AI agent assistant control surface while
-keeping reusable behavior below the CLI shell.
+P0 - umbrella planning backlog for making `agent-cli` a transparent, repo-agnostic workflow client
+without making user repositories depend on Robota.
 
 ## Request
 
-Plan how `agent-cli` should evolve so AI workflows run well inside a user's repository and can drive
-that repository's harness reliably.
+Plan how `agent-cli` should evolve so AI workflows run well inside a user's repository while the
+repository remains fully independent from `agent-cli`.
 
-The planning must:
+The core question is:
 
-- study Josh's newsletter article, "Y Combinator says the most reliable way to build an AI-native
-  company";
-- create an agent profile inspired by the article's operating principles;
-- compare relevant public behavior from major AI assistant tools;
-- propose how Robota `agent-cli` should evolve;
-- keep `agent-cli` as UI/TUI only, with workflow contracts implemented in lower owner packages.
+> If the user owns the harness and the repository must work without Robota, what basic repo context,
+> process execution, background state, and user-local memory infrastructure should `agent-cli`
+> provide so the user can predict what Robota will do and trust it to act on the user's intent?
+
+This umbrella backlog splits the work into focused backlog documents that keep the same backlog
+shape and can later become independent implementation PRs.
+
+## Non-Negotiable Product Principles
+
+- **Repo owns the harness.** Build, test, lint, typecheck, release, docs, smoke, visual, and custom
+  checks belong to the user repository.
+- **The repo must work without `agent-cli`.** A human, CI job, another agent, or a shell can run the
+  same harness without Robota being installed.
+- **`agent-cli` must not inject harness files.** No automatic Robota manifest, CI patch,
+  `.agents/`, `.robota/`, task file, script, package dependency, or hook installation is allowed as
+  part of basic operation.
+- **Command choice is user-directed.** `agent-cli` must not infer a repository harness contract,
+  rank likely commands, or present a guessed command catalog as default product behavior.
+- **Transparency is part of correctness.** A feature is incomplete if the user cannot tell what
+  Robota is doing, why a state changed, what source produced a shown item, or how to inspect/remove
+  remembered local state.
+- **Local memory is user-local only.** Baseline memory must be stored outside the repository. No
+  workspace-local ignored state, repo-side cache, or tracked repo file is allowed for baseline
+  memory.
+- **Advisory repo inspection is explicit.** If a user asks Robota to inspect docs, scripts, CI, or
+  failures, that is an explicit advisory task, not baseline CLI behavior.
 
 ## Source Article Summary
 
@@ -38,12 +58,17 @@ Important principles to carry into Robota:
 
 - AI should be treated as an operating layer for work, not a small productivity add-on.
 - Important work should become a closed loop: decide, execute, measure, learn, and adjust.
-- The repository must be legible and queryable by AI: instructions, specs, task history, commands,
-  evidence, and decisions must be durable artifacts.
-- Software-factory style work starts with human-authored specs and success tests, then agents
-  implement and iterate until the harness passes.
+- The repository must be legible and queryable by AI through repo-owned instructions, specs,
+  commands, evidence, and decisions.
 - Humans remain responsible for choosing goals and judging whether the result is good enough.
 - Token spend should be optimized as leverage and throughput, not only minimized as cost.
+
+Robota interpretation:
+
+- Robota should help the user operate a mature repo well, but should not become the source of the
+  repo's harness structure.
+- The primary product goal is predictable assistance. Robota should have strong basic capabilities,
+  but hidden automation and unclear state transitions are product failures.
 
 ## Prior Art To Study
 
@@ -63,131 +88,111 @@ Important principles to carry into Robota:
 - Jules Tools CLI: remote session list/new/status/pull style workflow for delegated agent sessions:
   <https://jules.google/docs/cli/reference/>
 
-## Agent Profile
+## Neutral Reviewer Profile
 
-Name: `AI Native Workflow Reviewer`
+Name: `Repo Workflow Client Reviewer`
 
 Important: this profile must not impersonate Josh, YC, Diana Hu, OpenAI, Anthropic, Cursor, Google,
 or any named person/company. It should be an original Robota reviewer inspired by the article's
-principles: closed loops, high context, software-factory discipline, token leverage, and
-founder/operator accountability.
+principles: closed loops, high context, software-factory discipline, token leverage, and operator
+accountability.
 
 Reviewer role:
 
-- Inspect a proposed Robota workflow or `agent-cli` feature.
-- Identify whether the repo is legible enough for an agent to operate.
-- Check whether the flow records artifacts that a later agent can query.
-- Check whether human goal-setting and result judgment remain explicit.
-- Reject designs that move durable workflow semantics into `agent-cli`.
-- Recommend the smallest owner-first implementation slice.
+- Inspect a proposed `agent-cli` workflow feature.
+- Reject designs that require the user's repo to depend on Robota.
+- Reject baseline designs that infer, rank, or own repo commands.
+- Reject baseline designs that perform evidence judgment, failure diagnosis, repair loops, review
+  gates, hook installation, or repo workflow orchestration.
+- Check whether command origin, background status, memory usage, and UI state are visible enough for
+  a user to predict behavior.
+- Recommend the smallest non-invasive client implementation slice.
 
-Output shape:
+## Split Backlog Items
 
-```text
-Findings:
-- [severity] owner: workflow risk or evidence gap
+- [Transparent workflow contract](cli-transparent-workflow-contract.md): action provenance, named
+  states, memory inspection, and UI disclosure rules shared by all baseline workflow features.
+- [User-local storage foundation](cli-user-local-storage-foundation.md): canonical user-local-only
+  storage root, category contracts, inspection/removal APIs, and repo-outside validation.
+- [Transparent process execution](cli-transparent-process-execution.md): running user-supplied
+  commands with visible origin, cwd, environment summary, output, cancellation, and terminal result.
+- [Background work state management](cli-background-work-state-management.md): switchable main
+  thread, shell job, and agent task state with transparent lifecycle and retention behavior.
+- [User-local memory transparency](cli-user-local-memory-transparency.md): cwd, view preference, and
+  task association storage that is inspectable, removable, and stored outside the repository.
+- [Repository situational awareness](cli-repository-situational-awareness.md): passive display of
+  current working context without command inference, repo scanning, or package-manager guessing.
 
-Required owner updates:
-- SPEC / architecture / manifest / harness contract changes
+## Expected Outcomes
 
-Recommended next slice:
-- smallest PR that improves the closed loop
-```
-
-## Planning Direction
-
-The recommended plan is to make `agent-cli` the local workflow cockpit, not the owner of workflow
-logic.
-
-Feature pillars:
-
-1. **Repository legibility bootstrap**
-   - Detect package manager, install/build/test/lint/typecheck/docs commands, CI config,
-     instructions, specs, task files, and harness entrypoints.
-   - Produce setup gaps as actionable tasks.
-
-2. **Workflow manifest and harness command registry**
-   - Let a repo declare canonical harness commands and evidence requirements.
-   - Commands must be parsed and executed by SDK/runtime/harness owner APIs, not CLI components.
-
-3. **Spec-and-test-first task intake**
-   - Turn a user request into goal, owner package, governing SPEC/API doc, success criteria,
-     failing-test plan, verification commands, and stop conditions.
-
-4. **Closed-loop execution workspace**
-   - Model plan, implement, verify, diagnose, retry, review, and archive as a structured workflow
-     run.
-   - Capture artifacts: plan, changed files, command evidence, failing signatures, fixes attempted,
-     final evidence, and open risks.
-
-5. **Background workflow dashboard**
-   - Show main thread, shell jobs, harness runs, and agent tasks in one switchable workspace list.
-   - Support status, latest output, elapsed time, cost/tokens, touched files, input-needed state,
-     cancellation, follow-up, takeover, and result pull/apply flows.
-
-6. **Deterministic workflow hooks**
-   - Support repo-defined session-start, prompt-submit, before-command, after-command,
-     before-commit, before-merge, after-verification, and stop/continue hooks.
-   - Hooks may inject context or block unsafe steps deterministically.
-
-7. **Review and evidence gate**
-   - Group diffs by owner package.
-   - Link every review section to verification evidence.
-   - Generate PR summaries from structured artifacts, not free-form chat memory.
-
-8. **Environment setup profiles**
-   - Let repos describe install/start/watch/test services.
-   - Show readiness before work begins.
-
-9. **Token and cost leverage telemetry**
-   - Track token spend, model choice, command time, retry loops, and evidence produced.
-   - Report cost as workflow leverage.
-
-10. **Workflow packaging**
-    - Let teams save repeated loops as repo-local skills/workflows: release prep, bug triage,
-      package audit, dependency upgrade, docs sync, code review, and security pass.
+- Work can be promoted as focused PRs instead of one oversized CLI feature.
+- Every focused backlog inherits the same repo-agnostic and transparent behavior rules.
+- `agent-cli` becomes more capable at the moment the user tries to act, while avoiding hidden repo
+  inference or Robota-owned harness structure.
+- SDK/runtime ownership is established before TUI work, reducing the risk that `agent-cli` becomes
+  the owner of workflow semantics.
+- Later review can evaluate each capability independently: transparency contract, process
+  execution, background state, user-local storage, local memory, and repo context display.
 
 ## Architecture Ownership Rule
 
-`agent-cli` owns only TUI screens, keyboard navigation, prompt intake, review UI, and local host
-adapter wiring.
+`agent-cli` owns only TUI screens, keyboard navigation, prompt intake, task list rendering, and local
+host adapter wiring.
 
 Lower owners must be established first:
 
-- `agent-sdk`: workflow session APIs, task intake contracts, command/hook facades, artifact readers,
-  review summary APIs.
-- `agent-runtime`: workflow/background task lifecycle, cancellation, runners, event streams, task
-  state machines.
-- harness owner package or cross-cutting spec: workflow manifest schema, harness command registry,
-  verification evidence model, hook contract.
-- `agent-command-*`: user-visible commands such as workflow status, harness run, review, task
-  intake, and workflow packaging.
+- `agent-runtime`: process lifecycle, background task lifecycle, cancellation, output streams,
+  named status transitions, retention windows, and task state machines.
+- `agent-sdk`: stable APIs for repo context display, process execution requests, background task
+  projections, action provenance, local preference inspection/removal, and session-state access.
+- `agent-command-*`: user-visible commands for run/status/task switching/preference inspection,
+  backed by SDK/runtime contracts.
 
-Do not implement durable workflow state, manifest parsing, command semantics, retention policy,
-artifact schema, or hook policy inside `agent-cli`.
+Do not implement durable workflow state, repo manifest parsing requirements, command semantics,
+retention policy, artifact schema, evidence judgment, review policy, or hook policy inside
+`agent-cli`.
+
+Do not require a Robota manifest or Robota package dependency in user repositories.
 
 ## Recommended First Slice
 
-Create a design and contract PR before UI work:
+Promote the split backlogs in this order:
 
-1. Confirm the `AI Native Workflow Reviewer` profile and reviewer output contract.
-2. Define the repository workflow manifest schema and harness command registry.
-3. Update the cross-cutting spec index and architecture map.
-4. Update `agent-cli`, `agent-sdk`, and `agent-runtime` SPEC files with ownership boundaries.
-5. Add follow-up backlog slices for parser tests, SDK projections, CLI dashboard, review/evidence
-   gate, hooks, environment profiles, telemetry, and workflow packaging.
+1. `cli-transparent-workflow-contract.md`
+2. `cli-user-local-storage-foundation.md`
+3. `cli-transparent-process-execution.md`
+4. `cli-background-work-state-management.md`
+5. `cli-user-local-memory-transparency.md`
+6. `cli-repository-situational-awareness.md`
+
+Each implementation PR should update the owning package specs before changing `agent-cli` UI.
 
 ## Acceptance Criteria
 
+- [ ] The umbrella backlog links every focused backlog item.
 - [ ] The planning document cites the source article and prior-art docs.
 - [ ] The reviewer profile is inspired by the article but does not impersonate a named person.
-- [ ] The plan clearly separates CLI UI from SDK/runtime/harness ownership.
-- [ ] The first implementation slice is small enough to land as a single PR.
-- [ ] Follow-up slices exist for manifest parsing, harness registry, workflow artifacts, hooks,
-      background dashboard, review evidence, and telemetry.
+- [ ] The plan clearly states that user repos own their harness and must not depend on Robota.
+- [ ] The plan clearly separates CLI UI from SDK/runtime ownership.
+- [ ] The plan forbids automatic repo injection of Robota manifests, hooks, scripts, package
+      dependencies, or CI changes.
+- [ ] The plan forbids baseline command discovery, evidence judgment, failure diagnosis, repair
+      loops, review gates, readiness scoring, and hook ownership.
+
+## Test Plan
+
+- Add document-link validation for every split backlog item referenced by the umbrella backlog and
+  `README.md`.
+- Add document authority checks that fail if implementation details are placed only in `agent-cli`
+  without SDK/runtime ownership.
+- For each focused backlog promoted to implementation, require package-level contract tests before
+  TUI rendering tests.
+- Include at least one fixture repository with no Robota files and no Robota local state inside the
+  repo to verify that the planned behavior remains repo-agnostic.
 
 ## Verification Plan
 
 - `pnpm harness:scan`
 - Document authority scan must pass when this backlog is later promoted.
 - Implementation PRs must add contract tests before TUI screens.
+- Tests must include repos without Robota files to prove the client remains repo-agnostic.

--- a/.agents/backlog/cli-background-work-state-management.md
+++ b/.agents/backlog/cli-background-work-state-management.md
@@ -1,0 +1,129 @@
+# Background Work State Management for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - baseline transparency feature for switching between main conversation, shell jobs, and agent
+tasks.
+
+## Request
+
+Design and implement transparent background work state management for `agent-cli`.
+
+The TUI should let the user enter a background-work view where the main thread, shell work, and
+agent tasks appear as a switchable list. The selected item should use a filled indicator and
+unselected items should use an empty indicator. Selecting an item should switch to its current
+output, progress, or interaction state.
+
+## Non-Negotiable Product Principles
+
+- **Background state must be transparent.** Users must be able to see what exists, where it came
+  from, what state it is in, and what actions are available.
+- **State ownership belongs below CLI.** `agent-cli` renders the list and controls navigation; SDK
+  and runtime own task lifecycle, state transitions, cancellation, and retention.
+- **Completed work should remain understandable.** Background entries should be retained long enough
+  for the user to inspect terminal result, latest output, and next action, then be explicitly
+  archived or cleared.
+- **Repo independence remains mandatory.** Background state is local workflow state, not repo schema.
+
+## State Scope
+
+Background entries must support:
+
+- main conversation thread;
+- local shell/process jobs;
+- agent tasks;
+- future skill-spawned agent tasks through the same lower-level task model and registration API.
+
+Each entry should expose:
+
+- id, type, title, origin/source, selected state, lifecycle status;
+- cwd or workspace context when applicable;
+- elapsed time and start time;
+- latest output summary;
+- input-needed state;
+- cancelability and supported actions;
+- terminal result;
+- retention/archive/clear state.
+
+## Expected Outcomes
+
+- Users can freely switch between the main conversation, shell jobs, and agent tasks without losing
+  track of what is running.
+- Background work becomes predictable because every entry has a type, origin, status, selected
+  state, latest output, and available actions.
+- Completed work remains inspectable long enough to understand what happened, then can be explicitly
+  archived or cleared.
+- Skill-spawned agent work and ordinary shell work can share the same projection model instead of
+  receiving separate CLI-only behavior.
+- Skills that spawn agents do not receive a special CLI path; they register task lifecycle through
+  the same SDK/runtime layer as every other background task.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only TUI entry rendering, keyboard navigation, selection indicators, and view
+switching.
+
+Lower owners must be established first:
+
+- `agent-runtime`: task lifecycle, event streams, cancellation, terminal states, retention windows,
+  and archive/clear state.
+- `agent-sdk`: background task projection APIs, selected-task state, and task action contracts.
+- `agent-command-*`: user-visible status/switch/cancel/archive commands backed by SDK/runtime
+  contracts.
+
+Do not implement task lifecycle, terminal-state rules, retention policy, or agent-task ownership
+inside `agent-cli`.
+
+Skills and tools that spawn agent tasks must register those tasks through SDK/runtime contracts.
+They must not write directly to CLI UI state or define a separate background-task path.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Define the background task projection model.
+2. Define lifecycle states and allowed transitions.
+3. Define task actions: select, follow, cancel, archive, clear, and return-to-main.
+4. Define retention behavior for completed, failed, and cancelled tasks.
+5. Update `agent-runtime`, `agent-sdk`, `agent-command-*`, and `agent-cli` SPEC files.
+6. Add focused tests for state transitions and projection stability.
+
+## Acceptance Criteria
+
+- [ ] The main thread, shell jobs, and agent tasks share one background task projection model.
+- [ ] The TUI can render selected and unselected entries without owning lifecycle state.
+- [ ] Each entry exposes origin, status, latest output, elapsed time, input-needed state,
+      cancelability, and terminal result.
+- [ ] Completed tasks have explicit retention/archive/clear behavior.
+- [ ] Skill-spawned agent tasks can fit the same model without CLI-specific special cases.
+- [ ] Skill-spawned agent tasks register through SDK/runtime task contracts, not CLI UI state.
+
+## Test Plan
+
+- Add runtime state machine tests for queued, running, waiting-for-input, completed, failed,
+  cancelled, and archived transitions.
+- Add runtime tests for cancellation, input-needed state, terminal result retention, archive, and
+  clear behavior.
+- Add SDK projection tests for main thread, shell process, agent task, and skill-spawned agent task
+  entries.
+- Add tests proving skill-spawned agent tasks use the same SDK/runtime registration path as other
+  agent tasks.
+- Add CLI rendering tests for selected and unselected indicators, latest output summary, elapsed
+  time, input-needed state, and supported actions.
+- Add regression tests proving `agent-cli` does not own lifecycle state or duplicate terminal-state
+  rules.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Add runtime tests for task state transitions and retention.
+- Add SDK contract tests for background task projections.
+- Add CLI rendering tests after lower contracts exist.

--- a/.agents/backlog/cli-repository-situational-awareness.md
+++ b/.agents/backlog/cli-repository-situational-awareness.md
@@ -1,0 +1,116 @@
+# Repository Situational Awareness for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P1 - baseline context display feature for helping users understand where Robota is operating.
+
+## Request
+
+Make `agent-cli` show the current operating context clearly without turning context display into
+repo scanning, package-manager guessing, command discovery, harness scoring, or repo workflow
+inference.
+
+The feature must answer:
+
+> Where is Robota currently operating, what session-known state is visible, and what source produced
+> each displayed context item?
+
+## Non-Negotiable Product Principles
+
+- **Repo reads stay minimal and session-directed.** Displaying context must not create Robota files,
+  modify repo files, scan the repo, guess package manager setup, or infer a harness contract.
+- **Context source must be clear.** Each displayed item should identify whether it came from git
+  state, cwd, active session state, or explicit user reference.
+- **Command discovery is explicit-only.** Passive context display must not infer "the test command",
+  "the build command", or any canonical harness command.
+- **Repo independence remains mandatory.** The repository must work the same without Robota.
+
+## Context Scope
+
+Allowed baseline context:
+
+- repo root;
+- current branch;
+- dirty status summary;
+- cwd;
+- explicitly opened or referenced docs;
+- active background task workspace context.
+
+Restricted context:
+
+- no command candidate ranking;
+- no readiness scoring;
+- no CI-to-local command mapping;
+- no package manager guessing;
+- no visible workspace file enumeration;
+- no automatic setup profile generation;
+- no repo-side manifest or config requirement.
+
+## Expected Outcomes
+
+- Users can quickly understand where Robota is operating before running commands or switching work.
+- Displayed context becomes trustworthy because every item has a visible source.
+- Session-known context helps orientation without becoming repo scanning, command discovery,
+  readiness scoring, or hidden repo workflow inference.
+- Repo independence remains clear because context display does not create Robota files or require
+  repo-side configuration.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only TUI display of repository context.
+
+Lower owners must be established first:
+
+- `agent-sdk`: current context projection APIs, context provenance fields, and minimal read
+  boundaries.
+- `agent-command-*`: user-visible context/status commands backed by SDK contracts.
+
+Do not implement repo scanning policy, package-manager guessing, command inference, readiness
+scoring, or context provenance rules inside `agent-cli`.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Define the repo context projection model.
+2. Define allowed session-known context sources and provenance labels.
+3. Define forbidden baseline inference behavior.
+4. Update `agent-sdk`, `agent-command-*`, and `agent-cli` SPEC files.
+5. Add tests proving context display does not create repo files, scan workspace files, guess package
+   managers, or infer commands.
+
+## Acceptance Criteria
+
+- [ ] The context view shows repo root, branch, dirty status, cwd, explicitly referenced docs, and
+      active background workspace context where available.
+- [ ] Each context item has a clear source/provenance.
+- [ ] Context display does not infer canonical commands, readiness scores, package manager setup, or
+      visible workspace files.
+- [ ] Context display does not write repo files.
+- [ ] CLI UI depends on SDK context projections rather than owning repo scanning policy.
+
+## Test Plan
+
+- Add SDK tests for repo root, branch, dirty status, cwd, explicit document-reference projections,
+  and active background workspace context.
+- Add provenance tests proving each displayed context item includes a source label.
+- Add negative tests proving context projection does not infer canonical commands, readiness scores,
+  CI mappings, package manager setup, visible workspace files, or setup profiles.
+- Add tests proving context display does not create or modify repo files.
+- Add CLI rendering tests after SDK projections exist.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Add SDK tests for repo context projection and provenance.
+- Add tests proving no repo files are written.
+- Add tests proving no package-manager guessing or workspace-file enumeration occurs.
+- Add CLI rendering tests after SDK contracts exist.

--- a/.agents/backlog/cli-transparent-process-execution.md
+++ b/.agents/backlog/cli-transparent-process-execution.md
@@ -1,0 +1,123 @@
+# Transparent Process Execution for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - baseline local workflow capability for running user-supplied commands predictably.
+
+## Request
+
+Make `agent-cli` excellent at running commands the user chose or explicitly accepted, while keeping
+the command's meaning owned by the user and repository.
+
+The feature must answer:
+
+> What exactly is running, where is it running, why was it selected, what can I do to it, and what
+> happened when it finished?
+
+## Non-Negotiable Product Principles
+
+- **Command choice is user-directed.** `agent-cli` must not infer a repository harness contract,
+  rank likely commands, or present a guessed command catalog as default behavior.
+- **Commands are opaque capabilities.** `agent-cli` may run, display, and cancel user-directed
+  commands, but it must not own their meaning or persist them as reusable preferences.
+- **Process execution must be transparent.** The user must see origin, cwd, environment summary,
+  status, output, cancellation policy, and terminal result.
+- **Repo independence remains mandatory.** The runner must not require repo-side Robota adapters,
+  manifests, scripts, hooks, or package dependencies.
+
+## Execution Scope
+
+Allowed baseline behavior:
+
+- run user-entered commands;
+- run commands explicitly accepted from assistant suggestions;
+- stream output with pagination;
+- support foreground and background process modes;
+- support cancellation, timeout, exit code, duration, and retained output summary.
+
+Restricted behavior:
+
+- do not infer that a command is the canonical test/build/lint command;
+- do not execute commands from remembered history, session recall, or user-local preference;
+- do not score command readiness;
+- do not judge command output as correctness evidence unless the user asks for advisory analysis;
+- do not automatically start repair loops after failure.
+
+## Expected Outcomes
+
+- Users can tell exactly what command is running, why it was selected, where it is running, and how
+  to stop it.
+- Command execution becomes reliable enough for ordinary local work without requiring repo-specific
+  Robota adapters.
+- Commands run only from current user input or explicit acceptance, keeping command choice tied to
+  present user intent.
+- Failed commands are understandable as process results, not silently converted into diagnosis or
+  repair workflows.
+- Process state can be projected into the background work view without duplicating lifecycle logic
+  inside `agent-cli`.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only process execution UI: prompt intake, run confirmation, output panes, keyboard
+controls, and status rendering.
+
+Lower owners must be established first:
+
+- `agent-runtime`: process lifecycle, stdout/stderr streams, stdin policy, timeout, cancellation,
+  exit status, duration, and retention limits.
+- `agent-sdk`: stable process execution request/result APIs, command provenance, and projected
+  process status.
+- `agent-command-*`: user-visible run/status commands backed by SDK/runtime contracts.
+
+Do not implement command semantics, output interpretation, retention policy, or process lifecycle
+state inside `agent-cli`.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Define the process execution request contract: command, origin, cwd, env summary, stdin policy,
+   timeout, foreground/background mode, and cancellation capability.
+2. Define the process execution status contract: queued/running/waiting-for-input/completed/failed/
+   cancelled/archived, latest output summary, exit code, duration, and retained transcript pointer.
+3. Define output retention limits and truncation disclosure.
+4. Update `agent-runtime`, `agent-sdk`, `agent-command-*`, and `agent-cli` SPEC files.
+5. Add focused tests for command provenance, cancellation, terminal status, and output truncation.
+
+## Acceptance Criteria
+
+- [ ] A user can see what command is running, where it is running, and why it was selected.
+- [ ] Commands only run from current user input or explicit user acceptance.
+- [ ] The runner supports foreground/background execution, cancellation, timeout, output paging,
+      exit code, and duration.
+- [ ] Command history or retained output does not become correctness evidence by default.
+- [ ] The implementation does not require repo-side Robota adapters or files.
+- [ ] CLI UI depends on SDK/runtime contracts rather than owning process lifecycle state.
+
+## Test Plan
+
+- Add runtime tests for foreground and background process execution.
+- Add runtime tests for cancellation, timeout, exit code, duration, and terminal status.
+- Add output tests for stdout/stderr streaming, pagination, truncation, and truncation disclosure.
+- Add SDK contract tests for command origin, cwd, environment summary, and process status
+  projection.
+- Add CLI tests that verify command origin, cwd, status, latest output, and terminal result are
+  visible.
+- Add negative tests proving remembered history, session recall, and user-local preferences cannot
+  directly execute commands.
+- Add negative tests proving command output is not classified as correctness evidence by default.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Add contract tests for process execution request/status models.
+- Add runtime tests for cancellation, timeout, exit status, and output truncation.
+- Add CLI tests only after SDK/runtime contracts exist.

--- a/.agents/backlog/cli-transparent-workflow-contract.md
+++ b/.agents/backlog/cli-transparent-workflow-contract.md
@@ -1,0 +1,136 @@
+# Transparent Workflow Contract for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - foundational contract that every transparent workflow feature must satisfy before UI work.
+
+## Request
+
+Define the cross-cutting transparency contract for `agent-cli` workflow features.
+
+The contract must make Robota predictable when the user is trying to do something: actions, state
+changes, memory use, and UI transitions must have visible provenance and simple rules.
+
+## Non-Negotiable Product Principles
+
+- **Transparency is part of correctness.** A feature is incomplete if the user cannot tell what
+  Robota is doing, why a state changed, what source produced a shown item, or how to inspect/remove
+  remembered local state.
+- **Every action has visible provenance.** The UI/API must distinguish user-entered commands,
+  assistant suggestions accepted by the user, active session state, user-local UI preferences, and
+  explicitly referenced repo-owned documents. User-local preferences must not be a source for
+  command execution.
+- **Hidden automation is not a baseline feature.** If Robota suggests or infers something, it must
+  be labeled as a suggestion and require explicit user acceptance before execution.
+- **Repo independence remains mandatory.** The contract must not require Robota files, manifests,
+  hooks, scripts, package dependencies, or CI changes in the user repository.
+
+## Contract Scope
+
+The contract must define:
+
+- action provenance fields;
+- named state transitions;
+- memory inspection and deletion rules;
+- UI disclosure requirements;
+- boundaries between user-directed execution and explicit advisory analysis;
+- the rule that remembered commands are not a baseline command source.
+
+## Required Contract Rules
+
+1. **Action transparency**
+   - Before or while running work, show what will run or is running: command or task label, origin,
+     cwd, selected environment summary, start time, timeout/cancellation policy, and whether it is
+     foreground or background.
+   - For command execution, origin must be either user input or an accepted assistant suggestion.
+   - For display and navigation, origin may also include active session state, user-local UI
+     preference, or explicit repo document reference.
+   - User-local UI preferences may affect display and navigation, but must not execute commands.
+
+2. **State transparency**
+   - Background entries must show type, owner/source, status, selected state, elapsed time, latest
+     output summary, input-needed state, cancelability, and terminal result.
+   - State transitions must be small and named: queued, running, waiting-for-input, completed,
+     failed, cancelled, or archived.
+
+3. **Memory transparency**
+   - Local memory must be visible through an inspection command or TUI panel.
+   - Each remembered item must show key, value summary, scope, source, last-used time, storage
+     location, and deletion/disable action.
+   - Robota must not silently convert repeated behavior into a persistent preference.
+   - Remembered commands are not a baseline command source and must not be reused for execution.
+
+4. **Interface transparency**
+   - The UI should expose the smallest complete set of facts needed to act confidently.
+   - Internal implementation details can remain hidden, but user-impacting state, actions, and
+     memory must be inspectable.
+
+## Expected Outcomes
+
+- Users can predict why Robota is showing or doing something because action provenance, state, and
+  memory visibility have common labels.
+- Process execution, background work, local memory, and repo context features share one vocabulary
+  instead of inventing separate UI rules.
+- Hidden automation becomes easier to reject during review because every user-impacting action must
+  declare its source.
+- `agent-cli` remains a renderer of transparent state while SDK/runtime own the contracts and
+  lifecycle rules.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only TUI presentation of the transparency contract.
+
+Lower owners must be established first:
+
+- `agent-runtime`: named lifecycle states and transition rules for processes and tasks.
+- `agent-sdk`: action provenance types, projected state models, and local memory inspection APIs.
+- `agent-command-*`: user-visible commands that expose status and memory inspection through SDK
+  contracts.
+
+Do not define action provenance, lifecycle state names, memory storage shape, or retention policy
+inside `agent-cli`.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Add or update the cross-cutting spec for transparent workflow primitives.
+2. Define action provenance as a typed contract.
+3. Define lifecycle state names and valid transitions.
+4. Define memory inspection/removal requirements.
+5. Update `agent-cli`, `agent-sdk`, and `agent-runtime` SPEC files with ownership boundaries.
+6. Add follow-up backlog links to process execution, background state, local memory, and repo
+   context work.
+
+## Acceptance Criteria
+
+- [ ] The contract defines action provenance, named states, memory inspection, and UI disclosure.
+- [ ] The contract separates CLI UI from SDK/runtime ownership.
+- [ ] The contract forbids hidden baseline automation and command inference.
+- [ ] The contract forbids remembered commands from becoming a baseline command source.
+- [ ] The contract requires user-impacting state and remembered values to be inspectable.
+- [ ] The contract does not require any repo-side Robota file or dependency.
+
+## Test Plan
+
+- Add type-level or unit tests for accepted action provenance values.
+- Add state machine tests for allowed lifecycle transitions and invalid transition rejection.
+- Add contract tests for memory projection fields: key, value summary, scope, source, storage
+  location, last-used time, and deletion/disable capability.
+- Add CLI rendering tests only after SDK/runtime contracts exist, verifying that provenance and
+  state labels are visible without exposing private implementation details.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Document authority scan must pass when this backlog is later promoted.
+- Implementation PRs must add contract tests before TUI screens.
+- Tests must include repos without Robota files to prove the client remains repo-agnostic.

--- a/.agents/backlog/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/cli-user-local-memory-transparency.md
@@ -1,0 +1,139 @@
+# User-Local Memory Transparency for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - baseline transparency feature for local preferences and remembered workflow state.
+
+## Request
+
+Define user-local memory and preference behavior for `agent-cli` so remembered values help the user
+without becoming hidden automation, command reuse, or repo-owned configuration.
+
+This backlog depends on
+[User-Local Storage Foundation](cli-user-local-storage-foundation.md) for storage root resolution,
+repo-outside validation, inspection/removal APIs, and persistence policy.
+
+The feature must answer:
+
+> What did Robota remember, where is it stored, where is it displayed, and how can I remove or
+> disable it?
+
+## Non-Negotiable Product Principles
+
+- **User-local memory is allowed only outside the repo.** Preferred working directories, UI state,
+  and session state must be stored in user-local storage outside the repository.
+- **Local memory must be inspectable.** Users must be able to view what is remembered, where it is
+  stored, where it may be displayed, and how to delete or disable it.
+- **Remembered command reuse is excluded.** Commands must not be persisted as reusable preferences
+  and must not execute from local memory, session recall, or command history.
+- **Memory may affect UI only within defined bounds.** Remembered values may affect display and
+  navigation preferences, but not command execution.
+- **Team-shared workflows are not Robota requirements.** If teams want repo-shared workflow files,
+  they should add them intentionally through their own repo conventions.
+
+## Memory Scope
+
+Allowed baseline memory:
+
+- last visible cwd or view choices for display/navigation only;
+- TUI view preferences;
+- session-local task associations;
+- last selected background task;
+- local display preferences.
+
+Restricted memory:
+
+- no hidden persistent command inference;
+- no automatic conversion from repeated behavior into persistent preference;
+- no command history or remembered command reuse as a baseline memory feature;
+- no repo-local writes of any kind for baseline memory, including ignored files;
+- no repo-shared workflow format required by `agent-cli`.
+
+Each remembered item should expose:
+
+- key;
+- value summary;
+- scope;
+- source;
+- storage location;
+- created/last-used time;
+- display/navigation rule;
+- delete/disable action.
+
+## Expected Outcomes
+
+- Users can benefit from remembered local choices without wondering whether Robota is hiding
+  automation.
+- View choices and task associations become predictable because their source and display/navigation
+  rule are visible.
+- Local memory remains helpful for the individual user while avoiding repo-owned workflow
+  requirements.
+- Command execution remains tied to current user input or explicit acceptance, not remembered
+  history.
+- Troubleshooting becomes simpler because users can inspect, delete, or disable remembered values
+  directly.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only TUI panels and commands that display, confirm, delete, or disable remembered
+values.
+
+Lower owners must be established first:
+
+- `agent-sdk`: local preference store APIs, memory item projection, inspection/removal contracts,
+  user-local-only storage policy, and display/navigation disclosure metadata.
+- `agent-runtime`: session-local state association for running/background work where needed.
+- `agent-command-*`: user-visible preference inspect/delete/disable commands backed by SDK
+  contracts.
+
+Do not implement memory storage shape, persistence policy, or display/navigation rules inside
+`agent-cli`.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Confirm the user-local storage foundation contract is available.
+2. Define the user-local memory item model.
+3. Consume the storage foundation's user-local-only persistence and repo-outside validation APIs.
+4. Define inspection, deletion, disablement, and display/navigation-disclosure APIs.
+5. Define what values can be remembered by default and what requires explicit opt-in.
+6. Update `agent-sdk`, `agent-runtime`, `agent-command-*`, and `agent-cli` SPEC files.
+7. Add tests for memory projection, deletion, disablement, no repo-local writes, and no remembered
+   command execution.
+
+## Acceptance Criteria
+
+- [ ] Users can inspect remembered values, storage locations, sources, last-used time, and
+      display/navigation rules.
+- [ ] Users can delete or disable remembered values.
+- [ ] Remembered values cannot execute commands.
+- [ ] No repo-local files are written for baseline memory, including ignored files.
+- [ ] CLI UI depends on SDK/runtime memory contracts rather than owning storage policy.
+
+## Test Plan
+
+- Add SDK contract tests for memory item projection fields and storage scope labels.
+- Add tests for inspection, deletion, disablement, and disabled-item non-reuse.
+- Add tests proving repeated behavior does not silently become a persistent preference.
+- Add tests proving memory writes stay outside the repository entirely.
+- Add tests proving remembered commands, session recall, and command history cannot execute
+  commands.
+- Add CLI tests verifying users can see storage location, source, last-used time,
+  display/navigation rule, and delete/disable actions.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Add SDK contract tests for memory inspection/removal.
+- Add tests proving memory writes stay outside the repository entirely.
+- Add tests proving remembered values cannot execute commands.
+- Add CLI tests after memory contracts exist.

--- a/.agents/backlog/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/cli-user-local-storage-foundation.md
@@ -1,0 +1,133 @@
+# User-Local Storage Foundation for agent-cli
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - prerequisite storage policy work for transparent workflow memory, preferences, and local task
+state.
+
+## Request
+
+Define the user-local storage foundation that `agent-cli`, `agent-sdk`, and related command modules
+must use for baseline workflow state.
+
+The feature must answer:
+
+> Where does Robota store user-local state, how can users inspect it, and how do we prove no
+> baseline workflow state is written into the user's repository?
+
+## Non-Negotiable Product Principles
+
+- **User-local only for baseline workflow state.** Baseline workflow memory, preferences, display
+  state, task associations, and transparent workflow metadata must be stored outside the repository.
+- **No repo-local fallback.** No tracked repo file, ignored repo file, project `.robota/` cache, or
+  workspace-local state path is allowed for baseline workflow storage.
+- **Storage must be inspectable.** Users must be able to see the effective user-local root, stored
+  categories, item summaries, and deletion/disable actions.
+- **Commands are not remembered for execution.** User-local storage must not persist commands as
+  reusable execution preferences.
+- **Repo independence remains mandatory.** User repositories must remain usable without Robota and
+  must not need Robota-created files to support baseline workflow features.
+
+## Storage Scope
+
+This backlog covers baseline workflow storage for:
+
+- UI/view preferences;
+- display/navigation choices;
+- local memory item projections;
+- background task associations;
+- transparent workflow metadata;
+- inspection and deletion indexes.
+
+This backlog must explicitly exclude:
+
+- command history as an execution source;
+- project-local `.robota/` workflow state for baseline features;
+- repo-shared workflow definitions;
+- repo-side manifests, hooks, scripts, or package dependencies.
+
+The implementation plan must audit existing `.robota/` usage before changing behavior. Existing
+project-local storage decisions may require separate migration backlogs if they conflict with this
+policy.
+
+## Expected Outcomes
+
+- `agent-cli` can provide transparent local memory without introducing repository dependency.
+- Users can predict and inspect where Robota stores local state.
+- Later memory and background-work features have one storage policy instead of choosing paths
+  independently.
+- Architecture reviews can reject baseline features that write workflow state inside the repo.
+- Existing project-local storage usage becomes visible as either legacy behavior, explicit
+  project-owned behavior, or migration work.
+
+## Architecture Ownership Rule
+
+`agent-cli` owns only UI and commands that display the effective storage root, category summaries,
+and deletion/disable actions.
+
+Lower owners must be established first:
+
+- `agent-sdk`: user-local storage root resolution, category contracts, item projection APIs,
+  inspection/removal APIs, and repo-outside validation.
+- `agent-runtime`: session-local associations that need to be persisted through SDK storage
+  contracts.
+- `agent-command-*`: user-visible storage/memory/preference inspection commands backed by SDK
+  contracts.
+
+Do not implement storage path resolution, persistence policy, migration policy, or repo-outside
+validation inside `agent-cli`.
+
+## Recommended First Slice
+
+Create a design and contract PR before UI work:
+
+1. Audit current user-level and project-level `.robota` storage usage in `agent-cli`, `agent-sdk`,
+   `agent-runtime`, and command modules.
+2. Define the canonical user-local storage root policy and category layout for baseline workflow
+   state.
+3. Define a repo-outside validation rule that rejects paths inside the active repository.
+4. Define inspection/removal APIs for user-local categories and items.
+5. Define migration/backlog recommendations for any existing project-local storage that conflicts
+   with baseline user-local-only policy.
+6. Update the cross-cutting specs and package `SPEC.md` files before any TUI work.
+7. Add follow-up implementation slices for storage root resolution, storage inspection command, and
+   memory feature integration.
+
+## Acceptance Criteria
+
+- [ ] The policy defines exactly one allowed persistent storage class for baseline workflow state:
+      user-local storage outside the repository.
+- [ ] The policy forbids repo-local baseline storage, including ignored files and project `.robota`
+      caches.
+- [ ] The policy states that remembered commands cannot be stored as reusable execution preferences.
+- [ ] The policy defines inspect/delete/disable requirements for stored user-local items.
+- [ ] Existing `.robota` storage usage is audited and classified before implementation.
+- [ ] CLI UI depends on SDK storage contracts rather than owning path resolution or persistence
+      policy.
+
+## Test Plan
+
+- Add SDK tests for user-local root resolution and category layout.
+- Add tests proving the resolved storage root is outside the active repository.
+- Add negative tests proving repo-local, ignored-file, and project `.robota` storage paths are
+  rejected for baseline workflow state.
+- Add contract tests for category inspection, item deletion, and disablement.
+- Add tests proving commands cannot be stored or loaded as reusable execution preferences.
+- Add CLI tests only after SDK contracts exist, verifying the effective storage root and stored item
+  summaries are visible.
+
+## Verification Plan
+
+- `pnpm harness:scan`
+- Document authority scan must pass when this backlog is later promoted.
+- Implementation PRs must add SDK storage contract tests before TUI screens.
+- Tests must include fixture repositories with no Robota files and must prove no baseline storage is
+  written inside the repo.


### PR DESCRIPTION
## Recommendation Gate

Recommendation: merge the previously prepared transparent workflow backlog split into the initiative base branch before implementation work begins.

Rationale:
- The split backlog documents define the focused PR units for the transparent workflow initiative.
- Targeting the initiative base branch follows the new backlog execution rule and keeps the final develop PR user-controlled.
- The documents preserve the intended architecture: agent-cli remains UI/TUI only while SDK/runtime and command packages own reusable contracts and lifecycle behavior.
- The split adds a user-local storage foundation backlog before user-local memory work, matching the stricter repository-independence rule.

## Changes

- Converted the original workflow planning backlog into an umbrella backlog.
- Added focused backlog documents for transparency contract, user-local storage foundation, process execution, background work state, user-local memory transparency, and repository situational awareness.
- Updated the backlog README with the focused backlog list.

## Tests

- pnpm harness:scan was run before the original commit.
- pre-push fast verification passed for this branch after merging latest develop.

## Residual Risk

- This PR is planning-only. Implementation work remains in later child PRs against the initiative base branch.