### PR TITLE
docs(rules): require user scenario gates

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -9,6 +9,20 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 2. When prioritized, move to `.agents/tasks/` and update status.
 3. When done, archive to `.agents/tasks/completed/`.
 
+## Backlog Entry Requirements
+
+Backlogs that change user-visible behavior, command behavior, workflow behavior, or documentation
+for such behavior must include both:
+
+- `## Test Plan`: the agent's engineering verification plan, such as unit, integration, harness,
+  build, and CI checks.
+- `## User Test Scenarios`: manual user scenarios with prerequisites, user actions, expected
+  visible results, cleanup/reset steps, and whether the agent can verify the scenario directly,
+  partially, or only by static/manual review.
+
+The user scenario gate is checked separately from the engineering test plan before the backlog is
+declared complete.
+
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -15,6 +15,7 @@ The recommendation must include:
 - why it matches repository rules, layering, ownership, and architecture boundaries;
 - affected packages, docs, or commands;
 - the expected test and verification plan;
+- the expected user test scenario plan, separate from agent/CI verification;
 - any decisions that require the user instead of agent autonomy.
 
 If the recommendation is coherent with repository rules, layering, architecture, and the backlog
@@ -29,7 +30,37 @@ judgment, stop and ask the user for a decision.
   work unit must have its own recommendation gate.
 - Do not combine unrelated backlogs in one PR.
 - Every PR description must include the accepted recommendation, rationale, implementation summary,
-  tests run, and residual risks.
+  tests run, user scenario gate result, and residual risks.
+
+## User Test Scenario Rule
+
+Every backlog that changes user-visible behavior, command behavior, workflow behavior, or
+documentation for such behavior must include a user-facing test scenario section before
+implementation starts.
+
+User test scenarios are separate from the agent's engineering test plan:
+
+- The engineering test plan covers unit, integration, type, harness, CI, build, and internal
+  verification commands.
+- The user test scenario describes what a user can do manually after the work is complete to confirm
+  the feature behaves as intended.
+
+Each user test scenario must include:
+
+- prerequisite state or sample setup;
+- user actions in order;
+- expected visible result;
+- any cleanup or reset step;
+- whether the agent can verify the scenario directly, partially, or only by static/manual review.
+
+Before declaring a backlog or work unit complete, the agent must run or review the user test
+scenario as a final gate when feasible. If the scenario cannot be executed in the current
+environment, the agent must still validate it for coherence against the implemented behavior and
+state the limitation.
+
+When the user scenario gate passes, the final user-facing response must tell the user that the
+scenario is available to run and summarize the scenario briefly. If the scenario gate does not pass,
+the work is not complete and the agent must fix the issue or ask for a decision.
 
 ## Base Branch Workflow
 
@@ -71,6 +102,8 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 ## Stop Conditions
 
 - No recommendation gate was presented for the backlog or work unit.
+- A required user-facing backlog lacks a user test scenario section.
+- The user scenario gate fails or cannot be coherently mapped to the completed behavior.
 - The recommendation conflicts with repo rules, layering, package ownership, or backlog intent.
 - The work would combine unrelated backlogs into one PR.
 - The final initiative PR would be auto-merged into `develop`.
@@ -80,8 +113,12 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 ## Checklist
 
 - [ ] Recommendation gate presented before work begins.
-- [ ] Recommendation includes rationale, ownership, affected scope, tests, and open decisions.
+- [ ] Recommendation includes rationale, ownership, affected scope, engineering tests, user
+      scenarios, and open decisions.
+- [ ] Backlog includes user test scenarios when behavior is user-visible.
 - [ ] PR scope maps to exactly one backlog or explicitly split work unit.
+- [ ] User scenario gate was run or coherently reviewed before completion.
 - [ ] Child PR targets the initiative base branch.
 - [ ] Final initiative PR targets `develop` and is not auto-merged.
