### PR TITLE
docs(backlog): add v2 pre-launch audit backlog items and reports

### DIFF
--- a/.agents/backlog/CLI2-001-help-flag-missing.md
+++ b/.agents/backlog/CLI2-001-help-flag-missing.md
@@ -1,0 +1,99 @@
+---
+title: 'CLI2-001: --help 플래그 미구현 — 첫 탐색 경험 차단'
+status: todo
+created: 2026-05-10
+priority: critical
+urgency: now
+area: cli
+source: pm-prelaunch-report-2026-05-10-v2
+---
+
+## Problem
+
+`robota --help`를 실행하면 CLI 사용법 안내 대신 Node.js `parseArgs()`의 기본 오류 메시지가 노출된다.
+
+```
+Unknown option '--help'. To specify a positional argument starting with a '-',
+place it at the end of the command after '--', as in '-- "--help"'
+```
+
+개발자가 CLI를 설치한 후 가장 먼저 시도하는 `robota --help`가 동작하지 않아 첫 탐색 경험이 차단된다. Claude Code(`claude --help`)는 전체 플래그 목록과 예시를 출력한다.
+
+## Required Change
+
+`packages/agent-cli/src/cli-args.ts`에 `--help` / `-h` 옵션을 추가하고, 전체 플래그 목록과 사용 예시를 출력하는 `printHelp()` 함수를 구현한다. `--version`처럼 출력 후 즉시 `process.exit(0)`로 종료한다.
+
+```typescript
+// cli-args.ts에 추가
+if (args.help) {
+  printHelp();
+  process.exit(0);
+}
+
+function printHelp(): void {
+  process.stdout.write(`
+Usage: robota [options] [-p <prompt>]
+
+Options:
+  -p, --print <prompt>       Run in headless/print mode with the given prompt
+  --output-format <format>   Output format: text | json | stream-json (default: text)
+  --system-prompt <text>     System prompt override (not yet implemented)
+  --language <lang>          Language preference (e.g. ko, en)
+  --no-session-persistence   Disable session persistence for this run
+  --model <model>            Override model for this session
+  --permission-mode <mode>   Permission mode: default | acceptEdits | bypassPermissions
+  -h, --help                 Show this help message
+  --version                  Show version number
+
+Examples:
+  robota                     Start interactive TUI session
+  robota -p "Hello"          Print mode: send prompt and exit
+  robota -p "Hello" --output-format json
+`);
+}
+```
+
+## Scope
+
+- `packages/agent-cli/src/cli-args.ts` — `--help`/`-h` 옵션 추가 및 `printHelp()` 구현
+- `packages/agent-cli/src/cli.ts` — help 처리 분기 추가
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-cli build` 후 `node dist/cli.js --help` 실행 — 플래그 목록 출력 및 exit 0 확인
+2. `node dist/cli.js -h` 실행 — 동일 출력 확인
+3. `node dist/cli.js --help --print "test"` 실행 — help 우선 처리 확인
+4. 기존 `-p` / `--version` 동작 회귀 없음 확인
+
+## User Execution Test Scenarios
+
+### 시나리오 1: --help 플래그 출력 확인
+
+**전제조건**: `robota` 바이너리가 설치되어 있거나 `pnpm build` 후 `bin/robota.cjs` 접근 가능
+
+**실행 단계**:
+
+```bash
+robota --help
+```
+
+**기대 결과**: 플래그 목록(최소 `-p`, `--output-format`, `--help`, `--version` 포함)과 사용 예시가 출력되고 exit code 0으로 종료된다.
+
+**증거 필드** (구현 후 기입):
+
+- 명령 출력: \_
+- exit code: \_
+
+### 시나리오 2: -h 단축 플래그 동작 확인
+
+**실행 단계**:
+
+```bash
+robota -h
+```
+
+**기대 결과**: `--help`와 동일한 출력.
+
+**증거 필드** (구현 후 기입):
+
+- 명령 출력: \_

--- a/.agents/backlog/CLI2-002-language-flag-ignored-in-tui.md
+++ b/.agents/backlog/CLI2-002-language-flag-ignored-in-tui.md
@@ -1,0 +1,73 @@
+---
+title: 'CLI2-002: --language 플래그가 인터랙티브 TUI 모드에서 무시됨'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2
+---
+
+## Problem
+
+`robota --language ko`로 시작해도 TUI 세션 언어가 변경되지 않는다.
+
+- `packages/agent-cli/src/ui/render.tsx:26` — `IRenderOptions`에 `language?: string` 선언됨
+- `packages/agent-cli/src/ui/App.tsx` — `IProps` 인터페이스에 `language` 필드 없음
+- `packages/agent-cli/src/cli.ts:395` — `language: args.language`가 `renderApp()`에 전달됨
+
+`renderApp(options)` 호출 시 `<App {...options} />`로 스프레드되지만 `App.tsx`의 `IProps`에 `language`가 없어 컴포넌트가 수신하지 않는다. `InteractiveSession`은 `language` 옵션 자체를 받지 않고 설정 파일(`settings.json`)에서만 읽는다.
+
+DEV-M-004와 동일한 이슈.
+
+## Required Change
+
+1. `App.tsx`의 `IProps`에 `language?: string` 추가
+2. `InteractiveSession` 생성 시 `language` 옵션 전달 (SDK가 지원하는 경우) 또는 설정 파일 임시 override 방식 적용
+3. 단기 대안: CLI `--help` 또는 `--language` 설명에 "현재 설정 파일을 통해서만 적용됨" 명시
+
+```typescript
+// App.tsx IProps에 추가
+interface IProps extends IRenderOptions {
+  language?: string;
+  // ...
+}
+
+// InteractiveSession 생성 시 language 전달
+const session = new InteractiveSession({
+  // ...
+  language: props.language,
+});
+```
+
+## Scope
+
+- `packages/agent-cli/src/ui/App.tsx` — `IProps`에 `language` 추가, 세션 생성 시 전달
+- `packages/agent-cli/src/ui/render.tsx` — `IRenderOptions` 확인
+- `packages/agent-sdk/src/interactive/interactive-session.ts` — `IInteractiveSessionStandardOptions`에 `language` 지원 여부 확인 및 추가
+
+## Test Plan
+
+1. `robota --language ko`로 세션 시작 후 AI 응답 언어 확인 (설정 파일에 language 없는 환경)
+2. `IProps`, `IRenderOptions`, `IInteractiveSessionStandardOptions` 타입 정합성 typecheck 통과 확인
+3. `language` 미지정 시 기존 동작(설정 파일 기반) 회귀 없음 확인
+
+## User Execution Test Scenarios
+
+### 시나리오 1: --language 플래그로 세션 언어 변경 확인
+
+**전제조건**: `robota` 바이너리 설치, `settings.json`에 `language` 항목이 없거나 `en`으로 설정된 환경
+
+**실행 단계**:
+
+```bash
+robota --language ko
+```
+
+TUI가 열리면 "안녕하세요" 또는 임의 메시지를 입력 후 AI 응답 언어 확인
+
+**기대 결과**: AI가 한국어로 응답한다. `settings.json`의 language 설정보다 CLI 플래그가 우선 적용된다.
+
+**증거 필드** (구현 후 기입):
+
+- 관찰 결과: \_

--- a/.agents/backlog/CLI2-003-slash-command-uninitialized-session-throw.md
+++ b/.agents/backlog/CLI2-003-slash-command-uninitialized-session-throw.md
@@ -1,0 +1,68 @@
+---
+title: 'CLI2-003: 슬래시 커맨드 실행 직후 미초기화 세션에서 throw'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2
+---
+
+## Problem
+
+앱 시작 직후 세션 초기화 전에 슬래시 커맨드(예: `/help`)를 빠르게 입력하면 unhandled exception이 발생할 수 있다.
+
+`packages/agent-cli/src/ui/hooks/useSlashRouting.ts:74`:
+
+```typescript
+const ctx = interactiveSession.getContextState(); // try-catch 없음
+```
+
+`applySystemCommandResult()` 함수에서 `getContextState()`를 보호 없이 호출한다. `InteractiveSession.getContextState()`는 내부적으로 `getSessionOrThrow()`를 호출하고, 세션이 아직 초기화되지 않았으면 `Error('InteractiveSession not initialized...')`를 throw한다 (`packages/agent-sdk/src/interactive/interactive-session.ts:340-343`).
+
+## Required Change
+
+`getContextState()` 호출을 try-catch로 보호하거나, 미초기화 상태에서 기본값을 반환하도록 처리한다.
+
+```typescript
+// useSlashRouting.ts — applySystemCommandResult() 내부
+try {
+  const ctx = interactiveSession.getContextState();
+  manager.setContextState({ ... });
+} catch {
+  // Session not yet initialized — skip context update
+}
+```
+
+장기적으로는 `InteractiveSession`이 `isReady()` 메서드나 `onReady` 이벤트를 노출하여 폴링 없이 초기화 완료를 감지할 수 있도록 SDK를 개선한다. (`DEV-L-002` 참조)
+
+## Scope
+
+- `packages/agent-cli/src/ui/hooks/useSlashRouting.ts:74` — `getContextState()` 호출 보호
+
+## Test Plan
+
+1. 앱 시작 직후 타이밍 관련 단위 테스트 추가: 미초기화 상태에서 슬래시 커맨드 라우팅 호출 시 throw 없음 확인
+2. `pnpm typecheck` 통과 확인
+3. 기존 슬래시 커맨드 동작 회귀 없음 확인 (초기화 완료 후 정상 동작)
+
+## User Execution Test Scenarios
+
+### 시나리오 1: 앱 시작 직후 즉시 슬래시 커맨드 입력
+
+**전제조건**: `robota` 바이너리 설치, 빠른 입력 가능한 환경
+
+**실행 단계**:
+
+```bash
+robota
+```
+
+TUI가 열리는 즉시(로딩 중) `/help` 입력
+
+**기대 결과**: 오류 없이 처리된다. 세션 초기화 전이면 컨텍스트 업데이트가 조용히 스킵되고, 초기화 완료 후에는 정상 동작한다.
+
+**증거 필드** (구현 후 기입):
+
+- 관찰 결과: \_
+- 오류 발생 여부: \_

--- a/.agents/backlog/CLI2-004-no-session-persistence-ignored-in-tui.md
+++ b/.agents/backlog/CLI2-004-no-session-persistence-ignored-in-tui.md
@@ -1,0 +1,78 @@
+---
+title: 'CLI2-004: --no-session-persistence 플래그가 인터랙티브 TUI 모드에서 무시됨'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2
+---
+
+## Problem
+
+`--no-session-persistence` 플래그는 print mode(`-p`)에서는 올바르게 처리되지만, 인터랙티브 TUI 모드에서는 항상 세션이 저장된다.
+
+`packages/agent-cli/src/cli.ts:361, 399`:
+
+```typescript
+// 헤드리스(-p) 모드: 올바르게 처리됨
+sessionStore: args.noSessionPersistence ? undefined : sessionStore,
+
+// 인터랙티브 TUI 모드: noSessionPersistence 무시, 항상 sessionStore 전달
+renderApp({
+  ...
+  sessionStore,   // noSessionPersistence 체크 없음
+  ...
+});
+```
+
+## Required Change
+
+인터랙티브 모드 `renderApp()` 호출 시에도 동일한 조건을 적용한다.
+
+```typescript
+renderApp({
+  ...
+  sessionStore: args.noSessionPersistence ? undefined : sessionStore,
+  ...
+});
+```
+
+## Scope
+
+- `packages/agent-cli/src/cli.ts` — `renderApp()` 호출부 `sessionStore` 전달 조건 수정
+
+## Test Plan
+
+1. `--no-session-persistence` 플래그로 TUI 세션 시작 후 종료, 세션 저장소에 기록이 남지 않음 확인
+2. `-p` 모드와 TUI 모드 동작 일치 확인
+3. `--no-session-persistence` 미지정 시 세션 저장 정상 동작 회귀 없음 확인
+
+## User Execution Test Scenarios
+
+### 시나리오 1: TUI 모드에서 세션 비저장 확인
+
+**전제조건**: `robota` 바이너리 설치, 세션 저장 디렉토리 접근 가능
+
+**실행 단계**:
+
+```bash
+# 세션 저장소 초기 상태 확인
+ls ~/.robota/sessions/ 2>/dev/null || echo "empty"
+
+# --no-session-persistence로 TUI 세션 시작
+robota --no-session-persistence
+```
+
+TUI에서 메시지를 주고받은 뒤 종료(`/exit` 또는 Ctrl+C)
+
+```bash
+# 세션 저장 여부 확인
+ls ~/.robota/sessions/
+```
+
+**기대 결과**: 세션 종료 후 저장소에 새로운 세션 파일이 생성되지 않는다.
+
+**증거 필드** (구현 후 기입):
+
+- 세션 저장소 파일 목록 변화: \_

--- a/.agents/backlog/CLI2-005-prompt-input-stdin-listener-leak.md
+++ b/.agents/backlog/CLI2-005-prompt-input-stdin-listener-leak.md
@@ -1,0 +1,50 @@
+---
+title: 'CLI2-005: promptInput Ctrl+C 경로에서 stdin 리스너 누수'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: cli
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`packages/agent-cli/src/cli.ts:133-136`의 `promptInput` 함수에서 사용자가 Ctrl+C(`\x03`)를 누르면 `process.exit(0)`을 직접 호출하기 전에 stdin의 `onData` 리스너를 제거하지 않고 raw mode도 복원하지 않는다.
+
+```typescript
+} else if (ch === '\x03') {
+    process.stdout.write('\n');
+    process.exit(0);  // stdin listener never removed, raw mode never restored
+}
+```
+
+테스트 환경이나 `process.exit`가 모킹된 경우 리스너 누수가 발생한다. 또한 raw mode가 복원되지 않으면 터미널 상태가 오염될 수 있다.
+
+## Required Change
+
+`process.exit(0)` 호출 전에 stdin 정리를 수행한다.
+
+```typescript
+} else if (ch === '\x03') {
+    stdin.removeListener('data', onData);
+    stdin.setRawMode(wasRaw ?? false);
+    stdin.pause();
+    process.stdout.write('\n');
+    process.exit(0);
+}
+```
+
+## Scope
+
+- `packages/agent-cli/src/cli.ts` — `promptInput()` 함수의 Ctrl+C 처리 분기
+
+## Test Plan
+
+1. `promptInput()`의 Ctrl+C 경로에 대한 단위 테스트 추가: `process.exit` 모킹 후 `stdin.removeListener` 및 `setRawMode` 호출 확인
+2. `pnpm typecheck` 및 `pnpm lint` 통과 확인
+3. 정상 입력 경로 회귀 없음 확인
+
+## User Execution Test Scenarios
+
+Not applicable. 이 변경은 `process.exit`가 모킹된 테스트 환경에서만 관찰 가능한 내부 리소스 정리 버그다. 일반 사용자 실행 환경에서는 `process.exit(0)`이 즉시 프로세스를 종료하므로 누수가 런타임에 영향을 주지 않는다. 검증은 Test Plan의 단위 테스트로 수행한다.

--- a/.agents/backlog/CLI2-006-output-format-no-validation.md
+++ b/.agents/backlog/CLI2-006-output-format-no-validation.md
@@ -1,0 +1,91 @@
+---
+title: 'CLI2-006: --output-format 인수 유효성 검사 없이 as 캐스팅 — 잘못된 값이 stream-json으로 무음 폴백'
+status: todo
+created: 2026-05-10
+priority: critical
+urgency: now
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2 (QA-C-001)
+---
+
+## Problem
+
+`packages/agent-cli/src/cli.ts:378`에서 `--output-format` 인수를 유효성 검사 없이 `as` 캐스팅으로 처리한다.
+
+```typescript
+outputFormat: (args.outputFormat as 'text' | 'json' | 'stream-json') ?? 'text',
+```
+
+사용자가 `--output-format xml` 같은 잘못된 값을 전달해도 오류가 발생하지 않는다.
+`packages/agent-transport-headless/src/headless-runner.ts:50-57`에서 알 수 없는 포맷은
+경고 없이 `stream-json` 모드로 폴백된다.
+
+```typescript
+if (outputFormat === 'text') { return runTextFormat(...); }
+if (outputFormat === 'json') { return runJsonFormat(...); }
+return runStreamJsonFormat(session, prompt);  // 잘못된 값이면 여기로 폴백
+```
+
+결과: `robota -p "hello" --output-format xml` → stream-json 형식으로 출력됨. 사용자 인지 불가.
+
+## Required Change
+
+`packages/agent-cli/src/cli-args.ts`의 `parseCliArgs()`에 `parseOutputFormat()` 함수 추가.
+기존 `parsePermissionMode()` 패턴과 동일하게 구현:
+
+```typescript
+const VALID_OUTPUT_FORMATS = ['text', 'json', 'stream-json'] as const;
+export function parseOutputFormat(
+  raw: string | undefined,
+): 'text' | 'json' | 'stream-json' | undefined {
+  if (raw === undefined) return undefined;
+  if (!(VALID_OUTPUT_FORMATS as readonly string[]).includes(raw)) {
+    process.stderr.write(`Invalid --output-format "${raw}". Valid: text | json | stream-json\n`);
+    process.exit(1);
+  }
+  return raw as 'text' | 'json' | 'stream-json';
+}
+```
+
+`cli.ts:378`의 `as` 캐스팅 제거 후 `parseOutputFormat(args.outputFormat)` 호출로 교체.
+
+## Scope
+
+- `packages/agent-cli/src/cli-args.ts` — `parseOutputFormat()` 함수 추가
+- `packages/agent-cli/src/cli.ts:378` — `as` 캐스팅 → `parseOutputFormat()` 호출로 교체
+
+## Test Plan
+
+- `parseOutputFormat('xml')` 호출 시 stderr 출력 + exit(1) 확인 (단위 테스트)
+- `parseOutputFormat('text' | 'json' | 'stream-json')` 호출 시 정상 반환 확인
+- `parsePermissionMode()` 기존 테스트 패턴 참고
+
+## User Execution Test Scenarios
+
+**Prerequisites:** `pnpm build` (agent-cli), Node.js 22+
+
+**Scenario — 잘못된 포맷 값으로 실행:**
+
+```bash
+robota -p "hello" --output-format xml
+```
+
+**Expected observable result:**
+
+```
+Invalid --output-format "xml". Valid: text | json | stream-json
+```
+
+Exit code: 1
+
+**Scenario — 올바른 포맷 값으로 실행:**
+
+```bash
+robota -p "hello" --output-format json
+```
+
+**Expected observable result:** JSON 형식으로 응답 출력 (오류 없음)
+
+**Cleanup:** 없음
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/CLI2-008-agent-command-mode-orphan-package.md
+++ b/.agents/backlog/CLI2-008-agent-command-mode-orphan-package.md
@@ -1,0 +1,70 @@
+---
+title: 'CLI2-008: agent-command-mode 패키지가 CLI에 등록되지 않은 orphan 상태'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: cli
+source: pm-prelaunch-report-2026-05-10-v2 (PM-I-002)
+---
+
+## Problem
+
+`@robota-sdk/agent-command-mode` 패키지가 구현되어 있으나 `createDefaultCliCommandModules()`에
+등록되지 않아 `/mode` 커맨드를 사용자가 접근할 수 없다.
+
+`packages/agent-cli/src/cli.ts`의 `createDefaultCliCommandModules()`에
+`createPermissionsCommandModule`은 포함되어 있으나 `createModeCommandModule`은 없다.
+
+해당 패키지는 v3.0.0-beta.61로 배포되어 있으나 CLI에서 접근 불가 — 실질적으로 orphan 상태.
+
+## Required Change
+
+다음 중 하나를 선택하여 처리:
+
+**Option A (등록):** 실제로 필요한 기능이라면 `createDefaultCliCommandModules()`에 추가.
+
+**Option B (제거):** 사용하지 않는 패키지라면:
+
+- `packages/agent-command-mode/` 디렉토리 삭제
+- `pnpm-workspace.yaml` 및 관련 패키지의 `package.json` 의존성 제거
+- npm에서 deprecated 처리 또는 unpublish (배포된 버전이 있는 경우)
+
+선택 전 `/permissions` 커맨드(`createPermissionsCommandModule`)와 기능 중복 여부 확인 필요.
+
+## Scope
+
+- `packages/agent-cli/src/cli.ts` — Option A 선택 시 등록 추가
+- `packages/agent-command-mode/` — Option B 선택 시 전체 삭제
+- 관련 `package.json` 의존성 정리
+
+## Test Plan
+
+- Option A: `/mode` 커맨드가 TUI에서 동작하는지 확인
+- Option B: 빌드 및 typecheck 통과 확인, `pnpm harness:verify` 통과 확인
+
+## User Execution Test Scenarios
+
+**Prerequisites:** `pnpm build` (agent-cli), Node.js 22+
+
+**Scenario — Option A (등록 후):**
+
+```bash
+robota
+# TUI 진입 후
+/mode
+```
+
+**Expected observable result:** `/mode` 커맨드 응답 (도움말 또는 기능 실행)
+
+**Scenario — Option B (제거 후):**
+
+```bash
+pnpm typecheck && pnpm build
+```
+
+**Expected observable result:** 빌드 오류 없음
+
+**Cleanup:** 없음
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/CLI2-009-resolve-git-branch-sync-ui-blocking.md
+++ b/.agents/backlog/CLI2-009-resolve-git-branch-sync-ui-blocking.md
@@ -1,0 +1,59 @@
+---
+title: 'CLI2-009: SessionStatusBar의 resolveGitBranch()가 동기 execSync로 UI 차단 가능'
+status: todo
+created: 2026-05-10
+priority: low
+urgency: later
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2 (QA-L-001)
+---
+
+## Problem
+
+`packages/agent-cli/src/ui/SessionStatusBar.tsx:39`:
+
+```typescript
+const gitBranch = useMemo(() => resolveGitBranch(cwd), [cwd]);
+```
+
+`useMemo`가 `cwd` 변경 시에만 재계산하므로 올바른 패턴이다. 그러나 `resolveGitBranch()`가
+내부적으로 동기 `execSync('git branch ...')`를 호출한다. 대규모 git 저장소나 느린 파일시스템에서
+매 cwd 변경마다 UI 렌더링이 일시 차단될 수 있다.
+
+## Required Change
+
+`resolveGitBranch()`를 비동기화하고 `useEffect` + `useState` 패턴으로 전환:
+
+```typescript
+const [gitBranch, setGitBranch] = useState<string | undefined>(undefined);
+
+useEffect(() => {
+  resolveGitBranchAsync(cwd)
+    .then(setGitBranch)
+    .catch(() => setGitBranch(undefined));
+}, [cwd]);
+```
+
+`resolveGitBranch()` 내부에서 `execSync` → `exec` (callback) 또는 `execAsync` (promisified)로 전환.
+
+## Scope
+
+- `packages/agent-cli/src/ui/SessionStatusBar.tsx` — `useMemo` → `useEffect + useState`
+- `resolveGitBranch()` 구현체 — `execSync` → `exec` 비동기 전환
+
+## Test Plan
+
+- 대규모 저장소에서 `cwd` 변경 시 UI 블로킹 없음 확인 (수동 검증)
+- `pnpm typecheck` 통과 확인
+
+## User Execution Test Scenarios
+
+Not applicable — 내부 비동기 전환으로 외부 관찰 가능한 동작 변화 없음. UI 렌더링 지연
+개선은 대규모 저장소 환경에서만 측정 가능.
+
+## Test Plan (검증)
+
+- `pnpm typecheck && pnpm build` 통과 확인
+- 수동: 대규모 git 저장소에서 TUI 시작 후 상태바 즉시 표시 확인 (branch 값이 나중에 채워짐)
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DEP-001-unused-dependencies-agent-server.md
+++ b/.agents/backlog/DEP-001-unused-dependencies-agent-server.md
@@ -1,0 +1,58 @@
+---
+title: 'DEP-001: agent-server 미사용 의존성 — express-winston, winston, @robota-sdk/agent-provider-bytedance'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: server
+source: qa-prelaunch-report-2026-05-10-v2 (QA-M-001)
+---
+
+## Problem
+
+`apps/agent-server/package.json`에 다음 의존성이 선언되어 있으나 `src/` 디렉토리 내
+어디에서도 import되지 않는다:
+
+- `express-winston: "^4.2.0"` — 미사용
+- `winston: "^3.11.0"` — 미사용
+- `@robota-sdk/agent-provider-bytedance` — 미사용 (`app.ts`에서 BytedanceProvider 참조 없음)
+
+설치/번들 크기가 불필요하게 증가한다. `@robota-sdk/agent-provider-bytedance`는 이전 리포트에서
+확인된 실제 ByteDance API 키(`BYTEDANCE_API_KEY`)와 연관될 수 있어 사용 의도 불명확.
+
+## Required Change
+
+`apps/agent-server/package.json`에서 미사용 의존성 3개 제거:
+
+```bash
+pnpm --filter agent-server remove express-winston winston @robota-sdk/agent-provider-bytedance
+```
+
+ByteDance 프로바이더를 실제로 지원할 계획이라면 `app.ts`에 해당 로직을 추가하는 별도 작업으로 처리.
+
+## Scope
+
+- `apps/agent-server/package.json` — 의존성 3개 제거
+- `apps/agent-server/src/` — 혹시 누락된 import가 있는지 grep 확인 후 제거
+
+## Test Plan
+
+- 제거 후 `pnpm --filter agent-server typecheck` 통과 확인
+- `pnpm --filter agent-server build` 통과 확인
+- `src/` 디렉토리 내 `express-winston | winston | bytedance` grep → 결과 없음 확인
+
+## User Execution Test Scenarios
+
+Not applicable — 패키지 의존성 정리. 외부 관찰 가능한 서버 동작 변화 없음.
+
+## Verification Evidence
+
+```bash
+pnpm --filter agent-server typecheck
+# Expected: 오류 없음
+
+grep -r "express-winston\|winston\|bytedance" apps/agent-server/src/
+# Expected: 결과 없음
+```
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DEP-002-google-api-key-env-name-mismatch.md
+++ b/.agents/backlog/DEP-002-google-api-key-env-name-mismatch.md
@@ -1,0 +1,77 @@
+---
+title: 'DEP-002: agent-server app.ts의 GoogleProvider가 GOOGLE_API_KEY를 읽으나 실제 키는 GEMINI_API_KEY로 저장'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: server
+source: qa-prelaunch-report-2026-05-10-v2 (QA-M-004)
+---
+
+## Problem
+
+`apps/agent-server/src/app.ts:82-85`:
+
+```typescript
+if (process.env.GOOGLE_API_KEY) {
+  providers.google = new GoogleProvider({
+    apiKey: process.env.GOOGLE_API_KEY,
+  });
+}
+```
+
+이전 QA 리포트에서 확인된 실제 키는 `GEMINI_API_KEY`로 저장되어 있었으나, 코드에서는
+`GOOGLE_API_KEY`를 읽는다. `.env`에 `GEMINI_API_KEY=...`를 설정하면 Google 프로바이더가
+조용히 비활성화된다.
+
+재현: `.env`에 `GEMINI_API_KEY=...` 설정 후 서버 시작 → `/api/v1/remote/health` 응답에서
+`providers` 배열에 `google` 미포함.
+
+## Required Change
+
+다음 중 하나를 선택:
+
+**Option A (권장): GEMINI_API_KEY도 폴백으로 지원**
+
+```typescript
+const googleApiKey = process.env.GOOGLE_API_KEY ?? process.env.GEMINI_API_KEY;
+if (googleApiKey) {
+  providers.google = new GoogleProvider({ apiKey: googleApiKey });
+}
+```
+
+**Option B: 환경변수 이름을 GEMINI_API_KEY로 통일**
+
+코드를 `GEMINI_API_KEY`로 변경하고 `apps/agent-server/.env.example`도 업데이트.
+
+**Option C: GOOGLE_API_KEY 이름으로 문서화**
+
+`.env.example`에 `GOOGLE_API_KEY` 이름을 명시하고 사용자가 해당 이름으로 설정하도록 안내.
+
+## Scope
+
+- `apps/agent-server/src/app.ts` — 환경변수 읽기 로직 수정
+- `apps/agent-server/.env.example` — 올바른 환경변수 이름 반영
+
+## Test Plan
+
+- `GEMINI_API_KEY` 설정 후 서버 시작 → `/api/v1/remote/health` 응답에 `google` 포함 확인
+- `GOOGLE_API_KEY` 설정 후 서버 시작 → 동일하게 `google` 포함 확인
+- 두 환경변수 모두 미설정 시 `google` 미포함 확인
+
+## User Execution Test Scenarios
+
+**Prerequisites:** agent-server 빌드 및 실행 환경, `.env` 파일
+
+**Scenario — GEMINI_API_KEY 설정 후:**
+
+```bash
+GEMINI_API_KEY=test_key node apps/agent-server/dist/server.js &
+curl http://localhost:3000/api/v1/remote/health | jq '.providers'
+```
+
+**Expected observable result:** `["google"]` (또는 google 포함 배열)
+
+**Cleanup:** 서버 프로세스 종료
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DEV-001-as-unknown-as-isideeffects-dead-code.md
+++ b/.agents/backlog/DEV-001-as-unknown-as-isideeffects-dead-code.md
@@ -1,0 +1,81 @@
+---
+title: 'DEV-001: useSideEffects.ts의 as unknown as ISideEffects 이중 캐스팅 — 사이드 이펙트 경로 dead code'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: now
+area: cli
+source: qa-prelaunch-report-2026-05-10-v2, dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`packages/agent-cli/src/ui/hooks/useSideEffects.ts:239-241`에서 `InteractiveSession`을 `ISideEffects` 인터페이스로 이중 캐스팅한다.
+
+```typescript
+function getHostSideEffects(interactiveSession: InteractiveSession): ISideEffects {
+  return interactiveSession as unknown as ISideEffects;
+}
+```
+
+`ISideEffects`는 `_pendingModelId`, `_resetRequested`, `_exitRequested`, `_triggerResumePicker`, `_sessionName`, `_statusLinePatch` 등의 언더스코어 플래그를 선언하는데, `InteractiveSession`은 이 필드들을 실제로 갖고 있지 않다. JavaScript에서 존재하지 않는 optional 속성을 읽으면 `undefined`를 반환하므로, `if (sideEffects._pendingModelId)` 등의 조건 분기는 항상 `false`가 되어 dead code가 된다.
+
+또한 `command-effect-handler.ts:66`에서는 `sideEffects._statusLinePatch = effect.patch`로 쓰기 작업을 수행하는데, 실제로는 `InteractiveSession` 인스턴스에 동적 속성을 덧붙이는 것이다.
+
+**참조**: QA-M-002, DEV-H-001 (중복 → 단일 이슈로 통합)
+
+## Required Change
+
+`CommandEffectQueue`(이미 존재함)를 사이드 이펙트의 SSOT로 사용한다. `getHostSideEffects` 패턴을 완전히 제거하고 모든 사이드 이펙트를 `commandEffectQueue` / `applyCommandEffects`를 통해 처리한다.
+
+1. `getHostSideEffects()` 함수 제거
+2. `_statusLinePatch` 쓰기를 `deps.applyStatusLinePatch(effect.patch)` 콜백으로 이동 (line 67에 이미 존재)
+3. `ISideEffects` 인터페이스를 `CommandEffectQueue`가 이미 제공하는 타입으로 대체하거나 제거
+4. 사이드 이펙트 플래그를 `InteractiveSession` 대신 별도의 상태 객체에서 관리
+
+## Scope
+
+- `packages/agent-cli/src/ui/hooks/useSideEffects.ts`
+- `packages/agent-cli/src/ui/hooks/command-effect-handler.ts`
+- `ISideEffects` 인터페이스 정의 파일 (확인 후 업데이트)
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-cli typecheck` — 타입 오류 없음 확인
+2. `pnpm --filter @robota-sdk/agent-cli test` — 기존 테스트 모두 통과 확인
+3. 모델 변경(`_pendingModelId`), 세션 리셋(`_resetRequested`), 종료(`_exitRequested`) 경로를 단위 테스트로 커버
+4. `pnpm build` — 빌드 성공 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 모델 전환 사이드 이펙트 동작 확인
+
+**Prerequisites**: robota CLI 설치, 유효한 프로바이더 API 키 설정
+
+**Steps**:
+
+```bash
+robota
+# TUI 시작 후
+/model  # 모델 변경 커맨드 실행
+# 다른 모델 선택
+# 새 모델로 대화 시도
+```
+
+**Expected observable result**: 모델 변경 후 세션이 변경된 모델로 대화가 진행됨. 이전에는 `_pendingModelId`가 항상 falsy여서 변경 효과가 없었음.
+
+**Evidence**: (구현 후 기록)
+
+### Scenario 2: 세션 리셋 사이드 이펙트 동작 확인
+
+**Prerequisites**: robota CLI TUI 모드 실행 중
+
+**Steps**:
+
+```bash
+/reset  # 세션 리셋 커맨드 실행
+```
+
+**Expected observable result**: 세션이 실제로 초기화되어 대화 히스토리가 지워짐
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-002-non-null-assertion-websocket-sessionid.md
+++ b/.agents/backlog/DEV-002-non-null-assertion-websocket-sessionid.md
@@ -1,0 +1,74 @@
+---
+title: 'DEV-002: WebSocket handler client.sessionId! non-null assertion — 런타임 크래시 위험'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: now
+area: server
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/websocket-server.ts:143`에서 `client.sessionId!`를 non-null assertion으로 사용한다.
+
+```typescript
+case 'playground_update':
+    if (client.isAuthenticated) {
+        this.broadcastToSession(client.sessionId!, message, clientId);
+    } else {
+        this.sendError(clientId, 'Authentication required');
+    }
+```
+
+현재 로직상 `isAuthenticated`가 `true`이면 `sessionId`도 반드시 설정되어 있어 실제 버그는 아니다. 그러나 인증 흐름이 리팩터링되면 assertion이 깨지면서 `Cannot read property of undefined` 런타임 크래시가 발생한다. 같은 패턴이 `lines 203, 226`에도 존재한다(`this.userSessions.get(userId)!`).
+
+## Required Change
+
+명시적 null guard로 교체하여 타입 시스템이 안전성을 보장하도록 한다.
+
+```typescript
+// Before
+this.broadcastToSession(client.sessionId!, message, clientId);
+
+// After
+if (client.isAuthenticated && client.sessionId !== undefined) {
+  this.broadcastToSession(client.sessionId, message, clientId);
+} else if (client.isAuthenticated) {
+  // sessionId가 없는 authenticated 상태는 버그 — 에러 로깅
+  this.sendError(clientId, 'Session state error: missing sessionId');
+}
+```
+
+`userSessions.get(userId)!` 패턴도 동일하게 수정: `.get()` 결과를 변수에 받아 `undefined` 체크 후 사용.
+
+## Scope
+
+- `apps/agent-server/src/websocket-server.ts` (lines 143, 203, 226)
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-server typecheck` — non-null assertion 제거 후 타입 오류 없음 확인
+2. `pnpm --filter @robota-sdk/agent-server build` — 빌드 성공 확인
+3. 인증 흐름 단위 테스트: `isAuthenticated=true, sessionId=undefined` 케이스에서 크래시 없이 에러 메시지 반환 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 인증 후 playground_update 메시지 처리
+
+**Prerequisites**: agent-server 로컬 실행, WebSocket 클라이언트(wscat 또는 테스트 스크립트)
+
+**Steps**:
+
+```bash
+# agent-server 시작
+pnpm --filter @robota-sdk/agent-server dev
+
+# WebSocket 연결 및 인증
+wscat -c ws://localhost:3001/ws
+# auth 메시지 전송 후 playground_update 메시지 전송
+```
+
+**Expected observable result**: 크래시 없이 정상 처리 또는 명확한 에러 메시지 반환
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-003-require-main-esm-misuse.md
+++ b/.agents/backlog/DEV-003-require-main-esm-misuse.md
@@ -1,0 +1,76 @@
+---
+title: 'DEV-003: server.ts의 require.main === module — ESM 전환 시 startServer() 미실행 위험'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: server
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/server.ts:72`에서 CJS 전용 관용구를 사용한다.
+
+```typescript
+if (require.main === module) {
+  startServer();
+}
+```
+
+현재 agent-server는 `"type": "module"` 없이 CJS로 컴파일되고 `tsx`로 개발 실행하므로 런타임에는 동작한다. 그러나 빌드 출력이 ESM 타겟으로 전환되면 이 조건은 항상 `false`가 되어 `startServer()`가 절대 호출되지 않는다. 에러 메시지도 없이 서버가 시작되지 않는 침묵의 장애가 발생한다.
+
+ESM 동등 관용구는 `import.meta.url === new URL(process.argv[1], 'file://').href`이나, `server.ts`는 `node dist/server.js`로 직접 실행되므로 guard 자체가 불필요하다(`index.ts`가 Firebase export를 별도로 처리함).
+
+**참조**: QA-011 업데이트 항목 (v2 보고서 확인)
+
+## Required Change
+
+guard를 제거하고 `startServer()`를 무조건 호출한다. `index.ts`가 Firebase Functions export를 담당하므로 `server.ts`는 직접 실행 진입점으로만 사용된다.
+
+```typescript
+// Before
+if (require.main === module) {
+  startServer();
+}
+
+// After
+startServer();
+```
+
+ESM 전환을 고려한다면 ESM-safe 형태로 교체:
+
+```typescript
+// ESM-safe alternative (if ESM output is intended)
+const isMain = import.meta.url === new URL(process.argv[1], 'file://').href;
+if (isMain) {
+  startServer();
+}
+```
+
+## Scope
+
+- `apps/agent-server/src/server.ts` (line 72)
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-server build` — 빌드 성공 확인
+2. `node dist/server.js` 직접 실행 → 서버 정상 시작 확인
+3. `pnpm --filter @robota-sdk/agent-server typecheck` — 타입 오류 없음 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 빌드 후 서버 직접 실행
+
+**Prerequisites**: `apps/agent-server` 빌드 완료
+
+**Steps**:
+
+```bash
+pnpm --filter @robota-sdk/agent-server build
+node apps/agent-server/dist/server.js
+```
+
+**Expected observable result**: 서버가 정상적으로 시작되며 `Listening on port 3001` (또는 설정된 포트) 로그 출력
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-004-websocket-error-type-always-auth.md
+++ b/.agents/backlog/DEV-004-websocket-error-type-always-auth.md
@@ -1,0 +1,79 @@
+---
+title: 'DEV-004: sendError가 모든 에러에 type:auth 전송 — 잘못된 WebSocket 프로토콜'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: server
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/websocket-server.ts:250-259`의 `sendError` 메서드가 인증 오류가 아닌 모든 에러(Invalid message format, Unknown message type, Authentication required 등)를 `type: 'auth'`로 전송한다.
+
+```typescript
+private sendError(clientId: string, error: string): void {
+    this.sendMessage(clientId, {
+        type: 'auth',   // 항상 'auth' — 비인증 오류에도 동일
+        timestamp: new Date().toISOString(),
+        data: { success: false, error },
+    });
+}
+```
+
+`message.type`으로 라우팅하는 클라이언트는 런타임 오류를 인증 응답으로 오해한다. 예를 들어 "Invalid message format" 오류가 `type: 'auth'`로 오면 클라이언트는 인증이 실패했다고 판단하여 재인증을 시도하는 무한 루프가 발생할 수 있다.
+
+## Required Change
+
+`TPlaygroundWebSocketMessageKind`에 `'error'` 타입을 추가하고, `sendError`는 `type: 'error'`를 사용한다. `type: 'auth'`는 인증 응답 전용으로 예약한다.
+
+```typescript
+// TPlaygroundWebSocketMessageKind에 'error' 추가
+type TPlaygroundWebSocketMessageKind = 'auth' | 'error' | 'message' | ...;
+
+// sendError 수정
+private sendError(clientId: string, error: string): void {
+    this.sendMessage(clientId, {
+        type: 'error',
+        timestamp: new Date().toISOString(),
+        data: { success: false, error },
+    });
+}
+```
+
+인증 실패는 기존 auth 응답 경로에서 `success: false`로 처리하므로 `sendError`와 분리된다.
+
+## Scope
+
+- `apps/agent-server/src/websocket-server.ts`
+- `TPlaygroundWebSocketMessageKind` 타입 정의 파일
+- `packages/agent-playground/` 클라이언트 측 메시지 핸들러 (타입 동기화)
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-server typecheck` — 타입 오류 없음 확인
+2. `pnpm --filter @robota-sdk/agent-playground typecheck` — 클라이언트 타입 동기화 확인
+3. WebSocket 통합 테스트: 잘못된 메시지 전송 시 `type: 'error'` 응답 수신 확인
+4. 인증 실패 시 여전히 `type: 'auth', success: false` 응답 수신 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 잘못된 메시지 포맷 전송 시 에러 타입 확인
+
+**Prerequisites**: agent-server 로컬 실행, wscat 설치
+
+**Steps**:
+
+```bash
+# agent-server 시작
+pnpm --filter @robota-sdk/agent-server dev
+
+# WebSocket 연결 후 잘못된 메시지 전송
+wscat -c ws://localhost:3001/ws
+> {"type":"invalid_type","data":{}}
+```
+
+**Expected observable result**: `{"type":"error","data":{"success":false,"error":"Unknown message type"}}` 형태의 응답 수신 (이전: `type: 'auth'`로 잘못 반환됨)
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-005-parseint-missing-radix.md
+++ b/.agents/backlog/DEV-005-parseint-missing-radix.md
@@ -1,0 +1,64 @@
+---
+title: 'DEV-005: parseInt 기수 누락 — RATE_LIMIT_MAX 잘못된 값 시 rate limiting 비활성화'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: server
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/app.ts:53`에서 `parseInt`를 기수(radix) 없이 호출한다.
+
+```typescript
+max: parseInt(process.env.RATE_LIMIT_MAX || '100'),  // 기수 없음, NaN 가능
+```
+
+`RATE_LIMIT_MAX`가 비숫자 문자열로 잘못 설정되면 `parseInt`는 `NaN`을 반환한다. `express-rate-limit`의 `max` 옵션이 `NaN`을 받으면 rate limiting이 조용히 비활성화된다. 보안 설정이 무음으로 꺼지는 것이므로 위험하다.
+
+`"0x10"` 또는 `0`으로 시작하는 문자열에서도 기수 없이 호출하면 구현 정의 동작이 발생한다.
+
+## Required Change
+
+기수 `10`을 명시하고, NaN 또는 유효하지 않은 값이면 시작 시 오류를 throw한다.
+
+```typescript
+// Before
+max: parseInt(process.env.RATE_LIMIT_MAX || '100'),
+
+// After
+const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX ?? '100', 10);
+if (!Number.isFinite(rateLimitMax) || rateLimitMax <= 0) {
+  throw new Error(`Invalid RATE_LIMIT_MAX: "${process.env.RATE_LIMIT_MAX}"`);
+}
+// ... rateLimit({ max: rateLimitMax, ... })
+```
+
+## Scope
+
+- `apps/agent-server/src/app.ts` (line 53)
+
+## Test Plan
+
+1. `RATE_LIMIT_MAX=abc`로 서버 시작 → 즉시 오류 throw 및 종료 확인
+2. `RATE_LIMIT_MAX=50`으로 서버 시작 → rate limit 50으로 설정 확인
+3. `RATE_LIMIT_MAX` 미설정 → 기본값 100 사용 확인
+4. `pnpm --filter @robota-sdk/agent-server typecheck` — 타입 오류 없음 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 잘못된 RATE_LIMIT_MAX 설정 시 즉시 오류
+
+**Prerequisites**: agent-server 빌드 완료
+
+**Steps**:
+
+```bash
+RATE_LIMIT_MAX=abc node apps/agent-server/dist/server.js
+```
+
+**Expected observable result**: 서버 시작 즉시 `Error: Invalid RATE_LIMIT_MAX: "abc"` 오류 출력 후 종료 (이전: 조용히 NaN으로 rate limiting 비활성화)
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-006-tool-concurrent-duplicate-matching-bug.md
+++ b/.agents/backlog/DEV-006-tool-concurrent-duplicate-matching-bug.md
@@ -1,0 +1,89 @@
+---
+title: 'DEV-006: onToolEnd 중복 도구 이름 매칭 버그 — 동시 동일 도구 실행 시 상태 불일치'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: soon
+area: cli
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`packages/agent-cli/src/ui/tui-state-manager.ts:90`의 `onToolEnd`에서 활성 도구를 `toolName`으로만 매칭한다.
+
+```typescript
+onToolEnd = (state: IToolState): void => {
+    const idx = this.activeTools.findIndex(
+        (t) => t.toolName === state.toolName && t.isRunning  // 이름만으로 매칭
+    );
+    ...
+};
+```
+
+동일한 도구(예: `Bash`)가 동시에 두 번 실행되면 `findIndex`는 첫 번째 항목만 반환한다. 두 번째 실행이 완료되어도 첫 번째 항목이 잘못 업데이트되고, 두 번째 항목은 영구적으로 "실행 중" 상태로 남아 TUI에 표시된다.
+
+## Required Change
+
+도구 호출을 안정적인 `toolCallId`로 식별한다. `IToolState`가 `toolCallId`를 제공하는지 확인하고, 제공한다면 `onToolStart`에서 ID를 기록하여 `onToolEnd`에서 매칭한다. SDK가 call ID를 제공하지 않는다면 삽입 순서 기반 인덱스로 추적한다.
+
+```typescript
+// IToolState에 toolCallId가 있는 경우
+onToolEnd = (state: IToolState): void => {
+    const idx = this.activeTools.findIndex(
+        (t) => t.toolCallId === state.toolCallId
+    );
+    ...
+};
+
+// toolCallId가 없는 경우 — onToolStart에서 인덱스 기반 추적
+private toolStartOrder: Map<string, number[]> = new Map();
+
+onToolStart = (state: IToolState): void => {
+    const order = this.toolStartOrder.get(state.toolName) ?? [];
+    order.push(this.activeTools.length);
+    this.toolStartOrder.set(state.toolName, order);
+    this.activeTools.push({ ...state, isRunning: true });
+    this.notify();
+};
+
+onToolEnd = (state: IToolState): void => {
+    const order = this.toolStartOrder.get(state.toolName);
+    const idx = order?.shift() ?? -1;
+    if (idx !== -1) {
+        this.activeTools[idx] = { ...this.activeTools[idx], isRunning: false };
+    }
+    this.notify();
+};
+```
+
+## Scope
+
+- `packages/agent-cli/src/ui/tui-state-manager.ts`
+- `IToolState` 인터페이스 확인 (toolCallId 존재 여부)
+
+## Test Plan
+
+1. 동일 도구 2회 동시 실행 시나리오 단위 테스트 추가
+2. `onToolStart` 2회 → `onToolEnd` 2회 호출 후 `activeTools`에 완료 상태 2개 확인
+3. `pnpm --filter @robota-sdk/agent-cli test` — 기존 테스트 통과 확인
+4. `pnpm --filter @robota-sdk/agent-cli typecheck` — 타입 오류 없음 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: 병렬 Bash 도구 실행 후 TUI 상태 확인
+
+**Prerequisites**: robota CLI TUI 모드, 병렬 도구 실행을 트리거하는 프롬프트
+
+**Steps**:
+
+```bash
+robota
+# TUI 시작 후
+# 병렬 도구 실행을 유도하는 프롬프트 입력
+# 예: "동시에 두 파일을 읽어서 비교해줘"
+```
+
+**Expected observable result**: 두 도구가 모두 완료된 후 TUI의 도구 상태 표시에서 두 항목 모두 완료(running 아님)로 표시됨. 이전에는 하나가 영구적으로 "실행 중"으로 남음.
+
+**Evidence**: (구현 후 기록)

--- a/.agents/backlog/DEV-007-substr-deprecated.md
+++ b/.agents/backlog/DEV-007-substr-deprecated.md
@@ -1,0 +1,51 @@
+---
+title: 'DEV-007: websocket-server.ts의 substr deprecated — slice로 교체'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: later
+area: server
+source: dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/websocket-server.ts:297`에서 `String.prototype.substr`을 사용한다.
+
+```typescript
+return `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+```
+
+`substr`은 ES2015부터 deprecated이며 Annex B 스펙에서 제거되었다. 표준 `slice`로 교체해야 한다.
+
+또한 QA-013 리포트에서 이미 지적되었으나 미수정 상태다(v2 보고서 업데이트 항목 확인).
+
+**참조**: QA-013, DEV-M-001 (동일 이슈)
+
+## Required Change
+
+```typescript
+// Before
+return `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+// After
+return `client_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+```
+
+`substr(2, 9)`는 인덱스 2부터 길이 9를 추출한다. `slice`로 변환 시 `slice(2, 11)`이 동등하다 (시작 2, 끝 2+9=11).
+
+추가로 DEV-L-004에서 지적한 것처럼 `Math.random()` 대신 `crypto.randomUUID()`로 개선하는 것을 고려한다.
+
+## Scope
+
+- `apps/agent-server/src/websocket-server.ts` (line 297)
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-server typecheck` — 타입 오류 없음 확인
+2. `pnpm --filter @robota-sdk/agent-server build` — 빌드 성공 확인
+3. `rg "substr" apps/agent-server/src/` — substr 사용 잔존 없음 확인
+
+## User Execution Test Scenarios
+
+Not applicable. `substr` → `slice` 교체는 런타임 동작이 동일한 내부 구현 변경이다. 사용자가 관찰 가능한 동작 변화가 없으므로 User Execution Test Scenario가 해당되지 않는다. 검증은 타입체크 및 빌드 성공으로 충분하다.

