### PR TITLE
feat(plg-014): skills support — Skills panel + SkillNode + code export integration

### DIFF
--- a/apps/agent-server/src/catalog/skills.ts
+++ b/apps/agent-server/src/catalog/skills.ts
@@ -1,0 +1,30 @@
+export interface ISkillCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+export interface ISkillCatalogResponse {
+  skills: ISkillCatalogEntry[];
+}
+
+const SKILL_CATALOG: ISkillCatalogEntry[] = [
+  {
+    id: 'code-reviewer',
+    name: 'Code Reviewer',
+    description:
+      'Reviews code for bugs, security issues, and style improvements with actionable feedback',
+    tags: ['code', 'review', 'quality'],
+  },
+  {
+    id: 'summarizer',
+    name: 'Summarizer',
+    description: 'Condenses long text into clear, structured summaries with key points',
+    tags: ['text', 'summary', 'analysis'],
+  },
+];
+
+export function getSkillCatalog(): ISkillCatalogResponse {
+  return { skills: SKILL_CATALOG };
+}

--- a/apps/agent-server/src/routes/playground.ts
+++ b/apps/agent-server/src/routes/playground.ts
@@ -1,6 +1,7 @@
 import { Router, type IRouter } from 'express';
 
 import { getProviderCatalog } from '../catalog/providers.js';
+import { getSkillCatalog } from '../catalog/skills.js';
 import { getToolCatalog } from '../catalog/tools.js';
 import { byokKeySanitizer } from '../middleware/byok-key-sanitizer.js';
 import { playgroundExecuteHandler } from './handlers/playground-execute.js';
