### PR TITLE
fix(harness): update stale patterns + add agent-subagent-runner docs index

### DIFF
--- a/packages/agent-subagent-runner/docs/README.md
+++ b/packages/agent-subagent-runner/docs/README.md
@@ -1,0 +1,3 @@
+# Agent Subagent Runner Docs Index
+
+- `SPEC.md`: Child-process subagent runner scope, IPC protocol, and package boundaries.

--- a/scripts/harness/check-background-workspace-conformance.mjs
+++ b/scripts/harness/check-background-workspace-conformance.mjs
@@ -50,7 +50,7 @@ const REQUIRED_FILES = [
   },
   {
     file: '.agents/specs/architecture-map/agent-system.md',
-    pattern: /Background workspace\/read model\s+\|\s+`agent-sdk`\s+\+\s+`agent-runtime`/,
+    pattern: /Background workspace\/read model\s+\|\s+`agent-framework`\s+\+\s+`agent-executor`/,
     type: 'missing-architecture-map-workspace-owner',
     detail:
       'Architecture map must keep background workspace ownership in agent-framework + agent-executor.',

--- a/scripts/harness/check-capability-placement.mjs
+++ b/scripts/harness/check-capability-placement.mjs
@@ -86,6 +86,7 @@ const DOCUMENTED_WORKSPACE_PATTERNS = [
   { pathPattern: /^packages\/agent-playground$/, textPattern: /agent-playground/ },
   { pathPattern: /^packages\/agent-remote-client$/, textPattern: /agent-remote-client/ },
   { pathPattern: /^packages\/agent-team$/, textPattern: /agent-team/ },
+  { pathPattern: /^packages\/agent-subagent-runner$/, textPattern: /agent-subagent-runner/ },
   { pathPattern: /^packages\/agent-event-service$/, textPattern: /agent-event-service/ },
   { pathPattern: /^apps\/agent-web$/, textPattern: /agent-web/ },
   { pathPattern: /^apps\/agent-server$/, textPattern: /agent-server/ },


### PR DESCRIPTION
## Summary

- `check-background-workspace-conformance.mjs`: update required pattern from `agent-sdk + agent-runtime` to `agent-framework + agent-executor` to match current package names documented in `agent-system.md`
- `check-capability-placement.mjs`: add `agent-subagent-runner` to `DOCUMENTED_WORKSPACE_PATTERNS` (package added by ARCH-REV-010 but not registered in harness)
- `packages/agent-subagent-runner/docs/README.md`: create docs index required by harness docs structure validation

Part of ARCH-CONF-007 execution — verifying that ARCH-REV boundary rules are enforced by the harness.

## Test plan

- [x] `pnpm harness:scan` passes with zero findings
- [x] All 6 ARCH-CONF-007 boundary grep checks pass (no import violations found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)