### PR TITLE
feat(docs): Terminal Precision design — dark + fluorescent accents

### DIFF
--- a/apps/docs/src/app/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/[[...slug]]/page.tsx
@@ -56,57 +56,114 @@ export async function generateMetadata({
   };
 }
 
+const QUICK_LINKS = [
+  {
+    title: 'Getting Started',
+    href: '/getting-started',
+    desc: 'CLI quick start — first agent in 5 lines',
+    tag: '01',
+  },
+  {
+    title: 'Guide',
+    href: '/guide',
+    desc: 'Architecture, SDK, CLI, plugins, and more',
+    tag: '02',
+  },
+  {
+    title: 'Examples',
+    href: '/examples',
+    desc: 'Real-world code examples for common use cases',
+    tag: '03',
+  },
+  {
+    title: 'Packages',
+    href: '/packages',
+    desc: 'API reference for every SDK package',
+    tag: '04',
+  },
+  {
+    title: 'Changelog',
+    href: '/changelog',
+    desc: 'Release notes and version history',
+    tag: '05',
+  },
+  {
+    title: 'Development',
+    href: '/development',
+    desc: 'Contributing guide and development setup',
+    tag: '06',
+  },
+];
+
 // Custom home page — rendered for the root slug ([])
 function HomePage() {
   return (
     <div>
+      {/* Hero */}
       <div
         style={{
           marginBottom: '3rem',
-          paddingBottom: '2rem',
+          paddingBottom: '2.5rem',
           borderBottom: '1px solid var(--border)',
         }}
       >
+        {/* Badge */}
         <div
           style={{
-            display: 'inline-block',
-            padding: '0.25rem 0.75rem',
-            background: 'var(--accent-dim)',
-            border: '1px solid rgba(167,139,250,0.25)',
-            borderRadius: '9999px',
-            fontSize: '0.8rem',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.375rem',
+            padding: '0.2rem 0.625rem',
+            background: 'var(--primary-dim)',
+            border: '1px solid rgba(0,255,136,0.2)',
+            borderRadius: '0.25rem',
+            fontSize: '0.72rem',
+            fontFamily: 'var(--font-code)',
             color: 'var(--primary)',
-            marginBottom: '1.25rem',
-            fontWeight: 500,
+            marginBottom: '1.5rem',
+            letterSpacing: '0.06em',
           }}
         >
-          Open Source · MIT Licensed
+          <span style={{ opacity: 0.6 }}>$</span> open-source · MIT licensed
         </div>
+
         <h1
           style={{
-            fontSize: '2.5rem',
-            fontWeight: 800,
-            lineHeight: 1.15,
-            marginBottom: '1rem',
-            color: 'var(--foreground)',
+            fontFamily: 'var(--font-display)',
+            fontSize: '2.25rem',
+            fontWeight: 700,
+            lineHeight: 1.12,
+            marginBottom: '1.125rem',
+            color: 'var(--foreground-hi)',
+            letterSpacing: '-0.025em',
           }}
         >
           Robota SDK
           <br />
-          <span style={{ color: 'var(--primary)' }}>Documentation</span>
+          <span
+            style={{
+              color: 'var(--primary)',
+              textShadow: '0 0 32px rgba(0,255,136,0.25)',
+            }}
+          >
+            Documentation
+          </span>
         </h1>
+
         <p
           style={{
-            fontSize: '1.125rem',
+            fontSize: '1rem',
+            fontFamily: 'var(--font-body)',
             color: 'var(--muted-foreground)',
-            lineHeight: 1.7,
-            maxWidth: '56ch',
-            marginBottom: '1.5rem',
+            lineHeight: 1.75,
+            maxWidth: '52ch',
+            marginBottom: '1.75rem',
           }}
         >
           Multi-provider AI agent SDK and CLI — TypeScript-native, self-hostable. Supports
           Anthropic, OpenAI, DeepSeek, Gemini, and local models.
         </p>
+
         <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
           <a
             href="/getting-started"
@@ -114,14 +171,17 @@ function HomePage() {
               display: 'inline-flex',
               alignItems: 'center',
               gap: '0.375rem',
-              padding: '0.6rem 1.25rem',
+              padding: '0.55rem 1.25rem',
               background: 'var(--primary)',
               color: 'var(--primary-foreground)',
-              borderRadius: '0.5rem',
+              borderRadius: '0.25rem',
               fontWeight: 600,
-              fontSize: '0.9rem',
+              fontSize: '0.85rem',
+              fontFamily: 'var(--font-display)',
               textDecoration: 'none',
-              transition: 'opacity 0.15s',
+              letterSpacing: '0.02em',
+              boxShadow: '0 0 24px rgba(0,255,136,0.2)',
+              transition: 'box-shadow 0.2s',
             }}
           >
             Get Started →
@@ -132,14 +192,16 @@ function HomePage() {
               display: 'inline-flex',
               alignItems: 'center',
               gap: '0.375rem',
-              padding: '0.6rem 1.25rem',
-              background: 'var(--muted)',
+              padding: '0.55rem 1.25rem',
+              background: 'transparent',
               color: 'var(--foreground)',
-              border: '1px solid var(--border)',
-              borderRadius: '0.5rem',
+              border: '1px solid var(--border-strong)',
+              borderRadius: '0.25rem',
               fontWeight: 500,
-              fontSize: '0.9rem',
+              fontSize: '0.85rem',
+              fontFamily: 'var(--font-display)',
               textDecoration: 'none',
+              letterSpacing: '0.02em',
               transition: 'border-color 0.15s',
             }}
           >
