### PR TITLE
docs(specs): define user-local memory contract

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,5 +12,4 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Memory Transparency for agent-cli](cli-user-local-memory-transparency.md)
 - [Repository Situational Awareness for agent-cli](cli-repository-situational-awareness.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -122,8 +122,9 @@ Reviewer role:
 - [Background work state management](completed/cli-background-work-state-management.md) (completed):
   switchable main thread, shell job, and agent task state with transparent lifecycle and retention
   behavior.
-- [User-local memory transparency](cli-user-local-memory-transparency.md): cwd, view preference, and
-  task association storage that is inspectable, removable, and stored outside the repository.
+- [User-local memory transparency](completed/cli-user-local-memory-transparency.md) (completed):
+  cwd, view preference, and task association storage that is inspectable, removable, and stored
+  outside the repository.
 - [Repository situational awareness](cli-repository-situational-awareness.md): passive display of
   current working context without command inference, repo scanning, or package-manager guessing.
 
@@ -166,7 +167,7 @@ Promote the split backlogs in this order:
 2. `completed/cli-user-local-storage-foundation.md`
 3. `completed/cli-transparent-process-execution.md`
 4. `completed/cli-background-work-state-management.md`
-5. `cli-user-local-memory-transparency.md`
+5. `completed/cli-user-local-memory-transparency.md`
 6. `cli-repository-situational-awareness.md`
 
 Each implementation PR should update the owning package specs before changing `agent-cli` UI.

--- a/.agents/backlog/completed/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/completed/cli-user-local-memory-transparency.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -112,12 +112,12 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] Users can inspect remembered values, storage locations, sources, last-used time, and
+- [x] Users can inspect remembered values, storage locations, sources, last-used time, and
       display/navigation rules.
-- [ ] Users can delete or disable remembered values.
-- [ ] Remembered values cannot execute commands.
-- [ ] No repo-local files are written for baseline memory, including ignored files.
-- [ ] CLI UI depends on SDK/runtime memory contracts rather than owning storage policy.
+- [x] Users can delete or disable remembered values.
+- [x] Remembered values cannot execute commands.
+- [x] No repo-local files are written for baseline memory, including ignored files.
+- [x] CLI UI depends on SDK/runtime memory contracts rather than owning storage policy.
 
 ## Test Plan
 
@@ -137,3 +137,15 @@ Create a design and contract PR before UI work:
 - Add tests proving memory writes stay outside the repository entirely.
 - Add tests proving remembered values cannot execute commands.
 - Add CLI tests after memory contracts exist.
