### PR TITLE
docs(backlog): add user scenario gates

### DIFF
--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -196,6 +196,19 @@ Each implementation PR should update the owning package specs before changing `a
 - Include at least one fixture repository with no Robota files and no Robota local state inside the
   repo to verify that the planned behavior remains repo-agnostic.
 
+## User Test Scenarios
+
+### Scenario: Review The Split Workflow Plan
+
+- Prerequisites: Open `.agents/backlog/README.md` and this planning backlog.
+- User actions: Follow each focused backlog link, then read the architecture ownership and
+  restricted-behavior sections.
+- Expected visible result: The user can see that user repositories own their harness, `agent-cli`
+  does not inject repo files or dependencies, and each focused backlog has a separate scope.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. The agent can verify links and document text with
+  repository reads and `pnpm harness:scan`.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
+++ b/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
@@ -1,0 +1,103 @@
+# Backlog User Scenario Gate Rule
+
+## Status
+
+Completed.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - process quality rule for backlog-driven work.
+
+## Request
+
+Require future user-facing backlogs to include user test scenarios in addition to the agent's
+engineering test plan.
+
+The rule must answer:
+
+> What can the user run or inspect after this work is complete, and how does that differ from the
+> agent's own verification plan?
+
+## Non-Negotiable Product Principles
+
+- **Separate user scenarios from engineering tests.** Unit, integration, harness, build, and CI
+  checks are the agent's test plan. User scenarios describe what the user can manually run or
+  inspect.
+- **Gate completion on the scenario.** A backlog is not complete until the user scenario is run or
+  coherently reviewed against the completed behavior.
+- **Report scenario availability.** When the scenario gate passes, the final response must tell the
+  user that the scenario is available to run.
+- **Keep orchestration thin.** The backlog execution skill coordinates the scenario gate but does
+  not own detailed test design.
+
+## Expected Outcomes
+
+- Backlogs become easier for users to validate without reading internal test details.
+- PRs record both internal verification and user-facing scenario evidence.
+- Future work exposes a clear manual scenario before the user is asked to trust the result.
+- The process remains compatible with the one-backlog-per-PR and initiative base branch workflow.
+
+## Architecture Ownership Rule
+
+`.agents/rules/backlog-execution.md` owns the mandatory rule. The
+`backlog-execution-orchestrator` skill owns only sequencing, enforcement, PR body requirements, and
+handoff shape. Detailed engineering tests remain owned by testing and package-specific skills.
+
+## Recommended First Slice
+
+1. Update `.agents/rules/backlog-execution.md` with a user test scenario rule.
+2. Update `.agents/skills/backlog-execution-orchestrator/SKILL.md` to enforce the scenario gate.
+3. Update `.agents/backlog/README.md` so backlog authors know to include `## Test Plan` and
+   `## User Test Scenarios`.
+4. Add user scenario sections to the current initiative backlogs that were completed before the new
+   rule existed.
+
+## Acceptance Criteria
+
+- [x] Backlog execution rules require user-facing scenarios for user-visible work.
+- [x] The orchestration skill checks scenario presence and final scenario gate result.
+- [x] PR bodies must report the user scenario gate result.
+- [x] Backlog README explains the difference between `## Test Plan` and
+      `## User Test Scenarios`.
+- [x] Current initiative backlogs include user-facing scenarios.
+
+## Test Plan
+
+- Run `git diff --check`.
+- Run `pnpm harness:scan`.
+- Verify the rules and orchestration skill mention the user scenario gate.
+- Verify the current initiative backlog files include `## User Test Scenarios`.
+
+## User Test Scenarios
+
+### Scenario: Validate A Future Backlog Has A User Scenario
+
+- Prerequisites: Open `.agents/backlog/README.md`,
+  `.agents/rules/backlog-execution.md`, and
+  `.agents/skills/backlog-execution-orchestrator/SKILL.md`.
+- User actions: Check that a user-facing backlog is expected to contain both `## Test Plan` and
+  `## User Test Scenarios`; then confirm the skill requires the scenario gate result in PR bodies
+  and final handoff.
+- Expected visible result: The user can see the engineering test plan is separate from the manual
+  user scenario, and the scenario must be run or coherently reviewed before completion.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review plus `pnpm harness:scan`.
+
+## Verification Plan
+
+- `git diff --check`
+- `pnpm harness:scan`
+- Confirm current initiative backlog files contain `## User Test Scenarios`.
+
+## Result
+
+Completed by updating backlog execution rules, the backlog execution orchestrator skill, backlog
+README guidance, and the current initiative backlog files.
+
+- The rule now requires user-facing test scenarios for user-visible backlog work.
+- The orchestrator skill records the user scenario gate as part of the normal PR pipeline.
+- Current initiative backlogs now include user scenarios that users can inspect manually.

--- a/.agents/backlog/completed/cli-background-work-state-management.md
+++ b/.agents/backlog/completed/cli-background-work-state-management.md
@@ -121,6 +121,20 @@ Create a design and contract PR before UI work:
 - Add regression tests proving `agent-cli` does not own lifecycle state or duplicate terminal-state
   rules.
 
+## User Test Scenarios
+
+### Scenario: Review The Switchable Background Work Contract
+
+- Prerequisites: Open `.agents/specs/background-work-state.md`.
+- User actions: Review the common entry model, state/retention rules, action contract, and ownership
+  table.
+- Expected visible result: The user can confirm that main conversation, shell/process jobs, agent
+  jobs, groups, and future skill-spawned work share one SDK-owned projection, while `agent-cli`
+  renders selection and details only.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. Runtime archive/clear and expanded TUI behavior remain
+  follow-up implementation work.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/cli-repository-situational-awareness.md
+++ b/.agents/backlog/completed/cli-repository-situational-awareness.md
@@ -107,6 +107,20 @@ Create a design and contract PR before UI work:
 - Add tests proving context display does not create or modify repo files.
 - Add CLI rendering tests after SDK projections exist.
 
