### PR TITLE
feat(hooks): add permission_mode to hook inputs + fix command timeout (HOOK-004, HOOK-007)

### DIFF
--- a/packages/agent-core/src/hooks/executors/command-executor.ts
+++ b/packages/agent-core/src/hooks/executors/command-executor.ts
@@ -15,8 +15,8 @@ import type {
   IHookTypeExecutor,
 } from '../types.js';
 
-/** Default timeout in seconds */
-const DEFAULT_TIMEOUT_SECONDS = 10;
+/** Default timeout in seconds — matches Claude Code's 600s default */
+const DEFAULT_TIMEOUT_SECONDS = 600;
 
 export class CommandExecutor implements IHookTypeExecutor {
   readonly type = 'command' as const;

--- a/packages/agent-core/src/hooks/types.ts
+++ b/packages/agent-core/src/hooks/types.ts
@@ -108,6 +108,8 @@ export interface IHookInput {
   agent_type?: string;
   /** Subagent transcript path when available (SubagentStop only) */
   agent_transcript_path?: string;
+  /** Claude Code permission mode at time of event (e.g. "default", "plan", "acceptEdits", "bypassPermissions") */
+  permission_mode?: string;
   /** Additional environment variables to pass to hook child processes */
   env?: Record<string, string>;
 }

--- a/packages/agent-sessions/src/permission-enforcer.ts
+++ b/packages/agent-sessions/src/permission-enforcer.ts
@@ -98,7 +98,13 @@ export class PermissionEnforcer {
           args: parameters as Record<string, string | number | boolean | object>,
         });
 
