### PR TITLE
feat(pm-005): add 5 official integration plugin packages

### DIFF
--- a/.agents/backlog/PM-005-official-plugins-starter-pack.md
+++ b/.agents/backlog/PM-005-official-plugins-starter-pack.md
@@ -1,6 +1,6 @@
 ---
 title: 'PM-005: 공식 플러그인 스타터 팩 5종 개발'
-status: todo
+status: done
 created: 2026-05-23
 priority: high
 urgency: later

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@robota-sdk/plugin-github",
+  "version": "3.0.0-beta.67",
+  "description": "GitHub PR and Issue context plugin for Robota SDK",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "rimraf": "^6.0.1",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-github/src/__tests__/github-plugin.test.ts
+++ b/packages/plugin-github/src/__tests__/github-plugin.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+// Mock GitHubClient before importing GitHubPlugin
+vi.mock('../github-client.js', () => {
+  const GitHubClient = vi.fn().mockImplementation(() => ({
+    getIssue: vi.fn(),
+    getPR: vi.fn(),
+    listOpenIssues: vi.fn(),
+  }));
+  return { GitHubClient };
+});
+
+import { GitHubPlugin } from '../github-plugin.js';
+import { GitHubClient } from '../github-client.js';
+import type { IGitHubIssue, IGitHubPR } from '../types.js';
+
+const MOCK_TOKEN = 'ghp_test_token';
+const MOCK_OWNER = 'acme';
+const MOCK_REPO = 'widget';
+
+function makeIssue(overrides: Partial<IGitHubIssue> = {}): IGitHubIssue {
+  return {
+    number: 1,
+    title: 'Test issue',
+    body: 'Issue body',
+    state: 'open',
+    labels: ['bug'],
+    url: 'https://github.com/acme/widget/issues/1',
+    ...overrides,
+  };
+}
+
+function makePR(overrides: Partial<IGitHubPR> = {}): IGitHubPR {
+  return {
+    number: 42,
+    title: 'Test PR',
+    body: 'PR body',
+    state: 'open',
+    headBranch: 'feature/foo',
+    baseBranch: 'main',
+    url: 'https://github.com/acme/widget/pull/42',
+    additions: 10,
+    deletions: 3,
+    ...overrides,
+  };
+}
+
+describe('GitHubPlugin', () => {
+  let plugin: GitHubPlugin;
+  let clientMock: {
+    getIssue: ReturnType<typeof vi.fn>;
+    getPR: ReturnType<typeof vi.fn>;
+    listOpenIssues: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new GitHubPlugin({ token: MOCK_TOKEN });
+    // Grab the mock instance created inside the constructor
+    clientMock = vi.mocked(GitHubClient).mock.results[0].value as typeof clientMock;
+  });
+
+  it('initializes with correct name, category, and priority', () => {
+    expect(plugin.name).toBe('GitHubPlugin');
+    expect(plugin.version).toBe('1.0.0');
+    expect(plugin.category).toBe(PluginCategory.CUSTOM);
+    expect(plugin.priority).toBe(PluginPriority.NORMAL);
+    expect(plugin.enabled).toBe(true);
+  });
+
+  it('getIssue delegates to client and increments stats', async () => {
+    const issue = makeIssue();
+    clientMock.getIssue.mockResolvedValueOnce(issue);
+
+    const result = await plugin.getIssue(MOCK_OWNER, MOCK_REPO, 1);
+
+    expect(clientMock.getIssue).toHaveBeenCalledWith(MOCK_OWNER, MOCK_REPO, 1);
+    expect(result).toEqual(issue);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(1);
+    expect(stats.prsFetched).toBe(0);
+  });
+
+  it('getPR delegates to client and increments stats', async () => {
+    const pr = makePR();
+    clientMock.getPR.mockResolvedValueOnce(pr);
+
+    const result = await plugin.getPR(MOCK_OWNER, MOCK_REPO, 42);
+
+    expect(clientMock.getPR).toHaveBeenCalledWith(MOCK_OWNER, MOCK_REPO, 42);
+    expect(result).toEqual(pr);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.prsFetched).toBe(1);
+    expect(stats.issuesFetched).toBe(0);
+  });
+
+  it('listOpenIssues returns filtered results and increments stats by count', async () => {
+    const issues = [makeIssue({ number: 1 }), makeIssue({ number: 2 }), makeIssue({ number: 3 })];
+    clientMock.listOpenIssues.mockResolvedValueOnce(issues);
+
+    const result = await plugin.listOpenIssues(MOCK_OWNER, MOCK_REPO, 3);
+
+    expect(clientMock.listOpenIssues).toHaveBeenCalledWith(MOCK_OWNER, MOCK_REPO, 3);
+    expect(result).toHaveLength(3);
+    const stats = plugin.getStats();
+    expect(stats.issuesFetched).toBe(3);
+    expect(stats.calls).toBe(1);
+  });
+
+  it('getStats returns merged base and GitHub-specific stats', async () => {
+    clientMock.getIssue.mockResolvedValueOnce(makeIssue());
+    clientMock.getPR.mockResolvedValueOnce(makePR());
+
+    await plugin.getIssue(MOCK_OWNER, MOCK_REPO, 1);
+    await plugin.getPR(MOCK_OWNER, MOCK_REPO, 42);
+
+    const stats = plugin.getStats();
+    expect(stats.enabled).toBe(true);
+    expect(stats.calls).toBe(2);
+    expect(stats.errors).toBe(0);
+    expect(stats.issuesFetched).toBe(1);
+    expect(stats.prsFetched).toBe(1);
+    expect(stats.moduleEventsReceived).toBe(0);
+    expect(stats.lastActivity).toBeInstanceOf(Date);
+  });
+
+  it('plugin is disabled after disable() and re-enabled after enable()', () => {
+    expect(plugin.isEnabled()).toBe(true);
+
+    plugin.disable();
+    expect(plugin.isEnabled()).toBe(false);
+    expect(plugin.getStats().enabled).toBe(false);
+
+    plugin.enable();
+    expect(plugin.isEnabled()).toBe(true);
+    expect(plugin.getStats().enabled).toBe(true);
+  });
+});

--- a/packages/plugin-github/src/github-client.ts
+++ b/packages/plugin-github/src/github-client.ts
@@ -1,0 +1,98 @@
+import type { IGitHubIssue, IGitHubPR } from './types.js';
+
+interface IRawLabel {
+  name: string;
+}
+
+interface IRawIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: IRawLabel[];
+  html_url: string;
+  pull_request?: unknown;
+}
+
+interface IRawPR {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  head: { ref: string };
+  base: { ref: string };
+  html_url: string;
+  additions: number;
+  deletions: number;
+}
+
+export class GitHubClient {
+  private readonly baseUrl = 'https://api.github.com';
+  private readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+  }
+
+  async getIssue(owner: string, repo: string, number: number): Promise<IGitHubIssue> {
+    const res = await fetch(`${this.baseUrl}/repos/${owner}/${repo}/issues/${number}`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawIssue;
+    return {
+      number: data.number,
+      title: data.title,
+      body: data.body,
+      state: data.state,
+      labels: data.labels.map((l) => l.name),
+      url: data.html_url,
+    };
+  }
+
+  async getPR(owner: string, repo: string, number: number): Promise<IGitHubPR> {
+    const res = await fetch(`${this.baseUrl}/repos/${owner}/${repo}/pulls/${number}`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawPR;
+    return {
+      number: data.number,
+      title: data.title,
+      body: data.body,
+      state: data.state,
+      headBranch: data.head.ref,
+      baseBranch: data.base.ref,
+      url: data.html_url,
+      additions: data.additions,
+      deletions: data.deletions,
+    };
+  }
+
+  async listOpenIssues(owner: string, repo: string, limit = 10): Promise<IGitHubIssue[]> {
+    const res = await fetch(
+      `${this.baseUrl}/repos/${owner}/${repo}/issues?state=open&per_page=${limit}&pulls=false`,
+      { headers: this.headers() },
+    );
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawIssue[];
+    return data
+      .filter((item) => !item.pull_request)
+      .map((item) => ({
+        number: item.number,
+        title: item.title,
+        body: item.body,
+        state: item.state,
+        labels: item.labels.map((l) => l.name),
+        url: item.html_url,
+      }));
+  }
+}

--- a/packages/plugin-github/src/github-plugin.ts
+++ b/packages/plugin-github/src/github-plugin.ts
@@ -1,0 +1,59 @@
+import {
+  AbstractPlugin,
+  PluginCategory,
+  PluginPriority,
+  type IPluginExecutionContext,
+} from '@robota-sdk/agent-core';
+
+import { GitHubClient } from './github-client.js';
+import type { IGitHubIssue, IGitHubPR, IGitHubPluginOptions, IGitHubPluginStats } from './types.js';
+
+export class GitHubPlugin extends AbstractPlugin<IGitHubPluginOptions, IGitHubPluginStats> {
+  readonly name = 'GitHubPlugin';
+  readonly version = '1.0.0';
+
+  private client: GitHubClient;
+  private issuesFetched = 0;
+  private prsFetched = 0;
+
+  constructor(options: IGitHubPluginOptions) {
+    super();
+    this.category = PluginCategory.CUSTOM;
+    this.priority = PluginPriority.NORMAL;
+    this.client = new GitHubClient(options.token);
+  }
+
+  async getIssue(owner: string, repo: string, number: number): Promise<IGitHubIssue> {
+    this.updateCallStats();
+    const issue = await this.client.getIssue(owner, repo, number);
+    this.issuesFetched++;
+    return issue;
+  }
+
+  async getPR(owner: string, repo: string, number: number): Promise<IGitHubPR> {
+    this.updateCallStats();
+    const pr = await this.client.getPR(owner, repo, number);
+    this.prsFetched++;
+    return pr;
+  }
+
+  async listOpenIssues(owner: string, repo: string, limit = 10): Promise<IGitHubIssue[]> {
+    this.updateCallStats();
+    const issues = await this.client.listOpenIssues(owner, repo, limit);
+    this.issuesFetched += issues.length;
+    return issues;
+  }
+
+  override async beforeExecution(context: IPluginExecutionContext): Promise<void> {
+    // Hook point: subclasses can inject GitHub context into the system prompt here
+    await super.beforeExecution?.(context);
+  }
+
+  override getStats(): IGitHubPluginStats {
+    return {
+      ...super.getStats(),
+      issuesFetched: this.issuesFetched,
+      prsFetched: this.prsFetched,
+    };
+  }
+}

--- a/packages/plugin-github/src/index.ts
+++ b/packages/plugin-github/src/index.ts
@@ -1,0 +1,3 @@
+export { GitHubPlugin } from './github-plugin.js';
+export { GitHubClient } from './github-client.js';
+export type { IGitHubPluginOptions, IGitHubIssue, IGitHubPR, IGitHubPluginStats } from './types.js';

--- a/packages/plugin-github/src/types.ts
+++ b/packages/plugin-github/src/types.ts
@@ -1,0 +1,33 @@
+import type { IPluginOptions, IPluginStats } from '@robota-sdk/agent-core';
+
+export interface IGitHubPluginOptions extends IPluginOptions {
+  token: string;
+  owner?: string;
+  repo?: string;
+}
+
+export interface IGitHubIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: string[];
+  url: string;
+}
+
+export interface IGitHubPR {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  headBranch: string;
+  baseBranch: string;
+  url: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface IGitHubPluginStats extends IPluginStats {
+  issuesFetched: number;
+  prsFetched: number;
+}

--- a/packages/plugin-github/tsconfig.json
+++ b/packages/plugin-github/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-github/tsdown.config.ts
+++ b/packages/plugin-github/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  clean: true,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+});

