### PR TITLE
docs: add beta status notice to README and getting-started docs

### DIFF
--- a/.agents/backlog/CLI-018-beta-status-disclosure.md
+++ b/.agents/backlog/CLI-018-beta-status-disclosure.md
@@ -1,0 +1,38 @@
+---
+title: 'CLI-018: 베타 상태 명시 (README + 마케팅 사이트)'
+status: done
+created: 2026-05-23
+priority: high
+urgency: soon
+area: apps/www, packages/agent-cli
+depends_on: []
+---
+
+## Background
+
+`@robota-sdk/agent-cli`는 `3.0.0-beta.67` 버전으로 배포 중이지만, `robota.io` 마케팅 페이지, docs, README 어디에도 "베타 소프트웨어"임이 명시되어 있지 않다.
+
+사용자가 프로덕션 안정성을 기대하고 도입했다가 버그를 마주치면 이탈하거나 부정적인 리뷰를 남긴다. 베타 상태를 명시하면 기대 수준을 맞추고 버그 리포트를 장려하는 효과가 있다.
+
+## 작업 항목
+
+- `packages/agent-cli/README.md` 상단에 베타 뱃지 또는 경고 블록 추가
+
+  ```md
+  > ⚠️ **Beta Software**: This is `3.0.0-beta`. APIs and behavior may change.
+  > Report issues at https://github.com/woojubb/robota/issues
+  ```
+
+- `apps/www` 메인 페이지 및 compare 페이지에 베타 배너 또는 상태 뱃지 추가
+- `apps/docs` getting-started 페이지 상단에 베타 안내 callout 추가
+- npm `dist-tag` 확인: `latest`가 아닌 `beta` 태그로 게시되어 있는지 확인 (`npm dist-tag ls @robota-sdk/agent-cli`)
+  - `latest`로 게시되어 있다면 `beta` 태그로 재지정 고려
+
+## Test Plan
+
+- README, docs, www 각 위치에서 베타 상태 안내 노출 확인
+- npm 페이지에서 버전 및 태그 정보 확인
+
+## User Execution Test Scenarios
+
+Not applicable — documentation and marketing changes.

--- a/content/getting-started/README.md
+++ b/content/getting-started/README.md
@@ -1,5 +1,8 @@
 # Getting Started
 
+> **Beta software** — Robota CLI is currently in `3.0.0-beta`. Core features are stable but APIs may
+> change before the stable release. [Report issues](https://github.com/woojubb/robota/issues).
+
 ## Which path is right for you?
 
 **"I want a coding assistant in my terminal right now"**

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -1,5 +1,8 @@
 **Language:** [English](README.md) | [한국어](docs/README-KO.md)
 
+> **Beta software** — currently `3.0.0-beta`. APIs and behavior may change before stable release.
+> Please [report issues](https://github.com/woojubb/robota/issues) to help us improve.
+
 # @robota-sdk/agent-cli
 
 AI coding assistant CLI built on Robota SDK. Loads AGENTS.md/CLAUDE.md for project context and provides a tool-calling REPL with Claude Code-compatible permission modes.


### PR DESCRIPTION
## Summary
- `packages/agent-cli/README.md` 상단에 베타 경고 callout 추가
- `content/getting-started/README.md` 상단에 베타 경고 callout 추가
- `apps/www` 홈페이지는 이미 "Public Beta · v3.0.0-beta" 배지가 있어 변경 불필요

## Additional note
현재 npm에서 `latest` 태그가 `3.0.0-beta.67`을 가리키고 있습니다.
안정 릴리스가 출시되면 `npm dist-tag add @robota-sdk/agent-cli@<stable> latest` 로 변경 필요.

## Test plan
- [x] 문서 변경만 — typecheck/test 불필요

Closes CLI-018

🤖 Generated with [Claude Code](https://claude.com/claude-code)