### PR TITLE
docs(arch-rev-008): fix stale package names in agent-team and agent-web-ui SPEC.md

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-008-fix-stale-names-in-spec-files.md
+++ b/.agents/backlog/completed/ARCH-REV-008-fix-stale-names-in-spec-files.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-REV-008: Fix stale package names in agent-team and agent-web-ui SPEC.md files'
-status: todo
+status: done
 created: 2026-05-18
 priority: high
 urgency: now

--- a/packages/agent-team/docs/SPEC.md
+++ b/packages/agent-team/docs/SPEC.md
@@ -8,16 +8,16 @@
 
 ## Boundaries
 
-- Does not redefine core agent contracts. `Robota`, tool interfaces (`IToolSchema`, `IToolResult`, `TToolParameters`), and event interfaces (`IEventService`, `IAIProvider`) are imported from `@robota-sdk/agent-core`. `FunctionTool` is imported from `@robota-sdk/agent-tools`. `RelayMcpTool` is imported from `@robota-sdk/agent-tool-mcp`. `bindWithOwnerPath` is imported from `@robota-sdk/agent-event-service`.
+- Does not redefine core agent contracts. `Robota`, tool interfaces (`IToolSchema`, `IToolResult`, `TToolParameters`), event interfaces (`IEventService`, `IAIProvider`), and `bindWithOwnerPath` are imported from `@robota-sdk/agent-core`. `FunctionTool` is imported from `@robota-sdk/agent-tools`. `RelayMcpTool` is imported from `@robota-sdk/agent-tool-mcp`.
 - Keeps team coordination policies explicit and separate from provider integration.
 - Does not own AI provider implementations; provider and model selection is resolved through `@robota-sdk/agent-core` infrastructure.
 - Does not manage session persistence or conversation history; those concerns belong to `@robota-sdk/agent-session`.
 - Template definitions are static JSON; no runtime template creation or persistence API is exposed.
 - Implements relay tool behavior (delegating work to child agents) using the tool contract from
   `@robota-sdk/agent-tools` and MCP relay support from `@robota-sdk/agent-tool-mcp`. Allowed
-  dependencies: `@robota-sdk/agent-core`, `@robota-sdk/agent-tools`, `@robota-sdk/agent-tool-mcp`,
-  and `@robota-sdk/agent-event-service`. Must not import `agent-sdk`, `agent-sessions`,
-  `agent-cli`, or any other agent-\* package outside this list.
+  dependencies: `@robota-sdk/agent-core`, `@robota-sdk/agent-tools`, `@robota-sdk/agent-tool-mcp`.
+  Must not import `agent-framework`, `agent-session`, `agent-cli`, or any other agent-\* package
+  outside this list.
 - Injected by the consuming layer (agent-cli or composition root) at construction time.
   This package does not own a global agent registry; the consumer provides AI providers and
   event service at wiring time.
@@ -100,13 +100,13 @@ None. This package defines no classes. All exports are tool instances created vi
 
 ### Cross-Package Port Consumers
 
-| Port (Owner)                              | Consumer                                                                   | Location                               |
-| ----------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------- |
-| `FunctionTool` (agent-tools)              | `listTemplateCategoriesTool`, `listTemplatesTool`, `getTemplateDetailTool` | `src/assign-task/relay-assign-task.ts` |
-| `RelayMcpTool` (agent-tool-mcp)           | `createAssignTaskRelayTool` result                                         | `src/assign-task/relay-assign-task.ts` |
-| `IEventService` (agents)                  | `createAssignTaskRelayTool` parameter                                      | `src/assign-task/relay-assign-task.ts` |
-| `IAIProvider` (agents)                    | `createAssignTaskRelayTool` parameter                                      | `src/assign-task/relay-assign-task.ts` |
-| `bindWithOwnerPath` (agent-event-service) | relay tool owner-path propagation                                          | `src/assign-task/relay-assign-task.ts` |
+| Port (Owner)                     | Consumer                                                                   | Location                               |
+| -------------------------------- | -------------------------------------------------------------------------- | -------------------------------------- |
+| `FunctionTool` (agent-tools)     | `listTemplateCategoriesTool`, `listTemplatesTool`, `getTemplateDetailTool` | `src/assign-task/relay-assign-task.ts` |
+| `RelayMcpTool` (agent-tool-mcp)  | `createAssignTaskRelayTool` result                                         | `src/assign-task/relay-assign-task.ts` |
+| `IEventService` (agents)         | `createAssignTaskRelayTool` parameter                                      | `src/assign-task/relay-assign-task.ts` |
+| `IAIProvider` (agents)           | `createAssignTaskRelayTool` parameter                                      | `src/assign-task/relay-assign-task.ts` |
+| `bindWithOwnerPath` (agent-core) | relay tool owner-path propagation                                          | `src/assign-task/relay-assign-task.ts` |
 
 ## Test Strategy
 

