### PR TITLE
docs(specs): define repository awareness contract

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -12,4 +12,3 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [Repository Situational Awareness for agent-cli](cli-repository-situational-awareness.md)

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -125,8 +125,9 @@ Reviewer role:
 - [User-local memory transparency](completed/cli-user-local-memory-transparency.md) (completed):
   cwd, view preference, and task association storage that is inspectable, removable, and stored
   outside the repository.
-- [Repository situational awareness](cli-repository-situational-awareness.md): passive display of
-  current working context without command inference, repo scanning, or package-manager guessing.
+- [Repository situational awareness](completed/cli-repository-situational-awareness.md) (completed):
+  passive display of current working context without command inference, repo scanning, or
+  package-manager guessing.
 
 ## Expected Outcomes
 
@@ -168,7 +169,7 @@ Promote the split backlogs in this order:
 3. `completed/cli-transparent-process-execution.md`
 4. `completed/cli-background-work-state-management.md`
 5. `completed/cli-user-local-memory-transparency.md`
-6. `cli-repository-situational-awareness.md`
+6. `completed/cli-repository-situational-awareness.md`
 
 Each implementation PR should update the owning package specs before changing `agent-cli` UI.
 

--- a/.agents/backlog/completed/cli-repository-situational-awareness.md
+++ b/.agents/backlog/completed/cli-repository-situational-awareness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -89,13 +89,13 @@ Create a design and contract PR before UI work:
 
 ## Acceptance Criteria
 
-- [ ] The context view shows repo root, branch, dirty status, cwd, explicitly referenced docs, and
+- [x] The context view shows repo root, branch, dirty status, cwd, explicitly referenced docs, and
       active background workspace context where available.
-- [ ] Each context item has a clear source/provenance.
-- [ ] Context display does not infer canonical commands, readiness scores, package manager setup, or
+- [x] Each context item has a clear source/provenance.
+- [x] Context display does not infer canonical commands, readiness scores, package manager setup, or
       visible workspace files.
-- [ ] Context display does not write repo files.
-- [ ] CLI UI depends on SDK context projections rather than owning repo scanning policy.
+- [x] Context display does not write repo files.
+- [x] CLI UI depends on SDK context projections rather than owning repo scanning policy.
 
 ## Test Plan
 
@@ -114,3 +114,16 @@ Create a design and contract PR before UI work:
 - Add tests proving no repo files are written.
 - Add tests proving no package-manager guessing or workspace-file enumeration occurs.
 - Add CLI rendering tests after SDK contracts exist.
+
+## Result
+
+Completed by adding `.agents/specs/repository-situational-awareness.md` and linking package
+ownership from `agent-sdk`, `agent-cli`, `agent-command-context`, and `agent-command-statusline`
+SPEC files.
+
+- The contract defines passive context item fields, allowed provenance sources, bounded read rules,
+  and command/automation boundaries.
+- Dirty status is limited to summary display by default, without visible workspace file
+  enumeration.
+- SDK projection APIs, host adapter tests, command formatting, and CLI rendering tests remain
+  follow-up implementation work.

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -5,19 +5,20 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 
 ## Index
 
-| Spec                                                           | Scope                                                                                  |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| (See `packages/*/docs/SPEC.md` for package-level specs)        | Per-package contracts                                                                  |
-| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                     | Repository-level architecture map router                                               |
-| [architecture-map/README.md](architecture-map/README.md)       | Architecture-map document tree and update policy                                       |
-| [agent-invocation-router.md](agent-invocation-router.md)       | Agent command descriptors, deterministic invocation routing, and claim guards          |
-| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)   | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
-| [background-work-state.md](background-work-state.md)           | Switchable main-thread, process, agent, group, and skill-spawned work state contract   |
-| [background-task-layer.md](background-task-layer.md)           | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
-| [command-inventory.md](command-inventory.md)                   | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
-| [process-execution.md](process-execution.md)                   | Transparent local process execution request, status, output, and provenance contract   |
-| [subagent-process-manager.md](subagent-process-manager.md)     | CLI subagent process management, parallel execution, and TUI lifecycle                 |
-| [transparent-workflow.md](transparent-workflow.md)             | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
-| [user-local-memory.md](user-local-memory.md)                   | Inspectable user-local memory and preference behavior for display/navigation only      |
-| [user-local-storage.md](user-local-storage.md)                 | User-local-only baseline workflow storage policy, category inspection, and path guards |
-| [verification-pipeline-plan.md](verification-pipeline-plan.md) | Local hooks, harness verification, CI, build, and release verification planning        |
+| Spec                                                                       | Scope                                                                                  |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| (See `packages/*/docs/SPEC.md` for package-level specs)                    | Per-package contracts                                                                  |
+| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                                 | Repository-level architecture map router                                               |
+| [architecture-map/README.md](architecture-map/README.md)                   | Architecture-map document tree and update policy                                       |
+| [agent-invocation-router.md](agent-invocation-router.md)                   | Agent command descriptors, deterministic invocation routing, and claim guards          |
+| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)               | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
+| [background-work-state.md](background-work-state.md)                       | Switchable main-thread, process, agent, group, and skill-spawned work state contract   |
+| [background-task-layer.md](background-task-layer.md)                       | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
+| [command-inventory.md](command-inventory.md)                               | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
+| [process-execution.md](process-execution.md)                               | Transparent local process execution request, status, output, and provenance contract   |
+| [repository-situational-awareness.md](repository-situational-awareness.md) | Passive repo context display without command inference or repo writes                  |
+| [subagent-process-manager.md](subagent-process-manager.md)                 | CLI subagent process management, parallel execution, and TUI lifecycle                 |
+| [transparent-workflow.md](transparent-workflow.md)                         | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
+| [user-local-memory.md](user-local-memory.md)                               | Inspectable user-local memory and preference behavior for display/navigation only      |
+| [user-local-storage.md](user-local-storage.md)                             | User-local-only baseline workflow storage policy, category inspection, and path guards |
+| [verification-pipeline-plan.md](verification-pipeline-plan.md)             | Local hooks, harness verification, CI, build, and release verification planning        |

