### PR TITLE
refactor(refactor-005): remove as-unknown-as casts via generic ITransportAdapter<TSession>

### DIFF
--- a/packages/agent-cli/src/transports/transport-registry.ts
+++ b/packages/agent-cli/src/transports/transport-registry.ts
@@ -5,7 +5,8 @@
  *   { "ws": { "enabled": true, "options": { "port": 7070 } } }
  */
 
-import type { TUniversalValue, ISession } from '@robota-sdk/agent-core';
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type {
   IConfigurableTransport,
   ITransportConfig,
@@ -14,18 +15,18 @@ import type {
 import { readSettings, writeSettings, type TSettingsData } from '../utils/settings-io.js';
 
 export class TransportRegistry {
-  private readonly entries = new Map<string, IConfigurableTransport>();
+  private readonly entries = new Map<string, IConfigurableTransport<IInteractiveSession>>();
   private readonly settingsPath: string;
 
   constructor(settingsPath: string) {
     this.settingsPath = settingsPath;
   }
 
-  register(transport: IConfigurableTransport): void {
+  register(transport: IConfigurableTransport<IInteractiveSession>): void {
     this.entries.set(transport.name, transport);
   }
 
-  getAll(): ITransportEntry[] {
+  getAll(): ITransportEntry<IInteractiveSession>[] {
     const saved = this.readTransportSettings();
     return Array.from(this.entries.values()).map((transport) => ({
       transport,
@@ -33,7 +34,7 @@ export class TransportRegistry {
     }));
   }
 
-  getEnabled(): IConfigurableTransport[] {
+  getEnabled(): IConfigurableTransport<IInteractiveSession>[] {
     return this.getAll()
       .filter((e) => e.config.enabled)
       .map((e) => e.transport);
@@ -57,7 +58,7 @@ export class TransportRegistry {
     writeSettings(this.settingsPath, settings);
   }
 
-  async startAll(session: ISession): Promise<void> {
+  async startAll(session: IInteractiveSession): Promise<void> {
     const enabled = this.getEnabled();
     for (const transport of enabled) {
       transport.attach(session);
@@ -72,7 +73,7 @@ export class TransportRegistry {
   }
 
   private resolveConfig(
-    transport: IConfigurableTransport,
+    transport: IConfigurableTransport<IInteractiveSession>,
     saved?: TSettingsData,
   ): ITransportConfig {
     const enabled = (saved?.enabled as boolean | undefined) ?? transport.defaultEnabled;

--- a/packages/agent-interface-transport/src/transport-adapter.ts
+++ b/packages/agent-interface-transport/src/transport-adapter.ts
@@ -6,9 +6,9 @@
 
 import type { ISession } from '@robota-sdk/agent-core';
 
-export interface ITransportAdapter {
+export interface ITransportAdapter<TSession = ISession> {
   readonly name: string;
-  attach(session: ISession): void;
+  attach(session: TSession): void;
   start(): Promise<void>;
   stop(): Promise<void>;
 }

--- a/packages/agent-interface-transport/src/transport-config.ts
+++ b/packages/agent-interface-transport/src/transport-config.ts
@@ -10,7 +10,8 @@ export interface ITransportConfig {
   options?: Record<string, TUniversalValue>;
 }
 
-export interface IConfigurableTransport extends ITransportAdapter {
+export interface IConfigurableTransport<TSession = import('@robota-sdk/agent-core').ISession>
+  extends ITransportAdapter<TSession> {
   readonly defaultEnabled: boolean;
   readonly optionsSchema?: Record<
     string,
@@ -19,14 +20,14 @@ export interface IConfigurableTransport extends ITransportAdapter {
   validateOptions?(options: Record<string, TUniversalValue>): boolean;
 }
 
-export interface ITransportEntry {
-  transport: IConfigurableTransport;
+export interface ITransportEntry<TSession = import('@robota-sdk/agent-core').ISession> {
+  transport: IConfigurableTransport<TSession>;
   config: ITransportConfig;
 }
 
-export interface ITransportRegistryView {
-  getAll(): ITransportEntry[];
+export interface ITransportRegistryView<TSession = import('@robota-sdk/agent-core').ISession> {
+  getAll(): ITransportEntry<TSession>[];
   setEnabled(name: string, enabled: boolean): Promise<void>;
-  startAll(session: import('@robota-sdk/agent-core').ISession): Promise<void>;
+  startAll(session: TSession): Promise<void>;
   stopAll(): Promise<void>;
 }

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -334,7 +334,7 @@ export class InteractiveSession
     return this.sessionName;
   }
 
-  attachTransport(transport: ITransportAdapter): void {
+  attachTransport(transport: ITransportAdapter<IInteractiveSession>): void {
     transport.attach(this);
   }
 

--- a/packages/agent-transport-headless/src/headless-transport.ts
+++ b/packages/agent-transport-headless/src/headless-transport.ts
@@ -6,7 +6,6 @@
  */
 
 import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
-import type { ISession } from '@robota-sdk/agent-core';
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 import { createHeadlessRunner } from './headless-runner.js';
 import type { TOutputFormat } from './headless-runner.js';
@@ -20,14 +19,14 @@ export interface IHeadlessTransportOptions {
 
 export function createHeadlessTransport(
   options: IHeadlessTransportOptions,
-): ITransportAdapter & { getExitCode(): number } {
+): ITransportAdapter<IInteractiveSession> & { getExitCode(): number } {
   let session: IInteractiveSession | null = null;
   let exitCode = 0;
 
   return {
     name: 'headless',
-    attach(s: ISession) {
-      session = s as unknown as IInteractiveSession;
+    attach(s: IInteractiveSession) {
+      session = s;
     },
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');

--- a/packages/agent-transport-http/src/http-transport.ts
+++ b/packages/agent-transport-http/src/http-transport.ts
@@ -7,6 +7,7 @@
 
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
+
 import { createAgentRoutes } from './routes.js';
 import type { Hono } from 'hono';
 
@@ -17,14 +18,14 @@ export interface IHttpTransportOptions {
 
 export function createHttpTransport(
   options?: IHttpTransportOptions,
-): ITransportAdapter & { getApp(): Hono } {
+): ITransportAdapter<IInteractiveSession> & { getApp(): Hono } {
   let session: IInteractiveSession | null = null;
   let app: Hono | null = null;
 
   return {
     name: 'http',
-    attach(s) {
-      session = s as unknown as IInteractiveSession;
+    attach(s: IInteractiveSession) {
+      session = s;
     },
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');

--- a/packages/agent-transport-mcp/src/mcp-transport.ts
+++ b/packages/agent-transport-mcp/src/mcp-transport.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import { createAgentMcpServer } from './mcp-server.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 
@@ -21,13 +21,13 @@ export interface IMcpTransportOptions {
 
 export function createMcpTransport(
   options: IMcpTransportOptions,
-): ITransportAdapter & { getServer(): Server } {
-  let session: InteractiveSession | null = null;
+): ITransportAdapter<IInteractiveSession> & { getServer(): Server } {
+  let session: IInteractiveSession | null = null;
   let server: Server | null = null;
 
   return {
     name: 'mcp',
-    attach(s: InteractiveSession) {
+    attach(s: IInteractiveSession) {
       session = s;
     },
     async start() {

--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -6,6 +6,7 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSession,
   IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TShellExecFn,
@@ -62,7 +63,7 @@ interface IProps {
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;
   startupUpdateNotice?: Promise<string | undefined>;
-  transportRegistry?: ITransportRegistryView;
+  transportRegistry?: ITransportRegistryView<IInteractiveSession>;
   cliAdapter: ITuiCliAdapter;
   reloadPluginCommandSource?: (registry: CommandRegistry) => void;
 }

--- a/packages/agent-transport-tui/src/TransportTUI.tsx
+++ b/packages/agent-transport-tui/src/TransportTUI.tsx
@@ -10,11 +10,12 @@ import type {
   ITransportEntry,
   ITransportRegistryView,
 } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 
 const TRANSPORT_NAME_WIDTH = 18;
 
 interface IEntryRowProps {
-  entry: ITransportEntry;
+  entry: ITransportEntry<IInteractiveSession>;
   selected: boolean;
 }
 
@@ -36,10 +37,10 @@ function TransportEntryRow({ entry, selected }: IEntryRowProps): React.ReactElem
 type TKey = { upArrow: boolean; downArrow: boolean; escape: boolean; return: boolean };
 
 function useTransportInput(
-  entries: ITransportEntry[],
+  entries: ITransportEntry<IInteractiveSession>[],
   cursor: number,
   saving: boolean,
-  registry: ITransportRegistryView,
+  registry: ITransportRegistryView<IInteractiveSession>,
   setCursor: (fn: (c: number) => number) => void,
   setSaving: (v: boolean) => void,
   onClose: () => void,
@@ -80,7 +81,7 @@ function useTransportInput(
 }
 
 interface IProps {
-  registry: ITransportRegistryView;
+  registry: ITransportRegistryView<IInteractiveSession>;
   onClose: () => void;
 }
 

--- a/packages/agent-transport-tui/src/hooks/useInteractiveSession.ts
+++ b/packages/agent-transport-tui/src/hooks/useInteractiveSession.ts
@@ -15,6 +15,7 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSession,
   IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TPermissionResultValue,
@@ -49,7 +50,7 @@ export interface IInteractiveSessionProps {
   commandModules?: readonly ICommandModule[];
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;
-  transportRegistry?: ITransportRegistryView;
+  transportRegistry?: ITransportRegistryView<IInteractiveSession>;
   language?: string;
   reloadPluginCommandSource?: (registry: CommandRegistry) => void;
 }
@@ -223,9 +224,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   useEffect(() => {
     if (!props.transportRegistry) return;
     const reg = props.transportRegistry;
-    reg
-      .startAll(interactiveSession as import('@robota-sdk/agent-core').ISession)
-      .catch(() => undefined);
+    reg.startAll(interactiveSession).catch(() => undefined);
     return () => {
       reg.stopAll().catch(() => undefined);
     };

--- a/packages/agent-transport-tui/src/render.tsx
+++ b/packages/agent-transport-tui/src/render.tsx
@@ -11,6 +11,7 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
+  IInteractiveSession,
   IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TShellExecFn,
@@ -40,7 +41,7 @@ export interface IRenderOptions {
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;
   startupUpdateNotice?: Promise<string | undefined>;
-  transportRegistry?: ITransportRegistryView;
+  transportRegistry?: ITransportRegistryView<IInteractiveSession>;
   cliAdapter: ITuiCliAdapter;
   reloadPluginCommandSource?: (registry: CommandRegistry) => void;
 }

--- a/packages/agent-transport-tui/src/tui-transport.ts
+++ b/packages/agent-transport-tui/src/tui-transport.ts
@@ -1,9 +1,9 @@
-import type { ISession } from '@robota-sdk/agent-core';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
 import type { TUniversalValue } from '@robota-sdk/agent-core';
 import { renderApp, type IRenderOptions } from './render.js';
 
-export class TuiTransport implements IConfigurableTransport {
+export class TuiTransport implements IConfigurableTransport<IInteractiveSession> {
   readonly name = 'tui';
   readonly defaultEnabled = true;
   readonly optionsSchema = {};
@@ -14,9 +14,8 @@ export class TuiTransport implements IConfigurableTransport {
     this.options = options;
   }
 
-  attach(_session: ISession): void {
+  attach(_session: IInteractiveSession): void {
     // TuiTransport creates its own InteractiveSession internally via useInteractiveSession.
-    // The attach() hook is a no-op for now.
   }
 
   async start(): Promise<void> {

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -6,7 +6,6 @@
 import { createServer, type Server } from 'node:http';
 import { WebSocketServer, WebSocket } from 'ws';
 import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
-import type { ISession } from '@robota-sdk/agent-core';
 import type { TUniversalValue } from '@robota-sdk/agent-core';
 import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
 import { createWsHandler } from './ws-handler.js';
@@ -20,7 +19,7 @@ export interface IWsTransportConfig {
   maxRetries?: number;
 }
 
-export class WsTransport implements IConfigurableTransport {
+export class WsTransport implements IConfigurableTransport<IInteractiveSession> {
   readonly name = 'ws';
   readonly defaultEnabled = true;
   readonly optionsSchema = {
@@ -42,8 +41,8 @@ export class WsTransport implements IConfigurableTransport {
     this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
   }
 
-  attach(session: ISession): void {
-    this.session = session as unknown as IInteractiveSession;
+  attach(session: IInteractiveSession): void {
+    this.session = session;
   }
 
   async start(): Promise<void> {

--- a/packages/agent-transport-ws/src/ws-transport.ts
+++ b/packages/agent-transport-ws/src/ws-transport.ts
@@ -5,8 +5,7 @@
  * After start(), the consumer must wire onMessage to their WebSocket.
  */
 
-import type { InteractiveSession } from '@robota-sdk/agent-sdk';
-import type { ISession } from '@robota-sdk/agent-core';
+import type { IInteractiveSession } from '@robota-sdk/agent-sdk';
 import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 import { createWsHandler } from './ws-handler.js';
 import type { TServerMessage } from './ws-protocol.js';
@@ -18,15 +17,15 @@ export interface IWsTransportOptions {
 
 export function createWsTransport(
   options: IWsTransportOptions,
-): ITransportAdapter & { onMessage: ((data: string) => void) | null } {
-  let session: InteractiveSession | null = null;
+): ITransportAdapter<IInteractiveSession> & { onMessage: ((data: string) => void) | null } {
+  let session: IInteractiveSession | null = null;
   let cleanup: (() => void) | null = null;
 
   return {
     name: 'ws',
     onMessage: null,
-    attach(s: ISession) {
-      session = s as InteractiveSession;
+    attach(s: IInteractiveSession) {
+      session = s;
     },
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');


### PR DESCRIPTION
## Summary

- `ITransportAdapter<TSession = ISession>` generic 도입으로 transport attach() 계약 불일치 해결
- 3개 transport (headless, ws-configurable, http)의 `as unknown as IInteractiveSession` cast 완전 제거
- ws-transport, mcp-transport의 `InteractiveSession` concrete 참조 → `IInteractiveSession` interface로 교체
- `TuiTransport`, `TransportRegistry`, TUI 컴포넌트 모두 `IInteractiveSession` generic으로 통일

## Test plan

- [x] `pnpm typecheck` — 전체 통과 (에러 없음)
- [x] `grep "as unknown as IInteractiveSession" packages/agent-transport-*/src --include="*.ts" -r` — 프로덕션 코드에서 결과 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)