### PR TITLE
feat(ctx-001): hash-based staleness detection for AGENTS.md/CLAUDE.md context files

### DIFF
--- a/packages/agent-sdk/src/__tests__/hook-wiring.test.ts
+++ b/packages/agent-sdk/src/__tests__/hook-wiring.test.ts
@@ -322,7 +322,7 @@ describe('Hook wiring via createSession', () => {
     expect(sessionStartCalls[0].config).toBe(SAMPLE_HOOKS);
 
     // Verify session was created successfully
-    expect(session.getSessionId()).toBeDefined();
+    expect(session.session.getSessionId()).toBeDefined();
   });
 
   it('should wire SDK hook executors (prompt, agent) when factories provided', async () => {

--- a/packages/agent-sdk/src/assembly/create-session.ts
+++ b/packages/agent-sdk/src/assembly/create-session.ts
@@ -183,13 +183,23 @@ export interface ICreateSessionOptions {
   sandboxClient?: ISandboxClient;
 }
 
+/** Result of createSession — session instance plus a system-message rebuilder for context refresh. */
+export interface ICreateSessionResult {
+  session: Session;
+  /**
+   * Rebuild the system message using updated context strings.
+   * Called by staleness detection when AGENTS.md or CLAUDE.md files change between turns.
+   */
+  rebuildSystemMessage: (agentsMd: string, claudeMd: string) => string;
+}
+
 /**
  * Create a fully-configured Session instance.
  *
  * Assembles provider, tools, and system prompt, then passes them
  * to Session as pre-constructed dependencies.
  */
-export function createSession(options: ICreateSessionOptions): Session {
+export function createSession(options: ICreateSessionOptions): ICreateSessionResult {
   if (!options.provider) {
     throw new Error(
       'provider is required. SDK is provider-neutral — consumer must create and pass a provider instance.',
@@ -356,19 +366,20 @@ export function createSession(options: ICreateSessionOptions): Session {
         )
       : []),
   ];
-  const systemMessage = buildPrompt({
+  const resolvedToolDescriptions =
+    options.toolDescriptions ??
+    (backgroundProcessToolDeps
+      ? [
+          ...defaultToolDescriptions,
+          'BackgroundProcess — start long-running shell commands as managed background tasks',
+        ]
+      : defaultToolDescriptions);
+  const staticPromptParams: ISystemPromptParams = {
     agentsMd: options.context.agentsMd,
     claudeMd: options.context.claudeMd,
     memoryMd: options.context.memoryMd,
     taskContext: options.context.taskContext,
-    toolDescriptions:
-      options.toolDescriptions ??
-      (backgroundProcessToolDeps
-        ? [
-            ...defaultToolDescriptions,
-            'BackgroundProcess — start long-running shell commands as managed background tasks',
-          ]
-        : defaultToolDescriptions),
+    toolDescriptions: resolvedToolDescriptions,
     trustLevel: options.config.defaultTrustLevel,
     projectInfo: options.projectInfo ?? { type: 'unknown', language: 'unknown' },
     cwd,
@@ -387,10 +398,20 @@ export function createSession(options: ICreateSessionOptions): Session {
         }
       : {}),
     commandDescriptors: options.commandDescriptors ?? [],
-  });
+  };
+  const systemMessage = buildPrompt(staticPromptParams);
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`
     : systemMessage;
+
+  const rebuildSystemMessage = (newAgentsMd: string, newClaudeMd: string): string => {
+    const rebuilt = buildPrompt({
+      ...staticPromptParams,
+      agentsMd: newAgentsMd,
+      claudeMd: newClaudeMd,
+    });
+    return options.appendSystemPrompt ? `${rebuilt}\n\n${options.appendSystemPrompt}` : rebuilt;
+  };
 
   // Merge default allow patterns for config folders with user-configured permissions
   const defaultAllow = [
@@ -442,7 +463,7 @@ export function createSession(options: ICreateSessionOptions): Session {
   if (backgroundTaskManager) storeSessionBackgroundTaskManager(session, backgroundTaskManager);
   if (agentToolDeps) storeAgentToolDeps(session, agentToolDeps);
 
-  return session;
+  return { session, rebuildSystemMessage };
 }
 
 function createSessionId(): string {

--- a/packages/agent-sdk/src/assembly/index.ts
+++ b/packages/agent-sdk/src/assembly/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { createSession } from './create-session.js';
-export type { ICreateSessionOptions } from './create-session.js';
+export type { ICreateSessionOptions, ICreateSessionResult } from './create-session.js';
 export { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
 export {
   getSubagentSuffix,

--- a/packages/agent-sdk/src/context/__tests__/context-file-tracker.test.ts
+++ b/packages/agent-sdk/src/context/__tests__/context-file-tracker.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  computeContentHash,
+  loadFileWithHash,
+  checkContextStaleness,
+  refreshContextEntries,
+} from '../context-file-tracker.js';
+import type { IContextFileEntry } from '../context-file-tracker.js';
+
+const testDir = join(tmpdir(), `ctx-file-tracker-test-${Date.now()}`);
+
+beforeEach(() => {
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('computeContentHash', () => {
+  it('returns a non-empty hex string', () => {
+    const hash = computeContentHash('hello world');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns the same hash for identical content', () => {
+    const a = computeContentHash('same content');
+    const b = computeContentHash('same content');
+    expect(a).toBe(b);
+  });
+
+  it('returns different hashes for different content', () => {
+    const a = computeContentHash('content A');
+    const b = computeContentHash('content B');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns consistent hash for empty string', () => {
+    const hash = computeContentHash('');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('loadFileWithHash', () => {
+  it('returns an entry with filePath, content, and contentHash', () => {
+    const filePath = join(testDir, 'test.md');
+    const content = '# Test\n\nHello world.';
+    writeFileSync(filePath, content, 'utf-8');
+
+    const entry = loadFileWithHash(filePath);
+    expect(entry.filePath).toBe(filePath);
+    expect(entry.content).toBe(content);
+    expect(entry.contentHash).toBe(computeContentHash(content));
+  });
+
+  it('hash matches content hash', () => {
+    const filePath = join(testDir, 'agents.md');
+    const content = '# AGENTS.md\n\nSome instructions.';
+    writeFileSync(filePath, content, 'utf-8');
+
+    const entry = loadFileWithHash(filePath);
+    expect(entry.contentHash).toBe(computeContentHash(entry.content));
+  });
+});
+
+describe('checkContextStaleness', () => {
+  it('returns empty arrays when all files are fresh', async () => {
+    const filePath = join(testDir, 'fresh.md');
+    const content = 'fresh content';
+    writeFileSync(filePath, content, 'utf-8');
+    const entry: IContextFileEntry = {
+      filePath,
+      content,
+      contentHash: computeContentHash(content),
+    };
+
+    const { stale, fresh } = await checkContextStaleness([entry]);
+    expect(stale).toHaveLength(0);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].filePath).toBe(filePath);
+  });
+
+  it('returns stale entry when file has changed on disk', async () => {
+    const filePath = join(testDir, 'stale.md');
+    const originalContent = 'original content';
+    writeFileSync(filePath, originalContent, 'utf-8');
+    const entry: IContextFileEntry = {
+      filePath,
+      content: originalContent,
+      contentHash: computeContentHash(originalContent),
+    };
+
+    // Modify the file on disk after we loaded it
+    writeFileSync(filePath, 'modified content', 'utf-8');
+
+    const { stale, fresh } = await checkContextStaleness([entry]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].filePath).toBe(filePath);
+    expect(fresh).toHaveLength(0);
+  });
+
+  it('marks file as fresh when file does not exist on disk', async () => {
+    const filePath = join(testDir, 'nonexistent.md');
+    const entry: IContextFileEntry = {
+      filePath,
+      content: 'some content',
+      contentHash: computeContentHash('some content'),
+    };
+
+    const { stale, fresh } = await checkContextStaleness([entry]);
+    // File not found on disk — treated as fresh (can't confirm it changed)
+    expect(stale).toHaveLength(0);
+    expect(fresh).toHaveLength(1);
+  });
+
+  it('handles multiple entries correctly', async () => {
+    const freshPath = join(testDir, 'fresh.md');
+    const stalePath = join(testDir, 'stale.md');
+    const freshContent = 'fresh';
+    const originalContent = 'original';
+
+    writeFileSync(freshPath, freshContent, 'utf-8');
+    writeFileSync(stalePath, originalContent, 'utf-8');
+
+    const entries: IContextFileEntry[] = [
+      { filePath: freshPath, content: freshContent, contentHash: computeContentHash(freshContent) },
+      {
+        filePath: stalePath,
+        content: originalContent,
+        contentHash: computeContentHash(originalContent),
+      },
+    ];
+
+    writeFileSync(stalePath, 'changed content', 'utf-8');
+
+    const { stale, fresh } = await checkContextStaleness(entries);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].filePath).toBe(stalePath);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0].filePath).toBe(freshPath);
+  });
+
+  it('returns empty arrays for empty input', async () => {
+    const { stale, fresh } = await checkContextStaleness([]);
+    expect(stale).toHaveLength(0);
+    expect(fresh).toHaveLength(0);
+  });
+});
+
+describe('refreshContextEntries', () => {
+  it('returns updated entries for stale files', async () => {
+    const filePath = join(testDir, 'refresh.md');
+    const originalContent = 'original';
+    const updatedContent = 'updated on disk';
+    writeFileSync(filePath, originalContent, 'utf-8');
+
+    const entry: IContextFileEntry = {
+      filePath,
+      content: originalContent,
+      contentHash: computeContentHash(originalContent),
+    };
+
+    writeFileSync(filePath, updatedContent, 'utf-8');
+
+    const { updated, refreshed } = await refreshContextEntries([entry]);
+    expect(refreshed).toContain(filePath);
+    const refreshedEntry = updated.find((e) => e.filePath === filePath);
+    expect(refreshedEntry?.content).toBe(updatedContent);
+    expect(refreshedEntry?.contentHash).toBe(computeContentHash(updatedContent));
+  });
+
+  it('keeps fresh entries unchanged', async () => {
+    const filePath = join(testDir, 'still-fresh.md');
+    const content = 'unchanged content';
+    writeFileSync(filePath, content, 'utf-8');
+
+    const entry: IContextFileEntry = {
+      filePath,
+      content,
+      contentHash: computeContentHash(content),
+    };
+
+    const { updated, refreshed } = await refreshContextEntries([entry]);
+    expect(refreshed).toHaveLength(0);
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toEqual(entry);
+  });
+
+  it('handles mix of stale and fresh entries', async () => {
+    const freshPath = join(testDir, 'keep.md');
+    const stalePath = join(testDir, 'update.md');
+    writeFileSync(freshPath, 'keep', 'utf-8');
+    writeFileSync(stalePath, 'old', 'utf-8');
+
+    const entries: IContextFileEntry[] = [
+      { filePath: freshPath, content: 'keep', contentHash: computeContentHash('keep') },
+      { filePath: stalePath, content: 'old', contentHash: computeContentHash('old') },
+    ];
+
+    writeFileSync(stalePath, 'new', 'utf-8');
+
+    const { updated, refreshed } = await refreshContextEntries(entries);
+    expect(refreshed).toEqual([stalePath]);
+    expect(updated.find((e) => e.filePath === freshPath)?.content).toBe('keep');
+    expect(updated.find((e) => e.filePath === stalePath)?.content).toBe('new');
+  });
+});

--- a/packages/agent-sdk/src/context/context-file-tracker.ts
+++ b/packages/agent-sdk/src/context/context-file-tracker.ts
@@ -1,0 +1,89 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+
+/** A single context file entry tracked with its content hash. */
+export interface IContextFileEntry {
+  /** Absolute path to the file. */
+  filePath: string;
+  /** Content as read at load time. */
+  content: string;
+  /** SHA-256 hex digest of `content`. */
+  contentHash: string;
+}
+
+/** Compute a SHA-256 hex digest of the given string content. */
+export function computeContentHash(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+/** Read a file from disk and return an entry with its content hash. */
+export function loadFileWithHash(filePath: string): IContextFileEntry {
+  const content = readFileSync(filePath, 'utf-8');
+  return { filePath, content, contentHash: computeContentHash(content) };
+}
+
+/** Result of a staleness check. */
+export interface IContextStalenessCheckResult {
+  stale: IContextFileEntry[];
+  fresh: IContextFileEntry[];
+}
+
+/**
+ * Compare stored content hashes against what is currently on disk.
+ * Files that no longer exist on disk are treated as fresh (not changed).
+ */
+export async function checkContextStaleness(
+  entries: readonly IContextFileEntry[],
+): Promise<IContextStalenessCheckResult> {
+  const stale: IContextFileEntry[] = [];
+  const fresh: IContextFileEntry[] = [];
+
+  for (const entry of entries) {
+    if (!existsSync(entry.filePath)) {
+      fresh.push(entry);
+      continue;
+    }
+    const diskContent = readFileSync(entry.filePath, 'utf-8');
+    const diskHash = computeContentHash(diskContent);
+    if (diskHash !== entry.contentHash) {
+      stale.push(entry);
+    } else {
+      fresh.push(entry);
+    }
+  }
+
+  return { stale, fresh };
+}
+
+/** Result of refreshing stale context entries. */
+export interface IContextRefreshResult {
+  /** All entries, with stale ones replaced by their re-read versions. */
+  updated: IContextFileEntry[];
+  /** File paths that were refreshed (had stale content). */
+  refreshed: string[];
+}
+
+/**
+ * Re-read any stale files from disk and return updated entries.
+ * Fresh entries are returned unchanged.
+ */
+export async function refreshContextEntries(
+  entries: readonly IContextFileEntry[],
+): Promise<IContextRefreshResult> {
+  const { stale } = await checkContextStaleness(entries);
+  const staleSet = new Set(stale.map((e) => e.filePath));
+  const refreshed: string[] = [];
+
+  const updated = entries.map((entry) => {
+    if (!staleSet.has(entry.filePath)) return entry;
+    const diskContent = readFileSync(entry.filePath, 'utf-8');
+    refreshed.push(entry.filePath);
+    return {
+      filePath: entry.filePath,
+      content: diskContent,
+      contentHash: computeContentHash(diskContent),
+    };
+  });
+
+  return { updated, refreshed };
+}

--- a/packages/agent-sdk/src/context/context-loader.ts
+++ b/packages/agent-sdk/src/context/context-loader.ts
@@ -3,10 +3,14 @@
  * AGENTS.md and CLAUDE.md files, then concatenates them root-first
  * so that more-specific (closer) instructions appear last.
  */
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { ProjectMemoryStore } from '../memory/project-memory-store.js';
 import { loadTaskContext } from './task-context.js';
+import { loadFileWithHash } from './context-file-tracker.js';
+import type { IContextFileEntry } from './context-file-tracker.js';
+
+export type { IContextFileEntry };
 
 export interface ILoadedContext {
   /** Concatenated content of all AGENTS.md files found (root-first) */
@@ -19,6 +23,10 @@ export interface ILoadedContext {
   taskContext?: string;
   /** Extracted "Compact Instructions" section from CLAUDE.md, if present */
   compactInstructions?: string;
+  /** Per-file entries for all AGENTS.md files, root-first. Present for staleness detection. */
+  agentsFileEntries?: IContextFileEntry[];
+  /** Per-file entries for all CLAUDE.md files, root-first. Present for staleness detection. */
+  claudeFileEntries?: IContextFileEntry[];
 }
 
 const AGENTS_FILENAME = 'AGENTS.md';
@@ -93,9 +101,11 @@ export async function loadContext(cwd: string): Promise<ILoadedContext> {
   const agentsPaths = collectFilesWalkingUp(cwd, AGENTS_FILENAME);
   const claudePaths = collectFilesWalkingUp(cwd, CLAUDE_FILENAME);
 
-  const agentsMd = agentsPaths.map((p) => readFileSync(p, 'utf-8')).join('\n\n');
+  const agentsEntries = agentsPaths.map((p) => loadFileWithHash(p));
+  const claudeEntries = claudePaths.map((p) => loadFileWithHash(p));
 
-  const claudeMd = claudePaths.map((p) => readFileSync(p, 'utf-8')).join('\n\n');
+  const agentsMd = agentsEntries.map((e) => e.content).join('\n\n');
+  const claudeMd = claudeEntries.map((e) => e.content).join('\n\n');
 
   const compactInstructions = extractCompactInstructions(claudeMd);
   const startupMemory = new ProjectMemoryStore(cwd).loadStartupMemory();
@@ -103,5 +113,13 @@ export async function loadContext(cwd: string): Promise<ILoadedContext> {
   const loadedTaskContext = loadTaskContext(cwd);
   const taskContext = loadedTaskContext.trim().length > 0 ? loadedTaskContext : undefined;
 
-  return { agentsMd, claudeMd, memoryMd, taskContext, compactInstructions };
+  return {
+    agentsMd,
+    claudeMd,
+    memoryMd,
+    taskContext,
+    compactInstructions,
+    agentsFileEntries: agentsEntries,
+    claudeFileEntries: claudeEntries,
+  };
 }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -25,6 +25,7 @@ export type {
   TInteractivePermissionHandler,
   TInteractiveEventName,
   IInteractiveSessionEvents,
+  IContextFileRefreshedEvent,
   ITransportAdapter,
   IConfigurableTransport,
   ITransportConfig,

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-bare.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-bare.test.ts
@@ -194,7 +194,7 @@ describe('createInteractiveSession — bare mode', () => {
 
     // Should return a valid session object with getSessionId
     expect(session).toBeDefined();
-    expect(typeof session.getSessionId).toBe('function');
+    expect(typeof session.session.getSessionId).toBe('function');
   });
 
   it('bare=true: loadConfig IS still called (config loading is not skipped)', async () => {

--- a/packages/agent-sdk/src/interactive/index.ts
+++ b/packages/agent-sdk/src/interactive/index.ts
@@ -25,6 +25,7 @@ export type {
   TInteractivePermissionHandler,
   TInteractiveEventName,
   IInteractiveSessionEvents,
+  IContextFileRefreshedEvent,
 } from './types.js';
 export type {
   ITransportAdapter,

--- a/packages/agent-sdk/src/interactive/interactive-session-init.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-init.ts
@@ -7,6 +7,7 @@
 
 import { createSession } from '../assembly/index.js';
 import type { ICreateSessionOptions } from '../assembly/index.js';
+import type { IContextFileEntry } from '../context/context-loader.js';
 import { FileSessionLogger } from '@robota-sdk/agent-sessions';
 import type { Session } from '@robota-sdk/agent-sessions';
 import type { ICompactEvent } from '@robota-sdk/agent-sessions';
@@ -172,17 +173,37 @@ export interface IInitOptions {
   sandboxSnapshotId?: string;
 }
 
+/** Return value of createInteractiveSession — session plus staleness tracking data. */
+export interface ICreatedInteractiveSession {
+  session: Session;
+  /** Per-file entries for AGENTS.md files loaded at startup. Used for staleness detection. */
+  agentsFileEntries: IContextFileEntry[];
+  /** Per-file entries for CLAUDE.md files loaded at startup. Used for staleness detection. */
+  claudeFileEntries: IContextFileEntry[];
+  /** Rebuilds the system message given updated agentsMd and claudeMd strings. */
+  rebuildSystemMessage: (agentsMd: string, claudeMd: string) => string;
+}
+
 /**
  * Create and return a fully initialized Session.
  *
  * Loads config, context, project info in parallel, merges plugin hooks,
  * then constructs the session via createSession().
  */
-export async function createInteractiveSession(options: IInitOptions): Promise<Session> {
+export async function createInteractiveSession(
+  options: IInitOptions,
+): Promise<ICreatedInteractiveSession> {
   const cwd = options.cwd;
   const [config, context, projectInfo] = await Promise.all([
     options.config ? Promise.resolve(options.config) : loadConfig(cwd),
-    options.bare ? Promise.resolve({ agentsMd: '', claudeMd: '' }) : loadContext(cwd),
+    options.bare
+      ? Promise.resolve({
+          agentsMd: '',
+          claudeMd: '',
+          agentsFileEntries: [],
+          claudeFileEntries: [],
+        })
+      : loadContext(cwd),
     options.bare
       ? Promise.resolve({ type: 'unknown' as const, language: 'unknown' as const })
       : detectProject(cwd),
@@ -225,7 +246,7 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
   const sessionId =
     options.resumeSessionId && !options.forkSession ? options.resumeSessionId : undefined;
 
-  return createSession({
+  const { session, rebuildSystemMessage } = createSession({
     config: mergedConfig,
     cwd,
     context,
@@ -264,6 +285,13 @@ export async function createInteractiveSession(options: IInitOptions): Promise<S
     reversibleExecution: options.reversibleExecution,
     sandboxClient: options.sandboxClient,
   });
+
+  return {
+    session,
+    agentsFileEntries: context.agentsFileEntries ?? [],
+    claudeFileEntries: context.claudeFileEntries ?? [],
+    rebuildSystemMessage,
+  };
 }
 
 async function applyInteractiveWorkspaceManifest(

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -114,6 +114,7 @@ import {
 import type {
   IInteractiveSessionOptions,
   IInteractiveSessionStandardOptions,
+  ICreatedInteractiveSession,
 } from './interactive-session-init.js';
 import type { IInteractiveSessionStore } from './session-persistence.js';
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
@@ -132,6 +133,8 @@ import {
   recordInteractiveContextReferences,
 } from './interactive-session-context-references.js';
 import type { IPromptFileReferenceRecord } from '../context/prompt-file-references.js';
+import { refreshContextEntries } from '../context/context-file-tracker.js';
+import type { IContextFileEntry } from '../context/context-file-tracker.js';
 import { EditCheckpointStore } from '../checkpoints/edit-checkpoint-store.js';
 import type {
   IEditCheckpointInspection,
@@ -213,6 +216,9 @@ export class InteractiveSession implements ISession {
   private readonly sandboxClient?: ISandboxClient;
   private sandboxSnapshotId?: string;
   private commandInvocationSource: TCommandInvocationSource = 'user';
+  private agentsFileEntries: IContextFileEntry[] = [];
+  private claudeFileEntries: IContextFileEntry[] = [];
+  private rebuildSystemMessage: ICreatedInteractiveSession['rebuildSystemMessage'] | null = null;
 
   constructor(options: IInteractiveSessionOptions) {
     this.commandModules = [...('commandModules' in options ? (options.commandModules ?? []) : [])];
@@ -285,7 +291,7 @@ export class InteractiveSession implements ISession {
     this.autoCompactThresholdSource =
       config.autoCompactThreshold === undefined ? 'default' : 'settings';
     this.editCheckpointStore = new EditCheckpointStore({ cwd: options.cwd });
-    this.session = await createInteractiveSession({
+    const created = await createInteractiveSession({
       cwd: options.cwd,
       provider: options.provider,
       config,
@@ -321,6 +327,10 @@ export class InteractiveSession implements ISession {
           }
         : {}),
     });
+    this.session = created.session;
+    this.agentsFileEntries = created.agentsFileEntries;
+    this.claudeFileEntries = created.claudeFileEntries;
+    this.rebuildSystemMessage = created.rebuildSystemMessage;
 
     if (this.pendingRestoreMessages) {
       for (const msg of this.pendingRestoreMessages) injectSavedMessage(this.session, msg);
@@ -1350,11 +1360,34 @@ export class InteractiveSession implements ISession {
     }
   }
 
+  private async checkAndRefreshContextIfStale(): Promise<void> {
+    if (!this.rebuildSystemMessage) return;
+    const allEntries = [...this.agentsFileEntries, ...this.claudeFileEntries];
+    if (allEntries.length === 0) return;
+
+    const agentsCount = this.agentsFileEntries.length;
+    const { updated, refreshed } = await refreshContextEntries(allEntries);
+    if (refreshed.length === 0) return;
+
+    this.agentsFileEntries = updated.slice(0, agentsCount);
+    this.claudeFileEntries = updated.slice(agentsCount);
+
+    const newAgentsMd = this.agentsFileEntries.map((e) => e.content).join('\n\n');
+    const newClaudeMd = this.claudeFileEntries.map((e) => e.content).join('\n\n');
+    const newSystemMessage = this.rebuildSystemMessage(newAgentsMd, newClaudeMd);
+    this.getSessionOrThrow().updateSystemMessage(newSystemMessage);
+
+    for (const filePath of refreshed) {
+      this.emit('context_file_refreshed', { filePath });
+    }
+  }
+
   private async executePrompt(
     input: string,
     displayInput?: string,
     rawInput?: string,
   ): Promise<void> {
+    await this.checkAndRefreshContextIfStale();
     this.executing = true;
     this.clearStreaming();
     this.emit('user_message', displayInput ?? input);

--- a/packages/agent-sdk/src/interactive/types.ts
+++ b/packages/agent-sdk/src/interactive/types.ts
@@ -84,6 +84,13 @@ export interface IInteractiveSessionEvents {
   background_job_group_event: (event: TBackgroundJobGroupEvent) => void;
   execution_workspace_event: (event: IExecutionWorkspaceEvent) => void;
   user_message: (content: string) => void;
+  /** Emitted when a context file (AGENTS.md or CLAUDE.md) is refreshed due to staleness. */
+  context_file_refreshed: (event: IContextFileRefreshedEvent) => void;
+}
+
+/** Emitted when a context file is found stale and re-read before a turn. */
+export interface IContextFileRefreshedEvent {
+  filePath: string;
 }
 
 export type TInteractiveEventName = keyof IInteractiveSessionEvents;

--- a/packages/agent-sessions/src/session.ts
+++ b/packages/agent-sessions/src/session.ts
@@ -71,7 +71,7 @@ export class Session {
   private readonly sessionStore?: ISessionStore;
   private readonly cwd: string;
   private readonly aiProvider: IAIProvider;
-  private readonly systemMessage: string;
+  private systemMessage: string;
   private readonly toolSchemas: IToolSchema[];
   private model: string;
   private readonly hooks?: Record<string, unknown>;
@@ -278,6 +278,19 @@ export class Session {
   /** Return the exact system prompt used by this session. */
   getSystemMessage(): string {
     return this.systemMessage;
+  }
+
+  /**
+   * Replace the active system message and propagate the change to the underlying agent.
+   * Used by staleness detection to refresh context files between turns.
+   */
+  updateSystemMessage(newMessage: string): void {
+    this.systemMessage = newMessage;
+    this.robota.setModel({
+      provider: this.aiProvider.name,
+      model: this.model,
+      systemMessage: newMessage,
+    });
   }
 
   /** Return tool schemas registered for this session. */


### PR DESCRIPTION
## Summary

- Introduces per-file SHA-256 content hash tracking for AGENTS.md and CLAUDE.md files loaded at session start
- Before each interactive turn, stale files are re-read, the system message is rebuilt, and `context_file_refreshed` events are emitted
- Adds `Session.updateSystemMessage()` using `Robota.setModel()` to propagate changes without restarting
- No regression: 748 tests pass, 0 typecheck errors across agent-sdk + agent-sessions + agent-cli

## Changes

| File | Change |
|---|---|
| `context-file-tracker.ts` | NEW — `IContextFileEntry`, `computeContentHash`, `loadFileWithHash`, `checkContextStaleness`, `refreshContextEntries` |
| `context-loader.ts` | Returns `agentsFileEntries` + `claudeFileEntries` alongside concatenated strings |
| `create-session.ts` | Returns `ICreateSessionResult { session, rebuildSystemMessage }` closure |
| `interactive-session-init.ts` | Returns `ICreatedInteractiveSession` with file entries + rebuilder |
| `interactive-session.ts` | `checkAndRefreshContextIfStale()` before each `executePrompt()` |
| `session.ts` | `updateSystemMessage()` via `robota.setModel()` |
| `types.ts` | `context_file_refreshed` event + `IContextFileRefreshedEvent` |

## Test Plan

- [x] `context-file-tracker.test.ts` — 14 unit tests (hash consistency, staleness detection, refresh)
- [x] Existing 748 agent-sdk tests pass with no regressions
- [x] `pnpm typecheck` passes for agent-sdk, agent-sessions, agent-cli

Closes CTX-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)