### PR TITLE
docs(pm-017,pm-021): add quarterly roadmap and showcase page

### DIFF
--- a/.agents/backlog/PM-017-public-roadmap-page.md
+++ b/.agents/backlog/PM-017-public-roadmap-page.md
@@ -1,6 +1,6 @@
 ---
 title: 'PM-017: 분기별 공개 로드맵 페이지 (robota.io/roadmap)'
-status: todo
+status: done
 created: 2026-05-23
 priority: medium
 urgency: later

--- a/.agents/backlog/PM-021-build-with-robota-showcase.md
+++ b/.agents/backlog/PM-021-build-with-robota-showcase.md
@@ -1,6 +1,6 @@
 ---
 title: 'PM-021: "Build with robota" 쇼케이스 페이지'
-status: todo
+status: done
 created: 2026-05-23
 priority: low
 urgency: later

--- a/apps/docs/.vitepress/config/en.js
+++ b/apps/docs/.vitepress/config/en.js
@@ -9,6 +9,8 @@ export const enConfig = {
       { text: 'Examples', link: '/examples/' },
       { text: 'Packages', link: '/packages/' },
       { text: 'Changelog', link: '/changelog/' },
+      { text: 'Showcase', link: '/showcase/' },
+      { text: 'Roadmap', link: '/roadmap' },
       { text: 'Development', link: '/development/' },
       { text: 'Playground', link: 'https://play.robota.io', target: '_blank' },
     ],

--- a/content/README.md
+++ b/content/README.md
@@ -217,6 +217,8 @@ agent-core             ← Foundation: Robota engine, abstractions, plugins
 - [Getting Started](./getting-started/) — Installation and first steps
 - [Guide](./guide/) — Architecture, building agents, SDK, CLI
 - [Changelog](./changelog/) — What's new in each release
+- [Showcase](./showcase/) — Projects built with Robota SDK
+- [Roadmap](./roadmap.md) — What's coming next
 - [Examples](./examples/) — Working code samples
 - [Development](./development/) — Contributing and monorepo setup
 

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -1,36 +1,74 @@
+---
+title: Roadmap
+description: What's coming next in Robota SDK — current priorities, next quarter, and future exploration.
+---
+
 # Roadmap
 
-Robota SDK is currently in public beta (v3.0.0-beta). This page outlines what's coming next.
+Robota SDK is currently in **public beta (v3.0.0-beta)**. This page is updated quarterly.
 
