### PR TITLE
feat(user-local): add storage inspection command

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -52,5 +52,4 @@ the backlog, the user execution test scenario gate does not pass.
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Storage Inspection Implementation](user-local-storage-inspection-implementation.md)
 - [User-Local Memory Inspection Implementation](user-local-memory-inspection-implementation.md)

--- a/.agents/backlog/completed/user-local-storage-inspection-implementation.md
+++ b/.agents/backlog/completed/user-local-storage-inspection-implementation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -19,7 +19,7 @@ Implement the user-local storage foundation defined by
 root, categories, and stored item summaries through a Robota product surface.
 
 This backlog implements the follow-up work deferred by
-[User-Local Storage Foundation](completed/cli-user-local-storage-foundation.md).
+[User-Local Storage Foundation](cli-user-local-storage-foundation.md).
 
 ## Recommendation Gate
 
@@ -57,16 +57,16 @@ Open decisions:
 
 ## Acceptance Criteria
 
-- [ ] SDK resolves the effective user-local root under the user's home directory by default.
-- [ ] SDK rejects a baseline workflow storage root inside the active repository.
-- [ ] SDK exposes stable category projections for `preferences`, `view-state`,
+- [x] SDK resolves the effective user-local root under the user's home directory by default.
+- [x] SDK rejects a baseline workflow storage root inside the active repository.
+- [x] SDK exposes stable category projections for `preferences`, `view-state`,
       `memory-projections`, `task-associations`, `workflow-metadata`, and `inspection-index`.
-- [ ] Product command `robota user-local storage list --format json` prints the effective root and
+- [x] Product command `robota user-local storage list --format json` prints the effective root and
       category summaries without requiring provider configuration.
-- [ ] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
+- [x] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
       state in the active repository.
-- [ ] Stored command strings are not exposed as reusable execution preferences.
-- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
+- [x] Stored command strings are not exposed as reusable execution preferences.
+- [x] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -121,8 +121,28 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation using the commands above.
-- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
-  command output and repository `find` result are recorded here.
+- Evidence:
+  - Executed after implementation from `/Users/jungyoun/Documents/dev/robota`.
+  - Build command: `pnpm --filter @robota-sdk/agent-cli build` exited 0 after package builds for
+    `@robota-sdk/agent-sdk` and `@robota-sdk/agent-command-user-local`.
+  - Product command exited 0 and printed JSON with:
+    - `root:
+"/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.Kp2lGxRyLa/.robota"`
+    - `activeRepositoryRoot:
+"/private/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.CZ0kZpeuex"`
+    - categories: `preferences`, `view-state`, `memory-projections`, `task-associations`,
+      `workflow-metadata`, and `inspection-index`
+    - every category reported `mayExecuteCommands: false`, `itemCount: 0`, and `items: []`
+  - Repository-state command:
+
+    ```bash
+    find "$FIXTURE_REPO" -maxdepth 2 -name ".robota" -o -name "robota*"
+    ```
+
+    printed no output, confirming no project `.robota` or Robota baseline workflow state was
+    created inside the fixture repository.
+
+  - Cleanup executed with `rm -rf "$TMP_HOME" "$FIXTURE_REPO"`.
 
 ## Implementation Notes
 
@@ -130,3 +150,8 @@ Open decisions:
   SDK/command-owned code.
 - If implementation chooses a different final product command, update this backlog before coding and
   keep the scenario equally runnable by the user.
+
+## Result
+
+Implemented with SDK-owned user-local storage projection APIs, a provider-free
+`@robota-sdk/agent-command-user-local` command owner, and thin `agent-cli` direct command routing.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -10,7 +10,7 @@ packages/
 ├── agent-tools/                 # Tool implementations: FunctionTool, built-ins, schema helpers, sandbox ports/manifests
 ├── agent-tool-mcp/              # MCP tool implementations
 ├── agent-sdk/                   # SDK assembly layer: InteractiveSession, command contracts/common APIs
-├── agent-command-*/             # Command modules: agent, background, compact, context, exit, help, language, memory, mode, model, permissions, plugin, provider, reset, rewind, session, skills, statusline
+├── agent-command-*/             # Command modules: agent, background, compact, context, exit, help, language, memory, mode, model, permissions, plugin, provider, reset, rewind, session, skills, statusline, user-local
 ├── agent-cli/                   # Terminal UI and local runtime adapters
 ├── agent-event-service/         # Compatibility re-export package for event service APIs
 ├── agent-provider-*/            # Provider packages: anthropic, openai, openai-compatible, deepseek, gemma, qwen, gemini, google, bytedance

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -12,8 +12,8 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 ## Plan
 
