### PR TITLE
feat(ux-014): auto-name sessions from first user message via AI

### DIFF
--- a/.agents/backlog/UX-014-session-auto-naming.md
+++ b/.agents/backlog/UX-014-session-auto-naming.md
@@ -1,6 +1,6 @@
 ---
 title: 'UX-014: 세션 자동 이름 생성 — 첫 메시지 기반 AI 요약'
-status: todo
+status: done
 created: 2026-05-23
 priority: medium
 urgency: soon

--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -99,6 +99,7 @@ function AppInner(
   props: IProps & { onSessionSwitch: (sessionId: string) => void },
 ): React.ReactElement {
   const cwd = props.cwd;
+  const [sessionName, setSessionName] = useState<string | undefined>(props.sessionName);
 
   const {
     interactiveSession,
@@ -131,6 +132,7 @@ function AppInner(
     resumeSessionId: props.resumeSessionId,
     forkSession: props.forkSession,
     sessionName: props.sessionName,
+    onAutoNamed: setSessionName,
     backgroundTaskRunners: props.backgroundTaskRunners,
     subagentRunnerFactory: props.subagentRunnerFactory,
     commandModules: props.commandModules,
@@ -145,7 +147,6 @@ function AppInner(
   const fallbackPluginCallbacks = usePluginCallbacks(cwd);
   const pluginCallbacks = props.commandHostAdapters?.plugin ?? fallbackPluginCallbacks;
   const { exit } = useApp();
-  const [sessionName, setSessionName] = useState<string | undefined>(props.sessionName);
   const [updateNotice, setUpdateNotice] = useState<string | undefined>();
   const [showExecutionWorkspaceSwitcher, setShowExecutionWorkspaceSwitcher] = useState(false);
   const [executionDetailPage, setExecutionDetailPage] = useState<IExecutionDetailPage | null>(null);

--- a/packages/agent-transport/src/tui/__tests__/session-naming.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/session-naming.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateSessionName } from '../session-naming.js';
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+function makeProvider(responseContent: string): IAIProvider {
+  return {
+    name: 'mock',
+    version: '1.0.0',
+    chat: vi.fn().mockResolvedValue({ role: 'assistant', content: responseContent }),
+    generateResponse: vi.fn(),
+    supportsTools: () => false,
+  } as unknown as IAIProvider;
+}
+
+describe('generateSessionName', () => {
+  it('returns sanitized name from provider response', async () => {
+    const provider = makeProvider('refactor-auth-middleware');
+    const name = await generateSessionName(provider, 'Refactor the auth middleware');
+    expect(name).toBe('refactor-auth-middleware');
+  });
+
+  it('lowercases and strips special characters', async () => {
+    const provider = makeProvider('Fix: Database Connection!');
+    const name = await generateSessionName(provider, 'Fix database connection');
+    expect(name).toBe('fix-database-connection');
+  });
+
+  it('collapses multiple spaces to single hyphen', async () => {
+    const provider = makeProvider('write  api   docs');
+    const name = await generateSessionName(provider, 'Write API docs');
+    expect(name).toBe('write-api-docs');
+  });
+
+  it('falls back to sanitized first message when response is too short', async () => {
+    const provider = makeProvider('ok');
+    const name = await generateSessionName(provider, 'Fix login bug');
+    expect(name).toBe('fix-login-bug');
+  });
+
+  it('truncates long names to 60 chars', async () => {
+    const long = 'a'.repeat(100);
+    const provider = makeProvider(long);
+    const name = await generateSessionName(provider, 'something');
+    expect(name.length).toBeLessThanOrEqual(60);
+  });
+
+  it('passes maxTokens: 20 to provider', async () => {
+    const provider = makeProvider('short-name');
+    await generateSessionName(provider, 'test');
+    expect(provider.chat).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ maxTokens: 20 }),
+    );
+  });
+
+  it('truncates first message to 200 chars before sending', async () => {
+    const long = 'x'.repeat(500);
+    const provider = makeProvider('short-name');
+    await generateSessionName(provider, long);
+    const messages = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const userMsg = messages.find((m: { role: string }) => m.role === 'user');
+    expect(userMsg.content.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/packages/agent-transport/src/tui/hooks/useInteractiveSession.ts
+++ b/packages/agent-transport/src/tui/hooks/useInteractiveSession.ts
@@ -1,10 +1,11 @@
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { CommandEffectQueue, type ICommandEffectQueue } from './command-effect-queue.js';
 import { initializeSession, type IInitState } from './use-interactive-session-init.js';
 import { usePermissionQueue } from './usePermissionQueue.js';
 import { useSlashRouting } from './useSlashRouting.js';
+import { generateSessionName } from '../session-naming.js';
 
 import type { TuiStateManager } from '../tui-state-manager.js';
 import type { IPermissionRequest } from '../types.js';
@@ -41,6 +42,7 @@ export interface IInteractiveSessionProps {
   resumeSessionId?: string;
   forkSession?: boolean;
   sessionName?: string;
+  onAutoNamed?: (name: string) => void;
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   subagentRunnerFactory?: TSubagentRunnerFactory;
   commandModules?: readonly ICommandModule[];
@@ -118,6 +120,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
   const [, forceRender] = useState(0);
   const [isShuttingDown, setIsShuttingDown] = useState(false);
   const { permissionHandler, permissionRequest } = usePermissionQueue();
+  const autoNameTriggeredRef = useRef(false);
 
   // Initialize once — useState lazy initializer runs exactly once per mount, safe for Concurrent Mode
   const [initState] = useState<IInitState>(() => initializeSession(props, permissionHandler));
@@ -148,9 +151,24 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
     const onCompact = (): void => applyCompactEventToManager(interactiveSession, manager);
     const onSkillActivation = (): void =>
       applySkillActivationEventToManager(interactiveSession, manager);
+
+    const onUserMessage = (content: string): void => {
+      if (autoNameTriggeredRef.current) return;
+      if (props.sessionName || interactiveSession.getName()) return;
+      autoNameTriggeredRef.current = true;
+      generateSessionName(props.provider, content)
+        .then((name) => {
+          interactiveSession.setName(name);
+          props.onAutoNamed?.(name);
+        })
+        .catch(() => {
+          autoNameTriggeredRef.current = false;
+        });
+    };
     const onExecutionWorkspaceEvent = (event: IExecutionWorkspaceEvent): void =>
       manager.syncExecutionWorkspaceSnapshot(event.snapshot);
 
+    interactiveSession.on('user_message', onUserMessage);
     interactiveSession.on('text_delta', manager.onTextDelta);
     interactiveSession.on('tool_start', manager.onToolStart);
     interactiveSession.on('tool_end', manager.onToolEnd);
@@ -186,6 +204,7 @@ export function useInteractiveSession(props: IInteractiveSessionProps): IInterac
 
     return () => {
       clearInterval(initCheck);
+      interactiveSession.off('user_message', onUserMessage);
       interactiveSession.off('text_delta', manager.onTextDelta);
       interactiveSession.off('tool_start', manager.onToolStart);
       interactiveSession.off('tool_end', manager.onToolEnd);

--- a/packages/agent-transport/src/tui/session-naming.ts
+++ b/packages/agent-transport/src/tui/session-naming.ts
@@ -1,0 +1,33 @@
+import { createSystemMessage, createUserMessage } from '@robota-sdk/agent-core';
+
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+const SYSTEM_PROMPT =
+  'You generate short session titles. Respond with ONLY a 3-5 word lowercase-hyphenated title (e.g. refactor-auth-middleware). No explanation, no punctuation, no quotes.';
+
+const MAX_FIRST_MESSAGE_CHARS = 200;
+
+function sanitizeName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 60);
+}
+
+export async function generateSessionName(
+  provider: IAIProvider,
+  firstMessage: string,
+): Promise<string> {
+  const truncated = firstMessage.slice(0, MAX_FIRST_MESSAGE_CHARS);
+  const response = await provider.chat(
+    [createSystemMessage(SYSTEM_PROMPT), createUserMessage(truncated)],
+    { maxTokens: 20 },
+  );
+  const raw = typeof response.content === 'string' ? response.content : '';
+  const name = sanitizeName(raw);
+  if (!name || name.length < 3) return sanitizeName(firstMessage);
+  return name;
+}


### PR DESCRIPTION
## Summary

After the first user message is submitted in the TUI, a background AI call generates a 3–5 word lowercase-hyphenated session name (e.g. `refactor-auth-middleware`). The name is persisted to the session store and displayed immediately in the status bar and session picker — replacing the UUID default.

**Changes:**

- `session-naming.ts`: `generateSessionName(provider, firstMessage)` — sends a minimal prompt to `provider.chat()` requesting a short hyphenated title; sanitizes the response; falls back to sanitized first message if AI returns unusable output
- `useInteractiveSession.ts`: subscribes to `user_message` event; on first message when session has no pre-existing name, fires `generateSessionName()` asynchronously and calls `interactiveSession.setName()` + `onAutoNamed()` callback
- `App.tsx`: moves `sessionName` useState above `useInteractiveSession` call so `setSessionName` is available as `onAutoNamed`
- `session-naming.test.ts`: 7 unit tests (sanitization, truncation, fallback, provider arg verification)

## Test plan

- [ ] 415 agent-transport tests pass
- [ ] Start a new TUI session → type a message → status bar shows generated name within a few seconds
- [ ] Resume session → name persists across sessions
- [ ] Pre-named session (`--name "my-session"`) → auto-naming skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)