--- a/.agents/backlog/DEV-008-server-shutdown-order-wrong.md
+++ b/.agents/backlog/DEV-008-server-shutdown-order-wrong.md
@@ -1,0 +1,70 @@
+---
+title: 'DEV-008: agent-server 종료 시 HTTP server.close() 후 wsServer.close() 순서 역전 — 활성 WebSocket이 30s 타임아웃 강제 종료 유발'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: soon
+area: server
+source: dev-prelaunch-report-2026-05-10 (DEV-M-006)
+---
+
+## Problem
+
+`apps/agent-server/src/server.ts:50-61`:
+
+```typescript
+server.close(() => { ... process.exit(0); });
+wsServer.close();
+```
+
+`server.close()`를 먼저 호출하면 새 연결 수락은 중단되지만, 콜백은 기존 연결이 모두 닫힌
+후에만 실행된다. 활성 WebSocket 연결이 HTTP 서버를 계속 열어두어 `server.close()` 콜백이
+지연된다. 결국 30초 타임아웃이 먼저 발동하여 `process.exit(1)`으로 강제 종료된다.
+
+올바른 순서: WebSocket 연결을 먼저 닫아야 HTTP 서버가 즉시 drain된다.
+
+## Required Change
+
+`apps/agent-server/src/server.ts` 종료 핸들러에서 순서 교체:
+
+```typescript
+// BEFORE
+server.close(() => { ... process.exit(0); });
+wsServer.close();
+
+// AFTER
+wsServer.close();
+server.close(() => {
+  logger.info('HTTP server closed');
+  process.exit(0);
+});
+```
+
+## Scope
+
+- `apps/agent-server/src/server.ts` — 종료 핸들러 순서 수정
+
+## Test Plan
+
+- `SIGTERM` 시그널 전송 후 30초 타임아웃 없이 정상 종료(exit code 0) 확인
+- 활성 WebSocket 연결이 있는 상태에서 `SIGTERM` → 연결 종료 후 HTTP 서버 종료 순서 확인
+
+## User Execution Test Scenarios
+
+**Prerequisites:** agent-server 빌드 및 실행 환경, WebSocket 클라이언트 도구
+
+**Scenario — SIGTERM 정상 종료:**
+
+```bash
+node apps/agent-server/dist/server.js &
+SERVER_PID=$!
+# (WebSocket 연결 없는 경우)
+kill -TERM $SERVER_PID
+# 30초 이내 종료 확인
+```
+
+**Expected observable result:** 30초 타임아웃 없이 정상 종료 메시지 출력 후 exit code 0
+
+**Cleanup:** 없음 (프로세스 이미 종료됨)
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DEV-009-useinteractivesession-react-init-anti-pattern.md
+++ b/.agents/backlog/DEV-009-useinteractivesession-react-init-anti-pattern.md
@@ -1,0 +1,77 @@
+---
+title: 'DEV-009: useInteractiveSession이 렌더 본문에서 세션 초기화 — React strict mode 이중 초기화 위험'
+status: todo
+created: 2026-05-10
+priority: medium
+urgency: later
+area: cli
+source: dev-prelaunch-report-2026-05-10 (DEV-M-002)
+---
+
+## Problem
+
+`packages/agent-cli/src/ui/hooks/useInteractiveSession.ts:197-200`:
+
+```typescript
+if (stateRef.current === null) {
+  stateRef.current = initializeSession(props, permissionHandler);
+}
+```
+
+세션 초기화가 렌더 함수 본문에서 실행된다. Ink는 strict mode로 실행되지 않으므로 현재는
+동작하지만, React strict mode에서는 렌더가 두 번 호출되어 이중 초기화가 발생할 수 있다.
+
+`ref`가 null 체크로 한 번만 실행되도록 막고 있으나, 이는 동시성 기능(Concurrent Mode)과
+호환되지 않는 패턴이다.
+
+## Required Change
+
+렌더 본문에서 `useEffect` 또는 `useState` lazy initializer로 이동:
+
+**Option A (권장): `useRef` + lazy factory 패턴**
+
+```typescript
+// 최초 render 시 한 번만 실행되는 패턴
+const stateRef = useRef<IInitState | null>(null);
+if (stateRef.current === null) {
+  stateRef.current = initializeSession(props, permissionHandler);
+}
+```
+
+이 패턴은 React 18 공식 문서에서 "stable ref initialization"으로 인정되므로 현재 구현은
+실제로는 올바른 패턴이다. 다만 Ink가 React 18 Concurrent Mode를 사용하지 않는 동안은 안전.
+
+**Option B: `useState` lazy initializer 사용**
+
+```typescript
+const [state] = useState<IInitState>(() => initializeSession(props, permissionHandler));
+```
+
+`useState`의 lazy initializer는 React에서 보장된 "최초 1회 실행" 패턴이다.
+
+현재 Ink 버전이 Concurrent Mode를 지원하지 않는다면 즉각 수정 불필요 — Low urgency 로 유지.
+Ink가 React 18 Concurrent Mode 사용 버전으로 업그레이드될 때 함께 수정.
+
+## Scope
+
+- `packages/agent-cli/src/ui/hooks/useInteractiveSession.ts:197-200` — 초기화 패턴 수정
+
+## Test Plan
+
+- `pnpm typecheck` 통과 확인
+- 기존 세션 초기화 테스트 통과 확인
+- 세션이 정확히 1번만 초기화되는지 단위 테스트로 확인
+
+## User Execution Test Scenarios
+
+Not applicable — 내부 React 패턴 변경. 외부 관찰 가능한 TUI 동작 변화 없음.
+세션이 두 번 초기화되는 버그(strict mode에서만 발현)를 예방하는 변경.
+
+## Verification Evidence
+
+```bash
+pnpm typecheck && pnpm build
+# Expected: 오류 없음
+```
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DOC2-001-nodejs-version-requirement-inconsistency.md
+++ b/.agents/backlog/DOC2-001-nodejs-version-requirement-inconsistency.md
@@ -1,0 +1,87 @@
+---
+title: 'DOC2-001: Node.js 버전 요구사항 3중 불일치 — README/docs/CLI 간 다른 메시지'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: now
+area: documentation
+source: pm-prelaunch-report-2026-05-10-v2 (PM-C-002, PM-I-003)
+---
+
+## Problem
+
+세 문서에서 Node.js 버전 요구사항이 모두 다르다:
+
+| 문서                                 | 표기                                               |
+| ------------------------------------ | -------------------------------------------------- |
+| `/README.md` (루트, GitHub 진입점)   | "Node.js 18+ required"                             |
+| `/content/getting-started/README.md` | "Node.js: 18.0.0 or higher (recommended: 22.14.0)" |
+| `/packages/agent-cli/README.md`      | "Node.js **22 or higher** is required"             |
+| `bin/robota.cjs` (실제 강제 버전)    | `>= 22` — 22 미만이면 즉시 `process.exit(1)`       |
+
+또한 `content/getting-started/README.md`는 같은 문서 내에서도 Prerequisites 섹션(18.0.0+)과
+System Requirements 박스(22+)가 충돌한다.
+
+GitHub에서 발견한 사용자가 "18+ required"를 보고 Node 18 환경에서 설치 → 실행 시 바이너리 오류.
+
+## Required Change
+
+### 1. 루트 README.md
+
+"Node.js 18+ required" → "Node.js **22 or higher** required"
+
+### 2. content/getting-started/README.md
+
+Prerequisites 섹션을 CLI와 SDK로 분리:
+
+```markdown
+## Prerequisites
+
+**Robota CLI** requires **Node.js 22 or higher** (enforced at runtime).
+
+**Robota SDK** requires Node.js 18 or higher (22 recommended).
+
+Check your version:
+\`\`\`bash
+node --version # Must be v22+ for CLI
+\`\`\`
+```
+
+같은 문서 내 "System Requirements" 박스도 통일.
+
+### 3. 검토 대상
+
+- `/apps/agent-web/README.md` — 있다면 버전 표기 확인
+- `/apps/agent-server/README.md` — Node 18 표기 여부 확인
+
+## Scope
+
+- `/README.md` — Node.js 버전 표기 수정
+- `/content/getting-started/README.md` — CLI/SDK 요구사항 분리 명시
+- `packages/agent-cli/README.md` — 이미 올바름 (22+), 다른 문서와 일관성만 확인
+
+## Test Plan
+
+- 각 문서에서 Node.js 버전 요구사항 grep 후 일관성 확인:
+  ```bash
+  rg -n "Node.js|node.js|nodejs" README.md content/getting-started/README.md packages/agent-cli/README.md
+  ```
+- `bin/robota.cjs`의 실제 강제 버전(22)과 일치 확인
+
+## User Execution Test Scenarios
+
+Not applicable — 문서 전용 변경. 외부 관찰 가능한 CLI/TUI 동작 없음.
+
+## Verification Evidence
+
+변경 후 다음 grep 결과를 기록:
+
+```bash
+rg -n "18\+" README.md content/getting-started/README.md packages/agent-cli/README.md
+# Expected: 결과 없음 (루트 README의 18+ 제거됨)
+
+rg -n "22" README.md content/getting-started/README.md packages/agent-cli/README.md
+# Expected: 모든 문서에서 Node.js 22+ 요구사항 확인
+```
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/DOC2-003-github-issue-pr-templates-missing.md
+++ b/.agents/backlog/DOC2-003-github-issue-pr-templates-missing.md
@@ -1,0 +1,90 @@
+---
+title: 'DOC2-003: GitHub 이슈/PR 템플릿 없음 — 베타 출시 후 커뮤니티 지원 준비 미완'
+status: todo
+created: 2026-05-10
+priority: low
+urgency: soon
+area: documentation
+source: pm-prelaunch-report-2026-05-10-v2 (PM-I-004)
+---
+
+## Problem
+
+`.github/` 디렉토리에 `CODEOWNERS`, `workflows/`, `lighthouse/`만 존재.
+`ISSUE_TEMPLATE/`과 `PULL_REQUEST_TEMPLATE.md`가 없다.
+
+`CONTRIBUTING.md`는 존재하지만 이슈 템플릿 없이는 버그 리포트 시 필수 정보(Node.js 버전,
+OS, 터미널, 프로바이더, 오류 메시지) 수집이 안 된다. 베타 출시 후 노이즈 이슈가 많아지고
+대응 비용이 높아진다.
+
+## Required Change
+
+### 1. `.github/ISSUE_TEMPLATE/bug_report.md`
+
+```markdown
+---
+name: Bug Report
+about: Report a bug in Robota
+labels: bug
+---
+
+**Environment**
+
+- Robota version: (run `robota --version`)
+- Node.js version: (run `node --version`)
+- OS: (macOS / Linux / Windows)
+- Terminal: (iTerm2 / Terminal.app / Windows Terminal / other)
+- AI Provider: (OpenAI / Anthropic / Google / other)
+
+**Description**
+A clear description of the bug.
+
+**Steps to Reproduce**
+
+1.
+2.
+3.
+
+**Expected Behavior**
+
+**Actual Behavior**
+
+**Error Output** (if any)
+\`\`\`
+paste error output here
+\`\`\`
+```
+
+### 2. `.github/ISSUE_TEMPLATE/feature_request.md`
+
+기본 기능 요청 템플릿 (문제 설명, 원하는 동작, 대안 검토).
+
+### 3. `.github/PULL_REQUEST_TEMPLATE.md` (선택)
+
+변경 유형, 테스트 확인, 관련 이슈 링크.
+
+## Scope
+
+- `.github/ISSUE_TEMPLATE/bug_report.md` — 신규 생성
+- `.github/ISSUE_TEMPLATE/feature_request.md` — 신규 생성
+- `.github/PULL_REQUEST_TEMPLATE.md` — 선택적 신규 생성
+
+## Test Plan
+
+- `.github/ISSUE_TEMPLATE/` 디렉토리 및 파일 존재 확인
+- GitHub UI에서 새 이슈 생성 시 템플릿 선택 화면 표시 확인
+
+## User Execution Test Scenarios
+
+Not applicable — GitHub 저장소 UI 전용 변경. 로컬 CLI/TUI 동작 없음.
+
+## Verification Evidence
+
+변경 후:
+
+```bash
+ls .github/ISSUE_TEMPLATE/
+# Expected: bug_report.md  feature_request.md
+```
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/PLG-001-playground-websocket-url-hardcoded.md
+++ b/.agents/backlog/PLG-001-playground-websocket-url-hardcoded.md
@@ -1,0 +1,89 @@
+---
+title: 'PLG-001: Web Playground가 ws://localhost:3001/ws로 하드코딩 — 공개 사이트에서 동작 불가'
+status: todo
+created: 2026-05-10
+priority: critical
+urgency: now
+area: playground
+source: pm-prelaunch-report-2026-05-10-v2 (PM-C-003)
+---
+
+## Problem
+
+`packages/agent-playground/src/playground/components/PlaygroundApp.tsx`:
+
+```typescript
+export function PlaygroundApp(props: { defaultServerUrl?: string }): React.ReactElement {
+  return (
+    <PlaygroundProvider defaultServerUrl={props.defaultServerUrl ?? 'ws://localhost:3001/ws'}>
+```
+
+`apps/agent-web/src/app/playground/page.tsx`에서 `PlaygroundApp`을 props 없이 호출:
+
+```typescript
+export default function PlaygroundPage() {
+  return <PlaygroundApp />;  // defaultServerUrl 전달 없음 → localhost:3001 폴백
+}
+```
+
+`apps/agent-web/.env.example`에도 playground 서버 URL 환경변수가 없다.
+공개 사이트(robota.io)에서 Playground를 사용하면 localhost:3001에 연결을 시도하고 실패한다.
+
+## Required Change
+
+**Option A (권장): 환경변수화**
+
+1. `apps/agent-web/.env.example`에 추가:
+
+   ```
+   NEXT_PUBLIC_PLAYGROUND_WS_URL=ws://localhost:3001/ws
+   ```
+
+2. `apps/agent-web/src/app/playground/page.tsx` 수정:
+   ```typescript
+   export default function PlaygroundPage() {
+     return <PlaygroundApp defaultServerUrl={process.env.NEXT_PUBLIC_PLAYGROUND_WS_URL} />;
+   }
+   ```
+
+**Option B: 서버 미연결 시 안내 UI 표시**
+
+`PlaygroundProvider` 내에서 연결 실패 시 "서버 연결이 필요합니다" 안내 메시지 표시.
+`defaultServerUrl`이 undefined면 연결 시도 자체를 건너뜀.
+
+**Option C: Playground를 self-hosted 기능으로 명시**
+
+- `/playground` 페이지에 "self-hosted agent-server 필요" 안내 추가
+- `/playground/demo` (정적 시각화)를 전면에 내세움
+
+## Scope
+
+- `apps/agent-web/.env.example` — `NEXT_PUBLIC_PLAYGROUND_WS_URL` 추가
+- `apps/agent-web/src/app/playground/page.tsx` — 환경변수 전달
+- (Option B 선택 시) `packages/agent-playground/src/playground/` — 연결 실패 UI
+
+## Test Plan
+
+- `NEXT_PUBLIC_PLAYGROUND_WS_URL` 미설정 시 동작 확인 (Option A: undefined 전달, Option B: 안내 UI)
+- `.env.example` 환경변수 이름 문서화 확인
+- `pnpm typecheck && pnpm build` 통과 확인
+
+## User Execution Test Scenarios
+
+**Prerequisites:** `pnpm build` (agent-web), 로컬 개발 서버 실행 (`pnpm --filter agent-web dev`)
+
+**Scenario — 환경변수 미설정 (Option A):**
+
+브라우저에서 `http://localhost:3000/playground` 접속.
+
+**Expected observable result:** 서버 URL 미설정 안내 또는 연결 실패 메시지 (빈 화면 아님)
+
+**Scenario — 환경변수 설정 후:**
+
+`.env.local`에 `NEXT_PUBLIC_PLAYGROUND_WS_URL=ws://localhost:3001/ws` 설정 후 접속.
+
+**Expected observable result:** WebSocket 연결 시도 (agent-server 실행 시 실제 연결)
+
+**Cleanup:** `.env.local` 파일 삭제
+
+**Evidence:** (구현 후 기록)

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -158,3 +158,68 @@ PM 사전 출시 점검에서 식별된 문서화 부족.
 | ------------------------------------------- | -------------------------------------------- | -------- |
 | [DOC-001](DOC-001-getting-started-guide.md) | 공개 docs 사이트 Getting Started 가이드 추가 | high     |
 | [DOC-002](DOC-002-multilang-readme.md)      | 한국어 README 및 다국어 지원 추가            | medium   |
