### PR TITLE
refactor(016): widen IZodSchema — eliminate as-unknown-as casts in 8 builtin tools

### DIFF
--- a/packages/agent-tools/src/builtins/bash-tool.ts
+++ b/packages/agent-tools/src/builtins/bash-tool.ts
@@ -9,7 +9,6 @@
 import { spawn } from 'node:child_process';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 
@@ -141,7 +140,7 @@ export function createBashTool(options: ISandboxToolOptions = {}) {
   return createZodFunctionTool(
     'Bash',
     'Executes a given bash command and returns its output.\n\nThe working directory persists between commands, but shell state does not.\n\nIMPORTANT: Avoid using this tool to run `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands. Instead, use the appropriate dedicated tool:\n - File search: Use Glob (NOT find or ls)\n - Content search: Use Grep (NOT grep or rg)\n - Read files: Use Read (NOT cat/head/tail)\n - Edit files: Use Edit (NOT sed/awk)\n\nFor simple commands, keep the description brief (5-10 words). For complex commands, include enough context to clarify what the command does.\n\nOutput is limited to 30,000 characters. Longer output will be middle-truncated.',
-    BashSchema as unknown as IZodSchema,
+    BashSchema,
     async (params) => {
       // createZodFunctionTool passes validated params; cast is safe
       return runBash(params as TBashArgs, options);

--- a/packages/agent-tools/src/builtins/edit-tool.ts
+++ b/packages/agent-tools/src/builtins/edit-tool.ts
@@ -8,7 +8,6 @@
 import { readFile } from 'node:fs/promises';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 import { atomicWriteUtf8File } from './atomic-file-write.js';
@@ -112,7 +111,7 @@ export function createEditTool(options: ISandboxToolOptions = {}) {
   return createZodFunctionTool(
     'Edit',
     'Performs exact string replacements in files.\n\nYou must use the Read tool at least once before editing. When editing text from Read output, preserve the exact indentation.\n\nThe edit will FAIL if old_string is not unique in the file. Either provide more surrounding context to make it unique, or use replace_all to change every instance.\n\nALWAYS prefer editing existing files over creating new ones.',
-    EditSchema as unknown as IZodSchema,
+    EditSchema,
     async (params) => {
       return editFileTool(params as TEditArgs, options);
     },

--- a/packages/agent-tools/src/builtins/glob-tool.ts
+++ b/packages/agent-tools/src/builtins/glob-tool.ts
@@ -10,7 +10,6 @@ import { resolve } from 'node:path';
 import fg from 'fast-glob';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { TToolResult } from '../types/tool-result.js';
 
 const DEFAULT_MAX_RESULTS = 1000;
@@ -100,7 +99,7 @@ async function globFileTool(args: TGlobArgs): Promise<string> {
 export const globTool = createZodFunctionTool(
   'Glob',
   "Fast file pattern matching tool that works with any codebase size.\n\nSupports glob patterns like '**/*.js' or 'src/**/*.ts'. Returns matching file paths sorted by modification time.\n\nUse this tool when you need to find files by name patterns. When doing an open-ended search that may require multiple rounds, use the Agent tool instead.\n\nDefault limit is 1000 results. Use the limit parameter if you need fewer results to save context space.",
-  GlobSchema as unknown as IZodSchema,
+  GlobSchema,
   async (params) => {
     return globFileTool(params as TGlobArgs);
   },

--- a/packages/agent-tools/src/builtins/grep-tool.ts
+++ b/packages/agent-tools/src/builtins/grep-tool.ts
@@ -10,7 +10,6 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { TToolResult } from '../types/tool-result.js';
 
 const GrepSchema = z.object({
@@ -225,7 +224,7 @@ async function grepFileTool(args: TGrepArgs): Promise<string> {
 export const grepTool = createZodFunctionTool(
   'Grep',
   "A powerful search tool built on regex matching.\n\nSupports full regex syntax (e.g., 'log.*Error', 'function\\\\s+\\\\w+'). Filter files with glob parameter (e.g., '*.js', '**/*.tsx').\n\nOutput modes: 'content' shows matching lines with context, 'files_with_matches' shows only file paths (default), 'count' shows match counts.\n\nUse this tool for ALL search tasks. NEVER invoke grep or rg as a Bash command.\n\nUse head_limit to control result size and save context space.",
-  GrepSchema as unknown as IZodSchema,
+  GrepSchema,
   async (params) => {
     return grepFileTool(params as TGrepArgs);
   },

--- a/packages/agent-tools/src/builtins/read-tool.ts
+++ b/packages/agent-tools/src/builtins/read-tool.ts
@@ -8,7 +8,6 @@
 import { readFile, stat } from 'node:fs/promises';
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 
@@ -161,7 +160,7 @@ export function createReadTool(options: ISandboxToolOptions = {}) {
   return createZodFunctionTool(
     'Read',
     'Reads a file from the local filesystem.\n\nBy default, reads up to 2000 lines from the beginning of the file. You can optionally specify offset and limit for partial reads.\n\nResults are returned using cat -n format, with line numbers starting at 1.\n\nThe file_path parameter must be an absolute path, not a relative path.',
-    ReadSchema as unknown as IZodSchema,
+    ReadSchema,
     async (params) => {
       return readFileTool(params as TReadArgs, options);
     },

--- a/packages/agent-tools/src/builtins/web-fetch-tool.ts
+++ b/packages/agent-tools/src/builtins/web-fetch-tool.ts
@@ -7,7 +7,6 @@
 
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { TToolResult } from '../types/tool-result.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -101,6 +100,6 @@ async function runWebFetch(args: TWebFetchArgs): Promise<string> {
 export const webFetchTool = createZodFunctionTool(
   'WebFetch',
   'Fetch a URL and return its content as text. HTML pages are converted to plain text.',
-  WebFetchSchema as unknown as IZodSchema,
+  WebFetchSchema,
   async (params) => runWebFetch(params as TWebFetchArgs),
 );

--- a/packages/agent-tools/src/builtins/web-search-tool.ts
+++ b/packages/agent-tools/src/builtins/web-search-tool.ts
@@ -7,7 +7,6 @@
 
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { TToolResult } from '../types/tool-result.js';
 
 const DEFAULT_LIMIT = 10;
@@ -98,6 +97,6 @@ async function runWebSearch(args: TWebSearchArgs): Promise<string> {
 export const webSearchTool = createZodFunctionTool(
   'WebSearch',
   'Search the web and return results with title, URL, and snippet.',
-  WebSearchSchema as unknown as IZodSchema,
+  WebSearchSchema,
   async (params) => runWebSearch(params as TWebSearchArgs),
 );

--- a/packages/agent-tools/src/builtins/write-tool.ts
+++ b/packages/agent-tools/src/builtins/write-tool.ts
@@ -4,7 +4,6 @@
 
 import { z } from 'zod';
 import { createZodFunctionTool } from '../implementations/function-tool';
-import type { IZodSchema } from '../implementations/function-tool/types';
 import type { ISandboxToolOptions } from '../sandbox/types.js';
 import type { TToolResult } from '../types/tool-result.js';
 import { atomicWriteUtf8File } from './atomic-file-write.js';
@@ -48,7 +47,7 @@ export function createWriteTool(options: ISandboxToolOptions = {}) {
   return createZodFunctionTool(
     'Write',
     'Writes a file to the local filesystem. This will overwrite an existing file if one exists.\n\nALWAYS prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.\n\nNEVER create documentation files (*.md) or README files unless explicitly requested by the user.',
-    WriteSchema as unknown as IZodSchema,
+    WriteSchema,
     async (params) => {
       return writeFileTool(params as TWriteArgs, options);
     },

--- a/packages/agent-tools/src/implementations/function-tool.ts
+++ b/packages/agent-tools/src/implementations/function-tool.ts
@@ -202,7 +202,7 @@ export function createZodFunctionTool(
       throw new ValidationError(`Zod validation failed: ${parseResult.error}`);
     }
 
-    const result = await fn(parseResult.data || parameters, context);
+    const result = await fn((parseResult.data as TToolParameters) || parameters, context);
     // Ensure result is always a string for consistency with core package
     return typeof result === 'string' ? result : JSON.stringify(result);
   };

--- a/packages/agent-tools/src/implementations/function-tool/types.ts
+++ b/packages/agent-tools/src/implementations/function-tool/types.ts
@@ -1,25 +1,15 @@
-/**
- * FunctionTool - Type definitions for Facade pattern implementation
- *
- * REASON: Complex Zod schema type compatibility requires separation of concerns
- * ALTERNATIVES_CONSIDERED:
- * 1. Fix all Zod undefined issues in single file (creates maintenance burden)
- * 2. Use any types strategically (reduces type safety)
- * 3. Remove Zod support entirely (breaks existing functionality)
- * 4. Create complex conditional types (adds cognitive overhead)
- * 5. Use type assertions everywhere (increases runtime risk)
- * NOTE: Tool functionality is now integrated into @robota-sdk/agent-tools package
- */
-
 import type { TToolParameters, TUniversalValue } from '@robota-sdk/agent-core';
 
 /**
  * Zod schema compatibility types
+ *
+ * Widened to `unknown` so that actual Zod schemas (ZodObject<...>) are structurally
+ * assignable without `as unknown as IZodSchema` casts at call sites.
  */
 export interface IZodParseResult {
   success: boolean;
-  data?: TToolParameters;
-  error?: string | Error;
+  data?: unknown;
+  error?: unknown;
 }
 
 export interface IZodSchemaDef {
@@ -35,8 +25,8 @@ export interface IZodSchemaDef {
 }
 
 export interface IZodSchema {
-  parse(value: TToolParameters): TToolParameters;
-  safeParse(value: TToolParameters): IZodParseResult;
+  parse(value: unknown): unknown;
+  safeParse(value: unknown): IZodParseResult;
   _def?: IZodSchemaDef;
 }
 


### PR DESCRIPTION
## Summary

- Widened `IZodSchema.parse`/`safeParse` signatures to accept/return `unknown`, so actual `ZodObject<...>` types are structurally assignable without double-cast
- Removed `import type { IZodSchema }` and `as unknown as IZodSchema` from all 8 builtin tool files (`bash-tool`, `edit-tool`, `glob-tool`, `grep-tool`, `read-tool`, `web-fetch-tool`, `web-search-tool`, `write-tool`)
- Factory `createZodFunctionTool` uses a single `as TToolParameters` cast internally (not `as unknown as`)

## Verification

- `pnpm --filter @robota-sdk/agent-tools build` — pass
- `pnpm --filter @robota-sdk/agent-tools test` — 109/109 pass
- `pnpm typecheck` — pass (all packages)

Closes REFACTOR-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)