### PR TITLE
docs(backlog): add PLG-009~018 backlog items + PLG-008 epic restructure

### DIFF
--- a/.agents/backlog/PLG-008-visual-agent-builder-playground.md
+++ b/.agents/backlog/PLG-008-visual-agent-builder-playground.md
@@ -1,145 +1,90 @@
 ---
-title: 'PLG-008: Visual Agent Builder — agent-framework 기반 Playground 재구축'
+title: 'PLG-008: Visual Agent Code Generator — @robota-sdk/agent-framework 기반 에이전트 앱 조립 도구 (Epic)'
 status: todo
 created: 2026-05-19
 priority: high
 urgency: later
-area: apps/agent-web, packages/agent-playground
+area: apps/agent-web, apps/agent-server, packages/agent-playground
 depends_on: []
 ---
 
 ## Background
 
-현재 Playground는 구형 아키텍처로 구현되어 있다. Create Agent → React Flow에 agent 노드 생성
-→ 오른쪽 Tools 패널에서 tool을 에이전트 노드로 드래그 → 주입된 상태로 채팅 실행. 이 흐름은
-개념은 올바르나 구현이 agent-framework가 아닌 레거시 코드 위에 얹혀 있어 신뢰성이 낮다.
+현재 Playground는 agent 노드 생성 → tool 드래그 → 채팅 실행 흐름을 가지고 있으나,
+레거시 아키텍처 위에 얹혀 있어 신뢰성이 낮다.
 
-목표: Playground를 **agent-framework 위에서** 다시 만들어 tools / skills를 실시간으로 조립하고,
-완성된 조합을 **복사 가능한 코드**(TypeScript snippet)로 내보낼 수 있는 Visual Agent Builder로
-발전시킨다. agent-cli 패키지가 agent-framework 위에 올라간 방식과 동일한 계층 구조를 따른다.
+**핵심 목표**: 새로운 agent 애플리케이션을 만들 때 쓸 수 있는 **코드 생성 도구**다.
+사용자가 Visual UI에서 provider, model, tools, skills를 조립하면, 그 조합을 그대로 재현하는
+**TypeScript 코드 스니펫**이 생성된다. 이 코드를 새 프로젝트에 붙여넣으면 즉시 동작하는
+`@robota-sdk/agent-framework` 기반 에이전트 애플리케이션의 기반이 된다.
 
-## Goals
+**비유**: shadcn/ui CLI가 컴포넌트 코드를 생성해주는 것처럼, 이 도구는 agent application
+bootstrap 코드를 생성해준다.
 
-1. **agent-framework 기반 실행 엔진**: `@robota-sdk/agents` (또는 후속 core)를 직접 사용해
-   에이전트 인스턴스를 브라우저에서 생성·실행.
-2. **Visual Assembly UI**: React Flow 캔버스에서 agent 노드 생성 후 tool/skill 노드를 연결해
-   의존성을 시각적으로 구성.
-3. **Drag-and-Drop Tool Injection**: Tools 패널 → agent 노드로 드래그 시 framework API를 통해
-   실시간으로 도구를 주입. 현재 `updateAgentToolsFromCard` 방식을 framework 공개 API로 대체.
-4. **Real-time Chat + Workflow Trace**: 채팅 입력 → agent 실행 → tool calling 이벤트가 React
-   Flow에 실시간으로 노드/엣지로 시각화.
-5. **Code Export**: 현재 캔버스 조합(provider, model, tools, system prompt)을 그대로 재현하는
-   TypeScript 코드 스니펫을 클립보드에 복사.
+## 하위 백로그 항목
+
+이 항목은 Epic이다. 실제 구현은 다음 하위 항목들에서 진행된다.
+
+### Backend Foundation (선행 작업)
+
+| ID                                               | 제목                                                                       | 우선순위 |
+| ------------------------------------------------ | -------------------------------------------------------------------------- | -------- |
+| [PLG-018](PLG-018-playground-router-module.md)   | Playground Router Module — /api/playground/\* 전용 라우터 + BYOK sanitizer | medium   |
+| [PLG-016](PLG-016-provider-model-catalog-api.md) | Provider & Model Catalog API                                               | medium   |
+| [PLG-017](PLG-017-tool-registry-api.md)          | Tool Registry API + 서버사이드 tool 등록                                   | medium   |
+| [PLG-015](PLG-015-playground-execution-api.md)   | Playground Execution API — SSE 스트리밍 에이전트 실행                      | high     |
+
+### Frontend Migration & Redesign
+
+| ID                                                  | 제목                                                         | 우선순위 |
+| --------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| [PLG-009](PLG-009-framework-executor-client.md)     | Framework Executor Client — PlaygroundExecutor SSE 기반 교체 | high     |
+| [PLG-010](PLG-010-assembly-canvas-redesign.md)      | Assembly Canvas 재설계 — AgentNode + ToolNode + 엣지 연결    | high     |
+| [PLG-011](PLG-011-execution-timeline-separation.md) | Execution Timeline 분리                                      | medium   |
+| [PLG-012](PLG-012-code-generator-engine.md)         | Code Generator 엔진 — 캔버스 상태 → TypeScript 코드          | high     |
+| [PLG-013](PLG-013-code-export-ui.md)                | Code Export UI — 미리보기 + syntax highlight + Copy 버튼     | high     |
+| [PLG-014](PLG-014-skills-support.md)                | Skills Support — Skills 패널 + skill 노드 + Code Export 반영 | medium   |
+
+## 의존 그래프
+
+```
+PLG-018 ──┐
+PLG-016   ├──→ PLG-015 ──→ PLG-009 ──→ PLG-010 ──→ PLG-011
+PLG-017 ──┘                                     └──→ PLG-012 ──→ PLG-013 ──→ PLG-014
+```
+
+## 생성 코드 목표 산출물 (Phase 3)
+
+```typescript
+import { InteractiveSession } from '@robota-sdk/agent-framework';
+import { getCurrentTimeTool } from '@robota-sdk/agent-tools/current-time';
+
+const session = new InteractiveSession({
+  provider: {
+    name: 'openai',
+    model: 'gpt-4o-mini',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  tools: [getCurrentTimeTool],
+  systemPrompt: 'You are a helpful assistant.',
+});
+
+const response = await session.run('What time is it in Seoul?');
+console.log(response);
+```
 
 ## Non-Goals
 
-- agent 간 orchestration / multi-agent flow (별도 백로그로 분리)
+- agent 간 orchestration / multi-agent flow (별도 백로그)
 - MCP 서버 연결 UI (후속 작업)
 - 저장/불러오기 persistence (로컬스토리지 이후 단계)
