### PR TITLE
refactor(sdk-001+sdk-002): IAgentJobHostContext + IInteractiveSession + test factory

### DIFF
--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -4,10 +4,10 @@ import {
   SystemCommandExecutor,
   createSystemCommands,
 } from '@robota-sdk/agent-sdk';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IAgentJobHostContext } from '@robota-sdk/agent-sdk';
 import { createAgentCommandModule } from '../agent-command-module.js';
 
-function createMockSession(overrides?: Record<string, unknown>): InteractiveSession {
+function createMockSession(overrides?: Record<string, unknown>): IAgentJobHostContext {
   const session = {
     listAgentDefinitions: vi.fn().mockReturnValue([
       { name: 'general-purpose', description: 'General-purpose task execution agent.' },
@@ -67,7 +67,7 @@ function createMockSession(overrides?: Record<string, unknown>): InteractiveSess
     closeAgentJob: vi.fn(),
     ...overrides,
   };
-  return session as unknown as InteractiveSession;
+  return session as unknown as IAgentJobHostContext;
 }
 
 describe('agent command module', () => {

--- a/packages/agent-command-agent/src/__tests__/agent-command.test.ts
+++ b/packages/agent-command-agent/src/__tests__/agent-command.test.ts
@@ -4,10 +4,10 @@ import {
   SystemCommandExecutor,
   createSystemCommands,
 } from '@robota-sdk/agent-sdk';
-import type { IAgentJobHostContext } from '@robota-sdk/agent-sdk';
+import type { IAgentJobHostContext, ICommandHostContext } from '@robota-sdk/agent-sdk';
 import { createAgentCommandModule } from '../agent-command-module.js';
 
-function createMockSession(overrides?: Record<string, unknown>): IAgentJobHostContext {
+function createMockSession(overrides?: Record<string, unknown>): ICommandHostContext {
   const session = {
     listAgentDefinitions: vi.fn().mockReturnValue([
       { name: 'general-purpose', description: 'General-purpose task execution agent.' },
@@ -67,7 +67,7 @@ function createMockSession(overrides?: Record<string, unknown>): IAgentJobHostCo
     closeAgentJob: vi.fn(),
     ...overrides,
   };
-  return session as unknown as IAgentJobHostContext;
+  return session as unknown as ICommandHostContext;
 }
 
 describe('agent command module', () => {

--- a/packages/agent-command-agent/src/agent-command-module.ts
+++ b/packages/agent-command-agent/src/agent-command-module.ts
@@ -1,10 +1,16 @@
 import type {
+  IAgentJobHostContext,
   ICommand,
+  ICommandHostContext,
   ICommandModule,
   ICommandSource,
   ISystemCommand,
 } from '@robota-sdk/agent-sdk';
 import { executeAgentCommand } from './agent-command.js';
+
+function asAgentHostContext(context: ICommandHostContext): IAgentJobHostContext {
+  return context as unknown as IAgentJobHostContext;
+}
 
 function createAgentSubcommands(): ICommand[] {
   return [
@@ -45,7 +51,7 @@ export function createAgentSystemCommand(): ISystemCommand {
   return {
     name: entry.name,
     description: entry.description,
-    execute: executeAgentCommand,
+    execute: (context, args) => executeAgentCommand(asAgentHostContext(context), args),
     ...(entry.modelInvocable !== undefined ? { modelInvocable: entry.modelInvocable } : {}),
     ...(entry.userInvocable !== undefined ? { userInvocable: entry.userInvocable } : {}),
     ...(entry.argumentHint !== undefined ? { argumentHint: entry.argumentHint } : {}),

--- a/packages/agent-command-agent/src/agent-command.ts
+++ b/packages/agent-command-agent/src/agent-command.ts
@@ -1,5 +1,9 @@
 import { summarizeBackgroundJobGroup } from '@robota-sdk/agent-sdk';
-import type { ICommandResult, InteractiveSession } from '@robota-sdk/agent-sdk';
+import type {
+  IAgentJobHostContext,
+  ICommandResult,
+  ISubagentJobState,
+} from '@robota-sdk/agent-sdk';
 import { parseParallelRequests, parseRunRequest, tokenizeArgs } from './agent-command-parser.js';
 import type { IAgentRunRequest } from './agent-command-parser.js';
 
@@ -7,12 +11,12 @@ function formatError<TError>(error: TError): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function getAvailableAgentNames(session: InteractiveSession): ReadonlySet<string> {
+function getAvailableAgentNames(session: IAgentJobHostContext): ReadonlySet<string> {
   return new Set(session.listAgentDefinitions().map((agent) => agent.name));
 }
 
 function validateAgentType(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   agentType: string,
 ): ICommandResult | undefined {
   const agents = session.listAgentDefinitions();
@@ -24,9 +28,9 @@ function validateAgentType(
 }
 
 async function spawnAgentJob(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   request: IAgentRunRequest,
-): Promise<ICommandResult | { state: Awaited<ReturnType<InteractiveSession['spawnAgentJob']>> }> {
+): Promise<ICommandResult | { state: ISubagentJobState }> {
   const invalid = validateAgentType(session, request.agentType);
   if (invalid) return invalid;
   try {
@@ -40,7 +44,7 @@ function executeOpenSwitcher(): ICommandResult {
   return { message: '', effects: [{ type: 'agent-switcher-requested' }], success: true };
 }
 
-async function executeList(session: InteractiveSession): Promise<ICommandResult> {
+async function executeList(session: IAgentJobHostContext): Promise<ICommandResult> {
   const agents = session.listAgentDefinitions();
   const jobs = session.listAgentJobs();
   const lines = [
@@ -57,7 +61,7 @@ async function executeList(session: InteractiveSession): Promise<ICommandResult>
   };
 }
 
-function formatAgentJobLine(job: ReturnType<InteractiveSession['listAgentJobs']>[number]): string {
+function formatAgentJobLine(job: ISubagentJobState): string {
   const worktree = [
     job.worktreePath ? `worktree=${job.worktreePath}` : undefined,
     job.branchName ? `branch=${job.branchName}` : undefined,
@@ -67,7 +71,7 @@ function formatAgentJobLine(job: ReturnType<InteractiveSession['listAgentJobs']>
 }
 
 async function executeRun(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const request = parseRunRequest(tokens, getAvailableAgentNames(session));
@@ -90,7 +94,7 @@ async function executeRun(
 }
 
 async function executeParallel(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const wait = tokens.includes('--wait') || !tokens.includes('--detach');
@@ -109,7 +113,7 @@ async function executeParallel(
     .find((result): result is ICommandResult => result !== undefined);
   if (invalid) return invalid;
 
-  let states: Array<Awaited<ReturnType<InteractiveSession['spawnAgentJob']>>>;
+  let states: ISubagentJobState[];
   try {
     states = await Promise.all(jobs.map((job) => session.spawnAgentJob(job)));
   } catch (error) {
@@ -141,7 +145,7 @@ async function executeParallel(
 }
 
 async function executeWait(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [groupId] = tokens;
@@ -156,7 +160,7 @@ async function executeWait(
 }
 
 async function executeRead(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId, offset] = tokens;
@@ -172,7 +176,7 @@ async function executeRead(
 }
 
 async function executeSend(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId, ...promptParts] = tokens;
@@ -185,7 +189,7 @@ async function executeSend(
 }
 
 async function executeStop(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId, ...reasonParts] = tokens;
@@ -195,7 +199,7 @@ async function executeStop(
 }
 
 async function executeClose(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   tokens: readonly string[],
 ): Promise<ICommandResult> {
   const [agentId] = tokens;
@@ -205,7 +209,7 @@ async function executeClose(
 }
 
 export async function executeAgentCommand(
-  session: InteractiveSession,
+  session: IAgentJobHostContext,
   args: string,
 ): Promise<ICommandResult> {
   try {

--- a/packages/agent-sdk/src/command-api/host-context.ts
+++ b/packages/agent-sdk/src/command-api/host-context.ts
@@ -1,11 +1,15 @@
 import type { IContextWindowState, TPermissionMode } from '@robota-sdk/agent-core';
 import type { ISessionReplayValidationResult } from '@robota-sdk/agent-sessions';
 import type {
+  IBackgroundJobGroupCreateRequest,
+  IBackgroundJobGroupState,
   IBackgroundTaskListFilter,
   IBackgroundTaskLogCursor,
   IBackgroundTaskLogPage,
   IBackgroundTaskState,
+  TBackgroundTaskIsolation,
 } from '../background-tasks/index.js';
+import type { ISubagentJobState } from '../subagents/index.js';
 import type { ICommandHostAdapters } from './host-adapters.js';
 import type {
   IEditCheckpointInspection,
@@ -106,4 +110,28 @@ export interface ICommandHostContext {
   ): Promise<IBackgroundTaskLogPage>;
   cancelBackgroundTask(taskId: string, reason?: string): Promise<void>;
   closeBackgroundTask(taskId: string): Promise<void>;
+}
+
+export interface IAgentJobHostContext {
+  listAgentDefinitions(): Array<{ name: string; description: string }>;
+  listAgentJobs(): ISubagentJobState[];
+  spawnAgentJob(input: {
+    agentType: string;
+    label: string;
+    mode: 'foreground' | 'background';
+    prompt: string;
+    model?: string;
+    isolation?: TBackgroundTaskIsolation;
+  }): Promise<ISubagentJobState>;
+  sendAgentJob(jobId: string, prompt: string): Promise<void>;
+  cancelAgentJob(jobId: string, reason?: string): Promise<void>;
+  closeAgentJob(jobId: string): Promise<void>;
+  createBackgroundJobGroup(
+    input: Omit<IBackgroundJobGroupCreateRequest, 'parentSessionId'>,
+  ): IBackgroundJobGroupState;
+  waitBackgroundJobGroup(groupId: string): Promise<IBackgroundJobGroupState>;
+  readBackgroundTaskLog(
+    taskId: string,
+    cursor?: IBackgroundTaskLogCursor,
+  ): Promise<IBackgroundTaskLogPage>;
 }

--- a/packages/agent-sdk/src/command-api/index.ts
+++ b/packages/agent-sdk/src/command-api/index.ts
@@ -9,6 +9,7 @@ export type {
 export type { TCommandEffect } from './effects.js';
 export type { ICommandResult, TCommandResultDataValue } from './command-result.js';
 export type {
+  IAgentJobHostContext,
   ICommandHostContext,
   ICommandListEntry,
   ICommandSessionReplayValidationReport,

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { BuiltinCommandSource, createBuiltinCommandModule } from '../builtin-source.js';
 import { SystemCommandExecutor, createSystemCommands } from '../system-command.js';
 import { formatCommandHelpMessage } from '../../command-api/help/help-command-api.js';
-import type { InteractiveSession } from '../../interactive/interactive-session.js';
+import type { IInteractiveSession } from '../../interactive/i-interactive-session.js';
 import type { ICommandModule } from '../../command-api/command-module.js';
 
 function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspace') {
@@ -71,7 +71,7 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
     ...overrides,
     _underlying: underlying,
     getCwd: () => cwd,
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('SystemCommandExecutor', () => {

--- a/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
+++ b/packages/agent-sdk/src/commands/__tests__/system-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { BuiltinCommandSource, createBuiltinCommandModule } from '../builtin-source.js';
 import { SystemCommandExecutor, createSystemCommands } from '../system-command.js';
 import { formatCommandHelpMessage } from '../../command-api/help/help-command-api.js';
-import type { IInteractiveSession } from '../../interactive/i-interactive-session.js';
+import type { ICommandHostContext } from '../../command-api/index.js';
 import type { ICommandModule } from '../../command-api/command-module.js';
 
 function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspace') {
@@ -71,7 +71,7 @@ function createMockSession(overrides?: Record<string, unknown>, cwd = '/workspac
     ...overrides,
     _underlying: underlying,
     getCwd: () => cwd,
-  } as unknown as IInteractiveSession;
+  } as unknown as ICommandHostContext;
 }
 
 describe('SystemCommandExecutor', () => {

--- a/packages/agent-sdk/src/commands/index.ts
+++ b/packages/agent-sdk/src/commands/index.ts
@@ -1,4 +1,5 @@
 export type {
+  IAgentJobHostContext,
   ICommand,
   ICommandChoicePromptOption,
   ICommandHostAdapters,

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -10,6 +10,7 @@ export {
   resolveSessionIdByIdOrName,
 } from './interactive/index.js';
 export type {
+  IInteractiveSession,
   IInteractiveSessionOptions,
   IInteractiveSessionShutdownOptions,
   ISkillActivationEvent,
@@ -53,6 +54,7 @@ export type {
   TCapabilitySafety,
 } from './capabilities/types.js';
 export type {
+  IAgentJobHostContext,
   ICommand,
   ICommandHostAdapters,
   ICommandHostContext,
@@ -606,6 +608,9 @@ export type {
 
 // ── Permissions ─────────────────────────────────────────────
 export { promptForApproval } from './permissions/permission-prompt.js';
+
+// ── Testing utilities ────────────────────────────────────────
+export { createTestInteractiveSession } from './testing/create-test-interactive-session.js';
 
 // ──────────────────────────────────────────────────────────────
 // INTERNAL (not exported):

--- a/packages/agent-sdk/src/interactive/i-interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/i-interactive-session.ts
@@ -21,6 +21,9 @@ import type {
 
 /** Minimal session surface consumed by transport adapters and test factories. */
 export interface IInteractiveSession {
+  /** True once the underlying session has been initialized. */
+  readonly isInitialized?: boolean;
+
   // Submission
   submit(input: string, displayInput?: string, rawInput?: string): Promise<void>;
   abort(): void;

--- a/packages/agent-sdk/src/interactive/i-interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/i-interactive-session.ts
@@ -1,0 +1,86 @@
+import type { TUniversalMessage, IContextWindowState } from '@robota-sdk/agent-core';
+import type {
+  IBackgroundJobGroupCreateRequest,
+  IBackgroundJobGroupState,
+  IBackgroundTaskInput,
+  IBackgroundTaskListFilter,
+  IBackgroundTaskLogCursor,
+  IBackgroundTaskLogPage,
+  IBackgroundTaskState,
+  IExecutionWorkspaceSnapshot,
+  IExecutionWorkspaceSnapshotOptions,
+  TBackgroundTaskIsolation,
+} from '../background-tasks/index.js';
+import type { ICommandResult, ICommandListEntry } from '../commands/index.js';
+import type { ISubagentJobState } from '../subagents/index.js';
+import type {
+  IExecutionResult,
+  TInteractiveEventName,
+  IInteractiveSessionEvents,
+} from './types.js';
+
+/** Minimal session surface consumed by transport adapters and test factories. */
+export interface IInteractiveSession {
+  // Submission
+  submit(input: string, displayInput?: string, rawInput?: string): Promise<void>;
+  abort(): void;
+  cancelQueue(): void;
+  shutdown(options?: { reason?: string; message?: string }): Promise<void>;
+
+  // State
+  isExecuting(): boolean;
+  getPendingPrompt(): string | null;
+  getMessages(): TUniversalMessage[];
+  getContextState(): IContextWindowState;
+  getSession(): { getSessionId(): string };
+  getCwd(): string;
+
+  // Commands
+  executeCommand(name: string, args: string): Promise<ICommandResult | null>;
+  listCommands(): ICommandListEntry[];
+
+  // Events
+  on<E extends TInteractiveEventName>(event: E, handler: IInteractiveSessionEvents[E]): void;
+  off<E extends TInteractiveEventName>(event: E, handler: IInteractiveSessionEvents[E]): void;
+
+  // Background tasks
+  listBackgroundTasks(filter?: IBackgroundTaskListFilter): IBackgroundTaskState[];
+  getBackgroundTask(taskId: string): IBackgroundTaskState | undefined;
+  cancelBackgroundTask(taskId: string, reason?: string): Promise<void>;
+  closeBackgroundTask(taskId: string): Promise<void>;
+  sendBackgroundTask(taskId: string, input: IBackgroundTaskInput): Promise<void>;
+  readBackgroundTaskLog(
+    taskId: string,
+    cursor?: IBackgroundTaskLogCursor,
+  ): Promise<IBackgroundTaskLogPage>;
+
+  // Background job groups
+  listBackgroundJobGroups(): IBackgroundJobGroupState[];
+  getBackgroundJobGroup(groupId: string): IBackgroundJobGroupState | undefined;
+  createBackgroundJobGroup(
+    input: Omit<IBackgroundJobGroupCreateRequest, 'parentSessionId'>,
+  ): IBackgroundJobGroupState;
+  waitBackgroundJobGroup(groupId: string): Promise<IBackgroundJobGroupState>;
+
+  // Execution workspace
+  getExecutionWorkspaceSnapshot(
+    options?: IExecutionWorkspaceSnapshotOptions,
+  ): IExecutionWorkspaceSnapshot;
+
+  // Agent jobs
+  listAgentDefinitions(): Array<{ name: string; description: string }>;
+  listAgentJobs(): ISubagentJobState[];
+  spawnAgentJob(input: {
+    agentType: string;
+    label: string;
+    mode: 'foreground' | 'background';
+    prompt: string;
+    model?: string;
+    isolation?: TBackgroundTaskIsolation;
+  }): Promise<ISubagentJobState>;
+  sendAgentJob(jobId: string, prompt: string): Promise<void>;
+  cancelAgentJob(jobId: string, reason?: string): Promise<void>;
+  closeAgentJob(jobId: string): Promise<void>;
+}
+
+export type { IExecutionResult };

--- a/packages/agent-sdk/src/interactive/index.ts
+++ b/packages/agent-sdk/src/interactive/index.ts
@@ -1,4 +1,5 @@
 export { InteractiveSession } from './interactive-session.js';
+export type { IInteractiveSession } from './i-interactive-session.js';
 export {
   createProjectSessionStore,
   listResumableSessionSummaries,

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -26,7 +26,9 @@ import {
   createSystemMessage,
   messageToHistoryEntry,
 } from '@robota-sdk/agent-core';
+import type { IInteractiveSession } from './i-interactive-session.js';
 import type {
+  IAgentJobHostContext,
   ICommand,
   ICommandHostAdapters,
   ICommandModule,
@@ -174,7 +176,7 @@ function getBackgroundTaskEventEntryId(event: TBackgroundTaskEvent): string | un
   return undefined;
 }
 
-export class InteractiveSession implements ISession {
+export class InteractiveSession implements ISession, IAgentJobHostContext, IInteractiveSession {
   private session: Session | null = null;
   private readonly commandExecutor: SystemCommandExecutor;
   private readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();

--- a/packages/agent-sdk/src/testing/create-test-interactive-session.ts
+++ b/packages/agent-sdk/src/testing/create-test-interactive-session.ts
@@ -1,0 +1,79 @@
+import type { IInteractiveSession } from '../interactive/i-interactive-session.js';
+
+const EMPTY_CONTEXT_STATE = {
+  usedTokens: 0,
+  maxTokens: 200000,
+  usedPercentage: 0,
+  remainingPercentage: 100,
+};
+
+const EMPTY_EXECUTION_WORKSPACE = {
+  sessionId: 'test-session-id',
+  updatedAt: new Date().toISOString(),
+  entries: [] as [],
+};
+
+const EMPTY_BACKGROUND_GROUP = {
+  id: '',
+  parentSessionId: 'test-session-id',
+  waitPolicy: 'wait_all' as const,
+  taskIds: [],
+  status: 'completed' as const,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  results: [],
+};
+
+/** Creates a stub IInteractiveSession for use in tests. All methods return sensible defaults.
+ *  Pass overrides to spy on or replace specific methods. */
+export function createTestInteractiveSession(
+  overrides?: Partial<IInteractiveSession>,
+): IInteractiveSession {
+  const base: IInteractiveSession = {
+    submit: () => Promise.resolve(),
+    abort: () => {},
+    cancelQueue: () => {},
+    shutdown: () => Promise.resolve(),
+    isExecuting: () => false,
+    getPendingPrompt: () => null,
+    getMessages: () => [],
+    getContextState: () => ({ ...EMPTY_CONTEXT_STATE }),
+    getSession: () => ({ getSessionId: () => 'test-session-id' }),
+    getCwd: () => '/workspace',
+    executeCommand: () => Promise.resolve(null),
+    listCommands: () => [],
+    on: () => {},
+    off: () => {},
+    listBackgroundTasks: () => [],
+    getBackgroundTask: () => undefined,
+    cancelBackgroundTask: () => Promise.resolve(),
+    closeBackgroundTask: () => Promise.resolve(),
+    sendBackgroundTask: () => Promise.resolve(),
+    readBackgroundTaskLog: () => Promise.resolve({ taskId: '', lines: [] }),
+    listBackgroundJobGroups: () => [],
+    getBackgroundJobGroup: () => undefined,
+    createBackgroundJobGroup: () => ({ ...EMPTY_BACKGROUND_GROUP }),
+    waitBackgroundJobGroup: () => Promise.resolve({ ...EMPTY_BACKGROUND_GROUP }),
+    getExecutionWorkspaceSnapshot: () => ({ ...EMPTY_EXECUTION_WORKSPACE }),
+    listAgentDefinitions: () => [],
+    listAgentJobs: () => [],
+    spawnAgentJob: () =>
+      Promise.resolve({
+        id: 'agent_1',
+        type: 'general-purpose',
+        label: 'general-purpose',
+        parentSessionId: 'test-session-id',
+        status: 'running' as const,
+        mode: 'background' as const,
+        depth: 1,
+        cwd: '/workspace',
+        promptPreview: '',
+        updatedAt: new Date().toISOString(),
+      }),
+    sendAgentJob: () => Promise.resolve(),
+    cancelAgentJob: () => Promise.resolve(),
+    closeAgentJob: () => Promise.resolve(),
+    ...overrides,
+  };
+  return base;
+}

--- a/packages/agent-transport-headless/src/__tests__/headless-runner-initialization.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner-initialization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import { createHeadlessRunner } from '../headless-runner.js';
 
 describe('createHeadlessRunner initialization', () => {
@@ -28,7 +28,7 @@ describe('createHeadlessRunner initialization', () => {
         }
         return { getSessionId: () => 'initialized-session' };
       }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
 
     try {
       const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });

--- a/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { IExecutionResult } from '@robota-sdk/agent-sdk';
 import type { TBackgroundJobGroupEvent } from '@robota-sdk/agent-sdk';
 import type { TBackgroundTaskEvent } from '@robota-sdk/agent-sdk';
@@ -42,7 +42,7 @@ function createMockSession(behavior: 'complete' | 'interrupted' | 'error', respo
     }),
     executeCommand: vi.fn().mockResolvedValue(null),
     getSession: vi.fn(() => ({ getSessionId: () => 'test-session-id' })),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createHeadlessRunner (text format)', () => {
@@ -113,7 +113,7 @@ describe('createHeadlessRunner (text format)', () => {
         success: true,
         data: { agentId: 'agent_1' },
       }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const runner = createHeadlessRunner({ session, outputFormat: 'text' });
 
     const exitCode = await runner.run('/agent run Plan --background "draft architecture"');
@@ -154,7 +154,7 @@ describe('createHeadlessRunner (text format)', () => {
         };
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'test-session-id' })),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const runner = createHeadlessRunner({ session, outputFormat: 'text' });
 
     const exitCode = await runner.run('/audit src/index.ts');
@@ -261,7 +261,7 @@ describe('createHeadlessRunner (stream-json format)', () => {
         }
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'stream-session' })),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
 
     const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
     const exitCode = await runner.run('test prompt');
@@ -326,7 +326,7 @@ describe('createHeadlessRunner (stream-json format)', () => {
         }
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'stream-session' })),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
 
     const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
     const exitCode = await runner.run('test prompt');
@@ -382,7 +382,7 @@ describe('createHeadlessRunner (stream-json format)', () => {
         };
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'stream-session' })),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
 
     const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
     const exitCode = await runner.run('/agent run Plan --background "draft architecture"');
@@ -451,7 +451,7 @@ describe('createHeadlessRunner (stream-json format)', () => {
         };
       }),
       getSession: vi.fn(() => ({ getSessionId: () => 'stream-session' })),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
 
     const runner = createHeadlessRunner({ session, outputFormat: 'stream-json' });
     const exitCode = await runner.run('/agent wait group_1');

--- a/packages/agent-transport-headless/src/__tests__/headless-transport.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-transport.test.ts
@@ -120,7 +120,7 @@ describe('createHeadlessTransport', () => {
 
     try {
       const transport = createHeadlessTransport({ outputFormat: 'text', prompt: 'hello' });
-      transport.attach(mockSession);
+      transport.attach(mockSession as never);
       await transport.start();
 
       expect(transport.getExitCode()).toBe(0);
@@ -148,7 +148,7 @@ describe('createHeadlessTransport (json adapter)', () => {
     });
 
     const transport = createHeadlessTransport({ outputFormat: 'json', prompt: 'test prompt' });
-    transport.attach(mockSession);
+    transport.attach(mockSession as never);
     await transport.start();
 
     expect(transport.getExitCode()).toBe(0);
@@ -186,7 +186,7 @@ describe('createHeadlessTransport (stream-json adapter)', () => {
       outputFormat: 'stream-json',
       prompt: 'test prompt',
     });
-    transport.attach(mockSession);
+    transport.attach(mockSession as never);
     await transport.start();
 
     expect(transport.getExitCode()).toBe(0);
@@ -247,7 +247,7 @@ describe('createHeadlessTransport (error and interrupted)', () => {
     const mockSession = createEventDrivenMockSession('error');
 
     const transport = createHeadlessTransport({ outputFormat: 'text', prompt: 'test prompt' });
-    transport.attach(mockSession);
+    transport.attach(mockSession as never);
     await transport.start();
 
     expect(transport.getExitCode()).toBe(1);
@@ -259,7 +259,7 @@ describe('createHeadlessTransport (error and interrupted)', () => {
     });
 
     const transport = createHeadlessTransport({ outputFormat: 'text', prompt: 'test prompt' });
-    transport.attach(mockSession);
+    transport.attach(mockSession as never);
     await transport.start();
 
     expect(transport.getExitCode()).toBe(0);

--- a/packages/agent-transport-headless/src/__tests__/headless-transport.test.ts
+++ b/packages/agent-transport-headless/src/__tests__/headless-transport.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHeadlessTransport } from '../headless-transport.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { IExecutionResult } from '@robota-sdk/agent-sdk';
 
-function createMockSession(): InteractiveSession {
+function createMockSession(): IInteractiveSession {
   return {
     submit: vi.fn(),
     abort: vi.fn(),
@@ -19,13 +19,13 @@ function createMockSession(): InteractiveSession {
     getSession: vi.fn().mockReturnValue({ getSessionId: () => 'test-session-id' }),
     on: vi.fn(),
     off: vi.fn(),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 function createEventDrivenMockSession(
   behavior: 'complete' | 'error' | 'interrupted' = 'complete',
   options?: { response?: string; textDeltas?: string[] },
-): InteractiveSession {
+): IInteractiveSession {
   const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
   const response = options?.response ?? 'test output';
   const textDeltas = options?.textDeltas;
@@ -88,7 +88,7 @@ function createEventDrivenMockSession(
         if (idx >= 0) handlers.splice(idx, 1);
       }
     }),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createHeadlessTransport', () => {

--- a/packages/agent-transport-headless/src/headless-runner.ts
+++ b/packages/agent-transport-headless/src/headless-runner.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type {
-  InteractiveSession,
+  IInteractiveSession,
   IExecutionResult,
   ICommandResult,
   TBackgroundJobGroupEvent,
@@ -10,7 +10,7 @@ import type {
 export type TOutputFormat = 'text' | 'json' | 'stream-json';
 
 export interface IHeadlessRunnerOptions {
-  session: InteractiveSession;
+  session: IInteractiveSession;
   outputFormat: TOutputFormat;
 }
 
@@ -73,7 +73,7 @@ function parseSlashCommand(prompt: string): { name: string; args: string } | nul
 }
 
 async function executeSlashCommandIfPresent(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   prompt: string,
 ): Promise<TSlashCommandExecution> {
   const command = parseSlashCommand(prompt);
@@ -96,7 +96,7 @@ async function executeSlashCommandIfPresent(
   };
 }
 
-function getSessionId(session: InteractiveSession): string {
+function getSessionId(session: IInteractiveSession): string {
   try {
     return session.getSession().getSessionId();
   } catch {
@@ -104,7 +104,7 @@ function getSessionId(session: InteractiveSession): string {
   }
 }
 
-function writeStreamJsonEvent(session: InteractiveSession, event: TStreamJsonEvent): void {
+function writeStreamJsonEvent(session: IInteractiveSession, event: TStreamJsonEvent): void {
   const output = JSON.stringify({
     type: 'stream_event',
     event,
@@ -114,7 +114,7 @@ function writeStreamJsonEvent(session: InteractiveSession, event: TStreamJsonEve
   process.stdout.write(output + '\n');
 }
 
-function runJsonFormat(session: InteractiveSession, prompt: string): Promise<number> {
+function runJsonFormat(session: IInteractiveSession, prompt: string): Promise<number> {
   return new Promise<number>((resolve) => {
     const cleanup = (): void => {
       session.off('complete', onComplete);
@@ -163,7 +163,7 @@ function runJsonFormat(session: InteractiveSession, prompt: string): Promise<num
   });
 }
 
-function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promise<number> {
+function runStreamJsonFormat(session: IInteractiveSession, prompt: string): Promise<number> {
   return new Promise<number>((resolve) => {
     const cleanup = subscribeStreamJsonEvents(session, resolve);
 
@@ -187,7 +187,7 @@ function runStreamJsonFormat(session: InteractiveSession, prompt: string): Promi
 }
 
 function subscribeStreamJsonEvents(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   resolve: (exitCode: number) => void,
 ): () => void {
   const onTextDelta = (text: string): void => {
@@ -241,7 +241,7 @@ interface IStreamJsonHandlers {
 }
 
 function unsubscribeStreamJsonEvents(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   handlers: IStreamJsonHandlers,
 ): void {
   session.off('text_delta', handlers.onTextDelta);
@@ -253,7 +253,7 @@ function unsubscribeStreamJsonEvents(
 }
 
 function completeStream(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   cleanup: () => void,
   result: IExecutionResult,
   resolve: (exitCode: number) => void,
@@ -263,7 +263,7 @@ function completeStream(
   resolve(0);
 }
 
-function runTextFormat(session: InteractiveSession, prompt: string): Promise<number> {
+function runTextFormat(session: IInteractiveSession, prompt: string): Promise<number> {
   return new Promise<number>((resolve) => {
     const cleanup = (): void => {
       session.off('complete', onComplete);

--- a/packages/agent-transport-headless/src/headless-transport.ts
+++ b/packages/agent-transport-headless/src/headless-transport.ts
@@ -5,7 +5,7 @@
  * After start() completes, getExitCode() returns the runner's exit code.
  */
 
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { ISession } from '@robota-sdk/agent-core';
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 import { createHeadlessRunner } from './headless-runner.js';
@@ -21,13 +21,13 @@ export interface IHeadlessTransportOptions {
 export function createHeadlessTransport(
   options: IHeadlessTransportOptions,
 ): ITransportAdapter & { getExitCode(): number } {
-  let session: InteractiveSession | null = null;
+  let session: IInteractiveSession | null = null;
   let exitCode = 0;
 
   return {
     name: 'headless',
     attach(s: ISession) {
-      session = s as InteractiveSession;
+      session = s as unknown as IInteractiveSession;
     },
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');

--- a/packages/agent-transport-http/src/__tests__/http-transport.test.ts
+++ b/packages/agent-transport-http/src/__tests__/http-transport.test.ts
@@ -38,7 +38,7 @@ describe('createHttpTransport', () => {
 
   it('creates a Hono app after attach + start', async () => {
     const transport = createHttpTransport();
-    transport.attach(createMockSession());
+    transport.attach(createMockSession() as never);
     await transport.start();
     const app = transport.getApp();
     expect(app).toBeDefined();
@@ -47,7 +47,7 @@ describe('createHttpTransport', () => {
 
   it('nullifies app after stop()', async () => {
     const transport = createHttpTransport();
-    transport.attach(createMockSession());
+    transport.attach(createMockSession() as never);
     await transport.start();
     await transport.stop();
     expect(() => transport.getApp()).toThrow('Transport not started');

--- a/packages/agent-transport-http/src/__tests__/http-transport.test.ts
+++ b/packages/agent-transport-http/src/__tests__/http-transport.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createHttpTransport } from '../http-transport.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
-function createMockSession(): InteractiveSession {
+function createMockSession(): IInteractiveSession {
   return {
     submit: vi.fn(),
     abort: vi.fn(),
@@ -17,7 +17,7 @@ function createMockSession(): InteractiveSession {
     listCommands: vi.fn().mockReturnValue([]),
     on: vi.fn(),
     off: vi.fn(),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createHttpTransport', () => {

--- a/packages/agent-transport-http/src/__tests__/routes.test.ts
+++ b/packages/agent-transport-http/src/__tests__/routes.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createAgentRoutes } from '../routes.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
 function createMockSession(overrides?: Record<string, unknown>) {
   return {
@@ -31,11 +31,11 @@ function createMockSession(overrides?: Record<string, unknown>) {
     on: vi.fn(),
     off: vi.fn(),
     ...overrides,
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('HTTP Transport Routes', () => {
-  function createApp(session?: InteractiveSession) {
+  function createApp(session?: IInteractiveSession) {
     const mockSession = session ?? createMockSession();
     const app = createAgentRoutes({
       sessionFactory: () => mockSession,

--- a/packages/agent-transport-http/src/http-transport.ts
+++ b/packages/agent-transport-http/src/http-transport.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import { createAgentRoutes } from './routes.js';
 import type { Hono } from 'hono';
 
@@ -18,13 +18,13 @@ export interface IHttpTransportOptions {
 export function createHttpTransport(
   options?: IHttpTransportOptions,
 ): ITransportAdapter & { getApp(): Hono } {
-  let session: InteractiveSession | null = null;
+  let session: IInteractiveSession | null = null;
   let app: Hono | null = null;
 
   return {
     name: 'http',
-    attach(s: InteractiveSession) {
-      session = s;
+    attach(s) {
+      session = s as unknown as IInteractiveSession;
     },
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');

--- a/packages/agent-transport-http/src/routes.ts
+++ b/packages/agent-transport-http/src/routes.ts
@@ -1,20 +1,20 @@
 /**
- * HTTP transport adapter — exposes InteractiveSession over REST API.
+ * HTTP transport adapter — exposes IInteractiveSession over REST API.
  *
  * Built on Hono for Cloudflare Workers + Node.js + AWS Lambda compatibility.
- * Each endpoint maps 1:1 to an InteractiveSession API method.
+ * Each endpoint maps 1:1 to an IInteractiveSession API method.
  */
 
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import type { Context } from 'hono';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
-/** Callback that resolves an InteractiveSession from the request context. */
-export type ISessionFactory = (c: Context) => InteractiveSession | Promise<InteractiveSession>;
+/** Callback that resolves an IInteractiveSession from the request context. */
+export type ISessionFactory = (c: Context) => IInteractiveSession | Promise<IInteractiveSession>;
 
 export interface IAgentRoutesOptions {
-  /** Resolve an InteractiveSession per request (e.g., by auth token, session ID). */
+  /** Resolve an IInteractiveSession per request (e.g., by auth token, session ID). */
   sessionFactory: ISessionFactory;
 }
 

--- a/packages/agent-transport-mcp/src/__tests__/mcp-server.test.ts
+++ b/packages/agent-transport-mcp/src/__tests__/mcp-server.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createAgentMcpServer } from '../mcp-server.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
 function createMockSession(commands?: Array<{ name: string; description: string }>) {
   return {
@@ -26,7 +26,7 @@ function createMockSession(commands?: Array<{ name: string; description: string 
     ),
     on: vi.fn(),
     off: vi.fn(),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createAgentMcpServer', () => {

--- a/packages/agent-transport-mcp/src/__tests__/mcp-transport.test.ts
+++ b/packages/agent-transport-mcp/src/__tests__/mcp-transport.test.ts
@@ -38,7 +38,7 @@ describe('createMcpTransport', () => {
 
   it('creates an MCP server after attach + start', async () => {
     const transport = createMcpTransport({ name: 'test', version: '1.0.0' });
-    transport.attach(createMockSession());
+    transport.attach(createMockSession() as never);
     await transport.start();
     const server = transport.getServer();
     expect(server).toBeDefined();

--- a/packages/agent-transport-mcp/src/__tests__/mcp-transport.test.ts
+++ b/packages/agent-transport-mcp/src/__tests__/mcp-transport.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createMcpTransport } from '../mcp-transport.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
-function createMockSession(): InteractiveSession {
+function createMockSession(): IInteractiveSession {
   return {
     submit: vi.fn(),
     abort: vi.fn(),
@@ -17,7 +17,7 @@ function createMockSession(): InteractiveSession {
     listCommands: vi.fn().mockReturnValue([]),
     on: vi.fn(),
     off: vi.fn(),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createMcpTransport', () => {

--- a/packages/agent-transport-mcp/src/mcp-server.ts
+++ b/packages/agent-transport-mcp/src/mcp-server.ts
@@ -1,5 +1,5 @@
 /**
- * MCP transport adapter — exposes InteractiveSession as an MCP server.
+ * MCP transport adapter — exposes IInteractiveSession as an MCP server.
  *
  * Uses the low-level MCP Server class to avoid TypeScript depth issues
  * with McpServer.registerTool() generics. Registers tools/list and
@@ -8,21 +8,21 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import type { InteractiveSession, IExecutionResult } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession, IExecutionResult } from '@robota-sdk/agent-sdk';
 
 export interface IAgentMcpOptions {
   /** Name for the MCP server. */
   name: string;
   /** Version string. */
   version: string;
-  /** InteractiveSession to expose. */
-  session: InteractiveSession;
+  /** IInteractiveSession to expose. */
+  session: IInteractiveSession;
   /** If true, register each system command as a separate MCP tool. Default: true. */
   exposeCommands?: boolean;
 }
 
 /**
- * Create an MCP server that exposes InteractiveSession over Model Context Protocol.
+ * Create an MCP server that exposes IInteractiveSession over Model Context Protocol.
  *
  * Usage:
  * ```typescript
@@ -126,7 +126,10 @@ export function createAgentMcpServer(options: IAgentMcpOptions): Server {
 /**
  * Submit a prompt and wait for the complete/interrupted/error event.
  */
-function waitForCompletion(session: InteractiveSession, prompt: string): Promise<IExecutionResult> {
+function waitForCompletion(
+  session: IInteractiveSession,
+  prompt: string,
+): Promise<IExecutionResult> {
   return new Promise((resolve, reject) => {
     const onComplete = (result: IExecutionResult): void => {
       cleanup();

--- a/packages/agent-transport-tui/src/__tests__/slash-routing-effects.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/slash-routing-effects.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { afterEach, vi } from 'vitest';
 import { CommandRegistry, BundlePluginLoader, PluginCommandSource } from '@robota-sdk/agent-sdk';
-import type { ICommandInteraction, InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { ICommandInteraction, IInteractiveSession } from '@robota-sdk/agent-sdk';
 import { TuiStateManager } from '../tui-state-manager.js';
 import { applySystemCommandResult } from '../hooks/useSlashRouting.js';
 import { CommandEffectQueue } from '../hooks/command-effect-queue.js';
@@ -45,7 +45,7 @@ describe('applySystemCommandResult', () => {
   it('stores statusline settings patch as a CLI side effect', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const manager = new TuiStateManager();
     const queue = new CommandEffectQueue();
 
@@ -71,7 +71,7 @@ describe('applySystemCommandResult', () => {
   it('stores generic command interactions without interpreting command-specific data', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const manager = new TuiStateManager();
     const queue = new CommandEffectQueue();
     const interaction: ICommandInteraction = {
@@ -105,7 +105,7 @@ describe('applySystemCommandResult', () => {
   it('stores host command side effects', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const manager = new TuiStateManager();
     const queue = new CommandEffectQueue();
 
@@ -131,7 +131,7 @@ describe('applySystemCommandResult', () => {
   it('applies conversation history clearing immediately before adding the command result', () => {
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const manager = new TuiStateManager();
     const queue = new CommandEffectQueue();
     manager.addEntry({
@@ -192,7 +192,7 @@ describe('applySystemCommandResult', () => {
     vi.stubEnv('HOME', home);
     const session = {
       getContextState: () => ({ usedPercentage: 0, usedTokens: 0, maxTokens: 0 }),
-    } as unknown as InteractiveSession;
+    } as unknown as IInteractiveSession;
     const registry = createRegistry();
     const queue = new CommandEffectQueue();
     registry.addSource({

--- a/packages/agent-transport-tui/src/hooks/useSlashRouting.ts
+++ b/packages/agent-transport-tui/src/hooks/useSlashRouting.ts
@@ -5,7 +5,7 @@
 
 import { useCallback } from 'react';
 import type {
-  InteractiveSession,
+  IInteractiveSession,
   CommandRegistry,
   ICommandResult,
   TCommandEffect,
@@ -15,7 +15,7 @@ import type { TuiStateManager } from '../tui-state-manager.js';
 import type { ICommandEffectQueue } from './command-effect-queue.js';
 
 export function useSlashRouting(
-  interactiveSession: InteractiveSession,
+  interactiveSession: IInteractiveSession,
   registry: CommandRegistry,
   manager: TuiStateManager,
   commandEffectQueue: ICommandEffectQueue,
@@ -63,7 +63,7 @@ export function useSlashRouting(
 
 export function applySystemCommandResult(
   result: ICommandResult,
-  interactiveSession: InteractiveSession,
+  interactiveSession: IInteractiveSession,
   registry: CommandRegistry,
   manager: TuiStateManager,
   commandEffectQueue: ICommandEffectQueue,

--- a/packages/agent-transport-ws/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-handler.test.ts
@@ -10,7 +10,7 @@ import type {
   IBackgroundTaskState,
   IExecutionWorkspaceEvent,
   IExecutionWorkspaceSnapshot,
-  InteractiveSession,
+  IInteractiveSession,
   IBackgroundJobGroupState,
   TBackgroundJobGroupEvent,
   TBackgroundTaskEvent,
@@ -94,7 +94,7 @@ function createMockSession() {
     _emit: (event: string, ...args: unknown[]) => {
       listeners.get(event)?.forEach((h) => h(...args));
     },
-  } as unknown as InteractiveSession & { _emit: (event: string, ...args: unknown[]) => void };
+  } as unknown as IInteractiveSession & { _emit: (event: string, ...args: unknown[]) => void };
 }
 
 describe('WebSocket Transport Handler', () => {
@@ -102,7 +102,7 @@ describe('WebSocket Transport Handler', () => {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
     const { onMessage, cleanup } = createWsHandler({
-      session: session as unknown as InteractiveSession,
+      session: session as unknown as IInteractiveSession,
       send: (msg) => sent.push(msg),
     });
     return { session, sent, onMessage, cleanup };

--- a/packages/agent-transport-ws/src/__tests__/ws-transport.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-transport.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createWsTransport } from '../ws-transport.js';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
-function createMockSession(): InteractiveSession {
+function createMockSession(): IInteractiveSession {
   return {
     submit: vi.fn(),
     abort: vi.fn(),
@@ -17,7 +17,7 @@ function createMockSession(): InteractiveSession {
     listCommands: vi.fn().mockReturnValue([]),
     on: vi.fn(),
     off: vi.fn(),
-  } as unknown as InteractiveSession;
+  } as unknown as IInteractiveSession;
 }
 
 describe('createWsTransport', () => {

--- a/packages/agent-transport-ws/src/__tests__/ws-transport.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-transport.test.ts
@@ -38,14 +38,14 @@ describe('createWsTransport', () => {
 
   it('provides onMessage after attach + start', async () => {
     const transport = createWsTransport({ send: vi.fn() });
-    transport.attach(createMockSession());
+    transport.attach(createMockSession() as never);
     await transport.start();
     expect(typeof transport.onMessage).toBe('function');
   });
 
   it('clears onMessage after stop()', async () => {
     const transport = createWsTransport({ send: vi.fn() });
-    transport.attach(createMockSession());
+    transport.attach(createMockSession() as never);
     await transport.start();
     await transport.stop();
     expect(transport.onMessage).toBeNull();

--- a/packages/agent-transport-ws/src/ws-background-messages.ts
+++ b/packages/agent-transport-ws/src/ws-background-messages.ts
@@ -1,8 +1,8 @@
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { TBackgroundControlAction, TClientMessage, TServerMessage } from './ws-protocol.js';
 
 export function handleBackgroundQueryMessage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<
     TClientMessage,
@@ -39,7 +39,7 @@ export function handleBackgroundQueryMessage(
 }
 
 export function handleBackgroundControlMessage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<
     TClientMessage,
@@ -72,7 +72,7 @@ export function handleBackgroundControlMessage(
 }
 
 function sendBackgroundTaskSnapshot(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'get-background-task' }>,
 ): void {
@@ -88,7 +88,7 @@ function sendBackgroundTaskSnapshot(
 }
 
 function sendBackgroundTaskLogPage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'read-background-task-log' }>,
 ): void {
@@ -103,7 +103,7 @@ function sendBackgroundTaskLogPage(
 }
 
 function sendBackgroundJobGroupSnapshot(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'get-background-job-group' }>,
 ): void {
@@ -119,7 +119,7 @@ function sendBackgroundJobGroupSnapshot(
 }
 
 function sendBackgroundJobGroupWaitResult(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'wait-background-job-group' }>,
 ): void {
@@ -134,7 +134,7 @@ function sendBackgroundJobGroupWaitResult(
 }
 
 function sendBackgroundTaskInput(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'send-background-task' }>,
 ): void {

--- a/packages/agent-transport-ws/src/ws-handler.ts
+++ b/packages/agent-transport-ws/src/ws-handler.ts
@@ -1,15 +1,15 @@
 /**
- * WebSocket transport adapter — exposes InteractiveSession over WebSocket.
+ * WebSocket transport adapter — exposes IInteractiveSession over WebSocket.
  *
  * Framework-agnostic: works with any WebSocket implementation via
  * send/onMessage callbacks. No dependency on ws, uWebSockets, etc.
  *
  * Protocol: JSON messages with { type, ...payload } structure.
- * Server pushes InteractiveSession events to client in real-time.
+ * Server pushes IInteractiveSession events to client in real-time.
  */
 
 import type {
-  InteractiveSession,
+  IInteractiveSession,
   IExecutionResult,
   IExecutionWorkspaceEvent,
   TBackgroundJobGroupEvent,
@@ -23,14 +23,14 @@ import {
 } from './ws-background-messages.js';
 
 export interface IWsHandlerOptions {
-  /** InteractiveSession to expose. */
-  session: InteractiveSession;
+  /** IInteractiveSession to expose. */
+  session: IInteractiveSession;
   /** Send a JSON message to the client. */
   send: (message: TServerMessage) => void;
 }
 
 /**
- * Create a WebSocket message handler for an InteractiveSession.
+ * Create a WebSocket message handler for an IInteractiveSession.
  *
  * Returns:
  * - `onMessage(data)`: call this when the WebSocket receives a message
@@ -58,7 +58,7 @@ export function createWsHandler(options: IWsHandlerOptions): {
 }
 
 function subscribeSessionEvents(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
 ): () => void {
   const onUserMessage = (content: string): void => send({ type: 'user_message', content });
@@ -104,7 +104,7 @@ function subscribeSessionEvents(
 }
 
 function createWsMessageHandler(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
 ): (data: string) => void {
   return (data: string): void => {
@@ -127,7 +127,7 @@ function parseClientMessage(
 }
 
 function handleClientMessage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: TClientMessage,
 ): void {
@@ -216,7 +216,7 @@ function isBackgroundControlMessage(
 }
 
 function handleSessionControlMessage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<TClientMessage, { type: 'submit' | 'command' | 'abort' | 'cancel-queue' }>,
 ): void {
@@ -248,7 +248,7 @@ function handleSessionControlMessage(
 }
 
 function handleSessionQueryMessage(
-  session: InteractiveSession,
+  session: IInteractiveSession,
   send: (message: TServerMessage) => void,
   msg: Extract<
     TClientMessage,

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -5,7 +5,7 @@
 
 import { createServer, type Server } from 'node:http';
 import { WebSocketServer, WebSocket } from 'ws';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { ISession } from '@robota-sdk/agent-core';
 import type { TUniversalValue } from '@robota-sdk/agent-core';
 import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
@@ -32,7 +32,7 @@ export class WsTransport implements IConfigurableTransport {
     },
   };
 
-  private session: InteractiveSession | null = null;
+  private session: IInteractiveSession | null = null;
   private stopFn: (() => Promise<void>) | null = null;
   private readonly port: number;
   private readonly maxRetries: number;
@@ -43,7 +43,7 @@ export class WsTransport implements IConfigurableTransport {
   }
 
   attach(session: ISession): void {
-    this.session = session as InteractiveSession;
+    this.session = session as unknown as IInteractiveSession;
   }
 
   async start(): Promise<void> {
@@ -66,7 +66,7 @@ export class WsTransport implements IConfigurableTransport {
   }
 
   private bindWithRetry(
-    session: InteractiveSession,
+    session: IInteractiveSession,
     port: number,
     retriesLeft: number,
   ): Promise<{ stop: () => Promise<void> }> {
@@ -78,7 +78,7 @@ export class WsTransport implements IConfigurableTransport {
   }
 
   private tryBind(
-    session: InteractiveSession,
+    session: IInteractiveSession,
     port: number,
   ): Promise<{ stop: () => Promise<void> }> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- **SDK-002**: `IAgentJobHostContext` capability sub-interface — `agent-command-agent` uses it instead of depending on `InteractiveSession` directly
- **SDK-001**: `IInteractiveSession` minimal interface for transport adapters and test factories; `createTestInteractiveSession()` factory added
- All 4 transport packages (headless, http, mcp, ws) + TUI now typed against `IInteractiveSession`; no more `as unknown as InteractiveSession` in test files

## Changes

- `packages/agent-sdk`: new `IInteractiveSession` interface, `IAgentJobHostContext` interface, `createTestInteractiveSession()` test factory
- `packages/agent-command-agent`: `InteractiveSession` → `IAgentJobHostContext` via bridge `asAgentHostContext()`
- `packages/agent-transport-{headless,http,mcp,ws}`: import `IInteractiveSession`, `attach()` casts internally with `as unknown`
- `packages/agent-transport-tui`: `useSlashRouting` / `applySystemCommandResult` param typed as `IInteractiveSession`
- All transport test files: `createMockSession()` returns `IInteractiveSession`; `attach()` calls use `as never`

## Test plan

- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm test` — all test suites pass (no regressions)
- [x] Pre-push harness verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)