-- [ ] Create initiative base branch from `develop`.
-- [ ] Implement user-local storage inspection in one child PR.
+- [x] Create initiative base branch from `develop`.
+- [x] Implement user-local storage inspection in one child PR.
 - [ ] Implement user-local memory inspection in one child PR.
 - [ ] Complete the planning umbrella backlog after implementation evidence exists.
 - [ ] Merge the initiative into `develop`.
@@ -24,6 +24,9 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 - Created initiative base branch `feat/user-local-inspection-initiative` from `develop`.
 - Confirmed active backlog items and implementation order.
+- Implemented user-local storage inspection on `feat/user-local-storage-inspection`.
+- Verified the storage User Execution Test Scenario with the built CLI and recorded evidence in the
+  completed backlog.
 
 ## Decisions
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -28,6 +28,9 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
   contracts described in the cross-cutting transparent workflow spec
 - Does NOT own baseline workflow storage root resolution, repo-outside validation, category
   contracts, or item deletion/disable semantics — these are owned by SDK storage contracts
+- Does NOT own user-local command behavior — `@robota-sdk/agent-command-user-local` owns the
+  provider-free `user-local` command behavior while CLI only routes direct product invocation and
+  prints command-owned output
 - Does NOT own workflow manifests, harness command registry semantics, workflow artifact schemas,
   deterministic workflow hook policy, review/evidence gates, or workflow run lifecycle — these must
   be owned below the CLI by SDK/runtime/harness contracts before TUI screens are added
@@ -91,6 +94,11 @@ Existing CLI-owned operational cache such as `~/.robota/update-check.json` remai
 not baseline workflow state. Existing project-local sessions, logs, checkpoints, and memory are
 classified by the storage spec and must not be reused for new baseline workflow features without a
 separate migration PR.
+
+The direct product command `robota user-local storage list --format json` is provider-free. The CLI
+detects the `user-local` positional command before provider setup, delegates parsing and output
+formatting to `@robota-sdk/agent-command-user-local`, and exits without constructing an AI provider
+or opening the TUI.
 
 ### Transparent Process Execution Boundary
 

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -67,6 +67,7 @@
     "@robota-sdk/agent-command-session": "workspace:*",
     "@robota-sdk/agent-command-skills": "workspace:*",
     "@robota-sdk/agent-command-statusline": "workspace:*",
+    "@robota-sdk/agent-command-user-local": "workspace:*",
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-provider-anthropic": "workspace:*",
     "@robota-sdk/agent-provider-deepseek": "workspace:*",

--- a/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   IAIProvider,
   IChatOptions,
@@ -11,7 +11,7 @@ import type {
 } from '@robota-sdk/agent-core';
 import { CommandRegistry, InteractiveSession } from '@robota-sdk/agent-sdk';
 import { createHeadlessTransport } from '@robota-sdk/agent-transport-headless';