@@ -23,6 +24,11 @@ playgroundRouter.get('/catalog/providers', (_req, res) => {
 // PLG-017: Tool Catalog
 playgroundRouter.get('/catalog/tools', (_req, res) => {
   res.json(getToolCatalog());
+});
+
+// PLG-014: Skill Catalog
+playgroundRouter.get('/catalog/skills', (_req, res) => {
+  res.json(getSkillCatalog());
 });
 
 // PLG-015: POST /api/playground/execute — SSE streaming agent execution

--- a/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
@@ -18,8 +18,10 @@ import type {
   IConversationEvent,
 } from '../../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../../tools/catalog';
+import type { IPlaygroundSkillMeta } from '../../../skills/catalog';
 import { AgentNode } from './nodes/agent-node';
 import { ToolNode } from './nodes/tool-node';
+import { SkillNode } from './nodes/skill-node';
 import {
   UserMessageNode,
   AssistantResponseNode,
@@ -32,6 +34,7 @@ import { eventsToFlow } from '../workflow-visualization/events-to-flow';
 const nodeTypes = {
   agent: AgentNode,
   tool: ToolNode,
+  skill: SkillNode,
   user_message: UserMessageNode,
   assistant_response: AssistantResponseNode,
   tool_call_start: ToolCallNode,
@@ -39,17 +42,22 @@ const nodeTypes = {
   tool_call_error: ToolErrorNode,
 };
 
-const AGENT_POSITION = { x: 120, y: 120 };
-const TOOL_START_X = 450;
+const AGENT_POSITION = { x: 220, y: 120 };
+const TOOL_START_X = 550;
 const TOOL_START_Y = 60;
 const TOOL_GAP_Y = 130;
+const SKILL_START_X = -220;
+const SKILL_START_Y = 60;
+const SKILL_GAP_Y = 130;
 const EVENT_CHAIN_OFFSET_X = 40;
 const EVENT_CHAIN_OFFSET_Y = 340;
 
 export interface IAssemblyCanvasProps {
   agentConfig: IPlaygroundAgentConfig | null;
   activeTools: IPlaygroundToolMeta[];
+  activeSkills?: IPlaygroundSkillMeta[];
   onDropTool: (tool: IPlaygroundToolMeta) => void;
+  onDropSkill?: (skill: IPlaygroundSkillMeta) => void;
   events?: IConversationEvent[];
 }
 
@@ -60,7 +68,9 @@ function buildAgentNodeId(config: IPlaygroundAgentConfig): string {
 function AssemblyCanvasContent({
   agentConfig,
   activeTools,
+  activeSkills = [],
   onDropTool,
+  onDropSkill,
   events = [],
 }: IAssemblyCanvasProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -106,6 +116,23 @@ function AssemblyCanvasContent({
       style: { stroke: '#7c3aed', strokeWidth: 2, opacity: 0.8 },
     }));
 
+    const skillNodes: Node[] = activeSkills.map((skill, idx) => ({
+      id: `skill-${skill.id}`,
+      type: 'skill',
+      position: { x: SKILL_START_X, y: SKILL_START_Y + idx * SKILL_GAP_Y },
+      data: { name: skill.name, description: skill.description },
+    }));
+
+    const skillEdges: Edge[] = activeSkills.map((skill) => ({
+      id: `edge-skill-${skill.id}`,
+      source: `skill-${skill.id}`,
+      sourceHandle: 'skill-output',
+      target: agentNodeId,
+      targetHandle: 'tool-input',
+      animated: true,
+      style: { stroke: '#8b5cf6', strokeWidth: 1.5, opacity: 0.7, strokeDasharray: '4 2' },
+    }));
+
     const { nodes: rawEventNodes, edges: eventEdges } = eventsToFlow(events);
 
     const eventNodes: Node[] = rawEventNodes.map((n) => ({
@@ -130,12 +157,15 @@ function AssemblyCanvasContent({
           ]
         : [];
 
-    setNodes([agentNode, ...toolNodes, ...eventNodes]);
-    setEdges([...toolEdges, ...agentToChainEdge, ...eventEdges]);
-  }, [agentConfig, activeTools, events, setNodes, setEdges]);
+    setNodes([agentNode, ...skillNodes, ...toolNodes, ...eventNodes]);
+    setEdges([...skillEdges, ...toolEdges, ...agentToChainEdge, ...eventEdges]);
+  }, [agentConfig, activeTools, activeSkills, events, setNodes, setEdges]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (e.dataTransfer.types.includes('application/robota-tool')) {
+    if (
+      e.dataTransfer.types.includes('application/robota-tool') ||
+      e.dataTransfer.types.includes('application/robota-skill')
+    ) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
       setIsDragOver(true);
@@ -152,12 +182,19 @@ function AssemblyCanvasContent({
     (e: React.DragEvent) => {
       e.preventDefault();
       setIsDragOver(false);
-      const raw = e.dataTransfer.getData('application/robota-tool');
-      if (!raw) return;
-      const tool = JSON.parse(raw) as IPlaygroundToolMeta;
-      onDropTool(tool);
+      const rawTool = e.dataTransfer.getData('application/robota-tool');
+      if (rawTool) {
+        const tool = JSON.parse(rawTool) as IPlaygroundToolMeta;
+        onDropTool(tool);
+        return;
+      }
+      const rawSkill = e.dataTransfer.getData('application/robota-skill');
+      if (rawSkill && onDropSkill) {
+        const skill = JSON.parse(rawSkill) as IPlaygroundSkillMeta;
+        onDropSkill(skill);
+      }
     },
-    [onDropTool],
+    [onDropTool, onDropSkill],
   );
 
   if (!agentConfig) {

--- a/packages/agent-playground/src/components/playground/assembly-canvas/nodes/skill-node.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/nodes/skill-node.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Sparkles } from 'lucide-react';
+
+export interface ISkillNodeData extends Record<string, unknown> {
+  name: string;
+  description?: string;
+}
+
+export function SkillNode({ data }: { data: ISkillNodeData }) {
+  return (
+    <div className="bg-card border border-violet-500/40 rounded-lg shadow-sm shadow-violet-500/10 w-44">
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="skill-output"
+        className="!w-3 !h-3 !bg-violet-500 !border-2 !border-background"
+      />
+      <div className="px-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <Sparkles className="h-3.5 w-3.5 text-violet-400 shrink-0" />
+          <span className="text-xs font-semibold text-violet-300 truncate">{data.name}</span>
+        </div>
+        {data.description && (
+          <p className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-relaxed">
+            {data.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent-playground/src/components/playground/code-export/code-export-panel.tsx
+++ b/packages/agent-playground/src/components/playground/code-export/code-export-panel.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Check, Copy, Code } from 'lucide-react';
 import type { IPlaygroundAgentConfig } from '../../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../../tools/catalog';
+import type { IPlaygroundSkillMeta } from '../../../skills/catalog';
 import { generateAgentCode } from '../../../lib/code-generator';
 import { SyntaxHighlighter } from './syntax-highlighter';
 import { InstallGuide } from './install-guide';
@@ -14,6 +15,7 @@ const COPY_FEEDBACK_MS = 2000;
 interface ICodeExportPanelProps {
   agentConfig: IPlaygroundAgentConfig | null;
   activeTools: IPlaygroundToolMeta[];
+  activeSkills?: IPlaygroundSkillMeta[];
 }
 
 function useDebounced<T>(value: T, ms: number): T {
@@ -25,7 +27,11 @@ function useDebounced<T>(value: T, ms: number): T {
   return debounced;
 }
 
-export function CodeExportPanel({ agentConfig, activeTools }: ICodeExportPanelProps) {
+export function CodeExportPanel({
+  agentConfig,
+  activeTools,
+  activeSkills = [],
+}: ICodeExportPanelProps) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -39,9 +45,10 @@ export function CodeExportPanel({ agentConfig, activeTools }: ICodeExportPanelPr
               systemPrompt: agentConfig.defaultModel.systemMessage ?? '',
             },
             tools: activeTools.map((t) => t.id),
+            skills: activeSkills.map((s) => s.id),
           }
         : null,
-    [agentConfig, activeTools],
+    [agentConfig, activeTools, activeSkills],
   );
 
   const debouncedState = useDebounced(assemblyState, DEBOUNCE_MS);

--- a/packages/agent-playground/src/lib/code-generator/__tests__/code-generator.test.ts
+++ b/packages/agent-playground/src/lib/code-generator/__tests__/code-generator.test.ts
@@ -7,6 +7,7 @@ describe('generateAgentCode', () => {
     const state: IAssemblyState = {
       agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: 'You are helpful.' },
       tools: ['current-time'],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
@@ -26,6 +27,7 @@ describe('generateAgentCode', () => {
     const state: IAssemblyState = {
       agent: { provider: 'anthropic', model: 'claude-3-5-haiku', systemPrompt: '' },
       tools: [],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
@@ -42,6 +44,7 @@ describe('generateAgentCode', () => {
         systemPrompt: 'Use `code` and ${vars}.',
       },
       tools: [],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
@@ -53,6 +56,7 @@ describe('generateAgentCode', () => {
     const state: IAssemblyState = {
       agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: '' },
       tools: [],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
@@ -63,6 +67,7 @@ describe('generateAgentCode', () => {
     const state: IAssemblyState = {
       agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: '' },
       tools: [],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
@@ -73,10 +78,35 @@ describe('generateAgentCode', () => {
     const state: IAssemblyState = {
       agent: { provider: 'gemini', model: 'gemini-2.0-flash', systemPrompt: '' },
       tools: [],
+      skills: [],
     };
     const code = generateAgentCode(state);
 
     expect(code).toContain('GeminiProvider');
     expect(code).toContain('process.env.GEMINI_API_KEY');
+  });
+
+  it('appends skill system prompt additions to systemMessage', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: 'You are helpful.' },
+      tools: [],
+      skills: ['code-reviewer'],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain('You are helpful.');
+    expect(code).toContain('You are an expert code reviewer.');
+  });
+
+  it('generates systemMessage from skill only when base prompt is empty', () => {
+    const state: IAssemblyState = {
+      agent: { provider: 'openai', model: 'gpt-4o-mini', systemPrompt: '' },
+      tools: [],
+      skills: ['summarizer'],
+    };
+    const code = generateAgentCode(state);
+
+    expect(code).toContain('systemMessage');
+    expect(code).toContain('You are an expert at summarizing content.');
   });
 });

--- a/packages/agent-playground/src/lib/code-generator/assembly-serializer.ts
+++ b/packages/agent-playground/src/lib/code-generator/assembly-serializer.ts
@@ -1,6 +1,7 @@
 import type { IAssemblyState } from './index';
 import { getProviderTemplate } from './provider-templates';
 import { getToolImportEntry } from './tool-import-registry';
+import { getSkillById } from '../../skills/catalog';
 
 function escapeTemplateLiteral(str: string): string {
   return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
@@ -45,8 +46,16 @@ function buildRobotaOptions(
     `    model: '${state.agent.model}',`,
   ];
 
-  if (state.agent.systemPrompt) {
-    const escaped = escapeTemplateLiteral(state.agent.systemPrompt);
+  const skillAdditions = (state.skills ?? [])
+    .map((id) => getSkillById(id)?.systemPromptAddition)
+    .filter(Boolean) as string[];
+
+  const fullSystemPrompt = [state.agent.systemPrompt, ...skillAdditions]
+    .filter(Boolean)
+    .join('\n\n');
+
+  if (fullSystemPrompt) {
+    const escaped = escapeTemplateLiteral(fullSystemPrompt);
     lines.push(`    systemMessage: \`${escaped}\`,`);
   }
 

--- a/packages/agent-playground/src/lib/code-generator/index.ts
+++ b/packages/agent-playground/src/lib/code-generator/index.ts
@@ -5,6 +5,7 @@ export interface IAssemblyState {
     systemPrompt: string;
   };
   tools: string[];
+  skills: string[];
 }
 
 export { serializeToCode as generateAgentCode } from './assembly-serializer';

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -13,9 +13,11 @@ import {
 import { useRobotaExecution } from '../../hooks/use-robota-execution';
 import { useModal } from '../../hooks/use-modal';
 import { Button } from '../../components/ui/button';
-import { Bot, Trash2, Wrench, Wifi, WifiOff, Loader2 } from 'lucide-react';
+import { Bot, Trash2, Wrench, Sparkles, Wifi, WifiOff, Loader2 } from 'lucide-react';
 import type { IPlaygroundAgentConfig } from '../../lib/playground/robota-executor';
 import type { IPlaygroundToolMeta } from '../../tools/catalog';
+import type { IPlaygroundSkillMeta } from '../../skills/catalog';
+import { getPlaygroundSkillCatalog } from '../../skills/catalog';
 import { ChatInterface } from '../../components/playground/chat-interface';
 import { Toaster } from '../../components/ui/sonner';
 import { WebLogger } from '../../lib/web-logger';
@@ -172,8 +174,11 @@ function PlaygroundContent(): React.ReactElement {
   const { isModalOpen, openModal, closeModal } = useModal();
   const [agentDraft, setAgentDraft] = useState<IPlaygroundAgentConfig | null>(null);
   const [chatTab, setChatTab] = useState<'chat' | 'code'>('chat');
+  const [rightTab, setRightTab] = useState<'tools' | 'skills'>('tools');
   const { toast } = useToast();
   const toolItems = state.toolItems;
+  const skillCatalog = useMemo(() => getPlaygroundSkillCatalog(), []);
+  const [activeSkillIds, setActiveSkillIds] = useState<string[]>([]);
   const toolItemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [lastAddedToolId, setLastAddedToolId] = useState<string | null>(null);
   const sortedToolItems = useMemo(
@@ -249,6 +254,10 @@ function PlaygroundContent(): React.ReactElement {
     () => toolItems.filter((t) => agentActiveToolIds.includes(t.id)),
     [toolItems, agentActiveToolIds],
   );
+  const activeSkills = useMemo(
+    () => skillCatalog.filter((s) => activeSkillIds.includes(s.id)),
+    [skillCatalog, activeSkillIds],
+  );
 
   const handleDropTool = async (tool: IPlaygroundToolMeta) => {
     if (!currentAgentId) {
@@ -269,6 +278,24 @@ function PlaygroundContent(): React.ReactElement {
       description: tool.description,
     });
     toast({ title: `${tool.name} added to agent` });
+  };
+
+  const handleDropSkill = (skill: IPlaygroundSkillMeta) => {
+    if (!currentAgentId) {
+      toast({ title: 'Create an agent first', variant: 'destructive' });
+      return;
+    }
+    if (activeSkillIds.includes(skill.id)) {
+      toast({ title: `${skill.name} already added`, variant: 'default' });
+      return;
+    }
+    setActiveSkillIds((prev) => [...prev, skill.id]);
+    toast({ title: `${skill.name} added to agent` });
+  };
+
+  const handleRemoveSkill = (skill: IPlaygroundSkillMeta) => {
+    setActiveSkillIds((prev) => prev.filter((id) => id !== skill.id));
+    toast({ title: 'Skill removed', description: `${skill.name} was removed.` });
   };
 
   if (!state.isInitialized && !providerConfig) {
@@ -358,7 +385,11 @@ function PlaygroundContent(): React.ReactElement {
                 starterPrompts={isAgentReady ? BYOK_STARTER_PROMPTS : undefined}
               />
             ) : (
-              <CodeExportPanel agentConfig={state.currentAgentConfig} activeTools={activeTools} />
+              <CodeExportPanel
+                agentConfig={state.currentAgentConfig}
+                activeTools={activeTools}
+                activeSkills={activeSkills}
+              />
             )}
           </div>
         </div>
@@ -368,85 +399,173 @@ function PlaygroundContent(): React.ReactElement {
           <AssemblyCanvas
             agentConfig={state.currentAgentConfig}
             activeTools={activeTools}
+            activeSkills={activeSkills}
             onDropTool={handleDropTool}
+            onDropSkill={handleDropSkill}
             events={state.conversationHistory}
           />
         </div>
 
-        {/* Right: Tools */}
-        <div className="w-64 h-full bg-card border-l border-border overflow-y-auto">
-          <div className="p-4 h-full flex flex-col">
-            <div className="flex items-center gap-2 mb-3">
-              <Wrench className="h-5 w-5 text-muted-foreground" />
-              <h3 className="font-semibold text-foreground">Tools</h3>
-            </div>
-            <div className="space-y-2 overflow-auto pr-1">
-              {sortedToolItems.map((tool) => (
-                <div
-                  key={tool.id}
-                  className="border border-border rounded bg-card hover:shadow-sm transition-shadow"
-                >
-                  <div className="flex items-start gap-2 p-3">
-                    <button
-                      type="button"
-                      className="flex-1 text-left cursor-grab select-none focus:outline-none focus:ring-2 focus:ring-primary rounded"
-                      draggable
-                      onDragStart={(e) => {
-                        e.dataTransfer.setData('application/robota-tool', JSON.stringify(tool));
-                      }}
-                      title="Drag onto an agent node to add"
-                      ref={(el) => {
-                        if (el) toolItemRefs.current.set(tool.id, el);
-                      }}
-                    >
-                      <div className="text-sm font-medium text-foreground">{tool.name}</div>
-                      <div className="text-xs text-muted-foreground mt-1 leading-relaxed line-clamp-4">
-                        {tool.description}
-                      </div>
-                      {tool.tags && tool.tags.length > 0 && (
-                        <div className="flex flex-wrap gap-1 mt-2">
-                          {tool.tags.map((tag) => (
-                            <span
-                              key={tag}
-                              className="inline-block bg-primary/10 text-primary text-xs px-2 py-1 rounded"
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      disabled={tool.type === 'builtin'}
-                      onClick={() => handleRemoveTool(tool)}
-                      title={
-                        tool.type === 'builtin' ? 'Builtin tools cannot be removed' : 'Remove tool'
-                      }
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className="mt-3">
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full"
-                onClick={() => {
-                  setToolDraft({ name: '', description: '' });
-                  openModal('addTool');
-                }}
-              >
-                + Add Tool
-              </Button>
-            </div>
+        {/* Right: Tools / Skills tabs */}
+        <div className="w-64 h-full bg-card border-l border-border flex flex-col overflow-hidden">
+          {/* Tab header */}
+          <div className="px-3 py-2 border-b border-border flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => setRightTab('tools')}
+              className={`flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded transition-colors ${
+                rightTab === 'tools'
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <Wrench className="h-3.5 w-3.5" />
+              Tools
+            </button>
+            <button
+              type="button"
+              onClick={() => setRightTab('skills')}
+              className={`flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded transition-colors ${
+                rightTab === 'skills'
+                  ? 'bg-violet-500/15 text-violet-400'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              Skills
+            </button>
           </div>
+
+          {/* Tools panel */}
+          {rightTab === 'tools' && (
+            <div className="flex-1 flex flex-col overflow-hidden p-3">
+              <div className="flex-1 space-y-2 overflow-auto pr-1">
+                {sortedToolItems.map((tool) => (
+                  <div
+                    key={tool.id}
+                    className="border border-border rounded bg-card hover:shadow-sm transition-shadow"
+                  >
+                    <div className="flex items-start gap-2 p-3">
+                      <button
+                        type="button"
+                        className="flex-1 text-left cursor-grab select-none focus:outline-none focus:ring-2 focus:ring-primary rounded"
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData('application/robota-tool', JSON.stringify(tool));
+                        }}
+                        title="Drag onto an agent node to add"
+                        ref={(el) => {
+                          if (el) toolItemRefs.current.set(tool.id, el);
+                        }}
+                      >
+                        <div className="text-sm font-medium text-foreground">{tool.name}</div>
+                        <div className="text-xs text-muted-foreground mt-1 leading-relaxed line-clamp-4">
+                          {tool.description}
+                        </div>
+                        {tool.tags && tool.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-2">
+                            {tool.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-block bg-primary/10 text-primary text-xs px-2 py-1 rounded"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        disabled={tool.type === 'builtin'}
+                        onClick={() => handleRemoveTool(tool)}
+                        title={
+                          tool.type === 'builtin'
+                            ? 'Builtin tools cannot be removed'
+                            : 'Remove tool'
+                        }
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    setToolDraft({ name: '', description: '' });
+                    openModal('addTool');
+                  }}
+                >
+                  + Add Tool
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Skills panel */}
+          {rightTab === 'skills' && (
+            <div className="flex-1 flex flex-col overflow-hidden p-3">
+              <div className="flex-1 space-y-2 overflow-auto pr-1">
+                {skillCatalog.map((skill) => (
+                  <div
+                    key={skill.id}
+                    className="border border-violet-500/30 rounded bg-card hover:shadow-sm hover:border-violet-500/50 transition-all"
+                  >
+                    <div className="flex items-start gap-2 p-3">
+                      <button
+                        type="button"
+                        className="flex-1 text-left cursor-grab select-none focus:outline-none focus:ring-2 focus:ring-violet-500 rounded"
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData('application/robota-skill', JSON.stringify(skill));
+                        }}
+                        title="Drag onto an agent node to add"
+                      >
+                        <div className="flex items-center gap-1.5">
+                          <Sparkles className="h-3 w-3 text-violet-400 shrink-0" />
+                          <div className="text-sm font-medium text-foreground">{skill.name}</div>
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1 leading-relaxed line-clamp-3">
+                          {skill.description}
+                        </div>
+                        {skill.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-2">
+                            {skill.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-block bg-violet-500/10 text-violet-400 text-xs px-2 py-1 rounded"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        disabled={!activeSkillIds.includes(skill.id)}
+                        onClick={() => handleRemoveSkill(skill)}
+                        title={activeSkillIds.includes(skill.id) ? 'Remove skill' : 'Not yet added'}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </main>
       <CreateAgentModal

--- a/packages/agent-playground/src/skills/catalog.ts
+++ b/packages/agent-playground/src/skills/catalog.ts
@@ -1,0 +1,42 @@
+import type { IPlaygroundSkillMeta } from './types';
+
+export type { IPlaygroundSkillMeta } from './types';
+
+const CODE_REVIEWER_SKILL: IPlaygroundSkillMeta = {
+  id: 'code-reviewer',
+  name: 'Code Reviewer',
+  description:
+    'Reviews code for bugs, security issues, and style improvements with actionable feedback',
+  tags: ['code', 'review', 'quality'],
+  systemPromptAddition: [
+    'You are an expert code reviewer. When reviewing code:',
+    '- Identify bugs, security vulnerabilities, and performance issues',
+    '- Suggest idiomatic improvements and best practices',
+    '- Provide clear, actionable feedback with examples',
+    '- Prioritize issues by severity (critical, major, minor)',
+  ].join('\n'),
+};
+
+const SUMMARIZER_SKILL: IPlaygroundSkillMeta = {
+  id: 'summarizer',
+  name: 'Summarizer',
+  description: 'Condenses long text into clear, structured summaries with key points',
+  tags: ['text', 'summary', 'analysis'],
+  systemPromptAddition: [
+    'You are an expert at summarizing content. When summarizing:',
+    '- Extract the most important points concisely',
+    '- Use structured formatting (bullet points, headers) when helpful',
+    '- Preserve key facts, figures, and conclusions',
+    '- Match summary length to content complexity',
+  ].join('\n'),
+};
+
+const SKILL_CATALOG: IPlaygroundSkillMeta[] = [CODE_REVIEWER_SKILL, SUMMARIZER_SKILL];
+
+export function getPlaygroundSkillCatalog(): IPlaygroundSkillMeta[] {
+  return SKILL_CATALOG;
+}
+
+export function getSkillById(id: string): IPlaygroundSkillMeta | undefined {
+  return SKILL_CATALOG.find((s) => s.id === id);
+}

--- a/packages/agent-playground/src/skills/types.ts
+++ b/packages/agent-playground/src/skills/types.ts
@@ -1,0 +1,7 @@
+export interface IPlaygroundSkillMeta {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  systemPromptAddition: string;
+}


### PR DESCRIPTION
## Summary
- `IPlaygroundSkillMeta` type + catalog with `systemPromptAddition` (Code Reviewer, Summarizer)
- `SkillNode`: violet sparkle icon, dashed edge to AgentNode, visually distinct from ToolNode
- Right sidebar Tools/Skills tab toggle; skill cards draggable with `application/robota-skill` MIME type
- `AssemblyCanvas`: `activeSkills` prop, skill nodes positioned left of AgentNode, `onDropSkill` callback
- `IAssemblyState.skills: string[]` — skill system prompts merged into generated `systemMessage`
- `GET /api/playground/catalog/skills` endpoint on agent-server

## Test plan
- [x] 2 new code-generator tests (skill prompt merge, skill-only prompt); 150 total pass
- [x] Browser verified: Skills tab shows Code Reviewer + Summarizer cards (violet border)
- [x] Browser verified: drag skill → SkillNode appears on canvas with dashed edge to AgentNode
- [x] Browser verified: Code Export tab shows skill system prompt in generated `systemMessage`
- [x] curl verified: `GET /api/playground/catalog/skills` returns both skills
- [x] `pnpm typecheck` passes (both agent-playground and agent-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)