### PR TITLE
release: session log correlation + clearChat reset + DAG verification (20 cycles)

### DIFF
--- a/.agents/backlog/PLG-019-remove-assign-task-use-agent-command.md
+++ b/.agents/backlog/PLG-019-remove-assign-task-use-agent-command.md
@@ -1,0 +1,57 @@
+---
+title: 'PLG-019: AssignTask 제거 — 서브에이전트는 Agent Command로만 구현'
+status: todo
+created: 2026-05-20
+priority: high
+urgency: now
+area: packages/agent-playground, packages/agent-team
+depends_on: []
+---
+
+## Background
+
+현재 Playground에는 서브에이전트를 spawn하는 방법이 두 가지 존재한다:
+
+1. **AssignTask** (`packages/agent-playground/src/tools/catalog.ts`) — `@robota-sdk/agent-team`의 `createAssignTaskRelayTool`을 래핑한 플레이그라운드 전용 relay tool
+2. **Agent Command** (`/agent` command, `robota_command_agent` tool) — `@robota-sdk/agent-command`의 `createAgentCommandModule()`이 제공하는 모델 호출 가능 커맨드
+
+두 방법이 병존하면 구현이 중복되고 DAG 시각화 로직에서도 `robota_command_agent`만 처리하도록 되어 있어 AssignTask가 사실상 dead code 상태다.
+
+**결정**: AssignTask를 완전히 제거하고 Agent Command(`robota_command_agent`)만 사용한다.
+
+## Goals
+
+- AssignTask 관련 코드를 레포 전체에서 완전히 제거
+- `@robota-sdk/agent-team` 패키지 의존성이 AssignTask 때문만이라면 해당 의존성도 제거
+- `robota_command_agent` (Agent Command)로 병렬 서브에이전트 호출이 Playground에서 정상 동작함을 검증
+
+## Scope
+
+### 제거 대상
+
+- `packages/agent-playground/src/tools/catalog.ts` — `ASSIGN_TASK_META`, `assignTask` ToolRegistry 항목 제거
+- `packages/agent-playground/src/tools/catalog.ts` — `createAssignTaskRelayTool` import 및 `@robota-sdk/agent-team` import 제거
+- `packages/agent-playground/package.json` — `@robota-sdk/agent-team` 의존성 확인 후 제거 (AssignTask 외 다른 용도가 없으면)
+- 관련 타입/인터페이스/테스트 파일 정리
+
+### 검증 항목
+
+- [ ] AssignTask 관련 코드가 레포에 남아있지 않음 (`grep -r "assignTask\|AssignTask\|assign_task" --include="*.ts"`)
+- [ ] `@robota-sdk/agent-team` import가 agent-playground에 남아있지 않음
+- [ ] Playground에서 에이전트 생성 후 "병렬로 두 가지 작업을 동시에 처리해줘" 요청 시 `robota_command_agent` tool이 호출되어 DAG에 `agent_job_created`, `agent_job_completed` 노드가 정상 표시됨
+- [ ] typecheck, lint, test 통과
+
+## User Execution Test Scenarios
+
+### Scenario 1: AssignTask 완전 제거 확인
+
+1. Playground UI에서 Tools 패널 열기
+2. AssignTask 툴이 목록에 없음을 확인
+3. `grep -r "AssignTask" packages/agent-playground/src` 결과 없음 확인
+
+### Scenario 2: Agent Command로 병렬 서브에이전트 실행
+
+1. Playground에서 에이전트 생성
+2. "현재 서울 시각과 뉴욕 시각을 동시에 두 개의 서브에이전트로 조회해줘" 입력
+3. DAG에 `agent_job_created` 노드 2개, `agent_job_completed` 노드 2개가 표시됨을 확인
+4. `window.__robota_dag.events` 콘솔 조회로 0 orphans, 0 duplicate edges 확인

--- a/apps/agent-server/src/routes/handlers/playground-session-submit.ts
+++ b/apps/agent-server/src/routes/handlers/playground-session-submit.ts
@@ -57,10 +57,20 @@ export async function playgroundSessionSubmitHandler(req: Request, res: Response
     });
   };
 
