### PR TITLE
feat(INFRA-BL-009): migrate agent-cli from tsup to tsdown

### DIFF
--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -38,9 +38,9 @@
     "bin"
   ],
   "scripts": {
-    "build": "pnpm --filter @robota-sdk/agent-web build:spa && node scripts/copy-web-assets.mjs && tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "pnpm --filter @robota-sdk/agent-web build:spa && node scripts/copy-web-assets.mjs && tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsx src/bin.ts",
     "start": "node dist/node/bin.js",
     "test": "vitest run --passWithNoTests",
@@ -97,7 +97,7 @@
     "@types/marked": "^6.0.0",
     "@types/ws": "^8.5.10",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"

--- a/packages/agent-cli/tsdown.config.ts
+++ b/packages/agent-cli/tsdown.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig([
+  {
+    entry: { bin: 'src/bin.ts' },
+    format: ['esm'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: false,
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    minify: true,
+    splitting: false,
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+  },
+  {
+    entry: {
+      index: 'src/index.ts',
+      'subagents/child-process-subagent-worker': 'src/subagents/child-process-subagent-worker.ts',
+    },
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: false,
+    dts: true,
+    sourcemap: false,
+    treeshake: true,
+    minify: true,
+    splitting: false,
+    outExtensions: ({ format }) => ({
+      js: format === 'cjs' ? '.cjs' : '.js',
+      dts: '.d.ts',
+    }),
+    deps: { neverBundle: [/^@robota-sdk\/.*/] },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,9 +459,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       tsx:
         specifier: ^4.7.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

- Replace tsup with tsdown 0.22.0 in agent-cli
- Two-config array: bin entry (ESM only) + library entries (ESM+CJS, index + worker)
- `splitting: false` prevents hash-named internal chunk files
- Main `build` script retains the web-spa build prefix

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-cli build:js` passes
- [x] All 142 agent-cli tests pass
- [x] `pnpm build` (full monorepo) passes
- [x] `pnpm harness:scan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)