### PR TITLE
docs(arch-rev-009): add transport and plugin contract rows to cross-cutting-contracts.md

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-009-update-cross-cutting-contracts.md
+++ b/.agents/backlog/completed/ARCH-REV-009-update-cross-cutting-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-REV-009: Update cross-cutting-contracts.md — add missing transport and plugin contract rows'
-status: todo
+status: done
 created: 2026-05-18
 priority: high
 urgency: now

--- a/.agents/specs/architecture-map/cross-cutting-contracts.md
+++ b/.agents/specs/architecture-map/cross-cutting-contracts.md
@@ -21,11 +21,16 @@ graph LR
     FS["agent-framework SPEC\nInteractiveSession · command contracts\nSDK facades"]
     SS["agent-session SPEC\nconversation lifecycle · storage port\ncompaction"]
   end
+  subgraph TypeContracts["Type Contract Packages — zero runtime deps"]
+    IT["agent-interface-transport SPEC\nITransportAdapter · IConfigurableTransport\nITransportConfig"]
+    IU["agent-interface-tui SPEC\nITuiCommandInteraction · ITuiCliAdapter\nITuiPickerItem"]
+  end
   subgraph Functional["Functional Specs"]
     CI["command-inventory.md\ncommand modules + lifecycle"]
     BT["background-task-layer.md\ntask + runner composition"]
     SP["subagent-process-manager.md\nCLI subagent process lifecycle"]
     VP["verification-pipeline-plan.md\nhooks · harness · CI · release"]
+    PL["agent-plugin SPEC\nplugin registration · event subscription\nconsumer opt-in composition"]
   end
   subgraph Server["Server & External"]
     OA["agent-server openapi.yaml\nHTTP API (OpenAPI 3.1)"]
@@ -34,19 +39,22 @@ graph LR
 
 ## Contract Owner Index
 
