### PR TITLE
feat(plg-012): code generator engine — canvas state → TypeScript code

### DIFF
--- a/packages/agent-playground/src/lib/code-generator/__tests__/code-generator.test.ts
+++ b/packages/agent-playground/src/lib/code-generator/__tests__/code-generator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { generateAgentCode } from '../index';
+import type { IAssemblyState } from '../index';
+
+describe('generateAgentCode', () => {
+  it('generates code with OpenAI + current-time tool', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: 'You are helpful.' },
+      tools: ['current-time'],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain("import { Robota } from '@robota-sdk/agent-core'");
+    expect(code).toContain("import { OpenAIProvider } from '@robota-sdk/agent-provider/openai'");
+    expect(code).toContain("import { createCurrentTimeTool } from '@robota-sdk/agent-tools'");
+    expect(code).toContain('process.env.OPENAI_API_KEY');
+    expect(code).toContain("provider: 'openai'");
+    expect(code).toContain("model: 'gpt-4o-mini'");
+    expect(code).toContain('You are helpful.');
+    expect(code).toContain('tools: [createCurrentTimeTool()]');
+    expect(code).toContain("robota.run('Your message here')");
+    expect(code).toContain('robota.destroy()');
+  });
+
+  it('generates code with Anthropic provider using ANTHROPIC_API_KEY', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'anthropic', model: 'claude-3-5-haiku', systemPrompt: '' },
+      tools: [],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain('AnthropicProvider');
+    expect(code).toContain('@robota-sdk/agent-provider/anthropic');
+    expect(code).toContain('process.env.ANTHROPIC_API_KEY');
+  });
+
+  it('escapes backticks in system prompt', () => {
+    const state: IAssemblyState = {
+      agent: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        systemPrompt: 'Use `code` and ${vars}.',
+      },
+      tools: [],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain('\\`code\\`');
+    expect(code).toContain('\\${vars}');
+  });
+
+  it('omits tools array when no tools', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: '' },
+      tools: [],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).not.toContain('tools:');
+  });
+
+  it('omits systemMessage when system prompt is empty', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: '' },
+      tools: [],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).not.toContain('systemMessage');
+  });
+
+  it('generates code with Gemini provider', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'gemini', model: 'gemini-2.0-flash', systemPrompt: '' },
+      tools: [],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain('GeminiProvider');
+    expect(code).toContain('process.env.GEMINI_API_KEY');
+  });
+});

