### PR TITLE
feat(arch-fix-023): move env-ref utilities from agent-sdk to agent-core

### DIFF
--- a/packages/agent-cli/src/utils/env-ref.ts
+++ b/packages/agent-cli/src/utils/env-ref.ts
@@ -3,4 +3,4 @@ export {
   hasUsableSecretReference,
   isEnvReference,
   resolveEnvReference,
-} from '@robota-sdk/agent-sdk';
+} from '@robota-sdk/agent-core';

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -199,6 +199,19 @@ NOTE: `ToolRegistry`, `FunctionTool`, `createFunctionTool`, `createZodFunctionTo
 | `IPermissionLists`      | type     | Allow/deny pattern lists                                                   |
 | `TKnownToolName`        | type     | Known tool names: Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch |
 
+### Environment Reference Utilities
+
+Zero-dependency utilities for the `$ENV:<name>` environment variable reference format. This is the
+canonical location for env-ref logic; all higher layers import from here.
+
+| Export                     | Kind     | Description                                                               |
+| -------------------------- | -------- | ------------------------------------------------------------------------- |
+| `ENV_REFERENCE_PREFIX`     | const    | `'$ENV:'` — the canonical prefix for environment variable references      |
+| `isEnvReference`           | function | Return true when a string starts with `$ENV:`                             |
+| `formatEnvReference`       | function | Return the `$ENV:<name>` formatted string for the given variable name     |
+| `resolveEnvReference`      | function | Resolve `$ENV:<name>` → `process.env[name]`; return value or `undefined`  |
+| `hasUsableSecretReference` | function | Return true when the value is a non-empty string that resolves to a value |
+
 ### Hooks
 
 | Export              | Kind      | Description                                                                                                                      |

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -121,6 +121,15 @@ export type {
   IRemoteExecutorConfig,
 } from './interfaces/executor';
 
+// Environment reference utilities
+export {
+  ENV_REFERENCE_PREFIX,
+  isEnvReference,
+  formatEnvReference,
+  resolveEnvReference,
+  hasUsableSecretReference,
+} from './utils/env-ref.js';
+
 // Logger
 export { logger, SilentLogger, createLogger, type ILogger } from './utils/logger';
 

--- a/packages/agent-core/src/utils/env-ref.test.ts
+++ b/packages/agent-core/src/utils/env-ref.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  ENV_REFERENCE_PREFIX,
+  isEnvReference,
+  formatEnvReference,
+  resolveEnvReference,
+  hasUsableSecretReference,
+} from './env-ref.js';
+
+describe('env-ref utilities', () => {
+  describe('ENV_REFERENCE_PREFIX', () => {
+    it('is $ENV:', () => {
+      expect(ENV_REFERENCE_PREFIX).toBe('$ENV:');
+    });
+  });
+
+  describe('isEnvReference', () => {
+    it('returns true for $ENV: prefixed strings', () => {
+      expect(isEnvReference('$ENV:MY_KEY')).toBe(true);
+    });
+
+    it('returns false for plain strings', () => {
+      expect(isEnvReference('plain-api-key')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isEnvReference('')).toBe(false);
+    });
+
+    it('returns false for partial prefix', () => {
+      expect(isEnvReference('$ENV')).toBe(false);
+    });
+  });
+
+  describe('formatEnvReference', () => {
+    it('formats a name as $ENV:<name>', () => {
+      expect(formatEnvReference('MY_KEY')).toBe('$ENV:MY_KEY');
+    });
+
+    it('formats empty name', () => {
+      expect(formatEnvReference('')).toBe('$ENV:');
+    });
+  });
+
+  describe('resolveEnvReference', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('returns the env value when set', () => {
+      process.env['TEST_API_KEY'] = 'sk-test-value';
+      expect(resolveEnvReference('$ENV:TEST_API_KEY')).toBe('sk-test-value');
+    });
+
+    it('returns undefined when env var is not set', () => {
+      delete process.env['MISSING_KEY'];
+      expect(resolveEnvReference('$ENV:MISSING_KEY')).toBeUndefined();
+    });
+
+    it('returns the value as-is when not an env reference', () => {
+      expect(resolveEnvReference('plain-api-key')).toBe('plain-api-key');
+    });
+
+    it('returns undefined for $ENV: with empty name', () => {
+      expect(resolveEnvReference('$ENV:')).toBeUndefined();
+    });
+
+    it('trims whitespace from the env var name', () => {
+      process.env['SPACED_KEY'] = 'spaced-value';
+      expect(resolveEnvReference('$ENV:  SPACED_KEY  ')).toBe('spaced-value');
+    });
+  });
+
+  describe('hasUsableSecretReference', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('returns true for a plain non-empty string', () => {
+      expect(hasUsableSecretReference('plain-api-key')).toBe(true);
+    });
+
+    it('returns true when env reference resolves to a value', () => {
+      process.env['MY_KEY'] = 'resolved-value';
+      expect(hasUsableSecretReference('$ENV:MY_KEY')).toBe(true);
+    });
+
+    it('returns false for undefined', () => {
+      expect(hasUsableSecretReference(undefined)).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(hasUsableSecretReference('')).toBe(false);
+    });
+
+    it('returns false when env reference does not resolve', () => {
+      delete process.env['MISSING_KEY'];
+      expect(hasUsableSecretReference('$ENV:MISSING_KEY')).toBe(false);
+    });
+  });
+});

--- a/packages/agent-core/src/utils/env-ref.ts
+++ b/packages/agent-core/src/utils/env-ref.ts
@@ -1,4 +1,4 @@
-const ENV_REFERENCE_PREFIX = '$ENV:';
+export const ENV_REFERENCE_PREFIX = '$ENV:';
 
 export function isEnvReference(value: string): boolean {
   return value.startsWith(ENV_REFERENCE_PREFIX);

--- a/packages/agent-sdk/src/command-api/index.ts
+++ b/packages/agent-sdk/src/command-api/index.ts
@@ -103,7 +103,7 @@ export {
   hasUsableSecretReference,
   isEnvReference,
   resolveEnvReference,
-} from './provider/provider-env-ref.js';
+} from '@robota-sdk/agent-core';
 export {
   probeProviderProfile,
   testProviderProfileCommand,

--- a/packages/agent-sdk/src/command-api/model/model-command-api.ts
+++ b/packages/agent-sdk/src/command-api/model/model-command-api.ts
@@ -9,7 +9,7 @@ import {
 } from '@robota-sdk/agent-core';
 import type { ICommand } from '../types.js';
 import type { TProviderSettingsDocument } from '../provider/provider-settings.js';
-import { resolveEnvReference } from '../provider/provider-env-ref.js';
+import { resolveEnvReference } from '@robota-sdk/agent-core';
 
 export const MODEL_COMMAND_DESCRIPTION = 'Change AI model';
 export const MODEL_COMMAND_ARGUMENT_HINT = '<model-id>';

--- a/packages/agent-sdk/src/command-api/provider/provider-settings.ts
+++ b/packages/agent-sdk/src/command-api/provider/provider-settings.ts
@@ -6,7 +6,7 @@ import type {
   TUniversalValue,
 } from '@robota-sdk/agent-core';
 import { findProviderDefinition, getProviderCredentialRequirement } from '@robota-sdk/agent-core';
-import { formatEnvReference, hasUsableSecretReference } from './provider-env-ref.js';
+import { formatEnvReference, hasUsableSecretReference } from '@robota-sdk/agent-core';
 
 export interface IProviderProfileSettings extends IProviderProfileConfig {
   [key: string]: TUniversalValue;

--- a/packages/agent-sdk/src/commands/index.ts
+++ b/packages/agent-sdk/src/commands/index.ts
@@ -114,7 +114,7 @@ export {
   hasUsableSecretReference,
   isEnvReference,
   resolveEnvReference,
-} from '../command-api/provider/provider-env-ref.js';
+} from '@robota-sdk/agent-core';
 export {
   formatCommandHelpMessage,
   HELP_COMMAND_DESCRIPTION,


### PR DESCRIPTION
## Summary

- Moves zero-dependency env-ref utilities (`isEnvReference`, `formatEnvReference`, `resolveEnvReference`, `hasUsableSecretReference`, `ENV_REFERENCE_PREFIX`) from `agent-sdk/src/command-api/provider/provider-env-ref.ts` into `agent-core/src/utils/env-ref.ts`
- These functions have no external dependencies — `agent-core` is their correct home per the layer hierarchy
- All consumers in `agent-sdk` and `agent-cli` updated to import from `@robota-sdk/agent-core`
- `provider-env-ref.ts` deleted (no backward-compat shim per project policy)
- 17 unit tests added in `agent-core`

## Resolves

ARCH-FIX-023: env-ref utilities to agent-core

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-core test` — 45 files, 695 tests pass
- [x] `pnpm build` — agent-core, agent-sdk, agent-cli all build clean
- [x] `pnpm typecheck` — no errors
- [x] `pnpm lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)