+
+### Pre-Launch Audit v2 — CLI Quality (2026-05-10)
+
+QA/PM/Dev v2 사전 출시 점검에서 발견된 CLI 동작 결함.
+
+| ID                                                                | 제목                                                                                    | 우선순위 |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------- |
+| [CLI2-001](CLI2-001-help-flag-missing.md)                         | --help 플래그 미지원 — 첫 탐색 경험 차단                                                | critical |
+| [CLI2-002](CLI2-002-language-flag-ignored-in-tui.md)              | --language 플래그가 인터랙티브 TUI 모드에서 무시됨                                      | high     |
+| [CLI2-003](CLI2-003-slash-command-uninitialized-session-throw.md) | 슬래시 커맨드 실행 직후 미초기화 세션에서 getContextState() throw                       | high     |
+| [CLI2-004](CLI2-004-no-session-persistence-ignored-in-tui.md)     | --no-session-persistence 플래그가 인터랙티브 TUI 모드에서 무시됨                        | medium   |
+| [CLI2-005](CLI2-005-prompt-input-stdin-listener-leak.md)          | promptInput() Ctrl+C 경로에서 stdin 리스너 누수                                         | medium   |
+| [CLI2-006](CLI2-006-output-format-no-validation.md)               | --output-format 인수 유효성 검사 없이 as 캐스팅 — 잘못된 값이 stream-json으로 무음 폴백 | critical |
+| [CLI2-008](CLI2-008-agent-command-mode-orphan-package.md)         | agent-command-mode 패키지가 CLI에 등록되지 않은 orphan 상태                             | medium   |
+| [CLI2-009](CLI2-009-resolve-git-branch-sync-ui-blocking.md)       | SessionStatusBar의 resolveGitBranch()가 동기 execSync로 UI 차단 가능                    | low      |
+
+### Pre-Launch Audit v2 — TypeScript Dev Quality (2026-05-10)
+
+TypeScript Dev v2 사전 출시 점검에서 발견된 타입/구조 결함.
+
+| ID                                                                  | 제목                                                                                   | 우선순위 |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------- |
+| [DEV-001](DEV-001-as-unknown-as-isideeffects-dead-code.md)          | useSideEffects의 as unknown as ISideEffects 이중 캐스팅 — dead code 경로               | high     |
+| [DEV-002](DEV-002-non-null-assertion-websocket-sessionid.md)        | WebSocket client.sessionId! non-null assertion — 인증 로직 변경 시 런타임 크래시 위험  | critical |
+| [DEV-003](DEV-003-require-main-esm-misuse.md)                       | server.ts의 require.main === module — ESM 컴파일 시 항상 false                         | critical |
+| [DEV-004](DEV-004-websocket-error-type-always-auth.md)              | sendError가 모든 오류에 type: 'auth' 전송 — 잘못된 프로토콜                            | high     |
+| [DEV-005](DEV-005-parseint-missing-radix.md)                        | parseInt(RATE_LIMIT_MAX) 기수 없음 — NaN 시 rate limit 무력화                          | high     |
+| [DEV-006](DEV-006-tool-concurrent-duplicate-matching-bug.md)        | onToolEnd 중복 도구명 매칭 버그 — 동시 실행 시 잘못된 상태 업데이트                    | high     |
+| [DEV-007](DEV-007-substr-deprecated.md)                             | websocket-server.ts의 substr() deprecated — slice()로 교체                             | medium   |
+| [DEV-008](DEV-008-server-shutdown-order-wrong.md)                   | agent-server 종료 시 shutdown 순서 역전 — 활성 WebSocket이 30s 타임아웃 강제 종료 유발 | medium   |
+| [DEV-009](DEV-009-useinteractivesession-react-init-anti-pattern.md) | useInteractiveSession 렌더 본문 세션 초기화 — React strict mode 이중 초기화 위험       | medium   |
+
+### Pre-Launch Audit v2 — Server Quality (2026-05-10)
+
+TypeScript Dev/QA v2 점검에서 발견된 서버 품질 이슈.
+
+| ID                                                             | 제목                                                               | 우선순위 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------ | -------- |
+| [SRV2-001](SRV2-001-firebase-req-any-cors-whitelist-bypass.md) | Firebase handler any 타입 + 이중 CORS 적용으로 화이트리스트 무력화 | high     |
+
+### Pre-Launch Audit v2 — Playground (2026-05-10)
+
+PM v2 점검에서 발견된 Web Playground 동작 결함.
+
+| ID                                                       | 제목                                                                           | 우선순위 |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
+| [PLG-001](PLG-001-playground-websocket-url-hardcoded.md) | Web Playground가 ws://localhost:3001/ws로 하드코딩 — 공개 사이트에서 동작 불가 | critical |
+
+### Pre-Launch Audit v2 — Documentation (2026-05-10)
+
+PM v2 점검에서 발견된 문서 불일치 및 누락.
+
+| ID                                                               | 제목                                                              | 우선순위 |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------- | -------- |
+| [DOC2-001](DOC2-001-nodejs-version-requirement-inconsistency.md) | Node.js 버전 요구사항 3중 불일치 — README/docs/CLI 간 다른 메시지 | high     |
+| [DOC2-003](DOC2-003-github-issue-pr-templates-missing.md)        | GitHub 이슈/PR 템플릿 없음 — 베타 출시 후 커뮤니티 지원 준비 미완 | low      |
+
+### Pre-Launch Audit v2 — Dependencies (2026-05-10)
+
+QA v2 점검에서 발견된 의존성 관리 이슈.
+
+| ID                                                     | 제목                                                                                        | 우선순위 |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------- | -------- |
+| [DEP-001](DEP-001-unused-dependencies-agent-server.md) | agent-server 미사용 의존성 — express-winston, winston, @robota-sdk/agent-provider-bytedance | medium   |
+| [DEP-002](DEP-002-google-api-key-env-name-mismatch.md) | agent-server의 GoogleProvider가 GOOGLE_API_KEY를 읽으나 실제 키는 GEMINI_API_KEY            | medium   |