--- a/.agents/specs/background-work-state.md
+++ b/.agents/specs/background-work-state.md
@@ -151,5 +151,7 @@ Before adding additional TUI behavior beyond the existing switcher, implementati
   preferences and retained inspectable metadata.
 - [user-local-memory.md](user-local-memory.md) owns remembered display/navigation preferences such
   as the last selected background entry.
+- [repository-situational-awareness.md](repository-situational-awareness.md) owns passive display of
+  active background workspace context alongside cwd and Git summaries.
 - [background-task-layer.md](background-task-layer.md) owns generic background task lifecycle
   primitives.

--- a/.agents/specs/process-execution.md
+++ b/.agents/specs/process-execution.md
@@ -152,5 +152,7 @@ Before adding a user-facing process-run UI, implementation PRs must add:
   them ineligible as command sources.
 - [background-work-state.md](background-work-state.md) owns how process tasks appear in switchable
   main-thread/background work views.
+- [repository-situational-awareness.md](repository-situational-awareness.md) owns passive context
+  display and forbids context items as command sources.
 - [background-task-layer.md](background-task-layer.md) owns generic background process task
   lifecycle primitives.

--- a/.agents/specs/repository-situational-awareness.md
+++ b/.agents/specs/repository-situational-awareness.md
@@ -1,0 +1,143 @@
+# Repository Situational Awareness Contract
+
+## Status
+
+Design contract.
+
+This specification defines passive repository context display for Robota clients. The goal is to
+show where Robota is operating and what session-known context is available without turning context
+display into repository scanning, command discovery, setup inference, or harness scoring.
+
+## Scope
+
+This contract covers display-only context items:
+
+- current `cwd`;
+- repository root when a bounded repository-root probe is available;
+- current branch when available;
+- dirty status summary when available;
+- explicitly referenced documents;
+- active background workspace context.
+
+It applies to SDK context projections, command modules that expose context/status output, `agent-cli`
+TUI surfaces, status bars, and future transports.
+
+## Non-Goals
+
+- Inferring canonical build, test, lint, release, or harness commands.
+- Guessing package managers, frameworks, CI mappings, or setup profiles.
+- Scoring repository readiness.
+- Enumerating visible workspace files.
+- Writing repository files, ignored files, manifests, hooks, scripts, or caches.
+- Requiring Robota configuration or dependencies inside the user's repository.
+
+## Context Item Model
+
+Every context item must be projected with visible source and bounded display data:
+
+| Field          | Requirement                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| `id`           | Stable item id for the current snapshot.                                                          |
+| `kind`         | `cwd`, `repo-root`, `git-branch`, `dirty-summary`, `explicit-reference`, or `background-context`. |
+| `label`        | Human-readable label suitable for compact UI.                                                     |
+| `valueSummary` | Bounded value summary. Dirty state must not enumerate filenames by default.                       |
+| `source`       | Provenance source that produced the item.                                                         |
+| `capturedAt`   | Capture timestamp when available.                                                                 |
+| `actions`      | Display-only actions such as inspect reference or open background detail.                         |
+
+Allowed provenance sources:
+
+| Source                    | Meaning                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `cwd`                     | The session working directory supplied to the SDK/client.                       |
+| `git-state`               | Bounded Git metadata such as root, branch, and dirty summary.                   |
+| `active-session-state`    | SDK session state such as context usage or current foreground/background work.  |
+| `explicit-user-reference` | Documents explicitly referenced through prompt file references or context APIs. |
+| `background-workspace`    | SDK execution workspace entries for background task context.                    |
+
+Context projection must not include raw file contents. Explicit document references may show path,
+status, size, and source metadata already recorded by the SDK reference inventory.
+
+## Read Boundary
+
+Passive context display may use only bounded reads:
+
+- session `cwd`;
+- bounded Git root/branch/dirty-summary probes through SDK or injected host adapters;
+- SDK context-reference inventory for explicit references;
+- SDK execution workspace snapshot for background context;
+- existing session context-window state.
+
+Passive context display must not:
+
+- walk the workspace tree;
+- parse package manifests to infer commands;
+- scan CI files;
+- inspect dependency lockfiles;
+- rank files or commands;
+- create setup profiles;
+- write repository-local state.
+
+Dirty status must be summarized. A default context row may show counts or coarse states such as
+clean, modified, untracked, or conflicted, but it must not list file paths unless the user invokes a
+separate explicit Git/status inspection feature.
+
+## Command And Automation Boundary
+
+Repository situational awareness is not an execution source.
+
+Rules:
+
+- Context items may orient the user before they run or accept commands.
+- Context items must not execute commands.
+- Context items must not become remembered command preferences.
+- Context items must not trigger background work, repair loops, review gates, readiness scores, or
+  workflow orchestration.
+- Any future command suggested from context requires a separate transparent process execution
+  contract and explicit user input or accepted assistant suggestion provenance.
+
+## Ownership
+
+| Concern                                                         | Owner             | Rule                                                             |
+| --------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------- |
+| Context item projection, provenance, bounded read contracts     | `agent-sdk`       | Own reusable read models and negative inference rules.           |
+| Git metadata adapters                                           | SDK host adapter  | Provide bounded root/branch/dirty summaries without file walks.  |
+| `/context`, `/statusline`, or future status command formatting  | `agent-command-*` | Consume SDK projections and format user-visible output.          |
+| TUI panels, status bars, row rendering, and keyboard navigation | `agent-cli`       | Render SDK/command projections only.                             |
+| Background workspace context                                    | `agent-sdk`       | Reuse execution workspace snapshots; do not duplicate lifecycle. |
+
+`agent-cli` must not implement package-manager guessing, command discovery, readiness scoring,
+workspace enumeration, or repository write policy.
+
+## Existing Capability Notes
+
+The CLI already shows some operational context such as cwd-derived session state, git branch in the
+status bar, context-window usage, and background workspace entries. This contract governs future
+expansion: new situational awareness surfaces must receive SDK-owned projections instead of adding
+new CLI-local repository interpretation.
+
+Existing SDK context loading may read explicit context sources for prompt construction. Passive
+situational awareness must not reuse broader context-loading internals to infer package manager,
+framework, command, or readiness facts for display.
+
+## Implementation Gates
+
+Before adding a context view or expanding status bars beyond existing fields, implementation PRs
+must add:
+
+- SDK projection tests for cwd, repo root, branch, dirty summary, explicit references, and active
+  background workspace context;
+- provenance tests proving every displayed item includes a source;
+- negative tests proving no package-manager guessing, command inference, CI mapping, readiness
+  scoring, setup profile generation, or workspace-file enumeration occurs;
+- tests proving context display does not create or modify repository files;
+- CLI rendering tests after SDK projections exist.
+
+## Relationship To Other Specs
+
+- [transparent-workflow.md](transparent-workflow.md) owns action provenance and UI disclosure.
+- [process-execution.md](process-execution.md) owns command execution provenance and forbids
+  context items as command sources.
+- [background-work-state.md](background-work-state.md) owns active background workspace entries.
+- [user-local-memory.md](user-local-memory.md) owns remembered display/navigation preferences, which
+  may affect context view defaults but cannot execute commands.

