### PR TITLE
docs(docs-001): add /settings and /user-local to command-inventory.md

### DIFF
--- a/.agents/backlog/completed/DOCS-001-update-command-inventory-settings-user-local.md
+++ b/.agents/backlog/completed/DOCS-001-update-command-inventory-settings-user-local.md
@@ -1,6 +1,6 @@
 ---
 title: 'DOCS-001: Add /settings and /user-local to command-inventory.md'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/.agents/specs/command-inventory.md
+++ b/.agents/specs/command-inventory.md
@@ -37,7 +37,9 @@ not mean the implementation lives in `agent-sdk` or `agent-cli`.
 | `/reset`          | `@robota-sdk/agent-command-reset`       | inline    | no              | `settings-reset-requested` effect                         |
 | `/resume`         | `@robota-sdk/agent-command-session`     | inline    | no              | `session-picker-requested` effect                         |
 | `/rewind`         | `@robota-sdk/agent-command-rewind`      | inline    | no              | checkpoint list/restore/rollback APIs                     |
+| `/settings`       | `@robota-sdk/agent-command-settings`    | inline    | no              | `settings-tui-requested` effect                           |
 | `/statusline`     | `@robota-sdk/agent-command-statusline`  | inline    | no              | `statusline-settings-patch` effect                        |
+| `/user-local`     | `@robota-sdk/agent-command-user-local`  | inline    | no              | user-local storage reads/writes (memory, storage inspect) |
 
 ## Retired Sources
 


### PR DESCRIPTION
## Summary

Adds two missing entries to the canonical command inventory:
- `/settings` — `@robota-sdk/agent-command-settings`, emits `settings-tui-requested` effect
- `/user-local` — `@robota-sdk/agent-command-user-local`, user-local storage reads/writes

Both commands were already implemented and wired in CLI; the inventory was the only missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)