### PR TITLE
docs(agents): define user execution test scenarios

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -16,27 +16,29 @@ workflow behavior must include both:
 
 - `## Test Plan`: the agent's engineering verification plan, such as unit, integration, harness,
   build, and CI checks.
-- `## User Test Scenarios`: concrete product-surface scenarios with prerequisites, exact command
-  lines or UI steps, required test environment setup, expected observable results, cleanup/reset
-  steps, and an evidence field that must be filled after implementation.
+- `## User Execution Test Scenarios`: concrete product-surface scenarios with prerequisites, exact
+  command lines or UI steps, required test environment setup, expected observable results,
+  cleanup/reset steps, and an evidence field that must be filled after implementation.
 
-The user scenario gate is checked separately from the engineering test plan before the backlog is
-declared complete. The planned scenario must be written before implementation starts, but the gate
-itself is run after implementation against the completed code path or delivered artifact. For
-code-changing backlogs, reviewing backlog text, documentation text, or static prose is not a valid
-user scenario gate.
+The user execution test scenario gate is checked separately from the engineering test plan before
+the backlog is declared complete. The planned scenario must be written before implementation starts,
+but the gate itself is run after implementation against the completed code path or delivered
+artifact. For code-changing backlogs, reviewing backlog text, documentation text, or static prose is
+not a valid user execution test scenario gate.
 
-A user test scenario must use a product surface: the Robota CLI command or local equivalent that
-invokes the same product binary, Robota TUI actions, Robota browser UI flows, or public SDK/example
-usage for SDK-only features. For `agent-cli` and command-package backlogs, prefer a Robota CLI or
-TUI action. `rg`, harness commands, unit tests, source inspection, and other internal repository
-checks belong in `## Test Plan`, not `## User Test Scenarios`.
+A user execution test scenario is what the user can personally execute to see the product change
+working. It must use a product surface: the Robota CLI command or local equivalent that invokes the
+same product binary, Robota TUI actions, Robota browser UI flows, or public SDK/example usage for
+SDK-only features. For `agent-cli` and command-package backlogs, prefer a Robota CLI or TUI action.
+`rg`, harness commands, unit tests, source inspection, CI checks, and other internal repository
+checks belong in `## Test Plan`, not `## User Execution Test Scenarios`.
 
 Documentation-only, rule-only, skill-only, backlog-only, or governance-only changes that do not
-deliver runnable user-facing behavior must not invent a user test scenario. Record `Not applicable`
-with the reason, and keep document/rule/static checks in `## Test Plan` or a verification evidence
-section. If documentation changes describe a user procedure, the user scenario must execute the
-procedure itself; it must not inspect the document to prove the document is well written.
+deliver runnable user-facing behavior must not invent a user execution test scenario. Record
+`Not applicable` with the reason, and keep document/rule/static checks in `## Test Plan` or a
+verification evidence section. If documentation changes describe a user procedure, the user
+execution test scenario must execute the procedure itself; it must not inspect the document to prove
+the document is well written.
 
 If the scenario needs a fixture, test project, local server, seed data, or demo command, the backlog
 must state whether that environment already exists, will be built by the work, or requires a user
@@ -45,7 +47,7 @@ decision. A scenario that the user cannot realistically run after completion is 
 After implementation, the agent must run the scenario when executable, compare the observed result
 with the expected observable result, and update the backlog with the captured evidence. Without
 command output, exit code, screenshot, log excerpt, diff, or another concrete artifact recorded in
-the backlog, the user scenario gate does not pass.
+the backlog, the user execution test scenario gate does not pass.
 
 ## Items
 

--- a/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
@@ -196,7 +196,7 @@ Each implementation PR should update the owning package specs before changing `a
 - Include at least one fixture repository with no Robota files and no Robota local state inside the
   repo to verify that the planned behavior remains repo-agnostic.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog is a planning umbrella and does not deliver runnable Robota product
 behavior. Product-surface scenarios must be added by the focused implementation backlogs that build

--- a/.agents/backlog/completed/backlog-executable-user-scenario-gate.md
+++ b/.agents/backlog/completed/backlog-executable-user-scenario-gate.md
@@ -1,4 +1,4 @@
-# Executable User Scenario Gate Hardening
+# Executable User Execution Test Scenario Gate Hardening
 
 ## Status
 
@@ -10,13 +10,13 @@ Completed.
 
 ## Priority
 
-P0 - correction to make user scenario gates concrete, executable, and evidenced.
+P0 - correction to make user execution test scenario gates concrete, executable, and evidenced.
 
 ## Request
 
-Strengthen the backlog user scenario rule so scenarios are not abstract summaries. A valid user test
-scenario must give the user exact commands or UI steps, expected observable results, and evidence
-that the agent executed the scenario when execution is feasible.
+Strengthen the backlog user execution test scenario rule so scenarios are not abstract summaries. A
+valid user execution test scenario must give the user exact commands or UI steps, expected
+observable results, and evidence that the agent executed the scenario when execution is feasible.
 
 ## Non-Negotiable Product Principles
 
@@ -26,7 +26,7 @@ that the agent executed the scenario when execution is feasible.
   file change the user should expect.
 - **Agent execution first.** If the scenario can be run by the agent using shell, filesystem, HTTP,
   browser, TUI, or local scripts, the agent must run it before declaring the gate passed.
-- **Evidence required.** No user scenario gate may pass without captured evidence such as command
+- **Evidence required.** No user execution test scenario gate may pass without captured evidence such as command
   output, exit code, screenshot, log excerpt, rendered UI observation, or changed-file diff.
 - **Manual-only is exceptional.** Manual-only scenarios must explain why the agent cannot execute
   them and must not be reported as executed.
@@ -36,18 +36,18 @@ that the agent executed the scenario when execution is feasible.
 ## Expected Outcomes
 
 - Users receive actionable scenarios they can run directly.
-- PRs contain evidence from the agent-executed user scenario gate.
+- PRs contain evidence from the agent-executed user execution test scenario gate.
 - Gates without evidence fail by rule.
-- Abstract static review no longer counts as a passed user scenario when an executable check is
+- Abstract static review no longer counts as a passed user execution test scenario when an executable check is
   available.
 - Future product-behavior backlog scenarios become product-command-backed and reproducible.
-- Document/governance-only backlog checks are recorded as process verification, not user scenarios.
+- Document/governance-only backlog checks are recorded as process verification, not user execution test scenarios.
 
 ## Architecture Ownership Rule
 
 The mandatory constraint belongs in `.agents/rules/backlog-execution.md`. The
 `backlog-execution-orchestrator` skill sequences and reports the gate but does not design package
-tests. Backlog files own the concrete user scenarios for their own scope.
+tests. Backlog files own the concrete user execution test scenarios for their own scope.
 
 ## Recommended First Slice
 
@@ -56,17 +56,17 @@ tests. Backlog files own the concrete user scenarios for their own scope.
 2. Strengthen `.agents/skills/backlog-execution-orchestrator/SKILL.md` to execute scenarios when
    feasible and report observed evidence in PRs.
 3. Update `.agents/backlog/README.md` with the concrete scenario requirement.
-4. Replace document-inspection user scenarios with process verification evidence, and require future
+4. Replace document-inspection user execution test scenarios with process verification evidence, and require future
    product-behavior scenarios to use product surfaces.
 
 ## Acceptance Criteria
 
-- [x] The rule rejects abstract user scenarios.
+- [x] The rule rejects abstract user execution test scenarios.
 - [x] The rule requires exact commands/UI steps and expected observable results.
 - [x] The rule requires agent execution when feasible.
 - [x] The rule requires captured evidence and rejects evidence-free gates.
 - [x] The orchestration skill requires observed evidence in PR bodies.
-- [x] Current initiative document/governance checks are not presented as user scenarios.
+- [x] Current initiative document/governance checks are not presented as user execution test scenarios.
 - [x] Product-behavior scenarios are required to use product surfaces.
 
 ## Test Plan
@@ -78,7 +78,7 @@ tests. Backlog files own the concrete user scenarios for their own scope.
 - Confirm current initiative document/governance checks are process verification, not user
   scenarios.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog changed process rules and orchestration guidance only. It did not
 deliver runnable Robota product behavior, so document inspection must not be presented as a user
@@ -92,14 +92,14 @@ test scenario.
 - Verification commands:
 
   ```bash
