### PR TITLE
feat(INFRA-BL-009): migrate 38 Type A node-only packages from tsup to tsdown

### DIFF
--- a/packages/agent-command-agent/package.json
+++ b/packages/agent-command-agent/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-agent/tsdown.config.ts
+++ b/packages/agent-command-agent/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-background/package.json
+++ b/packages/agent-command-background/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-background/tsdown.config.ts
+++ b/packages/agent-command-background/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-compact/package.json
+++ b/packages/agent-command-compact/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-compact/tsdown.config.ts
+++ b/packages/agent-command-compact/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-context/package.json
+++ b/packages/agent-command-context/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-context/tsdown.config.ts
+++ b/packages/agent-command-context/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-exit/package.json
+++ b/packages/agent-command-exit/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-exit/tsdown.config.ts
+++ b/packages/agent-command-exit/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-help/package.json
+++ b/packages/agent-command-help/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-help/tsdown.config.ts
+++ b/packages/agent-command-help/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-language/package.json
+++ b/packages/agent-command-language/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-language/tsdown.config.ts
+++ b/packages/agent-command-language/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-memory/package.json
+++ b/packages/agent-command-memory/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-memory/tsdown.config.ts
+++ b/packages/agent-command-memory/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-mode/package.json
+++ b/packages/agent-command-mode/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-mode/tsdown.config.ts
+++ b/packages/agent-command-mode/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-model/package.json
+++ b/packages/agent-command-model/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-model/tsdown.config.ts
+++ b/packages/agent-command-model/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-permissions/package.json
+++ b/packages/agent-command-permissions/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-permissions/tsdown.config.ts
+++ b/packages/agent-command-permissions/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-plugin/package.json
+++ b/packages/agent-command-plugin/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-plugin/tsdown.config.ts
+++ b/packages/agent-command-plugin/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-provider/package.json
+++ b/packages/agent-command-provider/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-provider/tsdown.config.ts
+++ b/packages/agent-command-provider/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-reset/package.json
+++ b/packages/agent-command-reset/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-reset/tsdown.config.ts
+++ b/packages/agent-command-reset/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-rewind/package.json
+++ b/packages/agent-command-rewind/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-rewind/tsdown.config.ts
+++ b/packages/agent-command-rewind/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-session/package.json
+++ b/packages/agent-command-session/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-session/tsdown.config.ts
+++ b/packages/agent-command-session/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-settings/package.json
+++ b/packages/agent-command-settings/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-settings/tsdown.config.ts
+++ b/packages/agent-command-settings/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-skills/package.json
+++ b/packages/agent-command-skills/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-skills/tsdown.config.ts
+++ b/packages/agent-command-skills/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-statusline/package.json
+++ b/packages/agent-command-statusline/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-statusline/tsdown.config.ts
+++ b/packages/agent-command-statusline/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-command-user-local/package.json
+++ b/packages/agent-command-user-local/package.json
@@ -32,9 +32,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean --no-dts",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-command-user-local/tsdown.config.ts
+++ b/packages/agent-command-user-local/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -34,9 +34,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -63,7 +63,7 @@
   "devDependencies": {
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-executor/tsdown.config.ts
+++ b/packages/agent-executor/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -31,9 +31,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-framework/tsdown.config.ts
+++ b/packages/agent-framework/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -31,9 +31,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -44,7 +44,7 @@
   "dependencies": {},
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-interface-transport/tsdown.config.ts
+++ b/packages/agent-interface-transport/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-conversation-history/package.json
+++ b/packages/agent-plugin-conversation-history/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-conversation-history/tsdown.config.ts
+++ b/packages/agent-plugin-conversation-history/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-error-handling/package.json
+++ b/packages/agent-plugin-error-handling/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-error-handling/tsdown.config.ts
+++ b/packages/agent-plugin-error-handling/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-execution-analytics/package.json
+++ b/packages/agent-plugin-execution-analytics/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-execution-analytics/tsdown.config.ts
+++ b/packages/agent-plugin-execution-analytics/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-logging/package.json
+++ b/packages/agent-plugin-logging/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-logging/tsdown.config.ts
+++ b/packages/agent-plugin-logging/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-performance/package.json
+++ b/packages/agent-plugin-performance/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-performance/tsdown.config.ts
+++ b/packages/agent-plugin-performance/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-usage/package.json
+++ b/packages/agent-plugin-usage/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-usage/tsdown.config.ts
+++ b/packages/agent-plugin-usage/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-plugin-webhook/package.json
+++ b/packages/agent-plugin-webhook/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-plugin-webhook/tsdown.config.ts
+++ b/packages/agent-plugin-webhook/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-remote-client/tsdown.config.ts
+++ b/packages/agent-remote-client/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -34,9 +34,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "build:check": "pnpm run typecheck && pnpm run build",
     "dev": "tsup --watch",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
@@ -82,11 +82,11 @@
   "peerDependencies": {},
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
+    "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
-    "vitest": "^1.6.1",
-    "eslint": "^8.56.0"
+    "vitest": "^1.6.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/agent-session/tsdown.config.ts
+++ b/packages/agent-session/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -42,7 +42,7 @@
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-tool-mcp/tsdown.config.ts
+++ b/packages/agent-tool-mcp/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-transport-headless/package.json
+++ b/packages/agent-transport-headless/package.json
@@ -31,9 +31,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@robota-sdk/agent-command-skills": "workspace:*",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-transport-headless/tsdown.config.ts
+++ b/packages/agent-transport-headless/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-transport-http/package.json
+++ b/packages/agent-transport-http/package.json
@@ -30,9 +30,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-transport-http/tsdown.config.ts
+++ b/packages/agent-transport-http/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-transport-mcp/package.json
+++ b/packages/agent-transport-mcp/package.json
@@ -30,9 +30,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-transport-mcp/tsdown.config.ts
+++ b/packages/agent-transport-mcp/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-transport-tui/package.json
+++ b/packages/agent-transport-tui/package.json
@@ -22,9 +22,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -47,12 +47,12 @@
     "string-width": "^8.2.0"
   },
   "devDependencies": {
-    "@robota-sdk/agent-command-provider": "workspace:*",
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
+    "@robota-sdk/agent-command-provider": "workspace:*",
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"

--- a/packages/agent-transport-tui/tsdown.config.ts
+++ b/packages/agent-transport-tui/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/packages/agent-transport-ws/package.json
+++ b/packages/agent-transport-ws/package.json
@@ -30,9 +30,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist/node --clean",
-    "build:js": "tsup src/index.ts --format esm,cjs --out-dir dist/node --clean",
-    "build:types": "tsup src/index.ts --format esm,cjs --dts-only --out-dir dist/node",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/ws": "^8.5.10",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-transport-ws/tsdown.config.ts
+++ b/packages/agent-transport-ws/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  clean: true,
+  dts: true,
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  outExtensions: ({ format }) => ({
+    js: format === 'cjs' ? '.cjs' : '.js',
+    dts: '.d.ts',
+  }),
+  deps: {
+    neverBundle: [/^@robota-sdk\/.*/],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 8.0.3
       knip:
         specifier: ^5.86.0
-        version: 5.86.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.9)(typescript@5.8.3)
+        version: 5.86.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.19.9)(typescript@5.8.3)
       lint-staged:
         specifier: ^15.2.0
         version: 15.5.2