-
-## Scope
-
-### Phase 1 — 실행 엔진 교체 (foundation)
-
-- `PlaygroundExecutor` / `PlaygroundAgentSession` 을 agent-framework 공개 API로 교체
-- BYOK 모드 유지 (브라우저에서 직접 provider key 입력)
-- `useRobotaExecution` 훅의 내부 구현만 교체, 외부 인터페이스는 유지하여 UI 레이어 변경 최소화
-
-### Phase 2 — React Flow 캔버스 재설계
-
-- 캔버스에 **agent 노드** 타입 추가 (provider, model, system prompt 표시)
-- **tool 노드** 타입 추가 (tool name, description, parameter summary)
-- agent 노드 ↔ tool 노드를 엣지로 연결하면 tool이 에이전트에 주입
-- tool 노드는 Tools 패널에서 드래그하거나 캔버스에서 직접 추가 가능
-- 대화 이벤트 (user message, assistant response, tool call, tool result)는 별도 "Execution
-  Timeline" 영역에 표시하여 조립 캔버스와 분리
-
-### Phase 3 — Code Export
-
-- 캔버스 상태를 직렬화하여 TypeScript 코드 스니펫 생성
-- 생성 코드는 `@robota-sdk/agents` import 기준으로 실행 가능한 최소 코드
-- "Copy Code" 버튼으로 클립보드에 복사
-- 코드 미리보기 패널 (syntax highlight)
-
-### Phase 4 — Skills 지원
-
-- Skills 패널 추가 (현재 tools 패널과 동급)
-- skill 노드를 agent 노드에 연결하면 agent에 skill context 주입
-- Code Export에 skill 조합 반영
-
-## Architecture
-
-```
-apps/agent-web
-└── /playground
-    ├── AssemblyCanvas (React Flow)
-    │   ├── AgentNode         — provider, model, system prompt 편집
-    │   ├── ToolNode          — 연결된 tool 표시
-    │   └── ExecutionEdge     — tool call 이벤트 애니메이션
-    ├── SidePanel
-    │   ├── ToolsCatalog      — draggable tool cards
-    │   └── SkillsCatalog     — draggable skill cards (Phase 4)
-    ├── ChatPanel             — 에이전트 실행 입력/출력
-    └── CodeExportPanel       — 생성된 TypeScript 코드 미리보기
-
-packages/agent-playground
-└── 실행 엔진을 agent-framework API로 교체
-    ├── framework-executor.ts  — 교체된 실행 엔진
-    └── code-generator.ts      — 캔버스 → TypeScript 코드 생성
-```
+- agent-cli 재구현
 
 ## Test Plan
 
-- `packages/agent-playground`: 단위 테스트
-  - framework-executor: agent 생성 → tool 주입 → run 실행 흐름
-  - code-generator: 캔버스 상태 → 올바른 TypeScript 스니펫 생성
-- `apps/agent-web`: E2E (Playwright)
-  - 에이전트 생성 → tool 드래그 → 채팅 → tool call 이벤트 확인
-  - Code Export 버튼 → 클립보드 내용 검증
-- build 검증: `pnpm typecheck && pnpm lint && pnpm test`
+각 하위 항목의 Test Plan을 참조. Epic 레벨 통합 검증은 PLG-013 완료 후 진행한다.
 
 ## User Execution Test Scenarios
 
-### Scenario 1: Tool Drag-and-Drop + Chat
-
-**Prerequisites**: `pnpm dev` (agent-web), `pnpm start` (agent-server), OpenAI API key 설정
-
-**Steps**:
-
-1. `http://localhost:7071/playground` 접속
-2. "Create Agent" → Provider: OpenAI, Model: gpt-4o-mini → Create
-3. React Flow 캔버스에 agent 노드가 생성됨을 확인
-4. 오른쪽 Tools 패널에서 "Current Time" 카드를 agent 노드 위로 드래그
-5. agent 노드에 "Current Time" 연결 표시 확인
-6. 채팅 입력: "What is the current time in Seoul?"
-7. AI가 `getCurrentTime` tool을 호출하고 결과를 반환하는지 확인
-8. React Flow에 tool_call → tool_result 노드가 시각화되는지 확인
-
-**Expected observable result**:
-
-- agent 노드가 tool 연결 상태를 표시
-- 채팅 응답이 실제 현재 시각 (KST) 포함
-- Workflow에 User → tool_call(getCurrentTime) → tool_result → Assistant 노드 체인 표시
-
-**Evidence**: `<스크린샷 또는 실행 로그 — 구현 후 기입>`
-
-### Scenario 2: Code Export
-
-**Prerequisites**: Scenario 1 완료 상태
-
-**Steps**:
-
-1. "Copy Code" 버튼 클릭 (또는 Code Export 패널 열기)
-2. 생성된 TypeScript 코드를 확인
-
-**Expected observable result**:
-
-```typescript
-import { Robota } from '@robota-sdk/agents';
-// provider, tool 설정이 포함된 실행 가능한 코드
-```
-
-- 코드가 클립보드에 복사되고 미리보기 패널에 표시됨
-- 코드를 별도 파일에 붙여넣어 `ts-node` 실행 시 동작
-
-**Evidence**: `<코드 스니펫 캡처 — 구현 후 기입>`
+각 하위 항목의 User Execution Test Scenarios를 참조.
+Epic 완료 기준: PLG-009 + PLG-010 + PLG-012 + PLG-013 시나리오 모두 통과.

