### PR TITLE
feat(user-local): add transparent user-local inspection

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -51,4 +51,4 @@ the backlog, the user execution test scenario gate does not pass.
 
 ## Items
 
-- [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
+No active backlog items.

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -52,4 +52,3 @@ the backlog, the user execution test scenario gate does not pass.
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Memory Inspection Implementation](user-local-memory-inspection-implementation.md)

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -52,5 +52,4 @@ the backlog, the user execution test scenario gate does not pass.
 ## Items
 
 - [Transparent Repo-Agnostic Workflow Client Planning](cli-ai-workflow-reviewer-harness-planning.md)
-- [User-Local Storage Inspection Implementation](user-local-storage-inspection-implementation.md)
 - [User-Local Memory Inspection Implementation](user-local-memory-inspection-implementation.md)

--- a/.agents/backlog/completed/cli-ai-workflow-reviewer-harness-planning.md
+++ b/.agents/backlog/completed/cli-ai-workflow-reviewer-harness-planning.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -26,6 +26,19 @@ The core question is:
 
 This umbrella backlog splits the work into focused backlog documents that keep the same backlog
 shape and can later become independent implementation PRs.
+
+## Completion Summary
+
+Completed on 2026-05-09 as the planning umbrella for the user-local inspection initiative.
+
+Implementation evidence from this initiative is recorded in:
+
+- [User-local storage inspection implementation](user-local-storage-inspection-implementation.md)
+- [User-local memory inspection implementation](user-local-memory-inspection-implementation.md)
+
+The storage and memory implementation backlogs include concrete Robota CLI User Execution Test
+Scenarios, expected observable results, and captured execution evidence. This umbrella item remains
+planning-only and therefore does not define its own product-surface scenario.
 
 ## Non-Negotiable Product Principles
 
@@ -175,14 +188,14 @@ Each implementation PR should update the owning package specs before changing `a
 
 ## Acceptance Criteria
 
-- [ ] The umbrella backlog links every focused backlog item.
-- [ ] The planning document cites the source article and prior-art docs.
-- [ ] The reviewer profile is inspired by the article but does not impersonate a named person.
-- [ ] The plan clearly states that user repos own their harness and must not depend on Robota.
-- [ ] The plan clearly separates CLI UI from SDK/runtime ownership.
-- [ ] The plan forbids automatic repo injection of Robota manifests, hooks, scripts, package
+- [x] The umbrella backlog links every focused backlog item.
+- [x] The planning document cites the source article and prior-art docs.
+- [x] The reviewer profile is inspired by the article but does not impersonate a named person.
+- [x] The plan clearly states that user repos own their harness and must not depend on Robota.
+- [x] The plan clearly separates CLI UI from SDK/runtime ownership.
+- [x] The plan forbids automatic repo injection of Robota manifests, hooks, scripts, package
       dependencies, or CI changes.
-- [ ] The plan forbids baseline command discovery, evidence judgment, failure diagnosis, repair
+- [x] The plan forbids baseline command discovery, evidence judgment, failure diagnosis, repair
       loops, review gates, readiness scoring, and hook ownership.
 
 ## Test Plan
@@ -204,21 +217,27 @@ the CLI/TUI/SDK behavior.
 
 ## Process Verification Evidence
 
-### Verification: Split Workflow Plan Is Linked
+### Verification: Split Workflow Plan Is Linked And Archived
 
 - Prerequisites: Run from the repository root.
 - Verification commands:
 
   ```bash
-  rg -n "completed/cli-transparent-workflow-contract|completed/cli-repository-situational-awareness|Do not require a Robota manifest|baseline command discovery|SDK/runtime ownership" .agents/backlog/cli-ai-workflow-reviewer-harness-planning.md
-  rg -n "Transparent Repo-Agnostic Workflow Client Planning" .agents/backlog/README.md
+  test -f .agents/backlog/completed/cli-ai-workflow-reviewer-harness-planning.md
+  rg -n "completed/cli-transparent-workflow-contract|completed/cli-repository-situational-awareness|Do not require a Robota manifest|baseline command discovery|SDK/runtime ownership" .agents/backlog/completed/cli-ai-workflow-reviewer-harness-planning.md
+  rg -n "user-local-storage-inspection-implementation|user-local-memory-inspection-implementation|Not applicable" .agents/backlog/completed/cli-ai-workflow-reviewer-harness-planning.md
+  ! rg -q "Transparent Repo-Agnostic Workflow Client Planning" .agents/backlog/README.md
   ```
 
 - Expected result: The first command prints the split backlog links, the no-Robota-manifest
-  rule, the command-discovery restriction, and SDK/runtime ownership text. The second command shows
-  the umbrella backlog remains listed in the backlog index.
-- Evidence: Executed as process verification during planning; no product-surface scenario applies
-  until implementation backlogs add runnable behavior.
+  rule, the command-discovery restriction, and SDK/runtime ownership text. The implementation
+  evidence command prints links to the storage and memory implementation backlogs. The README check
+  exits successfully because the completed umbrella backlog is no longer listed as active work.
+- Evidence: Executed on 2026-05-09 from `docs/complete-workflow-client-planning`. The link/archive
+  verification command exited 0 and printed the split backlog links, implementation evidence links,
+  `Not applicable` scenario marker, no-Robota-manifest rule, command-discovery restriction, and
+  SDK/runtime ownership text. `pnpm harness:scan` exited 0; the only scan output requiring context
+  was the existing file-size warning list and non-blocking app/internal `dist/` warnings.
 
 ## Verification Plan
 

--- a/.agents/backlog/completed/user-local-memory-inspection-implementation.md
+++ b/.agents/backlog/completed/user-local-memory-inspection-implementation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -15,11 +15,11 @@ P0 - implementation of inspectable user-local memory and preference transparency
 ## Request
 
 Implement the user-local memory inspection, deletion, and disablement behavior defined by
-[user-local-memory.md](../specs/user-local-memory.md), using the storage foundation from
-[user-local-storage.md](../specs/user-local-storage.md).
+[user-local-memory.md](../../specs/user-local-memory.md), using the storage foundation from
+[user-local-storage.md](../../specs/user-local-storage.md).
 
 This backlog implements the follow-up work deferred by
-[User-Local Memory Transparency](completed/cli-user-local-memory-transparency.md).
+[User-Local Memory Transparency](cli-user-local-memory-transparency.md).
 
 ## Recommendation Gate
 
@@ -47,31 +47,33 @@ Affected scope:
 
 - `packages/agent-sdk`: memory item projection, persistence facade, delete/disable semantics,
   disabled-item non-use.
-- `packages/agent-command-memory` or another command owner: user-visible command behavior and output
-  formatting.
+- `@robota-sdk/agent-command-user-local`: user-visible command behavior and output formatting.
 - `packages/agent-cli`: provider-free command routing and terminal output only.
 - `packages/agent-sessions` only if session-local ids need to be referenced in projections.
 
-Open decisions:
+Decision:
 
-- Whether the command owner should extend `agent-command-memory` or use a dedicated user-local
-  command package should be decided during implementation. The decision must preserve the same SDK
-  ownership and product-surface scenario.
+- Use `@robota-sdk/agent-command-user-local` rather than `@robota-sdk/agent-command-memory`.
+  Rationale: existing `/memory` is explicit project memory under `.robota/memory`, while this
+  backlog implements baseline user-local display/navigation memory under the SDK user-local storage
+  contract.
+- Delete followed by inspect exits non-zero with `User-local memory item not found.`. Rationale:
+  the absence is script-detectable and user-readable.
 
 ## Acceptance Criteria
 
-- [ ] Users can create or seed an allowed display/navigation memory item through an explicit product
+- [x] Users can create or seed an allowed display/navigation memory item through an explicit product
       command for inspection/testing.
-- [ ] Users can list remembered user-local items with category, key, summary, scope, source,
+- [x] Users can list remembered user-local items with category, key, summary, scope, source,
       storage location, enabled state, last-used time, and display/navigation rule.
-- [ ] Users can inspect a single remembered item and see `commandExecutionEffect: "none"`.
-- [ ] Users can disable a remembered item without deleting it.
-- [ ] Disabled remembered items remain visible in inspection output and do not affect
+- [x] Users can inspect a single remembered item and see `commandExecutionEffect: "none"`.
+- [x] Users can disable a remembered item without deleting it.
+- [x] Disabled remembered items remain visible in inspection output and do not affect
       display/navigation.
-- [ ] Users can delete a remembered item.
-- [ ] No command strings are stored or exposed as reusable execution preferences.
-- [ ] No baseline user-local memory is written inside the active repository, including `.robota/`.
-- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
+- [x] Users can delete a remembered item.
+- [x] No command strings are stored or exposed as reusable execution preferences.
+- [x] No baseline user-local memory is written inside the active repository, including `.robota/`.
+- [x] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -136,8 +138,30 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation using the commands above.
-- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
-  command output and repository `find` result are recorded here.
+- Evidence:
+  - Executed after implementation from `/Users/jungyoun/Documents/dev/robota` against the built CLI.
+  - Product command sequence exited 0 through `set`, `list`, first `inspect`, `disable`, and second
+    `inspect`.
+  - `memory set` printed:
+    `Stored user-local memory item view-preference/last-panel at /var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.yb5Ivc89JG/.robota/memory-projections/view-preference__last-panel.json`
+  - `memory list --format json` printed `root:
+"/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.yb5Ivc89JG/.robota"` and one item with
+    category `view-preference`, key `last-panel`, summary `Open the background panel`, valueSummary
+    `background`, source `user-input`, scope `user`, enabled `true`, displayNavigationRule
+    `May affect UI panel, filter, density, or sorting display/navigation only.`, and
+    `commandExecutionEffect: "none"`.
+  - The first `memory inspect` printed the same item with `enabled: true`.
+  - `memory disable` printed: `Disabled user-local memory item view-preference/last-panel`.
+  - The second `memory inspect` printed the same item with `enabled: false` and
+    `commandExecutionEffect: "none"`.
+  - Repository-state command:
+
+    ```bash
+    find "$FIXTURE_REPO" -maxdepth 2 \( -name ".robota" -o -name "robota*" \) -print
+    ```
+
+    printed no output, confirming no project `.robota` or Robota baseline workflow state was
+    created inside the fixture repository.
 
 ### Scenario: Delete A User-Local Memory Item
 
@@ -155,9 +179,7 @@ Open decisions:
 
 - Expected observable result:
   - `memory delete` exits 0 and reports that `view-preference/last-panel` was deleted.
-  - The follow-up `memory inspect` exits non-zero with a user-readable “not found” message, or exits
-    0 with JSON that marks the item absent. The implementation must choose one behavior and update
-    this scenario before completion.
+  - The follow-up `memory inspect` exits non-zero with `User-local memory item not found.`.
 - Cleanup/reset:
 
   ```bash
@@ -165,8 +187,19 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation.
-- Evidence: Pending until implementation. The implementation PR must record the chosen not-found
-  behavior and observed output here.
+- Evidence:
+  - Executed after the first scenario using the same `TMP_HOME` and `FIXTURE_REPO`.
+  - `memory delete` exited 0 and printed:
+    `Deleted user-local memory item view-preference/last-panel`.
+  - Follow-up `memory inspect view-preference last-panel --format json` exited non-zero with status
+    `1` and printed: `User-local memory item not found.`
+  - Cleanup executed with `rm -rf "$TMP_HOME" "$FIXTURE_REPO"`.
+
+## Result
+
+Implemented with SDK-owned user-local memory APIs, provider-free
+`@robota-sdk/agent-command-user-local` memory subcommands, thin `agent-cli` direct routing, and
+captured User Execution Test Scenario evidence.
 
 ## Implementation Notes
 

--- a/.agents/backlog/completed/user-local-storage-inspection-implementation.md
+++ b/.agents/backlog/completed/user-local-storage-inspection-implementation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Backlog.
+Completed.
 
 ## Created
 
@@ -19,7 +19,7 @@ Implement the user-local storage foundation defined by
 root, categories, and stored item summaries through a Robota product surface.
 
 This backlog implements the follow-up work deferred by
-[User-Local Storage Foundation](completed/cli-user-local-storage-foundation.md).
+[User-Local Storage Foundation](cli-user-local-storage-foundation.md).
 
 ## Recommendation Gate
 
