### PR TITLE
docs(agents): require implementation-backed user scenarios

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -11,20 +11,41 @@ Active tasks live in `.agents/tasks/`. Completed tasks are archived to `.agents/
 
 ## Backlog Entry Requirements
 
-Backlogs that change user-visible behavior, command behavior, workflow behavior, or documentation
-for such behavior must include both:
+Backlogs that change runnable user-facing behavior, command behavior, TUI/browser behavior, or
+workflow behavior must include both:
 
 - `## Test Plan`: the agent's engineering verification plan, such as unit, integration, harness,
   build, and CI checks.
-- `## User Test Scenarios`: concrete scenarios with prerequisites, exact command lines or UI steps,
-  expected observable results, cleanup/reset steps, and the agent-executed evidence required for the
-  gate.
+- `## User Test Scenarios`: concrete product-surface scenarios with prerequisites, exact command
+  lines or UI steps, required test environment setup, expected observable results, cleanup/reset
+  steps, and an evidence field that must be filled after implementation.
 
 The user scenario gate is checked separately from the engineering test plan before the backlog is
-declared complete. Static review is not enough when a command, browser flow, TUI flow, local script,
-or other workspace-available check can reasonably be executed. Captured evidence is mandatory:
-without command output, exit code, screenshot, log excerpt, diff, or another concrete artifact, the
-user scenario gate does not pass.
+declared complete. The planned scenario must be written before implementation starts, but the gate
+itself is run after implementation against the completed code path or delivered artifact. For
+code-changing backlogs, reviewing backlog text, documentation text, or static prose is not a valid
+user scenario gate.
+
+A user test scenario must use a product surface: the Robota CLI command or local equivalent that
+invokes the same product binary, Robota TUI actions, Robota browser UI flows, or public SDK/example
+usage for SDK-only features. For `agent-cli` and command-package backlogs, prefer a Robota CLI or
+TUI action. `rg`, harness commands, unit tests, source inspection, and other internal repository
+checks belong in `## Test Plan`, not `## User Test Scenarios`.
+
+Documentation-only, rule-only, skill-only, backlog-only, or governance-only changes that do not
+deliver runnable user-facing behavior must not invent a user test scenario. Record `Not applicable`
+with the reason, and keep document/rule/static checks in `## Test Plan` or a verification evidence
+section. If documentation changes describe a user procedure, the user scenario must execute the
+procedure itself; it must not inspect the document to prove the document is well written.
+
+If the scenario needs a fixture, test project, local server, seed data, or demo command, the backlog
+must state whether that environment already exists, will be built by the work, or requires a user
+decision. A scenario that the user cannot realistically run after completion is not acceptable.
+
+After implementation, the agent must run the scenario when executable, compare the observed result
+with the expected observable result, and update the backlog with the captured evidence. Without
+command output, exit code, screenshot, log excerpt, diff, or another concrete artifact recorded in
+the backlog, the user scenario gate does not pass.
 
 ## Items
 

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -198,21 +198,27 @@ Each implementation PR should update the owning package specs before changing `a
 
 ## User Test Scenarios
 
-### Scenario: Review The Split Workflow Plan
+Not applicable. This backlog is a planning umbrella and does not deliver runnable Robota product
+behavior. Product-surface scenarios must be added by the focused implementation backlogs that build
+the CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/backlog/README.md` and this planning backlog.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Split Workflow Plan Is Linked
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "completed/cli-transparent-workflow-contract|completed/cli-repository-situational-awareness|Do not require a Robota manifest|baseline command discovery|SDK/runtime ownership" .agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
   rg -n "Transparent Repo-Agnostic Workflow Client Planning" .agents/backlog/README.md
   ```
 
-- Expected visible result: The first command prints the split backlog links, the no-Robota-manifest
+- Expected result: The first command prints the split backlog links, the no-Robota-manifest
   rule, the command-discovery restriction, and SDK/runtime ownership text. The second command shows
   the umbrella backlog remains listed in the backlog index.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`.
+- Evidence: Executed as process verification during planning; no product-surface scenario applies
+  until implementation backlogs add runnable behavior.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/backlog-executable-user-scenario-gate.md
+++ b/.agents/backlog/completed/backlog-executable-user-scenario-gate.md
@@ -40,7 +40,8 @@ that the agent executed the scenario when execution is feasible.
 - Gates without evidence fail by rule.
 - Abstract static review no longer counts as a passed user scenario when an executable check is
   available.
-- Current initiative backlog scenarios become command-backed and reproducible.
+- Future product-behavior backlog scenarios become product-command-backed and reproducible.
+- Document/governance-only backlog checks are recorded as process verification, not user scenarios.
 
 ## Architecture Ownership Rule
 
@@ -55,7 +56,8 @@ tests. Backlog files own the concrete user scenarios for their own scope.
 2. Strengthen `.agents/skills/backlog-execution-orchestrator/SKILL.md` to execute scenarios when
    feasible and report observed evidence in PRs.
 3. Update `.agents/backlog/README.md` with the concrete scenario requirement.
