### PR TITLE
feat(plg-017): tool registry API — GET /api/playground/catalog/tools

### DIFF
--- a/apps/agent-server/src/catalog/tools.ts
+++ b/apps/agent-server/src/catalog/tools.ts
@@ -1,0 +1,169 @@
+export interface IToolCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  inputSchema: object;
+  category: string;
+}
+
+export interface IToolCatalogResponse {
+  tools: IToolCatalogEntry[];
+}
+
+export interface IServerToolEntry extends IToolCatalogEntry {
+  execute: (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+function executeCurrentTime(params: Record<string, unknown>): Promise<unknown> {
+  try {
+    const timezoneRaw = params['timezone'];
+    const formatRaw = params['format'];
+    const includeWeekdayRaw = params['includeWeekday'];
+
+    const timezone =
+      typeof timezoneRaw === 'string' && timezoneRaw.trim().length > 0
+        ? timezoneRaw.trim()
+        : 'local';
+
+    const format =
+      formatRaw === 'iso' ||
+      formatRaw === 'readable' ||
+      formatRaw === 'timestamp' ||
+      formatRaw === 'detailed'
+        ? formatRaw
+        : 'readable';
+
+    const includeWeekday = typeof includeWeekdayRaw === 'boolean' ? includeWeekdayRaw : true;
+    const now = new Date();
+    const timezoneInfo =
+      timezone === 'local' ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone;
+
+    switch (format) {
+      case 'iso': {
+        if (timezone === 'local') {
+          return Promise.resolve({
+            success: true,
+            time: now.toISOString(),
+            timezone: timezoneInfo,
+            timestamp: now.getTime(),
+          });
+        }
+        const isoStr = new Intl.DateTimeFormat('sv-SE', {
+          timeZone: timezone,
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: false,
+        }).format(now);
+        return Promise.resolve({
+          success: true,
+          time: isoStr.replace(' ', 'T') + 'Z',
+          timezone: timezoneInfo,
+          timestamp: now.getTime(),
+        });
+      }
+      case 'timestamp':
+        return Promise.resolve({
+          success: true,
+          timestamp: now.getTime(),
+          timezone: timezoneInfo,
+          readable: now.toLocaleString('en-US', {
+            timeZone: timezone === 'local' ? undefined : timezone,
+          }),
+        });
+      case 'detailed':
+        return Promise.resolve({
+          success: true,
+          detailed: now.toLocaleString('en-US', {
+            timeZone: timezone === 'local' ? undefined : timezone,
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            weekday: 'long',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            timeZoneName: 'long',
+          }),
+          iso: now.toISOString(),
+          timestamp: now.getTime(),
+          timezone: timezoneInfo,
+        });
+      default: {
+        const opts: Intl.DateTimeFormatOptions = {
+          timeZone: timezone === 'local' ? undefined : timezone,
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+          hour12: true,
+        };
+        if (includeWeekday) opts.weekday = 'short';
+        return Promise.resolve({
+          success: true,
+          time: now.toLocaleString('en-US', opts),
+          timezone: timezoneInfo,
+          timestamp: now.getTime(),
+          iso: now.toISOString(),
+        });
+      }
+    }
+  } catch (error) {
+    return Promise.resolve({
+      success: false,
+      error: `Failed to get current time: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      timestamp: Date.now(),
+    });
+  }
+}
+
+const TOOL_REGISTRY = new Map<string, IServerToolEntry>([
+  [
+    'current-time',
+    {
+      id: 'current-time',
+      name: 'Current Time',
+      description: 'Get current date and time information with timezone support',
+      category: 'utility',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          timezone: {
+            type: 'string',
+            description: 'Timezone identifier (e.g., "Asia/Seoul", "UTC"). Defaults to local.',
+            default: 'local',
+          },
+          format: {
+            type: 'string',
+            enum: ['iso', 'readable', 'timestamp', 'detailed'],
+            description: 'Output format. Defaults to "readable".',
+            default: 'readable',
+          },
+          includeWeekday: {
+            type: 'boolean',
+            description: 'Include day of the week in the output',
+            default: true,
+          },
+        },
+        required: [],
+      },
+      execute: (input) => executeCurrentTime(input),
+    },
+  ],
+]);
+
+export function getToolRegistry(): Map<string, IServerToolEntry> {
+  return TOOL_REGISTRY;
+}
+
+export function getToolCatalog(): IToolCatalogResponse {
+  const tools: IToolCatalogEntry[] = Array.from(TOOL_REGISTRY.values()).map(
+    ({ execute: _execute, ...entry }) => entry,
+  );
+  return { tools };
+}

--- a/apps/agent-server/src/routes/playground.ts
+++ b/apps/agent-server/src/routes/playground.ts
@@ -1,6 +1,7 @@
 import { Router, type IRouter } from 'express';
 
 import { getProviderCatalog } from '../catalog/providers.js';
+import { getToolCatalog } from '../catalog/tools.js';
 import { byokKeySanitizer } from '../middleware/byok-key-sanitizer.js';
 
 export const playgroundRouter: IRouter = Router();
@@ -18,5 +19,9 @@ playgroundRouter.get('/catalog/providers', (_req, res) => {
   res.json(getProviderCatalog());
 });
 
-// PLG-017: GET /api/playground/catalog/tools — added in PLG-017
+// PLG-017: Tool Catalog
+playgroundRouter.get('/catalog/tools', (_req, res) => {
+  res.json(getToolCatalog());
+});
+
 // PLG-015: POST /api/playground/execute — added in PLG-015


### PR DESCRIPTION
## Summary
- `catalog/tools.ts`: `IServerToolEntry` 인터페이스 + `TOOL_REGISTRY` Map
  - `current-time` tool 등록 (execute 함수 포함, PLG-015에서 사용)
  - `getToolCatalog()`: execute 제거 후 HTTP 응답용 직렬화
  - `getToolRegistry()`: PLG-015 실행 핸들러에서 tool 실행 시 사용
- `GET /api/playground/catalog/tools` 엔드포인트 추가

## Verification
```bash
curl http://localhost:3001/api/playground/catalog/tools
# → current-time tool with inputSchema ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)