### PR TITLE
chore: mark ARCH-REV-001~004 done — fix project-structure agent-command-* wildcard

### DIFF
--- a/.agents/backlog/completed/ARCH-REV-001-fix-project-structure-accuracy.md
+++ b/.agents/backlog/completed/ARCH-REV-001-fix-project-structure-accuracy.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-REV-001: Fix project-structure.md accuracy — wrong paths and phantom packages'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-18
 priority: critical
 urgency: now

--- a/.agents/backlog/completed/ARCH-REV-002-fix-dependency-direction-diagram.md
+++ b/.agents/backlog/completed/ARCH-REV-002-fix-dependency-direction-diagram.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-REV-002: Fix dependency-direction.md diagram errors (4 inaccuracies verified against package.json)'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-18
 priority: critical
 urgency: now

--- a/.agents/backlog/completed/ARCH-REV-003-fix-code-quality-stale-package-names.md
+++ b/.agents/backlog/completed/ARCH-REV-003-fix-code-quality-stale-package-names.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-REV-003: Fix stale package names in code-quality.md Layered Assembly Architecture section'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-18
 priority: high
 urgency: now

--- a/.agents/backlog/completed/ARCH-REV-004-refresh-composition-tree.md
+++ b/.agents/backlog/completed/ARCH-REV-004-refresh-composition-tree.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-REV-004: Refresh composition-tree.md — stale post-CLIR refactor (startup sequence, TuiTransport, App.tsx)'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-18
 priority: critical
 urgency: now

--- a/.agents/backlog/completed/ARCH-SPEC-001-missing-spec-md-files.md
+++ b/.agents/backlog/completed/ARCH-SPEC-001-missing-spec-md-files.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-SPEC-001: 누락된 SPEC.md 작성 — agent-interface-transport, agent-interface-tui, agent-remote-client'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-20
 priority: medium
 urgency: later

--- a/.agents/backlog/completed/ARCH-UPDATE-001-sync-architecture-map-recent-work.md
+++ b/.agents/backlog/completed/ARCH-UPDATE-001-sync-architecture-map-recent-work.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-UPDATE-001: Architecture Map Sync — PLG-008~019, CORE-001, TOOL-001, DAG fix 반영'
-status: todo
+status: done
+completed: 2026-05-22
 created: 2026-05-20
 priority: high
 urgency: soon

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -47,7 +47,7 @@ See [capability-placement.md](specs/architecture-map/capability-placement.md) fo
 
 ## Command Package Rule
 
-User-visible internal commands belong in `agent-command-*` packages or command-module owners that consume `@robota-sdk/agent-framework` command contracts. `agent-framework` owns command infrastructure and reusable common APIs; `agent-cli` composes selected modules and renders generic UI.
+User-visible internal commands belong in `agent-command` or command-module owners that consume `@robota-sdk/agent-framework` command contracts. `agent-framework` owns command infrastructure and reusable common APIs; `agent-cli` composes selected modules and renders generic UI.
 
 ## Interface Package Rule
 


### PR DESCRIPTION
## Summary

- **ARCH-REV-001**: Replaced stale `` `agent-command-*` `` wildcard with `` `agent-command` `` in the Command Package Rule section of `.agents/project-structure.md` (the last remaining fix; app path and phantom package fixes were already applied in prior sessions)
- **ARCH-REV-002**: Verified all 4 diagram fixes already applied — `TypeContracts→Domain` edge removed, `Assembly→Orchestration` changed to `Playground→Orchestration`, Assembly node updated to include `agent-command`, `agent-subagent-runner` moved to OptIn subgraph in `capability-placement.md`
- **ARCH-REV-003**: Verified all 6 stale package names already updated in `code-quality.md` (agent-runtime→agent-executor, agent-sessions→agent-session, etc.)
- **ARCH-REV-004**: Verified all 6 inaccuracies already fixed in `composition-tree.md` (startup sequence, cli.ts line count 98, TuiTransport constructor, InteractiveSession location, App.tsx render tree, CommandEffectQueue file)
- **ARCH-UPDATE-001, ARCH-SPEC-001**: Backlog status corrected to `done` (work completed in prior sessions)

## Test plan

- [x] `pnpm harness:scan` passes (dist freshness + docs structure)
- [x] `grep agent-command-\*` returns zero results in `.agents/project-structure.md`
- [x] All 6 backlog items now have `status: done` with `completed: 2026-05-22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)