@@ -57,16 +57,16 @@ Open decisions:
 
 ## Acceptance Criteria
 
-- [ ] SDK resolves the effective user-local root under the user's home directory by default.
-- [ ] SDK rejects a baseline workflow storage root inside the active repository.
-- [ ] SDK exposes stable category projections for `preferences`, `view-state`,
+- [x] SDK resolves the effective user-local root under the user's home directory by default.
+- [x] SDK rejects a baseline workflow storage root inside the active repository.
+- [x] SDK exposes stable category projections for `preferences`, `view-state`,
       `memory-projections`, `task-associations`, `workflow-metadata`, and `inspection-index`.
-- [ ] Product command `robota user-local storage list --format json` prints the effective root and
+- [x] Product command `robota user-local storage list --format json` prints the effective root and
       category summaries without requiring provider configuration.
-- [ ] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
+- [x] The product command does not create tracked, ignored, or project `.robota/` baseline workflow
       state in the active repository.
-- [ ] Stored command strings are not exposed as reusable execution preferences.
-- [ ] The backlog is updated with User Execution Test Scenario evidence after implementation.
+- [x] Stored command strings are not exposed as reusable execution preferences.
+- [x] The backlog is updated with User Execution Test Scenario evidence after implementation.
 
 ## Test Plan
 