--- a/.agents/backlog/SRV2-001-firebase-req-any-cors-whitelist-bypass.md
+++ b/.agents/backlog/SRV2-001-firebase-req-any-cors-whitelist-bypass.md
@@ -1,0 +1,83 @@
+---
+title: 'SRV2-001: Firebase handler req:any 타입 오류 및 cors:true CORS 화이트리스트 무력화'
+status: todo
+created: 2026-05-10
+priority: high
+urgency: now
+area: server
+source: qa-prelaunch-report-2026-05-10-v2, dev-prelaunch-report-2026-05-10
+---
+
+## Problem
+
+`apps/agent-server/src/index.ts:28`에 두 가지 문제가 동시에 존재한다.
+
+1. **`req: any, res: any` 타입 사용**: Firebase Functions health check 핸들러가 `(req: any, res: any)` 타입으로 선언되어 있다. 프로젝트 전체의 `strict: true`, `noImplicitAny: true` 규칙(tsconfig.base.json)을 위반한다. 컴파일 타임에 잘못된 속성 접근을 감지할 수 없다.
+
+2. **이중 CORS 적용으로 화이트리스트 무력화**: `index.ts`의 Firebase Functions에서 `cors: true`가 설정되고(`index.ts:14, 23`), `createApp()` 내부에서 `cors` 미들웨어가 또 한 번 적용된다(`app.ts:39`). Firebase `cors: true`는 Firebase가 자체적으로 모든 origin을 허용하도록 설정하므로 `app.ts`의 화이트리스트(`robota.io` 등)가 무력화된다. CORS 정책이 의도와 달리 모든 origin에 열려 API가 외부에 노출된다.
+
+**참조**: QA-H-003, DEV-C-001 (중복 → 단일 이슈로 통합)
+
+## Required Change
+
+1. `index.ts`에서 Firebase Functions 옵션의 `cors: true` → `cors: false`로 변경하여 Express의 CORS 미들웨어만 동작하도록 수정
+2. `req: any, res: any` → `req: Request, res: Response`로 수정 (`firebase-functions/v2/https`에서 import)
+
+```typescript
+// Before
+import { onRequest } from 'firebase-functions/v2/https';
+
+export const health = onRequest({
+  cors: true,  // 모든 origin 허용 → 화이트리스트 무력화
+  region: 'us-central1',
+  ...
+}, (req: any, res: any) => {  // any 타입 → strict 위반
+  res.json({ ... });
+});
+
+// After
+import { onRequest } from 'firebase-functions/v2/https';
+import type { Request, Response } from 'firebase-functions/v2/https';
+
+export const health = onRequest({
+  cors: false,  // Express CORS 미들웨어가 화이트리스트 적용
+  region: 'us-central1',
+  ...
+}, (req: Request, res: Response) => {
+  res.json({ ... });
+});
+```
+
+## Scope
+
+- `apps/agent-server/src/index.ts`
+- TypeScript 타입 검사 통과 확인
+
+## Test Plan
+
+1. `pnpm --filter @robota-sdk/agent-server typecheck` — `any` 제거 후 타입 오류 없음 확인
+2. `pnpm --filter @robota-sdk/agent-server build` — 빌드 성공 확인
+3. 로컬에서 Firebase Functions Emulator 실행 후 health endpoint에 `Origin: https://evil.com` 헤더로 요청 → `Access-Control-Allow-Origin: https://evil.com` 응답이 없어야 함
+4. `Origin: https://robota.io` 헤더로 요청 → CORS 허용 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: CORS 화이트리스트 동작 확인
+
+**Prerequisites**: Firebase Emulator 또는 배포된 agent-server 환경
+
+**Steps**:
+
+```bash
+# 허용되지 않은 origin 요청 → CORS 거부 확인
+curl -s -I -H "Origin: https://evil.com" http://localhost:5001/<project>/us-central1/health
+# 응답 헤더에 Access-Control-Allow-Origin: https://evil.com 없어야 함
+
+# 허용된 origin 요청 → CORS 허용 확인
+curl -s -I -H "Origin: https://robota.io" http://localhost:5001/<project>/us-central1/health
+# 응답 헤더에 Access-Control-Allow-Origin: https://robota.io 있어야 함
+```
+
+**Expected observable result**: evil.com origin은 CORS 거부, robota.io는 허용
+
+**Evidence**: (구현 후 기록)

