### PR TITLE
docs(specs): define transparent workflow contract

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,7 +12,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [Transparent Workflow Contract for agent-cli](cli-transparent-workflow-contract.md)
 - [User-Local Storage Foundation for agent-cli](cli-user-local-storage-foundation.md)
 - [Transparent Process Execution for agent-cli](cli-transparent-process-execution.md)
 - [Background Work State Management for agent-cli](cli-background-work-state-management.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -110,8 +110,9 @@ Reviewer role:
 
 ## Split Backlog Items
 
-- [Transparent workflow contract](cli-transparent-workflow-contract.md): action provenance, named
-  states, memory inspection, and UI disclosure rules shared by all baseline workflow features.
+- [Transparent workflow contract](completed/cli-transparent-workflow-contract.md) (completed):
+  action provenance, named states, memory inspection, and UI disclosure rules shared by all
+  baseline workflow features.
 - [User-local storage foundation](cli-user-local-storage-foundation.md): canonical user-local-only
   storage root, category contracts, inspection/removal APIs, and repo-outside validation.
 - [Transparent process execution](cli-transparent-process-execution.md): running user-supplied
@@ -158,7 +159,7 @@ Do not require a Robota manifest or Robota package dependency in user repositori
 
 Promote the split backlogs in this order:
 
-1. `cli-transparent-workflow-contract.md`
+1. `completed/cli-transparent-workflow-contract.md`
 2. `cli-user-local-storage-foundation.md`
 3. `cli-transparent-process-execution.md`
 4. `cli-background-work-state-management.md`

--- a/.agents/backlog/completed/cli-transparent-workflow-contract.md
+++ b/.agents/backlog/completed/cli-transparent-workflow-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -112,12 +112,12 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] The contract defines action provenance, named states, memory inspection, and UI disclosure.
-- [ ] The contract separates CLI UI from SDK/runtime ownership.
-- [ ] The contract forbids hidden baseline automation and command inference.
-- [ ] The contract forbids remembered commands from becoming a baseline command source.
-- [ ] The contract requires user-impacting state and remembered values to be inspectable.
-- [ ] The contract does not require any repo-side Robota file or dependency.
+- [x] The contract defines action provenance, named states, memory inspection, and UI disclosure.
+- [x] The contract separates CLI UI from SDK/runtime ownership.
+- [x] The contract forbids hidden baseline automation and command inference.
+- [x] The contract forbids remembered commands from becoming a baseline command source.
+- [x] The contract requires user-impacting state and remembered values to be inspectable.
+- [x] The contract does not require any repo-side Robota file or dependency.
 
 ## Test Plan
 
@@ -134,3 +134,16 @@ Create a design and contract PR before UI work:
 - Document authority scan must pass when this backlog is later promoted.
 - Implementation PRs must add contract tests before TUI screens.
 - Tests must include repos without Robota files to prove the client remains repo-agnostic.
+
+## Result
+
+Completed by adding `.agents/specs/transparent-workflow.md` and linking package ownership from
+`agent-runtime`, `agent-sdk`, and `agent-cli` SPEC files.
+
+- The contract establishes action provenance, state vocabulary, memory inspection fields, UI
+  disclosure, and repository independence rules.
+- `agent-cli` remains a renderer of SDK/runtime projections.
+- Runtime compatibility for current `waiting_permission` status is documented as a projection to
+  user-facing `waiting-for-input`.
+- Code-level provenance, state-machine, memory projection, and CLI rendering tests are deferred to
+  the implementation backlogs that add those APIs.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -5,14 +5,15 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 
 ## Index
 
