### PR TITLE
feat(hooks): change PreToolUse block format to CC-compatible signal (HOOK-003)

### DIFF
--- a/packages/agent-sessions/src/tool-hook-helpers.ts
+++ b/packages/agent-sessions/src/tool-hook-helpers.ts
@@ -66,9 +66,8 @@ export async function runPreToolHook(
     return {
       success: true,
       data: JSON.stringify({
-        success: false,
-        output: '',
-        error: `Blocked by hook: ${hookResult.reason}`,
+        blocked: true,
+        reason: hookResult.reason ?? 'Blocked by hook',
       }),
       metadata: {},
     };


### PR DESCRIPTION
## Summary

- **HOOK-003**: Change the tool result format when PreToolUse hook blocks a tool call

## Problem

Previously, when a PreToolUse hook blocked a tool, the SDK returned:
```json
{ "success": false, "output": "", "error": "Blocked by hook: <reason>" }
```

This tells the AI "the tool ran and failed," which is misleading. Claude Code instead cancels the tool call entirely, showing the hook's stderr to the user.

## Change (Option B — practical compatibility)

Since not returning a tool_result would leave an orphaned `tool_use` entry in conversation history (causing API 400 errors), we return a tool_result but with a clear re-plan signal:

```json
{ "blocked": true, "reason": "<reason>" }
```

This gives the AI a clear signal to re-plan rather than treat the block as a tool execution failure.

## Files changed

- `packages/agent-sessions/src/tool-hook-helpers.ts` — update blocked tool result data format

## Test plan

- `pnpm typecheck` — clean
- `pnpm --filter @robota-sdk/agent-sessions build:js` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)