### PR TITLE
feat(multi-001): TUI agent multiplexer — /agent switcher + input routing

### DIFF
--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -470,4 +470,33 @@ describe('agent command module', () => {
         .waitBackgroundJobGroup,
     ).toHaveBeenCalledWith('group_1');
   });
+
+  it('opens agent switcher when called with no args', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute('agent', session, '');
+
+    expect(result?.success).toBe(true);
+    expect(result?.effects).toEqual([{ type: 'agent-switcher-requested' }]);
+  });
+
+  it('shows text list when agent list subcommand is used explicitly', async () => {
+    const module = createAgentCommandModule();
+    const executor = new SystemCommandExecutor([
+      ...createSystemCommands(),
+      ...(module.systemCommands ?? []),
+    ]);
+    const session = createMockSession();
+
+    const result = await executor.execute('agent', session, 'list');
+
+    expect(result?.success).toBe(true);
+    expect(result?.message).toContain('Available agents:');
+    expect(result?.effects).toBeUndefined();
+  });
 });

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -36,6 +36,10 @@ async function spawnAgentJob(
   }
 }
 
+function executeOpenSwitcher(): ICommandResult {
+  return { message: '', effects: [{ type: 'agent-switcher-requested' }], success: true };
+}
+
 async function executeList(session: InteractiveSession): Promise<ICommandResult> {
   const agents = session.listAgentDefinitions();
   const jobs = session.listAgentJobs();
@@ -205,6 +209,7 @@ export async function executeAgentCommand(
   args: string,
 ): Promise<ICommandResult> {
   try {
+    if (args.trim() === '') return executeOpenSwitcher();
     const [action = 'list', ...tokens] = tokenizeArgs(args);
     if (action === 'list' && tokens.length === 0) return executeList(session);
     if (action === 'run') return executeRun(session, tokens);

--- a/packages/agent-sdk/src/background-tasks/__tests__/execution-workspace-projection.test.ts
+++ b/packages/agent-sdk/src/background-tasks/__tests__/execution-workspace-projection.test.ts
@@ -82,7 +82,7 @@ describe('execution workspace projection', () => {
       kind: 'background_task',
       groupId: createBackgroundGroupExecutionEntryId('group_1'),
       origin: { kind: 'skill', skillId: 'security-review' },
-      controls: ['select', 'cancel', 'read_log'],
+      controls: ['select', 'cancel', 'send', 'read_log'],
     });
   });
 
@@ -113,5 +113,29 @@ describe('execution workspace projection', () => {
       visibility: 'collapsed',
       controls: ['select', 'close'],
     });
+  });
+
+  it('adds send control to running agent tasks but not process tasks', () => {
+    const snapshot = createExecutionWorkspaceSnapshot({
+      sessionId: 'session_parent',
+      mainThread: {
+        sessionId: 'session_parent',
+        isExecuting: false,
+        hasPendingPrompt: false,
+        historyLength: 0,
+        updatedAt: '2026-05-09T00:00:00.000Z',
+      },
+      groups: [],
+      tasks: [
+        createTask({ id: 'agent_1', kind: 'agent', status: 'running' }),
+        createTask({ id: 'proc_1', kind: 'process', status: 'running' }),
+        createTask({ id: 'agent_done', kind: 'agent', status: 'completed', unread: true }),
+      ],
+    });
+
+    const taskById = Object.fromEntries(snapshot.entries.map((e) => [e.sourceId, e]));
+    expect(taskById['agent_1'].controls).toContain('send');
+    expect(taskById['proc_1'].controls).not.toContain('send');
+    expect(taskById['agent_done'].controls).not.toContain('send');
   });
 });

--- a/packages/agent-sdk/src/background-tasks/execution-workspace-projection.ts
+++ b/packages/agent-sdk/src/background-tasks/execution-workspace-projection.ts
@@ -140,6 +140,7 @@ function createTaskControls(state: IBackgroundTaskState): readonly TExecutionCon
   const controls: TExecutionControl[] = ['select'];
   if (isTerminalBackgroundTaskStatus(state.status)) controls.push('close');
   else controls.push('cancel');
+  if (state.kind === 'agent' && state.status === 'running') controls.push('send');
   if (state.logPath || state.transcriptPath) controls.push('read_log');
   return controls;
 }

--- a/packages/agent-sdk/src/command-api/effects.ts
+++ b/packages/agent-sdk/src/command-api/effects.ts
@@ -14,4 +14,5 @@ export type TCommandEffect =
   | { type: 'session-renamed'; name: string }
   | { type: 'conversation-history-cleared' }
   | { type: 'session-execution-started' }