-| Spec                                                           | Scope                                                                                 |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| (See `packages/*/docs/SPEC.md` for package-level specs)        | Per-package contracts                                                                 |
-| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                     | Repository-level architecture map router                                              |
-| [architecture-map/README.md](architecture-map/README.md)       | Architecture-map document tree and update policy                                      |
-| [agent-invocation-router.md](agent-invocation-router.md)       | Agent command descriptors, deterministic invocation routing, and claim guards         |
-| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)   | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design    |
-| [background-task-layer.md](background-task-layer.md)           | Generic background task lifecycle, composition, runners, and TUI/transport projection |
-| [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces     |
-| [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                |
-| [verification-pipeline-plan.md](verification-pipeline-plan.md) | Local hooks, harness verification, CI, build, and release verification planning       |
+| Spec                                                           | Scope                                                                                  |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| (See `packages/*/docs/SPEC.md` for package-level specs)        | Per-package contracts                                                                  |
+| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                     | Repository-level architecture map router                                               |
+| [architecture-map/README.md](architecture-map/README.md)       | Architecture-map document tree and update policy                                       |
+| [agent-invocation-router.md](agent-invocation-router.md)       | Agent command descriptors, deterministic invocation routing, and claim guards          |
+| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)   | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
+| [background-task-layer.md](background-task-layer.md)           | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
+| [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
+| [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                 |
+| [transparent-workflow.md](transparent-workflow.md)             | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
+| [verification-pipeline-plan.md](verification-pipeline-plan.md) | Local hooks, harness verification, CI, build, and release verification planning        |

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -1,0 +1,195 @@
+# Transparent Workflow Contract
+
+## Status
+
+Design contract.
+
+This specification defines the cross-cutting transparency contract for baseline Robota workflow
+features. Implementation is incremental, but package-level work must follow this contract before
+adding new TUI surfaces.
+
+## Scope
+
+This contract covers user-impacting workflow state that a client displays or acts on:
+
+- action provenance;
+- shell/process/agent task state vocabulary;
+- memory and preference inspection;
+- UI disclosure;
+- boundaries between user-directed execution and advisory analysis;
+- repository independence.
+
+It applies to `agent-cli`, SDK clients, command modules, runtime task projections, and future
+transport clients that render the same workflow state.
+
+## Non-Goals
+
+- Defining repository-owned harness files, manifests, scripts, hooks, package dependencies, or CI.
+- Inferring, ranking, or auto-selecting repository commands.
+- Replacing the provider/tool permission system.
+- Making `agent-cli` own durable workflow semantics.
+- Migrating existing project-local persistence. Storage migration and classification belong to the
+  user-local storage foundation backlog.
+
+## Ownership
+
+| Concern                                                                | Owner             | Rule                                                                                            |
+| ---------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------- |
+| Runtime lifecycle states and transition validation                     | `agent-runtime`   | Own pure task state transitions, terminal detection, cancellation, and close/dismiss mechanics. |
+| Action provenance, projections, memory/preference inspection contracts | `agent-sdk`       | Own typed contracts and read models consumed by command modules, transports, and CLIs.          |
+| User-visible command behavior                                          | `agent-command-*` | Expose inspection/control commands through SDK common APIs.                                     |
+| Terminal presentation                                                  | `agent-cli`       | Render SDK/runtime projections and keep only ephemeral view selection state.                    |
+
+`agent-cli` must not define action provenance, lifecycle state names, memory storage shape,
+retention policy, or command execution eligibility.
+
+## Action Provenance
+
+Every user-impacting action or displayed workflow item must have visible provenance. The SDK-owned
+provenance contract must distinguish these sources:
+
+| Source                             | May execute commands? | Intended use                                                                                            |
+| ---------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `user-input`                       | yes                   | Direct prompt, slash command, selected command, pasted command, or explicit user operation.             |
+| `accepted-assistant-suggestion`    | yes                   | Assistant-proposed action accepted by explicit approval or the current user-selected permission policy. |
+| `active-session-state`             | no                    | Current foreground/background state used for display, navigation, and continuation.                     |
+| `user-local-preference`            | no                    | User-local UI preference or remembered view choice used only for display/navigation.                    |
+| `explicit-repo-document-reference` | no                    | A repo-owned document explicitly referenced by the user for advisory context.                           |
+
+Execution eligibility is intentionally narrower than display eligibility:
+
+- Shell/process/harness command execution must originate from `user-input` or
+  `accepted-assistant-suggestion`.
+- User-local preferences and remembered values may affect UI defaults, sorting, view selection, or
+  display, but must not execute commands.
+- Remembered commands are not a baseline command source. They must not be replayed or suggested as
+  executable defaults unless a later explicit feature adds a separate user-confirmed contract.
+- Advisory repo analysis may inspect documents or commands only when the user asks for that
+  analysis. Baseline CLI operation must not convert advisory findings into hidden automation.
+
+The existing SDK `IExecutionOrigin` is a task/workspace origin projection. It is not sufficient by
+itself as command authorization provenance. New transparent workflow APIs must either extend it or
+pair it with a typed action provenance record before UI surfaces depend on it.
+
+## State Vocabulary
+
+Workflow clients must use one user-facing state vocabulary:
+
+| State               | Meaning                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `queued`            | Work is registered but not started.                                                                          |
+| `running`           | Work is actively executing.                                                                                  |
+| `waiting-for-input` | Work is blocked on user input, permission, or a runner-supported send channel.                               |
+| `completed`         | Work reached a successful terminal result.                                                                   |
+| `failed`            | Work reached an error terminal result.                                                                       |
+| `cancelled`         | Work ended by user or policy cancellation.                                                                   |
+| `archived`          | Terminal work is no longer default-visible but remains inspectable until deleted or expired by owner policy. |
+
+Valid baseline transitions:
+
+| From                | Event               | To                  |
+| ------------------- | ------------------- | ------------------- |
+| `queued`            | start               | `running`           |
+| `queued`            | cancel              | `cancelled`         |
+| `running`           | wait for user input | `waiting-for-input` |
+| `running`           | complete            | `completed`         |
+| `running`           | fail                | `failed`            |
+| `running`           | cancel              | `cancelled`         |
+| `waiting-for-input` | resume              | `running`           |
+| `waiting-for-input` | fail                | `failed`            |
+| `waiting-for-input` | cancel              | `cancelled`         |
+| `completed`         | archive             | `archived`          |
+| `failed`            | archive             | `archived`          |
+| `cancelled`         | archive             | `archived`          |
+
+Terminal execution states are `completed`, `failed`, and `cancelled`. `archived` is a visibility and
+retention projection over terminal work; it must not restart work. Selection is not a lifecycle
+transition.
+
+Compatibility note: the current runtime task status `waiting_permission` is the mechanical
+permission-wait status. SDK/client projections must display it as `waiting-for-input` for this
+contract until a future implementation changes or aliases the runtime type under normal API
+compatibility rules.
+
+## Memory Transparency
+
+Baseline transparent workflow memory must be inspectable and user-local unless a separate
+repo-owned feature explicitly says otherwise.
+
+Inspection projections must include:
+
+- storage root;
+- category;
+- item summary;
+- source;
+- scope;
+- storage location;
+- created time when available;
+- last-used time when available;
+- whether the item is enabled;
+- delete and/or disable action availability.
+
+Robota must not silently convert repeated behavior into a persistent preference. Any future
+candidate-capture flow must show the proposed memory item, source, storage location, and effect
+before it is enabled.
+
+Existing project memory remains a separate current feature. The user-local storage foundation
+backlog must audit and classify current project-local memory, settings, sessions, logs, checkpoints,
+and caches before changing storage behavior.
+
+## UI Disclosure
+
+Before or while work is running, clients must be able to show:
+
+- task or command label;
+- provenance source;
+- working directory;
+- environment summary suitable for display without secrets;
+- start time;
+- timeout and cancellation policy;
+- foreground/background mode;
+- latest output summary;
+- input-needed state;
+- cancelability;
+- terminal result.
+
+The UI should expose the smallest complete set of facts needed to act confidently. Raw implementation
+details may remain hidden, but user-impacting state, actions, and memory must be inspectable.
+
+## Repository Independence
+
+Baseline workflow-client features must not require any Robota file or dependency inside a user's
+repository. In particular, they must not require:
+
+- a Robota manifest;
+- injected `.agents` or `.robota` files;
+- package scripts or package dependencies;
+- CI changes;
+- repository hooks;
+- ignored repository-local caches.
+
+When the user explicitly asks for advisory analysis, Robota may inspect repo-owned files within the
+normal session/tool permission model and report recommendations. That analysis must remain advisory
+until the user accepts an action.
+
+## Verification Requirements
+
+Implementation PRs that promote this contract into code must add tests before TUI-only rendering:
+
+- type-level or unit tests for accepted action provenance values and execution eligibility;
+- runtime state-machine tests for allowed lifecycle transitions and invalid transition rejection;
+- SDK projection tests for mapping runtime states into the shared vocabulary;
+- memory projection tests for storage root, category, item summary, source, scope, storage location,
+  last-used time, and delete/disable capability;
+- CLI rendering tests only after SDK/runtime contracts exist.
+
+At least one scenario or fixture must prove baseline behavior works in a repository with no Robota
+files and no Robota local state inside the repository.
+
+## Follow-Up Backlogs
+
+- [User-local storage foundation](../backlog/cli-user-local-storage-foundation.md)
+- [Transparent process execution](../backlog/cli-transparent-process-execution.md)
+- [Background work state management](../backlog/cli-background-work-state-management.md)
+- [User-local memory transparency](../backlog/cli-user-local-memory-transparency.md)
+- [Repository situational awareness](../backlog/cli-repository-situational-awareness.md)

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -23,6 +23,9 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 - Does NOT own `CommandRegistry`, `ICommand`, or `ICommandSource` — command registry contracts are imported from `@robota-sdk/agent-sdk`; skill command metadata is provided by `@robota-sdk/agent-command-skills`
 - Does NOT use `SystemCommandExecutor` directly — uses `session.executeCommand(name, args)` instead
 - Does NOT own reusable background/subagent lifecycle contracts or log pagination helpers — these are owned by `@robota-sdk/agent-runtime` and consumed through `@robota-sdk/agent-sdk` re-exports
+- Does NOT own transparent workflow action provenance, shared state vocabulary, memory inspection
+  contracts, command execution eligibility, or retention policy — these are owned by SDK/runtime
+  contracts described in the cross-cutting transparent workflow spec
 - Does NOT own workflow manifests, harness command registry semantics, workflow artifact schemas,
   deterministic workflow hook policy, review/evidence gates, or workflow run lifecycle — these must
   be owned below the CLI by SDK/runtime/harness contracts before TUI screens are added
@@ -58,6 +61,15 @@ The CLI is a pure TUI layer. All business logic (session lifecycle, slash comman
 3. Creates the provider instance by calling `definition.createProvider(config)`.
 4. Creates `InteractiveSession({ cwd, provider, commandHostAdapters, sessionStore })` — config and context loading happen internally inside the SDK. CLI-owned adapters expose host services such as user-settings persistence and plugin management without letting command packages import CLI files. Session persistence is passed only through SDK-owned facade types.
 5. Subscribes to `InteractiveSession` events and converts them to React state for rendering.
+
+### Transparent Workflow Boundary
+
+Transparent workflow rules are defined in
+[../../../.agents/specs/transparent-workflow.md](../../../.agents/specs/transparent-workflow.md).
+The CLI may render provenance, lifecycle state, memory/preference inspection, and disclosure fields
+only from SDK/runtime projections. It may keep ephemeral terminal view state such as the selected
+workspace entry, but it must not infer command origin, replay remembered commands, define state
+transitions, choose retention policy, or inspect/delete memory outside SDK/command APIs.
 
 ### Provider Profile Creation
 
@@ -332,6 +344,7 @@ The CLI TUI renders structured session/runtime data. It must not parse assistant
 | Live tool execution          | `StreamingIndicator`                  | SDK tool state events                  | Show current tool state using the shared status marker set                        |
 | Background work              | `BackgroundTaskPanel`                 | SDK execution workspace entries        | Show SDK default-visible background task entries as a compact one-level tree      |
 | Execution workspace switcher | `ExecutionWorkspaceSwitcher`          | SDK execution workspace snapshot       | Switch between main-thread, background task, and group entries without mutation   |
+| Transparent workflow facts   | TUI surfaces                          | SDK/runtime projections                | Render provenance, state, memory, and disclosure fields without owning semantics  |
 | Status/activity              | `StatusBar` and `SessionStatusBar`    | session state, context state, settings | Show current activity and session metadata in the primary scan path               |
 | Diff blocks                  | `ToolDiffBlock` and markdown renderer | structured diff lines                  | Render diff bodies through fenced `diff` markdown; keep metadata outside the body |
 | Setup/permission prompts     | prompt components                     | CLI flow descriptors                   | Render generic interactions only; prompt semantics remain in flow modules         |
@@ -1311,6 +1324,9 @@ CLI may filter the always-visible compact panel to `visibility: default` backgro
 but it must not invent a separate retention timeout, close/dismiss policy, unread policy, or group
 completion rule. Explicit controls such as cancel, close, wait, send, or read-log remain SDK/command
 APIs and are not implied by view selection.
+
+When rendering user-facing workflow states, the CLI follows the transparent workflow vocabulary. It
+may display a debug/raw runtime status only in an explicitly labeled diagnostic context.
 
 ### AI Workflow Control Surface
 

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -110,6 +110,20 @@ snapshots, and never interprets SDK-, command-, skill-, transport-, or UI-specif
 layers may use metadata for origin projection, grouping, or workspace read models, but lifecycle
 transitions, queueing, cancellation, and runner behavior must not depend on those keys.
 
+## Transparent Workflow Relationship
+
+The cross-cutting transparent workflow contract is defined in
+[../../../.agents/specs/transparent-workflow.md](../../../.agents/specs/transparent-workflow.md).
+`agent-runtime` owns the mechanical background task lifecycle state machine and transition
+validation for agent/process work. It does not own command authorization provenance, user-local
+preference semantics, memory inspection, or TUI disclosure policy.
+
+Current runtime statuses are `queued`, `running`, `waiting_permission`, `completed`, `failed`, and
+`cancelled`. The transparent workflow user-facing vocabulary displays `waiting_permission` as
+`waiting-for-input`; a future API change may alias or rename this status only with compatibility
+tests. `archived` is a visibility/retention projection over terminal records, not a state that
+restarts execution. Runtime `close()` remains the mechanical terminal-record dismissal operation.
+
 ## Error Taxonomy
 
 `BackgroundTaskError` is the package error class for lifecycle and runner failures.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -313,6 +313,28 @@ agent-cli (Ink TUI — CLI-specific)
 - **Checkpoint common APIs**: `agent-sdk/command-api/checkpoint/` owns command-facing checkpoint metadata constants, subcommand projection helpers, and inspect/list/restore/rollback facades over `ICommandHostContext`. `rewind` command behavior lives in `@robota-sdk/agent-command-rewind` and consumes these APIs as an external command module.
 - **Boundary**: `command-api` may define contracts and reusable command-facing helpers. It must not own product UI, concrete settings file I/O, process restart/exit, provider construction, or command-specific flows that can live in `agent-command-*` packages.
 
+### Transparent Workflow Contract (SDK-Specific)
+
+The cross-cutting contract lives in
+[../../../.agents/specs/transparent-workflow.md](../../../.agents/specs/transparent-workflow.md). The SDK
+is the designated owner for reusable transparent workflow contracts and projections:
+
+- any new action provenance types and execution eligibility helpers;
+- mapping runtime task states into the shared user-facing state vocabulary;
+- execution workspace read models for main-thread, background task, and background group switching;
+- any new memory and preference inspection/removal API shapes;
+- command-facing facades that let `agent-command-*` expose status and memory controls without
+  importing CLI code.
+
+`IExecutionOrigin` is the current task/workspace origin projection. It is not command authorization
+provenance by itself. Future transparent workflow implementation PRs must add or extend typed action
+provenance before new host command/process execution surfaces depend on it.
+
+User-local preferences, remembered values, and session state may influence display and navigation,
+but they must not execute commands. Shell/process/harness command execution must originate from
+direct user input or an assistant suggestion accepted through explicit UI approval or the current
+user-selected permission policy.
+
 ### System Command System (SDK-Specific)
 
 - **Package**: `agent-sdk/commands/`
@@ -1369,7 +1391,8 @@ Execution workspace entries use a common `IExecutionWorkspaceEntry` shape:
 - `background_group` entries are projections of `BackgroundJobOrchestrator` groups.
 - `origin` is SDK-owned provenance. Runtime stores only opaque primitive metadata; the SDK maps it
   into `IExecutionOrigin` for commands, model commands, tool calls, skills, transports, and system
-  work.
+  work. This is presentation provenance; command execution eligibility for transparent workflow
+  features must follow the action provenance contract.
 - `controls` is presentation-neutral and advisory. Selecting an entry is never a lifecycle
   mutation; cancellation, close, send, read, wait, and group summary remain explicit APIs.
 
@@ -1377,6 +1400,10 @@ Default visibility keeps active, permission-blocked, failed, cancelled, and unre
 in the workspace list. Clean completed tasks remain queryable through runtime state until `close()`
 or session cleanup, but clients may choose a collapsed recent/history presentation from the SDK
 entry metadata instead of deleting records.
+
+The workspace state vocabulary follows the transparent workflow contract. Current runtime
+`waiting_permission` snapshots must be projected for clients as user-facing `waiting-for-input`
+state when the surface is not exposing raw runtime types for debugging.
 
 When session persistence is enabled, `InteractiveSession` must persist background task state as part of the project-local session record. Lifecycle, tool start/end, permission, completion, failure, cancellation, and close events update the session JSON with the latest task snapshots and durable event summaries. High-frequency `background_task_text_delta` events must not rewrite the main session JSON per chunk; they are written to append-only JSONL session logs and task/subagent transcript files so debugging data is available while streaming is still in progress without risking partial JSON writes.
 


### PR DESCRIPTION
## Recommendation Gate

Recommendation accepted: handle the transparent workflow contract as a design/contract PR before code implementation.

Rationale:
- The backlog is foundational and spans action provenance, state vocabulary, memory inspection, and UI disclosure, so the shared contract must exist before TUI work.
- The repo layering requires `agent-cli` to remain presentation-only. This PR places the cross-cutting contract in `.agents/specs/` and records ownership in `agent-sdk`, `agent-runtime`, and `agent-cli` SPEC files.
- No runtime code is added here because action provenance types, memory projection APIs, and CLI rendering tests belong to later implementation backlogs.

## Implementation Summary

- Added `.agents/specs/transparent-workflow.md` as the cross-client contract for action provenance, state vocabulary, memory visibility, UI disclosure, and repo independence.
- Updated `.agents/specs/README.md` to route the new spec.
- Updated `agent-runtime`, `agent-sdk`, and `agent-cli` SPEC files with ownership boundaries and the current `waiting_permission` to user-facing `waiting-for-input` compatibility note.
- Moved the transparent workflow contract backlog item to completed and updated the umbrella backlog links.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification ran and reported no runnable package checks for the docs-only package scopes.

## Residual Risk

- Code-level action provenance, state-machine, memory projection, and CLI rendering tests are intentionally deferred to the implementation backlogs.
- `pnpm harness:scan` still reports the repository's existing file-size warnings; this PR did not add or change those files.
- The runtime still exposes raw `waiting_permission`; later implementation must add or verify the SDK projection to `waiting-for-input` before user-facing TUI depends on it.

## Next Backlog

Next recommended backlog after this PR is `cli-user-local-storage-foundation.md`.
