### PR TITLE
refactor(REFACTOR-009): IFileSystem/IFileSystemAsync port pattern for agent-framework

### DIFF
--- a/packages/agent-core/src/interfaces/file-system.ts
+++ b/packages/agent-core/src/interfaces/file-system.ts
@@ -1,0 +1,41 @@
+export interface IDirent {
+  name: string;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+export interface IStats {
+  mtimeMs: number;
+  birthtimeMs: number;
+  size: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+}
+
+export interface IFileSystem {
+  existsSync(path: string): boolean;
+  readFileSync(path: string, encoding: BufferEncoding): string;
+  writeFileSync(path: string, data: string, encoding?: BufferEncoding): void;
+  mkdirSync(path: string, options?: { recursive?: boolean }): void;
+  readdirSync(path: string): string[];
+  readdirSync(path: string, options: { withFileTypes: true }): IDirent[];
+  statSync(path: string): IStats;
+  rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
+  cpSync(source: string, destination: string, options?: { recursive?: boolean }): void;
+  renameSync(oldPath: string, newPath: string): void;
+  constants: { F_OK: number; R_OK: number; W_OK: number };
+}
+
+export interface IFileSystemAsync {
+  access(path: string, mode?: number): Promise<void>;
+  copyFile(src: string, dest: string, flags?: number): Promise<void>;
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  readFile(path: string, encoding: BufferEncoding): Promise<string>;
+  readdir(path: string): Promise<string[]>;
+  readdir(path: string, options: { withFileTypes: true }): Promise<IDirent[]>;
+  realpath(path: string): Promise<string>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void>;
+  stat(path: string): Promise<IStats>;
+  writeFile(path: string, data: string, encoding?: BufferEncoding): Promise<void>;
+}

--- a/packages/agent-core/src/interfaces/index.ts
+++ b/packages/agent-core/src/interfaces/index.ts
@@ -192,3 +192,5 @@ export type { ICacheKey, ICacheEntry, ICacheStorage, ICacheStats, ICacheOptions 
 export type { ISpinner, ITerminalOutput } from './terminal-output';
 
 export type { ISession } from './session';
+
+export type { IDirent, IStats, IFileSystem, IFileSystemAsync } from './file-system';

--- a/packages/agent-framework/src/adapters/node-file-system.ts
+++ b/packages/agent-framework/src/adapters/node-file-system.ts
@@ -1,0 +1,125 @@
+import {
+  constants,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {
+  access,
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+
+import type { IDirent, IFileSystem, IFileSystemAsync, IStats } from '@robota-sdk/agent-core';
+
+export class NodeFileSystem implements IFileSystem {
+  existsSync(path: string): boolean {
+    return existsSync(path);
+  }
+
+  readFileSync(path: string, encoding: BufferEncoding): string {
+    return readFileSync(path, encoding);
+  }
+
+  writeFileSync(path: string, data: string, encoding?: BufferEncoding): void {
+    writeFileSync(path, data, encoding ?? 'utf8');
+  }
+
+  mkdirSync(path: string, options?: { recursive?: boolean }): void {
+    mkdirSync(path, options);
+  }
+
+  readdirSync(path: string): string[];
+  // eslint-disable-next-line no-dupe-class-members
+  readdirSync(path: string, options: { withFileTypes: true }): IDirent[];
+  // eslint-disable-next-line no-dupe-class-members
+  readdirSync(path: string, options?: { withFileTypes?: true }): string[] | IDirent[] {
+    if (options?.withFileTypes) {
+      return readdirSync(path, { withFileTypes: true }) as IDirent[];
+    }
+    return readdirSync(path) as string[];
+  }
+
+  statSync(path: string): IStats {
+    return statSync(path) as IStats;
+  }
+
+  rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void {
+    rmSync(path, options);
+  }
+
+  cpSync(source: string, destination: string, options?: { recursive?: boolean }): void {
+    cpSync(source, destination, options);
+  }
+
+  renameSync(oldPath: string, newPath: string): void {
+    renameSync(oldPath, newPath);
+  }
+
+  get constants(): { F_OK: number; R_OK: number; W_OK: number } {
+    return constants;
+  }
+}
+
+export class NodeFileSystemAsync implements IFileSystemAsync {
+  async access(path: string, mode?: number): Promise<void> {
+    await access(path, mode);
+  }
+
+  async copyFile(src: string, dest: string, flags?: number): Promise<void> {
+    await copyFile(src, dest, flags);
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    await mkdir(path, options);
+  }
+
+  async readFile(path: string, encoding: BufferEncoding): Promise<string> {
+    return readFile(path, encoding);
+  }
+
+  async readdir(path: string): Promise<string[]>;
+  // eslint-disable-next-line no-dupe-class-members
+  async readdir(path: string, options: { withFileTypes: true }): Promise<IDirent[]>;
+  // eslint-disable-next-line no-dupe-class-members
+  async readdir(path: string, options?: { withFileTypes?: true }): Promise<string[] | IDirent[]> {
+    if (options?.withFileTypes) {
+      const result = await readdir(path, { withFileTypes: true });
+      return result as IDirent[];
+    }
+    return readdir(path) as Promise<string[]>;
+  }
+
+  async realpath(path: string): Promise<string> {
+    return realpath(path);
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    await rename(oldPath, newPath);
+  }
+
+  async rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void> {
+    await rm(path, options);
+  }
+
+  async stat(path: string): Promise<IStats> {
+    return stat(path) as Promise<IStats>;
+  }
+
+  async writeFile(path: string, data: string, encoding?: BufferEncoding): Promise<void> {
+    await writeFile(path, data, encoding ?? 'utf8');
+  }
+}

--- a/packages/agent-framework/src/agents/agent-definition-loader.ts
+++ b/packages/agent-framework/src/agents/agent-definition-loader.ts
@@ -1,6 +1,7 @@
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
+import type { IFileSystem, IDirent } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { IAgentDefinition } from './agent-definition-types.js';
 import { BUILT_IN_AGENTS } from './built-in-agents.js';
 
@@ -80,15 +81,16 @@ function parseFrontmatter(content: string): { frontmatter: IRawFrontmatter | nul
 }
 
 /** Scan a directory for .md files and return parsed agent definitions. */
-function scanAgentsDir(dir: string): IAgentDefinition[] {
-  if (!existsSync(dir)) return [];
+function scanAgentsDir(dir: string, fs: IFileSystem): IAgentDefinition[] {
+  if (!fs.existsSync(dir)) return [];
 
   const agents: IAgentDefinition[] = [];
-  let entries: import('node:fs').Dirent[];
+  let entries: IDirent[];
 
   try {
-    entries = readdirSync(dir, { withFileTypes: true }) as import('node:fs').Dirent[];
+    entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch {
+    // allow-fallback: unreadable agents directory returns empty list
     return [];
   }
 
@@ -96,7 +98,7 @@ function scanAgentsDir(dir: string): IAgentDefinition[] {
     if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
 
     const filePath = join(dir, entry.name);
-    const content = readFileSync(filePath, 'utf-8');
+    const content = fs.readFileSync(filePath, 'utf-8');
     const { frontmatter, body } = parseFrontmatter(content);
     const fallbackName = basename(entry.name, '.md');
 
@@ -134,20 +136,22 @@ function scanAgentsDir(dir: string): IAgentDefinition[] {
 export class AgentDefinitionLoader {
   private readonly cwd: string;
   private readonly home: string;
+  private readonly fs: IFileSystem;
 
-  constructor(cwd: string, home?: string) {
+  constructor(cwd: string, home?: string, fs: IFileSystem = new NodeFileSystem()) {
     this.cwd = cwd;
     this.home = home ?? homedir();
+    this.fs = fs;
   }
 
   /** Load all agent definitions, merged with built-in agents. Custom overrides built-in on name collision. */
   loadAll(): IAgentDefinition[] {
     const sources: IAgentDefinition[][] = [
-      scanAgentsDir(join(this.cwd, '.robota', 'agents')),
-      scanAgentsDir(join(this.cwd, '.agents', 'agents')),
-      scanAgentsDir(join(this.cwd, '.claude', 'agents')),
-      scanAgentsDir(join(this.home, '.robota', 'agents')),
-      scanAgentsDir(join(this.home, '.claude', 'agents')),
+      scanAgentsDir(join(this.cwd, '.robota', 'agents'), this.fs),
+      scanAgentsDir(join(this.cwd, '.agents', 'agents'), this.fs),
+      scanAgentsDir(join(this.cwd, '.claude', 'agents'), this.fs),
+      scanAgentsDir(join(this.home, '.robota', 'agents'), this.fs),
+      scanAgentsDir(join(this.home, '.claude', 'agents'), this.fs),
     ];
 
     // Deduplicate custom agents: higher-priority source wins

--- a/packages/agent-framework/src/assembly/subagent-logger.ts
+++ b/packages/agent-framework/src/assembly/subagent-logger.ts
@@ -6,9 +6,10 @@
  *   {baseLogsDir}/{parentSessionId}/subagents/{agentId}.jsonl
  */
 
-import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { FileSessionLogger } from '@robota-sdk/agent-session';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 /**
  * Create a FileSessionLogger for a subagent session.
@@ -25,9 +26,10 @@ export function createSubagentLogger(
   parentSessionId: string,
   _agentId: string,
   baseLogsDir: string,
+  fs: IFileSystem = new NodeFileSystem(),
 ): FileSessionLogger {
   const subagentDir = join(baseLogsDir, parentSessionId, 'subagents');
-  mkdirSync(subagentDir, { recursive: true });
+  fs.mkdirSync(subagentDir, { recursive: true });
   return new FileSessionLogger(subagentDir);
 }
 

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-inspection.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-inspection.ts
@@ -1,5 +1,6 @@
-import { statSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type {
   IEditCheckpointInspection,
   IEditCheckpointInspectionPlan,
@@ -13,11 +14,13 @@ interface IEditCheckpointInspectionInput {
   target: IEditCheckpointManifest;
   manifests: readonly IEditCheckpointManifest[];
   checkpointDir: (sessionId: string, checkpointId: string) => string;
+  fs?: IFileSystem;
 }
 
 export function buildEditCheckpointInspection(
   input: IEditCheckpointInspectionInput,
 ): IEditCheckpointInspection {
+  const fs = input.fs ?? new NodeFileSystem();
   const later = input.manifests.filter((manifest) => manifest.sequence > input.target.sequence);
   const rollbackRange = input.manifests.filter(
     (manifest) => manifest.sequence >= input.target.sequence,
@@ -29,7 +32,7 @@ export function buildEditCheckpointInspection(
       const snapshotPath = file.snapshotFile
         ? join(input.checkpointDir(input.sessionId, input.target.id), file.snapshotFile)
         : undefined;
-      const snapshotStats = snapshotPath ? statSafe(snapshotPath) : undefined;
+      const snapshotStats = snapshotPath ? statSafe(snapshotPath, fs) : undefined;
       return {
         originalPath: file.originalPath,
         relativePath: relative(input.cwd, file.originalPath),
@@ -64,10 +67,11 @@ function toInspectionPlan(
   };
 }
 
-function statSafe(path: string): { size: number } | undefined {
+function statSafe(path: string, fs: IFileSystem): { size: number } | undefined {
   try {
-    return statSync(path);
+    return fs.statSync(path);
   } catch {
+    // allow-fallback: missing snapshot file returns undefined to mark snapshot unavailable
     return undefined;
   }
 }

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
@@ -1,6 +1,7 @@
-import { access, copyFile, mkdir, rename, rm, writeFile } from 'node:fs/promises';
-import { constants, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
+
+import type { IFileSystem, IFileSystemAsync } from '@robota-sdk/agent-core';
+import { NodeFileSystem, NodeFileSystemAsync } from '../adapters/node-file-system.js';
 import { projectPaths } from '../paths.js';
 import type {
   IEditCheckpointFileRecord,
@@ -32,7 +33,11 @@ export class EditCheckpointStore {
   private readonly now: () => Date;
   private activeTurn: IActiveEditCheckpointTurn | null = null;
 
-  constructor(options: IEditCheckpointStoreOptions) {
+  constructor(
+    options: IEditCheckpointStoreOptions,
+    private readonly fs: IFileSystem = new NodeFileSystem(),
+    private readonly fsAsync: IFileSystemAsync = new NodeFileSystemAsync(),
+  ) {
     this.cwd = resolve(options.cwd);
     this.rootDir = projectPaths(this.cwd).checkpoints;
     this.now = options.now ?? (() => new Date());
@@ -46,7 +51,7 @@ export class EditCheckpointStore {
     const nextSequence = this.nextSequence(input.sessionId);
     const id = `turn-${String(nextSequence).padStart(ID_PAD, '0')}`;
     const dir = join(this.sessionDir(input.sessionId), id);
-    await mkdir(join(dir, SNAPSHOT_DIR), { recursive: true });
+    await this.fsAsync.mkdir(join(dir, SNAPSHOT_DIR), { recursive: true });
 
     const manifest: IEditCheckpointManifest = {
       version: 1,
@@ -133,7 +138,10 @@ export class EditCheckpointStore {
     }
 
     for (const manifest of later) {
-      await rm(this.checkpointDir(sessionId, manifest.id), { recursive: true, force: true });
+      await this.fsAsync.rm(this.checkpointDir(sessionId, manifest.id), {
+        recursive: true,
+        force: true,
+      });
     }
 
     return {
@@ -167,7 +175,10 @@ export class EditCheckpointStore {
     }
 
     for (const manifest of rollbackRange) {
-      await rm(this.checkpointDir(sessionId, manifest.id), { recursive: true, force: true });
+      await this.fsAsync.rm(this.checkpointDir(sessionId, manifest.id), {
+        recursive: true,
+        force: true,
+      });
     }
 
     return {
@@ -182,7 +193,7 @@ export class EditCheckpointStore {
     originalPath: string,
     active: IActiveEditCheckpointTurn,
   ): Promise<IEditCheckpointFileRecord> {
-    const existed = await pathExists(originalPath);
+    const existed = await pathExists(this.fsAsync, this.fs, originalPath);
     if (!existed) {
       return {
         originalPath,
@@ -194,7 +205,7 @@ export class EditCheckpointStore {
       SNAPSHOT_DIR,
       `${String(active.manifest.files.length + 1).padStart(SNAPSHOT_PAD, '0')}.content`,
     );
-    await copyFile(originalPath, join(active.dir, snapshotFile));
+    await this.fsAsync.copyFile(originalPath, join(active.dir, snapshotFile));
     return {
       originalPath,
       existed: true,
@@ -208,14 +219,14 @@ export class EditCheckpointStore {
     record: IEditCheckpointFileRecord,
   ): Promise<void> {
     if (!record.existed) {
-      await rm(record.originalPath, { force: true });
+      await this.fsAsync.rm(record.originalPath, { force: true });
       return;
     }
     if (!record.snapshotFile) {
       throw new Error(`Checkpoint file record is missing a snapshot: ${record.originalPath}`);
     }
-    await mkdir(dirname(record.originalPath), { recursive: true });
-    await copyFile(
+    await this.fsAsync.mkdir(dirname(record.originalPath), { recursive: true });
+    await this.fsAsync.copyFile(
       join(this.checkpointDir(sessionId, checkpointId), record.snapshotFile),
       record.originalPath,
     );
@@ -223,9 +234,9 @@ export class EditCheckpointStore {
 
   private loadManifests(sessionId: string): IEditCheckpointManifest[] {
     const dir = this.sessionDir(sessionId);
-    return readDirSyncSafe(dir)
+    return readDirSyncSafe(this.fs, dir)
       .map((entry) => join(dir, entry, MANIFEST_FILE))
-      .map((manifestPath) => readJsonManifest(manifestPath))
+      .map((manifestPath) => readJsonManifest(this.fs, manifestPath))
       .filter((manifest): manifest is IEditCheckpointManifest => manifest !== undefined)
       .sort((a, b) => a.sequence - b.sequence);
   }
@@ -236,11 +247,11 @@ export class EditCheckpointStore {
   }
 
   private async writeManifest(dir: string, manifest: IEditCheckpointManifest): Promise<void> {
-    await mkdir(dir, { recursive: true });
+    await this.fsAsync.mkdir(dir, { recursive: true });
     const path = join(dir, MANIFEST_FILE);
     const tmp = `${path}.tmp`;
-    await writeFile(tmp, JSON.stringify(manifest, null, 2), 'utf8');
-    await rename(tmp, path);
+    await this.fsAsync.writeFile(tmp, JSON.stringify(manifest, null, 2), 'utf8');
+    await this.fsAsync.rename(tmp, path);
   }
 
   private sessionDir(sessionId: string): string {
@@ -272,28 +283,35 @@ function isInside(parent: string, child: string): boolean {
   return rel.length === 0 || (!rel.startsWith('..') && !rel.startsWith('/'));
 }
 
-async function pathExists(path: string): Promise<boolean> {
+async function pathExists(
+  fsAsync: IFileSystemAsync,
+  fs: IFileSystem,
+  path: string,
+): Promise<boolean> {
   try {
-    await access(path, constants.F_OK);
+    await fsAsync.access(path, fs.constants.F_OK);
     return true;
   } catch {
+    // allow-fallback: access failure means file absent, false is the correct result
     return false;
   }
 }
 
-function readDirSyncSafe(dir: string): string[] {
+function readDirSyncSafe(fs: IFileSystem, dir: string): string[] {
   try {
-    return readdirSync(dir);
+    return fs.readdirSync(dir);
   } catch {
+    // allow-fallback: missing directory returns empty list, not an error
     return [];
   }
 }
 
-function readJsonManifest(path: string): IEditCheckpointManifest | undefined {
+function readJsonManifest(fs: IFileSystem, path: string): IEditCheckpointManifest | undefined {
   try {
-    const raw = readFileSync(path, 'utf8');
+    const raw = fs.readFileSync(path, 'utf8');
     return JSON.parse(raw) as IEditCheckpointManifest;
   } catch {
+    // allow-fallback: corrupted/missing manifest is filtered out by caller
     return undefined;
   }
 }

--- a/packages/agent-framework/src/command-api/provider/provider-merge.ts
+++ b/packages/agent-framework/src/command-api/provider/provider-merge.ts
@@ -1,13 +1,15 @@
-import { existsSync, readFileSync } from 'node:fs';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../../adapters/node-file-system.js';
 import type { IProviderConfig, IProviderDefinition } from '@robota-sdk/agent-core';
 import { normalizeProviderConfig } from '@robota-sdk/agent-executor';
 import type { IProviderProfileSettings, TProviderSettingsDocument } from './provider-settings.js';
 
 export function readMergedProviderSettingsFromPaths(
   paths: readonly string[],
+  fs: IFileSystem = new NodeFileSystem(),
 ): TProviderSettingsDocument {
   return paths.reduce<TProviderSettingsDocument>((settings, filePath) => {
-    const parsed = readSettingsFile(filePath);
+    const parsed = readSettingsFile(filePath, fs);
     if (parsed === undefined) {
       return settings;
     }
@@ -15,12 +17,15 @@ export function readMergedProviderSettingsFromPaths(
   }, {});
 }
 
-function readSettingsFile(filePath: string): TProviderSettingsDocument | undefined {
-  if (!existsSync(filePath)) {
+function readSettingsFile(
+  filePath: string,
+  fs: IFileSystem,
+): TProviderSettingsDocument | undefined {
+  if (!fs.existsSync(filePath)) {
     return undefined;
   }
   try {
-    const raw = readFileSync(filePath, 'utf8');
+    const raw = fs.readFileSync(filePath, 'utf8');
     return JSON.parse(raw) as TProviderSettingsDocument;
   } catch {
     // allow-fallback: unparseable settings file is skipped to allow the config chain to continue

--- a/packages/agent-framework/src/commands/skill-source.ts
+++ b/packages/agent-framework/src/commands/skill-source.ts
@@ -1,6 +1,7 @@
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
+import type { IFileSystem, IDirent } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { ICommandSource, ICommand } from '../command-api/types.js';
 
 interface IFrontmatter {
@@ -92,18 +93,18 @@ function buildCommand(
 }
 
 /** Scan a skills directory for subdirectories containing SKILL.md */
-function scanSkillsDir(skillsDir: string): ICommand[] {
-  if (!existsSync(skillsDir)) return [];
+function scanSkillsDir(skillsDir: string, fs: IFileSystem): ICommand[] {
+  if (!fs.existsSync(skillsDir)) return [];
 
   const commands: ICommand[] = [];
-  const entries = readdirSync(skillsDir, { withFileTypes: true });
+  const entries: IDirent[] = fs.readdirSync(skillsDir, { withFileTypes: true });
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const skillFile = join(skillsDir, entry.name, 'SKILL.md');
-    if (!existsSync(skillFile)) continue;
+    if (!fs.existsSync(skillFile)) continue;
 
-    const content = readFileSync(skillFile, 'utf-8');
+    const content = fs.readFileSync(skillFile, 'utf-8');
     const frontmatter = parseFrontmatter(content);
     commands.push(buildCommand(frontmatter, content, entry.name));
   }
@@ -112,16 +113,16 @@ function scanSkillsDir(skillsDir: string): ICommand[] {
 }
 
 /** Scan a commands directory for .md files (Claude Code legacy format) */
-function scanCommandsDir(commandsDir: string): ICommand[] {
-  if (!existsSync(commandsDir)) return [];
+function scanCommandsDir(commandsDir: string, fs: IFileSystem): ICommand[] {
+  if (!fs.existsSync(commandsDir)) return [];
 
   const commands: ICommand[] = [];
-  const entries = readdirSync(commandsDir, { withFileTypes: true });
+  const entries: IDirent[] = fs.readdirSync(commandsDir, { withFileTypes: true });
 
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
     const filePath = join(commandsDir, entry.name);
-    const content = readFileSync(filePath, 'utf-8');
+    const content = fs.readFileSync(filePath, 'utf-8');
     const frontmatter = parseFrontmatter(content);
     const fallbackName = basename(entry.name, '.md');
     commands.push(buildCommand(frontmatter, content, fallbackName));
@@ -135,21 +136,23 @@ export class SkillCommandSource implements ICommandSource {
   readonly name = 'skill';
   private readonly cwd: string;
   private readonly home: string;
+  private readonly fs: IFileSystem;
   private cachedCommands: ICommand[] | null = null;
 
-  constructor(cwd: string, home?: string) {
+  constructor(cwd: string, home?: string, fs: IFileSystem = new NodeFileSystem()) {
     this.cwd = cwd;
     this.home = home ?? homedir();
+    this.fs = fs;
   }
 
   getCommands(): ICommand[] {
     if (this.cachedCommands) return this.cachedCommands;
 
     const sources: ICommand[][] = [
-      scanSkillsDir(join(this.cwd, '.claude', 'skills')),
-      scanCommandsDir(join(this.cwd, '.claude', 'commands')),
-      scanSkillsDir(join(this.home, '.robota', 'skills')),
-      scanSkillsDir(join(this.cwd, '.agents', 'skills')),
+      scanSkillsDir(join(this.cwd, '.claude', 'skills'), this.fs),
+      scanCommandsDir(join(this.cwd, '.claude', 'commands'), this.fs),
+      scanSkillsDir(join(this.home, '.robota', 'skills'), this.fs),
+      scanSkillsDir(join(this.cwd, '.agents', 'skills'), this.fs),
     ];
 
     const seen = new Set<string>();

--- a/packages/agent-framework/src/context/context-file-tracker.ts
+++ b/packages/agent-framework/src/context/context-file-tracker.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 /** A single context file entry tracked with its content hash. */
 export interface IContextFileEntry {
@@ -17,8 +18,11 @@ export function computeContentHash(content: string): string {
 }
 
 /** Read a file from disk and return an entry with its content hash. */
-export function loadFileWithHash(filePath: string): IContextFileEntry {
-  const content = readFileSync(filePath, 'utf-8');
+export function loadFileWithHash(
+  filePath: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): IContextFileEntry {
+  const content = fs.readFileSync(filePath, 'utf-8');
   return { filePath, content, contentHash: computeContentHash(content) };
 }
 
@@ -34,16 +38,17 @@ export interface IContextStalenessCheckResult {
  */
 export async function checkContextStaleness(
   entries: readonly IContextFileEntry[],
+  fs: IFileSystem = new NodeFileSystem(),
 ): Promise<IContextStalenessCheckResult> {
   const stale: IContextFileEntry[] = [];
   const fresh: IContextFileEntry[] = [];
 
   for (const entry of entries) {
-    if (!existsSync(entry.filePath)) {
+    if (!fs.existsSync(entry.filePath)) {
       fresh.push(entry);
       continue;
     }
-    const diskContent = readFileSync(entry.filePath, 'utf-8');
+    const diskContent = fs.readFileSync(entry.filePath, 'utf-8');
     const diskHash = computeContentHash(diskContent);
     if (diskHash !== entry.contentHash) {
       stale.push(entry);
@@ -69,14 +74,15 @@ export interface IContextRefreshResult {
  */
 export async function refreshContextEntries(
   entries: readonly IContextFileEntry[],
+  fs: IFileSystem = new NodeFileSystem(),
 ): Promise<IContextRefreshResult> {
-  const { stale } = await checkContextStaleness(entries);
+  const { stale } = await checkContextStaleness(entries, fs);
   const staleSet = new Set(stale.map((e) => e.filePath));
   const refreshed: string[] = [];
 
   const updated = entries.map((entry) => {
     if (!staleSet.has(entry.filePath)) return entry;
-    const diskContent = readFileSync(entry.filePath, 'utf-8');
+    const diskContent = fs.readFileSync(entry.filePath, 'utf-8');
     refreshed.push(entry.filePath);
     return {
       filePath: entry.filePath,

--- a/packages/agent-framework/src/context/prompt-file-reference-resolver.ts
+++ b/packages/agent-framework/src/context/prompt-file-reference-resolver.ts
@@ -1,5 +1,7 @@
-import { readFile, realpath, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
+
+import type { IFileSystemAsync } from '@robota-sdk/agent-core';
+import { NodeFileSystemAsync } from '../adapters/node-file-system.js';
 import type {
   IPromptFileReferenceDiagnostic,
   IPromptFileReferenceLimits,
@@ -38,6 +40,7 @@ interface IResolveState {
   diagnostics: IPromptFileReferenceDiagnostic[];
   loadedPaths: Set<string>;
   totalBytes: number;
+  fsAsync: IFileSystemAsync;
 }
 
 interface IReferenceFileInfo {
@@ -75,14 +78,16 @@ export async function resolvePromptFileReferencePaths(
 async function createResolveState(
   options: IPromptFileReferenceResolveOptions,
 ): Promise<IResolveState> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   return {
-    rootPath: await resolveWorkspaceRoot(options.cwd),
+    rootPath: await resolveWorkspaceRoot(options.cwd, fsAsync),
     limits: resolveLimits(options.limits),
     reason: options.reason ?? 'prompt-reference',
     references: [],
     diagnostics: [],
     loadedPaths: new Set<string>(),
     totalBytes: 0,
+    fsAsync,
   };
 }
 
@@ -102,10 +107,11 @@ function resolveLimits(limits: IPromptFileReferenceLimits | undefined): IResolve
   };
 }
 
-async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+async function resolveWorkspaceRoot(cwd: string, fsAsync: IFileSystemAsync): Promise<string> {
   try {
-    return await realpath(cwd);
+    return await fsAsync.realpath(cwd);
   } catch {
+    // allow-fallback: realpath fails for non-existent cwd; resolve() gives a usable absolute path
     return resolve(cwd);
   }
 }
@@ -161,7 +167,7 @@ async function resolveReferencePath(
   }
 
   try {
-    const sourcePath = await realpath(candidatePath);
+    const sourcePath = await state.fsAsync.realpath(candidatePath);
     if (isPathWithinRoot(sourcePath, state.rootPath)) return sourcePath;
     pushDiagnostic(
       state,
@@ -170,6 +176,7 @@ async function resolveReferencePath(
       'Referenced path resolves outside the workspace.',
     );
   } catch {
+    // allow-fallback: realpath failure means file absent; diagnostic is the intended result
     pushDiagnostic(state, 'not-found', reference, 'Referenced file was not found.');
   }
   return undefined;
@@ -194,7 +201,7 @@ async function inspectReferenceFile(
   state: IResolveState,
 ): Promise<IReferenceFileInfo | undefined> {
   try {
-    const fileStat = await stat(sourcePath);
+    const fileStat = await state.fsAsync.stat(sourcePath);
     if (fileStat.isDirectory()) {
       pushDiagnostic(
         state,
@@ -224,6 +231,7 @@ async function inspectReferenceFile(
     }
     return { sourcePath, byteLength: fileStat.size };
   } catch {
+    // allow-fallback: stat failure means unreadable; diagnostic is the intended result
     pushDiagnostic(state, 'unreadable', reference, 'Referenced file could not be inspected.');
     return undefined;
   }
@@ -235,8 +243,9 @@ async function readReferenceFile(
   state: IResolveState,
 ): Promise<string | undefined> {
   try {
-    return await readFile(sourcePath, 'utf8');
+    return await state.fsAsync.readFile(sourcePath, 'utf8');
   } catch {
+    // allow-fallback: read failure means unreadable; diagnostic is the intended result
     pushDiagnostic(state, 'unreadable', reference, 'Referenced file could not be read.');
     return undefined;
   }

--- a/packages/agent-framework/src/context/prompt-file-reference-types.ts
+++ b/packages/agent-framework/src/context/prompt-file-reference-types.ts
@@ -1,3 +1,5 @@
+import type { IFileSystemAsync } from '@robota-sdk/agent-core';
+
 export type TPromptFileReferenceReason = 'manual' | 'prompt-reference';
 
 export type TPromptFileReferenceDiagnosticCode =
@@ -49,6 +51,7 @@ export interface IPromptFileReferenceResolveOptions {
   cwd: string;
   limits?: IPromptFileReferenceLimits;
   reason?: TPromptFileReferenceReason;
+  fsAsync?: IFileSystemAsync;
 }
 
 export interface IResolvedPromptFileReferences {

--- a/packages/agent-framework/src/context/task-context.ts
+++ b/packages/agent-framework/src/context/task-context.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 export type TTaskFileStatus = 'todo' | 'in-progress' | 'blocked' | 'completed' | 'unknown';
 
@@ -147,15 +148,15 @@ function appendProgressEntry(content: string, now: Date, progressMessage: string
   return lines.join('\n');
 }
 
-function resolveGitDirectory(cwd: string): string | undefined {
+function resolveGitDirectory(cwd: string, fs: IFileSystem): string | undefined {
   let current = resolve(cwd);
   let reachedRoot = false;
   while (!reachedRoot) {
     const gitPath = join(current, '.git');
-    if (existsSync(gitPath)) {
-      const stats = statSync(gitPath);
+    if (fs.existsSync(gitPath)) {
+      const stats = fs.statSync(gitPath);
       if (stats.isDirectory()) return gitPath;
-      const content = readFileSync(gitPath, 'utf8').trim();
+      const content = fs.readFileSync(gitPath, 'utf8').trim();
       const gitdir = content.match(/^gitdir:\s*(.+)$/)?.[1];
       if (gitdir) return isAbsolute(gitdir) ? gitdir : resolve(current, gitdir);
     }
@@ -167,24 +168,28 @@ function resolveGitDirectory(cwd: string): string | undefined {
   return undefined;
 }
 
-export function readCurrentGitBranch(cwd: string): string | undefined {
-  const gitDir = resolveGitDirectory(cwd);
+export function readCurrentGitBranch(
+  cwd: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): string | undefined {
+  const gitDir = resolveGitDirectory(cwd, fs);
   if (!gitDir) return undefined;
   const headPath = join(gitDir, 'HEAD');
-  if (!existsSync(headPath)) return undefined;
+  if (!fs.existsSync(headPath)) return undefined;
 
-  const head = readFileSync(headPath, 'utf8').trim();
+  const head = fs.readFileSync(headPath, 'utf8').trim();
   const branch = head.match(/^ref:\s+refs\/heads\/(.+)$/)?.[1];
   return branch?.trim();
 }
 
-export function discoverTaskFiles(cwd: string): string[] {
+export function discoverTaskFiles(cwd: string, fs: IFileSystem = new NodeFileSystem()): string[] {
   const tasksDir = join(cwd, TASKS_DIR);
-  if (!existsSync(tasksDir)) {
+  if (!fs.existsSync(tasksDir)) {
     return [];
   }
 
-  return readdirSync(tasksDir, { withFileTypes: true })
+  return fs
+    .readdirSync(tasksDir, { withFileTypes: true })
     .filter((entry) => entry.isFile())
     .map((entry) => entry.name)
     .filter((name) => name !== README_FILENAME && name.endsWith(MARKDOWN_EXTENSION))
@@ -192,8 +197,12 @@ export function discoverTaskFiles(cwd: string): string[] {
     .map((name) => join(tasksDir, name));
 }
 
-export function parseTaskFile(taskPath: string, cwd: string): ITaskContextFile {
-  const content = readFileSync(taskPath, 'utf8');
+export function parseTaskFile(
+  taskPath: string,
+  cwd: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): ITaskContextFile {
+  const content = fs.readFileSync(taskPath, 'utf8');
   return {
     path: taskPath,
     relativePath: relative(cwd, taskPath),
@@ -225,9 +234,13 @@ export function formatTaskContext(tasks: readonly ITaskContextFile[]): string {
   return tasks.map(formatTask).join('\n\n');
 }
 
-export function loadTaskContext(cwd: string, options: ITaskSelectionOptions = {}): string {
-  const currentBranch = options.currentBranch ?? readCurrentGitBranch(cwd);
-  const tasks = discoverTaskFiles(cwd).map((path) => parseTaskFile(path, cwd));
+export function loadTaskContext(
+  cwd: string,
+  options: ITaskSelectionOptions = {},
+  fs: IFileSystem = new NodeFileSystem(),
+): string {
+  const currentBranch = options.currentBranch ?? readCurrentGitBranch(cwd, fs);
+  const tasks = discoverTaskFiles(cwd, fs).map((path) => parseTaskFile(path, cwd, fs));
   return formatTaskContext(selectRelevantTasks(tasks, { ...options, currentBranch }));
 }
 
@@ -235,10 +248,11 @@ export function updateTaskFileStatus(
   taskPath: string,
   status: TTaskFileStatus,
   options: IUpdateTaskFileStatusOptions = {},
+  fs: IFileSystem = new NodeFileSystem(),
 ): void {
-  const updated = upsertStatusLine(readFileSync(taskPath, 'utf8'), status);
+  const updated = upsertStatusLine(fs.readFileSync(taskPath, 'utf8'), status);
   const withProgress = options.progressMessage
     ? appendProgressEntry(updated, options.now ?? new Date(), options.progressMessage)
     : updated;
-  writeFileSync(taskPath, withProgress, 'utf8');
+  fs.writeFileSync(taskPath, withProgress, 'utf8');
 }

--- a/packages/agent-framework/src/interactive/interactive-session-streaming.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-streaming.ts
@@ -6,7 +6,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
 import type { IDiffLine, IToolState } from './types.js';
@@ -97,13 +98,15 @@ function buildEditDiffLinesWithContext(
   newString: string,
   startLine: number,
   filePath: string,
+  fs: IFileSystem = new NodeFileSystem(),
 ): IDiffLine[] {
   const diffLines = buildEditDiffLines(oldString, newString, startLine);
 
   let fileLines: string[];
   try {
-    fileLines = readFileSync(filePath, 'utf8').split('\n');
+    fileLines = fs.readFileSync(filePath, 'utf8').split('\n');
   } catch {
+    // allow-fallback: unreadable file returns diff without context lines
     return diffLines;
   }
 

--- a/packages/agent-framework/src/interactive/session-persistence.ts
+++ b/packages/agent-framework/src/interactive/session-persistence.ts
@@ -5,8 +5,9 @@ import {
   SessionStore,
   type ISessionRecord,
 } from '@robota-sdk/agent-session';
-import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type {
   IBackgroundJobGroupState,
   IBackgroundTaskState,
@@ -55,9 +56,12 @@ export interface IResumableSessionSummary {
   preview: string;
 }
 
-export function createProjectSessionStore(cwd: string): IInteractiveSessionStore {
+export function createProjectSessionStore(
+  cwd: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): IInteractiveSessionStore {
   const paths = projectPaths(cwd);
-  return new ProjectSessionStoreFacade(paths.sessions, paths.logs);
+  return new ProjectSessionStoreFacade(paths.sessions, paths.logs, fs);
 }
 
 export function listResumableSessionSummaries(
@@ -97,10 +101,12 @@ export function resolveSessionIdByIdOrName(
 class ProjectSessionStoreFacade implements IInteractiveSessionStore {
   private readonly store: SessionStore;
   private readonly logsDir: string | undefined;
+  private readonly fs: IFileSystem;
 
-  constructor(baseDir: string, logsDir?: string) {
+  constructor(baseDir: string, logsDir?: string, fs: IFileSystem = new NodeFileSystem()) {
     this.store = new SessionStore(baseDir);
     this.logsDir = logsDir;
+    this.fs = fs;
   }
 
   save(session: IInteractiveSessionRecord): void {
@@ -159,10 +165,11 @@ class ProjectSessionStoreFacade implements IInteractiveSessionStore {
   }
 
   private listReplayLogRecords(): IInteractiveSessionRecord[] {
-    if (!this.logsDir || !existsSync(this.logsDir)) {
+    if (!this.logsDir || !this.fs.existsSync(this.logsDir)) {
       return [];
     }
-    return readdirSync(this.logsDir)
+    return this.fs
+      .readdirSync(this.logsDir)
       .filter((file) => file.endsWith('.jsonl'))
       .map((file) => this.loadFromReplayLog(file.slice(0, -'.jsonl'.length)))
       .filter((record): record is IInteractiveSessionRecord => record !== undefined);

--- a/packages/agent-framework/src/memory/pending-memory-store.ts
+++ b/packages/agent-framework/src/memory/pending-memory-store.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type {
   IMemoryCandidate,
   IMemoryPendingRecord,
@@ -25,7 +26,11 @@ export class PendingMemoryStore {
   private readonly path: string;
   private readonly now: () => Date;
 
-  constructor(cwd: string, now: () => Date = () => new Date()) {
+  constructor(
+    cwd: string,
+    now: () => Date = () => new Date(),
+    private readonly fs: IFileSystem = new NodeFileSystem(),
+  ) {
     this.path = join(memoryRoot(cwd), PENDING_FILENAME);
     this.now = now;
   }
@@ -77,17 +82,18 @@ export class PendingMemoryStore {
   }
 
   private read(): IPendingMemoryDocument {
-    if (!existsSync(this.path)) return emptyDocument();
+    if (!this.fs.existsSync(this.path)) return emptyDocument();
     try {
-      const parsed = JSON.parse(readFileSync(this.path, 'utf8')) as IPendingMemoryDocument;
+      const parsed = JSON.parse(this.fs.readFileSync(this.path, 'utf8')) as IPendingMemoryDocument;
       return { version: 1, records: parsed.records ?? [] };
     } catch {
+      // allow-fallback: corrupt JSON treated as empty document
       return emptyDocument();
     }
   }
 
   private write(document: IPendingMemoryDocument): void {
-    mkdirSync(dirname(this.path), { recursive: true });
-    writeFileSync(this.path, JSON.stringify(document, null, 2), 'utf8');
+    this.fs.mkdirSync(dirname(this.path), { recursive: true });
+    this.fs.writeFileSync(this.path, JSON.stringify(document, null, 2), 'utf8');
   }
 }

--- a/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
@@ -5,8 +5,9 @@
  * cache directory, and tracks installations in `installed_plugins.json`.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { PluginSettingsStore } from './plugin-settings-store.js';
 import type { MarketplaceClient, IMarketplacePluginEntry, TExecFn } from './marketplace-client.js';
 
@@ -32,6 +33,8 @@ export interface IBundlePluginInstallerOptions {
   marketplaceClient: MarketplaceClient;
   /** Shell exec adapter — must be provided at composition root (e.g., execSync). */
   exec: TExecFn;
+  /** File system adapter for testability. */
+  fs?: IFileSystem;
 }
 
 /** Default git clone timeout in milliseconds (60 seconds). */
@@ -45,6 +48,7 @@ export class BundlePluginInstaller {
   private readonly settingsStore: PluginSettingsStore;
   private readonly marketplaceClient: MarketplaceClient;
   private readonly exec: TExecFn;
+  private readonly fs: IFileSystem;
 
   constructor(options: IBundlePluginInstallerOptions) {
     this.pluginsDir = options.pluginsDir;
@@ -53,6 +57,7 @@ export class BundlePluginInstaller {
     this.settingsStore = options.settingsStore;
     this.marketplaceClient = options.marketplaceClient;
     this.exec = options.exec;
+    this.fs = options.fs ?? new NodeFileSystem();
   }
 
   /**
@@ -77,7 +82,7 @@ export class BundlePluginInstaller {
     // Target directory: cache/<marketplace>/<plugin>/<version>/
     const targetDir = join(this.cacheDir, marketplaceName, pluginName, version);
 
-    if (existsSync(targetDir)) {
+    if (this.fs.existsSync(targetDir)) {
       throw new Error(
         `Plugin "${pluginName}" version "${version}" is already installed from "${marketplaceName}"`,
       );
@@ -112,8 +117,8 @@ export class BundlePluginInstaller {
     }
 
     // Remove the installed directory
-    if (existsSync(record.installPath)) {
-      rmSync(record.installPath, { recursive: true, force: true });
+    if (this.fs.existsSync(record.installPath)) {
+      this.fs.rmSync(record.installPath, { recursive: true, force: true });
     }
 
     // Remove from registry
@@ -180,7 +185,7 @@ export class BundlePluginInstaller {
     pluginName: string,
     targetDir: string,
   ): void {
-    mkdirSync(targetDir, { recursive: true });
+    this.fs.mkdirSync(targetDir, { recursive: true });
 
     const source = this.normalizeSource(rawSource);
 
@@ -190,13 +195,13 @@ export class BundlePluginInstaller {
         const marketplaceDir = this.marketplaceClient.getMarketplaceDir(marketplaceName);
         const sourcePath = join(marketplaceDir, source);
 
-        if (!existsSync(sourcePath)) {
+        if (!this.fs.existsSync(sourcePath)) {
           throw new Error(
             `Plugin source path "${source}" not found in marketplace "${marketplaceName}"`,
           );
         }
 
-        cpSync(sourcePath, targetDir, { recursive: true });
+        this.fs.cpSync(sourcePath, targetDir, { recursive: true });
       } else if (source.type === 'github') {
         // Clone from GitHub
         const repoUrl = `https://github.com/${source.repo}.git`;
@@ -215,8 +220,8 @@ export class BundlePluginInstaller {
       }
     } catch (err) {
       // Clean up empty target directory on failure
-      if (existsSync(targetDir)) {
-        rmSync(targetDir, { recursive: true, force: true });
+      if (this.fs.existsSync(targetDir)) {
+        this.fs.rmSync(targetDir, { recursive: true, force: true });
       }
       throw err;
     }
@@ -225,7 +230,7 @@ export class BundlePluginInstaller {
   /** Clone a git repository to the target directory. */
   private cloneToDir(repoUrl: string, targetDir: string, pluginName: string): void {
     // Remove the directory first since mkdirSync already created it
-    rmSync(targetDir, { recursive: true, force: true });
+    this.fs.rmSync(targetDir, { recursive: true, force: true });
 
     const command = `git clone --depth 1 ${repoUrl} ${targetDir}`;
     try {
@@ -238,17 +243,18 @@ export class BundlePluginInstaller {
 
   /** Read the installed_plugins.json registry. */
   private readRegistry(): TInstalledPluginsRegistry {
-    if (!existsSync(this.registryPath)) {
+    if (!this.fs.existsSync(this.registryPath)) {
       return {};
     }
     try {
-      const raw = readFileSync(this.registryPath, 'utf-8');
+      const raw = this.fs.readFileSync(this.registryPath, 'utf-8');
       const data: unknown = JSON.parse(raw);
       if (typeof data === 'object' && data !== null) {
         return data as TInstalledPluginsRegistry;
       }
       return {};
     } catch {
+      // allow-fallback: corrupt installed_plugins.json returns empty registry to allow recovery
       return {};
     }
   }
@@ -256,9 +262,9 @@ export class BundlePluginInstaller {
   /** Write the installed_plugins.json registry. */
   private writeRegistry(registry: TInstalledPluginsRegistry): void {
     const dir = dirname(this.registryPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    if (!this.fs.existsSync(dir)) {
+      this.fs.mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(this.registryPath, JSON.stringify(registry, null, 2), 'utf-8');
+    this.fs.writeFileSync(this.registryPath, JSON.stringify(registry, null, 2), 'utf-8');
   }
 }

--- a/packages/agent-framework/src/plugins/bundle-plugin-loader.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-loader.ts
@@ -8,8 +8,9 @@
  * For each plugin, the latest version directory (lexicographically last) is loaded.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type {
   IBundlePluginManifest,
   IBundleSkill,
@@ -26,10 +27,16 @@ import {
 export class BundlePluginLoader {
   private readonly pluginsDir: string;
   private readonly enabledPlugins: TEnabledPlugins;
+  private readonly fs: IFileSystem;
 
-  constructor(pluginsDir: string, enabledPlugins?: TEnabledPlugins) {
+  constructor(
+    pluginsDir: string,
+    enabledPlugins?: TEnabledPlugins,
+    fs: IFileSystem = new NodeFileSystem(),
+  ) {
     this.pluginsDir = pluginsDir;
     this.enabledPlugins = enabledPlugins ?? {};
+    this.fs = fs;
   }
 
   /** Load all discovered and enabled bundle plugins (sync). */
@@ -50,21 +57,21 @@ export class BundlePluginLoader {
    */
   private discoverAndLoad(): ILoadedBundlePlugin[] {
     const cacheDir = join(this.pluginsDir, 'cache');
-    if (!existsSync(cacheDir)) {
+    if (!this.fs.existsSync(cacheDir)) {
       return [];
     }
 
     const results: ILoadedBundlePlugin[] = [];
 
     // Iterate marketplaces
-    const marketplaces = getSortedSubdirs(cacheDir);
+    const marketplaces = getSortedSubdirs(cacheDir, this.fs);
     for (const marketplace of marketplaces) {
       const marketplaceDir = join(cacheDir, marketplace);
-      const plugins = getSortedSubdirs(marketplaceDir);
+      const plugins = getSortedSubdirs(marketplaceDir, this.fs);
 
       for (const pluginName of plugins) {
         const pluginDir = join(marketplaceDir, pluginName);
-        const versions = getSortedSubdirs(pluginDir);
+        const versions = getSortedSubdirs(pluginDir, this.fs);
 
         if (versions.length === 0) continue;
 
@@ -73,7 +80,7 @@ export class BundlePluginLoader {
         const versionDir = join(pluginDir, latestVersion);
 
         const manifestPath = join(versionDir, '.claude-plugin', 'plugin.json');
-        if (!existsSync(manifestPath)) continue;
+        if (!this.fs.existsSync(manifestPath)) continue;
 
         const manifest = this.readManifest(manifestPath);
         if (!manifest) continue;
@@ -92,7 +99,7 @@ export class BundlePluginLoader {
 
   /** Read and validate a plugin.json manifest. Returns null if the manifest structure is invalid. */
   private readManifest(path: string): IBundlePluginManifest | null {
-    const raw = readFileSync(path, 'utf-8');
+    const raw = this.fs.readFileSync(path, 'utf-8');
     const data: unknown = JSON.parse(raw);
     return validateManifest(data);
   }
@@ -129,18 +136,18 @@ export class BundlePluginLoader {
   /** Load skills from the plugin's skills/ directory. */
   private loadSkills(pluginDir: string, pluginName: string): IBundleSkill[] {
     const skillsDir = join(pluginDir, 'skills');
-    if (!existsSync(skillsDir)) return [];
+    if (!this.fs.existsSync(skillsDir)) return [];
 
-    const entries = readdirSync(skillsDir, { withFileTypes: true });
+    const entries = this.fs.readdirSync(skillsDir, { withFileTypes: true });
     const skills: IBundleSkill[] = [];
 
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
 
       const skillFile = join(skillsDir, entry.name, 'SKILL.md');
-      if (!existsSync(skillFile)) continue;
+      if (!this.fs.existsSync(skillFile)) continue;
 
-      const raw = readFileSync(skillFile, 'utf-8');
+      const raw = this.fs.readFileSync(skillFile, 'utf-8');
       const { metadata, content } = parseSkillFrontmatter(raw);
 
       const description = typeof metadata.description === 'string' ? metadata.description : '';
@@ -161,15 +168,15 @@ export class BundlePluginLoader {
   /** Load commands from the plugin's commands/ directory (flat .md files). */
   private loadCommands(pluginDir: string, pluginName: string): IBundleSkill[] {
     const commandsDir = join(pluginDir, 'commands');
-    if (!existsSync(commandsDir)) return [];
+    if (!this.fs.existsSync(commandsDir)) return [];
 
-    const entries = readdirSync(commandsDir, { withFileTypes: true });
+    const entries = this.fs.readdirSync(commandsDir, { withFileTypes: true });
     const commands: IBundleSkill[] = [];
 
     for (const entry of entries) {
       if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
 
-      const raw = readFileSync(join(commandsDir, entry.name), 'utf-8');
+      const raw = this.fs.readFileSync(join(commandsDir, entry.name), 'utf-8');
       const { metadata, content } = parseSkillFrontmatter(raw);
 
       const name =
@@ -190,9 +197,9 @@ export class BundlePluginLoader {
   /** Load hooks from hooks/hooks.json if present. */
   private loadHooks(pluginDir: string): Record<string, unknown> {
     const hooksPath = join(pluginDir, 'hooks', 'hooks.json');
-    if (!existsSync(hooksPath)) return {};
+    if (!this.fs.existsSync(hooksPath)) return {};
 
-    const raw = readFileSync(hooksPath, 'utf-8');
+    const raw = this.fs.readFileSync(hooksPath, 'utf-8');
     const data: unknown = JSON.parse(raw);
     if (typeof data === 'object' && data !== null) {
       return data as Record<string, unknown>;
@@ -203,18 +210,18 @@ export class BundlePluginLoader {
   /** Load MCP server configuration from `.mcp.json` at the plugin root if present. */
   private loadMcpConfig(pluginDir: string): unknown | undefined {
     const mcpPath = join(pluginDir, '.mcp.json');
-    if (!existsSync(mcpPath)) return undefined;
+    if (!this.fs.existsSync(mcpPath)) return undefined;
 
-    const raw = readFileSync(mcpPath, 'utf-8');
+    const raw = this.fs.readFileSync(mcpPath, 'utf-8');
     return JSON.parse(raw) as unknown;
   }
 
   /** Load agent definitions from agents/ directory if present. */
   private loadAgents(pluginDir: string): string[] {
     const agentsDir = join(pluginDir, 'agents');
-    if (!existsSync(agentsDir)) return [];
+    if (!this.fs.existsSync(agentsDir)) return [];
 
-    const entries = readdirSync(agentsDir, { withFileTypes: true });
+    const entries = this.fs.readdirSync(agentsDir, { withFileTypes: true });
     return entries
       .filter((e) => e.isDirectory() || e.name.endsWith('.md'))
       .map((e) => e.name.replace(/\.md$/, ''));

--- a/packages/agent-framework/src/plugins/bundle-plugin-utils.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-utils.ts
@@ -5,7 +5,8 @@
  * used by BundlePluginLoader.
  */
 
-import { existsSync, readdirSync } from 'node:fs';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { IBundlePluginManifest } from './bundle-plugin-types.js';
 
 /**
@@ -91,15 +92,19 @@ export function validateManifest(data: unknown): IBundlePluginManifest | null {
  * Get sorted subdirectories from a directory.
  * Returns directory names sorted lexicographically.
  */
-export function getSortedSubdirs(dirPath: string): string[] {
-  if (!existsSync(dirPath)) return [];
+export function getSortedSubdirs(
+  dirPath: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): string[] {
+  if (!fs.existsSync(dirPath)) return [];
   try {
-    const entries = readdirSync(dirPath, { withFileTypes: true });
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
     return entries
       .filter((e) => e.isDirectory())
       .map((e) => e.name)
       .sort();
   } catch {
+    // allow-fallback: unreadable directory returns empty list to allow plugin discovery to continue
     return [];
   }
 }

--- a/packages/agent-framework/src/plugins/marketplace-client.ts
+++ b/packages/agent-framework/src/plugins/marketplace-client.ts
@@ -6,8 +6,9 @@
  * in `known_marketplaces.json`.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import {
   readRegistry,
   writeRegistry,
@@ -39,12 +40,14 @@ export class MarketplaceClient {
   private readonly exec: TExecFn;
   private readonly marketplacesDir: string;
   private readonly registryPath: string;
+  private readonly fs: IFileSystem;
 
-  constructor(options: IMarketplaceClientOptions) {
+  constructor(options: IMarketplaceClientOptions & { fs?: IFileSystem }) {
     this.pluginsDir = options.pluginsDir;
     this.exec = options.exec;
     this.marketplacesDir = join(this.pluginsDir, 'marketplaces');
     this.registryPath = join(this.pluginsDir, 'known_marketplaces.json');
+    this.fs = options.fs ?? new NodeFileSystem();
   }
 
   /**
@@ -61,13 +64,13 @@ export class MarketplaceClient {
     const tempName = 'temp-' + Date.now().toString(36);
     const tempDir = join(this.marketplacesDir, tempName);
 
-    mkdirSync(this.marketplacesDir, { recursive: true });
+    this.fs.mkdirSync(this.marketplacesDir, { recursive: true });
 
     if (source.type === 'local') {
-      if (!existsSync(source.path)) {
+      if (!this.fs.existsSync(source.path)) {
         throw new Error(`Local marketplace path does not exist: ${source.path}`);
       }
-      cpSync(source.path, tempDir, { recursive: true });
+      this.fs.cpSync(source.path, tempDir, { recursive: true });
     } else {
       const cloneUrl = this.resolveCloneUrl(source);
       const command = `git clone --depth 1 ${cloneUrl} ${tempDir}`;
@@ -80,8 +83,8 @@ export class MarketplaceClient {
     }
 
     const manifestPath = join(tempDir, '.claude-plugin', 'marketplace.json');
-    if (!existsSync(manifestPath)) {
-      rmSync(tempDir, { recursive: true, force: true });
+    if (!this.fs.existsSync(manifestPath)) {
+      this.fs.rmSync(tempDir, { recursive: true, force: true });
       throw new Error(
         source.type === 'local'
           ? 'Local directory does not contain .claude-plugin/marketplace.json'
@@ -93,25 +96,25 @@ export class MarketplaceClient {
     const name = manifest.name;
 
     if (!name) {
-      rmSync(tempDir, { recursive: true, force: true });
+      this.fs.rmSync(tempDir, { recursive: true, force: true });
       throw new Error('Marketplace manifest does not contain a "name" field');
     }
 
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     if (registry[name]) {
-      rmSync(tempDir, { recursive: true, force: true });
+      this.fs.rmSync(tempDir, { recursive: true, force: true });
       throw new Error(`Marketplace "${name}" already exists`);
     }
 
     const finalDir = join(this.marketplacesDir, name);
-    renameSync(tempDir, finalDir);
+    this.fs.renameSync(tempDir, finalDir);
 
     registry[name] = {
       source,
       installLocation: finalDir,
       lastUpdated: new Date().toISOString(),
     };
-    writeRegistry(this.registryPath, registry);
+    writeRegistry(this.registryPath, registry, this.fs);
 
     return name;
   }
@@ -122,20 +125,20 @@ export class MarketplaceClient {
    * and removes from the registry.
    */
   removeMarketplace(name: string): void {
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     const entry = registry[name];
     if (!entry) {
       throw new Error(`Marketplace "${name}" not found`);
     }
 
-    removeInstalledPluginsForMarketplace(this.pluginsDir, name);
+    removeInstalledPluginsForMarketplace(this.pluginsDir, name, this.fs);
 
-    if (existsSync(entry.installLocation)) {
-      rmSync(entry.installLocation, { recursive: true, force: true });
+    if (this.fs.existsSync(entry.installLocation)) {
+      this.fs.rmSync(entry.installLocation, { recursive: true, force: true });
     }
 
     delete registry[name];
-    writeRegistry(this.registryPath, registry);
+    writeRegistry(this.registryPath, registry, this.fs);
   }
 
   /**
@@ -144,23 +147,23 @@ export class MarketplaceClient {
    * updated manifest is automatically available after pull.
    */
   updateMarketplace(name: string): void {
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     const entry = registry[name];
     if (!entry) {
       throw new Error(`Marketplace "${name}" not found`);
     }
 
-    if (!existsSync(entry.installLocation)) {
+    if (!this.fs.existsSync(entry.installLocation)) {
       throw new Error(`Marketplace directory for "${name}" does not exist`);
     }
 
     if (entry.source.type === 'local') {
       const localSource = entry.source as { type: 'local'; path: string };
-      if (!existsSync(localSource.path)) {
+      if (!this.fs.existsSync(localSource.path)) {
         throw new Error(`Local marketplace path does not exist: ${localSource.path}`);
       }
-      rmSync(entry.installLocation, { recursive: true, force: true });
-      cpSync(localSource.path, entry.installLocation, { recursive: true });
+      this.fs.rmSync(entry.installLocation, { recursive: true, force: true });
+      this.fs.cpSync(localSource.path, entry.installLocation, { recursive: true });
     } else {
       const command = `git -C ${entry.installLocation} pull`;
       try {
@@ -172,12 +175,12 @@ export class MarketplaceClient {
     }
 
     entry.lastUpdated = new Date().toISOString();
-    writeRegistry(this.registryPath, registry);
+    writeRegistry(this.registryPath, registry, this.fs);
   }
 
   /** List all registered marketplaces. */
   listMarketplaces(): Array<{ name: string; source: TMarketplaceSource; lastUpdated: string }> {
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     return Object.entries(registry).map(([name, entry]) => ({
       name,
       source: entry.source,
@@ -187,14 +190,14 @@ export class MarketplaceClient {
 
   /** Read the marketplace manifest from a registered marketplace's clone. */
   fetchManifest(marketplaceName: string): IMarketplaceManifest {
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     const entry = registry[marketplaceName];
     if (!entry) {
       throw new Error(`Marketplace "${marketplaceName}" not found`);
     }
 
     const manifestPath = join(entry.installLocation, '.claude-plugin', 'marketplace.json');
-    if (!existsSync(manifestPath)) {
+    if (!this.fs.existsSync(manifestPath)) {
       throw new Error(
         `Marketplace "${marketplaceName}" does not contain .claude-plugin/marketplace.json`,
       );
@@ -205,7 +208,7 @@ export class MarketplaceClient {
 
   /** Get the clone directory path for a registered marketplace. */
   getMarketplaceDir(name: string): string {
-    const registry = readRegistry(this.registryPath);
+    const registry = readRegistry(this.registryPath, this.fs);
     const entry = registry[name];
     if (!entry) {
       throw new Error(`Marketplace "${name}" not found`);
@@ -226,6 +229,7 @@ export class MarketplaceClient {
       });
       return result.toString().trim().slice(0, 12);
     } catch {
+      // allow-fallback: git SHA unavailable returns 'unknown' as version identifier
       return 'unknown';
     }
   }
@@ -242,6 +246,7 @@ export class MarketplaceClient {
           results.push({ ...plugin, marketplace: name });
         }
       } catch {
+        // allow-fallback: failed marketplace is skipped to allow other marketplaces to load
         // Skip failed marketplaces
       }
     }
@@ -267,7 +272,7 @@ export class MarketplaceClient {
 
   /** Read and parse a marketplace.json from a file path. */
   private readManifestFromPath(path: string): IMarketplaceManifest {
-    const raw = readFileSync(path, 'utf-8');
+    const raw = this.fs.readFileSync(path, 'utf-8');
     const data: unknown = JSON.parse(raw);
 
     if (typeof data !== 'object' || data === null) {

--- a/packages/agent-framework/src/plugins/marketplace-registry.ts
+++ b/packages/agent-framework/src/plugins/marketplace-registry.ts
@@ -5,34 +5,43 @@
  * cleanup of installed plugins when a marketplace is removed.
  */
 
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { TKnownMarketplacesRegistry } from './marketplace-types.js';
 
 /** Read the known_marketplaces.json registry. Returns empty object if missing or corrupt. */
-export function readRegistry(registryPath: string): TKnownMarketplacesRegistry {
-  if (!existsSync(registryPath)) {
+export function readRegistry(
+  registryPath: string,
+  fs: IFileSystem = new NodeFileSystem(),
+): TKnownMarketplacesRegistry {
+  if (!fs.existsSync(registryPath)) {
     return {};
   }
   try {
-    const raw = readFileSync(registryPath, 'utf-8');
+    const raw = fs.readFileSync(registryPath, 'utf-8');
     const data: unknown = JSON.parse(raw);
     if (typeof data === 'object' && data !== null) {
       return data as TKnownMarketplacesRegistry;
     }
     return {};
   } catch {
+    // allow-fallback: corrupt registry file returns empty object to allow recovery
     return {};
   }
 }
 
 /** Write the known_marketplaces.json registry, creating parent dirs if needed. */
-export function writeRegistry(registryPath: string, registry: TKnownMarketplacesRegistry): void {
+export function writeRegistry(
+  registryPath: string,
+  registry: TKnownMarketplacesRegistry,
+  fs: IFileSystem = new NodeFileSystem(),
+): void {
   const dir = dirname(registryPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
   }
-  writeFileSync(registryPath, JSON.stringify(registry, null, 2), 'utf-8');
+  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2), 'utf-8');
 }
 
 /**
@@ -43,17 +52,19 @@ export function writeRegistry(registryPath: string, registry: TKnownMarketplaces
 export function removeInstalledPluginsForMarketplace(
   pluginsDir: string,
   marketplaceName: string,
+  fs: IFileSystem = new NodeFileSystem(),
 ): void {
   const installedPath = join(pluginsDir, 'installed_plugins.json');
-  if (!existsSync(installedPath)) return;
+  if (!fs.existsSync(installedPath)) return;
 
   let registry: Record<string, { marketplace?: string; installPath?: string }>;
   try {
-    const raw = readFileSync(installedPath, 'utf-8');
+    const raw = fs.readFileSync(installedPath, 'utf-8');
     const data: unknown = JSON.parse(raw);
     if (typeof data !== 'object' || data === null) return;
     registry = data as Record<string, { marketplace?: string; installPath?: string }>;
   } catch {
+    // allow-fallback: corrupt installed_plugins.json is skipped, no plugins removed
     return;
   }
 
@@ -61,8 +72,8 @@ export function removeInstalledPluginsForMarketplace(
   for (const [pluginId, record] of Object.entries(registry)) {
     if (record.marketplace === marketplaceName) {
       // Remove the cache directory for this plugin
-      if (record.installPath && existsSync(record.installPath)) {
-        rmSync(record.installPath, { recursive: true, force: true });
+      if (record.installPath && fs.existsSync(record.installPath)) {
+        fs.rmSync(record.installPath, { recursive: true, force: true });
       }
       delete registry[pluginId];
       changed = true;
@@ -71,9 +82,9 @@ export function removeInstalledPluginsForMarketplace(
 
   if (changed) {
     const dir = dirname(installedPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(installedPath, JSON.stringify(registry, null, 2), 'utf-8');
+    fs.writeFileSync(installedPath, JSON.stringify(registry, null, 2), 'utf-8');
   }
 }

--- a/packages/agent-framework/src/plugins/plugin-settings-store.ts
+++ b/packages/agent-framework/src/plugins/plugin-settings-store.ts
@@ -5,8 +5,9 @@
  * concurrent writes from overwriting each other's changes.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+import { NodeFileSystem } from '../adapters/node-file-system.js';
 import type { TMarketplaceSource } from './marketplace-types.js';
 
 /** Persisted marketplace source entry. */
@@ -23,24 +24,27 @@ export interface IPluginSettings {
 /** Centralized settings store for plugin configuration. */
 export class PluginSettingsStore {
   private readonly settingsPath: string;
+  private readonly fs: IFileSystem;
 
-  constructor(settingsPath: string) {
+  constructor(settingsPath: string, fs: IFileSystem = new NodeFileSystem()) {
     this.settingsPath = settingsPath;
+    this.fs = fs;
   }
 
   /** Read the full settings file from disk. */
   private readAll(): Record<string, unknown> {
-    if (!existsSync(this.settingsPath)) {
+    if (!this.fs.existsSync(this.settingsPath)) {
       return {};
     }
     try {
-      const raw = readFileSync(this.settingsPath, 'utf-8');
+      const raw = this.fs.readFileSync(this.settingsPath, 'utf-8');
       const data: unknown = JSON.parse(raw);
       if (typeof data === 'object' && data !== null) {
         return data as Record<string, unknown>;
       }
       return {};
     } catch {
+      // allow-fallback: corrupt settings file returns empty object to allow recovery
       return {};
     }
   }
@@ -48,10 +52,10 @@ export class PluginSettingsStore {
   /** Write the full settings file to disk. */
   private writeAll(settings: Record<string, unknown>): void {
     const dir = dirname(this.settingsPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+    if (!this.fs.existsSync(dir)) {
+      this.fs.mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(this.settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+    this.fs.writeFileSync(this.settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
   }
 
   // --- enabledPlugins ---

--- a/packages/agent-framework/src/user-local/memory.ts
+++ b/packages/agent-framework/src/user-local/memory.ts
@@ -1,5 +1,7 @@
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
+
+import type { IDirent, IFileSystemAsync } from '@robota-sdk/agent-core';
+import { NodeFileSystemAsync } from '../adapters/node-file-system.js';
 import { resolveUserLocalStorageRoot } from './storage.js';
 import type { IResolveUserLocalStorageRootOptions } from './storage.js';
 import {
@@ -166,11 +168,12 @@ function projectMemoryItem(
 async function readMemoryFile(
   root: string,
   storageLocation: string,
+  fsAsync: IFileSystemAsync,
 ): Promise<IUserLocalMemoryItemProjection> {
   return projectMemoryItem(
     root,
     storageLocation,
-    parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation),
+    parseMemoryRecord(await fsAsync.readFile(storageLocation, 'utf8'), storageLocation),
   );
 }
 
@@ -189,6 +192,7 @@ async function resolveMemoryFile(
 export async function setUserLocalMemoryItem(
   options: IUserLocalMemorySetOptions,
 ): Promise<IUserLocalMemoryItemProjection> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const category = assertUserLocalMemoryCategory(options.category);
   const key = assertSafeSegment('key', options.key);
   const summary = boundedText('summary', options.summary, MAX_SUMMARY_LENGTH);
@@ -201,7 +205,10 @@ export async function setUserLocalMemoryItem(
   let createdAt = now;
 
   try {
-    const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+    const existing = parseMemoryRecord(
+      await fsAsync.readFile(storageLocation, 'utf8'),
+      storageLocation,
+    );
     createdAt = existing.createdAt;
   } catch (error) {
     if (error instanceof Error && error.message.includes('ENOENT')) {
@@ -224,27 +231,29 @@ export async function setUserLocalMemoryItem(
     enabled: true,
   };
 
-  await fs.mkdir(memoryRoot, { recursive: true });
-  await fs.writeFile(storageLocation, `${JSON.stringify(item, null, 2)}\n`, 'utf8');
+  await fsAsync.mkdir(memoryRoot, { recursive: true });
+  await fsAsync.writeFile(storageLocation, `${JSON.stringify(item, null, 2)}\n`, 'utf8');
   return projectMemoryItem(root, storageLocation, item);
 }
 
 export async function listUserLocalMemoryItems(
   options: IUserLocalMemoryListOptions,
 ): Promise<IUserLocalMemoryListProjection> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const { root, memoryRoot } = await resolveMemoryRoot(options);
-  let entries: readonly import('node:fs').Dirent[];
+  let entries: readonly IDirent[];
 
   try {
-    entries = await fs.readdir(memoryRoot, { withFileTypes: true });
+    entries = await fsAsync.readdir(memoryRoot, { withFileTypes: true });
   } catch {
+    // allow-fallback: missing memory directory means no items exist
     entries = [];
   }
 
   const items = await Promise.all(
     entries
       .filter((entry) => entry.isFile() && entry.name.endsWith(FILE_EXTENSION))
-      .map((entry) => readMemoryFile(root, path.join(memoryRoot, entry.name))),
+      .map((entry) => readMemoryFile(root, path.join(memoryRoot, entry.name), fsAsync)),
   );
 
   return {
@@ -259,30 +268,36 @@ export async function listUserLocalMemoryItems(
 export async function inspectUserLocalMemoryItem(
   options: IUserLocalMemoryItemOptions,
 ): Promise<IUserLocalMemoryItemProjection> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const { root, storageLocation } = await resolveMemoryFile(options);
-  return readMemoryFile(root, storageLocation);
+  return readMemoryFile(root, storageLocation, fsAsync);
 }
 
 export async function disableUserLocalMemoryItem(
   options: IUserLocalMemoryItemOptions,
 ): Promise<IUserLocalMemoryItemProjection> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const { root, storageLocation } = await resolveMemoryFile(options);
-  const existing = parseMemoryRecord(await fs.readFile(storageLocation, 'utf8'), storageLocation);
+  const existing = parseMemoryRecord(
+    await fsAsync.readFile(storageLocation, 'utf8'),
+    storageLocation,
+  );
   const disabled: IUserLocalMemoryFile = {
     ...existing,
     enabled: false,
     lastUsedAt: formatIsoDate((options.now ?? (() => new Date()))()),
   };
 
-  await fs.writeFile(storageLocation, `${JSON.stringify(disabled, null, 2)}\n`, 'utf8');
+  await fsAsync.writeFile(storageLocation, `${JSON.stringify(disabled, null, 2)}\n`, 'utf8');
   return projectMemoryItem(root, storageLocation, disabled);
 }
 
 export async function deleteUserLocalMemoryItem(
   options: IUserLocalMemoryItemOptions,
 ): Promise<IUserLocalMemoryDeleteResult> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const { storageLocation } = await resolveMemoryFile(options);
-  await fs.rm(storageLocation);
+  await fsAsync.rm(storageLocation);
   return {
     category: options.category,
     key: options.key,

--- a/packages/agent-framework/src/user-local/storage.ts
+++ b/packages/agent-framework/src/user-local/storage.ts
@@ -1,6 +1,8 @@
-import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
+
+import type { IDirent, IFileSystemAsync } from '@robota-sdk/agent-core';
+import { NodeFileSystemAsync } from '../adapters/node-file-system.js';
 
 export const USER_LOCAL_STORAGE_CATEGORIES = [
   'preferences',
@@ -54,6 +56,7 @@ export interface IResolveUserLocalStorageRootOptions {
   readonly activeRepositoryRoot: string;
   readonly homeDir?: string;
   readonly storageRoot?: string;
+  readonly fsAsync?: IFileSystemAsync;
 }
 
 export interface IInspectUserLocalStorageOptions extends IResolveUserLocalStorageRootOptions {
@@ -117,22 +120,24 @@ function isEqualOrInside(parentPath: string, candidatePath: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
-async function resolveForComparison(absPath: string): Promise<string> {
+async function resolveForComparison(absPath: string, fsAsync: IFileSystemAsync): Promise<string> {
   let current = absPath;
 
   while (path.dirname(current) !== current) {
     try {
-      const realCurrent = await fs.realpath(current);
+      const realCurrent = await fsAsync.realpath(current);
       const relativeMissingPath = path.relative(current, absPath);
       return path.resolve(realCurrent, relativeMissingPath);
     } catch {
+      // allow-fallback: walk up to first existing ancestor, not an error suppression
       current = path.dirname(current);
     }
   }
 
   try {
-    return await fs.realpath(current);
+    return await fsAsync.realpath(current);
   } catch {
+    // allow-fallback: filesystem root unreachable; resolve() gives a safe absolute path
     return path.resolve(absPath);
   }
 }
@@ -140,6 +145,7 @@ async function resolveForComparison(absPath: string): Promise<string> {
 export async function resolveUserLocalStorageRoot(
   options: IResolveUserLocalStorageRootOptions,
 ): Promise<string> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
   assertAbsolutePath('activeRepositoryRoot', activeRepositoryRoot);
 
@@ -151,8 +157,8 @@ export async function resolveUserLocalStorageRoot(
   assertAbsolutePath('userLocalStorageRoot', candidateRoot);
 
   const resolvedRoot = path.resolve(candidateRoot);
-  const comparableRoot = await resolveForComparison(resolvedRoot);
-  const comparableRepositoryRoot = await resolveForComparison(activeRepositoryRoot);
+  const comparableRoot = await resolveForComparison(resolvedRoot, fsAsync);
+  const comparableRepositoryRoot = await resolveForComparison(activeRepositoryRoot, fsAsync);
 
   if (isEqualOrInside(comparableRepositoryRoot, comparableRoot)) {
     throw new Error(
@@ -170,20 +176,22 @@ function resolveCategoryLocation(root: string, category: TUserLocalStorageCatego
 async function listItemSummaries(
   root: string,
   category: TUserLocalStorageCategory,
+  fsAsync: IFileSystemAsync,
 ): Promise<readonly IUserLocalStorageItemSummary[]> {
   const storageLocation = resolveCategoryLocation(root, category);
-  let entries: readonly import('node:fs').Dirent[];
+  let entries: readonly IDirent[];
 
   try {
-    entries = await fs.readdir(storageLocation, { withFileTypes: true });
+    entries = await fsAsync.readdir(storageLocation, { withFileTypes: true });
   } catch {
+    // allow-fallback: missing category directory returns empty list
     return [];
   }
 
   const summaries = await Promise.all(
     entries.map(async (entry): Promise<IUserLocalStorageItemSummary> => {
       const itemLocation = path.join(storageLocation, entry.name);
-      const stats = await fs.stat(itemLocation);
+      const stats = await fsAsync.stat(itemLocation);
       const key = entry.name;
       return {
         root,
@@ -193,8 +201,8 @@ async function listItemSummaries(
         source: 'user-local-storage',
         scope: 'user',
         storageLocation: itemLocation,
-        createdAt: formatIsoDate(stats.birthtime),
-        lastUsedAt: formatIsoDate(stats.mtime),
+        createdAt: formatIsoDate(new Date(stats.birthtimeMs)),
+        lastUsedAt: formatIsoDate(new Date(stats.mtimeMs)),
         enabled: true,
         deleteAvailable: true,
         disableAvailable: false,
@@ -208,12 +216,13 @@ async function listItemSummaries(
 export async function inspectUserLocalStorage(
   options: IInspectUserLocalStorageOptions,
 ): Promise<IUserLocalStorageInspection> {
+  const fsAsync = options.fsAsync ?? new NodeFileSystemAsync();
   const root = await resolveUserLocalStorageRoot(options);
   const activeRepositoryRoot = path.resolve(options.activeRepositoryRoot);
   const createDirectories = options.createDirectories ?? true;
 
   if (createDirectories) {
-    await fs.mkdir(root, { recursive: true });
+    await fsAsync.mkdir(root, { recursive: true });
   }
 
   const categories = await Promise.all(
@@ -221,9 +230,9 @@ export async function inspectUserLocalStorage(
       async (definition): Promise<IUserLocalStorageCategoryProjection> => {
         const storageLocation = resolveCategoryLocation(root, definition.category);
         if (createDirectories) {
-          await fs.mkdir(storageLocation, { recursive: true });
+          await fsAsync.mkdir(storageLocation, { recursive: true });
         }
-        const items = await listItemSummaries(root, definition.category);
+        const items = await listItemSummaries(root, definition.category, fsAsync);
         return {
           category: definition.category,
           purpose: definition.purpose,


### PR DESCRIPTION
## Summary
- `IFileSystem` + `IFileSystemAsync` 인터페이스를 `agent-core`에 정의
- `NodeFileSystem` / `NodeFileSystemAsync` 어댑터를 `agent-framework/src/adapters/`에 추가
- `agent-framework` 내 19개 파일에서 `node:fs` / `node:fs/promises` 직접 import를 제거하고 포트 패턴으로 교체
- 생성자/옵션 파라미터의 기본값으로 `NodeFileSystem*` 인스턴스를 제공하여 하위호환성 유지

## Test plan
- [ ] `pnpm --filter @robota-sdk/agent-framework typecheck` 통과
- [ ] `pnpm --filter @robota-sdk/agent-framework test` — 773 tests passed
- [ ] `pnpm harness:scan` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)