### PR TITLE
docs(pm-002): add Why Robota comparison page at /compare/

### DIFF
--- a/.agents/backlog/completed/PM-002-why-robota-comparison-page.md
+++ b/.agents/backlog/completed/PM-002-why-robota-comparison-page.md
@@ -1,0 +1,34 @@
+---
+title: 'PM-002: Why Robota comparison page'
+status: done
+completed: 2026-05-23
+created: 2026-05-23
+priority: high
+urgency: now
+area: apps/docs, content/
+depends_on: []
+---
+
+## Background
+
+New users asked "why use this instead of Claude Code?" but no comparison existed anywhere in the docs.
+
+## Changes Made
+
+- Created `content/compare/README.md` — full comparison page with:
+  - Feature matrix: Robota vs Claude Code, Cursor, Aider, Cline
+  - Cost comparison table with monthly estimates
+  - 5 key differentiator sections (multi-provider, embeddable SDK, MIT, local model, no subscription)
+  - "When to choose something else" section for honest guidance
+  - Quick Start block with `npx @robota-sdk/agent-cli`
+- Added "Why Robota" nav item to `apps/docs/.vitepress/config/en.js` → `/compare/`
+- Updated `content/README.md` comparison table to include Cursor/Aider/Cline and added link to full page
+
+## Test Plan
+
+- Page renders at `/compare/` when docs site is built
+- Nav item visible on all pages
+
+## User Execution Test Scenarios
+
+Not applicable — documentation/marketing page.

--- a/apps/docs/.vitepress/config/en.js
+++ b/apps/docs/.vitepress/config/en.js
@@ -3,6 +3,7 @@ export const enConfig = {
     // Navigation menu
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'Why Robota', link: '/compare/' },
       { text: 'Getting Started', link: '/getting-started/' },
       { text: 'Guide', link: '/guide/' },
       { text: 'Examples', link: '/examples/' },

--- a/content/README.md
+++ b/content/README.md
@@ -31,15 +31,17 @@ The CLI is built on top of the Assembly Layer. The Assembly Layer is assembled f
 
 ## Robota vs Alternatives
 
-|                                | **Robota**   | Claude Code       | LangChain JS      | OpenAI Agents SDK |
-| ------------------------------ | ------------ | ----------------- | ----------------- | ----------------- |
-| Multi-provider (one API)       | ✅           | ❌ Anthropic only | ✅ complex        | ❌ OpenAI only    |
-| TypeScript-first, strict types | ✅           | ✅                | ⚠️ Python primary | ✅                |
-| Ready-to-use CLI included      | ✅           | ✅                | ❌                | ❌                |
-| Self-hostable / open source    | ✅ MIT       | ❌ proprietary    | ✅                | ✅                |
-| Local model support            | ✅ LM Studio | ❌                | ✅                | ❌                |
-| Embeddable SDK (HTTP/WS/MCP)   | ✅           | ❌                | ⚠️ limited        | ⚠️ limited        |
-| Zero `any` in production code  | ✅           | n/a               | ❌                | ❌                |
+|                                        | **Robota** |    Claude Code    |     Cursor      | Aider | Cline |
+| -------------------------------------- | :--------: | :---------------: | :-------------: | :---: | :---: |
+| Multi-provider (one config)            |     ✅     | ❌ Anthropic only |   ❌ limited    |  ✅   |  ✅   |
+| BYOK — no subscription required        |     ✅     |        ✅         | ❌ subscription |  ✅   |  ✅   |
+| Local model support (Ollama/LM Studio) |     ✅     |        ❌         |       ❌        |  ✅   |  ✅   |
+| Embeddable SDK (use in your own app)   |     ✅     |        ❌         |       ❌        |  ❌   |  ❌   |
+| Open source (MIT)                      |     ✅     |  ❌ proprietary   | ❌ proprietary  |  ✅   |  ✅   |
+| Terminal CLI                           |     ✅     |        ✅         |   ❌ IDE only   |  ✅   |  ✅   |
+| Session persistence & resume           |     ✅     |        ✅         |       ✅        |  ❌   |  ❌   |
+
+**[→ Full comparison: features, cost, and when to choose each tool](/compare/)**
 
 ## Claude Code Users: Drop-in Compatible
 

