### PR TITLE
docs(arch-rev-007): add merge commit evidence to layering-audit CLI-AUDIT-012–023

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-007-add-evidence-to-layering-audit.md
+++ b/.agents/backlog/completed/ARCH-REV-007-add-evidence-to-layering-audit.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-REV-007: Add missing evidence to layering-audit.md (CLI-AUDIT-012 through CLI-AUDIT-023)'
-status: todo
+status: done
 created: 2026-05-18
 priority: high
 urgency: now

--- a/.agents/specs/architecture-map/agent-cli/layering-audit.md
+++ b/.agents/specs/architecture-map/agent-cli/layering-audit.md
@@ -120,11 +120,11 @@ All behavior functions extracted:
 - `runPrintMode` → `src/modes/print-mode.ts`
 - `createDefaultTransportRegistry` → `src/transports/transport-registry.ts`
 
-`cli.ts` is now 196 lines, zero function definitions, pure import-and-call.
+`cli.ts` is now 98 lines, zero function definitions, pure import-and-call.
 
 ### CLI-AUDIT-012: `getSettingsPathForScope` belongs in agent-framework
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `getSettingsPathForScope(cwd, scope: string | undefined)` in `utils/provider-setup.ts` is
 pure path resolution logic with no CLI-type dependencies. Equivalent path-resolution functions
@@ -135,14 +135,14 @@ in agent-cli before calling.
 
 ### CLI-AUDIT-013: `utils/provider-setup.ts` is startup orchestration, not a utility
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `provider-setup.ts` moved to `src/startup/provider-startup.ts`. Old file and test deleted.
 New test at `src/startup/__tests__/provider-startup.test.ts`.
 
 ### CLI-AUDIT-014: `ensureConfig` and `runInteractiveProviderSetup` coupled to `IParsedCliArgs`
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `ensureConfig(cwd, args: IParsedCliArgs, ...)` and `runInteractiveProviderSetup(cwd, args: IParsedCliArgs, ...)`
 use only `args.provider` and `args.settingsScope` respectively. Passing the full CLI arg struct
@@ -154,14 +154,14 @@ CLI maps `IParsedCliArgs` → `IProviderSetupContext` at call site.
 
 ### CLI-AUDIT-015: agent-cli plugin files have uncovered catch blocks
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `plugin-command-source-loader.ts` and `plugin-command-adapter.ts` catch blocks now have
 `// allow-fallback: <reason>` comments (added inline; formatter moved to next line on disk).
 
 ### CLI-AUDIT-016: `isInteractiveTerminal` — terminal I/O check leaked into agent-command
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `agent-command/src/provider/provider-startup.ts` contained `process.stdin.isTTY` /
 `process.stdout.isTTY` — a terminal I/O concern that belongs in the CLI layer.
@@ -172,7 +172,7 @@ TTY check via `isInteractive: () => process.stdin.isTTY === true && process.stdo
 
 ### CLI-AUDIT-017: `process.cwd()` fallback hidden in `createSkillsCommandModule`
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `agent-command/src/skills/skills-command-module.ts` used `options.cwd ?? process.cwd()`,
 making `cwd` silently depend on the process working directory when omitted.
@@ -182,7 +182,7 @@ explicitly; no call-site changes needed.
 
 ### CLI-AUDIT-018: `PrintTerminal` — stdio adapter owned by CLI, belongs in agent-transport/headless
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-cli/src/print-terminal.ts` implemented `ITerminalOutput` using Node.js `readline`
 and `process.stdout`/`stderr`. This is a terminal I/O adapter for print/headless mode — the same
@@ -194,7 +194,7 @@ Fix: moved to `packages/agent-transport/src/headless/print-terminal.ts`. Exporte
 
 ### CLI-AUDIT-019: `TransportRegistry` — settings-backed transport manager owned by CLI, belongs in agent-transport
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-cli/src/transports/transport-registry.ts` had zero CLI-specific type dependencies.
 It used only `TUniversalValue` from agent-core, `IInteractiveSession` / settings-io from
@@ -208,7 +208,7 @@ now imports `createDefaultTransportRegistry` from `@robota-sdk/agent-transport`.
 
 ### CLI-AUDIT-020: `DEFAULT_PROVIDER_DEFINITIONS` — default provider set owned by CLI, belongs in agent-provider
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-cli/src/utils/provider-default-definitions.ts` assembled the standard set of all
 `IProviderDefinition` instances. It had zero CLI-specific type dependencies — only `IProviderDefinition`
@@ -223,7 +223,7 @@ exported from `@robota-sdk/agent-provider` root. All callers in `agent-cli` now 
 
 ### CLI-AUDIT-021: `promptInput` — raw stdin adapter owned by CLI, belongs in agent-transport/headless
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-cli/src/utils/cli-input.ts` implemented raw-mode stdin reading for masked
 API key entry. It had zero CLI-specific type dependencies — same category as `PrintTerminal`
@@ -235,7 +235,7 @@ alongside `PrintTerminal` from `@robota-sdk/agent-transport/headless`. Original 
 
 ### CLI-AUDIT-022: `ChildProcessSubagentRunner` + worker — concrete runtime owned by agent-framework/agent-cli, belongs in dedicated package
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-framework/src/subagents/child-process-subagent-runner.ts` (runner + factory) and
 `packages/agent-cli/src/subagents/child-process-subagent-worker.ts` (worker entry point) were split
@@ -261,7 +261,7 @@ Fix: created new package `@robota-sdk/agent-subagent-runner`. Moved to it:
 
 ### CLI-AUDIT-023: `plugin-command-adapter` + `plugin-command-source-loader` — plugin bridge owned by agent-cli, belongs in agent-command
 
-Status: resolved — branch refactor/arch-002-slim-agent-cli (2026-05-17).
+Status: resolved — merge commit ade5fed70 (refactor/arch-002-slim-agent-cli, 2026-05-17).
 
 `packages/agent-cli/src/plugins/plugin-command-adapter.ts` and `plugin-command-source-loader.ts`
 had zero CLI-specific type dependencies — only `agent-framework` types and Node.js stdlib.


### PR DESCRIPTION
## Summary
- Replace stale `branch refactor/arch-002-slim-agent-cli (2026-05-17)` references with `merge commit ade5fed70` in CLI-AUDIT-012 through CLI-AUDIT-023
- Correct cli.ts line count from 196 to 98 in CLI-AUDIT-011

## Backlog
ARCH-REV-007 — evidence policy requires commit hash or PR number; branch reference is non-unique after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)