### PR TITLE
docs(specs): define process execution contract

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,7 +12,6 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [Transparent Process Execution for agent-cli](cli-transparent-process-execution.md)
 - [Background Work State Management for agent-cli](cli-background-work-state-management.md)
 - [User-Local Memory Transparency for agent-cli](cli-user-local-memory-transparency.md)
 - [Repository Situational Awareness for agent-cli](cli-repository-situational-awareness.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -116,8 +116,9 @@ Reviewer role:
 - [User-local storage foundation](completed/cli-user-local-storage-foundation.md) (completed):
   canonical user-local-only storage root, category contracts, inspection/removal APIs, and
   repo-outside validation.
-- [Transparent process execution](cli-transparent-process-execution.md): running user-supplied
-  commands with visible origin, cwd, environment summary, output, cancellation, and terminal result.
+- [Transparent process execution](completed/cli-transparent-process-execution.md) (completed):
+  running user-supplied commands with visible origin, cwd, environment summary, output,
+  cancellation, and terminal result.
 - [Background work state management](cli-background-work-state-management.md): switchable main
   thread, shell job, and agent task state with transparent lifecycle and retention behavior.
 - [User-local memory transparency](cli-user-local-memory-transparency.md): cwd, view preference, and
@@ -162,7 +163,7 @@ Promote the split backlogs in this order:
 
 1. `completed/cli-transparent-workflow-contract.md`
 2. `completed/cli-user-local-storage-foundation.md`
-3. `cli-transparent-process-execution.md`
+3. `completed/cli-transparent-process-execution.md`
 4. `cli-background-work-state-management.md`
 5. `cli-user-local-memory-transparency.md`
 6. `cli-repository-situational-awareness.md`

--- a/.agents/backlog/completed/cli-transparent-process-execution.md
+++ b/.agents/backlog/completed/cli-transparent-process-execution.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -94,13 +94,17 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] A user can see what command is running, where it is running, and why it was selected.
-- [ ] Commands only run from current user input or explicit user acceptance.
-- [ ] The runner supports foreground/background execution, cancellation, timeout, output paging,
+- [x] The process execution contract requires users to see what command is running, where it is
+      running, and why it was selected.
+- [x] The process execution contract requires commands to run only from current user input or
+      explicit user acceptance.
+- [x] The process execution contract covers foreground/background execution, cancellation, timeout, output paging,
       exit code, and duration.
-- [ ] Command history or retained output does not become correctness evidence by default.
-- [ ] The implementation does not require repo-side Robota adapters or files.
-- [ ] CLI UI depends on SDK/runtime contracts rather than owning process lifecycle state.
+- [x] The process execution contract states that command history or retained output does not become
+      correctness evidence by default.
+- [x] The process execution contract does not require repo-side Robota adapters or files.
+- [x] The process execution contract requires CLI UI to depend on SDK/runtime contracts rather than
+      owning process lifecycle state.
 
 ## Test Plan
 
@@ -121,3 +125,15 @@ Create a design and contract PR before UI work:
 - Add contract tests for process execution request/status models.
 - Add runtime tests for cancellation, timeout, exit status, and output truncation.
 - Add CLI tests only after SDK/runtime contracts exist.