@@ -152,74 +214,61 @@ function HomePage() {
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-          gap: '1rem',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(230px, 1fr))',
+          gap: '0.75rem',
           marginBottom: '3rem',
         }}
       >
-        {[
-          {
-            title: 'Getting Started',
-            href: '/getting-started',
-            desc: 'CLI quick start and first agent in 5 lines',
-            icon: '🚀',
-          },
-          {
-            title: 'Guide',
-            href: '/guide',
-            desc: 'Architecture, SDK, CLI, plugins, and more',
-            icon: '📖',
-          },
-          {
-            title: 'Examples',
-            href: '/examples',
-            desc: 'Real-world code examples for common use cases',
-            icon: '💡',
-          },
-          {
-            title: 'Packages',
-            href: '/packages',
-            desc: 'API reference for every SDK package',
-            icon: '📦',
-          },
-          {
-            title: 'Changelog',
-            href: '/changelog',
-            desc: 'Release notes and version history',
-            icon: '📋',
-          },
-          {
-            title: 'Development',
-            href: '/development',
-            desc: 'Contributing guide and development setup',
-            icon: '🛠',
-          },
-        ].map((card) => (
+        {QUICK_LINKS.map((card) => (
           <a
             key={card.href}
             href={card.href}
             style={{
               display: 'block',
-              padding: '1.25rem',
+              padding: '1.125rem',
               background: 'var(--card)',
               border: '1px solid var(--border)',
-              borderRadius: '0.625rem',
+              borderRadius: '0.375rem',
               textDecoration: 'none',
-              transition: 'border-color 0.15s, background 0.15s',
+              transition: 'border-color 0.2s, background 0.2s',
+              position: 'relative',
+              overflow: 'hidden',
             }}
           >
-            <div style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{card.icon}</div>
+            <span
+              style={{
+                position: 'absolute',
+                top: '0.75rem',
+                right: '0.875rem',
+                fontFamily: 'var(--font-code)',
+                fontSize: '0.65rem',
+                color: 'rgba(0,255,136,0.25)',
+                letterSpacing: '0.04em',
+                userSelect: 'none',
+              }}
+            >
+              {card.tag}
+            </span>
             <div
               style={{
+                fontFamily: 'var(--font-display)',
                 fontWeight: 600,
-                fontSize: '0.95rem',
-                color: 'var(--foreground)',
-                marginBottom: '0.35rem',
+                fontSize: '0.875rem',
+                color: 'var(--foreground-hi)',
+                marginBottom: '0.375rem',
+                letterSpacing: '-0.01em',
               }}
             >
               {card.title}
             </div>
-            <div style={{ fontSize: '0.82rem', color: 'var(--muted-foreground)', lineHeight: 1.5 }}>
+            <div
+              style={{
+                fontSize: '0.775rem',
+                fontFamily: 'var(--font-body)',
+                color: 'var(--muted-foreground)',
+                lineHeight: 1.55,
+              }}
+            >
               {card.desc}
             </div>
           </a>
@@ -228,37 +277,43 @@ function HomePage() {
 
       {/* Quick install */}
       <div>
-        <h2
+        <p
           style={{
-            fontSize: '1.2rem',
+            fontFamily: 'var(--font-display)',
+            fontSize: '0.7rem',
             fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            color: 'var(--muted-foreground)',
             marginBottom: '0.75rem',
-            color: 'var(--foreground)',
           }}
         >
           Quick Install
-        </h2>
+        </p>
         <pre
           style={{
-            background: '#0d1117',
-            border: '1px solid var(--border)',
-            borderRadius: '0.5rem',
-            padding: '1rem 1.25rem',
-            fontSize: '0.875rem',
-            fontFamily: 'ui-monospace, "Cascadia Code", Menlo, Consolas, monospace',
-            color: '#e8e6f0',
+            background: '#020207',
+            border: '1px solid var(--border-strong)',
+            borderTop: '1px solid var(--primary)',
+            borderRadius: '0.375rem',
+            padding: '1.125rem 1.375rem',
+            fontSize: '0.825rem',
+            fontFamily: 'var(--font-code)',
+            color: '#d4d4d8',
             overflowX: 'auto',
+            lineHeight: 1.65,
           }}
         >
           <code>
-            <span style={{ color: '#7b7a95' }}># Install the CLI globally</span>
+            <span style={{ color: '#52525b' }}># Install the CLI globally</span>
             {'\n'}
-            <span style={{ color: '#a78bfa' }}>pnpm</span> add -g @robota-sdk/agent-cli
+            <span style={{ color: 'var(--primary)', opacity: 0.85 }}>pnpm</span>
+            {' add -g @robota-sdk/agent-cli'}
             {'\n\n'}
-            <span style={{ color: '#7b7a95' }}># Or install SDK packages for your app</span>
+            <span style={{ color: '#52525b' }}># Or install SDK packages for your app</span>
             {'\n'}
-            <span style={{ color: '#a78bfa' }}>pnpm</span> add @robota-sdk/agent-core
-            @robota-sdk/agent-provider
+            <span style={{ color: 'var(--primary)', opacity: 0.85 }}>pnpm</span>
+            {' add @robota-sdk/agent-core @robota-sdk/agent-provider'}
           </code>
         </pre>
       </div>

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -20,119 +20,187 @@
 }
 
 :root {
-  --radius: 0.5rem;
-  --background: #0a0a0f;
-  --foreground: #e8e6f0;
-  --card: #131320;
-  --card-foreground: #e8e6f0;
-  --primary: #a78bfa;
-  --primary-foreground: #0a0a0f;
-  --muted: #1a1a2e;
-  --muted-foreground: #7b7a95;
-  --border: #252540;
-  --accent: #a78bfa;
-  --accent-dim: rgba(167, 139, 250, 0.12);
+  --radius: 0.375rem;
 
-  /* Docs layout */
-  --sidebar-width: 260px;
-  --toc-width: 220px;
-  --content-max-width: 800px;
-  --header-height: 60px;
+  /* Core palette */
+  --background:      #050508;
+  --background-alt:  #09090e;
+  --foreground:      #d4d4d8;
+  --foreground-hi:   #f4f4f5;
+  --card:            #0d0d14;
+  --card-foreground: #d4d4d8;
+
+  /* Accents */
+  --primary:            #00ff88;       /* fluorescent green */
+  --primary-dim:        rgba(0,255,136,0.12);
+  --primary-glow:       rgba(0,255,136,0.20);
+  --primary-foreground: #050508;
+  --secondary:          #00d4ff;       /* fluorescent cyan */
+  --secondary-dim:      rgba(0,212,255,0.10);
+
+  /* Muted / UI */
+  --muted:            #111118;
+  --muted-foreground: #71717a;
+  --border:           rgba(255,255,255,0.07);
+  --border-strong:    rgba(255,255,255,0.12);
+  --accent:           #00ff88;
+  --accent-dim:       rgba(0,255,136,0.10);
+
+  /* Layout */
+  --sidebar-width:    264px;
+  --toc-width:        216px;
+  --content-max-width: 780px;
+  --header-height:    56px;
+
+  /* Typography */
+  --font-display: var(--font-mono-display), 'IBM Plex Mono', ui-monospace, monospace;
+  --font-body:    var(--font-sans), 'IBM Plex Sans', ui-sans-serif, sans-serif;
+  --font-code:    var(--font-code), 'JetBrains Mono', 'Cascadia Code', ui-monospace, monospace;
 }
 
 @layer base {
   * {
-    @apply border-[var(--border)];
+    box-sizing: border-box;
   }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
     background: var(--background);
     color: var(--foreground);
-    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.6;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
+
+  ::selection {
+    background: var(--primary-dim);
+    color: var(--primary);
+  }
+
+  /* Subtle scrollbar */
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb {
+    background: rgba(255,255,255,0.08);
+    border-radius: 3px;
+  }
+  ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.14); }
 }
 
-/* Prose / markdown content */
+/* ─── Prose / markdown content ─────────────────────────────────────────── */
+
 .prose {
   color: var(--foreground);
   max-width: var(--content-max-width);
+  font-family: var(--font-body);
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5 {
+  font-family: var(--font-display);
+  color: var(--foreground-hi);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .prose h1 {
-  font-size: 2rem;
+  font-size: 1.875rem;
   font-weight: 700;
   margin-top: 0;
-  margin-bottom: 1rem;
-  color: var(--foreground);
-  line-height: 1.2;
+  margin-bottom: 1.25rem;
+  line-height: 1.15;
+  color: var(--foreground-hi);
 }
 
 .prose h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-top: 2rem;
-  margin-bottom: 0.75rem;
-  color: var(--foreground);
-  line-height: 1.3;
-  border-bottom: 1px solid var(--border);
+  font-size: 1.35rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.875rem;
+  line-height: 1.25;
   padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.prose h2::before {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 3rem;
+  height: 1px;
+  background: var(--primary);
+  opacity: 0.7;
 }
 
 .prose h3 {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
-  color: var(--foreground);
+  font-size: 1.1rem;
+  margin-top: 2rem;
+  margin-bottom: 0.625rem;
+  line-height: 1.3;
+  color: var(--foreground-hi);
 }
 
 .prose h4 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-top: 1.25rem;
+  font-size: 0.95rem;
+  margin-top: 1.5rem;
   margin-bottom: 0.4rem;
-  color: var(--foreground);
+  color: var(--foreground-hi);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .prose p {
   margin-top: 0;
-  margin-bottom: 1rem;
-  line-height: 1.75;
+  margin-bottom: 1.125rem;
+  line-height: 1.8;
   color: var(--foreground);
-  opacity: 0.9;
 }
 
 .prose a {
   color: var(--primary);
-  text-decoration: underline;
-  text-underline-offset: 3px;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(0,255,136,0.3);
+  transition: border-color 0.15s, color 0.15s;
 }
 
 .prose a:hover {
-  opacity: 0.8;
+  color: var(--foreground-hi);
+  border-bottom-color: var(--primary);
 }
 
 .prose ul,
 .prose ol {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 1.125rem;
   padding-left: 1.5rem;
 }
 
 .prose li {
-  margin-bottom: 0.375rem;
-  line-height: 1.7;
-  opacity: 0.9;
+  margin-bottom: 0.4rem;
+  line-height: 1.75;
+  color: var(--foreground);
 }
 
+.prose ul li::marker { color: var(--primary); }
+
+/* Inline code */
 .prose code {
-  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
-  font-size: 0.875em;
+  font-family: var(--font-code);
+  font-size: 0.84em;
   background: var(--muted);
   color: var(--primary);
-  padding: 0.15em 0.4em;
+  padding: 0.15em 0.45em;
   border-radius: 0.25rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
 }
 
 .prose pre {
@@ -140,7 +208,7 @@
   margin-bottom: 1.5rem;
   border-radius: 0.5rem;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
 }
 
 .prose pre code {
@@ -152,48 +220,68 @@
 }
 
 .prose blockquote {
-  border-left: 4px solid var(--border);
-  padding-left: 1rem;
-  margin-left: 0;
-  margin-right: 0;
-  color: var(--muted-foreground);
-  font-style: italic;
+  border-left: 3px solid var(--primary);
+  padding: 0.5rem 1rem;
+  margin: 1.5rem 0;
+  background: var(--primary-dim);
+  border-radius: 0 0.375rem 0.375rem 0;
+  color: var(--foreground);
+  font-style: normal;
 }
 
+.prose blockquote p { margin: 0; opacity: 0.9; }
+
+/* Tables */
 .prose table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1.5rem;
   font-size: 0.875rem;
+  font-family: var(--font-body);
 }
 
 .prose th {
-  background: var(--card);
-  border: 1px solid var(--border);
-  padding: 0.5rem 0.75rem;
+  background: var(--muted);
+  border: 1px solid var(--border-strong);
+  padding: 0.5rem 0.875rem;
   text-align: left;
   font-weight: 600;
-  color: var(--foreground);
+  color: var(--foreground-hi);
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .prose td {
   border: 1px solid var(--border);
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 0.875rem;
   color: var(--foreground);
-  opacity: 0.9;
 }
 
-.prose tr:nth-child(even) td {
-  background: rgba(255, 255, 255, 0.02);
-}
+.prose tr:hover td { background: rgba(0,255,136,0.025); }
 
 .prose hr {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 2rem 0;
+  margin: 2.5rem 0;
 }
 
-/* Shiki / rehype-pretty-code code blocks */
+/* Anchor links on headings */
+.prose .anchor {
+  color: inherit;
+  text-decoration: none;
+}
+
+.prose .anchor:hover::after {
+  content: ' #';
+  color: var(--primary);
+  opacity: 0.6;
+  font-weight: 400;
+}
+
+/* ─── Shiki / rehype-pretty-code ────────────────────────────────────────── */
+
 [data-rehype-pretty-code-figure] {
   position: relative;
   margin-bottom: 1.5rem;
@@ -201,11 +289,34 @@
 
 [data-rehype-pretty-code-figure] pre {
   overflow-x: auto;
-  padding: 1rem 1.25rem;
-  background: #0d1117 !important;
-  border: 1px solid var(--border);
-  border-radius: 0.5rem;
+  padding: 1.125rem 1.375rem;
+  background: #020207 !important;
+  border: 1px solid var(--border-strong);
+  border-top: none;
+  border-radius: 0 0 0.5rem 0.5rem;
   margin: 0;
+  font-family: var(--font-code);
+  font-size: 0.85rem;
+  line-height: 1.65;
+}
+
+/* Code block without title: show top border with gradient */
+[data-rehype-pretty-code-figure]:not(:has([data-rehype-pretty-code-title])) pre {
+  border-top: 1px solid var(--border-strong);
+  border-radius: 0.5rem;
+  position: relative;
+}
+
+[data-rehype-pretty-code-figure]:not(:has([data-rehype-pretty-code-title])) pre::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--primary) 0%, var(--secondary) 60%, transparent 100%);
+  opacity: 0.5;
+  border-radius: 0.5rem 0.5rem 0 0;
 }
 
 [data-rehype-pretty-code-figure] [data-line] {
@@ -213,24 +324,83 @@
 }
 
 [data-rehype-pretty-code-title] {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-bottom: none;
+  background: #0d0d18;
+  border: 1px solid var(--border-strong);
+  border-bottom: 1px solid rgba(255,255,255,0.04);
   border-radius: 0.5rem 0.5rem 0 0;
-  padding: 0.4rem 1rem;
-  font-size: 0.8rem;
-  font-family: ui-monospace, monospace;
+  padding: 0.45rem 1.25rem;
+  font-size: 0.75rem;
+  font-family: var(--font-code);
   color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  position: relative;
+  overflow: hidden;
 }
 
-[data-rehype-pretty-code-title] + pre {
-  border-radius: 0 0 0.5rem 0.5rem;
+[data-rehype-pretty-code-title]::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--primary) 0%, var(--secondary) 60%, transparent 100%);
+  opacity: 0.5;
 }
 
-/* Pagefind search modal */
+/* ─── Header top gradient line ──────────────────────────────────────────── */
+
+.docs-header-line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    var(--primary) 30%,
+    var(--secondary) 70%,
+    transparent 100%
+  );
+  opacity: 0.6;
+}
+
+/* ─── Nav link hover ─────────────────────────────────────────────────────── */
+
+.nav-link {
+  position: relative;
+  transition: color 0.15s !important;
+}
+
+.nav-link:hover {
+  color: var(--foreground-hi) !important;
+  background: transparent !important;
+}
+
+/* ─── Sidebar ────────────────────────────────────────────────────────────── */
+
+.sidebar-item-active {
+  color: var(--primary) !important;
+  background: var(--primary-dim) !important;
+  border-left: 2px solid var(--primary) !important;
+}
+
+.sidebar-item-link {
+  transition: color 0.15s, background 0.15s;
+}
+
+.sidebar-item-link:hover {
+  color: var(--foreground-hi) !important;
+  background: rgba(255,255,255,0.04) !important;
+}
+
+/* ─── Pagefind search ────────────────────────────────────────────────────── */
+
 .pagefind-ui {
   --pagefind-ui-background: var(--card);
-  --pagefind-ui-border: var(--border);
+  --pagefind-ui-border: var(--border-strong);
   --pagefind-ui-text: var(--foreground);
   --pagefind-ui-primary: var(--primary);
 }

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,6 +1,28 @@
 import type { Metadata } from 'next';
