### PR TITLE
feat(agent-provider): implement Anthropic vision — convert image parts to content blocks

### DIFF
--- a/.agents/backlog/CLI-014-anthropic-vision-capability-fix.md
+++ b/.agents/backlog/CLI-014-anthropic-vision-capability-fix.md
@@ -1,0 +1,51 @@
+---
+title: 'CLI-014: Anthropic provider vision capability 선언-미구현 불일치 수정'
+status: done
+created: 2026-05-23
+priority: critical
+urgency: now
+area: packages/agent-provider
+depends_on: []
+---
+
+## Background
+
+`packages/agent-provider/src/anthropic/provider-definition.ts:81`에 `'vision'`이 capabilities로 선언되어 있으나, `convertToAnthropicFormat` (`message-converter.ts:18-23`)이 user 메시지를 `content: msg.content || ''` 단일 문자열로만 변환한다. `TUniversalMessage`의 `parts` 배열(이미지 포함)을 완전히 무시한다.
+
+이미지 포함 user 메시지가 Anthropic 프로바이더에게 전달되면 이미지가 조용히 drop된다. 사용자는 vision 기능이 작동한다고 믿지만 실제로는 텍스트만 전달된다.
+
+## 작업 항목
+
+두 가지 선택지 중 하나를 선택한다:
+
+**Option A (단기 수정): capability 선언 제거**
+
+- `provider-definition.ts`에서 `'vision'`을 capabilities에서 제거
+- 이미지 포함 메시지 전달 시 명시적 에러 또는 경고 emit
+
+**Option B (완전 구현): message-converter에서 parts 처리 추가**
+
+- `convertToAnthropicFormat`이 `msg.parts` 배열을 Anthropic `content_block` 형식으로 변환
+  - `text` 파트 → `{ type: 'text', text: string }`
+  - `image` 파트 → `{ type: 'image', source: { type: 'base64', ... } }` 또는 `url` 방식
+- Anthropic API 명세에 맞는 `content_block[]` 포맷으로 user 메시지 전송
+- vision capability 선언 유지
+
+Option A를 즉시 적용하고, Option B는 별도 백로그(medium priority)로 분리하는 것을 권장한다.
+
+## Test Plan
+
+- Option A 선택 시: 이미지 포함 메시지 전송 시 capability 없음 에러가 명시적으로 발생하는지 확인
+- Option B 선택 시: base64 인코딩 이미지 포함 메시지가 Anthropic API에 올바른 형식으로 전달되는지 확인
+- capabilities 선언과 실제 동작 일치 여부 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: vision 선언 제거 확인 (Option A)
+
+```bash
+# 이미지 포함 메시지 시도 시 명시적 오류 발생 확인
+robota -p "이 이미지를 설명해줘" --attach screenshot.png
+```
+
+Expected: vision 미지원 명시적 오류 메시지 출력 (이미지 조용히 drop 없음)