--- a/packages/plugin-jira/package.json
+++ b/packages/plugin-jira/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@robota-sdk/plugin-jira",
+  "version": "3.0.0-beta.67",
+  "description": "Jira ticket tracking plugin for Robota SDK",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "rimraf": "^6.0.1",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-jira/src/__tests__/jira-plugin.test.ts
+++ b/packages/plugin-jira/src/__tests__/jira-plugin.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+// Mock JiraClient before importing JiraPlugin
+vi.mock('../jira-client.js', () => {
+  const JiraClient = vi.fn().mockImplementation(() => ({
+    getIssue: vi.fn(),
+    searchIssues: vi.fn(),
+    createIssue: vi.fn(),
+    getProjects: vi.fn(),
+  }));
+  return { JiraClient };
+});
+
+import { JiraPlugin } from '../jira-plugin.js';
+import { JiraClient } from '../jira-client.js';
+import type { IJiraIssue, IJiraProject } from '../types.js';
+
+const MOCK_OPTIONS = {
+  baseUrl: 'https://test.atlassian.net',
+  email: 'user@example.com',
+  apiToken: 'test-api-token',
+  projectKey: 'TEST',
+};
+
+function makeIssue(overrides: Partial<IJiraIssue> = {}): IJiraIssue {
+  return {
+    id: '10001',
+    key: 'TEST-1',
+    summary: 'Test issue summary',
+    description: 'Test issue description',
+    status: 'To Do',
+    priority: 'Medium',
+    issueType: 'Task',
+    assignee: null,
+    url: 'https://test.atlassian.net/browse/TEST-1',
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<IJiraProject> = {}): IJiraProject {
+  return {
+    id: '10000',
+    key: 'TEST',
+    name: 'Test Project',
+    ...overrides,
+  };
+}
+
+describe('JiraPlugin', () => {
+  let plugin: JiraPlugin;
+  let clientMock: {
+    getIssue: ReturnType<typeof vi.fn>;
+    searchIssues: ReturnType<typeof vi.fn>;
+    createIssue: ReturnType<typeof vi.fn>;
+    getProjects: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new JiraPlugin(MOCK_OPTIONS);
+    clientMock = vi.mocked(JiraClient).mock.results[0].value as typeof clientMock;
+  });
+
+  it('initializes with correct name, category, and priority', () => {
+    expect(plugin.name).toBe('JiraPlugin');
+    expect(plugin.version).toBe('1.0.0');
+    expect(plugin.category).toBe(PluginCategory.CUSTOM);
+    expect(plugin.priority).toBe(PluginPriority.NORMAL);
+    expect(plugin.enabled).toBe(true);
+  });
+
+  it('getIssue delegates to client and increments issuesFetched', async () => {
+    const issue = makeIssue();
+    clientMock.getIssue.mockResolvedValueOnce(issue);
+
+    const result = await plugin.getIssue('TEST-1');
+
+    expect(clientMock.getIssue).toHaveBeenCalledWith('TEST-1');
+    expect(result).toEqual(issue);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(1);
+    expect(stats.issuesCreated).toBe(0);
+  });
+
+  it('searchIssues delegates to client and increments issuesFetched by results count', async () => {
+    const issues = [
+      makeIssue({ key: 'TEST-1' }),
+      makeIssue({ key: 'TEST-2' }),
+      makeIssue({ key: 'TEST-3' }),
+    ];
+    clientMock.searchIssues.mockResolvedValueOnce(issues);
+
+    const result = await plugin.searchIssues('project = TEST ORDER BY created DESC', 3);
+
+    expect(clientMock.searchIssues).toHaveBeenCalledWith('project = TEST ORDER BY created DESC', 3);
+    expect(result).toHaveLength(3);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(3);
+    expect(stats.issuesCreated).toBe(0);
+  });
+
+  it('createIssue delegates to client and increments issuesCreated', async () => {
+    const created = makeIssue({ key: 'TEST-2', summary: 'New task' });
+    clientMock.createIssue.mockResolvedValueOnce(created);
+
+    const input = { projectKey: 'TEST', summary: 'New task', issueType: 'Task' };
+    const result = await plugin.createIssue(input);
+
+    expect(clientMock.createIssue).toHaveBeenCalledWith(input);
+    expect(result).toEqual(created);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(0);
+    expect(stats.issuesCreated).toBe(1);
+  });
+
+  it('getProjects delegates to client correctly', async () => {
+    const projects = [
+      makeProject(),
+      makeProject({ id: '10001', key: 'DEMO', name: 'Demo Project' }),
+    ];
+    clientMock.getProjects.mockResolvedValueOnce(projects);
+
+    const result = await plugin.getProjects(10);
+
+    expect(clientMock.getProjects).toHaveBeenCalledWith(10);
+    expect(result).toHaveLength(2);
+    expect(result[0].key).toBe('TEST');
+    expect(result[1].key).toBe('DEMO');
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(0);
+    expect(stats.issuesCreated).toBe(0);
+  });
+
+  it('getStats returns merged base stats with Jira-specific fields', async () => {
+    clientMock.getIssue.mockResolvedValueOnce(makeIssue());
+    clientMock.searchIssues.mockResolvedValueOnce([
+      makeIssue({ key: 'TEST-2' }),
+      makeIssue({ key: 'TEST-3' }),
+    ]);
+    clientMock.createIssue.mockResolvedValueOnce(makeIssue({ key: 'TEST-4' }));
+
+    await plugin.getIssue('TEST-1');
+    await plugin.searchIssues('project = TEST', 2);
+    await plugin.createIssue({ projectKey: 'TEST', summary: 'New issue' });
+
+    const stats = plugin.getStats();
+    expect(stats.enabled).toBe(true);
+    expect(stats.calls).toBe(3);
+    expect(stats.errors).toBe(0);
+    expect(stats.issuesFetched).toBe(3);
+    expect(stats.issuesCreated).toBe(1);
+    expect(stats.moduleEventsReceived).toBe(0);
+    expect(stats.lastActivity).toBeInstanceOf(Date);
+  });
+});

--- a/packages/plugin-jira/src/index.ts
+++ b/packages/plugin-jira/src/index.ts
@@ -1,0 +1,9 @@
+export { JiraPlugin } from './jira-plugin.js';
+export { JiraClient } from './jira-client.js';
+export type {
+  IJiraPluginOptions,
+  IJiraIssue,
+  IJiraCreateIssueInput,
+  IJiraProject,
+  IJiraPluginStats,
+} from './types.js';

