### PR TITLE
fix(cli): add startup checks and UX improvements for pre-launch

### DIFF
--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -2,9 +2,22 @@
 
 AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for project context and provides a tool-calling REPL with Claude Code-compatible permission modes.
 
-## Installation
+## Prerequisites
 
-Requires Node.js 22+.
+Node.js **22 or higher** is required.
+
+```bash
+node --version  # Must output v22.x.x or higher
+```
+
+If your version is below 22, upgrade using [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+nvm install 22
+nvm use 22
+```
+
+## Installation
 
 ```bash
 # Global install

--- a/packages/agent-cli/src/bin.ts
+++ b/packages/agent-cli/src/bin.ts
@@ -26,6 +26,29 @@ process.on('uncaughtException', (err) => {
   throw err;
 });
 
+// Node.js version check
+const REQUIRED_NODE_MAJOR = 22;
+const [nodeMajor] = process.versions.node.split('.').map(Number);
+if (nodeMajor < REQUIRED_NODE_MAJOR) {
+  process.stderr.write(
+    `\n  Robota requires Node.js ${REQUIRED_NODE_MAJOR} or higher.\n` +
+      `  Current version: ${process.versions.node}\n\n` +
+      `  Upgrade options:\n` +
+      `    nvm: nvm install ${REQUIRED_NODE_MAJOR} && nvm use ${REQUIRED_NODE_MAJOR}\n` +
+      `    Download: https://nodejs.org/en/download\n\n`,
+  );
+  process.exit(1);
+}
+
+// macOS Terminal.app CJK crash warning
+if (process.env.TERM_PROGRAM === 'Apple_Terminal') {
+  process.stderr.write(
+    `\n  ⚠️  Warning: macOS Terminal.app detected.\n` +
+      `  CJK input (Korean/Chinese/Japanese) may cause crashes.\n` +
+      `  Recommended: use iTerm2 or another terminal emulator.\n\n`,
+  );
+}
+
 startCli().catch((err: Error | TUniversalValue) => {
   const message = err instanceof Error ? err.message : String(err);
   process.stderr.write(message + '\n');

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -97,11 +97,22 @@ function readVersion(): string {
 
 /** Prompt for input in raw mode. Mask with asterisks if masked=true. */
 function promptInput(label: string, masked = false): Promise<string> {
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
     process.stdout.write(label);
     let input = '';
     const stdin = process.stdin;
     const wasRaw = stdin.isRaw;
+    if (!stdin.isTTY) {
+      reject(
+        new Error(
+          'Cannot prompt for input: stdin is not a TTY.\n' +
+            'Set your API key via environment variable instead:\n' +
+            '  ANTHROPIC_API_KEY=<key> robota\n' +
+            '  OPENAI_API_KEY=<key> robota',
+        ),
+      );
+      return;
+    }
     stdin.setRawMode(true);
     stdin.resume();
     stdin.setEncoding('utf8');
@@ -338,6 +349,9 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     const appendSystemPrompt = appendParts.length > 0 ? appendParts.join('\n\n') : undefined;
 
     // TODO: wire --system-prompt once IInteractiveSessionStandardOptions adds systemPrompt field
+    if (args.systemPrompt) {
+      process.stderr.write('Warning: --system-prompt is not yet functional and will be ignored.\n');
+    }
 
     const session = new InteractiveSession({
       cwd,


### PR DESCRIPTION
## Summary

- **CLI-001**: `promptInput()`에 `isTTY` 가드 추가 — non-TTY 환경(CI, 파이프)에서 `stdin.setRawMode()` 호출 시 크래시 방지
- **CLI-002**: `--system-prompt` 플래그 사용 시 stderr에 미구현 경고 출력
- **UX-001**: bin.ts 시작 시 Node.js 22+ 버전 확인 — 미달 시 명확한 업그레이드 안내 메시지 출력 후 종료
- **UX-002**: macOS Terminal.app 감지 시 CJK 입력 크래시 경고 출력
- **README**: Prerequisites 섹션 추가로 Node.js 22+ 요구사항 명시

## Test plan

- [x] `typecheck` 통과 (`pnpm --filter @robota-sdk/agent-cli typecheck`)
- [x] `lint` bin.ts magic number → `REQUIRED_NODE_MAJOR` 상수로 추출하여 경고 제거
- [x] `test` 통과 (기존 실패 테스트는 dist 아티팩트 누락으로 인한 pre-existing 문제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)