### PR TITLE
feat(INFRA-BL-009): migrate agent-playground and agent-web-ui from tsup to tsdown

### DIFF
--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -32,9 +32,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "dev": "tsup --watch",
     "clean": "rimraf dist",
     "test": "vitest run --passWithNoTests",
@@ -88,7 +88,7 @@
     "eslint": "^8.56.0",
     "jsdom": "^25.0.1",
     "rimraf": "^5.0.5",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/packages/agent-playground/tsdown.config.ts
+++ b/packages/agent-playground/tsdown.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts', 'src/client.ts'],
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -30,9 +30,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:js": "tsup --no-dts",
-    "build:types": "tsup --dts-only",
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
     "build:spa": "vite build --config vite.spa.config.ts",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
@@ -58,7 +58,7 @@
     "react-dom": "19.2.4",
     "rimraf": "^5.0.5",
     "tailwindcss": "^4.0.0",
-    "tsup": "^8.0.1",
+    "tsdown": "^0.22.0",
     "typescript": "^5.3.3",
     "vite": "^7.3.2",
     "vitest": "^1.6.1"

--- a/packages/agent-web-ui/tsdown.config.ts
+++ b/packages/agent-web-ui/tsdown.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+const shared = {
+  entry: ['src/index.ts'],
+  sourcemap: false,
+  treeshake: true,
+  dts: true,
+  outExtensions,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    format: ['esm', 'cjs'],
+    outDir: 'dist/node',
+    platform: 'node',
+    clean: true,
+  },
+  {
+    ...shared,
+    format: ['esm'],
+    outDir: 'dist/browser',
+    platform: 'browser',
+    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,9 +1101,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -1892,15 +1892,15 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.0
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.0(tsx@4.21.0)(typescript@5.8.3)
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
       vite:
         specifier: '>=7.3.2'
-        version: 8.0.8(@types/node@20.19.9)(esbuild@0.25.8)(tsx@4.21.0)
+        version: 8.0.8(@types/node@20.19.9)(tsx@4.21.0)
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.9)
@@ -8319,7 +8319,7 @@ packages:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.8(@types/node@20.19.9)(esbuild@0.25.8)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@20.19.9)(tsx@4.21.0)
     dev: true
 
   /@testing-library/dom@10.4.0:
@@ -9715,7 +9715,7 @@ packages:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.8(@types/node@20.19.9)(esbuild@0.25.8)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@20.19.9)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -23672,64 +23672,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@8.0.8(@types/node@20.19.9)(esbuild@0.25.8)(tsx@4.21.0):
-    resolution:
-      {
-        integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-    dependencies:
-      '@types/node': 20.19.9
-      esbuild: 0.25.8
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.15
-      tsx: 4.21.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@8.0.8(@types/node@20.19.9)(esbuild@0.27.3)(tsx@4.21.0):
     resolution:
       {
@@ -23787,6 +23729,63 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: false
+
+  /vite@8.0.8(@types/node@20.19.9)(tsx@4.21.0):
+    resolution:
+      {
+        integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 20.19.9
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.15
+      tsx: 4.21.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /vitefu@1.1.2(vite@8.0.8):
     resolution:


### PR DESCRIPTION
## Summary

- Replace tsup with tsdown 0.22.0 in the two remaining UI packages
- agent-playground: dual build with both `src/index.ts` and `src/client.ts` entries
- agent-web-ui: standard dual build; Vite SPA build script unchanged

## Test plan

- [x] Both packages build successfully
- [x] `pnpm build` (full monorepo) passes
- [x] `pnpm harness:scan` passes (build-contracts: 54 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)