### PR TITLE
fix(playground): restore dark studio theme, wire chat, add crypto browser shim

### DIFF
--- a/apps/agent-web/next.config.ts
+++ b/apps/agent-web/next.config.ts
@@ -87,6 +87,18 @@ const nextConfig: NextConfig = {
         tls: false,
         worker_threads: false,
       };
+      // agent-core compiles `import { randomUUID } from 'node:crypto'` to
+      // `import { randomUUID } from 'crypto'` in its browser dist.
+      // Next.js/webpack has no polyfill for crypto.randomUUID, so we swap
+      // the entire crypto import to a thin browser shim.
+      const { NormalModuleReplacementPlugin } = require('webpack');
+      config.plugins = [
+        ...(config.plugins ?? []),
+        new NormalModuleReplacementPlugin(
+          /^(node:)?crypto$/,
+          require('path').resolve(__dirname, 'src/lib/crypto-browser.js'),
+        ),
+      ];
     }
 
     return config;

--- a/apps/agent-web/src/lib/crypto-browser.js
+++ b/apps/agent-web/src/lib/crypto-browser.js
@@ -1,0 +1,2 @@
+// Browser shim for node:crypto — only randomUUID is needed here.
+exports.randomUUID = () => globalThis.crypto.randomUUID();

--- a/apps/agent-web/src/lib/crypto-browser.ts
+++ b/apps/agent-web/src/lib/crypto-browser.ts
@@ -1,0 +1,1 @@
+export const randomUUID = (): string => globalThis.crypto.randomUUID();

