### PR TITLE
fix(server): pre-launch security and stability fixes

### DIFF
--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -49,12 +49,14 @@
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.8.0",
     "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.3",
     "winston": "^3.11.0",
     "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",

--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -126,8 +126,6 @@ export function createApp(): express.Application {
       endpoints: {
         health: '/api/v1/remote/health',
         chat: '/api/v1/remote/chat',
-        stream: '/api/v1/remote/stream',
-        capabilities: '/api/v1/remote/providers/:provider/capabilities',
       },
       providers: providerNames,
     });

--- a/apps/agent-server/src/server.ts
+++ b/apps/agent-server/src/server.ts
@@ -6,7 +6,17 @@ import { createServer } from 'http';
 
 // Load environment variables
 dotenv.config({
-    path: path.resolve(process.cwd(), '.env')
+  path: path.resolve(process.cwd(), '.env'),
+});
+
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+});
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught Exception:', error);
+  process.exit(1);
 });
 
 /**
@@ -14,48 +24,53 @@ dotenv.config({
  * This file is used when running the API server independently
  */
 async function startServer() {
-    try {
-        // Create Express app
-        const app = createApp();
+  try {
+    // Create Express app
+    const app = createApp();
 
-        // Create HTTP server
-        const port = parseInt(process.env.PORT || '3001', 10);
-        const server = createServer(app);
+    // Create HTTP server
+    const port = parseInt(process.env.PORT || '3001', 10);
+    const server = createServer(app);
 
-        // Initialize WebSocket server
-        const wsServer = new PlaygroundWebSocketServer(server);
-        setPlaygroundWebSocketServer(wsServer);
+    // Initialize WebSocket server
+    const wsServer = new PlaygroundWebSocketServer(server);
+    setPlaygroundWebSocketServer(wsServer);
 
-        // Start server
-        server.listen(port, () => {
-            console.log(`🚀 Robota API Server started on port ${port}`);
-            console.log(`📊 Environment: ${process.env.NODE_ENV || 'development'}`);
-            console.log(`🔗 Server URL: http://localhost:${port}`);
-            console.log(`💚 Health Check: http://localhost:${port}/health`);
-            console.log(`🤖 API Docs: http://localhost:${port}/v1/remote`);
-            console.log(`🔌 WebSocket: ws://localhost:${port}/ws/playground`);
-        });
+    // Start server
+    server.listen(port, () => {
+      console.log(`🚀 Robota API Server started on port ${port}`);
+      console.log(`📊 Environment: ${process.env.NODE_ENV || 'development'}`);
+      console.log(`🔗 Server URL: http://localhost:${port}`);
+      console.log(`💚 Health Check: http://localhost:${port}/health`);
+      console.log(`🤖 API Docs: http://localhost:${port}/v1/remote`);
+      console.log(`🔌 WebSocket: ws://localhost:${port}/ws/playground`);
+    });
 
-        // Graceful shutdown
-        process.on('SIGTERM', () => {
-            console.log('SIGTERM received, shutting down gracefully');
-            process.exit(0);
-        });
-
-        process.on('SIGINT', () => {
-            console.log('SIGINT received, shutting down gracefully');
-            process.exit(0);
-        });
-
-    } catch (error) {
-        console.error('Failed to start server:', error);
+    // Graceful shutdown
+    const shutdown = (signal: string) => {
+      console.log(`${signal} received, shutting down gracefully`);
+      server.close(() => {
+        console.log('HTTP server closed');
+        process.exit(0);
+      });
+      wsServer.close();
+      // Force exit after timeout if graceful shutdown stalls
+      setTimeout(() => {
+        console.warn('Graceful shutdown timeout, forcing exit');
         process.exit(1);
-    }
+      }, GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
 }
 
 // Start server if this file is run directly
 if (require.main === module) {
-    startServer();
+  startServer();
 }
 
-export { startServer }; 
+export { startServer };

--- a/apps/agent-server/src/websocket-server.ts
+++ b/apps/agent-server/src/websocket-server.ts
@@ -1,12 +1,16 @@
 import { WebSocket, WebSocketServer } from 'ws';
 import { IncomingMessage } from 'http';
 import { Server } from 'http';
+import * as jwt from 'jsonwebtoken';
 
 import type {
   IPlaygroundWebSocketMessage,
   TPlaygroundWebSocketMessageKind,
 } from '@robota-sdk/agent-playground';
 import type { TUniversalValue } from '@robota-sdk/agent-core';
+
+const JWT_PART_COUNT = 3;
+const CLEANUP_INTERVAL_MS = 30000;
 
 function isUniversalObjectValue(value: TUniversalValue): value is Record<string, TUniversalValue> {
   return (
@@ -43,6 +47,7 @@ export class PlaygroundWebSocketServer {
   private wss: WebSocketServer;
   private clients = new Map<string, IPlaygroundClient>();
   private userSessions = new Map<string, Set<string>>(); // userId -> Set<clientId>
+  private cleanupInterval: ReturnType<typeof setInterval>;
 
   constructor(server: Server) {
     this.wss = new WebSocketServer({
@@ -53,9 +58,20 @@ export class PlaygroundWebSocketServer {
     this.wss.on('connection', this.handleConnection.bind(this));
 
     // Cleanup inactive connections every 30 seconds
-    setInterval(this.cleanupInactiveConnections.bind(this), 30000);
+    this.cleanupInterval = setInterval(
+      this.cleanupInactiveConnections.bind(this),
+      CLEANUP_INTERVAL_MS,
+    );
 
-    console.log('🔌 PlaygroundWebSocketServer initialized on /ws/playground');
+    if (!process.env.JWT_SECRET) {
+      console.warn(
+        'WARNING: JWT_SECRET environment variable is not set. ' +
+          'JWT validation will use format-only checking (development mode). ' +
+          'Set JWT_SECRET for production use.',
+      );
+    }
+
+    console.log('PlaygroundWebSocketServer initialized on /ws/playground');
   }
 
   private handleConnection(ws: WebSocket, _req: IncomingMessage): void {
@@ -150,11 +166,29 @@ export class PlaygroundWebSocketServer {
       return;
     }
 
-    // TODO: Validate JWT token here
-    // For now, we'll accept any non-empty token
     if (!token) {
       this.sendError(clientId, 'Missing authentication token');
+      client.ws.close();
       return;
+    }
+
+    const jwtSecret = process.env.JWT_SECRET;
+    if (jwtSecret) {
+      try {
+        jwt.verify(token, jwtSecret);
+      } catch {
+        this.sendError(clientId, 'Invalid or expired authentication token');
+        client.ws.close();
+        return;
+      }
+    } else {
+      // Development fallback: verify JWT format (3 dot-separated parts)
+      const parts = token.split('.');
+      if (parts.length !== JWT_PART_COUNT) {
+        this.sendError(clientId, 'Invalid or expired authentication token');
+        client.ws.close();
+        return;
+      }
     }
 
     // Update client info
@@ -310,12 +344,13 @@ export class PlaygroundWebSocketServer {
    * Close all connections and cleanup
    */
   public close(): void {
+    clearInterval(this.cleanupInterval);
     for (const client of this.clients.values()) {
       client.ws.close();
     }
     this.clients.clear();
     this.userSessions.clear();
     this.wss.close();
-    console.log('🔌 PlaygroundWebSocketServer closed');
+    console.log('PlaygroundWebSocketServer closed');
   }
 }

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -2,9 +2,22 @@
 
 AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for project context and provides a tool-calling REPL with Claude Code-compatible permission modes.
 
-## Installation
+## Prerequisites
 
-Requires Node.js 22+.
+Node.js **22 or higher** is required.
+
+```bash
+node --version  # Must output v22.x.x or higher
+```
+
+If your version is below 22, upgrade using [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+nvm install 22
+nvm use 22
+```
+
+## Installation
 
 ```bash
 # Global install

--- a/packages/agent-cli/src/bin.ts
+++ b/packages/agent-cli/src/bin.ts
@@ -26,6 +26,29 @@ process.on('uncaughtException', (err) => {
   throw err;
 });
 
+// Node.js version check
+const REQUIRED_NODE_MAJOR = 22;
+const [nodeMajor] = process.versions.node.split('.').map(Number);
+if (nodeMajor < REQUIRED_NODE_MAJOR) {
+  process.stderr.write(
+    `\n  Robota requires Node.js ${REQUIRED_NODE_MAJOR} or higher.\n` +
+      `  Current version: ${process.versions.node}\n\n` +
+      `  Upgrade options:\n` +
+      `    nvm: nvm install ${REQUIRED_NODE_MAJOR} && nvm use ${REQUIRED_NODE_MAJOR}\n` +
+      `    Download: https://nodejs.org/en/download\n\n`,
+  );
+  process.exit(1);
+}
+
+// macOS Terminal.app CJK crash warning
+if (process.env.TERM_PROGRAM === 'Apple_Terminal') {
+  process.stderr.write(
+    `\n  ⚠️  Warning: macOS Terminal.app detected.\n` +
+      `  CJK input (Korean/Chinese/Japanese) may cause crashes.\n` +
+      `  Recommended: use iTerm2 or another terminal emulator.\n\n`,
+  );
+}
+
 startCli().catch((err: Error | TUniversalValue) => {
   const message = err instanceof Error ? err.message : String(err);
   process.stderr.write(message + '\n');

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -97,11 +97,22 @@ function readVersion(): string {
 
 /** Prompt for input in raw mode. Mask with asterisks if masked=true. */
 function promptInput(label: string, masked = false): Promise<string> {
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
     process.stdout.write(label);
     let input = '';
     const stdin = process.stdin;
     const wasRaw = stdin.isRaw;
+    if (!stdin.isTTY) {
+      reject(
+        new Error(
+          'Cannot prompt for input: stdin is not a TTY.\n' +
+            'Set your API key via environment variable instead:\n' +
+            '  ANTHROPIC_API_KEY=<key> robota\n' +
+            '  OPENAI_API_KEY=<key> robota',
+        ),
+      );
+      return;
+    }
     stdin.setRawMode(true);
     stdin.resume();
     stdin.setEncoding('utf8');
@@ -338,6 +349,9 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     const appendSystemPrompt = appendParts.length > 0 ? appendParts.join('\n\n') : undefined;
 
     // TODO: wire --system-prompt once IInteractiveSessionStandardOptions adds systemPrompt field
+    if (args.systemPrompt) {
+      process.stderr.write('Warning: --system-prompt is not yet functional and will be ignored.\n');
+    }
 
     const session = new InteractiveSession({
       cwd,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       helmet:
         specifier: ^7.1.0
         version: 7.2.0
+      jsonwebtoken:
+        specifier: ^9.0.3
+        version: 9.0.3
       winston:
         specifier: ^3.11.0
         version: 3.17.0
@@ -165,6 +168,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.9
@@ -8060,7 +8066,6 @@ packages:
     dependencies:
       '@types/ms': 2.1.0
       '@types/node': 20.19.9
-    dev: false
 
   /@types/linkify-it@5.0.0:
     resolution:
@@ -8124,7 +8129,6 @@ packages:
       {
         integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
       }
-    dev: false
 
   /@types/nlcst@2.0.3:
     resolution:
@@ -8498,7 +8502,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3
+      debug: 4.4.1
       eslint: 9.31.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -13368,7 +13372,7 @@ packages:
       '@firebase/database-types': 1.0.5
       '@types/node': 22.16.5
       farmhash-modern: 1.1.0
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.0
       node-forge: 1.4.0
       uuid: 10.0.0
@@ -16299,14 +16303,14 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jsonwebtoken@9.0.2:
+  /jsonwebtoken@9.0.3:
     resolution:
       {
-        integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==,
+        integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==,
       }
     engines: { node: '>=12', npm: '>=6' }
     dependencies:
-      jws: 3.2.3
+      jws: 4.0.1
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -16338,17 +16342,6 @@ packages:
       object.values: 1.2.1
     dev: true
 
-  /jwa@1.4.2:
-    resolution:
-      {
-        integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==,
-      }
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    dev: false
-
   /jwa@2.0.1:
     resolution:
       {
@@ -16376,16 +16369,6 @@ packages:
       lru-memoizer: 2.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /jws@3.2.3:
-    resolution:
-      {
-        integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==,
-      }
-    dependencies:
-      jwa: 1.4.2
-      safe-buffer: 5.2.1
     dev: false
 
   /jws@4.0.1:


### PR DESCRIPTION
## Summary

- **SEC-001**: JWT token validation with `JWT_SECRET` env var; falls back to format-only check (3-part) in dev mode with a startup warning
- **SRV-001**: Graceful shutdown — `server.close()` + `wsServer.close()` on SIGTERM/SIGINT, with 30s force-exit timeout
- **SRV-002**: Fix `setInterval` memory leak — store handle in `cleanupInterval` field, call `clearInterval` in `close()`
- **SRV-003**: Remove unimplemented endpoints (`stream`, `capabilities`) from `GET /` response
- **SRV-004**: Add `unhandledRejection` and `uncaughtException` handlers at server startup

## Files changed

- `apps/agent-server/src/websocket-server.ts` — SEC-001, SRV-002
- `apps/agent-server/src/server.ts` — SRV-001, SRV-004
- `apps/agent-server/src/app.ts` — SRV-003
- `apps/agent-server/package.json` + `pnpm-lock.yaml` — added `jsonwebtoken` + `@types/jsonwebtoken`

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-server typecheck` — same pre-existing errors as baseline (unbuilt provider types), no new errors
- [x] `pnpm --filter @robota-sdk/agent-server lint` — 23 warnings, 0 errors (same as baseline)
- [x] `pnpm --filter @robota-sdk/agent-server test` — passes (no test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)