### PR TITLE
docs(backlog): add ARCH-BL-001~004 — package consolidation plan

### DIFF
--- a/.agents/backlog/ARCH-BL-001-consolidate-provider-packages.md
+++ b/.agents/backlog/ARCH-BL-001-consolidate-provider-packages.md
@@ -1,0 +1,176 @@
+---
+title: 'ARCH-BL-001: Consolidate agent-provider-* into single agent-provider package'
+status: backlog
+created: 2026-05-16
+priority: high
+urgency: soon
+area: packages/agent-provider-*, packages/agent-provider (new)
+depends_on: []
+---
+
+## Problem
+
+현재 AI provider가 8개의 독립 npm 패키지로 분산되어 있다.
+
+```
+@robota-sdk/agent-provider-anthropic
+@robota-sdk/agent-provider-openai
+@robota-sdk/agent-provider-openai-compatible
+@robota-sdk/agent-provider-deepseek
+@robota-sdk/agent-provider-gemini
+@robota-sdk/agent-provider-google
+@robota-sdk/agent-provider-gemma
+@robota-sdk/agent-provider-bytedance
+```
+
+사용자가 여러 provider를 사용하려면 여러 패키지를 설치해야 하고, 우리는 8개의 독립 릴리즈 사이클을 관리해야 한다.
+
+## Goal
+
+모든 공식 provider를 단일 `@robota-sdk/agent-provider` 패키지로 통합한다.
+
+- 내부 레이어 구조(각 provider가 `agent-core` 인터페이스를 구현하는 방식)는 **그대로 유지**
+- 사용자는 `agent-provider` 미포함 커스텀 provider를 만들기 위해 `agent-core` 인터페이스를 구현하는 자체 패키지를 만들 수 있다 (확장 지점은 동일)
+- Tree-shaking으로 사용하지 않는 provider는 번들에 포함되지 않아야 함
+
+## Design
+
+### Package structure
+
+```
+packages/
+├── agent-provider/              # NEW: 통합 패키지
+│   ├── src/
+│   │   ├── index.ts             # 모든 provider re-export
+│   │   ├── anthropic/           # 기존 agent-provider-anthropic 코드 이동
+│   │   ├── openai/              # 기존 agent-provider-openai 코드 이동
+│   │   ├── openai-compatible/
+│   │   ├── deepseek/
+│   │   ├── gemini/
+│   │   ├── google/
+│   │   ├── gemma/
+│   │   └── bytedance/
+│   └── package.json
+└── agent-provider-* (기존)     # 삭제 대상 (마이그레이션 완료 후)
+```
+
+### Export surface
+
+```ts
+// 사용자는 하나의 패키지로 모든 provider 사용 가능
+import { AnthropicProvider } from '@robota-sdk/agent-provider';
+import { OpenAIProvider } from '@robota-sdk/agent-provider';
+import { GeminiProvider } from '@robota-sdk/agent-provider';
+
+// 커스텀 provider는 agent-core 인터페이스로 확장
+import type { IAIProvider } from '@robota-sdk/agent-core';
+class MyCustomProvider implements IAIProvider { ... }
+```
+
+### Sub-path exports (대용량 의존성 격리)
+
+각 provider가 서로 다른 SDK 의존성을 가지므로, sub-path export를 사용한다.
+
+```json
+{
+  "exports": {
+    "./anthropic": "./dist/node/anthropic/index.js",
+    "./openai": "./dist/node/openai/index.js",
+    "./gemini": "./dist/node/gemini/index.js",
+    ".": "./dist/node/index.js"
+  }
+}
+```
+
+루트 export에서 모두 re-export하되, 각 provider의 외부 SDK(`@anthropic-ai/sdk`, `openai`, `@google/generative-ai`)는 `peerDependencies` 또는 `optionalDependencies`로 선언한다.
+
+### Dependency rule
+
+```
+agent-provider → agent-core (only)
+```
+
+레이어 규칙 변경 없음. 기존 8개 패키지가 각각 `agent-core`에만 의존했던 것과 동일하다.
+
+## Circular Dependency Prevention
+
+### 금지 의존 방향
+
+```
+agent-core  ←──  agent-provider      ✅ 허용 (단방향)
+agent-core  ──→  agent-provider      ❌ 절대 금지
+agent-framework ──→ agent-provider   ❌ 절대 금지 (framework는 IAIProvider 인터페이스만 사용)
+```
+
+provider는 레이어 최하단에 위치하므로 패키지 수준 순환 위험은 낮다.
+그러나 통합 이후 서브 모듈 간 cross-import가 생기는 것이 주요 위험이다.
+
+### 서브 모듈 간 직접 import 금지
+
+```ts
+// ❌ 금지: anthropic 서브모듈이 openai 서브모듈을 직접 참조
+// src/anthropic/client.ts
+import { normalizeResponse } from '../openai/normalizer.js';
+
+// ✅ 허용: 공통 유틸은 shared/ 로만
+// src/shared/normalizer.ts  ← 공통 로직 위치
+import { normalizeResponse } from '../shared/normalizer.js';
+```
+
+### 탐지 및 차단 수단
+
+1. **ESLint `import-x/no-cycle`**: 빌드 전 소스 레벨 순환 감지
+2. **`madge --circular`**: CI에서 `src/` 전체 스캔
+   ```bash
+   pnpm madge --circular --ts-config tsconfig.json src/
+   ```
+3. **`pnpm harness:scan`**: cycle-check step 추가 예정 (ARCH-BL-005 또는 별도 인프라 태스크)
+4. **TypeScript `paths` 제한**: 각 서브 디렉토리의 `tsconfig.json`에서 형제 서브 디렉토리를 paths에서 제외
+
+## Migration Steps
+
+1. `packages/agent-provider` 신규 패키지 생성
+2. 기존 8개 패키지 소스를 서브 디렉토리로 이동
+3. `package.json` — peerDependencies 정리 (각 provider SDK를 optional peer로)
+4. `tsdown.config.ts` — sub-path entry 포함 빌드 설정
+5. `agent-framework`, `agent-cli` 등 downstream consumer import 경로 일괄 변경
+6. 기존 8개 패키지에 deprecation notice 추가 후 삭제
+
+## Test Plan
+
+- [ ] `pnpm typecheck` 전체 통과
+- [ ] `pnpm build` — `agent-provider` 패키지 빌드 성공
+- [ ] sub-path export (`./anthropic`, `./openai` 등) 타입 해석 정상
+- [ ] Tree-shaking 검증: anthropic만 import 시 openai 번들 미포함
+- [ ] `pnpm harness:scan:build-contracts` 통과
+- [ ] 각 provider 단위 테스트 이전 완료 및 통과
+
+## User Execution Test Scenarios
+
+### Scenario 1: 단일 패키지로 provider 사용
+
+**Prerequisites**: `@robota-sdk/agent-provider` 설치, 각 provider SDK peer 설치
+
+**Steps**:
+
+```ts
+import { AnthropicProvider, OpenAIProvider } from '@robota-sdk/agent-provider';
+const provider = new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY });
+```
+
+**Expected**: 타입 정상, 런타임 정상
+
+**Evidence**: _(migration 완료 후 채움)_
+
+### Scenario 2: 커스텀 provider 확장
+
+**Steps**:
+
+```ts
+import type { IAIProvider } from '@robota-sdk/agent-core';
+class MyProvider implements IAIProvider { ... }
+```
+
+**Expected**: `@robota-sdk/agent-provider` 미설치 상태에서도 `agent-core`만으로 커스텀 provider 구현 가능
+
+**Evidence**: _(migration 완료 후 채움)_