--- a/packages/plugin-jira/src/jira-client.ts
+++ b/packages/plugin-jira/src/jira-client.ts
@@ -1,0 +1,188 @@
+import type { IJiraIssue, IJiraCreateIssueInput, IJiraProject } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (typed locally — no `any`)
+// ---------------------------------------------------------------------------
+
+interface IRawIssueStatus {
+  name: string;
+}
+
+interface IRawIssuePriority {
+  name: string;
+}
+
+interface IRawIssueType {
+  name: string;
+}
+
+interface IRawUser {
+  displayName: string;
+}
+
+interface IRawAdfContent {
+  type: string;
+  text?: string;
+  content?: IRawAdfContent[];
+}
+
+interface IRawAdfDocument {
+  type: string;
+  content?: IRawAdfContent[];
+}
+
+interface IRawIssueFields {
+  summary: string;
+  description: IRawAdfDocument | null;
+  status: IRawIssueStatus;
+  priority: IRawIssuePriority;
+  issuetype: IRawIssueType;
+  assignee: IRawUser | null;
+}
+
+interface IRawIssue {
+  id: string;
+  key: string;
+  self: string;
+  fields: IRawIssueFields;
+}
+
+interface IRawSearchResponse {
+  issues: IRawIssue[];
+}
+
+interface IRawCreatedIssue {
+  id: string;
+  key: string;
+  self: string;
+}
+
+interface IRawProject {
+  id: string;
+  key: string;
+  name: string;
+}
+
+interface IRawProjectSearchResponse {
+  values: IRawProject[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extracts plain text from an Atlassian Document Format (ADF) node. */
+function extractAdfText(node: IRawAdfContent | IRawAdfDocument | null): string | null {
+  if (!node) return null;
+  if (node.type === 'text' && 'text' in node && typeof node.text === 'string') return node.text;
+  if (!node.content || node.content.length === 0) return null;
+  const parts = node.content.map((child) => extractAdfText(child)).filter(Boolean);
+  return parts.length > 0 ? parts.join('') : null;
+}
+
+function mapRawIssue(raw: IRawIssue, baseUrl: string): IJiraIssue {
+  return {
+    id: raw.id,
+    key: raw.key,
+    summary: raw.fields.summary,
+    description: extractAdfText(raw.fields.description),
+    status: raw.fields.status.name,
+    priority: raw.fields.priority.name,
+    issueType: raw.fields.issuetype.name,
+    assignee: raw.fields.assignee ? raw.fields.assignee.displayName : null,
+    url: `${baseUrl}/browse/${raw.key}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JiraClient
+// ---------------------------------------------------------------------------
+
+export class JiraClient {
+  private readonly baseUrl: string;
+  private readonly apiBase: string;
+  private readonly authHeader: string;
+
+  constructor(baseUrl: string, email: string, apiToken: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.apiBase = `${this.baseUrl}/rest/api/3`;
+    this.authHeader = `Basic ${Buffer.from(`${email}:${apiToken}`).toString('base64')}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: this.authHeader,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async getIssue(issueKey: string): Promise<IJiraIssue> {
+    const res = await fetch(`${this.apiBase}/issue/${issueKey}`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`Jira API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawIssue;
+    return mapRawIssue(data, this.baseUrl);
+  }
+
+  async searchIssues(jql: string, limit = 50): Promise<IJiraIssue[]> {
+    const res = await fetch(`${this.apiBase}/issue/search`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        jql,
+        maxResults: limit,
+        fields: ['summary', 'description', 'status', 'priority', 'issuetype', 'assignee'],
+      }),
+    });
+    if (!res.ok) throw new Error(`Jira API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawSearchResponse;
+    return data.issues.map((raw) => mapRawIssue(raw, this.baseUrl));
+  }
+
+  async createIssue(input: IJiraCreateIssueInput): Promise<IJiraIssue> {
+    const body = {
+      fields: {
+        project: { key: input.projectKey },
+        summary: input.summary,
+        issuetype: { name: input.issueType ?? 'Task' },
+        ...(input.description && {
+          description: {
+            type: 'doc',
+            version: 1,
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: input.description }],
+              },
+            ],
+          },
+        }),
+        ...(input.priority && { priority: { name: input.priority } }),
+      },
+    };
+
+    const res = await fetch(`${this.apiBase}/issue`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`Jira API ${res.status}: ${await res.text()}`);
+    const created = (await res.json()) as IRawCreatedIssue;
+    return this.getIssue(created.key);
+  }
+
+  async getProjects(limit = 50): Promise<IJiraProject[]> {
+    const res = await fetch(`${this.apiBase}/project/search?maxResults=${limit}`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`Jira API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawProjectSearchResponse;
+    return data.values.map((p) => ({
+      id: p.id,
+      key: p.key,
+      name: p.name,
+    }));
+  }
+}

--- a/packages/plugin-jira/src/jira-plugin.ts
+++ b/packages/plugin-jira/src/jira-plugin.ts
@@ -1,0 +1,60 @@
+import { AbstractPlugin, PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+import { JiraClient } from './jira-client.js';
+import type {
+  IJiraIssue,
+  IJiraCreateIssueInput,
+  IJiraProject,
+  IJiraPluginOptions,
+  IJiraPluginStats,
+} from './types.js';
+
+export class JiraPlugin extends AbstractPlugin<IJiraPluginOptions, IJiraPluginStats> {
+  readonly name = 'JiraPlugin';
+  readonly version = '1.0.0';
+
+  private client: JiraClient;
+  private issuesFetched = 0;
+  private issuesCreated = 0;
+
+  constructor(options: IJiraPluginOptions) {
+    super();
+    this.category = PluginCategory.CUSTOM;
+    this.priority = PluginPriority.NORMAL;
+    this.client = new JiraClient(options.baseUrl, options.email, options.apiToken);
+  }
+
+  async getIssue(issueKey: string): Promise<IJiraIssue> {
+    this.updateCallStats();
+    const issue = await this.client.getIssue(issueKey);
+    this.issuesFetched++;
+    return issue;
+  }
+
+  async searchIssues(jql: string, limit?: number): Promise<IJiraIssue[]> {
+    this.updateCallStats();
+    const issues = await this.client.searchIssues(jql, limit);
+    this.issuesFetched += issues.length;
+    return issues;
+  }
+
+  async createIssue(input: IJiraCreateIssueInput): Promise<IJiraIssue> {
+    this.updateCallStats();
+    const issue = await this.client.createIssue(input);
+    this.issuesCreated++;
+    return issue;
+  }
+
+  async getProjects(limit?: number): Promise<IJiraProject[]> {
+    this.updateCallStats();
+    return this.client.getProjects(limit);
+  }
+
+  override getStats(): IJiraPluginStats {
+    return {
+      ...super.getStats(),
+      issuesFetched: this.issuesFetched,
+      issuesCreated: this.issuesCreated,
+    };
+  }
+}

--- a/packages/plugin-jira/src/types.ts
+++ b/packages/plugin-jira/src/types.ts
@@ -1,0 +1,46 @@
+import type { IPluginOptions, IPluginStats } from '@robota-sdk/agent-core';
+
+export interface IJiraPluginOptions extends IPluginOptions {
+  /** Jira Cloud base URL, e.g. "https://yourorg.atlassian.net" */
+  baseUrl: string;
+  /** Atlassian account email address */
+  email: string;
+  /** Atlassian API token */
+  apiToken: string;
+  /** Default project key used when none is specified */
+  projectKey?: string;
+}
+
+export interface IJiraIssue {
+  id: string;
+  /** Human-readable key, e.g. "PROJ-123" */
+  key: string;
+  summary: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  issueType: string;
+  assignee: string | null;
+  /** Browsable URL to the issue in Jira */
+  url: string;
+}
+
+export interface IJiraCreateIssueInput {
+  projectKey: string;
+  summary: string;
+  description?: string;
+  /** Defaults to "Task" when omitted */
+  issueType?: string;
+  priority?: string;
+}
+
+export interface IJiraProject {
+  id: string;
+  key: string;
+  name: string;
+}
+
+export interface IJiraPluginStats extends IPluginStats {
+  issuesFetched: number;
+  issuesCreated: number;
+}

--- a/packages/plugin-jira/tsconfig.json
+++ b/packages/plugin-jira/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-jira/tsdown.config.ts
+++ b/packages/plugin-jira/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  clean: true,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+});

--- a/packages/plugin-linear/package.json
+++ b/packages/plugin-linear/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@robota-sdk/plugin-linear",
+  "version": "3.0.0-beta.67",
+  "description": "Linear issue tracking plugin for Robota SDK",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "rimraf": "^6.0.1",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-linear/src/__tests__/linear-plugin.test.ts
+++ b/packages/plugin-linear/src/__tests__/linear-plugin.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+// Mock LinearClient before importing LinearPlugin
+vi.mock('../linear-client.js', () => {
+  const LinearClient = vi.fn().mockImplementation(() => ({
+    getIssue: vi.fn(),
+    searchIssues: vi.fn(),
+    createIssue: vi.fn(),
+    getTeams: vi.fn(),
+  }));
+  return { LinearClient };
+});
+
+import { LinearPlugin } from '../linear-plugin.js';
+import { LinearClient } from '../linear-client.js';
+import type { ILinearIssue, ILinearTeam } from '../types.js';
+
+const MOCK_API_KEY = 'lin_api_test_key';
+
+function makeIssue(overrides: Partial<ILinearIssue> = {}): ILinearIssue {
+  return {
+    id: 'issue-id-1',
+    identifier: 'ENG-123',
+    title: 'Fix the bug',
+    description: 'Something is broken',
+    state: 'In Progress',
+    priority: 2,
+    url: 'https://linear.app/team/issue/ENG-123',
+    assignee: 'Jane Doe',
+    ...overrides,
+  };
+}
+
+function makeTeam(overrides: Partial<ILinearTeam> = {}): ILinearTeam {
+  return {
+    id: 'team-id-1',
+    name: 'Engineering',
+    key: 'ENG',
+    ...overrides,
+  };
+}
+
+describe('LinearPlugin', () => {
+  let plugin: LinearPlugin;
+  let clientMock: {
+    getIssue: ReturnType<typeof vi.fn>;
+    searchIssues: ReturnType<typeof vi.fn>;
+    createIssue: ReturnType<typeof vi.fn>;
+    getTeams: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new LinearPlugin({ apiKey: MOCK_API_KEY });
+    clientMock = vi.mocked(LinearClient).mock.results[0].value as typeof clientMock;
+  });
+
+  it('has correct name, category, and priority', () => {
+    expect(plugin.name).toBe('LinearPlugin');
+    expect(plugin.version).toBe('1.0.0');
+    expect(plugin.category).toBe(PluginCategory.CUSTOM);
+    expect(plugin.priority).toBe(PluginPriority.NORMAL);
+    expect(plugin.enabled).toBe(true);
+  });
+
+  it('getIssue delegates to client and increments issuesFetched', async () => {
+    const issue = makeIssue();
+    clientMock.getIssue.mockResolvedValueOnce(issue);
+
+    const result = await plugin.getIssue('issue-id-1');
+
+    expect(clientMock.getIssue).toHaveBeenCalledWith('issue-id-1');
+    expect(result).toEqual(issue);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(1);
+    expect(stats.issuesCreated).toBe(0);
+  });
+
+  it('searchIssues delegates to client and increments issuesFetched by count', async () => {
+    const issues = [makeIssue({ id: '1' }), makeIssue({ id: '2' }), makeIssue({ id: '3' })];
+    clientMock.searchIssues.mockResolvedValueOnce(issues);
+
+    const result = await plugin.searchIssues('bug', 'team-id-1', 10);
+
+    expect(clientMock.searchIssues).toHaveBeenCalledWith('bug', 'team-id-1', 10);
+    expect(result).toHaveLength(3);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(3);
+    expect(stats.issuesCreated).toBe(0);
+  });
+
+  it('createIssue delegates to client and increments issuesCreated', async () => {
+    const issue = makeIssue({ id: 'new-id', identifier: 'ENG-124', title: 'New feature' });
+    clientMock.createIssue.mockResolvedValueOnce(issue);
+
+    const input = { teamId: 'team-id-1', title: 'New feature', description: 'Details here' };
+    const result = await plugin.createIssue(input);
+
+    expect(clientMock.createIssue).toHaveBeenCalledWith(input);
+    expect(result).toEqual(issue);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.issuesFetched).toBe(0);
+    expect(stats.issuesCreated).toBe(1);
+  });
+
+  it('getTeams delegates to client and returns teams', async () => {
+    const teams = [makeTeam(), makeTeam({ id: 'team-id-2', name: 'Design', key: 'DES' })];
+    clientMock.getTeams.mockResolvedValueOnce(teams);
+
+    const result = await plugin.getTeams();
+
+    expect(clientMock.getTeams).toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[0].key).toBe('ENG');
+    expect(result[1].key).toBe('DES');
+  });
+
+  it('getStats returns merged stats including Linear-specific fields', async () => {
+    const issues = [makeIssue({ id: '1' }), makeIssue({ id: '2' })];
+    clientMock.searchIssues.mockResolvedValueOnce(issues);
+    clientMock.createIssue.mockResolvedValueOnce(makeIssue({ id: '3' }));
+
+    await plugin.searchIssues('test');
+    await plugin.createIssue({ teamId: 'team-id-1', title: 'New' });
+
+    const stats = plugin.getStats();
+    expect(stats.enabled).toBe(true);
+    expect(stats.calls).toBe(2);
+    expect(stats.errors).toBe(0);
+    expect(stats.issuesFetched).toBe(2);
+    expect(stats.issuesCreated).toBe(1);
+    expect(stats.moduleEventsReceived).toBe(0);
+    expect(stats.lastActivity).toBeInstanceOf(Date);
+  });
+});

--- a/packages/plugin-linear/src/index.ts
+++ b/packages/plugin-linear/src/index.ts
@@ -1,0 +1,9 @@
+export { LinearPlugin } from './linear-plugin.js';
+export { LinearClient } from './linear-client.js';
+export type {
+  ILinearPluginOptions,
+  ILinearIssue,
+  ILinearTeam,
+  ILinearCreateIssueInput,
+  ILinearPluginStats,
+} from './types.js';

--- a/packages/plugin-linear/src/linear-client.ts
+++ b/packages/plugin-linear/src/linear-client.ts
@@ -1,0 +1,232 @@
+import type { ILinearIssue, ILinearTeam, ILinearCreateIssueInput } from './types.js';
+
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
+
+// ---------------------------------------------------------------------------
+// Raw GraphQL response shapes
+// ---------------------------------------------------------------------------
+
+interface IRawIssueNode {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  priority: number;
+  state: { name: string } | null;
+  assignee: { displayName: string } | null;
+}
+
+interface IRawIssueResponse {
+  data: {
+    issue: IRawIssueNode;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface IRawIssuesResponse {
+  data: {
+    issues: {
+      nodes: IRawIssueNode[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface IRawIssueCreateNode {
+  issue: IRawIssueNode | null;
+  success: boolean;
+}
+
+interface IRawIssueCreateResponse {
+  data: {
+    issueCreate: IRawIssueCreateNode;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+interface IRawTeamNode {
+  id: string;
+  name: string;
+  key: string;
+}
+
+interface IRawTeamsResponse {
+  data: {
+    teams: {
+      nodes: IRawTeamNode[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function mapIssueNode(node: IRawIssueNode): ILinearIssue {
+  return {
+    id: node.id,
+    identifier: node.identifier,
+    title: node.title,
+    description: node.description,
+    state: node.state?.name ?? 'Unknown',
+    priority: node.priority,
+    url: node.url,
+    assignee: node.assignee?.displayName ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class LinearClient {
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  private async graphqlRequest<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    const res = await fetch(LINEAR_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: this.apiKey,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Linear HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const json = (await res.json()) as T & { errors?: Array<{ message: string }> };
+    if (json.errors && json.errors.length > 0) {
+      throw new Error(`Linear GraphQL error: ${json.errors.map((e) => e.message).join(', ')}`);
+    }
+    return json;
+  }
+
+  /**
+   * Fetch a single issue by its ID.
+   */
+  async getIssue(issueId: string): Promise<ILinearIssue> {
+    const query = `
+      query GetIssue($id: String!) {
+        issue(id: $id) {
+          id
+          identifier
+          title
+          description
+          url
+          priority
+          state { name }
+          assignee { displayName }
+        }
+      }
+    `;
+    const data = await this.graphqlRequest<IRawIssueResponse>(query, { id: issueId });
+    return mapIssueNode(data.data.issue);
+  }
+
+  /**
+   * Search for issues matching a query string, optionally scoped to a team.
+   */
+  async searchIssues(query: string, teamId?: string, limit = 25): Promise<ILinearIssue[]> {
+    const gql = `
+      query SearchIssues($filter: IssueFilter, $first: Int) {
+        issues(filter: $filter, first: $first) {
+          nodes {
+            id
+            identifier
+            title
+            description
+            url
+            priority
+            state { name }
+            assignee { displayName }
+          }
+        }
+      }
+    `;
+
+    const filter: Record<string, unknown> = {
+      or: [
+        { title: { containsIgnoreCase: query } },
+        { description: { containsIgnoreCase: query } },
+      ],
+    };
+    if (teamId) {
+      filter['team'] = { id: { eq: teamId } };
+    }
+
+    const data = await this.graphqlRequest<IRawIssuesResponse>(gql, {
+      filter,
+      first: limit,
+    });
+    return data.data.issues.nodes.map(mapIssueNode);
+  }
+
+  /**
+   * Create a new issue.
+   */
+  async createIssue(input: ILinearCreateIssueInput): Promise<ILinearIssue> {
+    const mutation = `
+      mutation IssueCreate($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue {
+            id
+            identifier
+            title
+            description
+            url
+            priority
+            state { name }
+            assignee { displayName }
+          }
+        }
+      }
+    `;
+
+    const variables: Record<string, unknown> = {
+      input: {
+        teamId: input.teamId,
+        title: input.title,
+        ...(input.description !== undefined && { description: input.description }),
+        ...(input.priority !== undefined && { priority: input.priority }),
+      },
+    };
+
+    const data = await this.graphqlRequest<IRawIssueCreateResponse>(mutation, variables);
+    if (!data.data.issueCreate.success || data.data.issueCreate.issue === null) {
+      throw new Error('Linear issueCreate mutation did not return a created issue');
+    }
+    return mapIssueNode(data.data.issueCreate.issue);
+  }
+
+  /**
+   * List all teams accessible with the configured API key.
+   */
+  async getTeams(): Promise<ILinearTeam[]> {
+    const query = `
+      query GetTeams {
+        teams {
+          nodes {
+            id
+            name
+            key
+          }
+        }
+      }
+    `;
+    const data = await this.graphqlRequest<IRawTeamsResponse>(query);
+    return data.data.teams.nodes.map((node) => ({
+      id: node.id,
+      name: node.name,
+      key: node.key,
+    }));
+  }
+}

--- a/packages/plugin-linear/src/linear-plugin.ts
+++ b/packages/plugin-linear/src/linear-plugin.ts
@@ -1,0 +1,73 @@
+import { AbstractPlugin, PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+import { LinearClient } from './linear-client.js';
+import type {
+  ILinearCreateIssueInput,
+  ILinearIssue,
+  ILinearPluginOptions,
+  ILinearPluginStats,
+  ILinearTeam,
+} from './types.js';
+
+export class LinearPlugin extends AbstractPlugin<ILinearPluginOptions, ILinearPluginStats> {
+  readonly name = 'LinearPlugin';
+  readonly version = '1.0.0';
+
+  private readonly client: LinearClient;
+  private issuesFetched = 0;
+  private issuesCreated = 0;
+
+  constructor(options: ILinearPluginOptions) {
+    super();
+    this.category = PluginCategory.CUSTOM;
+    this.priority = PluginPriority.NORMAL;
+    this.client = new LinearClient(options.apiKey);
+    this.options = options;
+  }
+
+  /**
+   * Fetch a single issue by its ID.
+   */
+  async getIssue(issueId: string): Promise<ILinearIssue> {
+    this.updateCallStats();
+    const issue = await this.client.getIssue(issueId);
+    this.issuesFetched++;
+    return issue;
+  }
+
+  /**
+   * Search for issues matching a query string, optionally scoped to a team.
+   */
+  async searchIssues(query: string, teamId?: string, limit?: number): Promise<ILinearIssue[]> {
+    this.updateCallStats();
+    const issues = await this.client.searchIssues(query, teamId, limit);
+    this.issuesFetched += issues.length;
+    return issues;
+  }
+
+  /**
+   * Create a new Linear issue.
+   */
+  async createIssue(input: ILinearCreateIssueInput): Promise<ILinearIssue> {
+    this.updateCallStats();
+    const issue = await this.client.createIssue(input);
+    this.issuesCreated++;
+    return issue;
+  }
+
+  /**
+   * List all teams accessible with the configured API key.
+   */
+  async getTeams(): Promise<ILinearTeam[]> {
+    this.updateCallStats();
+    return this.client.getTeams();
+  }
+
+  override getStats(): ILinearPluginStats {
+    return {
+      ...super.getStats(),
+      issuesFetched: this.issuesFetched,
+      issuesCreated: this.issuesCreated,
+    };
+  }
+}

--- a/packages/plugin-linear/src/types.ts
+++ b/packages/plugin-linear/src/types.ts
@@ -1,0 +1,41 @@
+import type { IPluginOptions, IPluginStats } from '@robota-sdk/agent-core';
+
+/** Options for LinearPlugin */
+export interface ILinearPluginOptions extends IPluginOptions {
+  apiKey: string;
+  teamId?: string;
+}
+
+/** A single Linear issue */
+export interface ILinearIssue {
+  id: string;
+  /** Human-readable identifier, e.g. "ENG-123" */
+  identifier: string;
+  title: string;
+  description: string | null;
+  state: string;
+  priority: number;
+  url: string;
+  assignee: string | null;
+}
+
+/** A Linear team */
+export interface ILinearTeam {
+  id: string;
+  name: string;
+  key: string;
+}
+
+/** Input for creating a Linear issue */
+export interface ILinearCreateIssueInput {
+  teamId: string;
+  title: string;
+  description?: string;
+  priority?: number;
+}
+
+/** Runtime statistics for LinearPlugin */
+export interface ILinearPluginStats extends IPluginStats {
+  issuesFetched: number;
+  issuesCreated: number;
+}

--- a/packages/plugin-linear/tsconfig.json
+++ b/packages/plugin-linear/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-linear/tsdown.config.ts
+++ b/packages/plugin-linear/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  clean: true,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+});

--- a/packages/plugin-notion/package.json
+++ b/packages/plugin-notion/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@robota-sdk/plugin-notion",
+  "version": "3.0.0-beta.67",
+  "description": "Notion page and database plugin for Robota SDK",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "rimraf": "^6.0.1",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-notion/src/__tests__/notion-plugin.test.ts
+++ b/packages/plugin-notion/src/__tests__/notion-plugin.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+// Mock NotionClient before importing NotionPlugin
+vi.mock('../notion-client.js', () => {
+  const NotionClient = vi.fn().mockImplementation(() => ({
+    getPage: vi.fn(),
+    getPageBlocks: vi.fn(),
+    createPage: vi.fn(),
+    searchPages: vi.fn(),
+  }));
+  return { NotionClient };
+});
+
+import { NotionPlugin } from '../notion-plugin.js';
+import { NotionClient } from '../notion-client.js';
+import type { INotionPage, INotionBlock } from '../types.js';
+
+const MOCK_TOKEN = 'secret_test_token';
+
+function makePage(overrides: Partial<INotionPage> = {}): INotionPage {
+  return {
+    id: 'page-id-1',
+    title: 'Test Page',
+    url: 'https://www.notion.so/Test-Page-page-id-1',
+    lastEdited: '2024-01-01T00:00:00.000Z',
+    properties: {},
+    ...overrides,
+  };
+}
+
+function makeBlock(overrides: Partial<INotionBlock> = {}): INotionBlock {
+  return {
+    id: 'block-id-1',
+    type: 'paragraph',
+    text: 'Hello world',
+    ...overrides,
+  };
+}
+
+describe('NotionPlugin', () => {
+  let plugin: NotionPlugin;
+  let clientMock: {
+    getPage: ReturnType<typeof vi.fn>;
+    getPageBlocks: ReturnType<typeof vi.fn>;
+    createPage: ReturnType<typeof vi.fn>;
+    searchPages: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new NotionPlugin({ token: MOCK_TOKEN });
+    clientMock = vi.mocked(NotionClient).mock.results[0].value as typeof clientMock;
+  });
+
+  it('initializes with correct name, category, and priority', () => {
+    expect(plugin.name).toBe('NotionPlugin');
+    expect(plugin.version).toBe('1.0.0');
+    expect(plugin.category).toBe(PluginCategory.CUSTOM);
+    expect(plugin.priority).toBe(PluginPriority.NORMAL);
+    expect(plugin.enabled).toBe(true);
+  });
+
+  it('getPage delegates to client and increments pagesFetched', async () => {
+    const page = makePage();
+    clientMock.getPage.mockResolvedValueOnce(page);
+
+    const result = await plugin.getPage('page-id-1');
+
+    expect(clientMock.getPage).toHaveBeenCalledWith('page-id-1');
+    expect(result).toEqual(page);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.pagesFetched).toBe(1);
+    expect(stats.pagesCreated).toBe(0);
+    expect(stats.blocksRead).toBe(0);
+  });
+
+  it('getPageBlocks delegates to client and increments blocksRead', async () => {
+    const blocks = [makeBlock({ id: 'b1' }), makeBlock({ id: 'b2' }), makeBlock({ id: 'b3' })];
+    clientMock.getPageBlocks.mockResolvedValueOnce(blocks);
+
+    const result = await plugin.getPageBlocks('page-id-1');
+
+    expect(clientMock.getPageBlocks).toHaveBeenCalledWith('page-id-1');
+    expect(result).toHaveLength(3);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.blocksRead).toBe(3);
+    expect(stats.pagesFetched).toBe(0);
+  });
+
+  it('createPage delegates to client and increments pagesCreated', async () => {
+    const page = makePage({ title: 'New Page' });
+    clientMock.createPage.mockResolvedValueOnce(page);
+
+    const result = await plugin.createPage('parent-id', 'New Page', 'Some content');
+
+    expect(clientMock.createPage).toHaveBeenCalledWith('parent-id', 'New Page', 'Some content');
+    expect(result).toEqual(page);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.pagesCreated).toBe(1);
+    expect(stats.pagesFetched).toBe(0);
+  });
+
+  it('searchPages delegates to client and increments pagesFetched by result count', async () => {
+    const pages = [makePage({ id: 'p1' }), makePage({ id: 'p2' })];
+    clientMock.searchPages.mockResolvedValueOnce(pages);
+
+    const result = await plugin.searchPages('test query', 10);
+
+    expect(clientMock.searchPages).toHaveBeenCalledWith('test query', 10);
+    expect(result).toHaveLength(2);
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.pagesFetched).toBe(2);
+    expect(stats.pagesCreated).toBe(0);
+  });
+
+  it('getStats returns merged base and Notion-specific stats', async () => {
+    clientMock.getPage.mockResolvedValueOnce(makePage());
+    clientMock.createPage.mockResolvedValueOnce(makePage({ title: 'Created' }));
+    clientMock.getPageBlocks.mockResolvedValueOnce([makeBlock(), makeBlock()]);
+
+    await plugin.getPage('page-id-1');
+    await plugin.createPage('parent-id', 'Created');
+    await plugin.getPageBlocks('page-id-1');
+
+    const stats = plugin.getStats();
+    expect(stats.enabled).toBe(true);
+    expect(stats.calls).toBe(3);
+    expect(stats.errors).toBe(0);
+    expect(stats.pagesFetched).toBe(1);
+    expect(stats.pagesCreated).toBe(1);
+    expect(stats.blocksRead).toBe(2);
+    expect(stats.moduleEventsReceived).toBe(0);
+    expect(stats.lastActivity).toBeInstanceOf(Date);
+  });
+
+  it('plugin is disabled after disable() and re-enabled after enable()', () => {
+    expect(plugin.isEnabled()).toBe(true);
+
+    plugin.disable();
+    expect(plugin.isEnabled()).toBe(false);
+    expect(plugin.getStats().enabled).toBe(false);
+
+    plugin.enable();
+    expect(plugin.isEnabled()).toBe(true);
+    expect(plugin.getStats().enabled).toBe(true);
+  });
+});

--- a/packages/plugin-notion/src/index.ts
+++ b/packages/plugin-notion/src/index.ts
@@ -1,0 +1,9 @@
+export { NotionPlugin } from './notion-plugin.js';
+export { NotionClient } from './notion-client.js';
+export type {
+  INotionPluginOptions,
+  INotionPage,
+  INotionBlock,
+  INotionDatabase,
+  INotionPluginStats,
+} from './types.js';

--- a/packages/plugin-notion/src/notion-client.ts
+++ b/packages/plugin-notion/src/notion-client.ts
@@ -1,0 +1,172 @@
+import type { INotionPage, INotionBlock } from './types.js';
+
+interface IRawRichTextItem {
+  plain_text?: string;
+}
+
+interface IRawTitleProperty {
+  title?: IRawRichTextItem[];
+}
+
+interface IRawProperties {
+  title?: IRawTitleProperty;
+  Name?: IRawTitleProperty;
+  [key: string]: unknown;
+}
+
+interface IRawPage {
+  id: string;
+  url: string;
+  last_edited_time: string;
+  properties: IRawProperties;
+}
+
+interface IRawParagraphContent {
+  rich_text?: IRawRichTextItem[];
+}
+
+interface IRawBlockContent {
+  rich_text?: IRawRichTextItem[];
+}
+
+interface IRawBlock {
+  id: string;
+  type: string;
+  paragraph?: IRawParagraphContent;
+  heading_1?: IRawBlockContent;
+  heading_2?: IRawBlockContent;
+  heading_3?: IRawBlockContent;
+  bulleted_list_item?: IRawBlockContent;
+  numbered_list_item?: IRawBlockContent;
+  to_do?: IRawBlockContent;
+  toggle?: IRawBlockContent;
+  quote?: IRawBlockContent;
+  callout?: IRawBlockContent;
+  code?: IRawBlockContent;
+  [key: string]: unknown;
+}
+
+interface IRawBlocksResponse {
+  results: IRawBlock[];
+}
+
+interface IRawSearchResponse {
+  results: IRawPage[];
+}
+
+function extractTitleFromProperties(properties: IRawProperties): string {
+  const titleProp = properties.title ?? properties.Name;
+  if (titleProp?.title && titleProp.title.length > 0) {
+    return titleProp.title.map((t) => t.plain_text ?? '').join('');
+  }
+  return '';
+}
+
+function extractPlainText(block: IRawBlock): string {
+  const content = block[block.type] as IRawBlockContent | undefined;
+  if (!content?.rich_text) return '';
+  return content.rich_text.map((t) => t.plain_text ?? '').join('');
+}
+
+export class NotionClient {
+  private readonly baseUrl = 'https://api.notion.com/v1';
+  private readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Notion-Version': '2022-06-28',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async getPage(pageId: string): Promise<INotionPage> {
+    const res = await fetch(`${this.baseUrl}/pages/${pageId}`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`Notion API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawPage;
+    return {
+      id: data.id,
+      title: extractTitleFromProperties(data.properties),
+      url: data.url,
+      lastEdited: data.last_edited_time,
+      properties: data.properties as Record<string, unknown>,
+    };
+  }
+
+  async getPageBlocks(pageId: string): Promise<INotionBlock[]> {
+    const res = await fetch(`${this.baseUrl}/blocks/${pageId}/children`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`Notion API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawBlocksResponse;
+    return data.results.map((block) => ({
+      id: block.id,
+      type: block.type,
+      text: extractPlainText(block),
+    }));
+  }
+
+  async createPage(parentPageId: string, title: string, content?: string): Promise<INotionPage> {
+    const children = content
+      ? [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [{ type: 'text', text: { content } }],
+            },
+          },
+        ]
+      : [];
+
+    const res = await fetch(`${this.baseUrl}/pages`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        parent: { page_id: parentPageId },
+        properties: {
+          title: {
+            title: [{ type: 'text', text: { content: title } }],
+          },
+        },
+        children,
+      }),
+    });
+    if (!res.ok) throw new Error(`Notion API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawPage;
+    return {
+      id: data.id,
+      title: extractTitleFromProperties(data.properties),
+      url: data.url,
+      lastEdited: data.last_edited_time,
+      properties: data.properties as Record<string, unknown>,
+    };
+  }
+
+  async searchPages(query: string, limit = 10): Promise<INotionPage[]> {
+    const res = await fetch(`${this.baseUrl}/search`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        query,
+        filter: { value: 'page', property: 'object' },
+        page_size: limit,
+      }),
+    });
+    if (!res.ok) throw new Error(`Notion API ${res.status}: ${await res.text()}`);
+    const data = (await res.json()) as IRawSearchResponse;
+    return data.results.map((page) => ({
+      id: page.id,
+      title: extractTitleFromProperties(page.properties),
+      url: page.url,
+      lastEdited: page.last_edited_time,
+      properties: page.properties as Record<string, unknown>,
+    }));
+  }
+}

