### PR TITLE
docs(specs): define background work state contract

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,6 +12,5 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [Background Work State Management for agent-cli](cli-background-work-state-management.md)
 - [User-Local Memory Transparency for agent-cli](cli-user-local-memory-transparency.md)
 - [Repository Situational Awareness for agent-cli](cli-repository-situational-awareness.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -119,8 +119,9 @@ Reviewer role:
 - [Transparent process execution](completed/cli-transparent-process-execution.md) (completed):
   running user-supplied commands with visible origin, cwd, environment summary, output,
   cancellation, and terminal result.
-- [Background work state management](cli-background-work-state-management.md): switchable main
-  thread, shell job, and agent task state with transparent lifecycle and retention behavior.
+- [Background work state management](completed/cli-background-work-state-management.md) (completed):
+  switchable main thread, shell job, and agent task state with transparent lifecycle and retention
+  behavior.
 - [User-local memory transparency](cli-user-local-memory-transparency.md): cwd, view preference, and
   task association storage that is inspectable, removable, and stored outside the repository.
 - [Repository situational awareness](cli-repository-situational-awareness.md): passive display of
@@ -164,7 +165,7 @@ Promote the split backlogs in this order:
 1. `completed/cli-transparent-workflow-contract.md`
 2. `completed/cli-user-local-storage-foundation.md`
 3. `completed/cli-transparent-process-execution.md`
-4. `cli-background-work-state-management.md`
+4. `completed/cli-background-work-state-management.md`
 5. `cli-user-local-memory-transparency.md`
 6. `cli-repository-situational-awareness.md`
 

--- a/.agents/backlog/completed/cli-background-work-state-management.md
+++ b/.agents/backlog/completed/cli-background-work-state-management.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -98,13 +98,13 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] The main thread, shell jobs, and agent tasks share one background task projection model.
-- [ ] The TUI can render selected and unselected entries without owning lifecycle state.
-- [ ] Each entry exposes origin, status, latest output, elapsed time, input-needed state,
+- [x] The main thread, shell jobs, and agent tasks share one background task projection model.
+- [x] The TUI can render selected and unselected entries without owning lifecycle state.
+- [x] Each entry exposes origin, status, latest output, elapsed time, input-needed state,
       cancelability, and terminal result.
-- [ ] Completed tasks have explicit retention/archive/clear behavior.
-- [ ] Skill-spawned agent tasks can fit the same model without CLI-specific special cases.
-- [ ] Skill-spawned agent tasks register through SDK/runtime task contracts, not CLI UI state.
+- [x] Completed tasks have explicit retention/archive/clear behavior.
+- [x] Skill-spawned agent tasks can fit the same model without CLI-specific special cases.
+- [x] Skill-spawned agent tasks register through SDK/runtime task contracts, not CLI UI state.
 
 ## Test Plan
 
@@ -127,3 +127,16 @@ Create a design and contract PR before UI work:
 - Add runtime tests for task state transitions and retention.
 - Add SDK contract tests for background task projections.
 - Add CLI rendering tests after lower contracts exist.
+
+## Result
+
+Completed by adding `.agents/specs/background-work-state.md` and linking package ownership from
+`agent-runtime`, `agent-sdk`, `agent-cli`, `agent-command-background`, `agent-command-agent`, and
+`agent-command-skills` SPEC files.
+
+- The contract defines one switchable projection model for main-thread, process, agent, grouped,
+  and skill-spawned work.
+- Existing SDK/CLI execution workspace capabilities are audited separately from missing archive,
+  clear, elapsed, input-needed, and terminal-result projection fields.
+- Runtime retention APIs, SDK projection fields, command controls, and CLI rendering tests remain
+  follow-up implementation work.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -12,6 +12,7 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 | [architecture-map/README.md](architecture-map/README.md)       | Architecture-map document tree and update policy                                       |
 | [agent-invocation-router.md](agent-invocation-router.md)       | Agent command descriptors, deterministic invocation routing, and claim guards          |
 | [ai-workflow-control-plane.md](ai-workflow-control-plane.md)   | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
