### PR TITLE
docs(backlog): add user-local implementation scenarios

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -50,3 +50,5 @@ the backlog, the user scenario gate does not pass.
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
+- [User-Local Storage Inspection Implementation](user-local-storage-inspection-implementation.md)
+- [User-Local Memory Inspection Implementation](user-local-memory-inspection-implementation.md)

--- a/.agents/backlog/completed/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/completed/cli-user-local-memory-transparency.md
@@ -172,3 +172,5 @@ Completed by adding `.agents/specs/user-local-memory.md` and linking package own
   memory feature, not baseline user-local memory.
 - SDK storage APIs, delete/disable command behavior, migration from project memory, and CLI
   rendering tests remain follow-up implementation work.
+- Follow-up implementation backlog:
+  [User-Local Memory Inspection Implementation](../user-local-memory-inspection-implementation.md).

--- a/.agents/backlog/completed/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/completed/cli-user-local-storage-foundation.md
@@ -166,3 +166,5 @@ Completed by adding `.agents/specs/user-local-storage.md` and linking package ow
   avoid them deliberately.
 - The policy forbids remembered commands from becoming executable preferences.
 - SDK storage root/category/inspection contracts and tests are deferred to implementation PRs.
+- Follow-up implementation backlog:
+  [User-Local Storage Inspection Implementation](../user-local-storage-inspection-implementation.md).