--- a/packages/plugin-notion/src/notion-plugin.ts
+++ b/packages/plugin-notion/src/notion-plugin.ts
@@ -1,0 +1,63 @@
+import { AbstractPlugin, PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+import { NotionClient } from './notion-client.js';
+import type {
+  INotionPluginOptions,
+  INotionPluginStats,
+  INotionPage,
+  INotionBlock,
+} from './types.js';
+
+export class NotionPlugin extends AbstractPlugin<INotionPluginOptions, INotionPluginStats> {
+  readonly name = 'NotionPlugin';
+  readonly version = '1.0.0';
+
+  private client: NotionClient;
+  private pagesFetched = 0;
+  private pagesCreated = 0;
+  private blocksRead = 0;
+
+  constructor(options: INotionPluginOptions) {
+    super();
+    this.category = PluginCategory.CUSTOM;
+    this.priority = PluginPriority.NORMAL;
+    this.client = new NotionClient(options.token);
+  }
+
+  async getPage(pageId: string): Promise<INotionPage> {
+    this.updateCallStats();
+    const page = await this.client.getPage(pageId);
+    this.pagesFetched++;
+    return page;
+  }
+
+  async getPageBlocks(pageId: string): Promise<INotionBlock[]> {
+    this.updateCallStats();
+    const blocks = await this.client.getPageBlocks(pageId);
+    this.blocksRead += blocks.length;
+    return blocks;
+  }
+
+  async createPage(parentPageId: string, title: string, content?: string): Promise<INotionPage> {
+    this.updateCallStats();
+    const page = await this.client.createPage(parentPageId, title, content);
+    this.pagesCreated++;
+    return page;
+  }
+
+  async searchPages(query: string, limit?: number): Promise<INotionPage[]> {
+    this.updateCallStats();
+    const pages = await this.client.searchPages(query, limit);
+    this.pagesFetched += pages.length;
+    return pages;
+  }
+
+  override getStats(): INotionPluginStats {
+    return {
+      ...super.getStats(),
+      pagesFetched: this.pagesFetched,
+      pagesCreated: this.pagesCreated,
+      blocksRead: this.blocksRead,
+    };
+  }
+}

--- a/packages/plugin-notion/src/types.ts
+++ b/packages/plugin-notion/src/types.ts
@@ -1,0 +1,31 @@
+import type { IPluginOptions, IPluginStats } from '@robota-sdk/agent-core';
+
+export interface INotionPluginOptions extends IPluginOptions {
+  token: string;
+}
+
+export interface INotionPage {
+  id: string;
+  title: string;
+  url: string;
+  lastEdited: string;
+  properties: Record<string, unknown>;
+}
+
+export interface INotionBlock {
+  id: string;
+  type: string;
+  text: string;
+}
+
+export interface INotionDatabase {
+  id: string;
+  title: string;
+  url: string;
+}
+
+export interface INotionPluginStats extends IPluginStats {
+  pagesFetched: number;
+  pagesCreated: number;
+  blocksRead: number;
+}

--- a/packages/plugin-notion/tsconfig.json
+++ b/packages/plugin-notion/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-notion/tsdown.config.ts
+++ b/packages/plugin-notion/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  clean: true,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+});

