### PR TITLE
feat(user-local): add memory inspection commands

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -52,4 +52,3 @@ the backlog, the user execution test scenario gate does not pass.
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Memory Inspection Implementation](user-local-memory-inspection-implementation.md)

--- a/.agents/backlog/completed/user-local-memory-inspection-implementation.md
+++ b/.agents/backlog/completed/user-local-memory-inspection-implementation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -15,11 +15,11 @@ P0 - implementation of inspectable user-local memory and preference transparency
 ## Request
 
 Implement the user-local memory inspection, deletion, and disablement behavior defined by
-[user-local-memory.md](../specs/user-local-memory.md), using the storage foundation from
-[user-local-storage.md](../specs/user-local-storage.md).
+[user-local-memory.md](../../specs/user-local-memory.md), using the storage foundation from
+[user-local-storage.md](../../specs/user-local-storage.md).
 
 This backlog implements the follow-up work deferred by
-[User-Local Memory Transparency](completed/cli-user-local-memory-transparency.md).
+[User-Local Memory Transparency](cli-user-local-memory-transparency.md).
 
 ## Recommendation Gate
 
@@ -47,31 +47,33 @@ Affected scope:
 
 - `packages/agent-sdk`: memory item projection, persistence facade, delete/disable semantics,
   disabled-item non-use.
-- `packages/agent-command-memory` or another command owner: user-visible command behavior and output
-  formatting.
+- `@robota-sdk/agent-command-user-local`: user-visible command behavior and output formatting.
 - `packages/agent-cli`: provider-free command routing and terminal output only.
 - `packages/agent-sessions` only if session-local ids need to be referenced in projections.
 
-Open decisions:
+Decision:
 
-- Whether the command owner should extend `agent-command-memory` or use a dedicated user-local
-  command package should be decided during implementation. The decision must preserve the same SDK
-  ownership and product-surface scenario.
+- Use `@robota-sdk/agent-command-user-local` rather than `@robota-sdk/agent-command-memory`.
+  Rationale: existing `/memory` is explicit project memory under `.robota/memory`, while this
+  backlog implements baseline user-local display/navigation memory under the SDK user-local storage
+  contract.
+- Delete followed by inspect exits non-zero with `User-local memory item not found.`. Rationale:
+  the absence is script-detectable and user-readable.
 
 ## Acceptance Criteria
 
-- [ ] Users can create or seed an allowed display/navigation memory item through an explicit product
+- [x] Users can create or seed an allowed display/navigation memory item through an explicit product
       command for inspection/testing.
-- [ ] Users can list remembered user-local items with category, key, summary, scope, source,
+- [x] Users can list remembered user-local items with category, key, summary, scope, source,
       storage location, enabled state, last-used time, and display/navigation rule.
-- [ ] Users can inspect a single remembered item and see `commandExecutionEffect: "none"`.
-- [ ] Users can disable a remembered item without deleting it.
-- [ ] Disabled remembered items remain visible in inspection output and do not affect
+- [x] Users can inspect a single remembered item and see `commandExecutionEffect: "none"`.
+- [x] Users can disable a remembered item without deleting it.
+- [x] Disabled remembered items remain visible in inspection output and do not affect
       display/navigation.
-- [ ] Users can delete a remembered item.
-- [ ] No command strings are stored or exposed as reusable execution preferences.
-- [ ] No baseline user-local memory is written inside the active repository, including `.robota/`.
-- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
+- [x] Users can delete a remembered item.
+- [x] No command strings are stored or exposed as reusable execution preferences.
+- [x] No baseline user-local memory is written inside the active repository, including `.robota/`.
+- [x] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -136,8 +138,30 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation using the commands above.
-- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
-  command output and repository `find` result are recorded here.
+- Evidence:
+  - Executed after implementation from `/Users/jungyoun/Documents/dev/robota` against the built CLI.
+  - Product command sequence exited 0 through `set`, `list`, first `inspect`, `disable`, and second
+    `inspect`.
+  - `memory set` printed:
+    `Stored user-local memory item view-preference/last-panel at /var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.yb5Ivc89JG/.robota/memory-projections/view-preference__last-panel.json`
+  - `memory list --format json` printed `root:
+"/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.yb5Ivc89JG/.robota"` and one item with
+    category `view-preference`, key `last-panel`, summary `Open the background panel`, valueSummary
+    `background`, source `user-input`, scope `user`, enabled `true`, displayNavigationRule
+    `May affect UI panel, filter, density, or sorting display/navigation only.`, and
+    `commandExecutionEffect: "none"`.
+  - The first `memory inspect` printed the same item with `enabled: true`.
+  - `memory disable` printed: `Disabled user-local memory item view-preference/last-panel`.
+  - The second `memory inspect` printed the same item with `enabled: false` and
+    `commandExecutionEffect: "none"`.
+  - Repository-state command:
+
+    ```bash
+    find "$FIXTURE_REPO" -maxdepth 2 \( -name ".robota" -o -name "robota*" \) -print
+    ```
+
+    printed no output, confirming no project `.robota` or Robota baseline workflow state was
+    created inside the fixture repository.
 
 ### Scenario: Delete A User-Local Memory Item
 
@@ -155,9 +179,7 @@ Open decisions:
 
 - Expected observable result:
   - `memory delete` exits 0 and reports that `view-preference/last-panel` was deleted.
