### PR TITLE
feat(pm-001): onboarding branch — guide users without API key

### DIFF
--- a/.agents/backlog/completed/PM-001-onboarding-wizard.md
+++ b/.agents/backlog/completed/PM-001-onboarding-wizard.md
@@ -1,0 +1,34 @@
+---
+title: 'PM-001: Onboarding Wizard — API key branch at first run'
+status: done
+completed: 2026-05-23
+created: 2026-05-23
+priority: critical
+urgency: now
+area: packages/agent-command
+depends_on: [UX-012]
+---
+
+## Background
+
+New users hit an API key requirement on first run with no guidance. 90% of users who don't reach
+an AHA moment in the first 5 minutes abandon the tool.
+
+## Changes Made
+
+- Added `packages/agent-command/src/provider/provider-onboarding.ts`:
+  - `runOnboardingBranch()` — prompts "Do you have an API key?" with 3 choices
+  - Choice 1 (has key): proceeds to standard provider selection
+  - Choice 2 (no key, cloud): shows Gemini free API key guide + link, then auto-selects Gemini
+  - Choice 3 (no key, local): shows LM Studio setup guide + link, then auto-selects Gemma/local
+- Updated `runProviderStartupSetup()` in `provider-startup.ts` to call `runOnboardingBranch()`
+  at the start; skips provider selection when a type is preselected by the onboarding branch
+
+## Test Plan
+
+- 151/151 agent-command tests passing
+- Typecheck clean
+
+## User Execution Test Scenarios
+
+Not applicable — first-run UX change verified via code review.

--- a/packages/agent-command/src/provider/provider-onboarding.ts
+++ b/packages/agent-command/src/provider/provider-onboarding.ts
@@ -1,0 +1,64 @@
+import type { TPromptInput } from './provider-setup-flow.js';
+import type { ITerminalOutput } from '@robota-sdk/agent-core';
+
+export type TOnboardingPath = 'has-key' | 'free-key' | 'local';
+
+export interface IOnboardingResult {
+  path: TOnboardingPath;
+  preselectedType?: string;
+}
+
+const ONBOARDING_PROMPT = `
+  Do you have an API key for an AI provider?
+
+    1. Yes, I have an API key
+    2. No — get a free key (Google Gemini, takes ~2 min)
+    3. No — use a local model (LM Studio, no API key needed)
+
+  Choose [1-3] (default: 1): `;
+
+const GEMINI_GUIDE = `
+  ── Get a free Gemini API key ────────────────────────────────────────────────
+
+  1. Open  https://aistudio.google.com/apikey  in your browser
+  2. Sign in with your Google account
+  3. Click "Create API key"  (takes ~30 seconds)
+  4. Copy the key starting with "AIza..."
+
+  ─────────────────────────────────────────────────────────────────────────────
+`;
+
+const LOCAL_MODEL_GUIDE = `
+  ── Set up a local model with LM Studio ──────────────────────────────────────
+
+  1. Download LM Studio from  https://lmstudio.ai
+  2. Open LM Studio → search for a model (e.g. "llama" or "phi") → Download
+  3. Go to  Developer  tab → click  Start Server
+     (default address: http://localhost:1234)
+
+  When the server is running, come back here and press Enter to continue.
+
+  ─────────────────────────────────────────────────────────────────────────────
+`;
+
+export async function runOnboardingBranch(
+  promptInput: TPromptInput,
+  terminal: ITerminalOutput,
+): Promise<IOnboardingResult> {
+  const raw = await promptInput(ONBOARDING_PROMPT);
+  const choice = raw.trim() || '1';
+
+  if (choice === '2') {
+    terminal.writeLine(GEMINI_GUIDE);
+    await promptInput('  Press Enter when you have your API key: ');
+    return { path: 'free-key', preselectedType: 'gemini' };
+  }
+
+  if (choice === '3') {
+    terminal.writeLine(LOCAL_MODEL_GUIDE);
+    await promptInput('  Press Enter when LM Studio server is running: ');
+    return { path: 'local', preselectedType: 'gemma' };
+  }
+
+  return { path: 'has-key' };
+}

--- a/packages/agent-command/src/provider/provider-startup.ts
+++ b/packages/agent-command/src/provider/provider-startup.ts
@@ -10,6 +10,7 @@ import {
   applyProviderConfiguration,
 } from '@robota-sdk/agent-framework';
 
+import { runOnboardingBranch } from './provider-onboarding.js';
 import {
   formatProviderSetupSelectionPrompt,
   resolveProviderSetupSelection,
@@ -38,11 +39,22 @@ export async function runProviderStartupSetup(
   terminal: ITerminalOutput,
   providerDefinitions: readonly IProviderDefinition[],
 ): Promise<void> {
-  const providerChoice = await promptInput(formatProviderSetupSelectionPrompt(providerDefinitions));
-  const type = resolveProviderSetupSelection(providerChoice, providerDefinitions);
+  const onboarding = await runOnboardingBranch(promptInput, terminal);
+  const existingProfileNames = Object.keys(readMergedProviderSettings(cwd).providers ?? {});
   const settingsPath = resolveSettingsPathForScope(cwd, ctx.settingsScope);
+
+  let type: string;
+  if (onboarding.preselectedType !== undefined) {
+    type = onboarding.preselectedType;
+  } else {
+    const providerChoice = await promptInput(
+      formatProviderSetupSelectionPrompt(providerDefinitions),
+    );
+    type = resolveProviderSetupSelection(providerChoice, providerDefinitions);
+  }
+
   const input = await runProviderSetupPromptFlow(type, promptInput, providerDefinitions, {
-    existingProfileNames: Object.keys(readMergedProviderSettings(cwd).providers ?? {}),
+    existingProfileNames,
   });
   applyProviderConfiguration(settingsPath, input, { providerDefinitions });
   const language = await promptInput('  Response language (ko/en/ja/zh, default: en): ');


### PR DESCRIPTION
## Summary

- Adds a "Do you have an API key?" gate before the provider selection at first run
- Three paths: has key → normal flow; free key → Gemini guide; local model → LM Studio guide
- Users choosing free/local paths skip provider selection and land directly in the appropriate setup

## Paths

| Input | Path | Effect |
|-------|------|--------|
| 1 (default) | Has key | Standard provider selection |
| 2 | No key — cloud | Shows Gemini free key guide + link → auto-selects Gemini setup |
| 3 | No key — local | Shows LM Studio setup guide + link → auto-selects Gemma/local setup |

## Test plan

- [x] 151/151 agent-command tests passing
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)