--- a/content/compare/README.md
+++ b/content/compare/README.md
@@ -1,0 +1,106 @@
+---
+title: Why Robota — Compare AI Coding Tools
+description: How Robota compares to Claude Code, Cursor, Aider, and Cline — features, cost, and freedom.
+---
+
+# Why Robota?
+
+> **TL;DR** — Robota is the only AI coding CLI that lets you bring your own API key for any provider, run completely offline with a local model, and embed the same engine directly into your own app — all under the MIT license.
+
+---
+
+## Feature Comparison
+
+|                                        |  **Robota**  |    Claude Code    |        Cursor         |    Aider    |    Cline    |
+| -------------------------------------- | :----------: | :---------------: | :-------------------: | :---------: | :---------: |
+| Multi-provider (one config)            |      ✅      | ❌ Anthropic only | ❌ OpenAI + Anthropic |   ✅ many   |   ✅ many   |
+| BYOK — no subscription required        |      ✅      |        ✅         |    ❌ subscription    |     ✅      |     ✅      |
+| Local model support (Ollama/LM Studio) |      ✅      |        ❌         |          ❌           |     ✅      |     ✅      |
+| Embeddable SDK (use in your own app)   |      ✅      |        ❌         |          ❌           |     ❌      |     ❌      |
+| Open source (MIT)                      |      ✅      |  ❌ proprietary   |    ❌ proprietary     | ✅ Apache 2 | ✅ Apache 2 |
+| TypeScript-first, strict types         |      ✅      |        ✅         |          ✅           |  ❌ Python  |     ✅      |
+| Terminal CLI                           |      ✅      |        ✅         |      ❌ IDE only      |     ✅      |     ✅      |
+| IDE extension                          | ❌ (roadmap) |        ✅         |          ✅           |     ❌      |  ✅ VSCode  |
+| Session persistence & resume           |      ✅      |        ✅         |          ✅           |     ❌      |     ❌      |
+| Background agents                      |      ✅      |        ✅         |          ❌           |     ❌      |     ❌      |
+| Self-hostable                          |      ✅      |        ❌         |          ❌           |     ✅      |     ✅      |
+
+---
+
+## Cost Comparison
+
+| Tool        | Pricing model            | Monthly cost estimate (4h/day)      |
+| ----------- | ------------------------ | ----------------------------------- |
+| **Robota**  | BYOK — pay your provider | ~$5–30 depending on model and usage |
+| Claude Code | BYOK (Anthropic API)     | ~$20–80 with Claude Sonnet          |
+| Cursor      | Subscription             | $20/mo (Pro) + API overages         |
+| Aider       | BYOK                     | ~$5–30 depending on model           |
+| Cline       | BYOK (VSCode extension)  | ~$5–30 depending on model           |
+
+**Robota with Gemini** — Google's Gemini 1.5 Flash has a free tier that covers casual use at zero cost. [Get a free key →](https://aistudio.google.com/apikey)
+
+**Robota with local models** — Connect LM Studio or Ollama and pay nothing. No API key, no subscription, fully offline.
+
+---
+
+## What Makes Robota Different
+
+### 1. Any Provider — One Config
+
+Switch between Anthropic Claude, OpenAI GPT, Google Gemini, DeepSeek, Qwen, or your own Ollama instance by changing one line in `~/.robota/settings.json`. No code changes. No subscription lock-in.
+
+```json
+{ "currentProvider": "gemini-flash" }
+```
+
+### 2. Embeddable SDK
+
+Robota ships as a proper SDK (`@robota-sdk/agent-framework`), not just a CLI. You can embed the same agent runtime — with all its tools, permissions, and session management — directly into your own application:
+
+```typescript
+import { query } from '@robota-sdk/agent-framework';
+
+const result = await query('List all TypeScript files in src/');
+```
+
+No other AI coding assistant exposes this. Claude Code, Cursor, and Cline are closed products — you cannot embed them.
+
+### 3. Fully Open Source (MIT)
+
+Every line of Robota is MIT-licensed and publicly auditable. You can fork it, modify it, self-host it, and build commercial products on top of it — with no CLA required.
+
+### 4. Local Model First-Class Support
+
+Configure any Ollama or LM Studio model as your provider. No internet connection required for inference. Your code and prompts never leave your machine.
+
+### 5. No Subscription — Ever
+
+Robota itself is free. You pay only what you owe to your AI provider (or nothing if you run locally). There is no "Pro plan" gating features, no seat licenses, no usage caps imposed by Robota.
+
+---
+
+## When to Choose Something Else
+
+**Choose Claude Code** if you want the tightest Claude integration and are happy with Anthropic-only.
+
+**Choose Cursor** if you want an IDE-first experience with inline diff editing and tab completion — Robota does not have an IDE extension yet.
+
+**Choose Aider** if you prefer a Python ecosystem and work primarily in git-based batch commits.
+
+**Choose Cline** if you want a VSCode sidebar agent and are not interested in embedding or SDK usage.
+
+---
+
+## Quick Start
+
+```bash
+# Try it now — no install needed
+npx @robota-sdk/agent-cli
+
+# Install globally
+npm install -g @robota-sdk/agent-cli
+robota
+```
+
+→ [Getting Started guide](/getting-started/)
+→ [CLI reference](/guide/cli)


### PR DESCRIPTION
## Summary

- Adds `content/compare/README.md` — full comparison of Robota vs Claude Code, Cursor, Aider, Cline
- Covers: feature matrix, cost table, 5 key differentiators, honest "when to choose something else" section
- Adds "Why Robota" as the second nav item → `/compare/`
- Updates the home page comparison table to include the four main AI coding tools instead of LangChain/OpenAI SDK

## Test plan

- [x] Content file created and formatted
- [x] Nav config updated
- [x] Docs home comparison table updated with link to full page

🤖 Generated with [Claude Code](https://claude.com/claude-code)