### PR TITLE
fix(sdk-005): remove chalk from agent-sdk

### DIFF
--- a/.agents/backlog/completed/SDK-005-remove-chalk-from-agent-sdk.md
+++ b/.agents/backlog/completed/SDK-005-remove-chalk-from-agent-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: 'SDK-005: Remove chalk from agent-sdk'
-status: backlog
+status: done
 created: 2026-05-15
 priority: low
 urgency: later

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -47,7 +47,6 @@
     "@robota-sdk/agent-runtime": "workspace:*",
     "@robota-sdk/agent-sessions": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
-    "chalk": "^5.3.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/packages/agent-sdk/src/permissions/permission-prompt.ts
+++ b/packages/agent-sdk/src/permissions/permission-prompt.ts
@@ -4,16 +4,12 @@
  * Used by both agent-sdk query() and agent-cli.
  */
 
-import chalk from 'chalk';
 import type { ITerminalOutput } from '../types.js';
 import type { TToolArgs } from '@robota-sdk/agent-core';
 
 const PERMISSION_OPTIONS = ['Allow', 'Deny'];
 const ALLOW_INDEX = 0;
 
-/**
- * Format tool arguments as a human-readable string for display in the prompt.
- */
 function formatArgs(toolArgs: TToolArgs): string {
   const entries = Object.entries(toolArgs);
   if (entries.length === 0) {
@@ -24,17 +20,14 @@ function formatArgs(toolArgs: TToolArgs): string {
     .join(', ');
 }
 
-/**
- * Prompt the user for approval before running a tool.
- */
 export async function promptForApproval(
   terminal: ITerminalOutput,
   toolName: string,
   toolArgs: TToolArgs,
 ): Promise<boolean> {
   terminal.writeLine('');
-  terminal.writeLine(chalk.yellow(`[Permission Required] Tool: ${toolName}`));
-  terminal.writeLine(chalk.dim(`  ${formatArgs(toolArgs)}`));
+  terminal.writeError(`[Permission Required] Tool: ${toolName}`);
+  terminal.writeLine(`  ${formatArgs(toolArgs)}`);
   terminal.writeLine('');
 
   const selected = await terminal.select(PERMISSION_OPTIONS, ALLOW_INDEX);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1570,9 +1570,6 @@ importers:
       '@robota-sdk/agent-tools':
         specifier: workspace:*
         version: link:../agent-tools
-      chalk:
-        specifier: ^5.3.0
-        version: 5.6.2
       zod:
         specifier: ^3.24.0
         version: 3.25.76


### PR DESCRIPTION
## Summary

- Remove `chalk` import and usage from `permission-prompt.ts`
- Replace `chalk.yellow(...)` with `terminal.writeError(...)` — CLI adapter applies styling at render time
- Replace `chalk.dim(...)` with plain `terminal.writeLine(...)` — indentation preserved via leading spaces
- Remove `chalk` from `packages/agent-sdk/package.json` dependencies

Fixes SDK being non-neutral about ANSI escape sequences (ARCH-SA-007, ARCH-SD-009).

## Test plan

- [x] `chalk` absent from `agent-sdk/package.json`
- [x] `pnpm --filter @robota-sdk/agent-sdk build` passes
- [x] 774 tests pass for `agent-sdk`
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)