-| Contract area                          | Owner document                                                                                   | Notes                                                                       |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| Package inventory and dependency rules | [../../project-structure.md](../../project-structure.md)                                         | Package list and dependency direction rules.                                |
-| Capability placement                   | [capability-placement.md](capability-placement.md)                                               | Owner-first path for new product-visible behavior.                          |
-| Built-in command ownership             | [../command-inventory.md](../command-inventory.md)                                               | Command modules, lifecycle, model visibility, and host effects.             |
-| Agent invocation routing               | [../agent-invocation-router.md](../agent-invocation-router.md)                                   | Deterministic agent command descriptors and routing claim guards.           |
-| AI workflow control plane              | [../ai-workflow-control-plane.md](../ai-workflow-control-plane.md)                               | Workflow manifest, command registry, artifacts, hooks, review, and CLI UI.  |
-| Background task lifecycle              | [../background-task-layer.md](../background-task-layer.md)                                       | Generic background task composition, runners, projection, and CLI boundary. |
-| Subagent process management            | [../subagent-process-manager.md](../subagent-process-manager.md)                                 | CLI subagent process execution and parallel lifecycle.                      |
-| Verification pipeline                  | [../verification-pipeline-plan.md](../verification-pipeline-plan.md)                             | Local hooks, harness, CI, build, and release verification.                  |
-| Agent core contracts                   | [../../../packages/agent-core/docs/SPEC.md](../../../packages/agent-core/docs/SPEC.md)           | Provider, history, permission, hooks, and model catalog contracts.          |
-| Agent SDK contracts                    | [../../../packages/agent-framework/docs/SPEC.md](../../../packages/agent-framework/docs/SPEC.md) | InteractiveSession, command contracts/common APIs, and SDK facades.         |
-| Event contracts                        | [../../../packages/agent-core/docs/SPEC.md](../../../packages/agent-core/docs/SPEC.md)           | Agent lifecycle events owned by `agent-core`.                               |
-| Session contracts                      | [../../../packages/agent-session/docs/SPEC.md](../../../packages/agent-session/docs/SPEC.md)     | Conversation lifecycle, persistence, and compaction contracts.              |
-| Storage port contracts                 | [../../../packages/agent-session/docs/SPEC.md](../../../packages/agent-session/docs/SPEC.md)     | Storage port interfaces owned by `agent-session`.                           |
-| Agent server HTTP API                  | [../../../apps/agent-server/openapi.yaml](../../../apps/agent-server/openapi.yaml)               | OpenAPI 3.1 spec for all HTTP endpoints.                                    |
+| Contract area                          | Owner document                                                                                                       | Notes                                                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Package inventory and dependency rules | [../../project-structure.md](../../project-structure.md)                                                             | Package list and dependency direction rules.                                           |
+| Capability placement                   | [capability-placement.md](capability-placement.md)                                                                   | Owner-first path for new product-visible behavior.                                     |
+| Built-in command ownership             | [../command-inventory.md](../command-inventory.md)                                                                   | Command modules, lifecycle, model visibility, and host effects.                        |
+| Agent invocation routing               | [../agent-invocation-router.md](../agent-invocation-router.md)                                                       | Deterministic agent command descriptors and routing claim guards.                      |
+| AI workflow control plane              | [../ai-workflow-control-plane.md](../ai-workflow-control-plane.md)                                                   | Workflow manifest, command registry, artifacts, hooks, review, and CLI UI.             |
+| Background task lifecycle              | [../background-task-layer.md](../background-task-layer.md)                                                           | Generic background task composition, runners, projection, and CLI boundary.            |
+| Subagent process management            | [../subagent-process-manager.md](../subagent-process-manager.md)                                                     | CLI subagent process execution and parallel lifecycle.                                 |
+| Verification pipeline                  | [../verification-pipeline-plan.md](../verification-pipeline-plan.md)                                                 | Local hooks, harness, CI, build, and release verification.                             |
+| Agent core contracts                   | [../../../packages/agent-core/docs/SPEC.md](../../../packages/agent-core/docs/SPEC.md)                               | Provider, history, permission, hooks, and model catalog contracts.                     |
+| Agent SDK contracts                    | [../../../packages/agent-framework/docs/SPEC.md](../../../packages/agent-framework/docs/SPEC.md)                     | InteractiveSession, command contracts/common APIs, and SDK facades.                    |
+| Event contracts                        | [../../../packages/agent-core/docs/SPEC.md](../../../packages/agent-core/docs/SPEC.md)                               | Agent lifecycle events owned by `agent-core`.                                          |
+| Session contracts                      | [../../../packages/agent-session/docs/SPEC.md](../../../packages/agent-session/docs/SPEC.md)                         | Conversation lifecycle, persistence, and compaction contracts.                         |
+| Storage port contracts                 | [../../../packages/agent-session/docs/SPEC.md](../../../packages/agent-session/docs/SPEC.md)                         | Storage port interfaces owned by `agent-session`.                                      |
+| Agent server HTTP API                  | [../../../apps/agent-server/openapi.yaml](../../../apps/agent-server/openapi.yaml)                                   | OpenAPI 3.1 spec for all HTTP endpoints.                                               |
+| Transport protocol contracts           | [../../../packages/agent-interface-transport/docs/SPEC.md](../../../packages/agent-interface-transport/docs/SPEC.md) | `ITransportAdapter`, `IConfigurableTransport`, `ITransportConfig` — zero runtime deps. |
+| TUI interaction contracts              | [../../../packages/agent-interface-tui/docs/SPEC.md](../../../packages/agent-interface-tui/docs/SPEC.md)             | `ITuiCommandInteraction`, `ITuiCliAdapter`, `ITuiPickerItem` — zero runtime deps.      |
+| Plugin opt-in contract                 | [../../../packages/agent-plugin/docs/SPEC.md](../../../packages/agent-plugin/docs/SPEC.md)                           | Plugin registration, event subscription model, and consumer opt-in composition rule.   |


### PR DESCRIPTION
## Summary
- Add `TypeContracts` subgraph to Mermaid diagram with `agent-interface-transport` and `agent-interface-tui` nodes
- Add `agent-plugin` node to Functional subgraph
- Add 3 new rows to Contract Owner Index: transport protocol, TUI interaction, plugin opt-in

## Backlog
ARCH-REV-009 — purely additive; fills discovery gap for cross-cutting contract families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)