### PR TITLE
feat(plg-018): playground router module + BYOK key sanitizer middleware

### DIFF
--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -9,6 +9,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 
+import { playgroundRouter } from './routes/playground.js';
 import { resolveApiDocsEnabled } from './utils/env-flags.js';
 
 import type { PlaygroundWebSocketServer } from './websocket-server';
@@ -224,6 +225,9 @@ export function createApp(): express.Application {
       environment: process.env.NODE_ENV || 'development',
     });
   });
+
+  // Playground API routes (PLG-015~017 endpoints added here incrementally)
+  app.use('/api/playground', playgroundRouter);
 
   // 404 handler
   app.use('*', (req, res) => {

--- a/apps/agent-server/src/middleware/byok-key-sanitizer.ts
+++ b/apps/agent-server/src/middleware/byok-key-sanitizer.ts
@@ -1,0 +1,23 @@
+import type { Request, Response, NextFunction } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      byokKey?: string;
+    }
+  }
+}
+
+/**
+ * Extracts the BYOK API key from X-Provider-API-Key header into req.byokKey,
+ * then removes it from headers so it never appears in access logs.
+ */
+export function byokKeySanitizer(req: Request, _res: Response, next: NextFunction): void {
+  const key = req.headers['x-provider-api-key'];
+  if (typeof key === 'string' && key.length > 0) {
+    req.byokKey = key;
+    delete req.headers['x-provider-api-key'];
+  }
+  next();
+}

--- a/apps/agent-server/src/routes/playground.ts
+++ b/apps/agent-server/src/routes/playground.ts
@@ -1,0 +1,17 @@
+import { Router, type IRouter } from 'express';
+
+import { byokKeySanitizer } from '../middleware/byok-key-sanitizer.js';
+
+export const playgroundRouter: IRouter = Router();
+
+// Apply BYOK key sanitizer to all playground routes
+playgroundRouter.use(byokKeySanitizer);
+
+// Health check for playground API
+playgroundRouter.get('/health', (_req, res) => {
+  res.json({ status: 'ok', service: 'playground' });
+});
+
+// PLG-016: GET /api/playground/catalog/providers — added in PLG-016
+// PLG-017: GET /api/playground/catalog/tools — added in PLG-017
+// PLG-015: POST /api/playground/execute — added in PLG-015


### PR DESCRIPTION
## Summary
- `byok-key-sanitizer.ts` 미들웨어: `X-Provider-API-Key` 헤더를 `req.byokKey`로 이동 후 헤더에서 제거 (로그 노출 방지)
- `routes/playground.ts`: `/api/playground/*` 전용 Express IRouter (sanitizer 적용)
- `app.ts`: `app.use('/api/playground', playgroundRouter)` 마운트

## Verification
- `GET /api/playground/health` → `{"status":"ok","service":"playground"}` ✅
- `GET /api/v1/remote/health` 기존 엔드포인트 유지 ✅
- `GET /health` 기존 엔드포인트 유지 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)