### PR TITLE
fix(cli2-014): show model ID in status bar instead of human-readable name

### DIFF
--- a/packages/agent-transport-tui/src/SessionStatusBar.tsx
+++ b/packages/agent-transport-tui/src/SessionStatusBar.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
-import { getModelName } from '@robota-sdk/agent-core';
 import type { IStatusLineCommandSettings } from '@robota-sdk/agent-sdk';
 import { useTuiCliAdapter } from './tui-cli-adapter-context.js';
 import StatusBar from './StatusBar.js';
@@ -43,7 +42,7 @@ export default function SessionStatusBar({
   return (
     <StatusBar
       permissionMode={permissionMode}
-      modelName={modelId ? getModelName(modelId) : ''}
+      modelName={modelId ?? ''}
       providerProfileName={providerProfileName}
       providerType={providerType}
       sessionId={sessionId}


### PR DESCRIPTION
## Summary

- Remove `getModelName()` conversion in `SessionStatusBar` — raw model ID passed directly to `StatusBar`
- Model names are unreliable for unknown/future models and add redundant info when profile name already identifies the provider

## Before / After

```
Before: anthropic (anthropic) Claude Sonnet 4.6
After:  anthropic (anthropic) claude-sonnet-4-6
```

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-transport-tui typecheck` — clean
- [x] `pnpm --filter @robota-sdk/agent-transport-tui test` — 321 tests pass

Closes CLI2-014

🤖 Generated with [Claude Code](https://claude.com/claude-code)