### PR TITLE
chore: archive already-implemented backlog items

### DIFF
--- a/.agents/backlog/completed/CLI2-002-language-flag-ignored-in-tui.md
+++ b/.agents/backlog/completed/CLI2-002-language-flag-ignored-in-tui.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-002: --language 플래그가 인터랙티브 TUI 모드에서 무시됨'
-status: todo
+status: done
 created: 2026-05-10
 priority: high
 urgency: soon

--- a/.agents/backlog/completed/CLI2-004-no-session-persistence-ignored-in-tui.md
+++ b/.agents/backlog/completed/CLI2-004-no-session-persistence-ignored-in-tui.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-004: --no-session-persistence 플래그가 인터랙티브 TUI 모드에서 무시됨'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: soon

--- a/.agents/backlog/completed/CLI2-005-prompt-input-stdin-listener-leak.md
+++ b/.agents/backlog/completed/CLI2-005-prompt-input-stdin-listener-leak.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-005: promptInput Ctrl+C 경로에서 stdin 리스너 누수'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: soon

--- a/.agents/backlog/completed/CLI2-008-agent-command-mode-orphan-package.md
+++ b/.agents/backlog/completed/CLI2-008-agent-command-mode-orphan-package.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-008: agent-command-mode 패키지가 CLI에 등록되지 않은 orphan 상태'
-status: todo
+status: done
 created: 2026-05-10
 priority: medium
 urgency: soon

--- a/.agents/backlog/completed/CLI2-009-resolve-git-branch-sync-ui-blocking.md
+++ b/.agents/backlog/completed/CLI2-009-resolve-git-branch-sync-ui-blocking.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-009: SessionStatusBar의 resolveGitBranch()가 동기 execSync로 UI 차단 가능'
-status: todo
+status: done
 created: 2026-05-10
 priority: low
 urgency: later

--- a/.agents/backlog/completed/CLI2-011-slash-autocomplete-row-width-alignment.md
+++ b/.agents/backlog/completed/CLI2-011-slash-autocomplete-row-width-alignment.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-011: 슬래시 자동완성 행 전체 폭 기준 말줄임표 처리'
-status: todo
+status: superseded-by-CLI2-012
 created: 2026-05-11
 priority: medium
 urgency: normal

--- a/.agents/backlog/completed/DEV-001-as-unknown-as-isideeffects-dead-code.md
+++ b/.agents/backlog/completed/DEV-001-as-unknown-as-isideeffects-dead-code.md
@@ -1,6 +1,6 @@
 ---
 title: 'DEV-001: useSideEffects.ts의 as unknown as ISideEffects 이중 캐스팅 — 사이드 이펙트 경로 dead code'
-status: todo
+status: done
 created: 2026-05-10
 priority: high
 urgency: now


### PR DESCRIPTION
## Summary
- Archive 7 backlog items that were already implemented or superseded
- DEV-001, CLI2-002, CLI2-004, CLI2-005, CLI2-008, CLI2-009: already implemented in previous sessions
- CLI2-011: superseded by CLI2-012 (uses Ink `wrap="truncate-end"` instead of manual truncation)

## Test plan
- [ ] No code changes — backlog file movements only
- [ ] `pnpm harness:scan` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)