### PR TITLE
docs(arch-rev-006): fix execution-modes.md — print mode API and sidecar status

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-006-fix-execution-modes-sidecar-and-print.md
+++ b/.agents/backlog/completed/ARCH-REV-006-fix-execution-modes-sidecar-and-print.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-REV-006: Fix execution-modes.md — WebSocket sidecar marks as planned, print mode API update'
-status: todo
+status: done
 created: 2026-05-18
 priority: high
 urgency: now

--- a/.agents/specs/architecture-map/agent-cli/execution-modes.md
+++ b/.agents/specs/architecture-map/agent-cli/execution-modes.md
@@ -40,26 +40,30 @@ See [packages/agent-cli/docs/SPEC.md](../../../../packages/agent-cli/docs/SPEC.m
 ```mermaid
 sequenceDiagram
   participant CLI as cli.ts -p path
-  participant SDK as InteractiveSession
+  participant Runtime as IAgentRuntime
+  participant Session as IInteractiveSession
   participant Transport as agent-transport/headless
-  participant Session as agent-session Session
+  participant SessionSvc as agent-session Session
 
   CLI->>CLI: collect positional prompt or piped stdin
   CLI->>CLI: build appendSystemPrompt from flags
-  CLI->>SDK: new InteractiveSession({ permissionMode: bypassPermissions, bare, allowedTools, noSessionPersistence, commandModules })
+  CLI->>Runtime: runtime.createSession({ permissionMode, maxTurns, sessionStore, bare, allowedTools, appendSystemPrompt })
+  Runtime-->>CLI: session (IInteractiveSession)
   CLI->>Transport: createHeadlessTransport({ outputFormat, prompt })
-  CLI->>SDK: attachTransport(transport)
-  CLI->>Transport: start()
-  Transport->>SDK: submit prompt
-  SDK->>Session: run loop
-  Session-->>Transport: text/json/stream-json output events
-  CLI->>SDK: shutdown()
+  CLI->>Session: session.attachTransport(transport)
+  CLI->>Transport: transport.start()
+  Transport->>Session: submit prompt
+  Session->>SessionSvc: run loop
+  SessionSvc-->>Transport: text/json/stream-json output events
+  CLI->>Session: session.shutdown()
 ```
 
 Flags: `-p`, piped stdin, `--output-format`, `--permission-mode`, `--max-turns`, `--bare`,
 `--allowed-tools`, `--no-session-persistence`, `--append-system-prompt`, `--json-schema`.
 
 ## WebSocket Sidecar Mode
+
+> **[Planned — not yet implemented]** The `--web` / `--web-port` flags and `startWebSidecarServer()` described below do not exist in the codebase. This section documents the planned design intent referenced in `agent-web-ui/docs/SPEC.md`. Do not rely on it as a current implementation reference.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary
- Print mode diagram: replace `new InteractiveSession()` with `runtime.createSession()` to match actual `IAgentRuntime.createSession()` pattern
- WebSocket Sidecar section: add `[Planned — not yet implemented]` notice — `startWebSidecarServer()` and `--web` flag are absent from codebase

## Backlog
ARCH-REV-006 — both fixes verified against actual source (`packages/agent-cli/src/modes/print-mode.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)