@@ -481,9 +481,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -500,9 +500,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -519,9 +519,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -538,9 +538,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -557,9 +557,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -576,9 +576,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -595,9 +595,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -614,9 +614,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -633,9 +633,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -652,9 +652,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -671,9 +671,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -690,9 +690,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -712,9 +712,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -731,9 +731,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -750,9 +750,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -769,9 +769,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -788,9 +788,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -807,9 +807,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -826,9 +826,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -845,9 +845,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -910,9 +910,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -944,9 +944,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -959,9 +959,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1116,9 +1116,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1134,9 +1134,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1152,9 +1152,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1188,9 +1188,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1206,9 +1206,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1224,9 +1224,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1246,9 +1246,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1555,9 +1555,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1577,9 +1577,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1639,9 +1639,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1695,9 +1695,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1720,9 +1720,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1748,9 +1748,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1812,9 +1812,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       tsx:
         specifier: ^4.7.0
         version: 4.21.0
@@ -1846,9 +1846,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -3257,7 +3257,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
-    dev: true
     optional: true
 
   /@emnapi/runtime@1.9.2:
@@ -4904,7 +4903,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.10.0
     dev: false
     optional: true
 
@@ -5503,8 +5502,8 @@ packages:
       }
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     dev: true
     optional: true
@@ -5913,7 +5912,7 @@ packages:
     dev: true
     optional: true
 
-  /@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  /@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     resolution:
       {
         integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==,
@@ -5922,7 +5921,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -17205,7 +17204,7 @@ packages:
     engines: { node: '>=6' }
     dev: true
 
-  /knip@5.86.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.9)(typescript@5.8.3):
+  /knip@5.86.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.19.9)(typescript@5.8.3):
     resolution:
       {
         integrity: sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q==,
@@ -17222,7 +17221,7 @@ packages:
       formatly: 0.3.0
       jiti: 2.6.1
       minimist: 1.2.8
-      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
       picomatch: 4.0.4
       smol-toml: 1.6.0
@@ -19412,7 +19411,7 @@ packages:
       safe-push-apply: 1.0.0
     dev: true
 
-  /oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  /oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     resolution:
       {
         integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==,
@@ -19434,7 +19433,7 @@ packages:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -22505,7 +22504,6 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-    dev: true
 
   /tinypool@0.8.4:
     resolution:
@@ -23784,7 +23782,7 @@ packages:
       picomatch: 4.0.4
       postcss: 8.5.10
       rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tsx: 4.21.0
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
## Summary

- Replace tsup with tsdown 0.22.0 across 38 Type A (node-only) packages
- Add `tsdown.config.ts` to each package with `outExtensions` forcing `.d.ts` output and `deps.neverBundle` for `@robota-sdk/*`
- Update build scripts: `build: tsdown`, `build:js: tsdown --no-dts`, `build:types: tsdown --dts`
- Update pnpm lockfile

## Test plan

- [x] `pnpm build` passes (full monorepo)
- [x] `pnpm harness:scan` passes (build-contracts: 54 packages)
- [x] `pnpm test` all tests pass
- [x] Build output contracts preserved: `index.js` + `index.cjs` + `index.d.ts` per package, no `.d.mts`

## Packages migrated (38)

agent-command-{agent,background,compact,context,exit,help,language,memory,mode,model,permissions,plugin,provider,reset,rewind,session,settings,skills,statusline,user-local}, agent-executor, agent-framework, agent-interface-transport, agent-plugin-{conversation-history,error-handling,execution-analytics,logging,performance,usage,webhook}, agent-remote-client, agent-session, agent-tool-mcp, agent-transport-{headless,http,mcp,tui,ws}

🤖 Generated with [Claude Code](https://claude.com/claude-code)