### PR TITLE
fix(prov-002): use provider type as profile name base, not model ID

### DIFF
--- a/packages/agent-sdk/src/command-api/__tests__/command-api.test.ts
+++ b/packages/agent-sdk/src/command-api/__tests__/command-api.test.ts
@@ -209,16 +209,18 @@ describe('command-api contracts', () => {
     expect(() => validateProviderProfile('openai-main', profile)).not.toThrow();
   });
 
-  it('suggests provider profile names from models and disambiguates duplicates', () => {
-    expect(suggestProviderProfileName({ type: 'anthropic', model: 'Claude Sonnet 4.6' })).toBe(
-      'claude-sonnet-4-6',
-    );
+  it('suggests provider profile names from type and disambiguates duplicates', () => {
+    expect(suggestProviderProfileName({ type: 'anthropic' })).toBe('anthropic');
+    expect(suggestProviderProfileName({ type: 'openai' })).toBe('openai');
+    expect(
+      suggestProviderProfileName({ type: 'anthropic' }, { existingProfileNames: ['anthropic'] }),
+    ).toBe('anthropic-2');
     expect(
       suggestProviderProfileName(
-        { type: 'anthropic', model: 'claude-sonnet-4-6' },
-        { existingProfileNames: ['claude-sonnet-4-6', 'claude-sonnet-4-6-2'] },
+        { type: 'anthropic' },
+        { existingProfileNames: ['anthropic', 'anthropic-2'] },
       ),
-    ).toBe('claude-sonnet-4-6-3');
+    ).toBe('anthropic-3');
   });
 
   it('exposes auto compact common APIs without command implementation imports', () => {

--- a/packages/agent-sdk/src/command-api/provider/provider-profile-names.ts
+++ b/packages/agent-sdk/src/command-api/provider/provider-profile-names.ts
@@ -3,7 +3,6 @@ const FIRST_DUPLICATE_SUFFIX = 2;
 
 export interface IProviderProfileNameSuggestionInput {
   type: string;
-  model?: string;
 }
 
 export interface IProviderProfileNameSuggestionOptions {
@@ -14,10 +13,7 @@ export function suggestProviderProfileName(
   input: IProviderProfileNameSuggestionInput,
   options: IProviderProfileNameSuggestionOptions = {},
 ): string {
-  const baseName =
-    sanitizeProviderProfileName(input.model) ??
-    sanitizeProviderProfileName(input.type) ??
-    FALLBACK_PROFILE_NAME;
+  const baseName = sanitizeProviderProfileName(input.type) ?? FALLBACK_PROFILE_NAME;
   const existing = new Set(options.existingProfileNames ?? []);
   if (!existing.has(baseName)) {
     return baseName;

--- a/packages/agent-sdk/src/command-api/provider/provider-setup-flow.ts
+++ b/packages/agent-sdk/src/command-api/provider/provider-setup-flow.ts
@@ -294,7 +294,7 @@ function buildProviderSetupInput(state: IProviderSetupFlowState): IProviderSetup
   const profile =
     state.profileName ??
     suggestProviderProfileName(
-      { type: state.type, model: state.values.model },
+      { type: state.type },
       { existingProfileNames: state.existingProfileNames },
     );
   const apiKey = state.values.apiKey;


### PR DESCRIPTION
## Summary

- `suggestProviderProfileName` now uses `input.type` (e.g. `anthropic`, `openai`) as the profile name base instead of `input.model`
- Duplicate profiles get a numeric suffix: `anthropic`, `anthropic-2`, `anthropic-3`
- Removes `model` field from `IProviderProfileNameSuggestionInput` — it was the only consumer and is no longer needed

## Why

Using model ID as profile name caused `claude-sonnet-4-6-2` to appear in the status bar, which users mistook for a real model revision. Profile name identifies which API key/account is in use, not which model — the model is a changeable setting inside the profile.

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-sdk test` — 734 tests pass
- [x] `pnpm --filter @robota-sdk/agent-sdk typecheck` — clean

Closes PROV-002

🤖 Generated with [Claude Code](https://claude.com/claude-code)