-- [ ] PR description records the accepted recommendation and verification evidence.
+- [ ] PR description records the accepted recommendation, verification evidence, and user scenario
+      gate result.

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -25,6 +25,6 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 | [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gates, publish flow |
 | [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates   |
 | [research.md](research.md)                     | Research-first implementation and recommendation authority         |
-| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, one-backlog PRs, initiative branches |
+| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user scenario gates, initiative PRs  |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation            |
 | [learning-loop.md](learning-loop.md)           | Lesson capture and mechanical enforcement preference               |

--- a/.agents/rules/process.md
+++ b/.agents/rules/process.md
@@ -14,6 +14,6 @@ This file routes to detailed rule documents. Each linked file contains the full 
 | [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gate discipline, publish boundary                           |
 | [documentation-sync.md](documentation-sync.md) | Document role sync, package README, and robota.io source update requirements                               |
 | [research.md](research.md)                     | Research-first implementation, documentation-only prior art, recommendation authority                      |
-| [backlog-execution.md](backlog-execution.md)   | Recommendation gates, one-backlog PRs, initiative branch workflow, orchestration skill boundary            |
+| [backlog-execution.md](backlog-execution.md)   | Recommendation gates, one-backlog PRs, user scenario gates, initiative branch workflow                     |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation                                                    |
 | [learning-loop.md](learning-loop.md)           | Convert repeated lessons into rules, hooks, harness checks, or tested automation                           |

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -27,6 +27,7 @@ This skill owns orchestration only:
 - branch and PR sequencing;
 - owner-skill routing;
 - verification checkpoint ordering;
+- user test scenario gate enforcement;
 - PR summary requirements;
 - final handoff state.
 
@@ -42,19 +43,25 @@ or implementation details.
    - why it matches repo rules, layering, and ownership;
    - affected scope;
    - test and verification plan;
+   - user test scenario plan;
    - decisions that require the user.
-3. If the recommendation is coherent with rules and architecture, proceed. If not, stop and ask.
-4. Use `branch-guard` before commits or branch changes.
-5. For multi-backlog initiatives:
+3. Ensure the backlog or work unit includes a user-facing test scenario section when it changes
+   user-visible behavior, command behavior, workflow behavior, or user-facing docs.
+4. If the recommendation is coherent with rules and architecture, proceed. If not, stop and ask.
+5. Use `branch-guard` before commits or branch changes.
+6. For multi-backlog initiatives:
    - create or confirm the initiative base branch from `develop`;
    - create one child branch per backlog or split work unit;
    - open each child PR into the initiative base branch;
    - merge each child PR after checks pass;
    - open the final initiative PR into `develop`;
    - do not auto-merge the final `develop` PR.
-6. Route detailed work to owner skills.
-7. Ensure every PR body records recommendation, rationale, implementation summary, tests, and
-   residual risks.
+7. Route detailed work to owner skills.
+8. Run or coherently review the user test scenario as a final gate. If it passes, include the
+   scenario in the user handoff as something the user can execute. If it fails, keep working or ask
+   for a decision.
+9. Ensure every PR body records recommendation, rationale, implementation summary, tests, user
+   scenario gate result, and residual risks.
 
 ## Owner Skill Routing
 
@@ -80,12 +87,15 @@ Every child PR must include:
 - rationale against backlog intent and architecture;
 - implementation summary;
 - tests and verification commands;
+- user test scenario gate result;
 - residual risks or skipped checks;
 - next backlog or handoff note when relevant.
 
 ## Stop Conditions
 
 - No recommendation gate was presented.
+- A required user-facing backlog has no user test scenario section.
+- The user test scenario gate fails or cannot be coherently mapped to the completed behavior.
 - The recommendation conflicts with rules, ownership, architecture, or backlog intent.
 - The work combines unrelated backlogs in one PR.
 - A child branch targets `develop` instead of the initiative base branch during a multi-backlog

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -7,17 +7,17 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Process & Planning
 
-| Skill                                                                     | Description                                                     |
-| ------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries |
-| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring       |
-| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes    |
-| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                     |
-| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                |
-| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Recommendation-gated backlog PR pipeline                        |
-| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work        |
-| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize       |
-| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages   |
+| Skill                                                                     | Description                                                      |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries  |
+| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring        |
+| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes     |
+| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                      |
+| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                 |
+| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Recommendation-gated backlog PR pipeline with user scenario gate |
+| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work         |
+| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize        |
+| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages    |
 
 ## Code Quality & Architecture
 


### PR DESCRIPTION
## Accepted Recommendation

Add a user scenario gate to the existing backlog execution rule and orchestration skill instead of creating a separate heavy process. This keeps the rule close to the recommendation-gated backlog workflow that already governs backlog PRs.

## Rationale

- Matches the request because each backlog now needs a user-facing scenario in addition to the agent engineering test plan.
- Matches repository layering because the mandatory rule owns the constraint, while the orchestration skill only sequences the gate and delegates detailed testing to owner skills.
- Keeps the distinction clear: engineering tests verify implementation internally; user scenarios describe what the user can manually run after completion.

## Implementation Summary

- Added `User Test Scenario Rule` to `.agents/rules/backlog-execution.md`.
- Updated `backlog-execution-orchestrator` to enforce scenario presence, final scenario gate, PR body reporting, and user handoff.
- Updated backlog README entry requirements to require `## Test Plan` and `## User Test Scenarios` for user-facing backlogs.
- Updated rule/skill indexes to reflect the new gate.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification via `git push`

## User Scenario Gate

Reviewed and passed by static/manual inspection: a future user-facing backlog can be checked for a separate `## User Test Scenarios` section with prerequisites, user actions, expected visible result, cleanup/reset, and agent-verifiability. The orchestration skill now requires that scenario to be run or coherently reviewed before completion, and the final user response must tell the user when the scenario is available to run.

## Residual Risk

This is a process/documentation change. There is not yet a mechanical harness check that enforces `## User Test Scenarios` on every future backlog; the rule allows adding one later if drift appears.