### PR TITLE
fix(playground): fix WebSocket, browser bundle, and Tailwind styles

### DIFF
--- a/apps/agent-web/.env.example
+++ b/apps/agent-web/.env.example
@@ -6,3 +6,8 @@
 # ── Next.js (exposed to browser) ──
 # NEXT_PUBLIC_API_VERSION=v1
 # NEXT_PUBLIC_DAG_API_BASE_URL=http://localhost:3012
+
+# ── Playground ──
+# WebSocket URL for the Robota agent server. Defaults to ws://localhost:3001/ws/playground if unset.
+# Set this to your deployed agent-server WebSocket endpoint for production.
+# NEXT_PUBLIC_PLAYGROUND_WS_URL=ws://localhost:3001

--- a/apps/agent-web/src/app/globals.css
+++ b/apps/agent-web/src/app/globals.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+@source "../../../../packages/agent-playground/src";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/apps/agent-web/src/app/playground/page.tsx
+++ b/apps/agent-web/src/app/playground/page.tsx
@@ -11,5 +11,5 @@ const PlaygroundApp = dynamic(
 );
 
 export default function PlaygroundPage() {
-  return <PlaygroundApp />;
+  return <PlaygroundApp defaultServerUrl={process.env.NEXT_PUBLIC_PLAYGROUND_WS_URL} />;
 }

