### PR TITLE
feat(INFRA-BL-009): migrate agent-provider-openai from tsup to tsdown

### DIFF
--- a/packages/agent-provider-openai/package.json
+++ b/packages/agent-provider-openai/package.json
@@ -48,9 +48,9 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -104,7 +104,7 @@
     "@typescript-eslint/parser": "^6.18.0",
     "eslint": "^8.56.0",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },

--- a/packages/agent-provider-openai/tsdown.config.ts
+++ b/packages/agent-provider-openai/tsdown.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    entry: {
+      file: 'src/loggers/file.ts',
+      console: 'src/loggers/console.ts',
+    },
+    format: ['esm', 'cjs'],
+    outDir: 'dist/loggers',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1468,9 +1468,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3


### PR DESCRIPTION
## Summary

- Replace tsup with tsdown 0.22.0 in agent-provider-openai
- Three-config array: node build + loggers sub-path build + browser build
- Loggers export contract preserved: `file.js/.cjs/.d.ts`, `console.js/.cjs/.d.ts`

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-provider-openai build` passes
- [x] `pnpm build` (full monorepo) passes
- [x] `pnpm harness:scan` passes (build-contracts: 54 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)