### PR TITLE
feat(cli2-001): add --help / -h flag to robota CLI

### DIFF
--- a/.agents/backlog/completed/CLI2-001-help-flag-missing.md
+++ b/.agents/backlog/completed/CLI2-001-help-flag-missing.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI2-001: --help 플래그 미구현 — 첫 탐색 경험 차단'
-status: todo
+status: done
 created: 2026-05-10
 priority: critical
 urgency: now
@@ -81,8 +81,8 @@ robota --help
 
 **증거 필드** (구현 후 기입):
 
-- 명령 출력: \_
-- exit code: \_
+- 명령 출력: `node packages/agent-cli/dist/node/bin.js --help` — Usage 헤더 + 전체 플래그 목록(`-p`, `--output-format`, `--help`, `--version` 포함) + Examples 출력
+- exit code: 0
 
 ### 시나리오 2: -h 단축 플래그 동작 확인
 
@@ -96,4 +96,4 @@ robota -h
 
 **증거 필드** (구현 후 기입):
 
-- 명령 출력: \_
+- 명령 출력: `node packages/agent-cli/dist/node/bin.js -h` — --help와 동일한 출력 확인

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -41,7 +41,7 @@ import type {
   ICommandModule,
   TProviderSettingsDocument,
 } from '@robota-sdk/agent-sdk';
-import { parseCliArgs } from './utils/cli-args.js';
+import { parseCliArgs, printHelp } from './utils/cli-args.js';
 import type { IParsedCliArgs } from './utils/cli-args.js';
 import {
   getUserSettingsPath,
@@ -351,6 +351,11 @@ async function runPrintMode(
 export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const args = parseCliArgs();
   const version = readVersion();
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
 
   if (args.version) {
     process.stdout.write(`robota ${version}\n`);

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -4,6 +4,7 @@ import {
   parseMaxTurns,
   parseOutputFormat,
   parseCliArgs,
+  printHelp,
 } from '../cli-args.js';
 
 describe('parsePermissionMode', () => {
@@ -235,5 +236,43 @@ describe('new non-interactive flags', () => {
   it('defaults jsonSchema to undefined', () => {
     process.argv = ['node', 'cli'];
     expect(parseCliArgs().jsonSchema).toBeUndefined();
+  });
+});
+
+describe('help flag', () => {
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    originalArgv = process.argv;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it('parses --help flag', () => {
+    process.argv = ['node', 'cli', '--help'];
+    expect(parseCliArgs().help).toBe(true);
+  });
+
+  it('parses -h short flag', () => {
+    process.argv = ['node', 'cli', '-h'];
+    expect(parseCliArgs().help).toBe(true);
+  });
+
+  it('defaults help to false', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().help).toBe(false);
+  });
+
+  it('printHelp writes to stdout', () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    printHelp();
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(output).toContain('--help');
+    expect(output).toContain('--version');
+    expect(output).toContain('-p');
+    stdoutSpy.mockRestore();
   });
 });

--- a/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/provider-setup.test.ts
@@ -115,6 +115,7 @@ const providerDefinitions: readonly IProviderDefinition[] = [
 function baseArgs(): IParsedCliArgs {
   return {
     positional: [],
+    help: false,
     printMode: false,
     continueMode: false,
     resumeId: undefined,

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -13,6 +13,7 @@ export type TOutputFormat = (typeof VALID_OUTPUT_FORMATS)[number];
 
 export interface IParsedCliArgs {
   positional: string[];
+  help: boolean;
   printMode: boolean;
   continueMode: boolean;
   resumeId: string | undefined;
@@ -46,6 +47,39 @@ export interface IParsedCliArgs {
   settingsScope: string | undefined;
   checkUpdate: boolean;
   disableUpdateCheck: boolean;
+}
+
+/** Print CLI usage help to stdout. */
+export function printHelp(): void {
+  process.stdout.write(`
+Usage: robota [options] [-p <prompt>]
+
+Options:
+  -p <prompt>                Run in print (headless) mode with the given prompt
+  --output-format <format>   Output format: text | json | stream-json (default: text)
+  --system-prompt <text>     Override the system prompt for this session
+  --append-system-prompt <t> Append text to the system prompt
+  --language <lang>          Language preference (e.g. ko, en)
+  --no-session-persistence   Disable session persistence for this run
+  --model <model>            Override model for this session
+  --permission-mode <mode>   Permission mode: plan | default | acceptEdits | bypassPermissions
+  --max-turns <n>            Maximum agent turns before stopping
+  -c, --continue             Continue the most recent session
+  -r, --resume <id>          Resume a session by ID or name
+  -n, --name <name>          Name for the new session
+  --fork-session             Fork the current session
+  --configure                Run interactive provider configuration
+  --configure-provider <n>   Configure a specific provider
+  --check-update             Check for CLI updates
+  --version                  Show version number
+  -h, --help                 Show this help message
+
+Examples:
+  robota                           Start interactive TUI session
+  robota -p "Hello"                Print mode: send prompt and exit
+  robota -p "Hello" --output-format json
+  robota --continue                Resume the last session
+`);
 }
 
 /** Validate and return a TOutputFormat from a raw CLI string, or exit on error. */
@@ -86,6 +120,7 @@ export function parseCliArgs(): IParsedCliArgs {
   const { values, positionals } = parseArgs({
     allowPositionals: true,
     options: {
+      help: { type: 'boolean', short: 'h', default: false },
       p: { type: 'boolean', short: 'p', default: false },
       continue: { type: 'boolean', short: 'c', default: false },
       resume: { type: 'string', short: 'r' },
@@ -124,6 +159,7 @@ export function parseCliArgs(): IParsedCliArgs {
 
   return {
     positional: positionals,
+    help: values['help'] ?? false,
     printMode: values['p'] ?? false,
     continueMode: values['continue'] ?? false,
     resumeId: values['resume'],


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` flag that prints full usage information and exits with code 0
- Fixes the first-time user exploration issue where `robota --help` showed a Node.js error
- Includes all major flags in the help output with examples

## Test plan
- [x] `node dist/node/bin.js --help` — prints usage + exits 0
- [x] `node dist/node/bin.js -h` — same output
- [x] Unit tests: `parseCliArgs().help` parses correctly, `printHelp()` writes to stdout
- [x] 145 existing tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)