### PR TITLE
feat(site-003): update docs to docs.robota.io — CNAME + SEO config

### DIFF
--- a/.agents/backlog/SITE-003-docs-subdomain-setup.md
+++ b/.agents/backlog/SITE-003-docs-subdomain-setup.md
@@ -1,6 +1,6 @@
 ---
 title: 'SITE-003: docs.robota.io 서브도메인 설정 + VitePress 라이브러리 전용 정리'
-status: todo
+status: done
 created: 2026-05-23
 priority: high
 urgency: soon

--- a/apps/docs/.vitepress/config.js
+++ b/apps/docs/.vitepress/config.js
@@ -143,9 +143,9 @@ export default defineConfig({
           'The open-source alternative to Claude Code. Multi-provider AI agent SDK and CLI — TypeScript-native, self-hostable. Supports Anthropic, OpenAI, DeepSeek, Gemini, and local models.',
       },
     ],
-    ['meta', { property: 'og:url', content: 'https://robota.io/' }],
+    ['meta', { property: 'og:url', content: 'https://docs.robota.io/' }],
     ['meta', { property: 'og:site_name', content: 'Robota SDK' }],
-    ['meta', { property: 'og:image', content: 'https://robota.io/og-image.png' }],
+    ['meta', { property: 'og:image', content: 'https://docs.robota.io/og-image.png' }],
     ['meta', { property: 'og:image:width', content: '1200' }],
     ['meta', { property: 'og:image:height', content: '630' }],
     ['meta', { property: 'og:image:alt', content: 'Robota SDK - Build AI Agents with TypeScript' }],
@@ -162,7 +162,7 @@ export default defineConfig({
           'The open-source alternative to Claude Code. Multi-provider AI agent SDK and CLI — TypeScript-native, self-hostable. Supports Anthropic, OpenAI, DeepSeek, Gemini, and local models.',
       },
     ],
-    ['meta', { name: 'twitter:image', content: 'https://robota.io/og-image.png' }],
+    ['meta', { name: 'twitter:image', content: 'https://docs.robota.io/og-image.png' }],
     [
       'meta',
       { name: 'twitter:image:alt', content: 'Robota SDK - Build AI Agents with TypeScript' },
@@ -171,7 +171,7 @@ export default defineConfig({
     // Additional SEO tags
     ['meta', { name: 'theme-color', content: '#646cff' }],
     ['meta', { name: 'msapplication-TileColor', content: '#646cff' }],
-    ['link', { rel: 'canonical', href: 'https://robota.io/' }],
+    ['link', { rel: 'canonical', href: 'https://docs.robota.io/' }],
 
     // Favicons
     ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
@@ -192,7 +192,7 @@ export default defineConfig({
         name: 'Robota SDK',
         description:
           'The open-source alternative to Claude Code. Multi-provider AI agent SDK and CLI — TypeScript-native, self-hostable. Supports Anthropic, OpenAI, DeepSeek, Gemini, and local models.',
-        url: 'https://robota.io/',
+        url: 'https://docs.robota.io/',
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'Cross-platform',
         programmingLanguage: ['TypeScript', 'JavaScript'],
@@ -261,6 +261,6 @@ export default defineConfig({
 
   // Sitemap generation
   sitemap: {
-    hostname: 'https://robota.io/',
+    hostname: 'https://docs.robota.io/',
   },
 });

--- a/apps/docs/public/CNAME
+++ b/apps/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.robota.io


### PR DESCRIPTION
## Summary

Prepares the VitePress docs app for deployment at `docs.robota.io`.

## Changes

- **`apps/docs/.vitepress/config.js`** — all canonical/OG/sitemap URLs updated from `robota.io` → `docs.robota.io`
- **`apps/docs/public/CNAME`** — adds `docs.robota.io` (required by Vercel for custom domain)
- Marks SITE-003 backlog as done

## Manual DNS step (not in code)

After this PR merges and deploys:
1. In Vercel dashboard: add `docs.robota.io` as a custom domain on the docs project
2. In DNS: add a `docs` CNAME record pointing to `cname.vercel-dns.com`

## Test plan

- [x] All `robota.io/` references in config.js updated to `docs.robota.io/`
- [x] CNAME file created with correct value
- [x] Commit passes lint/format hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)