-  - The follow-up `memory inspect` exits non-zero with a user-readable “not found” message, or exits
-    0 with JSON that marks the item absent. The implementation must choose one behavior and update
-    this scenario before completion.
+  - The follow-up `memory inspect` exits non-zero with `User-local memory item not found.`.
 - Cleanup/reset:
 
   ```bash
@@ -165,8 +187,19 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation.
-- Evidence: Pending until implementation. The implementation PR must record the chosen not-found
-  behavior and observed output here.
+- Evidence:
+  - Executed after the first scenario using the same `TMP_HOME` and `FIXTURE_REPO`.
+  - `memory delete` exited 0 and printed:
+    `Deleted user-local memory item view-preference/last-panel`.
+  - Follow-up `memory inspect view-preference last-panel --format json` exited non-zero with status
+    `1` and printed: `User-local memory item not found.`
+  - Cleanup executed with `rm -rf "$TMP_HOME" "$FIXTURE_REPO"`.
+
+## Result
+
+Implemented with SDK-owned user-local memory APIs, provider-free
+`@robota-sdk/agent-command-user-local` memory subcommands, thin `agent-cli` direct routing, and
+captured User Execution Test Scenario evidence.
 
 ## Implementation Notes
 

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -14,7 +14,7 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 - [x] Create initiative base branch from `develop`.
 - [x] Implement user-local storage inspection in one child PR.
-- [ ] Implement user-local memory inspection in one child PR.
+- [x] Implement user-local memory inspection in one child PR.
 - [ ] Complete the planning umbrella backlog after implementation evidence exists.
 - [ ] Merge the initiative into `develop`.
 
@@ -27,6 +27,9 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - Implemented user-local storage inspection on `feat/user-local-storage-inspection`.
 - Verified the storage User Execution Test Scenario with the built CLI and recorded evidence in the
   completed backlog.
+- Implemented user-local memory inspection on `feat/user-local-memory-inspection`.
+- Verified memory set/list/inspect/disable/delete User Execution Test Scenarios with the built CLI
+  and recorded evidence in the completed backlog.
 
 ## Decisions
 

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -1406,6 +1406,11 @@ state, storage location, source, last-used time, and delete/disable actions retu
 command APIs. It must not own storage shape, write user-local memory directly, write baseline memory
 inside the repository, or convert remembered values into command execution.
 
+Provider-free `user-local memory ...` commands are routed directly to
+`@robota-sdk/agent-command-user-local` before provider setup. CLI parsing may pass terminal options
+such as `--summary`, `--source`, and `--format`, but command behavior and persistence remain outside
+`agent-cli`.
+
 ### Project Memory Review Surface
 
 Project memory storage and policy primitives are SDK-owned, while `/memory` command behavior is owned by `@robota-sdk/agent-command-memory`. The CLI and TUI must not extract memory candidates, select relevant topics, decide approval policy, or write `.robota/memory` files directly. They compose the memory command module, route `/memory` commands through `session.executeCommand()`, and render returned messages/data.

--- a/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
@@ -123,6 +123,52 @@ describe('default CLI command composition', () => {
     }
   });
 
+  it('routes direct user-local memory commands before provider setup', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-memory-'));
+    const home = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-memory-home-'));
+    const originalArgv = process.argv;
+    const originalHome = process.env.HOME;
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.argv = [
+      'node',
+      'robota',
+      'user-local',
+      'memory',
+      'set',
+      'view-preference',
+      'last-panel',
+      'background',
+      '--summary',
+      'Open the background panel',
+      '--source',
+      'user-input',
+    ];
+    process.env.HOME = home;
+    process.stdout.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await startCli({ providerDefinitions: [] });
+      expect(writes.join('')).toContain('Stored user-local memory item view-preference/last-panel');
+      expect(existsSync(join(cwd, '.robota'))).toBe(false);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.argv = originalArgv;
+      cwdSpy.mockRestore();
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('runs permissions mode changes through headless slash-command execution', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-headless-permissions-'));
     const session = new InteractiveSession({

--- a/packages/agent-cli/src/user-local-direct-command.ts
+++ b/packages/agent-cli/src/user-local-direct-command.ts
@@ -13,6 +13,8 @@ export async function runUserLocalDirectCommandIfRequested(
     cwd,
     argv: args.positional.slice(1),
     format: args.format,
+    summary: args.summary,
+    source: args.source,
   });
   const output = result.message.endsWith('\n') ? result.message : `${result.message}\n`;
   if (!result.success) {

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -76,6 +76,26 @@ describe('parseCliArgs', () => {
     expect(args.outputFormat).toBe('json');
   });
 
+  it('parses user-local passthrough metadata flags', () => {
+    process.argv = [
+      'node',
+      'cli',
+      'user-local',
+      'memory',
+      'set',
+      'view-preference',
+      'last-panel',
+      'background',
+      '--summary',
+      'Open the background panel',
+      '--source',
+      'user-input',
+    ];
+    const args = parseCliArgs();
+    expect(args.summary).toBe('Open the background panel');
+    expect(args.source).toBe('user-input');
+  });
+
   it('parses --system-prompt flag', () => {
     process.argv = ['node', 'cli', '-p', '--system-prompt', 'You are helpful', 'test'];
     const args = parseCliArgs();

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -126,6 +126,8 @@ function baseArgs(): IParsedCliArgs {
     sessionName: undefined,
     outputFormat: undefined,
     format: undefined,
+    summary: undefined,
+    source: undefined,
     systemPrompt: undefined,
     appendSystemPrompt: undefined,
     taskFile: undefined,

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -21,6 +21,8 @@ export interface IParsedCliArgs {
   sessionName: string | undefined;
   outputFormat: string | undefined;
   format: string | undefined;
+  summary: string | undefined;
+  source: string | undefined;
   systemPrompt: string | undefined;
   appendSystemPrompt: string | undefined;
   taskFile: string | undefined;
@@ -80,6 +82,8 @@ export function parseCliArgs(): IParsedCliArgs {
       name: { type: 'string', short: 'n' },
       'output-format': { type: 'string' },
       format: { type: 'string' },
+      summary: { type: 'string' },
+      source: { type: 'string' },
       'system-prompt': { type: 'string' },
       'append-system-prompt': { type: 'string' },
       'task-file': { type: 'string' },
@@ -116,6 +120,8 @@ export function parseCliArgs(): IParsedCliArgs {
     sessionName: values['name'],
     outputFormat: values['output-format'],
     format: values['format'],
+    summary: values['summary'],
+    source: values['source'],
     systemPrompt: values['system-prompt'],
     appendSystemPrompt: values['append-system-prompt'],
     taskFile: values['task-file'],

--- a/packages/agent-command-user-local/docs/SPEC.md
+++ b/packages/agent-command-user-local/docs/SPEC.md
@@ -29,13 +29,22 @@ import {
 - User invocable: yes
 - Model invocable: no
 - Safety: `read-only` for storage inspection
-- Argument hint: `storage list [--format json]`
+- Argument hint: `storage list [--format json] | memory set/list/inspect/disable/delete`
 
 ## Behavior
 
 - `user-local storage list --format json` prints the effective user-local root and stable category
   summaries using SDK projections.
+- `user-local memory set <category> <key> <value> --summary <summary> --source <source>` stores
+  an explicit display/navigation memory item through SDK user-local APIs.
+- `user-local memory list --format json` prints inspectable memory item projections.
+- `user-local memory inspect <category> <key> --format json` prints one item, including
+  `displayNavigationRule` and `commandExecutionEffect: "none"`.
+- `user-local memory disable <category> <key>` disables an item without deleting it.
+- `user-local memory delete <category> <key>` deletes an item. A follow-up inspect for that item
+  returns a user-readable not-found error.
 - Storage inspection is provider-free and must run before provider setup is required.
+- User-local memory commands are provider-free and must run before provider setup is required.
 - The command must not create or reuse repository-local `.robota/` baseline workflow state.
 - The command must not expose stored command strings as reusable execution preferences.
 
@@ -44,7 +53,7 @@ import {
 - This package must not import `agent-cli` or TUI code.
 - This package must not inspect or assemble storage paths directly; it calls SDK user-local APIs.
 - CLI direct invocation may call this package's direct execution helper before provider setup.
-- Future memory inspection/delete/disable behavior must stay in this package while persistence
+- User-local memory inspection/delete/disable behavior stays in this package while persistence
   semantics remain in SDK user-local APIs.
 
 ## Verification

--- a/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
+++ b/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
@@ -58,4 +58,88 @@ describe('user-local command', () => {
       }
     }
   });
+
+  it('stores, lists, inspects, disables, and deletes user-local memory items', async () => {
+    const workspace = await createTempRoot('robota-user-local-memory-command-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const setResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'set', 'view-preference', 'last-panel', 'background'],
+        summary: 'Open the background panel',
+        source: 'user-input',
+      });
+      expect(setResult.success).toBe(true);
+      expect(setResult.message).toContain('view-preference/last-panel');
+
+      const listResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'list'],
+        format: 'json',
+      });
+      const list = JSON.parse(listResult.message) as {
+        items: readonly { category: string; key: string; enabled: boolean }[];
+      };
+      expect(listResult.success).toBe(true);
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0]).toMatchObject({
+        category: 'view-preference',
+        key: 'last-panel',
+        enabled: true,
+      });
+
+      const inspectResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      const inspected = JSON.parse(inspectResult.message) as {
+        commandExecutionEffect: string;
+        displayNavigationRule: string;
+      };
+      expect(inspectResult.success).toBe(true);
+      expect(inspected.commandExecutionEffect).toBe('none');
+      expect(inspected.displayNavigationRule).toContain('display/navigation only');
+
+      const disableResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'disable', 'view-preference', 'last-panel'],
+      });
+      expect(disableResult.success).toBe(true);
+
+      const disabledInspectResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      const disabled = JSON.parse(disabledInspectResult.message) as { enabled: boolean };
+      expect(disabled.enabled).toBe(false);
+
+      const deleteResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'delete', 'view-preference', 'last-panel'],
+      });
+      expect(deleteResult.success).toBe(true);
+
+      const missingResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      expect(missingResult.success).toBe(false);
+      expect(missingResult.message).toBe('User-local memory item not found.');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/agent-command-user-local/src/user-local-command-constants.ts
+++ b/packages/agent-command-user-local/src/user-local-command-constants.ts
@@ -1,0 +1,5 @@
+export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
+export const USER_LOCAL_COMMAND_ARGUMENT_HINT =
+  'storage list [--format json] | memory set/list/inspect/disable/delete';
+export const USER_LOCAL_COMMAND_USAGE =
+  'Usage: user-local storage list [--format json] | user-local memory set <category> <key> <value> --summary <summary> --source <source> | user-local memory list [--format json] | user-local memory inspect <category> <key> [--format json] | user-local memory disable <category> <key> | user-local memory delete <category> <key>';

--- a/packages/agent-command-user-local/src/user-local-command-module.ts
+++ b/packages/agent-command-user-local/src/user-local-command-module.ts
@@ -24,6 +24,11 @@ export function createUserLocalCommandEntry(): ICommand {
         description: 'Inspect user-local storage categories',
         source: 'user-local',
       },
+      {
+        name: 'memory',
+        description: 'Inspect and manage user-local memory items',
+        source: 'user-local',
+      },
     ],
   };
 }

--- a/packages/agent-command-user-local/src/user-local-command.ts
+++ b/packages/agent-command-user-local/src/user-local-command.ts
@@ -1,9 +1,12 @@
 import type { ICommandHostContext, ICommandResult } from '@robota-sdk/agent-sdk';
 import { inspectUserLocalStorage } from '@robota-sdk/agent-sdk';
-
-export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
-export const USER_LOCAL_COMMAND_ARGUMENT_HINT = 'storage list [--format json]';
-export const USER_LOCAL_COMMAND_USAGE = 'Usage: user-local storage list [--format json]';
+import { executeMemoryCommand } from './user-local-memory-command.js';
+import { USER_LOCAL_COMMAND_USAGE } from './user-local-command-constants.js';
+export {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  USER_LOCAL_COMMAND_USAGE,
+} from './user-local-command-constants.js';
 
 type TUserLocalOutputFormat = 'text' | 'json';
 
@@ -11,12 +14,24 @@ export interface IUserLocalDirectCommandOptions {
   readonly cwd: string;
   readonly argv: readonly string[];
   readonly format?: string;
+  readonly summary?: string;
+  readonly source?: string;
 }
 
 interface IParsedUserLocalCommand {
   readonly target?: string;
   readonly action?: string;
+  readonly positional: readonly string[];
   readonly format: TUserLocalOutputFormat;
+  readonly summary?: string;
+  readonly source?: string;
+}
+
+interface IParsedUserLocalOption {
+  readonly format?: string;
+  readonly summary?: string;
+  readonly source?: string;
+  readonly nextIndex: number;
 }
 
 function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
@@ -29,22 +44,53 @@ function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
   throw new Error(`Unsupported user-local output format: ${value}`);
 }
 
+function parseUserLocalOption(
+  arg: string,
+  argv: readonly string[],
+  index: number,
+): IParsedUserLocalOption | null {
+  if (arg === '--format') {
+    return { format: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--format=')) {
+    return { format: arg.slice('--format='.length), nextIndex: index };
+  }
+  if (arg === '--summary') {
+    return { summary: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--summary=')) {
+    return { summary: arg.slice('--summary='.length), nextIndex: index };
+  }
+  if (arg === '--source') {
+    return { source: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--source=')) {
+    return { source: arg.slice('--source='.length), nextIndex: index };
+  }
+  return null;
+}
+
 function parseUserLocalArgs(
   argv: readonly string[],
-  directFormat?: string,
+  directOptions: {
+    readonly format?: string;
+    readonly summary?: string;
+    readonly source?: string;
+  } = {},
 ): IParsedUserLocalCommand {
-  let format = directFormat;
+  let format = directOptions.format;
+  let summary = directOptions.summary;
+  let source = directOptions.source;
   const positional: string[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === '--format') {
-      format = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith('--format=')) {
-      format = arg.slice('--format='.length);
+    const option = parseUserLocalOption(arg, argv, index);
+    if (option !== null) {
+      format = option.format ?? format;
+      summary = option.summary ?? summary;
+      source = option.source ?? source;
+      index = option.nextIndex;
       continue;
     }
     positional.push(arg);
@@ -53,7 +99,10 @@ function parseUserLocalArgs(
   return {
     target: positional[0],
     action: positional[1],
+    positional: positional.slice(2),
     format: parseOutputFormat(format),
+    summary,
+    source,
   };
 }
 
@@ -69,37 +118,53 @@ function formatStorageInspectionText(
   return [`User-local storage root: ${root}`, 'Categories:', ...categoryLines].join('\n');
 }
 
-async function executeParsedUserLocalCommand(
+async function executeStorageCommand(
   cwd: string,
   parsed: IParsedUserLocalCommand,
 ): Promise<ICommandResult> {
-  if (parsed.target !== 'storage' || (parsed.action ?? 'list') !== 'list') {
+  if ((parsed.action ?? 'list') !== 'list') {
     return {
       message: USER_LOCAL_COMMAND_USAGE,
       success: false,
     };
   }
 
-  try {
-    const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
-    return {
-      message:
-        parsed.format === 'json'
-          ? JSON.stringify(inspection, null, 2)
-          : formatStorageInspectionText(inspection.root, inspection.categories),
-      success: true,
-      data: {
-        root: inspection.root,
-        categories: inspection.categories,
-        inspection,
-      },
-    };
-  } catch (error) {
-    return {
-      message: error instanceof Error ? error.message : String(error),
-      success: false,
-    };
+  const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
+  return {
+    message:
+      parsed.format === 'json'
+        ? JSON.stringify(inspection, null, 2)
+        : formatStorageInspectionText(inspection.root, inspection.categories),
+    success: true,
+    data: {
+      root: inspection.root,
+      categories: inspection.categories,
+      inspection,
+    },
+  };
+}
+
+async function executeParsedUserLocalCommand(
+  cwd: string,
+  parsed: IParsedUserLocalCommand,
+): Promise<ICommandResult> {
+  if (parsed.target === 'storage') {
+    return executeStorageCommand(cwd, parsed);
   }
+  if (parsed.target === 'memory') {
+    return executeMemoryCommand(cwd, parsed);
+  }
+  return {
+    message: USER_LOCAL_COMMAND_USAGE,
+    success: false,
+  };
+}
+
+function formatCommandErrorMessage(errorMessage: string): string {
+  if (errorMessage.includes('ENOENT')) {
+    return 'User-local memory item not found.';
+  }
+  return errorMessage;
 }
 
 export async function executeUserLocalDirectCommand(
@@ -108,11 +173,15 @@ export async function executeUserLocalDirectCommand(
   try {
     return await executeParsedUserLocalCommand(
       options.cwd,
-      parseUserLocalArgs(options.argv, options.format),
+      parseUserLocalArgs(options.argv, {
+        format: options.format,
+        summary: options.summary,
+        source: options.source,
+      }),
     );
   } catch (error) {
     return {
-      message: error instanceof Error ? error.message : String(error),
+      message: formatCommandErrorMessage(error instanceof Error ? error.message : String(error)),
       success: false,
     };
   }
@@ -129,7 +198,7 @@ export async function executeUserLocalCommand(
     );
   } catch (error) {
     return {
-      message: error instanceof Error ? error.message : String(error),
+      message: formatCommandErrorMessage(error instanceof Error ? error.message : String(error)),
       success: false,
     };
   }

--- a/packages/agent-command-user-local/src/user-local-memory-command.ts
+++ b/packages/agent-command-user-local/src/user-local-memory-command.ts
@@ -1,0 +1,147 @@
+import type { ICommandResult, TUserLocalMemoryCategory } from '@robota-sdk/agent-sdk';
+import {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  setUserLocalMemoryItem,
+} from '@robota-sdk/agent-sdk';
+import { USER_LOCAL_COMMAND_USAGE } from './user-local-command-constants.js';
+
+export interface IUserLocalMemoryCommandArgs {
+  readonly action?: string;
+  readonly positional: readonly string[];
+  readonly format: 'text' | 'json';
+  readonly summary?: string;
+  readonly source?: string;
+}
+
+function formatMemoryListText(
+  items: readonly { category: string; key: string; enabled: boolean }[],
+): string {
+  if (items.length === 0) {
+    return 'No user-local memory items.';
+  }
+  return items
+    .map((item) => `- ${item.category}/${item.key} (${item.enabled ? 'enabled' : 'disabled'})`)
+    .join('\n');
+}
+
+function parseMemoryCategory(value: string | undefined): TUserLocalMemoryCategory {
+  if (value === undefined) {
+    throw new Error('User-local memory category is required.');
+  }
+  return value as TUserLocalMemoryCategory;
+}
+
+async function executeMemoryListCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const list = await listUserLocalMemoryItems({ activeRepositoryRoot });
+  return {
+    message:
+      parsed.format === 'json' ? JSON.stringify(list, null, 2) : formatMemoryListText(list.items),
+    success: true,
+    data: { list },
+  };
+}
+
+async function executeMemorySetCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key, value] = parsed.positional;
+  const item = await setUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+    value: value ?? '',
+    summary: parsed.summary ?? '',
+    source: parsed.source ?? '',
+  });
+  return {
+    message: `Stored user-local memory item ${item.category}/${item.key} at ${item.storageLocation}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryInspectCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const item = await inspectUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message:
+      parsed.format === 'json'
+        ? JSON.stringify(item, null, 2)
+        : `${item.category}/${item.key}: ${item.summary}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryDisableCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const item = await disableUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message: `Disabled user-local memory item ${item.category}/${item.key}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryDeleteCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const result = await deleteUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message: `Deleted user-local memory item ${result.category}/${result.key}`,
+    success: true,
+    data: { result },
+  };
+}
+
+export async function executeMemoryCommand(
+  cwd: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  if ((parsed.action ?? 'list') === 'list') {
+    return executeMemoryListCommand(cwd, parsed);
+  }
+  if (parsed.action === 'set') {
+    return executeMemorySetCommand(cwd, parsed);
+  }
+  if (parsed.action === 'inspect') {
+    return executeMemoryInspectCommand(cwd, parsed);
+  }
+  if (parsed.action === 'disable') {
+    return executeMemoryDisableCommand(cwd, parsed);
+  }
+  if (parsed.action === 'delete') {
+    return executeMemoryDeleteCommand(cwd, parsed);
+  }
+  return {
+    message: USER_LOCAL_COMMAND_USAGE,
+    success: false,
+  };
+}

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -155,7 +155,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── prompt-file-reference-*.ts ← `@file` prompt reference parser/resolver, path policy, formatting, and diagnostics
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
 ├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