--- a/.agents/backlog/ARCH-BL-002-consolidate-transport-packages.md
+++ b/.agents/backlog/ARCH-BL-002-consolidate-transport-packages.md
@@ -1,0 +1,188 @@
+---
+title: 'ARCH-BL-002: Consolidate agent-transport-* into single agent-transport package'
+status: backlog
+created: 2026-05-16
+priority: high
+urgency: soon
+area: packages/agent-transport-*, packages/agent-transport (new)
+depends_on: []
+---
+
+## Problem
+
+현재 transport가 5개의 독립 npm 패키지로 분산되어 있다.
+
+```
+@robota-sdk/agent-transport-tui
+@robota-sdk/agent-transport-headless
+@robota-sdk/agent-transport-http
+@robota-sdk/agent-transport-ws
+@robota-sdk/agent-transport-mcp
+```
+
+각 transport는 별개의 릴리즈 사이클과 버전 관리를 갖는다. CLI나 서버를 구성할 때 여러 패키지를 별도로 설치해야 한다.
+
+## Goal
+
+모든 공식 transport를 단일 `@robota-sdk/agent-transport` 패키지로 통합한다.
+
+- `agent-interface-transport`가 정의하는 `ITransportAdapter` 인터페이스는 **그대로 유지** (확장 지점)
+- 사용자는 `ITransportAdapter`를 구현하는 자체 transport 패키지를 만들어 붙일 수 있다
+- 각 transport는 독립적인 외부 의존성을 가지므로 sub-path export로 격리
+
+## Design
+
+### Package structure
+
+```
+packages/
+├── agent-transport/             # NEW: 통합 패키지
+│   ├── src/
+│   │   ├── index.ts             # 공통 타입 + 전체 re-export
+│   │   ├── tui/                 # 기존 agent-transport-tui 코드 이동
+│   │   ├── headless/            # 기존 agent-transport-headless 코드 이동
+│   │   ├── http/                # 기존 agent-transport-http 코드 이동
+│   │   ├── ws/                  # 기존 agent-transport-ws 코드 이동
+│   │   └── mcp/                 # 기존 agent-transport-mcp 코드 이동
+│   └── package.json
+└── agent-transport-* (기존)     # 삭제 대상 (마이그레이션 완료 후)
+```
+
+### Export surface
+
+```ts
+// 통합 패키지에서 원하는 transport만 import
+import { createTuiTransport } from '@robota-sdk/agent-transport/tui';
+import { createHeadlessTransport } from '@robota-sdk/agent-transport/headless';
+import { createHttpTransport } from '@robota-sdk/agent-transport/http';
+
+// 커스텀 transport는 agent-interface-transport로 확장
+import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+class MyTransport implements ITransportAdapter { ... }
+```
+
+### Sub-path exports
+
+각 transport의 외부 의존성(ink, express, ws, @modelcontextprotocol/sdk 등)이 다르므로 sub-path 필수:
+
+```json
+{
+  "exports": {
+    "./tui": "./dist/node/tui/index.js",
+    "./headless": "./dist/node/headless/index.js",
+    "./http": "./dist/node/http/index.js",
+    "./ws": "./dist/node/ws/index.js",
+    "./mcp": "./dist/node/mcp/index.js",
+    ".": "./dist/node/index.js"
+  }
+}
+```
+
+각 transport의 외부 SDK는 `optionalDependencies` 또는 `peerDependencies`로 선언.
+
+### Dependency rule
+
+```
+agent-transport → agent-interface-transport
+agent-transport → agent-framework (InteractiveSession 등)
+```
+
+기존 각 transport 패키지의 의존 관계와 동일하게 유지.
+
+## Circular Dependency Prevention
+
+### 금지 의존 방향
+
+```
+agent-framework  ──→  agent-interface-transport  ←──  agent-transport   ✅ 다이아몬드 구조 (허용)
+agent-framework  ──→  agent-transport             ❌ 절대 금지
+agent-transport  ──→  agent-cli                   ❌ 절대 금지
+transport 서브모듈  ──→  다른 transport 서브모듈   ❌ 금지 (예: tui → http)
+```
+
+`agent-interface-transport`가 별도 패키지로 남아있는 이유가 바로 이 다이아몬드 구조를 유지하기 위해서다.
+**`agent-interface-transport`는 통합 대상이 아니며 이 작업 이후에도 독립 패키지로 유지한다.**
+
+### agent-interface-transport 역할 보존
+
+```
+                    agent-core
+                        ↑
+           ┌────────────┴────────────┐
+    agent-framework         agent-transport
+           ↑                        ↑
+    agent-interface-transport ──────┘
+          (계약만 정의, 구현 없음)
+```
+
+`agent-framework`와 `agent-transport` 양쪽이 `agent-interface-transport`의 타입을 import하고,
+서로는 직접 참조하지 않는다. 이 구조가 깨지면 즉시 순환이 발생한다.
+
+### 서브 모듈 간 직접 import 금지
+
+```ts
+// ❌ 금지: tui 서브모듈이 headless를 직접 참조
+// src/tui/runner.ts
+import { HeadlessRunner } from '../headless/runner.js';
+
+// ✅ 허용: 공통 유틸은 shared/ 로만
+import { formatOutput } from '../shared/format.js';
+```
+
+### 탐지 및 차단 수단
+
+1. **ESLint `import-x/no-cycle`**: 빌드 전 소스 레벨 순환 감지
+2. **`madge --circular`**: CI에서 `src/` 전체 스캔
+   ```bash
+   pnpm madge --circular --ts-config tsconfig.json src/
+   ```
+3. **`pnpm harness:scan`**: cycle-check step 추가 예정
+4. **`agent-interface-transport` 존재 확인**: harness에서 이 패키지가 삭제/병합되지 않았는지 검사
+
+## Migration Steps
+
+1. `packages/agent-transport` 신규 패키지 생성
+2. 기존 5개 패키지 소스를 서브 디렉토리로 이동
+3. `package.json` — 각 외부 SDK를 optional peer로 정리
+4. `tsdown.config.ts` — sub-path entry 포함 빌드 설정
+5. `agent-cli`, `agent-web-ui`, `apps/*` 등 downstream consumer import 경로 일괄 변경
+6. 기존 5개 패키지에 deprecation notice 추가 후 삭제
+
+## Test Plan
+
+- [ ] `pnpm typecheck` 전체 통과
+- [ ] `pnpm build` — `agent-transport` 패키지 빌드 성공
+- [ ] sub-path export 타입 해석 정상 (tui, headless, http, ws, mcp)
+- [ ] 각 transport 단위/통합 테스트 이전 완료 및 통과
+- [ ] `pnpm harness:scan:build-contracts` 통과
+- [ ] CLI E2E: TUI transport 정상 동작 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: Sub-path import으로 transport 선택
+
+**Prerequisites**: `@robota-sdk/agent-transport` + 해당 peer 설치
+
+**Steps**:
+
+```ts
+import { createHeadlessTransport } from '@robota-sdk/agent-transport/headless';
+const transport = createHeadlessTransport({ outputFormat: 'text' });
+```
+
+**Expected**: 타입 정상, 런타임 정상. tui/ink 등 다른 transport 의존성은 번들 미포함.
+
+**Evidence**: _(migration 완료 후 채움)_
+
+### Scenario 2: 커스텀 transport 확장
+
+**Steps**:
+
+```ts
+import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+class MyTransport implements ITransportAdapter { ... }
+```
+
+**Expected**: `@robota-sdk/agent-transport` 미설치 상태에서도 구현 가능. 계층 구조 정상.
+
+**Evidence**: _(migration 완료 후 채움)_

