### PR TITLE
design: finalize CLI-025 and CLI-026 architecture docs

### DIFF
--- a/.design/cli-025-provider-hot-swap.md
+++ b/.design/cli-025-provider-hot-swap.md
@@ -1,8 +1,10 @@
 # CLI-025: 프로바이더 핫 스왑 설계
 
+> **결정 사항:** `/model` 커맨드는 삭제. 프로바이더/모델 전환은 `/provider switch <profile-name>` 단일 경로로 통일한다.
+
 ## 배경
 
-현재 `/model` 또는 `/provider switch` 커맨드는 CLI를 재시작한다. 재시작 시 세션 히스토리가 보존되지 않아 장기 세션에서 모델 전환이 불편하다.
+현재 `/provider switch` 커맨드는 CLI를 재시작한다. 재시작 시 세션 히스토리가 보존되지 않아 장기 세션에서 프로바이더 전환이 불편하다.
 
 ## 현재 구조
 
@@ -56,30 +58,35 @@ swapProvider(newProvider: IAIProvider): void {
 
 ## `/provider switch` UX
 
-현재 `/provider` 커맨드는 TUI 메뉴를 연다. 헤드리스 경로에서는 목록을 출력한다.
-
-변경: `/provider switch <profile-name>` 서브커맨드 추가.
+`/provider switch <profile-name>` 서브커맨드로 프로바이더와 모델을 동시에 전환한다.
+프로파일은 `settings.json`에 정의된 named provider profile이다 (type + model + apiKey 포함).
 
 ```
 /provider switch openai
 → "Switched to openai (gpt-4o). History preserved. (Turn 12)"
+
+/provider switch anthropic-opus
+→ "Switched to anthropic-opus (claude-opus-4-7). History preserved. (Turn 12)"
 ```
 
-기존 `/model` 커맨드의 재시작 동작은 유지하되, `/provider switch`는 재시작 없이 동작한다.
+TUI에서는 `/provider` 메뉴 → "Switch" 항목에서 선택, 헤드리스에서는 직접 서브커맨드로 호출 가능.
+
+**`/model` 커맨드는 삭제한다.** 모델 선택은 프로파일 관리(`/provider add/edit`)를 통해 처리한다.
 
 ## 영향 범위
 
-| 파일                                                              | 변경 내용                                      |
-| ----------------------------------------------------------------- | ---------------------------------------------- |
-| `packages/agent-core/src/session.ts`                              | `swapProvider()` 메서드 추가                   |
-| `packages/agent-framework/src/interactive/interactive-session.ts` | `swapProvider()` 메서드 추가                   |
-| `packages/agent-command/src/provider/provider-switch-command.ts`  | `/provider switch` 서브커맨드 신규             |
-| `packages/agent-framework/src/runtime/agent-runtime.ts`           | `IAgentRuntime`에 optional `swapProvider` 노출 |
+| 파일                                                              | 변경 내용                                   |
+| ----------------------------------------------------------------- | ------------------------------------------- |
+| `packages/agent-core/src/session.ts`                              | `swapProvider()` 메서드 추가, SPEC.md 수정  |
+| `packages/agent-framework/src/interactive/interactive-session.ts` | `swapProvider()` 메서드 추가                |
+| `packages/agent-command/src/provider/provider-switch-command.ts`  | `/provider switch` 서브커맨드 신규          |
+| `packages/agent-command/src/model/`                               | `/model` 커맨드 **삭제**                    |
+| `packages/agent-cli/src/utils/cli-args.ts`                        | `--model` 플래그 및 관련 help 텍스트 삭제   |
+| `content/guide/cli.md`                                            | `/model` 제거, `/provider switch` 추가 설명 |
 
 ## 리스크
 
 - `agent-core/Session`은 현재 provider를 불변으로 설계됨 — setter 추가 시 SPEC.md 수정 필요
-- `/model` 커맨드와 `/provider switch`의 동작 차이를 사용자가 혼동할 수 있음 (문서화 필요)
 - 히스토리 포맷 호환성: vision parts를 가진 메시지를 vision 미지원 provider로 전환 시 parts가 조용히 drop됨 — 경고 메시지 추가 권장
 
 ## 구현 순서

--- a/.design/cli-025-provider-hot-swap.md
+++ b/.design/cli-025-provider-hot-swap.md
@@ -1,0 +1,90 @@
+# CLI-025: 프로바이더 핫 스왑 설계
+
+## 배경
+
+현재 `/model` 또는 `/provider switch` 커맨드는 CLI를 재시작한다. 재시작 시 세션 히스토리가 보존되지 않아 장기 세션에서 모델 전환이 불편하다.
+
+## 현재 구조
+
+```
+InteractiveSession
+  └── provider: IAIProvider  (생성 시 주입, 이후 불변)
+      └── Session (agent-core)
+          └── ConversationStore → history
+```
+
+`InteractiveSession`은 `provider`를 생성자에서 받아 `agent-core/Session` 인스턴스로 넘긴다. `Session` 내부도 provider를 불변으로 보유한다.
+
+## 설계 방향
+
+### Option A: InteractiveSession에 `swapProvider()` 추가 (권장)
+
+`InteractiveSession`에 `swapProvider(newProvider: IAIProvider): void` 메서드를 추가한다.
+
+```typescript
+// packages/agent-framework/src/interactive/interactive-session.ts
+swapProvider(newProvider: IAIProvider): void {
+  // 1. 현재 진행 중인 generation 중단
+  this.session?.abort();
+  // 2. agent-core Session의 provider 교체
+  this.session?.swapProvider(newProvider);
+  // 3. 내부 provider 참조 업데이트
+  this._provider = newProvider;
+}
+```
+
+`agent-core/Session`에도 `swapProvider()` 메서드를 추가해야 한다:
+
+```typescript
+// packages/agent-core/src/session.ts
+swapProvider(newProvider: IAIProvider): void {
+  this.provider = newProvider;
+  // history는 유지, 새 provider에 맞게 parts 필터링은 하지 않음
+  // (포맷 비호환은 각 provider converter가 gracefully 처리)
+}
+```
+
+**포맷 호환성:** 기존 히스토리에 vision parts가 있는데 새 provider가 vision을 지원하지 않으면, 해당 provider의 message-converter가 parts를 무시하고 text만 전달한다 (현재 fallback 동작).
+
+**히스토리 압축(compaction):** 선택적 옵션으로 `swapProvider(provider, { compact: true })`를 통해 전환 전 히스토리를 요약할 수 있다.
+
+### Option B: 새 Session 생성 + history 이전 (복잡)
+
+기존 세션을 종료하고 새 Session을 만든 뒤, 히스토리를 복사하는 방식. 이벤트 핸들러/transport 재연결이 필요해 복잡도가 높다.
+
+**→ Option A를 권장.**
+
+## `/provider switch` UX
+
+현재 `/provider` 커맨드는 TUI 메뉴를 연다. 헤드리스 경로에서는 목록을 출력한다.
+
+변경: `/provider switch <profile-name>` 서브커맨드 추가.
+
+```
+/provider switch openai
+→ "Switched to openai (gpt-4o). History preserved. (Turn 12)"
+```
+
+기존 `/model` 커맨드의 재시작 동작은 유지하되, `/provider switch`는 재시작 없이 동작한다.
+
+## 영향 범위
+
+| 파일                                                              | 변경 내용                                      |
+| ----------------------------------------------------------------- | ---------------------------------------------- |
+| `packages/agent-core/src/session.ts`                              | `swapProvider()` 메서드 추가                   |
+| `packages/agent-framework/src/interactive/interactive-session.ts` | `swapProvider()` 메서드 추가                   |
+| `packages/agent-command/src/provider/provider-switch-command.ts`  | `/provider switch` 서브커맨드 신규             |
+| `packages/agent-framework/src/runtime/agent-runtime.ts`           | `IAgentRuntime`에 optional `swapProvider` 노출 |
+
+## 리스크
+
+- `agent-core/Session`은 현재 provider를 불변으로 설계됨 — setter 추가 시 SPEC.md 수정 필요
+- `/model` 커맨드와 `/provider switch`의 동작 차이를 사용자가 혼동할 수 있음 (문서화 필요)
+- 히스토리 포맷 호환성: vision parts를 가진 메시지를 vision 미지원 provider로 전환 시 parts가 조용히 drop됨 — 경고 메시지 추가 권장
+
+## 구현 순서
+
+1. `agent-core/Session.swapProvider()` 추가 + SPEC.md 수정
+2. `InteractiveSession.swapProvider()` 추가
+3. `/provider switch <name>` 커맨드 구현
+4. 통합 테스트 작성

--- a/.design/cli-026-enterprise-settings.md
+++ b/.design/cli-026-enterprise-settings.md
@@ -30,22 +30,38 @@ org-policy.json  (org/system — 최상위, 모든 설정 오버라이드 가능
 `org-policy`는 **오버라이드(override)가 아니라 제약(constraint)** 모델로 동작한다.
 개인/프로젝트 설정이 정책 범위를 초과하면 시작 시 에러를 발생시킨다.
 
+### 확정된 설계 결정
+
+| 항목                      | 결정                                                                  |
+| ------------------------- | --------------------------------------------------------------------- |
+| fetch 실패 시             | **fail-open + 경고** (캐시 있으면 캐시 사용, 없으면 정책 미적용 계속) |
+| `strictEnforcement: true` | fail-closed 옵션 (정책 파일 자체에서 선택)                            |
+| 원격 fetch                | **v1 포함** — HTTPS 전용, 3초 timeout, 1시간 TTL 캐시                 |
+| 인증 헤더                 | v1 없음 (네트워크 접근 제어에 의존)                                   |
+| `auditLogEndpoint`        | **v2로 연기**                                                         |
+| tool 접근 제어            | `allowedTools` (allowlist 방식 유지)                                  |
+
 ### 정책 파일 로드 경로
 
 우선순위 순:
 
-1. `ROBOTA_ORG_POLICY_URL` 환경 변수 → HTTP(S) fetch (원격 배포 지원)
+1. `ROBOTA_ORG_POLICY_URL` 환경 변수 → HTTPS fetch (3s timeout, 1h TTL 캐시)
 2. `ROBOTA_ORG_POLICY_FILE` 환경 변수 → 파일 경로
 3. `~/.robota/org-policy.json` → 사용자 로컬 (MDM 배포용)
 
-파일이 없으면 정책 없음 (기존 동작 유지).
+파일/URL이 없으면 정책 없음 (기존 동작 유지).  
+fetch 실패 시: 캐시 → fail-open with warning.
 
-### `org-policy.json` 스키마
+캐시 경로: `~/.robota/org-policy-cache.json`
+
+### `org-policy.json` 스키마 (v1 확정)
 
 ```typescript
 interface IOrgPolicy {
   version: 1;
-  /** 사용 가능한 tool 목록. 미지정 시 제한 없음 */
+  /** true = 정책 로드 실패 시 시작 차단 (기본: false = fail-open) */
+  strictEnforcement?: boolean;
+  /** 허용된 tool 이름 목록 (allowlist). 미지정 시 제한 없음 */
   allowedTools?: string[];
   /** 차단된 slash-command 목록 */
   blockedCommands?: string[];
@@ -53,8 +69,6 @@ interface IOrgPolicy {
   allowedProviders?: string[];
   /** API 키를 반드시 env var에서 로드 강제 */
   requireApiKeyFromEnv?: boolean;
-  /** 감사 로그 수집 엔드포인트 */
-  auditLogEndpoint?: string;
   /** 정책 위반 시 표시할 관리자 연락처 */
   adminContact?: string;
 }
@@ -65,13 +79,17 @@ interface IOrgPolicy {
 1. **시작 시 (startup):** `config-loader.ts`에서 org-policy를 로드하고 `IResolvedConfig`와 교차 검증
 2. **커맨드 실행 시 (runtime):** `blockedCommands`는 `CommandRegistry`에서 커맨드 등록 전 필터링
 3. **tool 실행 시:** `allowedTools`는 `InteractiveSession`의 tool 호출 시 검증
+4. **provider 전환 시:** `allowedProviders`는 `/provider switch` 시점에도 재검증
 
 ### 에러 메시지 예시
 
 ```
 [Org Policy] Provider "openai" is not in the allowed providers list.
-Allowed providers: anthropic
+Allowed: anthropic
 Contact your administrator: security@example.com
+
+[Org Policy] WARNING: Policy could not be loaded (fetch failed). Running without policy enforcement.
+Retry URL: https://policy.example.com/robota-policy.json
 ```
 
 ## 영향 범위

--- a/.design/cli-026-enterprise-settings.md
+++ b/.design/cli-026-enterprise-settings.md
@@ -1,0 +1,100 @@
+# CLI-026: 엔터프라이즈 설정 레이어 설계
+
+## 배경
+
+현재 설정 우선순위 (낮은 것 → 높은 것):
+
+```
+~/.robota/settings.json       (user)
+~/.claude/settings.json       (user, Claude Code compat)
+.robota/settings.json         (project)
+.robota/settings.local.json   (project-local)
+.claude/settings.json         (project, Claude Code compat)
+.claude/settings.local.json   (project-local, 최우선)
+```
+
+조직 정책을 강제할 수 있는 `org` 레이어가 없다.
+
+## 설계 방향
+
+### 설정 우선순위 (확장 후)
+
+```
+org-policy.json  (org/system — 최상위, 모든 설정 오버라이드 가능)
+  ↓ 위반 시 에러, 허용된 범위 내에서만 아래 레이어 적용
+~/.robota/settings.json       (user)
+.robota/settings.local.json   (project-local)
+...
+```
+
+`org-policy`는 **오버라이드(override)가 아니라 제약(constraint)** 모델로 동작한다.
+개인/프로젝트 설정이 정책 범위를 초과하면 시작 시 에러를 발생시킨다.
+
+### 정책 파일 로드 경로
+
+우선순위 순:
+
+1. `ROBOTA_ORG_POLICY_URL` 환경 변수 → HTTP(S) fetch (원격 배포 지원)
+2. `ROBOTA_ORG_POLICY_FILE` 환경 변수 → 파일 경로
+3. `~/.robota/org-policy.json` → 사용자 로컬 (MDM 배포용)
+
+파일이 없으면 정책 없음 (기존 동작 유지).
+
+### `org-policy.json` 스키마
+
+```typescript
+interface IOrgPolicy {
+  version: 1;
+  /** 사용 가능한 tool 목록. 미지정 시 제한 없음 */
+  allowedTools?: string[];
+  /** 차단된 slash-command 목록 */
+  blockedCommands?: string[];
+  /** 허용된 provider type 목록 */
+  allowedProviders?: string[];
+  /** API 키를 반드시 env var에서 로드 강제 */
+  requireApiKeyFromEnv?: boolean;
+  /** 감사 로그 수집 엔드포인트 */
+  auditLogEndpoint?: string;
+  /** 정책 위반 시 표시할 관리자 연락처 */
+  adminContact?: string;
+}
+```
+
+### 정책 적용 시점
+
+1. **시작 시 (startup):** `config-loader.ts`에서 org-policy를 로드하고 `IResolvedConfig`와 교차 검증
+2. **커맨드 실행 시 (runtime):** `blockedCommands`는 `CommandRegistry`에서 커맨드 등록 전 필터링
+3. **tool 실행 시:** `allowedTools`는 `InteractiveSession`의 tool 호출 시 검증
+
+### 에러 메시지 예시
+
+```
+[Org Policy] Provider "openai" is not in the allowed providers list.
+Allowed providers: anthropic
+Contact your administrator: security@example.com
+```
+
+## 영향 범위
+
+| 파일                                                              | 변경 내용                                      |
+| ----------------------------------------------------------------- | ---------------------------------------------- |
+| `packages/agent-framework/src/config/org-policy-loader.ts`        | 신규 — 정책 파일 로드 및 파싱                  |
+| `packages/agent-framework/src/config/config-loader.ts`            | org-policy 로드 후 `IResolvedConfig` 교차 검증 |
+| `packages/agent-framework/src/config/config-types.ts`             | `IOrgPolicy` 타입 추가                         |
+| `packages/agent-command/src/`                                     | `blockedCommands` 필터링 적용                  |
+| `packages/agent-framework/src/interactive/interactive-session.ts` | `allowedTools` 정책 검증                       |
+
+## 리스크
+
+- **원격 fetch 실패 시 동작:** 기본값은 "fail open" (정책 없음으로 처리) vs "fail closed" (시작 불가) — 팀 논의 필요
+- **정책 파일 위변조:** HTTP fetch 시 HTTPS 강제 + 인증 토큰 지원 필요 여부 검토
+- **성능:** 시작 시 원격 fetch가 startup latency를 증가시킬 수 있음 — 캐싱 전략 필요
+
+## 구현 순서
+
+1. `IOrgPolicy` 타입 + `org-policy-loader.ts` 구현 (파일 기반부터)
+2. `config-loader.ts`에 교차 검증 통합
+3. `blockedCommands` 커맨드 필터링 적용
+4. `allowedTools` 툴 실행 시 검증
+5. 원격 fetch 지원 (HTTPS only, timeout)
+6. 단위 테스트 및 통합 테스트


### PR DESCRIPTION
Design documents for review. No code changes.

- `.design/cli-025-provider-hot-swap.md` — `/model` deletion, `/provider switch` hot-swap via `swapProvider()`
- `.design/cli-026-enterprise-settings.md` — fail-open+cache, remote fetch v1, `allowedTools` allowlist, `auditLogEndpoint` deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)