### PR TITLE
fix(arch-fix-026): ITerminalOutput/ISpinner from agent-core + fix pre-existing type errors

### DIFF
--- a/.agents/backlog/completed/ARCH-FIX-026-fix-terminal-output-import-chain.md
+++ b/.agents/backlog/completed/ARCH-FIX-026-fix-terminal-output-import-chain.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-FIX-026: Fix ITerminalOutput/ISpinner import chain — source from agent-core'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/packages/agent-sdk/src/command-api/command-result.ts
+++ b/packages/agent-sdk/src/command-api/command-result.ts
@@ -14,7 +14,7 @@ export interface ICommandResult {
   /** Command completed successfully */
   success: boolean;
   /** Additional structured data (command-specific diagnostics only) */
-  data?: Record<string, TCommandResultDataValue>;
+  data?: Record<string, unknown>;
   /** Typed host effects requested by the command */
   effects?: readonly TCommandEffect[];
   /** Command-owned follow-up prompt and continuation */

--- a/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-sdk/src/subagents/in-process-subagent-runner.ts
@@ -5,7 +5,8 @@ import type {
   TPermissionMode,
   TToolArgs,
 } from '@robota-sdk/agent-core';
-import type { ITerminalOutput, TPermissionHandler } from '@robota-sdk/agent-sessions';
+import type { ITerminalOutput } from '@robota-sdk/agent-core';
+import type { TPermissionHandler } from '@robota-sdk/agent-sessions';
 import type { IAgentDefinition } from '../agents/agent-definition-types.js';
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
 import type { ISubagentOptions } from '../assembly/create-subagent-session.js';

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -10,5 +10,5 @@ export { TRUST_TO_MODE } from '@robota-sdk/agent-core';
 // Tool result type from agent-tools
 export type { TToolResult } from '@robota-sdk/agent-tools';
 
-// Terminal types from agent-sessions
-export type { ITerminalOutput, ISpinner } from '@robota-sdk/agent-sessions';
+// Terminal types from agent-core (canonical owner)
+export type { ITerminalOutput, ISpinner } from '@robota-sdk/agent-core';

--- a/packages/agent-transport-tui/package.json
+++ b/packages/agent-transport-tui/package.json
@@ -35,7 +35,6 @@
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-interface-transport": "workspace:*",
     "@robota-sdk/agent-sdk": "workspace:*",
-    "@robota-sdk/agent-sessions": "workspace:*",
     "chalk": "^5.3.0",
     "ink": "^7.0.1",
     "ink-select-input": "^6.2.0",

--- a/packages/agent-transport-tui/src/InkTerminal.ts
+++ b/packages/agent-transport-tui/src/InkTerminal.ts
@@ -7,7 +7,7 @@
  */
 
 import type { TToolArgs } from '@robota-sdk/agent-core';
-import type { ITerminalOutput, ISpinner } from '@robota-sdk/agent-sessions';
+import type { ITerminalOutput, ISpinner } from '@robota-sdk/agent-core';
 
 export type TPermissionResolver = (toolName: string, toolArgs: TToolArgs) => Promise<boolean>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1788,9 +1788,6 @@ importers:
       '@robota-sdk/agent-sdk':
         specifier: workspace:*
         version: link:../agent-sdk
-      '@robota-sdk/agent-sessions':
-        specifier: workspace:*
-        version: link:../agent-sessions
       chalk:
         specifier: ^5.3.0
         version: 5.6.2


### PR DESCRIPTION
## Summary

**ARCH-FIX-026**: Redirects `ITerminalOutput`/`ISpinner` imports to canonical owner (`agent-core`):
- `agent-sdk/src/types.ts`
- `agent-sdk/src/subagents/in-process-subagent-runner.ts`
- `agent-transport-tui/src/InkTerminal.ts`
- Removes `@robota-sdk/agent-sessions` from `agent-transport-tui/package.json` (zero remaining usage)

**Pre-existing type fix**: `ICommandResult.data` widened to `Record<string, unknown>`.
Domain interfaces (`IContextReferenceItem`, `IBackgroundJobGroupSummary`) were being placed
into `data` but were not assignable to `TCommandResultDataValue`. Diagnostic data has no
guaranteed shape so `Record<string, unknown>` is correct.

## Test plan
- `pnpm typecheck` clean
- `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)