### PR TITLE
feat(plg-011): integrate execution event nodes into assembly canvas

### DIFF
--- a/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
@@ -13,32 +13,56 @@ import {
   type Edge,
 } from '@xyflow/react';
 import { Bot } from 'lucide-react';
-import type { IPlaygroundAgentConfig } from '../../../lib/playground/robota-executor';
+import type {
+  IPlaygroundAgentConfig,
+  IConversationEvent,
+} from '../../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../../tools/catalog';
 import { AgentNode } from './nodes/agent-node';
 import { ToolNode } from './nodes/tool-node';
+import {
+  UserMessageNode,
+  AssistantResponseNode,
+  ToolCallNode,
+  ToolResultNode,
+  ToolErrorNode,
+} from '../workflow-visualization/workflow-nodes';
+import { eventsToFlow } from '../workflow-visualization/events-to-flow';
 
 const nodeTypes = {
   agent: AgentNode,
   tool: ToolNode,
+  user_message: UserMessageNode,
+  assistant_response: AssistantResponseNode,
+  tool_call_start: ToolCallNode,
+  tool_call_complete: ToolResultNode,
+  tool_call_error: ToolErrorNode,
 };
 
 const AGENT_POSITION = { x: 120, y: 120 };
 const TOOL_START_X = 450;
 const TOOL_START_Y = 60;
 const TOOL_GAP_Y = 130;
+const EVENT_CHAIN_OFFSET_X = 40;
+const EVENT_CHAIN_OFFSET_Y = 340;
 
 export interface IAssemblyCanvasProps {
   agentConfig: IPlaygroundAgentConfig | null;
   activeTools: IPlaygroundToolMeta[];
   onDropTool: (tool: IPlaygroundToolMeta) => void;
+  events?: IConversationEvent[];
 }
 
 function buildAgentNodeId(config: IPlaygroundAgentConfig): string {
   return `agent-${config.id ?? config.name}`;
 }
 
-function AssemblyCanvasContent({ agentConfig, activeTools, onDropTool }: IAssemblyCanvasProps) {
+function AssemblyCanvasContent({
+  agentConfig,
+  activeTools,
+  onDropTool,
+  events = [],
+}: IAssemblyCanvasProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -82,9 +106,33 @@ function AssemblyCanvasContent({ agentConfig, activeTools, onDropTool }: IAssemb
       style: { stroke: '#7c3aed', strokeWidth: 2, opacity: 0.8 },
     }));
 
