### PR TITLE
feat(plg-013): code export UI — syntax-highlighted TypeScript panel

### DIFF
--- a/packages/agent-playground/src/components/playground/code-export/__tests__/code-export-panel.test.tsx
+++ b/packages/agent-playground/src/components/playground/code-export/__tests__/code-export-panel.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CodeExportPanel } from '../code-export-panel';
+import type { IPlaygroundAgentConfig } from '../../../../lib/playground/robota-executor';
+
+const mockAgentConfig: IPlaygroundAgentConfig = {
+  id: 'agent-1',
+  name: 'Test Agent',
+  defaultModel: {
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    systemMessage: 'You are helpful.',
+  },
+};
+
+describe('CodeExportPanel', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('shows empty state when no agent configured', () => {
+    render(<CodeExportPanel agentConfig={null} activeTools={[]} />);
+    expect(screen.getByText('Create an agent to generate code')).toBeTruthy();
+  });
+
+  it('renders code after debounce with agent config', async () => {
+    render(<CodeExportPanel agentConfig={mockAgentConfig} activeTools={[]} />);
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getAllByText(/Robota/).length).toBeGreaterThan(0);
+  });
+
+  it('shows Copy Code button when agent is configured', () => {
+    render(<CodeExportPanel agentConfig={mockAgentConfig} activeTools={[]} />);
+    expect(screen.getByRole('button', { name: /Copy/i })).toBeTruthy();
+  });
+
+  it('calls clipboard.writeText on Copy click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<CodeExportPanel agentConfig={mockAgentConfig} activeTools={[]} />);
+    const btn = screen.getByRole('button', { name: /Copy/i });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    fireEvent.click(btn);
+
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalled(), { timeout: 1000 });
+  });
+});

