### PR TITLE
refactor(refactor-010): remove IMarketplaceSource duplicate from plugin-settings-store

### DIFF
--- a/packages/agent-sdk/src/plugins/plugin-settings-store.ts
+++ b/packages/agent-sdk/src/plugins/plugin-settings-store.ts
@@ -7,12 +7,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
-/** Source type for a marketplace registry. */
-export type IMarketplaceSource =
-  | { type: 'github'; repo: string; ref?: string }
-  | { type: 'git'; url: string; ref?: string }
-  | { type: 'local'; path: string }
-  | { type: 'url'; url: string };
+import type { IMarketplaceSource } from './marketplace-types.js';
 
 /** Persisted marketplace source entry. */
 export interface IPersistedMarketplaceSource {


### PR DESCRIPTION
## Summary

- `plugin-settings-store.ts`에 `IMarketplaceSource`가 `marketplace-types.ts`와 verbatim 중복 정의되어 있던 문제를 제거
- `plugin-settings-store.ts`에서 이제 `marketplace-types.ts`로부터 import
- SSOT 위반 해소 (REFACTOR-010)

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-sdk build` — 빌드 성공
- [x] `pnpm --filter @robota-sdk/agent-sdk test` — 774 tests 통과
- [x] `grep "type IMarketplaceSource" packages/agent-sdk/src --include="*.ts" -r` — `marketplace-types.ts` 한 곳만 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)