--- a/packages/plugin-slack/package.json
+++ b/packages/plugin-slack/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@robota-sdk/plugin-slack",
+  "version": "3.0.0-beta.67",
+  "description": "Slack messaging plugin for Robota SDK",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage",
+    "clean": "rimraf dist",
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "rimraf": "^6.0.1",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugin-slack/src/__tests__/slack-plugin.test.ts
+++ b/packages/plugin-slack/src/__tests__/slack-plugin.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+// Mock SlackClient before importing SlackPlugin
+vi.mock('../slack-client.js', () => {
+  const SlackClient = vi.fn().mockImplementation(() => ({
+    postMessage: vi.fn(),
+    getChannelHistory: vi.fn(),
+    uploadText: vi.fn(),
+  }));
+  return { SlackClient };
+});
+
+import { SlackPlugin } from '../slack-plugin.js';
+import { SlackClient } from '../slack-client.js';
+import type { ISlackMessage, ISlackPostResult } from '../types.js';
+
+const MOCK_TOKEN = 'xoxb-test-token';
+const MOCK_CHANNEL = '#general';
+const DEFAULT_CHANNEL = '#announcements';
+
+function makePostResult(overrides: Partial<ISlackPostResult> = {}): ISlackPostResult {
+  return {
+    ok: true,
+    ts: '1234567890.123456',
+    channel: MOCK_CHANNEL,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ISlackMessage> = {}): ISlackMessage {
+  return {
+    ts: '1234567890.000001',
+    channel: MOCK_CHANNEL,
+    text: 'Hello from Slack',
+    ...overrides,
+  };
+}
+
+describe('SlackPlugin', () => {
+  let plugin: SlackPlugin;
+  let clientMock: {
+    postMessage: ReturnType<typeof vi.fn>;
+    getChannelHistory: ReturnType<typeof vi.fn>;
+    uploadText: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new SlackPlugin({ token: MOCK_TOKEN });
+    clientMock = vi.mocked(SlackClient).mock.results[0].value as typeof clientMock;
+  });
+
+  it('initializes with correct name, category, and priority', () => {
+    expect(plugin.name).toBe('SlackPlugin');
+    expect(plugin.version).toBe('1.0.0');
+    expect(plugin.category).toBe(PluginCategory.NOTIFICATION);
+    expect(plugin.priority).toBe(PluginPriority.NORMAL);
+    expect(plugin.enabled).toBe(true);
+  });
+
+  it('postMessage sends to correct channel and increments stats', async () => {
+    const result = makePostResult();
+    clientMock.postMessage.mockResolvedValueOnce(result);
+
+    const returned = await plugin.postMessage(MOCK_CHANNEL, 'Hello!');
+
+    expect(clientMock.postMessage).toHaveBeenCalledWith(MOCK_CHANNEL, 'Hello!', undefined);
+    expect(returned).toEqual(result);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.messagesSent).toBe(1);
+    expect(stats.messagesFetched).toBe(0);
+  });
+
+  it('postToDefault uses the configured default channel', async () => {
+    vi.clearAllMocks();
+    const pluginWithDefault = new SlackPlugin({
+      token: MOCK_TOKEN,
+      defaultChannel: DEFAULT_CHANNEL,
+    });
+    const defaultClientMock = vi.mocked(SlackClient).mock.results[0].value as typeof clientMock;
+
+    const result = makePostResult({ channel: DEFAULT_CHANNEL });
+    defaultClientMock.postMessage.mockResolvedValueOnce(result);
+
+    const returned = await pluginWithDefault.postToDefault('Announcement!');
+
+    expect(defaultClientMock.postMessage).toHaveBeenCalledWith(
+      DEFAULT_CHANNEL,
+      'Announcement!',
+      undefined,
+    );
+    expect(returned.channel).toBe(DEFAULT_CHANNEL);
+  });
+
+  it('postToDefault throws when no default channel is configured', async () => {
+    await expect(plugin.postToDefault('No channel!')).rejects.toThrow(
+      'SlackPlugin: no defaultChannel configured',
+    );
+  });
+
+  it('getHistory fetches messages and increments stats', async () => {
+    const messages = [makeMessage({ ts: '1' }), makeMessage({ ts: '2' }), makeMessage({ ts: '3' })];
+    clientMock.getChannelHistory.mockResolvedValueOnce(messages);
+
+    const returned = await plugin.getHistory(MOCK_CHANNEL, 3);
+
+    expect(clientMock.getChannelHistory).toHaveBeenCalledWith(MOCK_CHANNEL, 3);
+    expect(returned).toHaveLength(3);
+
+    const stats = plugin.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.messagesFetched).toBe(3);
+    expect(stats.messagesSent).toBe(0);
+  });
+
+  it('getStats returns merged stats including Slack-specific fields', async () => {
+    clientMock.postMessage.mockResolvedValueOnce(makePostResult());
+    clientMock.getChannelHistory.mockResolvedValueOnce([makeMessage(), makeMessage()]);
+
+    await plugin.postMessage(MOCK_CHANNEL, 'Hi');
+    await plugin.getHistory(MOCK_CHANNEL);
+
+    const stats = plugin.getStats();
+    expect(stats.enabled).toBe(true);
+    expect(stats.calls).toBe(2);
+    expect(stats.errors).toBe(0);
+    expect(stats.messagesSent).toBe(1);
+    expect(stats.messagesFetched).toBe(2);
+    expect(stats.moduleEventsReceived).toBe(0);
+    expect(stats.lastActivity).toBeInstanceOf(Date);
+  });
+});

