### PR TITLE
docs(backlog): add test plan execution evidence to ARCH-CONF-006

### DIFF
--- a/.agents/backlog/ARCH-CONF-006-implementation-conformance-sweep.md
+++ b/.agents/backlog/ARCH-CONF-006-implementation-conformance-sweep.md
@@ -86,3 +86,21 @@ grep -r "@robota-sdk/agent-cli" packages/agent-command-*/src/ --include="*.ts"
 ## User Execution Test Scenarios
 
 Not applicable — verification-only task. Implementation fixes (if any) are tracked in separate fix backlog items.
+
+## Test Plan Execution Evidence (2026-05-10)
+
+All 7 verification checks executed and passed:
+
+1. **agent-core ZERO deps** → `OK — no @robota-sdk/* prod/peer deps`
+2. **agent-sdk React-free** → `OK — no 'react' imports in agent-sdk/src`
+3. **agent-sessions does NOT depend on agent-runtime** → `OK — no agent-runtime dependency`
+4. **agent-plugin-\* only depends on agent-core** → All 9 plugins: OK
+5. **agent-cli does NOT import agent-sessions directly** → `OK — no agent-sessions in agent-cli/src`
+6. **agent-sdk does NOT import agent-command-\*** → `OK — no agent-command-* imports in agent-sdk/src`
+7. **agent-command-\* does NOT import agent-cli** → `OK — no agent-cli imports in agent-command-*`
+
+Additionally verified via `pnpm harness:scan`:
+
+- `harness:scan:deps` (check-dependency-direction.mjs) → ✅ No dependency direction violations
+- `harness:scan:sdk-react-free` (check-sdk-react-free.mjs) → ✅ agent-sdk is React-free
+- `harness:scan:publish` → ✅ agent-core has zero @robota-sdk dependencies


### PR DESCRIPTION
## Summary

- ARCH-CONF-006 백로그에 Test Plan 실행 증거 추가
- 7개 아키텍처 준수 검증 명령어 모두 실행 후 통과 확인 (2026-05-10)
- `pnpm harness:scan` (deps, sdk-react-free, publish checks) 통과 확인 기록
- ARCH-CONF-007 하네스 스크립트 정상 작동 간접 증명

## 24시간 내 처리 백로그 검토 결과

| 카테고리 | 항목 | 상태 |
|---------|------|------|
| ARCH-AUDIT-001~011 | 문서 변경, Not applicable | ✅ 정상 |
| ARCH-CONF-001~005,008 | SPEC.md 변경, Not applicable | ✅ 정상 |
| ARCH-CONF-006 | 검증 태스크, Test Plan 7개 검사 통과 | ✅ 증거 추가 |
| ARCH-CONF-007 | 하네스 스크립트, harness:scan 통과 | ✅ 정상 |
| HOOK-003~007 | demo 스크립트 실행 증거 | ✅ 정상 |
| user-local 구현 | CLI 재검증 통과 | ✅ 정상 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)