### PR TITLE
refactor(020): replace console.* with DI ILogger in agent-server

### DIFF
--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -3,11 +3,14 @@ import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import type { IAIProvider } from '@robota-sdk/agent-core';
+import { ConsoleLogger } from '@robota-sdk/agent-core';
 import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
 import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
 import { GoogleProvider } from '@robota-sdk/agent-provider-google';
 import { PlaygroundWebSocketServer } from './websocket-server';
 import { resolveApiDocsEnabled } from './utils/env-flags.js';
+
+const appLogger = new ConsoleLogger('agent-server');
 
 // Global WebSocket server instance (will be initialized in server.ts)
 export let playgroundWebSocketServer: PlaygroundWebSocketServer | null = null;
@@ -180,7 +183,7 @@ export function createApp(): express.Application {
   // Error handling
   app.use(
     (error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-      console.error('API Error:', error);
+      appLogger.error('API Error:', error as Error);
       const statusCode =
         typeof error === 'object' &&
         error !== null &&

--- a/apps/agent-server/src/server.ts
+++ b/apps/agent-server/src/server.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { createApp, setPlaygroundWebSocketServer } from './app';
 import { PlaygroundWebSocketServer } from './websocket-server';
 import { createServer } from 'http';
+import { ConsoleLogger } from '@robota-sdk/agent-core';
 
 // Load environment variables
 dotenv.config({
@@ -10,12 +11,13 @@ dotenv.config({
 });
 
 const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
+const logger = new ConsoleLogger('agent-server');
 
 process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  logger.error('Unhandled Rejection at:', String(promise), 'reason:', reason as Error);
 });
 process.on('uncaughtException', (error) => {
-  console.error('Uncaught Exception:', error);
+  logger.error('Uncaught Exception:', error);
   process.exit(1);
 });
 
@@ -33,37 +35,37 @@ async function startServer() {
     const server = createServer(app);
 
     // Initialize WebSocket server
-    const wsServer = new PlaygroundWebSocketServer(server);
+    const wsServer = new PlaygroundWebSocketServer(server, logger);
     setPlaygroundWebSocketServer(wsServer);
 
     // Start server
     server.listen(port, () => {
-      console.log(`🚀 Robota API Server started on port ${port}`);
-      console.log(`📊 Environment: ${process.env.NODE_ENV || 'development'}`);
-      console.log(`🔗 Server URL: http://localhost:${port}`);
-      console.log(`💚 Health Check: http://localhost:${port}/health`);
-      console.log(`🤖 API Docs: http://localhost:${port}/v1/remote`);
-      console.log(`🔌 WebSocket: ws://localhost:${port}/ws/playground`);
+      logger.info(`Robota API Server started on port ${port}`);
+      logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
+      logger.info(`Server URL: http://localhost:${port}`);
+      logger.info(`Health Check: http://localhost:${port}/health`);
+      logger.info(`API Docs: http://localhost:${port}/v1/remote`);
+      logger.info(`WebSocket: ws://localhost:${port}/ws/playground`);
     });
 
     // Graceful shutdown
     const shutdown = (signal: string) => {
-      console.log(`${signal} received, shutting down gracefully`);
+      logger.info(`${signal} received, shutting down gracefully`);
       wsServer.close();
       server.close(() => {
-        console.log('HTTP server closed');
+        logger.info('HTTP server closed');
         process.exit(0);
       });
       // Force exit after timeout if graceful shutdown stalls
       setTimeout(() => {
-        console.warn('Graceful shutdown timeout, forcing exit');
+        logger.warn('Graceful shutdown timeout, forcing exit');
         process.exit(1);
       }, GRACEFUL_SHUTDOWN_TIMEOUT_MS);
     };
     process.on('SIGTERM', () => shutdown('SIGTERM'));
     process.on('SIGINT', () => shutdown('SIGINT'));
   } catch (error) {
-    console.error('Failed to start server:', error);
+    logger.error('Failed to start server:', error as Error);
     process.exit(1);
   }
 }

--- a/apps/agent-server/src/websocket-server.ts
+++ b/apps/agent-server/src/websocket-server.ts
@@ -7,7 +7,8 @@ import type {
   IPlaygroundWebSocketMessage,
   TPlaygroundWebSocketMessageKind,
 } from '@robota-sdk/agent-playground';
-import type { TUniversalValue } from '@robota-sdk/agent-core';
+import type { ILogger, TUniversalValue } from '@robota-sdk/agent-core';
+import { ConsoleLogger } from '@robota-sdk/agent-core';
 
 const JWT_PART_COUNT = 3;
 const CLEANUP_INTERVAL_MS = 30000;
@@ -48,8 +49,10 @@ export class PlaygroundWebSocketServer {
   private clients = new Map<string, IPlaygroundClient>();
   private userSessions = new Map<string, Set<string>>(); // userId -> Set<clientId>
   private cleanupInterval: ReturnType<typeof setInterval>;
+  private logger: ILogger;
 
-  constructor(server: Server) {
+  constructor(server: Server, logger?: ILogger) {
+    this.logger = logger ?? new ConsoleLogger('PlaygroundWebSocketServer');
     this.wss = new WebSocketServer({
       server,
       path: '/ws/playground',
@@ -64,14 +67,14 @@ export class PlaygroundWebSocketServer {
     );
 
     if (!process.env.JWT_SECRET) {
-      console.warn(
-        'WARNING: JWT_SECRET environment variable is not set. ' +
+      this.logger.warn(
+        'JWT_SECRET environment variable is not set. ' +
           'JWT validation will use format-only checking (development mode). ' +
           'Set JWT_SECRET for production use.',
       );
     }
 
-    console.log('PlaygroundWebSocketServer initialized on /ws/playground');
+    this.logger.info('PlaygroundWebSocketServer initialized on /ws/playground');
   }
 
   private handleConnection(ws: WebSocket, _req: IncomingMessage): void {
@@ -84,7 +87,7 @@ export class PlaygroundWebSocketServer {
     };
 
     this.clients.set(clientId, client);
-    console.log(`🔗 New WebSocket connection: ${clientId}`);
+    this.logger.info(`New WebSocket connection: ${clientId}`);
 
     // Set up message handling
     ws.on('message', (data: Buffer) => {
@@ -92,7 +95,7 @@ export class PlaygroundWebSocketServer {
         const message: IPlaygroundWebSocketMessage = JSON.parse(data.toString());
         this.handleMessage(clientId, message);
       } catch (error) {
-        console.error(`❌ Invalid message from ${clientId}:`, error);
+        this.logger.error(`Invalid message from ${clientId}:`, error as Error);
         this.sendError(clientId, 'Invalid message format');
       }
     });
@@ -104,7 +107,7 @@ export class PlaygroundWebSocketServer {
 
     // Handle errors
     ws.on('error', (error) => {
-      console.error(`❌ WebSocket error for ${clientId}:`, error);
+      this.logger.error(`WebSocket error for ${clientId}:`, error);
       this.handleDisconnection(clientId);
     });
 
@@ -220,7 +223,7 @@ export class PlaygroundWebSocketServer {
       },
     });
 
-    console.log(`✅ Client ${clientId} authenticated as user ${userId}, session ${sessionId}`);
+    this.logger.info(`Client ${clientId} authenticated as user ${userId}, session ${sessionId}`);
   }
 
   private handleDisconnection(clientId: string): void {
@@ -238,7 +241,7 @@ export class PlaygroundWebSocketServer {
       }
 
       this.clients.delete(clientId);
-      console.log(`🔌 Client ${clientId} disconnected`);
+      this.logger.info(`Client ${clientId} disconnected`);
     }
   }
 
@@ -248,7 +251,7 @@ export class PlaygroundWebSocketServer {
       try {
         client.ws.send(JSON.stringify(message));
       } catch (error) {
-        console.error(`❌ Failed to send message to ${clientId}:`, error);
+        this.logger.error(`Failed to send message to ${clientId}:`, error as Error);
         this.handleDisconnection(clientId);
       }
     }
@@ -284,7 +287,7 @@ export class PlaygroundWebSocketServer {
       }
     }
 
-    console.log(`📡 Broadcasted to ${broadcastCount} clients in session ${sessionId}`);
+    this.logger.debug(`Broadcasted to ${broadcastCount} clients in session ${sessionId}`);
   }
 
   private cleanupInactiveConnections(): void {
@@ -293,7 +296,7 @@ export class PlaygroundWebSocketServer {
 
     for (const [clientId, client] of this.clients) {
       if (now.getTime() - client.lastActivity.getTime() > timeout) {
-        console.log(`🧹 Cleaning up inactive client: ${clientId}`);
+        this.logger.debug(`Cleaning up inactive client: ${clientId}`);
         client.ws.close();
         this.handleDisconnection(clientId);
       }
@@ -358,6 +361,6 @@ export class PlaygroundWebSocketServer {
     this.clients.clear();
     this.userSessions.clear();
     this.wss.close();
-    console.log('PlaygroundWebSocketServer closed');
+    this.logger.info('PlaygroundWebSocketServer closed');
   }
 }


### PR DESCRIPTION
## Summary

- Added optional `ILogger` parameter to `PlaygroundWebSocketServer` constructor (defaults to `ConsoleLogger`)
- Replaced all `console.log/warn/error` calls in `server.ts`, `websocket-server.ts`, and `app.ts` with DI logger calls
- Removed emoji prefixes from log messages
- `server.ts` creates a shared `ConsoleLogger` and passes it to `PlaygroundWebSocketServer`

## Verification

- `grep -r "console." apps/agent-server/src --include="*.ts"` — no results
- `pnpm typecheck` — pass (all packages)

Closes REFACTOR-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)