### PR TITLE
fix(sdk-004): replace bare object with Record<string,unknown> in TCommandResultDataValue

### DIFF
--- a/.agents/backlog/completed/SDK-004-replace-bare-object-command-result.md
+++ b/.agents/backlog/completed/SDK-004-replace-bare-object-command-result.md
@@ -1,6 +1,6 @@
 ---
 title: 'SDK-004: Replace bare object type in TCommandResultDataValue'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/packages/agent-sdk/src/command-api/command-result.ts
+++ b/packages/agent-sdk/src/command-api/command-result.ts
@@ -2,7 +2,10 @@ import type { TUniversalValue } from '@robota-sdk/agent-core';
 import type { TCommandEffect } from './effects.js';
 import type { ICommandInteraction } from './interactions.js';
 
-export type TCommandResultDataValue = TUniversalValue | object | readonly object[];
+export type TCommandResultDataValue =
+  | TUniversalValue
+  | Record<string, unknown>
+  | readonly Record<string, unknown>[];
 
 /** Result of a system command execution. */
 export interface ICommandResult {


### PR DESCRIPTION
## Summary

- Replaces `object` with `Record<string, unknown>` in `TCommandResultDataValue`
- Replaces `readonly object[]` with `readonly Record<string, unknown>[]`
- `TUniversalValue` already covers structured objects; bare `object` blocked type-safe property access

## Test plan
- `pnpm typecheck` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)