### PR TITLE
fix(playground): layout fixes, dark theme, drag-and-drop tool injection

### DIFF
--- a/.agents/backlog/PLG-008-visual-agent-builder-playground.md
+++ b/.agents/backlog/PLG-008-visual-agent-builder-playground.md
@@ -1,0 +1,145 @@
+---
+title: 'PLG-008: Visual Agent Builder — agent-framework 기반 Playground 재구축'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: later
+area: apps/agent-web, packages/agent-playground
+depends_on: []
+---
+
+## Background
+
+현재 Playground는 구형 아키텍처로 구현되어 있다. Create Agent → React Flow에 agent 노드 생성
+→ 오른쪽 Tools 패널에서 tool을 에이전트 노드로 드래그 → 주입된 상태로 채팅 실행. 이 흐름은
+개념은 올바르나 구현이 agent-framework가 아닌 레거시 코드 위에 얹혀 있어 신뢰성이 낮다.
+
+목표: Playground를 **agent-framework 위에서** 다시 만들어 tools / skills를 실시간으로 조립하고,
+완성된 조합을 **복사 가능한 코드**(TypeScript snippet)로 내보낼 수 있는 Visual Agent Builder로
+발전시킨다. agent-cli 패키지가 agent-framework 위에 올라간 방식과 동일한 계층 구조를 따른다.
+
+## Goals
+
+1. **agent-framework 기반 실행 엔진**: `@robota-sdk/agents` (또는 후속 core)를 직접 사용해
+   에이전트 인스턴스를 브라우저에서 생성·실행.
+2. **Visual Assembly UI**: React Flow 캔버스에서 agent 노드 생성 후 tool/skill 노드를 연결해
+   의존성을 시각적으로 구성.
+3. **Drag-and-Drop Tool Injection**: Tools 패널 → agent 노드로 드래그 시 framework API를 통해
+   실시간으로 도구를 주입. 현재 `updateAgentToolsFromCard` 방식을 framework 공개 API로 대체.
+4. **Real-time Chat + Workflow Trace**: 채팅 입력 → agent 실행 → tool calling 이벤트가 React
+   Flow에 실시간으로 노드/엣지로 시각화.
+5. **Code Export**: 현재 캔버스 조합(provider, model, tools, system prompt)을 그대로 재현하는
+   TypeScript 코드 스니펫을 클립보드에 복사.
+
+## Non-Goals
+
+- agent 간 orchestration / multi-agent flow (별도 백로그로 분리)
+- MCP 서버 연결 UI (후속 작업)
+- 저장/불러오기 persistence (로컬스토리지 이후 단계)
+
+## Scope
+
+### Phase 1 — 실행 엔진 교체 (foundation)
+
+- `PlaygroundExecutor` / `PlaygroundAgentSession` 을 agent-framework 공개 API로 교체
+- BYOK 모드 유지 (브라우저에서 직접 provider key 입력)
+- `useRobotaExecution` 훅의 내부 구현만 교체, 외부 인터페이스는 유지하여 UI 레이어 변경 최소화
+
+### Phase 2 — React Flow 캔버스 재설계
+
+- 캔버스에 **agent 노드** 타입 추가 (provider, model, system prompt 표시)
+- **tool 노드** 타입 추가 (tool name, description, parameter summary)
+- agent 노드 ↔ tool 노드를 엣지로 연결하면 tool이 에이전트에 주입
+- tool 노드는 Tools 패널에서 드래그하거나 캔버스에서 직접 추가 가능
+- 대화 이벤트 (user message, assistant response, tool call, tool result)는 별도 "Execution
+  Timeline" 영역에 표시하여 조립 캔버스와 분리
+
+### Phase 3 — Code Export
+
+- 캔버스 상태를 직렬화하여 TypeScript 코드 스니펫 생성
+- 생성 코드는 `@robota-sdk/agents` import 기준으로 실행 가능한 최소 코드
+- "Copy Code" 버튼으로 클립보드에 복사
+- 코드 미리보기 패널 (syntax highlight)
+
+### Phase 4 — Skills 지원
+
+- Skills 패널 추가 (현재 tools 패널과 동급)
+- skill 노드를 agent 노드에 연결하면 agent에 skill context 주입
+- Code Export에 skill 조합 반영
+
+## Architecture
+
+```
+apps/agent-web
+└── /playground
+    ├── AssemblyCanvas (React Flow)
+    │   ├── AgentNode         — provider, model, system prompt 편집
+    │   ├── ToolNode          — 연결된 tool 표시
+    │   └── ExecutionEdge     — tool call 이벤트 애니메이션
+    ├── SidePanel
+    │   ├── ToolsCatalog      — draggable tool cards
+    │   └── SkillsCatalog     — draggable skill cards (Phase 4)
+    ├── ChatPanel             — 에이전트 실행 입력/출력
+    └── CodeExportPanel       — 생성된 TypeScript 코드 미리보기
+
+packages/agent-playground
+└── 실행 엔진을 agent-framework API로 교체
+    ├── framework-executor.ts  — 교체된 실행 엔진
+    └── code-generator.ts      — 캔버스 → TypeScript 코드 생성
+```
+
+## Test Plan
+
+- `packages/agent-playground`: 단위 테스트
+  - framework-executor: agent 생성 → tool 주입 → run 실행 흐름
+  - code-generator: 캔버스 상태 → 올바른 TypeScript 스니펫 생성
+- `apps/agent-web`: E2E (Playwright)
+  - 에이전트 생성 → tool 드래그 → 채팅 → tool call 이벤트 확인
+  - Code Export 버튼 → 클립보드 내용 검증
+- build 검증: `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Tool Drag-and-Drop + Chat
+
+**Prerequisites**: `pnpm dev` (agent-web), `pnpm start` (agent-server), OpenAI API key 설정
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. "Create Agent" → Provider: OpenAI, Model: gpt-4o-mini → Create
+3. React Flow 캔버스에 agent 노드가 생성됨을 확인
+4. 오른쪽 Tools 패널에서 "Current Time" 카드를 agent 노드 위로 드래그
+5. agent 노드에 "Current Time" 연결 표시 확인
+6. 채팅 입력: "What is the current time in Seoul?"
+7. AI가 `getCurrentTime` tool을 호출하고 결과를 반환하는지 확인
+8. React Flow에 tool_call → tool_result 노드가 시각화되는지 확인
+
+**Expected observable result**:
+
+- agent 노드가 tool 연결 상태를 표시
+- 채팅 응답이 실제 현재 시각 (KST) 포함
+- Workflow에 User → tool_call(getCurrentTime) → tool_result → Assistant 노드 체인 표시
+
+**Evidence**: `<스크린샷 또는 실행 로그 — 구현 후 기입>`
+
+### Scenario 2: Code Export
+
+**Prerequisites**: Scenario 1 완료 상태
+
+**Steps**:
+
+1. "Copy Code" 버튼 클릭 (또는 Code Export 패널 열기)
+2. 생성된 TypeScript 코드를 확인
+
+**Expected observable result**:
+
+```typescript
+import { Robota } from '@robota-sdk/agents';
+// provider, tool 설정이 포함된 실행 가능한 코드
+```
+
+- 코드가 클립보드에 복사되고 미리보기 패널에 표시됨
+- 코드를 별도 파일에 붙여넣어 `ts-node` 실행 시 동작
+
+**Evidence**: `<코드 스니펫 캡처 — 구현 후 기입>`

--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -46,6 +46,7 @@ export function createApp(): express.Application {
     cors({
       origin: process.env.CORS_ORIGINS?.split(',') || [
         'http://localhost:3000',
+        'http://localhost:7071',
         'https://robota.io',
       ],
       credentials: true,

--- a/apps/agent-web/next.config.ts
+++ b/apps/agent-web/next.config.ts
@@ -87,6 +87,15 @@ const nextConfig: NextConfig = {
         tls: false,
         worker_threads: false,
       };
+      // node: protocol modules are not polyfillable in the browser — alias to false (empty module)
+      config.resolve.alias = {
+        ...(config.resolve.alias ?? {}),
+        'node:child_process': false,
+        'node:fs': false,
+        'node:net': false,
+        'node:tls': false,
+        'node:worker_threads': false,
+      };
       // agent-core compiles `import { randomUUID } from 'node:crypto'` to
       // `import { randomUUID } from 'crypto'` in its browser dist.
       // Next.js/webpack has no polyfill for crypto.randomUUID, so we swap
@@ -97,6 +106,10 @@ const nextConfig: NextConfig = {
         new NormalModuleReplacementPlugin(
           /^(node:)?crypto$/,
           require('path').resolve(__dirname, 'src/lib/crypto-browser.js'),
+        ),
+        new NormalModuleReplacementPlugin(
+          /^(node:)?child_process$/,
+          require('path').resolve(__dirname, 'src/lib/child-process-browser.js'),
         ),
       ];
     }

--- a/apps/agent-web/src/lib/child-process-browser.js
+++ b/apps/agent-web/src/lib/child-process-browser.js
@@ -1,0 +1,17 @@
+// Browser stub for node:child_process — shell commands cannot run in a browser context
+export function spawn() {
+  throw new Error('spawn is not available in browser context');
+}
+export function exec() {
+  throw new Error('exec is not available in browser context');
+}
+export function execSync() {
+  throw new Error('execSync is not available in browser context');
+}
+export function spawnSync() {
+  throw new Error('spawnSync is not available in browser context');
+}
+export function fork() {
+  throw new Error('fork is not available in browser context');
+}
+export default { spawn, exec, execSync, spawnSync, fork };

--- a/packages/agent-playground/src/components/playground/chat-interface/chat-interface.tsx
+++ b/packages/agent-playground/src/components/playground/chat-interface/chat-interface.tsx
@@ -11,7 +11,7 @@ export function ChatInterface(props: IChatPanelProps) {
   const chat = useChatInterfaceState(props);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col overflow-hidden">
       <ChatHeader
         isAgentReady={isAgentReady}
         hasMessages={chat.messages.length > 0}

--- a/packages/agent-playground/src/components/playground/chat-interface/messages-area.tsx
+++ b/packages/agent-playground/src/components/playground/chat-interface/messages-area.tsx
@@ -24,7 +24,7 @@ export function MessagesArea({
   onSelectStarterPrompt,
 }: IMessagesAreaProps) {
   return (
-    <ScrollArea className="flex-1 p-4">
+    <ScrollArea className="flex-1 min-h-0 p-4">
       <div className="space-y-4">
         {messages.length === 0 ? (
           <EmptyChatState

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
@@ -8,25 +8,34 @@ import type { IFlowNodeData } from './events-to-flow';
 
 const CONTENT_PREVIEW_LENGTH = 80;
 
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/`(.+?)`/g, '$1')
+    .replace(/#{1,6}\s/g, '');
+}
+
 function preview(content: string): string {
-  if (content.length <= CONTENT_PREVIEW_LENGTH) return content;
-  return content.slice(0, CONTENT_PREVIEW_LENGTH) + '…';
+  const stripped = stripMarkdown(content);
+  if (stripped.length <= CONTENT_PREVIEW_LENGTH) return stripped;
+  return stripped.slice(0, CONTENT_PREVIEW_LENGTH) + '…';
 }
 
 function NodeShell({
-  borderColor,
+  accentColor,
   children,
   hasTarget = true,
   hasSource = true,
 }: {
-  borderColor: string;
+  accentColor: string;
   children: React.ReactNode;
   hasTarget?: boolean;
   hasSource?: boolean;
 }) {
   return (
     <div
-      className={`w-52 rounded-lg border-2 ${borderColor} bg-card text-card-foreground shadow-sm p-2.5 text-sm`}
+      className={`w-52 rounded-lg border border-border/50 ${accentColor} bg-card text-card-foreground shadow-md p-2.5 text-sm`}
     >
       {hasTarget && <Handle type="target" position={Position.Top} />}
       {children}
@@ -38,10 +47,10 @@ function NodeShell({
 export function UserMessageNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell borderColor="border-blue-500" hasTarget={false}>
+    <NodeShell accentColor="border-l-4 border-l-blue-500" hasTarget={false}>
       <div className="flex items-center gap-1.5 mb-1">
-        <MessageSquare className="h-3 w-3 text-blue-500 shrink-0" />
-        <span className="font-medium text-xs">User</span>
+        <MessageSquare className="h-3 w-3 text-blue-400 shrink-0" />
+        <span className="font-semibold text-xs text-foreground">User</span>
       </div>
       <p className="text-xs text-muted-foreground leading-relaxed">{preview(d.content)}</p>
     </NodeShell>
@@ -51,10 +60,10 @@ export function UserMessageNode({ data }: NodeProps) {
 export function AssistantResponseNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell borderColor="border-green-500">
+    <NodeShell accentColor="border-l-4 border-l-emerald-500">
       <div className="flex items-center gap-1.5 mb-1">
-        <Bot className="h-3 w-3 text-green-500 shrink-0" />
-        <span className="font-medium text-xs">Assistant</span>
+        <Bot className="h-3 w-3 text-emerald-400 shrink-0" />
+        <span className="font-semibold text-xs text-foreground">Assistant</span>
       </div>
       <p className="text-xs text-muted-foreground leading-relaxed">{preview(d.content)}</p>
     </NodeShell>
@@ -64,10 +73,10 @@ export function AssistantResponseNode({ data }: NodeProps) {
 export function ToolCallNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell borderColor="border-purple-500">
+    <NodeShell accentColor="border-l-4 border-l-purple-500">
       <div className="flex items-center gap-1.5">
-        <Wrench className="h-3 w-3 text-purple-500 shrink-0" />
-        <span className="font-medium text-xs">{d.toolName || 'Tool call'}</span>
+        <Wrench className="h-3 w-3 text-purple-400 shrink-0" />
+        <span className="font-semibold text-xs text-foreground">{d.toolName || 'Tool call'}</span>
       </div>
     </NodeShell>
   );
@@ -76,10 +85,10 @@ export function ToolCallNode({ data }: NodeProps) {
 export function ToolResultNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell borderColor="border-orange-500">
+    <NodeShell accentColor="border-l-4 border-l-amber-500">
       <div className="flex items-center gap-1.5">
-        <CheckCircle className="h-3 w-3 text-orange-500 shrink-0" />
-        <span className="font-medium text-xs">{d.toolName || 'Tool result'}</span>
+        <CheckCircle className="h-3 w-3 text-amber-400 shrink-0" />
+        <span className="font-semibold text-xs text-foreground">{d.toolName || 'Tool result'}</span>
       </div>
       {d.content && (
         <p className="text-xs text-muted-foreground mt-1 leading-relaxed">{preview(d.content)}</p>
@@ -91,10 +100,10 @@ export function ToolResultNode({ data }: NodeProps) {
 export function ToolErrorNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell borderColor="border-red-500">
+    <NodeShell accentColor="border-l-4 border-l-red-500">
       <div className="flex items-center gap-1.5">
-        <XCircle className="h-3 w-3 text-red-500 shrink-0" />
-        <span className="font-medium text-xs">{d.toolName || 'Tool error'}</span>
+        <XCircle className="h-3 w-3 text-red-400 shrink-0" />
+        <span className="font-semibold text-xs text-foreground">{d.toolName || 'Tool error'}</span>
       </div>
       {d.content && (
         <p className="text-xs text-muted-foreground mt-1 leading-relaxed">{preview(d.content)}</p>

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ReactFlow,
   Controls,
@@ -9,12 +9,12 @@ import {
   useNodesState,
   useEdgesState,
   ReactFlowProvider,
-  MiniMap,
   type Node,
   type Edge,
 } from '@xyflow/react';
-import { GitBranch } from 'lucide-react';
+import { GitBranch, Wrench } from 'lucide-react';
 import type { IConversationEvent } from '../../../lib/playground/robota-executor';
+import type { IPlaygroundToolMeta } from '../../../tools/catalog';
 import { eventsToFlow } from './events-to-flow';
 import {
   UserMessageNode,
@@ -35,11 +35,18 @@ const nodeTypes = {
 interface IWorkflowVisualizationProps {
   events: IConversationEvent[];
   className?: string;
+  activeTools?: IPlaygroundToolMeta[];
+  onDropTool?: (tool: IPlaygroundToolMeta) => void;
 }
 
-function WorkflowVisualizationContent({ events }: IWorkflowVisualizationProps) {
+function WorkflowVisualizationContent({
+  events,
+  activeTools,
+  onDropTool,
+}: IWorkflowVisualizationProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const flowData = useMemo(() => eventsToFlow(events), [events]);
 
@@ -48,41 +55,113 @@ function WorkflowVisualizationContent({ events }: IWorkflowVisualizationProps) {
     setEdges(flowData.edges);
   }, [flowData, setNodes, setEdges]);
 
-  if (events.length === 0) {
-    return (
-      <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-muted-foreground">
-        <GitBranch className="h-10 w-10 opacity-30" />
-        <p className="text-sm">대화를 시작하면 실행 흐름이 여기에 표시됩니다</p>
-      </div>
-    );
-  }
+  const handleDragOver = (e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('application/robota-tool')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setIsDragOver(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragOver(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const raw = e.dataTransfer.getData('application/robota-tool');
+    if (!raw || !onDropTool) return;
+    const tool = JSON.parse(raw) as IPlaygroundToolMeta;
+    onDropTool(tool);
+  };
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      nodeTypes={nodeTypes}
-      fitView
-      fitViewOptions={{ padding: 0.2 }}
-      minZoom={0.3}
-      maxZoom={2}
-      attributionPosition="bottom-left"
-      colorMode="dark"
+    <div
+      className={`w-full h-full flex flex-col relative transition-colors ${isDragOver ? 'bg-primary/5 ring-2 ring-inset ring-primary/40' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     >
-      <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
-      <Controls />
-      <MiniMap nodeStrokeWidth={3} zoomable pannable />
-    </ReactFlow>
+      {activeTools && activeTools.length > 0 && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-card/60 flex-wrap shrink-0">
+          <Wrench className="h-3 w-3 text-muted-foreground shrink-0" />
+          {activeTools.map((t) => (
+            <span
+              key={t.id}
+              className="inline-flex items-center gap-1 text-xs bg-primary/15 text-primary px-2 py-0.5 rounded-full"
+            >
+              {t.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {isDragOver && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+          <div className="bg-primary/10 border-2 border-dashed border-primary/60 rounded-xl px-8 py-4 text-primary text-sm font-medium">
+            Drop to add tool to agent
+          </div>
+        </div>
+      )}
+
+      {events.length === 0 && !isDragOver ? (
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+          <GitBranch className="h-10 w-10 opacity-30" />
+          <p className="text-sm">대화를 시작하면 실행 흐름이 여기에 표시됩니다</p>
+          {onDropTool && (
+            <p className="text-xs opacity-60">툴을 여기에 드래그하여 에이전트에 추가하세요</p>
+          )}
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            nodeTypes={nodeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+            minZoom={0.3}
+            maxZoom={2}
+            attributionPosition="bottom-left"
+            colorMode="dark"
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={false}
+            style={
+              {
+                '--xy-node-border-default': 'none',
+                '--xy-node-selected-border': 'none',
+              } as React.CSSProperties
+            }
+          >
+            <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+            <Controls />
+          </ReactFlow>
+        </div>
+      )}
+    </div>
   );
 }
 
-export function WorkflowVisualization({ events, className }: IWorkflowVisualizationProps) {
+export function WorkflowVisualization({
+  events,
+  className,
+  activeTools,
+  onDropTool,
+}: IWorkflowVisualizationProps) {
   return (
     <div className={`w-full h-full ${className ?? ''}`}>
       <ReactFlowProvider>
-        <WorkflowVisualizationContent events={events} />
+        <WorkflowVisualizationContent
+          events={events}
+          activeTools={activeTools}
+          onDropTool={onDropTool}
+        />
       </ReactFlowProvider>
     </div>
   );

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
@@ -64,7 +64,7 @@ function WorkflowVisualizationContent({
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+    if (!e.currentTarget.contains(e.relatedTarget as HTMLElement | null)) {
       setIsDragOver(false);
     }
   };

--- a/packages/agent-playground/src/components/ui/modal.tsx
+++ b/packages/agent-playground/src/components/ui/modal.tsx
@@ -69,14 +69,14 @@ export function Modal({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-gray-900/20 transition-opacity duration-300"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-300"
         onClick={onClose}
       />
 
       {/* Modal Content */}
       <div
         className={`
-                    relative bg-white rounded-lg shadow-xl 
+                    relative bg-card border border-border rounded-lg shadow-xl
                     transition-all duration-300 transform
                     w-full mx-4 my-8 max-h-[90vh] overflow-hidden
                     ${sizeClasses[size]}
@@ -86,13 +86,13 @@ export function Modal({
       >
         {/* Header */}
         {title && (
-          <div className="flex items-center justify-between p-6 border-b border-gray-200">
-            <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+          <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+            <h2 className="text-base font-semibold text-card-foreground">{title}</h2>
             <button
               onClick={onClose}
-              className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+              className="p-1.5 hover:bg-accent rounded-md transition-colors"
             >
-              <X className="h-5 w-5 text-gray-500" />
+              <X className="h-4 w-4 text-muted-foreground" />
             </button>
           </div>
         )}
@@ -101,9 +101,9 @@ export function Modal({
         {!title && (
           <button
             onClick={onClose}
-            className="absolute top-4 right-4 p-2 hover:bg-gray-100 rounded-full transition-colors z-10"
+            className="absolute top-4 right-4 p-1.5 hover:bg-accent rounded-md transition-colors z-10"
           >
-            <X className="h-5 w-5 text-gray-500" />
+            <X className="h-4 w-4 text-muted-foreground" />
           </button>
         )}
 

--- a/packages/agent-playground/src/contexts/playground-context/types.ts
+++ b/packages/agent-playground/src/contexts/playground-context/types.ts
@@ -24,6 +24,10 @@ export interface IPlaygroundActionsValue {
   setExecuting: (isExecuting: boolean) => void;
   setToolItems: (tools: IPlaygroundToolMeta[]) => void;
   addToolToAgentOverlay: (agentId: string, toolId: string) => void;
+  injectToolIntoAgent: (
+    agentId: string,
+    card: { id: string; name: string; description?: string },
+  ) => Promise<void>;
   getVisualizationData: () => IVisualizationData | null;
   getConnectionStatus: () => { connected: boolean; url: string };
 }

--- a/packages/agent-playground/src/contexts/playground-context/use-common-actions.ts
+++ b/packages/agent-playground/src/contexts/playground-context/use-common-actions.ts
@@ -57,10 +57,20 @@ function useHistoryAuthActions(
     }
   }, [logger, refs.executorRef]);
 
+  const injectToolIntoAgent = useCallback(
+    async (agentId: string, card: { id: string; name: string; description?: string }) => {
+      if (!refs.executorRef.current) throw new Error('No executor available');
+      await refs.executorRef.current.updateAgentToolsFromCard(agentId, card);
+      dispatch({ type: 'ADD_TOOL_TO_AGENT_OVERLAY', payload: { agentId, toolId: card.id } });
+    },
+    [dispatch, refs.executorRef],
+  );
+
   return {
     clearHistory,
     setAuth,
     disposeExecutor,
+    injectToolIntoAgent,
   };
 }
 

--- a/packages/agent-playground/src/contexts/playground-context/use-create-agent-action.ts
+++ b/packages/agent-playground/src/contexts/playground-context/use-create-agent-action.ts
@@ -16,6 +16,7 @@ export function useCreateAgentAction(
         dispatch({ type: 'SET_LOADING', payload: true });
         await refs.executorRef.current.createAgent(config);
         dispatch({ type: 'ADD_AGENT_CONFIG', payload: config });
+        dispatch({ type: 'CLEAR_AGENT_TOOL_OVERLAY', payload: config.id ?? config.name });
         dispatch({ type: 'SET_LOADING', payload: false });
       } catch (error) {
         dispatch({

--- a/packages/agent-playground/src/contexts/playground-reducer.ts
+++ b/packages/agent-playground/src/contexts/playground-reducer.ts
@@ -68,7 +68,8 @@ export type TPlaygroundReducerAction =
   | { type: 'CLEAR_CONVERSATION_HISTORY' }
   | { type: 'SET_EXECUTION_RESULT'; payload: IPlaygroundExecutorResult }
   | { type: 'SET_TOOL_ITEMS'; payload: IPlaygroundToolMeta[] }
-  | { type: 'ADD_TOOL_TO_AGENT_OVERLAY'; payload: { agentId: string; toolId: string } };
+  | { type: 'ADD_TOOL_TO_AGENT_OVERLAY'; payload: { agentId: string; toolId: string } }
+  | { type: 'CLEAR_AGENT_TOOL_OVERLAY'; payload: string };
 
 // ===== Initial State =====
 
@@ -188,6 +189,11 @@ export function playgroundReducer(
         ...state,
         addedToolsByAgent: { ...state.addedToolsByAgent, [agentId]: [...prev, toolId] },
       };
+    }
+    case 'CLEAR_AGENT_TOOL_OVERLAY': {
+      const next = { ...state.addedToolsByAgent };
+      delete next[action.payload];
+      return { ...state, addedToolsByAgent: next };
     }
     default:
       return state;

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -13,7 +13,6 @@ import {
 import { useRobotaExecution } from '../../hooks/use-robota-execution';
 import { useModal } from '../../hooks/use-modal';
 import { Button } from '../../components/ui/button';
-import { Badge } from '../../components/ui/badge';
 import { Bot, Trash2, Wrench, Wifi, WifiOff, Loader2 } from 'lucide-react';
 import type { IPlaygroundAgentConfig } from '../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../tools/catalog';
@@ -67,7 +66,7 @@ function ConnectionScreen({
 }: TConnectionScreenProps): React.ReactElement {
   const isConnecting = status === 'connecting';
   return (
-    <div className="w-full h-full min-h-[60vh] flex items-center justify-center bg-background">
+    <div className="w-full h-full flex items-center justify-center bg-background">
       <div className="flex flex-col items-center gap-6 max-w-sm text-center px-6">
         {isConnecting ? (
           <div className="relative flex items-center justify-center w-16 h-16">
@@ -248,8 +247,8 @@ function PlaygroundContent(): React.ReactElement {
   const isAgentReady = isByokMode || canExecute;
 
   return (
-    <div className="w-full h-full min-h-[60vh] flex flex-col bg-background">
-      <header className="px-4 py-2 border-b border-border flex items-center justify-between">
+    <div className="w-full h-full flex flex-col bg-background">
+      <header className="px-4 py-2 border-b border-border flex items-center justify-between shrink-0">
         <div>
           <h1 className="text-lg font-semibold text-foreground">Playground</h1>
           <p className="text-sm text-muted-foreground">
@@ -278,10 +277,15 @@ function PlaygroundContent(): React.ReactElement {
               Disconnect
             </Button>
           ) : (
-            <Badge variant={state.isWebSocketConnected ? 'default' : 'secondary'} className="gap-1">
+            <Button
+              size="sm"
+              variant={state.isWebSocketConnected ? 'default' : 'secondary'}
+              className="gap-1 pointer-events-none"
+              tabIndex={-1}
+            >
               <Wifi className="h-3 w-3" />
               {state.isWebSocketConnected ? 'Connected' : 'Disconnected'}
-            </Badge>
+            </Button>
           )}
         </div>
       </header>

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -167,6 +167,7 @@ function PlaygroundContent(): React.ReactElement {
   const state = usePlaygroundState();
   const { setToolItems } = usePlaygroundActions();
   const { createAgent, getDefaultAgentConfig, executePrompt, canExecute } = useRobotaExecution();
+  const { injectToolIntoAgent } = usePlaygroundActions();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
   const { toast } = useToast();
@@ -235,6 +236,37 @@ function PlaygroundContent(): React.ReactElement {
   const handleDisconnectByok = () => {
     byokHistoryRef.current = [];
     clearConfig();
+  };
+
+  const currentAgentId = state.currentAgentConfig
+    ? state.currentAgentConfig.id || state.currentAgentConfig.name
+    : null;
+
+  const agentActiveToolIds = currentAgentId ? (state.addedToolsByAgent[currentAgentId] ?? []) : [];
+  const activeTools = useMemo(
+    () => toolItems.filter((t) => agentActiveToolIds.includes(t.id)),
+    [toolItems, agentActiveToolIds],
+  );
+
+  const handleDropTool = async (tool: IPlaygroundToolMeta) => {
+    if (!currentAgentId) {
+      toast({ title: 'Create an agent first', variant: 'destructive' });
+      return;
+    }
+    if (agentActiveToolIds.includes(tool.id)) {
+      toast({ title: `${tool.name} already added`, variant: 'default' });
+      return;
+    }
+    if (tool.type !== 'builtin') {
+      toast({ title: 'Custom tools cannot be injected yet', variant: 'destructive' });
+      return;
+    }
+    await injectToolIntoAgent(currentAgentId, {
+      id: tool.id,
+      name: tool.name,
+      description: tool.description,
+    });
+    toast({ title: `${tool.name} added to agent` });
   };
 
   if (!state.isInitialized && !providerConfig) {
@@ -307,7 +339,11 @@ function PlaygroundContent(): React.ReactElement {
             </span>
           </div>
           <div className="flex-1 overflow-hidden">
-            <WorkflowVisualization events={state.conversationHistory} />
+            <WorkflowVisualization
+              events={state.conversationHistory}
+              activeTools={activeTools}
+              onDropTool={handleDropTool}
+            />
           </div>
         </div>
 

--- a/packages/agent-playground/src/playground/components/ProviderSetupScreen.tsx
+++ b/packages/agent-playground/src/playground/components/ProviderSetupScreen.tsx
@@ -60,7 +60,7 @@ export function ProviderSetupScreen({ onConnect }: TProviderSetupScreenProps): R
   };
 
   return (
-    <div className="w-full h-full min-h-[60vh] flex items-center justify-center bg-background">
+    <div className="w-full h-full flex items-center justify-center bg-background">
       <div className="flex flex-col gap-4 max-w-sm w-full px-6">
         <div className="flex items-center gap-2 mb-2">
           <Key className="w-5 h-5 text-primary" />

--- a/packages/agent-playground/src/tools/current-time/index.ts
+++ b/packages/agent-playground/src/tools/current-time/index.ts
@@ -5,6 +5,7 @@ import type { IPlaygroundToolMeta } from '../types';
 export const CURRENT_TIME_META: IPlaygroundToolMeta = {
   id: 'current-time',
   name: 'Current Time',
+  type: 'builtin',
   description: 'Get current date and time information with timezone support',
   category: 'utility',
   tags: ['time', 'date', 'timezone', 'utility'],


### PR DESCRIPTION
## Summary

- **Layout fixes**: ChatInterface overflow, ScrollArea min-h-0, flex containers properly constrained
- **Dark theme**: Modal, buttons, badges all use CSS variable-based colors
- **React Flow double border fix**: NodeShell redesigned with left-accent bar (`border-l-4`) instead of full border
- **Drag-and-drop tool injection**: Drag tools from sidebar onto Workflow area to inject into agent; active tools shown as badges
- **Markdown stripping**: Workflow node previews strip raw markdown formatting
- **PLG-008 backlog**: Visual Agent Builder — agent-framework 기반 Playground 재구축

## Test plan

- [ ] Navigate to `/playground` — layout renders correctly (no overflow, no broken flex)
- [ ] Create Agent modal opens with dark theme styling
- [ ] Drag "Current Time" tool onto Workflow area → badge appears at top, toast confirms injection
- [ ] Chat "What time is it?" → agent responds (requires server API key)
- [ ] Workflow nodes show clean single left-accent border (no double border)
- [ ] `pnpm typecheck && pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)