-  | { type: 'statusline-settings-patch'; patch: TStatusLineCommandSettingsPatch };
+  | { type: 'statusline-settings-patch'; patch: TStatusLineCommandSettingsPatch }
+  | { type: 'agent-switcher-requested' };

--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
@@ -178,7 +178,38 @@ function AppInner(
     setSessionName,
     setStatusLineSettings,
     showSessionPickerOnStart: props.showSessionPickerOnStart,
+    openAgentSwitcher: () => setShowExecutionWorkspaceSwitcher(true),
   });
+
+  const isSelectedEntryInteractive =
+    !selectedExecutionEntry ||
+    selectedExecutionEntry.kind === 'main_thread' ||
+    selectedExecutionEntry.controls.includes('send');
+
+  const activeAgentLabel =
+    selectedExecutionEntry && selectedExecutionEntry.kind !== 'main_thread'
+      ? selectedExecutionEntry.title
+      : undefined;
+
+  const mainThreadEntryId = useMemo(
+    () => executionWorkspaceSnapshot?.entries.find((e) => e.kind === 'main_thread')?.id,
+    [executionWorkspaceSnapshot],
+  );
+
+  const handleSubmitWithRouting = useCallback(
+    async (input: string): Promise<void> => {
+      if (
+        selectedExecutionEntry &&
+        selectedExecutionEntry.kind !== 'main_thread' &&
+        selectedExecutionEntry.controls.includes('send')
+      ) {
+        await interactiveSession.sendAgentJob(selectedExecutionEntry.sourceId, input);
+      } else {
+        await handleSubmit(input);
+      }
+    },
+    [selectedExecutionEntry, handleSubmit, interactiveSession],
+  );
 
   // Sync session name from InteractiveSession when resuming
   useEffect(() => {
@@ -228,6 +259,27 @@ function AppInner(
     if (!key.ctrl || input !== 'b') return;
     if (permissionRequest || showPluginTUI || showSessionPicker || isShuttingDown) return;
     setShowExecutionWorkspaceSwitcher((shown) => !shown);
+  });
+
+  // ESC returns to main thread when a background entry is selected (and not thinking).
+  useInput((_input: string, key: { escape: boolean }) => {
+    if (!key.escape || isThinking) return;
+    if (
+      permissionRequest ||
+      showPluginTUI ||
+      showTransportTUI ||
+      showSessionPicker ||
+      showExecutionWorkspaceSwitcher
+    ) {
+      return;
+    }
+    if (
+      selectedExecutionEntry &&
+      selectedExecutionEntry.kind !== 'main_thread' &&
+      mainThreadEntryId !== undefined
+    ) {
+      selectExecutionWorkspaceEntry(mainThreadEntryId);
+    }
   });
 
   // Ctrl+C graceful shutdown
@@ -391,9 +443,10 @@ function AppInner(
         contextState={contextState}
         sessionName={sessionName}
         settings={statusLineSettings}
+        activeAgentLabel={activeAgentLabel}
       />
       <InputArea
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitWithRouting}
         onCancelQueue={handleCancelQueue}
         isDisabled={
           !!permissionRequest ||
@@ -403,7 +456,8 @@ function AppInner(
           showExecutionWorkspaceSwitcher ||
           isShuttingDown ||
           pendingInteractionPrompt !== null ||
-          (isThinking && !!pendingPrompt)
+          (isThinking && !!pendingPrompt) ||
+          !isSelectedEntryInteractive
         }
         isAborting={isAborting}
         pendingPrompt={pendingPrompt}

--- a/packages/agent-transport-tui/src/SessionStatusBar.tsx
+++ b/packages/agent-transport-tui/src/SessionStatusBar.tsx
@@ -17,6 +17,7 @@ interface IProps {
   contextState: { percentage: number; usedTokens: number; maxTokens: number };
   sessionName?: string;
   settings: IStatusLineCommandSettings;
+  activeAgentLabel?: string;
 }
 
 export default function SessionStatusBar({
@@ -32,6 +33,7 @@ export default function SessionStatusBar({
   contextState,
   sessionName,
   settings,
+  activeAgentLabel,
 }: IProps): React.ReactElement | null {
   const cliAdapter = useTuiCliAdapter();
   const gitBranch = useMemo(() => cliAdapter.getGitBranch(cwd), [cliAdapter, cwd]);
@@ -58,6 +60,7 @@ export default function SessionStatusBar({
       sessionName={sessionName}
       gitBranch={gitBranch}
       showGitBranch={settings.gitBranch}
+      activeAgentLabel={activeAgentLabel}
     />
   );
 }

--- a/packages/agent-transport-tui/src/StatusBar.tsx
+++ b/packages/agent-transport-tui/src/StatusBar.tsx
@@ -23,6 +23,7 @@ interface IProps {
   sessionName?: string;
   gitBranch?: string;
   showGitBranch?: boolean;
+  activeAgentLabel?: string;
 }
 
 interface IStatusLeftProps {
@@ -177,6 +178,7 @@ export default function StatusBar({
   sessionName,
   gitBranch,
   showGitBranch = true,
+  activeAgentLabel,
 }: IProps): React.ReactElement {
   return (
     <Box
@@ -201,6 +203,11 @@ export default function StatusBar({
         gitBranch={gitBranch}
         showGitBranch={showGitBranch}
       />
+      {activeAgentLabel !== undefined && (
+        <Text color="yellow" bold>
+          [{activeAgentLabel}]
+        </Text>
+      )}
     </Box>
   );
 }

--- a/packages/agent-transport-tui/src/__tests__/command-effect-handler.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/command-effect-handler.test.ts
@@ -59,6 +59,7 @@ function createDeps(settingsPath: string) {
     openPluginTUI: vi.fn(),
     openTransportTUI: vi.fn(),
     openSessionPicker: vi.fn(),
+    openAgentSwitcher: vi.fn(),
     renameSession: vi.fn(),
     applyStatusLinePatch: vi.fn(),
     cliAdapter: createCliAdapter(settingsPath),

--- a/packages/agent-transport-tui/src/hooks/command-effect-handler.ts
+++ b/packages/agent-transport-tui/src/hooks/command-effect-handler.ts
@@ -11,6 +11,7 @@ export interface ICommandEffectHandlerDeps {
   openPluginTUI: () => void;
   openSessionPicker: () => void;
   openTransportTUI: () => void;
+  openAgentSwitcher: () => void;
   renameSession: (name: string) => void;
   applyStatusLinePatch: (patch: TStatusLineCommandSettingsPatch) => boolean;
   cliAdapter: ITuiCliAdapter;
@@ -50,6 +51,10 @@ export function applyCommandEffects(
     }
     if (effect.type === 'settings-tui-requested') {
       deps.openTransportTUI();
+      return true;
+    }
+    if (effect.type === 'agent-switcher-requested') {
+      deps.openAgentSwitcher();
       return true;
     }
     if (effect.type === 'session-picker-requested') {

--- a/packages/agent-transport-tui/src/hooks/side-effects-types.ts
+++ b/packages/agent-transport-tui/src/hooks/side-effects-types.ts
@@ -18,6 +18,7 @@ export interface IUseSideEffectsOptions {
   setSessionName: (name: string) => void;
   setStatusLineSettings: (settings: IStatusLineSettings) => void;
   showSessionPickerOnStart?: boolean;
+  openAgentSwitcher?: () => void;
 }
 
 export interface IUseSideEffectsResult {

--- a/packages/agent-transport-tui/src/hooks/useSideEffects.ts
+++ b/packages/agent-transport-tui/src/hooks/useSideEffects.ts
@@ -24,6 +24,7 @@ export function useSideEffects({
   setSessionName,
   setStatusLineSettings,
   showSessionPickerOnStart,
+  openAgentSwitcher,
 }: IUseSideEffectsOptions): IUseSideEffectsResult {
   const { exit } = useApp();
   const cliAdapter = useTuiCliAdapter();
@@ -58,6 +59,7 @@ export function useSideEffects({
         openPluginTUI: () => setShowPluginTUI(true),
         openSessionPicker: () => setShowSessionPicker(true),
         openTransportTUI: () => setShowTransportTUI(true),
+        openAgentSwitcher: () => openAgentSwitcher?.(),
         renameSession: (name) => {
           interactiveSession.setName(name);
           setSessionName(name);


### PR DESCRIPTION
## Summary

- **`/agent`** (no args) now opens the TUI agent switcher (same as Ctrl+B); **`/agent list`** still prints the text list
- Running agent-kind background tasks gain a `send` control in the execution workspace projection, enabling prompt routing to them
- **InputArea routes submit to `sendAgentJob()`** when a running agent entry is selected in the workspace switcher
- **ESC** returns to the main thread when not thinking and a background agent is focused
- **StatusBar badge** shows the active agent label (e.g. `[Research: auth module]`) when not on the main thread
- **InputArea is disabled** when a non-interactive (non-sendable) background entry is selected

## Test plan

- [x] `createTaskControls` adds `send` for running agent tasks, not for process tasks or terminal agent tasks (`execution-workspace-projection.test.ts`)
- [x] `/agent` with no args returns `{ effects: [{ type: 'agent-switcher-requested' }] }` (`agent-command.test.ts`)
- [x] `/agent list` explicitly returns text list with no effects (`agent-command.test.ts`)
- [x] `applyCommandEffects` test deps include `openAgentSwitcher` (no typecheck error)
- [x] `pnpm typecheck && pnpm lint && pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)