-4. Replace current initiative user scenarios with executable command-backed scenarios.
+4. Replace document-inspection user scenarios with process verification evidence, and require future
+   product-behavior scenarios to use product surfaces.
 
 ## Acceptance Criteria
 
@@ -64,8 +66,8 @@ tests. Backlog files own the concrete user scenarios for their own scope.
 - [x] The rule requires agent execution when feasible.
 - [x] The rule requires captured evidence and rejects evidence-free gates.
 - [x] The orchestration skill requires observed evidence in PR bodies.
-- [x] Current initiative user scenarios include concrete commands.
-- [x] The concrete scenarios were executed by the agent before completion.
+- [x] Current initiative document/governance checks are not presented as user scenarios.
+- [x] Product-behavior scenarios are required to use product surfaces.
 
 ## Test Plan
 
@@ -73,14 +75,21 @@ tests. Backlog files own the concrete user scenarios for their own scope.
 - Run `pnpm harness:scan`.
 - Run `rg` checks proving rule/skill text contains exact-command, expected-result, execution, and
   evidence requirements.
-- Run each current initiative user scenario command and confirm expected matches are printed.
+- Confirm current initiative document/governance checks are process verification, not user
+  scenarios.
 
 ## User Test Scenarios
 
-### Scenario: Verify User Scenario Gates Are Executable And Evidenced
+Not applicable. This backlog changed process rules and orchestration guidance only. It did not
+deliver runnable Robota product behavior, so document inspection must not be presented as a user
+test scenario.
+
+## Process Verification Evidence
+
+### Verification: Scenario Gate Is Executable And Evidenced
 
 - Prerequisites: Run from the repository root.
-- User actions:
+- Verification commands:
 
   ```bash
   rg -n "exact command lines, UI actions|expected observable result|must execute the user test scenario|The user scenario gate was not executed" .agents/rules/backlog-execution.md
@@ -88,19 +97,19 @@ tests. Backlog files own the concrete user scenarios for their own scope.
   rg -n "^## User Test Scenarios" .agents/backlog/cli-ai-workflow-reviewer-harness-planning.md .agents/backlog/completed/*.md
   ```
 