--- a/.agents/reports/dev-prelaunch-report-2026-05-10.md
+++ b/.agents/reports/dev-prelaunch-report-2026-05-10.md
@@ -1,0 +1,424 @@
+# TypeScript Dev Pre-launch Report — Robota CLI (2026-05-10)
+
+## Executive Summary
+
+**Scope**: `packages/agent-cli/` (6,607 lines, ~60 source files) and `apps/agent-server/` (894 lines, 7 source files).
+
+| Severity          | Count |
+| ----------------- | ----- |
+| Critical          | 3     |
+| High              | 5     |
+| Medium            | 6     |
+| Low / Refactoring | 5     |
+
+**Overall assessment**: The agent-cli codebase is architecturally sound — clean layer separation, proper event cleanup in React hooks, good type discipline throughout. The three critical issues are concentrated in `apps/agent-server/` (production security) and one structural design smell in the CLI hook layer. No memory leaks found. All event listeners registered in `useEffect` are properly unregistered in cleanup functions. `setInterval` in `useInteractiveSession` and `WaveText` are correctly cleared.
+
+---
+
+## Critical Issues (즉시 수정 필요)
+
+### DEV-C-001: Firebase Function handler typed `any` — bypasses request/response type checking
+
+**위치**: `apps/agent-server/src/index.ts:28`
+
+**문제**: The `health` Firebase Function uses `req: any, res: any`, silently disabling TypeScript type checking for the handler. Any access to nonexistent properties or incorrect method calls on `req`/`res` will not be caught at compile time.
+
+**코드 예시**:
+
+```typescript
+// BEFORE (problematic)
+export const health = onRequest({
+    cors: true,
+    region: 'us-central1',
+    memory: '256MiB',
+    timeoutSeconds: 60,
+    maxInstances: 10
+}, (req: any, res: any) => {
+    res.json({ ... });
+});
+```
+
+**수정 방향**: Use the types exported by `firebase-functions/v2/https`:
+
+```typescript
+import type { Request, Response } from 'firebase-functions/v2/https';
+
+export const health = onRequest({ ... }, (req: Request, res: Response) => {
+    res.json({ ... });
+});
+```
+
+---
+
+### DEV-C-002: Non-null assertion on unverified `client.sessionId` — runtime crash risk
+
+**위치**: `apps/agent-server/src/websocket-server.ts:143`
+
+**문제**: `client.sessionId!` is used inside the `playground_update` message handler after checking only `client.isAuthenticated`. However, `isAuthenticated` is set to `true` in `handleAuthentication` only after `client.sessionId = sessionId` is assigned (lines 196–197). The logic is actually correct today, but this non-null assertion pattern is fragile: if authentication logic is refactored, the assertion becomes a silent runtime crash (`Cannot read property of undefined`).
+
+**코드 예시**:
+
+```typescript
+// apps/agent-server/src/websocket-server.ts:141-147
+case 'playground_update':
+    if (client.isAuthenticated) {
+        // sessionId! — if authentication flow changes, this crashes at runtime
+        this.broadcastToSession(client.sessionId!, message, clientId);
+    } else {
+        this.sendError(clientId, 'Authentication required');
+    }
+```
+
+**수정 방향**: Add explicit null guard or encode the invariant in the type system:
+
+```typescript
+if (client.isAuthenticated && client.sessionId !== undefined) {
+  this.broadcastToSession(client.sessionId, message, clientId);
+}
+```
+
+Similarly, `this.userSessions.get(userId)!` at lines 203 and 226 should be guarded (line 203 has a `.has()` check immediately above it, so the `!` is safe today; line 226 is inside an `if (client.userId && this.userSessions.has(client.userId))` guard, so also safe today — but both should be refactored to avoid the pattern).
+
+---
+
+### DEV-C-003: `require.main === module` in an ESM-compiled file — always false in production
+
+**위치**: `apps/agent-server/src/server.ts:72`
+
+**문제**: `require.main === module` is a CJS idiom. The agent-server package has no `"type": "module"` in `package.json`, so it compiles to CJS — this works in development via `tsx` (which handles it). However, if the build output (`dist/server.js`) is ever compiled to ESM (e.g., via a tsup ESM target), this guard will silently be `false` and `startServer()` will never be called. The equivalent ESM idiom is `import.meta.url === new URL(process.argv[1], 'file://').href`.
+
+**코드 예시**:
+
+```typescript
+// apps/agent-server/src/server.ts:71-73
+if (require.main === module) {
+  startServer();
+}
+```
+
+**수정 방향**: The server is only called via `node dist/server.js` directly (see `"start"` script), so this guard is not needed. Either remove it and call `startServer()` unconditionally (since `index.ts` handles the Firebase export separately), or use the ESM-safe form if ESM output is ever intended.
+
+---
+
+## High Issues (출시 전 수정 권장)
+
+### DEV-H-001: `as unknown as ISideEffects` cast — reads nonexistent properties off `InteractiveSession`
+
+**위치**: `packages/agent-cli/src/ui/hooks/useSideEffects.ts:239-240`
+
+**문제**: `getHostSideEffects` casts `InteractiveSession` to `ISideEffects` via `as unknown as`. The `ISideEffects` interface declares `_pendingModelId`, `_resetRequested`, `_exitRequested`, `_triggerResumePicker`, `_sessionName`, `_statusLinePatch`. None of these properties exist on `InteractiveSession`. Reading nonexistent optional properties in JavaScript returns `undefined`, so the `if (sideEffects._pendingModelId)` checks at lines 118–148 will always evaluate to falsy — meaning these side-effect paths are dead code in practice.
+
+The `sideEffects` object is also used as a write target (`sideEffects._statusLinePatch = effect.patch` in `command-effect-handler.ts:66`) — this silently writes to a property on the `InteractiveSession` instance. The property may be garbage-collected or cause unexpected behavior if the session ever checks for it.
+
+**코드 예시**:
+
+```typescript
+// useSideEffects.ts:239-240
+function getHostSideEffects(interactiveSession: InteractiveSession): ISideEffects {
+  return interactiveSession as unknown as ISideEffects;
+}
+
+// useSideEffects.ts:115-148 — reading always-undefined fields
+const sideEffects = getHostSideEffects(interactiveSession);
+if (sideEffects._pendingModelId) { ... }   // always false
+if (sideEffects._resetRequested) { ... }   // always false
+```
+
+**수정 방향**: The `CommandEffectQueue` (which already exists) should be the SSOT for pending effects. Eliminate the `getHostSideEffects` pattern entirely. Route all side effects through `commandEffectQueue` / `applyCommandEffects` using the `deps` callbacks. The `_statusLinePatch` write in `command-effect-handler.ts` should be moved to a `deps.applyStatusLinePatch(effect.patch)` callback (which already exists at line 67).
+
+---
+
+### DEV-H-002: `sendError` always sends `type: 'auth'` for non-auth errors — incorrect protocol
+
+**위치**: `apps/agent-server/src/websocket-server.ts:250-259`
+
+**문제**: All error messages (including "Invalid message format", "Unknown message type", "Authentication required") are sent with `type: 'auth'` regardless of context. Clients that check `message.type` to route incoming messages will misinterpret runtime errors as authentication responses.
+
+**코드 예시**:
+
+```typescript
+private sendError(clientId: string, error: string): void {
+    this.sendMessage(clientId, {
+        type: 'auth',   // always 'auth' — wrong for non-auth errors
+        timestamp: new Date().toISOString(),
+        data: { success: false, error },
+    });
+}
+```
+
+**수정 방향**: Add an `error` message type to `TPlaygroundWebSocketMessageKind` and send `type: 'error'` for runtime errors. Reserve `type: 'auth'` for auth responses only.
+
+---
+
+### DEV-H-003: `parseInt(process.env.RATE_LIMIT_MAX || '100')` — missing radix, NaN possible
+
+**위치**: `apps/agent-server/src/app.ts:53`
+
+**문제**: `parseInt` without a radix argument is ambiguous. If `RATE_LIMIT_MAX` is set to a string like `"0x10"` or starts with `0`, the result is implementation-defined. More critically, if `RATE_LIMIT_MAX` is set to a non-numeric string (misconfiguration), the result is `NaN`. The `express-rate-limit` `max` option receiving `NaN` silently disables rate limiting.
+
+**코드 예시**:
+
+```typescript
+max: parseInt(process.env.RATE_LIMIT_MAX || '100'),  // no radix, NaN if misconfigured
+```
+
+**수정 방향**:
+
+```typescript
+const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX ?? '100', 10);
+if (!Number.isFinite(rateLimitMax) || rateLimitMax <= 0) {
+  throw new Error(`Invalid RATE_LIMIT_MAX: "${process.env.RATE_LIMIT_MAX}"`);
+}
+```
+
+---
+
+### DEV-H-004: `onToolEnd` deduplication uses `toolName` only — breaks with concurrent identical tool calls
+
+**위치**: `packages/agent-cli/src/ui/tui-state-manager.ts:90`
+
+**문제**: When a tool completes, the active tool is matched by `toolName` and `isRunning`. If the same tool runs twice concurrently (e.g., two simultaneous `Bash` calls), `findIndex` returns the first matching entry, so the wrong state entry gets updated. The second entry never transitions to completed.
+
+**코드 예시**:
+
+```typescript
+onToolEnd = (state: IToolState): void => {
+    const idx = this.activeTools.findIndex(
+        (t) => t.toolName === state.toolName && t.isRunning  // matches first, not the specific call
+    );
+    ...
+};
+```
+
+**수정 방향**: Identify tool invocations by a stable `toolCallId` (if `IToolState` exposes one) or by insertion order. If the SDK does not provide a call ID, use an index-based approach tracked at `onToolStart`.
+
+---
+
+### DEV-H-005: `--system-prompt` flag silently ignored with only a warning
+
+**위치**: `packages/agent-cli/src/cli.ts:351-354`
+
+**문제**: The `--system-prompt` flag is parsed, shown in `IParsedCliArgs`, but deliberately not wired:
+
+```typescript
+// TODO: wire --system-prompt once IInteractiveSessionStandardOptions adds systemPrompt field
+if (args.systemPrompt) {
+  process.stderr.write('Warning: --system-prompt is not yet functional and will be ignored.\n');
+}
+```
+
+This means a user who passes `--system-prompt "..."` gets a warning but no error — and no effect. This is a broken API surface in a beta release. It should either be removed from the CLI entirely until implemented, or throw an error to prevent user confusion.
+
+**수정 방향**: Remove the flag from `parseCliArgs` and the `IParsedCliArgs` interface, or throw `process.exit(1)` with a clear "not yet implemented" message.
+
+---
+
+## Medium Issues
+
+### DEV-M-001: `substr` is deprecated — use `slice`
+
+**위치**: `apps/agent-server/src/websocket-server.ts:297`
+
+**문제**: `String.prototype.substr` is deprecated since ES2015 and removed in the Annex B specification. Should use `slice`.
+
+**코드 예시**:
+
+```typescript
+return `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+//                                                              ^^^^^^
+```
+
+**수정 방향**:
+
+```typescript
+return `client_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+```
+
+---
+
+### DEV-M-002: `useInteractiveSession` initializes session outside `useEffect` in render body
+
+**위치**: `packages/agent-cli/src/ui/hooks/useInteractiveSession.ts:197-200`
+
+**문제**: Session initialization runs during render (not in `useEffect`) via:
+
+```typescript
+if (stateRef.current === null) {
+  stateRef.current = initializeSession(props, permissionHandler);
+}
+```
+
+This is a React anti-pattern in strict mode because render functions may be called multiple times. Since Ink does not run in strict mode, this works today — but it is a fragile pattern that will cause double-initialization bugs if strict mode is ever enabled.
+
+**수정 방향**: Use `useRef` with lazy initialization via a factory argument: `useRef<IInitState | null>(null)` with `useMemo` (stable across renders) or `useState(initializeSession)` for one-time initialization.
+
+---
+
+### DEV-M-003: `promptInput` in `cli.ts` leaks stdin listener on Ctrl+C path
+
+**위치**: `packages/agent-cli/src/cli.ts:133-136`
+
+**문제**: When the user presses Ctrl+C (`\x03`) inside `promptInput`, the function calls `process.exit(0)` directly without first removing the `onData` listener from `stdin` or resetting stdin raw mode. In a test environment or if `process.exit` is mocked, this causes a listener leak.
+
+**코드 예시**:
+
+```typescript
+} else if (ch === '\x03') {
+    process.stdout.write('\n');
+    process.exit(0);  // stdin listener never removed, raw mode never restored
+}
+```
+
+**수정 방향**:
+
+```typescript
+} else if (ch === '\x03') {
+    stdin.removeListener('data', onData);
+    stdin.setRawMode(wasRaw ?? false);
+    stdin.pause();
+    process.stdout.write('\n');
+    process.exit(0);
+}
+```
+
+---
+
+### DEV-M-004: `App.tsx` — `language` prop accepted but never consumed
+
+**위치**: `packages/agent-cli/src/ui/render.tsx:26`, `packages/agent-cli/src/ui/App.tsx`
+
+**문제**: `IRenderOptions` declares `language?: string` and `cli.ts:395` passes `language: args.language` to `renderApp`. However, `IProps` in `App.tsx` does not declare `language` and it is never passed down to `InteractiveSession`. The language argument is silently dropped.
+
+**수정 방향**: Either wire `language` into `InteractiveSession` construction (if it supports runtime language override) or remove it from `IRenderOptions` and `renderApp` until it is implemented.
+
+---
+
+### DEV-M-005: `type` cast in `broadcastToUser` is unnecessary and masks type mismatch
+
+**위치**: `apps/agent-server/src/websocket-server.ts:314`
+
+**문제**: `message.type as TPlaygroundWebSocketMessageKind` is needed because `Omit<IPlaygroundWebSocketMessage, 'timestamp'>` still retains `type` from the original type but TypeScript infers it as `TPlaygroundWebSocketMessageKind` already. The cast suggests the types are misaligned or the `Omit` is not removing the right field.
+
+**코드 예시**:
+
+```typescript
+const messageWithTimestamp: IPlaygroundWebSocketMessage = {
+  ...message,
+  type: message.type as TPlaygroundWebSocketMessageKind, // cast should not be needed
+  timestamp: new Date().toISOString(),
+};
+```
+
+**수정 방향**: Verify that `IPlaygroundWebSocketMessage.type` is `TPlaygroundWebSocketMessageKind` and that `Omit` is correct. The cast should be removable if types are well-defined.
+
+---
+
+### DEV-M-006: Server shutdown doesn't close WebSocket connections before HTTP server close
+
+**위치**: `apps/agent-server/src/server.ts:50-61`
+
+**문제**: In the shutdown handler:
+
+```typescript
+server.close(() => { ... process.exit(0); });
+wsServer.close();
+```
+
+`wsServer.close()` is called after `server.close()`. `server.close()` stops accepting new connections but the callback fires only after existing connections drain. Active WebSocket connections keep the HTTP server from draining, creating a race where the 30s timeout fires first and forces `process.exit(1)`.
+
+**수정 방향**: Close WebSocket connections first, then call `server.close()`:
+
+```typescript
+wsServer.close();
+server.close(() => {
+  process.exit(0);
+});
+```
+
+---
+
+## Low Issues / Refactoring Opportunities
+
+### DEV-L-001: `readVersion()` in `cli.ts` is overly defensive — could use build-time injection
+
+**위치**: `packages/agent-cli/src/cli.ts:75-96`
+
+`readVersion()` parses `package.json` at runtime via two candidate paths and falls back to `'0.0.0'`. Since the build process (tsup) controls output paths, the version could be injected at build time via `define: { __VERSION__: JSON.stringify(pkg.version) }` in `tsup.config.ts`, eliminating the filesystem read and the fallback path entirely.
+
+---
+
+### DEV-L-002: `pollingInterval` in `useInteractiveSession` is a 200ms `setInterval` for one-time init
+
+**위치**: `packages/agent-cli/src/ui/hooks/useInteractiveSession.ts:236-254`
+
+The `initCheck` interval polls every 200ms to detect when `interactiveSession.getContextState()` stops throwing. This is a polling hack. If `InteractiveSession` exposed an `onReady` event or a `isReady()` predicate, this could be replaced with a single event subscription. Consider adding that to the SDK.
+
+---
+
+### DEV-L-003: `TuiStateManager` has public mutable fields — breaks encapsulation
+
+**위치**: `packages/agent-cli/src/ui/tui-state-manager.ts:54-66`
+
+Fields like `history`, `streamingText`, `activeTools`, `isThinking`, `isAborting`, etc. are all `public` (no access modifier = public in TypeScript classes). External code can mutate these directly without triggering `notify()`. The React hook reads these fields directly (`manager.history`, `manager.streamingText`). Consider making them `readonly` getters.
+
+---
+
+### DEV-L-004: `generateClientId()` uses `Math.random()` — not cryptographically secure
+
+**위치**: `apps/agent-server/src/websocket-server.ts:296-298`
+
+WebSocket client IDs are used as authentication correlation tokens in maps. `Math.random()` is not cryptographically secure. Use `crypto.randomUUID()` (available in Node.js 14.17+):
+
+```typescript
+private generateClientId(): string {
+    return `client_${randomUUID()}`;
+}
+```
+
+---
+
+### DEV-L-005: `App.tsx` has 6 `useEffect` calls — component has too many concerns
+
+**위치**: `packages/agent-cli/src/ui/App.tsx`
+
+`AppInner` manages: update notice async loading, terminal title sync, ESC abort input, Ctrl+B toggle, Ctrl+C shutdown, SIGINT/SIGTERM signal handlers, execution detail page loading — all via separate `useEffect` calls directly in the component. Signal handlers and terminal title management could be extracted into dedicated custom hooks for testability and clarity.
+
+---
+
+## Package Distribution Audit
+
+### `packages/agent-cli/` — npm package (`@robota-sdk/agent-cli`)
+
+**`"files"` field** (`package.json:36-39`):
+
+```json
+"files": ["dist", "bin"]
+```
+
+| Item               | Status   | Notes                                      |
+| ------------------ | -------- | ------------------------------------------ |
+| `dist/`            | Included | Contains all compiled JS and `.d.ts` files |
+| `bin/robota.cjs`   | Included | CJS wrapper correctly in `bin/`            |
+| `src/`             | Excluded | Correct — source not needed in npm package |
+| `node_modules/`    | Excluded | Correct (npm default)                      |
+| `CHANGELOG.md`     | Excluded | Acceptable                                 |
+| `README.md`        | Excluded | Acceptable (auto-included by npm)          |
+| `tsup.config.ts`   | Excluded | Correct                                    |
+| `vitest.config.ts` | Excluded | Correct                                    |
+
+**bin field** (`package.json:6-8`):
+
+```json
+"bin": { "robota": "./bin/robota.cjs" }
+```
+
+`bin/robota.cjs` is present and in the `files` list. Correct.
+
+**Missing**: No `peerDependencies` declaration for `react` (currently a direct `dependency`). React is a peer concern for consumers who may embed the CLI's exported API. Since this is a CLI package (not a library), this is a low-priority concern — but `react: 19.2.4` as a hard dep is unusual for a package that also exports via `./index`.
+
+**`engines` field**:
+
+- `packages/agent-cli`: `"node": ">=22.0.0"` — matches `bin/robota.cjs` runtime check (line 7)
+- `apps/agent-server`: `"node": ">=18.0.0"` — inconsistent, server uses Node 22+ APIs implicitly via dependencies
+
+**Overall distribution assessment**: The CLI package is correctly configured for distribution. The `bin` wrapper, `files` field, and `dist` output structure are all correct.