--- a/.agents/backlog/ARCH-BL-003-consolidate-command-packages.md
+++ b/.agents/backlog/ARCH-BL-003-consolidate-command-packages.md
@@ -1,0 +1,231 @@
+---
+title: 'ARCH-BL-003: Consolidate agent-command-* into single agent-command package'
+status: backlog
+created: 2026-05-16
+priority: high
+urgency: soon
+area: packages/agent-command-*, packages/agent-command (new)
+depends_on: []
+---
+
+## Problem
+
+현재 커맨드 모듈이 21개의 독립 npm 패키지로 분산되어 있다.
+
+```
+@robota-sdk/agent-command-agent
+@robota-sdk/agent-command-background
+@robota-sdk/agent-command-compact
+@robota-sdk/agent-command-context
+@robota-sdk/agent-command-exit
+@robota-sdk/agent-command-help
+@robota-sdk/agent-command-language
+@robota-sdk/agent-command-memory
+@robota-sdk/agent-command-mode
+@robota-sdk/agent-command-model
+@robota-sdk/agent-command-permissions
+@robota-sdk/agent-command-plugin
+@robota-sdk/agent-command-provider
+@robota-sdk/agent-command-reset
+@robota-sdk/agent-command-rewind
+@robota-sdk/agent-command-session
+@robota-sdk/agent-command-settings
+@robota-sdk/agent-command-skills
+@robota-sdk/agent-command-statusline
+@robota-sdk/agent-command-user-local
+```
+
+21개의 릴리즈 사이클, 21개의 `package.json`, 21개의 `tsdown.config.ts`를 유지해야 한다.
+agent-cli가 모두를 조립할 때 import 경로가 21줄이 필요하다.
+
+## Goal
+
+모든 공식 커맨드 모듈을 단일 `@robota-sdk/agent-command` 패키지로 통합한다.
+
+- `ICommandModule` 인터페이스(agent-framework 소유)는 **그대로 유지** (확장 지점)
+- 사용자는 `ICommandModule`을 구현하는 자체 커맨드 패키지를 만들어 CLI에 등록할 수 있다
+- CLI는 필요한 커맨드만 골라서 조립하는 방식을 유지 (tree-shaking)
+
+## Design
+
+### Package structure
+
+```
+packages/
+├── agent-command/               # NEW: 통합 패키지
+│   ├── src/
+│   │   ├── index.ts             # 모든 커맨드 모듈 re-export
+│   │   ├── agent/               # 기존 agent-command-agent 코드 이동
+│   │   ├── background/
+│   │   ├── compact/
+│   │   ├── context/
+│   │   ├── exit/
+│   │   ├── help/
+│   │   ├── language/
+│   │   ├── memory/
+│   │   ├── mode/
+│   │   ├── model/
+│   │   ├── permissions/
+│   │   ├── plugin/
+│   │   ├── provider/
+│   │   ├── reset/
+│   │   ├── rewind/
+│   │   ├── session/
+│   │   ├── settings/
+│   │   ├── skills/
+│   │   ├── statusline/
+│   │   └── user-local/
+│   └── package.json
+└── agent-command-* (기존)       # 삭제 대상 (마이그레이션 완료 후)
+```
+
+### Export surface
+
+```ts
+// 통합 패키지에서 필요한 커맨드만 import
+import { createProviderCommandModule } from '@robota-sdk/agent-command';
+import { createModelCommandModule } from '@robota-sdk/agent-command';
+import { createHelpCommandModule } from '@robota-sdk/agent-command';
+
+// 커스텀 커맨드는 ICommandModule 인터페이스로 확장
+import type { ICommandModule } from '@robota-sdk/agent-framework';
+const myCommand: ICommandModule = { name: 'my-cmd', ... };
+```
+
+### Sub-path exports (선택적)
+
+각 커맨드가 독립적인 외부 의존성을 거의 갖지 않으므로 루트 export로 통합해도 무방하다.
+단, `agent-command-provider`처럼 무거운 의존성이 있는 경우 sub-path를 고려한다.
+
+```json
+{
+  "exports": {
+    ".": "./dist/node/index.js",
+    "./provider": "./dist/node/provider/index.js"
+  }
+}
+```
+
+### Dependency rule
+
+```
+agent-command → agent-framework (ICommandModule, command contracts)
+agent-command → agent-core (공통 타입)
+agent-command → agent-session, agent-tools (각 커맨드 구현 필요 시)
+```
+
+기존 21개 패키지들의 의존 관계를 하나로 합산.
+
+## Circular Dependency Prevention
+
+### 금지 의존 방향
+
+```
+agent-framework  ──→  agent-command    ❌ 절대 금지 (framework는 ICommandModule 인터페이스만 소유)
+agent-command    ──→  agent-transport  ❌ 절대 금지 (명령어가 transport에 의존하면 안 됨)
+agent-command    ──→  agent-cli        ❌ 절대 금지
+command 서브모듈  ──→  다른 command 서브모듈  ❌ 금지 (예: provider/ → model/)
+```
+
+가장 위험한 시나리오는 `agent-framework`가 `agent-command`를 import하는 경우다.
+framework는 `ICommandModule` 인터페이스만 소유하며, 구체 커맨드 구현체를 참조해서는 안 된다.
+
+### ICommandModule 계약 위치 명확화
+
+```
+agent-framework
+  ├── commands/
+  │   ├── ICommandModule.ts       ← 인터페이스 소유 (framework)
+  │   ├── CommandRegistry.ts      ← 레지스트리 (framework)
+  │   └── CommandExecutor.ts      ← 실행 인프라 (framework)
+
+agent-command
+  ├── provider/
+  │   └── index.ts                ← ICommandModule 구현체 (command)
+  ├── model/
+  └── ...
+
+agent-cli                         ← 조립: 어떤 커맨드를 등록할지 결정
+```
+
+`agent-framework`는 인터페이스와 실행 인프라만 갖는다. 커맨드 목록을 하드코딩하지 않는다.
+
+### 서브 모듈 간 공유 로직 처리
+
+21개 커맨드 중 유사한 유틸이 있더라도 서브 디렉토리 간 직접 import는 금지:
+
+```ts
+// ❌ 금지: provider/ 커맨드가 model/ 유틸을 직접 참조
+import { formatModelName } from '../model/formatter.js';
+
+// ✅ 허용: 공통 유틸은 shared/ 로만
+import { formatModelName } from '../shared/formatter.js';
+```
+
+### 탐지 및 차단 수단
+
+1. **ESLint `import-x/no-cycle`**: 빌드 전 소스 레벨 순환 감지
+2. **`madge --circular`**: CI에서 `src/` 전체 스캔
+   ```bash
+   pnpm madge --circular --ts-config tsconfig.json src/
+   ```
+3. **`pnpm harness:scan`**: cycle-check step 추가 예정
+4. **agent-framework 오염 검사**: `grep -r "agent-command" packages/agent-framework/src/` — framework가 command를 import하면 즉시 차단
+
+## Migration Steps
+
+1. `packages/agent-command` 신규 패키지 생성
+2. 기존 21개 패키지 소스를 서브 디렉토리로 이동
+3. `package.json` — 21개의 의존성 합산, 중복 제거
+4. `tsdown.config.ts` — 단일 entry 빌드 설정 (tree-shaking 보장)
+5. `agent-cli` import 경로 21줄 → 1줄로 변경
+6. 기존 21개 패키지에 deprecation notice 추가 후 삭제
+
+## Test Plan
+
+- [ ] `pnpm typecheck` 전체 통과
+- [ ] `pnpm build` — `agent-command` 패키지 빌드 성공
+- [ ] `agent-cli`에서 각 커맨드 모듈 import 정상
+- [ ] 각 커맨드 단위 테스트 이전 완료 및 통과 (21개 패키지 테스트 통합)
+- [ ] `pnpm harness:scan:build-contracts` 통과
+- [ ] CLI E2E: `/help`, `/provider`, `/model` 등 주요 커맨드 정상 동작
+
+## User Execution Test Scenarios
+
+### Scenario 1: 통합 패키지에서 커맨드 import
+
+**Prerequisites**: `@robota-sdk/agent-command` 설치
+
+**Steps**:
+
+```ts
+import {
+  createProviderCommandModule,
+  createModelCommandModule,
+  createHelpCommandModule,
+} from '@robota-sdk/agent-command';
+```
+
+**Expected**: 타입 정상. agent-cli 빌드 성공. `/help`, `/model`, `/provider` 정상 동작.
+
+**Evidence**: _(migration 완료 후 채움)_
+
+### Scenario 2: 커스텀 커맨드 확장
+
+**Steps**:
+
+```ts
+import type { ICommandModule } from '@robota-sdk/agent-framework';
+
+const myCommand: ICommandModule = {
+  name: 'my-cmd',
+  description: 'My custom command',
+  execute: async (args, options) => ({ message: 'hello', success: true }),
+};
+// CLI에 등록
+session.registerCommand(myCommand);
+```
+
+**Expected**: `@robota-sdk/agent-command` 미설치 상태에서도 커스텀 커맨드 구현 및 등록 가능.
+
+**Evidence**: _(migration 완료 후 채움)_

