### PR TITLE
feat(INFRA-BL-009): migrate 11 browser dual packages from tsup to tsdown

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -95,7 +95,7 @@
     "eslint": "^8.56.0",
     "openapi-types": "^12.1.3",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-core/tsdown.config.ts
+++ b/packages/agent-core/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-anthropic/package.json
+++ b/packages/agent-provider-anthropic/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -89,7 +89,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-anthropic/tsdown.config.ts
+++ b/packages/agent-provider-anthropic/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-bytedance/package.json
+++ b/packages/agent-provider-bytedance/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -73,7 +73,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-bytedance/tsdown.config.ts
+++ b/packages/agent-provider-bytedance/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-deepseek/package.json
+++ b/packages/agent-provider-deepseek/package.json
@@ -38,9 +38,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -74,7 +74,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-deepseek/tsdown.config.ts
+++ b/packages/agent-provider-deepseek/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-gemini/package.json
+++ b/packages/agent-provider-gemini/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -93,7 +93,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-gemini/tsdown.config.ts
+++ b/packages/agent-provider-gemini/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-gemma/package.json
+++ b/packages/agent-provider-gemma/package.json
@@ -38,9 +38,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -75,7 +75,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-gemma/tsdown.config.ts
+++ b/packages/agent-provider-gemma/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-google/package.json
+++ b/packages/agent-provider-google/package.json
@@ -36,9 +36,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -72,7 +72,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-google/tsdown.config.ts
+++ b/packages/agent-provider-google/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-openai-compatible/package.json
+++ b/packages/agent-provider-openai-compatible/package.json
@@ -38,9 +38,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -73,7 +73,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-openai-compatible/tsdown.config.ts
+++ b/packages/agent-provider-openai-compatible/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-provider-qwen/package.json
+++ b/packages/agent-provider-qwen/package.json
@@ -38,9 +38,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -76,7 +76,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-qwen/tsdown.config.ts
+++ b/packages/agent-provider-qwen/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-team/package.json
+++ b/packages/agent-team/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "build:check": "pnpm run typecheck && pnpm run build",
     "dev": "tsup --watch",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
@@ -84,11 +84,11 @@
   "devDependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "@types/uuid": "^9.0.7",
+    "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
-    "vitest": "^1.6.1",
-    "eslint": "^8.56.0"
+    "vitest": "^1.6.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/agent-team/tsdown.config.ts
+++ b/packages/agent-team/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    minify: false,
+    outExtensions: ({ format }) => ({
+      js: format === 'cjs' ? '.js' : '.mjs',
+      dts: '.d.ts',
+    }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+  },
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    minify: true,
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -34,9 +34,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
@@ -56,7 +56,7 @@
     "@robota-sdk/agent-core": "workspace:*",
     "openapi-types": "^12.1.3",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },

--- a/packages/agent-tools/tsdown.config.ts
+++ b/packages/agent-tools/tsdown.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig([
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    outExtensions: ({ format }) => ({
+      js: format === 'cjs' ? '.cjs' : '.js',
+      dts: '.d.ts',
+    }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+  },
+  {
+    entry: { browser: 'src/browser.ts' },
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    minify: true,
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,9 +885,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1277,9 +1277,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1304,9 +1304,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1338,9 +1338,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1369,9 +1369,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1403,9 +1403,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1434,9 +1434,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1499,9 +1499,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1533,9 +1533,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1614,9 +1614,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1667,9 +1667,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3


### PR DESCRIPTION
## Summary

- Replace tsup with tsdown 0.22.0 across 11 Type B (node+browser dual) packages
- Array config pattern: node build (ESM+CJS) + browser build (ESM only)
- `outExtensions` forces `.d.ts` DTS output for both builds
- `define: { 'process.env.NODE_ENV': '"production"' }` preserved for browser builds

## Special cases

- **agent-team**: preserves `.mjs`/`.js` output contract (ESM=.mjs, CJS=.js) + `minify: false` for node
- **agent-tools**: preserves separate browser entry `src/browser.ts` → `dist/browser/browser.js`

## Test plan

- [x] All 11 packages build successfully with tsdown
- [x] `pnpm build` (full monorepo) passes
- [x] `pnpm harness:scan` passes (build-contracts: 54 packages)
- [x] Output contract preserved: `index.js` + `index.cjs` + `index.d.ts` per package

## Packages migrated (11)

agent-core, agent-provider-{anthropic,bytedance,deepseek,gemini,gemma,google,openai-compatible,qwen}, agent-team, agent-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)