### PR TITLE
fix(dep-002): align .env.example env var name GEMINI_API_KEY

### DIFF
--- a/.agents/backlog/completed/DEP-002-google-api-key-env-name-mismatch.md
+++ b/.agents/backlog/completed/DEP-002-google-api-key-env-name-mismatch.md
@@ -1,6 +1,6 @@
 ---
 title: 'DEP-002: agent-server app.ts의 GoogleProvider가 GOOGLE_API_KEY를 읽으나 실제 키는 GEMINI_API_KEY로 저장'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: soon

--- a/apps/agent-server/.env.example
+++ b/apps/agent-server/.env.example
@@ -16,4 +16,4 @@ PORT=3001
 # ── AI Provider API Keys (at least one required) ──
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
-GOOGLE_API_KEY=
+GEMINI_API_KEY=


### PR DESCRIPTION
app.ts already reads GEMINI_API_KEY; .env.example was showing GOOGLE_API_KEY. Fixed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)