+import { IBM_Plex_Mono, IBM_Plex_Sans, JetBrains_Mono } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 import './globals.css';
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-mono-display',
+  display: 'swap',
+});
+
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-code',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: {
@@ -23,7 +45,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${ibmPlexMono.variable} ${ibmPlexSans.variable} ${jetbrainsMono.variable}`}
+    >
       <body>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           {children}

--- a/apps/docs/src/components/Header.tsx
+++ b/apps/docs/src/components/Header.tsx
@@ -20,29 +20,56 @@ export function Header() {
         top: 0,
         zIndex: 50,
         height: 'var(--header-height)',
-        background: 'rgba(10,10,15,0.85)',
-        backdropFilter: 'blur(12px)',
+        background: 'rgba(5,5,8,0.92)',
+        backdropFilter: 'blur(16px)',
+        WebkitBackdropFilter: 'blur(16px)',
         borderBottom: '1px solid var(--border)',
         display: 'flex',
         alignItems: 'center',
-        padding: '0 1.25rem',
+        padding: '0 1.5rem',
         gap: '1.5rem',
       }}
     >
+      {/* Top gradient line */}
+      <div className="docs-header-line" />
+
       {/* Logo */}
       <Link
         href="/"
         style={{
-          fontWeight: 700,
-          fontSize: '1rem',
-          color: 'var(--foreground)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.375rem',
           textDecoration: 'none',
-          whiteSpace: 'nowrap',
           flexShrink: 0,
         }}
       >
-        <span style={{ color: 'var(--primary)' }}>robota</span>
-        <span style={{ color: 'var(--muted-foreground)', fontWeight: 400 }}> docs</span>
+        <span
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontWeight: 700,
+            fontSize: '1rem',
+            color: 'var(--primary)',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          robota
+        </span>
+        <span
+          style={{
+            fontFamily: 'var(--font-code)',
+            fontWeight: 400,
+            fontSize: '0.75rem',
+            color: 'var(--muted-foreground)',
+            background: 'var(--muted)',
+            border: '1px solid var(--border-strong)',
+            borderRadius: '0.25rem',
+            padding: '0.1rem 0.4rem',
+            letterSpacing: '0.02em',
+          }}
+        >
+          docs
+        </span>
       </Link>
 
       {/* Center nav */}
@@ -50,7 +77,7 @@ export function Header() {
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: '0.125rem',
+          gap: '0.0625rem',
           flex: 1,
           overflowX: 'auto',
         }}
@@ -65,17 +92,18 @@ export function Header() {
               rel="noopener noreferrer"
               style={{
                 padding: '0.25rem 0.625rem',
-                fontSize: '0.85rem',
+                fontSize: '0.8rem',
+                fontFamily: 'var(--font-body)',
                 color: 'var(--muted-foreground)',
                 textDecoration: 'none',
-                borderRadius: '0.375rem',
+                borderRadius: '0.25rem',
                 whiteSpace: 'nowrap',
-                transition: 'color 0.15s, background 0.15s',
+                letterSpacing: '0.01em',
               }}
               className="nav-link"
             >
               {link.label}
-              <span style={{ fontSize: '0.7rem', marginLeft: '0.2rem', opacity: 0.6 }}>↗</span>
+              <span style={{ fontSize: '0.65rem', marginLeft: '0.2rem', opacity: 0.5 }}>↗</span>
             </a>
           ) : (
             <Link
@@ -83,12 +111,13 @@ export function Header() {
               href={link.href}
               style={{
                 padding: '0.25rem 0.625rem',
-                fontSize: '0.85rem',
+                fontSize: '0.8rem',
+                fontFamily: 'var(--font-body)',
                 color: 'var(--muted-foreground)',
                 textDecoration: 'none',
-                borderRadius: '0.375rem',
+                borderRadius: '0.25rem',
                 whiteSpace: 'nowrap',
-                transition: 'color 0.15s, background 0.15s',
+                letterSpacing: '0.01em',
               }}
               className="nav-link"
             >
@@ -110,19 +139,20 @@ export function Header() {
           rel="noopener noreferrer"
           aria-label="GitHub repository"
           style={{
-            width: 32,
-            height: 32,
+            width: 30,
+            height: 30,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             color: 'var(--muted-foreground)',
-            border: '1px solid var(--border)',
-            borderRadius: '0.375rem',
+            border: '1px solid var(--border-strong)',
+            borderRadius: '0.25rem',
             textDecoration: 'none',
             transition: 'color 0.15s, border-color 0.15s',
           }}
+          className="nav-link"
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
           </svg>
         </a>
@@ -131,15 +161,18 @@ export function Header() {
         <a
           href="https://robota.io"
           style={{
-            padding: '0.25rem 0.625rem',
-            fontSize: '0.8rem',
+            padding: '0.2rem 0.6rem',
+            fontSize: '0.75rem',
+            fontFamily: 'var(--font-code)',
             color: 'var(--muted-foreground)',
-            border: '1px solid var(--border)',
-            borderRadius: '0.375rem',
+            border: '1px solid var(--border-strong)',
+            borderRadius: '0.25rem',
             textDecoration: 'none',
             whiteSpace: 'nowrap',
             transition: 'color 0.15s, border-color 0.15s',
+            letterSpacing: '0.01em',
           }}
+          className="nav-link"
         >
           ← robota.io
         </a>

--- a/apps/docs/src/components/Sidebar.tsx
+++ b/apps/docs/src/components/Sidebar.tsx
@@ -26,9 +26,10 @@ function SidebarSection({ item, depth }: SectionProps) {
 
   const hasChildren = item.children && item.children.length > 0;
 
-  return (
-    <div>
-      {hasChildren ? (
+  if (depth === 0 && hasChildren) {
+    return (
+      <div style={{ marginBottom: '0.125rem' }}>
+        {/* Section header — clickable toggle */}
         <button
           onClick={() => setOpen((o) => !o)}
           style={{
@@ -36,19 +37,20 @@ function SidebarSection({ item, depth }: SectionProps) {
             alignItems: 'center',
             justifyContent: 'space-between',
             width: '100%',
-            padding: depth === 0 ? '0.4rem 0.75rem' : '0.3rem 0.75rem 0.3rem 1.25rem',
+            padding: '0.3rem 0.75rem',
             background: 'transparent',
             border: 'none',
-            borderRadius: '0.375rem',
-            color: isActive || isChildActive ? 'var(--primary)' : 'var(--foreground)',
-            fontWeight: depth === 0 ? 600 : 400,
-            fontSize: depth === 0 ? '0.8rem' : '0.825rem',
+            borderRadius: '0.25rem',
+            color: isChildActive || isActive ? 'var(--primary)' : 'var(--muted-foreground)',
+            fontFamily: 'var(--font-display)',
+            fontWeight: 600,
+            fontSize: '0.7rem',
             cursor: 'pointer',
             textAlign: 'left',
-            opacity: depth === 0 ? 1 : 0.85,
-            transition: 'color 0.15s, background 0.15s',
-            letterSpacing: depth === 0 ? '0.06em' : undefined,
-            textTransform: depth === 0 ? 'uppercase' : undefined,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            transition: 'color 0.15s',
+            marginTop: '1rem',
           }}
         >
           <Link
@@ -60,7 +62,7 @@ function SidebarSection({ item, depth }: SectionProps) {
           </Link>
           <span
             style={{
-              fontSize: '0.65rem',
+              fontSize: '0.6rem',
               transition: 'transform 0.2s',
               transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
               opacity: 0.5,
@@ -70,55 +72,139 @@ function SidebarSection({ item, depth }: SectionProps) {
             ▶
           </span>
         </button>
-      ) : (
-        <Link
-          href={item.href}
-          style={{
-            display: 'block',
-            padding: depth === 0 ? '0.4rem 0.75rem' : '0.3rem 0.75rem 0.3rem 1.25rem',
-            borderRadius: '0.375rem',
-            color: isActive ? 'var(--primary)' : 'var(--muted-foreground)',
-            background: isActive ? 'var(--accent-dim)' : 'transparent',
-            fontWeight: isActive ? 500 : 400,
-            fontSize: depth === 0 ? '0.8rem' : '0.825rem',
-            textDecoration: 'none',
-            transition: 'color 0.15s, background 0.15s',
-            letterSpacing: depth === 0 ? '0.06em' : undefined,
-            textTransform: depth === 0 ? 'uppercase' : undefined,
-          }}
-        >
-          {item.title}
-        </Link>
-      )}
 
-      {hasChildren && open && (
-        <div style={{ marginLeft: depth === 0 ? '0.25rem' : '0.75rem' }}>
-          {item.children!.map((child) => (
-            <SidebarSection key={child.href} item={child} depth={depth + 1} />
-          ))}
-        </div>
-      )}
-    </div>
+        {open && (
+          <div style={{ marginTop: '0.125rem' }}>
+            {item.children!.map((child) => (
+              <SidebarSection key={child.href} item={child} depth={1} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (depth === 0 && !hasChildren) {
+    return (
+      <Link
+        href={item.href}
+        style={{
+          display: 'block',
+          padding: '0.3rem 0.75rem',
+          borderRadius: '0.25rem',
+          color: isActive ? 'var(--primary)' : 'var(--muted-foreground)',
+          background: isActive ? 'var(--primary-dim)' : 'transparent',
+          borderLeft: isActive ? '2px solid var(--primary)' : '2px solid transparent',
+          fontFamily: 'var(--font-display)',
+          fontWeight: 600,
+          fontSize: '0.7rem',
+          textDecoration: 'none',
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          marginTop: '1rem',
+          transition: 'color 0.15s, background 0.15s',
+        }}
+        className="sidebar-item-link"
+      >
+        {item.title}
+      </Link>
+    );
+  }
+
+  /* depth >= 1 — leaf items */
+  const hasNestedChildren = hasChildren;
+  if (hasNestedChildren) {
+    return (
+      <div>
+        <button
+          onClick={() => setOpen((o) => !o)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            padding: '0.275rem 0.75rem 0.275rem 1.25rem',
+            background: isActive ? 'var(--primary-dim)' : 'transparent',
+            border: 'none',
+            borderLeft: isActive ? '2px solid var(--primary)' : '2px solid transparent',
+            borderRadius: '0 0.25rem 0.25rem 0',
+            color: isActive || isChildActive ? 'var(--foreground-hi)' : 'var(--muted-foreground)',
+            fontFamily: 'var(--font-body)',
+            fontWeight: isActive ? 500 : 400,
+            fontSize: '0.825rem',
+            cursor: 'pointer',
+            textAlign: 'left',
+            transition: 'color 0.15s, background 0.15s',
+          }}
+          className="sidebar-item-link"
+        >
+          <Link
+            href={item.href}
+            onClick={(e) => e.stopPropagation()}
+            style={{ color: 'inherit', textDecoration: 'none', flex: 1 }}
+          >
+            {item.title}
+          </Link>
+          <span
+            style={{
+              fontSize: '0.6rem',
+              transition: 'transform 0.2s',
+              transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+              opacity: 0.4,
+            }}
+          >
+            ▶
+          </span>
+        </button>
+        {open && (
+          <div style={{ marginLeft: '0.5rem' }}>
+            {item.children!.map((child) => (
+              <SidebarSection key={child.href} item={child} depth={depth + 1} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={item.href}
+      style={{
+        display: 'block',
+        padding: '0.275rem 0.75rem 0.275rem 1.25rem',
+        borderRadius: '0 0.25rem 0.25rem 0',
+        borderLeft: isActive ? '2px solid var(--primary)' : '2px solid transparent',
+        color: isActive ? 'var(--foreground-hi)' : 'var(--muted-foreground)',
+        background: isActive ? 'var(--primary-dim)' : 'transparent',
+        fontFamily: 'var(--font-body)',
+        fontWeight: isActive ? 500 : 400,
+        fontSize: '0.825rem',
+        textDecoration: 'none',
+        transition: 'color 0.15s, background 0.15s',
+      }}
+      className="sidebar-item-link"
+    >
+      {item.title}
+    </Link>
   );
 }
 
 export function Sidebar({ items, mobileOpen, onClose }: SidebarProps) {
   return (
     <>
-      {/* Mobile overlay */}
       {mobileOpen && (
         <div
           onClick={onClose}
           style={{
             position: 'fixed',
             inset: 0,
-            background: 'rgba(0,0,0,0.5)',
+            background: 'rgba(0,0,0,0.6)',
             zIndex: 39,
           }}
         />
       )}
 
-      {/* Sidebar panel */}
       <aside
         style={{
           position: 'fixed',
@@ -130,12 +216,11 @@ export function Sidebar({ items, mobileOpen, onClose }: SidebarProps) {
           overflowX: 'hidden',
           background: 'var(--background)',
           borderRight: '1px solid var(--border)',
-          padding: '1rem 0.5rem',
+          padding: '0.5rem 0.5rem 2rem',
           zIndex: 40,
           transform: mobileOpen ? 'translateX(0)' : undefined,
           display: 'flex',
           flexDirection: 'column',
-          gap: '0.125rem',
         }}
         className="docs-sidebar"
       >

--- a/apps/docs/src/components/TableOfContents.tsx
+++ b/apps/docs/src/components/TableOfContents.tsx
@@ -18,23 +18,15 @@ export function TableOfContents({ entries }: TableOfContentsProps) {
 
     observerRef.current = new IntersectionObserver(
       (observed) => {
-        // Find the topmost intersecting heading
         const visible = observed
           .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => {
-            const aTop = a.boundingClientRect.top;
-            const bTop = b.boundingClientRect.top;
-            return aTop - bTop;
-          });
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
 
         if (visible.length > 0) {
           setActiveId(visible[0].target.id);
         }
       },
-      {
-        rootMargin: '-60px 0px -70% 0px',
-        threshold: 0,
-      },
+      { rootMargin: '-60px 0px -70% 0px', threshold: 0 },
     );
 
     for (const id of headingIds) {
@@ -58,57 +50,68 @@ export function TableOfContents({ entries }: TableOfContentsProps) {
         alignSelf: 'flex-start',
         maxHeight: 'calc(100vh - var(--header-height) - 3rem)',
         overflowY: 'auto',
-        padding: '0 0.5rem',
       }}
     >
       <p
         style={{
-          fontSize: '0.7rem',
+          fontFamily: 'var(--font-display)',
+          fontSize: '0.65rem',
           fontWeight: 600,
-          letterSpacing: '0.08em',
+          letterSpacing: '0.12em',
           textTransform: 'uppercase',
           color: 'var(--muted-foreground)',
-          marginBottom: '0.75rem',
+          marginBottom: '0.875rem',
           marginTop: 0,
         }}
       >
         On this page
       </p>
-      <ul
-        style={{
-          listStyle: 'none',
-          margin: 0,
-          padding: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '0.125rem',
-        }}
-      >
-        {entries.map((entry) => (
-          <li key={entry.id}>
-            <a
-              href={`#${entry.id}`}
-              style={{
-                display: 'block',
-                fontSize: '0.8rem',
-                lineHeight: 1.5,
-                paddingLeft: entry.level === 3 ? '0.875rem' : '0',
-                paddingTop: '0.2rem',
-                paddingBottom: '0.2rem',
-                color: activeId === entry.id ? 'var(--primary)' : 'var(--muted-foreground)',
-                textDecoration: 'none',
-                borderLeft:
-                  entry.level === 3
-                    ? `2px solid ${activeId === entry.id ? 'var(--primary)' : 'var(--border)'}`
-                    : undefined,
-                transition: 'color 0.15s, border-color 0.15s',
-                wordBreak: 'break-word',
-              }}
-            >
-              {entry.text}
-            </a>
-          </li>
-        ))}
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {entries.map((entry) => {
+          const isActive = activeId === entry.id;
+          return (
+            <li key={entry.id} style={{ marginBottom: '0.1rem' }}>
+              <a
+                href={`#${entry.id}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '0.5rem',
+                  fontSize: '0.775rem',
+                  fontFamily: 'var(--font-body)',
+                  lineHeight: 1.55,
+                  paddingLeft: entry.level === 3 ? '1rem' : '0',
+                  paddingTop: '0.225rem',
+                  paddingBottom: '0.225rem',
+                  color: isActive ? 'var(--primary)' : 'var(--muted-foreground)',
+                  textDecoration: 'none',
+                  transition: 'color 0.15s',
+                  wordBreak: 'break-word',
+                  position: 'relative',
+                }}
+              >
+                {/* Active indicator dot */}
+                {isActive && (
+                  <span
+                    style={{
+                      position: 'absolute',
+                      left: entry.level === 3 ? '0.25rem' : '-0.75rem',
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      width: 4,
+                      height: 4,
+                      borderRadius: '50%',
+                      background: 'var(--primary)',
+                      boxShadow: '0 0 6px var(--primary)',
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
+                {entry.text}
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary

- **Color system**: `#050508` near-black bg, `#00ff88` fluorescent green accent, `#00d4ff` cyan secondary
- **Typography**: IBM Plex Mono (headings) + IBM Plex Sans (body) + JetBrains Mono (code) via `next/font`
- **Header**: gradient line (green→cyan) at top, `docs` badge in code style
- **Sidebar**: uppercase section labels, active item green left-border + bg glow
- **ToC**: glowing dot indicator on active section
- **Prose**: h2 green underline accent, green list markers, inline code green tint
- **Code blocks**: `#020207` background, gradient top border, JetBrains Mono
- **Home page**: terminal-style badge, numbered quick-link cards, green-glow CTA

## Screenshots

Home, Getting Started, CLI Reference — verified in browser before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)