-## Now — Beta Stabilization
+**Last updated:** 2026-05-23 · [Changelog](/changelog/) · [GitHub Issues](https://github.com/woojubb/robota/issues)
 
-- Bug fixes and stability improvements based on early adopter feedback
-- Hook system Claude Code compatibility (HOOK-001 through HOOK-007)
-- CLI quality improvements (help flag, output format validation, session persistence)
-- Security hardening (WebSocket JWT auth, secrets management)
+---
 
-## Next — v1.0.0
+## Now — Beta Polish (Q2 2026)
 
-v1.0.0 will be declared when the following are complete:
+Active work in the current development window:
 
-- All critical and high-priority CLI bugs resolved
-- Session replay and fork working reliably
-- Documentation in sync across all three layers (SPEC.md, package README, robota.io)
-- Core user journeys verified end-to-end
+| Feature                                          | Status     | Notes   |
+| ------------------------------------------------ | ---------- | ------- |
+| Context warning banner (70% / 90%)               | ✅ Done    | beta.67 |
+| `/compact` result summary                        | ✅ Done    | beta.67 |
+| 3-level permission memory (session / project)    | ✅ Done    | beta.67 |
+| `robota init` project setup command              | ✅ Done    | beta.67 |
+| Plugin development guide + directory             | ✅ Done    | beta.67 |
+| Changelog page at `/changelog/`                  | ✅ Done    | beta.67 |
+| `?` key keyboard shortcut overlay                | ✅ Done    | beta.67 |
+| `--dry-run` flag (plan-only preview)             | ✅ Done    | beta.67 |
+| Session auto-naming from first message           | 🔄 Planned | beta.68 |
+| `/cost` improvements — per-session cost tracking | 📋 Planned | beta.68 |
 
-There is no fixed date. We will publish a blog post and GitHub release when v1.0.0 ships.
+---
 
-## Later — Playground & Cloud
+## Next — Q3 2026
 
-- **Public Playground** — Try Robota in the browser with your own API key, no installation required
-- **Robota Cloud (experimental)** — Hosted sessions, team sharing, usage dashboard (BYOK free tier → team plan)
+Planned for the next quarter:
+
+- **v1.0.0 release candidate** — declared when all P0 bugs are resolved and core user journeys are verified end-to-end
+- **GitHub Actions official action** (`robota-sdk/action@v1`) — run Robota as a CI bot in any workflow
+- **Official plugins starter pack** — 5 community plugin templates: logging, Slack alerts, cost tracking, Linear integration, Datadog metrics
+- **SDK embedding examples** — Next.js, Express, and CLI script reference implementations in a separate repo
+- **Robota Cloud beta** — hosted sessions, team sharing, usage dashboard (BYOK free tier)
+
+---
+
+## Later — Exploration
+
+Ideas under consideration. No commitment on timing:
+
+- Session share links (share a conversation URL)
+- Multi-agent visual canvas in the terminal
+- Native VS Code extension (beyond the current CLI)
+- Enterprise SSO and audit logs
+
+---
+
+## Vote and Suggest
+
+Have a feature request? [Open a GitHub Discussion](https://github.com/woojubb/robota/discussions) or upvote an existing [issue](https://github.com/woojubb/robota/issues).
+
+The most-upvoted issues influence priority in the next quarter planning.
+
+---
+
+## Completed
+
+See the [Changelog](/changelog/) for features shipped in each release.
+
+---
 
 ## Community
 
 - [GitHub Discussions](https://github.com/woojubb/robota/discussions) — Questions, ideas, show and tell
 - [GitHub Issues](https://github.com/woojubb/robota/issues) — Bug reports and feature requests
 - [Contributing Guide](https://github.com/woojubb/robota/blob/main/.github/CONTRIBUTING.md)
-
----
-
-_Last updated: 2026-05-18_

--- a/content/showcase/README.md
+++ b/content/showcase/README.md
@@ -1,0 +1,74 @@
+---
+title: Build with Robota
+description: Projects and tools built using Robota SDK — from CLI assistants to embedded AI agents.
+---
+
+# Build with Robota
+
+Real projects built with Robota SDK. From terminal coding assistants to embedded AI in custom applications.
+
+**→ [Submit your project](#submit-your-project)**
+
+---
+
+## Featured Projects
+
+### Robota CLI
+
+The reference implementation. A full AI coding assistant built entirely on top of `@robota-sdk/agent-framework` and `@robota-sdk/agent-transport/tui`.
+
+- **Source:** [github.com/woojubb/robota](https://github.com/woojubb/robota)
+- **Packages used:** `agent-cli`, `agent-framework`, `agent-transport`, `agent-command`, `agent-tools`
+- **What it demonstrates:** Multi-provider switching, session persistence, permission system, plugin lifecycle, streaming TUI
+
+---
+
+### Visual Agent Builder Playground
+
+A drag-and-drop canvas for assembling agents and exporting working TypeScript code. Runs entirely in the browser with BYOK (bring your own key).
+
+- **Live:** [play.robota.io/playground](https://play.robota.io/playground)
+- **Packages used:** `agent-framework`, `agent-provider`, `agent-tools`
+- **What it demonstrates:** Browser-based SDK usage, SSE streaming, multi-provider BYOK
+
+---
+
+## Community Projects
+
+_No community projects listed yet. Be the first to [submit yours](#submit-your-project)._
+
+---
+
+## Submit Your Project
+
+To add your project to this page:
+
+1. Your project must use at least one `@robota-sdk/*` package
+2. Open a PR adding an entry to the **Community Projects** section above
+
+**Entry format:**
+
+```markdown
+### Your Project Name
+
+One sentence description.
+
+- **Source / Live:** link
+- **Packages used:** list of @robota-sdk/\* packages
+- **What it demonstrates:** key integration patterns
+```
+
+**Requirements:**
+
+- Public source code or live demo
+- Uses at least one `@robota-sdk/*` package
+- Working as of the PR date
+
+---
+
+## Related
+
+- [Building Agents — guide](/guide/building-agents)
+- [SDK framework](/guide/sdk)
+- [Plugin Directory](/plugins/)
+- [Examples](/examples/)


### PR DESCRIPTION
## Summary

- Rewrites `content/roadmap.md` as a proper quarterly roadmap with Q2 2026 status table (current sprint items + completion status), Q3 2026 plans, later exploration ideas, and vote/suggest links to GitHub Issues
- Adds `content/showcase/README.md` — "Build with Robota" page featuring the CLI and Visual Playground as reference implementations, with a community submission format
- Adds Showcase and Roadmap links to the VitePress nav bar
- Updates `content/README.md` Documentation section with links to both pages

## Test plan

- [ ] `/roadmap` renders with table and section headers
- [ ] `/showcase/` renders with project entries
- [ ] Nav bar shows Showcase and Roadmap items

🤖 Generated with [Claude Code](https://claude.com/claude-code)