--- a/.agents/backlog/user-local-memory-inspection-implementation.md
+++ b/.agents/backlog/user-local-memory-inspection-implementation.md
@@ -1,0 +1,176 @@
+# User-Local Memory Inspection Implementation
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - implementation of inspectable user-local memory and preference transparency.
+
+## Request
+
+Implement the user-local memory inspection, deletion, and disablement behavior defined by
+[user-local-memory.md](../specs/user-local-memory.md), using the storage foundation from
+[user-local-storage.md](../specs/user-local-storage.md).
+
+This backlog implements the follow-up work deferred by
+[User-Local Memory Transparency](completed/cli-user-local-memory-transparency.md).
+
+## Recommendation Gate
+
+Recommended approach:
+
+- Depend on the user-local storage implementation backlog first.
+- Implement SDK-owned memory item projections, explicit create/update hooks for allowed
+  display/navigation preferences, delete behavior, disable behavior, and disabled-item non-use.
+- Expose provider-free product commands through CLI routing and command-owned behavior:
+  - `robota user-local memory set ...`
+  - `robota user-local memory list --format json`
+  - `robota user-local memory inspect <category> <key> --format json`
+  - `robota user-local memory disable <category> <key>`
+  - `robota user-local memory delete <category> <key>`
+- Keep command execution effect fixed to `none` for baseline user-local memory.
+
+Why this matches the backlog intent:
+
+- The user can see exactly what Robota remembered, where it is stored, what it can affect, and how
+  to remove or disable it.
+- Remembered state remains display/navigation-only and cannot become hidden command automation.
+- User repositories remain independent because storage is user-local and repo-outside validated.
+
+Affected scope:
+
+- `packages/agent-sdk`: memory item projection, persistence facade, delete/disable semantics,
+  disabled-item non-use.
+- `packages/agent-command-memory` or another command owner: user-visible command behavior and output
+  formatting.
+- `packages/agent-cli`: provider-free command routing and terminal output only.
+- `packages/agent-sessions` only if session-local ids need to be referenced in projections.
+
+Open decisions:
+
+- Whether the command owner should extend `agent-command-memory` or use a dedicated user-local
+  command package should be decided during implementation. The decision must preserve the same SDK
+  ownership and product-surface scenario.
+
+## Acceptance Criteria
+
+- [ ] Users can create or seed an allowed display/navigation memory item through an explicit product
+      command for inspection/testing.
+- [ ] Users can list remembered user-local items with category, key, summary, scope, source,
+      storage location, enabled state, last-used time, and display/navigation rule.
+- [ ] Users can inspect a single remembered item and see `commandExecutionEffect: "none"`.
+- [ ] Users can disable a remembered item without deleting it.
+- [ ] Disabled remembered items remain visible in inspection output and do not affect
+      display/navigation.
+- [ ] Users can delete a remembered item.
+- [ ] No command strings are stored or exposed as reusable execution preferences.
+- [ ] No baseline user-local memory is written inside the active repository, including `.robota/`.
+- [ ] The backlog is updated with User Test Scenario evidence after implementation.
+
+## Test Plan
+
+- Add SDK contract tests for memory item projection fields.
+- Add SDK tests for create/list/inspect/delete/disable behavior.
+- Add negative tests proving disabled items are not used for display/navigation defaults.
+- Add negative tests proving command strings, command history, session recall, and remembered values
+  cannot execute commands.
+- Add repo-outside storage tests using a fixture repository with no Robota files.
+- Add command-package tests for output shape and error messages.
+- Add CLI routing tests proving the commands are provider-free.
+- Run `pnpm harness:scan`.
+
+## User Test Scenarios
+
+### Scenario: Inspect And Disable A User-Local View Preference
+
+- Prerequisites:
+  - The user-local storage inspection implementation is complete.
+  - The implementation must build `packages/agent-cli/dist/node/bin.js`.
+  - The implementation must provide provider-free product commands for user-local memory set, list,
+    inspect, disable, and delete.
+- Test environment:
+
+  ```bash
+  ROBOTA_REPO="/Users/jungyoun/Documents/dev/robota"
+  TMP_HOME="$(mktemp -d)"
+  FIXTURE_REPO="$(mktemp -d)"
+  pnpm --dir "$ROBOTA_REPO" --filter @robota-sdk/agent-cli build
+  ```
+
+- User actions:
+
+  ```bash
+  (
+    cd "$FIXTURE_REPO"
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory set view-preference last-panel background --summary "Open the background panel" --source user-input
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory list --format json
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory disable view-preference last-panel
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
+  )
+  find "$FIXTURE_REPO" -maxdepth 2 -name ".robota" -o -name "robota*"
+  ```
+
+- Expected observable result:
+  - `memory set` exits 0 and reports that `view-preference/last-panel` was stored under user-local
+    storage.
+  - `memory list --format json` exits 0 and includes an item with category `view-preference`, key
+    `last-panel`, source `user-input`, and storage location under `$TMP_HOME/.robota`.
+  - The first `memory inspect` exits 0 and shows `enabled: true`,
+    `displayNavigationRule` describing panel display/navigation only, and
+    `commandExecutionEffect: "none"`.
+  - `memory disable` exits 0 and reports that the item was disabled.
+  - The second `memory inspect` exits 0 and shows `enabled: false` while still showing the item.
+  - The `find` command prints no project `.robota` or Robota baseline workflow state inside
+    `$FIXTURE_REPO`.
+- Cleanup/reset:
+
+  ```bash
+  rm -rf "$TMP_HOME" "$FIXTURE_REPO"
+  ```
+
+- Agent verification: Must be executed after implementation using the commands above.
+- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
+  command output and repository `find` result are recorded here.
+
+### Scenario: Delete A User-Local Memory Item
+
+- Prerequisites: Run after the first scenario setup or recreate the same `TMP_HOME` and
+  `FIXTURE_REPO` setup.
+- User actions:
+
+  ```bash
+  (
+    cd "$FIXTURE_REPO"
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory delete view-preference last-panel
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
+  )
+  ```
+
+- Expected observable result:
+  - `memory delete` exits 0 and reports that `view-preference/last-panel` was deleted.
+  - The follow-up `memory inspect` exits non-zero with a user-readable “not found” message, or exits
+    0 with JSON that marks the item absent. The implementation must choose one behavior and update
+    this scenario before completion.
+- Cleanup/reset:
+
+  ```bash
+  rm -rf "$TMP_HOME" "$FIXTURE_REPO"
+  ```
+
+- Agent verification: Must be executed after implementation.
+- Evidence: Pending until implementation. The implementation PR must record the chosen not-found
+  behavior and observed output here.
+
+## Implementation Notes
+
+- The `memory set` command in this backlog is for explicit user-created display/navigation memory.
+  It must not infer preferences from repeated behavior.
+- If implementation chooses a different final product command, update this backlog before coding and
+  keep the scenario equally runnable by the user.

