### PR TITLE
docs(sdk-003): document agent-plugin-* packages as consumer opt-in

### DIFF
--- a/.agents/backlog/completed/SDK-003-wire-plugin-packages-or-document.md
+++ b/.agents/backlog/completed/SDK-003-wire-plugin-packages-or-document.md
@@ -1,6 +1,6 @@
 ---
 title: 'SDK-003: Wire plugin packages in assembly or document as consumer opt-in'
-status: backlog
+status: done
 created: 2026-05-15
 priority: medium
 urgency: later

--- a/.agents/specs/architecture-map/agent-system.md
+++ b/.agents/specs/architecture-map/agent-system.md
@@ -26,7 +26,7 @@ flowchart TD
   AgentCLI --> Providers
   AgentCLI --> Headless
   TuiTransport --> SDK
-  AgentCLI --> Plugins
+  AgentCLI -. "consumer opt-in" .-> Plugins
   Headless --> SDK
   Commands --> SDK
   Commands -. "agent-command-provider only" .-> Core
@@ -34,7 +34,7 @@ flowchart TD
   SDK --> Runtime
   SDK --> Tools
   SDK --> Core
-  SDK --> Plugins
+  SDK -. "consumer opt-in" .-> Plugins
   Providers --> Core
   Sessions --> Core
   Runtime --> Core
@@ -57,6 +57,8 @@ Agent stack ownership:
 | Background workspace/read model                   | `agent-sdk` + `agent-runtime`       | CLI renders SDK projections; keeps only ephemeral UI selection state. |
 
 Provider profile identity is the settings profile key, not provider `type` or model uniqueness. See [commands-and-provider-flow.md](agent-cli/commands-and-provider-flow.md) for profile switching semantics.
+
+**Plugin consumer opt-in**: `agent-plugin-*` packages are not imported by `agent-cli` or `agent-sdk` production source. Plugins are registered by consuming applications at composition time. The dashed edges above (`consumer opt-in`) reflect this: no plugin imports exist in the CLI or SDK assembly paths. Application consumers pass plugin instances to the SDK assembly API.
 
 ## API Boundary
 

--- a/packages/agent-plugin-conversation-history/docs/SPEC.md
+++ b/packages/agent-plugin-conversation-history/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-conversation-history Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Conversation history plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-error-handling/docs/SPEC.md
+++ b/packages/agent-plugin-error-handling/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-error-handling Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Error handling plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-event-emitter/docs/SPEC.md
+++ b/packages/agent-plugin-event-emitter/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-event-emitter Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Event emitter plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-execution-analytics/docs/SPEC.md
+++ b/packages/agent-plugin-execution-analytics/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-execution-analytics Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Execution analytics plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-limits/docs/SPEC.md
+++ b/packages/agent-plugin-limits/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-limits Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Rate limiting plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-logging/docs/SPEC.md
+++ b/packages/agent-plugin-logging/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-logging Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Logging plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-performance/docs/SPEC.md
+++ b/packages/agent-plugin-performance/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-performance Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Performance monitoring plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-usage/docs/SPEC.md
+++ b/packages/agent-plugin-usage/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-usage Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Usage tracking plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-plugin-webhook/docs/SPEC.md
+++ b/packages/agent-plugin-webhook/docs/SPEC.md
@@ -1,5 +1,12 @@
 # agent-plugin-webhook Specification
 
+## Status
+
+**Consumer opt-in — not built into the CLI or SDK by default (as of 2026-05-15).**
+
+This plugin is not imported by any `agent-cli` or `agent-sdk` production assembly path. Application
+consumers register this plugin at composition time by passing an instance to the SDK assembly API.
+
 ## Scope
 
 Webhook notification plugin for Robota SDK. This is a private package (not published to npm).

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -409,6 +409,29 @@ Manages plugin installation and uninstallation:
 - Tracks installed plugins in a registry file
 - Handles enable/disable state per plugin
 
+## Plugins
+
+`agent-plugin-*` packages are **consumer opt-in** — they are not built into the CLI or SDK by default. Application consumers register plugins at composition time by passing plugin instances to the SDK assembly API.
+
+```typescript
+import { InteractiveSession } from '@robota-sdk/agent-sdk';
+import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { ConversationHistoryPlugin } from '@robota-sdk/agent-plugin-conversation-history';
+import { LoggingPlugin } from '@robota-sdk/agent-plugin-logging';
+
+const session = new InteractiveSession({
+  cwd: process.cwd(),
+  config,
+  context,
+  plugins: [
+    new ConversationHistoryPlugin({ maxMessages: 100 }),
+    new LoggingPlugin({ level: 'info' }),
+  ],
+});
+```
+
+Each plugin implements `AbstractPlugin` from `@robota-sdk/agent-core` and depends only on `agent-core`. Available plugins: `agent-plugin-conversation-history`, `agent-plugin-error-handling`, `agent-plugin-event-emitter`, `agent-plugin-execution-analytics`, `agent-plugin-limits`, `agent-plugin-logging`, `agent-plugin-performance`, `agent-plugin-usage`, `agent-plugin-webhook`.
+
 ## Configuration
 
 Settings are merged from lowest to highest priority:


### PR DESCRIPTION
## Summary

- Add `## Status` section to all 9 `agent-plugin-*/docs/SPEC.md` files documenting that plugins are consumer opt-in (not built into CLI/SDK by default)
- Update `.agents/specs/architecture-map/agent-system.md` to show dashed `consumer opt-in` edges from `AgentCLI` and `SDK` to `Plugins`
- Add plugin registration example to `packages/agent-sdk/README.md`
- Archive `SDK-003` backlog as `done`

## Test plan

- [ ] Architecture map shows dashed opt-in edges for plugin nodes
- [ ] All 9 plugin SPEC.md files have Status section with consumer opt-in language
- [ ] agent-sdk README has plugin registration example
- [ ] No production source changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)