### PR TITLE
docs(arch-fix-029): document playground intentional no-sdk-session design

### DIFF
--- a/.agents/backlog/completed/ARCH-FIX-029-document-playground-execution-path.md
+++ b/.agents/backlog/completed/ARCH-FIX-029-document-playground-execution-path.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-FIX-029: Document playground execution path decision in architecture'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/.agents/specs/architecture-map/agent-system.md
+++ b/.agents/specs/architecture-map/agent-system.md
@@ -98,3 +98,8 @@ Playground ownership:
 | Browser-safe React package entry       | `agent-playground/client` | Must not expose Node-only services.                                                                                                                     |
 | Executor, hooks, components, context   | `agent-playground`        | Internal modules under `src/lib/` and `src/components/`; see [packages/agent-playground/docs/SPEC.md](../../../packages/agent-playground/docs/SPEC.md). |
 | Secure provider execution from browser | `agent-remote-client`     | API keys stay server-side through `RemoteExecutor`.                                                                                                     |
+
+**No agent-sdk session stack (intentional)**: `agent-playground` does not depend on
+`agent-sdk`, `agent-sessions`, or `agent-runtime`. Session management and all server-side
+policy run in `apps/agent-server`; the playground is a lightweight client UI only.
+See [packages/agent-playground/docs/SPEC.md](../../../packages/agent-playground/docs/SPEC.md).

--- a/packages/agent-playground/docs/SPEC.md
+++ b/packages/agent-playground/docs/SPEC.md
@@ -12,6 +12,28 @@ Owns the Robota Playground UI package: React components, hooks, executor logic, 
   contracts in `src/lib/playground/types.ts`.
 - Does not define deployment or hosting behavior; that belongs to `apps/agent-web`.
 
+## Architecture Decision: No agent-sdk Session Stack
+
+The playground intentionally does not depend on `@robota-sdk/agent-sdk`,
+`@robota-sdk/agent-sessions`, or `@robota-sdk/agent-runtime`. This is a deliberate
+lightweight client design, not architectural drift.
+
+**Rationale**: The playground is a browser UI that delegates agent execution to
+`apps/agent-server` via `@robota-sdk/agent-remote-client`. Session management,
+conversation persistence, compaction, permission enforcement, context loading, and
+command APIs all run on the server side. The playground renders the results without
+running a local session stack.
+
+**Dependency boundary**:
+
+- Allowed: `@robota-sdk/agent-core` (type contracts), `@robota-sdk/agent-remote-client`
+  (remote execution), provider packages for type references only.
+- Not allowed: `@robota-sdk/agent-sdk`, `@robota-sdk/agent-sessions`,
+  `@robota-sdk/agent-runtime`.
+
+If the playground needs to support local (offline) execution in the future, that work
+must go through a dedicated backlog item and explicit architectural review.
+
 ## Architecture Overview
 
 Facade-pattern executor (`PlaygroundExecutor`) wraps Robota agent instances for browser-based execution. AI providers are constructed with a `RemoteExecutor` so API keys stay server-side. Executor internals are a directory module under `src/lib/playground/robota-executor/` with `PlaygroundAgentSession`, remote provider construction, tool normalization, plugin factories, result shaping, and statistics recording split from the stateful facade while preserving the previous import path. Two plugins (`PlaygroundHistoryPlugin`, `PlaygroundStatisticsPlugin`) are standalone classes that collect conversation events and UX metrics.


### PR DESCRIPTION
## Summary

Adds an explicit Architecture Decision section to `packages/agent-playground/docs/SPEC.md`
and a note to `agent-system.md` confirming that the playground intentionally omits
`agent-sdk`/`agent-sessions`/`agent-runtime` — it is a lightweight browser client UI that
delegates execution to `apps/agent-server` via `agent-remote-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)