--- a/.agents/reports/pm-prelaunch-report-2026-05-10-v2.md
+++ b/.agents/reports/pm-prelaunch-report-2026-05-10-v2.md
@@ -1,0 +1,261 @@
+# PM Pre-launch Report — Robota CLI (2026-05-10 v2)
+
+**작성일**: 2026-05-10  
+**이전 보고서**: `pm-prelaunch-report-2026-05-10.md` (v1)  
+**조사 방법**: CLI 소스코드, 빌드 바이너리, 문서 콘텐츠, 플레이그라운드, 에이전트 서버 직접 읽기  
+**범위**: 이전 보고서에서 다루지 않은 신규 관점만 포함
+
+---
+
+## Executive Summary
+
+v1 보고서가 "기술적 완성도" 중심이었다면, 이번 v2 보고서는 **실제 사용자 경험 흐름**을 추적한 결과다. 핵심 발견은 세 가지다.
+
+1. **CLI 진입점 UX 결함**: `--help` 플래그 미지원으로 새 사용자의 첫 탐색 경험이 막힌다. 불필요하게 TUI가 시작된다.
+2. **Node.js 버전 표기 불일치**: 루트 README는 "18+", Getting Started는 "18+(권장 22)", CLI는 실제로 22+ 강제 — 문서 3개소에서 다른 메시지를 제공한다.
+3. **Web Playground 실사용 불가**: 프로덕션 서버 URL 없이 `ws://localhost:3001/ws`로 하드코딩되어 공개 사이트에서 실제로 동작하지 않는다.
+
+기술적 기반은 탄탄하다. 바이너리 레벨 Node.js 버전 체크, macOS Terminal.app 조기 경고, 프로바이더 정의 기반 대화형 설정, 업데이트 체크 캐시까지 잘 구현되어 있다. 사용자 경험 연결고리 몇 곳을 메우면 출시 품질에 도달할 수 있다.
+
+---
+
+## Launch Readiness Scorecard
+
+| Category           | Score | Notes                                                                                 |
+| ------------------ | ----- | ------------------------------------------------------------------------------------- |
+| Core functionality | 8/10  | 8개 도구, 19개 슬래시 커맨드, 멀티프로바이더 — `--system-prompt` 미동작 1건 제외 탄탄 |
+| Onboarding         | 5/10  | `--help` 없음, Node.js 버전 표기 3중 불일치, 단 첫 실행 설정 흐름은 우수              |
+| Documentation      | 6/10  | CLI/SDK 가이드 충실하나 docs 사이트(.temp 빌드)에 실제 전달 확인 필요, 버전 불일치    |
+| Stability          | 7/10  | 바이너리 레벨 오류 처리 견고, IME 크래시 억제 로직 존재, apps 테스트는 최소 수준      |
+| Multi-provider     | 8/10  | 6개 채팅 프로바이더 + 1개 비디오(ByteDance) 지원, CLI/서버 동일 provider 사용 확인    |
+
+---
+
+## Critical Gaps (출시 차단 수준)
+
+### PM-C-001: `--help` 플래그 미지원 — 첫 탐색 경험 차단
+
+**사용자 영향**: 개발자가 CLI를 설치한 후 가장 먼저 시도하는 것은 `robota --help`다. 현재 이 명령을 실행하면 TUI가 열리거나 오류 메시지가 출력되는 대신 아무 안내 없이 인터랙티브 세션이 시작된다.
+
+**현재 동작** (`bin/robota.cjs` 기반 실제 확인):
+
+```
+Unknown option '--help'. To specify a positional argument starting with a '-',
+place it at the end of the command after '--', as in '-- "--help"'
+```
+
+Node.js `parseArgs()`의 기본 오류 메시지가 그대로 사용자에게 노출된다. 사용법 안내가 전혀 없다.
+
+**필요한 변경**:
+
+- `cli-args.ts`에 `--help` / `-h` 옵션 추가
+- CLI 플래그 전체 목록과 간단한 사용 예시를 출력하는 `printHelp()` 함수 구현
+- `--version`처럼 출력 후 즉시 종료
+
+**Claude Code 비교**: `claude --help`는 전체 플래그 목록과 예시를 출력한다.
+
+---
+
+### PM-C-002: Node.js 버전 요구사항 3중 불일치
+
+**사용자 영향**: 사용자가 설치 전 요구사항을 확인할 때 세 문서에서 다른 정보를 받는다.
+
+**현재 상태 (실제 파일 확인)**:
+
+| 문서                                                         | 표기                                               |
+| ------------------------------------------------------------ | -------------------------------------------------- |
+| `/README.md` (루트, GitHub 진입점)                           | "Node.js 18+ required"                             |
+| `/content/getting-started/README.md` (docs 사이트 첫 페이지) | "Node.js: 18.0.0 or higher (recommended: 22.14.0)" |
+| `/packages/agent-cli/README.md`                              | "Node.js **22 or higher** is required"             |
+| `bin/robota.cjs` (실제 강제 버전)                            | `>= 22` — 22 미만이면 즉시 `process.exit(1)`       |
+
+GitHub에서 프로젝트를 처음 발견한 사용자는 "18+ required"를 보고 Node 18/20 환경에서 설치를 시도한다. 설치 후 실행하면 `Robota requires Node.js 22 or higher` 오류가 나온다.
+
+**필요한 변경**:
+
+- 루트 `README.md`: "Node.js 18+ required" → "Node.js **22 or higher** required"
+- `content/getting-started/README.md`: Prerequisites 섹션을 `>= 22` 로 통일 (SDK 사용자는 18+일 수 있으므로 CLI와 SDK 구분 명시)
+
+---
+
+### PM-C-003: Web Playground 공개 사이트에서 실제 동작 불가
+
+**사용자 영향**: robota.io에서 Playground를 클릭한 사용자가 에이전트와 대화를 시도하면 응답을 받을 수 없다. 제품 신뢰도에 치명적이다.
+
+**현재 상태** (코드 직접 확인):
+
+```typescript
+// packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+export function PlaygroundApp(props: { defaultServerUrl?: string }): React.ReactElement {
+  return (
+    <PlaygroundProvider defaultServerUrl={props.defaultServerUrl ?? 'ws://localhost:3001/ws'}>
+```
+
+`apps/agent-web/src/app/playground/page.tsx`에서 `PlaygroundApp`을 props 없이 호출:
+
+```typescript
+export default function PlaygroundPage() {
+  return <PlaygroundApp />;  // defaultServerUrl 전달 없음 → localhost:3001 폴백
+}
+```
+
+`apps/agent-web/.env.example`에도 playground 서버 URL 관련 환경변수가 없다. 즉, 공개 배포 시 서버 연결 설정 경로가 존재하지 않는다.
+
+**PlaygroundDemo** (`/playground/demo`)는 LLM 호출 없이 정적 시각화만 보여주므로 동작하지만, 이것이 "AI와 대화할 수 있다"는 기대를 충족하지 못한다.
+
+**필요한 변경**:
+
+- `NEXT_PUBLIC_PLAYGROUND_WS_URL` 환경변수를 추가하고 `PlaygroundApp`에 전달
+- 또는: 서버가 없으면 "서버 연결 필요" 안내 UI 표시
+- 또는: `/playground/demo` 를 전면에 내세우고 실제 AI 대화는 "self-hosted" 기능으로 명시
+
+---
+
+## Important Gaps (출시 전 개선 권장)
+
+### PM-I-001: `--system-prompt` 플래그 미동작 — 문서화된 기능이 경고와 함께 무시됨
+
+**사용자 영향**: README와 CLI 플래그 목록에 `--system-prompt <text>`가 문서화되어 있으나 실제로는 경고를 출력하고 무시한다.
+
+**현재 상태** (`cli.ts` 라인 351-353):
+
+```typescript
+// TODO: wire --system-prompt once IInteractiveSessionStandardOptions adds systemPrompt field
+if (args.systemPrompt) {
+  process.stderr.write('Warning: --system-prompt is not yet functional and will be ignored.\n');
+}
+```
+
+**필요한 변경**:
+
+- 구현 완료까지 `--system-prompt`를 CLI 플래그에서 제거하거나 README에서 "(미구현)" 표시
+- 또는: `IInteractiveSessionStandardOptions`에 `systemPrompt` 필드를 추가하여 완성
+
+---
+
+### PM-I-002: `agent-command-mode` 패키지가 CLI에 등록되지 않음 — orphan 패키지
+
+**사용자 영향**: `/mode` 커맨드가 패키지(`@robota-sdk/agent-command-mode`)로 구현되어 있으나 `createDefaultCliCommandModules()`에 등록되지 않아 사용자가 접근할 수 없다.
+
+**현재 상태** (`cli.ts` `createDefaultCliCommandModules` 확인):
+`createPermissionsCommandModule`은 포함되어 있으나 `createModeCommandModule`은 없다. `/mode` 커맨드는 `getHistory`, `clearHistory` 같은 기능을 담당하는 것으로 보이지만 실제 CLI에서 접근 불가.
+
+**필요한 변경**:
+
+- `/mode` 커맨드가 실제로 필요한지 검토
+- 필요하다면 `createDefaultCliCommandModules`에 추가
+- 불필요하다면 패키지를 deprecated 처리 또는 제거 (현재 `backlog: none`)
+
+---
+
+### PM-I-003: Getting Started 문서의 Node.js 버전이 SDK와 CLI를 혼용
+
+**사용자 영향**: `content/getting-started/README.md`의 Prerequisites 섹션이 SDK 사용자(18+)와 CLI 사용자(22+ 필수)를 구분하지 않아 혼란을 준다.
+
+**현재 상태**:
+
+```markdown
+## Prerequisites
+
+- **Node.js**: 18.0.0 or higher (recommended: 22.14.0)
+```
+
+바로 아래 "System Requirements" 박스에서는:
+
+```markdown
+- **Node.js 22 or higher** — check with `node --version`
+```
+
+같은 문서 내에서도 두 개의 다른 버전이 명시된다.
+
+**필요한 변경**:
+
+- CLI 섹션과 SDK 섹션의 Node.js 요구사항을 명시적으로 분리
+- CLI: "Node.js 22 or higher required (enforced at runtime)"
+- SDK: "Node.js 18 or higher (22 recommended)"
+
+---
+
+### PM-I-004: GitHub 이슈/PR 템플릿 없음 — 커뮤니티 지원 준비 미완
+
+**사용자 영향**: 베타 출시 후 버그 리포트나 기능 요청이 들어올 때 정보 수집 구조가 없다. 노이즈 이슈가 많아지고 대응 비용이 높아진다.
+
+**현재 상태**: `.github/` 디렉토리에 `CODEOWNERS`, `workflows/`, `lighthouse/`만 존재. `ISSUE_TEMPLATE/`과 `PULL_REQUEST_TEMPLATE` 없음.
+
+`CONTRIBUTING.md`는 존재하지만 이슈 템플릿 없이는 실효성 낮음.
+
+**필요한 변경**:
+
+- `.github/ISSUE_TEMPLATE/bug_report.md`: Node.js 버전, OS, 터미널, 프로바이더, 오류 메시지 필드 포함
+- `.github/ISSUE_TEMPLATE/feature_request.md`: 기본 템플릿
+- (선택) `.github/PULL_REQUEST_TEMPLATE.md`
+
+---
+
+### PM-I-005: ByteDance 프로바이더가 CLI에서 숨겨진 기능
+
+**사용자 영향**: `@robota-sdk/agent-provider-bytedance`가 v3.0.0-beta.61로 배포되어 있으나 이것은 채팅 프로바이더가 아닌 **비디오 생성 프로바이더** (`IVideoGenerationProvider` 구현)다. CLI 기본 프로바이더에 포함되지 않고 문서에서도 설명이 없다. 사용자가 발견하면 "비디오 생성 AI"를 설치했다고 오해할 수 있다.
+
+**현재 상태**: ByteDance 프로바이더 설명: "ByteDance/BytePlus media integration for Robota SDK - Seedance video generation provider support". CLI 기본 provider 목록에 없음. Getting Started 문서의 "Supported Providers" 표에도 없음.
+
+**필요한 변경**:
+
+- Getting Started 문서에서 "지원 프로바이더" 표 분리: 채팅 프로바이더 / 미디어 생성 프로바이더
+- ByteDance(Seedance)가 비디오 생성용임을 명확히 문서화
+
+---
+
+## Nice-to-have (출시 후 로드맵)
+
+### PM-N-001: `robota --help` 이후 인터랙티브 온보딩 플로우
+
+현재 첫 실행 시 provider 선택 → API 키 입력 → 언어 선택으로 이어지는 설정 흐름이 이미 잘 구현되어 있다. 여기에 "처음이세요? 빠른 시작 가이드를 보려면 `/help`를 입력하세요" 같은 안내를 추가하면 첫 성공 경험까지의 경로가 더 명확해진다.
+
+### PM-N-002: `robota --version` 에 beta 상태 명시
+
+현재 `robota --version` 출력: `robota 3.0.0-beta.61`
+
+여기에 "This is a beta release. Report issues at https://github.com/woojubb/robota/issues" 한 줄을 추가하면 beta 상태를 명시적으로 전달한다.
+
+### PM-N-003: Playground Demo 개선 — 정적 시각화 → 인터랙티브 시뮬레이션
+
+현재 `/playground/demo`는 하드코딩된 실행 트리 시각화만 보여준다. LLM 없이도 "에이전트가 실제로 작동하는 것처럼" 보여주는 시뮬레이션 모드를 추가하면 API 키 없는 첫 방문자의 인상을 크게 개선할 수 있다.
+
+### PM-N-004: 입력 히스토리 탐색 문서화
+
+`InputArea.tsx`에서 `navigatePromptHistory`가 구현되어 있어 위 화살표로 이전 입력을 탐색할 수 있다. 그러나 README나 키보드 단축키 표에 이 기능이 문서화되어 있지 않다. 소소하지만 개발자가 좋아하는 기능이다.
+
+### PM-N-005: `/mode` 커맨드 재검토
+
+`@robota-sdk/agent-command-mode` 패키지가 구현되어 있으나 CLI에 등록되지 않은 orphan 상태다. 이 커맨드는 `/permissions`의 기능과 상당 부분 겹친다. 배포 전에 역할을 명확히 하거나 제거하는 결정이 필요하다.
+
+---
+
+## Competitor Feature Comparison (신규 관점 보완)
+
+이전 보고서의 기능 비교표에서 다루지 않은 **온보딩 및 첫 실행 경험** 관점 추가.
+
+| 온보딩 경험                          | Claude Code                | Robota                            | 비고                             |
+| ------------------------------------ | -------------------------- | --------------------------------- | -------------------------------- |
+| `--help` 플래그                      | ✅ 전체 플래그 목록        | ❌ 오류 메시지 출력               | 차이 있음                        |
+| 첫 실행 설정 마법사                  | ✅                         | ✅                                | 동등                             |
+| Node.js 버전 체크 (친절한 오류)      | ✅                         | ✅                                | Robota가 더 상세 (nvm 명령 포함) |
+| macOS Terminal 경고                  | ❌ (첫 실행 후 알 수 있음) | ✅ (바이너리 레벨 즉시 경고)      | Robota 우위                      |
+| npm 업데이트 체크                    | ✅                         | ✅ (캐시 기반, 하루 1회)          | 동등                             |
+| 웹 플레이그라운드 (API 키 없이 체험) | ❌                         | ⚠️ Demo만 가능, 실제 AI 대화 불가 | 모두 취약                        |
+| 문서 일관성 (버전 표기)              | ✅                         | ❌ 3개소 불일치                   | 개선 필요                        |
+| GitHub 이슈 템플릿                   | ✅                         | ❌ 없음                           | 출시 전 추가 권장                |
+
+---
+
+## 종합 평가
+
+v1 보고서와 달리 이번 조사는 **사용자가 실제로 제품에 닿는 순간**을 추적했다. 코드와 문서를 상호 대조하여 확인한 실제 불일치는 v1이 발견한 "큰 그림" 갭보다 작지만, 사용자 신뢰에 직접적으로 영향을 미치는 표면 결함들이다.
+
+**출시를 차단할 수준의 변경**은 3건이며, 모두 코드 수정보다는 문서/설정 수정 수준이다:
+
+1. `--help` 플래그 추가 (구현 난이도: 낮음, 영향도: 높음)
+2. Node.js 버전 표기 통일 (문서 수정, 30분 이내)
+3. Playground 서버 URL 환경변수화 또는 "연결 필요" 안내 UI
+
+v2 보고서 기준 출시 준비도: **RC 전환을 위한 마지막 표면 정리 단계**. 3건의 Critical gap과 2건의 Important gap을 해결하면 사용자에게 일관된 첫인상을 제공할 수 있다.

