### PR TITLE
fix(dev-005,dev-007): validate RATE_LIMIT_MAX at startup

### DIFF
--- a/.agents/backlog/completed/DEV-005-parseint-missing-radix.md
+++ b/.agents/backlog/completed/DEV-005-parseint-missing-radix.md
@@ -1,6 +1,6 @@
 ---
 title: 'DEV-005: parseInt 기수 누락 — RATE_LIMIT_MAX 잘못된 값 시 rate limiting 비활성화'
-status: todo
+status: done
 created: 2026-05-10
 priority: high
 urgency: soon

--- a/.agents/backlog/completed/DEV-007-substr-deprecated.md
+++ b/.agents/backlog/completed/DEV-007-substr-deprecated.md
@@ -1,6 +1,6 @@
 ---
 title: 'DEV-007: websocket-server.ts의 substr deprecated — slice로 교체'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: later

--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -48,9 +48,13 @@ export function createApp(): express.Application {
   );
 
   // Rate limiting
+  const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX ?? '100', 10);
+  if (!Number.isFinite(rateLimitMax) || rateLimitMax <= 0) {
+    throw new Error(`Invalid RATE_LIMIT_MAX: "${process.env.RATE_LIMIT_MAX}"`);
+  }
   const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: parseInt(process.env.RATE_LIMIT_MAX || '100', 10),
+    max: rateLimitMax,
     message: {
       error: 'Too many requests',
       retryAfter: '15 minutes',


### PR DESCRIPTION
- DEV-005: add NaN/negative check for RATE_LIMIT_MAX; invalid value throws on startup instead of silently disabling rate limiting
- DEV-007: already fixed (substr→slice); archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)