### PR TITLE
feat(hooks): thread transcript_path through all hook events (HOOK-005)

### DIFF
--- a/packages/agent-sessions/src/permission-enforcer.ts
+++ b/packages/agent-sessions/src/permission-enforcer.ts
@@ -44,6 +44,7 @@ export class PermissionEnforcer {
   private readonly sessionLogger?: ISessionLogger;
   private readonly onToolExecution?: IPermissionEnforcerOptions['onToolExecution'];
   private readonly hookTypeExecutors?: IPermissionEnforcerOptions['hookTypeExecutors'];
+  private readonly transcriptPath?: string;
   private readonly sessionAllowedTools = new Set<string>();
 
   constructor(options: IPermissionEnforcerOptions) {
@@ -57,6 +58,7 @@ export class PermissionEnforcer {
     this.sessionLogger = options.sessionLogger;
     this.onToolExecution = options.onToolExecution;
     this.hookTypeExecutors = options.hookTypeExecutors;
+    this.transcriptPath = options.transcriptPath;
   }
 
   /** Wrap all tools with permission checking */
@@ -104,6 +106,7 @@ export class PermissionEnforcer {
           toolName,
           parameters,
           enforcer.getPermissionMode(),
+          enforcer.transcriptPath,
         );
 
         const preResult = await runPreToolHook(

--- a/packages/agent-sessions/src/permission-types.ts
+++ b/packages/agent-sessions/src/permission-types.ts
@@ -71,6 +71,8 @@ export interface IPermissionEnforcerOptions {
   }) => void;
   /** Additional hook type executors (e.g. prompt, agent) beyond the core defaults. */
   hookTypeExecutors?: IHookTypeExecutor[];
+  /** Absolute path to session transcript file — passed to PreToolUse hook inputs as transcript_path */
+  transcriptPath?: string;
 }
 
 /** Returned when the user denies a permission prompt. success:true prevents ToolExecutionError. */

--- a/packages/agent-sessions/src/session-lifecycle.ts
+++ b/packages/agent-sessions/src/session-lifecycle.ts
@@ -48,12 +48,14 @@ export function fireSessionStartHook(
   hookTypeExecutors: IHookTypeExecutor[] | undefined,
   onStdout: (stdout: string) => void,
   permissionMode?: string,
+  transcriptPath?: string,
 ): void {
   const hookInput: IHookInput = {
     session_id: sessionId,
     cwd,
     hook_event_name: 'SessionStart',
     ...(permissionMode !== undefined && { permission_mode: permissionMode }),
+    ...(transcriptPath !== undefined && { transcript_path: transcriptPath }),
     env: {
       CLAUDE_PROJECT_DIR: cwd,
       CLAUDE_SESSION_ID: sessionId,
@@ -76,6 +78,7 @@ export async function fireSessionEndHook(
   hooks: Record<string, unknown> | undefined,
   hookTypeExecutors: IHookTypeExecutor[] | undefined,
   permissionMode?: string,
+  transcriptPath?: string,
 ): Promise<void> {
   const hookInput: IHookInput = {
     session_id: sessionId,
@@ -83,6 +86,7 @@ export async function fireSessionEndHook(
     hook_event_name: 'SessionEnd',
     reason,
     ...(permissionMode !== undefined && { permission_mode: permissionMode }),
+    ...(transcriptPath !== undefined && { transcript_path: transcriptPath }),
     env: {
       CLAUDE_PROJECT_DIR: cwd,
       CLAUDE_SESSION_ID: sessionId,

--- a/packages/agent-sessions/src/session-run.ts
+++ b/packages/agent-sessions/src/session-run.ts
@@ -29,6 +29,8 @@ export interface IRunContext {
   model: string;
   /** Current permission mode — passed to all hook inputs as permission_mode */
   permissionMode?: string;
+  /** Absolute path to session transcript file — passed to all hook inputs as transcript_path */
+  transcriptPath?: string;
   robota: Robota;
   aiProvider: IAIProvider;
   contextTracker: ContextWindowTracker;
@@ -89,6 +91,7 @@ export async function executeRun(
       user_message: rawInput ?? message,
       prompt: rawInput ?? message,
       ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
+      ...(ctx.transcriptPath !== undefined && { transcript_path: ctx.transcriptPath }),
       env: {
         CLAUDE_PROJECT_DIR: ctx.cwd,
         CLAUDE_SESSION_ID: ctx.sessionId,
@@ -169,6 +172,7 @@ export async function executeRun(
         reason: error instanceof Error ? error.message : String(error),
         stop_hook_active: false,
         ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
+        ...(ctx.transcriptPath !== undefined && { transcript_path: ctx.transcriptPath }),
         env: {
           CLAUDE_PROJECT_DIR: ctx.cwd,
           CLAUDE_SESSION_ID: ctx.sessionId,
@@ -227,6 +231,7 @@ export async function executeRun(
       last_assistant_message: response,
       stop_hook_active: false,
       ...(ctx.permissionMode !== undefined && { permission_mode: ctx.permissionMode }),
+      ...(ctx.transcriptPath !== undefined && { transcript_path: ctx.transcriptPath }),
       env: {
         CLAUDE_PROJECT_DIR: ctx.cwd,
         CLAUDE_SESSION_ID: ctx.sessionId,

--- a/packages/agent-sessions/src/session-store.ts
+++ b/packages/agent-sessions/src/session-store.ts
@@ -56,6 +56,8 @@ export interface ISessionStore {
   load(id: string): ISessionRecord | undefined;
   list(): ISessionRecord[];
   delete(id: string): void;
+  /** Return the absolute file path for a session file, if the store is file-backed. */
+  getFilePath?(id: string): string;
 }
 
 /**
@@ -88,6 +90,11 @@ export class SessionStore implements ISessionStore {
   /** Absolute path to a session's JSON file */
   private filePath(id: string): string {
     return join(this.baseDir, `${id}.json`);
+  }
+
+  /** Return the absolute file path for a session — implements ISessionStore.getFilePath */
+  getFilePath(id: string): string {
+    return this.filePath(id);
   }
 
   /**

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -91,6 +91,8 @@ export class Session {
   private shutdownPromise: Promise<void> | null = null;
   /** Stdout collected from SessionStart hooks, injected on first run(). */
   private sessionStartStdout = '';
+  /** Absolute path to the session transcript file, if file-backed storage is active. */
+  private readonly transcriptPath: string | undefined;
 
   constructor(options: ISessionOptions) {
     const { tools, provider, systemMessage, terminal, sessionStore, permissionHandler } = options;
@@ -118,6 +120,7 @@ export class Session {
       options.permissionMode ??
       (options.defaultTrustLevel ? TRUST_TO_MODE[options.defaultTrustLevel] : undefined) ??
       'default';
+    this.transcriptPath = sessionStore?.getFilePath?.(this.sessionId);
     this.log('session_init', {
       cwd: this.cwd,
       systemPromptLength: systemMessage.length,
@@ -142,6 +145,7 @@ export class Session {
       sessionLogger: options.sessionLogger,
       onToolExecution: options.onToolExecution,
       hookTypeExecutors: options.hookTypeExecutors,
+      transcriptPath: this.transcriptPath,
     });
 
     this.contextTracker = new ContextWindowTracker(
@@ -183,6 +187,7 @@ export class Session {
         this.sessionStartStdout = stdout;
       },
       this.permissionMode,
+      this.transcriptPath,
     );
   }
 
@@ -217,6 +222,7 @@ export class Session {
             this.sessionStartStdout = '';
           },
           permissionMode: this.permissionMode,
+          transcriptPath: this.transcriptPath,
           ...(this.maxTurns !== undefined ? { maxTurns: this.maxTurns } : {}),
           onTextDelta: this.onTextDeltaCallback,
           onContextUpdate: this.onContextUpdateCallback,
@@ -317,6 +323,7 @@ export class Session {
         this.hooks,
         this.hookTypeExecutors,
         this.permissionMode,
+        this.transcriptPath,
       );
     })();
     return this.shutdownPromise;

--- a/packages/agent-sessions/src/tool-hook-helpers.ts
+++ b/packages/agent-sessions/src/tool-hook-helpers.ts
@@ -37,6 +37,7 @@ export function buildHookInput(
   toolName: string,
   parameters: TToolParameters,
   permissionMode?: string,
+  transcriptPath?: string,
 ): IHookInput {
   return {
     session_id: sessionId,
@@ -45,6 +46,7 @@ export function buildHookInput(
     tool_name: toolName,
     tool_input: parameters as Record<string, string | number | boolean | object>,
     ...(permissionMode !== undefined && { permission_mode: permissionMode }),
+    ...(transcriptPath !== undefined && { transcript_path: transcriptPath }),
   };
 }
 


### PR DESCRIPTION
## Summary

- **HOOK-005**: Pass `transcript_path` to all hook event inputs so hook scripts can read the session transcript

The field `transcript_path` was already typed in `IHookInput` but was never set. This PR wires the actual path from `SessionStore` through to every hook firing point.

## Changes

- `packages/agent-sessions/src/session-store.ts` — add `getFilePath?(id: string): string` to `ISessionStore` interface; implement in `SessionStore`
- `packages/agent-sessions/src/session.ts` — derive `transcriptPath` from `sessionStore.getFilePath(sessionId)` at construction; pass to all hook call sites
- `packages/agent-sessions/src/session-run.ts` — add `transcriptPath` to `IRunContext`; pass to UserPromptSubmit/Stop/StopFailure hooks
- `packages/agent-sessions/src/session-lifecycle.ts` — pass `transcriptPath` to SessionStart/SessionEnd hooks
- `packages/agent-sessions/src/tool-hook-helpers.ts` — pass `transcriptPath` to PreToolUse hook input (propagates to PostToolUse too)
- `packages/agent-sessions/src/permission-enforcer.ts` — store `transcriptPath` from options; pass to `buildHookInput`
- `packages/agent-sessions/src/permission-types.ts` — add `transcriptPath?` to `IPermissionEnforcerOptions`

## Behavior

- When `sessionStore` is a file-backed `SessionStore`: `transcript_path` = absolute path to `${baseDir}/${sessionId}.json`
- When no store is configured (in-process, web): `transcript_path` is omitted from hook input

## Test plan

- `pnpm typecheck` — clean
- `pnpm --filter @robota-sdk/agent-sessions build:js` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)