### PR TITLE
feat(site-001): add apps/www — Next.js 15 marketing site

### DIFF
--- a/.agents/backlog/SITE-001-www-marketing-site.md
+++ b/.agents/backlog/SITE-001-www-marketing-site.md
@@ -1,0 +1,70 @@
+---
+title: 'SITE-001: www.robota.io 마케팅 랜딩 사이트 신설'
+status: todo
+created: 2026-05-23
+priority: high
+urgency: soon
+area: apps/www (신규)
+depends_on: []
+---
+
+## Background
+
+현재 `robota.io`는 VitePress 문서 사이트 하나에 라이브러리 문서·마케팅·도구·엔터프라이즈 등이 혼재되어 있다.
+일반 사용자(개발자가 아닌 잠재 고객)가 처음 robota.io에 접속했을 때 "이게 무엇인가"를 5초 안에 이해하기 어렵다.
+
+www.robota.io는 **일반 사용자 대상 마케팅/랜딩 사이트**로, docs와 완전히 분리하여 운영한다.
+
+## 콘텐츠 범위 (www.robota.io에 들어갈 것)
+
+| 페이지                   | 현재 위치                | 비고                          |
+| ------------------------ | ------------------------ | ----------------------------- |
+| Hero / 랜딩              | 없음 (신규)              | robota가 무엇인지 5초 설명    |
+| Why Robota (비교)        | `/compare/`              | 이전                          |
+| Cost Calculator          | `/tools/cost-calculator` | Vue → React 재작성 (SITE-002) |
+| Showcase                 | `/showcase/`             | 이전                          |
+| Roadmap                  | `/roadmap`               | 이전                          |
+| Enterprise               | `/enterprise/`           | 이전                          |
+| Pricing (BYOK 모델 설명) | 없음 (신규)              | Claude Code $20 vs BYOK 설명  |
+| Playground 링크          | 외부 링크                | play.robota.io 로 연결        |
+| Blog 링크                | blog.robota.io (별도)    | 링크만                        |
+| Docs 링크                | 없음 → docs.robota.io    | 헤더 상단 노출                |
+
+## 기술 스택
+
+- **프레임워크**: Next.js 15 App Router + React 19
+- **스타일링**: Tailwind CSS (frontend.md 규칙)
+- **위치**: `apps/www/` (신규 monorepo 앱)
+- **패키지명**: `robota-www`
+
+> apps/blog는 Astro로 별도 운영 중. www는 interactive 요소(Cost Calculator 등)가 있으므로 Next.js 채택.
+
+## 작업 항목
+
+1. `apps/www/` Next.js 15 앱 초기화
+   - pnpm workspace 등록
+   - Tailwind v4 설정
+   - `tsconfig.json`, `package.json` 구성
+2. 레이아웃 설계
+   - Header: logo, nav (Docs / Playground / GitHub), CTA 버튼
+   - Footer: links, copyright
+3. Hero 페이지 구현 (`/`)
+   - tagline, sub-copy, Install snippet, CTA (Get Started → docs.robota.io)
+   - 제품 스크린샷 또는 코드 애니메이션
+4. Nav 항목 라우팅 연결 (실제 콘텐츠 이전은 SITE-002에서)
+5. OG/SEO 메타태그, sitemap.xml, robots.txt
+
+## 도메인
+
+- 개발: `localhost:3000` (또는 빈 포트)
+- 배포: Vercel 프로젝트 신규 생성 → `www.robota.io` 도메인 연결
+
+## Test Plan
+
+- `pnpm --filter robota-www build` pass
+- `pnpm --filter robota-www typecheck` pass
+- Hero 페이지 lighthouse score ≥ 90
+
+## User Execution Test Scenarios
+
+Not applicable — web marketing site.

--- a/.agents/backlog/SITE-002-content-migration-docs-to-www.md
+++ b/.agents/backlog/SITE-002-content-migration-docs-to-www.md
@@ -1,0 +1,86 @@
+---
+title: 'SITE-002: 마케팅 콘텐츠 docs → www 이전 및 Cost Calculator React 재작성'
+status: todo
+created: 2026-05-23
+priority: high
+urgency: soon
+area: apps/www, apps/docs, content/
+depends_on: [SITE-001]
+---
+
+## Background
+
+SITE-001에서 www.robota.io 사이트 골격이 완성되면, 현재 docs VitePress에 섞여 있는
+마케팅 콘텐츠를 www로 이전한다.
+
+Cost Calculator는 이 과정에서 VitePress Vue 컴포넌트에서 **Next.js React 컴포넌트**로
+재작성한다 — frontend.md 규칙 준수(VitePress 외부에서 Vue 금지).
+
+## 이전 대상 페이지
+
+| 현재 경로 (docs)         | www 경로                 | 비고                   |
+| ------------------------ | ------------------------ | ---------------------- |
+| `/compare/`              | `/compare`               | Why Robota 비교 페이지 |
+| `/tools/cost-calculator` | `/tools/cost-calculator` | Vue → React 재작성     |
+| `/showcase/`             | `/showcase`              | Build with Robota      |
+| `/roadmap`               | `/roadmap`               | 분기별 공개 로드맵     |
+| `/enterprise/`           | `/enterprise`            | Enterprise 연락처      |
+
+## Cost Calculator 재작성 (Vue → React)
+
+현재: `apps/docs/.vitepress/theme/CostCalculator.vue`
+
+- VitePress `<style scoped>` CSS, `ref()`, `computed()` Vue 패턴
+
+변환 후: `apps/www/src/components/CostCalculator.tsx`
+
+- React `useState`, `useMemo` 패턴
+- Tailwind utility classes only (CSS 없음)
+- 기능 동일: 슬라이더, task type/level 라디오, 비용 계산, 공유 버튼
+
+## docs에서 제거할 nav 항목 (SITE-003에서 처리)
+
+이전 완료 후 docs VitePress nav에서 아래 항목 제거:
+
+- `Why Robota` → www.robota.io/compare 링크로 교체
+- `Cost Calculator` → www.robota.io/tools/cost-calculator 링크로 교체
+- `Showcase` → www.robota.io/showcase 링크로 교체
+- `Roadmap` → www.robota.io/roadmap 링크로 교체
+- `Enterprise` → www.robota.io/enterprise 링크로 교체
+- `Home` (/) → www.robota.io 링크로 교체
+
+docs nav에 남을 항목:
+
+- Getting Started, Guide, Examples, Packages, Changelog, Development, Playground
+
+## docs에서 삭제할 content/ 파일들 (이전 완료 후)
+
+```
+content/compare/
+content/enterprise/
+content/showcase/
+content/roadmap.md
+content/tools/
+```
+
+> v2.0.0/ 디렉토리는 영구 보존 대상 — 절대 삭제 금지.
+
+## 작업 항목
+
+1. www에 각 페이지 구현 (markdown → React/Next.js 페이지)
+2. CostCalculator.tsx 재작성 (React + Tailwind)
+3. docs VitePress에서 이전된 nav 항목 외부 링크로 교체
+4. 기존 content/ 마케팅 파일 삭제 (docs cleanup)
+5. `apps/docs/.vitepress/theme/CostCalculator.vue` 삭제
+
+## Test Plan
+
+- 모든 www 이전 페이지 build 확인
+- CostCalculator 계산 결과 정합성 확인
+- docs VitePress nav 항목 링크 정상 작동
+- `pnpm --filter robota-www build` pass
+- `pnpm --filter robota-docs build` pass
+
+## User Execution Test Scenarios
+
+Not applicable — web content migration.