+
+## Result
+
+Completed by adding `.agents/specs/process-execution.md` and linking package ownership from
+`agent-runtime`, `agent-sdk`, `agent-cli`, and `agent-command-background` SPEC files.
+
+- The contract defines process request, status, output, provenance, command-source, and ownership
+  rules.
+- Existing runtime/SDK/CLI process capabilities are audited separately from missing transparent
+  process UI/API contracts.
+- User-facing process-run commands, foreground process UI, SDK provenance types, and runtime/CLI
+  tests remain follow-up implementation work.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -14,6 +14,7 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 | [ai-workflow-control-plane.md](ai-workflow-control-plane.md)   | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
 | [background-task-layer.md](background-task-layer.md)           | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
 | [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
+| [process-execution.md](process-execution.md)                   | Transparent local process execution request, status, output, and provenance contract   |
 | [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                 |
 | [transparent-workflow.md](transparent-workflow.md)             | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
 | [user-local-storage.md](user-local-storage.md)                 | User-local-only baseline workflow storage policy, category inspection, and path guards |

--- a/.agents/specs/process-execution.md
+++ b/.agents/specs/process-execution.md
@@ -1,0 +1,152 @@
+# Transparent Process Execution Contract
+
+## Status
+
+Design contract.
+
+This specification defines transparent local process execution before new user-facing command or TUI
+surfaces are added.
+
+## Scope
+
+This contract covers process execution started by Robota when the command is user-directed:
+
+- user-entered commands;
+- assistant-suggested commands accepted by the user or current permission policy;
+- foreground or background process tasks;
+- stdout/stderr output pages and summaries;
+- timeout, cancellation, exit status, signal status, and duration;
+- visible provenance and working directory.
+
+It does not define command meaning. Build, test, lint, typecheck, release, and custom harness
+semantics belong to the user's repository and the user's current request.
+
+## Non-Goals
+
+- Inferring canonical repository commands.
+- Ranking likely commands from package metadata or file scans.
+- Persisting command history as reusable execution preferences.
+- Judging command output as correctness evidence by default.
+- Starting automatic repair loops after failure.
+- Requiring repo-side Robota manifests, adapters, scripts, hooks, package dependencies, or CI.
+
+## Current Capability Audit
+
+| Area                 | Current capability                                                                                                                             | Gap before transparent process UI                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Runtime task request | `IProcessBackgroundTaskRequest` carries `command`, `cwd`, `shell`, `env`, `stdin`, `timeoutMs`, and `outputLimitBytes`.                        | Request lacks typed action provenance, environment summary, stdin policy, and retention policy fields.   |
+| Runtime lifecycle    | `BackgroundTaskManager` manages queued/running/completed/failed/cancelled states, cancellation, wait, close, send, and log read.               | User-facing `waiting-for-input`, `archived`, duration, and disclosure mapping need SDK projection tests. |
+| CLI process adapter  | `createManagedShellProcessRunner()` starts a Node child process, captures stdout/stderr, supports timeout, cancellation, stdin, and log pages. | It is an adapter only; it must not become owner of command semantics, provenance, or retention.          |
+| SDK tool route       | `BackgroundProcess` starts a background process tool with opaque runtime metadata.                                                             | Tool-call origin is not enough for user-directed command authorization provenance.                       |
+| Command route        | `/background` can list, read, cancel, and close tasks.                                                                                         | No shared user-directed process-run command contract exists yet.                                         |
+| TUI route            | Background task panel and execution workspace render SDK projections.                                                                          | Process detail disclosure must come from SDK/runtime fields, not raw CLI inference.                      |
+
+## Request Contract
+
+SDK-owned process execution APIs must accept a structured request with these fields:
+
+| Field                | Owner                 | Requirement                                                            |
+| -------------------- | --------------------- | ---------------------------------------------------------------------- |
+| `command`            | SDK request           | Opaque shell command text selected by the user or accepted suggestion. |
+| `origin`             | SDK action provenance | Must be `user-input` or `accepted-assistant-suggestion` for execution. |
+| `cwd`                | SDK/runtime request   | Absolute or workspace-resolved working directory shown to the user.    |
+| `environmentSummary` | SDK projection        | Display-safe summary of environment changes without secrets.           |
+| `env`                | Runtime adapter input | Optional raw environment overrides passed only to the runner adapter.  |
+| `stdinPolicy`        | SDK/runtime request   | `none`, `initial`, or `interactive` to describe input behavior.        |
+| `stdin`              | Runtime adapter input | Optional initial stdin when policy allows it.                          |
+| `timeoutMs`          | Runtime request       | Wall-clock timeout for process execution.                              |
+| `mode`               | Runtime request       | `foreground` or `background`.                                          |
+| `cancellable`        | SDK projection        | Whether a user-visible cancel action is available.                     |
+| `outputLimitBytes`   | Runtime request       | Bounded captured output for result summaries.                          |
+| `retentionPolicy`    | SDK projection        | How terminal records remain visible, archived, or removable.           |
+
+The command string is opaque. SDK/runtime/CLI code may execute, display, cancel, and summarize the
+process result, but must not infer that the command is the repository's canonical harness action.
+
+## Status Contract
+
+Process status projections must include:
+
+| Field                 | Requirement                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `taskId`              | Stable id for controls and log reads.                                                                                    |
+| `state`               | Transparent workflow state: `queued`, `running`, `waiting-for-input`, `completed`, `failed`, `cancelled`, or `archived`. |
+| `commandSummary`      | Bounded command label safe for UI rows.                                                                                  |
+| `origin`              | Action provenance visible to clients.                                                                                    |
+| `cwd`                 | Working directory.                                                                                                       |
+| `environmentSummary`  | Display-safe environment summary.                                                                                        |
+| `mode`                | Foreground/background mode.                                                                                              |
+| `startedAt`           | Start timestamp when available.                                                                                          |
+| `completedAt`         | Terminal timestamp when available.                                                                                       |
+| `durationMs`          | Derived elapsed time for terminal results and live display.                                                              |
+| `exitCode`            | Process exit code when available.                                                                                        |
+| `signalCode`          | Signal when the process ended by signal.                                                                                 |
+| `latestOutputSummary` | Bounded stdout/stderr summary.                                                                                           |
+| `transcriptPointer`   | Log or cursor pointer for retained output.                                                                               |
+| `controls`            | Available explicit controls such as cancel, send, read-log, close, or archive.                                           |
+
+Selecting a process entry is never a lifecycle mutation. Cancel, send, close, archive, and read-log
+must remain explicit controls.
+
+## Output Contract
+
+Process output is diagnostic data, not correctness evidence by default.
+
+Rules:
+
+- stdout and stderr must remain distinguishable in retained logs.
+- Visible previews must be bounded and disclose truncation or omitted lines.
+- Full retained output must be reachable through SDK/runtime log-page APIs when retention allows it.
+- Output limit failures or truncation must be visible as process metadata.
+- Non-zero exit code, timeout, signal termination, and cancellation are process results. They must
+  not start diagnosis or repair loops unless the user asks for advisory analysis.
+
+## Command Source Rules
+
+Commands may execute only from:
+
+- current user input;
+- an assistant suggestion accepted through explicit UI approval or current user-selected permission
+  policy.
+
+Commands must not execute from:
+
+- remembered command history;
+- session recall;
+- user-local preferences;
+- package-manager guessing;
+- repository file scans;
+- inferred workflow readiness.
+
+## Ownership
+
+| Concern                                                                                 | Owner                                     | Rule                                                               |
+| --------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------ |
+| Process lifecycle, stdout/stderr, timeout, cancellation, send/read controls             | `agent-runtime`                           | Own generic process task contracts and state transitions.          |
+| Action provenance, process request/status projection, env summary, retention projection | `agent-sdk`                               | Own reusable contracts consumed by commands, transports, and CLIs. |
+| User-visible run/status command behavior                                                | `agent-command-*`                         | Execute through SDK/runtime APIs; do not infer command meaning.    |
+| Node child process spawning                                                             | Runtime shell such as `agent-cli` adapter | Implement host I/O only.                                           |
+| TUI rendering                                                                           | `agent-cli`                               | Render SDK projections, output panes, and controls only.           |
+
+## Implementation Gates
+
+Before adding a user-facing process-run UI, implementation PRs must add:
+
+- runtime tests for process cancellation, timeout, exit code, signal, duration, log paging, and
+  output truncation;
+- SDK tests for action provenance, cwd, environment summary, status projection, and retention
+  projection;
+- command tests proving remembered history, session recall, and user-local preferences cannot start
+  processes;
+- CLI rendering tests proving command summary, origin, cwd, state, latest output, and terminal
+  result are visible;
+- tests or fixtures proving no repo-side Robota file is required.
+
+## Relationship To Other Specs
+
+- [transparent-workflow.md](transparent-workflow.md) owns shared action provenance and state
+  vocabulary.
+- [user-local-storage.md](user-local-storage.md) forbids remembered commands as executable
+  preferences.
+- [background-task-layer.md](background-task-layer.md) owns generic background process task
+  lifecycle primitives.

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -190,7 +190,7 @@ files and no Robota local state inside the repository.
 ## Follow-Up Backlogs
 
 - [User-local storage foundation](../backlog/completed/cli-user-local-storage-foundation.md)
-- [Transparent process execution](../backlog/cli-transparent-process-execution.md)
+- [Transparent process execution](../backlog/completed/cli-transparent-process-execution.md)
 - [Background work state management](../backlog/cli-background-work-state-management.md)
 - [User-local memory transparency](../backlog/cli-user-local-memory-transparency.md)
 - [Repository situational awareness](../backlog/cli-repository-situational-awareness.md)

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -86,6 +86,15 @@ not baseline workflow state. Existing project-local sessions, logs, checkpoints,
 classified by the storage spec and must not be reused for new baseline workflow features without a
 separate migration PR.
 
+### Transparent Process Execution Boundary
+
+Transparent process execution rules are defined in
+[../../../.agents/specs/process-execution.md](../../../.agents/specs/process-execution.md). The CLI
+may provide terminal-local process runner adapters and render command rows, output panes, and
+controls from SDK/runtime projections. It must not infer canonical repo commands, score command
+readiness, persist commands as executable preferences, interpret output as correctness evidence, or
+own process lifecycle state.
+
 ### Provider Profile Creation
 
 The CLI owns provider profile resolution and provider definition composition. It must not branch on provider type names to decide defaults, required fields, setup prompts, endpoint probes, or constructor behavior. Those values come from injected `IProviderDefinition` records.

--- a/packages/agent-command-background/docs/SPEC.md
+++ b/packages/agent-command-background/docs/SPEC.md
@@ -38,6 +38,10 @@ Aliases:
 - Background task state remains SDK/runtime owned.
 - This package must consume SDK command-facing APIs through `@robota-sdk/agent-sdk`.
 - CLI products compose this module; SDK core must not embed `/background` registration or execution.
+- Any future process-run subcommand must follow
+  [../../../.agents/specs/process-execution.md](../../../.agents/specs/process-execution.md): it
+  may route an explicit user-directed command through SDK/runtime APIs, but it must not infer
+  command meaning, reuse remembered commands, or interpret output as correctness evidence.
 
 ## Dependencies
 

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -132,6 +132,15 @@ Baseline workflow storage policy is defined in
 workflow state. It may expose session-local task ids, metadata, events, and state snapshots; SDK
 storage contracts decide whether and how higher layers persist those associations.
 
+## Process Execution Relationship
+
+Transparent process execution is specified in
+[../../../.agents/specs/process-execution.md](../../../.agents/specs/process-execution.md).
+`agent-runtime` owns generic process task lifecycle, stdout/stderr log paging contracts, timeout,
+cancellation, send/read controls, exit code, signal code, and state transitions. Runtime does not
+own command selection, command meaning, environment-summary presentation, action provenance, or
+correctness interpretation.
+
 ## Error Taxonomy
 
 `BackgroundTaskError` is the package error class for lifecycle and runner failures.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -352,6 +352,24 @@ yet the complete transparent workflow storage contract. Future implementation PR
 user-local category APIs instead of having CLI or command modules assemble category paths
 themselves.
 
+### Transparent Process Execution (SDK-Specific)
+
+The process execution contract lives in
+[../../../.agents/specs/process-execution.md](../../../.agents/specs/process-execution.md). The SDK
+is the designated owner for process execution request/status projections that sit above runtime
+process tasks:
+
+- action provenance attached to user-directed process execution;
+- display-safe environment summaries;
+- working-directory projection;
+- foreground/background process status projection;
+- duration and terminal-result projection;
+- retention and transcript pointers consumed by command modules, transports, and CLIs.
+
+Existing `BackgroundProcess` and execution workspace APIs are the current building blocks. Future
+user-facing process-run commands must use SDK/runtime contracts and must not let CLI components
+assemble process semantics from raw child-process state.
+
 ### System Command System (SDK-Specific)
 
 - **Package**: `agent-sdk/commands/`


### PR DESCRIPTION
## Recommendation Gate

Recommendation accepted: treat transparent process execution as a design/contract PR before adding user-facing process-run UI or commands.

Rationale:
- The backlog explicitly recommends a design and contract PR before UI work.
- Current code already has runtime process tasks, a managed shell runner, `BackgroundProcess`, log paging, timeout, and cancellation, but it does not yet have a closed contract for user-directed command provenance, environment summaries, duration projection, foreground process UX, or command-history rejection.
- Adding a `/run` style UI before those contracts would risk putting command semantics and lifecycle interpretation into `agent-cli`.

## Implementation Summary

- Added `.agents/specs/process-execution.md` with process request, status, output, command-source, and ownership contracts.
- Audited current process capabilities and gaps across runtime, SDK, CLI adapter, and `/background` command surfaces.
- Linked the new contract from `.agents/specs/README.md`, transparent workflow follow-ups, and package SPEC files for `agent-runtime`, `agent-sdk`, `agent-cli`, and `agent-command-background`.
- Moved the transparent process execution backlog item to completed for the contract slice.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification ran and reported no runnable package checks for the docs-only package scopes.

## Residual Risk

- User-facing process-run commands, foreground process UI, SDK provenance types, and runtime/CLI tests remain follow-up implementation work.
- Current `BackgroundProcess` still uses generic tool-call metadata; implementation must add typed action provenance before using it as user-directed command authorization.
- `pnpm harness:scan` still reports the repository's existing file-size warnings; this PR did not add or change those source files.

## Next Backlog

Next recommended backlog after this PR is `cli-background-work-state-management.md`.
