### PR TITLE
refactor(021): remove process.cwd() fallback from getCwd()

### DIFF
--- a/packages/agent-sdk/src/__tests__/history-cross-package.test.ts
+++ b/packages/agent-sdk/src/__tests__/history-cross-package.test.ts
@@ -48,6 +48,7 @@ describe('IHistoryEntry cross-package integration', () => {
   it('history accumulates user + assistant entries across multiple submits', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'answer' }) as never,
+      cwd: '/tmp',
     } as never);
 
     await session.submit('first');
@@ -67,6 +68,7 @@ describe('IHistoryEntry cross-package integration', () => {
     const mockSession = createMockSession({ runResult: 'done' });
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     } as never);
 
     // Simulate tool execution via the execution controller
@@ -153,6 +155,7 @@ describe('IHistoryEntry cross-package integration', () => {
   it('all history entries have id, timestamp, category, type', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'test' }) as never,
+      cwd: '/tmp',
     } as never);
 
     await session.submit('test');

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -88,6 +88,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('user submits a prompt → user message + assistant message appear in history', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'Hello back!' }) as never,
+      cwd: '/tmp',
     });
 
     await session.submit('Hello');
@@ -112,6 +113,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const deltas: string[] = [];
@@ -132,6 +134,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     // Start first execution
@@ -164,6 +167,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const first = session.submit('first');
@@ -205,6 +209,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     let wasInterrupted = false;
@@ -243,6 +248,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('non-abort errors produce error system message', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runError: new Error('API rate limit exceeded') }) as never,
+      cwd: '/tmp',
     });
 
     let errorReceived: Error | null = null;
@@ -265,6 +271,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('getActiveTools returns empty array after execution completes', async () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     });
 
     // Before any execution
@@ -281,6 +288,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('thinking transitions: false → true → false on submit', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'done' }) as never,
+      cwd: '/tmp',
     });
 
     const states: boolean[] = [];
@@ -298,6 +306,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('context_update event fires after completion with current state', async () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     });
 
     let contextUsedTokens = 0;
@@ -309,14 +318,20 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     expect(contextUsedTokens).toBe(1000);
   });
 
-  it('injected sessions without cwd do not auto-start edit checkpoints', async () => {
+  it('injected sessions without cwd emit error on submit', async () => {
     const beginTurn = vi.spyOn(EditCheckpointStore.prototype, 'beginTurn');
     const session = new InteractiveSession({
       session: createMockSession() as never,
     });
 
+    let errorMsg: string | undefined;
+    session.on('error', (err) => {
+      errorMsg = err.message;
+    });
+
     try {
       await session.submit('test');
+      expect(errorMsg).toContain('cwd is not set');
       expect(beginTurn).not.toHaveBeenCalled();
     } finally {
       beginTurn.mockRestore();
@@ -328,6 +343,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('multiple prompts accumulate in message history', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'response' }) as never,
+      cwd: '/tmp',
     });
 
     await session.submit('first');
@@ -350,6 +366,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('off() stops receiving events', async () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     });
 
     let count = 0;
@@ -377,6 +394,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     await session.submit('expanded skill prompt', '/audit', '/rulebased-harness:audit');
@@ -391,6 +409,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     await session.submit('hello');
@@ -403,6 +422,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('displayInput overrides user message (skill prompt not shown as You:)', async () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     });
 
     await session.submit('full expanded skill prompt content', '/audit');
@@ -416,6 +436,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('without displayInput, user message shows the actual input', async () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     });
 
     await session.submit('Hello world');
@@ -442,6 +463,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     await session.submit('test');
@@ -461,6 +483,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     // Simulate tool events by checking the internal clear timing
@@ -497,6 +520,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     // Start first execution
@@ -539,6 +563,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const exec = session.submit('write a story');
@@ -581,6 +606,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'hello' }) as never,
+      cwd: '/tmp',
       sessionStore: mockSessionStore,
     } as never);
 
@@ -632,6 +658,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
       sessionStore: mockSessionStore,
       resumeSessionId: 'prev-session',
     } as never);
@@ -654,6 +681,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('getName returns session name', () => {
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
       sessionName: 'my-session',
     } as never);
     expect(session.getName()).toBe('my-session');
@@ -676,6 +704,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
       sessionStore: mockSessionStore,
     } as never);
 
@@ -696,6 +725,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
     } as never);
 
     session.attachTransport(mockTransport);
@@ -705,6 +735,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
   it('no tool summary when no tools were executed', async () => {
     const session = new InteractiveSession({
       session: createMockSession({ runResult: 'simple answer' }) as never,
+      cwd: '/tmp',
     } as never);
 
     await session.submit('hello');
@@ -729,6 +760,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
       const session = new InteractiveSession({
         session: createMockSession({ runResult: 'answer' }) as never,
+        cwd: '/tmp',
         sessionStore: mockSessionStore,
       } as never);
 
@@ -751,6 +783,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
       const session = new InteractiveSession({
         session: createMockSession({ runResult: 'answer' }) as never,
+        cwd: '/tmp',
         sessionStore: mockSessionStore,
       } as never);
 
@@ -776,6 +809,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
       const session = new InteractiveSession({
         session: createMockSession({ runResult: 'response' }) as never,
+        cwd: '/tmp',
         sessionStore: mockSessionStore,
       } as never);
 
@@ -829,6 +863,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
       const session = new InteractiveSession({
         session: createMockSession({ runResult: 'new answer' }) as never,
+        cwd: '/tmp',
         sessionStore: mockSessionStore,
         resumeSessionId: 'prev',
       } as never);
@@ -864,6 +899,7 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     } as never);
 
     // Manually trigger tool events via the execution controller