--- a/.agents/specs/transparent-workflow.md
+++ b/.agents/specs/transparent-workflow.md
@@ -193,4 +193,4 @@ files and no Robota local state inside the repository.
 - [Transparent process execution](../backlog/completed/cli-transparent-process-execution.md)
 - [Background work state management](../backlog/completed/cli-background-work-state-management.md)
 - [User-local memory transparency](../backlog/completed/cli-user-local-memory-transparency.md)
-- [Repository situational awareness](../backlog/cli-repository-situational-awareness.md)
+- [Repository situational awareness](../backlog/completed/cli-repository-situational-awareness.md)

--- a/.agents/specs/user-local-memory.md
+++ b/.agents/specs/user-local-memory.md
@@ -157,3 +157,5 @@ Before a TUI screen or command writes baseline user-local memory, implementation
   may reference user-local view preferences without becoming lifecycle state.
 - [process-execution.md](process-execution.md) owns command execution provenance and forbids
   remembered values as command sources.
+- [repository-situational-awareness.md](repository-situational-awareness.md) owns passive context
+  display that may use remembered view preferences only for display/navigation defaults.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -101,6 +101,15 @@ controls from SDK/runtime projections. It must not infer canonical repo commands
 readiness, persist commands as executable preferences, interpret output as correctness evidence, or
 own process lifecycle state.
 
