### PR TITLE
fix(agent-playground): prevent stale DAG events after clearChat

### DIFF
--- a/packages/agent-playground/src/contexts/playground-context/use-create-agent-action.ts
+++ b/packages/agent-playground/src/contexts/playground-context/use-create-agent-action.ts
@@ -17,6 +17,7 @@ export function useCreateAgentAction(
         await refs.executorRef.current.createAgent(config);
         dispatch({ type: 'ADD_AGENT_CONFIG', payload: config });
         dispatch({ type: 'CLEAR_AGENT_TOOL_OVERLAY', payload: config.id ?? config.name });
+        dispatch({ type: 'CLEAR_CONVERSATION_HISTORY' });
         dispatch({ type: 'SET_LOADING', payload: false });
       } catch (error) {
         dispatch({

--- a/packages/agent-playground/src/lib/playground/__tests__/robota-executor.test.ts
+++ b/packages/agent-playground/src/lib/playground/__tests__/robota-executor.test.ts
@@ -238,6 +238,40 @@ describe('PlaygroundExecutor', () => {
     expect(executor.getVisualizationData().events).toHaveLength(0);
   });
 
+  it('does not record events into historyPlugin after clearHistory is called mid-execution', async () => {
+    const executor = createExecutor();
+    await executor.createAgent(createConfig());
+
+    // Stream that yields one event, then we'll call clearHistory, then yield another
+    let resolveNext!: () => void;
+    const gate = new Promise<void>((res) => {
+      resolveNext = res;
+    });
+
+    sseMocks.sseSessionSubmit.mockImplementation(() =>
+      (async function* () {
+        yield { type: 'text_delta', data: { text: 'before' } } as TSseEvent;
+        // Pause — caller will call clearHistory() and then allow continuation
+        await gate;
+        yield { type: 'text_delta', data: { text: 'after' } } as TSseEvent;
+        yield DONE_EVENT;
+      })(),
+    );
+
+    const runPromise = executor.run('prompt');
+
+    // Allow the first event to be processed, then clear
+    await new Promise((r) => setTimeout(r, 0));
+    executor.clearHistory();
+    resolveNext();
+
+    await runPromise;
+
+    // Only events recorded after the clear would appear; historyPlugin should be empty
+    // because clearHistory() increments executionToken, causing the loop to break
+    expect(executor.getVisualizationData().events).toHaveLength(0);
+  });
+
   it('calls destroySession and disposes history plugin on dispose', async () => {
     const executor = createExecutor();
     await executor.createAgent(createConfig());

--- a/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
+++ b/packages/agent-playground/src/lib/playground/robota-executor/playground-executor.ts
@@ -47,6 +47,9 @@ export class PlaygroundExecutor {
   private localConfig: ILocalAgentConfig | null = null;
   private sessionId: string | null = null;
   private restoredMessages: IRestoredMessage[] = [];
+  // Incremented on every clearHistory()/createAgent() call so in-flight SSE loops can
+  // detect a mid-execution clear and stop recording stale events.
+  private executionToken = 0;
 
   constructor(
     private serverUrl: string,
@@ -73,6 +76,7 @@ export class PlaygroundExecutor {
       systemPrompt: config.defaultModel.systemMessage ?? config.systemMessage,
       toolIds: [],
     };
+    this.executionToken++;
     this.historyPlugin.clearEvents();
     await this.statisticsPlugin.recordUIInteraction('agent_create', {
       agentName: config.name,
@@ -152,6 +156,7 @@ export class PlaygroundExecutor {
     const taskTextAccumulators = new Map<string, string>();
     const sessionId = this.sessionId;
     const { apiKey } = this.localConfig;
+    const myToken = this.executionToken;
 
     try {
       this.historyPlugin.recordEvent({
@@ -164,6 +169,8 @@ export class PlaygroundExecutor {
       const stream = sseSessionSubmit(this.serverUrl, apiKey, sessionId, prompt);
 
       for await (const sseEvent of stream) {
+        // clearHistory()/createAgent() increments executionToken; stop recording stale events.
+        if (this.executionToken !== myToken) break;
         const conversationEvent = mapSseEventToConversationEvent(
           sseEvent,
           textAccumulator,
@@ -230,11 +237,14 @@ export class PlaygroundExecutor {
     const taskTextAccumulators = new Map<string, string>();
     const sessionId = this.sessionId;
     const { apiKey } = this.localConfig;
+    const myToken = this.executionToken;
 
     try {
       const stream = sseSessionSubmit(this.serverUrl, apiKey, sessionId, prompt);
 
       for await (const sseEvent of stream) {
+        // clearHistory()/createAgent() increments executionToken; stop recording stale events.
+        if (this.executionToken !== myToken) break;
         if (sseEvent.type === 'text_delta') {
           onChunk?.(sseEvent.data.text);
         }
@@ -310,6 +320,7 @@ export class PlaygroundExecutor {
   }
 
   clearHistory(): void {
+    this.executionToken++;
     if (this.sessionId) {
       const sessionId = this.sessionId;
       this.sessionId = null;


### PR DESCRIPTION
## Summary

- **Race condition fix**: Added `executionToken` counter to `PlaygroundExecutor`. `clearHistory()` and `createAgent()` both increment the token. The SSE event loop in `run()` and `execute()` checks the token at each iteration and breaks early if a clear happened mid-execution — preventing stale events from being recorded to `historyPlugin` after a clear.
- **createAgent missing dispatch**: `useCreateAgentAction` now dispatches `CLEAR_CONVERSATION_HISTORY` after a successful agent creation, so the DAG immediately resets when a new agent is created instead of showing the previous agent's conversation events.

## Root causes

1. If the user clicked "Clear Chat" while a message was still streaming, `historyPlugin.clearEvents()` was called but the SSE loop continued recording events. When the execution completed, `buildConversationEvents()` returned those post-clear events and `SET_CONVERSATION_HISTORY` overwrote the cleared state.

2. `executor.createAgent()` called `historyPlugin.clearEvents()` internally but `useCreateAgentAction` never dispatched `CLEAR_CONVERSATION_HISTORY`, so `state.conversationHistory` (and thus the DAG) kept the previous session's events until the next message was sent.

## Test plan

- New test: `does not record events into historyPlugin after clearHistory is called mid-execution` — uses a gated async generator to simulate a clear happening between SSE events and asserts that `getVisualizationData().events` is empty afterwards.
- All 165 existing tests pass; typecheck and lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)