--- a/.agents/backlog/PLG-009-framework-executor-client.md
+++ b/.agents/backlog/PLG-009-framework-executor-client.md
@@ -1,0 +1,87 @@
+---
+title: 'PLG-009: Framework Executor Client — PlaygroundExecutor를 PLG-015 SSE 엔드포인트 기반으로 교체'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: soon
+area: packages/agent-playground
+depends_on: [PLG-015]
+---
+
+## Background
+
+현재 `PlaygroundExecutor`는 `RemoteExecutor`를 통해 `/api/v1/remote/chat`을 호출하는
+브라우저사이드 Robota 인스턴스를 사용한다. tool calling 루프가 브라우저에서 실행되고
+스트리밍이 없어 UI 반응성이 낮다.
+
+PLG-015에서 서버사이드 SSE 실행 API가 구축되면, 이 작업은 PlaygroundExecutor 내부를
+새 엔드포인트를 호출하는 SSE 클라이언트로 교체한다. 외부 인터페이스(`createAgent`,
+`updateAgentToolsFromCard`, `run`)는 유지하여 UI 레이어 변경을 최소화한다.
+
+## Goals
+
+1. `PlaygroundExecutor.run(prompt)` 내부를 교체:
+   - 기존: 브라우저 Robota 인스턴스 → RemoteExecutor → `/api/v1/remote/chat`
+   - 신규: `POST /api/playground/execute` SSE 스트림 consume
+2. SSE 이벤트 파싱 → `IConversationEvent` 변환:
+   - `text_delta` → `assistant_response` 이벤트 (스트리밍 조각 누적)
+   - `tool_call_start` → `tool_call_start` 이벤트
+   - `tool_call_complete` → `tool_call_complete` 이벤트
+   - `error` → `tool_call_error` 이벤트
+   - `done` → 완료 신호
+3. `createAgent(config)`: 서버 호출 없음 — 로컬에 config 저장만 (stateless 모델)
+4. `updateAgentToolsFromCard(agentId, card)`: 로컬 tool 목록 업데이트 (서버 호출 불필요)
+5. BYOK 키 전달: `PlaygroundExecutor` 생성 시 `apiKey` 옵션으로 받아 SSE 요청 시
+   `X-Provider-API-Key` 헤더에 설정 (절대 로그 미기록)
+6. `PlaygroundWebSocketClient` 의존성 제거 (RemoteExecutor 방식 완전 폐기)
+7. PLG-016 카탈로그 API를 사용해 provider/model 목록을 동적으로 로드하는
+   `fetchProviderCatalog()` 유틸 함수 추가
+
+## Non-Goals
+
+- WebSocket 서버(`/ws/playground`) 제거 (다른 용도로 사용 중일 수 있음)
+- UI 레이어 변경 (PlaygroundContext, PlaygroundApp 등)
+- 스트리밍 UI 렌더링 (청크 단위 텍스트 표시) — 별도 UX 작업
+
+## Architecture
+
+```
+packages/agent-playground/src/lib/playground/
+├── robota-executor/
+│   ├── playground-executor.ts    ← 내부 교체, 인터페이스 유지
+│   ├── sse-client.ts             ← NEW: SSE fetch + 이벤트 파싱
+│   ├── event-mapper.ts           ← NEW: SSE 이벤트 → IConversationEvent 변환
+│   └── remote-providers.ts       ← DELETED (RemoteExecutor 폐기)
+└── catalog-client.ts             ← NEW: /api/playground/catalog/* 조회
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - `event-mapper.ts`: 각 SSE 이벤트 타입 → IConversationEvent 변환 검증
+  - `sse-client.ts`: ReadableStream mock으로 파싱 로직 검증
+  - `PlaygroundExecutor.run()`: SSE 스트림 mock → 이벤트 dispatch 검증
+- 통합 테스트: Playwright — 에이전트 생성 → 채팅 → 이벤트 수신 확인
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: 채팅 실행 + 실시간 이벤트
+
+**Prerequisites**: `pnpm dev` (agent-web), `pnpm start` (agent-server), OpenAI API 키 설정
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. "Create Agent" → Provider: OpenAI, Model: gpt-4o-mini, API Key 입력 → Create
+3. Workflow 영역에 "Current Time" tool 드래그
+4. 채팅 입력: "What is the current time in Seoul?"
+5. AI 응답 확인
+
+**Expected observable result**:
+
+- 채팅 응답에 실제 현재 시각(KST) 포함
+- Workflow에 `tool_call_start` → `tool_call_complete` → `assistant_response` 노드 표시
+- 브라우저 콘솔에 API 키 관련 로그 없음
+
+**Evidence**: `<스크린샷 — 구현 후 기입>`

--- a/.agents/backlog/PLG-010-assembly-canvas-redesign.md
+++ b/.agents/backlog/PLG-010-assembly-canvas-redesign.md
@@ -1,0 +1,103 @@
+---
+title: 'PLG-010: Assembly Canvas 재설계 — AgentNode + ToolNode + 엣지 연결 도구 주입'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: later
+area: apps/agent-web, packages/agent-playground
+depends_on: [PLG-009]
+---
+
+## Background
+
+현재 Playground의 React Flow 캔버스는 실행 이벤트(user message, tool_call, assistant_response)만
+표시하는 "Workflow Visualization" 용도다. 에이전트 조립(assembly) 기능이 없다.
+
+PLG-008 비전에서 캔버스는 두 가지 역할을 가진다:
+
+1. **Assembly**: provider + model + tools + skills를 시각적으로 조립
+2. **Execution Timeline**: 실행 이벤트 시각화 (PLG-011에서 분리)
+
+이 작업은 캔버스를 Assembly 전용으로 재설계한다. AgentNode(에이전트 설정 표시)와
+ToolNode(연결된 tool 표시)를 추가하고, 엣지로 연결하면 tool이 에이전트에 주입된다.
+
+## Goals
+
+1. `AgentNode` 커스텀 노드 타입 구현:
+   - 표시: provider 아이콘, model 이름, system prompt 미리보기 (truncated)
+   - 편집: 노드 클릭 시 사이드 패널에서 provider/model/system prompt 수정
+   - 상태: 연결된 tool 수 badge
+
+2. `ToolNode` 커스텀 노드 타입 구현:
+   - 표시: tool 이름, tool 설명 요약, 파라미터 수
+   - 소스: Tools 패널에서 드래그하거나 캔버스에서 직접 추가
+
+3. 엣지 연결 동작:
+   - ToolNode → AgentNode 엣지 생성 시 `injectToolIntoAgent()` 호출
+   - 엣지 삭제 시 tool 제거
+   - 연결 핸들: AgentNode 좌측(tool 입력), ToolNode 우측(출력)
+
+4. 캔버스 레이아웃:
+   - 캔버스 좌측: AgentNode (1개, 중앙 배치)
+   - 캔버스 우측: ToolNode 들 (연결된 tool 수만큼 세로 배열, auto-layout)
+   - 초기 상태: "Create Agent" 완료 시 AgentNode 자동 생성
+
+5. 현재 `workflow-visualization.tsx`의 실행 이벤트 노드 표시는 PLG-011에서 분리될 때까지
+   임시로 별도 탭 또는 토글로 유지
+
+## Non-Goals
+
+- multi-agent 캔버스 (에이전트 노드 여러 개 동시에)
+- skill 노드 (PLG-014에서 추가)
+- 캔버스 상태 서버 저장
+
+## Architecture
+
+```
+packages/agent-playground/src/components/playground/
+├── assembly-canvas/
+│   ├── assembly-canvas.tsx           ← NEW: 조립 전용 ReactFlow 캔버스
+│   ├── nodes/
+│   │   ├── agent-node.tsx            ← NEW: AgentNode
+│   │   └── tool-node.tsx             ← NEW: ToolNode
+│   └── hooks/
+│       └── use-assembly-layout.ts    ← NEW: 노드 자동 레이아웃
+└── workflow-visualization/           ← 기존 (PLG-011에서 분리 예정)
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - `AgentNode` 렌더링: provider/model/systemPrompt props 표시 검증
+  - `ToolNode` 렌더링: tool 이름/설명 표시 검증
+  - 엣지 연결 → `injectToolIntoAgent()` 호출 확인
+- Playwright E2E:
+  - "Create Agent" → AgentNode 자동 생성 확인
+  - ToolNode 드래그 → AgentNode에 엣지 연결 → tool badge 업데이트 확인
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Assembly Canvas 조립
+
+**Prerequisites**: `pnpm dev` (agent-web), `pnpm start` (agent-server)
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. "Create Agent" → Provider: OpenAI, Model: gpt-4o-mini → Create
+3. 캔버스에 AgentNode 생성 확인 (provider 아이콘 + model 이름 표시)
+4. 오른쪽 Tools 패널에서 "Current Time" 카드를 캔버스로 드래그
+5. ToolNode가 캔버스에 추가됨 확인
+6. ToolNode를 AgentNode로 드래그하여 엣지 연결
+7. AgentNode에 tool badge("1 tools") 표시 확인
+8. 채팅 입력: "What time is it now?"
+9. AI가 current-time tool 호출하고 응답 반환 확인
+
+**Expected observable result**:
+
+- AgentNode에 provider(OpenAI), model(gpt-4o-mini) 표시
+- 엣지 연결 후 AgentNode badge "1 tools"
+- 채팅 응답에 현재 시각 포함
+
+**Evidence**: `<스크린샷 — 구현 후 기입>`