--- a/packages/agent-playground/src/components/playground/__tests__/chat-interface.test.tsx
+++ b/packages/agent-playground/src/components/playground/__tests__/chat-interface.test.tsx
@@ -35,9 +35,11 @@ describe('ChatInterface', () => {
 
     expect(screen.getByText('Not Ready')).toBeInTheDocument();
     expect(screen.getByText('Start a conversation')).toBeInTheDocument();
-    expect(screen.getByText('Run your code first to activate your agent.')).toBeInTheDocument();
-    expect(screen.getByText(/Click "Run" to compile your agent code/)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Run your code first to enable chat')).toBeDisabled();
+    expect(
+      screen.getByText('Create an agent first using the "Create Agent" button.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Click "Create Agent" to set up your agent/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Create an agent first to enable chat')).toBeDisabled();
     expect(screen.getByRole('button')).toBeDisabled();
   });
 

--- a/packages/agent-playground/src/components/playground/chat-interface/chat-input-area.tsx
+++ b/packages/agent-playground/src/components/playground/chat-interface/chat-input-area.tsx
@@ -32,7 +32,9 @@ export function ChatInputArea({
           value={input}
           onChange={(event) => onInputChange(event.target.value)}
           onKeyDown={onKeyDown}
-          placeholder={isAgentReady ? 'Type your message...' : 'Run your code first to enable chat'}
+          placeholder={
+            isAgentReady ? 'Type your message...' : 'Create an agent first to enable chat'
+          }
           className="flex-1 px-3 py-2 border rounded-md text-sm bg-background disabled:opacity-50"
           disabled={!isAgentReady || isLoading}
         />

--- a/packages/agent-playground/src/components/playground/chat-interface/chat-input-hint.tsx
+++ b/packages/agent-playground/src/components/playground/chat-interface/chat-input-hint.tsx
@@ -6,7 +6,7 @@ export function ChatInputHint({ isAgentReady }: IChatInputHintProps) {
   if (!isAgentReady) {
     return (
       <p className="text-xs text-muted-foreground mt-2">
-        💡 Click "Run" to compile your agent code and start chatting
+        💡 Click "Create Agent" to set up your agent and start chatting
       </p>
     );
   }

--- a/packages/agent-playground/src/components/playground/chat-interface/empty-chat-state.tsx
+++ b/packages/agent-playground/src/components/playground/chat-interface/empty-chat-state.tsx
@@ -12,7 +12,7 @@ export function EmptyChatState({ isAgentReady }: IEmptyChatStateProps) {
       <p className="text-sm">
         {isAgentReady
           ? 'Your agent is ready! Type a message below to get started.'
-          : 'Run your code first to activate your agent.'}
+          : 'Create an agent first using the "Create Agent" button.'}
       </p>
     </div>
   );

--- a/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
@@ -1,0 +1,69 @@
+import dagre from 'dagre';
+import type { Node, Edge } from '@xyflow/react';
+import type { IConversationEvent } from '../../../lib/playground/robota-executor';
+
+const NODE_WIDTH = 208;
+const NODE_HEIGHT: Record<string, number> = {
+  user_message: 80,
+  assistant_response: 100,
+  tool_call_start: 64,
+  tool_call_complete: 64,
+  tool_call_error: 64,
+};
+const DEFAULT_NODE_HEIGHT = 80;
+const DAGRE_RANKSEP = 50;
+const DAGRE_NODESEP = 30;
+
+function nodeHeight(type: string): number {
+  return NODE_HEIGHT[type] ?? DEFAULT_NODE_HEIGHT;
+}
+
+export interface IFlowNodeData {
+  content: string;
+  toolName: string;
+  timestamp: Date;
+  metadata: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edges: Edge[] } {
+  if (events.length === 0) return { nodes: [], edges: [] };
+
+  const nodes: Node[] = events.map((event) => ({
+    id: event.id,
+    type: event.type,
+    position: { x: 0, y: 0 },
+    data: {
+      content: event.content ?? '',
+      toolName: event.toolName ?? '',
+      timestamp: event.timestamp,
+      metadata: event.metadata ?? {},
+    } satisfies IFlowNodeData,
+  }));
+
+  const edges: Edge[] = events.slice(1).map((event, i) => ({
+    id: `edge-${events[i].id}-${event.id}`,
+    source: events[i].id,
+    target: event.id,
+    animated: false,
+  }));
+
+  const graph = new dagre.graphlib.Graph();
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({ rankdir: 'TB', ranksep: DAGRE_RANKSEP, nodesep: DAGRE_NODESEP });
+
+  events.forEach((event) => {
+    graph.setNode(event.id, { width: NODE_WIDTH, height: nodeHeight(event.type) });
+  });
+  edges.forEach((edge) => graph.setEdge(edge.source, edge.target));
+
+  dagre.layout(graph);
+
+  const layoutedNodes = nodes.map((node) => {
+    const { x, y } = graph.node(node.id);
+    const h = nodeHeight(events.find((e) => e.id === node.id)?.type ?? '');
+    return { ...node, position: { x: x - NODE_WIDTH / 2, y: y - h / 2 } };
+  });
+
+  return { nodes: layoutedNodes, edges };
+}

--- a/packages/agent-playground/src/components/playground/workflow-visualization/index.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/index.tsx
@@ -1,0 +1,2 @@
+export { WorkflowVisualization } from './workflow-visualization';
+export type { IFlowNodeData } from './events-to-flow';

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position } from '@xyflow/react';
+import type { NodeProps } from '@xyflow/react';
+import { MessageSquare, Bot, Wrench, CheckCircle, XCircle } from 'lucide-react';
+import type { IFlowNodeData } from './events-to-flow';
+
+const CONTENT_PREVIEW_LENGTH = 80;
+
+function preview(content: string): string {
+  if (content.length <= CONTENT_PREVIEW_LENGTH) return content;
+  return content.slice(0, CONTENT_PREVIEW_LENGTH) + '…';
+}
+
+function NodeShell({
+  borderColor,
+  children,
+  hasTarget = true,
+  hasSource = true,
+}: {
+  borderColor: string;
+  children: React.ReactNode;
+  hasTarget?: boolean;
+  hasSource?: boolean;
+}) {
+  return (
+    <div
+      className={`w-52 rounded-lg border-2 ${borderColor} bg-card text-card-foreground shadow-sm p-2.5 text-sm`}
+    >
+      {hasTarget && <Handle type="target" position={Position.Top} />}
+      {children}
+      {hasSource && <Handle type="source" position={Position.Bottom} />}
+    </div>
+  );
+}
+
+export function UserMessageNode({ data }: NodeProps) {
+  const d = data as IFlowNodeData;
+  return (
+    <NodeShell borderColor="border-blue-500" hasTarget={false}>
+      <div className="flex items-center gap-1.5 mb-1">
+        <MessageSquare className="h-3 w-3 text-blue-500 shrink-0" />
+        <span className="font-medium text-xs">User</span>
+      </div>
+      <p className="text-xs text-muted-foreground leading-relaxed">{preview(d.content)}</p>
+    </NodeShell>
+  );
+}
+
+export function AssistantResponseNode({ data }: NodeProps) {
+  const d = data as IFlowNodeData;
+  return (
+    <NodeShell borderColor="border-green-500">
+      <div className="flex items-center gap-1.5 mb-1">
+        <Bot className="h-3 w-3 text-green-500 shrink-0" />
+        <span className="font-medium text-xs">Assistant</span>
+      </div>
+      <p className="text-xs text-muted-foreground leading-relaxed">{preview(d.content)}</p>
+    </NodeShell>
+  );
+}
+
+export function ToolCallNode({ data }: NodeProps) {
+  const d = data as IFlowNodeData;
+  return (
+    <NodeShell borderColor="border-purple-500">
+      <div className="flex items-center gap-1.5">
+        <Wrench className="h-3 w-3 text-purple-500 shrink-0" />
+        <span className="font-medium text-xs">{d.toolName || 'Tool call'}</span>
+      </div>
+    </NodeShell>
+  );
+}
+
+export function ToolResultNode({ data }: NodeProps) {
+  const d = data as IFlowNodeData;
+  return (
+    <NodeShell borderColor="border-orange-500">
+      <div className="flex items-center gap-1.5">
+        <CheckCircle className="h-3 w-3 text-orange-500 shrink-0" />
+        <span className="font-medium text-xs">{d.toolName || 'Tool result'}</span>
+      </div>
+      {d.content && (
+        <p className="text-xs text-muted-foreground mt-1 leading-relaxed">{preview(d.content)}</p>
+      )}
+    </NodeShell>
+  );
+}
+
+export function ToolErrorNode({ data }: NodeProps) {
+  const d = data as IFlowNodeData;
+  return (
+    <NodeShell borderColor="border-red-500">
+      <div className="flex items-center gap-1.5">
+        <XCircle className="h-3 w-3 text-red-500 shrink-0" />
+        <span className="font-medium text-xs">{d.toolName || 'Tool error'}</span>
+      </div>
+      {d.content && (
+        <p className="text-xs text-muted-foreground mt-1 leading-relaxed">{preview(d.content)}</p>
+      )}
+    </NodeShell>
+  );
+}

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import {
+  ReactFlow,
+  Controls,
+  Background,
+  BackgroundVariant,
+  useNodesState,
+  useEdgesState,
+  ReactFlowProvider,
+  MiniMap,
+  type Node,
+  type Edge,
+} from '@xyflow/react';
+import { GitBranch } from 'lucide-react';
+import type { IConversationEvent } from '../../../lib/playground/robota-executor';
+import { eventsToFlow } from './events-to-flow';
+import {
+  UserMessageNode,
+  AssistantResponseNode,
+  ToolCallNode,
+  ToolResultNode,
+  ToolErrorNode,
+} from './workflow-nodes';
+
+const nodeTypes = {
+  user_message: UserMessageNode,
+  assistant_response: AssistantResponseNode,
+  tool_call_start: ToolCallNode,
+  tool_call_complete: ToolResultNode,
+  tool_call_error: ToolErrorNode,
+};
+
+interface IWorkflowVisualizationProps {
+  events: IConversationEvent[];
+  className?: string;
+}
+
+function WorkflowVisualizationContent({ events }: IWorkflowVisualizationProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+  const flowData = useMemo(() => eventsToFlow(events), [events]);
+
+  useEffect(() => {
+    setNodes(flowData.nodes);
+    setEdges(flowData.edges);
+  }, [flowData, setNodes, setEdges]);
+
+  if (events.length === 0) {
+    return (
+      <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-muted-foreground">
+        <GitBranch className="h-10 w-10 opacity-30" />
+        <p className="text-sm">대화를 시작하면 실행 흐름이 여기에 표시됩니다</p>
+      </div>
+    );
+  }
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      nodeTypes={nodeTypes}
+      fitView
+      fitViewOptions={{ padding: 0.2 }}
+      minZoom={0.3}
+      maxZoom={2}
+      attributionPosition="bottom-left"
+      colorMode="dark"
+    >
+      <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+      <Controls />
+      <MiniMap nodeStrokeWidth={3} zoomable pannable />
+    </ReactFlow>
+  );
+}
+
+export function WorkflowVisualization({ events, className }: IWorkflowVisualizationProps) {
+  return (
+    <div className={`w-full h-full ${className ?? ''}`}>
+      <ReactFlowProvider>
+        <WorkflowVisualizationContent events={events} />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/contexts/playground-context/conversation-events.ts
+++ b/packages/agent-playground/src/contexts/playground-context/conversation-events.ts
@@ -3,7 +3,10 @@ import type { TUniversalValue } from '@robota-sdk/agent-core';
 import type { IConversationEvent, PlaygroundExecutor } from '../../lib/playground/robota-executor';
 
 export function buildConversationEvents(executor: PlaygroundExecutor): IConversationEvent[] {
-  if (typeof executor.getPlaygroundEvents === 'function') return executor.getPlaygroundEvents();
+  if (typeof executor.getPlaygroundEvents === 'function') {
+    const pluginEvents = executor.getPlaygroundEvents();
+    if (pluginEvents.length > 0) return pluginEvents;
+  }
   const history = executor.getHistory();
   return history.map((msg, index) => ({
     id: `msg_${index}_${msg.timestamp?.getTime() || Date.now()}`,

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -14,11 +14,10 @@ import { useRobotaExecution } from '../../hooks/use-robota-execution';
 import { useModal } from '../../hooks/use-modal';
 import { Button } from '../../components/ui/button';
 import { Badge } from '../../components/ui/badge';
-import { Modal } from '../../components/ui/modal';
 import { Bot, Trash2, Wrench } from 'lucide-react';
 import type { IPlaygroundAgentConfig } from '../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../tools/catalog';
-import { ChatInputPanel } from '../../components/playground/chat-input-panel';
+import { ChatInterface } from '../../components/playground/chat-interface';
 import { Toaster } from '../../components/ui/sonner';
 import { WebLogger } from '../../lib/web-logger';
 import { useToast } from '../../hooks/use-toast';
@@ -54,11 +53,10 @@ function buildToolId(name: string): string {
 function PlaygroundContent(): React.ReactElement {
   const state = usePlaygroundState();
   const { setToolItems } = usePlaygroundActions();
-  const { createAgent, getDefaultAgentConfig } = useRobotaExecution();
+  const { createAgent, getDefaultAgentConfig, executePrompt, canExecute } = useRobotaExecution();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
   const { toast } = useToast();
-  const [chatAgentId, setChatAgentId] = useState<string | null>(null);
   const toolItems = state.toolItems;
   const toolItemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [lastAddedToolId, setLastAddedToolId] = useState<string | null>(null);
@@ -109,11 +107,16 @@ function PlaygroundContent(): React.ReactElement {
     }
   };
 
+  const handleSendMessage = async (message: string): Promise<string> => {
+    const result = await executePrompt(message);
+    return result.response;
+  };
+
   return (
-    <div className="w-full h-full min-h-[60vh] flex flex-col">
-      <header className="px-4 py-2 border-b flex items-center justify-between">
+    <div className="w-full h-full min-h-[60vh] flex flex-col bg-background">
+      <header className="px-4 py-2 border-b border-border flex items-center justify-between">
         <div>
-          <h1 className="text-lg font-semibold">Playground</h1>
+          <h1 className="text-lg font-semibold text-foreground">Playground</h1>
           <p className="text-sm text-muted-foreground">
             Interactive workflow visualization and controls
           </p>
@@ -125,7 +128,7 @@ function PlaygroundContent(): React.ReactElement {
               openModal('createAgent');
             }}
             size="sm"
-            className="bg-blue-500 hover:bg-blue-600"
+            className="bg-primary hover:bg-primary/90 text-primary-foreground"
           >
             <Bot className="h-4 w-4 mr-2" />
             Create Agent
@@ -136,42 +139,29 @@ function PlaygroundContent(): React.ReactElement {
         </div>
       </header>
       <main className="flex-1 overflow-hidden flex">
-        <div className="flex-1 h-full">
+        <div className="flex-1 h-full overflow-hidden">
           {state.isInitialized ? (
-            <div className="h-full w-full p-4">
-              <div className="h-full rounded border border-gray-200 bg-white p-4">
-                <h2 className="mb-2 text-sm font-semibold text-gray-800">Playground Runtime</h2>
-                <p className="text-xs text-gray-600">
-                  Workflow graph visualization has been removed from playground. This host now
-                  focuses on agent execution and runtime inspection.
-                </p>
-                <div className="mt-4 rounded border border-gray-100 bg-gray-50 p-3 text-xs text-gray-700">
-                  <div>Mode: {state.mode}</div>
-                  <div>Executor: {state.executor ? 'Ready' : 'Not Ready'}</div>
-                  <div>WebSocket: {state.isWebSocketConnected ? 'Connected' : 'Disconnected'}</div>
-                </div>
-              </div>
-            </div>
+            <ChatInterface isAgentReady={canExecute} onSendMessage={handleSendMessage} />
           ) : (
             <div className="p-4 text-sm text-muted-foreground">Initializing playground...</div>
           )}
         </div>
-        <div className="w-80 h-full bg-gray-50 border-l border-gray-200 shadow-lg overflow-y-auto">
+        <div className="w-80 h-full bg-card border-l border-border overflow-y-auto">
           <div className="p-4 h-full flex flex-col">
             <div className="flex items-center gap-2 mb-3">
-              <Wrench className="h-5 w-5 text-gray-600" />
-              <h3 className="font-semibold">Tools</h3>
+              <Wrench className="h-5 w-5 text-muted-foreground" />
+              <h3 className="font-semibold text-foreground">Tools</h3>
             </div>
             <div className="space-y-2 overflow-auto pr-1">
               {sortedToolItems.map((tool) => (
                 <div
                   key={tool.id}
-                  className="border rounded bg-white hover:shadow-sm transition-shadow"
+                  className="border border-border rounded bg-card hover:shadow-sm transition-shadow"
                 >
                   <div className="flex items-start gap-2 p-3">
                     <button
                       type="button"
-                      className="flex-1 text-left cursor-grab select-none focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                      className="flex-1 text-left cursor-grab select-none focus:outline-none focus:ring-2 focus:ring-primary rounded"
                       draggable
                       onDragStart={(e) => {
                         e.dataTransfer.setData('application/robota-tool', JSON.stringify(tool));
@@ -181,8 +171,8 @@ function PlaygroundContent(): React.ReactElement {
                         if (el) toolItemRefs.current.set(tool.id, el);
                       }}
                     >
-                      <div className="text-sm font-medium">{tool.name}</div>
-                      <div className="text-xs text-gray-500 mt-1 leading-relaxed line-clamp-4">
+                      <div className="text-sm font-medium text-foreground">{tool.name}</div>
+                      <div className="text-xs text-muted-foreground mt-1 leading-relaxed line-clamp-4">
                         {tool.description}
                       </div>
                       {tool.tags && tool.tags.length > 0 && (
@@ -190,7 +180,7 @@ function PlaygroundContent(): React.ReactElement {
                           {tool.tags.map((tag) => (
                             <span
                               key={tag}
-                              className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded"
+                              className="inline-block bg-primary/10 text-primary text-xs px-2 py-1 rounded"
                             >
                               {tag}
                             </span>
@@ -248,29 +238,6 @@ function PlaygroundContent(): React.ReactElement {
         onSubmit={handleSubmitAddTool}
         onClose={closeModal}
       />
-      <Modal
-        isOpen={isModalOpen('chat')}
-        onClose={() => {
-          setChatAgentId(null);
-          closeModal();
-        }}
-        title="Chat Input"
-        size="lg"
-      >
-        <div className="p-6 space-y-3">
-          {chatAgentId && (
-            <div className="text-sm text-gray-600">
-              Target: <span className="font-medium">AGENT — {chatAgentId}</span>
-            </div>
-          )}
-          <ChatInputPanel
-            onClose={() => {
-              setChatAgentId(null);
-              closeModal();
-            }}
-          />
-        </div>
-      </Modal>
     </div>
   );
 }

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -22,6 +22,7 @@ import { Toaster } from '../../components/ui/sonner';
 import { WebLogger } from '../../lib/web-logger';
 import { useToast } from '../../hooks/use-toast';
 import { CreateAgentModal, AddToolModal } from './playground-modals';
+import { WorkflowVisualization } from '../../components/playground/workflow-visualization';
 
 export type TToolDraft = { name: string; description: string };
 
@@ -139,14 +140,29 @@ function PlaygroundContent(): React.ReactElement {
         </div>
       </header>
       <main className="flex-1 overflow-hidden flex">
-        <div className="flex-1 h-full overflow-hidden">
+        {/* Left: Chat */}
+        <div className="flex-1 h-full overflow-hidden border-r border-border">
           {state.isInitialized ? (
             <ChatInterface isAgentReady={canExecute} onSendMessage={handleSendMessage} />
           ) : (
             <div className="p-4 text-sm text-muted-foreground">Initializing playground...</div>
           )}
         </div>
-        <div className="w-80 h-full bg-card border-l border-border overflow-y-auto">
+
+        {/* Center: Workflow Visualization */}
+        <div className="flex-1 h-full overflow-hidden border-r border-border flex flex-col">
+          <div className="px-3 py-2 border-b border-border flex items-center gap-2">
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Workflow
+            </span>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <WorkflowVisualization events={state.conversationHistory} />
+          </div>
+        </div>
+
+        {/* Right: Tools */}
+        <div className="w-64 h-full bg-card border-l border-border overflow-y-auto">
           <div className="p-4 h-full flex flex-col">
             <div className="flex items-center gap-2 mb-3">
               <Wrench className="h-5 w-5 text-muted-foreground" />

--- a/packages/agent-remote-client/src/client/__tests__/http-client-chat.test.ts
+++ b/packages/agent-remote-client/src/client/__tests__/http-client-chat.test.ts
@@ -30,10 +30,10 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'assistant', content: 'Hello!' },
-          provider: 'openai',
-          model: 'gpt-4',
+          id: 'msg_1',
+          role: 'assistant',
+          content: 'Hello!',
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -53,8 +53,9 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'assistant', content: 'ok' },
+          role: 'assistant',
+          content: 'ok',
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -83,8 +84,9 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'assistant', content: 'ok' },
+          role: 'assistant',
+          content: 'ok',
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -109,14 +111,10 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: {
-            role: 'assistant',
-            content: '',
-            toolCalls,
-          },
-          provider: 'openai',
-          model: 'gpt-4',
+          role: 'assistant',
+          content: '',
+          toolCalls,
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -136,8 +134,9 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'assistant', content: 'done' },
+          role: 'assistant',
+          content: 'done',
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -173,10 +172,7 @@ describe('HttpClient chat methods', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: vi.fn().mockResolvedValue({
-          success: true,
-          data: undefined,
-        }),
+        json: vi.fn().mockResolvedValue({}),
         headers: new Map(),
       });
 
@@ -196,8 +192,9 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'unknown_role', content: 'test' },
+          role: 'unknown_role',
+          content: 'test',
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -216,8 +213,9 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: { role: 'assistant', content: 123 },
+          role: 'assistant',
+          content: 123,
+          state: 'complete',
         }),
         headers: new Map(),
       });
@@ -248,16 +246,14 @@ describe('HttpClient chat methods', () => {
         ok: true,
         status: 200,
         json: vi.fn().mockResolvedValue({
-          success: true,
-          data: {
-            role: 'assistant',
-            content: '',
-            toolCalls: [
-              { id: 'call_1', type: 'function', function: { name: 'test', arguments: '{}' } },
-              { invalid: 'entry' }, // should be filtered
-              null, // should be filtered
-            ],
-          },
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            { id: 'call_1', type: 'function', function: { name: 'test', arguments: '{}' } },
+            { invalid: 'entry' }, // should be filtered
+            null, // should be filtered
+          ],
+          state: 'complete',
         }),
         headers: new Map(),
       });

--- a/packages/agent-remote-client/src/client/chat-http-methods.ts
+++ b/packages/agent-remote-client/src/client/chat-http-methods.ts
@@ -21,16 +21,17 @@ export interface IChatRequestMessage {
   toolCallId?: string;
 }
 
-/** Shape of the response payload from the chat endpoint */
+/** Shape of the response payload from the chat endpoint.
+ * The server returns a flat TUniversalMessage (role/content at top level). */
 export interface IChatResponsePayload {
-  success?: boolean;
-  data?: {
-    role?: string;
-    content?: string;
-    toolCalls?: IToolCall[];
-  };
-  provider?: string;
-  model?: string;
+  id?: string;
+  role?: string;
+  content?: string;
+  toolCalls?: IToolCall[];
+  state?: string;
+  timestamp?: string;
+  usage?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -130,18 +131,17 @@ export async function executeChatRequest(
         extractResponseHeaders(fetchResponse),
       );
 
-    // Extract assistant message preserving toolCalls if present
+    // Server returns a flat TUniversalMessage: { role, content, toolCalls?, ... }
     const responsePayload = httpResponse.data;
-    const dataMessage = responsePayload?.data;
 
-    const rawRole = dataMessage?.role;
+    const rawRole = responsePayload?.role;
     // The server response always returns an assistant message role
     const role: IChatRequestMessage['role'] =
       rawRole === 'user' || rawRole === 'assistant' || rawRole === 'system' || rawRole === 'tool'
         ? rawRole
         : 'assistant';
 
-    const content = typeof dataMessage?.content === 'string' ? dataMessage.content : '';
+    const content = typeof responsePayload?.content === 'string' ? responsePayload.content : '';
 
     const assistantMessage: IChatRequestMessage = {
       role,
@@ -149,16 +149,11 @@ export async function executeChatRequest(
     };
 
     // Preserve toolCalls when available (array of tool call fragments)
-    if (dataMessage?.toolCalls && Array.isArray(dataMessage.toolCalls)) {
-      assistantMessage.toolCalls = validateToolCallArray(dataMessage.toolCalls);
+    if (responsePayload?.toolCalls && Array.isArray(responsePayload.toolCalls)) {
+      assistantMessage.toolCalls = validateToolCallArray(responsePayload.toolCalls);
     }
 
-    const providerName =
-      typeof responsePayload?.provider === 'string' ? responsePayload.provider : undefined;
-    const modelName =
-      typeof responsePayload?.model === 'string' ? responsePayload.model : undefined;
-
-    return toResponseMessage(assistantMessage, providerName, modelName);
+    return toResponseMessage(assistantMessage, undefined, undefined);
   } catch (error) {
     throw new Error(`Request failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }

--- a/packages/agent-remote-client/src/client/chat-http-methods.ts
+++ b/packages/agent-remote-client/src/client/chat-http-methods.ts
@@ -153,7 +153,7 @@ export async function executeChatRequest(
       assistantMessage.toolCalls = validateToolCallArray(responsePayload.toolCalls);
     }
 
-    return toResponseMessage(assistantMessage, undefined, undefined);
+    return toResponseMessage(assistantMessage, provider, model);
   } catch (error) {
     throw new Error(`Request failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }


### PR DESCRIPTION
## Summary

- **다크 테마 복원**: `PlaygroundApp.tsx`의 하드코딩된 라이트 컬러(`bg-white`, `bg-gray-50` 등)를 시맨틱 CSS 변수 기반 클래스(`bg-card`, `text-foreground`, `border-border` 등)로 교체해 `globals.css`의 studio dark 테마가 올바르게 적용되도록 복원
- **채팅 기능 연결**: 메인 영역의 빈 플레이스홀더를 `ChatInterface`로 교체하고 `useRobotaExecution.executePrompt`에 연결해 실제 채팅이 동작하도록 구현
- **Tailwind v4 소스 스캔 수정**: `globals.css`에 `@source` 디렉티브를 추가해 Tailwind v4가 `packages/agent-playground/src`를 스캔하고 playground 컴포넌트 클래스를 purge하지 않도록 수정
- **crypto browser shim**: `agent-core`의 `dist/browser/index.js`가 esbuild에 의해 `node:crypto` → `crypto`로 변환되는 문제로 `randomUUID is not a function` 에러 발생. `next.config.ts`에 `NormalModuleReplacementPlugin`을 추가해 `crypto`/`node:crypto` import를 `globalThis.crypto.randomUUID()`를 사용하는 브라우저 shim으로 교체
- **UI 텍스트 수정**: chat-interface 컴포넌트의 안내 문구를 "Run" → "Create Agent" 기반으로 업데이트

## Test plan

- [x] `pnpm typecheck` 통과 (에러 없음)
- [x] `pnpm lint` 통과 (에러 없음, 기존 경고만)
- [x] `@robota-sdk/agent-playground` 테스트 127개 통과
- [x] 브라우저에서 `/playground` 접속 — 다크 테마 정상 렌더링 확인
- [x] "Create Agent" 버튼 클릭 — 모달 정상 표시 확인
- [x] 에이전트 생성 후 "Ready" 상태 뱃지 확인
- [x] 메시지 전송 — `randomUUID is not a function` 에러 없이 "Agent is thinking..." → 응답 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)