--- a/packages/agent-playground/src/lib/code-generator/assembly-serializer.ts
+++ b/packages/agent-playground/src/lib/code-generator/assembly-serializer.ts
@@ -1,0 +1,90 @@
+import type { IAssemblyState } from './index';
+import { getProviderTemplate } from './provider-templates';
+import { getToolImportEntry } from './tool-import-registry';
+
+function escapeTemplateLiteral(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+function buildImports(state: IAssemblyState): string[] {
+  const lines: string[] = ["import { Robota } from '@robota-sdk/agent-core';"];
+
+  const providerTmpl = getProviderTemplate(state.agent.provider);
+  lines.push(`import { ${providerTmpl.className} } from '${providerTmpl.importPath}';`);
+
+  const toolEntries = state.tools
+    .map((id) => ({ id, entry: getToolImportEntry(id) }))
+    .filter((t): t is { id: string; entry: NonNullable<ReturnType<typeof getToolImportEntry>> } =>
+      Boolean(t.entry),
+    );
+
+  const byPath = new Map<string, string[]>();
+  for (const { entry } of toolEntries) {
+    const names = byPath.get(entry.importPath) ?? [];
+    if (!names.includes(entry.factoryName)) names.push(entry.factoryName);
+    byPath.set(entry.importPath, names);
+  }
+
+  for (const [path, names] of byPath) {
+    lines.push(`import { ${names.join(', ')} } from '${path}';`);
+  }
+
+  return lines;
+}
+
+function buildRobotaOptions(
+  state: IAssemblyState,
+  providerClassName: string,
+  envKey: string,
+): string[] {
+  const lines: string[] = [
+    `  name: 'My Agent',`,
+    `  aiProviders: [new ${providerClassName}({ apiKey: process.env.${envKey} })],`,
+    `  defaultModel: {`,
+    `    provider: '${state.agent.provider}',`,
+    `    model: '${state.agent.model}',`,
+  ];
+
+  if (state.agent.systemPrompt) {
+    const escaped = escapeTemplateLiteral(state.agent.systemPrompt);
+    lines.push(`    systemMessage: \`${escaped}\`,`);
+  }
+
+  lines.push(`  },`);
+
+  if (state.tools.length > 0) {
+    const toolCalls = state.tools
+      .map((id) => getToolImportEntry(id))
+      .filter(Boolean)
+      .map((e) => `${e!.factoryName}()`)
+      .join(', ');
+    if (toolCalls) lines.push(`  tools: [${toolCalls}],`);
+  }
+
+  return lines;
+}
+
+// The lines below are string literals that will be written into generated code files.
+// They are not executed here — allow-console applies to the generated output, not this module.
+const CONSOLE_LOG_LINE = `console.log(response);`; // allow-console: part of generated template, not runtime log
+
+export function serializeToCode(state: IAssemblyState): string {
+  const providerTmpl = getProviderTemplate(state.agent.provider);
+  const imports = buildImports(state);
+  const optionLines = buildRobotaOptions(state, providerTmpl.className, providerTmpl.envKey);
+
+  const parts: string[] = [
+    imports.join('\n'),
+    '',
+    `const robota = new Robota({`,
+    ...optionLines,
+    `});`,
+    '',
+    `const response = await robota.run('Your message here');`,
+    CONSOLE_LOG_LINE,
+    '',
+    `await robota.destroy();`,
+  ];
+
+  return parts.join('\n');
+}

--- a/packages/agent-playground/src/lib/code-generator/index.ts
+++ b/packages/agent-playground/src/lib/code-generator/index.ts
@@ -1,0 +1,10 @@
+export interface IAssemblyState {
+  agent: {
+    provider: string;
+    model: string;
+    systemPrompt: string;
+  };
+  tools: string[];
+}
+
+export { serializeToCode as generateAgentCode } from './assembly-serializer';

--- a/packages/agent-playground/src/lib/code-generator/provider-templates.ts
+++ b/packages/agent-playground/src/lib/code-generator/provider-templates.ts
@@ -1,0 +1,38 @@
+export interface IProviderTemplate {
+  importPath: string;
+  className: string;
+  envKey: string;
+}
+
+const PROVIDER_TEMPLATES: Record<string, IProviderTemplate> = {
+  openai: {
+    importPath: '@robota-sdk/agent-provider/openai',
+    className: 'OpenAIProvider',
+    envKey: 'OPENAI_API_KEY',
+  },
+  anthropic: {
+    importPath: '@robota-sdk/agent-provider/anthropic',
+    className: 'AnthropicProvider',
+    envKey: 'ANTHROPIC_API_KEY',
+  },
+  gemini: {
+    importPath: '@robota-sdk/agent-provider/gemini',
+    className: 'GeminiProvider',
+    envKey: 'GEMINI_API_KEY',
+  },
+  deepseek: {
+    importPath: '@robota-sdk/agent-provider/deepseek',
+    className: 'DeepSeekProvider',
+    envKey: 'DEEPSEEK_API_KEY',
+  },
+};
+
+export function getProviderTemplate(provider: string): IProviderTemplate {
+  return (
+    PROVIDER_TEMPLATES[provider.toLowerCase()] ?? {
+      importPath: `@robota-sdk/agent-provider/${provider.toLowerCase()}`,
+      className: `${provider.charAt(0).toUpperCase()}${provider.slice(1)}Provider`,
+      envKey: `${provider.toUpperCase()}_API_KEY`,
+    }
+  );
+}

--- a/packages/agent-playground/src/lib/code-generator/tool-import-registry.ts
+++ b/packages/agent-playground/src/lib/code-generator/tool-import-registry.ts
@@ -1,0 +1,19 @@
+export interface IToolImportEntry {
+  importPath: string;
+  factoryName: string;
+}
+
+const TOOL_IMPORTS: Record<string, IToolImportEntry> = {
+  'current-time': {
+    importPath: '@robota-sdk/agent-tools',
+    factoryName: 'createCurrentTimeTool',
+  },
+  assignTask: {
+    importPath: '@robota-sdk/agent-team',
+    factoryName: 'createAssignTaskRelayTool',
+  },
+};
+
+export function getToolImportEntry(toolId: string): IToolImportEntry | undefined {
+  return TOOL_IMPORTS[toolId];
+}


### PR DESCRIPTION
## Summary

- Implements `IAssemblyState` type and `generateAgentCode()` pure function
- Generates runnable TypeScript using actual Robota SDK APIs (`Robota` from `@robota-sdk/agent-core`, provider classes, tool factories)
- Provider mapping: openai/anthropic/gemini/deepseek → correct class name, import path, env key
- Tool mapping: current-time → `createCurrentTimeTool()` from `@robota-sdk/agent-tools`
- Escapes backticks and `${}` in system prompts inside template literals
- Omits `systemMessage` and `tools` array when not configured

## Test plan

- [x] 6 unit tests pass covering: OpenAI+tool, Anthropic, Gemini, template-literal escaping, empty tools, empty systemPrompt
- [x] 144/144 total tests pass
- [x] typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)