--- a/.agents/backlog/PLG-011-execution-timeline-separation.md
+++ b/.agents/backlog/PLG-011-execution-timeline-separation.md
@@ -1,0 +1,101 @@
+---
+title: 'PLG-011: Execution Timeline 분리 — 조립 캔버스와 실행 트레이스를 별도 영역으로'
+status: todo
+created: 2026-05-19
+priority: medium
+urgency: later
+area: apps/agent-web, packages/agent-playground
+depends_on: [PLG-010]
+---
+
+## Background
+
+PLG-010에서 React Flow 캔버스는 Assembly(조립) 전용이 된다.
+현재 캔버스에 표시되는 실행 이벤트(user_message, tool_call_start, tool_call_complete,
+assistant_response)는 별도 영역으로 분리해야 한다.
+
+조립 캔버스와 실행 트레이스가 같은 공간에 있으면:
+
+- 조립 상태를 보면서 실행 결과를 동시에 확인하기 어렵다
+- 실행 이벤트 노드들이 AgentNode/ToolNode와 시각적으로 섞인다
+
+이 작업은 실행 이벤트를 전용 "Execution Timeline" 컴포넌트로 분리한다.
+
+## Goals
+
+1. `ExecutionTimeline` 컴포넌트 구현:
+   - 레이아웃: 세로 스크롤 타임라인 (React Flow 대신 일반 DOM 리스트)
+   - 각 이벤트 타입별 카드:
+     - `user_message`: 파란색 우측 정렬 말풍선
+     - `assistant_response`: 회색 좌측 정렬 말풍선 (마크다운 렌더링)
+     - `tool_call_start`: 도구 아이콘 + tool 이름 + input JSON (collapsible)
+     - `tool_call_complete`: 결과 값 (collapsible)
+     - `tool_call_error`: 빨간색 오류 메시지
+   - 새 이벤트 추가 시 자동 스크롤 (최신 이벤트가 항상 보임)
+
+2. Playground 레이아웃 재구성:
+   - 좌측 패널: Assembly Canvas (AgentNode + ToolNode)
+   - 우측 상단: Chat 입력창 (기존 유지)
+   - 우측 하단: Execution Timeline (신규)
+   - 또는: 탭 방식으로 Assembly / Timeline 전환 (사용자 선호에 따라 결정)
+
+3. `workflow-visualization.tsx`의 실행 이벤트 렌더링 로직을 `ExecutionTimeline`으로 이전
+   - `eventsToFlow()` 함수는 더 이상 필요 없음 (제거 or PLG-010 용으로 축소)
+   - 기존 ReactFlow 기반 workflow 노드 타입들(`UserMessageNode` 등)은 제거
+
+4. `IConversationEvent` 스트림을 `ExecutionTimeline`이 구독하도록 연결
+
+## Non-Goals
+
+- 채팅 입력 UI 변경 (별도 작업)
+- 타임라인 이벤트 필터링/검색
+- 이벤트 export
+
+## Architecture
+
+```
+packages/agent-playground/src/components/playground/
+├── assembly-canvas/          ← PLG-010 (조립 캔버스)
+├── execution-timeline/
+│   ├── execution-timeline.tsx      ← NEW: 타임라인 컨테이너
+│   └── event-cards/
+│       ├── user-message-card.tsx   ← NEW
+│       ├── assistant-card.tsx      ← NEW (마크다운 렌더링)
+│       ├── tool-call-card.tsx      ← NEW (collapsible)
+│       └── tool-error-card.tsx     ← NEW
+└── workflow-visualization/         ← DELETED or 축소
+
+apps/agent-web/src/app/playground/
+└── page.tsx                  ← 레이아웃 재구성 (좌: Canvas, 우: Chat+Timeline)
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - 각 event card 컴포넌트 렌더링 (props 기반 snapshot)
+  - 자동 스크롤 동작 (마지막 이벤트 visible 확인)
+- Playwright E2E:
+  - 채팅 실행 후 timeline에 user_message → tool_call → assistant_response 순서로 표시
+  - tool_call_start 카드에 input JSON 표시, 클릭 시 collapse/expand
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: 실행 타임라인 확인
+
+**Prerequisites**: PLG-009, PLG-010 완료, `pnpm dev`, `pnpm start`, API 키 설정
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. 에이전트 생성, Current Time tool 연결
+3. 채팅 입력: "현재 서울 시각을 알려줘"
+4. Execution Timeline 영역 확인
+
+**Expected observable result**:
+
+- 타임라인에 순서대로: 사용자 메시지 카드 → tool_call_start(getCurrentTime) 카드 → tool_call_complete 카드 → AI 응답 카드
+- tool_call 카드의 input/output이 collapsible JSON으로 표시
+- Assembly Canvas는 영향 없이 AgentNode + ToolNode 유지
+
+**Evidence**: `<스크린샷 — 구현 후 기입>`

--- a/.agents/backlog/PLG-012-code-generator-engine.md
+++ b/.agents/backlog/PLG-012-code-generator-engine.md
@@ -1,0 +1,106 @@
+---
+title: 'PLG-012: Code Generator 엔진 — 캔버스 상태 → 실행 가능한 TypeScript 코드 직렬화'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: later
+area: packages/agent-playground
+depends_on: [PLG-010]
+---
+
+## Background
+
+PLG-008의 핵심 딜리버러블은 코드 생성이다. 사용자가 캔버스에서 조립한
+provider + model + tools + system prompt 설정을 그대로 재현하는 TypeScript 코드를
+생성하여 새 프로젝트에 붙여넣으면 바로 동작하는 에이전트 애플리케이션의 기반이 된다.
+
+이 작업은 캔버스 상태(IAssemblyState)를 입력으로 받아 `@robota-sdk/agent-framework`
+import 기준의 실행 가능한 TypeScript 코드 스니펫을 출력하는 순수 함수 엔진을 구현한다.
+
+## Goals
+
+1. `IAssemblyState` 타입 정의 (캔버스 직렬화 형태):
+
+   ```typescript
+   interface IAssemblyState {
+     agent: {
+       provider: string; // 'openai'
+       model: string; // 'gpt-4o-mini'
+       systemPrompt: string;
+     };
+     tools: string[]; // ['current-time']
+   }
+   ```
+
+2. `generateAgentCode(state: IAssemblyState): string` 순수 함수 구현:
+
+   ```typescript
+   // 출력 예시
+   import { InteractiveSession } from '@robota-sdk/agent-framework';
+   import { getCurrentTimeTool } from '@robota-sdk/agent-tools/current-time';
+
+   const session = new InteractiveSession({
+     provider: {
+       name: 'openai',
+       model: 'gpt-4o-mini',
+       apiKey: process.env.OPENAI_API_KEY,
+     },
+     tools: [getCurrentTimeTool],
+     systemPrompt: 'You are a helpful assistant.',
+   });
+
+   const response = await session.run('Your message here');
+   console.log(response);
+   ```
+
+3. Provider별 import 경로 매핑:
+   - `openai` → `process.env.OPENAI_API_KEY`
+   - `anthropic` → `process.env.ANTHROPIC_API_KEY`
+   - `gemini` → `process.env.GEMINI_API_KEY`
+
+4. Tool별 import 경로 매핑:
+   - `current-time` → `@robota-sdk/agent-tools/current-time`
+   - (이후 tool 추가 시 registry 확장)
+
+5. System prompt 이스케이프 처리 (템플릿 리터럴 내 backtick, `${}` 이스케이프)
+
+6. `packages/agent-playground/src/lib/code-generator/` 하위에 모듈 배치
+
+7. PLG-016 카탈로그를 활용해 tool import 경로를 동적으로 구성 (하드코딩 최소화)
+
+## Non-Goals
+
+- 생성된 코드의 런타임 실행 (서버사이드 검증)
+- skill 조합 코드 생성 (PLG-014에서 추가)
+- 다국어 코드 생성 (TypeScript만)
+
+## Architecture
+
+```
+packages/agent-playground/src/lib/code-generator/
+├── index.ts                  ← generateAgentCode() 공개 API
+├── assembly-serializer.ts    ← IAssemblyState → 코드 AST
+├── provider-templates.ts     ← provider별 코드 템플릿
+├── tool-import-registry.ts   ← tool ID → import 경로 매핑
+└── __tests__/
+    └── code-generator.test.ts
+```
+
+## Test Plan
+
+- 단위 테스트 (`code-generator.test.ts`):
+  - OpenAI + current-time → 정확한 TypeScript 스니펫 생성
+  - Anthropic provider → ANTHROPIC_API_KEY 환경변수 참조
+  - system prompt에 backtick 포함 시 이스케이프 처리
+  - tool 없는 경우 → tools 배열 생략
+  - 빈 system prompt → systemPrompt 프로퍼티 생략
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+Not applicable — 이 작업은 순수 함수 라이브러리 구현이며 사용자 직접 실행 가능한
+UI 표면이 없다. UI 연동은 PLG-013에서 이루어진다.
+
+단위 테스트가 이 작업의 완료 증거다:
+
+- `pnpm --filter @robota-sdk/agent-playground test` 실행 시 code-generator 테스트 전체 통과

--- a/.agents/backlog/PLG-013-code-export-ui.md
+++ b/.agents/backlog/PLG-013-code-export-ui.md
@@ -1,0 +1,120 @@
+---
+title: 'PLG-013: Code Export UI — 코드 미리보기 패널 + syntax highlight + Copy 버튼'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: later
+area: apps/agent-web, packages/agent-playground
+depends_on: [PLG-012]
+---
+
+## Background
+
+PLG-012에서 코드 생성 엔진이 구현되면, 사용자가 생성된 코드를 쉽게 확인하고
+클립보드에 복사할 수 있는 UI가 필요하다.
+
+이것이 PLG-008의 핵심 사용자 경험이다:
+
+- 캔버스에서 agent 조립 → "Copy Code" 클릭 → TypeScript 코드를 새 프로젝트에 붙여넣기 → 바로 실행
+
+## Goals
+
+1. `CodeExportPanel` 컴포넌트 구현:
+   - Assembly 상태 변경 시 실시간으로 코드 미리보기 업데이트 (debounce 300ms)
+   - Syntax highlight: `shiki` 또는 `prism-react-renderer` 사용 (TypeScript 하이라이팅)
+   - 줄 번호 표시
+   - 다크 테마 (Playground 전체 테마와 일치)
+
+2. "Copy Code" 버튼:
+   - 클릭 시 `navigator.clipboard.writeText()` 호출
+   - 복사 완료 후 버튼 아이콘이 체크마크로 2초간 변경 후 복원
+   - 클립보드 API 미지원 환경: 텍스트 선택 fallback
+
+3. Playground 레이아웃에 CodeExportPanel 통합:
+   - 위치: 채팅/타임라인 영역 하단 또는 별도 탭 (탭 방식 권장)
+   - 탭: "Chat" | "Code Export"
+   - Code Export 탭에 CodeExportPanel + Copy 버튼
+
+4. Assembly Canvas에 변경사항이 생길 때마다 코드 자동 갱신:
+   - AgentNode provider/model/systemPrompt 수정
+   - ToolNode 추가/제거
+   - 에이전트 없을 때: "Create an agent to generate code" 안내 문구
+
+5. "패키지 설치 가이드" 섹션 추가 (코드 하단):
+   ```
+   # Install dependencies
+   npm install @robota-sdk/agent-framework @robota-sdk/agent-provider
+   ```
+
+## Non-Goals
+
+- 코드 편집 기능 (read-only 미리보기)
+- 여러 언어 지원 (TypeScript만)
+- 파일 다운로드 (.ts 파일로 저장)
+- 코드 실행 in-browser
+
+## Architecture
+
+```
+packages/agent-playground/src/components/playground/
+└── code-export/
+    ├── code-export-panel.tsx     ← NEW: 미리보기 + Copy 버튼
+    ├── syntax-highlighter.tsx    ← NEW: shiki/prism 래퍼
+    └── install-guide.tsx         ← NEW: npm install 가이드
+
+apps/agent-web/src/app/playground/
+└── page.tsx                  ← 탭에 CodeExportPanel 추가
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - Assembly 상태 변경 → `generateAgentCode()` 호출 → 코드 업데이트 확인
+  - "Copy Code" 버튼 클릭 → `navigator.clipboard.writeText()` 호출 확인 (mock)
+  - 에이전트 없을 때 안내 문구 표시
+- Playwright E2E:
+  - 에이전트 생성 + tool 연결 → Code Export 탭 클릭 → 코드 확인
+  - "Copy Code" 클릭 → 클립보드 내용 검증 (`page.evaluate(() => navigator.clipboard.readText())`)
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Code Export 전체 흐름
+
+**Prerequisites**: PLG-009, PLG-010, PLG-012 완료, `pnpm dev` (agent-web)
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. "Create Agent" → Provider: OpenAI, Model: gpt-4o-mini, System Prompt: "You are a helpful assistant." → Create
+3. Tools 패널에서 "Current Time" tool 캔버스에 연결
+4. "Code Export" 탭 클릭
+5. 생성된 TypeScript 코드 확인
+6. "Copy Code" 버튼 클릭
+7. 새 파일에 붙여넣기 후 내용 확인
+
+**Expected observable result**:
+
+```typescript
+import { InteractiveSession } from '@robota-sdk/agent-framework';
+import { getCurrentTimeTool } from '@robota-sdk/agent-tools/current-time';
+
+const session = new InteractiveSession({
+  provider: {
+    name: 'openai',
+    model: 'gpt-4o-mini',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  tools: [getCurrentTimeTool],
+  systemPrompt: 'You are a helpful assistant.',
+});
+
+const response = await session.run('Your message here');
+console.log(response);
+```
+
+- syntax highlight 적용 (키워드, 문자열, import 색상 구분)
+- Copy 버튼 클릭 후 체크마크로 변경
+- 클립보드에 동일 코드 복사됨
+
+**Evidence**: `<스크린샷 + 클립보드 내용 — 구현 후 기입>`