+| [background-work-state.md](background-work-state.md)           | Switchable main-thread, process, agent, group, and skill-spawned work state contract   |
 | [background-task-layer.md](background-task-layer.md)           | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
 | [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
 | [process-execution.md](process-execution.md)                   | Transparent local process execution request, status, output, and provenance contract   |

--- a/.agents/specs/background-work-state.md
+++ b/.agents/specs/background-work-state.md
@@ -1,0 +1,153 @@
+# Background Work State Management Contract
+
+## Status
+
+Design contract.
+
+This specification defines the shared background work state model used by clients that let users
+inspect and switch between the main conversation, shell/process work, agent jobs, grouped jobs, and
+future skill-spawned agent work.
+
+## Scope
+
+This contract covers presentation-neutral state for:
+
+- the main conversation thread;
+- local shell or process tasks;
+- agent tasks;
+- background job groups;
+- future skill-spawned agent tasks registered through the same SDK/runtime task layer.
+
+It applies to SDK clients, command modules, runtime task projections, `agent-cli`, and future
+transports that render or control background work.
+
+## Non-Goals
+
+- Making `agent-cli` own lifecycle state, retention policy, task grouping, or terminal result
+  interpretation.
+- Creating a repo-local background state schema.
+- Requiring Robota files, package dependencies, hooks, or manifests in a user's repository.
+- Inferring which repository commands should run.
+- Treating process output as correctness evidence by default.
+
+## Current Capability Audit
+
+| Area                    | Current capability                                                                                                                                 | Gap before full feature                                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Runtime lifecycle       | `BackgroundTaskManager` owns queued/running/waiting_permission/completed/failed/cancelled states, events, cancel, close, send, wait, and log read. | No explicit archive retention projection, elapsed/duration projection contract, or input-needed alias at runtime surface. |
+| SDK execution workspace | `IExecutionWorkspaceSnapshot` and `IExecutionWorkspaceEntry` project main-thread, task, and group entries with origin, status, preview, controls.  | Entries do not yet expose all contract fields such as started time, elapsed time, terminal result, or archive/clear.      |
+| SDK task spawning       | `createExecutionWorkspaceTaskSpawner(...)` provides an origin-bound spawn port for commands, skills, and transports.                               | Skill-spawned agent registration needs contract tests proving it uses this same path.                                     |
+| CLI workspace switcher  | `ExecutionWorkspaceSwitcher`, `ExecutionWorkspaceDetailPane`, `BackgroundTaskPanel`, and `TuiStateManager` render SDK snapshots.                   | TUI tests must cover new fields once SDK projections exist.                                                               |
+| Command controls        | `/background` can list, read, cancel, and close task records through SDK/runtime APIs.                                                             | No archive, clear, switch, or follow command contract yet.                                                                |
+
+## Common Entry Model
+
+Background work entries must share one SDK-owned projection model. The current
+`IExecutionWorkspaceEntry` is the starting point and must remain presentation-neutral.
+
+Required projection fields for the full feature:
+
+| Field                 | Owner          | Requirement                                                                                      |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| `id`                  | SDK projection | Stable selectable entry id.                                                                      |
+| `type`                | SDK projection | Main thread, background task, or background group.                                               |
+| `title`               | SDK projection | Bounded human-readable label.                                                                    |
+| `origin`              | SDK projection | Visible source such as user command, tool call, skill, transport, or system work.                |
+| `selected`            | Client view    | Ephemeral view state. Selection is never a lifecycle transition.                                 |
+| `status`              | SDK/runtime    | Shared transparent workflow status. Runtime raw statuses are mapped by SDK when needed.          |
+| `cwd`                 | SDK projection | Working directory or workspace context when applicable.                                          |
+| `startedAt`           | SDK projection | Start timestamp when available.                                                                  |
+| `elapsedMs`           | SDK projection | Derived live or terminal elapsed duration.                                                       |
+| `latestOutputSummary` | SDK projection | Bounded stdout/stderr, agent transcript, group summary, or current action preview.               |
+| `inputNeeded`         | SDK projection | User-facing boolean or reason for permission/input wait.                                         |
+| `controls`            | SDK projection | Explicit available controls such as select, cancel, send, wait, read-log, close, archive, clear. |
+| `terminalResult`      | SDK projection | Completed, failed, cancelled, timeout, exit code, signal, or result summary when terminal.       |
+| `visibility`          | SDK projection | Default-visible, collapsed/recent, archived, or hidden after explicit clear/delete.              |
+| `retentionState`      | SDK projection | Whether the entry is retained for inspection, archived, clearable, or expired.                   |
+
+Clients may keep `selected` outside the SDK snapshot as terminal-local state, but they must use SDK
+entry ids and must not derive lifecycle, terminal, origin, or retention fields from raw runtime
+events when the SDK projection is available.
+
+## State And Retention
+
+Execution states follow [transparent-workflow.md](transparent-workflow.md):
+
+- `queued`
+- `running`
+- `waiting-for-input`
+- `completed`
+- `failed`
+- `cancelled`
+- `archived`
+
+Runtime `waiting_permission` is projected as user-facing `waiting-for-input` for normal clients.
+`archived` is a visibility and retention projection over terminal work. It is not a running
+execution state and must not restart or resume work.
+
+Retention behavior:
+
+- active, waiting, failed, cancelled, and unread-completed entries are default-visible;
+- clean completed entries may move to a collapsed or recent section while remaining inspectable;
+- archive hides terminal entries from default lists while preserving an inspectable record until
+  owner policy expires or the user clears it;
+- clear/delete removes an inspectable record through an explicit control and must not be triggered
+  by selection changes;
+- `close()` remains the current mechanical terminal-record dismissal operation until explicit
+  archive/clear APIs exist.
+
+## Action Contract
+
+Available actions are explicit controls, never side effects of selecting a row:
+
+| Action           | Owner                      | Rule                                                                 |
+| ---------------- | -------------------------- | -------------------------------------------------------------------- |
+| `select`         | Client view over SDK entry | Switch visible detail pane only.                                     |
+| `return-to-main` | Client view over SDK entry | Select the main conversation entry.                                  |
+| `follow`         | SDK/client contract        | Keep the selected detail pane pinned to live updates when supported. |
+| `cancel`         | Runtime through SDK        | Stop a queued or running task.                                       |
+| `send`           | Runtime through SDK        | Provide follow-up input only when the runner supports it.            |
+| `wait`           | SDK/runtime                | Wait for one task or group without changing ownership.               |
+| `read-log`       | Runtime through SDK        | Read retained output or transcript pages.                            |
+| `close`          | Runtime through SDK        | Dismiss a terminal runtime record under current APIs.                |
+| `archive`        | SDK/runtime retention      | Hide terminal retained work from default lists.                      |
+| `clear`          | SDK/runtime retention      | Explicitly remove retained work when owner policy allows it.         |
+
+## Ownership
+
+| Concern                                                                      | Owner             | Rule                                                                 |
+| ---------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------- |
+| Task lifecycle, transitions, cancellation, wait, send, close, logs           | `agent-runtime`   | Own mechanical state and runner-facing controls.                     |
+| Main/task/group entry projection, origin, controls, visibility, detail pages | `agent-sdk`       | Own presentation-neutral read models and task spawning ports.        |
+| `/background`, `/agent`, and future status/switch/archive commands           | `agent-command-*` | Expose user-visible commands through SDK/runtime contracts.          |
+| TUI switcher, row indicators, keyboard navigation, detail pane rendering     | `agent-cli`       | Render SDK projections and keep only ephemeral selected-entry state. |
+| Skill-spawned background work registration                                   | SDK skill runtime | Register through SDK/runtime task ports, never CLI UI state.         |
+
+`agent-cli` may render filled and empty indicators, maintain the focused menu row, and decide which
+detail pane is visible. It must not decide task completion, grouping, retention timeout, archive
+rules, input-needed semantics, or whether a task is cancellable.
+
+## Implementation Gates
+
+Before adding additional TUI behavior beyond the existing switcher, implementation PRs must add:
+
+- runtime tests for lifecycle transitions, cancellation, input wait, terminal retention, archive,
+  and clear behavior when those APIs are introduced;
+- SDK projection tests for main-thread, process task, agent task, grouped task, and skill-spawned
+  agent task entries;
+- SDK tests proving selected-entry changes do not mutate task lifecycle state;
+- command tests for `/background` or future status/switch/archive/clear commands;
+- CLI rendering tests for selected and unselected indicators, latest output, elapsed time,
+  input-needed state, terminal result, and available controls;
+- negative tests proving `agent-cli` does not duplicate lifecycle or retention decisions.
+
+## Relationship To Other Specs
+
+- [transparent-workflow.md](transparent-workflow.md) owns shared state vocabulary and disclosure
+  requirements.
+- [process-execution.md](process-execution.md) owns process request, output, and terminal result
+  contracts projected into background entries.
+- [user-local-storage.md](user-local-storage.md) owns user-local storage rules for baseline
+  preferences and retained inspectable metadata.
+- [background-task-layer.md](background-task-layer.md) owns generic background task lifecycle
+  primitives.

--- a/.agents/specs/process-execution.md
+++ b/.agents/specs/process-execution.md
@@ -148,5 +148,7 @@ Before adding a user-facing process-run UI, implementation PRs must add:
   vocabulary.
 - [user-local-storage.md](user-local-storage.md) forbids remembered commands as executable
   preferences.
+- [background-work-state.md](background-work-state.md) owns how process tasks appear in switchable
+  main-thread/background work views.
 - [background-task-layer.md](background-task-layer.md) owns generic background process task
   lifecycle primitives.

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -191,6 +191,6 @@ files and no Robota local state inside the repository.
 
 - [User-local storage foundation](../backlog/completed/cli-user-local-storage-foundation.md)
 - [Transparent process execution](../backlog/completed/cli-transparent-process-execution.md)
-- [Background work state management](../backlog/cli-background-work-state-management.md)
+- [Background work state management](../backlog/completed/cli-background-work-state-management.md)
 - [User-local memory transparency](../backlog/cli-user-local-memory-transparency.md)
 - [Repository situational awareness](../backlog/cli-repository-situational-awareness.md)

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -1298,6 +1298,12 @@ Background agent task lifecycle and progress are projected by the SDK execution 
 rendering. React components may render this SDK state only; they must not own task transitions,
 retention, grouping, unread semantics, or cancellation logic.
 
+The shared contract for switchable main-thread, process, agent, group, and skill-spawned work state
+is [../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+The CLI may render existing SDK fields and selection indicators now. Any future row fields such as
+elapsed time, input-needed reason, terminal result, archive, or clear controls must be introduced in
+SDK/runtime projections before TUI components display them.
+
 `BackgroundTaskPanel` renders SDK default-visible background task entries as a one-level tree headed
 by `Background work`. Each child row is built by the pure `formatBackgroundTaskRow` formatter from
 `IExecutionWorkspaceEntry` data and contains a compact status marker, human-readable task label,

--- a/packages/agent-command-agent/docs/SPEC.md
+++ b/packages/agent-command-agent/docs/SPEC.md
@@ -75,6 +75,15 @@ For parallel delegation, `/agent parallel ...` is the same-turn orchestration pa
 
 When the user enters `/agent run <natural-language prompt>`, the first unflagged token is treated as an agent type only if it matches an available agent definition or was supplied through `--agent`/`--type`. Otherwise the whole phrase remains the prompt and the command defaults to `general-purpose`. This keeps arbitrary natural-language prompts from being misread as unknown agent names.
 
+## Background Work State Relationship
+
+Agent jobs created by this command must appear through the shared background work state contract in
+[../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+This package may request SDK agent job APIs and return task or group ids, but lifecycle, grouping,
+origin projection, switchable entry state, retention, archive, and clear behavior remain owned by
+SDK/runtime contracts. `/agent open` may ask the host to focus an SDK-projected entry when the host
+supports it; it must not write directly to CLI UI state.
+
 ## Class Contract Registry
 
 | Class/Function             | Implements/Uses                     | Notes                                     |

--- a/packages/agent-command-background/docs/SPEC.md
+++ b/packages/agent-command-background/docs/SPEC.md
@@ -26,6 +26,11 @@ Supported forms:
 - `/background cancel <task-id> [reason]`: cancel a task.
 - `/background close <task-id>`: dismiss a terminal task.
 
+Future switch, follow, archive, and clear commands must follow the shared background work state
+contract in [../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+They must route through SDK/runtime APIs and must not define lifecycle or retention behavior inside
+this command package.
+
 Aliases:
 
 - `read`: `log`, `open`
@@ -38,6 +43,8 @@ Aliases:
 - Background task state remains SDK/runtime owned.
 - This package must consume SDK command-facing APIs through `@robota-sdk/agent-sdk`.
 - CLI products compose this module; SDK core must not embed `/background` registration or execution.
+- Background state, selected entries, archive visibility, and clear/delete semantics remain
+  SDK/runtime owned and are only surfaced by this command module.
 - Any future process-run subcommand must follow
   [../../../.agents/specs/process-execution.md](../../../.agents/specs/process-execution.md): it
   may route an explicit user-directed command through SDK/runtime APIs, but it must not infer

--- a/packages/agent-command-skills/docs/SPEC.md
+++ b/packages/agent-command-skills/docs/SPEC.md
@@ -35,6 +35,14 @@ The package exports an `ICommandModule` that consumes command contracts and skil
 
 When this model-invocable command module is composed, skill names and descriptions are listed in the system prompt `Skills` section as selection metadata. Full `SKILL.md` content is loaded only by SDK skill execution after `skills` activates a matching skill.
 
+## Background Work State Relationship
+
+Skills that spawn agent work must register through SDK/runtime task contracts and appear through the
+shared background work state model defined in
+[../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+This command package must not create a skill-specific background task path, write CLI UI state, or
+define separate lifecycle, retention, archive, or clear behavior.
+
 ## Verification Plan
 
 - `pnpm --filter @robota-sdk/agent-command-skills test`

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -141,6 +141,18 @@ cancellation, send/read controls, exit code, signal code, and state transitions.
 own command selection, command meaning, environment-summary presentation, action provenance, or
 correctness interpretation.
 
+## Background Work State Relationship
+
+Switchable background work state is specified in
+[../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+`agent-runtime` owns mechanical task lifecycle, events, cancellation, wait, send, close, and log
+read operations. It does not own selected workspace entry state, filled/empty UI indicators,
+presentation grouping, archive visibility, or TUI detail rendering.
+
+Runtime may expose retention metadata only as task lifecycle or registry state protected by
+state-machine tests. `archived` remains a visibility/retention projection over terminal records, not
+a status that restarts or resumes execution.
+
 ## Error Taxonomy
 
 `BackgroundTaskError` is the package error class for lifecycle and runner failures.

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -1418,6 +1418,13 @@ may render entries, keep ephemeral selection state, and invoke explicit controls
 infer lifecycle, retention, origin, unread/attention semantics, or control availability from raw
 events when this projection is available.
 
+The cross-client background work state contract is defined in
+[../../../.agents/specs/background-work-state.md](../../../.agents/specs/background-work-state.md).
+The current `IExecutionWorkspaceEntry` shape covers stable ids, entry kind, origin, status, labels,
+preview, current action, attention, visibility, updated time, and advisory controls. Future fields
+such as started time, elapsed time, input-needed reason, terminal result, retention state, archive,
+and clear controls must be added to the SDK projection before CLI or transport surfaces render them.
+
 Execution workspace entries use a common `IExecutionWorkspaceEntry` shape:
 
 - `main_thread` is an SDK projection backed by `InteractiveSession` history and current foreground


### PR DESCRIPTION
## Accepted Recommendation

Treat the background work state backlog as a contract PR before additional TUI work. The PR defines one SDK/runtime-owned projection model for main-thread, process, agent, group, and future skill-spawned work, while leaving `agent-cli` as a renderer/navigation layer.

## Rationale

- Matches the backlog intent because the current TUI switcher already renders SDK execution workspace snapshots, but the missing behavior needs lower-level ownership for retention, archive/clear, elapsed time, input-needed state, and terminal results.
- Matches repository layering because lifecycle and retention stay in `agent-runtime`, projections and action contracts stay in `agent-sdk`, command behavior stays in `agent-command-*`, and `agent-cli` owns only UI rendering and ephemeral selection.
- Preserves repo independence by keeping background state local workflow state rather than requiring Robota files or dependencies in user repositories.

## Implementation Summary

- Added `.agents/specs/background-work-state.md`.
- Linked the cross-cutting contract from transparent workflow and process execution specs.
- Updated `agent-runtime`, `agent-sdk`, `agent-cli`, `agent-command-background`, `agent-command-agent`, and `agent-command-skills` SPEC files with ownership rules.
- Moved the backlog to completed and recorded follow-up implementation gaps.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification via `git push`

## Residual Risk

This is a design/contract slice. Runtime archive/clear APIs, SDK projection fields, command controls, and CLI rendering tests remain follow-up implementation work. `pnpm harness:scan` still reports pre-existing file-size warnings and internal app dist warnings only.