--- a/.agents/backlog/ARCH-BL-004-consolidate-plugin-packages.md
+++ b/.agents/backlog/ARCH-BL-004-consolidate-plugin-packages.md
@@ -1,0 +1,216 @@
+---
+title: 'ARCH-BL-004: Consolidate agent-plugin-* into single agent-plugin package'
+status: backlog
+created: 2026-05-16
+priority: high
+urgency: soon
+area: packages/agent-plugin-*, packages/agent-plugin (new)
+depends_on: []
+---
+
+## Problem
+
+현재 플러그인이 8개의 독립 npm 패키지로 분산되어 있다.
+
+```
+@robota-sdk/agent-plugin-conversation-history
+@robota-sdk/agent-plugin-error-handling
+@robota-sdk/agent-plugin-execution-analytics
+@robota-sdk/agent-plugin-limits
+@robota-sdk/agent-plugin-logging
+@robota-sdk/agent-plugin-performance
+@robota-sdk/agent-plugin-usage
+@robota-sdk/agent-plugin-webhook
+```
+
+모두 `agent-core`의 플러그인 인터페이스를 구현하는 동일한 패턴이며, 각각 독립 릴리즈 사이클을 갖는다.
+
+## Goal
+
+모든 공식 플러그인을 단일 `@robota-sdk/agent-plugin` 패키지로 통합한다.
+
+- `agent-core`가 정의하는 플러그인 인터페이스(훅/이벤트 시스템)는 **그대로 유지** (확장 지점)
+- 사용자는 동일한 `agent-core` 인터페이스로 자체 플러그인 패키지를 만들어 등록할 수 있다
+- Tree-shaking으로 사용하지 않는 플러그인은 번들에 포함되지 않아야 함
+
+## Design
+
+### Package structure
+
+```
+packages/
+├── agent-plugin/                    # NEW: 통합 패키지
+│   ├── src/
+│   │   ├── index.ts                 # 모든 플러그인 re-export
+│   │   ├── conversation-history/    # 기존 agent-plugin-conversation-history 코드 이동
+│   │   ├── error-handling/
+│   │   ├── execution-analytics/
+│   │   ├── limits/
+│   │   ├── logging/
+│   │   ├── performance/
+│   │   ├── usage/
+│   │   ├── webhook/
+│   │   └── shared/                  # 플러그인 공통 유틸 (있다면)
+│   └── package.json
+└── agent-plugin-* (기존)            # 삭제 대상 (마이그레이션 완료 후)
+```
+
+### Export surface
+
+```ts
+// 통합 패키지에서 필요한 플러그인만 import
+import { createLoggingPlugin } from '@robota-sdk/agent-plugin';
+import { createUsagePlugin } from '@robota-sdk/agent-plugin';
+import { createLimitsPlugin } from '@robota-sdk/agent-plugin';
+
+// 커스텀 플러그인은 agent-core 인터페이스로 확장
+import type { IPlugin } from '@robota-sdk/agent-core';
+const myPlugin: IPlugin = {
+  name: 'my-plugin',
+  hooks: { ... },
+};
+```
+
+### Sub-path exports
+
+각 플러그인의 외부 의존성(webhook → `node-fetch` 등)이 있으므로 필요 시 sub-path 사용:
+
+```json
+{
+  "exports": {
+    ".": "./dist/node/index.js",
+    "./webhook": "./dist/node/webhook/index.js"
+  }
+}
+```
+
+외부 의존성이 없는 플러그인은 루트 export로 통합.
+
+### Dependency rule
+
+```
+agent-plugin → agent-core (only)
+```
+
+플러그인은 `agent-core`의 훅/이벤트 인터페이스만 사용한다.
+`agent-framework`, `agent-session`, `agent-tools`는 의존 금지.
+
+## Circular Dependency Prevention
+
+### 금지 의존 방향
+
+```
+agent-core   ──→  agent-plugin       ❌ 절대 금지 (core의 zero-dependency 원칙 위반)
+agent-plugin ──→  agent-framework    ❌ 절대 금지 (plugin은 core만 참조)
+agent-plugin ──→  agent-session      ❌ 절대 금지
+agent-plugin ──→  agent-tools        ❌ 절대 금지
+plugin 서브모듈  ──→  다른 plugin 서브모듈  ❌ 금지 (예: logging/ → usage/)
+```
+
+`agent-core`는 zero-dependency 패키지다. `agent-plugin`이 `agent-core`에 의존하는 것은
+허용되지만, 그 반대는 `agent-core`의 핵심 원칙을 파괴한다.
+
+### 플러그인 등록 방향 명확화
+
+```
+agent-core
+  ├── IPlugin 인터페이스 소유
+  └── PluginRegistry (등록소)
+
+agent-plugin
+  ├── ConversationHistoryPlugin implements IPlugin  ← 구현체만
+  ├── LoggingPlugin implements IPlugin
+  └── ...
+
+사용 시 (agent-framework 또는 사용자 코드):
+  import { createLoggingPlugin } from '@robota-sdk/agent-plugin';
+  robota.use(createLoggingPlugin());   ← core의 .use() 메서드로 등록
+```
+
+플러그인은 core에 **등록되는** 것이지, core가 플러그인을 **import하는** 것이 아니다.
+이 방향이 뒤집히는 순간 순환이 발생한다.
+
+### 서브 모듈 간 직접 import 금지
+
+```ts
+// ❌ 금지: logging 플러그인이 usage 플러그인을 직접 참조
+// src/logging/plugin.ts
+import { UsageCollector } from '../usage/collector.js';
+
+// ✅ 허용: 공통 유틸은 shared/ 로만
+import { formatTimestamp } from '../shared/format.js';
+
+// ✅ 허용: agent-core 인터페이스는 항상 허용
+import type { IHookInput } from '@robota-sdk/agent-core';
+```
+
+### 탐지 및 차단 수단
+
+1. **ESLint `import-x/no-cycle`**: 빌드 전 소스 레벨 순환 감지
+2. **`madge --circular`**: CI에서 `src/` 전체 스캔
+   ```bash
+   pnpm madge --circular --ts-config tsconfig.json src/
+   ```
+3. **`pnpm harness:scan`**: cycle-check step 추가 예정
+4. **agent-core 오염 검사**: `grep -r "agent-plugin" packages/agent-core/src/` — core가 plugin을 import하면 즉시 차단
+5. **의존성 방향 harness**: `agent-plugin`의 `package.json` `dependencies`에 `agent-framework`, `agent-session`, `agent-tools`가 없는지 검사
+
+## Migration Steps
+
+1. `packages/agent-plugin` 신규 패키지 생성
+2. 기존 8개 패키지 소스를 서브 디렉토리로 이동
+3. `package.json` — 8개의 의존성 합산, 중복 제거. 외부 의존성은 optional peer로
+4. `tsdown.config.ts` — 단일 entry 빌드 설정 (tree-shaking 보장)
+5. `agent-framework`, `agent-cli` 등 downstream consumer import 경로 일괄 변경
+6. 기존 8개 패키지에 deprecation notice 추가 후 삭제
+
+## Test Plan
+
+- [ ] `pnpm typecheck` 전체 통과
+- [ ] `pnpm build` — `agent-plugin` 패키지 빌드 성공
+- [ ] `madge --circular src/` — 순환 의존성 없음 확인
+- [ ] `grep -r "agent-plugin" packages/agent-core/src/` — 결과 없음 확인
+- [ ] 각 플러그인 단위 테스트 이전 완료 및 통과 (8개 패키지 테스트 통합)
+- [ ] `pnpm harness:scan:build-contracts` 통과
+- [ ] 플러그인 등록 후 훅 동작 통합 테스트
+
+## User Execution Test Scenarios
+
+### Scenario 1: 통합 패키지에서 플러그인 등록
+
+**Prerequisites**: `@robota-sdk/agent-plugin` 설치
+
+**Steps**:
+
+```ts
+import { createLoggingPlugin, createUsagePlugin } from '@robota-sdk/agent-plugin';
+
+robota.use(createLoggingPlugin({ level: 'info' }));
+robota.use(createUsagePlugin());
+```
+
+**Expected**: 타입 정상. 훅 정상 동작. 로그 출력 및 usage 수집 확인.
+
+**Evidence**: _(migration 완료 후 채움)_
+
+### Scenario 2: 커스텀 플러그인 확장
+
+**Steps**:
+
+```ts
+import type { IPlugin } from '@robota-sdk/agent-core';
+
+const myPlugin: IPlugin = {
+  name: 'my-plugin',
+  hooks: {
+    beforeExecution: async (input) => {
+      console.log('before:', input);
+    },
+  },
+};
+robota.use(myPlugin);
+```
+
+**Expected**: `@robota-sdk/agent-plugin` 미설치 상태에서도 `agent-core`만으로 커스텀 플러그인 구현 및 등록 가능.
+
+**Evidence**: _(migration 완료 후 채움)_


### PR DESCRIPTION
## Summary

- ARCH-BL-001: `agent-provider-*` (8개) → `agent-provider` 통합
- ARCH-BL-002: `agent-transport-*` (5개) → `agent-transport` 통합
- ARCH-BL-003: `agent-command-*` (21개) → `agent-command` 통합
- ARCH-BL-004: `agent-plugin-*` (8개) → `agent-plugin` 통합

총 42개 패키지 → 4개로 감소 계획. 각 항목에 순환의존성 방지 대책 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)