--- a/.agents/backlog/PLG-014-skills-support.md
+++ b/.agents/backlog/PLG-014-skills-support.md
@@ -1,0 +1,105 @@
+---
+title: 'PLG-014: Skills Support — Skills 패널 + skill 노드 + Code Export 반영'
+status: todo
+created: 2026-05-19
+priority: medium
+urgency: later
+area: apps/agent-web, packages/agent-playground
+depends_on: [PLG-013]
+---
+
+## Background
+
+PLG-013까지는 tools만 지원한다. `@robota-sdk/agent-framework`는 skills도 지원하며,
+skill은 에이전트에 특정 행동 패턴(예: 코드 리뷰, 요약, 번역)을 주입하는 단위다.
+
+Visual Agent Code Generator의 완성도를 높이려면 skills도 시각적으로 조립하고
+생성 코드에 반영할 수 있어야 한다.
+
+## Goals
+
+1. Skills 카탈로그 정의:
+   - `packages/agent-playground/src/skills/catalog.ts` 생성
+   - `IPlaygroundSkillMeta` 타입 정의 (IPlaygroundToolMeta와 유사 구조)
+   - 초기 등록 skill: placeholder 1~2개 (실제 skill은 agent-framework에서 가져옴)
+
+2. `SkillNode` 커스텀 노드 타입 구현 (ToolNode와 유사):
+   - 표시: skill 이름, 설명 요약, 설정 파라미터 수
+   - 색상: ToolNode와 시각적으로 구분 (예: 보라색 계열)
+
+3. Skills 패널 추가 (Tools 패널과 동급):
+   - 오른쪽 사이드바에 "Tools" / "Skills" 탭 추가
+   - 각 skill card에 drag 핸들
+
+4. SkillNode → AgentNode 엣지 연결 → skill 주입:
+   - `IAssemblyState`에 `skills: string[]` 추가
+   - `injectSkillIntoAgent()` 액션 구현
+
+5. Code Export 반영 (`PLG-012` 코드 생성 엔진 확장):
+   - skill이 연결된 경우 import + 설정 코드 생성
+
+   ```typescript
+   import { mySkill } from '@robota-sdk/agent-skills/my-skill';
+
+   const session = new InteractiveSession({
+     // ...
+     skills: [mySkill],
+   });
+   ```
+
+6. `GET /api/playground/catalog/skills` 엔드포인트 추가 (PLG-017 패턴과 동일):
+   - 서버사이드 skill 카탈로그 노출
+
+## Non-Goals
+
+- 커스텀 skill 업로드
+- skill 간 의존성 관리
+- skill 실행 결과 시각화 (tool call과 별개)
+
+## Architecture
+
+```
+packages/agent-playground/src/skills/
+├── catalog.ts                ← IPlaygroundSkillMeta 목록
+└── (skill 구현체는 @robota-sdk/agent-framework에서 가져옴)
+
+packages/agent-playground/src/components/playground/
+├── assembly-canvas/
+│   └── nodes/
+│       └── skill-node.tsx    ← NEW
+└── skills-panel/
+    └── skills-panel.tsx      ← NEW (tools-panel과 동일 구조)
+
+packages/agent-playground/src/lib/code-generator/
+└── skill-import-registry.ts  ← NEW (tool-import-registry와 동일 패턴)
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - `generateAgentCode()` — skill 포함 시 올바른 import + skills 배열 생성
+  - SkillNode 렌더링 검증
+- Playwright E2E:
+  - skill 카드 드래그 → AgentNode 연결 → Code Export에 skill 반영 확인
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Skill 조립 + Code Export
+
+**Prerequisites**: PLG-009~PLG-013 완료, `pnpm dev`, skill 1개 이상 등록됨
+
+**Steps**:
+
+1. `http://localhost:7071/playground` 접속
+2. 에이전트 생성 → Skills 패널 탭 클릭
+3. skill 카드를 캔버스로 드래그 → AgentNode에 연결
+4. "Code Export" 탭 클릭
+
+**Expected observable result**:
+
+- 생성 코드에 skill import 및 `skills: [...]` 배열 포함
+- Assembly Canvas에 SkillNode가 AgentNode에 연결된 상태로 표시
+- SkillNode 색상이 ToolNode와 시각적으로 구분됨
+
+**Evidence**: `<스크린샷 + 생성 코드 캡처 — 구현 후 기입>`

