### PR TITLE
docs(specs): define user-local storage foundation

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,7 +12,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Storage Foundation for agent-cli](cli-user-local-storage-foundation.md)
 - [Transparent Process Execution for agent-cli](cli-transparent-process-execution.md)
 - [Background Work State Management for agent-cli](cli-background-work-state-management.md)
 - [User-Local Memory Transparency for agent-cli](cli-user-local-memory-transparency.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -113,8 +113,9 @@ Reviewer role:
 - [Transparent workflow contract](completed/cli-transparent-workflow-contract.md) (completed):
   action provenance, named states, memory inspection, and UI disclosure rules shared by all
   baseline workflow features.
-- [User-local storage foundation](cli-user-local-storage-foundation.md): canonical user-local-only
-  storage root, category contracts, inspection/removal APIs, and repo-outside validation.
+- [User-local storage foundation](completed/cli-user-local-storage-foundation.md) (completed):
+  canonical user-local-only storage root, category contracts, inspection/removal APIs, and
+  repo-outside validation.
 - [Transparent process execution](cli-transparent-process-execution.md): running user-supplied
   commands with visible origin, cwd, environment summary, output, cancellation, and terminal result.
 - [Background work state management](cli-background-work-state-management.md): switchable main
@@ -160,7 +161,7 @@ Do not require a Robota manifest or Robota package dependency in user repositori
 Promote the split backlogs in this order:
 
 1. `completed/cli-transparent-workflow-contract.md`
-2. `cli-user-local-storage-foundation.md`
+2. `completed/cli-user-local-storage-foundation.md`
 3. `cli-transparent-process-execution.md`
 4. `cli-background-work-state-management.md`
 5. `cli-user-local-memory-transparency.md`

--- a/.agents/backlog/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/cli-user-local-memory-transparency.md
@@ -18,7 +18,7 @@ Define user-local memory and preference behavior for `agent-cli` so remembered v
 without becoming hidden automation, command reuse, or repo-owned configuration.
 
 This backlog depends on
-[User-Local Storage Foundation](cli-user-local-storage-foundation.md) for storage root resolution,
+[User-Local Storage Foundation](completed/cli-user-local-storage-foundation.md) for storage root resolution,
 repo-outside validation, inspection/removal APIs, and persistence policy.
 
 The feature must answer:

--- a/.agents/backlog/completed/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/completed/cli-user-local-storage-foundation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -103,14 +103,14 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] The policy defines exactly one allowed persistent storage class for baseline workflow state:
+- [x] The policy defines exactly one allowed persistent storage class for baseline workflow state:
       user-local storage outside the repository.
-- [ ] The policy forbids repo-local baseline storage, including ignored files and project `.robota`
+- [x] The policy forbids repo-local baseline storage, including ignored files and project `.robota`
       caches.
-- [ ] The policy states that remembered commands cannot be stored as reusable execution preferences.
-- [ ] The policy defines inspect/delete/disable requirements for stored user-local items.
-- [ ] Existing `.robota` storage usage is audited and classified before implementation.
-- [ ] CLI UI depends on SDK storage contracts rather than owning path resolution or persistence
+- [x] The policy states that remembered commands cannot be stored as reusable execution preferences.
+- [x] The policy defines inspect/delete/disable requirements for stored user-local items.
+- [x] Existing `.robota` storage usage is audited and classified before implementation.
+- [x] CLI UI depends on SDK storage contracts rather than owning path resolution or persistence
       policy.
 
 ## Test Plan
@@ -131,3 +131,15 @@ Create a design and contract PR before UI work:
 - Implementation PRs must add SDK storage contract tests before TUI screens.
 - Tests must include fixture repositories with no Robota files and must prove no baseline storage is
   written inside the repo.