-- Expected visible result: The first command prints the mandatory concrete scenario fields and
+- Expected result: The first command prints the mandatory concrete scenario fields and
   execution gate. The second command prints orchestration requirements to execute and report
   evidence. The third command prints user scenario sections, including the current initiative
   backlogs.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`.
+- Evidence: Executed during the original gate hardening and reclassified here as process
+  verification after product-surface scenario scoping.
 
 ## Verification Plan
 
 - `git diff --check`
 - `pnpm harness:scan`
-- Execute the user scenario commands listed above.
-- Execute each updated current-initiative scenario command.
+- Execute the process verification commands listed above.
+- Confirm document/governance-only backlogs do not present document inspection as user scenarios.
 
 ## Result
 

--- a/.agents/backlog/completed/backlog-implementation-user-scenario-gate.md
+++ b/.agents/backlog/completed/backlog-implementation-user-scenario-gate.md
@@ -1,0 +1,137 @@
+# Implementation User Scenario Gate Alignment
+
+## Status
+
+Completed.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - correction to make user scenario gates validate implemented work, not backlog quality.
+
+## Request
+
+Clarify the backlog execution flow so user test scenarios are planned in the backlog before
+implementation, executed after implementation against the completed code path or delivered artifact,
+and recorded back into the backlog with evidence before the gate can pass.
+
+## Non-Negotiable Product Principles
+
+- **Scenario planned before implementation.** The backlog must define the user test scenario before
+  work starts so the implementation target is concrete.
+- **Scenario targets completed work.** For code-changing backlogs, the scenario must exercise the
+  implemented code path. Backlog text review, documentation search, or static prose checks are not a
+  valid user scenario gate for code work.
+- **Runnable environment required.** If the scenario needs a fixture, demo command, local server,
+  test project, seed data, or other setup, the backlog must say whether it exists, will be built, or
+  requires a user decision.
+- **Agent runs the scenario after implementation.** When executable from the workspace, the agent
+  must run the scenario after implementation and compare observed output with the expected result.
+- **Backlog evidence required.** The backlog must be updated with observed evidence after execution.
+  No recorded evidence means the gate does not pass.
+- **User handoff is executable.** After the gate passes, the user must receive the verified scenario
+  with exact commands or UI steps and expected results they can run directly.
+- **Do not fake user scenarios for documents.** Document/rule/static checks are verification
+  evidence, not user test scenarios.
+- **Use product surfaces.** User test scenarios must use Robota product surfaces such as CLI
+  commands, TUI actions, browser UI flows, or public SDK/example usage.
+
+## Expected Outcomes
+
+- User scenario gates validate completed implementation behavior, not planning-document quality.
+- Future code backlogs cannot pass with only `rg` checks against backlog text or documentation.
+- Missing scenario environment becomes an explicit implementation item or user decision.
+- Completed backlogs contain the evidence needed to prove the user scenario gate passed.
+- Final user handoffs include concrete commands or UI steps that have already been verified.
+- Documentation-only or governance-only backlogs do not present document inspection as a user test
+  scenario.
+- User test scenarios are scoped to product usage instead of internal repository checks.
+
+## Architecture Ownership Rule
+
+The mandatory constraint belongs in `.agents/rules/backlog-execution.md`. The
+`backlog-execution-orchestrator` skill owns sequencing and reporting only. `.agents/backlog/README.md`
+owns the backlog entry format. Package-specific implementation and tests remain owned by the
+affected package specs and owner skills.
+
+## Recommended First Slice
+
+1. Update `.agents/rules/backlog-execution.md` with the full lifecycle:
+   planned scenario before implementation, environment readiness, post-implementation execution,
+   backlog evidence update, and final user handoff.
+2. Update `.agents/skills/backlog-execution-orchestrator/SKILL.md` so the orchestrator enforces the
+   lifecycle without redefining package-specific implementation details.
+3. Update `.agents/backlog/README.md` so future backlog entries require the same fields.
+4. Record this correction as a completed backlog item with evidence.
+
+## Acceptance Criteria
+
+- [x] Rules distinguish the planned user scenario from the post-implementation execution gate.
+- [x] Rules require code-changing backlogs to exercise implemented code paths.
+- [x] Rules require missing user scenario environment to be built, proposed, or decided.
+- [x] Rules require the backlog to be updated with observed evidence after execution.
+- [x] The orchestrator skill enforces the same lifecycle.
+- [x] Backlog authoring guidance describes the required lifecycle and evidence update.
+- [x] Documentation-only and governance-only changes are required to mark user scenarios as not
+      applicable instead of presenting document inspection as a user test scenario.
+- [x] User scenario scope is limited to product surfaces such as Robota CLI, TUI, browser UI, or
+      public SDK/example usage.
+
+## Test Plan
+
+- Run `git diff --check`.
+- Run `pnpm harness:scan`.
+- Run targeted `rg` checks proving the rules, skill, and backlog README contain the implementation
+  target, environment readiness, post-implementation execution, and backlog evidence update
+  requirements.
+
+## User Test Scenarios
+
+Not applicable. This backlog changes process rules, a workflow skill, and backlog authoring
+guidance. It does not deliver runnable user-facing product behavior. Document inspection would only
+prove that the process documents changed, so it must not be presented as a user test scenario.
+
+## Process Verification Evidence
+
+### Verification: Implementation-Focused Gate Rules
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
+
+  ```bash
+  rg -n "implemented code path|completed implementation|product surface|internal repository checks|Missing user scenario test environment" .agents/rules/backlog-execution.md
+  rg -n "completed implementation or delivered artifact|product surface|internal repository verification|where the backlog was updated" .agents/skills/backlog-execution-orchestrator/SKILL.md
+  rg -n "completed code path or delivered artifact|product-surface scenarios|rg`, harness commands|must not invent a user test scenario" .agents/backlog/README.md
+  ```
+
+- Expected result: The first command prints rule lines requiring implementation-code
+  scenarios, completed-work execution, backlog evidence updates, and environment handling. The
+  second command prints orchestrator lines requiring the same lifecycle. The third command prints
+  backlog entry guidance that rejects static text checks for code-changing backlogs and requires
+  captured evidence to be recorded.
+- Evidence:
+  - `rg` against `.agents/rules/backlog-execution.md` printed lines 48, 54, 84, 99, 151, 152, 176,
+    and 179, covering product-surface scope, implemented-code scenarios, completed-work execution,
+    internal-check exclusion, and missing environment handling.
+  - `rg` against `.agents/skills/backlog-execution-orchestrator/SKILL.md` printed lines 46, 47, 55,
+    115, and 128, covering product-surface scenario planning, completed-work behavior, backlog
+    evidence reporting, and internal-verification rejection.
+  - `rg` against `.agents/backlog/README.md` printed lines 19, 25, 32, and 36, covering
+    product-surface scenarios, completed-artifact execution, internal-check exclusion, and
+    not-applicable handling for document/governance-only work.
+
+## Verification Plan
+
+- `git diff --check`
+- `pnpm harness:scan`
+- Execute the process verification commands above and update this backlog with the observed
+  evidence.
+
+## Result
+
+Completed by updating the backlog execution rule, backlog execution orchestrator skill, and backlog
+entry requirements so user scenario gates are planned before implementation, executed after
+implementation against the completed work, and recorded with evidence in the backlog.

--- a/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
+++ b/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
@@ -63,23 +63,28 @@ handoff shape. Detailed engineering tests remain owned by testing and package-sp
 - [x] PR bodies must report the user scenario gate result.
 - [x] Backlog README explains the difference between `## Test Plan` and
       `## User Test Scenarios`.
-- [x] Current initiative backlogs include user-facing scenarios.
+- [x] Current initiative backlogs either include product-surface user scenarios or record why user
+      scenarios are not applicable.
 
 ## Test Plan
 
 - Run `git diff --check`.
 - Run `pnpm harness:scan`.
 - Verify the rules and orchestration skill mention the user scenario gate.