--- a/.agents/backlog/SITE-003-docs-subdomain-setup.md
+++ b/.agents/backlog/SITE-003-docs-subdomain-setup.md
@@ -1,0 +1,100 @@
+---
+title: 'SITE-003: docs.robota.io 서브도메인 설정 + VitePress 라이브러리 전용 정리'
+status: todo
+created: 2026-05-23
+priority: high
+urgency: soon
+area: apps/docs, Vercel/DNS
+depends_on: [SITE-002]
+---
+
+## Background
+
+현재 docs VitePress는 `robota.io`에서 직접 서빙 중이다.
+마케팅 콘텐츠가 www로 이전된 후, VitePress를 `docs.robota.io`로 분리 운영한다.
+
+SITE-002 완료 후 docs는 라이브러리 문서에만 집중한 깔끔한 사이트가 된다.
+
+## docs.robota.io에 남을 콘텐츠
+
+| 경로                | 내용                           |
+| ------------------- | ------------------------------ |
+| `/`                 | Docs 홈 (Quick Start 진입점)   |
+| `/getting-started/` | 설치 및 초기 설정              |
+| `/guide/`           | CLI 사용법, local LLM, plugins |
+| `/examples/`        | 코드 예제                      |
+| `/packages/`        | 패키지 API 레퍼런스            |
+| `/api-reference/`   | 상세 API                       |
+| `/plugins/`         | 플러그인 개발 가이드           |
+| `/changelog/`       | 릴리스 노트                    |
+| `/development/`     | 기여 가이드                    |
+
+**제거되는 nav 항목** (SITE-002에서 이미 www로 이전된 것):
+
+- Home (/) → www.robota.io 링크
+- Why Robota → www.robota.io/compare
+- Showcase → www.robota.io/showcase
+- Roadmap → www.robota.io/roadmap
+- Enterprise → www.robota.io/enterprise
+- Cost Calculator → www.robota.io/tools/cost-calculator
+
+**docs nav에 추가**:
+
+- `← robota.io` 로고 클릭 시 www.robota.io로 이동
+
+## 배포 설정 작업 (Vercel)
+
+1. Vercel 프로젝트에서 `docs.robota.io` 도메인 추가
+   - DNS: `docs` CNAME → `cname.vercel-dns.com`
+2. `robota.io` 기존 프로젝트에 임시 redirect 설정
+   - `robota.io` → `docs.robota.io` (301 redirect, SITE-004 완료 전까지)
+   - `www.robota.io` → `robota.io` 기존 redirect 제거 (SITE-004에서 역할 변경)
+
+## vercel.json 변경 (docs 프로젝트)
+
+```json
+{
+  "redirects": [
+    {
+      "source": "/compare/(.*)",
+      "destination": "https://www.robota.io/compare/$1",
+      "permanent": false
+    },
+    {
+      "source": "/showcase/(.*)",
+      "destination": "https://www.robota.io/showcase/$1",
+      "permanent": false
+    },
+    {
+      "source": "/roadmap(.*)",
+      "destination": "https://www.robota.io/roadmap$1",
+      "permanent": false
+    },
+    {
+      "source": "/enterprise/(.*)",
+      "destination": "https://www.robota.io/enterprise/$1",
+      "permanent": false
+    },
+    { "source": "/tools/(.*)", "destination": "https://www.robota.io/tools/$1", "permanent": false }
+  ]
+}
+```
+
+이전된 URL로 접속 시 www.robota.io로 자동 리다이렉션 — SEO 링크 보호.
+
+## VitePress config 변경
+
+- `apps/docs/.vitepress/config.js`: `base`, `title`, `description` docs 전용으로 업데이트
+- `apps/docs/.vitepress/config/en.js`: nav 항목 정리 (마케팅 항목 제거/교체)
+- `CNAME` 파일: `docs.robota.io` 로 업데이트
+
+## Test Plan
+
+- `pnpm --filter robota-docs build` pass
+- docs.robota.io 접속 시 라이브러리 문서 정상 표시
+- 이전된 URL (/compare, /showcase 등) 접속 시 www.robota.io로 301 redirect 확인
+- robota.io 접속 시 docs.robota.io로 임시 redirect 확인
+
+## User Execution Test Scenarios
+
+Not applicable — infrastructure/deploy.

--- a/.agents/backlog/SITE-004-domain-redirect-migration.md
+++ b/.agents/backlog/SITE-004-domain-redirect-migration.md
@@ -1,0 +1,70 @@
+---
+title: 'SITE-004: 도메인 리다이렉션 최종 전환 — robota.io → www.robota.io'
+status: todo
+created: 2026-05-23
+priority: medium
+urgency: later
+area: Vercel DNS / 도메인 설정
+depends_on: [SITE-001, SITE-002, SITE-003]
+---
+
+## Background
+
+SITE-001~003 완료 후 두 사이트가 모두 안정적으로 운영되면, 마지막 단계로 도메인 리다이렉션을 최종 전환한다.
+
+## 전체 도메인 전환 타임라인
+
+### Phase 1 — SITE-003 완료 시점 (임시 상태)
+
+| 도메인           | 행선지              | 비고                                 |
+| ---------------- | ------------------- | ------------------------------------ |
+| `robota.io`      | → `docs.robota.io`  | 301 임시 redirect (기존 북마크 보호) |
+| `docs.robota.io` | VitePress docs 서빙 | 신규                                 |
+| `www.robota.io`  | Next.js www 서빙    | 신규                                 |
+| `play.robota.io` | Playground          | 변동 없음                            |
+| `blog.robota.io` | Astro 블로그        | 변동 없음 (미래)                     |
+
+### Phase 2 — 최종 전환 (이 백로그 항목)
+
+| 도메인           | 행선지              | 비고              |
+| ---------------- | ------------------- | ----------------- |
+| `robota.io`      | → `www.robota.io`   | 301 영구 redirect |
+| `www.robota.io`  | Next.js www 서빙    | 메인 사이트       |
+| `docs.robota.io` | VitePress docs 서빙 | 라이브러리 문서   |
+| `play.robota.io` | Playground          | 변동 없음         |
+
+## 최종 전환 체크리스트
+
+Phase 2 전환 전 반드시 확인:
+
+- [ ] www.robota.io 모든 페이지 정상 서빙 (2주 이상 안정 운영 확인)
+- [ ] docs.robota.io SEO 인덱싱 완료 (Google Search Console 확인)
+- [ ] www.robota.io → docs.robota.io 링크 헤더/푸터에 잘 노출
+- [ ] OG 태그, sitemap.xml 양쪽 모두 정상
+- [ ] 기존 robota.io 인바운드 링크 주요 경로 모두 redirect 처리 확인
+
+## 작업 항목
+
+1. Vercel `robota.io` 프로젝트 redirect 규칙 수정
+   - Phase 1: `robota.io` → `docs.robota.io`
+   - Phase 2: `robota.io` → `www.robota.io`
+2. `www.robota.io` 에서 `docs.robota.io` 진입점 헤더에 명확히 노출
+   - 헤더 nav: `Docs` → `docs.robota.io`
+3. Google Search Console에 sitemap 재제출
+4. 기존 `www.robota.io → robota.io` redirect 제거 (역할이 반전되므로)
+
+## 주의 사항
+
+- `robota.io` 직접 접속자가 많으므로 Phase 1(임시 → docs) 기간을 **최소 2주 이상** 유지
+- Phase 2 전환 후 `robota.io → docs.robota.io` redirect는 제거하고 `robota.io → www.robota.io`로 단순화
+- CNAME 파일: docs VitePress 빌드 아티팩트의 CNAME은 `docs.robota.io` 유지
+
+## Test Plan
+
+- `robota.io` 접속 시 최종적으로 `www.robota.io` 로 301 redirect 확인
+- `www.robota.io/docs` 또는 헤더 Docs 링크 클릭 시 `docs.robota.io` 로 정상 이동
+- Google Search Console 크롤 오류 없음 확인
+
+## User Execution Test Scenarios
+
+Not applicable — infrastructure/DNS.

--- a/apps/www/next-env.d.ts
+++ b/apps/www/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  output: 'standalone',
+};
+
+export default nextConfig;

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "robota-www",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3010",
+    "build": "next build",
+    "start": "next start --port 3010",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.4.1",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "15.4.1",
+    "@tailwindcss/postcss": "^4",
+    "tailwindcss": "^4",
+    "tw-animate-css": "^1",
+    "typescript": "^5"
+  }
+}

--- a/apps/www/postcss.config.mjs
+++ b/apps/www/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ['@tailwindcss/postcss'],
+};
+
+export default config;

