### PR TITLE
docs(backlog): add missing UE section to backlog-execution-orchestrator-skill

### DIFF
--- a/.agents/backlog/completed/backlog-execution-orchestrator-skill.md
+++ b/.agents/backlog/completed/backlog-execution-orchestrator-skill.md
@@ -92,6 +92,10 @@ Create the skill as a small procedural wrapper:
 - [x] The skill requires child PRs to merge into the initiative base branch.
 - [x] The skill requires the final `develop` PR to remain unmerged for the user.
 
+## User Execution Test Scenarios
+
+Not applicable — skill-only change. This backlog delivered `.agents/skills/backlog-execution-orchestrator/SKILL.md`, a process orchestration skill definition. It does not deliver runnable Robota product behavior (no CLI command, TUI action, browser UI, or public SDK API). Governance and skill-only changes do not require a product-surface user execution test scenario.
+
 ## Test Plan
 
 - Add a document/governance check only if the rule starts drifting or the skill is repeatedly


### PR DESCRIPTION
## Summary

- `completed/backlog-execution-orchestrator-skill.md`에 `## User Execution Test Scenarios` 섹션 누락 발견 → 추가
- 이 백로그는 skill-only 변경 (`.agents/skills/backlog-execution-orchestrator/SKILL.md` 생성)이므로 "Not applicable" 분류가 올바름
- 24시간 내 처리된 비-HOOK 백로그 전수 검사 결과 이 파일이 유일한 누락 건

## 24시간 내 비-HOOK 백로그 전수 검사 결과

| 그룹 | 항목 수 | UE 분류 | 결과 |
|------|---------|---------|------|
| ARCH-AUDIT-001~011 | 11 | Not applicable (문서 변경) | ✅ 정상 |
| ARCH-CONF-001~008 | 8 | Not applicable (SPEC/검증/하네스) | ✅ 정상 |
| completed/ cli-* 스펙 문서 | 6 | Not applicable (계약 문서) | ✅ 정상 |
| completed/ 거버넌스/규칙 | 3 | Not applicable (규칙/스킬) | ✅ 정상 |
| completed/ user-local 구현 | 2 | 시나리오 + 증거 | ✅ CLI 재검증 통과 |
| completed/ backlog-execution-orchestrator-skill | 1 | **UE 섹션 누락** → 수정 | ✅ 이번 PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)