### PR TITLE
docs(arch-fix-025): document auth/credits as forward-declared contracts

### DIFF
--- a/.agents/backlog/completed/ARCH-FIX-025-wire-auth-credits-or-document-debt.md
+++ b/.agents/backlog/completed/ARCH-FIX-025-wire-auth-credits-or-document-debt.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-FIX-025: Wire auth/credits packages or formally document as forward-declared debt'
-status: backlog
+status: done
 created: 2026-05-15
 priority: high
 urgency: soon

--- a/packages/auth/docs/SPEC.md
+++ b/packages/auth/docs/SPEC.md
@@ -1,5 +1,19 @@
 # Auth Specification
 
+## Status
+
+**Forward-declared contract — not yet wired in production (as of 2026-05-15).**
+
+`@robota-sdk/auth` is a correct, complete contract package. It has no production consumers:
+`apps/agent-server` performs inline JWT verification using `jsonwebtoken` directly
+(`websocket-server.ts` lines 4, 66, 178–191) instead of using this package's verifier port.
+
+This is acknowledged technical debt. The migration path is:
+
+1. Add `@robota-sdk/auth` as a dependency of `apps/agent-server`
+2. Replace inline `jsonwebtoken` calls with `IAuthVerifier` from this package
+3. Track this work as a separate backlog item when auth enforcement becomes a priority
+
 ## Scope
 
 `@robota-sdk/auth` owns authentication contracts and pure authorization policy helpers for Robota runtimes. It defines credential, principal, auth context, verifier port, error, and scope policy types.

--- a/packages/credits/docs/SPEC.md
+++ b/packages/credits/docs/SPEC.md
@@ -1,5 +1,20 @@
 # Credits Specification
 
+## Status
+
+**Forward-declared contract — not yet wired in production (as of 2026-05-15).**
+
+`@robota-sdk/credits` is a correct, complete contract package. It has no production consumers:
+no production package or app depends on `@robota-sdk/credits`. Credit accounting policy
+documented in this specification is not enforced at runtime anywhere.
+
+This is acknowledged technical debt. The migration path is:
+
+1. Decide the enforcement point (agent-server, agent-sdk, or a future billing adapter)
+2. Add `@robota-sdk/credits` as a dependency at that enforcement point
+3. Implement the `ICreditAccount` and `ICreditReservation` ports at that layer
+4. Track this work as a separate backlog item when credit enforcement becomes a priority
+
 ## Scope
 
 `@robota-sdk/credits` owns credit account, reservation, ledger, and settlement contracts for Robota runtimes. It provides pure policy helpers for reservation, release, and settlement decisions using integer credit units.


### PR DESCRIPTION
## Summary

Adds **Status** sections to `packages/auth/docs/SPEC.md` and `packages/credits/docs/SPEC.md`:
- Acknowledges both packages have zero production consumers as of 2026-05-15
- Documents `apps/agent-server` inline JWT auth as acknowledged technical debt
- Provides concrete migration path for each package

🤖 Generated with [Claude Code](https://claude.com/claude-code)