+### Repository Situational Awareness Boundary
+
+Passive repository context display is defined in
+[../../../.agents/specs/repository-situational-awareness.md](../../../.agents/specs/repository-situational-awareness.md).
+The CLI may render cwd, repository root, branch, dirty summary, explicit references, and active
+background workspace context only from SDK/command projections. It must not walk the workspace,
+guess package managers, infer commands, score readiness, create setup profiles, or write repository
+files for context display.
+
 ### Provider Profile Creation
 
 The CLI owns provider profile resolution and provider definition composition. It must not branch on provider type names to decide defaults, required fields, setup prompts, endpoint probes, or constructor behavior. Those values come from injected `IProviderDefinition` records.

--- a/packages/agent-command-context/docs/SPEC.md
+++ b/packages/agent-command-context/docs/SPEC.md
@@ -55,6 +55,12 @@ the command package never reads files directly. Auto-compact controls update the
 immediately and persist through the SDK command host settings adapter when one is available. The
 command does not parse prose or call session internals.
 
+Future repository situational awareness output must follow
+[../../../.agents/specs/repository-situational-awareness.md](../../../.agents/specs/repository-situational-awareness.md).
+This package may format SDK-projected context items and provenance labels, but it must not read the
+workspace directly, infer package managers, discover commands, score readiness, or write repository
+files.
+
 ## Class Contract Registry
 
 | Class/Function               | Implements/Uses                           | Notes                                                 |

--- a/packages/agent-command-statusline/docs/SPEC.md
+++ b/packages/agent-command-statusline/docs/SPEC.md
@@ -36,6 +36,10 @@ Own the user-visible `/statusline` command as a composable command module. The p
 - Must not import `@robota-sdk/agent-cli`.
 - Must not read or write settings directly.
 - Must not render status bar output directly.
+- Git/statusline context fields must follow
+  [../../../.agents/specs/repository-situational-awareness.md](../../../.agents/specs/repository-situational-awareness.md):
+  they may surface bounded SDK/host-adapter projections such as branch or dirty summary, but must
+  not infer commands, package managers, readiness, or setup profiles.
 
 ## Test Plan
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -385,6 +385,19 @@ Existing `BackgroundProcess` and execution workspace APIs are the current buildi
 user-facing process-run commands must use SDK/runtime contracts and must not let CLI components
 assemble process semantics from raw child-process state.
 
+### Repository Situational Awareness (SDK-Specific)
+
+Passive repository context display is specified in
+[../../../.agents/specs/repository-situational-awareness.md](../../../.agents/specs/repository-situational-awareness.md).
+The SDK is the designated owner for context item projections, provenance fields, and bounded read
+contracts for cwd, repository root, branch, dirty summary, explicit context references, and active
+background workspace context.
+
+Situational awareness projections must not infer commands, package managers, CI mappings,
+repository readiness, setup profiles, or harness contracts. Existing context loading may continue to
+serve prompt construction, but passive display surfaces must use explicit projection APIs instead of
+reusing broad context-loading internals for repository interpretation.
+
 ### System Command System (SDK-Specific)
 
 - **Package**: `agent-sdk/commands/`


### PR DESCRIPTION
## Accepted Recommendation

Treat repository situational awareness as a passive context projection contract before UI work. The PR limits context display to bounded, sourced facts such as cwd, repo root, branch, dirty summary, explicit references, and active background workspace context.

## Rationale

- Matches the backlog intent because it answers where Robota is operating and what source produced each displayed item.
- Matches repository layering because `agent-sdk` owns projections/provenance/read boundaries, `agent-command-*` formats command output, and `agent-cli` only renders.
- Preserves repo independence because passive context display does not write repository files, require Robota manifests, infer harness commands, guess package managers, or score readiness.

## Implementation Summary

- Added `.agents/specs/repository-situational-awareness.md`.
- Linked the contract from transparent workflow, process execution, background work state, and user-local memory specs.
- Updated `agent-sdk`, `agent-cli`, `agent-command-context`, and `agent-command-statusline` SPEC files.
- Moved the backlog to completed and recorded follow-up implementation work.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification via `git push`

## Residual Risk

This is a design/contract slice. SDK projection APIs, host adapter tests, command formatting, and CLI rendering tests remain follow-up implementation work. `pnpm harness:scan` still reports pre-existing file-size warnings and internal app dist warnings only.