+  let mainComplete = false;
+  let pendingBackgroundTasks = 0;
+
+  const tryClose = (): void => {
+    if (mainComplete && pendingBackgroundTasks === 0) {
+      cleanup();
+      sendEvent(res, { type: 'done', data: { usage: {} } });
+      res.end();
+    }
+  };
+
   const onComplete = (): void => {
-    cleanup();
-    sendEvent(res, { type: 'done', data: { usage: {} } });
-    res.end();
+    mainComplete = true;
+    tryClose();
   };
 
   const onError = (error: Error): void => {
@@ -78,6 +88,12 @@ export async function playgroundSessionSubmitHandler(req: Request, res: Response
   const onBackgroundTaskEvent = (event: TBackgroundTaskEvent): void => {
     switch (event.type) {
       case 'background_task_created': {
+        pendingBackgroundTasks += 1;
+        console.log(
+          '[SSE] bg_task_created: taskId=%s pendingBg=%d',
+          event.task.id,
+          pendingBackgroundTasks,
+        );
         const originToolCallId = event.task.metadata?.['executionOriginToolCallId'];
         sendEvent(res, {
           type: 'agent_job_created',
@@ -113,6 +129,12 @@ export async function playgroundSessionSubmitHandler(req: Request, res: Response
         });
         break;
       case 'background_task_completed':
+        pendingBackgroundTasks = Math.max(0, pendingBackgroundTasks - 1);
+        console.log(
+          '[SSE] bg_task_completed: taskId=%s pendingBg=%d',
+          event.task.id,
+          pendingBackgroundTasks,
+        );
         sendEvent(res, {
           type: 'agent_job_completed',
           data: {
@@ -121,12 +143,15 @@ export async function playgroundSessionSubmitHandler(req: Request, res: Response
             agentType: event.task.agentType,
           },
         });
+        tryClose();
         break;
       case 'background_task_failed':
+        pendingBackgroundTasks = Math.max(0, pendingBackgroundTasks - 1);
         sendEvent(res, {
           type: 'agent_job_failed',
           data: { taskId: event.task.id, label: event.task.label },
         });
+        tryClose();
         break;
     }
   };

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -214,8 +214,17 @@ function logBackgroundTaskEvent(
   sessionId: string,
   event: TBackgroundTaskEvent,
 ): void {
+  const correlationFields: Record<string, string> = {};
+  if (event.type === 'background_task_created') {
+    correlationFields['taskId'] = event.task.id;
+    const originToolCallId = event.task.metadata?.['executionOriginToolCallId'];
+    if (typeof originToolCallId === 'string') {
+      correlationFields['originToolCallId'] = originToolCallId;
+    }
+  }
   logger.log(sessionId, 'background_task_event', {
     backgroundEventType: event.type,
     backgroundEvent: event,
+    ...correlationFields,
   });
 }

--- a/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
@@ -90,8 +90,21 @@ function AssemblyCanvasContent({
         unknown
       >) ?? {}),
       test: (mockEvents: IConversationEvent[]) => eventsToFlow(mockEvents),
+      renderMock: (mockEvents: IConversationEvent[]) => {
+        const { nodes: raw, edges: mockEdges } = eventsToFlow(mockEvents);
+        setNodes(
+          raw.map((n) => ({
+            ...n,
+            position: {
+              x: n.position.x + EVENT_CHAIN_OFFSET_X,
+              y: n.position.y + EVENT_CHAIN_OFFSET_Y,
+            },
+          })),
+        );
+        setEdges(mockEdges);
+      },
     };
-  }, []);
+  }, [setNodes, setEdges]);
 
   useEffect(() => {
     if (!agentConfig) {
@@ -177,6 +190,10 @@ function AssemblyCanvasContent({
     setEdges([...skillEdges, ...toolEdges, ...agentToChainEdge, ...eventEdges]);
 
     (window as unknown as Record<string, unknown>).__robota_dag = {
+      ...(((window as unknown as Record<string, unknown>).__robota_dag as Record<
+        string,
+        unknown
+      >) ?? {}),
       events,
       eventNodes: rawEventNodes,
       eventEdges,

--- a/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
+++ b/packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx
@@ -84,6 +84,16 @@ function AssemblyCanvasContent({
   const [isDragOver, setIsDragOver] = useState(false);
 
   useEffect(() => {
+    (window as unknown as Record<string, unknown>).__robota_dag = {
+      ...(((window as unknown as Record<string, unknown>).__robota_dag as Record<
+        string,
+        unknown
+      >) ?? {}),
+      test: (mockEvents: IConversationEvent[]) => eventsToFlow(mockEvents),
+    };
+  }, []);
+
+  useEffect(() => {
     if (!agentConfig) {
       setNodes([]);
       setEdges([]);
@@ -165,6 +175,13 @@ function AssemblyCanvasContent({
 
     setNodes([agentNode, ...skillNodes, ...toolNodes, ...eventNodes]);
     setEdges([...skillEdges, ...toolEdges, ...agentToChainEdge, ...eventEdges]);
+
+    (window as unknown as Record<string, unknown>).__robota_dag = {
+      events,
+      eventNodes: rawEventNodes,
+      eventEdges,
+      test: (mockEvents: IConversationEvent[]) => eventsToFlow(mockEvents),
+    };
   }, [agentConfig, activeTools, activeSkills, events, setNodes, setEdges]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {

--- a/packages/agent-playground/src/components/playground/chat-interface/types.ts
+++ b/packages/agent-playground/src/components/playground/chat-interface/types.ts
@@ -18,6 +18,7 @@ export interface ISlashCommand {
 export interface IChatPanelProps {
   isAgentReady: boolean;
   onSendMessage?: (message: string) => Promise<string>;
+  onClearChat?: () => void;
   starterPrompts?: string[];
   availableCommands?: ISlashCommand[];
   initialMessages?: IChatPanelMessage[];

--- a/packages/agent-playground/src/components/playground/chat-interface/use-chat-interface-state.ts
+++ b/packages/agent-playground/src/components/playground/chat-interface/use-chat-interface-state.ts
@@ -25,6 +25,7 @@ interface IUseChatInterfaceStateReturn {
 export function useChatInterfaceState({
   isAgentReady,
   onSendMessage,
+  onClearChat,
   initialMessages,
 }: IChatPanelProps): IUseChatInterfaceStateReturn {
   const [messages, setMessages] = useState<IChatPanelMessage[]>(initialMessages ?? []);
@@ -54,7 +55,8 @@ export function useChatInterfaceState({
 
   const clearChat = useCallback(() => {
     setMessages([]);
-  }, []);
+    onClearChat?.();
+  }, [onClearChat]);
 
   const retryLastMessage = useCallback(() => {
     const lastUserMessage = findLastUserMessage(messages);

--- a/packages/agent-playground/src/components/playground/workflow-visualization/__tests__/events-to-flow.test.ts
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/__tests__/events-to-flow.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { eventsToFlow } from '../events-to-flow';
+import type { IConversationEvent } from '../../../../lib/playground/robota-executor';
+
+function edge(source: string, target: string) {
+  return expect.objectContaining({ source, target });
+}
+
+function hasEdge(edges: { source: string; target: string }[], src: string, tgt: string): boolean {
+  return edges.some((e) => e.source === src && e.target === tgt);
+}
+
+function edgeCount(edges: { source: string; target: string }[], src: string, tgt: string): number {
+  return edges.filter((e) => e.source === src && e.target === tgt).length;
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function userMsg(id: string): IConversationEvent {
+  return { id, type: 'user_message', timestamp: new Date(), content: 'test' };
+}
+
+function toolStart(id: string, toolName: string, toolCallId: string): IConversationEvent {
+  return {
+    id,
+    type: 'tool_call_start',
+    timestamp: new Date(),
+    toolName,
+    content: '',
+    metadata: { toolCallId },
+  };
+}
+
+function toolComplete(id: string, toolCallId: string): IConversationEvent {
+  return {
+    id,
+    type: 'tool_call_complete',
+    timestamp: new Date(),
+    content: 'done',
+    metadata: { toolCallId },
+  };
+}
+
+function agentJobCreated(taskId: string, originToolCallId: string): IConversationEvent {
+  return {
+    id: `job-created-${taskId}`,
+    type: 'agent_job_created',
+    timestamp: new Date(),
+    taskId,
+    content: `task ${taskId}`,
+    metadata: { originToolCallId, label: `task ${taskId}` },
+  };
+}
+
+function agentJobCompleted(taskId: string): IConversationEvent {
+  return {
+    id: `job-completed-${taskId}`,
+    type: 'agent_job_completed',
+    timestamp: new Date(),
+    taskId,
+    content: 'done',
+    metadata: { label: `task ${taskId}` },
+  };
+}
+
+function agentJobFailed(taskId: string): IConversationEvent {
+  return {
+    id: `job-failed-${taskId}`,
+    type: 'agent_job_failed',
+    timestamp: new Date(),
+    taskId,
+    content: 'failed',
+    metadata: { label: `task ${taskId}` },
+  };
+}
+
+function assistantResponse(id: string): IConversationEvent {
+  return {
+    id,
+    type: 'assistant_response',
+    timestamp: new Date(),
+    content: 'Here is my response.',
+    metadata: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+  };
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('eventsToFlow', () => {
+  it('returns empty for no events', () => {
+    const { nodes, edges } = eventsToFlow([]);
+    expect(nodes).toHaveLength(0);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('creates sequential edges for linear flow', () => {
+    const events = [
+      userMsg('u1'),
+      toolStart('tc1', 'search', 'call-1'),
+      toolComplete('tcc1', 'call-1'),
+      assistantResponse('ar1'),
+    ];
+    const { nodes, edges } = eventsToFlow(events);
+
+    expect(nodes).toHaveLength(4);
+    expect(hasEdge(edges, 'u1', 'tc1')).toBe(true);
+    expect(hasEdge(edges, 'tc1', 'tcc1')).toBe(true);
+    expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
+  });
+
+  describe('parallel tool calls (no agents)', () => {
+    it('forks from the same source and converges at the next main event', () => {
+      const events = [
+        userMsg('u1'),
+        toolStart('tc1', 'search', 'call-1'),
+        toolStart('tc2', 'search', 'call-2'),
+        toolComplete('tcc1', 'call-1'),
+        toolComplete('tcc2', 'call-2'),
+        assistantResponse('ar1'),
+      ];
+      const { edges } = eventsToFlow(events);
+
+      // Both tools fork from user message
+      expect(hasEdge(edges, 'u1', 'tc1')).toBe(true);
+      expect(hasEdge(edges, 'u1', 'tc2')).toBe(true);
+
+      // Each tool maps to its completion
+      expect(hasEdge(edges, 'tc1', 'tcc1')).toBe(true);
+      expect(hasEdge(edges, 'tc2', 'tcc2')).toBe(true);
+
+      // Both tails converge to assistant
+      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(true);
+    });
+  });
+
+  describe('single agent branch (one tool → one agent)', () => {
+    it('forks agent from tool_call_start and joins at assistant_response', () => {
+      const events = [
+        userMsg('u1'),
+        toolStart('tc1', 'robota_command_agent', 'call-1'),
+        agentJobCreated('T1', 'call-1'),
+        agentJobCompleted('T1'),
+        toolComplete('tcc1', 'call-1'),
+        assistantResponse('ar1'),
+      ];
+      const { edges } = eventsToFlow(events);
+
+      expect(hasEdge(edges, 'u1', 'tc1')).toBe(true);
+      expect(hasEdge(edges, 'tc1', 'job-created-T1')).toBe(true);
+      expect(hasEdge(edges, 'job-created-T1', 'job-completed-T1')).toBe(true);
+      expect(hasEdge(edges, 'job-completed-T1', 'ar1')).toBe(true);
+    });
+  });
+
+  describe('parallel agents: one completes, one fails', () => {
+    // This is the primary regression scenario.
+    // Event order (from playground-session-submit.ts):
+    //   tool_call_start × 2 → agent_job_created × 2 →
+    //   agent_job_completed / agent_job_failed →
+    //   tool_call_complete × 2 → assistant_response
+
+    function makeParallelAgentEvents(options: { devFirst?: boolean } = {}) {
+      return [
+        userMsg('u1'),
+        toolStart('tc1', 'robota_command_agent', 'call-1'),
+        toolStart('tc2', 'robota_command_agent', 'call-2'),
+        agentJobCreated('T1', 'call-1'),
+        agentJobCreated('T2', 'call-2'),
+        ...(options.devFirst
+          ? [agentJobCompleted('T1'), agentJobFailed('T2')]
+          : [agentJobFailed('T2'), agentJobCompleted('T1')]),
+        toolComplete('tcc1', 'call-1'),
+        toolComplete('tcc2', 'call-2'),
+        assistantResponse('ar1'),
+      ];
+    }
+
+    it('forks both agents from their respective tool_call_start nodes', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
+
+      expect(hasEdge(edges, 'tc1', 'job-created-T1')).toBe(true);
+      expect(hasEdge(edges, 'tc2', 'job-created-T2')).toBe(true);
+    });
+
+    it('connects agent_job_completed and agent_job_failed to their created nodes', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
+
+      expect(hasEdge(edges, 'job-created-T1', 'job-completed-T1')).toBe(true);
+      expect(hasEdge(edges, 'job-created-T2', 'job-failed-T2')).toBe(true);
+    });
+
+    it('converges both branches to the assistant_response node', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
+
+      expect(hasEdge(edges, 'job-completed-T1', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'job-failed-T2', 'ar1')).toBe(true);
+    });
+
+    it('converges tool_call_complete tails to the assistant_response node', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
+
+      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(true);
+    });
+
+    it('produces no duplicate edges to assistant_response', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
+
+      // The main-join check must not add a duplicate tcc2→ar1 edge
+      expect(edgeCount(edges, 'tcc2', 'ar1')).toBe(1);
+      expect(edgeCount(edges, 'tcc1', 'ar1')).toBe(1);
+    });
+
+    it('works the same way when designer fails before developer completes', () => {
+      const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: false }));
+
+      expect(hasEdge(edges, 'job-completed-T1', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'job-failed-T2', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
+      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(true);
+      expect(edgeCount(edges, 'tcc2', 'ar1')).toBe(1);
+    });
+
+    it('includes all expected nodes', () => {
+      const { nodes } = eventsToFlow(makeParallelAgentEvents());
+      const nodeIds = nodes.map((n) => n.id);
+
+      expect(nodeIds).toContain('u1');
+      expect(nodeIds).toContain('tc1');
+      expect(nodeIds).toContain('tc2');
+      expect(nodeIds).toContain('job-created-T1');
+      expect(nodeIds).toContain('job-created-T2');
+      expect(nodeIds).toContain('job-completed-T1');
+      expect(nodeIds).toContain('job-failed-T2');
+      expect(nodeIds).toContain('tcc1');
+      expect(nodeIds).toContain('tcc2');
+      expect(nodeIds).toContain('ar1');
+    });
+  });
+});

--- a/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
@@ -231,6 +231,9 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
     const shouldConverge = allBranchesDone || (parallelGroupDone && openBranches.size === 0);
 
     if (shouldConverge) {
+      // Snapshot tails before clearing so the main-join check below can test membership.
+      const parallelTailsSnapshot = new Set(parallelTails);
+
       // Converge parallel tool tails (if any)
       if (parallelGroupDone) {
         for (const tail of parallelTails) {
@@ -261,9 +264,13 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
             });
           }
         }
-        // Also pull in any main-thread node that ran while branches were open,
-        // but only if it wasn't already included in the parallel convergence above.
-        if (lastMainId && lastMainId !== agentForkSourceId && !parallelTails.has(lastMainId)) {
+        // Pull in the main-thread node that was active while branches were open,
+        // but skip it if it was already converged as a parallel tool tail above.
+        if (
+          lastMainId &&
+          lastMainId !== agentForkSourceId &&
+          !parallelTailsSnapshot.has(lastMainId)
+        ) {
           edges.push({
             id: `edge-main-join-${lastMainId}-${event.id}`,
             source: lastMainId,

--- a/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/workflow-visualization.tsx
@@ -61,6 +61,16 @@ function WorkflowVisualizationContent({
     setEdges(flowData.edges);
   }, [flowData, setNodes, setEdges]);
 
+  useEffect(() => {
+    (window as unknown as Record<string, unknown>).__robota_dag = {
+      nodes,
+      edges,
+      events,
+      recompute: () => eventsToFlow(events),
+      test: (mockEvents: IConversationEvent[]) => eventsToFlow(mockEvents),
+    };
+  }, [nodes, edges, events]);
+
   const handleDragOver = (e: React.DragEvent) => {
     if (e.dataTransfer.types.includes('application/robota-tool')) {
       e.preventDefault();

--- a/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
+++ b/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
@@ -128,7 +128,7 @@ export class PlaygroundExecutor {
   }
 
   async run(prompt: string): Promise<IPlaygroundExecutorResult> {
-    if (!this.localConfig || !this.sessionId) {
+    if (!this.localConfig) {
       return createFailureResult({
         response: 'No agent configured',
         duration: 0,
@@ -136,6 +136,15 @@ export class PlaygroundExecutor {
         visualizationData: this.getVisualizationData(),
         includeUiError: true,
       });
+    }
+
+    if (!this.sessionId) {
+      const sessionResponse = await createSession(this.serverUrl, this.localConfig.apiKey, {
+        provider: this.localConfig.provider,
+        model: this.localConfig.model,
+        systemPrompt: this.localConfig.systemPrompt,
+      });
+      this.sessionId = sessionResponse.sessionId;
     }
 
     const startTime = Date.now();
@@ -301,6 +310,11 @@ export class PlaygroundExecutor {
   }
 
   clearHistory(): void {
+    if (this.sessionId) {
+      const sessionId = this.sessionId;
+      this.sessionId = null;
+      void destroySession(this.serverUrl, this.localConfig?.apiKey, sessionId);
+    }
     this.historyPlugin.clearEvents();
   }
 

--- a/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
+++ b/packages/agent-playground/src/playground/components/PlaygroundApp.tsx
@@ -183,7 +183,7 @@ function buildByokBaseUrl(wsUrl: string): string {
 
 function PlaygroundContent(): React.ReactElement {
   const state = usePlaygroundState();
-  const { setToolItems, setConversationHistory } = usePlaygroundActions();
+  const { setToolItems, setConversationHistory, clearHistory } = usePlaygroundActions();
   const { createAgent, popRestoredMessages, getDefaultAgentConfig, executePrompt, canExecute } =
     useRobotaExecution();
   const { injectToolIntoAgent } = usePlaygroundActions();
@@ -292,6 +292,16 @@ function PlaygroundContent(): React.ReactElement {
       setAgentDraft(null);
       closeModal();
     }
+  };
+
+  const handleClearChat = () => {
+    if (isByokMode) {
+      byokHistoryRef.current = [];
+    } else {
+      clearHistory();
+    }
+    setInitialMessages([]);
+    setChatKey((k) => k + 1);
   };
 
   const handleSendMessage = async (message: string): Promise<string> => {
@@ -552,6 +562,7 @@ function PlaygroundContent(): React.ReactElement {
                 key={chatKey}
                 isAgentReady={isAgentReady}
                 onSendMessage={handleSendMessage}
+                onClearChat={handleClearChat}
                 starterPrompts={isAgentReady ? BYOK_STARTER_PROMPTS : undefined}
                 availableCommands={activeSkills.map((s) => ({
                   name: s.id,


### PR DESCRIPTION
## Summary

이번 릴리즈는 세션 로그 아키텍처 개선, clearChat 완전 리셋, 20 사이클 DAG 검증 완료를 포함합니다.

- **Session log 인과 체인 명시화**: `background_task_created` 로그에 `originToolCallId`, `taskId` top-level 필드 추가 — `/resume` 복원 시 tool call과 서브에이전트 lifecycle을 명시적으로 연결 가능
- **clearChat 완전 리셋**: 버튼 클릭 시 DAG 이벤트(`CLEAR_CONVERSATION_HISTORY`) + 서버 세션 destroy + 다음 메시지에서 세션 자동 재생성
- **SSE 안정성**: `onComplete` 이전에 background task가 완료되는 race condition 처리
- **백로그 PLG-019**: AssignTask 제거, Agent Command만 사용

## Test plan

- [x] typecheck 전체 통과
- [x] 테스트 828개 (agent-framework) + 164개 (agent-playground) 통과
- [x] 브라우저 20 사이클 DAG 검증: 56 events, 0 orphans, 0 duplicate edges
- [x] 병렬 tool call (최대 3개 동시) DAG 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)