--- a/.agents/backlog/user-local-storage-inspection-implementation.md
+++ b/.agents/backlog/user-local-storage-inspection-implementation.md
@@ -1,0 +1,132 @@
+# User-Local Storage Inspection Implementation
+
+## Status
+
+Backlog.
+
+## Created
+
+2026-05-09
+
+## Priority
+
+P0 - implementation prerequisite for user-local memory, preferences, and transparent workflow state.
+
+## Request
+
+Implement the user-local storage foundation defined by
+[user-local-storage.md](../specs/user-local-storage.md) so users can inspect the effective storage
+root, categories, and stored item summaries through a Robota product surface.
+
+This backlog implements the follow-up work deferred by
+[User-Local Storage Foundation](completed/cli-user-local-storage-foundation.md).
+
+## Recommendation Gate
+
+Recommended approach:
+
+- Implement SDK-owned user-local root resolution, repo-outside validation, category projection, and
+  item inspection contracts first.
+- Add a user-visible product command routed by `agent-cli` but owned by SDK/command contracts:
+  `robota user-local storage list --format json`.
+- Keep this command provider-free so users can inspect local Robota state without configuring an AI
+  provider or opening the TUI.
+- Use the repository-local built CLI binary for user scenario verification:
+  `node packages/agent-cli/dist/node/bin.js ...`.
+
+Why this matches the backlog intent:
+
+- The feature proves Robota can disclose where baseline workflow state would be stored before any
+  memory UI depends on it.
+- It keeps the user's repository independent because storage is resolved under user-local home and
+  validated outside the active repository.
+- It keeps `agent-cli` thin: CLI routing and output formatting are allowed, while storage semantics
+  belong to SDK contracts.
+
+Affected scope:
+
+- `packages/agent-sdk`: storage root resolver, repo-outside validation, category/item projections.
+- `packages/agent-command-*` or a new command owner: product command behavior and output shape.
+- `packages/agent-cli`: provider-free command routing to the command owner.
+- Package `SPEC.md` files and cross-cutting specs as needed.
+
+Open decisions:
+
+- Exact command owner package name can be chosen during implementation. It must not put storage
+  semantics inside `agent-cli`.
+
+## Acceptance Criteria
+
+- [ ] SDK resolves the effective user-local root under the user's home directory by default.
+- [ ] SDK rejects a baseline workflow storage root inside the active repository.
+- [ ] SDK exposes stable category projections for `preferences`, `view-state`,
+      `memory-projections`, `task-associations`, `workflow-metadata`, and `inspection-index`.
+- [ ] Product command `robota user-local storage list --format json` prints the effective root and
+      category summaries without requiring provider configuration.
+- [ ] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
+      state in the active repository.
+- [ ] Stored command strings are not exposed as reusable execution preferences.
+- [ ] The backlog is updated with User Test Scenario evidence after implementation.
+
+## Test Plan
+
+- Add SDK unit tests for default root resolution and injected test home/root behavior.
+- Add SDK negative tests for roots equal to or inside the active repository, including symlink cases
+  where feasible.
+- Add SDK contract tests for storage category projections and item summary fields.
+- Add command-package tests for JSON output and provider-free execution.
+- Add CLI routing tests proving the product command reaches the command owner without opening the
+  provider setup flow.
+- Run `pnpm harness:scan`.
+
+## User Test Scenarios
+
+### Scenario: Inspect User-Local Storage From A Repository With No Robota Files
+
+- Prerequisites:
+  - The implementation must build `packages/agent-cli/dist/node/bin.js`.
+  - The implementation must provide the product command
+    `robota user-local storage list --format json`.
+  - No provider configuration should be required for this command.
+- Test environment:
+
+  ```bash
+  ROBOTA_REPO="/Users/jungyoun/Documents/dev/robota"
+  TMP_HOME="$(mktemp -d)"
+  FIXTURE_REPO="$(mktemp -d)"
+  pnpm --dir "$ROBOTA_REPO" --filter @robota-sdk/agent-cli build
+  ```
+
+- User actions:
+
+  ```bash
+  (
+    cd "$FIXTURE_REPO"
+    HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local storage list --format json
+  )
+  find "$FIXTURE_REPO" -maxdepth 2 -name ".robota" -o -name "robota*"
+  ```
+
+- Expected observable result:
+  - The first command exits 0 and prints JSON containing a `root` under `$TMP_HOME/.robota`.
+  - The JSON contains category names including `preferences`, `view-state`, `memory-projections`,
+    `task-associations`, `workflow-metadata`, and `inspection-index`.
+  - The JSON does not contain any reusable command execution preference.
+  - The `find` command prints no project `.robota` or Robota baseline workflow state inside
+    `$FIXTURE_REPO`.
+- Cleanup/reset:
+
+  ```bash
+  rm -rf "$TMP_HOME" "$FIXTURE_REPO"
+  ```
+
+- Agent verification: Must be executed after implementation using the commands above.
+- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
+  command output and repository `find` result are recorded here.
+
+## Implementation Notes
+
+- The product command may be implemented as a CLI subcommand, but storage semantics must remain in
+  SDK/command-owned code.
+- If implementation chooses a different final product command, update this backlog before coding and
+  keep the scenario equally runnable by the user.


### PR DESCRIPTION
## Summary

- Add follow-up implementation backlogs for user-local storage inspection and user-local memory inspection.
- Define product-surface scenarios using Robota CLI commands for the future implementation work.
- Link the new implementation backlogs from the completed contract backlogs and backlog index.

## Verification

- `git diff --check`
- `pnpm harness:scan`
- Pre-push fast verification: `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check`

## User Scenario Status

Not executed yet because these are not implementation PRs. The new backlogs intentionally contain pending product-surface execution scenarios that must be run after the future implementation exists.

## Residual Risk

No runtime code changed. Existing harness file-size warnings remain pre-existing.