-import { createDefaultCliCommandModules } from '../cli.js';
+import { createDefaultCliCommandModules, startCli } from '../cli.js';
 
 function createFakeProvider(): IAIProvider {
   return {
@@ -57,12 +57,70 @@ describe('default CLI command composition', () => {
     }
 
     expect(registry.getCommands().map((command) => command.name)).not.toContain('mode');
+    expect(registry.getCommands().map((command) => command.name)).toContain('user-local');
     expect(registry.getSubcommands('permissions').map((command) => command.name)).toEqual([
       'plan',
       'default',
       'acceptEdits',
       'bypassPermissions',
     ]);
+  });
+
+  it('routes direct user-local storage inspection before provider setup', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-'));
+    const home = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-home-'));
+    const originalArgv = process.argv;
+    const originalHome = process.env.HOME;
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.argv = ['node', 'robota', 'user-local', 'storage', 'list', '--format', 'json'];
+    process.env.HOME = home;
+    process.stdout.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await startCli({ providerDefinitions: [] });
+      const output = parseJsonObject(writes.join('').trim());
+      expect(output['root']).toBe(join(home, '.robota'));
+      const categories = output['categories'];
+      expect(Array.isArray(categories)).toBe(true);
+      if (!Array.isArray(categories)) {
+        throw new Error('Expected categories array');
+      }
+      const categoryNames = categories.map((item) => {
+        if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+          throw new Error('Expected category object');
+        }
+        const category = (item as Record<string, unknown>)['category'];
+        if (typeof category !== 'string') {
+          throw new Error('Expected category string');
+        }
+        return category;
+      });
+      expect(categoryNames).toEqual([
+        'preferences',
+        'view-state',
+        'memory-projections',
+        'task-associations',
+        'workflow-metadata',
+        'inspection-index',
+      ]);
+      expect(existsSync(join(cwd, '.robota'))).toBe(false);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.argv = originalArgv;
+      cwdSpy.mockRestore();
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('runs permissions mode changes through headless slash-command execution', async () => {

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -26,6 +26,7 @@ import { createRewindCommandModule } from '@robota-sdk/agent-command-rewind';
 import { createStatusLineCommandModule } from '@robota-sdk/agent-command-statusline';
 import { createSessionCommandModule } from '@robota-sdk/agent-command-session';
 import { createSkillsCommandModule } from '@robota-sdk/agent-command-skills';
+import { createUserLocalCommandModule } from '@robota-sdk/agent-command-user-local';
 import {
   InteractiveSession,
   createProjectSessionStore,
@@ -68,6 +69,7 @@ import {
   shouldRunStartupCliUpdateCheck,
 } from './utils/update-check.js';
 import { createCliPluginCommandAdapter } from './plugins/plugin-command-adapter.js';
+import { runUserLocalDirectCommandIfRequested } from './user-local-direct-command.js';
 
 /** Read version from package.json at runtime. */
 function readVersion(): string {
@@ -180,6 +182,7 @@ export function createDefaultCliCommandModules({
     createLanguageCommandModule(),
     createBackgroundCommandModule(),
     createMemoryCommandModule(),
+    createUserLocalCommandModule(),
     createCompactCommandModule(),
     createContextCommandModule(),
     createExitCommandModule(),
@@ -227,6 +230,11 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   const cwd = process.cwd();
+
+  if (await runUserLocalDirectCommandIfRequested(args, cwd)) {
+    return;
+  }
+
   const commandHostAdapters: ICommandHostAdapters = {
     settings: {
       read: () => readSettings(getUserSettingsPath()),

--- a/packages/agent-cli/src/user-local-direct-command.ts
+++ b/packages/agent-cli/src/user-local-direct-command.ts
@@ -1,0 +1,24 @@
+import { executeUserLocalDirectCommand } from '@robota-sdk/agent-command-user-local';
+import type { IParsedCliArgs } from './utils/cli-args.js';
+
+export async function runUserLocalDirectCommandIfRequested(
+  args: IParsedCliArgs,
+  cwd: string,
+): Promise<boolean> {
+  if (args.positional[0] !== 'user-local') {
+    return false;
+  }
+
+  const result = await executeUserLocalDirectCommand({
+    cwd,
+    argv: args.positional.slice(1),
+    format: args.format,
+  });
+  const output = result.message.endsWith('\n') ? result.message : `${result.message}\n`;
+  if (!result.success) {
+    process.stderr.write(output);
+    process.exit(1);
+  }
+  process.stdout.write(output);
+  return true;
+}

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -125,6 +125,7 @@ function baseArgs(): IParsedCliArgs {
     forkSession: false,
     sessionName: undefined,
     outputFormat: undefined,
+    format: undefined,
     systemPrompt: undefined,
     appendSystemPrompt: undefined,
     taskFile: undefined,

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -20,6 +20,7 @@ export interface IParsedCliArgs {
   forkSession: boolean;
   sessionName: string | undefined;
   outputFormat: string | undefined;
+  format: string | undefined;
   systemPrompt: string | undefined;
   appendSystemPrompt: string | undefined;
   taskFile: string | undefined;
@@ -78,6 +79,7 @@ export function parseCliArgs(): IParsedCliArgs {
       'fork-session': { type: 'boolean', default: false },
       name: { type: 'string', short: 'n' },
       'output-format': { type: 'string' },
+      format: { type: 'string' },
       'system-prompt': { type: 'string' },
       'append-system-prompt': { type: 'string' },
       'task-file': { type: 'string' },
@@ -113,6 +115,7 @@ export function parseCliArgs(): IParsedCliArgs {
     forkSession: values['fork-session'] ?? false,
     sessionName: values['name'],
     outputFormat: values['output-format'],
+    format: values['format'],
     systemPrompt: values['system-prompt'],
     appendSystemPrompt: values['append-system-prompt'],
     taskFile: values['task-file'],

--- a/packages/agent-command-user-local/docs/README.md
+++ b/packages/agent-command-user-local/docs/README.md
@@ -1,0 +1,3 @@
+# @robota-sdk/agent-command-user-local Docs
+
+See [SPEC.md](SPEC.md).

--- a/packages/agent-command-user-local/docs/SPEC.md
+++ b/packages/agent-command-user-local/docs/SPEC.md
@@ -1,0 +1,57 @@
+# SPEC.md - @robota-sdk/agent-command-user-local
+
+## Purpose
+
+`@robota-sdk/agent-command-user-local` owns provider-free `user-local` command behavior for
+inspecting Robota user-local state through SDK-owned contracts.
+
+## Ownership
+
+- Owns `user-local` command metadata, argument parsing, output formatting, and provider-free direct
+  CLI command execution helpers.
+- Consumes user-local storage and memory APIs from `@robota-sdk/agent-sdk`.
+- Does not resolve storage roots, validate repo-outside paths, persist user-local items, read
+  provider configuration, or render TUI screens.
+
+## Public API
+
+```ts
+import {
+  createUserLocalCommandModule,
+  executeUserLocalDirectCommand,
+} from '@robota-sdk/agent-command-user-local';
+```
+
+## Command Contract
+
+- Command name: `user-local`
+- Source: `user-local`
+- User invocable: yes
+- Model invocable: no
+- Safety: `read-only` for storage inspection
+- Argument hint: `storage list [--format json]`
+
+## Behavior
+
+- `user-local storage list --format json` prints the effective user-local root and stable category
+  summaries using SDK projections.
+- Storage inspection is provider-free and must run before provider setup is required.
+- The command must not create or reuse repository-local `.robota/` baseline workflow state.
+- The command must not expose stored command strings as reusable execution preferences.
+
+## Boundary Rules
+
+- This package must not import `agent-cli` or TUI code.
+- This package must not inspect or assemble storage paths directly; it calls SDK user-local APIs.
+- CLI direct invocation may call this package's direct execution helper before provider setup.
+- Future memory inspection/delete/disable behavior must stay in this package while persistence
+  semantics remain in SDK user-local APIs.
+
+## Verification
+
+```bash
+pnpm --filter @robota-sdk/agent-command-user-local build
+pnpm --filter @robota-sdk/agent-command-user-local test
+pnpm --filter @robota-sdk/agent-command-user-local typecheck
+pnpm --filter @robota-sdk/agent-command-user-local lint
+```

--- a/packages/agent-command-user-local/package.json
+++ b/packages/agent-command-user-local/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@robota-sdk/agent-command-user-local",
+  "version": "3.0.0-beta.61",
+  "description": "Composable user-local inspection command module for Robota",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/woojubb/robota.git",
+    "directory": "packages/agent-command-user-local"
+  },
+  "homepage": "https://robota.io/",
+  "bugs": {
+    "url": "https://github.com/woojubb/robota/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
+    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/ --ext .ts",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
+++ b/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeUserLocalDirectCommand } from '../user-local-command.js';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local command', () => {
+  it('prints storage inspection JSON without provider configuration', async () => {
+    const workspace = await createTempRoot('robota-user-local-command-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const result = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['storage', 'list'],
+        format: 'json',
+      });
+      const parsed = JSON.parse(result.message) as {
+        root: string;
+        categories: readonly { category: string; mayExecuteCommands: boolean }[];
+      };
+
+      expect(result.success).toBe(true);
+      expect(parsed.root).toBe(path.join(home, '.robota'));
+      expect(parsed.categories.map((item) => item.category)).toEqual([
+        'preferences',
+        'view-state',
+        'memory-projections',
+        'task-associations',
+        'workflow-metadata',
+        'inspection-index',
+      ]);
+      expect(parsed.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+});

--- a/packages/agent-command-user-local/src/index.ts
+++ b/packages/agent-command-user-local/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  UserLocalCommandSource,
+  createUserLocalCommandEntry,
+  createUserLocalCommandModule,
+} from './user-local-command-module.js';
+export {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  USER_LOCAL_COMMAND_USAGE,
+  executeUserLocalCommand,
+  executeUserLocalDirectCommand,
+} from './user-local-command.js';
+export type { IUserLocalDirectCommandOptions } from './user-local-command.js';

--- a/packages/agent-command-user-local/src/user-local-command-module.ts
+++ b/packages/agent-command-user-local/src/user-local-command-module.ts
@@ -1,0 +1,59 @@
+import type {
+  ICommand,
+  ICommandModule,
+  ICommandSource,
+  ISystemCommand,
+} from '@robota-sdk/agent-sdk';
+import {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  executeUserLocalCommand,
+} from './user-local-command.js';
+
+export function createUserLocalCommandEntry(): ICommand {
+  return {
+    name: 'user-local',
+    description: USER_LOCAL_COMMAND_DESCRIPTION,
+    source: 'user-local',
+    argumentHint: USER_LOCAL_COMMAND_ARGUMENT_HINT,
+    modelInvocable: false,
+    safety: 'read-only',
+    subcommands: [
+      {
+        name: 'storage',
+        description: 'Inspect user-local storage categories',
+        source: 'user-local',
+      },
+    ],
+  };
+}
+
+function createUserLocalSystemCommand(): ISystemCommand {
+  const entry = createUserLocalCommandEntry();
+  return {
+    name: entry.name,
+    description: entry.description,
+    userInvocable: true,
+    modelInvocable: false,
+    argumentHint: entry.argumentHint,
+    safety: entry.safety,
+    subcommands: entry.subcommands,
+    execute: executeUserLocalCommand,
+  };
+}
+
+export class UserLocalCommandSource implements ICommandSource {
+  readonly name = 'user-local';
+
+  getCommands(): ICommand[] {
+    return [createUserLocalCommandEntry()];
+  }
+}
+
+export function createUserLocalCommandModule(): ICommandModule {
+  return {
+    name: 'agent-command-user-local',
+    commandSources: [new UserLocalCommandSource()],
+    systemCommands: [createUserLocalSystemCommand()],
+  };
+}

--- a/packages/agent-command-user-local/src/user-local-command.ts
+++ b/packages/agent-command-user-local/src/user-local-command.ts
@@ -1,0 +1,136 @@
+import type { ICommandHostContext, ICommandResult } from '@robota-sdk/agent-sdk';
+import { inspectUserLocalStorage } from '@robota-sdk/agent-sdk';
+
+export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
+export const USER_LOCAL_COMMAND_ARGUMENT_HINT = 'storage list [--format json]';
+export const USER_LOCAL_COMMAND_USAGE = 'Usage: user-local storage list [--format json]';
+
+type TUserLocalOutputFormat = 'text' | 'json';
+
+export interface IUserLocalDirectCommandOptions {
+  readonly cwd: string;
+  readonly argv: readonly string[];
+  readonly format?: string;
+}
+
+interface IParsedUserLocalCommand {
+  readonly target?: string;
+  readonly action?: string;
+  readonly format: TUserLocalOutputFormat;
+}
+
+function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
+  if (value === undefined || value === 'text') {
+    return 'text';
+  }
+  if (value === 'json') {
+    return 'json';
+  }
+  throw new Error(`Unsupported user-local output format: ${value}`);
+}
+
+function parseUserLocalArgs(
+  argv: readonly string[],
+  directFormat?: string,
+): IParsedUserLocalCommand {
+  let format = directFormat;
+  const positional: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--format') {
+      format = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--format=')) {
+      format = arg.slice('--format='.length);
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  return {
+    target: positional[0],
+    action: positional[1],
+    format: parseOutputFormat(format),
+  };
+}
+
+function splitRawArgs(rawArgs: string): readonly string[] {
+  return rawArgs.trim().split(/\s+/).filter(Boolean);
+}
+
+function formatStorageInspectionText(
+  root: string,
+  categories: readonly { category: string }[],
+): string {
+  const categoryLines = categories.map((item) => `- ${item.category}`);
+  return [`User-local storage root: ${root}`, 'Categories:', ...categoryLines].join('\n');
+}
+
+async function executeParsedUserLocalCommand(
+  cwd: string,
+  parsed: IParsedUserLocalCommand,
+): Promise<ICommandResult> {
+  if (parsed.target !== 'storage' || (parsed.action ?? 'list') !== 'list') {
+    return {
+      message: USER_LOCAL_COMMAND_USAGE,
+      success: false,
+    };
+  }
+
+  try {
+    const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
+    return {
+      message:
+        parsed.format === 'json'
+          ? JSON.stringify(inspection, null, 2)
+          : formatStorageInspectionText(inspection.root, inspection.categories),
+      success: true,
+      data: {
+        root: inspection.root,
+        categories: inspection.categories,
+        inspection,
+      },
+    };
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+export async function executeUserLocalDirectCommand(
+  options: IUserLocalDirectCommandOptions,
+): Promise<ICommandResult> {
+  try {
+    return await executeParsedUserLocalCommand(
+      options.cwd,
+      parseUserLocalArgs(options.argv, options.format),
+    );
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+export async function executeUserLocalCommand(
+  context: ICommandHostContext,
+  rawArgs: string,
+): Promise<ICommandResult> {
+  try {
+    return await executeParsedUserLocalCommand(
+      context.getCwd(),
+      parseUserLocalArgs(splitRawArgs(rawArgs)),
+    );
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}

--- a/packages/agent-command-user-local/tsconfig.json
+++ b/packages/agent-command-user-local/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -155,6 +155,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── prompt-file-reference-*.ts ← `@file` prompt reference parser/resolver, path policy, formatting, and diagnostics
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
 ├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
+├── src/user-local/             ← user-local storage root validation, category projections, and future baseline memory persistence
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/self-hosting/           ← self-hosting verification planner + lifecycle state machine
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
@@ -543,6 +544,24 @@ Resolved provider fields:
   User-local display/navigation preferences are governed by
   [../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md) and
   must not be stored in `.robota/memory/`.
+
+### User-Local Storage
+
+- **Package**: `agent-sdk/user-local/`
+- **Purpose**: Resolve and inspect baseline workflow storage under user-local storage outside the
+  active repository.
+- **Default root**: `~/.robota`.
+- **Validation**: SDK APIs reject empty roots, relative roots, roots equal to the active repository,
+  and roots inside the active repository, including symlink-resolved paths when possible.
+- **Categories**: `preferences`, `view-state`, `memory-projections`, `task-associations`,
+  `workflow-metadata`, and `inspection-index`.
+- **Inspection projection**: SDK returns root, active repository root, category summaries, item
+  summaries, storage locations, enabled/delete/disable metadata, and timestamps when available.
+- **Command boundary**: `@robota-sdk/agent-command-user-local` formats provider-free
+  `user-local storage list --format json` output from SDK projections. `agent-cli` only routes the
+  direct product command before provider setup and prints the command-owned output.
+- **Repository independence**: SDK user-local APIs must not create repository `.robota/` baseline
+  workflow state.
 
 ### Context Window Management
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -256,6 +256,23 @@ export type {
   TPromptInput,
 } from './commands/index.js';
 
+// ── User-local storage ─────────────────────────────────────
+export {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from './user-local/index.js';
+export type {
+  IInspectUserLocalStorageOptions,
+  IResolveUserLocalStorageRootOptions,
+  IUserLocalStorageCategoryDefinition,
+  IUserLocalStorageCategoryProjection,
+  IUserLocalStorageInspection,
+  IUserLocalStorageItemSummary,
+  TUserLocalStorageCategory,
+} from './user-local/index.js';
+
 // ── Skill prompt utilities ───────────────────────────────────
 export { substituteVariables, preprocessShellCommands } from './utils/skill-prompt.js';
 export type { SkillPromptContext } from './utils/skill-prompt.js';

--- a/packages/agent-sdk/src/user-local/__tests__/storage.test.ts
+++ b/packages/agent-sdk/src/user-local/__tests__/storage.test.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from '../storage.js';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local storage', () => {
+  it('resolves the default root under injected user home outside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-default-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+
+    const root = await resolveUserLocalStorageRoot({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+    });
+
+    expect(root).toBe(path.join(home, '.robota'));
+  });
+
+  it('rejects storage roots inside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-reject-');
+    const repo = path.join(workspace, 'repo');
+    await fs.mkdir(repo);
+
+    await expect(
+      resolveUserLocalStorageRoot({
+        activeRepositoryRoot: repo,
+        storageRoot: path.join(repo, '.robota'),
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+
+  it('rejects symlinked roots that resolve inside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-symlink-');
+    const repo = path.join(workspace, 'repo');
+    const target = path.join(repo, '.robota');
+    const link = path.join(workspace, 'linked-root');
+    await fs.mkdir(target, { recursive: true });
+    await fs.symlink(target, link);
+
+    await expect(
+      resolveUserLocalStorageRoot({
+        activeRepositoryRoot: repo,
+        storageRoot: link,
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+
+  it('projects stable categories without writing repository-local state', async () => {
+    const workspace = await createTempRoot('robota-user-local-inspect-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+
+    const inspection = await inspectUserLocalStorage({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      now: () => new Date('2026-05-09T00:00:00.000Z'),
+    });
+
+    expect(inspection).toMatchObject({
+      root: path.join(home, '.robota'),
+      activeRepositoryRoot: repo,
+      generatedAt: '2026-05-09T00:00:00.000Z',
+    });
+    expect(inspection.categories.map((item) => item.category)).toEqual([
+      ...USER_LOCAL_STORAGE_CATEGORIES,
+    ]);
+    expect(inspection.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
+    expect(inspection.categories.every((item) => item.itemCount === 0)).toBe(true);
+    expect(await pathExists(path.join(repo, '.robota'))).toBe(false);
+  });
+});

--- a/packages/agent-sdk/src/user-local/index.ts
+++ b/packages/agent-sdk/src/user-local/index.ts
@@ -1,0 +1,15 @@
+export {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from './storage.js';
+export type {
+  IInspectUserLocalStorageOptions,
+  IResolveUserLocalStorageRootOptions,
+  IUserLocalStorageCategoryDefinition,
+  IUserLocalStorageCategoryProjection,
+  IUserLocalStorageInspection,
+  IUserLocalStorageItemSummary,
+  TUserLocalStorageCategory,
+} from './storage.js';

--- a/packages/agent-sdk/src/user-local/storage.ts
+++ b/packages/agent-sdk/src/user-local/storage.ts
@@ -1,0 +1,245 @@
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+export const USER_LOCAL_STORAGE_CATEGORIES = [
+  'preferences',
+  'view-state',
+  'memory-projections',
+  'task-associations',
+  'workflow-metadata',
+  'inspection-index',
+] as const;
+
+export type TUserLocalStorageCategory = (typeof USER_LOCAL_STORAGE_CATEGORIES)[number];
+
+export interface IUserLocalStorageCategoryDefinition {
+  readonly category: TUserLocalStorageCategory;
+  readonly purpose: string;
+  readonly mayExecuteCommands: false;
+}
+
+export interface IUserLocalStorageItemSummary {
+  readonly root: string;
+  readonly category: TUserLocalStorageCategory;
+  readonly key: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly storageLocation: string;
+  readonly createdAt?: string;
+  readonly lastUsedAt?: string;
+  readonly enabled: boolean;
+  readonly deleteAvailable: boolean;
+  readonly disableAvailable: boolean;
+}
+
+export interface IUserLocalStorageCategoryProjection {
+  readonly category: TUserLocalStorageCategory;
+  readonly purpose: string;
+  readonly mayExecuteCommands: false;
+  readonly storageLocation: string;
+  readonly itemCount: number;
+  readonly items: readonly IUserLocalStorageItemSummary[];
+}
+
+export interface IUserLocalStorageInspection {
+  readonly root: string;
+  readonly activeRepositoryRoot: string;
+  readonly categories: readonly IUserLocalStorageCategoryProjection[];
+  readonly generatedAt: string;
+}
+
+export interface IResolveUserLocalStorageRootOptions {
+  readonly activeRepositoryRoot: string;
+  readonly homeDir?: string;
+  readonly storageRoot?: string;
+}
+
+export interface IInspectUserLocalStorageOptions extends IResolveUserLocalStorageRootOptions {
+  readonly now?: () => Date;
+  readonly createDirectories?: boolean;
+}
+
+export const USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS: readonly IUserLocalStorageCategoryDefinition[] =
+  [
+    {
+      category: 'preferences',
+      purpose: 'User-local UI and display preferences.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'view-state',
+      purpose: 'Last selected panels, filters, and navigation state.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'memory-projections',
+      purpose: 'Inspectable local memory item projections and user choices.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'task-associations',
+      purpose: 'User-local associations between sessions, tasks, and background items.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'workflow-metadata',
+      purpose: 'Transparent workflow metadata that is not repo-owned.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'inspection-index',
+      purpose: 'Category and item summaries for user inspection and deletion.',
+      mayExecuteCommands: false,
+    },
+  ];
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString();
+}
+
+function assertAbsolutePath(name: string, value: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (!path.isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path: ${value}`);
+  }
+}
+
+function resolveDefaultHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
+function isEqualOrInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function resolveForComparison(absPath: string): Promise<string> {
+  let current = absPath;
+
+  while (path.dirname(current) !== current) {
+    try {
+      const realCurrent = await fs.realpath(current);
+      const relativeMissingPath = path.relative(current, absPath);
+      return path.resolve(realCurrent, relativeMissingPath);
+    } catch {
+      current = path.dirname(current);
+    }
+  }
+
+  try {
+    return await fs.realpath(current);
+  } catch {
+    return path.resolve(absPath);
+  }
+}
+
+export async function resolveUserLocalStorageRoot(
+  options: IResolveUserLocalStorageRootOptions,
+): Promise<string> {
+  const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
+  assertAbsolutePath('activeRepositoryRoot', activeRepositoryRoot);
+
+  const candidateRoot =
+    options.storageRoot !== undefined
+      ? options.storageRoot
+      : path.join(options.homeDir ?? resolveDefaultHomeDir(), '.robota');
+
+  assertAbsolutePath('userLocalStorageRoot', candidateRoot);
+
+  const resolvedRoot = path.resolve(candidateRoot);
+  const comparableRoot = await resolveForComparison(resolvedRoot);
+  const comparableRepositoryRoot = await resolveForComparison(activeRepositoryRoot);
+
+  if (isEqualOrInside(comparableRepositoryRoot, comparableRoot)) {
+    throw new Error(
+      `User-local storage root must be outside the active repository: ${resolvedRoot}`,
+    );
+  }
+
+  return resolvedRoot;
+}
+
+function resolveCategoryLocation(root: string, category: TUserLocalStorageCategory): string {
+  return path.join(root, category);
+}
+
+async function listItemSummaries(
+  root: string,
+  category: TUserLocalStorageCategory,
+): Promise<readonly IUserLocalStorageItemSummary[]> {
+  const storageLocation = resolveCategoryLocation(root, category);
+  let entries: readonly import('node:fs').Dirent[];
+
+  try {
+    entries = await fs.readdir(storageLocation, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const summaries = await Promise.all(
+    entries.map(async (entry): Promise<IUserLocalStorageItemSummary> => {
+      const itemLocation = path.join(storageLocation, entry.name);
+      const stats = await fs.stat(itemLocation);
+      const key = entry.name;
+      return {
+        root,
+        category,
+        key,
+        summary: `${category}/${key}`,
+        source: 'user-local-storage',
+        scope: 'user',
+        storageLocation: itemLocation,
+        createdAt: formatIsoDate(stats.birthtime),
+        lastUsedAt: formatIsoDate(stats.mtime),
+        enabled: true,
+        deleteAvailable: true,
+        disableAvailable: false,
+      };
+    }),
+  );
+
+  return summaries.sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export async function inspectUserLocalStorage(
+  options: IInspectUserLocalStorageOptions,
+): Promise<IUserLocalStorageInspection> {
+  const root = await resolveUserLocalStorageRoot(options);
+  const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
+  const createDirectories = options.createDirectories ?? true;
+
+  if (createDirectories) {
+    await fs.mkdir(root, { recursive: true });
+  }
+
+  const categories = await Promise.all(
+    USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS.map(
+      async (definition): Promise<IUserLocalStorageCategoryProjection> => {
+        const storageLocation = resolveCategoryLocation(root, definition.category);
+        if (createDirectories) {
+          await fs.mkdir(storageLocation, { recursive: true });
+        }
+        const items = await listItemSummaries(root, definition.category);
+        return {
+          category: definition.category,
+          purpose: definition.purpose,
+          mayExecuteCommands: definition.mayExecuteCommands,
+          storageLocation,
+          itemCount: items.length,
+          items,
+        };
+      },
+    ),
+  );
+
+  return {
+    root,
+    activeRepositoryRoot,
+    categories,
+    generatedAt: formatIsoDate((options.now ?? (() => new Date()))()),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       '@robota-sdk/agent-command-statusline':
         specifier: workspace:*
         version: link:../agent-command-statusline
+      '@robota-sdk/agent-command-user-local':
+        specifier: workspace:*
+        version: link:../agent-command-user-local
       '@robota-sdk/agent-core':
         specifier: workspace:*
         version: link:../agent-core
@@ -784,6 +787,25 @@ importers:
         version: 1.6.1(@types/node@20.19.9)
 
   packages/agent-command-statusline:
+    dependencies:
+      '@robota-sdk/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+    devDependencies:
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.9)
+
+  packages/agent-command-user-local:
     dependencies:
       '@robota-sdk/agent-sdk':
         specifier: workspace:*


### PR DESCRIPTION
## Accepted Recommendation

Implement SDK-owned user-local root resolution, repository-outside validation, category projections, and a provider-free product command exposed as `robota user-local storage list --format json`. Keep `agent-cli` limited to direct command routing and terminal output; command semantics live in `@robota-sdk/agent-command-user-local`, and storage semantics live in `@robota-sdk/agent-sdk`.

## Rationale

This matches the backlog because users need to inspect where Robota user-local state lives before memory and transparent workflow state depend on it. It preserves repo independence by resolving baseline state under user-local home and validating that the storage root is outside the active repository. It also follows the layering rule that `agent-cli` adds UI/routing only, not lower-level behavior.

## Implementation Summary

- Added `packages/agent-sdk/src/user-local/storage.ts` for root resolution, category projections, item summaries, and repo-inside rejection.
- Added `@robota-sdk/agent-command-user-local` as the command owner for provider-free user-local inspection.
- Routed `user-local` direct commands in `agent-cli` before provider setup.
- Updated package specs, project structure docs, lockfile, task tracking, and moved the storage backlog to completed with evidence.

## Verification

- `pnpm --filter @robota-sdk/agent-sdk test -- src/user-local/__tests__/storage.test.ts`
- `pnpm --filter @robota-sdk/agent-command-user-local test`
- `pnpm --filter @robota-sdk/agent-cli test -- src/__tests__/cli-command-composition.test.ts`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-command-user-local typecheck`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-sdk lint` (0 errors, existing warnings)
- `pnpm --filter @robota-sdk/agent-command-user-local lint`
- `pnpm --filter @robota-sdk/agent-cli lint` (0 errors, existing warnings)
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-command-user-local build`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm harness:scan` (exit 0; existing file-size warnings remain nonblocking)
- Pre-push hook: `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check` via `git push`, including monorepo build and scoped package checks.

## User Execution Test Scenario Gate

Backlog evidence updated in `.agents/backlog/completed/user-local-storage-inspection-implementation.md`.

Executed against the built CLI from a temporary fixture repository:

```bash
ROBOTA_REPO="/Users/jungyoun/Documents/dev/robota"
TMP_HOME="$(mktemp -d)"
FIXTURE_REPO="$(mktemp -d)"
(
  cd "$FIXTURE_REPO"
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local storage list --format json
)
find "$FIXTURE_REPO" -maxdepth 2 \( -name ".robota" -o -name "robota*" \) -print
rm -rf "$TMP_HOME" "$FIXTURE_REPO"
```

Expected: exit 0, JSON `root` under `$TMP_HOME/.robota`, all six user-local categories present, no reusable command execution preference, and no `.robota` state inside `$FIXTURE_REPO`.

Observed: command exited 0, root was `/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.Kp2lGxRyLa/.robota`, categories were `preferences`, `view-state`, `memory-projections`, `task-associations`, `workflow-metadata`, and `inspection-index`, each category had `mayExecuteCommands: false`, and fixture `find` printed no output.

## Residual Risk

- Existing lint/file-size warnings remain in `agent-cli` and `agent-sdk`; this PR does not broaden that refactor scope.
- The storage command currently supports inspection only; memory item mutation/inspection is intentionally deferred to the next backlog.
