### PR TITLE
fix(arch-fix-027): ITransportAdapter from agent-interface-transport in http/mcp transports

### DIFF
--- a/.agents/backlog/completed/ARCH-FIX-027-fix-transport-http-mcp-interface-source.md
+++ b/.agents/backlog/completed/ARCH-FIX-027-fix-transport-http-mcp-interface-source.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-FIX-027: Fix agent-transport-http/mcp to import from agent-interface-transport'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/packages/agent-transport-http/package.json
+++ b/packages/agent-transport-http/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
   },
   "dependencies": {
+    "@robota-sdk/agent-interface-transport": "workspace:*",
     "@robota-sdk/agent-sdk": "workspace:*",
     "hono": "^4.7.0"
   },

--- a/packages/agent-transport-http/src/http-transport.ts
+++ b/packages/agent-transport-http/src/http-transport.ts
@@ -5,7 +5,8 @@
  * while exposing the underlying Hono app via getApp().
  */
 
-import type { InteractiveSession, ITransportAdapter } from '@robota-sdk/agent-sdk';
+import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { createAgentRoutes } from './routes.js';
 import type { Hono } from 'hono';
 

--- a/packages/agent-transport-mcp/package.json
+++ b/packages/agent-transport-mcp/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
   },
   "dependencies": {
+    "@robota-sdk/agent-interface-transport": "workspace:*",
     "@robota-sdk/agent-sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "zod": "^3.24.4"

--- a/packages/agent-transport-mcp/src/mcp-transport.ts
+++ b/packages/agent-transport-mcp/src/mcp-transport.ts
@@ -5,7 +5,8 @@
  * while exposing the underlying MCP Server via getServer().
  */
 
-import type { InteractiveSession, ITransportAdapter } from '@robota-sdk/agent-sdk';
+import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { InteractiveSession } from '@robota-sdk/agent-sdk';
 import { createAgentMcpServer } from './mcp-server.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1732,6 +1732,9 @@ importers:
 
   packages/agent-transport-http:
     dependencies:
+      '@robota-sdk/agent-interface-transport':
+        specifier: workspace:*
+        version: link:../agent-interface-transport
       '@robota-sdk/agent-sdk':
         specifier: workspace:*
         version: link:../agent-sdk
@@ -1757,6 +1760,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.28.0
         version: 1.28.0(zod@3.25.76)
+      '@robota-sdk/agent-interface-transport':
+        specifier: workspace:*
+        version: link:../agent-interface-transport
       '@robota-sdk/agent-sdk':
         specifier: workspace:*
         version: link:../agent-sdk


### PR DESCRIPTION
## Summary

`agent-transport-http` and `agent-transport-mcp` now source `ITransportAdapter` from
`@robota-sdk/agent-interface-transport` instead of `@robota-sdk/agent-sdk`, matching the
pattern used by TUI, headless, and WS transports. `InteractiveSession` stays in `agent-sdk`.

Added `@robota-sdk/agent-interface-transport` as an explicit dependency to both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)