@@ -121,8 +121,28 @@ Open decisions:
   ```
 
 - Agent verification: Must be executed after implementation using the commands above.
-- Evidence: Pending until implementation. The backlog cannot be marked complete until the observed
-  command output and repository `find` result are recorded here.
+- Evidence:
+  - Executed after implementation from `/Users/jungyoun/Documents/dev/robota`.
+  - Build command: `pnpm --filter @robota-sdk/agent-cli build` exited 0 after package builds for
+    `@robota-sdk/agent-sdk` and `@robota-sdk/agent-command-user-local`.
+  - Product command exited 0 and printed JSON with:
+    - `root:
+"/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.Kp2lGxRyLa/.robota"`
+    - `activeRepositoryRoot:
+"/private/var/folders/78/9lnqy12x2bn8x5c17zmvrsnr0000gn/T/tmp.CZ0kZpeuex"`
+    - categories: `preferences`, `view-state`, `memory-projections`, `task-associations`,
+      `workflow-metadata`, and `inspection-index`
+    - every category reported `mayExecuteCommands: false`, `itemCount: 0`, and `items: []`
+  - Repository-state command:
+
+    ```bash
+    find "$FIXTURE_REPO" -maxdepth 2 -name ".robota" -o -name "robota*"
+    ```
+
+    printed no output, confirming no project `.robota` or Robota baseline workflow state was
+    created inside the fixture repository.
+
+  - Cleanup executed with `rm -rf "$TMP_HOME" "$FIXTURE_REPO"`.
 
 ## Implementation Notes
 
@@ -130,3 +150,8 @@ Open decisions:
   SDK/command-owned code.
 - If implementation chooses a different final product command, update this backlog before coding and
   keep the scenario equally runnable by the user.
+
+## Result
+
+Implemented with SDK-owned user-local storage projection APIs, a provider-free
+`@robota-sdk/agent-command-user-local` command owner, and thin `agent-cli` direct command routing.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -10,7 +10,7 @@ packages/
 ├── agent-tools/                 # Tool implementations: FunctionTool, built-ins, schema helpers, sandbox ports/manifests
 ├── agent-tool-mcp/              # MCP tool implementations
 ├── agent-sdk/                   # SDK assembly layer: InteractiveSession, command contracts/common APIs
-├── agent-command-*/             # Command modules: agent, background, compact, context, exit, help, language, memory, mode, model, permissions, plugin, provider, reset, rewind, session, skills, statusline
+├── agent-command-*/             # Command modules: agent, background, compact, context, exit, help, language, memory, mode, model, permissions, plugin, provider, reset, rewind, session, skills, statusline, user-local
 ├── agent-cli/                   # Terminal UI and local runtime adapters
 ├── agent-event-service/         # Compatibility re-export package for event service APIs
 ├── agent-provider-*/            # Provider packages: anthropic, openai, openai-compatible, deepseek, gemma, qwen, gemini, google, bytedance

--- a/.agents/tasks/completed/user-local-inspection-implementation.md
+++ b/.agents/tasks/completed/user-local-inspection-implementation.md
@@ -1,6 +1,6 @@
 # User-Local Inspection Implementation
 
-- **Status**: in-progress
+- **Status**: completed
 - **Created**: 2026-05-09
 - **Branch**: feat/user-local-inspection-initiative
 - **Scope**: packages/agent-sdk, packages/agent-command-\*, packages/agent-cli, .agents/backlog
@@ -16,7 +16,7 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - [x] Implement user-local storage inspection in one child PR.
 - [x] Implement user-local memory inspection in one child PR.
 - [x] Complete the planning umbrella backlog after implementation evidence exists.
-- [ ] Merge the initiative into `develop`.
+- [x] Prepare the initiative for merge into `develop`.
 
 ## Progress
 
@@ -33,6 +33,8 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - Merged PR #338 and PR #339 into `feat/user-local-inspection-initiative`.
 - Archived the transparent workflow client planning umbrella backlog after linking the storage and
   memory implementation evidence.
+- Merged PR #340 into `feat/user-local-inspection-initiative`.
+- Archived this initiative task after all backlog PRs landed on the initiative base.
 
 ## Decisions
 
@@ -61,4 +63,5 @@ implementation PRs.
 
 ## Result
 
-Pending.
+Implemented user-local storage and memory inspection through focused child PRs, completed the
+planning umbrella backlog, and prepared the initiative branch for the final merge into `develop`.

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -1,0 +1,55 @@
+# User-Local Inspection Implementation
+
+- **Status**: in-progress
+- **Created**: 2026-05-09
+- **Branch**: feat/user-local-inspection-initiative
+- **Scope**: packages/agent-sdk, packages/agent-command-\*, packages/agent-cli, .agents/backlog
+
+## Objective
+
+Implement the active user-local storage and memory inspection backlogs through focused PRs while
+preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
+
+## Plan
+
+- [ ] Create initiative base branch from `develop`.
+- [ ] Implement user-local storage inspection in one child PR.
+- [ ] Implement user-local memory inspection in one child PR.
+- [ ] Complete the planning umbrella backlog after implementation evidence exists.
+- [ ] Merge the initiative into `develop`.
+
+## Progress
+
+### 2026-05-09
+
+- Created initiative base branch `feat/user-local-inspection-initiative` from `develop`.
+- Confirmed active backlog items and implementation order.
+
+## Decisions
+
+- Use one child PR per active backlog implementation.
+- Keep user-local storage and memory semantics in SDK/command-owned code; CLI may only route
+  provider-free commands and render terminal output.
+
+## Blockers
+
+- None.
+
+## Test Plan
+
+- Run targeted builds and tests for each affected package after each backlog implementation.
+- Run the backlog-defined User Execution Test Scenario commands for storage and memory after the
+  product commands are implemented.
+- Run `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check`
+  before pushing initiative changes.
+- Run `pnpm harness:scan` before the final merge to `develop`.
+
+## User Execution Test Scenarios
+
+Not applicable to this task-tracking file itself. The runnable product scenarios are owned by the
+individual user-local storage and user-local memory backlog items and must be executed after their
+implementation PRs.
+
+## Result
+
+Pending.

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -12,8 +12,8 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 ## Plan
 
-- [ ] Create initiative base branch from `develop`.
-- [ ] Implement user-local storage inspection in one child PR.
+- [x] Create initiative base branch from `develop`.
+- [x] Implement user-local storage inspection in one child PR.
 - [ ] Implement user-local memory inspection in one child PR.
 - [ ] Complete the planning umbrella backlog after implementation evidence exists.
 - [ ] Merge the initiative into `develop`.
@@ -24,6 +24,9 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 - Created initiative base branch `feat/user-local-inspection-initiative` from `develop`.
 - Confirmed active backlog items and implementation order.
+- Implemented user-local storage inspection on `feat/user-local-storage-inspection`.
+- Verified the storage User Execution Test Scenario with the built CLI and recorded evidence in the
+  completed backlog.
 
 ## Decisions
 

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -15,7 +15,7 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - [x] Create initiative base branch from `develop`.
 - [x] Implement user-local storage inspection in one child PR.
 - [x] Implement user-local memory inspection in one child PR.
-- [ ] Complete the planning umbrella backlog after implementation evidence exists.
+- [x] Complete the planning umbrella backlog after implementation evidence exists.
 - [ ] Merge the initiative into `develop`.
 
 ## Progress
@@ -30,6 +30,9 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - Implemented user-local memory inspection on `feat/user-local-memory-inspection`.
 - Verified memory set/list/inspect/disable/delete User Execution Test Scenarios with the built CLI
   and recorded evidence in the completed backlog.
+- Merged PR #338 and PR #339 into `feat/user-local-inspection-initiative`.
+- Archived the transparent workflow client planning umbrella backlog after linking the storage and
+  memory implementation evidence.
 
 ## Decisions
 

--- a/.agents/tasks/user-local-inspection-implementation.md
+++ b/.agents/tasks/user-local-inspection-implementation.md
@@ -14,7 +14,7 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 
 - [x] Create initiative base branch from `develop`.
 - [x] Implement user-local storage inspection in one child PR.
-- [ ] Implement user-local memory inspection in one child PR.
+- [x] Implement user-local memory inspection in one child PR.
 - [ ] Complete the planning umbrella backlog after implementation evidence exists.
 - [ ] Merge the initiative into `develop`.
 
@@ -27,6 +27,9 @@ preserving SDK/command ownership and keeping `agent-cli` as routing/UI only.
 - Implemented user-local storage inspection on `feat/user-local-storage-inspection`.
 - Verified the storage User Execution Test Scenario with the built CLI and recorded evidence in the
   completed backlog.
+- Implemented user-local memory inspection on `feat/user-local-memory-inspection`.
+- Verified memory set/list/inspect/disable/delete User Execution Test Scenarios with the built CLI
+  and recorded evidence in the completed backlog.
 
 ## Decisions
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "overrides": {
       "fast-xml-parser": ">=4.5.5",
       "fast-xml-builder": "1.2.0",
-      "fast-uri": "3.1.1",
+      "fast-uri": "3.1.2",
       "node-forge": ">=1.4.0",
       "protobufjs": ">=7.5.5",
       "jws@^3.0.0": "^3.2.3",

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -1406,6 +1406,11 @@ state, storage location, source, last-used time, and delete/disable actions retu
 command APIs. It must not own storage shape, write user-local memory directly, write baseline memory
 inside the repository, or convert remembered values into command execution.
 
+Provider-free `user-local memory ...` commands are routed directly to
+`@robota-sdk/agent-command-user-local` before provider setup. CLI parsing may pass terminal options
+such as `--summary`, `--source`, and `--format`, but command behavior and persistence remain outside
+`agent-cli`.
+
 ### Project Memory Review Surface
 
 Project memory storage and policy primitives are SDK-owned, while `/memory` command behavior is owned by `@robota-sdk/agent-command-memory`. The CLI and TUI must not extract memory candidates, select relevant topics, decide approval policy, or write `.robota/memory` files directly. They compose the memory command module, route `/memory` commands through `session.executeCommand()`, and render returned messages/data.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -28,6 +28,9 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
   contracts described in the cross-cutting transparent workflow spec
 - Does NOT own baseline workflow storage root resolution, repo-outside validation, category
   contracts, or item deletion/disable semantics — these are owned by SDK storage contracts
+- Does NOT own user-local command behavior — `@robota-sdk/agent-command-user-local` owns the
+  provider-free `user-local` command behavior while CLI only routes direct product invocation and
+  prints command-owned output
 - Does NOT own workflow manifests, harness command registry semantics, workflow artifact schemas,
   deterministic workflow hook policy, review/evidence gates, or workflow run lifecycle — these must
   be owned below the CLI by SDK/runtime/harness contracts before TUI screens are added
@@ -91,6 +94,11 @@ Existing CLI-owned operational cache such as `~/.robota/update-check.json` remai
 not baseline workflow state. Existing project-local sessions, logs, checkpoints, and memory are
 classified by the storage spec and must not be reused for new baseline workflow features without a
 separate migration PR.
+
+The direct product command `robota user-local storage list --format json` is provider-free. The CLI
+detects the `user-local` positional command before provider setup, delegates parsing and output
+formatting to `@robota-sdk/agent-command-user-local`, and exits without constructing an AI provider
+or opening the TUI.
 
 ### Transparent Process Execution Boundary
 

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -67,6 +67,7 @@
     "@robota-sdk/agent-command-session": "workspace:*",
     "@robota-sdk/agent-command-skills": "workspace:*",
     "@robota-sdk/agent-command-statusline": "workspace:*",
+    "@robota-sdk/agent-command-user-local": "workspace:*",
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-provider-anthropic": "workspace:*",
     "@robota-sdk/agent-provider-deepseek": "workspace:*",

--- a/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   IAIProvider,
   IChatOptions,
@@ -11,7 +11,7 @@ import type {
 } from '@robota-sdk/agent-core';
 import { CommandRegistry, InteractiveSession } from '@robota-sdk/agent-sdk';
 import { createHeadlessTransport } from '@robota-sdk/agent-transport-headless';
-import { createDefaultCliCommandModules } from '../cli.js';
+import { createDefaultCliCommandModules, startCli } from '../cli.js';
 
 function createFakeProvider(): IAIProvider {
   return {
@@ -57,12 +57,70 @@ describe('default CLI command composition', () => {
     }
 
     expect(registry.getCommands().map((command) => command.name)).not.toContain('mode');
+    expect(registry.getCommands().map((command) => command.name)).toContain('user-local');
     expect(registry.getSubcommands('permissions').map((command) => command.name)).toEqual([
       'plan',
       'default',
       'acceptEdits',
       'bypassPermissions',
     ]);
+  });
+
+  it('routes direct user-local storage inspection before provider setup', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-'));
+    const home = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-home-'));
+    const originalArgv = process.argv;
+    const originalHome = process.env.HOME;
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.argv = ['node', 'robota', 'user-local', 'storage', 'list', '--format', 'json'];
+    process.env.HOME = home;
+    process.stdout.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await startCli({ providerDefinitions: [] });
+      const output = parseJsonObject(writes.join('').trim());
+      expect(output['root']).toBe(join(home, '.robota'));
+      const categories = output['categories'];
+      expect(Array.isArray(categories)).toBe(true);
+      if (!Array.isArray(categories)) {
+        throw new Error('Expected categories array');
+      }
+      const categoryNames = categories.map((item) => {
+        if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+          throw new Error('Expected category object');
+        }
+        const category = (item as Record<string, unknown>)['category'];
+        if (typeof category !== 'string') {
+          throw new Error('Expected category string');
+        }
+        return category;
+      });
+      expect(categoryNames).toEqual([
+        'preferences',
+        'view-state',
+        'memory-projections',
+        'task-associations',
+        'workflow-metadata',
+        'inspection-index',
+      ]);
+      expect(existsSync(join(cwd, '.robota'))).toBe(false);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.argv = originalArgv;
+      cwdSpy.mockRestore();
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('runs permissions mode changes through headless slash-command execution', async () => {

--- a/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-command-composition.test.ts
@@ -123,6 +123,52 @@ describe('default CLI command composition', () => {
     }
   });
 
+  it('routes direct user-local memory commands before provider setup', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-memory-'));
+    const home = mkdtempSync(join(tmpdir(), 'robota-direct-user-local-memory-home-'));
+    const originalArgv = process.argv;
+    const originalHome = process.env.HOME;
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.argv = [
+      'node',
+      'robota',
+      'user-local',
+      'memory',
+      'set',
+      'view-preference',
+      'last-panel',
+      'background',
+      '--summary',
+      'Open the background panel',
+      '--source',
+      'user-input',
+    ];
+    process.env.HOME = home;
+    process.stdout.write = ((chunk: string) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await startCli({ providerDefinitions: [] });
+      expect(writes.join('')).toContain('Stored user-local memory item view-preference/last-panel');
+      expect(existsSync(join(cwd, '.robota'))).toBe(false);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.argv = originalArgv;
+      cwdSpy.mockRestore();
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('runs permissions mode changes through headless slash-command execution', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-headless-permissions-'));
     const session = new InteractiveSession({

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -26,6 +26,7 @@ import { createRewindCommandModule } from '@robota-sdk/agent-command-rewind';
 import { createStatusLineCommandModule } from '@robota-sdk/agent-command-statusline';
 import { createSessionCommandModule } from '@robota-sdk/agent-command-session';
 import { createSkillsCommandModule } from '@robota-sdk/agent-command-skills';
+import { createUserLocalCommandModule } from '@robota-sdk/agent-command-user-local';
 import {
   InteractiveSession,
   createProjectSessionStore,
@@ -68,6 +69,7 @@ import {
   shouldRunStartupCliUpdateCheck,
 } from './utils/update-check.js';
 import { createCliPluginCommandAdapter } from './plugins/plugin-command-adapter.js';
+import { runUserLocalDirectCommandIfRequested } from './user-local-direct-command.js';
 
 /** Read version from package.json at runtime. */
 function readVersion(): string {
@@ -180,6 +182,7 @@ export function createDefaultCliCommandModules({
     createLanguageCommandModule(),
     createBackgroundCommandModule(),
     createMemoryCommandModule(),
+    createUserLocalCommandModule(),
     createCompactCommandModule(),
     createContextCommandModule(),
     createExitCommandModule(),
@@ -227,6 +230,11 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   const cwd = process.cwd();
+
+  if (await runUserLocalDirectCommandIfRequested(args, cwd)) {
+    return;
+  }
+
   const commandHostAdapters: ICommandHostAdapters = {
     settings: {
       read: () => readSettings(getUserSettingsPath()),

--- a/packages/agent-cli/src/user-local-direct-command.ts
+++ b/packages/agent-cli/src/user-local-direct-command.ts
@@ -1,0 +1,24 @@
+import { executeUserLocalDirectCommand } from '@robota-sdk/agent-command-user-local';
+import type { IParsedCliArgs } from './utils/cli-args.js';
+
+export async function runUserLocalDirectCommandIfRequested(
+  args: IParsedCliArgs,
+  cwd: string,
+): Promise<boolean> {
+  if (args.positional[0] !== 'user-local') {
+    return false;
+  }
+
+  const result = await executeUserLocalDirectCommand({
+    cwd,
+    argv: args.positional.slice(1),
+    format: args.format,
+  });
+  const output = result.message.endsWith('\n') ? result.message : `${result.message}\n`;
+  if (!result.success) {
+    process.stderr.write(output);
+    process.exit(1);
+  }
+  process.stdout.write(output);
+  return true;
+}

--- a/packages/agent-cli/src/user-local-direct-command.ts
+++ b/packages/agent-cli/src/user-local-direct-command.ts
@@ -13,6 +13,8 @@ export async function runUserLocalDirectCommandIfRequested(
     cwd,
     argv: args.positional.slice(1),
     format: args.format,
+    summary: args.summary,
+    source: args.source,
   });
   const output = result.message.endsWith('\n') ? result.message : `${result.message}\n`;
   if (!result.success) {

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -76,6 +76,26 @@ describe('parseCliArgs', () => {
     expect(args.outputFormat).toBe('json');
   });
 
+  it('parses user-local passthrough metadata flags', () => {
+    process.argv = [
+      'node',
+      'cli',
+      'user-local',
+      'memory',
+      'set',
+      'view-preference',
+      'last-panel',
+      'background',
+      '--summary',
+      'Open the background panel',
+      '--source',
+      'user-input',
+    ];
+    const args = parseCliArgs();
+    expect(args.summary).toBe('Open the background panel');
+    expect(args.source).toBe('user-input');
+  });
+
   it('parses --system-prompt flag', () => {
     process.argv = ['node', 'cli', '-p', '--system-prompt', 'You are helpful', 'test'];
     const args = parseCliArgs();

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -125,6 +125,7 @@ function baseArgs(): IParsedCliArgs {
     forkSession: false,
     sessionName: undefined,
     outputFormat: undefined,
+    format: undefined,
     systemPrompt: undefined,
     appendSystemPrompt: undefined,
     taskFile: undefined,

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -126,6 +126,8 @@ function baseArgs(): IParsedCliArgs {
     sessionName: undefined,
     outputFormat: undefined,
     format: undefined,
+    summary: undefined,
+    source: undefined,
     systemPrompt: undefined,
     appendSystemPrompt: undefined,
     taskFile: undefined,

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -20,6 +20,7 @@ export interface IParsedCliArgs {
   forkSession: boolean;
   sessionName: string | undefined;
   outputFormat: string | undefined;
+  format: string | undefined;
   systemPrompt: string | undefined;
   appendSystemPrompt: string | undefined;
   taskFile: string | undefined;
@@ -78,6 +79,7 @@ export function parseCliArgs(): IParsedCliArgs {
       'fork-session': { type: 'boolean', default: false },
       name: { type: 'string', short: 'n' },
       'output-format': { type: 'string' },
+      format: { type: 'string' },
       'system-prompt': { type: 'string' },
       'append-system-prompt': { type: 'string' },
       'task-file': { type: 'string' },
@@ -113,6 +115,7 @@ export function parseCliArgs(): IParsedCliArgs {
     forkSession: values['fork-session'] ?? false,
     sessionName: values['name'],
     outputFormat: values['output-format'],
+    format: values['format'],
     systemPrompt: values['system-prompt'],
     appendSystemPrompt: values['append-system-prompt'],
     taskFile: values['task-file'],

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -21,6 +21,8 @@ export interface IParsedCliArgs {
   sessionName: string | undefined;
   outputFormat: string | undefined;
   format: string | undefined;
+  summary: string | undefined;
+  source: string | undefined;
   systemPrompt: string | undefined;
   appendSystemPrompt: string | undefined;
   taskFile: string | undefined;
@@ -80,6 +82,8 @@ export function parseCliArgs(): IParsedCliArgs {
       name: { type: 'string', short: 'n' },
       'output-format': { type: 'string' },
       format: { type: 'string' },
+      summary: { type: 'string' },
+      source: { type: 'string' },
       'system-prompt': { type: 'string' },
       'append-system-prompt': { type: 'string' },
       'task-file': { type: 'string' },
@@ -116,6 +120,8 @@ export function parseCliArgs(): IParsedCliArgs {
     sessionName: values['name'],
     outputFormat: values['output-format'],
     format: values['format'],
+    summary: values['summary'],
+    source: values['source'],
     systemPrompt: values['system-prompt'],
     appendSystemPrompt: values['append-system-prompt'],
     taskFile: values['task-file'],

--- a/packages/agent-command-user-local/docs/README.md
+++ b/packages/agent-command-user-local/docs/README.md
@@ -1,0 +1,3 @@
+# @robota-sdk/agent-command-user-local Docs
+
+See [SPEC.md](SPEC.md).

--- a/packages/agent-command-user-local/docs/SPEC.md
+++ b/packages/agent-command-user-local/docs/SPEC.md
@@ -1,0 +1,57 @@
+# SPEC.md - @robota-sdk/agent-command-user-local
+
+## Purpose
+
+`@robota-sdk/agent-command-user-local` owns provider-free `user-local` command behavior for
+inspecting Robota user-local state through SDK-owned contracts.
+
+## Ownership
+
+- Owns `user-local` command metadata, argument parsing, output formatting, and provider-free direct
+  CLI command execution helpers.
+- Consumes user-local storage and memory APIs from `@robota-sdk/agent-sdk`.
+- Does not resolve storage roots, validate repo-outside paths, persist user-local items, read
+  provider configuration, or render TUI screens.
+
+## Public API
+
+```ts
+import {
+  createUserLocalCommandModule,
+  executeUserLocalDirectCommand,
+} from '@robota-sdk/agent-command-user-local';
+```
+
+## Command Contract
+
+- Command name: `user-local`
+- Source: `user-local`
+- User invocable: yes
+- Model invocable: no
+- Safety: `read-only` for storage inspection
+- Argument hint: `storage list [--format json]`
+
+## Behavior
+
+- `user-local storage list --format json` prints the effective user-local root and stable category
+  summaries using SDK projections.
+- Storage inspection is provider-free and must run before provider setup is required.
+- The command must not create or reuse repository-local `.robota/` baseline workflow state.
+- The command must not expose stored command strings as reusable execution preferences.
+
+## Boundary Rules
+
+- This package must not import `agent-cli` or TUI code.
+- This package must not inspect or assemble storage paths directly; it calls SDK user-local APIs.
+- CLI direct invocation may call this package's direct execution helper before provider setup.
+- Future memory inspection/delete/disable behavior must stay in this package while persistence
+  semantics remain in SDK user-local APIs.
+
+## Verification
+
+```bash
+pnpm --filter @robota-sdk/agent-command-user-local build
+pnpm --filter @robota-sdk/agent-command-user-local test
+pnpm --filter @robota-sdk/agent-command-user-local typecheck
+pnpm --filter @robota-sdk/agent-command-user-local lint
+```

--- a/packages/agent-command-user-local/docs/SPEC.md
+++ b/packages/agent-command-user-local/docs/SPEC.md
@@ -29,13 +29,22 @@ import {
 - User invocable: yes
 - Model invocable: no
 - Safety: `read-only` for storage inspection
-- Argument hint: `storage list [--format json]`
+- Argument hint: `storage list [--format json] | memory set/list/inspect/disable/delete`
 
 ## Behavior
 
 - `user-local storage list --format json` prints the effective user-local root and stable category
   summaries using SDK projections.
+- `user-local memory set <category> <key> <value> --summary <summary> --source <source>` stores
+  an explicit display/navigation memory item through SDK user-local APIs.
+- `user-local memory list --format json` prints inspectable memory item projections.
+- `user-local memory inspect <category> <key> --format json` prints one item, including
+  `displayNavigationRule` and `commandExecutionEffect: "none"`.
+- `user-local memory disable <category> <key>` disables an item without deleting it.
+- `user-local memory delete <category> <key>` deletes an item. A follow-up inspect for that item
+  returns a user-readable not-found error.
 - Storage inspection is provider-free and must run before provider setup is required.
+- User-local memory commands are provider-free and must run before provider setup is required.
 - The command must not create or reuse repository-local `.robota/` baseline workflow state.
 - The command must not expose stored command strings as reusable execution preferences.
 
@@ -44,7 +53,7 @@ import {
 - This package must not import `agent-cli` or TUI code.
 - This package must not inspect or assemble storage paths directly; it calls SDK user-local APIs.
 - CLI direct invocation may call this package's direct execution helper before provider setup.
-- Future memory inspection/delete/disable behavior must stay in this package while persistence
+- User-local memory inspection/delete/disable behavior stays in this package while persistence
   semantics remain in SDK user-local APIs.
 
 ## Verification

--- a/packages/agent-command-user-local/package.json
+++ b/packages/agent-command-user-local/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@robota-sdk/agent-command-user-local",
+  "version": "3.0.0-beta.61",
+  "description": "Composable user-local inspection command module for Robota",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/woojubb/robota.git",
+    "directory": "packages/agent-command-user-local"
+  },
+  "homepage": "https://robota.io/",
+  "bugs": {
+    "url": "https://github.com/woojubb/robota/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
+    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
+    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/ --ext .ts",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.5",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
+++ b/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeUserLocalDirectCommand } from '../user-local-command.js';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local command', () => {
+  it('prints storage inspection JSON without provider configuration', async () => {
+    const workspace = await createTempRoot('robota-user-local-command-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const result = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['storage', 'list'],
+        format: 'json',
+      });
+      const parsed = JSON.parse(result.message) as {
+        root: string;
+        categories: readonly { category: string; mayExecuteCommands: boolean }[];
+      };
+
+      expect(result.success).toBe(true);
+      expect(parsed.root).toBe(path.join(home, '.robota'));
+      expect(parsed.categories.map((item) => item.category)).toEqual([
+        'preferences',
+        'view-state',
+        'memory-projections',
+        'task-associations',
+        'workflow-metadata',
+        'inspection-index',
+      ]);
+      expect(parsed.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+});

--- a/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
+++ b/packages/agent-command-user-local/src/__tests__/user-local-command.test.ts
@@ -58,4 +58,88 @@ describe('user-local command', () => {
       }
     }
   });
+
+  it('stores, lists, inspects, disables, and deletes user-local memory items', async () => {
+    const workspace = await createTempRoot('robota-user-local-memory-command-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+    const originalHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      const setResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'set', 'view-preference', 'last-panel', 'background'],
+        summary: 'Open the background panel',
+        source: 'user-input',
+      });
+      expect(setResult.success).toBe(true);
+      expect(setResult.message).toContain('view-preference/last-panel');
+
+      const listResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'list'],
+        format: 'json',
+      });
+      const list = JSON.parse(listResult.message) as {
+        items: readonly { category: string; key: string; enabled: boolean }[];
+      };
+      expect(listResult.success).toBe(true);
+      expect(list.items).toHaveLength(1);
+      expect(list.items[0]).toMatchObject({
+        category: 'view-preference',
+        key: 'last-panel',
+        enabled: true,
+      });
+
+      const inspectResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      const inspected = JSON.parse(inspectResult.message) as {
+        commandExecutionEffect: string;
+        displayNavigationRule: string;
+      };
+      expect(inspectResult.success).toBe(true);
+      expect(inspected.commandExecutionEffect).toBe('none');
+      expect(inspected.displayNavigationRule).toContain('display/navigation only');
+
+      const disableResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'disable', 'view-preference', 'last-panel'],
+      });
+      expect(disableResult.success).toBe(true);
+
+      const disabledInspectResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      const disabled = JSON.parse(disabledInspectResult.message) as { enabled: boolean };
+      expect(disabled.enabled).toBe(false);
+
+      const deleteResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'delete', 'view-preference', 'last-panel'],
+      });
+      expect(deleteResult.success).toBe(true);
+
+      const missingResult = await executeUserLocalDirectCommand({
+        cwd: repo,
+        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+        format: 'json',
+      });
+      expect(missingResult.success).toBe(false);
+      expect(missingResult.message).toBe('User-local memory item not found.');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/agent-command-user-local/src/index.ts
+++ b/packages/agent-command-user-local/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  UserLocalCommandSource,
+  createUserLocalCommandEntry,
+  createUserLocalCommandModule,
+} from './user-local-command-module.js';
+export {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  USER_LOCAL_COMMAND_USAGE,
+  executeUserLocalCommand,
+  executeUserLocalDirectCommand,
+} from './user-local-command.js';
+export type { IUserLocalDirectCommandOptions } from './user-local-command.js';

--- a/packages/agent-command-user-local/src/user-local-command-constants.ts
+++ b/packages/agent-command-user-local/src/user-local-command-constants.ts
@@ -1,0 +1,5 @@
+export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
+export const USER_LOCAL_COMMAND_ARGUMENT_HINT =
+  'storage list [--format json] | memory set/list/inspect/disable/delete';
+export const USER_LOCAL_COMMAND_USAGE =
+  'Usage: user-local storage list [--format json] | user-local memory set <category> <key> <value> --summary <summary> --source <source> | user-local memory list [--format json] | user-local memory inspect <category> <key> [--format json] | user-local memory disable <category> <key> | user-local memory delete <category> <key>';

--- a/packages/agent-command-user-local/src/user-local-command-module.ts
+++ b/packages/agent-command-user-local/src/user-local-command-module.ts
@@ -24,6 +24,11 @@ export function createUserLocalCommandEntry(): ICommand {
         description: 'Inspect user-local storage categories',
         source: 'user-local',
       },
+      {
+        name: 'memory',
+        description: 'Inspect and manage user-local memory items',
+        source: 'user-local',
+      },
     ],
   };
 }

--- a/packages/agent-command-user-local/src/user-local-command-module.ts
+++ b/packages/agent-command-user-local/src/user-local-command-module.ts
@@ -1,0 +1,59 @@
+import type {
+  ICommand,
+  ICommandModule,
+  ICommandSource,
+  ISystemCommand,
+} from '@robota-sdk/agent-sdk';
+import {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  executeUserLocalCommand,
+} from './user-local-command.js';
+
+export function createUserLocalCommandEntry(): ICommand {
+  return {
+    name: 'user-local',
+    description: USER_LOCAL_COMMAND_DESCRIPTION,
+    source: 'user-local',
+    argumentHint: USER_LOCAL_COMMAND_ARGUMENT_HINT,
+    modelInvocable: false,
+    safety: 'read-only',
+    subcommands: [
+      {
+        name: 'storage',
+        description: 'Inspect user-local storage categories',
+        source: 'user-local',
+      },
+    ],
+  };
+}
+
+function createUserLocalSystemCommand(): ISystemCommand {
+  const entry = createUserLocalCommandEntry();
+  return {
+    name: entry.name,
+    description: entry.description,
+    userInvocable: true,
+    modelInvocable: false,
+    argumentHint: entry.argumentHint,
+    safety: entry.safety,
+    subcommands: entry.subcommands,
+    execute: executeUserLocalCommand,
+  };
+}
+
+export class UserLocalCommandSource implements ICommandSource {
+  readonly name = 'user-local';
+
+  getCommands(): ICommand[] {
+    return [createUserLocalCommandEntry()];
+  }
+}
+
+export function createUserLocalCommandModule(): ICommandModule {
+  return {
+    name: 'agent-command-user-local',
+    commandSources: [new UserLocalCommandSource()],
+    systemCommands: [createUserLocalSystemCommand()],
+  };
+}

--- a/packages/agent-command-user-local/src/user-local-command.ts
+++ b/packages/agent-command-user-local/src/user-local-command.ts
@@ -1,0 +1,136 @@
+import type { ICommandHostContext, ICommandResult } from '@robota-sdk/agent-sdk';
+import { inspectUserLocalStorage } from '@robota-sdk/agent-sdk';
+
+export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
+export const USER_LOCAL_COMMAND_ARGUMENT_HINT = 'storage list [--format json]';
+export const USER_LOCAL_COMMAND_USAGE = 'Usage: user-local storage list [--format json]';
+
+type TUserLocalOutputFormat = 'text' | 'json';
+
+export interface IUserLocalDirectCommandOptions {
+  readonly cwd: string;
+  readonly argv: readonly string[];
+  readonly format?: string;
+}
+
+interface IParsedUserLocalCommand {
+  readonly target?: string;
+  readonly action?: string;
+  readonly format: TUserLocalOutputFormat;
+}
+
+function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
+  if (value === undefined || value === 'text') {
+    return 'text';
+  }
+  if (value === 'json') {
+    return 'json';
+  }
+  throw new Error(`Unsupported user-local output format: ${value}`);
+}
+
+function parseUserLocalArgs(
+  argv: readonly string[],
+  directFormat?: string,
+): IParsedUserLocalCommand {
+  let format = directFormat;
+  const positional: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--format') {
+      format = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--format=')) {
+      format = arg.slice('--format='.length);
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  return {
+    target: positional[0],
+    action: positional[1],
+    format: parseOutputFormat(format),
+  };
+}
+
+function splitRawArgs(rawArgs: string): readonly string[] {
+  return rawArgs.trim().split(/\s+/).filter(Boolean);
+}
+
+function formatStorageInspectionText(
+  root: string,
+  categories: readonly { category: string }[],
+): string {
+  const categoryLines = categories.map((item) => `- ${item.category}`);
+  return [`User-local storage root: ${root}`, 'Categories:', ...categoryLines].join('\n');
+}
+
+async function executeParsedUserLocalCommand(
+  cwd: string,
+  parsed: IParsedUserLocalCommand,
+): Promise<ICommandResult> {
+  if (parsed.target !== 'storage' || (parsed.action ?? 'list') !== 'list') {
+    return {
+      message: USER_LOCAL_COMMAND_USAGE,
+      success: false,
+    };
+  }
+
+  try {
+    const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
+    return {
+      message:
+        parsed.format === 'json'
+          ? JSON.stringify(inspection, null, 2)
+          : formatStorageInspectionText(inspection.root, inspection.categories),
+      success: true,
+      data: {
+        root: inspection.root,
+        categories: inspection.categories,
+        inspection,
+      },
+    };
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+export async function executeUserLocalDirectCommand(
+  options: IUserLocalDirectCommandOptions,
+): Promise<ICommandResult> {
+  try {
+    return await executeParsedUserLocalCommand(
+      options.cwd,
+      parseUserLocalArgs(options.argv, options.format),
+    );
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}
+
+export async function executeUserLocalCommand(
+  context: ICommandHostContext,
+  rawArgs: string,
+): Promise<ICommandResult> {
+  try {
+    return await executeParsedUserLocalCommand(
+      context.getCwd(),
+      parseUserLocalArgs(splitRawArgs(rawArgs)),
+    );
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+}

--- a/packages/agent-command-user-local/src/user-local-command.ts
+++ b/packages/agent-command-user-local/src/user-local-command.ts
@@ -1,9 +1,12 @@
 import type { ICommandHostContext, ICommandResult } from '@robota-sdk/agent-sdk';
 import { inspectUserLocalStorage } from '@robota-sdk/agent-sdk';
-
-export const USER_LOCAL_COMMAND_DESCRIPTION = 'Inspect Robota user-local storage and memory state.';
-export const USER_LOCAL_COMMAND_ARGUMENT_HINT = 'storage list [--format json]';
-export const USER_LOCAL_COMMAND_USAGE = 'Usage: user-local storage list [--format json]';
+import { executeMemoryCommand } from './user-local-memory-command.js';
+import { USER_LOCAL_COMMAND_USAGE } from './user-local-command-constants.js';
+export {
+  USER_LOCAL_COMMAND_ARGUMENT_HINT,
+  USER_LOCAL_COMMAND_DESCRIPTION,
+  USER_LOCAL_COMMAND_USAGE,
+} from './user-local-command-constants.js';
 
 type TUserLocalOutputFormat = 'text' | 'json';
 
@@ -11,12 +14,24 @@ export interface IUserLocalDirectCommandOptions {
   readonly cwd: string;
   readonly argv: readonly string[];
   readonly format?: string;
+  readonly summary?: string;
+  readonly source?: string;
 }
 
 interface IParsedUserLocalCommand {
   readonly target?: string;
   readonly action?: string;
+  readonly positional: readonly string[];
   readonly format: TUserLocalOutputFormat;
+  readonly summary?: string;
+  readonly source?: string;
+}
+
+interface IParsedUserLocalOption {
+  readonly format?: string;
+  readonly summary?: string;
+  readonly source?: string;
+  readonly nextIndex: number;
 }
 
 function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
@@ -29,22 +44,53 @@ function parseOutputFormat(value: string | undefined): TUserLocalOutputFormat {
   throw new Error(`Unsupported user-local output format: ${value}`);
 }
 
+function parseUserLocalOption(
+  arg: string,
+  argv: readonly string[],
+  index: number,
+): IParsedUserLocalOption | null {
+  if (arg === '--format') {
+    return { format: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--format=')) {
+    return { format: arg.slice('--format='.length), nextIndex: index };
+  }
+  if (arg === '--summary') {
+    return { summary: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--summary=')) {
+    return { summary: arg.slice('--summary='.length), nextIndex: index };
+  }
+  if (arg === '--source') {
+    return { source: argv[index + 1], nextIndex: index + 1 };
+  }
+  if (arg.startsWith('--source=')) {
+    return { source: arg.slice('--source='.length), nextIndex: index };
+  }
+  return null;
+}
+
 function parseUserLocalArgs(
   argv: readonly string[],
-  directFormat?: string,
+  directOptions: {
+    readonly format?: string;
+    readonly summary?: string;
+    readonly source?: string;
+  } = {},
 ): IParsedUserLocalCommand {
-  let format = directFormat;
+  let format = directOptions.format;
+  let summary = directOptions.summary;
+  let source = directOptions.source;
   const positional: string[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === '--format') {
-      format = argv[index + 1];
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith('--format=')) {
-      format = arg.slice('--format='.length);
+    const option = parseUserLocalOption(arg, argv, index);
+    if (option !== null) {
+      format = option.format ?? format;
+      summary = option.summary ?? summary;
+      source = option.source ?? source;
+      index = option.nextIndex;
       continue;
     }
     positional.push(arg);
@@ -53,7 +99,10 @@ function parseUserLocalArgs(
   return {
     target: positional[0],
     action: positional[1],
+    positional: positional.slice(2),
     format: parseOutputFormat(format),
+    summary,
+    source,
   };
 }
 
@@ -69,37 +118,53 @@ function formatStorageInspectionText(
   return [`User-local storage root: ${root}`, 'Categories:', ...categoryLines].join('\n');
 }
 
-async function executeParsedUserLocalCommand(
+async function executeStorageCommand(
   cwd: string,
   parsed: IParsedUserLocalCommand,
 ): Promise<ICommandResult> {
-  if (parsed.target !== 'storage' || (parsed.action ?? 'list') !== 'list') {
+  if ((parsed.action ?? 'list') !== 'list') {
     return {
       message: USER_LOCAL_COMMAND_USAGE,
       success: false,
     };
   }
 
-  try {
-    const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
-    return {
-      message:
-        parsed.format === 'json'
-          ? JSON.stringify(inspection, null, 2)
-          : formatStorageInspectionText(inspection.root, inspection.categories),
-      success: true,
-      data: {
-        root: inspection.root,
-        categories: inspection.categories,
-        inspection,
-      },
-    };
-  } catch (error) {
-    return {
-      message: error instanceof Error ? error.message : String(error),
-      success: false,
-    };
+  const inspection = await inspectUserLocalStorage({ activeRepositoryRoot: cwd });
+  return {
+    message:
+      parsed.format === 'json'
+        ? JSON.stringify(inspection, null, 2)
+        : formatStorageInspectionText(inspection.root, inspection.categories),
+    success: true,
+    data: {
+      root: inspection.root,
+      categories: inspection.categories,
+      inspection,
+    },
+  };
+}
+
+async function executeParsedUserLocalCommand(
+  cwd: string,
+  parsed: IParsedUserLocalCommand,
+): Promise<ICommandResult> {
+  if (parsed.target === 'storage') {
+    return executeStorageCommand(cwd, parsed);
   }
+  if (parsed.target === 'memory') {
+    return executeMemoryCommand(cwd, parsed);
+  }
+  return {
+    message: USER_LOCAL_COMMAND_USAGE,
+    success: false,
+  };
+}
+
+function formatCommandErrorMessage(errorMessage: string): string {
+  if (errorMessage.includes('ENOENT')) {
+    return 'User-local memory item not found.';
+  }
+  return errorMessage;
 }
 
 export async function executeUserLocalDirectCommand(
@@ -108,11 +173,15 @@ export async function executeUserLocalDirectCommand(
   try {
     return await executeParsedUserLocalCommand(
       options.cwd,
-      parseUserLocalArgs(options.argv, options.format),
+      parseUserLocalArgs(options.argv, {
+        format: options.format,
+        summary: options.summary,
+        source: options.source,
+      }),
     );
   } catch (error) {
     return {
-      message: error instanceof Error ? error.message : String(error),
+      message: formatCommandErrorMessage(error instanceof Error ? error.message : String(error)),
       success: false,
     };
   }
@@ -129,7 +198,7 @@ export async function executeUserLocalCommand(
     );
   } catch (error) {
     return {
-      message: error instanceof Error ? error.message : String(error),
+      message: formatCommandErrorMessage(error instanceof Error ? error.message : String(error)),
       success: false,
     };
   }

--- a/packages/agent-command-user-local/src/user-local-memory-command.ts
+++ b/packages/agent-command-user-local/src/user-local-memory-command.ts
@@ -1,0 +1,147 @@
+import type { ICommandResult, TUserLocalMemoryCategory } from '@robota-sdk/agent-sdk';
+import {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  setUserLocalMemoryItem,
+} from '@robota-sdk/agent-sdk';
+import { USER_LOCAL_COMMAND_USAGE } from './user-local-command-constants.js';
+
+export interface IUserLocalMemoryCommandArgs {
+  readonly action?: string;
+  readonly positional: readonly string[];
+  readonly format: 'text' | 'json';
+  readonly summary?: string;
+  readonly source?: string;
+}
+
+function formatMemoryListText(
+  items: readonly { category: string; key: string; enabled: boolean }[],
+): string {
+  if (items.length === 0) {
+    return 'No user-local memory items.';
+  }
+  return items
+    .map((item) => `- ${item.category}/${item.key} (${item.enabled ? 'enabled' : 'disabled'})`)
+    .join('\n');
+}
+
+function parseMemoryCategory(value: string | undefined): TUserLocalMemoryCategory {
+  if (value === undefined) {
+    throw new Error('User-local memory category is required.');
+  }
+  return value as TUserLocalMemoryCategory;
+}
+
+async function executeMemoryListCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const list = await listUserLocalMemoryItems({ activeRepositoryRoot });
+  return {
+    message:
+      parsed.format === 'json' ? JSON.stringify(list, null, 2) : formatMemoryListText(list.items),
+    success: true,
+    data: { list },
+  };
+}
+
+async function executeMemorySetCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key, value] = parsed.positional;
+  const item = await setUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+    value: value ?? '',
+    summary: parsed.summary ?? '',
+    source: parsed.source ?? '',
+  });
+  return {
+    message: `Stored user-local memory item ${item.category}/${item.key} at ${item.storageLocation}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryInspectCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const item = await inspectUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message:
+      parsed.format === 'json'
+        ? JSON.stringify(item, null, 2)
+        : `${item.category}/${item.key}: ${item.summary}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryDisableCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const item = await disableUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message: `Disabled user-local memory item ${item.category}/${item.key}`,
+    success: true,
+    data: { item },
+  };
+}
+
+async function executeMemoryDeleteCommand(
+  activeRepositoryRoot: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  const [category, key] = parsed.positional;
+  const result = await deleteUserLocalMemoryItem({
+    activeRepositoryRoot,
+    category: parseMemoryCategory(category),
+    key: key ?? '',
+  });
+  return {
+    message: `Deleted user-local memory item ${result.category}/${result.key}`,
+    success: true,
+    data: { result },
+  };
+}
+
+export async function executeMemoryCommand(
+  cwd: string,
+  parsed: IUserLocalMemoryCommandArgs,
+): Promise<ICommandResult> {
+  if ((parsed.action ?? 'list') === 'list') {
+    return executeMemoryListCommand(cwd, parsed);
+  }
+  if (parsed.action === 'set') {
+    return executeMemorySetCommand(cwd, parsed);
+  }
+  if (parsed.action === 'inspect') {
+    return executeMemoryInspectCommand(cwd, parsed);
+  }
+  if (parsed.action === 'disable') {
+    return executeMemoryDisableCommand(cwd, parsed);
+  }
+  if (parsed.action === 'delete') {
+    return executeMemoryDeleteCommand(cwd, parsed);
+  }
+  return {
+    message: USER_LOCAL_COMMAND_USAGE,
+    success: false,
+  };
+}

--- a/packages/agent-command-user-local/tsconfig.json
+++ b/packages/agent-command-user-local/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -155,6 +155,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── prompt-file-reference-*.ts ← `@file` prompt reference parser/resolver, path policy, formatting, and diagnostics
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
 ├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
+├── src/user-local/             ← user-local storage root validation, category projections, and future baseline memory persistence
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/self-hosting/           ← self-hosting verification planner + lifecycle state machine
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
@@ -543,6 +544,24 @@ Resolved provider fields:
   User-local display/navigation preferences are governed by
   [../../../.agents/specs/user-local-memory.md](../../../.agents/specs/user-local-memory.md) and
   must not be stored in `.robota/memory/`.
+
+### User-Local Storage
+
+- **Package**: `agent-sdk/user-local/`
+- **Purpose**: Resolve and inspect baseline workflow storage under user-local storage outside the
+  active repository.
+- **Default root**: `~/.robota`.
+- **Validation**: SDK APIs reject empty roots, relative roots, roots equal to the active repository,
+  and roots inside the active repository, including symlink-resolved paths when possible.
+- **Categories**: `preferences`, `view-state`, `memory-projections`, `task-associations`,
+  `workflow-metadata`, and `inspection-index`.
+- **Inspection projection**: SDK returns root, active repository root, category summaries, item
+  summaries, storage locations, enabled/delete/disable metadata, and timestamps when available.
+- **Command boundary**: `@robota-sdk/agent-command-user-local` formats provider-free
+  `user-local storage list --format json` output from SDK projections. `agent-cli` only routes the
+  direct product command before provider setup and prints the command-owned output.
+- **Repository independence**: SDK user-local APIs must not create repository `.robota/` baseline
+  workflow state.
 
 ### Context Window Management
 

--- a/packages/agent-sdk/docs/SPEC.md
+++ b/packages/agent-sdk/docs/SPEC.md
@@ -155,7 +155,7 @@ agent-sdk (assembly layer — SDK-specific features only)
 │   ├── prompt-file-reference-*.ts ← `@file` prompt reference parser/resolver, path policy, formatting, and diagnostics
 │   └── task-context.ts         ← active `.agents/tasks/*.md` discovery, selection, formatting, and status updates
 ├── src/memory/                 ← project memory store, reusable capture policy, retrieval services
-├── src/user-local/             ← user-local storage root validation, category projections, and future baseline memory persistence
+├── src/user-local/             ← user-local storage root validation, category projections, and baseline memory persistence
 ├── src/checkpoints/            ← edit checkpoint store + Write/Edit tool snapshot wrapper
 ├── src/self-hosting/           ← self-hosting verification planner + lifecycle state machine
 ├── src/tools/agent-tool.ts     ← Agent sub-session tool (SDK-specific: uses createSession)
@@ -346,12 +346,11 @@ category contracts, and item inspection/removal projections.
 Existing `projectPaths(cwd)` helpers remain valid for explicit project-owned features such as
 project settings, session replay/debug logs, edit checkpoints, and current project memory. New
 baseline transparent workflow state must not use `projectPaths(cwd)` or ad hoc `.robota/` paths.
-It must use SDK-owned user-local storage contracts once those are implemented.
+It must use SDK-owned user-local storage contracts.
 
-Existing `userPaths()` helpers expose only current user settings and sessions paths. They are not
-yet the complete transparent workflow storage contract. Future implementation PRs must add tested
-user-local category APIs instead of having CLI or command modules assemble category paths
-themselves.
+Existing `userPaths()` helpers expose only current user settings and sessions paths. User-local
+workflow state uses the tested `src/user-local/` APIs instead of CLI or command modules assembling
+category paths themselves.
 
 ### User-Local Memory Transparency (SDK-Specific)
 
@@ -562,6 +561,25 @@ Resolved provider fields:
   direct product command before provider setup and prints the command-owned output.
 - **Repository independence**: SDK user-local APIs must not create repository `.robota/` baseline
   workflow state.
+
+### User-Local Memory
+
+- **Package**: `agent-sdk/user-local/`
+- **Purpose**: Persist explicit display/navigation memory items under the user-local storage root.
+- **Storage category**: `memory-projections`.
+- **Allowed categories**: `view-preference`, `last-visible-cwd`, `background-selection`,
+  `task-association`, `display-preference`, and `inspection-choice`.
+- **Projection fields**: category, key, summary, value summary, source, scope, storage location,
+  timestamps, enabled state, display/navigation rule, delete/disable availability, and
+  `commandExecutionEffect: "none"`.
+- **Mutation APIs**: SDK owns set, list, inspect, disable, delete, and enabled-item read behavior.
+- **Disabled-item rule**: disabled items remain inspectable but `readEnabledUserLocalMemoryItem`
+  returns `null`, so they cannot affect display/navigation defaults.
+- **Command boundary**: `@robota-sdk/agent-command-user-local` formats provider-free
+  `user-local memory ...` output from SDK projections. `agent-cli` only routes the product command
+  and passes terminal options such as `--summary`, `--source`, and `--format`.
+- **Repository independence**: user-local memory APIs must not write baseline memory inside the
+  active repository or project `.robota/`.
 
 ### Context Window Management
 

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -256,6 +256,23 @@ export type {
   TPromptInput,
 } from './commands/index.js';
 
+// ── User-local storage ─────────────────────────────────────
+export {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from './user-local/index.js';
+export type {
+  IInspectUserLocalStorageOptions,
+  IResolveUserLocalStorageRootOptions,
+  IUserLocalStorageCategoryDefinition,
+  IUserLocalStorageCategoryProjection,
+  IUserLocalStorageInspection,
+  IUserLocalStorageItemSummary,
+  TUserLocalStorageCategory,
+} from './user-local/index.js';
+
 // ── Skill prompt utilities ───────────────────────────────────
 export { substituteVariables, preprocessShellCommands } from './utils/skill-prompt.js';
 export type { SkillPromptContext } from './utils/skill-prompt.js';

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -256,20 +256,35 @@ export type {
   TPromptInput,
 } from './commands/index.js';
 
-// ── User-local storage ─────────────────────────────────────
+// ── User-local storage and memory ──────────────────────────
 export {
+  USER_LOCAL_MEMORY_CATEGORIES,
   USER_LOCAL_STORAGE_CATEGORIES,
   USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
   inspectUserLocalStorage,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
   resolveUserLocalStorageRoot,
+  setUserLocalMemoryItem,
 } from './user-local/index.js';
 export type {
   IInspectUserLocalStorageOptions,
   IResolveUserLocalStorageRootOptions,
+  IUserLocalMemoryDeleteResult,
+  IUserLocalMemoryItemOptions,
+  IUserLocalMemoryItemProjection,
+  IUserLocalMemoryListOptions,
+  IUserLocalMemoryListProjection,
+  IUserLocalMemorySetOptions,
   IUserLocalStorageCategoryDefinition,
   IUserLocalStorageCategoryProjection,
   IUserLocalStorageInspection,
   IUserLocalStorageItemSummary,
+  TUserLocalMemoryCategory,
+  TUserLocalMemoryCommandExecutionEffect,
   TUserLocalStorageCategory,
 } from './user-local/index.js';
 

--- a/packages/agent-sdk/src/user-local/__tests__/memory.test.ts
+++ b/packages/agent-sdk/src/user-local/__tests__/memory.test.ts
@@ -1,0 +1,209 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
+  setUserLocalMemoryItem,
+} from '../memory.js';
+
+const tempRoots: string[] = [];
+const NOW = new Date('2026-05-09T00:00:00.000Z');
+const LATER = new Date('2026-05-09T00:01:00.000Z');
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+async function createWorkspace(): Promise<{
+  readonly repo: string;
+  readonly home: string;
+}> {
+  const workspace = await createTempRoot('robota-user-local-memory-');
+  const repo = path.join(workspace, 'repo');
+  const home = path.join(workspace, 'home');
+  await fs.mkdir(repo);
+  await fs.mkdir(home);
+  return { repo, home };
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local memory', () => {
+  it('stores and projects display/navigation memory outside the active repository', async () => {
+    const { repo, home } = await createWorkspace();
+
+    const item = await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    expect(item).toMatchObject({
+      root: path.join(home, '.robota'),
+      category: 'view-preference',
+      key: 'last-panel',
+      summary: 'Open the background panel',
+      valueSummary: 'background',
+      source: 'user-input',
+      scope: 'user',
+      createdAt: NOW.toISOString(),
+      lastUsedAt: NOW.toISOString(),
+      enabled: true,
+      commandExecutionEffect: 'none',
+      deleteAvailable: true,
+      disableAvailable: true,
+    });
+    expect(item.displayNavigationRule).toContain('display/navigation only');
+    expect(item.storageLocation).toBe(
+      path.join(home, '.robota', 'memory-projections', 'view-preference__last-panel.json'),
+    );
+    expect(await pathExists(path.join(repo, '.robota'))).toBe(false);
+  });
+
+  it('lists, inspects, disables, and hides disabled items from enabled reads', async () => {
+    const { repo, home } = await createWorkspace();
+
+    await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    const list = await listUserLocalMemoryItems({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+    });
+    expect(list.items.map((item) => `${item.category}/${item.key}`)).toEqual([
+      'view-preference/last-panel',
+    ]);
+
+    const inspected = await inspectUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+    });
+    expect(inspected.enabled).toBe(true);
+
+    const disabled = await disableUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      now: () => LATER,
+    });
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.lastUsedAt).toBe(LATER.toISOString());
+
+    const enabledRead = await readEnabledUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+    });
+    expect(enabledRead).toBeNull();
+  });
+
+  it('deletes an item and rejects follow-up inspection', async () => {
+    const { repo, home } = await createWorkspace();
+
+    await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'view-preference',
+      key: 'last-panel',
+      value: 'background',
+      summary: 'Open the background panel',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    await expect(
+      deleteUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        homeDir: home,
+        category: 'view-preference',
+        key: 'last-panel',
+      }),
+    ).resolves.toMatchObject({
+      category: 'view-preference',
+      key: 'last-panel',
+      deleted: true,
+    });
+
+    await expect(
+      inspectUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        homeDir: home,
+        category: 'view-preference',
+        key: 'last-panel',
+      }),
+    ).rejects.toThrow('ENOENT');
+  });
+
+  it('stores command-looking values as inert display values only', async () => {
+    const { repo, home } = await createWorkspace();
+
+    const item = await setUserLocalMemoryItem({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      category: 'display-preference',
+      key: 'compact-mode',
+      value: 'npm test',
+      summary: 'Display compact mode preference',
+      source: 'user-input',
+      now: () => NOW,
+    });
+
+    expect(item.commandExecutionEffect).toBe('none');
+    expect(item.displayNavigationRule).toContain('only');
+    expect(item).not.toHaveProperty('command');
+    expect(item).not.toHaveProperty('commandString');
+  });
+
+  it('rejects a storage root inside the active repository', async () => {
+    const { repo } = await createWorkspace();
+
+    await expect(
+      setUserLocalMemoryItem({
+        activeRepositoryRoot: repo,
+        storageRoot: path.join(repo, '.robota'),
+        category: 'view-preference',
+        key: 'last-panel',
+        value: 'background',
+        summary: 'Open the background panel',
+        source: 'user-input',
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+});

--- a/packages/agent-sdk/src/user-local/__tests__/storage.test.ts
+++ b/packages/agent-sdk/src/user-local/__tests__/storage.test.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from '../storage.js';
+
+const tempRoots: string[] = [];
+
+async function createTempRoot(name: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(tmpdir(), name));
+  tempRoots.push(root);
+  return root;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('user-local storage', () => {
+  it('resolves the default root under injected user home outside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-default-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+
+    const root = await resolveUserLocalStorageRoot({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+    });
+
+    expect(root).toBe(path.join(home, '.robota'));
+  });
+
+  it('rejects storage roots inside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-reject-');
+    const repo = path.join(workspace, 'repo');
+    await fs.mkdir(repo);
+
+    await expect(
+      resolveUserLocalStorageRoot({
+        activeRepositoryRoot: repo,
+        storageRoot: path.join(repo, '.robota'),
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+
+  it('rejects symlinked roots that resolve inside the active repository', async () => {
+    const workspace = await createTempRoot('robota-user-local-symlink-');
+    const repo = path.join(workspace, 'repo');
+    const target = path.join(repo, '.robota');
+    const link = path.join(workspace, 'linked-root');
+    await fs.mkdir(target, { recursive: true });
+    await fs.symlink(target, link);
+
+    await expect(
+      resolveUserLocalStorageRoot({
+        activeRepositoryRoot: repo,
+        storageRoot: link,
+      }),
+    ).rejects.toThrow('outside the active repository');
+  });
+
+  it('projects stable categories without writing repository-local state', async () => {
+    const workspace = await createTempRoot('robota-user-local-inspect-');
+    const repo = path.join(workspace, 'repo');
+    const home = path.join(workspace, 'home');
+    await fs.mkdir(repo);
+    await fs.mkdir(home);
+
+    const inspection = await inspectUserLocalStorage({
+      activeRepositoryRoot: repo,
+      homeDir: home,
+      now: () => new Date('2026-05-09T00:00:00.000Z'),
+    });
+
+    expect(inspection).toMatchObject({
+      root: path.join(home, '.robota'),
+      activeRepositoryRoot: repo,
+      generatedAt: '2026-05-09T00:00:00.000Z',
+    });
+    expect(inspection.categories.map((item) => item.category)).toEqual([
+      ...USER_LOCAL_STORAGE_CATEGORIES,
+    ]);
+    expect(inspection.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
+    expect(inspection.categories.every((item) => item.itemCount === 0)).toBe(true);
+    expect(await pathExists(path.join(repo, '.robota'))).toBe(false);
+  });
+});

--- a/packages/agent-sdk/src/user-local/index.ts
+++ b/packages/agent-sdk/src/user-local/index.ts
@@ -4,6 +4,15 @@ export {
   inspectUserLocalStorage,
   resolveUserLocalStorageRoot,
 } from './storage.js';
+export {
+  deleteUserLocalMemoryItem,
+  disableUserLocalMemoryItem,
+  inspectUserLocalMemoryItem,
+  listUserLocalMemoryItems,
+  readEnabledUserLocalMemoryItem,
+  setUserLocalMemoryItem,
+} from './memory.js';
+export { USER_LOCAL_MEMORY_CATEGORIES } from './memory-types.js';
 export type {
   IInspectUserLocalStorageOptions,
   IResolveUserLocalStorageRootOptions,
@@ -13,3 +22,13 @@ export type {
   IUserLocalStorageItemSummary,
   TUserLocalStorageCategory,
 } from './storage.js';
+export type {
+  IUserLocalMemoryDeleteResult,
+  IUserLocalMemoryItemOptions,
+  IUserLocalMemoryItemProjection,
+  IUserLocalMemoryListOptions,
+  IUserLocalMemoryListProjection,
+  IUserLocalMemorySetOptions,
+  TUserLocalMemoryCategory,
+  TUserLocalMemoryCommandExecutionEffect,
+} from './memory-types.js';

--- a/packages/agent-sdk/src/user-local/index.ts
+++ b/packages/agent-sdk/src/user-local/index.ts
@@ -1,0 +1,15 @@
+export {
+  USER_LOCAL_STORAGE_CATEGORIES,
+  USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS,
+  inspectUserLocalStorage,
+  resolveUserLocalStorageRoot,
+} from './storage.js';
+export type {
+  IInspectUserLocalStorageOptions,
+  IResolveUserLocalStorageRootOptions,
+  IUserLocalStorageCategoryDefinition,
+  IUserLocalStorageCategoryProjection,
+  IUserLocalStorageInspection,
+  IUserLocalStorageItemSummary,
+  TUserLocalStorageCategory,
+} from './storage.js';

--- a/packages/agent-sdk/src/user-local/memory-types.ts
+++ b/packages/agent-sdk/src/user-local/memory-types.ts
@@ -1,0 +1,76 @@
+import type { IResolveUserLocalStorageRootOptions } from './storage.js';
+
+export const USER_LOCAL_MEMORY_CATEGORIES = [
+  'view-preference',
+  'last-visible-cwd',
+  'background-selection',
+  'task-association',
+  'display-preference',
+  'inspection-choice',
+] as const;
+
+export type TUserLocalMemoryCategory = (typeof USER_LOCAL_MEMORY_CATEGORIES)[number];
+export type TUserLocalMemoryCommandExecutionEffect = 'none';
+
+export interface IUserLocalMemoryItemProjection {
+  readonly root: string;
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly summary: string;
+  readonly valueSummary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly storageLocation: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string;
+  readonly enabled: boolean;
+  readonly displayNavigationRule: string;
+  readonly commandExecutionEffect: TUserLocalMemoryCommandExecutionEffect;
+  readonly deleteAvailable: true;
+  readonly disableAvailable: true;
+}
+
+export interface IUserLocalMemoryListProjection {
+  readonly root: string;
+  readonly activeRepositoryRoot: string;
+  readonly items: readonly IUserLocalMemoryItemProjection[];
+}
+
+export interface IUserLocalMemorySetOptions extends IResolveUserLocalStorageRootOptions {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly value: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope?: string;
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryItemOptions extends IResolveUserLocalStorageRootOptions {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryListOptions extends IResolveUserLocalStorageRootOptions {
+  readonly now?: () => Date;
+}
+
+export interface IUserLocalMemoryDeleteResult {
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly deleted: boolean;
+}
+
+export interface IUserLocalMemoryFile {
+  readonly schemaVersion: 1;
+  readonly category: TUserLocalMemoryCategory;
+  readonly key: string;
+  readonly value: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string;
+  readonly enabled: boolean;
+}

--- a/packages/agent-sdk/src/user-local/memory.ts
+++ b/packages/agent-sdk/src/user-local/memory.ts
@@ -1,0 +1,298 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { resolveUserLocalStorageRoot } from './storage.js';
+import type { IResolveUserLocalStorageRootOptions } from './storage.js';
+import {
+  USER_LOCAL_MEMORY_CATEGORIES,
+  type IUserLocalMemoryDeleteResult,
+  type IUserLocalMemoryFile,
+  type IUserLocalMemoryItemOptions,
+  type IUserLocalMemoryItemProjection,
+  type IUserLocalMemoryListOptions,
+  type IUserLocalMemoryListProjection,
+  type IUserLocalMemorySetOptions,
+  type TUserLocalMemoryCategory,
+} from './memory-types.js';
+
+type TJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly TJsonValue[]
+  | { readonly [key: string]: TJsonValue };
+type TJsonRecord = { readonly [key: string]: TJsonValue };
+
+const MEMORY_STORAGE_CATEGORY = 'memory-projections';
+const FILE_EXTENSION = '.json';
+const MEMORY_SCHEMA_VERSION = 1;
+const MAX_SEGMENT_LENGTH = 80;
+const MAX_SUMMARY_LENGTH = 240;
+const MAX_SOURCE_LENGTH = 80;
+const MAX_SCOPE_LENGTH = 120;
+const MAX_VALUE_SUMMARY_LENGTH = 240;
+const DEFAULT_SCOPE = 'user';
+const SAFE_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9._-]*$/u;
+
+const DISPLAY_NAVIGATION_RULES: Record<TUserLocalMemoryCategory, string> = {
+  'view-preference': 'May affect UI panel, filter, density, or sorting display/navigation only.',
+  'last-visible-cwd': 'May display or preselect an already visible workspace context only.',
+  'background-selection': 'May restore the selected background entry in local UI only.',
+  'task-association': 'May group visible tasks by a local association only.',
+  'display-preference': 'May affect local text wrapping, compactness, or visibility only.',
+  'inspection-choice': 'May affect inspection display choices only.',
+};
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString();
+}
+
+function isUserLocalMemoryCategory(value: string): value is TUserLocalMemoryCategory {
+  return USER_LOCAL_MEMORY_CATEGORIES.includes(value as TUserLocalMemoryCategory);
+}
+
+function assertUserLocalMemoryCategory(value: string): TUserLocalMemoryCategory {
+  if (!isUserLocalMemoryCategory(value)) {
+    throw new Error(`Unsupported user-local memory category: ${value}`);
+  }
+  return value;
+}
+
+function assertSafeSegment(name: string, value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (trimmed.length > MAX_SEGMENT_LENGTH || !SAFE_SEGMENT_PATTERN.test(trimmed)) {
+    throw new Error(
+      `${name} must use lowercase letters, numbers, dots, underscores, or hyphens: ${value}`,
+    );
+  }
+  return trimmed;
+}
+
+function boundedText(name: string, value: string, maxLength: number): string {
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  if (normalized.length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (normalized.length > maxLength) {
+    return normalized.slice(0, maxLength);
+  }
+  return normalized;
+}
+
+function summarizeValue(value: string): string {
+  return boundedText('value', value, MAX_VALUE_SUMMARY_LENGTH);
+}
+
+function memoryFileName(category: TUserLocalMemoryCategory, key: string): string {
+  return `${category}__${key}${FILE_EXTENSION}`;
+}
+
+async function resolveMemoryRoot(
+  options: IResolveUserLocalStorageRootOptions,
+): Promise<{ readonly root: string; readonly memoryRoot: string }> {
+  const root = await resolveUserLocalStorageRoot(options);
+  return {
+    root,
+    memoryRoot: path.join(root, MEMORY_STORAGE_CATEGORY),
+  };
+}
+
+function parseMemoryRecord(raw: string, storageLocation: string): IUserLocalMemoryFile {
+  const record = JSON.parse(raw) as TJsonRecord;
+  const category = readString(record, 'category');
+  const schemaVersion = record['schemaVersion'];
+
+  if (schemaVersion !== MEMORY_SCHEMA_VERSION) {
+    throw new Error(`Unsupported user-local memory schema at ${storageLocation}`);
+  }
+
+  return {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    category: assertUserLocalMemoryCategory(category),
+    key: readString(record, 'key'),
+    value: readString(record, 'value'),
+    summary: readString(record, 'summary'),
+    source: readString(record, 'source'),
+    scope: readString(record, 'scope'),
+    createdAt: readString(record, 'createdAt'),
+    lastUsedAt: readString(record, 'lastUsedAt'),
+    enabled: readBoolean(record, 'enabled'),
+  };
+}
+
+function readString(record: TJsonRecord, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid user-local memory field: ${key}`);
+  }
+  return value;
+}
+
+function readBoolean(record: TJsonRecord, key: string): boolean {
+  const value = record[key];
+  if (typeof value !== 'boolean') {
+    throw new Error(`Invalid user-local memory field: ${key}`);
+  }
+  return value;
+}
+
+function projectMemoryItem(
+  root: string,
+  storageLocation: string,
+  item: IUserLocalMemoryFile,
+): IUserLocalMemoryItemProjection {
+  return {
+    root,
+    category: item.category,
+    key: item.key,
+    summary: item.summary,
+    valueSummary: summarizeValue(item.value),
+    source: item.source,
+    scope: item.scope,
+    storageLocation,
+    createdAt: item.createdAt,
+    lastUsedAt: item.lastUsedAt,
+    enabled: item.enabled,
+    displayNavigationRule: DISPLAY_NAVIGATION_RULES[item.category],
+    commandExecutionEffect: 'none',
+    deleteAvailable: true,
+    disableAvailable: true,
+  };
+}
+
+async function readMemoryFile(
+  root: string,
+  storageLocation: string,
+): Promise<IUserLocalMemoryItemProjection> {
+  return projectMemoryItem(
+    root,
+    storageLocation,
+    parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation),
+  );
+}
+
+async function resolveMemoryFile(
+  options: IUserLocalMemoryItemOptions,
+): Promise<{ readonly root: string; readonly storageLocation: string }> {
+  const category = assertUserLocalMemoryCategory(options.category);
+  const key = assertSafeSegment('key', options.key);
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  return {
+    root,
+    storageLocation: path.join(memoryRoot, memoryFileName(category, key)),
+  };
+}
+
+export async function setUserLocalMemoryItem(
+  options: IUserLocalMemorySetOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const category = assertUserLocalMemoryCategory(options.category);
+  const key = assertSafeSegment('key', options.key);
+  const summary = boundedText('summary', options.summary, MAX_SUMMARY_LENGTH);
+  const source = boundedText('source', options.source, MAX_SOURCE_LENGTH);
+  const scope = boundedText('scope', options.scope ?? DEFAULT_SCOPE, MAX_SCOPE_LENGTH);
+  const value = summarizeValue(options.value);
+  const now = formatIsoDate((options.now ?? (() => new Date()))());
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  const storageLocation = path.join(memoryRoot, memoryFileName(category, key));
+  let createdAt = now;
+
+  try {
+    const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+    createdAt = existing.createdAt;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      createdAt = now;
+    } else {
+      throw error;
+    }
+  }
+
+  const item: IUserLocalMemoryFile = {
+    schemaVersion: MEMORY_SCHEMA_VERSION,
+    category,
+    key,
+    value,
+    summary,
+    source,
+    scope,
+    createdAt,
+    lastUsedAt: now,
+    enabled: true,
+  };
+
+  await fs.mkdir(memoryRoot, { recursive: true });
+  await fs.writeFile(storageLocation, `${JSON.stringify(item, null, 2)}\n`, 'utf8');
+  return projectMemoryItem(root, storageLocation, item);
+}
+
+export async function listUserLocalMemoryItems(
+  options: IUserLocalMemoryListOptions,
+): Promise<IUserLocalMemoryListProjection> {
+  const { root, memoryRoot } = await resolveMemoryRoot(options);
+  let entries: readonly import('node:fs').Dirent[];
+
+  try {
+    entries = await fs.readdir(memoryRoot, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+
+  const items = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(FILE_EXTENSION))
+      .map((entry) => readMemoryFile(root, path.join(memoryRoot, entry.name))),
+  );
+
+  return {
+    root,
+    activeRepositoryRoot: path.resolve(options.activeRepositoryRoot),
+    items: items.sort((left, right) =>
+      `${left.category}/${left.key}`.localeCompare(`${right.category}/${right.key}`),
+    ),
+  };
+}
+
+export async function inspectUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const { root, storageLocation } = await resolveMemoryFile(options);
+  return readMemoryFile(root, storageLocation);
+}
+
+export async function disableUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection> {
+  const { root, storageLocation } = await resolveMemoryFile(options);
+  const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+  const disabled: IUserLocalMemoryFile = {
+    ...existing,
+    enabled: false,
+    lastUsedAt: formatIsoDate((options.now ?? (() => new Date()))()),
+  };
+
+  await fs.writeFile(storageLocation, `${JSON.stringify(disabled, null, 2)}\n`, 'utf8');
+  return projectMemoryItem(root, storageLocation, disabled);
+}
+
+export async function deleteUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryDeleteResult> {
+  const { storageLocation } = await resolveMemoryFile(options);
+  await fs.rm(storageLocation);
+  return {
+    category: options.category,
+    key: options.key,
+    deleted: true,
+  };
+}
+
+export async function readEnabledUserLocalMemoryItem(
+  options: IUserLocalMemoryItemOptions,
+): Promise<IUserLocalMemoryItemProjection | null> {
+  const item = await inspectUserLocalMemoryItem(options);
+  return item.enabled ? item : null;
+}

--- a/packages/agent-sdk/src/user-local/storage.ts
+++ b/packages/agent-sdk/src/user-local/storage.ts
@@ -1,0 +1,245 @@
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+export const USER_LOCAL_STORAGE_CATEGORIES = [
+  'preferences',
+  'view-state',
+  'memory-projections',
+  'task-associations',
+  'workflow-metadata',
+  'inspection-index',
+] as const;
+
+export type TUserLocalStorageCategory = (typeof USER_LOCAL_STORAGE_CATEGORIES)[number];
+
+export interface IUserLocalStorageCategoryDefinition {
+  readonly category: TUserLocalStorageCategory;
+  readonly purpose: string;
+  readonly mayExecuteCommands: false;
+}
+
+export interface IUserLocalStorageItemSummary {
+  readonly root: string;
+  readonly category: TUserLocalStorageCategory;
+  readonly key: string;
+  readonly summary: string;
+  readonly source: string;
+  readonly scope: string;
+  readonly storageLocation: string;
+  readonly createdAt?: string;
+  readonly lastUsedAt?: string;
+  readonly enabled: boolean;
+  readonly deleteAvailable: boolean;
+  readonly disableAvailable: boolean;
+}
+
+export interface IUserLocalStorageCategoryProjection {
+  readonly category: TUserLocalStorageCategory;
+  readonly purpose: string;
+  readonly mayExecuteCommands: false;
+  readonly storageLocation: string;
+  readonly itemCount: number;
+  readonly items: readonly IUserLocalStorageItemSummary[];
+}
+
+export interface IUserLocalStorageInspection {
+  readonly root: string;
+  readonly activeRepositoryRoot: string;
+  readonly categories: readonly IUserLocalStorageCategoryProjection[];
+  readonly generatedAt: string;
+}
+
+export interface IResolveUserLocalStorageRootOptions {
+  readonly activeRepositoryRoot: string;
+  readonly homeDir?: string;
+  readonly storageRoot?: string;
+}
+
+export interface IInspectUserLocalStorageOptions extends IResolveUserLocalStorageRootOptions {
+  readonly now?: () => Date;
+  readonly createDirectories?: boolean;
+}
+
+export const USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS: readonly IUserLocalStorageCategoryDefinition[] =
+  [
+    {
+      category: 'preferences',
+      purpose: 'User-local UI and display preferences.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'view-state',
+      purpose: 'Last selected panels, filters, and navigation state.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'memory-projections',
+      purpose: 'Inspectable local memory item projections and user choices.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'task-associations',
+      purpose: 'User-local associations between sessions, tasks, and background items.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'workflow-metadata',
+      purpose: 'Transparent workflow metadata that is not repo-owned.',
+      mayExecuteCommands: false,
+    },
+    {
+      category: 'inspection-index',
+      purpose: 'Category and item summaries for user inspection and deletion.',
+      mayExecuteCommands: false,
+    },
+  ];
+
+function formatIsoDate(date: Date): string {
+  return date.toISOString();
+}
+
+function assertAbsolutePath(name: string, value: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (!path.isAbsolute(value)) {
+    throw new Error(`${name} must be an absolute path: ${value}`);
+  }
+}
+
+function resolveDefaultHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
+function isEqualOrInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function resolveForComparison(absPath: string): Promise<string> {
+  let current = absPath;
+
+  while (path.dirname(current) !== current) {
+    try {
+      const realCurrent = await fs.realpath(current);
+      const relativeMissingPath = path.relative(current, absPath);
+      return path.resolve(realCurrent, relativeMissingPath);
+    } catch {
+      current = path.dirname(current);
+    }
+  }
+
+  try {
+    return await fs.realpath(current);
+  } catch {
+    return path.resolve(absPath);
+  }
+}
+
+export async function resolveUserLocalStorageRoot(
+  options: IResolveUserLocalStorageRootOptions,
+): Promise<string> {
+  const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
+  assertAbsolutePath('activeRepositoryRoot', activeRepositoryRoot);
+
+  const candidateRoot =
+    options.storageRoot !== undefined
+      ? options.storageRoot
+      : path.join(options.homeDir ?? resolveDefaultHomeDir(), '.robota');
+
+  assertAbsolutePath('userLocalStorageRoot', candidateRoot);
+
+  const resolvedRoot = path.resolve(candidateRoot);
+  const comparableRoot = await resolveForComparison(resolvedRoot);
+  const comparableRepositoryRoot = await resolveForComparison(activeRepositoryRoot);
+
+  if (isEqualOrInside(comparableRepositoryRoot, comparableRoot)) {
+    throw new Error(
+      `User-local storage root must be outside the active repository: ${resolvedRoot}`,
+    );
+  }
+
+  return resolvedRoot;
+}
+
+function resolveCategoryLocation(root: string, category: TUserLocalStorageCategory): string {
+  return path.join(root, category);
+}
+
+async function listItemSummaries(
+  root: string,
+  category: TUserLocalStorageCategory,
+): Promise<readonly IUserLocalStorageItemSummary[]> {
+  const storageLocation = resolveCategoryLocation(root, category);
+  let entries: readonly import('node:fs').Dirent[];
+
+  try {
+    entries = await fs.readdir(storageLocation, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const summaries = await Promise.all(
+    entries.map(async (entry): Promise<IUserLocalStorageItemSummary> => {
+      const itemLocation = path.join(storageLocation, entry.name);
+      const stats = await fs.stat(itemLocation);
+      const key = entry.name;
+      return {
+        root,
+        category,
+        key,
+        summary: `${category}/${key}`,
+        source: 'user-local-storage',
+        scope: 'user',
+        storageLocation: itemLocation,
+        createdAt: formatIsoDate(stats.birthtime),
+        lastUsedAt: formatIsoDate(stats.mtime),
+        enabled: true,
+        deleteAvailable: true,
+        disableAvailable: false,
+      };
+    }),
+  );
+
+  return summaries.sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export async function inspectUserLocalStorage(
+  options: IInspectUserLocalStorageOptions,
+): Promise<IUserLocalStorageInspection> {
+  const root = await resolveUserLocalStorageRoot(options);
+  const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
+  const createDirectories = options.createDirectories ?? true;
+
+  if (createDirectories) {
+    await fs.mkdir(root, { recursive: true });
+  }
+
+  const categories = await Promise.all(
+    USER_LOCAL_STORAGE_CATEGORY_DEFINITIONS.map(
+      async (definition): Promise<IUserLocalStorageCategoryProjection> => {
+        const storageLocation = resolveCategoryLocation(root, definition.category);
+        if (createDirectories) {
+          await fs.mkdir(storageLocation, { recursive: true });
+        }
+        const items = await listItemSummaries(root, definition.category);
+        return {
+          category: definition.category,
+          purpose: definition.purpose,
+          mayExecuteCommands: definition.mayExecuteCommands,
+          storageLocation,
+          itemCount: items.length,
+          items,
+        };
+      },
+    ),
+  );
+
+  return {
+    root,
+    activeRepositoryRoot,
+    categories,
+    generatedAt: formatIsoDate((options.now ?? (() => new Date()))()),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   fast-xml-parser: '>=4.5.5'
   fast-xml-builder: 1.2.0
-  fast-uri: 3.1.1
+  fast-uri: 3.1.2
   node-forge: '>=1.4.0'
   protobufjs: '>=7.5.5'
   jws@^3.0.0: ^3.2.3
@@ -9495,7 +9495,7 @@ packages:
       }
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     dev: false
@@ -13148,10 +13148,10 @@ packages:
       }
     dev: true
 
-  /fast-uri@3.1.1:
+  /fast-uri@3.1.2:
     resolution:
       {
-        integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==,
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
       }
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       '@robota-sdk/agent-command-statusline':
         specifier: workspace:*
         version: link:../agent-command-statusline
+      '@robota-sdk/agent-command-user-local':
+        specifier: workspace:*
+        version: link:../agent-command-user-local
       '@robota-sdk/agent-core':
         specifier: workspace:*
         version: link:../agent-core
@@ -784,6 +787,25 @@ importers:
         version: 1.6.1(@types/node@20.19.9)
 
   packages/agent-command-statusline:
+    dependencies:
+      '@robota-sdk/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+    devDependencies:
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.9)
+
+  packages/agent-command-user-local:
     dependencies:
       '@robota-sdk/agent-sdk':
         specifier: workspace:*


### PR DESCRIPTION
## Accepted Recommendation

Implement the active user-local inspection backlogs through a multi-PR initiative: keep storage and memory semantics in SDK-owned user-local APIs, expose product behavior through `@robota-sdk/agent-command-user-local`, and let `agent-cli` only perform provider-free routing to the command package.

## Rationale

This matches the repository layering rule: `agent-cli` does not own storage or memory semantics, user-local data stays outside user repositories, and command behavior is owned below the TUI/CLI surface. It also satisfies the backlog goal of transparent user-local inspection without injecting Robota files into a user's repo.

## Implementation Summary

- Added SDK user-local storage root/category inspection with repo-outside validation.
- Added SDK user-local memory persistence, list, inspect, disable, delete, and disabled-item read behavior.
- Added `@robota-sdk/agent-command-user-local` as the command owner for `user-local storage` and `user-local memory` commands.
- Added direct provider-free `agent-cli` routing for `user-local ...` commands.
- Updated package SPEC docs, backlog evidence, and task tracking.
- Completed child PRs: #338, #339, #340.

## Tests And Verification

- `pnpm --filter @robota-sdk/agent-sdk test -- src/user-local/__tests__/memory.test.ts src/user-local/__tests__/storage.test.ts`
- `pnpm --filter @robota-sdk/agent-command-user-local test`
- `pnpm --filter @robota-sdk/agent-cli test -- src/__tests__/cli-command-composition.test.ts src/utils/__tests__/cli-args.test.ts`
- `pnpm --filter @robota-sdk/agent-sdk typecheck`
- `pnpm --filter @robota-sdk/agent-command-user-local typecheck`
- `pnpm --filter @robota-sdk/agent-cli typecheck`
- `pnpm --filter @robota-sdk/agent-command-user-local lint`
- `pnpm --filter @robota-sdk/agent-sdk build`
- `pnpm --filter @robota-sdk/agent-command-user-local build`
- `pnpm --filter @robota-sdk/agent-cli build`
- `pnpm harness:scan`
- Push gate: `pnpm harness:verify -- --base-ref origin/develop --skip-dependent-scopes --skip-record-check`

## User Execution Test Scenario Gate

Storage scenario: verified with the built CLI using a temporary `HOME` and fixture repository. `user-local storage list --format json` returned the user-local root and all six categories, and the fixture repo contained no `.robota` or Robota local files.

Memory scenario: verified with the built CLI using a temporary `HOME` and fixture repository. `user-local memory set/list/inspect/disable/delete` worked end-to-end, disabled inspect showed `enabled: false`, delete succeeded, and post-delete inspect exited 1 with `User-local memory item not found.` The fixture repo contained no `.robota` or Robota local files.

The planning umbrella backlog is not a runnable product change; it records the not-applicable reason and links the implementation evidence.

## Residual Risk

Existing lint/file-size warnings remain outside this initiative's scope. Release-grade verification remains explicit and was not run: `HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push` or `pnpm harness:verify:release`.