-├── src/user-local/             ← user-local storage root validation, category projections, and future baseline memory persistence
+├── src/user-local/             ← user-local storage root validation, category projections, and baseline memory persistence
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/self-hosting/           ← self-hosting verification planner + lifecycle state machine
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
@@ -346,12 +346,11 @@ category contracts, and item inspection/removal projections.
 Existing `projectPaths(cwd)` helpers remain valid for explicit project-owned features such as
 project settings, session replay/debug logs, edit checkpoints, and current project memory. New
 baseline transparent workflow state must not use `projectPaths(cwd)` or ad hoc `.robota/` paths.
-It must use SDK-owned user-local storage contracts once those are implemented.
+It must use SDK-owned user-local storage contracts.
 
-Existing `userPaths()` helpers expose only current user settings and sessions paths. They are not
-yet the complete transparent workflow storage contract. Future implementation PRs must add tested
-user-local category APIs instead of having CLI or command modules assemble category paths
-themselves.
+Existing `userPaths()` helpers expose only current user settings and sessions paths. User-local
+workflow state uses the tested `src/user-local/` APIs instead of CLI or command modules assembling
+category paths themselves.
 
 ### User-Local Memory Transparency (SDK-Specific)
 
@@ -562,6 +561,25 @@ Resolved provider fields:
   direct product command before provider setup and prints the command-owned output.
 - **Repository independence**: SDK user-local APIs must not create repository `.robota/` baseline
   workflow state.