--- a/packages/agent-playground/src/components/playground/code-export/code-export-panel.tsx
+++ b/packages/agent-playground/src/components/playground/code-export/code-export-panel.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, Copy, Code } from 'lucide-react';
+import type { IPlaygroundAgentConfig } from '../../../lib/playground/robota-executor';
+import type { IPlaygroundToolMeta } from '../../../tools/catalog';
+import { generateAgentCode } from '../../../lib/code-generator';
+import { SyntaxHighlighter } from './syntax-highlighter';
+import { InstallGuide } from './install-guide';
+
+const DEBOUNCE_MS = 300;
+const COPY_FEEDBACK_MS = 2000;
+
+interface ICodeExportPanelProps {
+  agentConfig: IPlaygroundAgentConfig | null;
+  activeTools: IPlaygroundToolMeta[];
+}
+
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(id);
+  }, [value, ms]);
+  return debounced;
+}
+
+export function CodeExportPanel({ agentConfig, activeTools }: ICodeExportPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const assemblyState = useMemo(
+    () =>
+      agentConfig
+        ? {
+            agent: {
+              provider: agentConfig.defaultModel.provider,
+              model: agentConfig.defaultModel.model,
+              systemPrompt: agentConfig.defaultModel.systemMessage ?? '',
+            },
+            tools: activeTools.map((t) => t.id),
+          }
+        : null,
+    [agentConfig, activeTools],
+  );
+
+  const debouncedState = useDebounced(assemblyState, DEBOUNCE_MS);
+
+  const code = useMemo(
+    () => (debouncedState ? generateAgentCode(debouncedState) : null),
+    [debouncedState],
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!code) return;
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch (_err) {
+      // allow-fallback: clipboard API may be unavailable; fall back to DOM selection
+      const sel = window.getSelection();
+      const range = document.createRange();
+      const pre = document.querySelector('[data-code-export-pre]');
+      if (sel && pre) {
+        range.selectNodeContents(pre);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+    setCopied(true);
+    copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  }, [code]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  if (!agentConfig) {
+    return (
+      <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-muted-foreground">
+        <Code className="h-10 w-10 opacity-30" />
+        <p className="text-sm">Create an agent to generate code</p>
+        <p className="text-xs opacity-60">
+          Configure an agent and tools to see the TypeScript code
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
+        <span className="text-xs font-medium text-muted-foreground">TypeScript</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Copy code"
+        >
+          {copied ? (
+            <>
+              <Check className="h-3.5 w-3.5 text-green-400" />
+              <span className="text-green-400">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="h-3.5 w-3.5" />
+              <span>Copy Code</span>
+            </>
+          )}
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto p-4 bg-zinc-950/50">
+        <div data-code-export-pre>{code && <SyntaxHighlighter code={code} />}</div>
+        <InstallGuide />
+      </div>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/components/playground/code-export/install-guide.tsx
+++ b/packages/agent-playground/src/components/playground/code-export/install-guide.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import { Terminal } from 'lucide-react';
+
+const INSTALL_COMMAND =
+  'npm install @robota-sdk/agent-core @robota-sdk/agent-provider @robota-sdk/agent-tools';
+
+export function InstallGuide() {
+  return (
+    <div className="border-t border-border mt-4 pt-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-xs font-medium text-muted-foreground">Install dependencies</span>
+      </div>
+      <pre className="text-xs font-mono text-green-400 bg-black/40 rounded px-3 py-2 overflow-x-auto">
+        {INSTALL_COMMAND}
+      </pre>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/components/playground/code-export/syntax-highlighter.tsx
+++ b/packages/agent-playground/src/components/playground/code-export/syntax-highlighter.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+
+type TToken = { type: 'keyword' | 'string' | 'comment' | 'import-path' | 'plain'; text: string };
+
+const KEYWORDS = new Set([
+  'import',
+  'from',
+  'const',
+  'let',
+  'var',
+  'async',
+  'await',
+  'new',
+  'return',
+  'export',
+]);
+
+function tokenizeLine(line: string): TToken[] {
+  const tokens: TToken[] = [];
+  let remaining = line;
+
+  while (remaining.length > 0) {
+    // line comment
+    if (remaining.startsWith('//')) {
+      tokens.push({ type: 'comment', text: remaining });
+      return tokens;
+    }
+
+    // single-quoted or double-quoted string
+    const strMatch = remaining.match(/^(['"])((?:[^'"\\]|\\.)*)\1/);
+    if (strMatch) {
+      tokens.push({ type: 'string', text: strMatch[0] });
+      remaining = remaining.slice(strMatch[0].length);
+      continue;
+    }
+
+    // backtick template literal (simplified, single-line)
+    const tmplMatch = remaining.match(/^`[^`]*`/);
+    if (tmplMatch) {
+      tokens.push({ type: 'string', text: tmplMatch[0] });
+      remaining = remaining.slice(tmplMatch[0].length);
+      continue;
+    }
+
+    // word token
+    const wordMatch = remaining.match(/^[a-zA-Z_$][a-zA-Z0-9_$]*/);
+    if (wordMatch) {
+      const word = wordMatch[0];
+      tokens.push({ type: KEYWORDS.has(word) ? 'keyword' : 'plain', text: word });
+      remaining = remaining.slice(word.length);
+      continue;
+    }
+
+    // single char
+    tokens.push({ type: 'plain', text: remaining[0] });
+    remaining = remaining.slice(1);
+  }
+
+  return tokens;
+}
+
+const TOKEN_COLORS: Record<TToken['type'], string> = {
+  keyword: 'text-violet-400',
+  string: 'text-green-400',
+  comment: 'text-zinc-500 italic',
+  'import-path': 'text-amber-400',
+  plain: 'text-zinc-200',
+};
+
+interface ISyntaxHighlighterProps {
+  code: string;
+  showLineNumbers?: boolean;
+}
+
+export function SyntaxHighlighter({ code, showLineNumbers = true }: ISyntaxHighlighterProps) {
+  const lines = code.split('\n');
+
+  return (
+    <pre className="text-xs leading-relaxed font-mono overflow-x-auto">
+      {lines.map((line, i) => {
+        const tokens = tokenizeLine(line);
+        return (
+          <div key={i} className="flex">
+            {showLineNumbers && (
+              <span className="select-none text-zinc-600 text-right pr-4 w-8 shrink-0">
+                {i + 1}
+              </span>
+            )}
+            <span>
+              {tokens.map((token, j) => (
+                <span key={j} className={TOKEN_COLORS[token.type]}>
+                  {token.text}
+                </span>
+              ))}
+            </span>
+          </div>
+        );
+      })}
+    </pre>
+  );
+}

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -22,6 +22,7 @@ import { WebLogger } from '../../lib/web-logger';
 import { useToast } from '../../hooks/use-toast';
 import { CreateAgentModal, AddToolModal } from './playground-modals';
 import { AssemblyCanvas } from '../../components/playground/assembly-canvas';
+import { CodeExportPanel } from '../../components/playground/code-export/code-export-panel';
 import { useProviderConfig } from '../../hooks/use-provider-config';
 import type { IProviderConfig } from '../../hooks/use-provider-config';
 import { ProviderSetupScreen } from './ProviderSetupScreen';
@@ -170,6 +171,7 @@ function PlaygroundContent(): React.ReactElement {
   const { injectToolIntoAgent } = usePlaygroundActions();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
+  const [chatTab, setChatTab] = useState<'chat' | 'code'>('chat');
   const { toast } = useToast();
   const toolItems = state.toolItems;
   const toolItemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -322,13 +324,43 @@ function PlaygroundContent(): React.ReactElement {
         </div>
       </header>
       <main className="flex-1 overflow-hidden flex">
-        {/* Left: Chat */}
-        <div className="flex-1 h-full overflow-hidden border-r border-border">
-          <ChatInterface
-            isAgentReady={isAgentReady}
-            onSendMessage={handleSendMessage}
-            starterPrompts={isAgentReady ? BYOK_STARTER_PROMPTS : undefined}
-          />
+        {/* Left: Chat / Code Export tabs */}
+        <div className="flex-1 h-full overflow-hidden border-r border-border flex flex-col">
+          <div className="px-3 py-1.5 border-b border-border flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => setChatTab('chat')}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                chatTab === 'chat'
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Chat
+            </button>
+            <button
+              type="button"
+              onClick={() => setChatTab('code')}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                chatTab === 'code'
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Code Export
+            </button>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            {chatTab === 'chat' ? (
+              <ChatInterface
+                isAgentReady={isAgentReady}
+                onSendMessage={handleSendMessage}
+                starterPrompts={isAgentReady ? BYOK_STARTER_PROMPTS : undefined}
+              />
+            ) : (
+              <CodeExportPanel agentConfig={state.currentAgentConfig} activeTools={activeTools} />
+            )}
+          </div>
         </div>
 
         {/* Center: Agent Assembly Canvas */}


### PR DESCRIPTION
## Summary
- `CodeExportPanel`: debounced (300ms) code generation, clipboard copy with 2s checkmark feedback, empty state when no agent configured
- `SyntaxHighlighter`: custom regex tokenizer — keywords (violet), strings (green), comments (italic), line numbers
- `InstallGuide`: npm install command block shown below generated code
- `PlaygroundApp`: Chat / Code Export tab toggle in left panel; conversation events forwarded to AssemblyCanvas

## Test plan
- [x] 4 vitest unit tests pass (empty state, debounce render, copy button present, clipboard.writeText called)
- [x] Browser verified: empty state → agent created → code appears with syntax highlighting
- [x] Browser verified: drag Current Time tool → line 3 import + line 13 tools array auto-updates after 300ms debounce
- [x] `pnpm --filter @robota-sdk/agent-playground build` passes
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)