-        const hookInput = buildHookInput(enforcer.sessionId, enforcer.cwd, toolName, parameters);
+        const hookInput = buildHookInput(
+          enforcer.sessionId,
+          enforcer.cwd,
+          toolName,
+          parameters,
+          enforcer.getPermissionMode(),
+        );
 
         const preResult = await runPreToolHook(
           enforcer.config.hooks,

--- a/packages/agent-sessions/src/session-lifecycle.ts
+++ b/packages/agent-sessions/src/session-lifecycle.ts
@@ -47,11 +47,13 @@ export function fireSessionStartHook(
   hooks: Record<string, unknown> | undefined,
   hookTypeExecutors: IHookTypeExecutor[] | undefined,
   onStdout: (stdout: string) => void,
+  permissionMode?: string,
 ): void {
   const hookInput: IHookInput = {
     session_id: sessionId,
     cwd,
     hook_event_name: 'SessionStart',
+    ...(permissionMode !== undefined && { permission_mode: permissionMode }),
     env: {
       CLAUDE_PROJECT_DIR: cwd,
       CLAUDE_SESSION_ID: sessionId,
@@ -73,12 +75,14 @@ export async function fireSessionEndHook(
   reason: TSessionEndReason,
   hooks: Record<string, unknown> | undefined,
   hookTypeExecutors: IHookTypeExecutor[] | undefined,
+  permissionMode?: string,
 ): Promise<void> {
   const hookInput: IHookInput = {
     session_id: sessionId,
     cwd,
     hook_event_name: 'SessionEnd',
     reason,
+    ...(permissionMode !== undefined && { permission_mode: permissionMode }),
     env: {
       CLAUDE_PROJECT_DIR: cwd,
       CLAUDE_SESSION_ID: sessionId,

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -27,6 +27,8 @@ export interface IRunContext {
   sessionId: string;
   cwd: string;
   model: string;
+  /** Current permission mode — passed to all hook inputs as permission_mode */
+  permissionMode?: string;
   robota: Robota;
   aiProvider: IAIProvider;
   contextTracker: ContextWindowTracker;
@@ -86,6 +88,7 @@ export async function executeRun(
       hook_event_name: 'UserPromptSubmit',
       user_message: rawInput ?? message,
       prompt: rawInput ?? message,
+      ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
       env: {
         CLAUDE_PROJECT_DIR: ctx.cwd,
         CLAUDE_SESSION_ID: ctx.sessionId,
@@ -165,6 +168,7 @@ export async function executeRun(
         hook_event_name: 'StopFailure',
         reason: error instanceof Error ? error.message : String(error),
         stop_hook_active: false,
+        ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
         env: {
           CLAUDE_PROJECT_DIR: ctx.cwd,
           CLAUDE_SESSION_ID: ctx.sessionId,
@@ -222,6 +226,7 @@ export async function executeRun(
       response: response.substring(0, 500),
       last_assistant_message: response,
       stop_hook_active: false,
+      ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
       env: {
         CLAUDE_PROJECT_DIR: ctx.cwd,
         CLAUDE_SESSION_ID: ctx.sessionId,

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -174,9 +174,16 @@ export class Session {
     };
 
     this.robota = new Robota(agentConfig);
-    fireSessionStartHook(this.sessionId, this.cwd, this.hooks, this.hookTypeExecutors, (stdout) => {
-      this.sessionStartStdout = stdout;
-    });
+    fireSessionStartHook(
+      this.sessionId,
+      this.cwd,
+      this.hooks,
+      this.hookTypeExecutors,
+      (stdout) => {
+        this.sessionStartStdout = stdout;
+      },
+      this.permissionMode,
+    );
   }
 
   /**
@@ -209,6 +216,7 @@ export class Session {
           clearSessionStartStdout: () => {
             this.sessionStartStdout = '';
           },
+          permissionMode: this.permissionMode,
           ...(this.maxTurns !== undefined ? { maxTurns: this.maxTurns } : {}),
           onTextDelta: this.onTextDeltaCallback,
           onContextUpdate: this.onContextUpdateCallback,
@@ -308,6 +316,7 @@ export class Session {
         reason,
         this.hooks,
         this.hookTypeExecutors,
+        this.permissionMode,
       );
     })();
     return this.shutdownPromise;

--- a/packages/agent-sessions/src/tool-hook-helpers.ts
+++ b/packages/agent-sessions/src/tool-hook-helpers.ts
@@ -36,6 +36,7 @@ export function buildHookInput(
   cwd: string,
   toolName: string,
   parameters: TToolParameters,
+  permissionMode?: string,
 ): IHookInput {
   return {
     session_id: sessionId,
@@ -43,6 +44,7 @@ export function buildHookInput(
     hook_event_name: 'PreToolUse',
     tool_name: toolName,
     tool_input: parameters as Record<string, string | number | boolean | object>,
+    ...(permissionMode !== undefined && { permission_mode: permissionMode }),
   };
 }
 


### PR DESCRIPTION
## Summary

- **HOOK-004**: Add `permission_mode` field to `IHookInput`; thread current `permissionMode` from `Session` through `IRunContext` to all hook firing points (UserPromptSubmit, Stop, StopFailure, SessionStart, SessionEnd, PreToolUse, PostToolUse)
- **HOOK-007**: Change `DEFAULT_TIMEOUT_SECONDS` from 10s → 600s in `CommandExecutor` to match Claude Code's default timeout

## Changes

- `packages/agent-core/src/hooks/types.ts` — add `permission_mode?: string` to `IHookInput`
- `packages/agent-core/src/hooks/executors/command-executor.ts` — 10 → 600
- `packages/agent-sessions/src/session-run.ts` — add `permissionMode` to `IRunContext`; pass to UserPromptSubmit/Stop/StopFailure hooks
- `packages/agent-sessions/src/session-lifecycle.ts` — pass `permissionMode` to SessionStart/SessionEnd hooks
- `packages/agent-sessions/src/tool-hook-helpers.ts` — pass `permissionMode` to PreToolUse hook input
- `packages/agent-sessions/src/permission-enforcer.ts` — pass `getPermissionMode()` to `buildHookInput`
- `packages/agent-sessions/src/session.ts` — inject `this.permissionMode` in all hook call sites

## Test plan

- `pnpm typecheck` — clean
- `pnpm --filter @robota-sdk/agent-core build:js` — success
- `pnpm --filter @robota-sdk/agent-sessions build:js` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)