+
+## Result
+
+Completed by adding `.agents/specs/user-local-memory.md` and linking package ownership from
+`agent-sdk`, `agent-runtime`, `agent-cli`, `agent-command-memory`, and `agent-sessions` SPEC files.
+
+- The contract defines allowed display/navigation memory, restricted command/execution memory, item
+  projection fields, inspection, deletion, and disablement rules.
+- Existing project memory under `.robota/memory/` is documented as a separate explicit project
+  memory feature, not baseline user-local memory.
+- SDK storage APIs, delete/disable command behavior, migration from project memory, and CLI
+  rendering tests remain follow-up implementation work.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -18,5 +18,6 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 | [process-execution.md](process-execution.md)                   | Transparent local process execution request, status, output, and provenance contract   |
 | [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                 |
 | [transparent-workflow.md](transparent-workflow.md)             | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
+| [user-local-memory.md](user-local-memory.md)                   | Inspectable user-local memory and preference behavior for display/navigation only      |
 | [user-local-storage.md](user-local-storage.md)                 | User-local-only baseline workflow storage policy, category inspection, and path guards |
 | [verification-pipeline-plan.md](verification-pipeline-plan.md) | Local hooks, harness verification, CI, build, and release verification planning        |

--- a/.agents/specs/background-work-state.md
+++ b/.agents/specs/background-work-state.md
@@ -149,5 +149,7 @@ Before adding additional TUI behavior beyond the existing switcher, implementati
   contracts projected into background entries.
 - [user-local-storage.md](user-local-storage.md) owns user-local storage rules for baseline
   preferences and retained inspectable metadata.
+- [user-local-memory.md](user-local-memory.md) owns remembered display/navigation preferences such
+  as the last selected background entry.
 - [background-task-layer.md](background-task-layer.md) owns generic background task lifecycle
   primitives.

--- a/.agents/specs/process-execution.md
+++ b/.agents/specs/process-execution.md
@@ -148,6 +148,8 @@ Before adding a user-facing process-run UI, implementation PRs must add:
   vocabulary.
 - [user-local-storage.md](user-local-storage.md) forbids remembered commands as executable
   preferences.
+- [user-local-memory.md](user-local-memory.md) owns remembered display/navigation values and keeps
+  them ineligible as command sources.
 - [background-work-state.md](background-work-state.md) owns how process tasks appear in switchable
   main-thread/background work views.
 - [background-task-layer.md](background-task-layer.md) owns generic background process task

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -192,5 +192,5 @@ files and no Robota local state inside the repository.
 - [User-local storage foundation](../backlog/completed/cli-user-local-storage-foundation.md)
 - [Transparent process execution](../backlog/completed/cli-transparent-process-execution.md)
 - [Background work state management](../backlog/completed/cli-background-work-state-management.md)
-- [User-local memory transparency](../backlog/cli-user-local-memory-transparency.md)
+- [User-local memory transparency](../backlog/completed/cli-user-local-memory-transparency.md)
 - [Repository situational awareness](../backlog/cli-repository-situational-awareness.md)

--- a/.agents/specs/user-local-memory.md
+++ b/.agents/specs/user-local-memory.md
@@ -1,0 +1,159 @@
+# User-Local Memory Transparency Contract
+
+## Status
+
+Design contract.
+
+This specification defines inspectable user-local memory and preference behavior for baseline
+Robota workflow assistance. It builds on [user-local-storage.md](user-local-storage.md), which owns
+the storage root, category layout, repo-outside validation, and generic inspection projection.
+
+## Scope
+
+This contract covers user-local remembered state that may help display and navigation:
+
+- last visible cwd or workspace context for display only;
+- TUI view preferences;
+- last selected background entry or panel;
+- session-local task associations;
+- local display preferences;
+- user choices about whether a remembered item is enabled, disabled, or deleted.
+
+It applies to SDK storage contracts, command modules that expose inspection/removal, `agent-cli`
+surfaces that render remembered values, and future transports that present the same state.
+
+## Non-Goals
+
+- Persisting command strings as reusable preferences.
+- Executing commands from remembered values, command history, session recall, or local memory.
+- Inferring repository harness behavior from repeated user actions.
+- Writing baseline memory into tracked files, ignored files, project `.robota/`, or repository
+  caches.
+- Defining a team-shared workflow format.
+- Migrating every existing project memory or session artifact in this contract PR.
+
+## Allowed Baseline Memory
+
+Allowed remembered values must affect display or navigation only:
+
+| Memory kind            | Example use                                                     | May execute commands? |
+| ---------------------- | --------------------------------------------------------------- | --------------------- |
+| `view-preference`      | Open the same panel, filter, density, or sorting choice.        | no                    |
+| `last-visible-cwd`     | Display or preselect a workspace context already in session.    | no                    |
+| `background-selection` | Restore the last selected background entry in a local session.  | no                    |
+| `task-association`     | Associate a session-local task id with a user-visible grouping. | no                    |
+| `display-preference`   | Remember text wrapping, compactness, or visibility preferences. | no                    |
+| `inspection-choice`    | Remember disabled or hidden user-local items for inspection.    | no                    |
+
+Remembered cwd or view state must not become the execution cwd for a new process by itself. Process
+execution still requires current user input or accepted assistant suggestion provenance.
+
+## Restricted Memory
+
+The baseline memory contract forbids:
+
+- remembered shell commands;
+- inferred build, test, lint, release, or harness commands;
+- package manager guesses;
+- provider/tool permission decisions;
+- approval or denial decisions for future side effects;
+- hidden automatic conversion of repeated behavior into preferences;
+- correctness judgments derived from command output;
+- repair-loop, review-gate, or workflow readiness decisions.
+
+If a future feature wants one of these behaviors, it needs a separate spec, explicit user consent
+contract, and tests proving it does not bypass transparent workflow provenance.
+
+## Memory Item Model
+
+The SDK-owned memory item projection extends the user-local storage inspection projection with
+display/navigation disclosure:
+
+| Field                    | Requirement                                                                |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `category`               | Stable user-local category such as `preferences` or `view-state`.          |
+| `key`                    | Stable item key within the category.                                       |
+| `summary`                | Bounded human-readable item summary.                                       |
+| `valueSummary`           | Bounded non-secret value description.                                      |
+| `source`                 | Provenance source that created or last changed the item.                   |
+| `scope`                  | User, session, repo identity, or workspace identity scope.                 |
+| `storageLocation`        | Concrete path or opaque user-local location.                               |
+| `createdAt`              | Creation timestamp when available.                                         |
+| `lastUsedAt`             | Last display/navigation use timestamp when available.                      |
+| `enabled`                | Whether the item may currently affect display/navigation.                  |
+| `displayNavigationRule`  | Plain rule describing where the remembered value may affect the UI.        |
+| `commandExecutionEffect` | Always `none` for baseline user-local memory.                              |
+| `deleteAvailable`        | Whether an explicit delete action is available.                            |
+| `disableAvailable`       | Whether an explicit disable action is available without deleting the item. |
+
+The projection must not include secrets or full transcript content. When a value cannot be displayed
+safely, the SDK must provide a bounded summary and storage location rather than raw content.
+
+## Inspection And Removal
+
+SDK and command APIs must support:
+
+- listing user-local memory categories and item summaries;
+- inspecting one remembered item with storage location, source, scope, timestamps, enabled state,
+  and display/navigation rule;
+- deleting an item when `deleteAvailable` is true;
+- disabling an item when `disableAvailable` is true;
+- showing disabled items in inspection output;
+- proving disabled items do not affect display/navigation until explicitly re-enabled by a future
+  contract.
+
+Delete and disable are explicit user actions. Rendering a panel, selecting a task, or starting a
+new session must not silently delete, disable, or create remembered items.
+
+## Existing Project Memory Relationship
+
+Existing `.robota/memory/` project memory is an explicit project memory feature owned by
+`agent-sdk/memory/` and exposed through `@robota-sdk/agent-command-memory`. It is not the baseline
+user-local memory feature defined here.
+
+Rules:
+
+- Existing project memory may remain project-local until a separate migration PR changes it.
+- New baseline local preferences and remembered workflow state must not write to `.robota/memory/`.
+- Project memory content may be model-visible only through the existing explicit memory command and
+  prompt composition contracts.
+- User-local memory items must not be injected as command suggestions or hidden prompt behavior.
+- Migration or mirroring between project memory and user-local memory requires explicit user action,
+  storage disclosure, and tests.
+
+## Ownership
+
+| Concern                                                                | Owner              | Rule                                                      |
+| ---------------------------------------------------------------------- | ------------------ | --------------------------------------------------------- |
+| User-local memory item shapes, categories, inspection, delete, disable | `agent-sdk`        | Own reusable contracts and repo-outside storage policy.   |
+| Session-local task ids and background ids used as association inputs   | `agent-runtime`    | Expose ids and state only; do not persist user memory.    |
+| `/memory` and future preference/memory inspection command behavior     | `agent-command-*`  | Consume SDK APIs and format command output.               |
+| TUI panels, command routing, and display of remembered values          | `agent-cli`        | Render SDK/command projections only.                      |
+| Concrete storage root and path validation                              | user-local storage | Must remain user-local and outside the active repository. |
+
+`agent-cli` must not assemble storage paths, infer remembered items from repeated behavior, execute
+remembered commands, or mutate memory outside SDK/command APIs.
+
+## Implementation Gates
+
+Before a TUI screen or command writes baseline user-local memory, implementation PRs must add:
+
+- SDK tests for the memory item projection fields;
+- SDK tests for delete, disable, and disabled-item non-use;
+- negative tests for repository-local, ignored-file, and project `.robota/` writes;
+- negative tests proving remembered commands, session recall, and command history cannot execute
+  commands;
+- tests proving repeated behavior does not silently become a persistent preference;
+- CLI rendering tests for storage location, source, last-used time, display/navigation rule, and
+  delete/disable actions after SDK contracts exist.
+
+## Relationship To Other Specs
+
+- [transparent-workflow.md](transparent-workflow.md) owns action provenance and the rule that
+  user-local preferences cannot execute commands.
+- [user-local-storage.md](user-local-storage.md) owns the canonical `~/.robota` root, categories,
+  inspection fields, and repo-outside validation.
+- [background-work-state.md](background-work-state.md) owns switchable background entry state that
+  may reference user-local view preferences without becoming lifecycle state.
+- [process-execution.md](process-execution.md) owns command execution provenance and forbids
+  remembered values as command sources.

--- a/.agents/specs/user-local-storage.md
+++ b/.agents/specs/user-local-storage.md
@@ -156,3 +156,5 @@ Before a TUI screen or command stores baseline workflow state, implementation PR
 This storage policy implements the memory transparency and repo-independence requirements in
 [transparent-workflow.md](transparent-workflow.md). Transparent workflow features may display
 repository context, but their baseline stored state must use this user-local storage foundation.
+The detailed baseline memory and preference item model lives in
+[user-local-memory.md](user-local-memory.md).

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -81,6 +81,12 @@ may render the effective storage root, category summaries, and delete/disable ac
 or command-module projections. It must not resolve baseline storage paths, write workflow
 preferences into project `.robota/`, or remember commands as executable preferences.
 
+Inspectable user-local memory and preference behavior is defined in
+[../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md). The CLI
+may display remembered values, storage location, source, last-used time, and delete/disable actions
+only through SDK/command projections. It must not infer remembered items from repeated behavior or
+execute commands from remembered values.
+
 Existing CLI-owned operational cache such as `~/.robota/update-check.json` remains distribution UX,
 not baseline workflow state. Existing project-local sessions, logs, checkpoints, and memory are
 classified by the storage spec and must not be reused for new baseline workflow features without a
@@ -1375,6 +1381,13 @@ raw shell output. It may provide terminal-local runner adapters and render:
 - evidence links and review decisions recorded through owner APIs.
 
 ## Memory Management
+
+### User-Local Memory And Preference Transparency
+
+User-local memory is display/navigation state only. The CLI may render inspection rows, disabled
+state, storage location, source, last-used time, and delete/disable actions returned by SDK or
+command APIs. It must not own storage shape, write user-local memory directly, write baseline memory
+inside the repository, or convert remembered values into command execution.
 
 ### Project Memory Review Surface
 

--- a/packages/agent-command-memory/docs/SPEC.md
+++ b/packages/agent-command-memory/docs/SPEC.md
@@ -43,6 +43,10 @@ import { createMemoryCommandModule } from '@robota-sdk/agent-command-memory';
 - This package must not import SDK internal memory store files directly.
 - Project memory storage and session memory-event persistence stay behind SDK command memory APIs.
 - Slash invocation and model invocation must execute the same system command handler.
+- Future user-local memory inspection, delete, or disable subcommands must follow
+  [../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md). They
+  must consume SDK user-local memory APIs, disclose storage location and display/navigation effect,
+  and must not execute commands from remembered values.
 
 ## Verification
 

--- a/packages/agent-runtime/docs/SPEC.md
+++ b/packages/agent-runtime/docs/SPEC.md
@@ -132,6 +132,14 @@ Baseline workflow storage policy is defined in
 workflow state. It may expose session-local task ids, metadata, events, and state snapshots; SDK
 storage contracts decide whether and how higher layers persist those associations.
 
+## User-Local Memory Relationship
+
+Inspectable user-local memory behavior is specified in
+[../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md).
+`agent-runtime` may expose task ids, group ids, lifecycle state, and metadata that SDK projections
+use for user-local associations. Runtime must not read or write user-local memory, project memory,
+or command-history preferences, and remembered values must not influence runtime command execution.
+
 ## Process Execution Relationship
 
 Transparent process execution is specified in

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -352,6 +352,21 @@ yet the complete transparent workflow storage contract. Future implementation PR
 user-local category APIs instead of having CLI or command modules assemble category paths
 themselves.
 
+### User-Local Memory Transparency (SDK-Specific)
+
+The baseline user-local memory contract lives in
+[../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md). The SDK
+is the designated owner for memory item projection shapes, display/navigation disclosure rules,
+inspection APIs, delete/disable APIs, and disabled-item non-use.
+
+User-local memory may influence display and navigation only. It must not execute shell/process
+commands, select repository harness commands, grant permissions, inject hidden prompt behavior, or
+become the execution cwd for a new command by itself.
+
+Existing project memory under `.robota/memory/` remains a separate explicit project-memory feature.
+New baseline local preferences, last-view state, and task associations must use the SDK user-local
+storage contract instead of project memory paths.
+
 ### Transparent Process Execution (SDK-Specific)
 
 The process execution contract lives in
@@ -511,6 +526,10 @@ Resolved provider fields:
 - **Audit trail**: `/memory approve`, `/memory reject`, and future explicit memory workflows append memory events to the session record as `memoryEvents` for resume/debugging. High-frequency streaming data is not part of the memory event stream.
 - **Ownership**: SDK owns memory stores, memory policy primitives, and command-facing memory APIs. `@robota-sdk/agent-command-memory` owns command behavior. CLI only composes the module and renders command results/autocomplete metadata.
 - **Prompt composition boundary**: The system prompt may include the neutral `Project Memory` startup index and the `/memory` descriptor under `Built-in Commands`; it must not include extra hardcoded memory behavior instructions outside descriptor data.
+- **User-local memory boundary**: This project memory feature is not baseline user-local memory.
+  User-local display/navigation preferences are governed by
+  [../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md) and
+  must not be stored in `.robota/memory/`.
 
 ### Context Window Management
 

--- a/packages/agent-sessions/docs/SPEC.md
+++ b/packages/agent-sessions/docs/SPEC.md
@@ -174,6 +174,11 @@ The callback payload is provider-neutral `IContextWindowState`; provider-specifi
 | `contextReferences`        | `unknown[]` | No       | SDK-owned context reference inventory for resume/debugging.                                                                                                       |
 | `sandboxSnapshotId`        | `string`    | No       | Provider-owned sandbox workspace reference used by SDK resume hydration. `agent-sessions` stores this value opaquely and does not import sandbox packages.        |
 
+Memory event and used-reference fields are audit/debug data, not baseline user-local preferences.
+Inspectable user-local memory is governed by
+[../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md). Session
+records must not become a command source or hidden preference store.
+
 ### Session Data Migration
 
 `scripts/migrate-session-history.mjs` backfills the `history` field for sessions created before this field existed. It converts `messages[]` to `IHistoryEntry[]` format. Safe to run multiple times — skips sessions that already have `history`. Run once after upgrading.


### PR DESCRIPTION
## Accepted Recommendation

Treat the user-local memory transparency backlog as a contract PR before UI/storage implementation. The PR defines what Robota may remember for display/navigation, how those remembered values must be inspectable and removable, and why they can never become command execution sources.

## Rationale

- Matches the backlog intent because it answers what Robota remembered, where it is stored, how it is displayed, and how users delete or disable it.
- Matches repository layering because `agent-sdk` owns item projections and storage contracts, `agent-runtime` only exposes association inputs, `agent-command-*` exposes commands, and `agent-cli` only renders/dispatches.
- Preserves repo independence by requiring baseline memory to use user-local storage outside the repository and by excluding `.robota/memory` from new baseline preferences.

## Implementation Summary

- Added `.agents/specs/user-local-memory.md`.
- Linked the contract from transparent workflow, user-local storage, process execution, and background work state specs.
- Updated `agent-sdk`, `agent-runtime`, `agent-cli`, `agent-command-memory`, and `agent-sessions` SPEC files.
- Moved the backlog to completed and recorded remaining implementation work.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification via `git push`

## Residual Risk

This is a design/contract slice. SDK storage APIs, delete/disable command behavior, project-memory migration, and CLI rendering tests remain follow-up implementation work. `pnpm harness:scan` still reports pre-existing file-size warnings and internal app dist warnings only.