### PR TITLE
refactor(018): remove agent-core dep from agent-interface-transport

### DIFF
--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -41,9 +41,7 @@
     "clean": "rimraf dist",
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
   },
-  "dependencies": {
-    "@robota-sdk/agent-core": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "rimraf": "^5.0.5",
     "tsup": "^8.0.1",

--- a/packages/agent-interface-transport/src/transport-adapter.ts
+++ b/packages/agent-interface-transport/src/transport-adapter.ts
@@ -4,9 +4,7 @@
  * agent-transport-* implementations and the assembly layer.
  */
 
-import type { ISession } from '@robota-sdk/agent-core';
-
-export interface ITransportAdapter<TSession = ISession> {
+export interface ITransportAdapter<TSession = unknown> {
   readonly name: string;
   attach(session: TSession): void;
   start(): Promise<void>;

--- a/packages/agent-interface-transport/src/transport-config.ts
+++ b/packages/agent-interface-transport/src/transport-config.ts
@@ -2,30 +2,25 @@
  * Configurable transport contracts — enable/disable + options schema.
  */
 
-import type { TUniversalValue } from '@robota-sdk/agent-core';
 import type { ITransportAdapter } from './transport-adapter.js';
 
 export interface ITransportConfig {
   enabled: boolean;
-  options?: Record<string, TUniversalValue>;
+  options?: Record<string, unknown>;
 }
 
-export interface IConfigurableTransport<TSession = import('@robota-sdk/agent-core').ISession>
-  extends ITransportAdapter<TSession> {
+export interface IConfigurableTransport<TSession = unknown> extends ITransportAdapter<TSession> {
   readonly defaultEnabled: boolean;
-  readonly optionsSchema?: Record<
-    string,
-    { type: string; description: string; default?: TUniversalValue }
-  >;
-  validateOptions?(options: Record<string, TUniversalValue>): boolean;
+  readonly optionsSchema?: Record<string, { type: string; description: string; default?: unknown }>;
+  validateOptions?(options: Record<string, unknown>): boolean;
 }
 
-export interface ITransportEntry<TSession = import('@robota-sdk/agent-core').ISession> {
+export interface ITransportEntry<TSession = unknown> {
   transport: IConfigurableTransport<TSession>;
   config: ITransportConfig;
 }
 
-export interface ITransportRegistryView<TSession = import('@robota-sdk/agent-core').ISession> {
+export interface ITransportRegistryView<TSession = unknown> {
   getAll(): ITransportEntry<TSession>[];
   setEnabled(name: string, enabled: boolean): Promise<void>;
   startAll(session: TSession): Promise<void>;


### PR DESCRIPTION
## Summary

- Replaced `ISession`/`TUniversalValue` (from `@robota-sdk/agent-core`) with `unknown` in all generic defaults and config value types
- Removed `@robota-sdk/agent-core` from `dependencies` — package is now zero-dependency
- All callers already pass concrete type arguments (`ITransportAdapter<IInteractiveSession>`), so changing the default from `ISession` to `unknown` has no effect on existing code

## Verification

- `pnpm --filter @robota-sdk/agent-interface-transport build` — pass
- `pnpm typecheck` — pass (all packages)

Closes REFACTOR-018

🤖 Generated with [Claude Code](https://claude.com/claude-code)