--- a/packages/agent-playground/src/contexts/__tests__/playground-context.test.tsx
+++ b/packages/agent-playground/src/contexts/__tests__/playground-context.test.tsx
@@ -172,7 +172,7 @@ describe('PlaygroundProvider', () => {
     const executor = latestExecutor();
 
     expect(executor.construction.serverUrl).toBe('ws://playground.example.test');
-    expect(executor.construction.authToken).toBe('playground-token');
+    expect(executor.construction.authToken).toBe('dev.playground.token');
     expect(eventServiceMocks.DefaultEventService).toHaveBeenCalledTimes(1);
     expect(hook.result.current.state.serverUrl).toBe('ws://playground.example.test');
     expect(hook.result.current.actions.getConnectionStatus()).toEqual({

--- a/packages/agent-playground/src/contexts/playground-context/executor-lifecycle.ts
+++ b/packages/agent-playground/src/contexts/playground-context/executor-lifecycle.ts
@@ -25,7 +25,7 @@ export function useExecutorInitialization({
     if (stateExecutor || !defaultServerUrl) return;
     try {
       const eventService = new DefaultEventService();
-      const executor = new PlaygroundExecutor(defaultServerUrl, 'playground-token', {
+      const executor = new PlaygroundExecutor(defaultServerUrl, 'dev.playground.token', {
         logger,
         eventService,
       });

--- a/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
+++ b/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
@@ -51,6 +51,24 @@ export class PlaygroundExecutor {
     this.statisticsPlugin = createStatisticsPlugin();
     this.eventService = options.eventService;
     this.agentSession = new PlaygroundAgentSession(this.eventService);
+
+    if (serverUrl) {
+      const sessionId =
+        typeof crypto !== 'undefined' && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `session-${Date.now()}`;
+      this.websocketClient = new PlaygroundWebSocketClient(
+        serverUrl,
+        'playground-user',
+        sessionId,
+        authToken,
+      );
+      this.websocketClient.connect().catch((err) => {
+        this.logger.warn('WebSocket initial connect failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
   }
 
   async createAgent(config: IPlaygroundAgentConfig): Promise<void> {

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -279,7 +279,7 @@ export function PlaygroundApp(props: { defaultServerUrl?: string }): React.React
   return (
     <>
       <Toaster />
-      <PlaygroundProvider defaultServerUrl={props.defaultServerUrl ?? 'ws://localhost:3001/ws'}>
+      <PlaygroundProvider defaultServerUrl={props.defaultServerUrl ?? 'ws://localhost:3001'}>
         <PlaygroundContent />
       </PlaygroundProvider>
     </>

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -9,6 +9,9 @@
     ".": {
       "types": "./dist/node/index.d.ts",
       "source": "./src/index.ts",
+      "browser": {
+        "import": "./dist/browser/browser.js"
+      },
       "node": {
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs"
@@ -31,9 +34,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsup",
+    "build:js": "tsup --no-dts",
+    "build:types": "tsup --dts-only",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",

--- a/packages/agent-tools/src/browser.ts
+++ b/packages/agent-tools/src/browser.ts
@@ -1,0 +1,24 @@
+// Browser-safe entry point for @robota-sdk/agent-tools.
+// Excludes Node.js-only tools (bash, read, write, edit, glob, grep, web-fetch, web-search)
+// and the sandbox clients that depend on Node.js APIs.
+
+export type { TToolResult } from './types/tool-result';
+
+export { ToolRegistry } from './registry/tool-registry';
+
+export {
+  FunctionTool,
+  createFunctionTool,
+  createZodFunctionTool,
+} from './implementations/function-tool';
+export { OpenAPITool, createOpenAPITool } from './implementations/openapi-tool';
+export { zodToJsonSchema } from './implementations/function-tool/schema-converter';
+export type {
+  IZodSchema,
+  IZodParseResult,
+  IZodSchemaDef,
+  IFunctionToolValidationOptions,
+  ISchemaConversionOptions,
+  IFunctionToolExecutionMetadata,
+  IFunctionToolResult,
+} from './implementations/function-tool/types';

--- a/packages/agent-tools/tsup.config.ts
+++ b/packages/agent-tools/tsup.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from 'tsup';
+
+const baseConfig = {
+  dts: {
+    resolve: true,
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  treeshake: true,
+  skipNodeModulesBundle: true,
+  external: [/^@robota-sdk\/.*/],
+};
+
+export default defineConfig([
+  // Node.js build — full API including CLI tools (bash, glob, grep, etc.)
+  {
+    ...baseConfig,
+    entry: { index: 'src/index.ts' },
+    outDir: 'dist/node',
+    format: ['esm', 'cjs'],
+    platform: 'node',
+    target: 'node18',
+  },
+  // Browser build — browser-safe subset only (FunctionTool, ToolRegistry, OpenAPITool)
+  {
+    ...baseConfig,
+    entry: { browser: 'src/browser.ts' },
+    outDir: 'dist/browser',
+    format: ['esm'],
+    platform: 'browser',
+    minify: true,
+    define: {
+      'process.env.NODE_ENV': '"production"',
+    },
+    esbuildOptions(options) {
+      options.drop = ['debugger'];
+      options.dropLabels = ['DEV'];
+      options.conditions = ['module', 'import', 'browser'];
+    },
+  },
+]);


### PR DESCRIPTION
## Summary

- **agent-tools browser bundle**: Added `src/browser.ts` entry point and `tsup.config.ts` with separate node/browser targets to exclude Node.js-only deps (`fast-glob`, `@nodelib/fs.scandir`) from browser bundles. Added `"browser"` export condition in `package.json`.
- **WebSocket never connecting**: `PlaygroundExecutor` constructor was instantiating `PlaygroundWebSocketClient` but never calling `connect()`. Fixed by adding client instantiation with `crypto.randomUUID()` session ID.
- **Dev JWT format**: Server dev mode requires a 3-part dotted JWT format. Changed hardcoded token from `'playground-token'` to `'dev.playground.token'`.
- **WebSocket URL double-path**: `buildPlaygroundWebSocketUrl` already appends `/ws/playground`, so the default base URL must be `ws://localhost:3001` (no path).
- **Unhandled promise rejection**: React StrictMode disposes the first executor while WebSocket is still connecting. Added `.catch()` on `connect()` to suppress the unhandled rejection.
- **Tailwind styles not applied**: Tailwind v4 auto-scan only covers the app directory. Added `@source` directive for `packages/agent-playground/src` in `globals.css`.
- **Env var**: Pass `NEXT_PUBLIC_PLAYGROUND_WS_URL` from Next.js page to `PlaygroundApp`; documented in `.env.example`.

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-tools build` — node + browser bundles build cleanly
- [x] `pnpm --filter @robota-sdk/agent-playground test` — all 127 tests pass (updated auth token expectation)
- [x] Browser: `/playground` shows **WebSocket: Connected**, Executor: Ready, styles applied
- [x] Browser: No "1 Issue" overlay, no `Uncaught (in promise)` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)