### PR TITLE
feat(cli-012): add --dry-run flag — plan-only preview

### DIFF
--- a/.agents/backlog/CLI-012-dry-run-flag.md
+++ b/.agents/backlog/CLI-012-dry-run-flag.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI-012: --dry-run 플래그 — plan 모드 기반 작업 계획 미리보기'
-status: todo
+status: done
 created: 2026-05-23
 priority: medium
 urgency: later

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -26,12 +26,25 @@ async function resolvePrompt(opts: ISessionRunOptions): Promise<string> {
   return prompt;
 }
 
+const DRY_RUN_SYSTEM_PROMPT =
+  'You are in dry-run (plan) mode. Analyze the request and describe step by step what you would do, without executing any write or edit operations. Format your response as a numbered action plan.';
+
 export async function runPrintMode(
   opts: ISessionRunOptions,
   runtime: IAgentRuntime,
 ): Promise<void> {
   const prompt = await resolvePrompt(opts);
-  const appendSystemPrompt = buildAppendSystemPrompt(runtime.cwd, opts);
+
+  if (opts.dryRun) {
+    process.stdout.write('DRY RUN — plan mode enabled. No files will be modified.\n\n');
+  }
+
+  const appendSystemPromptParts: string[] = [];
+  if (opts.dryRun) appendSystemPromptParts.push(DRY_RUN_SYSTEM_PROMPT);
+  const baseAppend = buildAppendSystemPrompt(runtime.cwd, opts);
+  if (baseAppend) appendSystemPromptParts.push(baseAppend);
+  const appendSystemPrompt =
+    appendSystemPromptParts.length > 0 ? appendSystemPromptParts.join('\n\n') : undefined;
   const shellExec = createShellExec();
 
   const session = runtime.createSession({

--- a/packages/agent-cli/src/startup/args-to-options.ts
+++ b/packages/agent-cli/src/startup/args-to-options.ts
@@ -33,6 +33,7 @@ export interface ISessionRunOptions {
   appendSystemPrompt?: string;
   taskFile?: string;
   jsonSchema?: string;
+  dryRun: boolean;
 }
 
 export interface IUserLocalCommandOptions {
@@ -59,7 +60,7 @@ export function toConfigPhaseOptions(args: IParsedCliArgs): IConfigPhaseOptions 
     apiKeyEnv: args.apiKeyEnv,
     baseURL: args.baseURL,
     setCurrent: args.setCurrent,
-    printMode: args.printMode,
+    printMode: args.printMode || args.dryRun,
     positional: args.positional,
   };
 }
@@ -68,7 +69,7 @@ export function toSessionRunOptions(args: IParsedCliArgs): ISessionRunOptions {
   return {
     positional: args.positional,
     language: args.language,
-    permissionMode: args.permissionMode,
+    permissionMode: args.dryRun ? 'plan' : args.permissionMode,
     maxTurns: args.maxTurns,
     sessionName: args.sessionName,
     noSessionPersistence: args.noSessionPersistence,
@@ -82,6 +83,7 @@ export function toSessionRunOptions(args: IParsedCliArgs): ISessionRunOptions {
     appendSystemPrompt: args.appendSystemPrompt,
     taskFile: args.taskFile,
     jsonSchema: args.jsonSchema,
+    dryRun: args.dryRun,
   };
 }
 

--- a/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
+++ b/packages/agent-cli/src/utils/__tests__/cli-args.test.ts
@@ -207,6 +207,18 @@ describe('new non-interactive flags', () => {
     expect(parseCliArgs().allowedTools).toBe('Bash,Read,Write');
   });
 
+  it('parses --dry-run flag', () => {
+    process.argv = ['node', 'cli', '--dry-run', 'Refactor auth'];
+    const args = parseCliArgs();
+    expect(args.dryRun).toBe(true);
+    expect(args.positional).toContain('Refactor auth');
+  });
+
+  it('defaults dryRun to false', () => {
+    process.argv = ['node', 'cli'];
+    expect(parseCliArgs().dryRun).toBe(false);
+  });
+
   it('defaults allowedTools to undefined', () => {
     process.argv = ['node', 'cli'];
     expect(parseCliArgs().allowedTools).toBeUndefined();

--- a/packages/agent-cli/src/utils/cli-args.ts
+++ b/packages/agent-cli/src/utils/cli-args.ts
@@ -48,6 +48,7 @@ export interface IParsedCliArgs {
   settingsScope: string | undefined;
   checkUpdate: boolean;
   disableUpdateCheck: boolean;
+  dryRun: boolean;
 }
 
 /** Return CLI usage help text. */
@@ -71,6 +72,7 @@ Options:
   --fork-session             Fork the current session
   --configure                Run interactive provider configuration
   --configure-provider <n>   Configure a specific provider
+  --dry-run <prompt>         Plan-only run: show what the agent would do without modifying files
   --check-update             Check for CLI updates
   --version                  Show version number
   -h, --help                 Show this help message
@@ -83,6 +85,7 @@ Examples:
   robota init                      Initialize project files
   robota -p "Hello"                Print mode: send prompt and exit
   robota -p "Hello" --output-format json
+  robota --dry-run "Refactor the auth module"      Show plan without modifying files
   robota --continue                Resume the last session
 `;
 }
@@ -152,6 +155,7 @@ const PARSE_ARGS_CONFIG = {
     'settings-scope': { type: 'string' },
     'check-update': { type: 'boolean', default: false },
     'disable-update-check': { type: 'boolean', default: false },
+    'dry-run': { type: 'boolean', default: false },
   },
 } as const;
 
@@ -195,6 +199,7 @@ function mapParsedValues(
     settingsScope: values['settings-scope'],
     checkUpdate: values['check-update'] ?? false,
     disableUpdateCheck: values['disable-update-check'] ?? false,
+    dryRun: values['dry-run'] ?? false,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `--dry-run <prompt>` flag to the CLI
- Routes to print (headless) mode with `permissionMode: 'plan'` enforced — no file writes execute
- Prints a "DRY RUN — plan mode enabled" header before the agent response
- Injects a planning system prompt instructing the agent to describe its intended actions as a numbered plan
- 2 new tests in `cli-args.test.ts`

## Usage

```
robota --dry-run "Refactor the auth module"
```

Expected output:
```
DRY RUN — plan mode enabled. No files will be modified.

1. Read src/auth/auth-service.ts to understand the current structure
2. Identify ...
```

## Test plan

- [ ] 69 agent-cli tests pass
- [ ] `--dry-run "..."` outputs plan header and agent plan
- [ ] No files are modified during a dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)