### PR TITLE
fix(dep-001): remove unused agent-server deps — express-winston, winston, bytedance

### DIFF
--- a/.agents/backlog/completed/DEP-001-unused-dependencies-agent-server.md
+++ b/.agents/backlog/completed/DEP-001-unused-dependencies-agent-server.md
@@ -1,6 +1,6 @@
 ---
 title: 'DEP-001: agent-server 미사용 의존성 — express-winston, winston, @robota-sdk/agent-provider-bytedance'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: soon


### PR DESCRIPTION
Deps were already absent from package.json. Archive backlog entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)