+
+## Result
+
+Completed by adding `.agents/specs/user-local-storage.md` and linking package ownership from
+`agent-sdk` and `agent-cli` SPEC files.
+
+- The policy defines user-local storage outside the active repository as the only allowed persistent
+  storage class for baseline workflow state.
+- Existing `.robota` uses are audited and classified so later implementation PRs can migrate or
+  avoid them deliberately.
+- The policy forbids remembered commands from becoming executable preferences.
+- SDK storage root/category/inspection contracts and tests are deferred to implementation PRs.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -16,4 +16,5 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 | [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
 | [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                 |
 | [transparent-workflow.md](transparent-workflow.md)             | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
+| [user-local-storage.md](user-local-storage.md)                 | User-local-only baseline workflow storage policy, category inspection, and path guards |
 | [verification-pipeline-plan.md](verification-pipeline-plan.md) | Local hooks, harness verification, CI, build, and release verification planning        |

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -28,8 +28,8 @@ transport clients that render the same workflow state.
 - Inferring, ranking, or auto-selecting repository commands.
 - Replacing the provider/tool permission system.
 - Making `agent-cli` own durable workflow semantics.
-- Migrating existing project-local persistence. Storage migration and classification belong to the
-  user-local storage foundation backlog.
+- Migrating existing project-local persistence. Storage migration and classification are governed by
+  [user-local-storage.md](user-local-storage.md).
 
 ## Ownership
 
@@ -133,9 +133,10 @@ Robota must not silently convert repeated behavior into a persistent preference.
 candidate-capture flow must show the proposed memory item, source, storage location, and effect
 before it is enabled.
 
-Existing project memory remains a separate current feature. The user-local storage foundation
-backlog must audit and classify current project-local memory, settings, sessions, logs, checkpoints,
-and caches before changing storage behavior.
+Existing project memory remains a separate current feature. The
+[user-local storage foundation](user-local-storage.md) audits and classifies current project-local
+memory, settings, sessions, logs, checkpoints, and caches before implementation changes storage
+behavior.
 
 ## UI Disclosure
 
@@ -188,7 +189,7 @@ files and no Robota local state inside the repository.
 
 ## Follow-Up Backlogs
 
-- [User-local storage foundation](../backlog/cli-user-local-storage-foundation.md)
+- [User-local storage foundation](../backlog/completed/cli-user-local-storage-foundation.md)
 - [Transparent process execution](../backlog/cli-transparent-process-execution.md)
 - [Background work state management](../backlog/cli-background-work-state-management.md)
 - [User-local memory transparency](../backlog/cli-user-local-memory-transparency.md)

--- a/.agents/specs/user-local-storage.md
+++ b/.agents/specs/user-local-storage.md
@@ -1,0 +1,158 @@
+# User-Local Storage Foundation
+
+## Status
+
+Design contract.
+
+This specification defines the storage policy for baseline transparent workflow state. It does not
+change existing storage behavior by itself; implementation PRs must add SDK contracts and tests
+before any TUI feature depends on this policy.
+
+## Scope
+
+This policy applies to baseline workflow state that Robota stores for local assistance:
+
+- UI and view preferences;
+- display/navigation choices;
+- local memory item projections;
+- background task associations;
+- transparent workflow metadata;
+- inspection indexes and delete/disable projections.
+
+It does not make user repositories depend on Robota. User repositories must remain usable with no
+Robota files, package dependencies, hooks, scripts, manifests, or ignored local caches.
+
+## Non-Goals
+
+- Moving every existing `.robota` use in this PR.
+- Storing repository harness definitions.
+- Storing command history as reusable execution preferences.
+- Defining plugin, skill, agent-definition, session replay, or checkpoint semantics.
+- Replacing explicit project-owned configuration and debugging artifacts without a migration PR.
+
+## Canonical Storage Rule
+
+Baseline workflow state has exactly one allowed persistent storage class:
+
+```text
+user-local storage outside the active repository
+```
+
+The canonical product root is `~/.robota`. SDK APIs may later introduce a sub-root for workflow
+state such as `~/.robota/workflow/`, but all baseline workflow state must remain under the resolved
+user-local root and outside the active repository.
+
+Rules:
+
+- No tracked repository file may store baseline workflow state.
+- No ignored repository file may store baseline workflow state.
+- No project `.robota/` cache may store baseline workflow state.
+- No workspace-local fallback is allowed when user-local storage is unavailable.
+- Persistence must fail closed or operate in non-persistent mode when the SDK cannot prove the
+  target path is outside the repository.
+
+Test environments may inject a temporary user-local root, but production behavior must not silently
+fall back to the project tree.
+
+## Category Layout
+
+The SDK-owned storage contract must use stable category identifiers. The first implementation may
+choose exact filenames, but the categories below are the required logical layout:
+
+| Category             | Purpose                                                                | May execute commands? |
+| -------------------- | ---------------------------------------------------------------------- | --------------------- |
+| `preferences`        | User-local UI/display preferences.                                     | no                    |
+| `view-state`         | Last selected panels, filters, and navigation state.                   | no                    |
+| `memory-projections` | Inspectable local memory item projections and user choices.            | no                    |
+| `task-associations`  | User-local associations between sessions, tasks, and background items. | no                    |
+| `workflow-metadata`  | Transparent workflow metadata that is not repo-owned.                  | no                    |
+| `inspection-index`   | Category/item summaries for user inspection and deletion.              | no                    |
+
+Command strings must not be stored as reusable execution preferences in any category. Session logs
+may contain historical command text as transcript data, but transcript history is not a baseline
+command source.
+
+## Repo-Outside Validation
+
+SDK storage APIs must validate persistent baseline workflow paths before writing:
+
+1. Resolve the active repository/workspace root.
+2. Resolve the candidate storage root to an absolute normalized path.
+3. Resolve symlinks when the path or parent exists.
+4. Reject the candidate when it is equal to or inside the active repository root.
+5. Reject relative paths, empty roots, and roots that cannot be proven outside the repository.
+
+This validation belongs in `agent-sdk` or a lower reusable owner. `agent-cli` must not duplicate it.
+
+## Inspection Projection
+
+Every persisted baseline workflow item must be inspectable through SDK/command APIs. The projection
+must include:
+
+| Field              | Meaning                                                                   |
+| ------------------ | ------------------------------------------------------------------------- |
+| `root`             | Effective user-local storage root.                                        |
+| `category`         | Stable category identifier.                                               |
+| `key`              | Stable item key within the category.                                      |
+| `summary`          | Bounded human-readable item summary.                                      |
+| `source`           | Provenance source that created or last changed the item.                  |
+| `scope`            | Applicability scope, such as global user scope or a repo identity string. |
+| `storageLocation`  | Concrete path or opaque user-local location.                              |
+| `createdAt`        | Creation timestamp when available.                                        |
+| `lastUsedAt`       | Last use timestamp when available.                                        |
+| `enabled`          | Whether the item currently affects behavior.                              |
+| `deleteAvailable`  | Whether the item can be removed.                                          |
+| `disableAvailable` | Whether the item can be disabled without deletion.                        |
+
+Delete and disable actions must be explicit user actions. Robota must not silently remove or disable
+stored state as part of normal rendering.
+
+## Existing Storage Audit
+
+Current storage usage is classified below. This audit prevents new baseline workflow features from
+copying legacy/project-local behavior by accident.
+
+| Storage                                                   | Current owner/use                                           | Classification                                               | Required follow-up                                                                                                                            |
+| --------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/.robota/settings.json`                                 | User settings and provider profiles.                        | User-local existing.                                         | May be read by settings commands; new workflow preference categories should use the SDK user-local storage contract instead of ad hoc fields. |
+| `~/.robota/update-check.json`                             | CLI package update cache.                                   | CLI operational cache, not workflow state.                   | Keep CLI-owned; do not reuse for workflow state.                                                                                              |
+| `~/.robota/plugins/`                                      | User-installed bundle plugins.                              | User-owned extension storage.                                | Not baseline workflow state.                                                                                                                  |
+| `~/.robota/skills/`                                       | User-global skills.                                         | User-owned extension storage.                                | Not baseline workflow state.                                                                                                                  |
+| `~/.robota/agents/`                                       | User-global agent definitions.                              | User-owned extension storage.                                | Not baseline workflow state.                                                                                                                  |
+| `.robota/settings.json` and `.robota/settings.local.json` | Project and project-local configuration layers.             | Explicit project configuration, not baseline workflow state. | Do not store baseline preferences or workflow metadata here.                                                                                  |
+| `.robota/sessions/`                                       | Project-local session records for resume/debugging.         | Existing explicit project debugging state.                   | Do not use as baseline workflow memory; migration or user-local mirror needs a separate implementation PR.                                    |
+| `.robota/logs/`                                           | Project-local JSONL logs and subagent transcripts.          | Existing explicit project debugging state.                   | Do not use as baseline workflow memory; retention/inspection policy needs a separate PR if reused.                                            |
+| `.robota/memory/`                                         | Project memory index, topics, and pending candidates.       | Migration-required for user-local baseline memory.           | Audit and migrate only through the user-local memory transparency backlog.                                                                    |
+| `.robota/checkpoints/`                                    | Edit checkpoint pre-images for rewind.                      | Project safety artifact.                                     | Keep separate from baseline workflow state; migration is not part of this policy.                                                             |
+| `.robota/agents/`                                         | Project agent definitions.                                  | Project-owned extension definitions.                         | Not baseline workflow state.                                                                                                                  |
+| `.robota/plugins/`                                        | Project plugin installation/enablement.                     | Project-owned extension storage.                             | Not baseline workflow state; do not use for workflow preferences.                                                                             |
+| `.robota/worktrees/`                                      | Local isolation/worktree artifacts when enabled.            | Runtime isolation artifact, not baseline workflow state.     | Keep out of baseline storage; future isolation policy owns changes.                                                                           |
+| `.agents/**`                                              | Repo-owned instructions, tasks, skills, backlog, and rules. | Repository-owned source documents.                           | Read only through explicit context/skill/task contracts; never use as baseline storage.                                                       |
+
+## Ownership
+
+| Concern                                | Owner                                 | Rule                                                                             |
+| -------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| User-local root resolution             | `agent-sdk`                           | Resolve and validate the effective user-local root.                              |
+| Repo-outside validation                | `agent-sdk`                           | Reject baseline workflow paths inside the active repository.                     |
+| Category and item projection contracts | `agent-sdk`                           | Define stable category ids and inspect/delete/disable shapes.                    |
+| Session-local runtime associations     | `agent-runtime` through SDK contracts | Runtime may expose session-local ids; SDK decides persistence shape.             |
+| User-visible commands                  | `agent-command-*`                     | Expose storage inspection/removal using SDK command APIs.                        |
+| TUI rendering                          | `agent-cli`                           | Render roots, categories, item summaries, and actions from SDK projections only. |
+
+## Implementation Gates
+
+Before a TUI screen or command stores baseline workflow state, implementation PRs must add:
+
+- SDK unit tests for user-local root resolution;
+- negative tests for repo-local, ignored-file, and project `.robota` roots;
+- contract tests for category projection fields;
+- delete/disable behavior tests;
+- tests proving stored commands cannot be reused as execution preferences;
+- at least one fixture repository with no Robota files and no baseline storage written inside it.
+
+## Relationship To Transparent Workflow
+
+This storage policy implements the memory transparency and repo-independence requirements in
+[transparent-workflow.md](transparent-workflow.md). Transparent workflow features may display
+repository context, but their baseline stored state must use this user-local storage foundation.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -26,6 +26,8 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 - Does NOT own transparent workflow action provenance, shared state vocabulary, memory inspection
   contracts, command execution eligibility, or retention policy — these are owned by SDK/runtime
   contracts described in the cross-cutting transparent workflow spec
+- Does NOT own baseline workflow storage root resolution, repo-outside validation, category
+  contracts, or item deletion/disable semantics — these are owned by SDK storage contracts
 - Does NOT own workflow manifests, harness command registry semantics, workflow artifact schemas,
   deterministic workflow hook policy, review/evidence gates, or workflow run lifecycle — these must
   be owned below the CLI by SDK/runtime/harness contracts before TUI screens are added
@@ -70,6 +72,19 @@ The CLI may render provenance, lifecycle state, memory/preference inspection, an
 only from SDK/runtime projections. It may keep ephemeral terminal view state such as the selected
 workspace entry, but it must not infer command origin, replay remembered commands, define state
 transitions, choose retention policy, or inspect/delete memory outside SDK/command APIs.
+
+### User-Local Storage Boundary
+
+Baseline workflow storage rules are defined in
+[../../../.agents/specs/user-local-storage.md](../../../.agents/specs/user-local-storage.md). The CLI
+may render the effective storage root, category summaries, and delete/disable actions only from SDK
+or command-module projections. It must not resolve baseline storage paths, write workflow
+preferences into project `.robota/`, or remember commands as executable preferences.
+
+Existing CLI-owned operational cache such as `~/.robota/update-check.json` remains distribution UX,
+not baseline workflow state. Existing project-local sessions, logs, checkpoints, and memory are
+classified by the storage spec and must not be reused for new baseline workflow features without a
+separate migration PR.
 
 ### Provider Profile Creation
 

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -124,6 +124,14 @@ Current runtime statuses are `queued`, `running`, `waiting_permission`, `complet
 tests. `archived` is a visibility/retention projection over terminal records, not a state that
 restarts execution. Runtime `close()` remains the mechanical terminal-record dismissal operation.
 
+## User-Local Storage Relationship
+
+Baseline workflow storage policy is defined in
+[../../../.agents/specs/user-local-storage.md](../../../.agents/specs/user-local-storage.md).
+`agent-runtime` does not resolve storage roots, validate repository boundaries, or persist baseline
+workflow state. It may expose session-local task ids, metadata, events, and state snapshots; SDK
+storage contracts decide whether and how higher layers persist those associations.
+
 ## Error Taxonomy
 
 `BackgroundTaskError` is the package error class for lifecycle and runner failures.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -335,6 +335,23 @@ but they must not execute commands. Shell/process/harness command execution must
 direct user input or an assistant suggestion accepted through explicit UI approval or the current
 user-selected permission policy.
 
+### User-Local Storage Foundation (SDK-Specific)
+
+The cross-cutting storage policy lives in
+[../../../.agents/specs/user-local-storage.md](../../../.agents/specs/user-local-storage.md). The SDK
+is the designated owner for baseline workflow storage root resolution, repo-outside validation,
+category contracts, and item inspection/removal projections.
+
+Existing `projectPaths(cwd)` helpers remain valid for explicit project-owned features such as
+project settings, session replay/debug logs, edit checkpoints, and current project memory. New
+baseline transparent workflow state must not use `projectPaths(cwd)` or ad hoc `.robota/` paths.
+It must use SDK-owned user-local storage contracts once those are implemented.
+
+Existing `userPaths()` helpers expose only current user settings and sessions paths. They are not
+yet the complete transparent workflow storage contract. Future implementation PRs must add tested
+user-local category APIs instead of having CLI or command modules assemble category paths
+themselves.
+
 ### System Command System (SDK-Specific)
 
 - **Package**: `agent-sdk/commands/`


### PR DESCRIPTION
## Recommendation Gate

Recommendation accepted: handle the user-local storage foundation as a design/audit contract PR before implementation.

Rationale:
- The backlog asks where baseline workflow state may be stored and how users can inspect/remove it. That policy must be stable before SDK APIs or TUI screens are added.
- Existing `.robota` usage includes sessions, logs, checkpoints, project memory, settings, plugins, skills, agents, and update caches. Changing paths immediately would risk breaking resume/debug/rewind/provider behavior, so this PR audits and classifies current usage first.
- The architecture requires `agent-sdk` to own root resolution, repo-outside validation, category contracts, and item projections. `agent-cli` remains a renderer/host adapter.

## Implementation Summary

- Added `.agents/specs/user-local-storage.md` with canonical user-local-only baseline storage rules, category layout, repo-outside validation, inspection projection fields, and existing `.robota` storage audit.
- Linked the storage policy from `.agents/specs/README.md` and the transparent workflow spec.
- Updated `agent-sdk`, `agent-runtime`, and `agent-cli` SPEC files with storage ownership boundaries.
- Moved the user-local storage backlog item to completed and updated dependent backlog links.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification ran and reported no runnable package checks for the docs-only package scopes.

## Residual Risk

- SDK root/category APIs, repo-outside validation tests, and storage inspection commands are intentionally deferred to implementation PRs.
- Existing project-local `.robota/memory`, `.robota/sessions`, and `.robota/logs` behavior remains unchanged and classified for follow-up migration decisions.
- `pnpm harness:scan` still reports the repository's existing file-size warnings; this PR did not add or change those source files.

## Next Backlog

Next recommended backlog after this PR is `cli-transparent-process-execution.md`.
