### PR TITLE
docs(cli): add CI/CD integration guide with GitHub Actions example

### DIFF
--- a/.agents/backlog/CLI-021-cicd-integration-docs.md
+++ b/.agents/backlog/CLI-021-cicd-integration-docs.md
@@ -1,0 +1,47 @@
+---
+title: 'CLI-021: CI/CD 통합 예제 문서 추가 (GitHub Actions 헤드리스 모드)'
+status: done
+created: 2026-05-23
+priority: high
+urgency: soon
+area: apps/docs
+depends_on: []
+---
+
+## Background
+
+`robota -p "..."` 헤드리스 모드와 `--output-format json` 플래그로 CI/CD 파이프라인에서 Robota CLI를 스크립트처럼 사용할 수 있지만, 이를 보여주는 문서가 없다.
+
+GitHub Actions에서 Robota를 사용하는 예제는 파워 유저 획득과 바이럴 확산에 효과적인 콘텐츠다 (Claude Code, Cursor 등 경쟁사가 이 포지션을 공략 중).
+
+## 작업 항목
+
+- `content/guide/` 또는 `content/guide/cli.md`에 "CI/CD 통합" 섹션 추가
+- GitHub Actions 워크플로우 예제 작성:
+
+  ```yaml
+  # .github/workflows/ai-review.yml
+  - name: AI Code Review
+    run: robota -p "Review the diff and suggest improvements" --output-format json
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  ```
+
+- stdin 파이프 + 헤드리스 모드 조합 예제:
+
+  ```bash
+  git diff HEAD~1 | robota -p "Review this diff"
+  ```
+
+- `--no-session-persistence` 플래그 설명 (CI 환경에서 세션 저장 불필요)
+- `--permission-mode bypassPermissions` 설명 (CI에서 확인 프롬프트 없이 실행)
+- 환경 변수로 API 키 주입 방법 안내
+
+## Test Plan
+
+- 문서의 GitHub Actions 예제가 실제로 실행 가능한 올바른 YAML인지 확인
+- 예제 명령어가 현재 CLI 버전과 일치하는지 확인
+
+## User Execution Test Scenarios
+
+Not applicable — documentation changes.

--- a/content/guide/cli.md
+++ b/content/guide/cli.md
@@ -104,6 +104,94 @@ robota -p "query" --json-schema '{"type":"object"}'
 | 0    | Success |
 | 1    | Error   |
 
+## CI/CD Integration
+
+`robota -p` headless mode is designed for unattended script and pipeline use.
+No TUI is rendered; stdout carries only the response (or structured JSON), making it safe to capture.
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/ai-review.yml
+name: AI Code Review
+
+on:
+  pull_request:
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Robota CLI
+        run: npm install -g @robota-sdk/agent-cli
+
+      - name: AI Diff Review
+        run: |
+          git diff HEAD~1 | robota -p "Review this diff and list any issues" \
+            --permission-mode bypassPermissions \
+            --no-session-persistence \
+            --output-format json
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+### Piping Input
+
+Feed context from any command directly into Robota:
+
+```bash
+# Review a git diff
+git diff HEAD~1 | robota -p "Review this diff"
+
+# Summarise test output
+pnpm test 2>&1 | robota -p "Summarise failures and suggest fixes"
+
+# Analyse a file
+cat src/index.ts | robota -p "Find security issues"
+```
+
+### CI-Specific Flags
+
+| Flag                                  | Purpose                                                      |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `--permission-mode bypassPermissions` | Skip all confirmation prompts — required for unattended runs |
+| `--no-session-persistence`            | Do not write session files to disk                           |
+| `--output-format json`                | Machine-readable output; parse with `jq`                     |
+| `--output-format stream-json`         | Newline-delimited JSON for streaming pipelines               |
+| `--max-turns <n>`                     | Limit agentic loops to prevent runaway costs                 |
+
+### Parsing JSON Output
+
+```bash
+# Extract just the text result
+robota -p "Summarise the project" --output-format json | jq -r '.result'
+
+# Check success
+result=$(robota -p "Run checks" --output-format json)
+if [ "$(echo "$result" | jq -r '.subtype')" = "success" ]; then
+  echo "AI review passed"
+fi
+```
+
+### Environment Variables in CI
+
+Store provider API keys as encrypted secrets and inject them as environment variables.
+Robota reads them using the same names as in local development:
+
+```bash
+ANTHROPIC_API_KEY=...   # Claude (default)
+OPENAI_API_KEY=...      # OpenAI
+GEMINI_API_KEY=...      # Gemini
+```
+
 ## Interactive TUI
 
 The TUI (built with React + Ink) provides:


### PR DESCRIPTION
## Summary

- Adds **CI/CD Integration** section to `content/guide/cli.md` (between Headless Mode and Interactive TUI)
- GitHub Actions workflow example: install CLI, pipe `git diff`, run review
- Stdin piping examples (diff, test output, file analysis)
- CI-specific flags table: `--permission-mode bypassPermissions`, `--no-session-persistence`, `--output-format`, `--max-turns`
- JSON output parsing with `jq`
- Environment variable setup for all three providers

## Closes

CLI-021

## Test plan

- [ ] YAML in GitHub Actions example is valid syntax
- [ ] All CLI flags referenced exist in current `--help` output
- [ ] Section renders correctly in docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)