--- a/packages/agent-web-ui/docs/SPEC.md
+++ b/packages/agent-web-ui/docs/SPEC.md
@@ -17,11 +17,11 @@ different layers: this package is a library; the app is a deployment.
 
 ## Boundaries
 
-- Does NOT own WebSocket protocol framing — that is `@robota-sdk/agent-transport-ws`
+- Does NOT own WebSocket protocol framing — that is `@robota-sdk/agent-transport/ws`
   (`TServerMessage`, `TClientMessage`).
 - Does NOT own `InteractiveSession` or any SDK/session/runtime contracts — those live in
-  `agent-sdk`, `agent-sessions`, `agent-runtime`.
-- Does NOT own `agent-core` types directly — message types pass through `agent-transport-ws`.
+  `agent-framework`, `agent-session`, `agent-executor`.
+- Does NOT own `agent-core` types directly — message types pass through `agent-transport/ws`.
 - Does NOT own the CLI sidecar server — that is `agent-cli` (`startWebSidecarServer`).
 - OWNS: browser WebSocket client lifecycle (`IWsSessionClient`, reconnect logic).
 - OWNS: React state reconstruction from `TServerMessage` events (`useWsSession`).
@@ -35,7 +35,7 @@ agent-web (browser)
   └── useWsSession(url)
         └── createWsSessionClient  ← reconnects on disconnect (max 10 attempts, 2s delay)
               │  onMessage (TServerMessage)
-              └── agent-transport-ws  ← TServerMessage / TClientMessage types only
+              └── agent-transport/ws  ← TServerMessage / TClientMessage types only
 ```
 
 On connect the client sends `{ type: "get-messages" }` to request full history replay from
@@ -112,5 +112,5 @@ a `url` prop pointing at the CLI sidecar's WebSocket endpoint.
 
 | Port (Owner)                          | Usage                                              |
 | ------------------------------------- | -------------------------------------------------- |
-| `TServerMessage` (agent-transport-ws) | Parsed from WebSocket `onmessage` events           |
-| `TClientMessage` (agent-transport-ws) | Sent to sidecar via `ws.send(JSON.stringify(msg))` |
+| `TServerMessage` (agent-transport/ws) | Parsed from WebSocket `onmessage` events           |
+| `TClientMessage` (agent-transport/ws) | Sent to sidecar via `ws.send(JSON.stringify(msg))` |


### PR DESCRIPTION
## Summary
- `agent-team/SPEC.md`: replace `@robota-sdk/agent-event-service` → `@robota-sdk/agent-core` (`bindWithOwnerPath` confirmed in source); fix `agent-sdk`/`agent-sessions` → `agent-framework`/`agent-session`
- `agent-web-ui/SPEC.md`: replace `agent-transport-ws` → `agent-transport/ws` (consolidated subpath); fix `agent-sdk`/`agent-sessions`/`agent-runtime` → `agent-framework`/`agent-session`/`agent-executor`

## Backlog
ARCH-REV-008 — all renames verified against authoritative name map in `class-interface-inventory.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)