-- Verify the current initiative backlog files include `## User Test Scenarios`.
+- Verify current initiative backlog files do not present document inspection as a user scenario.
 
 ## User Test Scenarios
 
-### Scenario: Validate A Future Backlog Has A User Scenario
+Not applicable. This backlog changed process rules and authoring guidance only. It did not deliver
+runnable Robota product behavior, so document inspection must remain process verification rather
+than a user test scenario.
 
-- Prerequisites: Open `.agents/backlog/README.md`,
-  `.agents/rules/backlog-execution.md`, and
-  `.agents/skills/backlog-execution-orchestrator/SKILL.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Backlog Scenario Gate Rule Exists
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "## User Test Scenarios|exact command lines or UI steps|Static review is not enough" .agents/backlog/README.md
@@ -87,16 +92,16 @@ handoff shape. Detailed engineering tests remain owned by testing and package-sp
   rg -n "exact commands or UI steps|Execute the user test scenario|observed evidence" .agents/skills/backlog-execution-orchestrator/SKILL.md
   ```
 
-- Expected visible result: The commands print the backlog entry requirement, executable/observable
+- Expected result: The commands print the backlog entry requirement, executable/observable
   scenario rule, mandatory execution gate, stop condition, and PR evidence requirement.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`.
+- Evidence: Executed during the original rule update and replaced here as process verification after
+  product-surface scenario scoping.
 
 ## Verification Plan
 
 - `git diff --check`
 - `pnpm harness:scan`
-- Confirm current initiative backlog files contain `## User Test Scenarios`.
+- Confirm current initiative backlog files do not present document inspection as a user scenario.
 
 ## Result
 
@@ -106,4 +111,5 @@ README guidance, and the current initiative backlog files.
 - The rule now requires user-facing test scenarios for user-visible backlog work.
 - The orchestrator skill records the user scenario gate and evidence as part of the normal PR
   pipeline.
-- Current initiative backlogs now include user scenarios that users can inspect manually.
+- Current initiative backlogs now either include product-surface user scenarios or mark the scenario
+  as not applicable for document/governance-only work.

--- a/.agents/backlog/completed/cli-background-work-state-management.md
+++ b/.agents/backlog/completed/cli-background-work-state-management.md
@@ -123,20 +123,26 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Review The Switchable Background Work Contract
+Not applicable. This backlog produced a background-work state contract document and did not deliver
+runnable Robota product behavior. Product-surface scenarios must be added by follow-up
+implementation PRs that expose background switching through CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/specs/background-work-state.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Switchable Background Work Contract Is Documented
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "main conversation thread|local shell or process tasks|agent tasks|future skill-spawned|IExecutionWorkspaceEntry|must not decide task completion" .agents/specs/background-work-state.md
   ```
 
-- Expected visible result: The command prints the supported entry types, current SDK projection
+- Expected result: The command prints the supported entry types, current SDK projection
   anchor, future skill-spawned support, and the CLI non-ownership rule for task completion.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`. Runtime archive/clear and
-  expanded TUI behavior remain follow-up implementation work.
+- Evidence: Executed as process verification for the contract document. Runtime archive/clear and
+  expanded TUI behavior remain follow-up implementation work, where product-surface user scenarios
+  must be added.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-repository-situational-awareness.md
+++ b/.agents/backlog/completed/cli-repository-situational-awareness.md
@@ -109,20 +109,26 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Review Passive Repository Context Boundaries
+Not applicable. This backlog produced a repository situational awareness contract document and did
+not deliver runnable Robota product behavior. Product-surface scenarios must be added by follow-up
+implementation PRs that expose repository context through CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/specs/repository-situational-awareness.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Passive Repository Context Boundaries Are Documented
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "current `cwd`|repository root|dirty status summary|explicitly referenced documents|command discovery|must not list file paths|write repository-local state" .agents/specs/repository-situational-awareness.md
   ```
 
-- Expected visible result: The command prints allowed context items, command inference prohibition,
+- Expected result: The command prints allowed context items, command inference prohibition,
   file-listing restriction, and repository-write prohibition.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`. SDK projection APIs and
-  CLI rendering remain follow-up implementation work.
+- Evidence: Executed as process verification for the contract document. SDK projection APIs and CLI
+  rendering remain follow-up implementation work, where product-surface user scenarios must be
+  added.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-transparent-process-execution.md
+++ b/.agents/backlog/completed/cli-transparent-process-execution.md
@@ -121,20 +121,25 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Review What A User-Directed Process Must Disclose
+Not applicable. This backlog produced a process execution contract document and did not deliver
+runnable Robota product behavior. Product-surface scenarios must be added by follow-up
+implementation PRs that expose process execution through CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/specs/process-execution.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: User-Directed Process Disclosure Is Documented
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "`command`|`origin`|`cwd`|`environmentSummary`|`timeoutMs`|`durationMs`|Commands may execute only from|remembered command history" .agents/specs/process-execution.md
   ```
 
-- Expected visible result: The command prints the required process request/status fields, command
+- Expected result: The command prints the required process request/status fields, command
   source rule, and the restriction against remembered command history.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`. Runtime process execution
