### PR TITLE
docs: enhance CLI getting started guide

### DIFF
--- a/content/getting-started/README.md
+++ b/content/getting-started/README.md
@@ -30,6 +30,41 @@ npm install -g @robota-sdk/agent-cli
 
 > **macOS users**: Korean/CJK IME input may crash macOS Terminal.app. Use **[iTerm2](https://iterm2.com/)** instead. This is a known Ink + Terminal.app issue shared with Claude Code.
 
+## Quick Start — CLI (Robota Coding Assistant)
+
+Install the CLI globally:
+
+```bash
+npm install -g @robota-sdk/agent-cli
+# or
+pnpm add -g @robota-sdk/agent-cli
+```
+
+Start the assistant:
+
+```bash
+robota
+```
+
+On first run, you'll be guided through provider selection and API key configuration.
+
+### Supported Providers
+
+| Provider           | Model Examples                 | API Key                                                  |
+| ------------------ | ------------------------------ | -------------------------------------------------------- |
+| Anthropic (Claude) | claude-opus-4, claude-sonnet-4 | [console.anthropic.com](https://console.anthropic.com)   |
+| OpenAI             | gpt-4o, gpt-4-turbo            | [platform.openai.com](https://platform.openai.com)       |
+| DeepSeek           | deepseek-chat                  | [platform.deepseek.com](https://platform.deepseek.com)   |
+| Qwen (Alibaba)     | qwen-max                       | [dashscope.aliyuncs.com](https://dashscope.aliyuncs.com) |
+| Gemini             | gemini-2.0-flash               | [aistudio.google.com](https://aistudio.google.com)       |
+| LM Studio (local)  | any local model                | localhost — no key needed                                |
+
+### System Requirements
+
+- **Node.js 22 or higher** — check with `node --version`
+- macOS, Linux, or Windows (WSL recommended)
+- **macOS Terminal.app**: CJK input (Korean/Chinese/Japanese) may cause crashes — use iTerm2 instead
+
 ## Your First Agent
 
 ### 1. Create a simple conversational agent


### PR DESCRIPTION
## Summary

- Add CLI Quick Start section to `content/getting-started/README.md` with provider table (Anthropic, OpenAI, DeepSeek, Qwen, Gemini, LM Studio) and system requirements
- Add macOS Terminal.app CJK crash warning in the System Requirements block
- `content/guide/cli.md` already has comprehensive slash commands reference and permission modes table — no duplication needed

## Changes

- `content/getting-started/README.md`: new **Quick Start — CLI (Robota Coding Assistant)** section inserted before the "Your First Agent" SDK section

## Test plan

- [x] `pnpm --filter robota-docs build` passes with no errors
- [x] New section renders correctly with provider table and system requirements list
- [x] Only `content/` files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)