--- a/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-sdk/src/interactive/__tests__/interactive-session.test.ts
@@ -86,6 +86,7 @@ describe('InteractiveSession', () => {
     const mockSession = createMockSession({ runResult: 'hello world' });
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const thinkingStates: boolean[] = [];
@@ -108,6 +109,7 @@ describe('InteractiveSession', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     await session.submit('test prompt');
@@ -198,6 +200,7 @@ describe('InteractiveSession', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     // Start first execution
@@ -239,6 +242,7 @@ describe('InteractiveSession', () => {
     };
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
       commandModules: [blockingModule],
     });
     const thinkingStates: boolean[] = [];
@@ -282,6 +286,7 @@ describe('InteractiveSession', () => {
     };
     const session = new InteractiveSession({
       session: createMockSession() as never,
+      cwd: '/tmp',
       commandModules: [blockingModule],
     });
 
@@ -304,6 +309,7 @@ describe('InteractiveSession', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const first = session.submit('first');
@@ -328,6 +334,7 @@ describe('InteractiveSession', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     let interrupted = false;
@@ -358,6 +365,7 @@ describe('InteractiveSession', () => {
 
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     let errorMsg = '';
@@ -378,6 +386,7 @@ describe('InteractiveSession', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const calls: boolean[] = [];
@@ -398,6 +407,7 @@ describe('InteractiveSession', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     expect(session.getSession()).toBe(mockSession);
@@ -407,6 +417,7 @@ describe('InteractiveSession', () => {
     const mockSession = createMockSession();
     const session = new InteractiveSession({
       session: mockSession as never,
+      cwd: '/tmp',
     });
 
     const state = session.getContextState();
@@ -433,6 +444,7 @@ describe('InteractiveSession', () => {
 
       new InteractiveSession({
         session: mockSession as never,
+        cwd: '/tmp',
         sessionStore: mockStore as never,
         resumeSessionId: 'old-session',
       });
@@ -466,6 +478,7 @@ describe('InteractiveSession', () => {
 
       const session = new InteractiveSession({
         session: mockSession as never,
+        cwd: '/tmp',
         sessionStore: mockStore as never,
         resumeSessionId: 'old-session',
       });
@@ -479,6 +492,7 @@ describe('InteractiveSession', () => {
 
       const session = new InteractiveSession({
         session: mockSession as never,
+        cwd: '/tmp',
         sessionStore: mockStore as never,
       });
 
@@ -512,6 +526,7 @@ describe('InteractiveSession', () => {
       const mockSession = createMockSession();
       const session = new InteractiveSession({
         session: mockSession as never,
+        cwd: '/tmp',
         sessionStore: mockStore as never,
         resumeSessionId: 'old-session',
       });
@@ -538,6 +553,7 @@ describe('InteractiveSession', () => {
 
       const session = new InteractiveSession({
         session: mockSession as never,
+        cwd: '/tmp',
         sessionStore: mockStore as never,
         resumeSessionId: 'old-session',
       });

--- a/packages/agent-sdk/src/interactive/interactive-session-history-tracker.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-history-tracker.ts
@@ -189,7 +189,7 @@ export class SessionHistoryTracker {
     const { references, result } = await addInteractiveContextReference(
       this.contextReferences,
       path,
-      this.cwd || process.cwd(),
+      this.cwd,
     );
     this.contextReferences = references;
     this.persistSession();
@@ -234,7 +234,7 @@ export class SessionHistoryTracker {
 
   private getCheckpointStore(): EditCheckpointStore {
     if (!this.editCheckpointStore) {
-      this.editCheckpointStore = new EditCheckpointStore({ cwd: this.cwd || process.cwd() });
+      this.editCheckpointStore = new EditCheckpointStore({ cwd: this.cwd });
     }
     return this.editCheckpointStore;
   }

--- a/packages/agent-sdk/src/interactive/interactive-session-skill-router.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session-skill-router.ts
@@ -84,7 +84,7 @@ export class SessionSkillRouter {
     this.commandExecutor = new SystemCommandExecutor(
       commandModules.flatMap((module) => module.systemCommands ?? []),
     );
-    this.skillCommandSource = new SkillCommandSource(cwd || process.cwd());
+    this.skillCommandSource = new SkillCommandSource(cwd);
     this.commandHostAdapters = commandHostAdapters;
   }
 

--- a/packages/agent-sdk/src/interactive/interactive-session.ts
+++ b/packages/agent-sdk/src/interactive/interactive-session.ts
@@ -228,7 +228,8 @@ export class InteractiveSession
   }
 
   getCwd(): string {
-    return this.cwd ?? process.cwd();
+    if (!this.cwd) throw new Error('cwd is not set — provide cwd in session options');
+    return this.cwd;
   }
 
   get sessionId(): string {


### PR DESCRIPTION
## Summary

- `getCwd()` now throws `'cwd is not set — provide cwd in session options'` instead of silently falling back to `process.cwd()`
- Removed two `|| process.cwd()` fallbacks from `interactive-session-history-tracker.ts` and `interactive-session-skill-router.ts`
- `IInteractiveSessionStandardOptions.cwd` was already required; `IInteractiveSessionInjectedOptions.cwd` remains optional but `getCwd()` throws if not set
- Updated 6 test files: inject `cwd: '/tmp'` into injected-session tests; updated checkpoint test to listen for the `'error'` event

## Verification

- `pnpm --filter @robota-sdk/agent-sdk test` — 773/773 pass
- `pnpm typecheck` — pass (all packages)

Closes REFACTOR-021

🤖 Generated with [Claude Code](https://claude.com/claude-code)