-    setNodes([agentNode, ...toolNodes]);
-    setEdges(toolEdges);
-  }, [agentConfig, activeTools, setNodes, setEdges]);
+    const { nodes: rawEventNodes, edges: eventEdges } = eventsToFlow(events);
+
+    const eventNodes: Node[] = rawEventNodes.map((n) => ({
+      ...n,
+      position: {
+        x: n.position.x + EVENT_CHAIN_OFFSET_X,
+        y: n.position.y + EVENT_CHAIN_OFFSET_Y,
+      },
+    }));
+
+    const agentToChainEdge: Edge[] =
+      events.length > 0
+        ? [
+            {
+              id: `edge-agent-to-chain`,
+              source: agentNodeId,
+              sourceHandle: 'chain-output',
+              target: events[0].id,
+              animated: true,
+              style: { stroke: '#6366f1', strokeWidth: 1.5, opacity: 0.6 },
+            },
+          ]
+        : [];
+
+    setNodes([agentNode, ...toolNodes, ...eventNodes]);
+    setEdges([...toolEdges, ...agentToChainEdge, ...eventEdges]);
+  }, [agentConfig, activeTools, events, setNodes, setEdges]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (e.dataTransfer.types.includes('application/robota-tool')) {

--- a/packages/agent-playground/src/components/playground/assembly-canvas/nodes/agent-node.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/nodes/agent-node.tsx
@@ -31,6 +31,12 @@ export function AgentNode({ data }: { data: IAgentNodeData }) {
         id="tool-input"
         className="!w-3 !h-3 !bg-primary !border-2 !border-background"
       />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="chain-output"
+        className="!w-3 !h-3 !bg-violet-500 !border-2 !border-background"
+      />
       <div className="px-4 py-3">
         <div className="flex items-center gap-2 mb-2">
           <div className="flex items-center justify-center w-7 h-7 rounded-full bg-primary/10">

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-nodes.tsx
@@ -47,7 +47,7 @@ function NodeShell({
 export function UserMessageNode({ data }: NodeProps) {
   const d = data as IFlowNodeData;
   return (
-    <NodeShell accentColor="border-l-4 border-l-blue-500" hasTarget={false}>
+    <NodeShell accentColor="border-l-4 border-l-blue-500">
       <div className="flex items-center gap-1.5 mb-1">
         <MessageSquare className="h-3 w-3 text-blue-400 shrink-0" />
         <span className="font-semibold text-xs text-foreground">User</span>

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -21,7 +21,6 @@ import { Toaster } from '../../components/ui/sonner';
 import { WebLogger } from '../../lib/web-logger';
 import { useToast } from '../../hooks/use-toast';
 import { CreateAgentModal, AddToolModal } from './playground-modals';
-import { WorkflowVisualization } from '../../components/playground/workflow-visualization';
 import { AssemblyCanvas } from '../../components/playground/assembly-canvas';
 import { useProviderConfig } from '../../hooks/use-provider-config';
 import type { IProviderConfig } from '../../hooks/use-provider-config';
@@ -164,8 +163,6 @@ function buildByokBaseUrl(wsUrl: string): string {
     .replace(/\/ws$/, '');
 }
 
-type TCanvasTab = 'assembly' | 'execution';
-
 function PlaygroundContent(): React.ReactElement {
   const state = usePlaygroundState();
   const { setToolItems } = usePlaygroundActions();
@@ -173,7 +170,6 @@ function PlaygroundContent(): React.ReactElement {
   const { injectToolIntoAgent } = usePlaygroundActions();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
-  const [canvasTab, setCanvasTab] = useState<TCanvasTab>('assembly');
   const { toast } = useToast();
   const toolItems = state.toolItems;
   const toolItemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -226,7 +222,6 @@ function PlaygroundContent(): React.ReactElement {
       await createAgent(agentDraft);
       setAgentDraft(null);
       closeModal();
-      setCanvasTab('assembly');
     }
   };
 
@@ -336,47 +331,14 @@ function PlaygroundContent(): React.ReactElement {
           />
         </div>
 
-        {/* Center: Assembly / Execution Canvas */}
-        <div className="flex-1 h-full overflow-hidden border-r border-border flex flex-col">
-          <div className="px-3 py-1.5 border-b border-border flex items-center gap-1 shrink-0">
-            <button
-              type="button"
-              onClick={() => setCanvasTab('assembly')}
-              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-                canvasTab === 'assembly'
-                  ? 'bg-primary/15 text-primary'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Assembly
-            </button>
-            <button
-              type="button"
-              onClick={() => setCanvasTab('execution')}
-              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-                canvasTab === 'execution'
-                  ? 'bg-primary/15 text-primary'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Execution
-            </button>
-          </div>
-          <div className="flex-1 overflow-hidden">
-            {canvasTab === 'assembly' ? (
-              <AssemblyCanvas
-                agentConfig={state.currentAgentConfig}
-                activeTools={activeTools}
-                onDropTool={handleDropTool}
-              />
-            ) : (
-              <WorkflowVisualization
-                events={state.conversationHistory}
-                activeTools={activeTools}
-                onDropTool={handleDropTool}
-              />
-            )}
-          </div>
+        {/* Center: Agent Assembly Canvas */}
+        <div className="flex-1 h-full overflow-hidden border-r border-border">
+          <AssemblyCanvas
+            agentConfig={state.currentAgentConfig}
+            activeTools={activeTools}
+            onDropTool={handleDropTool}
+            events={state.conversationHistory}
+          />
         </div>
 
         {/* Right: Tools */}


### PR DESCRIPTION
## Summary

- Merge conversation history (user_message, tool_call_start, tool_call_complete, assistant_response) into the ReactFlow assembly canvas as connected nodes
- Remove Assembly/Execution tab toggle — single unified canvas shows agent, tools, and conversation chain together
- AgentNode gains a bottom `chain-output` handle; first event node connects directly from it
- UserMessageNode gains a top target handle to receive the incoming edge from AgentNode

## Changes

- `assembly-canvas.tsx`: accept `events` prop, import workflow-node types and `eventsToFlow`, offset event chain below AgentNode with connecting edge
- `agent-node.tsx`: add `chain-output` source handle at bottom
- `workflow-nodes.tsx`: set `UserMessageNode` `hasTarget={true}` (default) to receive incoming edge
- `PlaygroundApp.tsx`: remove tab state/buttons, pass `conversationHistory` to `AssemblyCanvas`

## Test plan

- [x] All 138 unit tests pass
- [x] Browser verified: agent created → AgentNode appears in canvas
- [x] Browser verified: tool dragged to canvas → ToolNode + "N tool connected" on AgentNode
- [x] Browser verified: chat message sent → User + Assistant event nodes chain below AgentNode
- [x] Browser verified: tool call triggered → User → current-time → Tool result → Assistant chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)