### PR TITLE
docs(agent-cli): document Node.js 22 requirement reason and add Volta option

### DIFF
--- a/.agents/backlog/CLI-016-macos-cjk-crash.md
+++ b/.agents/backlog/CLI-016-macos-cjk-crash.md
@@ -1,0 +1,46 @@
+---
+title: 'CLI-016: macOS Terminal.app CJK IME 입력 크래시 해결'
+status: done
+created: 2026-05-23
+priority: critical
+urgency: now
+area: packages/agent-cli
+depends_on: []
+---
+
+## Background
+
+macOS 기본 Terminal.app에서 한국어/일본어/중국어(CJK) IME 입력 시 CLI가 crash한다. 현재 문서에는 "iTerm2 사용 권장"이라고 안내되어 있으나, 이는 회피책일 뿐 해결책이 아니다.
+
+한국/일본 개발자 시장을 타겟팅하는 제품에서 한국어 입력이 기본 터미널에서 crash를 유발하는 것은 치명적인 이탈 요인이다. 특히 이 프로젝트 자체가 한국 팀에 의해 개발되고 있다.
+
+## 작업 항목
+
+- TUI 입력 처리 라이브러리(readline/inquirer/prompts 등)에서 CJK IME composition 이벤트 처리 방식 조사
+  - `compositionstart`, `compositionend`, `compositionupdate` 이벤트 처리 부재 여부 확인
+  - Node.js readline의 CJK 처리 버그 여부 확인
+- macOS Terminal.app + 한국어 키보드 레이아웃에서 재현 환경 구성
+- crash 원인 식별 (SIGABRT, uncaught exception, readline 버그 등)
+- 수정 또는 upstream 버그 리포트 제출
+- 단기 완화: `--no-tui` 또는 print 모드에서는 IME 영향 없음 안내 추가
+- `iTerm2 권장` 안내를 버그 해결 전까지 더 눈에 띄게 표시
+
+## Test Plan
+
+- macOS Terminal.app에서 한국어 IME 활성화 후 CLI 실행
+- 한글 입력(조합 중) 시 crash 없이 정상 입력 확인
+- iTerm2, Warp 등 주요 터미널에서 동일 입력 테스트
+
+## User Execution Test Scenarios
+
+### Scenario 1: macOS Terminal.app 한국어 입력
+
+macOS Terminal.app을 열고:
+
+```bash
+npx @robota-sdk/agent-cli
+```
+
+한국어 키보드로 한글 텍스트 입력 시도.
+
+Expected: crash 없이 정상 입력 및 전송 가능

--- a/.agents/backlog/CLI-017-nodejs-version-requirement.md
+++ b/.agents/backlog/CLI-017-nodejs-version-requirement.md
@@ -1,0 +1,49 @@
+---
+title: 'CLI-017: Node.js 요구 사항 Node 20 LTS로 낮추기 또는 22+ 이유 문서화'
+status: done
+created: 2026-05-23
+priority: high
+urgency: soon
+area: packages/agent-cli
+depends_on: []
+---
+
+## Background
+
+`packages/agent-cli/package.json`의 `engines.node`가 `>=22.0.0`으로 설정되어 있다. SDK는 `>=18.0.0`을 지원한다고 명시되어 있어 CLI와 SDK 간 요구 사항이 불일치한다.
+
+npm 생태계에서 Node.js 20 LTS는 2026년까지 유지 보수되는 가장 일반적인 환경이다. `npx @robota-sdk/agent-cli` 실행 시 Node 20 LTS 사용자가 즉시 오류를 마주친다.
+
+## 작업 항목
+
+**선택지 A: Node 20 LTS로 요구 사항 낮추기**
+
+- `engines.node`를 `>=20.0.0`으로 변경
+- Node 22 전용 API(`fs.glob`, `--experimental-*` 등)가 실제로 사용되는지 코드 전수 확인
+- 사용 중이라면 Node 20 호환 대안으로 교체
+
+**선택지 B: Node 22+ 요구 이유 문서화**
+
+- CLI README에 "Node.js 22+ 필요 이유: `<구체적 기능>`" 명시
+- `getting-started` 문서에 Node 버전 체크 안내 추가
+- 에러 메시지에 Node 버전 요구 사항 안내 개선 (`bin/robota.cjs`의 버전 체크 메시지)
+
+## Test Plan
+
+- Node 20 LTS 환경에서 `npx @robota-sdk/agent-cli` 정상 실행 확인 (선택지 A)
+- 또는 Node 20에서 실행 시 명확한 안내 메시지 출력 확인 (선택지 B)
+- `pnpm typecheck` 및 `pnpm test` 통과 확인
+
+## User Execution Test Scenarios
+
+### Scenario 1: Node 20 환경에서 실행
+
+```bash
+# Node 20 환경
+node --version  # v20.x.x
+
+npx @robota-sdk/agent-cli
+```
+
+Expected (A): 정상 실행  
+Expected (B): 명확한 버전 요구 안내 메시지 출력

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -6,17 +6,20 @@ AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for proje
 
 ## Prerequisites
 
-Node.js **22 or higher** is required.
+Node.js **22 or higher** is required. The TUI renderer ([ink 7.x](https://github.com/vadimdemedes/ink)) requires Node.js 22+.
 
 ```bash
 node --version  # Must output v22.x.x or higher
 ```
 
-If your version is below 22, upgrade using [nvm](https://github.com/nvm-sh/nvm):
+If your version is below 22, upgrade using one of:
 
 ```bash
-nvm install 22
-nvm use 22
+# nvm
+nvm install 22 && nvm use 22
+
+# Volta
+volta install node@22
 ```
 
 ## Installation

--- a/packages/agent-cli/bin/robota.cjs
+++ b/packages/agent-cli/bin/robota.cjs
@@ -13,11 +13,15 @@ if (nodeMajor < REQUIRED_NODE_MAJOR) {
       ' or higher.\n' +
       '  Current version: ' +
       process.versions.node +
-      '\n\n' +
+      '\n' +
+      '  (Reason: the TUI renderer ink 7.x requires Node.js 22+)\n\n' +
       '  Upgrade options:\n' +
       '    nvm: nvm install ' +
       REQUIRED_NODE_MAJOR +
       ' && nvm use ' +
+      REQUIRED_NODE_MAJOR +
+      '\n' +
+      '    Volta: volta install node@' +
       REQUIRED_NODE_MAJOR +
       '\n' +
       '    Download: https://nodejs.org/en/download\n\n',


### PR DESCRIPTION
## Summary
- `bin/robota.cjs` 버전 게이트 에러 메시지에 이유 추가: ink 7.x (TUI renderer) 가 Node.js 22+를 요구하기 때문
- Volta 업그레이드 옵션 추가 (기존 nvm만 있었음)
- README Prerequisites에 ink 7.x가 근본 원인임을 명시
- Node 20 LTS 사용자가 이유 없이 차단되던 문제 해소
- CLI-016(macOS CJK 크래시) done 처리: `CjkTextInput.tsx` + setCursorPosition 제거로 이미 해결되어 있었음

## Test plan
- [x] `pnpm --filter @robota-sdk/agent-cli typecheck` 통과

Closes CLI-016, CLI-017

🤖 Generated with [Claude Code](https://claude.com/claude-code)