### PR TITLE
chore(cli2-003): mark as done — isInitialized guard already implemented

### DIFF
--- a/.agents/backlog/completed/CLI2-003-slash-command-uninitialized-session-throw.md
+++ b/.agents/backlog/completed/CLI2-003-slash-command-uninitialized-session-throw.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-003: 슬래시 커맨드 실행 직후 미초기화 세션에서 throw'
-status: todo
+status: done
 created: 2026-05-10
 priority: high
 urgency: soon


### PR DESCRIPTION
CLI2-003 was already resolved in feat/plg-007. The `getContextState()` call is guarded by `interactiveSession.isInitialized` check. Archive backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)