### PR TITLE
feat(ux-018): add ? key keyboard shortcut overlay in TUI

### DIFF
--- a/.agents/backlog/UX-018-keyboard-shortcut-overlay.md
+++ b/.agents/backlog/UX-018-keyboard-shortcut-overlay.md
@@ -1,6 +1,6 @@
 ---
 title: 'UX-018: ? 키 인라인 단축키 오버레이 — TUI 내 도움말 즉시 접근'
-status: todo
+status: done
 created: 2026-05-23
 priority: medium
 urgency: later

--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -19,6 +19,7 @@ import { useSideEffects } from './hooks/useSideEffects.js';
 import { useStatusLineSettings } from './hooks/useStatusLineSettings.js';
 import InputArea from './InputArea.js';
 import InteractivePrompt from './InteractivePrompt.js';
+import KeyboardShortcutOverlay from './KeyboardShortcutOverlay.js';
 import MessageList from './MessageList.js';
 import PermissionPrompt from './PermissionPrompt.js';
 import PluginTUI from './PluginTUI.js';
@@ -152,6 +153,7 @@ function AppInner(
   const [isExecutionDetailLoading, setIsExecutionDetailLoading] = useState(false);
   const [statusLineSettings, setStatusLineSettings] = useStatusLineSettings();
   const [gitRefreshToken, setGitRefreshToken] = useState(0);
+  const [showShortcutOverlay, setShowShortcutOverlay] = useState(false);
   const backgroundWorkspaceEntries = useMemo(
     () => getDefaultBackgroundWorkspaceEntries(executionWorkspaceSnapshot),
     [executionWorkspaceSnapshot],
@@ -315,6 +317,23 @@ function AppInner(
     void handleShutdown('prompt_input_exit').finally(() => exit());
   });
 
+  // ? key toggles the keyboard shortcut overlay
+  useInput((input: string) => {
+    if (input !== '?') return;
+    if (
+      permissionRequest ||
+      showPluginTUI ||
+      showTransportTUI ||
+      showSessionPicker ||
+      showExecutionWorkspaceSwitcher ||
+      isThinking ||
+      isShuttingDown
+    ) {
+      return;
+    }
+    setShowShortcutOverlay((v) => !v);
+  });
+
   useEffect(() => {
     const onSigterm = (): void => {
       if (isShuttingDown) return;
@@ -457,6 +476,9 @@ function AppInner(
           }}
         />
       )}
+      {showShortcutOverlay && (
+        <KeyboardShortcutOverlay onClose={() => setShowShortcutOverlay(false)} />
+      )}
       <ContextWarningBanner percentage={contextState.percentage} />
       <SessionStatusBar
         cwd={cwd}
@@ -483,6 +505,7 @@ function AppInner(
           showTransportTUI ||
           showSessionPicker ||
           showExecutionWorkspaceSwitcher ||
+          showShortcutOverlay ||
           isShuttingDown ||
           pendingInteractionPrompt !== null ||
           (isThinking && !!pendingPrompt) ||

--- a/packages/agent-transport/src/tui/KeyboardShortcutOverlay.tsx
+++ b/packages/agent-transport/src/tui/KeyboardShortcutOverlay.tsx
@@ -1,0 +1,48 @@
+import { Box, Text, useInput } from 'ink';
+import React from 'react';
+
+const SHORTCUTS: Array<{ key: string; description: string }> = [
+  { key: 'Enter', description: 'Submit message' },
+  { key: 'ESC', description: 'Abort running task' },
+  { key: 'Ctrl+C', description: 'Exit' },
+  { key: '↑ / ↓', description: 'Navigate input history' },
+  { key: 'Ctrl+B', description: 'Open background task switcher' },
+  { key: '/compact', description: 'Summarize conversation to free context' },
+  { key: '/help', description: 'List all slash commands' },
+  { key: '?', description: 'Close this overlay' },
+];
+
+interface IProps {
+  onClose: () => void;
+}
+
+export default function KeyboardShortcutOverlay({ onClose }: IProps): React.ReactElement {
+  useInput((input, key) => {
+    if (input === '?' || key.escape) {
+      onClose();
+    }
+  });
+
+  const keyWidth = Math.max(...SHORTCUTS.map((s) => s.key.length)) + 2;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1} paddingY={0}>
+      <Text color="cyan" bold>
+        Keyboard Shortcuts
+      </Text>
+      <Box flexDirection="column" marginTop={1}>
+        {SHORTCUTS.map(({ key, description }) => (
+          <Box key={key}>
+            <Text color="yellow" bold>
+              {key.padEnd(keyWidth)}
+            </Text>
+            <Text>{description}</Text>
+          </Box>
+        ))}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>Press ? or ESC to close</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/agent-transport/src/tui/__tests__/KeyboardShortcutOverlay.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/KeyboardShortcutOverlay.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import KeyboardShortcutOverlay from '../KeyboardShortcutOverlay.js';
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('KeyboardShortcutOverlay', () => {
+  it('renders the title', () => {
+    const { lastFrame } = render(<KeyboardShortcutOverlay onClose={() => {}} />);
+    expect(lastFrame()).toContain('Keyboard Shortcuts');
+  });
+
+  it('renders all shortcut entries', () => {
+    const { lastFrame } = render(<KeyboardShortcutOverlay onClose={() => {}} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain('Enter');
+    expect(frame).toContain('ESC');
+    expect(frame).toContain('Ctrl+C');
+    expect(frame).toContain('Ctrl+B');
+    expect(frame).toContain('/compact');
+    expect(frame).toContain('/help');
+  });
+
+  it('calls onClose when ? is pressed', () => {
+    const onClose = vi.fn();
+    const { stdin } = render(<KeyboardShortcutOverlay onClose={onClose} />);
+    stdin.write('?');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when ESC is pressed', async () => {
+    const onClose = vi.fn();
+    const { stdin } = render(<KeyboardShortcutOverlay onClose={onClose} />);
+    stdin.write('\x1B');
+    await delay(50);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `KeyboardShortcutOverlay.tsx`: a bordered box listing all TUI keyboard shortcuts (Enter, ESC, Ctrl+C, Ctrl+B, ↑/↓ history, /compact, /help)
- Pressing `?` in the TUI toggles the overlay; pressing `?` or ESC closes it
- Input is disabled while the overlay is open
- Overlay is suppressed while the agent is thinking or another overlay (permission, plugin, session picker) is active
- 4 new tests in `KeyboardShortcutOverlay.test.tsx`

## Test plan

- [ ] All 408 `agent-transport` tests pass
- [ ] Press `?` in a live TUI session → overlay appears
- [ ] Press `?` or ESC → overlay closes, input re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)