+## User Test Scenarios
+
+### Scenario: Review Passive Repository Context Boundaries
+
+- Prerequisites: Open `.agents/specs/repository-situational-awareness.md`.
+- User actions: Review the context item model, allowed provenance sources, read boundary, and
+  command/automation boundary.
+- Expected visible result: The user can confirm that future context display may show cwd, repo root,
+  branch, dirty summary, explicit references, and background workspace context, but must not infer
+  commands, guess package managers, enumerate files, score readiness, or write repo files.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. SDK projection APIs and CLI rendering remain follow-up
+  implementation work.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/cli-transparent-process-execution.md
+++ b/.agents/backlog/completed/cli-transparent-process-execution.md
@@ -119,6 +119,20 @@ Create a design and contract PR before UI work:
   directly execute commands.
 - Add negative tests proving command output is not classified as correctness evidence by default.
 
+## User Test Scenarios
+
+### Scenario: Review What A User-Directed Process Must Disclose
+
+- Prerequisites: Open `.agents/specs/process-execution.md`.
+- User actions: Read the request contract, status contract, output contract, command source rules,
+  and ownership table.
+- Expected visible result: The user can confirm that a future process UI must show command origin,
+  cwd, environment summary, output, cancellation, timeout, exit result, and duration, while command
+  meaning remains owned by the user/repository.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. Runtime process execution remains follow-up
+  implementation work.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/cli-transparent-workflow-contract.md
+++ b/.agents/backlog/completed/cli-transparent-workflow-contract.md
@@ -128,6 +128,20 @@ Create a design and contract PR before UI work:
 - Add CLI rendering tests only after SDK/runtime contracts exist, verifying that provenance and
   state labels are visible without exposing private implementation details.
 
+## User Test Scenarios
+
+### Scenario: Inspect Baseline Transparency Rules
+
+- Prerequisites: Open `.agents/specs/transparent-workflow.md`.
+- User actions: Review the action provenance table, state vocabulary, memory transparency fields,
+  UI disclosure checklist, and repository independence section.
+- Expected visible result: The user can confirm that commands execute only from current user input
+  or accepted assistant suggestions, remembered commands are excluded, and CLI surfaces must render
+  SDK/runtime projections instead of owning workflow semantics.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. The agent can verify the spec links and required
+  sections with `pnpm harness:scan`.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/completed/cli-user-local-memory-transparency.md
@@ -130,6 +130,20 @@ Create a design and contract PR before UI work:
 - Add CLI tests verifying users can see storage location, source, last-used time,
   display/navigation rule, and delete/disable actions.
 
+## User Test Scenarios
+
+### Scenario: Review What Robota May Remember Locally
+
+- Prerequisites: Open `.agents/specs/user-local-memory.md`.
+- User actions: Review allowed baseline memory, restricted memory, memory item model, inspection and
+  removal rules, and the project memory boundary.
+- Expected visible result: The user can confirm remembered values are limited to
+  display/navigation, are inspectable with storage location and source, can be deleted or disabled,
+  and cannot execute commands.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. SDK storage APIs and CLI rendering remain follow-up
+  implementation work.
+
 ## Verification Plan
 
 - `pnpm harness:scan`

--- a/.agents/backlog/completed/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/completed/cli-user-local-storage-foundation.md
@@ -124,6 +124,20 @@ Create a design and contract PR before UI work:
 - Add CLI tests only after SDK contracts exist, verifying the effective storage root and stored item
   summaries are visible.
 
+## User Test Scenarios
+
+### Scenario: Confirm Baseline Storage Is User-Local Only
+
+- Prerequisites: Open `.agents/specs/user-local-storage.md`.
+- User actions: Review the canonical storage rule, category layout, repo-outside validation, and
+  existing storage audit.
+- Expected visible result: The user can confirm that baseline workflow state must live under the
+  user-local root outside the active repository, with no repo-local fallback and no remembered
+  commands as executable preferences.
+- Cleanup/reset: None.
+- Agent verification: Static/manual review. The agent can verify the storage spec is linked from
+  specs index and package SPEC files.
+
 ## Verification Plan
 
 - `pnpm harness:scan`


### PR DESCRIPTION
## Accepted Recommendation

Apply the new user scenario gate to the current initiative as a follow-up backlog PR. The existing rule PR #332 was merged first, then this PR adds the missing backlog record and user-facing scenarios for the initiative backlogs.

## Rationale

- Matches the request because the recent work is now represented in backlog form and includes user scenarios separate from engineering test plans.
- Matches the process rule because this is a single corrective backlog/documentation unit targeting the initiative base branch.
- Keeps scope focused: no additional architecture or implementation changes, only backlog scenario coverage.

## Implementation Summary

- Added `.agents/backlog/completed/backlog-user-scenario-gate-rule.md`.
- Added `## User Test Scenarios` to the transparent workflow planning backlog and the focused completed backlogs.
- Scenarios describe prerequisites, user actions, expected visible result, cleanup, and agent verifiability.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- pre-push scoped verification via `git push`
- `rg -n "^## User Test Scenarios"` over all target backlog files

## User Scenario Gate

Passed by static/manual review. Users can open the affected backlog/spec files and follow the scenario steps to verify the documented behavior boundaries: no repo dependency, SDK/runtime ownership below CLI, user-local storage/memory boundaries, background work transparency, passive repo context, and the new backlog user scenario process.

## Residual Risk

This is a documentation/process correction. The scenario gate is now documented and backlogs include scenarios, but there is still no mechanical harness check that requires `## User Test Scenarios` for every future user-facing backlog.