--- a/apps/www/src/app/compare/page.tsx
+++ b/apps/www/src/app/compare/page.tsx
@@ -1,0 +1,309 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Why Robota — Compare AI Coding Tools',
+  description:
+    'How Robota compares to Claude Code, Cursor, Aider, and Cline — features, cost, and freedom.',
+};
+
+const FEATURE_ROWS = [
+  {
+    feature: 'Multi-provider (one config)',
+    robota: true,
+    claudeCode: false,
+    cursor: false,
+    aider: true,
+    cline: true,
+  },
+  {
+    feature: 'BYOK — no subscription required',
+    robota: true,
+    claudeCode: true,
+    cursor: false,
+    aider: true,
+    cline: true,
+    cursorNote: 'subscription',
+  },
+  {
+    feature: 'Local model support (Ollama/LM Studio)',
+    robota: true,
+    claudeCode: false,
+    cursor: false,
+    aider: true,
+    cline: true,
+  },
+  {
+    feature: 'Embeddable SDK',
+    robota: true,
+    claudeCode: false,
+    cursor: false,
+    aider: false,
+    cline: false,
+  },
+  {
+    feature: 'Open source (MIT)',
+    robota: true,
+    claudeCode: false,
+    cursor: false,
+    aider: true,
+    cline: true,
+    claudeCodeNote: 'proprietary',
+    cursorNote: 'proprietary',
+    aiderNote: 'Apache 2',
+  },
+  {
+    feature: 'TypeScript-first, strict types',
+    robota: true,
+    claudeCode: true,
+    cursor: true,
+    aider: false,
+    cline: true,
+    aiderNote: 'Python',
+  },
+  {
+    feature: 'Terminal CLI',
+    robota: true,
+    claudeCode: true,
+    cursor: false,
+    aider: true,
+    cline: true,
+    cursorNote: 'IDE only',
+  },
+  {
+    feature: 'Session persistence & resume',
+    robota: true,
+    claudeCode: true,
+    cursor: true,
+    aider: false,
+    cline: false,
+  },
+  {
+    feature: 'Background agents',
+    robota: true,
+    claudeCode: true,
+    cursor: false,
+    aider: false,
+    cline: false,
+  },
+  {
+    feature: 'Self-hostable',
+    robota: true,
+    claudeCode: false,
+    cursor: false,
+    aider: true,
+    cline: true,
+  },
+];
+
+const COST_ROWS = [
+  { tool: 'Robota', model: 'BYOK — pay your provider', estimate: '~$5–30 depending on model' },
+  { tool: 'Claude Code', model: 'BYOK (Anthropic API)', estimate: '~$20–80 with Claude Sonnet' },
+  { tool: 'Cursor', model: 'Subscription', estimate: '$20/mo (Pro) + API overages' },
+  { tool: 'Aider', model: 'BYOK', estimate: '~$5–30 depending on model' },
+  { tool: 'Cline', model: 'BYOK (VSCode extension)', estimate: '~$5–30 depending on model' },
+];
+
+function Check() {
+  return <span className="text-green-400 font-bold">✓</span>;
+}
+
+function Cross({ note }: { note?: string }) {
+  return (
+    <span className="text-[var(--muted-foreground)]">
+      {note ? <span className="text-xs">{note}</span> : '✗'}
+    </span>
+  );
+}
+
+export default function ComparePage() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="text-center mb-12">
+        <h1 className="text-3xl font-extrabold text-[var(--foreground)] sm:text-4xl">
+          Why Robota?
+        </h1>
+        <p className="mt-4 text-lg text-[var(--muted-foreground)] max-w-2xl mx-auto">
+          The only AI coding CLI that lets you bring your own key for any provider, run offline with
+          a local model, and embed the same engine into your own app — all under the MIT license.
+        </p>
+      </div>
+
+      {/* Feature comparison table */}
+      <section className="mb-14">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">Feature Comparison</h2>
+        <div className="overflow-x-auto rounded-xl border border-[var(--border)]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Feature
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--primary)]">
+                  Robota
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--muted-foreground)]">
+                  Claude Code
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--muted-foreground)]">
+                  Cursor
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--muted-foreground)]">
+                  Aider
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--muted-foreground)]">
+                  Cline
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {FEATURE_ROWS.map((row, i) => (
+                <tr
+                  key={row.feature}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td className="px-4 py-3 text-[var(--foreground)]">{row.feature}</td>
+                  <td className="px-4 py-3 text-center">{row.robota ? <Check /> : <Cross />}</td>
+                  <td className="px-4 py-3 text-center">
+                    {row.claudeCode ? <Check /> : <Cross note={row.claudeCodeNote} />}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    {row.cursor ? <Check /> : <Cross note={row.cursorNote} />}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    {row.aider ? <Check /> : <Cross note={row.aiderNote} />}
+                  </td>
+                  <td className="px-4 py-3 text-center">{row.cline ? <Check /> : <Cross />}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Cost comparison */}
+      <section className="mb-14">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">Cost Comparison</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Estimated monthly cost at 4 h/day active usage.
+        </p>
+        <div className="overflow-x-auto rounded-xl border border-[var(--border)]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Tool
+                </th>
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Pricing model
+                </th>
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Monthly estimate
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COST_ROWS.map((row, i) => (
+                <tr
+                  key={row.tool}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td
+                    className={`px-4 py-3 font-medium ${row.tool === 'Robota' ? 'text-[var(--primary)]' : 'text-[var(--foreground)]'}`}
+                  >
+                    {row.tool}
+                  </td>
+                  <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.model}</td>
+                  <td className="px-4 py-3 text-[var(--foreground)]">{row.estimate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-4 text-sm text-[var(--muted-foreground)]">
+          <strong className="text-[var(--foreground)]">Robota + Gemini Flash</strong> —
+          Google&apos;s free tier covers casual use at zero cost.{' '}
+          <strong className="text-[var(--foreground)]">Robota + local Ollama</strong> — pay nothing,
+          fully offline.
+        </p>
+      </section>
+
+      {/* Key differentiators */}
+      <section className="mb-14">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-6">
+          What Makes Robota Different
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[
+            {
+              title: '1. Any Provider — One Config',
+              body: 'Switch between Anthropic, OpenAI, DeepSeek, Gemini, or Ollama by changing one line in ~/.robota/settings.json. No code changes, no new subscriptions.',
+            },
+            {
+              title: '2. Embeddable SDK',
+              body: 'Ship the same agent runtime to your users via @robota-sdk/agent-framework. No other AI coding assistant exposes this — Claude Code, Cursor, and Cline are closed products.',
+            },
+            {
+              title: '3. Fully Open Source (MIT)',
+              body: 'Every line is publicly auditable. Fork it, modify it, self-host it, build commercial products — no CLA required.',
+            },
+            {
+              title: '4. Local Model First-Class',
+              body: 'Point any Ollama or LM Studio model as your provider. Your code and prompts never leave your machine.',
+            },
+          ].map((item) => (
+            <div
+              key={item.title}
+              className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5"
+            >
+              <h3 className="font-semibold text-[var(--foreground)]">{item.title}</h3>
+              <p className="mt-2 text-sm text-[var(--muted-foreground)]">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* When to choose something else */}
+      <section className="mb-14 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">
+          When to Choose Something Else
+        </h2>
+        <ul className="space-y-3 text-sm text-[var(--muted-foreground)]">
+          <li>
+            <strong className="text-[var(--foreground)]">Choose Claude Code</strong> if you want the
+            tightest Claude integration and are happy with Anthropic-only.
+          </li>
+          <li>
+            <strong className="text-[var(--foreground)]">Choose Cursor</strong> if you want an
+            IDE-first experience with inline diff editing and tab completion.
+          </li>
+          <li>
+            <strong className="text-[var(--foreground)]">Choose Aider</strong> if you prefer a
+            Python ecosystem and work primarily with git-based batch commits.
+          </li>
+          <li>
+            <strong className="text-[var(--foreground)]">Choose Cline</strong> if you want a VSCode
+            sidebar agent and don&apos;t need embedding or SDK usage.
+          </li>
+        </ul>
+      </section>
+
+      <div className="text-center">
+        <a
+          href="https://docs.robota.io/getting-started/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg bg-[var(--primary)] px-6 py-3 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+        >
+          Try Robota now →
+        </a>
+        <p className="mt-3 text-sm text-[var(--muted-foreground)]">
+          Or{' '}
+          <Link href="/tools/cost-calculator" className="text-[var(--primary)] hover:underline">
+            calculate your exact cost
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/app/enterprise/page.tsx
+++ b/apps/www/src/app/enterprise/page.tsx
@@ -1,0 +1,223 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Enterprise',
+  description:
+    'Robota for engineering teams — security practices, self-hosted deployment, and enterprise support.',
+};
+
+const DATA_HANDLING = [
+  ['Prompts and responses', 'Sent only to the AI provider you configure'],
+  ['API keys', 'Stored in your local environment variables or secrets manager'],
+  ['Session history', 'Written to your local filesystem (~/.robota/sessions/)'],
+  ['Tool outputs (files, shell)', 'Stay on your machine'],
+];
+
+const FAQ = [
+  {
+    q: 'Does Robota store my code in the cloud?',
+    a: 'No. All file reads and writes happen on your local machine. The only data that leaves your machine is the prompt you send to your configured AI provider.',
+  },
+  {
+    q: 'Can we use Robota behind a corporate proxy?',
+    a: "Yes. Set the standard HTTPS_PROXY environment variable and the SDK's HTTP client will route through it.",
+  },
+  {
+    q: 'Can Robota be installed in a restricted network with no internet access?',
+    a: 'Yes — use a local LLM (Ollama, LM Studio) and install npm packages from an internal registry mirror.',
+  },
+  {
+    q: 'Is there a commercial license option?',
+    a: 'Robota is MIT-licensed and free to use commercially without restriction. Enterprise support contracts (SLA, dedicated channels, custom integrations) are available — contact us for details.',
+  },
+];
+
+export default function EnterprisePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="mb-12">
+        <h1 className="text-3xl font-extrabold text-[var(--foreground)] sm:text-4xl">Enterprise</h1>
+        <p className="mt-4 text-[var(--muted-foreground)]">
+          Robota is used by engineering teams that need a controllable, self-hostable AI coding
+          assistant. This page covers security practices, deployment options, and how to get in
+          touch.
+        </p>
+      </div>
+
+      {/* Contact */}
+      <section className="mb-12 rounded-xl border border-[var(--primary)]/30 bg-[var(--accent-dim)] p-6">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-2">Contact Us</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          To discuss team licensing, on-premises deployment, priority support, or custom
+          integrations, open a GitHub Discussion or email us directly.
+        </p>
+        <p className="text-sm text-[var(--muted-foreground)] mb-5">
+          We respond to all enterprise inquiries within{' '}
+          <strong className="text-[var(--foreground)]">30 business days</strong>.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <a
+            href="https://github.com/woojubb/robota/discussions"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+          >
+            GitHub Discussions (enterprise tag) ↗
+          </a>
+          <a
+            href="mailto:enterprise@robota.io"
+            className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+          >
+            enterprise@robota.io
+          </a>
+        </div>
+      </section>
+
+      {/* Security policy */}
+      <section className="mb-12">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">Security Policy</h2>
+
+        <h3 className="text-base font-semibold text-[var(--foreground)] mb-3">Data Handling</h3>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Robota operates as a local CLI or self-hosted server.{' '}
+          <strong className="text-[var(--foreground)]">
+            No conversation data is stored or transmitted to Robota servers
+          </strong>{' '}
+          — the SDK calls the AI provider of your choice directly from your machine or
+          infrastructure.
+        </p>
+        <div className="rounded-xl border border-[var(--border)] overflow-hidden mb-6">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Data type
+                </th>
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Where it goes
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {DATA_HANDLING.map(([type, dest], i) => (
+                <tr
+                  key={type}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td className="px-4 py-3 font-medium text-[var(--foreground)]">{type}</td>
+                  <td className="px-4 py-3 text-[var(--muted-foreground)]">{dest}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <h3 className="text-base font-semibold text-[var(--foreground)] mb-3">
+          On-Premises Deployment
+        </h3>
+        <p className="text-sm text-[var(--muted-foreground)] mb-3">
+          Robota supports fully air-gapped deployments using local LLMs:
+        </p>
+        <ul className="space-y-2 text-sm text-[var(--muted-foreground)] mb-4">
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span>{' '}
+            <strong className="text-[var(--foreground)]">Ollama</strong> — run models locally with
+            zero external network calls
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span>{' '}
+            <strong className="text-[var(--foreground)]">LM Studio</strong> — OpenAI-compatible
+            local server
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span>{' '}
+            <strong className="text-[var(--foreground)]">Any OpenAI-compatible endpoint</strong> —
+            point baseURL to your internal gateway
+          </li>
+        </ul>
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 font-mono text-sm text-[var(--muted-foreground)]">
+          <p>
+            <span className="text-purple-400">import</span> {'{ OpenAIProvider }'}{' '}
+            <span className="text-purple-400">from</span>{' '}
+            <span className="text-green-400">&apos;@robota-sdk/openai&apos;</span>;
+          </p>
+          <p className="mt-2">
+            <span className="text-purple-400">const</span> provider ={' '}
+            <span className="text-purple-400">new</span>{' '}
+            <span className="text-blue-400">OpenAIProvider</span>
+            {'({'}
+          </p>
+          <p className="ml-4">
+            apiKey: <span className="text-green-400">&apos;local&apos;</span>,
+          </p>
+          <p className="ml-4">
+            baseURL:{' '}
+            <span className="text-green-400">&apos;http://your-internal-gateway/v1&apos;</span>,
+          </p>
+          <p className="ml-4">
+            model: <span className="text-green-400">&apos;your-model-name&apos;</span>,
+          </p>
+          <p>{'}'});</p>
+        </div>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          {[
+            {
+              title: 'MIT License',
+              body: 'Full source code available for audit at github.com/woojubb/robota',
+            },
+            { title: 'No telemetry', body: 'No analytics, no phone-home in the SDK or CLI' },
+            {
+              title: 'Append-only session logs',
+              body: 'You control retention and deletion of all local session files',
+            },
+            {
+              title: 'SOC 2 / ISO 27001 compatible',
+              body: 'When combined with a compliant AI provider',
+            },
+          ].map((item) => (
+            <div
+              key={item.title}
+              className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4"
+            >
+              <p className="font-semibold text-[var(--foreground)] text-sm">{item.title}</p>
+              <p className="mt-1 text-xs text-[var(--muted-foreground)]">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mb-12">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-5">FAQ</h2>
+        <div className="space-y-4">
+          {FAQ.map((item) => (
+            <div
+              key={item.q}
+              className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5"
+            >
+              <p className="font-semibold text-[var(--foreground)] text-sm">{item.q}</p>
+              <p className="mt-2 text-sm text-[var(--muted-foreground)]">{item.a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Vulnerability disclosure */}
+      <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-2">
+          Vulnerability Disclosure
+        </h2>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          To report a security vulnerability, email{' '}
+          <a href="mailto:security@robota.io" className="text-[var(--primary)] hover:underline">
+            security@robota.io
+          </a>{' '}
+          with a description and reproduction steps. We follow responsible disclosure and aim to
+          issue a patch within <strong className="text-[var(--foreground)]">14 days</strong> of
+          confirmation.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -1,0 +1,47 @@
+@import 'tailwindcss';
+@import 'tw-animate-css';
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-accent: var(--accent);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+}
+
+:root {
+  --radius: 0.5rem;
+  --background: #0a0a0f;
+  --foreground: #e8e6f0;
+  --card: #131320;
+  --card-foreground: #e8e6f0;
+  --primary: #a78bfa;
+  --primary-foreground: #0a0a0f;
+  --muted: #1a1a2e;
+  --muted-foreground: #7b7a95;
+  --border: #252540;
+  --accent: #a78bfa;
+  --accent-dim: rgba(167, 139, 250, 0.12);
+}
+
+@layer base {
+  * {
+    @apply border-[var(--border)];
+  }
+  body {
+    background: var(--background);
+    color: var(--foreground);
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+}

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { Header } from '@/components/Header';
+import { Footer } from '@/components/Footer';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Robota — Open-Source AI Agent SDK',
+    template: '%s | Robota',
+  },
+  description:
+    'Open-source AI agent SDK and CLI. Multi-provider BYOK — Anthropic, OpenAI, DeepSeek, Gemini, or local models. MIT licensed.',
+  metadataBase: new URL('https://www.robota.io'),
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://www.robota.io',
+    siteName: 'Robota',
+    title: 'Robota — Open-Source AI Agent SDK',
+    description:
+      'Open-source AI agent SDK and CLI. Multi-provider BYOK — Anthropic, OpenAI, DeepSeek, Gemini, or local models. MIT licensed.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Robota — Open-Source AI Agent SDK',
+    description:
+      'Open-source AI agent SDK and CLI. Multi-provider BYOK — Anthropic, OpenAI, DeepSeek, Gemini, or local models. MIT licensed.',
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <Header />
+        <main>{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/apps/www/src/app/page.tsx
+++ b/apps/www/src/app/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Robota — Open-Source AI Agent SDK',
+};
+
+const PROVIDERS = [
+  { name: 'Anthropic', color: 'text-orange-400' },
+  { name: 'OpenAI', color: 'text-green-400' },
+  { name: 'DeepSeek', color: 'text-blue-400' },
+  { name: 'Gemini', color: 'text-yellow-400' },
+  { name: 'Ollama', color: 'text-purple-400' },
+];
+
+const FEATURES = [
+  {
+    icon: '🔑',
+    title: 'BYOK — No Subscription',
+    description:
+      'Bring your own API key. Pay only for tokens you use. No $20/month plans, no seat limits imposed by Robota.',
+  },
+  {
+    icon: '🔄',
+    title: 'Any Provider, One Config',
+    description:
+      'Switch between Anthropic, OpenAI, DeepSeek, Gemini, or a local Ollama model by changing one line in your config.',
+  },
+  {
+    icon: '📦',
+    title: 'Embeddable SDK',
+    description:
+      'Import @robota-sdk/agent-framework into your app and ship the same agent runtime your users already know.',
+  },
+  {
+    icon: '🏠',
+    title: 'Fully Self-Hostable',
+    description:
+      'Run entirely on-premises with local LLMs. No data leaves your machine except to the AI provider you choose.',
+  },
+  {
+    icon: '🔓',
+    title: 'MIT Licensed',
+    description:
+      'Every line is publicly auditable and free to fork, modify, and use in commercial products — no CLA required.',
+  },
+  {
+    icon: '⚡',
+    title: 'TypeScript-First',
+    description:
+      'Strict types end-to-end. No any, no implicit casts, no runtime surprises. Designed for real TypeScript codebases.',
+  },
+];
+
+export default function HomePage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="relative overflow-hidden py-20 sm:py-28">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-10%,rgba(167,139,250,0.18),transparent)]"
+        />
+        <div className="relative mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-400" />
+            Public Beta · v3.0.0-beta
+          </div>
+
+          <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-[var(--foreground)] sm:text-5xl lg:text-6xl">
+            The open-source AI agent SDK
+            <br />
+            <span className="text-[var(--primary)]">that you actually own</span>
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-2xl text-lg text-[var(--muted-foreground)]">
+            Multi-provider BYOK CLI and embeddable SDK. Switch between{' '}
+            {PROVIDERS.map((p, i) => (
+              <span key={p.name}>
+                <span className={p.color}>{p.name}</span>
+                {i < PROVIDERS.length - 1 ? ', ' : ''}
+              </span>
+            ))}{' '}
+            with one config change. MIT licensed.
+          </p>
+
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <a
+              href="https://docs.robota.io/getting-started/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg bg-[var(--primary)] px-5 py-2.5 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+            >
+              Get Started
+            </a>
+            <a
+              href="https://github.com/woojubb/robota"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-5 py-2.5 text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+            >
+              GitHub ↗
+            </a>
+            <Link
+              href="/compare"
+              className="rounded-lg border border-[var(--border)] bg-transparent px-5 py-2.5 text-sm font-semibold text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Compare Tools
+            </Link>
+          </div>
+
+          {/* Install snippet */}
+          <div className="mt-10 inline-block rounded-lg border border-[var(--border)] bg-[var(--card)] px-5 py-3 font-mono text-sm text-[var(--muted-foreground)]">
+            <span className="text-[var(--primary)]">$</span>{' '}
+            <span className="text-[var(--foreground)]">npx @robota-sdk/agent-cli</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Features grid */}
+      <section className="py-16 sm:py-20">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <h2 className="text-center text-2xl font-bold text-[var(--foreground)] sm:text-3xl">
+            Everything you need. Nothing you don&apos;t.
+          </h2>
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5"
+              >
+                <div className="text-2xl">{f.icon}</div>
+                <h3 className="mt-3 text-base font-semibold text-[var(--foreground)]">{f.title}</h3>
+                <p className="mt-1.5 text-sm text-[var(--muted-foreground)]">{f.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Cost teaser */}
+      <section className="py-16 sm:py-20 bg-[var(--card)]">
+        <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-2xl font-bold text-[var(--foreground)] sm:text-3xl">
+            Light users pay <span className="text-[var(--primary)]">less than $2/month</span>
+          </h2>
+          <p className="mt-4 text-[var(--muted-foreground)]">
+            Claude Code charges a flat $20/month. With Robota you pay only for tokens you actually
+            use — or nothing at all if you run a local model.
+          </p>
+          <Link
+            href="/tools/cost-calculator"
+            className="mt-6 inline-block rounded-lg border border-[var(--border)] bg-[var(--muted)] px-5 py-2.5 text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--muted)]/80 transition-colors"
+          >
+            Calculate your cost →
+          </Link>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 sm:py-24">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-2xl font-bold text-[var(--foreground)] sm:text-3xl">
+            Start in 30 seconds
+          </h2>
+          <p className="mt-4 text-[var(--muted-foreground)]">
+            No account. No subscription. Just a terminal and an API key.
+          </p>
+          <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 text-left font-mono text-sm">
+            <p>
+              <span className="text-[var(--muted-foreground)]"># Install globally</span>
+            </p>
+            <p className="mt-1">
+              <span className="text-[var(--primary)]">$</span>{' '}
+              <span className="text-[var(--foreground)]">npm install -g @robota-sdk/agent-cli</span>
+            </p>
+            <p className="mt-3">
+              <span className="text-[var(--muted-foreground)]"># Set your API key</span>
+            </p>
+            <p className="mt-1">
+              <span className="text-[var(--primary)]">$</span>{' '}
+              <span className="text-[var(--foreground)]">export ANTHROPIC_API_KEY=sk-ant-...</span>
+            </p>
+            <p className="mt-3">
+              <span className="text-[var(--muted-foreground)]"># Launch</span>
+            </p>
+            <p className="mt-1">
+              <span className="text-[var(--primary)]">$</span>{' '}
+              <span className="text-[var(--foreground)]">robota</span>
+            </p>
+          </div>
+          <a
+            href="https://docs.robota.io/getting-started/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-block rounded-lg bg-[var(--primary)] px-6 py-3 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+          >
+            Read the full Getting Started guide →
+          </a>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/www/src/app/roadmap/page.tsx
+++ b/apps/www/src/app/roadmap/page.tsx
@@ -1,0 +1,170 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Roadmap',
+  description:
+    "What's coming next in Robota SDK — current priorities, next quarter, and future exploration.",
+};
+
+const NOW = [
+  { feature: 'Context warning banner (70% / 90%)', status: 'done', release: 'beta.67' },
+  { feature: '/compact result summary', status: 'done', release: 'beta.67' },
+  { feature: '3-level permission memory (session / project)', status: 'done', release: 'beta.67' },
+  { feature: 'robota init project setup command', status: 'done', release: 'beta.67' },
+  { feature: 'Plugin development guide + directory', status: 'done', release: 'beta.67' },
+  { feature: 'Changelog page', status: 'done', release: 'beta.67' },
+  { feature: '? key keyboard shortcut overlay', status: 'done', release: 'beta.67' },
+  { feature: '--dry-run flag (plan-only preview)', status: 'done', release: 'beta.67' },
+  { feature: 'Session auto-naming from first message', status: 'planned', release: 'beta.68' },
+  {
+    feature: '/cost improvements — per-session cost tracking',
+    status: 'planned',
+    release: 'beta.68',
+  },
+];
+
+const NEXT = [
+  'v1.0.0 release candidate — declared when all P0 bugs are resolved and core user journeys verified end-to-end',
+  'GitHub Actions official action (robota-sdk/action@v1) — run Robota as a CI bot in any workflow',
+  'Official plugins starter pack — 5 community plugin templates: logging, Slack alerts, cost tracking, Linear integration, Datadog metrics',
+  'SDK embedding examples — Next.js, Express, and CLI script reference implementations',
+  'Robota Cloud beta — hosted sessions, team sharing, usage dashboard (BYOK free tier)',
+];
+
+const LATER = [
+  'Session share links (share a conversation URL)',
+  'Multi-agent visual canvas in the terminal',
+  'Native VS Code extension (beyond the current CLI)',
+  'Enterprise SSO and audit logs',
+];
+
+export default function RoadmapPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="mb-10">
+        <h1 className="text-3xl font-extrabold text-[var(--foreground)] sm:text-4xl">Roadmap</h1>
+        <p className="mt-3 text-[var(--muted-foreground)]">
+          Robota SDK is currently in{' '}
+          <strong className="text-[var(--foreground)]">public beta (v3.0.0-beta)</strong>. This page
+          is updated quarterly.
+        </p>
+        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+          Last updated: 2026-05-23 ·{' '}
+          <a
+            href="https://github.com/woojubb/robota/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--primary)] hover:underline"
+          >
+            GitHub Issues ↗
+          </a>
+        </p>
+      </div>
+
+      {/* Now */}
+      <section className="mb-12">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">Now — Beta Polish</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Q2 2026 · Active development window
+        </p>
+        <div className="rounded-xl border border-[var(--border)] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Feature
+                </th>
+                <th className="px-4 py-3 text-center font-semibold text-[var(--muted-foreground)]">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-right font-semibold text-[var(--muted-foreground)]">
+                  Release
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {NOW.map((item, i) => (
+                <tr
+                  key={item.feature}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td className="px-4 py-3 text-[var(--foreground)]">{item.feature}</td>
+                  <td className="px-4 py-3 text-center">
+                    {item.status === 'done' ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-green-400/10 px-2 py-0.5 text-xs font-medium text-green-400">
+                        ✓ Done
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-[var(--accent-dim)] px-2 py-0.5 text-xs font-medium text-[var(--primary)]">
+                        📋 Planned
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right text-xs text-[var(--muted-foreground)]">
+                    {item.release}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Next */}
+      <section className="mb-12">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">Next — Q3 2026</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">Planned for the next quarter</p>
+        <ul className="space-y-3">
+          {NEXT.map((item) => (
+            <li key={item} className="flex gap-3 text-sm">
+              <span className="mt-0.5 text-[var(--primary)] shrink-0">→</span>
+              <span className="text-[var(--muted-foreground)]">{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Later */}
+      <section className="mb-12">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-1">Later — Exploration</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          Ideas under consideration. No commitment on timing.
+        </p>
+        <ul className="space-y-2">
+          {LATER.map((item) => (
+            <li key={item} className="flex gap-3 text-sm">
+              <span className="mt-0.5 text-[var(--muted-foreground)] shrink-0">·</span>
+              <span className="text-[var(--muted-foreground)]">{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Vote */}
+      <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-2">Vote and Suggest</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          The most-upvoted issues influence priority in next-quarter planning.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <a
+            href="https://github.com/woojubb/robota/discussions"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+          >
+            GitHub Discussions ↗
+          </a>
+          <a
+            href="https://github.com/woojubb/robota/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg border border-[var(--border)] bg-[var(--muted)] px-4 py-2 text-sm font-semibold text-[var(--foreground)] hover:bg-[var(--muted)]/80 transition-colors"
+          >
+            Open Issues ↗
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/www/src/app/showcase/page.tsx
+++ b/apps/www/src/app/showcase/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Build with Robota — Showcase',
+  description:
+    'Projects and tools built using Robota SDK — from CLI assistants to embedded AI agents.',
+};
+
+const FEATURED = [
+  {
+    name: 'Robota CLI',
+    description:
+      'The reference implementation. A full AI coding assistant built entirely on top of @robota-sdk/agent-framework and the TUI transport.',
+    source: 'https://github.com/woojubb/robota',
+    packages: ['agent-cli', 'agent-framework', 'agent-transport', 'agent-command', 'agent-tools'],
+    highlights: [
+      'Multi-provider switching',
+      'Session persistence',
+      'Permission system',
+      'Plugin lifecycle',
+      'Streaming TUI',
+    ],
+  },
+  {
+    name: 'Visual Agent Builder Playground',
+    description:
+      'A drag-and-drop canvas for assembling agents and exporting working TypeScript code. Runs entirely in the browser with BYOK.',
+    live: 'https://play.robota.io/playground',
+    packages: ['agent-framework', 'agent-provider', 'agent-tools'],
+    highlights: ['Browser-based SDK usage', 'SSE streaming', 'Multi-provider BYOK', 'Code export'],
+  },
+];
+
+export default function ShowcasePage() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="mb-12 text-center">
+        <h1 className="text-3xl font-extrabold text-[var(--foreground)] sm:text-4xl">
+          Build with Robota
+        </h1>
+        <p className="mt-4 text-[var(--muted-foreground)] max-w-xl mx-auto">
+          Real projects built with Robota SDK — from terminal coding assistants to embedded AI in
+          custom applications.
+        </p>
+      </div>
+
+      {/* Featured */}
+      <section className="mb-14">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-5 uppercase tracking-wider text-xs text-[var(--muted-foreground)]">
+          Featured Projects
+        </h2>
+        <div className="grid gap-5">
+          {FEATURED.map((project) => (
+            <div
+              key={project.name}
+              className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <h3 className="text-lg font-bold text-[var(--foreground)]">{project.name}</h3>
+                <div className="flex gap-2">
+                  {project.source && (
+                    <a
+                      href={project.source}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-md border border-[var(--border)] px-3 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      Source ↗
+                    </a>
+                  )}
+                  {project.live && (
+                    <a
+                      href={project.live}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-md bg-[var(--accent-dim)] border border-[var(--primary)]/30 px-3 py-1 text-xs text-[var(--primary)] hover:opacity-80 transition-opacity"
+                    >
+                      Live demo ↗
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              <p className="mt-2 text-sm text-[var(--muted-foreground)]">{project.description}</p>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {project.packages.map((pkg) => (
+                  <span
+                    key={pkg}
+                    className="rounded-full border border-[var(--border)] bg-[var(--muted)] px-2.5 py-0.5 text-xs text-[var(--muted-foreground)]"
+                  >
+                    @robota-sdk/{pkg}
+                  </span>
+                ))}
+              </div>
+
+              <ul className="mt-4 grid grid-cols-2 gap-1 sm:grid-cols-3">
+                {project.highlights.map((h) => (
+                  <li
+                    key={h}
+                    className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]"
+                  >
+                    <span className="text-green-400">✓</span> {h}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Community */}
+      <section className="mb-14">
+        <h2 className="text-xs font-bold uppercase tracking-wider text-[var(--muted-foreground)] mb-5">
+          Community Projects
+        </h2>
+        <div className="rounded-xl border border-dashed border-[var(--border)] p-8 text-center text-[var(--muted-foreground)] text-sm">
+          No community projects listed yet. Be the first to submit yours.
+        </div>
+      </section>
+
+      {/* Submit */}
+      <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h2 className="text-lg font-bold text-[var(--foreground)] mb-3">Submit Your Project</h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-4">
+          To add your project to this page, open a PR adding an entry to the Community Projects
+          section of{' '}
+          <code className="rounded bg-[var(--muted)] px-1 py-0.5 text-xs">
+            apps/docs/docs/.temp/showcase/README.md
+          </code>
+          .
+        </p>
+        <ul className="space-y-1.5 text-sm text-[var(--muted-foreground)] mb-5">
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span> Must use at least one{' '}
+            <code className="text-xs bg-[var(--muted)] px-1 rounded">@robota-sdk/*</code> package
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span> Public source code or live demo
+            required
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[var(--primary)]">•</span> Must be working as of the PR date
+          </li>
+        </ul>
+        <a
+          href="https://github.com/woojubb/robota/pulls"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+        >
+          Open a Pull Request ↗
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/apps/www/src/app/tools/cost-calculator/page.tsx
+++ b/apps/www/src/app/tools/cost-calculator/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { CostCalculator } from '@/components/CostCalculator';
+
+export const metadata: Metadata = {
+  title: 'API Cost Calculator',
+  description:
+    'See how much you would pay using Robota with direct API access compared to a flat Claude Code subscription.',
+};
+
+const PRICE_TABLE = [
+  { provider: 'Anthropic', model: 'Claude Sonnet 4.x', input: '$3.00', output: '$15.00' },
+  { provider: 'Anthropic', model: 'Claude Haiku 4.x', input: '$0.80', output: '$4.00' },
+  { provider: 'OpenAI', model: 'GPT-4o', input: '$2.50', output: '$10.00' },
+  { provider: 'OpenAI', model: 'GPT-4o mini', input: '$0.15', output: '$0.60' },
+  { provider: 'DeepSeek', model: 'DeepSeek Chat', input: '$0.14', output: '$0.28' },
+  { provider: 'Google', model: 'Gemini 2.0 Flash', input: '$0.10', output: '$0.40' },
+];
+
+export default function CostCalculatorPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="mb-10">
+        <h1 className="text-3xl font-extrabold text-[var(--foreground)] sm:text-4xl">
+          API Cost Calculator
+        </h1>
+        <p className="mt-3 text-[var(--muted-foreground)]">
+          Adjust the sliders to match your coding habits and see how Robota BYOK compares to a flat
+          $20/month subscription.
+        </p>
+      </div>
+
+      <CostCalculator />
+
+      {/* How it works */}
+      <section className="mt-14">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">How the estimate works</h2>
+        <div className="rounded-xl border border-[var(--border)] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Factor
+                </th>
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  What it controls
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                ['Daily coding hours', 'Total time the AI assistant is active'],
+                [
+                  'Task type',
+                  'Input/output token ratio (code review is input-heavy; generation is output-heavy)',
+                ],
+                ['Context usage', 'Overall prompt frequency multiplier'],
+              ].map(([factor, desc], i) => (
+                <tr
+                  key={factor}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td className="px-4 py-3 font-medium text-[var(--foreground)]">{factor}</td>
+                  <td className="px-4 py-3 text-[var(--muted-foreground)]">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-sm text-[var(--muted-foreground)]">
+          A typical working month is assumed to be{' '}
+          <strong className="text-[var(--foreground)]">22 days</strong> at{' '}
+          <strong className="text-[var(--foreground)]">50,000 tokens/hour</strong>.
+        </p>
+      </section>
+
+      {/* Price reference */}
+      <section className="mt-12">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-4">
+          Token price reference{' '}
+          <span className="text-sm font-normal text-[var(--muted-foreground)]">(May 2026)</span>
+        </h2>
+        <div className="rounded-xl border border-[var(--border)] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Provider
+                </th>
+                <th className="px-4 py-3 text-left font-semibold text-[var(--muted-foreground)]">
+                  Model
+                </th>
+                <th className="px-4 py-3 text-right font-semibold text-[var(--muted-foreground)]">
+                  Input / 1M
+                </th>
+                <th className="px-4 py-3 text-right font-semibold text-[var(--muted-foreground)]">
+                  Output / 1M
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {PRICE_TABLE.map((row, i) => (
+                <tr
+                  key={row.model}
+                  className={`border-b border-[var(--border)] ${i % 2 === 0 ? 'bg-[var(--background)]' : 'bg-[var(--card)]/50'}`}
+                >
+                  <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.provider}</td>
+                  <td className="px-4 py-3 text-[var(--foreground)]">{row.model}</td>
+                  <td className="px-4 py-3 text-right text-[var(--foreground)]">{row.input}</td>
+                  <td className="px-4 py-3 text-right text-[var(--foreground)]">{row.output}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-xs text-[var(--muted-foreground)]">
+          Prices are updated manually. Check the provider&apos;s official pricing page before making
+          budget decisions.
+        </p>
+      </section>
+
+      {/* Why Robota saves */}
+      <section className="mt-12 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h2 className="text-xl font-bold text-[var(--foreground)] mb-3">
+          Why Robota lets you save
+        </h2>
+        <ul className="space-y-2 text-sm text-[var(--muted-foreground)]">
+          <li>
+            <strong className="text-[var(--foreground)]">Light users</strong> (1–2 h/day) often pay{' '}
+            <strong className="text-green-400">less than $2/month</strong> with efficient models.
+          </li>
+          <li>
+            <strong className="text-[var(--foreground)]">Heavy users</strong> can save by choosing
+            DeepSeek or Gemini Flash for routine tasks and reserving Sonnet for complex reasoning.
+          </li>
+          <li>
+            <strong className="text-[var(--foreground)]">Free with local models</strong> — connect
+            LM Studio or Ollama and pay zero. No API key required.
+          </li>
+        </ul>
+      </section>
+
+      <div className="mt-10 text-center">
+        <Link href="/compare" className="text-sm text-[var(--primary)] hover:underline">
+          ← Full feature comparison
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/components/CostCalculator.tsx
+++ b/apps/www/src/components/CostCalculator.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+const MODELS = [
+  { id: 'claude-sonnet', label: 'Claude Sonnet 4.x', inputPer1M: 3.0, outputPer1M: 15.0 },
+  { id: 'claude-haiku', label: 'Claude Haiku 4.x', inputPer1M: 0.8, outputPer1M: 4.0 },
+  { id: 'gpt4o', label: 'GPT-4o', inputPer1M: 2.5, outputPer1M: 10.0 },
+  { id: 'gpt4o-mini', label: 'GPT-4o mini', inputPer1M: 0.15, outputPer1M: 0.6 },
+  { id: 'deepseek', label: 'DeepSeek Chat', inputPer1M: 0.14, outputPer1M: 0.28 },
+  { id: 'gemini-flash', label: 'Gemini 2.0 Flash', inputPer1M: 0.1, outputPer1M: 0.4 },
+];
+
+const TASK_TYPES = [
+  { id: 'mixed', label: 'Mixed (typical)', inputRatio: 0.5 },
+  { id: 'codegen', label: 'Code generation', inputRatio: 0.3 },
+  { id: 'review', label: 'Code review', inputRatio: 0.7 },
+  { id: 'chat', label: 'Q&A / Chat', inputRatio: 0.6 },
+];
+
+const EXPERIENCE_LEVELS = [
+  { id: 'light', label: 'Light (short prompts)', multiplier: 0.6 },
+  { id: 'moderate', label: 'Moderate', multiplier: 1.0 },
+  { id: 'heavy', label: 'Heavy (long context)', multiplier: 1.8 },
+];
+
+const WORKING_DAYS = 22;
+const TOKENS_PER_HOUR = 50_000;
+const CLAUDE_CODE_MONTHLY = 20;
+
+function fmt(n: number) {
+  if (n < 0.01) return '<$0.01';
+  return `$${n.toFixed(2)}`;
+}
+
+export function CostCalculator() {
+  const [hours, setHours] = useState(2);
+  const [modelId, setModelId] = useState('claude-sonnet');
+  const [taskTypeId, setTaskTypeId] = useState('mixed');
+  const [levelId, setLevelId] = useState('moderate');
+
+  const result = useMemo(() => {
+    const model = MODELS.find((m) => m.id === modelId)!;
+    const task = TASK_TYPES.find((t) => t.id === taskTypeId)!;
+    const level = EXPERIENCE_LEVELS.find((l) => l.id === levelId)!;
+
+    const dailyTokens = hours * TOKENS_PER_HOUR * level.multiplier;
+    const monthlyTokens = dailyTokens * WORKING_DAYS;
+    const inputTokens = monthlyTokens * task.inputRatio;
+    const outputTokens = monthlyTokens * (1 - task.inputRatio);
+
+    const cost =
+      (inputTokens / 1_000_000) * model.inputPer1M + (outputTokens / 1_000_000) * model.outputPer1M;
+
+    const saving = CLAUDE_CODE_MONTHLY - cost;
+
+    return { cost, saving, monthlyTokens: Math.round(monthlyTokens / 1000) };
+  }, [hours, modelId, taskTypeId, levelId]);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+      {/* Inputs */}
+      <div className="p-6 grid gap-6 sm:grid-cols-2">
+        {/* Daily hours slider */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+            Daily coding hours: <span className="text-[var(--primary)]">{hours}h</span>
+          </label>
+          <input
+            type="range"
+            min={0.5}
+            max={8}
+            step={0.5}
+            value={hours}
+            onChange={(e) => setHours(parseFloat(e.target.value))}
+            className="w-full accent-[var(--primary)]"
+          />
+          <div className="flex justify-between text-xs text-[var(--muted-foreground)] mt-1">
+            <span>0.5h</span>
+            <span>8h</span>
+          </div>
+        </div>
+
+        {/* Model */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+            AI Model
+          </label>
+          <select
+            value={modelId}
+            onChange={(e) => setModelId(e.target.value)}
+            className="w-full rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm text-[var(--foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
+          >
+            {MODELS.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Task type */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+            Task type
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {TASK_TYPES.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setTaskTypeId(t.id)}
+                className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  taskTypeId === t.id
+                    ? 'border-[var(--primary)] bg-[var(--accent-dim)] text-[var(--primary)]'
+                    : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]/50'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Experience level */}
+        <div>
+          <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+            Context usage
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            {EXPERIENCE_LEVELS.map((l) => (
+              <button
+                key={l.id}
+                onClick={() => setLevelId(l.id)}
+                className={`rounded-md border px-2 py-1.5 text-xs font-medium transition-colors ${
+                  levelId === l.id
+                    ? 'border-[var(--primary)] bg-[var(--accent-dim)] text-[var(--primary)]'
+                    : 'border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]/50'
+                }`}
+              >
+                {l.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Result */}
+      <div className="border-t border-[var(--border)] bg-[var(--muted)] p-6 grid sm:grid-cols-3 gap-6 text-center">
+        <div>
+          <p className="text-xs text-[var(--muted-foreground)] uppercase tracking-wider mb-1">
+            Est. monthly tokens
+          </p>
+          <p className="text-2xl font-bold text-[var(--foreground)]">
+            {result.monthlyTokens.toLocaleString()}K
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--muted-foreground)] uppercase tracking-wider mb-1">
+            Robota BYOK cost
+          </p>
+          <p className="text-2xl font-bold text-[var(--primary)]">{fmt(result.cost)}</p>
+          <p className="text-xs text-[var(--muted-foreground)] mt-0.5">per month</p>
+        </div>
+        <div>
+          <p className="text-xs text-[var(--muted-foreground)] uppercase tracking-wider mb-1">
+            vs Claude Code $20/mo
+          </p>
+          {result.saving >= 0 ? (
+            <p className="text-2xl font-bold text-green-400">Save {fmt(result.saving)}</p>
+          ) : (
+            <p className="text-2xl font-bold text-orange-400">+{fmt(-result.saving)}</p>
+          )}
+        </div>
+      </div>
+
+      <p className="px-6 py-3 text-xs text-[var(--muted-foreground)] border-t border-[var(--border)]">
+        Estimate based on {TOKENS_PER_HOUR.toLocaleString()} tokens/hour and {WORKING_DAYS} working
+        days/month. Prices as of May 2026 — verify with provider before making budget decisions.
+      </p>
+    </div>
+  );
+}

--- a/apps/www/src/components/Footer.tsx
+++ b/apps/www/src/components/Footer.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link';
+
+export function Footer() {
+  return (
+    <footer className="border-t border-[var(--border)] bg-[var(--background)]">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-10">
+        <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
+          <div className="col-span-2 md:col-span-1">
+            <p className="text-lg font-bold text-[var(--foreground)]">robota</p>
+            <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+              Open-source AI agent SDK and CLI. MIT licensed.
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+              Product
+            </p>
+            <ul className="mt-3 space-y-2">
+              {[
+                { label: 'Why Robota', href: '/compare' },
+                { label: 'Cost Calculator', href: '/tools/cost-calculator' },
+                { label: 'Showcase', href: '/showcase' },
+                { label: 'Roadmap', href: '/roadmap' },
+              ].map(({ label, href }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+              Developers
+            </p>
+            <ul className="mt-3 space-y-2">
+              {[
+                { label: 'Documentation', href: 'https://docs.robota.io' },
+                { label: 'Getting Started', href: 'https://docs.robota.io/getting-started/' },
+                { label: 'GitHub', href: 'https://github.com/woojubb/robota' },
+                { label: 'npm', href: 'https://www.npmjs.com/package/@robota-sdk/agent-framework' },
+              ].map(({ label, href }) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+              Company
+            </p>
+            <ul className="mt-3 space-y-2">
+              {[
+                { label: 'Enterprise', href: '/enterprise' },
+                {
+                  label: 'GitHub Discussions',
+                  href: 'https://github.com/woojubb/robota/discussions',
+                },
+                { label: 'Issues', href: 'https://github.com/woojubb/robota/issues' },
+              ].map(({ label, href }) => (
+                <li key={href}>
+                  {href.startsWith('http') ? (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      {label}
+                    </a>
+                  ) : (
+                    <Link
+                      href={href}
+                      className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      {label}
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-8 border-t border-[var(--border)] pt-6 flex flex-col sm:flex-row justify-between gap-3">
+          <p className="text-xs text-[var(--muted-foreground)]">© 2026 Robota. MIT License.</p>
+          <a
+            href="https://play.robota.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+          >
+            Playground ↗
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/www/src/components/Header.tsx
+++ b/apps/www/src/components/Header.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--background)]/90 backdrop-blur-sm">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-14 items-center justify-between">
+          <Link href="/" className="flex items-center gap-2">
+            <span className="text-lg font-bold text-[var(--foreground)]">robota</span>
+            <span className="rounded-full bg-[var(--accent-dim)] px-2 py-0.5 text-xs font-medium text-[var(--accent)]">
+              beta
+            </span>
+          </Link>
+
+          <nav className="hidden items-center gap-1 md:flex">
+            <Link
+              href="/compare"
+              className="rounded-md px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Why Robota
+            </Link>
+            <Link
+              href="/tools/cost-calculator"
+              className="rounded-md px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Cost Calculator
+            </Link>
+            <Link
+              href="/showcase"
+              className="rounded-md px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Showcase
+            </Link>
+            <Link
+              href="/roadmap"
+              className="rounded-md px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Roadmap
+            </Link>
+          </nav>
+
+          <div className="flex items-center gap-2">
+            <a
+              href="https://docs.robota.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Docs ↗
+            </a>
+            <a
+              href="https://github.com/woojubb/robota"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-md bg-[var(--primary)] px-3 py-1.5 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+            >
+              GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,46 @@ importers:
         specifier: ^1.0.0
         version: 1.6.3(@algolia/client-search@5.34.0)(@types/node@20.19.9)(search-insights@2.17.3)(typescript@5.8.3)
 
+  apps/www:
+    dependencies:
+      next:
+        specifier: ^15.5.15
+        version: 15.5.15(@babel/core@7.28.0)(react-dom@19.1.0)(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.1.11
+      '@types/node':
+        specifier: ^22
+        version: 22.16.5
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.1.6(@types/react@19.2.14)
+      eslint:
+        specifier: ^9
+        version: 9.31.0
+      eslint-config-next:
+        specifier: 15.4.1
+        version: 15.4.1(eslint@9.31.0)(typescript@5.8.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.3.0
+      tw-animate-css:
+        specifier: ^1
+        version: 1.3.5
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
   packages/agent-cli:
     dependencies:
       '@robota-sdk/agent-command':
@@ -7133,10 +7173,10 @@ packages:
       }
     dependencies:
       '@ampproject/remapping': 2.3.0
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.21.2
       jiti: 2.6.1
       lightningcss: 1.30.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.11
     dev: true
@@ -7511,7 +7551,7 @@ packages:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
-      postcss: 8.5.6
+      postcss: 8.5.10
       tailwindcss: 4.1.11
     dev: true
 


### PR DESCRIPTION
## Summary

- Creates `apps/www` — the `www.robota.io` marketing site (Next.js 15 App Router + React 19 + Tailwind v4)
- All 7 pages build as static (SSG), typecheck passes, `next build` succeeds
- Adds SITE-001 through SITE-004 backlog items for the full docs/www domain split

## Pages

| Route | Content |
|---|---|
| `/` | Hero landing page with features grid and install snippet |
| `/compare` | Feature + cost comparison table vs Claude Code / Cursor / Aider / Cline |
| `/tools/cost-calculator` | Interactive React calculator (BYOK vs flat $20/mo) |
| `/showcase` | Projects built with Robota SDK |
| `/roadmap` | Q2/Q3 2026 roadmap table |
| `/enterprise` | Security policy, data handling, FAQ, contact |

## Test plan

- [x] `pnpm --filter robota-www typecheck` — zero errors
- [x] `pnpm --filter robota-www build` — 9 static pages generated, no errors
- [x] Dev server running on port 3010, all pages render correctly in browser
- [x] Cost Calculator client component works (sliders, model/task/level buttons, live cost output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)