--- a/.agents/backlog/PLG-015-playground-execution-api.md
+++ b/.agents/backlog/PLG-015-playground-execution-api.md
@@ -1,0 +1,176 @@
+---
+title: 'PLG-015: Playground Execution API — POST /api/playground/execute SSE 스트리밍 에이전트 실행'
+status: todo
+created: 2026-05-19
+priority: high
+urgency: soon
+area: apps/agent-server
+depends_on: [PLG-017, PLG-018]
+---
+
+## Background
+
+현재 Playground의 에이전트 실행 구조는 다음과 같다:
+
+```
+Browser: Robota agent (tool calling loop)
+  └── RemoteExecutor → /api/v1/remote/chat (단순 AI 프록시)
+```
+
+문제점:
+
+- tool calling 루프가 브라우저에서 실행 → 스트리밍 없음, request/response 방식
+- 서버는 AI provider 프록시 역할만 하고 에이전트 로직 없음
+- 이벤트가 실시간으로 UI에 전달되지 않음 (tool_call_start/complete 지연)
+
+이 작업은 에이전트 실행 전체(tool calling 루프 포함)를 서버사이드로 이전하고
+SSE(Server-Sent Events)로 실행 이벤트를 실시간 스트리밍하는 전용 엔드포인트를 구현한다.
+
+## Goals
+
+1. `POST /api/playground/execute` 엔드포인트 구현 (SSE streaming)
+
+   **Request**:
+
+   ```typescript
+   interface IPlaygroundExecuteRequest {
+     provider: string; // 'openai' | 'anthropic' | ...
+     model: string; // 'gpt-4o-mini'
+     tools: string[]; // ['current-time'] — PLG-017 registry ID
+     systemPrompt?: string;
+     message: string;
+     history?: IHistoryEntry[]; // 멀티턴 대화 컨텍스트
+   }
+   interface IHistoryEntry {
+     role: 'user' | 'assistant';
+     content: string;
+   }
+   ```
+
+   **Headers**:
+   - `X-Provider-API-Key`: BYOK 키 (없으면 서버 환경변수 키 사용, 둘 다 없으면 401)
+   - 해당 헤더는 **절대 로그에 기록하지 않음** (PLG-018 sanitizer 미들웨어 적용)
+
+   **Response** (Content-Type: text/event-stream):
+
+   ```
+   data: {"type":"text_delta","data":{"text":"안녕하세요"}}
+
+   data: {"type":"tool_call_start","data":{"id":"call_abc","name":"current-time","input":{}}}
+
+   data: {"type":"tool_call_complete","data":{"id":"call_abc","output":"2026-05-19T10:30:00+09:00"}}
+
+   data: {"type":"text_delta","data":{"text":"현재 시각은 10시 30분입니다."}}
+
+   data: {"type":"done","data":{"usage":{"promptTokens":120,"completionTokens":45}}}
+   ```
+
+   오류 시:
+
+   ```
+   data: {"type":"error","data":{"message":"API key invalid"}}
+   ```
+
+2. 서버사이드 `@robota-sdk/agent-framework` 기반 에이전트 인스턴스 생성 및 실행
+   - 요청마다 새 인스턴스 생성 (stateless)
+   - PLG-017 tool registry에서 tool 실행 함수 조회
+   - tool calling 루프 완전 처리 후 각 이벤트를 SSE로 즉시 전송
+
+3. BYOK + 서버 키 양쪽 모드 지원:
+   - `X-Provider-API-Key` 있으면 BYOK 모드
+   - 없으면 서버 환경변수 키 사용 (demo 모드)
+   - 둘 다 없으면 `401 Unauthorized`
+
+4. 요청당 타임아웃: 60초 (초과 시 `{"type":"error","data":{"message":"Execution timeout"}}` 후 스트림 종료)
+
+5. Rate limiting: 기존 전역 limiter와 별도로 `/api/playground/execute`에 추가 제한 적용
+   (기본: 분당 20회/IP)
+
+## Non-Goals
+
+- 서버사이드 세션 상태 유지 (stateless 설계, 멀티턴은 클라이언트가 history 전송)
+- 스트리밍 재연결/재시도 관리 (클라이언트 책임)
+- MCP tool 실행
+
+## Architecture
+
+```
+POST /api/playground/execute
+  └── byok-sanitizer middleware (PLG-018)
+  └── PlaygroundExecuteHandler
+        ├── resolveProvider()     ← BYOK 키 or 서버 키로 provider 인스턴스 생성
+        ├── resolveTools()        ← PLG-017 tool registry에서 tool 함수 로드
+        ├── createAgentSession()  ← @robota-sdk/agent-framework InteractiveSession
+        └── streamEvents()        ← SSE write loop
+              ├── on text_delta   → write SSE
+              ├── on tool_call_*  → write SSE
+              └── on done/error   → write SSE + close
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - `resolveProvider()`: BYOK 키 있을 때 / 서버 키만 있을 때 / 둘 다 없을 때 분기
+  - `resolveTools()`: 존재하는 tool ID / 없는 tool ID 처리
+  - SSE 이벤트 직렬화 형식 검증
+- 통합 테스트:
+  - curl --no-buffer로 SSE 스트림 수신 확인
+  - tool calling 흐름 (current-time tool 사용) 전체 이벤트 순서 검증
+  - 타임아웃 동작 확인
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: SSE 스트리밍 실행 (BYOK)
+
+**Prerequisites**: `apps/agent-server` 실행 중, 유효한 OpenAI API 키 보유
+
+**Steps**:
+
+```bash
+curl -N -X POST http://localhost:3001/api/playground/execute \
+  -H "Content-Type: application/json" \
+  -H "X-Provider-API-Key: sk-..." \
+  -d '{
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "tools": ["current-time"],
+    "systemPrompt": "You are a helpful assistant.",
+    "message": "What time is it now in Seoul?"
+  }'
+```
+
+**Expected observable result**:
+
+```
+data: {"type":"tool_call_start","data":{"id":"call_xxx","name":"current-time","input":{}}}
+
+data: {"type":"tool_call_complete","data":{"id":"call_xxx","output":"2026-05-19T10:30:00+09:00"}}
+
+data: {"type":"text_delta","data":{"text":"현재 서울 시각은 2026년 5월 19일 오전 10시 30분입니다."}}
+
+data: {"type":"done","data":{"usage":{"promptTokens":150,"completionTokens":30}}}
+```
+
+- 이벤트가 실시간으로 스트리밍됨 (청크 단위)
+- tool_call_start → tool_call_complete → text_delta → done 순서
+- 응답에 실제 현재 시각 포함
+
+**Evidence**: `<curl 출력 캡처 — 구현 후 기입>`
+
+### Scenario 2: 키 없을 때 401 반환
+
+**Prerequisites**: `apps/agent-server` 실행 중, 서버에 API 키 환경변수 없음
+
+**Steps**:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -X POST \
+  http://localhost:3001/api/playground/execute \
+  -H "Content-Type: application/json" \
+  -d '{"provider":"openai","model":"gpt-4o-mini","tools":[],"message":"hello"}'
+```
+
+**Expected observable result**: `401`
+
+**Evidence**: `<출력 캡처 — 구현 후 기입>`

