### PR TITLE
fix(cli2-006): add parseOutputFormat() validation; remove as cast for --output-format

### DIFF
--- a/.agents/backlog/completed/CLI2-006-output-format-no-validation.md
+++ b/.agents/backlog/completed/CLI2-006-output-format-no-validation.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-006: --output-format 인수 유효성 검사 없이 as 캐스팅 — 잘못된 값이 stream-json으로 무음 폴백'
-status: todo
+status: done
 created: 2026-05-10
 priority: critical
 urgency: now

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -339,7 +339,7 @@ async function runPrintMode(
   });
 
   const transport = createHeadlessTransport({
-    outputFormat: (args.outputFormat as 'text' | 'json' | 'stream-json') ?? 'text',
+    outputFormat: args.outputFormat ?? 'text',
     prompt,
   });
   session.attachTransport(transport);

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { parsePermissionMode, parseMaxTurns, parseCliArgs } from '../cli-args.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  parsePermissionMode,
+  parseMaxTurns,
+  parseOutputFormat,
+  parseCliArgs,
+} from '../cli-args.js';
 
 describe('parsePermissionMode', () => {
   it('returns undefined for undefined input', () => {
@@ -11,6 +16,30 @@ describe('parsePermissionMode', () => {
     expect(parsePermissionMode('default')).toBe('default');
     expect(parsePermissionMode('acceptEdits')).toBe('acceptEdits');
     expect(parsePermissionMode('bypassPermissions')).toBe('bypassPermissions');
+  });
+});
+
+describe('parseOutputFormat', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseOutputFormat(undefined)).toBeUndefined();
+  });
+
+  it('returns valid output formats', () => {
+    expect(parseOutputFormat('text')).toBe('text');
+    expect(parseOutputFormat('json')).toBe('json');
+    expect(parseOutputFormat('stream-json')).toBe('stream-json');
+  });
+
+  it('exits with error for invalid format', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    parseOutputFormat('xml');
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'Invalid --output-format "xml". Valid: text | json | stream-json\n',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });
 

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -8,6 +8,9 @@ import type { TPermissionMode } from '@robota-sdk/agent-core';
 
 const VALID_MODES: TPermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions'];
 
+const VALID_OUTPUT_FORMATS = ['text', 'json', 'stream-json'] as const;
+export type TOutputFormat = (typeof VALID_OUTPUT_FORMATS)[number];
+
 export interface IParsedCliArgs {
   positional: string[];
   printMode: boolean;
@@ -19,7 +22,7 @@ export interface IParsedCliArgs {
   maxTurns: number | undefined;
   forkSession: boolean;
   sessionName: string | undefined;
-  outputFormat: string | undefined;
+  outputFormat: TOutputFormat | undefined;
   format: string | undefined;
   summary: string | undefined;
   source: string | undefined;
@@ -43,6 +46,18 @@ export interface IParsedCliArgs {
   settingsScope: string | undefined;
   checkUpdate: boolean;
   disableUpdateCheck: boolean;
+}
+
+/** Validate and return a TOutputFormat from a raw CLI string, or exit on error. */
+export function parseOutputFormat(raw: string | undefined): TOutputFormat | undefined {
+  if (raw === undefined) return undefined;
+  if (!(VALID_OUTPUT_FORMATS as readonly string[]).includes(raw)) {
+    process.stderr.write(
+      `Invalid --output-format "${raw}". Valid: ${VALID_OUTPUT_FORMATS.join(' | ')}\n`,
+    );
+    process.exit(1);
+  }
+  return raw as TOutputFormat;
 }
 
 /** Validate and return a TPermissionMode from a raw CLI string, or exit on error. */
@@ -118,7 +133,7 @@ export function parseCliArgs(): IParsedCliArgs {
     maxTurns: parseMaxTurns(values['max-turns']),
     forkSession: values['fork-session'] ?? false,
     sessionName: values['name'],
-    outputFormat: values['output-format'],
+    outputFormat: parseOutputFormat(values['output-format']),
     format: values['format'],
     summary: values['summary'],
     source: values['source'],


### PR DESCRIPTION
## Summary

- Add `parseOutputFormat()` to `cli-args.ts` (mirrors `parsePermissionMode()` pattern)
- Export `TOutputFormat` type (`'text' | 'json' | 'stream-json'`)
- Change `IParsedCliArgs.outputFormat` from `string | undefined` to `TOutputFormat | undefined`
- Remove `as` cast in `cli.ts` — now uses the validated type directly
- Invalid values (e.g. `--output-format xml`) now print an error to stderr and exit(1) instead of silently falling back to stream-json
- Add `parseOutputFormat` unit tests (valid values + invalid value exit behavior)

## Test plan

- [ ] `parseOutputFormat('xml')` → stderr error + exit(1)
- [ ] `parseOutputFormat('text' | 'json' | 'stream-json')` → returns valid type
- [ ] All agent-cli tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)