### PR TITLE
feat(plg-010): Assembly Canvas — AgentNode + ToolNode + edge connection

### DIFF
--- a/packages/agent-playground/src/components/playground/__tests__/assembly-canvas.test.tsx
+++ b/packages/agent-playground/src/components/playground/__tests__/assembly-canvas.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentNode } from '../assembly-canvas/nodes/agent-node';
+import { ToolNode } from '../assembly-canvas/nodes/tool-node';
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await import('@xyflow/react');
+  return {
+    ...actual,
+    Handle: ({ type, position }: { type: string; position: string }) => (
+      <div data-testid="handle" data-type={type} data-position={position} />
+    ),
+    Position: { Left: 'left', Right: 'right' },
+  };
+});
+
+describe('AgentNode', () => {
+  it('renders agent name, provider, and model', () => {
+    render(
+      <AgentNode
+        data={{
+          name: 'Test Agent',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          toolCount: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Test Agent')).toBeTruthy();
+    expect(screen.getByText('openai')).toBeTruthy();
+    expect(screen.getByText('gpt-4o-mini')).toBeTruthy();
+  });
+
+  it('renders system message when provided', () => {
+    render(
+      <AgentNode
+        data={{
+          name: 'Agent',
+          provider: 'anthropic',
+          model: 'claude-3-5-haiku',
+          systemMessage: 'You are a helpful assistant.',
+          toolCount: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('You are a helpful assistant.')).toBeTruthy();
+  });
+
+  it('renders tool count badge when tools are connected', () => {
+    render(
+      <AgentNode
+        data={{
+          name: 'Agent',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          toolCount: 3,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('3 tools connected')).toBeTruthy();
+  });
+
+  it('renders singular tool label for one tool', () => {
+    render(
+      <AgentNode
+        data={{
+          name: 'Agent',
+          provider: 'openai',
+          model: 'gpt-4o-mini',
+          toolCount: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('1 tool connected')).toBeTruthy();
+  });
+});
+
+describe('ToolNode', () => {
+  it('renders tool name', () => {
+    render(<ToolNode data={{ name: 'current_time', description: 'Returns the current time.' }} />);
+
+    expect(screen.getByText('current_time')).toBeTruthy();
+    expect(screen.getByText('Returns the current time.')).toBeTruthy();
+  });
+
+  it('renders without description', () => {
+    render(<ToolNode data={{ name: 'no_desc_tool' }} />);
+
+    expect(screen.getByText('no_desc_tool')).toBeTruthy();
+  });
+});

--- a/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  ReactFlowProvider,
+  type Node,
+  type Edge,
+} from '@xyflow/react';
+import { Bot } from 'lucide-react';
+import type { IPlaygroundAgentConfig } from '../../../lib/playground/robota-executor';
+import type { IPlaygroundToolMeta } from '../../../tools/catalog';
+import { AgentNode } from './nodes/agent-node';
+import { ToolNode } from './nodes/tool-node';
+
+const nodeTypes = {
+  agent: AgentNode,
+  tool: ToolNode,
+};
+
+const AGENT_POSITION = { x: 120, y: 120 };
+const TOOL_START_X = 450;
+const TOOL_START_Y = 60;
+const TOOL_GAP_Y = 130;
+
+export interface IAssemblyCanvasProps {
+  agentConfig: IPlaygroundAgentConfig | null;
+  activeTools: IPlaygroundToolMeta[];
+  onDropTool: (tool: IPlaygroundToolMeta) => void;
+}
+
+function buildAgentNodeId(config: IPlaygroundAgentConfig): string {
+  return `agent-${config.id ?? config.name}`;
+}
+
+function AssemblyCanvasContent({ agentConfig, activeTools, onDropTool }: IAssemblyCanvasProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  useEffect(() => {
+    if (!agentConfig) {
+      setNodes([]);
+      setEdges([]);
+      return;
+    }
+
+    const agentNodeId = buildAgentNodeId(agentConfig);
+
+    const agentNode: Node = {
+      id: agentNodeId,
+      type: 'agent',
+      position: AGENT_POSITION,
+      data: {
+        name: agentConfig.name,
+        provider: agentConfig.defaultModel.provider,
+        model: agentConfig.defaultModel.model,
+        systemMessage: agentConfig.defaultModel.systemMessage,
+        toolCount: activeTools.length,
+      },
+    };
+
+    const toolNodes: Node[] = activeTools.map((tool, idx) => ({
+      id: `tool-${tool.id}`,
+      type: 'tool',
+      position: { x: TOOL_START_X, y: TOOL_START_Y + idx * TOOL_GAP_Y },
+      data: { name: tool.name, description: tool.description },
+    }));
+
+    const toolEdges: Edge[] = activeTools.map((tool) => ({
+      id: `edge-${tool.id}`,
+      source: `tool-${tool.id}`,
+      sourceHandle: 'tool-output',
+      target: agentNodeId,
+      targetHandle: 'tool-input',
+      animated: true,
+      style: { stroke: '#7c3aed', strokeWidth: 2, opacity: 0.8 },
+    }));
+
+    setNodes([agentNode, ...toolNodes]);
+    setEdges(toolEdges);
+  }, [agentConfig, activeTools, setNodes, setEdges]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes('application/robota-tool')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setIsDragOver(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as HTMLElement | null)) {
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const raw = e.dataTransfer.getData('application/robota-tool');
+      if (!raw) return;
+      const tool = JSON.parse(raw) as IPlaygroundToolMeta;
+      onDropTool(tool);
+    },
+    [onDropTool],
+  );
+
+  if (!agentConfig) {
+    return (
+      <div
+        className="w-full h-full flex flex-col items-center justify-center gap-3 text-muted-foreground"
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <Bot className="h-10 w-10 opacity-30" />
+        <p className="text-sm">Create an agent to start assembling</p>
+        <p className="text-xs opacity-60">Click "Create Agent" to add an agent node</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`w-full h-full relative transition-colors ${isDragOver ? 'bg-primary/5 ring-2 ring-inset ring-primary/30' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDragOver && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+          <div className="bg-primary/10 border-2 border-dashed border-primary/50 rounded-xl px-8 py-4 text-primary text-sm font-medium">
+            Drop to add tool to agent
+          </div>
+        </div>
+      )}
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.3 }}
+        minZoom={0.3}
+        maxZoom={2}
+        colorMode="dark"
+        nodesDraggable
+        nodesConnectable={false}
+        elementsSelectable={false}
+        attributionPosition="bottom-left"
+        style={
+          {
+            '--xy-node-border-default': 'none',
+            '--xy-node-selected-border': 'none',
+          } as React.CSSProperties
+        }
+      >
+        <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}
+
+export function AssemblyCanvas(props: IAssemblyCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <AssemblyCanvasContent {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/packages/agent-playground/src/components/playground/assembly-canvas/index.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/index.tsx
@@ -1,0 +1,4 @@
+export { AssemblyCanvas } from './assembly-canvas';
+export type { IAssemblyCanvasProps } from './assembly-canvas';
+export type { IAgentNodeData } from './nodes/agent-node';
+export type { IToolNodeData } from './nodes/tool-node';

--- a/packages/agent-playground/src/components/playground/assembly-canvas/nodes/agent-node.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/nodes/agent-node.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Bot } from 'lucide-react';
+
+const PROVIDER_COLORS: Record<string, string> = {
+  openai: 'bg-green-500/15 text-green-400',
+  anthropic: 'bg-violet-500/15 text-violet-400',
+  gemini: 'bg-yellow-500/15 text-yellow-400',
+  google: 'bg-yellow-500/15 text-yellow-400',
+  deepseek: 'bg-blue-500/15 text-blue-400',
+};
+
+export interface IAgentNodeData extends Record<string, unknown> {
+  name: string;
+  provider: string;
+  model: string;
+  systemMessage?: string;
+  toolCount: number;
+}
+
+export function AgentNode({ data }: { data: IAgentNodeData }) {
+  const colorClass = PROVIDER_COLORS[data.provider] ?? 'bg-primary/15 text-primary';
+
+  return (
+    <div className="bg-card border border-border rounded-xl shadow-md w-52">
+      <Handle
+        type="target"
+        position={Position.Right}
+        id="tool-input"
+        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+      />
+      <div className="px-4 py-3">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-primary/10">
+            <Bot className="h-4 w-4 text-primary" />
+          </div>
+          <span className="font-semibold text-sm text-foreground truncate">{data.name}</span>
+        </div>
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${colorClass}`}>
+            {data.provider}
+          </span>
+          <span className="text-xs text-muted-foreground truncate">{data.model}</span>
+        </div>
+        {data.systemMessage && (
+          <p className="text-xs text-muted-foreground mt-2 line-clamp-2 leading-relaxed">
+            {data.systemMessage}
+          </p>
+        )}
+        {data.toolCount > 0 && (
+          <div className="mt-2 pt-2 border-t border-border">
+            <span className="text-xs font-medium text-primary">
+              {data.toolCount} {data.toolCount === 1 ? 'tool' : 'tools'} connected
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/components/playground/assembly-canvas/nodes/tool-node.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/nodes/tool-node.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Wrench } from 'lucide-react';
+
+export interface IToolNodeData extends Record<string, unknown> {
+  name: string;
+  description?: string;
+}
+
+export function ToolNode({ data }: { data: IToolNodeData }) {
+  return (
+    <div className="bg-card border border-border rounded-lg shadow-sm w-44">
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="tool-output"
+        className="!w-3 !h-3 !bg-muted-foreground !border-2 !border-background"
+      />
+      <div className="px-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <Wrench className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-xs font-semibold text-foreground truncate">{data.name}</span>
+        </div>
+        {data.description && (
+          <p className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-relaxed">
+            {data.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -22,6 +22,7 @@ import { WebLogger } from '../../lib/web-logger';
 import { useToast } from '../../hooks/use-toast';
 import { CreateAgentModal, AddToolModal } from './playground-modals';
 import { WorkflowVisualization } from '../../components/playground/workflow-visualization';
+import { AssemblyCanvas } from '../../components/playground/assembly-canvas';
 import { useProviderConfig } from '../../hooks/use-provider-config';
 import type { IProviderConfig } from '../../hooks/use-provider-config';
 import { ProviderSetupScreen } from './ProviderSetupScreen';
@@ -163,6 +164,8 @@ function buildByokBaseUrl(wsUrl: string): string {
     .replace(/\/ws$/, '');
 }
 
+type TCanvasTab = 'assembly' | 'execution';
+
 function PlaygroundContent(): React.ReactElement {
   const state = usePlaygroundState();
   const { setToolItems } = usePlaygroundActions();
@@ -170,6 +173,7 @@ function PlaygroundContent(): React.ReactElement {
   const { injectToolIntoAgent } = usePlaygroundActions();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
+  const [canvasTab, setCanvasTab] = useState<TCanvasTab>('assembly');
   const { toast } = useToast();
   const toolItems = state.toolItems;
   const toolItemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -222,6 +226,7 @@ function PlaygroundContent(): React.ReactElement {
       await createAgent(agentDraft);
       setAgentDraft(null);
       closeModal();
+      setCanvasTab('assembly');
     }
   };
 
@@ -331,19 +336,46 @@ function PlaygroundContent(): React.ReactElement {
           />
         </div>
 
-        {/* Center: Workflow Visualization */}
+        {/* Center: Assembly / Execution Canvas */}
         <div className="flex-1 h-full overflow-hidden border-r border-border flex flex-col">
-          <div className="px-3 py-2 border-b border-border flex items-center gap-2">
-            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-              Workflow
-            </span>
+          <div className="px-3 py-1.5 border-b border-border flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => setCanvasTab('assembly')}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                canvasTab === 'assembly'
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Assembly
+            </button>
+            <button
+              type="button"
+              onClick={() => setCanvasTab('execution')}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                canvasTab === 'execution'
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Execution
+            </button>
           </div>
           <div className="flex-1 overflow-hidden">
-            <WorkflowVisualization
-              events={state.conversationHistory}
-              activeTools={activeTools}
-              onDropTool={handleDropTool}
-            />
+            {canvasTab === 'assembly' ? (
+              <AssemblyCanvas
+                agentConfig={state.currentAgentConfig}
+                activeTools={activeTools}
+                onDropTool={handleDropTool}
+              />
+            ) : (
+              <WorkflowVisualization
+                events={state.conversationHistory}
+                activeTools={activeTools}
+                onDropTool={handleDropTool}
+              />
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add `assembly-canvas/` with `AgentNode` and `ToolNode` ReactFlow custom nodes
- `AgentNode`: displays provider chip (color-coded), model name, system prompt preview, tool count badge
- `ToolNode`: displays tool name and description, rendered when a tool is dragged from the Tools panel
- Animated dashed edge connects ToolNode (LEFT handle) to AgentNode (RIGHT handle) when tool is injected
- Assembly/Execution tab toggle added to center panel; "Create Agent" auto-switches to Assembly tab
- Unit tests for AgentNode and ToolNode rendering (138 tests pass)

## Test plan
- [x] Browser-verified: Create Agent → AgentNode appears with provider/model
- [x] Browser-verified: Drag Current Time tool → ToolNode added + animated edge + badge "1 tool connected"
- [x] Browser-verified: Chat "What time is it now?" → tool called → current time returned
- [x] All 138 unit tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)