--- a/packages/agent-provider/src/anthropic/__tests__/message-converter.test.ts
+++ b/packages/agent-provider/src/anthropic/__tests__/message-converter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { TUniversalMessage } from '@robota-sdk/agent-core';
+import { convertToAnthropicFormat } from '../message-converter';
+
+describe('convertToAnthropicFormat', () => {
+  it('converts plain text user message', () => {
+    const messages: TUniversalMessage[] = [
+      {
+        id: 'msg-1',
+        state: 'complete',
+        role: 'user',
+        content: 'hello',
+        timestamp: new Date(),
+      },
+    ];
+    const result = convertToAnthropicFormat(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ role: 'user', content: 'hello' });
+  });
+
+  it('converts user message with inline image part', () => {
+    const messages: TUniversalMessage[] = [
+      {
+        id: 'msg-1',
+        state: 'complete',
+        role: 'user',
+        content: 'describe this image',
+        parts: [
+          { type: 'text', text: 'describe this image' },
+          { type: 'image_inline', mimeType: 'image/png', data: 'base64abc' },
+        ],
+        timestamp: new Date(),
+      },
+    ];
+    const result = convertToAnthropicFormat(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('user');
+    const content = result[0].content as Array<{ type: string }>;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: 'text', text: 'describe this image' });
+    expect(content[1]).toEqual({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'base64abc' },
+    });
+  });
+
+  it('converts user message with URI image part', () => {
+    const messages: TUniversalMessage[] = [
+      {
+        id: 'msg-1',
+        state: 'complete',
+        role: 'user',
+        content: '',
+        parts: [{ type: 'image_uri', uri: 'https://example.com/img.jpg' }],
+        timestamp: new Date(),
+      },
+    ];
+    const result = convertToAnthropicFormat(messages);
+    const content = result[0].content as Array<{ type: string }>;
+    expect(content).toHaveLength(1);
+    expect(content[0]).toEqual({
+      type: 'image',
+      source: { type: 'url', url: 'https://example.com/img.jpg' },
+    });
+  });
+
+  it('falls back to content string when parts is empty', () => {
+    const messages: TUniversalMessage[] = [
+      {
+        id: 'msg-1',
+        state: 'complete',
+        role: 'user',
+        content: 'no parts',
+        parts: [],
+        timestamp: new Date(),
+      },
+    ];
+    const result = convertToAnthropicFormat(messages);
+    expect(result[0].content).toBe('no parts');
+  });
+});

--- a/packages/agent-provider/src/anthropic/message-converter.ts
+++ b/packages/agent-provider/src/anthropic/message-converter.ts
@@ -6,7 +6,39 @@ import type {
   IToolSchema,
   IAssistantMessage,
   IToolMessage,
+  IUserMessage,
 } from '@robota-sdk/agent-core';
+
+/** Convert IUserMessage parts to Anthropic content blocks (text + images). */
+function convertUserParts(
+  msg: IUserMessage,
+): Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> {
+  if (!msg.parts || msg.parts.length === 0) {
+    return [{ type: 'text', text: msg.content || '' }];
+  }
+
+  const blocks: Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> = [];
+  for (const part of msg.parts) {
+    if (part.type === 'text') {
+      blocks.push({ type: 'text', text: part.text });
+    } else if (part.type === 'image_inline') {
+      blocks.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: part.mimeType as Anthropic.Base64ImageSource['media_type'],
+          data: part.data,
+        },
+      });
+    } else if (part.type === 'image_uri') {
+      blocks.push({
+        type: 'image',
+        source: { type: 'url', url: part.uri },
+      });
+    }
+  }
+  return blocks;
+}
 
 /**
  * Convert TUniversalMessage array to Anthropic message format.
@@ -18,6 +50,10 @@ import type {
 export function convertToAnthropicFormat(messages: TUniversalMessage[]): Anthropic.MessageParam[] {
   return messages.map((msg) => {
     if (msg.role === 'user') {
+      const userMsg = msg as IUserMessage;
+      if (userMsg.parts && userMsg.parts.length > 0) {
+        return { role: 'user', content: convertUserParts(userMsg) };
+      }
       return {
         role: 'user',
         content: msg.content || '',


### PR DESCRIPTION
## Summary
- `convertToAnthropicFormat`이 user 메시지를 항상 `content: string`으로 변환하여 `parts` 배열의 이미지가 조용히 drop되는 버그 수정
- `provider-definition.ts`에 `'vision'` capability가 선언되어 있었지만 구현이 없었음 (선언-미구현 불일치)
- `convertUserParts()` 헬퍼 추가: `image_inline` → `Base64ImageSource`, `image_uri` → `URLImageSource`, `text` → `TextBlockParam`
- parts가 없는 경우 기존 string 변환 유지 (기존 동작 회귀 없음)

## Test plan
- [x] `pnpm --filter @robota-sdk/agent-provider typecheck` 통과
- [x] `pnpm --filter @robota-sdk/agent-provider test` 541/541 통과 (message-converter 4개 신규 포함)

Closes CLI-014

🤖 Generated with [Claude Code](https://claude.com/claude-code)