-  remains follow-up implementation work.
+- Evidence: Executed as process verification for the contract document. Runtime process execution
+  remains follow-up implementation work, where product-surface user scenarios must be added.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-transparent-workflow-contract.md
+++ b/.agents/backlog/completed/cli-transparent-workflow-contract.md
@@ -130,19 +130,25 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Inspect Baseline Transparency Rules
+Not applicable. This backlog produced a cross-cutting contract document and did not deliver runnable
+Robota product behavior. Product-surface scenarios must be added by follow-up implementation PRs
+that expose the contract through CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/specs/transparent-workflow.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Baseline Transparency Rules Are Documented
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "user-input|accepted-assistant-suggestion|Remembered commands are not a baseline command source|agent-cli.*must not define|Repository Independence" .agents/specs/transparent-workflow.md
   ```
 
-- Expected visible result: The command prints the allowed execution provenance values, remembered
+- Expected result: The command prints the allowed execution provenance values, remembered
   command exclusion, CLI non-ownership rule, and repository independence heading.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`.
+- Evidence: Executed as process verification for the contract document; no product-surface scenario
+  applies until implementation exposes the behavior.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/completed/cli-user-local-memory-transparency.md
@@ -132,20 +132,26 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Review What Robota May Remember Locally
+Not applicable. This backlog produced a user-local memory contract document and did not deliver
+runnable Robota product behavior. Product-surface scenarios must be added by follow-up
+implementation PRs that expose memory inspection through CLI/TUI/SDK behavior.
 
-- Prerequisites: Open `.agents/specs/user-local-memory.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: User-Local Memory Boundaries Are Documented
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "Allowed remembered values must affect display or navigation only|remembered shell commands|commandExecutionEffect|deleteAvailable|disableAvailable|Existing `.robota/memory/` project memory" .agents/specs/user-local-memory.md
   ```
 
