### PR TITLE
fix(dag): position agent_spawned between agent_command and tool_result

### DIFF
--- a/packages/agent-playground/src/components/playground/workflow-visualization/__tests__/events-to-flow.test.ts
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/__tests__/events-to-flow.test.ts
@@ -136,19 +136,25 @@ describe('eventsToFlow', () => {
 
   describe('single agent branch (one tool → one agent)', () => {
     it('forks agent from tool_call_start and joins at assistant_response', () => {
+      // Real-world order: tool returns immediately ("Started job"), agent completes async
       const events = [
         userMsg('u1'),
         toolStart('tc1', 'robota_command_agent', 'call-1'),
         agentJobCreated('T1', 'call-1'),
-        agentJobCompleted('T1'),
         toolComplete('tcc1', 'call-1'),
+        agentJobCompleted('T1'),
         assistantResponse('ar1'),
       ];
       const { edges } = eventsToFlow(events);
 
       expect(hasEdge(edges, 'u1', 'tc1')).toBe(true);
+      // tool_call_start forks to agent_job_created
       expect(hasEdge(edges, 'tc1', 'job-created-T1')).toBe(true);
-      expect(hasEdge(edges, 'job-created-T1', 'job-completed-T1')).toBe(true);
+      // tool_call_complete hangs from agent_job_created (not tool_call_start)
+      expect(hasEdge(edges, 'job-created-T1', 'tcc1')).toBe(true);
+      // agent_job_completed follows tool_call_complete in the branch
+      expect(hasEdge(edges, 'tcc1', 'job-completed-T1')).toBe(true);
+      // branch tail converges to assistant
       expect(hasEdge(edges, 'job-completed-T1', 'ar1')).toBe(true);
     });
   });
@@ -160,6 +166,8 @@ describe('eventsToFlow', () => {
     //   agent_job_completed / agent_job_failed →
     //   tool_call_complete × 2 → assistant_response
 
+    // Real-world order: both tools return "Started job" immediately,
+    // then agents complete asynchronously afterward.
     function makeParallelAgentEvents(options: { devFirst?: boolean } = {}) {
       return [
         userMsg('u1'),
@@ -167,11 +175,11 @@ describe('eventsToFlow', () => {
         toolStart('tc2', 'robota_command_agent', 'call-2'),
         agentJobCreated('T1', 'call-1'),
         agentJobCreated('T2', 'call-2'),
+        toolComplete('tcc1', 'call-1'),
+        toolComplete('tcc2', 'call-2'),
         ...(options.devFirst
           ? [agentJobCompleted('T1'), agentJobFailed('T2')]
           : [agentJobFailed('T2'), agentJobCompleted('T1')]),
-        toolComplete('tcc1', 'call-1'),
-        toolComplete('tcc2', 'call-2'),
         assistantResponse('ar1'),
       ];
     }
@@ -183,11 +191,15 @@ describe('eventsToFlow', () => {
       expect(hasEdge(edges, 'tc2', 'job-created-T2')).toBe(true);
     });
 
-    it('connects agent_job_completed and agent_job_failed to their created nodes', () => {
+    it('connects agent_job_completed and agent_job_failed after tool_call_complete in branch', () => {
       const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
 
-      expect(hasEdge(edges, 'job-created-T1', 'job-completed-T1')).toBe(true);
-      expect(hasEdge(edges, 'job-created-T2', 'job-failed-T2')).toBe(true);
+      // tool_call_complete now hangs from agent_job_created
+      expect(hasEdge(edges, 'job-created-T1', 'tcc1')).toBe(true);
+      expect(hasEdge(edges, 'job-created-T2', 'tcc2')).toBe(true);
+      // agent_job_completed/failed follow tool_call_complete in the branch
+      expect(hasEdge(edges, 'tcc1', 'job-completed-T1')).toBe(true);
+      expect(hasEdge(edges, 'tcc2', 'job-failed-T2')).toBe(true);
     });
 
     it('converges both branches to the assistant_response node', () => {
@@ -197,19 +209,19 @@ describe('eventsToFlow', () => {
       expect(hasEdge(edges, 'job-failed-T2', 'ar1')).toBe(true);
     });
 
-    it('converges tool_call_complete tails to the assistant_response node', () => {
+    it('tool_call_complete does not directly converge to assistant_response', () => {
       const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
 
-      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
-      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(true);
+      // tcc nodes are in the branch chain, not parallel tails — no direct tcc→ar1 edge
+      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(false);
+      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(false);
     });
 
     it('produces no duplicate edges to assistant_response', () => {
       const { edges } = eventsToFlow(makeParallelAgentEvents({ devFirst: true }));
 
-      // The main-join check must not add a duplicate tcc2→ar1 edge
-      expect(edgeCount(edges, 'tcc2', 'ar1')).toBe(1);
-      expect(edgeCount(edges, 'tcc1', 'ar1')).toBe(1);
+      expect(edgeCount(edges, 'job-completed-T1', 'ar1')).toBe(1);
+      expect(edgeCount(edges, 'job-failed-T2', 'ar1')).toBe(1);
     });
 
     it('works the same way when designer fails before developer completes', () => {
@@ -217,9 +229,9 @@ describe('eventsToFlow', () => {
 
       expect(hasEdge(edges, 'job-completed-T1', 'ar1')).toBe(true);
       expect(hasEdge(edges, 'job-failed-T2', 'ar1')).toBe(true);
-      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(true);
-      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(true);
-      expect(edgeCount(edges, 'tcc2', 'ar1')).toBe(1);
+      expect(hasEdge(edges, 'tcc1', 'ar1')).toBe(false);
+      expect(hasEdge(edges, 'tcc2', 'ar1')).toBe(false);
+      expect(edgeCount(edges, 'job-completed-T1', 'ar1')).toBe(1);
     });
 
     it('includes all expected nodes', () => {

--- a/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
+++ b/packages/agent-playground/src/components/playground/workflow-visualization/events-to-flow.ts
@@ -78,6 +78,12 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
 
   // FIFO queue of agent-spawning tool_call_start nodeIds, for matching agent_job_created
   const agentToolStartQueue: string[] = [];
+  // Agent Command: tool_call_start.id → agent_job_created.id
+  const agentCommandJobCreated = new Map<string, string>();
+  // Agent Command: tool_call_start.id → taskId
+  const agentCommandToTaskId = new Map<string, string>();
+  // tool_call_complete.id for Agent Commands (excluded from main-join during branch convergence)
+  const agentCommandCompleteIds = new Set<string>();
 
   for (const event of events) {
     // ── tool_call_start ───────────────────────────────────────────────────
@@ -145,21 +151,40 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
       }
 
       if (startNodeId) {
-        edges.push({
-          id: `edge-tc-${startNodeId}-${event.id}`,
-          source: startNodeId,
-          target: event.id,
-          animated: false,
-        });
-
-        if (parallelGroupSize > 0) {
-          // Part of a truly parallel group — collect tails for later convergence
-          parallelTails.add(event.id);
+        const jobCreatedId = agentCommandJobCreated.get(startNodeId);
+        if (jobCreatedId) {
+          // Agent Command: tool_call_complete hangs from agent_job_created, not tool_call_start
+          edges.push({
+            id: `edge-tc-${jobCreatedId}-${event.id}`,
+            source: jobCreatedId,
+            target: event.id,
+            animated: false,
+          });
+          const branchTaskId = agentCommandToTaskId.get(startNodeId);
+          if (branchTaskId) {
+            taskLastId.set(branchTaskId, event.id);
+            agentCommandToTaskId.delete(startNodeId);
+          }
+          agentCommandJobCreated.delete(startNodeId);
+          agentCommandCompleteIds.add(event.id);
+          lastMainId = event.id;
         } else {
-          // Single (sequential) tool call — clean state
-          parallelGroupForkId = null;
+          edges.push({
+            id: `edge-tc-${startNodeId}-${event.id}`,
+            source: startNodeId,
+            target: event.id,
+            animated: false,
+          });
+
+          if (parallelGroupSize > 0) {
+            // Part of a truly parallel group — collect tails for later convergence
+            parallelTails.add(event.id);
+          } else {
+            // Single (sequential) tool call — clean state
+            parallelGroupForkId = null;
+          }
+          lastMainId = event.id;
         }
-        lastMainId = event.id;
       } else {
         // No matching start — sequential fallback
         if (lastMainId) {
@@ -197,6 +222,8 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
             style: { stroke: '#a78bfa' },
           });
           agentForkSourceId = forkFrom;
+          agentCommandJobCreated.set(forkFrom, event.id);
+          agentCommandToTaskId.set(forkFrom, taskId);
         }
         taskLastId.set(taskId, event.id);
         taskDone.set(taskId, false);
@@ -269,7 +296,8 @@ export function eventsToFlow(events: IConversationEvent[]): { nodes: Node[]; edg
         if (
           lastMainId &&
           lastMainId !== agentForkSourceId &&
-          !parallelTailsSnapshot.has(lastMainId)
+          !parallelTailsSnapshot.has(lastMainId) &&
+          !agentCommandCompleteIds.has(lastMainId)
         ) {
           edges.push({
             id: `edge-main-join-${lastMainId}-${event.id}`,


### PR DESCRIPTION
## Summary

- `tool_call_complete` for Agent Command tools now connects from `agent_job_created` instead of `tool_call_start`
- Correct chain: `tool_call_start → agent_job_created → tool_call_complete → agent_job_completed`
- Agent Command completions are excluded from the main-join convergence edge to avoid spurious edges
- Updated existing tests to reflect real-world event order and new edge expectations

## Test plan

- [ ] All 164 unit tests pass
- [ ] Browser verification: 4× `agent_job_created`, 4× `agent_job_completed`, orphans: 0, duplicateEdges: 0
- [ ] DAG visually shows correct chain: Agent Command → Agent spawned → Tool result → Agent done

🤖 Generated with [Claude Code](https://claude.com/claude-code)