### PR TITLE
feat(INFRA-BL-009-C): strengthen build output contract harness + fix flaky test

### DIFF
--- a/.agents/backlog/INFRA-BL-009-C-harness-file-existence-check.md
+++ b/.agents/backlog/INFRA-BL-009-C-harness-file-existence-check.md
@@ -121,15 +121,25 @@ function checkDtsExtension(pkgDir, pkg) {
   node scripts/harness/check-build-output-contracts.mjs
   ```
 - 예상 결과: 기존과 동일한 통과 결과, 추가된 파일 존재 검증 항목이 출력에 표시됨
-- 증거: [구현 후 기록]
+- 증거:
+  ```
+  Build output contract check passed for 54 package(s).
+  ```
+  (2026-05-16 실행 — 54개 패키지 통과, 에러 없음)
 
 ### 시나리오 2: DTS 확장자 오류 탐지
 
 - agent-executability: agent-executable
-- 전제조건: 테스트용 패키지 또는 fixture에 `"types": "dist/node/index.d.mts"` 기재
+- 전제조건: 단위 테스트 fixture 사용 (`scripts/harness/__tests__/check-build-output-contracts.test.mjs`)
 - 명령:
   ```bash
-  node scripts/harness/check-build-output-contracts.mjs
+  pnpm exec vitest run scripts/harness/__tests__/check-build-output-contracts.test.mjs
   ```
-- 예상 결과: `WRONG_DTS_EXT: types="dist/node/index.d.mts"` 오류 출력
-- 증거: [구현 후 기록]
+- 예상 결과: `flags .d.mts in top-level types field` 테스트 통과 — `.d.mts` 탐지 확인
+- 증거:
+  ```
+  ✓ scripts/harness/__tests__/check-build-output-contracts.test.mjs  (15 tests) 3ms
+  Test Files  1 passed (1)
+  Tests  15 passed (15)
+  ```
+  (2026-05-16 실행)

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -515,8 +515,13 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
   it('queued prompt preserves displayInput and rawInput', async () => {
     const mockSession = createMockSession();
-    const controllableRun = createControllableRun();
-    mockSession.run.mockImplementation(controllableRun.run);
+    const firstRun = createControllableRun();
+    const secondRun = createControllableRun();
+    let callCount = 0;
+    mockSession.run.mockImplementation(() => {
+      callCount += 1;
+      return callCount === 1 ? firstRun.run() : secondRun.run();
+    });
 
     const session = new InteractiveSession({
       session: mockSession as never,
@@ -525,25 +530,24 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
 
     // Start first execution
     const first = session.submit('first');
-    await controllableRun.started;
+    await firstRun.started;
 
     // Queue with displayInput + rawInput
     await session.submit('expanded prompt', '/skill', '/plugin:skill args');
     expect(session.getPendingPrompt()).toBe('expanded prompt');
 
-    // Complete first
-    controllableRun.resolve('done');
+    // Complete first; queued prompt should start automatically
+    firstRun.resolve('done');
     await first;
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait for the queued run to actually start (no fixed timeout)
+    await secondRun.started;
+    secondRun.resolve('done');
 
-    // Second call should have used the queued rawInput
+    // Second call must have used the queued rawInput
     const calls = mockSession.run.mock.calls;
-    const lastCall = calls[calls.length - 1];
-    if (lastCall) {
-      // If queued prompt executed, it should pass rawInput
-      expect(lastCall[0]).toBe('expanded prompt');
-      expect(lastCall[1]).toBe('/plugin:skill args');
-    }
+    expect(calls).toHaveLength(2);
+    expect(calls[1][0]).toBe('expanded prompt');
+    expect(calls[1][1]).toBe('/plugin:skill args');
   });
 
   // ── Regression: abort preserves interrupted assistant text ─────

--- a/packages/agent-provider-openai/tsup.config.ts
+++ b/packages/agent-provider-openai/tsup.config.ts
@@ -15,6 +15,8 @@ const baseConfig = {
   minify: true,
 };
 
+const nodeExternal = [/^@robota-sdk\/.*/, 'openai'];
+
 export default defineConfig([
   // Node.js build
   {
@@ -23,11 +25,19 @@ export default defineConfig([
     outDir: 'dist/node',
     format: ['esm', 'cjs'],
     platform: 'node',
-    external: [
-      // External dependencies that should not be bundled
-      /^@robota-sdk\/.*/, // All @robota-sdk packages
-      'openai',
-    ],
+    external: nodeExternal,
+  },
+  // Loggers sub-path build (./loggers/file, ./loggers/console)
+  {
+    ...baseConfig,
+    entry: {
+      file: 'src/loggers/file.ts',
+      console: 'src/loggers/console.ts',
+    },
+    outDir: 'dist/loggers',
+    format: ['esm', 'cjs'],
+    platform: 'node',
+    external: nodeExternal,
   },
   // Browser build
   {
@@ -36,16 +46,11 @@ export default defineConfig([
     outDir: 'dist/browser',
     format: ['esm'],
     platform: 'browser',
-    external: [
-      // External dependencies that should not be bundled
-      /^@robota-sdk\/.*/, // All @robota-sdk packages
-      'openai',
-    ],
+    external: nodeExternal,
     define: {
       'process.env.NODE_ENV': '"production"',
     },
     esbuildOptions(options) {
-      // Additional browser optimizations
       options.drop = ['console', 'debugger'];
       options.dropLabels = ['DEV'];
     },

--- a/scripts/harness/__tests__/check-build-output-contracts.test.mjs
+++ b/scripts/harness/__tests__/check-build-output-contracts.test.mjs
@@ -1,0 +1,162 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  findDtsExtensionFindings,
+  findDistFileFindings,
+  findBinPathFindings,
+  findExportPathFindings,
+} from '../check-build-output-contracts.mjs';
+
+const PKG = '@test/pkg';
+
+// ── findDtsExtensionFindings ────────────────────────────────────────────────
+
+describe('findDtsExtensionFindings', () => {
+  it('passes when types ends with .d.ts', () => {
+    const pkg = { types: 'dist/node/index.d.ts' };
+    expect(findDtsExtensionFindings(PKG, pkg)).toEqual([]);
+  });
+
+  it('flags .d.mts in top-level types field', () => {
+    const pkg = { types: 'dist/node/index.d.mts' };
+    const findings = findDtsExtensionFindings(PKG, pkg);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('.d.mts');
+    expect(findings[0]).toContain('must end with .d.ts');
+  });
+
+  it('flags .d.cts in top-level types field', () => {
+    const pkg = { types: 'dist/node/index.d.cts' };
+    const findings = findDtsExtensionFindings(PKG, pkg);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('.d.cts');
+  });
+
+  it('flags .d.mts in exports types', () => {
+    const pkg = {
+      exports: {
+        '.': { types: './dist/node/index.d.mts', import: './dist/node/index.js' },
+      },
+    };
+    const findings = findDtsExtensionFindings(PKG, pkg);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('./dist/node/index.d.mts');
+  });
+
+  it('passes when exports types ends with .d.ts', () => {
+    const pkg = {
+      exports: {
+        '.': { types: './dist/node/index.d.ts', import: './dist/node/index.js' },
+      },
+    };
+    expect(findDtsExtensionFindings(PKG, pkg)).toEqual([]);
+  });
+
+  it('ignores types not in dist/', () => {
+    const pkg = { types: 'src/index.d.mts' };
+    expect(findDtsExtensionFindings(PKG, pkg)).toEqual([]);
+  });
+});
+
+// ── findDistFileFindings ────────────────────────────────────────────────────
+
+async function createFixture(files) {
+  const root = await mkdtemp(path.join(tmpdir(), 'robota-build-contracts-'));
+  for (const [relativePath, content] of Object.entries(files)) {
+    const targetPath = path.join(root, relativePath);
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, content ?? '', 'utf8');
+  }
+  return root;
+}
+
+describe('findDistFileFindings', () => {
+  it('skips check when dist/ does not exist (build not run)', async () => {
+    const root = await createFixture({});
+    const pkg = { main: 'dist/node/index.js', types: 'dist/node/index.d.ts' };
+    expect(findDistFileFindings(PKG, pkg, root)).toEqual([]);
+  });
+
+  it('passes when all declared dist files exist', async () => {
+    const root = await createFixture({
+      'dist/node/index.js': '',
+      'dist/node/index.d.ts': '',
+    });
+    const pkg = { main: 'dist/node/index.js', types: 'dist/node/index.d.ts' };
+    expect(findDistFileFindings(PKG, pkg, root)).toEqual([]);
+  });
+
+  it('flags missing main file', async () => {
+    const root = await createFixture({ 'dist/node/index.d.ts': '' });
+    const pkg = { main: 'dist/node/index.js', types: 'dist/node/index.d.ts' };
+    const findings = findDistFileFindings(PKG, pkg, root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('main="dist/node/index.js"');
+    expect(findings[0]).toContain('file not found');
+  });
+
+  it('flags missing types file', async () => {
+    const root = await createFixture({ 'dist/node/index.js': '' });
+    const pkg = { main: 'dist/node/index.js', types: 'dist/node/index.d.ts' };
+    const findings = findDistFileFindings(PKG, pkg, root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('types="dist/node/index.d.ts"');
+  });
+
+  it('flags missing exports subpath file', async () => {
+    const root = await createFixture({ 'dist/node/index.js': '' });
+    const pkg = {
+      exports: {
+        '.': { import: './dist/node/index.js' },
+        './loggers/file': { import: './dist/loggers/file.js' },
+      },
+    };
+    const findings = findDistFileFindings(PKG, pkg, root);
+    expect(findings.some((f) => f.includes('./dist/loggers/file.js'))).toBe(true);
+  });
+});
+
+// ── findExportPathFindings ──────────────────────────────────────────────────
+
+describe('findExportPathFindings', () => {
+  it('passes on known extensions', () => {
+    const pkg = {
+      exports: {
+        '.': {
+          types: './dist/node/index.d.ts',
+          import: './dist/node/index.js',
+          require: './dist/node/index.cjs',
+        },
+      },
+    };
+    expect(findExportPathFindings(PKG, pkg)).toEqual([]);
+  });
+
+  it('flags unknown dist extension', () => {
+    const pkg = { exports: { '.': { import: './dist/node/index.ts' } } };
+    const findings = findExportPathFindings(PKG, pkg);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('unsupported dist output extension');
+  });
+});
+
+// ── findBinPathFindings ─────────────────────────────────────────────────────
+
+describe('findBinPathFindings', () => {
+  it('passes on valid bin paths', () => {
+    const pkg = { bin: { robota: 'dist/bin/robota.js' } };
+    expect(findBinPathFindings(PKG, pkg)).toEqual([]);
+  });
+
+  it('flags bin pointing at non-JS file in dist', () => {
+    const pkg = { bin: { robota: 'dist/bin/robota.ts' } };
+    const findings = findBinPathFindings(PKG, pkg);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('must point at JavaScript output');
+  });
+});

--- a/scripts/harness/check-build-output-contracts.mjs
+++ b/scripts/harness/check-build-output-contracts.mjs
@@ -8,21 +8,16 @@
  * used by consumers and npm publish metadata.
  */
 
+import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { listWorkspaceScopes, readJson, WORKSPACE_ROOT } from './shared.mjs';
 
 const DIST_PATH_PATTERN = /(?:^|\/)dist\//u;
 const TYPE_DECLARATION_PATTERN = /\.d\.(?:ts|cts|mts)$/u;
+const CANONICAL_DTS_PATTERN = /\.d\.ts$/u;
 const JAVASCRIPT_OUTPUT_PATTERN = /\.(?:js|cjs|mjs)$/u;
 const KNOWN_DIST_OUTPUT_PATTERN = /\.(?:js|cjs|mjs|d\.ts|d\.cts|d\.mts)$/u;
-
-let errors = 0;
-let checkedPackages = 0;
-
-function error(message) {
-  console.error(`[error] ${message}`);
-  errors += 1;
-}
 
 function collectExportPaths(value, paths = []) {
   if (typeof value === 'string') {
@@ -38,7 +33,19 @@ function collectExportPaths(value, paths = []) {
   return paths;
 }
 
-function hasDistContract(packageJson) {
+function collectExportTypesPaths(value, paths = []) {
+  if (!value || typeof value !== 'object') return paths;
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'types' && typeof nested === 'string') {
+      paths.push(nested);
+    } else {
+      collectExportTypesPaths(nested, paths);
+    }
+  }
+  return paths;
+}
+
+export function hasDistContract(packageJson) {
   const exportedPaths = collectExportPaths(packageJson.exports);
   return (
     typeof packageJson.main === 'string' ||
@@ -48,95 +55,189 @@ function hasDistContract(packageJson) {
   );
 }
 
-function checkScriptPair(scope, packageJson) {
-  if (!packageJson.scripts?.build) {
-    return;
-  }
-  if (!hasDistContract(packageJson)) {
-    return;
-  }
+export function findScriptPairFindings(workspaceName, packageJson) {
+  if (!packageJson.scripts?.build) return [];
+  if (!hasDistContract(packageJson)) return [];
+  const findings = [];
   if (!packageJson.scripts['build:js']) {
-    error(`${scope.workspaceName}: missing build:js for root two-pass build`);
+    findings.push(`${workspaceName}: missing build:js for root two-pass build`);
   }
   if (!packageJson.scripts['build:types']) {
-    error(`${scope.workspaceName}: missing build:types for root two-pass build`);
+    findings.push(`${workspaceName}: missing build:types for root two-pass build`);
   }
+  return findings;
 }
 
-function checkPackageFields(scope, packageJson) {
+export function findPackageFieldFindings(workspaceName, packageJson) {
+  const findings = [];
+
   if (typeof packageJson.main === 'string' && DIST_PATH_PATTERN.test(packageJson.main)) {
     if (!JAVASCRIPT_OUTPUT_PATTERN.test(packageJson.main)) {
-      error(
-        `${scope.workspaceName}: main must point at JavaScript output, got ${packageJson.main}`,
+      findings.push(
+        `${workspaceName}: main must point at JavaScript output, got ${packageJson.main}`,
       );
     }
   }
 
   if (typeof packageJson.module === 'string' && DIST_PATH_PATTERN.test(packageJson.module)) {
     if (!JAVASCRIPT_OUTPUT_PATTERN.test(packageJson.module)) {
-      error(
-        `${scope.workspaceName}: module must point at JavaScript output, got ${packageJson.module}`,
+      findings.push(
+        `${workspaceName}: module must point at JavaScript output, got ${packageJson.module}`,
       );
     }
   }
 
   if (typeof packageJson.types === 'string' && DIST_PATH_PATTERN.test(packageJson.types)) {
     if (!TYPE_DECLARATION_PATTERN.test(packageJson.types)) {
-      error(
-        `${scope.workspaceName}: types must point at TypeScript declaration output, got ${packageJson.types}`,
+      findings.push(
+        `${workspaceName}: types must point at TypeScript declaration output, got ${packageJson.types}`,
       );
     }
   }
+
+  return findings;
 }
 
-function checkExportPaths(scope, packageJson) {
+export function findExportPathFindings(workspaceName, packageJson) {
+  const findings = [];
   for (const exportPath of collectExportPaths(packageJson.exports)) {
-    if (!DIST_PATH_PATTERN.test(exportPath)) {
-      continue;
-    }
+    if (!DIST_PATH_PATTERN.test(exportPath)) continue;
     if (!KNOWN_DIST_OUTPUT_PATTERN.test(exportPath)) {
-      error(
-        `${scope.workspaceName}: export path has unsupported dist output extension: ${exportPath}`,
+      findings.push(
+        `${workspaceName}: export path has unsupported dist output extension: ${exportPath}`,
       );
     }
   }
+  return findings;
 }
 
-function checkBinPaths(scope, packageJson) {
-  if (!packageJson.bin || typeof packageJson.bin !== 'object') {
-    return;
-  }
+export function findBinPathFindings(workspaceName, packageJson) {
+  const findings = [];
+  if (!packageJson.bin || typeof packageJson.bin !== 'object') return findings;
   for (const [binName, binPath] of Object.entries(packageJson.bin)) {
     if (typeof binPath !== 'string') {
-      error(`${scope.workspaceName}: bin ${binName} must be a string path`);
+      findings.push(`${workspaceName}: bin ${binName} must be a string path`);
       continue;
     }
     if (DIST_PATH_PATTERN.test(binPath) && !JAVASCRIPT_OUTPUT_PATTERN.test(binPath)) {
-      error(
-        `${scope.workspaceName}: bin ${binName} must point at JavaScript output, got ${binPath}`,
+      findings.push(
+        `${workspaceName}: bin ${binName} must point at JavaScript output, got ${binPath}`,
       );
     }
   }
+  return findings;
 }
 
-const scopes = await listWorkspaceScopes();
+export function findDtsExtensionFindings(workspaceName, packageJson) {
+  const findings = [];
 
-for (const scope of scopes.filter((item) => item.kind === 'package')) {
-  const packageJson = await readJson(path.join(WORKSPACE_ROOT, scope.relativeDir, 'package.json'));
-  if (!hasDistContract(packageJson)) {
-    continue;
+  if (typeof packageJson.types === 'string' && DIST_PATH_PATTERN.test(packageJson.types)) {
+    if (
+      TYPE_DECLARATION_PATTERN.test(packageJson.types) &&
+      !CANONICAL_DTS_PATTERN.test(packageJson.types)
+    ) {
+      findings.push(
+        `${workspaceName}: types="${packageJson.types}" must end with .d.ts (not .d.mts or .d.cts)`,
+      );
+    }
   }
 
-  checkedPackages += 1;
-  checkScriptPair(scope, packageJson);
-  checkPackageFields(scope, packageJson);
-  checkExportPaths(scope, packageJson);
-  checkBinPaths(scope, packageJson);
+  for (const typesPath of collectExportTypesPaths(packageJson.exports)) {
+    if (
+      DIST_PATH_PATTERN.test(typesPath) &&
+      TYPE_DECLARATION_PATTERN.test(typesPath) &&
+      !CANONICAL_DTS_PATTERN.test(typesPath)
+    ) {
+      findings.push(
+        `${workspaceName}: exports types="${typesPath}" must end with .d.ts (not .d.mts or .d.cts)`,
+      );
+    }
+  }
+
+  return findings;
 }
 
-if (errors > 0) {
-  console.error(`Build output contract check failed with ${errors} error(s).`);
-  process.exit(1);
+export function findDistFileFindings(workspaceName, packageJson, pkgDir) {
+  const findings = [];
+  const distDir = path.join(pkgDir, 'dist');
+  if (!fs.existsSync(distDir)) return findings;
+
+  if (typeof packageJson.main === 'string' && DIST_PATH_PATTERN.test(packageJson.main)) {
+    if (!fs.existsSync(path.join(pkgDir, packageJson.main))) {
+      findings.push(`${workspaceName}: main="${packageJson.main}" declared but file not found`);
+    }
+  }
+
+  if (typeof packageJson.types === 'string' && DIST_PATH_PATTERN.test(packageJson.types)) {
+    if (!fs.existsSync(path.join(pkgDir, packageJson.types))) {
+      findings.push(`${workspaceName}: types="${packageJson.types}" declared but file not found`);
+    }
+  }
+
+  if (packageJson.exports && typeof packageJson.exports === 'object') {
+    for (const exportPath of collectExportPaths(packageJson.exports)) {
+      if (!DIST_PATH_PATTERN.test(exportPath)) continue;
+      if (!fs.existsSync(path.join(pkgDir, exportPath))) {
+        findings.push(`${workspaceName}: exports path "${exportPath}" declared but file not found`);
+      }
+    }
+  }
+
+  return findings;
 }
 
-console.log(`Build output contract check passed for ${checkedPackages} package(s).`);
+export async function findBuildOutputContractFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  const scopes = await listWorkspaceScopes(root);
+
+  for (const scope of scopes.filter((item) => item.kind === 'package')) {
+    const pkgDir = path.join(root, scope.relativeDir);
+    const packageJson = await readJson(path.join(pkgDir, 'package.json'));
+    if (!hasDistContract(packageJson)) continue;
+
+    const name = scope.workspaceName;
+    findings.push(...findScriptPairFindings(name, packageJson));
+    findings.push(...findPackageFieldFindings(name, packageJson));
+    findings.push(...findExportPathFindings(name, packageJson));
+    findings.push(...findBinPathFindings(name, packageJson));
+    findings.push(...findDtsExtensionFindings(name, packageJson));
+    findings.push(...findDistFileFindings(name, packageJson, pkgDir));
+  }
+
+  return findings;
+}
+
+async function main() {
+  const scopes = await listWorkspaceScopes();
+  let checkedPackages = 0;
+  const findings = [];
+
+  for (const scope of scopes.filter((item) => item.kind === 'package')) {
+    const pkgDir = path.join(WORKSPACE_ROOT, scope.relativeDir);
+    const packageJson = await readJson(path.join(pkgDir, 'package.json'));
+    if (!hasDistContract(packageJson)) continue;
+
+    checkedPackages += 1;
+    const name = scope.workspaceName;
+    findings.push(...findScriptPairFindings(name, packageJson));
+    findings.push(...findPackageFieldFindings(name, packageJson));
+    findings.push(...findExportPathFindings(name, packageJson));
+    findings.push(...findBinPathFindings(name, packageJson));
+    findings.push(...findDtsExtensionFindings(name, packageJson));
+    findings.push(...findDistFileFindings(name, packageJson, pkgDir));
+  }
+
+  if (findings.length > 0) {
+    for (const finding of findings) {
+      console.error(`[error] ${finding}`);
+    }
+    console.error(`Build output contract check failed with ${findings.length} error(s).`);
+    process.exit(1);
+  }
+
+  console.log(`Build output contract check passed for ${checkedPackages} package(s).`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}


### PR DESCRIPTION
## Summary

- Refactors `check-build-output-contracts.mjs` to export testable finder functions (`findDtsExtensionFindings`, `findDistFileFindings`, etc.)
- Adds `findDtsExtensionFindings`: flags `types` / `exports.*.types` paths ending with `.d.mts` or `.d.cts` (must end with `.d.ts`)
- Adds `findDistFileFindings`: when `dist/` exists, verifies all declared `main`, `types`, and `exports` paths are present on disk
- Adds 15 unit tests in `scripts/harness/__tests__/check-build-output-contracts.test.mjs`
- Fixes `agent-provider-openai` tsup config: adds `loggers` sub-path build entries (`./loggers/file`, `./loggers/console` were declared in `exports` but never built — caught by the new harness check)
- Fixes flaky `queued-prompt` test in `interactive-session-behavior.test.ts`: replaces 50ms `setTimeout` with a second `controllableRun.started` await

## Test plan

- [x] `pnpm harness:scan` passes (all 54 packages)
- [x] 15 new unit tests pass
- [x] `pnpm test` passes (3 consecutive runs to verify flaky test fix)
- [x] UETS evidence recorded in backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)