+
+### User-Local Memory
+
+- **Package**: `agent-sdk/user-local/`
+- **Purpose**: Persist explicit display/navigation memory items under the user-local storage root.
+- **Storage category**: `memory-projections`.
+- **Allowed categories**: `view-preference`, `last-visible-cwd`, `background-selection`,
+  `task-association`, `display-preference`, and `inspection-choice`.
+- **Projection fields**: category, key, summary, value summary, source, scope, storage location,
+  timestamps, enabled state, display/navigation rule, delete/disable availability, and
+  `commandExecutionEffect: "none"`.
+- **Mutation APIs**: SDK owns set, list, inspect, disable, delete, and enabled-item read behavior.
+- **Disabled-item rule**: disabled items remain inspectable but `readEnabledUserLocalMemoryItem`
+  returns `null`, so they cannot affect display/navigation defaults.
+- **Command boundary**: `@robota-sdk/agent-command-user-local` formats provider-free
+  `user-local memory ...` output from SDK projections. `agent-cli` only routes the product command
+  and passes terminal options such as `--summary`, `--source`, and `--format`.
+- **Repository independence**: user-local memory APIs must not write baseline memory inside the
+  active repository or project `.robota/`.
 
 ### Context Window Management
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -256,20 +256,35 @@ export type {
   TPromptInput,
 } from './commands/index.js';
 