-- Expected visible result: The command prints the display/navigation-only rule, restricted command
+- Expected result: The command prints the display/navigation-only rule, restricted command
   memory, command execution effect, delete/disable fields, and project-memory boundary.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`. SDK storage APIs and CLI
-  rendering remain follow-up implementation work.
+- Evidence: Executed as process verification for the contract document. SDK storage APIs and CLI
+  rendering remain follow-up implementation work, where product-surface user scenarios must be
+  added.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/completed/cli-user-local-storage-foundation.md
@@ -126,20 +126,26 @@ Create a design and contract PR before UI work:
 
 ## User Test Scenarios
 
-### Scenario: Confirm Baseline Storage Is User-Local Only
+Not applicable. This backlog produced a user-local storage contract document and did not deliver
+runnable Robota product behavior. Product-surface scenarios must be added by follow-up
+implementation PRs that expose storage inspection or behavior through CLI/TUI/SDK usage.
 
-- Prerequisites: Open `.agents/specs/user-local-storage.md`.
-- User actions:
+## Process Verification Evidence
+
+### Verification: Baseline Storage Is User-Local Only
+
+- Prerequisites: Run from the repository root.
+- Verification commands:
 
   ```bash
   rg -n "~/.robota|No workspace-local fallback|No project `.robota/` cache|Command strings must not be stored|Repo-Outside Validation" .agents/specs/user-local-storage.md
   ```
 
-- Expected visible result: The command prints the canonical user-local root, no fallback rule,
+- Expected result: The command prints the canonical user-local root, no fallback rule,
   project `.robota/` prohibition, command-string storage prohibition, and repo-outside validation
   section.
-- Cleanup/reset: None.
-- Agent verification: Direct command execution plus `pnpm harness:scan`.
+- Evidence: Executed as process verification for the contract document; no product-surface scenario
+  applies until implementation exposes the behavior.
 
 ## Verification Plan
 

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -15,7 +15,8 @@ The recommendation must include:
 - why it matches repository rules, layering, ownership, and architecture boundaries;
 - affected packages, docs, or commands;
 - the expected test and verification plan;
-- the expected user test scenario plan, separate from agent/CI verification;
+- the expected user test scenario plan when the backlog changes runnable user-facing behavior, or
+  the not-applicable reason when it does not;
 - any decisions that require the user instead of agent autonomy.
 
 If the recommendation is coherent with repository rules, layering, architecture, and the backlog
@@ -30,49 +31,78 @@ judgment, stop and ask the user for a decision.
   work unit must have its own recommendation gate.
 - Do not combine unrelated backlogs in one PR.
 - Every PR description must include the accepted recommendation, rationale, implementation summary,
-  tests run, user scenario gate result, and residual risks.
+  tests run, user scenario gate result or not-applicable reason, and residual risks.
 
 ## User Test Scenario Rule
 
-Every backlog that changes user-visible behavior, command behavior, workflow behavior, or
-documentation for such behavior must include a user-facing test scenario section before
-implementation starts.
+Every backlog that changes runnable user-facing behavior, command behavior, TUI/browser behavior, or
+workflow behavior must include a user-facing test scenario section before implementation starts.
 
 User test scenarios are separate from the agent's engineering test plan:
 
 - The engineering test plan covers unit, integration, type, harness, CI, build, and internal
   verification commands.
-- The user test scenario describes the exact command or UI interaction a user can run after the work
-  is complete to confirm the feature behaves as intended.
+- The user test scenario describes the exact product command, UI interaction, browser flow, TUI
+  flow, or public SDK/example flow a user can run after the work is implemented to confirm the
+  implemented code or delivered artifact behaves as intended.
+- A valid user test scenario must use a product surface. Product surfaces include the Robota CLI
+  command or local equivalent that invokes the same product binary, Robota TUI actions, Robota
+  browser UI flows, and public SDK/example usage for SDK-only features.
+- For `agent-cli` and command-package backlogs, the default user scenario surface is a Robota CLI or
+  TUI action, such as `robota ...` or the repository-local command that invokes the same CLI
+  entrypoint.
+- For code-changing backlogs, the user test scenario must exercise the implemented code path. A
+  documentation search, backlog review, or static text check may not be used as the user scenario
+  gate for code implementation work.
+- For documentation-only, rule-only, skill-only, backlog-only, or governance-only changes that do
+  not deliver runnable user-facing behavior, do not invent a user test scenario. Mark the user test
+  scenario as not applicable and record verification evidence in the engineering test plan instead.
+- If documentation changes describe a user procedure, any user test scenario must execute the
+  documented procedure itself. It must not inspect the document to prove the document is well
+  written.
 
 Each user test scenario must include:
 
-- prerequisite state or sample setup;
+- prerequisite state, sample setup, fixture data, server startup, environment variables, or other
+  test environment requirements;
 - exact command lines, UI actions, or browser/TUI interactions in order;
 - expected observable result, including exit code, output substring, visible UI state, or file
   change;
 - any cleanup or reset step;
 - whether the agent can verify the scenario directly, partially, or only by manual UI review;
-- the concrete evidence the agent captured when running or reviewing the scenario.
+- the evidence field that must be updated after implementation when the agent runs the scenario.
+
+The planned user test scenario is part of the backlog before implementation starts. If the scenario
+requires a test fixture, demo command, local server, test project, seed data, or other environment
+that does not exist yet, the agent must either build that environment as part of the backlog,
+propose it in the recommendation gate, or ask the user for a decision before proceeding. A scenario
+that cannot realistically be run by the user after completion is not acceptable.
 
 Before declaring a backlog or work unit complete, the agent must execute the user test scenario as a
 final gate whenever the scenario is command-line, file-system, HTTP, browser, or otherwise available
 from the workspace. The gate passes only when the observed result matches the expected observable
-result.
+result, and only when the scenario was run against the completed implementation or delivered
+artifact.
 
 Evidence is mandatory. A user scenario gate without captured evidence does not pass. Evidence may be
 command output, exit code, screenshot, log excerpt, rendered UI observation, changed-file diff, or
-another concrete artifact that proves the expected observable result occurred.
+another concrete artifact that proves the expected observable result occurred. After running the
+scenario, the agent must update the backlog item with the observed evidence before the backlog can be
+considered complete.
 
 Static review may not be used as a passing user scenario gate when an executable command, browser
 flow, TUI flow, or local script can reasonably be run. If a scenario is genuinely manual-only, it
 must be labeled `manual-only`, explain why it cannot be executed by the agent, and the PR must not
 claim it passed by execution.
 
+Document inspection, rule inspection, backlog inspection, source inspection, `rg` checks, harness
+commands, unit tests, and other internal repository checks are engineering or governance
+verification only. They must not be presented to the user as a user test scenario.
+
 When the user scenario gate passes, the final user-facing response must tell the user that the
-scenario is available to run, provide the concrete command or UI steps, and state the expected
-result. If the scenario gate does not pass, the work is not complete and the agent must fix the
-issue or ask for a decision.
+scenario was verified, provide the concrete command or UI steps the user can run, state the expected
+result, and summarize the evidence already observed by the agent. If the scenario gate does not
+pass, the work is not complete and the agent must fix the issue or ask for a decision.
 
 ## Base Branch Workflow
 
@@ -114,15 +144,25 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 ## Stop Conditions
 
 - No recommendation gate was presented for the backlog or work unit.
-- A required user-facing backlog lacks a user test scenario section.
+- A required runnable user-facing backlog lacks a user test scenario section.
 - A user test scenario is abstract, lacks exact commands/UI steps, or lacks expected observable
   results.
+- A code-changing backlog uses backlog text review, documentation search, or other static review as
+  the user scenario gate instead of exercising the implemented code path.
+- A user scenario uses internal repository verification instead of a product surface such as Robota
+  CLI, TUI, browser UI, or public SDK/example usage.
+- A documentation-only, rule-only, skill-only, backlog-only, or governance-only change presents
+  document inspection as a user test scenario.
+- The required test environment for the user scenario is missing and was neither built, proposed, nor
+  decided with the user.
 - The user scenario gate was not executed when it could reasonably be executed by the agent.
 - The user scenario gate has no captured evidence.
+- The backlog item was not updated with the observed user scenario evidence after execution.
 - The user scenario gate fails or cannot be mapped to the completed behavior.
 - The recommendation conflicts with repo rules, layering, package ownership, or backlog intent.
 - The work would combine unrelated backlogs into one PR.
 - The final initiative PR would be auto-merged into `develop`.
+- A final user response presents engineering or governance verification as a user test scenario.
 - An orchestration skill duplicates implementation details from invoked skills instead of only
   coordinating them.
 
@@ -130,13 +170,17 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 
 - [ ] Recommendation gate presented before work begins.
 - [ ] Recommendation includes rationale, ownership, affected scope, engineering tests, user
-      scenarios, and open decisions.
-- [ ] Backlog includes user test scenarios when behavior is user-visible.
+      scenarios or not-applicable reason, and open decisions.
+- [ ] Backlog includes user test scenarios only when runnable user-facing behavior changes.
 - [ ] PR scope maps to exactly one backlog or explicitly split work unit.
-- [ ] User scenario includes exact commands or UI steps and expected observable results.
-- [ ] User scenario gate was executed by the agent when executable.
+- [ ] User scenario targets the completed implementation or delivered artifact, not backlog quality.
+- [ ] User scenario includes exact commands or UI steps, required environment setup, and expected
+      observable results.
+- [ ] Missing user scenario test environment was built, proposed, or explicitly decided.
+- [ ] User scenario gate was executed by the agent against the completed work when executable.
 - [ ] User scenario gate includes captured evidence; no evidence means no pass.
+- [ ] Backlog item records the observed user scenario evidence after execution.
 - [ ] Child PR targets the initiative base branch.
 - [ ] Final initiative PR targets `develop` and is not auto-merged.
 - [ ] PR description records the accepted recommendation, verification evidence, and user scenario
-      gate result.
+      gate result or not-applicable reason.

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -43,12 +43,25 @@ or implementation details.
    - why it matches repo rules, layering, and ownership;
    - affected scope;
    - test and verification plan;
-   - concrete user test scenario plan with exact commands or UI steps and expected observable
-     result;
+   - concrete user test scenario plan using a product surface, with exact commands or UI steps and
+     expected observable result against the completed implementation or delivered artifact when the
+     backlog changes runnable user-facing behavior;
+   - not-applicable reason when the backlog does not change runnable user-facing behavior;
+   - required user scenario test environment and whether it already exists, will be built by the
+     backlog, or needs a user decision;
    - decisions that require the user.
 3. Ensure the backlog or work unit includes a user-facing test scenario section when it changes
-   user-visible behavior, command behavior, workflow behavior, or user-facing docs. The scenario
-   must be executable by command/tooling whenever feasible and must not be only an abstract review.
+   runnable user-facing behavior, command behavior, workflow behavior, or TUI/browser behavior. The
+   scenario must use a product surface, must be executable by command/tooling whenever feasible,
+   must be designed for the post-implementation behavior, and must not be only an abstract review.
+   Product surfaces include the Robota CLI command or local equivalent that invokes the same product
+   binary, Robota TUI actions, Robota browser UI flows, and public SDK/example usage for SDK-only
+   features. For `agent-cli` and command-package backlogs, prefer a Robota CLI or TUI action. For
+   code-changing work, it must exercise the implemented code path rather than checking backlog or
+   documentation text.
+   Documentation-only, rule-only, skill-only, backlog-only, or governance-only changes must use the
+   engineering test plan for verification and must not present document inspection as a user test
+   scenario.
 4. If the recommendation is coherent with rules and architecture, proceed. If not, stop and ask.
 5. Use `branch-guard` before commits or branch changes.
 6. For multi-backlog initiatives:
@@ -59,13 +72,20 @@ or implementation details.
    - open the final initiative PR into `develop`;
    - do not auto-merge the final `develop` PR.
 7. Route detailed work to owner skills.
-8. Execute the user test scenario as a final gate when command-line, file-system, HTTP, browser,
-   TUI, or local-script execution is available. If it passes, include the exact scenario and
-   expected result in the user handoff. Capture evidence for the gate; without evidence, the gate
-   does not pass. If it fails, keep working or ask for a decision. If the scenario is genuinely
-   manual-only, label it as such and explain why it could not be executed.
-9. Ensure every PR body records recommendation, rationale, implementation summary, tests, user
-   scenario gate result, and residual risks.
+8. After implementation, confirm the scenario environment exists when a user scenario applies. If it
+   does not, build the missing fixture/demo/server/test harness when that is within the backlog
+   scope, or stop for a user decision.
+9. Execute the user test scenario as a final gate when command-line, file-system, HTTP, browser,
+   TUI, or local-script execution is available. Run it against the completed implementation or
+   delivered artifact. If it passes, update the backlog with the exact scenario, expected result, and
+   observed evidence, then include the same runnable scenario in the user handoff. Without captured
+   evidence recorded in the backlog, the gate does not pass. If it fails, keep working or ask for a
+   decision. If the scenario is genuinely manual-only, label it as such and explain why it could not
+   be executed. If no user scenario applies, record the not-applicable reason and verification
+   evidence, but do not include it in the user handoff as a user test scenario.
+10. Ensure every PR body records recommendation, rationale, implementation summary, tests, user
+    scenario gate result or not-applicable reason, backlog evidence update when applicable, and
+    residual risks.
 
 ## Owner Skill Routing
 
@@ -91,22 +111,34 @@ Every child PR must include:
 - rationale against backlog intent and architecture;
 - implementation summary;
 - tests and verification commands;
-- user test scenario gate result, including exact command/UI steps and observed evidence;
+- user test scenario gate result, including exact command/UI steps, expected observable result,
+  observed evidence, and where the backlog was updated with that evidence; or not-applicable reason
+  when no runnable user-facing behavior changed;
 - residual risks or skipped checks;
 - next backlog or handoff note when relevant.
 
 ## Stop Conditions
 
 - No recommendation gate was presented.
-- A required user-facing backlog has no user test scenario section.
+- A required runnable user-facing backlog has no user test scenario section.
 - A user test scenario is abstract, lacks exact commands/UI steps, or lacks expected observable
   results.
+- A code-changing backlog uses a documentation search, backlog review, or static text check as the
+  user test scenario gate instead of exercising the implemented code.
+- A user test scenario uses internal repository verification instead of a product surface such as
+  Robota CLI, TUI, browser UI, or public SDK/example usage.
+- A documentation-only, rule-only, skill-only, backlog-only, or governance-only change presents
+  document inspection as a user test scenario.
+- The required user scenario test environment is missing and was not built, proposed, or decided
+  with the user.
 - The user test scenario gate was not executed when it could reasonably be executed by the agent.
 - The user test scenario gate has no captured evidence.
+- The backlog was not updated with the observed user scenario evidence after execution.
 - The user test scenario gate fails or cannot be mapped to the completed behavior.
 - The recommendation conflicts with rules, ownership, architecture, or backlog intent.
 - The work combines unrelated backlogs in one PR.
 - A child branch targets `develop` instead of the initiative base branch during a multi-backlog
   initiative.
 - The final initiative PR would be auto-merged into `develop`.
+- The final user handoff presents engineering or governance verification as a user test scenario.
 - This skill would need to duplicate detailed instructions already owned by another skill.


### PR DESCRIPTION
## Accepted Recommendation

Update the backlog execution rules, backlog execution orchestrator, and backlog entry guidance so user test scenarios are product-surface scenarios: Robota CLI commands, TUI actions, browser UI flows, or public SDK/example usage. Internal repository checks such as `rg`, harness, unit tests, and document inspection are engineering/governance verification only.

## Rationale

This matches the backlog intent because the gate must prove implemented user-facing behavior, not document quality. It preserves ownership: mandatory constraints stay in `.agents/rules/backlog-execution.md`, orchestration sequencing stays in `.agents/skills/backlog-execution-orchestrator/SKILL.md`, and backlog entry format stays in `.agents/backlog/README.md`.

## Implementation Summary

- Clarified that user scenarios apply only to runnable user-facing behavior.
- Required user scenarios to use product surfaces: Robota CLI/TUI/browser/public SDK-example usage.
- Required code-changing backlogs to exercise implemented code paths, not backlog or docs text.
- Required missing scenario environments to be built, proposed, or decided before proceeding.
- Required post-implementation scenario evidence to be recorded back into the backlog when a scenario applies.
- Reclassified previous document-inspection `rg` scenarios in this initiative as process verification evidence, with `User Test Scenarios: Not applicable` for docs/governance-only backlogs.

## Tests And Verification

- `git diff --check`
- `pnpm harness:scan`
- Pre-push fast verification: `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check`
- Custom scan confirmed selected `## User Test Scenarios` blocks no longer contain `rg`, harness, or `git diff --check` commands.

## User Scenario Gate

Not applicable for this PR. This PR changes process rules, a workflow skill, and backlog authoring guidance. It does not deliver runnable Robota product behavior. Presenting document inspection as a user test scenario would violate the new rule.

## Process Verification Evidence

Commands run:

```bash
rg -n "implemented code path|completed implementation|product surface|internal repository checks|Missing user scenario test environment" .agents/rules/backlog-execution.md
rg -n "completed implementation or delivered artifact|product surface|internal repository verification|where the backlog was updated" .agents/skills/backlog-execution-orchestrator/SKILL.md
rg -n "completed code path or delivered artifact|product-surface scenarios|rg`, harness commands|must not invent a user test scenario" .agents/backlog/README.md
```

Observed evidence recorded in `.agents/backlog/completed/backlog-implementation-user-scenario-gate.md`: rule lines 48, 54, 84, 99, 151, 152, 176, 179; skill lines 46, 47, 55, 115, 128; README lines 19, 25, 32, 36.

## Residual Risk

No runtime code changed. Existing file-size warnings from `pnpm harness:scan` remain pre-existing and non-blocking.