-  rg -n "exact command lines, UI actions|expected observable result|must execute the user test scenario|The user scenario gate was not executed" .agents/rules/backlog-execution.md
-  rg -n "exact commands or UI steps|Execute the user test scenario|observed evidence" .agents/skills/backlog-execution-orchestrator/SKILL.md
-  rg -n "^## User Test Scenarios" .agents/backlog/cli-ai-workflow-reviewer-harness-planning.md .agents/backlog/completed/*.md
+  rg -n "exact command lines, UI actions|expected observable result|must execute the user execution test scenario|The user execution test scenario gate was not executed" .agents/rules/backlog-execution.md
+  rg -n "exact commands or UI steps|Execute the user execution test scenario|observed evidence" .agents/skills/backlog-execution-orchestrator/SKILL.md
+  rg -n "^## User Execution Test Scenarios" .agents/backlog/cli-ai-workflow-reviewer-harness-planning.md .agents/backlog/completed/*.md
   ```
 
 - Expected result: The first command prints the mandatory concrete scenario fields and
   execution gate. The second command prints orchestration requirements to execute and report
-  evidence. The third command prints user scenario sections, including the current initiative
+  evidence. The third command prints user execution test scenario sections, including the current initiative
   backlogs.
 - Evidence: Executed during the original gate hardening and reclassified here as process
   verification after product-surface scenario scoping.
@@ -109,7 +109,7 @@ test scenario.
 - `git diff --check`
 - `pnpm harness:scan`
 - Execute the process verification commands listed above.
-- Confirm document/governance-only backlogs do not present document inspection as user scenarios.
+- Confirm document/governance-only backlogs do not present document inspection as user execution test scenarios.
 
 ## Result
 

--- a/.agents/backlog/completed/backlog-implementation-user-scenario-gate.md
+++ b/.agents/backlog/completed/backlog-implementation-user-scenario-gate.md
@@ -1,4 +1,4 @@
-# Implementation User Scenario Gate Alignment
+# Implementation User Execution Test Scenario Gate Alignment
 
 ## Status
 
@@ -10,21 +10,21 @@ Completed.
 
 ## Priority
 
-P0 - correction to make user scenario gates validate implemented work, not backlog quality.
+P0 - correction to make user execution test scenario gates validate implemented work, not backlog quality.
 
 ## Request
 
-Clarify the backlog execution flow so user test scenarios are planned in the backlog before
+Clarify the backlog execution flow so user execution test scenarios are planned in the backlog before
 implementation, executed after implementation against the completed code path or delivered artifact,
 and recorded back into the backlog with evidence before the gate can pass.
 
 ## Non-Negotiable Product Principles
 
-- **Scenario planned before implementation.** The backlog must define the user test scenario before
+- **Scenario planned before implementation.** The backlog must define the user execution test scenario before
   work starts so the implementation target is concrete.
 - **Scenario targets completed work.** For code-changing backlogs, the scenario must exercise the
   implemented code path. Backlog text review, documentation search, or static prose checks are not a
-  valid user scenario gate for code work.
+  valid user execution test scenario gate for code work.
 - **Runnable environment required.** If the scenario needs a fixture, demo command, local server,
   test project, seed data, or other setup, the backlog must say whether it exists, will be built, or
   requires a user decision.
@@ -34,21 +34,22 @@ and recorded back into the backlog with evidence before the gate can pass.
   No recorded evidence means the gate does not pass.
 - **User handoff is executable.** After the gate passes, the user must receive the verified scenario
   with exact commands or UI steps and expected results they can run directly.
-- **Do not fake user scenarios for documents.** Document/rule/static checks are verification
-  evidence, not user test scenarios.
-- **Use product surfaces.** User test scenarios must use Robota product surfaces such as CLI
-  commands, TUI actions, browser UI flows, or public SDK/example usage.
+- **Do not fake user execution test scenarios for documents.** Document/rule/static checks are verification
+  evidence, not user execution test scenarios.
+- **Use product surfaces.** User execution test scenarios must use Robota product surfaces such as
+  CLI commands, TUI actions, browser UI flows, or public SDK/example usage.
 
 ## Expected Outcomes
 
-- User scenario gates validate completed implementation behavior, not planning-document quality.
+- User execution test scenario gates validate completed implementation behavior, not
+  planning-document quality.
 - Future code backlogs cannot pass with only `rg` checks against backlog text or documentation.
 - Missing scenario environment becomes an explicit implementation item or user decision.
-- Completed backlogs contain the evidence needed to prove the user scenario gate passed.
+- Completed backlogs contain the evidence needed to prove the user execution test scenario gate passed.
 - Final user handoffs include concrete commands or UI steps that have already been verified.
-- Documentation-only or governance-only backlogs do not present document inspection as a user test
-  scenario.
-- User test scenarios are scoped to product usage instead of internal repository checks.
+- Documentation-only or governance-only backlogs do not present document inspection as a user
+  execution test scenario.
+- User execution test scenarios are scoped to product usage instead of internal repository checks.
 
 ## Architecture Ownership Rule
 
@@ -69,16 +70,16 @@ affected package specs and owner skills.
 
 ## Acceptance Criteria
 
-- [x] Rules distinguish the planned user scenario from the post-implementation execution gate.
+- [x] Rules distinguish the planned user execution test scenario from the post-implementation execution gate.
 - [x] Rules require code-changing backlogs to exercise implemented code paths.
-- [x] Rules require missing user scenario environment to be built, proposed, or decided.
+- [x] Rules require missing user execution test scenario environment to be built, proposed, or decided.
 - [x] Rules require the backlog to be updated with observed evidence after execution.
 - [x] The orchestrator skill enforces the same lifecycle.
 - [x] Backlog authoring guidance describes the required lifecycle and evidence update.
-- [x] Documentation-only and governance-only changes are required to mark user scenarios as not
-      applicable instead of presenting document inspection as a user test scenario.
-- [x] User scenario scope is limited to product surfaces such as Robota CLI, TUI, browser UI, or
-      public SDK/example usage.
+- [x] Documentation-only and governance-only changes are required to mark user execution test scenarios as not
+      applicable instead of presenting document inspection as a user execution test scenario.
+- [x] User execution test scenario scope is limited to product surfaces such as Robota CLI, TUI,
+      browser UI, or public SDK/example usage.
 
 ## Test Plan
 
@@ -88,11 +89,11 @@ affected package specs and owner skills.
   target, environment readiness, post-implementation execution, and backlog evidence update
   requirements.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog changes process rules, a workflow skill, and backlog authoring
 guidance. It does not deliver runnable user-facing product behavior. Document inspection would only
-prove that the process documents changed, so it must not be presented as a user test scenario.
+prove that the process documents changed, so it must not be presented as a user execution test scenario.
 
 ## Process Verification Evidence
 
@@ -102,9 +103,9 @@ prove that the process documents changed, so it must not be presented as a user 
 - Verification commands:
 
   ```bash
-  rg -n "implemented code path|completed implementation|product surface|internal repository checks|Missing user scenario test environment" .agents/rules/backlog-execution.md
+  rg -n "implemented code path|completed implementation|product surface|internal repository checks|Missing test environment for the user execution test scenario" .agents/rules/backlog-execution.md
   rg -n "completed implementation or delivered artifact|product surface|internal repository verification|where the backlog was updated" .agents/skills/backlog-execution-orchestrator/SKILL.md
-  rg -n "completed code path or delivered artifact|product-surface scenarios|rg`, harness commands|must not invent a user test scenario" .agents/backlog/README.md
+  rg -n "completed code path or delivered artifact|product-surface scenarios|rg`, harness commands|must not invent a user execution test scenario" .agents/backlog/README.md
   ```
 
 - Expected result: The first command prints rule lines requiring implementation-code
@@ -133,5 +134,5 @@ prove that the process documents changed, so it must not be presented as a user 
 ## Result
 
 Completed by updating the backlog execution rule, backlog execution orchestrator skill, and backlog
-entry requirements so user scenario gates are planned before implementation, executed after
+entry requirements so user execution test scenario gates are planned before implementation, executed after
 implementation against the completed work, and recorded with evidence in the backlog.

--- a/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
+++ b/.agents/backlog/completed/backlog-user-scenario-gate-rule.md
@@ -1,4 +1,4 @@
-# Backlog User Scenario Gate Rule
+# Backlog User Execution Test Scenario Gate Rule
 
 ## Status
 
@@ -14,7 +14,7 @@ P0 - process quality rule for backlog-driven work.
 
 ## Request
 
-Require future user-facing backlogs to include user test scenarios in addition to the agent's
+Require future user-facing backlogs to include user execution test scenarios in addition to the agent's
 engineering test plan.
 
 The rule must answer:
@@ -24,15 +24,15 @@ The rule must answer:
 
 ## Non-Negotiable Product Principles
 
-- **Separate user scenarios from engineering tests.** Unit, integration, harness, build, and CI
-  checks are the agent's test plan. User scenarios describe what the user can manually run or
-  inspect.
-- **Gate completion on executed evidence.** A backlog is not complete until the user scenario is
-  executed when feasible and evidence is captured.
-- **Report scenario availability.** When the scenario gate passes, the final response must tell the
-  user that the scenario is available to run.
-- **Keep orchestration thin.** The backlog execution skill coordinates the scenario gate but does
-  not own detailed test design.
+- **Separate user execution test scenarios from engineering tests.** Unit, integration, harness,
+  build, and CI checks are the agent's test plan. User execution test scenarios describe what the
+  user can directly run or operate in the product to observe the changed behavior.
+- **Gate completion on executed evidence.** A backlog is not complete until the user execution test
+  scenario is executed when feasible and evidence is captured.
+- **Report scenario availability.** When the user execution test scenario gate passes, the final
+  response must tell the user that the scenario is available to run.
+- **Keep orchestration thin.** The backlog execution skill coordinates the user execution test
+  scenario gate but does not own detailed test design.
 
 ## Expected Outcomes
 
@@ -49,35 +49,37 @@ handoff shape. Detailed engineering tests remain owned by testing and package-sp
 
 ## Recommended First Slice
 
-1. Update `.agents/rules/backlog-execution.md` with a user test scenario rule.
-2. Update `.agents/skills/backlog-execution-orchestrator/SKILL.md` to enforce the scenario gate.
+1. Update `.agents/rules/backlog-execution.md` with a user execution test scenario rule.
+2. Update `.agents/skills/backlog-execution-orchestrator/SKILL.md` to enforce the user execution
+   test scenario gate.
 3. Update `.agents/backlog/README.md` so backlog authors know to include `## Test Plan` and
-   `## User Test Scenarios`.
-4. Add user scenario sections to the current initiative backlogs that were completed before the new
+   `## User Execution Test Scenarios`.
+4. Add user execution test scenario sections to the current initiative backlogs that were completed before the new
    rule existed.
 
 ## Acceptance Criteria
 
 - [x] Backlog execution rules require user-facing scenarios for user-visible work.
-- [x] The orchestration skill checks scenario presence and final scenario gate result.
-- [x] PR bodies must report the user scenario gate result.
+- [x] The orchestration skill checks scenario presence and final user execution test scenario gate
+      result.
+- [x] PR bodies must report the user execution test scenario gate result.
 - [x] Backlog README explains the difference between `## Test Plan` and
-      `## User Test Scenarios`.
-- [x] Current initiative backlogs either include product-surface user scenarios or record why user
+      `## User Execution Test Scenarios`.
+- [x] Current initiative backlogs either include product-surface user execution test scenarios or record why user
       scenarios are not applicable.
 
 ## Test Plan
 
 - Run `git diff --check`.
 - Run `pnpm harness:scan`.
-- Verify the rules and orchestration skill mention the user scenario gate.
-- Verify current initiative backlog files do not present document inspection as a user scenario.
+- Verify the rules and orchestration skill mention the user execution test scenario gate.
+- Verify current initiative backlog files do not present document inspection as a user execution test scenario.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog changed process rules and authoring guidance only. It did not deliver
 runnable Robota product behavior, so document inspection must remain process verification rather
-than a user test scenario.
+than a user execution test scenario.
 
 ## Process Verification Evidence
 
@@ -87,9 +89,9 @@ than a user test scenario.
 - Verification commands:
 
   ```bash
-  rg -n "## User Test Scenarios|exact command lines or UI steps|Static review is not enough" .agents/backlog/README.md
-  rg -n "exact command lines, UI actions|expected observable result|must execute the user test scenario|The user scenario gate was not executed" .agents/rules/backlog-execution.md
-  rg -n "exact commands or UI steps|Execute the user test scenario|observed evidence" .agents/skills/backlog-execution-orchestrator/SKILL.md
+  rg -n "## User Execution Test Scenarios|exact command lines or UI steps|Static review is not enough" .agents/backlog/README.md
+  rg -n "exact command lines, UI actions|expected observable result|must execute the user execution test scenario|The user execution test scenario gate was not executed" .agents/rules/backlog-execution.md
+  rg -n "exact commands or UI steps|Execute the user execution test scenario|observed evidence" .agents/skills/backlog-execution-orchestrator/SKILL.md
   ```
 
 - Expected result: The commands print the backlog entry requirement, executable/observable
@@ -101,7 +103,7 @@ than a user test scenario.
 
 - `git diff --check`
 - `pnpm harness:scan`
-- Confirm current initiative backlog files do not present document inspection as a user scenario.
+- Confirm current initiative backlog files do not present document inspection as a user execution test scenario.
 
 ## Result
 
@@ -109,7 +111,7 @@ Completed by updating backlog execution rules, the backlog execution orchestrato
 README guidance, and the current initiative backlog files.
 
 - The rule now requires user-facing test scenarios for user-visible backlog work.
-- The orchestrator skill records the user scenario gate and evidence as part of the normal PR
+- The orchestrator skill records the user execution test scenario gate and evidence as part of the normal PR
   pipeline.
-- Current initiative backlogs now either include product-surface user scenarios or mark the scenario
+- Current initiative backlogs now either include product-surface user execution test scenarios or mark the scenario
   as not applicable for document/governance-only work.

--- a/.agents/backlog/completed/cli-background-work-state-management.md
+++ b/.agents/backlog/completed/cli-background-work-state-management.md
@@ -121,7 +121,7 @@ Create a design and contract PR before UI work:
 - Add regression tests proving `agent-cli` does not own lifecycle state or duplicate terminal-state
   rules.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a background-work state contract document and did not deliver
 runnable Robota product behavior. Product-surface scenarios must be added by follow-up
@@ -141,7 +141,7 @@ implementation PRs that expose background switching through CLI/TUI/SDK behavior
 - Expected result: The command prints the supported entry types, current SDK projection
   anchor, future skill-spawned support, and the CLI non-ownership rule for task completion.
 - Evidence: Executed as process verification for the contract document. Runtime archive/clear and
-  expanded TUI behavior remain follow-up implementation work, where product-surface user scenarios
+  expanded TUI behavior remain follow-up implementation work, where product-surface user execution test scenarios
   must be added.
 
 ## Verification Plan

--- a/.agents/backlog/completed/cli-repository-situational-awareness.md
+++ b/.agents/backlog/completed/cli-repository-situational-awareness.md
@@ -107,7 +107,7 @@ Create a design and contract PR before UI work:
 - Add tests proving context display does not create or modify repo files.
 - Add CLI rendering tests after SDK projections exist.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a repository situational awareness contract document and did
 not deliver runnable Robota product behavior. Product-surface scenarios must be added by follow-up
@@ -127,7 +127,7 @@ implementation PRs that expose repository context through CLI/TUI/SDK behavior.
 - Expected result: The command prints allowed context items, command inference prohibition,
   file-listing restriction, and repository-write prohibition.
 - Evidence: Executed as process verification for the contract document. SDK projection APIs and CLI
-  rendering remain follow-up implementation work, where product-surface user scenarios must be
+  rendering remain follow-up implementation work, where product-surface user execution test scenarios must be
   added.
 
 ## Verification Plan

--- a/.agents/backlog/completed/cli-transparent-process-execution.md
+++ b/.agents/backlog/completed/cli-transparent-process-execution.md
@@ -119,7 +119,7 @@ Create a design and contract PR before UI work:
   directly execute commands.
 - Add negative tests proving command output is not classified as correctness evidence by default.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a process execution contract document and did not deliver
 runnable Robota product behavior. Product-surface scenarios must be added by follow-up
@@ -139,7 +139,7 @@ implementation PRs that expose process execution through CLI/TUI/SDK behavior.
 - Expected result: The command prints the required process request/status fields, command
   source rule, and the restriction against remembered command history.
 - Evidence: Executed as process verification for the contract document. Runtime process execution
-  remains follow-up implementation work, where product-surface user scenarios must be added.
+  remains follow-up implementation work, where product-surface user execution test scenarios must be added.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/cli-transparent-workflow-contract.md
+++ b/.agents/backlog/completed/cli-transparent-workflow-contract.md
@@ -128,7 +128,7 @@ Create a design and contract PR before UI work:
 - Add CLI rendering tests only after SDK/runtime contracts exist, verifying that provenance and
   state labels are visible without exposing private implementation details.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a cross-cutting contract document and did not deliver runnable
 Robota product behavior. Product-surface scenarios must be added by follow-up implementation PRs

--- a/.agents/backlog/completed/cli-user-local-memory-transparency.md
+++ b/.agents/backlog/completed/cli-user-local-memory-transparency.md
@@ -130,7 +130,7 @@ Create a design and contract PR before UI work:
 - Add CLI tests verifying users can see storage location, source, last-used time,
   display/navigation rule, and delete/disable actions.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a user-local memory contract document and did not deliver
 runnable Robota product behavior. Product-surface scenarios must be added by follow-up
@@ -150,7 +150,7 @@ implementation PRs that expose memory inspection through CLI/TUI/SDK behavior.
 - Expected result: The command prints the display/navigation-only rule, restricted command
   memory, command execution effect, delete/disable fields, and project-memory boundary.
 - Evidence: Executed as process verification for the contract document. SDK storage APIs and CLI
-  rendering remain follow-up implementation work, where product-surface user scenarios must be
+  rendering remain follow-up implementation work, where product-surface user execution test scenarios must be
   added.
 
 ## Verification Plan

--- a/.agents/backlog/completed/cli-user-local-storage-foundation.md
+++ b/.agents/backlog/completed/cli-user-local-storage-foundation.md
@@ -124,7 +124,7 @@ Create a design and contract PR before UI work:
 - Add CLI tests only after SDK contracts exist, verifying the effective storage root and stored item
   summaries are visible.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 Not applicable. This backlog produced a user-local storage contract document and did not deliver
 runnable Robota product behavior. Product-surface scenarios must be added by follow-up

--- a/.agents/backlog/user-local-memory-inspection-implementation.md
+++ b/.agents/backlog/user-local-memory-inspection-implementation.md
@@ -71,7 +71,7 @@ Open decisions:
 - [ ] Users can delete a remembered item.
 - [ ] No command strings are stored or exposed as reusable execution preferences.
 - [ ] No baseline user-local memory is written inside the active repository, including `.robota/`.
-- [ ] The backlog is updated with User Test Scenario evidence after implementation.
+- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -85,7 +85,7 @@ Open decisions:
 - Add CLI routing tests proving the commands are provider-free.
 - Run `pnpm harness:scan`.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 ### Scenario: Inspect And Disable A User-Local View Preference
 

--- a/.agents/backlog/user-local-storage-inspection-implementation.md
+++ b/.agents/backlog/user-local-storage-inspection-implementation.md
@@ -31,7 +31,7 @@ Recommended approach:
   `robota user-local storage list --format json`.
 - Keep this command provider-free so users can inspect local Robota state without configuring an AI
   provider or opening the TUI.
-- Use the repository-local built CLI binary for user scenario verification:
+- Use the repository-local built CLI binary for user execution test scenario verification:
   `node packages/agent-cli/dist/node/bin.js ...`.
 
 Why this matches the backlog intent:
@@ -66,7 +66,7 @@ Open decisions:
 - [ ] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
       state in the active repository.
 - [ ] Stored command strings are not exposed as reusable execution preferences.
-- [ ] The backlog is updated with User Test Scenario evidence after implementation.
+- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -79,7 +79,7 @@ Open decisions:
   provider setup flow.
 - Run `pnpm harness:scan`.
 
-## User Test Scenarios
+## User Execution Test Scenarios
 
 ### Scenario: Inspect User-Local Storage From A Repository With No Robota Files
 

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -15,8 +15,8 @@ The recommendation must include:
 - why it matches repository rules, layering, ownership, and architecture boundaries;
 - affected packages, docs, or commands;
 - the expected test and verification plan;
-- the expected user test scenario plan when the backlog changes runnable user-facing behavior, or
-  the not-applicable reason when it does not;
+- the expected user execution test scenario plan when the backlog changes runnable user-facing
+  behavior, or the not-applicable reason when it does not;
 - any decisions that require the user instead of agent autonomy.
 
 If the recommendation is coherent with repository rules, layering, architecture, and the backlog
@@ -31,37 +31,42 @@ judgment, stop and ask the user for a decision.
   work unit must have its own recommendation gate.
 - Do not combine unrelated backlogs in one PR.
 - Every PR description must include the accepted recommendation, rationale, implementation summary,
-  tests run, user scenario gate result or not-applicable reason, and residual risks.
+  tests run, user execution test scenario gate result or not-applicable reason, and residual risks.
 
-## User Test Scenario Rule
+## User Execution Test Scenario Rule
 
 Every backlog that changes runnable user-facing behavior, command behavior, TUI/browser behavior, or
-workflow behavior must include a user-facing test scenario section before implementation starts.
+workflow behavior must include a `## User Execution Test Scenarios` section before implementation
+starts.
 
-User test scenarios are separate from the agent's engineering test plan:
+User execution test scenarios are separate from the agent's engineering test plan:
 
 - The engineering test plan covers unit, integration, type, harness, CI, build, and internal
   verification commands.
-- The user test scenario describes the exact product command, UI interaction, browser flow, TUI
-  flow, or public SDK/example flow a user can run after the work is implemented to confirm the
-  implemented code or delivered artifact behaves as intended.
-- A valid user test scenario must use a product surface. Product surfaces include the Robota CLI
-  command or local equivalent that invokes the same product binary, Robota TUI actions, Robota
-  browser UI flows, and public SDK/example usage for SDK-only features.
-- For `agent-cli` and command-package backlogs, the default user scenario surface is a Robota CLI or
-  TUI action, such as `robota ...` or the repository-local command that invokes the same CLI
-  entrypoint.
-- For code-changing backlogs, the user test scenario must exercise the implemented code path. A
-  documentation search, backlog review, or static text check may not be used as the user scenario
-  gate for code implementation work.
+- A user execution test scenario is what the user can personally execute to see the product change
+  working. It is not the agent's test command, CI command, unit test, harness command, or source
+  inspection.
+- The user execution test scenario describes the exact product command, UI interaction, browser
+  flow, TUI flow, or public SDK/example flow a user can run after the work is implemented to confirm
+  the implemented code or delivered artifact behaves as intended.
+- A valid user execution test scenario must use a product surface. Product surfaces include the
+  Robota CLI command or local equivalent that invokes the same product binary, Robota TUI actions,
+  Robota browser UI flows, and public SDK/example usage for SDK-only features.
+- For `agent-cli` and command-package backlogs, the default user execution test scenario surface is a
+  Robota CLI or TUI action, such as `robota ...` or the repository-local command that invokes the
+  same CLI entrypoint.
+- For code-changing backlogs, the user execution test scenario must exercise the implemented code
+  path. A documentation search, backlog review, or static text check may not be used as the user
+  execution test scenario gate for code implementation work.
 - For documentation-only, rule-only, skill-only, backlog-only, or governance-only changes that do
-  not deliver runnable user-facing behavior, do not invent a user test scenario. Mark the user test
-  scenario as not applicable and record verification evidence in the engineering test plan instead.
-- If documentation changes describe a user procedure, any user test scenario must execute the
+  not deliver runnable user-facing behavior, do not invent a user execution test scenario. Mark the
+  user execution test scenario as not applicable and record verification evidence in the engineering
+  test plan instead.
+- If documentation changes describe a user procedure, any user execution test scenario must execute the
   documented procedure itself. It must not inspect the document to prove the document is well
   written.
 
-Each user test scenario must include:
+Each user execution test scenario must include:
 
 - prerequisite state, sample setup, fixture data, server startup, environment variables, or other
   test environment requirements;
@@ -72,37 +77,38 @@ Each user test scenario must include:
 - whether the agent can verify the scenario directly, partially, or only by manual UI review;
 - the evidence field that must be updated after implementation when the agent runs the scenario.
 
-The planned user test scenario is part of the backlog before implementation starts. If the scenario
-requires a test fixture, demo command, local server, test project, seed data, or other environment
-that does not exist yet, the agent must either build that environment as part of the backlog,
-propose it in the recommendation gate, or ask the user for a decision before proceeding. A scenario
-that cannot realistically be run by the user after completion is not acceptable.
+The planned user execution test scenario is part of the backlog before implementation starts. If
+the scenario requires a test fixture, demo command, local server, test project, seed data, or other
+environment that does not exist yet, the agent must either build that environment as part of the
+backlog, propose it in the recommendation gate, or ask the user for a decision before proceeding. A
+scenario that cannot realistically be run by the user after completion is not acceptable.
 
-Before declaring a backlog or work unit complete, the agent must execute the user test scenario as a
-final gate whenever the scenario is command-line, file-system, HTTP, browser, or otherwise available
-from the workspace. The gate passes only when the observed result matches the expected observable
-result, and only when the scenario was run against the completed implementation or delivered
-artifact.
+Before declaring a backlog or work unit complete, the agent must execute the user execution test
+scenario as a final gate whenever the scenario is command-line, file-system, HTTP, browser, or
+otherwise available from the workspace. The gate passes only when the observed result matches the
+expected observable result, and only when the scenario was run against the completed implementation
+or delivered artifact.
 
-Evidence is mandatory. A user scenario gate without captured evidence does not pass. Evidence may be
-command output, exit code, screenshot, log excerpt, rendered UI observation, changed-file diff, or
-another concrete artifact that proves the expected observable result occurred. After running the
-scenario, the agent must update the backlog item with the observed evidence before the backlog can be
-considered complete.
+Evidence is mandatory. A user execution test scenario gate without captured evidence does not pass.
+Evidence may be command output, exit code, screenshot, log excerpt, rendered UI observation,
+changed-file diff, or another concrete artifact that proves the expected observable result occurred.
+After running the scenario, the agent must update the backlog item with the observed evidence before
+the backlog can be considered complete.
 
-Static review may not be used as a passing user scenario gate when an executable command, browser
-flow, TUI flow, or local script can reasonably be run. If a scenario is genuinely manual-only, it
-must be labeled `manual-only`, explain why it cannot be executed by the agent, and the PR must not
-claim it passed by execution.
+Static review may not be used as a passing user execution test scenario gate when an executable
+command, browser flow, TUI flow, or local script can reasonably be run. If a scenario is genuinely
+manual-only, it must be labeled `manual-only`, explain why it cannot be executed by the agent, and
+the PR must not claim it passed by execution.
 
 Document inspection, rule inspection, backlog inspection, source inspection, `rg` checks, harness
 commands, unit tests, and other internal repository checks are engineering or governance
-verification only. They must not be presented to the user as a user test scenario.
+verification only. They must not be presented to the user as a user execution test scenario.
 
-When the user scenario gate passes, the final user-facing response must tell the user that the
-scenario was verified, provide the concrete command or UI steps the user can run, state the expected
-result, and summarize the evidence already observed by the agent. If the scenario gate does not
-pass, the work is not complete and the agent must fix the issue or ask for a decision.
+When the user execution test scenario gate passes, the final user-facing response must tell the user
+that the scenario was verified, provide the concrete command or UI steps the user can run, state the
+expected result, and summarize the evidence already observed by the agent. If the user execution
+test scenario gate does not pass, the work is not complete and the agent must fix the issue or ask
+for a decision.
 
 ## Base Branch Workflow
 
@@ -144,25 +150,28 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 ## Stop Conditions
 
 - No recommendation gate was presented for the backlog or work unit.
-- A required runnable user-facing backlog lacks a user test scenario section.
-- A user test scenario is abstract, lacks exact commands/UI steps, or lacks expected observable
-  results.
+- A required runnable user-facing backlog lacks a user execution test scenario section.
+- A user execution test scenario is abstract, lacks exact commands/UI steps, or lacks expected
+  observable results.
 - A code-changing backlog uses backlog text review, documentation search, or other static review as
-  the user scenario gate instead of exercising the implemented code path.
-- A user scenario uses internal repository verification instead of a product surface such as Robota
-  CLI, TUI, browser UI, or public SDK/example usage.
+  the user execution test scenario gate instead of exercising the implemented code path.
+- A user execution test scenario asks the user to run tests, harness commands, CI checks, or source
+  inspection instead of executing the product behavior.
+- A user execution test scenario uses internal repository verification instead of a product surface such
+  as Robota CLI, TUI, browser UI, or public SDK/example usage.
 - A documentation-only, rule-only, skill-only, backlog-only, or governance-only change presents
-  document inspection as a user test scenario.
-- The required test environment for the user scenario is missing and was neither built, proposed, nor
-  decided with the user.
-- The user scenario gate was not executed when it could reasonably be executed by the agent.
-- The user scenario gate has no captured evidence.
-- The backlog item was not updated with the observed user scenario evidence after execution.
-- The user scenario gate fails or cannot be mapped to the completed behavior.
+  document inspection as a user execution test scenario.
+- The required test environment for the user execution test scenario is missing and was neither built,
+  proposed, nor decided with the user.
+- The user execution test scenario gate was not executed when it could reasonably be executed by the
+  agent.
+- The user execution test scenario gate has no captured evidence.
+- The backlog item was not updated with the observed user execution test scenario evidence after execution.
+- The user execution test scenario gate fails or cannot be mapped to the completed behavior.
 - The recommendation conflicts with repo rules, layering, package ownership, or backlog intent.
 - The work would combine unrelated backlogs into one PR.
 - The final initiative PR would be auto-merged into `develop`.
-- A final user response presents engineering or governance verification as a user test scenario.
+- A final user response presents engineering or governance verification as a user execution test scenario.
 - An orchestration skill duplicates implementation details from invoked skills instead of only
   coordinating them.
 
@@ -170,17 +179,22 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 
 - [ ] Recommendation gate presented before work begins.
 - [ ] Recommendation includes rationale, ownership, affected scope, engineering tests, user
-      scenarios or not-applicable reason, and open decisions.
-- [ ] Backlog includes user test scenarios only when runnable user-facing behavior changes.
+      execution test scenarios or not-applicable reason, and open decisions.
+- [ ] Backlog includes user execution test scenarios only when runnable user-facing behavior changes.
 - [ ] PR scope maps to exactly one backlog or explicitly split work unit.
-- [ ] User scenario targets the completed implementation or delivered artifact, not backlog quality.
-- [ ] User scenario includes exact commands or UI steps, required environment setup, and expected
-      observable results.
-- [ ] Missing user scenario test environment was built, proposed, or explicitly decided.
-- [ ] User scenario gate was executed by the agent against the completed work when executable.
-- [ ] User scenario gate includes captured evidence; no evidence means no pass.
-- [ ] Backlog item records the observed user scenario evidence after execution.
+- [ ] User execution test scenario targets the completed implementation or delivered artifact, not
+      backlog quality.
+- [ ] User execution test scenario asks the user to execute product behavior, not tests or internal
+      repository checks.
+- [ ] User execution test scenario includes exact commands or UI steps, required environment setup,
+      and expected observable results.
+- [ ] Missing test environment for the user execution test scenario was built, proposed, or
+      explicitly decided.
+- [ ] User execution test scenario gate was executed by the agent against the completed work when
+      executable.
+- [ ] User execution test scenario gate includes captured evidence; no evidence means no pass.
+- [ ] Backlog item records the observed user execution test scenario evidence after execution.
 - [ ] Child PR targets the initiative base branch.
 - [ ] Final initiative PR targets `develop` and is not auto-merged.
-- [ ] PR description records the accepted recommendation, verification evidence, and user scenario
+- [ ] PR description records the accepted recommendation, verification evidence, and user execution test scenario
       gate result or not-applicable reason.

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -16,15 +16,15 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 
 ## Process Sub-Rules (linked from process.md)
 
-| Document                                       | Scope                                                              |
-| ---------------------------------------------- | ------------------------------------------------------------------ |
-| [spec-workflow.md](spec-workflow.md)           | Spec-first development, document authority, structural docs        |
-| [tdd-and-planning.md](tdd-and-planning.md)     | TDD red-green-refactor, planning requirements                      |
-| [verification.md](verification.md)             | Build, browser, harness, and pre-push verification gates           |
-| [publish.md](publish.md)                       | Package publish safety gate and scope approval                     |
-| [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gates, publish flow |
-| [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates   |
-| [research.md](research.md)                     | Research-first implementation and recommendation authority         |
-| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user scenario gates, initiative PRs  |
-| [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation            |
-| [learning-loop.md](learning-loop.md)           | Lesson capture and mechanical enforcement preference               |
+| Document                                       | Scope                                                                            |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| [spec-workflow.md](spec-workflow.md)           | Spec-first development, document authority, structural docs                      |
+| [tdd-and-planning.md](tdd-and-planning.md)     | TDD red-green-refactor, planning requirements                                    |
+| [verification.md](verification.md)             | Build, browser, harness, and pre-push verification gates                         |
+| [publish.md](publish.md)                       | Package publish safety gate and scope approval                                   |
+| [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gates, publish flow               |
+| [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates                 |
+| [research.md](research.md)                     | Research-first implementation and recommendation authority                       |
+| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user execution test scenario gates, initiative PRs |
+| [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation                          |
+| [learning-loop.md](learning-loop.md)           | Lesson capture and mechanical enforcement preference                             |

--- a/.agents/rules/process.md
+++ b/.agents/rules/process.md
@@ -14,6 +14,6 @@ This file routes to detailed rule documents. Each linked file contains the full 
 | [release-operations.md](release-operations.md) | Release state machine, CI triage, long-running gate discipline, publish boundary                           |
 | [documentation-sync.md](documentation-sync.md) | Document role sync, package README, and robota.io source update requirements                               |
 | [research.md](research.md)                     | Research-first implementation, documentation-only prior art, recommendation authority                      |
-| [backlog-execution.md](backlog-execution.md)   | Recommendation gates, one-backlog PRs, user scenario gates, initiative branch workflow                     |
+| [backlog-execution.md](backlog-execution.md)   | Recommendation gates, one-backlog PRs, user execution test scenario gates, initiative branch workflow      |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation                                                    |
 | [learning-loop.md](learning-loop.md)           | Convert repeated lessons into rules, hooks, harness checks, or tested automation                           |

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -27,7 +27,7 @@ This skill owns orchestration only:
 - branch and PR sequencing;
 - owner-skill routing;
 - verification checkpoint ordering;
-- user test scenario gate enforcement;
+- user execution test scenario gate enforcement;
 - PR summary requirements;
 - final handoff state.
 
@@ -43,25 +43,26 @@ or implementation details.
    - why it matches repo rules, layering, and ownership;
    - affected scope;
    - test and verification plan;
-   - concrete user test scenario plan using a product surface, with exact commands or UI steps and
-     expected observable result against the completed implementation or delivered artifact when the
-     backlog changes runnable user-facing behavior;
+   - concrete user execution test scenario plan using a product surface, with exact commands or UI
+     steps and expected observable result against the completed implementation or delivered artifact
+     when the backlog changes runnable user-facing behavior;
    - not-applicable reason when the backlog does not change runnable user-facing behavior;
-   - required user scenario test environment and whether it already exists, will be built by the
-     backlog, or needs a user decision;
+   - required test environment for the user execution test scenario and whether it already exists,
+     will be built by the backlog, or needs a user decision;
    - decisions that require the user.
-3. Ensure the backlog or work unit includes a user-facing test scenario section when it changes
-   runnable user-facing behavior, command behavior, workflow behavior, or TUI/browser behavior. The
-   scenario must use a product surface, must be executable by command/tooling whenever feasible,
-   must be designed for the post-implementation behavior, and must not be only an abstract review.
+3. Ensure the backlog or work unit includes a `## User Execution Test Scenarios` section when it
+   changes runnable user-facing behavior, command behavior, workflow behavior, or TUI/browser
+   behavior. The scenario must use a product surface, must be executable by command/tooling whenever
+   feasible, must be designed for the post-implementation behavior, and must not be only an abstract
+   review.
    Product surfaces include the Robota CLI command or local equivalent that invokes the same product
    binary, Robota TUI actions, Robota browser UI flows, and public SDK/example usage for SDK-only
    features. For `agent-cli` and command-package backlogs, prefer a Robota CLI or TUI action. For
    code-changing work, it must exercise the implemented code path rather than checking backlog or
    documentation text.
    Documentation-only, rule-only, skill-only, backlog-only, or governance-only changes must use the
-   engineering test plan for verification and must not present document inspection as a user test
-   scenario.
+   engineering test plan for verification and must not present document inspection as a user
+   execution test scenario.
 4. If the recommendation is coherent with rules and architecture, proceed. If not, stop and ask.
 5. Use `branch-guard` before commits or branch changes.
 6. For multi-backlog initiatives:
@@ -72,20 +73,21 @@ or implementation details.
    - open the final initiative PR into `develop`;
    - do not auto-merge the final `develop` PR.
 7. Route detailed work to owner skills.
-8. After implementation, confirm the scenario environment exists when a user scenario applies. If it
-   does not, build the missing fixture/demo/server/test harness when that is within the backlog
-   scope, or stop for a user decision.
-9. Execute the user test scenario as a final gate when command-line, file-system, HTTP, browser,
-   TUI, or local-script execution is available. Run it against the completed implementation or
-   delivered artifact. If it passes, update the backlog with the exact scenario, expected result, and
-   observed evidence, then include the same runnable scenario in the user handoff. Without captured
-   evidence recorded in the backlog, the gate does not pass. If it fails, keep working or ask for a
-   decision. If the scenario is genuinely manual-only, label it as such and explain why it could not
-   be executed. If no user scenario applies, record the not-applicable reason and verification
-   evidence, but do not include it in the user handoff as a user test scenario.
+8. After implementation, confirm the scenario environment exists when a user execution test scenario
+   applies. If it does not, build the missing fixture/demo/server/test harness when that is within
+   the backlog scope, or stop for a user decision.
+9. Execute the user execution test scenario as a final gate when command-line, file-system, HTTP,
+   browser, TUI, or local-script execution is available. Run it against the completed implementation
+   or delivered artifact. If it passes, update the backlog with the exact scenario, expected result,
+   and observed evidence, then include the same runnable scenario in the user handoff. Without
+   captured evidence recorded in the backlog, the gate does not pass. If it fails, keep working or
+   ask for a decision. If the scenario is genuinely manual-only, label it as such and explain why it
+   could not be executed. If no user execution test scenario applies, record the not-applicable reason
+   and verification evidence, but do not include it in the user handoff as a user execution test
+   scenario.
 10. Ensure every PR body records recommendation, rationale, implementation summary, tests, user
-    scenario gate result or not-applicable reason, backlog evidence update when applicable, and
-    residual risks.
+    execution test scenario gate result or not-applicable reason, backlog evidence update when
+    applicable, and residual risks.
 
 ## Owner Skill Routing
 
@@ -111,7 +113,7 @@ Every child PR must include:
 - rationale against backlog intent and architecture;
 - implementation summary;
 - tests and verification commands;
-- user test scenario gate result, including exact command/UI steps, expected observable result,
+- user execution test scenario gate result, including exact command/UI steps, expected observable result,
   observed evidence, and where the backlog was updated with that evidence; or not-applicable reason
   when no runnable user-facing behavior changed;
 - residual risks or skipped checks;
@@ -120,25 +122,28 @@ Every child PR must include:
 ## Stop Conditions
 
 - No recommendation gate was presented.
-- A required runnable user-facing backlog has no user test scenario section.
-- A user test scenario is abstract, lacks exact commands/UI steps, or lacks expected observable
-  results.
+- A required runnable user-facing backlog has no user execution test scenario section.
+- A user execution test scenario is abstract, lacks exact commands/UI steps, or lacks expected
+  observable results.
 - A code-changing backlog uses a documentation search, backlog review, or static text check as the
-  user test scenario gate instead of exercising the implemented code.
-- A user test scenario uses internal repository verification instead of a product surface such as
-  Robota CLI, TUI, browser UI, or public SDK/example usage.
+  user execution test scenario gate instead of exercising the implemented code.
+- A user execution test scenario asks the user to run tests, harness commands, CI checks, or source
+  inspection instead of executing the product behavior.
+- A user execution test scenario uses internal repository verification instead of a product surface
+  such as Robota CLI, TUI, browser UI, or public SDK/example usage.
 - A documentation-only, rule-only, skill-only, backlog-only, or governance-only change presents
-  document inspection as a user test scenario.
-- The required user scenario test environment is missing and was not built, proposed, or decided
-  with the user.
-- The user test scenario gate was not executed when it could reasonably be executed by the agent.
-- The user test scenario gate has no captured evidence.
-- The backlog was not updated with the observed user scenario evidence after execution.
-- The user test scenario gate fails or cannot be mapped to the completed behavior.
+  document inspection as a user execution test scenario.
+- The required test environment for the user execution test scenario is missing and was not built,
+  proposed, or decided with the user.
+- The user execution test scenario gate was not executed when it could reasonably be executed by the
+  agent.
+- The user execution test scenario gate has no captured evidence.
+- The backlog was not updated with the observed user execution test scenario evidence after execution.
+- The user execution test scenario gate fails or cannot be mapped to the completed behavior.
 - The recommendation conflicts with rules, ownership, architecture, or backlog intent.
 - The work combines unrelated backlogs in one PR.
 - A child branch targets `develop` instead of the initiative base branch during a multi-backlog
   initiative.
 - The final initiative PR would be auto-merged into `develop`.
-- The final user handoff presents engineering or governance verification as a user test scenario.
+- The final user handoff presents engineering or governance verification as a user execution test scenario.
 - This skill would need to duplicate detailed instructions already owned by another skill.

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -7,17 +7,17 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Process & Planning
 
-| Skill                                                                     | Description                                                      |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries  |
-| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring        |
-| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes     |
-| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                      |
-| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                 |
-| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Recommendation-gated backlog PR pipeline with user scenario gate |
-| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work         |
-| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize        |
-| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages    |
+| Skill                                                                     | Description                                                                     |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries                 |
+| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring                       |
+| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes                    |
+| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                                     |
+| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                                |
+| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Recommendation-gated backlog PR pipeline with user execution test scenario gate |
+| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work                        |
+| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize                       |
+| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages                   |
 
 ## Code Quality & Architecture
 

--- a/scripts/harness/scan-consistency.mjs
+++ b/scripts/harness/scan-consistency.mjs
@@ -15,6 +15,12 @@ const WORKSPACE_ROOT = process.cwd();
 const AGENTS_PATH = path.join(WORKSPACE_ROOT, 'AGENTS.md');
 const ROOT_PACKAGE_JSON_PATH = path.join(WORKSPACE_ROOT, 'package.json');
 const SKILLS_ROOT = path.join(WORKSPACE_ROOT, '.agents', 'skills');
+const GUIDANCE_PHRASE_SCAN_TARGETS = [
+  'AGENTS.md',
+  '.agents/rules',
+  '.agents/skills',
+  '.agents/backlog',
+];
 
 const PHRASE_CHECKS = [
   {
@@ -42,6 +48,32 @@ const PHRASE_CHECKS = [
     id: 'unchecked-example-cast',
     pattern: /obj as ITaskRunPayload/,
     message: 'Boundary examples must not teach unchecked casts into owned payload types.',
+  },
+];
+
+const USER_WORD = 'user';
+const EXECUTION_WORD = 'execution';
+const TEST_WORD = 'test';
+const SCENARIO_WORD = 'scenario';
+
+const GUIDANCE_PHRASE_CHECKS = [
+  {
+    id: 'legacy-user-test-scenario-term',
+    pattern: new RegExp(`\\b${USER_WORD}\\s+${TEST_WORD}\\s+${SCENARIO_WORD}s?\\b`, 'i'),
+    message: 'Use "user execution test scenario" for user-runnable product verification.',
+  },
+  {
+    id: 'legacy-user-scenario-term',
+    pattern: new RegExp(
+      `\\b${USER_WORD}\\s+${SCENARIO_WORD}(?:s| gates?| evidence| surface| test environment)?\\b`,
+      'i',
+    ),
+    message: 'Use canonical user execution test scenario terminology instead of legacy shorthand.',
+  },
+  {
+    id: 'incomplete-user-execution-scenario-term',
+    pattern: new RegExp(`\\b${USER_WORD}\\s+${EXECUTION_WORD}\\s+${SCENARIO_WORD}s?\\b`, 'i'),
+    message: 'Use "user execution test scenario"; do not omit "test" from the term.',
   },
 ];
 
@@ -90,6 +122,38 @@ async function listSkillFiles() {
   return skillFiles.sort();
 }
 
+async function listMarkdownFilesRecursive(targetPath) {
+  const absPath = path.join(WORKSPACE_ROOT, targetPath);
+  if (!(await pathExists(absPath))) {
+    return [];
+  }
+
+  const stat = await fs.stat(absPath);
+  if (stat.isFile()) {
+    return targetPath.endsWith('.md') ? [absPath] : [];
+  }
+
+  if (!stat.isDirectory()) {
+    return [];
+  }
+
+  const entries = await fs.readdir(absPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const childTarget = path.join(targetPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFilesRecursive(childTarget)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(path.join(WORKSPACE_ROOT, childTarget));
+    }
+  }
+
+  return files.sort();
+}
+
 function relativePath(targetPath) {
   return path.relative(WORKSPACE_ROOT, targetPath);
 }
@@ -115,6 +179,13 @@ async function main() {
     // rules directory missing — skip
   }
   const skillFiles = await listSkillFiles();
+  const guidanceFiles = (
+    await Promise.all(
+      GUIDANCE_PHRASE_SCAN_TARGETS.map((target) => listMarkdownFilesRecursive(target)),
+    )
+  )
+    .flat()
+    .sort();
   const rootPackageJson = await readJson(ROOT_PACKAGE_JSON_PATH);
   const rootScripts =
     typeof rootPackageJson.scripts === 'object' && rootPackageJson.scripts !== null
@@ -172,6 +243,25 @@ async function main() {
         }
         findings.push({
           file: relativePath(skillFile),
+          type: check.id,
+          detail: check.message,
+        });
+        break;
+      }
+    }
+  }
+
+  for (const guidanceFile of guidanceFiles) {
+    const content = await fs.readFile(guidanceFile, 'utf8');
+    const lines = content.split(/\r?\n/);
+
+    for (const check of GUIDANCE_PHRASE_CHECKS) {
+      for (const line of lines) {
+        if (!check.pattern.test(line)) {
+          continue;
+        }
+        findings.push({
+          file: relativePath(guidanceFile),
           type: check.id,
           detail: check.message,
         });


### PR DESCRIPTION
## Recommendation
Adopt the new canonical term `User Execution Test Scenario` across backlog rules, backlog authoring guidance, and the backlog execution orchestrator. This matches the requested distinction: the user should receive a concrete product execution scenario they can personally run and observe, not the agent's test commands, test code, CI, harness checks, or document inspection.

## Rationale
- Preserves repository layering because this is governance/process guidance only; no package behavior or product runtime ownership changes.
- Keeps the orchestrator skill thin: it enforces the gate and PR reporting, while engineering tests remain owned by testing/package workflows.
- Adds a mechanical consistency scan so legacy shorthand cannot silently re-enter AGENTS/rules/skills/backlog guidance.

## Implementation
- Renamed rule, skill, backlog README, and existing backlog sections to `User Execution Test Scenarios`.
- Clarified that these scenarios use product surfaces: CLI/TUI/browser/public SDK/example execution.
- Clarified that tests, harness commands, CI, source inspection, and document review belong to engineering verification, not user execution scenarios.
- Extended `scripts/harness/scan-consistency.mjs` to reject legacy scenario terminology in guidance docs.

## Verification
- `git diff --check`
- `rg -n "User Test|user test|User Scenario|user scenario|user execution scenario|User execution scenario|User Execution Scenario|test scenario test environment" .agents/rules .agents/skills .agents/backlog AGENTS.md scripts` returned no matches
- `pnpm exec vitest run scripts/harness/__tests__/harness-smoke.test.mjs`
- `pnpm harness:scan`
- pre-push scoped verification passed, including `pnpm harness:scan:consistency`, `pnpm harness:scan:test-plans`, and 106 harness tests

## User Execution Test Scenario Gate
Not applicable. This PR changes governance docs and harness consistency checks only. It does not deliver runnable Robota product behavior, so presenting a product execution scenario would be artificial.

## Residual Risk
Low. Existing completed backlog filenames still contain historical slugs with `user-scenario`, but file contents and live guidance use the canonical term. The mechanical scan checks content, not historical path names.