-// ── User-local storage ─────────────────────────────────────
+// ── User-local storage and memory ──────────────────────────
 export {
+  USER_LOCAL_MEMORY_CATEGORIES,
   USER_LOCAL_STORAGE_CATEGORIES,
   USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
   inspectUserLocalStorage,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
   resolveUserLocalStorageRoot,
+  setUserLocalMemoryItem,
 } from './user-local/index.js';
 export type {
   IInspectUserLocalStorageOptions,
   IResolveUserLocalStorageRootOptions,
+  IUserLocalMemoryDeleteResult,
+  IUserLocalMemoryItemOptions,
+  IUserLocalMemoryItemProjection,
+  IUserLocalMemoryListOptions,
+  IUserLocalMemoryListProjection,
+  IUserLocalMemorySetOptions,
   IUserLocalStorageCategoryDefinition,
   IUserLocalStorageCategoryProjection,
   IUserLocalStorageInspection,
   IUserLocalStorageItemSummary,
+  TUserLocalMemoryCategory,
+  TUserLocalMemoryCommandExecutionEffect,
   TUserLocalStorageCategory,
 } from './user-local/index.js';
 

--- a/packages/agent-sdk/src/user-local/__tests__/memory.test.ts
+++ b/packages/agent-sdk/src/user-local/__tests__/memory.test.ts
@@ -1,0 +1,209 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
+  setUserLocalMemoryItem,
+} from '../memory.js';
+
+const tempRoots: string[] = [];
+const NOW = new Date('2026-05-09T00:00:00.000Z');
+const LATER = new Date('2026-05-09T00:01:00.000Z');
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+async function createWorkspace(): Promise<{
+  readonly repo: string;
+  readonly home: string;
+}> {
+  const workspace = await createTempRoot('robota-user-local-memory-');
+  const repo = path.join(workspace, 'repo');
+  const home = path.join(workspace, 'home');
+  await fs.mkdir(repo);
+  await fs.mkdir(home);
+  return { repo, home };
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local memory', () => {
+  it('stores and projects display/navigation memory outside the active repository', async () => {
+    const { repo, home } = await createWorkspace();
+
+    const item = await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    expect(item).toMatchObject({
+      root: path.join(home, '.robota'),
+      category: 'view-preference',
+      key: 'last-panel',
+      summary: 'Open the background panel',
+      valueSummary: 'background',
+      source: 'user-input',
+      scope: 'user',
+      createdAt: NOW.toISOString(),
+      lastUsedAt: NOW.toISOString(),
+      enabled: true,
+      commandExecutionEffect: 'none',
+      deleteAvailable: true,
+      disableAvailable: true,
+    });
+    expect(item.displayNavigationRule).toContain('display/navigation only');
+    expect(item.storageLocation).toBe(
+      path.join(home, '.robota', 'memory-projections', 'view-preference__last-panel.json'),
+    );
+    expect(await pathExists(path.join(repo, '.robota'))).toBe(false);
+  });
+
+  it('lists, inspects, disables, and hides disabled items from enabled reads', async () => {
+    const { repo, home } = await createWorkspace();
+
+    await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    const list = await listUserLocalMemoryItems({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+    });
+    expect(list.items.map((item) => `${item.category}/${item.key}`)).toEqual([
+      'view-preference/last-panel',
+    ]);
+
+    const inspected = await inspectUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+    });
+    expect(inspected.enabled).toBe(true);
+
+    const disabled = await disableUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      now: () => LATER,
+    });
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.lastUsedAt).toBe(LATER.toISOString());
+
+    const enabledRead = await readEnabledUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+    });
+    expect(enabledRead).toBeNull();
+  });
+
+  it('deletes an item and rejects follow-up inspection', async () => {
+    const { repo, home } = await createWorkspace();
+
+    await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    await expect(
+      deleteUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        homeDir: home,
+        category: 'view-preference',
+        key: 'last-panel',
+      }),
+    ).resolves.toMatchObject({
+      category: 'view-preference',
+      key: 'last-panel',
+      deleted: true,
+    });
+
+    await expect(
+      inspectUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        homeDir: home,
+        category: 'view-preference',
+        key: 'last-panel',
+      }),
+    ).rejects.toThrow('ENOENT');
+  });
+
+  it('stores command-looking values as inert display values only', async () => {
+    const { repo, home } = await createWorkspace();
+
+    const item = await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'display-preference',
+      key: 'compact-mode',
+      value: 'npm test',
+      summary: 'Display compact mode preference',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    expect(item.commandExecutionEffect).toBe('none');
+    expect(item.displayNavigationRule).toContain('only');
+    expect(item).not.toHaveProperty('command');
+    expect(item).not.toHaveProperty('commandString');
+  });
+
+  it('rejects a storage root inside the active repository', async () => {
+    const { repo } = await createWorkspace();
+
+    await expect(
+      setUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        storageRoot: path.join(repo, '.robota'),
+        category: 'view-preference',
+        key: 'last-panel',
+        value: 'background',
+        summary: 'Open the background panel',
+        source: 'user-input',
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+});

--- a/packages/agent-sdk/src/user-local/index.ts
+++ b/packages/agent-sdk/src/user-local/index.ts
@@ -4,6 +4,15 @@ export {
   inspectUserLocalStorage,
   resolveUserLocalStorageRoot,
 } from './storage.js';
+export {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
+  setUserLocalMemoryItem,
+} from './memory.js';
+export { USER_LOCAL_MEMORY_CATEGORIES } from './memory-types.js';
 export type {
   IInspectUserLocalStorageOptions,
   IResolveUserLocalStorageRootOptions,
@@ -13,3 +22,13 @@ export type {
   IUserLocalStorageItemSummary,
   TUserLocalStorageCategory,
 } from './storage.js';
+export type {
+  IUserLocalMemoryDeleteResult,
+  IUserLocalMemoryItemOptions,
+  IUserLocalMemoryItemProjection,
+  IUserLocalMemoryListOptions,
+  IUserLocalMemoryListProjection,
+  IUserLocalMemorySetOptions,
+  TUserLocalMemoryCategory,
+  TUserLocalMemoryCommandExecutionEffect,
+} from './memory-types.js';

--- a/packages/agent-sdk/src/user-local/memory-types.ts
+++ b/packages/agent-sdk/src/user-local/memory-types.ts
@@ -1,0 +1,76 @@
+import type { IResolveUserLocalStorageRootOptions } from './storage.js';
+
+export const USER_LOCAL_MEMORY_CATEGORIES = [
+  'view-preference',
+  'last-visible-cwd',
+  'background-selection',
+  'task-association',
+  'display-preference',
+  'inspection-choice',
+] as const;
+
+export type TUserLocalMemoryCategory = (typeof USER_LOCAL_MEMORY_CATEGORIES)[number];
+export type TUserLocalMemoryCommandExecutionEffect = 'none';
+
+export interface IUserLocalMemoryItemProjection {
+  readonly root: string;
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly summary: string;
+  readonly valueSummary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly storageLocation: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string;
+  readonly enabled: boolean;
+  readonly displayNavigationRule: string;
+  readonly commandExecutionEffect: TUserLocalMemoryCommandExecutionEffect;
+  readonly deleteAvailable: true;
+  readonly disableAvailable: true;
+}
+
+export interface IUserLocalMemoryListProjection {
+  readonly root: string;
+  readonly activeRepositoryRoot: string;
+  readonly items: readonly IUserLocalMemoryItemProjection[];
+}
+
+export interface IUserLocalMemorySetOptions extends IResolveUserLocalStorageRootOptions {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly value: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope?: string;
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryItemOptions extends IResolveUserLocalStorageRootOptions {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryListOptions extends IResolveUserLocalStorageRootOptions {
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryDeleteResult {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly deleted: boolean;
+}
+
+export interface IUserLocalMemoryFile {
+  readonly schemaVersion: 1;
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly value: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string;
+  readonly enabled: boolean;
+}

--- a/packages/agent-sdk/src/user-local/memory.ts
+++ b/packages/agent-sdk/src/user-local/memory.ts
@@ -1,0 +1,298 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { resolveUserLocalStorageRoot } from './storage.js';
+import type { IResolveUserLocalStorageRootOptions } from './storage.js';
+import {
+  USER_LOCAL_MEMORY_CATEGORIES,
+  type IUserLocalMemoryDeleteResult,
+  type IUserLocalMemoryFile,
+  type IUserLocalMemoryItemOptions,
+  type IUserLocalMemoryItemProjection,
+  type IUserLocalMemoryListOptions,
+  type IUserLocalMemoryListProjection,
+  type IUserLocalMemorySetOptions,
+  type TUserLocalMemoryCategory,
+} from './memory-types.js';
+
+type TJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly TJsonValue[]
+  | { readonly [key: string]: TJsonValue };
+type TJsonRecord = { readonly [key: string]: TJsonValue };
+
+const MEMORY_STORAGE_CATEGORY = 'memory-projections';
+const FILE_EXTENSION = '.json';
+const MEMORY_SCHEMA_VERSION = 1;
+const MAX_SEGMENT_LENGTH = 80;
+const MAX_SUMMARY_LENGTH = 240;
+const MAX_SOURCE_LENGTH = 80;
+const MAX_SCOPE_LENGTH = 120;
+const MAX_VALUE_SUMMARY_LENGTH = 240;
+const DEFAULT_SCOPE = 'user';
+const SAFE_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
+
+const DISPLAY_NAVIGATION_RULES: Record<TUserLocalMemoryCategory, string> = {
+  'view-preference': 'May affect UI panel, filter, density, or sorting display/navigation only.',
+  'last-visible-cwd': 'May display or preselect an already visible workspace context only.',
+  'background-selection': 'May restore the selected background entry in local UI only.',
+  'task-association': 'May group visible tasks by a local association only.',
+  'display-preference': 'May affect local text wrapping, compactness, or visibility only.',
+  'inspection-choice': 'May affect inspection display choices only.',
+};
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString();
+}
+
+function isUserLocalMemoryCategory(value: string): value is TUserLocalMemoryCategory {
+  return USER_LOCAL_MEMORY_CATEGORIES.includes(value as TUserLocalMemoryCategory);
+}
+
+function assertUserLocalMemoryCategory(value: string): TUserLocalMemoryCategory {
+  if (!isUserLocalMemoryCategory(value)) {
+    throw new Error(`Unsupported user-local memory category: ${value}`);
+  }
+  return value;
+}
+
+function assertSafeSegment(name: string, value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (trimmed.length > MAX_SEGMENT_LENGTH || !SAFE_SEGMENT_PATTERN.test(trimmed)) {
+    throw new Error(
+      `${name} must use lowercase letters, numbers, dots, underscores, or hyphens: ${value}`,
+    );
+  }
+  return trimmed;
+}
+
+function boundedText(name: string, value: string, maxLength: number): string {
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  if (normalized.length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (normalized.length > maxLength) {
+    return normalized.slice(0, maxLength);
+  }
+  return normalized;
+}
+
+function summarizeValue(value: string): string {
+  return boundedText('value', value, MAX_VALUE_SUMMARY_LENGTH);
+}
+
+function memoryFileName(category: TUserLocalMemoryCategory, key: string): string {
+  return `${category}__${key}${FILE_EXTENSION}`;
+}
+
+async function resolveMemoryRoot(
+  options: IResolveUserLocalStorageRootOptions,
+): Promise<{ readonly root: string; readonly memoryRoot: string }> {
+  const root = await resolveUserLocalStorageRoot(options);
+  return {
+    root,
+    memoryRoot: path.join(root, MEMORY_STORAGE_CATEGORY),
+  };
+}
+
+function parseMemoryRecord(raw: string, storageLocation: string): IUserLocalMemoryFile {
+  const record = JSON.parse(raw) as TJsonRecord;
+  const category = readString(record, 'category');
+  const schemaVersion = record['schemaVersion'];
+
+  if (schemaVersion !== MEMORY_SCHEMA_VERSION) {
+    throw new Error(`Unsupported user-local memory schema at ${storageLocation}`);
+  }
+
+  return {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    category: assertUserLocalMemoryCategory(category),
+    key: readString(record, 'key'),
+    value: readString(record, 'value'),
+    summary: readString(record, 'summary'),
+    source: readString(record, 'source'),
+    scope: readString(record, 'scope'),
+    createdAt: readString(record, 'createdAt'),
+    lastUsedAt: readString(record, 'lastUsedAt'),
+    enabled: readBoolean(record, 'enabled'),
+  };
+}
+
+function readString(record: TJsonRecord, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid user-local memory field: ${key}`);
+  }
+  return value;
+}
+
+function readBoolean(record: TJsonRecord, key: string): boolean {
+  const value = record[key];
+  if (typeof value !== 'boolean') {
+    throw new Error(`Invalid user-local memory field: ${key}`);
+  }
+  return value;
+}
+
+function projectMemoryItem(
+  root: string,
+  storageLocation: string,
+  item: IUserLocalMemoryFile,
+): IUserLocalMemoryItemProjection {
+  return {
+    root,
+    category: item.category,
+    key: item.key,
+    summary: item.summary,
+    valueSummary: summarizeValue(item.value),
+    source: item.source,
+    scope: item.scope,
+    storageLocation,
+    createdAt: item.createdAt,
+    lastUsedAt: item.lastUsedAt,
+    enabled: item.enabled,
+    displayNavigationRule: DISPLAY_NAVIGATION_RULES[item.category],
+    commandExecutionEffect: 'none',
+    deleteAvailable: true,
+    disableAvailable: true,
+  };
+}
+
+async function readMemoryFile(
+  root: string,
+  storageLocation: string,
+): Promise<IUserLocalMemoryItemProjection> {
+  return projectMemoryItem(
+    root,
+    storageLocation,
+    parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation),
+  );
+}
+
+async function resolveMemoryFile(
+  options: IUserLocalMemoryItemOptions,
+): Promise<{ readonly root: string; readonly storageLocation: string }> {
+  const category = assertUserLocalMemoryCategory(options.category);
+  const key = assertSafeSegment('key', options.key);
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  return {
+    root,
+    storageLocation: path.join(memoryRoot, memoryFileName(category, key)),
+  };
+}
+
+export async function setUserLocalMemoryItem(
+  options: IUserLocalMemorySetOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const category = assertUserLocalMemoryCategory(options.category);
+  const key = assertSafeSegment('key', options.key);
+  const summary = boundedText('summary', options.summary, MAX_SUMMARY_LENGTH);
+  const source = boundedText('source', options.source, MAX_SOURCE_LENGTH);
+  const scope = boundedText('scope', options.scope ?? DEFAULT_SCOPE, MAX_SCOPE_LENGTH);
+  const value = summarizeValue(options.value);
+  const now = formatIsoDate((options.now ?? (() => new Date()))());
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  const storageLocation = path.join(memoryRoot, memoryFileName(category, key));
+  let createdAt = now;
+
+  try {
+    const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+    createdAt = existing.createdAt;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      createdAt = now;
+    } else {
+      throw error;
+    }
+  }
+
+  const item: IUserLocalMemoryFile = {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    category,
+    key,
+    value,
+    summary,
+    source,
+    scope,
+    createdAt,
+    lastUsedAt: now,
+    enabled: true,
+  };
+
+  await fs.mkdir(memoryRoot, { recursive: true });
+  await fs.writeFile(storageLocation, `${JSON.stringify(item, null, 2)}\n`, 'utf8');
+  return projectMemoryItem(root, storageLocation, item);
+}
+
+export async function listUserLocalMemoryItems(
+  options: IUserLocalMemoryListOptions,
+): Promise<IUserLocalMemoryListProjection> {
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  let entries: readonly import('node:fs').Dirent[];
+
+  try {
+    entries = await fs.readdir(memoryRoot, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+
+  const items = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(FILE_EXTENSION))
+      .map((entry) => readMemoryFile(root, path.join(memoryRoot, entry.name))),
+  );
+
+  return {
+    root,
+    activeRepositoryRoot: path.resolve(options.activeRepositoryRoot),
+    items: items.sort((left, right) =>
+      `${left.category}/${left.key}`.localeCompare(`${right.category}/${right.key}`),
+    ),
+  };
+}
+
+export async function inspectUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const { root, storageLocation } = await resolveMemoryFile(options);
+  return readMemoryFile(root, storageLocation);
+}
+
+export async function disableUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const { root, storageLocation } = await resolveMemoryFile(options);
+  const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+  const disabled: IUserLocalMemoryFile = {
+    ...existing,
+    enabled: false,
+    lastUsedAt: formatIsoDate((options.now ?? (() => new Date()))()),
+  };
+
+  await fs.writeFile(storageLocation, `${JSON.stringify(disabled, null, 2)}\n`, 'utf8');
+  return projectMemoryItem(root, storageLocation, disabled);
+}
+
+export async function deleteUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryDeleteResult> {
+  const { storageLocation } = await resolveMemoryFile(options);
+  await fs.rm(storageLocation);
+  return {
+    category: options.category,
+    key: options.key,
+    deleted: true,
+  };
+}
+
+export async function readEnabledUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection | null> {
+  const item = await inspectUserLocalMemoryItem(options);
+  return item.enabled ? item : null;
+}


### PR DESCRIPTION
## Accepted Recommendation

Implement user-local memory below `agent-cli`: SDK owns persistence, projection, delete/disable, and disabled-item non-use; `@robota-sdk/agent-command-user-local` owns provider-free `user-local memory ...` command behavior; `agent-cli` only routes direct commands and passes terminal options.

Decision details:
- Use `@robota-sdk/agent-command-user-local`, not `@robota-sdk/agent-command-memory`, because existing `/memory` is explicit project memory under `.robota/memory`, while this backlog is baseline user-local display/navigation memory under `~/.robota`.
- Delete followed by inspect exits non-zero with `User-local memory item not found.` so scripts and users can clearly observe absence.

## Rationale

This matches the backlog because remembered state remains inspectable, user-local, display/navigation-only, and explicitly removable. It matches repository layering because storage root validation and memory semantics are SDK-owned, command formatting is command-package-owned, and `agent-cli` does not assemble paths or mutate memory directly.

## Implementation Summary

- Added SDK user-local memory APIs for set/list/inspect/disable/delete and enabled-item reads.
- Persisted user-local memory under the SDK user-local root in `memory-projections` and validated the root outside the active repository.
- Added provider-free `user-local memory set/list/inspect/disable/delete` command behavior to `@robota-sdk/agent-command-user-local`.
- Extended direct CLI argument passthrough for `--summary`, `--source`, and `--format`.
- Updated SDK, CLI, command SPECs and moved the memory backlog to completed with captured evidence.

## Verification

- `pnpm --filter @robota-sdk/agent-sdk test -- src/user-local/__tests__/memory.test.ts src/user-local/__tests__/storage.test.ts`
- `pnpm --filter @robota-sdk/agent-command-user-local test`
- `pnpm --filter @robota-sdk/agent-cli test -- src/__tests__/cli-command-composition.test.ts src/utils/__tests__/cli-args.test.ts`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-command-user-local typecheck`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-command-user-local lint`
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-command-user-local build`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm harness:scan` (exit 0; existing file-size warnings remain nonblocking)
- Pre-push hook: `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check`, including monorepo build and scoped package checks.

## User Execution Test Scenario Gate

Backlog evidence updated in `.agents/backlog/completed/user-local-memory-inspection-implementation.md`.

Executed against the built CLI from a temporary fixture repository:

```bash
ROBOTA_REPO="/Users/jungyoun/Documents/dev/robota"
TMP_HOME="$(mktemp -d)"
FIXTURE_REPO="$(mktemp -d)"
(
  cd "$FIXTURE_REPO"
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory set view-preference last-panel background --summary "Open the background panel" --source user-input
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory list --format json
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory disable view-preference last-panel
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
)
find "$FIXTURE_REPO" -maxdepth 2 \( -name ".robota" -o -name "robota*" \) -print
(
  cd "$FIXTURE_REPO"
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory delete view-preference last-panel
  HOME="$TMP_HOME" node "$ROBOTA_REPO/packages/agent-cli/dist/node/bin.js" user-local memory inspect view-preference last-panel --format json
)
rm -rf "$TMP_HOME" "$FIXTURE_REPO"
```

Expected: set/list/inspect/disable/inspect exits 0; list and inspect show category `view-preference`, key `last-panel`, source `user-input`, storage under `$TMP_HOME/.robota`, display/navigation-only rule, and `commandExecutionEffect: "none"`; disabled inspect keeps the item visible with `enabled: false`; fixture `find` prints no project `.robota`; delete exits 0 and follow-up inspect exits non-zero with `User-local memory item not found.`

Observed: command sequence behaved as expected. Final run used root `/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.yb5Ivc89JG/.robota`, fixture repo `/private/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.ZKQZclfoqR`, fixture `find` printed no output, delete printed `Deleted user-local memory item view-preference/last-panel`, and follow-up inspect exited with status `1` plus `User-local memory item not found.`

## Residual Risk

- Existing lint/file-size warnings remain in `agent-cli` and `agent-sdk`; new command-package warning introduced during development was removed before push.
- User-local memory is now explicit command-driven only; no automatic inference from repeated user behavior was added.
