### PR TITLE
docs(arch-rev-013): expand agent-system.md — MCP disambiguation, sidecar, playground data-flow

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-013-expand-agent-system-mcp-sidecar-playground.md
+++ b/.agents/backlog/completed/ARCH-REV-013-expand-agent-system-mcp-sidecar-playground.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-REV-013: Expand agent-system.md — MCP disambiguation, WebSocket sidecar cross-reference, playground data-flow'
-status: todo
+status: done
 created: 2026-05-18
 priority: high
 urgency: soon

--- a/.agents/specs/architecture-map/agent-system.md
+++ b/.agents/specs/architecture-map/agent-system.md
@@ -72,6 +72,8 @@ Agent stack ownership:
 
 Provider profile identity is the settings profile key, not provider `type` or model uniqueness. See [commands-and-provider-flow.md](agent-cli/commands-and-provider-flow.md) for profile switching semantics.
 
+**MCP dual role**: `agent-tool-mcp` and `agent-transport/mcp` serve opposite MCP directions. `agent-tool-mcp` is a **client adapter** — the agent calls external MCP tool servers. `agent-transport/mcp` is a **server adapter** — external MCP clients connect to a Robota session. These two packages have no dependency on each other. See [transport-architecture.md](transport-architecture.md) for the full MCP disambiguation table.
+
 **Plugin consumer opt-in**: `agent-plugin` packages are not imported by `agent-cli` or `agent-framework` production source. Plugins are registered by consuming applications at composition time. The dashed edges above (`consumer opt-in`) reflect this: no plugin imports exist in the CLI or framework assembly paths. Application consumers pass plugin instances to the framework assembly API.
 
 ## API Boundary
@@ -91,34 +93,61 @@ See [agent-cli-composition.md](agent-cli-composition.md) and [agent-cli/](agent-
 flowchart TD
   Browser["Browser"]
   AgentWeb["apps/agent-web\nNext.js product host"]
+  AgentServer["apps/agent-server\nAI provider proxy + WebSocket"]
   ClientEntry["agent-playground/client\nbrowser-safe React entry"]
   Playground["agent-playground\nexecutor + hooks + components"]
+  Team["agent-team\nmulti-agent task delegation"]
   RemoteClient["agent-remote-client\nRemoteExecutor (API keys stay server-side)"]
   Core["agent-core / agent-tools"]
   Providers["agent-provider\nprovider adapters"]
 
   Browser --> AgentWeb
+  AgentWeb --> AgentServer
   AgentWeb --> ClientEntry
   ClientEntry --> Playground
   Playground --> RemoteClient
+  Playground --> Team
   Playground --> Core
   Playground --> Providers
   RemoteClient --> Core
+  AgentServer --> Providers
 ```
+
+Data flow: `Browser → apps/agent-web → apps/agent-server → agent-provider → AI provider`. The
+browser never holds API keys — all provider calls are proxied through `apps/agent-server`. The
+playground package itself is a lightweight client UI; session management and server-side policy
+live in `apps/agent-server`.
 
 Playground ownership:
 
 | Concern                                | Owner                     | Contract                                                                                                                                                |
 | -------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Product route and deployment host      | `apps/agent-web`          | Imports browser-safe playground entry only.                                                                                                             |
+| AI provider proxy + WebSocket host     | `apps/agent-server`       | API keys and server-side provider policy stay here; never in browser.                                                                                   |
 | Browser-safe React package entry       | `agent-playground/client` | Must not expose Node-only services.                                                                                                                     |
 | Executor, hooks, components, context   | `agent-playground`        | Internal modules under `src/lib/` and `src/components/`; see [packages/agent-playground/docs/SPEC.md](../../../packages/agent-playground/docs/SPEC.md). |
+| Multi-agent task delegation            | `agent-team`              | `agent-playground` is the sole consumer. See [agent-team.md](agent-team.md).                                                                            |
 | Secure provider execution from browser | `agent-remote-client`     | API keys stay server-side through `RemoteExecutor`.                                                                                                     |
 
 **No agent-framework session stack (intentional)**: `agent-playground` does not depend on
 `agent-framework`, `agent-session`, or `agent-executor`. Session management and all server-side
 policy run in `apps/agent-server`; the playground is a lightweight client UI only.
 See [packages/agent-playground/docs/SPEC.md](../../../packages/agent-playground/docs/SPEC.md).
+
+## WebSocket Sidecar Mode [Planned]
+
+> **[Planned — not yet implemented]** The `--web` / `--web-port` flags and `startWebSidecarServer()` do not exist in the codebase. This section documents the intended design only.
+
+When implemented, sidecar mode will span four packages:
+
+| Package              | Role                                                                        |
+| -------------------- | --------------------------------------------------------------------------- |
+| `agent-cli`          | Launch `--web` flag; host `startWebSidecarServer(interactiveSession, port)` |
+| `agent-transport/ws` | `createWsHandler({ session, send })` — real-time session event relay        |
+| `agent-web-ui`       | Browser React components; `useWsSession(url)` hook for WebSocket connection |
+| `apps/agent-web`     | Deployment host; opens monitor URL in browser                               |
+
+For the intended sequence diagram see [agent-cli/execution-modes.md](agent-cli/execution-modes.md).
 
 ## Multi-Agent Orchestration
 


### PR DESCRIPTION
## Summary
- **MCP dual role**: disambiguation note in transport section → points to `transport-architecture.md`
- **WebSocket Sidecar Mode [Planned]**: new section connecting 4 packages (`agent-cli`, `agent-transport/ws`, `agent-web-ui`, `apps/agent-web`); links to `execution-modes.md`
- **Playground stack**: add `apps/agent-server` + `agent-team` to diagram; document `browser → agent-server → AI provider` data flow; add `Playground → agent-team` edge (sole consumer confirmed via `package.json`)

## Backlog
ARCH-REV-013 — final item in the 13-item ARCH-REV series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)