--- a/.agents/backlog/PLG-016-provider-model-catalog-api.md
+++ b/.agents/backlog/PLG-016-provider-model-catalog-api.md
@@ -1,0 +1,102 @@
+---
+title: 'PLG-016: Provider & Model Catalog API — GET /api/playground/catalog/providers'
+status: todo
+created: 2026-05-19
+priority: medium
+urgency: soon
+area: apps/agent-server
+depends_on: [PLG-018]
+---
+
+## Background
+
+현재 Playground UI는 사용 가능한 provider와 model 목록을 프론트엔드 코드에 하드코딩하고 있다.
+서버에 어떤 provider 키가 설정되어 있는지, 어떤 모델이 지원되는지 알 수 없어
+"Create Agent" 폼이 서버 실제 상태와 불일치하는 문제가 있다.
+
+이 작업은 프론트엔드가 서버에 사용 가능한 provider + model 목록을 동적으로 조회할 수 있는
+카탈로그 API를 제공한다. BYOK 사용자는 서버 키 없이 직접 키를 입력할 수 있음도 표시한다.
+
+## Goals
+
+1. `GET /api/playground/catalog/providers` 엔드포인트 구현
+2. 응답 스키마:
+   ```typescript
+   interface IProviderCatalogResponse {
+     providers: IProviderEntry[];
+   }
+   interface IProviderEntry {
+     id: string; // 'openai' | 'anthropic' | 'gemini' | 'deepseek'
+     name: string; // 'OpenAI' | 'Anthropic' | ...
+     serverKeyAvailable: boolean; // 서버에 API 키 환경변수가 설정된 경우 true
+     byokSupported: boolean; // BYOK 허용 여부 (PLG-015 구현 시 true)
+     models: IModelEntry[];
+   }
+   interface IModelEntry {
+     id: string; // 'gpt-4o-mini'
+     name: string; // 'GPT-4o Mini'
+     contextWindow: number; // 128000
+     supportsTools: boolean; // tool calling 지원 여부
+   }
+   ```
+3. 서버 키 노출 금지: `serverKeyAvailable: true`만 반환, 키 값 자체는 절대 포함하지 않음
+4. PLG-018 라우터 모듈에 등록
+5. 프론트엔드 "Create Agent" 폼이 이 API를 사용하도록 업데이트 (agent-playground 내 하드코딩 제거)
+
+## Non-Goals
+
+- 모델 목록 실시간 동기화 (AI 제공업체 API에서 live fetch) — 정적 목록으로 시작
+- 모델 가격 정보
+- 사용자별 provider 설정
+
+## Test Plan
+
+- 단위 테스트:
+  - 각 환경변수 조합에서 `serverKeyAvailable` 값이 올바른지 확인
+  - 응답 스키마 타입 검증
+- 통합 테스트: `GET /api/playground/catalog/providers` curl 응답 검증
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Provider Catalog 조회
+
+**Prerequisites**: `apps/agent-server` 실행 중, `OPENAI_API_KEY` 환경변수 설정됨
+
+**Steps**:
+
+```bash
+curl http://localhost:3001/api/playground/catalog/providers | jq .
+```
+
+**Expected observable result**:
+
+```json
+{
+  "providers": [
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "serverKeyAvailable": true,
+      "byokSupported": true,
+      "models": [
+        { "id": "gpt-4o", "name": "GPT-4o", "contextWindow": 128000, "supportsTools": true },
+        { "id": "gpt-4o-mini", "name": "GPT-4o Mini", "contextWindow": 128000, "supportsTools": true }
+      ]
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "serverKeyAvailable": false,
+      "byokSupported": true,
+      "models": [...]
+    }
+  ]
+}
+```
+
+- `openai.serverKeyAvailable: true` (키 설정됨)
+- `anthropic.serverKeyAvailable: false` (키 없음)
+- 응답에 실제 키 값 없음
+
+**Evidence**: `<curl 출력 캡처 — 구현 후 기입>`

--- a/.agents/backlog/PLG-017-tool-registry-api.md
+++ b/.agents/backlog/PLG-017-tool-registry-api.md
@@ -1,0 +1,107 @@
+---
+title: 'PLG-017: Tool Registry API — GET /api/playground/catalog/tools + 서버사이드 tool 등록'
+status: todo
+created: 2026-05-19
+priority: medium
+urgency: soon
+area: apps/agent-server, packages/agent-playground
+depends_on: [PLG-018]
+---
+
+## Background
+
+현재 Playground의 tool 목록은 `packages/agent-playground/src/tools/catalog.ts`에만 존재하며,
+서버사이드 실행 시 어떤 tool을 사용할 수 있는지 서버가 알지 못한다.
+
+PLG-015(서버사이드 실행 API)가 tool calling을 처리하려면 서버에도 tool 구현체가 등록되어야 한다.
+이 작업은 서버사이드 Tool Registry를 구축하고 프론트엔드가 조회할 수 있는 카탈로그 API를 제공한다.
+
+## Goals
+
+1. `packages/agent-playground/src/tools/` 하위 built-in tool 구현체를 서버사이드에서 재사용 가능한
+   형태로 정리 (tool 구현은 순수 TS 함수 — 브라우저/서버 모두에서 동작)
+2. `apps/agent-server/src/tools/registry.ts` 생성 — tool ID → 실행 함수 매핑
+   ```typescript
+   interface IServerToolEntry {
+     id: string;
+     name: string;
+     description: string;
+     inputSchema: object; // JSON Schema
+     execute: (input: Record<string, unknown>) => Promise<unknown>;
+   }
+   const toolRegistry = new Map<string, IServerToolEntry>();
+   ```
+3. `GET /api/playground/catalog/tools` 엔드포인트 구현
+   ```typescript
+   interface IToolCatalogResponse {
+     tools: IToolEntry[];
+   }
+   interface IToolEntry {
+     id: string; // 'current-time'
+     name: string; // 'Current Time'
+     description: string;
+     inputSchema: object; // JSON Schema (파라미터 정의)
+     category: string; // 'utility' | 'data' | ...
+   }
+   ```
+4. 초기 등록 tool: `current-time` (추가 tool은 이후 PLG 작업에서 확장)
+5. PLG-018 라우터 모듈에 등록
+6. PLG-015 실행 API가 이 registry를 통해 tool을 실행하도록 설계
+
+## Non-Goals
+
+- MCP tool 등록 (별도 백로그)
+- 사용자 정의 tool 업로드
+- tool 실행 결과 캐싱
+
+## Architecture
+
+```
+packages/agent-playground/src/tools/
+├── current-time/
+│   ├── index.ts          ← 메타데이터 (IPlaygroundToolMeta)
+│   └── execute.ts        ← 순수 실행 함수 (NEW: 서버/브라우저 공용)
+
+apps/agent-server/src/
+└── tools/
+    └── registry.ts       ← IServerToolEntry Map + 등록 로직
+        └── current-time.ts  ← agent-playground execute.ts 임포트 + 래핑
+```
+
+## Test Plan
+
+- 단위 테스트:
+  - `toolRegistry.get('current-time')` 등록 확인
+  - `execute({})` 호출 → 현재 시각 반환 확인
+- 통합 테스트: `GET /api/playground/catalog/tools` curl 응답 검증
+- `pnpm typecheck && pnpm lint && pnpm test`
+
+## User Execution Test Scenarios
+
+### Scenario 1: Tool Catalog 조회
+
+**Prerequisites**: `apps/agent-server` 실행 중
+
+**Steps**:
+
+```bash
+curl http://localhost:3001/api/playground/catalog/tools | jq .
+```
+
+**Expected observable result**:
+
+```json
+{
+  "tools": [
+    {
+      "id": "current-time",
+      "name": "Current Time",
+      "description": "Returns the current date and time",
+      "inputSchema": { "type": "object", "properties": {}, "required": [] },
+      "category": "utility"
+    }
+  ]
+}
+```
+
+**Evidence**: `<curl 출력 캡처 — 구현 후 기입>`