--- a/packages/plugin-slack/src/index.ts
+++ b/packages/plugin-slack/src/index.ts
@@ -1,0 +1,8 @@
+export { SlackPlugin } from './slack-plugin.js';
+export { SlackClient } from './slack-client.js';
+export type {
+  ISlackPluginOptions,
+  ISlackMessage,
+  ISlackPostResult,
+  ISlackPluginStats,
+} from './types.js';

--- a/packages/plugin-slack/src/slack-client.ts
+++ b/packages/plugin-slack/src/slack-client.ts
@@ -1,0 +1,183 @@
+import type { ISlackMessage, ISlackPostResult } from './types.js';
+
+/** Raw shape returned by Slack chat.postMessage */
+interface IRawPostMessageResponse {
+  ok: boolean;
+  ts: string;
+  channel: string;
+  error?: string;
+}
+
+/** Raw shape of a single message in conversations.history */
+interface IRawHistoryMessage {
+  ts: string;
+  text: string;
+  username?: string;
+}
+
+/** Raw shape returned by Slack conversations.history */
+interface IRawHistoryResponse {
+  ok: boolean;
+  messages: IRawHistoryMessage[];
+  error?: string;
+}
+
+/** Raw shape returned by files.getUploadURLExternal */
+interface IRawUploadUrlResponse {
+  ok: boolean;
+  upload_url: string;
+  file_id: string;
+  error?: string;
+}
+
+/** Raw shape returned by files.completeUploadExternal */
+interface IRawCompleteUploadResponse {
+  ok: boolean;
+  error?: string;
+}
+
+const SLACK_API_BASE = 'https://slack.com/api';
+
+export class SlackClient {
+  private readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  private authHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    };
+  }
+
+  /**
+   * Post a text message to a Slack channel.
+   */
+  async postMessage(
+    channel: string,
+    text: string,
+    options?: { username?: string; iconEmoji?: string },
+  ): Promise<ISlackPostResult> {
+    const body: Record<string, string> = { channel, text };
+    if (options?.username) body.username = options.username;
+    if (options?.iconEmoji) body.icon_emoji = options.iconEmoji;
+
+    const res = await fetch(`${SLACK_API_BASE}/chat.postMessage`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Slack HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const data = (await res.json()) as IRawPostMessageResponse;
+    if (!data.ok) {
+      throw new Error(`Slack API error: ${data.error ?? 'unknown'}`);
+    }
+
+    return { ok: data.ok, ts: data.ts, channel: data.channel };
+  }
+
+  /**
+   * Fetch message history from a Slack channel.
+   */
+  async getChannelHistory(channel: string, limit = 20): Promise<ISlackMessage[]> {
+    const params = new URLSearchParams({ channel, limit: String(limit) });
+    const res = await fetch(`${SLACK_API_BASE}/conversations.history?${params.toString()}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Slack HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const data = (await res.json()) as IRawHistoryResponse;
+    if (!data.ok) {
+      throw new Error(`Slack API error: ${data.error ?? 'unknown'}`);
+    }
+
+    return data.messages.map((msg) => ({
+      ts: msg.ts,
+      channel,
+      text: msg.text,
+      ...(msg.username !== undefined && { username: msg.username }),
+    }));
+  }
+
+  /**
+   * Upload a text file to a Slack channel using the v2 upload flow.
+   * Step 1: obtain a pre-signed upload URL via files.getUploadURLExternal.
+   * Step 2: PUT the content to the URL.
+   * Step 3: complete the upload via files.completeUploadExternal.
+   */
+  async uploadText(
+    channel: string,
+    filename: string,
+    content: string,
+    title?: string,
+  ): Promise<void> {
+    const length = new TextEncoder().encode(content).length;
+
+    // Step 1: get upload URL
+    const urlParams = new URLSearchParams({ filename, length: String(length) });
+    if (title) urlParams.set('title', title);
+
+    const urlRes = await fetch(
+      `${SLACK_API_BASE}/files.getUploadURLExternal?${urlParams.toString()}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${this.token}` },
+      },
+    );
+
+    if (!urlRes.ok) {
+      throw new Error(`Slack HTTP ${urlRes.status}: ${await urlRes.text()}`);
+    }
+
+    const urlData = (await urlRes.json()) as IRawUploadUrlResponse;
+    if (!urlData.ok) {
+      throw new Error(`Slack API error (getUploadURLExternal): ${urlData.error ?? 'unknown'}`);
+    }
+
+    // Step 2: PUT the content
+    const putRes = await fetch(urlData.upload_url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      body: content,
+    });
+
+    if (!putRes.ok) {
+      throw new Error(`Slack upload PUT failed with HTTP ${putRes.status}`);
+    }
+
+    // Step 3: complete the upload
+    const completeBody: Record<string, string | Array<{ id: string; title?: string }>> = {
+      files: [{ id: urlData.file_id, ...(title !== undefined && { title }) }],
+      channel_id: channel,
+    };
+
+    const completeRes = await fetch(`${SLACK_API_BASE}/files.completeUploadExternal`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify(completeBody),
+    });
+
+    if (!completeRes.ok) {
+      throw new Error(`Slack HTTP ${completeRes.status}: ${await completeRes.text()}`);
+    }
+
+    const completeData = (await completeRes.json()) as IRawCompleteUploadResponse;
+    if (!completeData.ok) {
+      throw new Error(
+        `Slack API error (completeUploadExternal): ${completeData.error ?? 'unknown'}`,
+      );
+    }
+  }
+}

--- a/packages/plugin-slack/src/slack-plugin.ts
+++ b/packages/plugin-slack/src/slack-plugin.ts
@@ -1,0 +1,74 @@
+import { AbstractPlugin, PluginCategory, PluginPriority } from '@robota-sdk/agent-core';
+
+import { SlackClient } from './slack-client.js';
+import type {
+  ISlackMessage,
+  ISlackPluginOptions,
+  ISlackPluginStats,
+  ISlackPostResult,
+} from './types.js';
+
+export class SlackPlugin extends AbstractPlugin<ISlackPluginOptions, ISlackPluginStats> {
+  readonly name = 'SlackPlugin';
+  readonly version = '1.0.0';
+
+  private client: SlackClient;
+  private messagesSent = 0;
+  private messagesFetched = 0;
+
+  constructor(options: ISlackPluginOptions) {
+    super();
+    this.category = PluginCategory.NOTIFICATION;
+    this.priority = PluginPriority.NORMAL;
+    this.client = new SlackClient(options.token);
+    // Store options so postToDefault can reference defaultChannel
+    this.options = options;
+  }
+
+  /**
+   * Post a message to the given Slack channel.
+   */
+  async postMessage(
+    channel: string,
+    text: string,
+    options?: { username?: string; iconEmoji?: string },
+  ): Promise<ISlackPostResult> {
+    this.updateCallStats();
+    const result = await this.client.postMessage(channel, text, options);
+    this.messagesSent++;
+    return result;
+  }
+
+  /**
+   * Post a message to the default channel configured in plugin options.
+   * Throws if no default channel is set.
+   */
+  async postToDefault(
+    text: string,
+    options?: { username?: string; iconEmoji?: string },
+  ): Promise<ISlackPostResult> {
+    const defaultChannel = this.options?.defaultChannel;
+    if (!defaultChannel) {
+      throw new Error('SlackPlugin: no defaultChannel configured');
+    }
+    return this.postMessage(defaultChannel, text, options);
+  }
+
+  /**
+   * Fetch the message history for a Slack channel.
+   */
+  async getHistory(channel: string, limit?: number): Promise<ISlackMessage[]> {
+    this.updateCallStats();
+    const messages = await this.client.getChannelHistory(channel, limit);
+    this.messagesFetched += messages.length;
+    return messages;
+  }
+
+  override getStats(): ISlackPluginStats {
+    return {
+      ...super.getStats(),
+      messagesSent: this.messagesSent,
+      messagesFetched: this.messagesFetched,
+    };
+  }
+}

--- a/packages/plugin-slack/src/types.ts
+++ b/packages/plugin-slack/src/types.ts
@@ -1,0 +1,28 @@
+import type { IPluginOptions, IPluginStats } from '@robota-sdk/agent-core';
+
+/** Options for SlackPlugin */
+export interface ISlackPluginOptions extends IPluginOptions {
+  token: string;
+  defaultChannel?: string;
+}
+
+/** A single message from a Slack channel */
+export interface ISlackMessage {
+  ts: string;
+  channel: string;
+  text: string;
+  username?: string;
+}
+
+/** Result returned after posting a message to Slack */
+export interface ISlackPostResult {
+  ok: boolean;
+  ts: string;
+  channel: string;
+}
+
+/** Runtime statistics for SlackPlugin */
+export interface ISlackPluginStats extends IPluginStats {
+  messagesSent: number;
+  messagesFetched: number;
+}

--- a/packages/plugin-slack/tsconfig.json
+++ b/packages/plugin-slack/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugin-slack/tsdown.config.ts
+++ b/packages/plugin-slack/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown';
+
+const outExtensions = ({ format }: { format: string }) => ({
+  js: format === 'cjs' ? '.cjs' : '.js',
+  dts: '.d.ts',
+});
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  platform: 'node',
+  sourcemap: false,
+  treeshake: true,
+  minify: true,
+  dts: true,
+  outExtensions,
+  clean: true,
+  deps: { neverBundle: [/^@robota-sdk\/.*/] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,6 +1036,116 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.9)
 
+  packages/plugin-github:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.16.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.16.5)
+
+  packages/plugin-jira:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.16.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.16.5)
+
+  packages/plugin-linear:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.16.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.16.5)
+
+  packages/plugin-notion:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.16.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.16.5)
+
+  packages/plugin-slack:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.16.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(tsx@4.21.0)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@22.16.5)
+
 packages:
   /@adobe/css-tools@4.4.3:
     resolution:


### PR DESCRIPTION
## Summary

Adds the official plugin starter pack — 5 new `@robota-sdk/plugin-*` packages, each extending `AbstractPlugin` with a typed API client (native `fetch`, no external SDK dependency):

| Package | Integration | Key methods |
|---|---|---|
| `@robota-sdk/plugin-github` | GitHub REST API v3 | `getIssue`, `getPR`, `listOpenIssues` |
| `@robota-sdk/plugin-slack` | Slack Web API | `postMessage`, `postToDefault`, `getHistory` |
| `@robota-sdk/plugin-notion` | Notion API v1 | `getPage`, `getPageBlocks`, `createPage`, `searchPages` |
| `@robota-sdk/plugin-linear` | Linear GraphQL API | `getIssue`, `searchIssues`, `createIssue`, `getTeams` |
| `@robota-sdk/plugin-jira` | Jira Cloud REST API v3 | `getIssue`, `searchIssues`, `createIssue`, `getProjects` |

Each package: TypeScript strict, all API response types local (no `any`), 6–7 unit tests with mocked clients.

## Test plan

- [ ] 37 new plugin tests pass (`pnpm --filter "@robota-sdk/plugin-*" test`)
- [ ] All 5 typecheck clean
- [ ] Build produces ESM + CJS + `.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)