--- a/.agents/reports/qa-prelaunch-report-2026-05-10-v2.md
+++ b/.agents/reports/qa-prelaunch-report-2026-05-10-v2.md
@@ -1,0 +1,323 @@
+# QA Pre-launch Report — Robota CLI (2026-05-10 v2)
+
+**Date**: 2026-05-10
+**Scope**: agent-cli (packages/agent-cli), agent-server (apps/agent-server), agent-web (apps/agent-web)
+**Reviewer**: QA Agent (Claude Sonnet 4.6)
+**Based on**: Code inspection — new issues only (previous issues in qa-prelaunch-report-2026-05-10.md excluded)
+
+---
+
+## Executive Summary
+
+- New issues found: **10**
+- Critical: **1**
+- High: **3**
+- Medium: **4**
+- Low: **2**
+
+Previous report (v1) covered 14 issues (QA-001 through QA-014). This report identifies 10 additional issues not covered in v1. Notably, the two Critical issues from v1 (real API keys in .env, JWT auth bypass) have been updated in the codebase — JWT verification now uses `jsonwebtoken` with a `JWT_SECRET` env var (websocket-server.ts:176-192), and the `promptInput()` non-TTY crash (QA-005) has been fixed with an `isTTY` guard (cli.ts:105-115).
+
+---
+
+## Critical Issues (출시 차단)
+
+### QA-C-001: `--output-format` CLI 인수가 검증 없이 캐스팅되어 잘못된 값 시 동작 undefined
+
+**위치**: `packages/agent-cli/src/cli.ts:378`
+
+**현상**:
+
+```typescript
+outputFormat: (args.outputFormat as 'text' | 'json' | 'stream-json') ?? 'text',
+```
+
+`--output-format`에 임의 문자열(예: `--output-format xml`)을 전달해도 TypeScript `as` 캐스팅으로 인해 오류 없이 통과되고, `createHeadlessTransport`에 그대로 전달된다.
+
+`packages/agent-transport-headless/src/headless-runner.ts:50-57`에서:
+
+```typescript
+if (outputFormat === 'text') { return runTextFormat(...); }
+if (outputFormat === 'json') { return runJsonFormat(...); }
+return runStreamJsonFormat(session, prompt);  // 알 수 없는 값이면 stream-json으로 폴백
+```
+
+인식 불가 포맷은 경고 없이 `stream-json` 모드로 폴백되어 사용자가 인지하지 못한 채 잘못된 형식의 출력이 발생한다.
+
+**재현 방법**:
+
+```bash
+robota -p "hello" --output-format xml
+```
+
+`xml`을 지정했는데 stream-json 형식으로 출력됨.
+
+**기대 동작**: 지원하지 않는 포맷 값에 대해 명확한 오류 메시지 출력 후 `process.exit(1)`.
+
+**수정 방안**: `cli-args.ts`의 `parseCliArgs()`에 `parseOutputFormat()` 함수 추가 (기존 `parsePermissionMode()`와 동일한 패턴):
+
+```typescript
+const VALID_OUTPUT_FORMATS = ['text', 'json', 'stream-json'] as const;
+export function parseOutputFormat(
+  raw: string | undefined,
+): 'text' | 'json' | 'stream-json' | undefined {
+  if (raw === undefined) return undefined;
+  if (!VALID_OUTPUT_FORMATS.includes(raw as 'text')) {
+    process.stderr.write(`Invalid --output-format "${raw}". Valid: text | json | stream-json\n`);
+    process.exit(1);
+  }
+  return raw as 'text' | 'json' | 'stream-json';
+}
+```
+
+---
+
+## High Issues (출시 전 수정 권장)
+
+### QA-H-001: `--language` CLI 플래그가 인터랙티브 TUI 모드에서 완전히 무시됨
+
+**위치**:
+
+- `packages/agent-cli/src/ui/render.tsx:26` — `IRenderOptions`에 `language?: string` 선언됨
+- `packages/agent-cli/src/ui/App.tsx:39-58` — `IProps` 인터페이스에 `language` 필드 없음
+- `packages/agent-cli/src/cli.ts:395` — `language: args.language`가 `renderApp()`에 전달됨
+
+**현상**:
+`renderApp(options)` 호출 시 `<App {...options} />` 로 스프레드되지만, `App.tsx`의 `IProps`에 `language`가 없어 컴포넌트가 이를 수신하지 않는다. `InteractiveSession`은 `language` 옵션 자체를 받지 않고(`IInteractiveSessionStandardOptions`에 해당 필드 없음) 설정 파일(`settings.json`)에서만 읽는다.
+
+결과적으로 `robota --language ko`로 시작해도 세션 언어는 변경되지 않는다. 사용자가 플래그를 사용해도 효과가 없어 혼란을 유발한다.
+
+**재현 방법**:
+
+```bash
+robota --language ko
+# 설정 파일에 language가 없는 경우 AI가 한국어로 응답하지 않음
+```
+
+**기대 동작**: `--language ko` 플래그가 해당 세션의 언어를 설정해야 함.
+
+**수정 방안**:
+
+1. `App.tsx`의 `IProps`에 `language?: string` 추가
+2. `useInteractiveSession`에 전달하거나, 설정 파일을 임시 override하는 방식 선택
+3. 단기: `--help`에서 `--language` 플래그 설명에 "applies to interactive setup only" 또는 "applies after restart" 명시
+
+---
+
+### QA-H-002: 슬래시 커맨드 실행 직후 `getContextState()` 호출이 미초기화 세션에서 throw
+
+**위치**: `packages/agent-cli/src/ui/hooks/useSlashRouting.ts:74`
+
+**현상**:
+
+```typescript
+const ctx = interactiveSession.getContextState(); // try-catch 없음
+```
+
+`applySystemCommandResult()` 함수에서 `getContextState()`를 보호 없이 호출한다. `InteractiveSession.getContextState()`는 내부적으로 `getSessionOrThrow()`를 호출하고, 세션이 아직 초기화되지 않았으면 `Error('InteractiveSession not initialized...')`를 throw한다 (`packages/agent-sdk/src/interactive/interactive-session.ts:340-343`).
+
+앱 시작 직후 (세션 초기화 전) 슬래시 커맨드(예: `/help`)를 빠르게 입력하면 unhandled exception이 발생할 수 있다.
+
+**재현 방법**:
+앱 시작 직후 즉시 `/help` 입력 (타이밍 의존).
+
+**기대 동작**: 미초기화 상태에서는 기본 컨텍스트 상태(0%)를 사용하거나 오류 없이 처리.
+
+**수정 방안**:
+
+```typescript
+try {
+  const ctx = interactiveSession.getContextState();
+  manager.setContextState({ ... });
+} catch {
+  // Session not yet initialized — skip context update
+}
+```
+
+---
+
+### QA-H-003: Firebase Functions entry point(`index.ts`)에서 `any` 타입 사용 및 이중 CORS 적용
+
+**위치**: `apps/agent-server/src/index.ts:28`
+
+**현상**:
+
+1. **`any` 타입 사용**: Firebase Functions health check 핸들러가 `(req: any, res: any)` 타입으로 선언되어 있다. 이는 프로젝트 전체의 `strict: true`, `noImplicitAny: true` 규칙(tsconfig.base.json)을 위반한다.
+
+2. **이중 CORS 적용**: `index.ts`의 Firebase Functions에서 `cors: true`가 설정되고(`index.ts:14, 23`), `createApp()` 내부에서 `cors` 미들웨어가 또 한 번 적용된다(`app.ts:39`). Firebase `cors: true`는 Firebase가 자체적으로 모든 origin을 허용하도록 설정하므로 `app.ts`의 화이트리스트(`robota.io` 등)가 무력화된다.
+
+**영향**: CORS 정책이 의도와 달리 모든 origin에 열려 API가 노출됨.
+
+**수정 방안**:
+
+- `index.ts`에서 `cors: false`로 변경하여 Express의 CORS 미들웨어만 동작하도록 수정
+- `req: any, res: any` → `req: Request, res: Response` (firebase-functions 타입 사용)
+
+---
+
+## Medium Issues (출시 후 단기간 내 수정)
+
+### QA-M-001: agent-server 미사용 의존성 — `express-winston`, `winston`, `@robota-sdk/agent-provider-bytedance`
+
+**위치**: `apps/agent-server/package.json`
+
+**현상**:
+`package.json`에 다음 의존성이 선언되어 있으나 `src/` 디렉토리 내 어디에서도 import되지 않는다:
+
+- `express-winston: "^4.2.0"` — 미사용
+- `winston: "^3.11.0"` — 미사용
+- `@robota-sdk/agent-provider-bytedance` — 미사용 (app.ts에서 BYTEDANCE_API_KEY/BytedanceProvider 참조 없음)
+
+설치/번들 크기가 증가하고, `bytedance` 의존성은 이전 리포트(QA-001)에서 언급된 실제 ByteDance API 키(`BYTEDANCE_API_KEY=ae9d99...`)와 연관될 수 있어 사용 의도 불명확.
+
+**수정 방안**: 미사용 패키지를 `package.json`에서 제거. ByteDance 프로바이더를 실제 지원할 계획이면 `app.ts`에 해당 로직 추가.
+
+---
+
+### QA-M-002: `useSideEffects.ts`의 `getHostSideEffects()` — `InteractiveSession`을 `ISideEffects`로 이중 캐스팅
+
+**위치**: `packages/agent-cli/src/ui/hooks/useSideEffects.ts:239-241`
+
+**현상**:
+
+```typescript
+function getHostSideEffects(interactiveSession: InteractiveSession): ISideEffects {
+  return interactiveSession as unknown as ISideEffects;
+}
+```
+
+`InteractiveSession` 인스턴스를 `ISideEffects` 인터페이스(내부 플래그 객체)로 이중 캐스팅한다. `ISideEffects`는 `_pendingModelId`, `_resetRequested` 등의 언더스코어 플래그들을 정의하는데, `InteractiveSession`이 이 필드들을 실제로 갖고 있는지 타입 시스템이 보장하지 못한다.
+
+이 패턴은 테스트 불가하고, `InteractiveSession` 구현 변경 시 조용히 깨질 수 있다.
+
+**영향**: 사이드 이펙트 플래그(`_pendingModelId` 등)가 실제로 `InteractiveSession`에 없는 경우 `undefined` 반환 → 명령 효과 미적용.
+
+**수정 방안**: `ISideEffects` 플래그를 `InteractiveSession`이 아닌 별도의 상태 객체로 관리. 또는 `InteractiveSession`에 공식 sideEffects 채널(이벤트 또는 속성)을 추가.
+
+---
+
+### QA-M-003: `--no-session-persistence` 플래그가 인터랙티브 TUI 모드에서 무시됨
+
+**위치**: `packages/agent-cli/src/cli.ts:361, 399`
+
+**현상**:
+
+```typescript
+// 헤드리스(-p) 모드: 올바르게 처리됨
+sessionStore: args.noSessionPersistence ? undefined : sessionStore,
+
+// 인터랙티브 TUI 모드: noSessionPersistence 무시, 항상 sessionStore 전달
+renderApp({
+  ...
+  sessionStore,   // noSessionPersistence 체크 없음
+  ...
+});
+```
+
+`--no-session-persistence` 플래그는 print mode(`-p`)에서는 올바르게 처리되지만, 인터랙티브 모드에서는 세션이 항상 저장된다.
+
+**기대 동작**: `--no-session-persistence` 시 TUI 모드에서도 세션 저장 불가.
+
+**수정 방안**:
+
+```typescript
+renderApp({
+  ...
+  sessionStore: args.noSessionPersistence ? undefined : sessionStore,
+  ...
+});
+```
+
+---
+
+### QA-M-004: `agent-server`의 `app.ts`에서 `GoogleProvider` 환경변수 키 불일치
+
+**위치**: `apps/agent-server/src/app.ts:82-85`
+
+**현상**:
+
+```typescript
+if (process.env.GOOGLE_API_KEY) {
+  providers.google = new GoogleProvider({
+    apiKey: process.env.GOOGLE_API_KEY,
+  });
+}
+```
+
+이전 QA-001 리포트에서 확인된 실제 키는 `GEMINI_API_KEY`로 저장되어 있었으나, 코드에서는 `GOOGLE_API_KEY`를 읽는다. `.env.example` 또는 배포 환경에서 `GEMINI_API_KEY`를 사용하면 Google 프로바이더가 조용히 비활성화된다.
+
+**재현 방법**: `.env`에 `GEMINI_API_KEY=...` 설정 후 서버 시작 → `/api/v1/remote/health`에서 `providers: []` (google 미포함).
+
+**기대 동작**: 환경변수 이름을 문서화하고 일관되게 사용 또는 `GEMINI_API_KEY`도 폴백으로 지원.
+
+---
+
+## Low Issues (낮은 우선순위)
+
+### QA-L-001: `SessionStatusBar`에서 `resolveGitBranch()` 호출이 모든 렌더링마다 실행될 수 있음
+
+**위치**: `packages/agent-cli/src/ui/SessionStatusBar.tsx:39`
+
+**현상**:
+
+```typescript
+const gitBranch = useMemo(() => resolveGitBranch(cwd), [cwd]);
+```
+
+`useMemo`는 `cwd` 변경 시에만 재계산하므로 올바른 패턴이다. 그러나 `resolveGitBranch()`는 동기적으로 `execSync`를 호출하여 `git branch` 명령을 실행한다. 대규모 git 저장소이거나 느린 파일시스템에서는 매 cwd 변경 시 UI가 일시 차단될 수 있다.
+
+**영향**: 저장소 크기나 파일시스템 성능에 따라 상태바 렌더링 지연.
+
+**수정 방안**: `resolveGitBranch()`를 비동기(`exec` 대신 `execAsync`) + 별도 `useEffect`로 이동, 결과를 `useState`에 저장.
+
+---
+
+### QA-L-002: `agent-web/src/lib/cache.ts`의 cleanup `setInterval`이 SSR 환경 체크 없이 등록됨
+
+**위치**: `apps/agent-web/src/lib/cache.ts:108-116`
+
+**현상**:
+
+```typescript
+if (typeof window !== 'undefined') {
+  setInterval(
+    () => {
+      cache.cleanup();
+      userCache.cleanup();
+      apiCache.cleanup();
+    },
+    10 * 60 * 1000,
+  );
+}
+```
+
+`window` 체크는 있으나 `setInterval` 반환값이 저장되지 않아 cleanup 함수 없이 영구 실행된다. Next.js 앱 라우터 환경에서 모듈이 여러 번 hot-reload되면 인터벌이 누적된다.
+
+**영향**: 개발 환경에서 hot-reload 시 메모리 누수 가능.
+
+**수정 방안**: 모듈 레벨에서 인터벌 핸들을 저장하거나, 앱 라이프사이클에서 정리하도록 변경.
+
+---
+
+## 이전 이슈 업데이트 (v1 → v2)
+
+| 이슈                            | 상태                          | 내용                                                                                                                                                                                              |
+| ------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| QA-002 (JWT 인증 미구현)        | **부분 수정**                 | `jsonwebtoken`으로 서명 검증 추가됨. 단, `JWT_SECRET` 미설정 시 3-파트 형식만 확인하는 개발 폴백 여전히 존재 (websocket-server.ts:185-191). 프로덕션 배포 전 `JWT_SECRET` 환경변수 필수 설정 필요 |
+| QA-003 (graceful shutdown)      | **수정됨**                    | `server.close()` → `wsServer.close()` → 30초 강제 종료 타임아웃 패턴 구현됨 (server.ts:50-62)                                                                                                     |
+| QA-004 (setInterval 누수)       | **수정됨**                    | `this.cleanupInterval` 필드에 저장, `close()`에서 `clearInterval` 호출 (websocket-server.ts:50, 347)                                                                                              |
+| QA-005 (비-TTY 크래시)          | **수정됨**                    | `stdin.isTTY` 가드 추가됨 (cli.ts:105-115)                                                                                                                                                        |
+| QA-006 (미구현 엔드포인트 광고) | **수정됨**                    | 루트 응답에서 `stream`, `capabilities` 엔드포인트 제거됨 (app.ts:126-130)                                                                                                                         |
+| QA-011 (require.main ESM)       | **수정됨** — 단, 새 이슈 확인 | `require.main === module` 조건 여전히 사용 (server.ts:72). tsup이 CJS로 컴파일하므로 런타임 동작하지만, v1 리포트 그대로 ESM 전환 시 깨짐                                                         |
+| QA-013 (deprecated substr)      | **미수정**                    | websocket-server.ts:297에 `substr(2, 9)` 여전히 존재                                                                                                                                              |
+
+---
+
+## 미점검 영역 (이번 v2 점검에서도 제외)
+
+| 영역                                        | 이유                                        |
+| ------------------------------------------- | ------------------------------------------- |
+| `packages/agent-sdk` 내부 세션 라이프사이클 | 범위 외 — 별도 SPEC.md 및 592개 테스트 존재 |
+| 실제 AI 프로바이더 응답 처리                | 실제 네트워크 및 API 키 필요                |
+| Firebase Functions 배포 설정                | Firebase 환경 미구축                        |
+| GitHub Actions CI 파이프라인                | 워크플로우 파일 미확인                      |
+| 접근성 (a11y)                               | TUI CLI 환경 특성상 해당 없음               |


### PR DESCRIPTION
## Summary

- QA/PM/TypeScript Dev v2 사전 출시 점검 3개 리포트 추가 (`qa-v2`, `pm-v2`, `dev`)
- 23개 신규 백로그 항목 생성 및 `README.md` 인덱스 업데이트

## New Backlog Items

| 그룹 | 항목 수 | Critical |
|------|---------|----------|
| CLI2 (CLI 동작 결함) | 8 | CLI2-006 (--output-format 미검증) |
| DEV (TypeScript 품질) | 9 | DEV-002, DEV-003 |
| SRV2 (서버 품질) | 1 | — |
| PLG (Playground) | 1 | PLG-001 (WS URL 하드코딩) |
| DOC2 (문서) | 2 | — |
| DEP (의존성) | 2 | — |

## Test plan

- [ ] 각 백로그 파일의 frontmatter (title, status, priority) 확인
- [ ] `README.md` 인덱스의 링크가 실제 파일을 가리키는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)