--- a/.agents/backlog/PLG-018-playground-router-module.md
+++ b/.agents/backlog/PLG-018-playground-router-module.md
@@ -1,0 +1,61 @@
+---
+title: 'PLG-018: Playground Router Module — /api/playground/* 전용 라우터 분리 + BYOK 키 sanitizer 미들웨어'
+status: todo
+created: 2026-05-19
+priority: medium
+urgency: soon
+area: apps/agent-server
+depends_on: []
+---
+
+## Background
+
+현재 `apps/agent-server/src/app.ts`에 모든 API 핸들러가 인라인으로 작성되어 있다.
+PLG-015~017 작업으로 `/api/playground/*` 엔드포인트가 추가되면 `app.ts`가 비대해진다.
+또한 BYOK 키(`X-Provider-API-Key` 헤더)가 다양한 핸들러에 흩어져 로그에 노출될 위험이 있다.
+
+이 작업은 playground 관련 엔드포인트를 전용 Express 라우터 모듈로 분리하고,
+BYOK 키가 절대 로그에 기록되지 않도록 sanitizer 미들웨어를 중앙화한다.
+
+## Goals
+
+1. `apps/agent-server/src/routes/playground.ts` 파일 생성 — 전용 Express Router
+2. `app.ts`에서 `app.use('/api/playground', playgroundRouter)` 한 줄로 마운트
+3. BYOK Key Sanitizer 미들웨어 구현:
+   - `X-Provider-API-Key` 헤더 값을 요청 처리 후 메모리에서 즉시 제거
+   - Express 로거가 해당 헤더를 기록하지 않도록 before-log 필터 적용
+   - `req.byokKey` 타입-안전 속성으로 핸들러에 전달 (string | undefined)
+4. 기존 `/api/v1/byok/chat` 엔드포인트를 새 라우터로 이전 (URL은 유지)
+5. 향후 PLG-015~017 핸들러가 이 라우터에 추가될 수 있는 구조 확보
+
+## Non-Goals
+
+- 기존 `/api/v1/remote/*` 엔드포인트 이전 (scope 외)
+- 인증 시스템 변경
+- WebSocket 서버 변경
+
+## Architecture
+
+```
+apps/agent-server/src/
+├── app.ts                    ← 간결하게 유지, 라우터 마운트만
+└── routes/
+    └── playground.ts         ← /api/playground/* 전용 라우터
+        ├── middleware/
+        │   └── byok-sanitizer.ts  ← BYOK 키 sanitizer
+        └── handlers/
+            └── byok-chat.ts  ← 기존 /api/v1/byok/chat 이전
+```
+
+## Test Plan
+
+- 단위 테스트: byok-sanitizer 미들웨어
+  - `X-Provider-API-Key` 헤더가 `req.byokKey`로 전달되는지 확인
+  - 요청 완료 후 헤더 값이 로그 필터에서 제거되는지 확인
+- 통합 테스트: 기존 `/api/v1/byok/chat` 동작 유지 확인
+- `pnpm typecheck && pnpm lint` 통과
+
+## User Execution Test Scenarios
+
+Not applicable — 순수 서버 내부 코드 조직화 작업. 기존 동작은 변경 없음.
+기능 검증은 Test Plan의 통합 테스트로 대체한다.

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -440,3 +440,29 @@ QA v2 점검에서 발견된 의존성 관리 이슈.
 | ----------------------------------------------- | ------------------------------------------------------------ | -------- |
 | [WEB-004](WEB-004-playground-interactive-ux.md) | Playground 온보딩/에러 상태 UI + Mermaid 아키텍처 다이어그램 | high     |
 | [PROD-001](PROD-001-public-playground.md)       | 퍼블릭 플레이그라운드 — API 키 입력 즉시 체험 데모 (BYOK)    | high     |
+
+### Playground — Visual Agent Code Generator (2026-05-19)
+
+`@robota-sdk/agent-framework` 기반 에이전트 앱 조립 도구. 캔버스에서 provider + model +
+tools + skills를 조립하면 새 프로젝트에 붙여넣을 수 있는 TypeScript 코드가 생성된다.
+Epic: [PLG-008](PLG-008-visual-agent-builder-playground.md)
+
+#### Backend Foundation
+
+| ID                                               | 제목                                                                  | 우선순위 |
+| ------------------------------------------------ | --------------------------------------------------------------------- | -------- |
+| [PLG-018](PLG-018-playground-router-module.md)   | Playground Router Module — /api/playground/\* 라우터 + BYOK sanitizer | medium   |
+| [PLG-016](PLG-016-provider-model-catalog-api.md) | Provider & Model Catalog API                                          | medium   |
+| [PLG-017](PLG-017-tool-registry-api.md)          | Tool Registry API + 서버사이드 tool 등록                              | medium   |
+| [PLG-015](PLG-015-playground-execution-api.md)   | Playground Execution API — SSE 스트리밍 에이전트 실행                 | high     |
+
+#### Frontend Migration & Redesign
+
+| ID                                                  | 제목                                                         | 우선순위 |
+| --------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| [PLG-009](PLG-009-framework-executor-client.md)     | Framework Executor Client — PlaygroundExecutor SSE 기반 교체 | high     |
+| [PLG-010](PLG-010-assembly-canvas-redesign.md)      | Assembly Canvas 재설계 — AgentNode + ToolNode + 엣지 연결    | high     |
+| [PLG-011](PLG-011-execution-timeline-separation.md) | Execution Timeline 분리                                      | medium   |
+| [PLG-012](PLG-012-code-generator-engine.md)         | Code Generator 엔진 — 캔버스 상태 → TypeScript 코드          | high     |
+| [PLG-013](PLG-013-code-export-ui.md)                | Code Export UI — 미리보기 + syntax highlight + Copy 버튼     | high     |
+| [PLG-014](PLG-014-skills-support.md)                | Skills Support — Skills 패널 + skill 노드 + Code Export 반영 | medium   |


### PR DESCRIPTION
## Summary
- PLG-008을 Epic 문서로 재구성 (하위 항목 참조 구조)
- PLG-009~018 신규 백로그 항목 추가 (Backend 4개 + Frontend 6개)
- README.md에 Visual Agent Code Generator 섹션 추가

## 의존 그래프
```
PLG-018 → PLG-015 → PLG-009 → PLG-010 → PLG-011
PLG-016 ↗                              → PLG-012 → PLG-013 → PLG-014
PLG-017 ↗
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)