### PR TITLE
docs(rules): establish live spec policy — SPEC.md as continuously evolving contract

### DIFF
--- a/.agents/rules/spec-workflow.md
+++ b/.agents/rules/spec-workflow.md
@@ -3,6 +3,41 @@
 Rules governing spec-first development, conformance verification, and spec maintenance.
 Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 
+### Live Spec Policy
+
+A `docs/SPEC.md` is a **living document**. It is never "done" — it grows with every change to its
+package. The spec is the canonical description of what the package is _right now_, not what it was
+when it was first written.
+
+**Universal update mandate.** Every PR that introduces any of the following MUST update the
+governing `docs/SPEC.md` in the same PR:
+
+| What changed                                   | SPEC section to update                  |
+| ---------------------------------------------- | --------------------------------------- |
+| New or removed public export                   | Public API Surface                      |
+| New or changed type or interface               | Type Ownership                          |
+| New class or `implements`/`extends` relation   | Class Contract Registry                 |
+| New or changed error type or code              | Error Taxonomy                          |
+| New or changed lifecycle event                 | State Lifecycle / Event Architecture    |
+| New or changed behavior or semantics           | Architecture Overview, relevant section |
+| New extension point (abstract class, callback) | Extension Points                        |
+
+A PR that changes package behavior without updating the SPEC is an **incomplete change** — treated
+the same as a missing test or a build failure.
+
+**Incremental evolution.** Only the sections affected by a change need to be updated. Never
+rewrite the whole document for a localized change. Add, edit, or remove only the rows, paragraphs,
+or tables that describe the changed behavior.
+
+**Spec-first invariant.** Write the new SPEC section(s) before writing implementation code. The
+spec is the design artifact. Implementation fills in what the spec already describes. Back-filling
+the spec after implementation is a process violation — the spec must come first.
+
+**Spec drift is a process violation.** If `docs/SPEC.md` no longer accurately describes the
+current state of its package, every subsequent PR on that package is incomplete. When drift is
+detected, schedule a SPEC catch-up as a dedicated backlog item before continuing normal work. See
+[`spec-code-conformance`](../skills/spec-code-conformance/SKILL.md) for the drift resolution loop.
+
 ### Spec-First Development
 
 - Any change touching a contract boundary (package imports, class dependencies, service connections, cross-package types) MUST update or create the governing spec BEFORE writing implementation code.

--- a/.agents/skills/spec-first-development/SKILL.md
+++ b/.agents/skills/spec-first-development/SKILL.md
@@ -1,74 +1,91 @@
 ---
 name: spec-first-development
-description: Use before implementing any change that touches a contract boundary (package imports, class dependencies, service connections, cross-package types). Ensures the governing spec is updated before code is written and a verification test plan exists.
+description: Use before implementing any change that adds, removes, or modifies package behavior, public API, types, or contracts. Ensures the governing spec is updated before code is written and a verification test plan exists.
 ---
 
 ## Rule Anchor
 
-- "Spec-First Development" in `.agents/rules/process.md`
+- "Live Spec Policy" in `.agents/rules/spec-workflow.md`
+- "Spec-First Development" in `.agents/rules/spec-workflow.md`
 
 ## When to Use
 
-Trigger this skill when a change affects any of these:
-- Package public API surface (exports, types, interfaces)
-- HTTP/WebSocket API endpoints (request/response shapes)
-- Class-to-class dependencies across module boundaries
-- Cross-package type definitions or contracts
+Trigger this skill for **any** of the following — not only contract-boundary changes:
+
+- Adding a new feature or behavior to a package
+- Changing existing behavior, semantics, or configuration
+- Adding or removing a public export (class, function, type, constant)
+- Adding or changing an error type, code, or recoverability
+- Adding or changing a lifecycle event or state transition
+- Adding or changing an HTTP/WebSocket endpoint (request/response shapes)
+- Adding or changing a class-to-class dependency across module boundaries
+- Removing a feature or deprecating an export
+
+If the change only touches internal implementation details with no observable behavioral difference
+and no public API change, the spec update is not required — but if in doubt, update the spec.
 
 ## Workflow
 
-### Step 1: Identify contract boundaries
+### Step 1: Identify the affected package and spec
 
-List all package/service/class connections affected by the change.
-For each boundary, answer:
-- What is the current spec? (SPEC.md, OpenAPI, contract definition, or none)
-- What part of the spec changes?
+Name the package that owns the changed behavior. Locate its governing spec:
 
-### Step 2: Check existing specs
+- Package behavior / public surface → `packages/<name>/docs/SPEC.md`
+- HTTP API → OpenAPI or API spec document
+- Cross-package contract → `.agents/specs/` cross-cutting spec
 
-For each identified boundary:
-- Package surface → check `packages/<name>/docs/SPEC.md`
-- HTTP API → check OpenAPI or API spec document
-- Class contract → check contract definition in owning package
+If no spec exists for the package, create one using
+[`spec-writing-standard`](../spec-writing-standard/SKILL.md) Mode A (Initial Creation) before
+continuing.
 
-If no spec exists, one must be created before proceeding.
+### Step 2: Determine which SPEC sections change
 
-### Step 3: Update or create spec
+Use the lookup table in [`spec-writing-standard`](../spec-writing-standard/SKILL.md) Mode B
+(Incremental Update, Step 1) to list the sections that must be updated. Write the list down before
+touching any code.
 
-- **Package SPEC.md** → use [`spec-writing-standard`](../spec-writing-standard/SKILL.md)
-- **API specification** → use [`api-spec-management`](../api-spec-management/SKILL.md)
-- **Class contract** → document in the owning package's `docs/SPEC.md` or dedicated contract file
+### Step 3: Update the spec incrementally
 
-The spec change must be reviewed and approved before implementation begins.
+Apply the targeted spec update using
+[`spec-writing-standard`](../spec-writing-standard/SKILL.md) Mode B (Incremental Update). Only
+the sections identified in Step 2 are changed.
 
-### Step 4: Define verification test plan
+For API specs, use [`api-spec-management`](../api-spec-management/SKILL.md).
 
-For each spec change, define:
-- **What to test:** which contract assertions validate the change
-- **How to test:** unit / integration / contract test
-- **Commands to run:** exact verification commands
+The spec update must be committed **before** or **in the same commit as** the implementation code.
+It must never be deferred to after the PR.
+
+### Step 4: Define a verification test plan
+
+For each spec section updated, state:
+
+- **What to verify**: which contract assertions validate the change
+- **How to verify**: unit / integration / contract test
+- **Commands to run**: exact verification commands
 
 Use [`contract-audit`](../contract-audit/SKILL.md) for contract consistency checks.
 
 ### Step 5: Implement to spec
 
-- Write code that conforms to the updated spec
+- Write code that conforms to the updated spec — the spec is now the design artifact
 - Follow TDD cycle (see [`tdd-red-green-refactor`](../tdd-red-green-refactor/SKILL.md))
 - Build and verify (see [`repo-change-loop`](../repo-change-loop/SKILL.md))
 
 ### Step 6: Verify conformance
 
-- After implementation, run the full conformance verification loop
-- See [`spec-code-conformance`](../spec-code-conformance/SKILL.md)
-- This step is mandatory — implementation is not complete until conformance is verified with zero gaps and regression tests pass
+Run the full conformance verification loop after implementation:
+
+- See [`spec-code-conformance`](../skills/spec-code-conformance/SKILL.md)
+- Implementation is not complete until conformance is verified with zero gaps and regression tests
+  pass
 
 ## Orchestrated Skills
 
-| Skill | Role in this workflow |
-|-------|----------------------|
-| `spec-writing-standard` | SPEC.md structure and quality gates |
-| `api-spec-management` | API spec format and update workflow |
-| `contract-audit` | Contract consistency verification |
-| `tdd-red-green-refactor` | Implementation cycle |
-| `repo-change-loop` | Build and verify loop |
-| `spec-code-conformance` | Post-implementation conformance verification loop |
+| Skill                    | Role in this workflow                        |
+| ------------------------ | -------------------------------------------- |
+| `spec-writing-standard`  | SPEC.md incremental update and quality gates |
+| `api-spec-management`    | API spec format and update workflow          |
+| `contract-audit`         | Contract consistency verification            |
+| `tdd-red-green-refactor` | Implementation cycle                         |
+| `repo-change-loop`       | Build and verify loop                        |
+| `spec-code-conformance`  | Post-implementation conformance verification |

--- a/.agents/skills/spec-writing-standard/SKILL.md
+++ b/.agents/skills/spec-writing-standard/SKILL.md
@@ -1,88 +1,193 @@
 ---
 name: spec-writing-standard
-description: Use when creating or updating a package SPEC.md. Defines required sections, quality gates, and drift detection workflow.
+description: Use when creating a new SPEC.md or incrementally updating an existing one. Covers both initial authoring and the ongoing incremental-update workflow that keeps the spec live.
 ---
 
 ## Rule Anchor
 
+- "Live Spec Policy" in `.agents/rules/spec-workflow.md`
 - "Owner Knowledge Policy" in `AGENTS.md`
-- "Spec Quality Gate" in `AGENTS.md`
-- "Continuous Improvement" in `AGENTS.md`
 
 ## Use This Skill When
 
-- Creating a new `docs/SPEC.md` for a workspace package or app.
-- Reviewing or expanding an existing SPEC.md that is too minimal.
-- Checking whether a SPEC.md reflects the current implementation after significant changes.
+- Creating a new `docs/SPEC.md` for a workspace package or app. → use **Initial Creation Mode**.
+- Updating an existing SPEC.md because a PR changed behavior, exports, types, or contracts. → use **Incremental Update Mode**.
+- Recovering a drifted SPEC.md that has fallen out of sync with its package. → use **Drift Recovery Mode**.
 
-## Preconditions
+---
+
+## Mode A — Initial Creation
+
+Use when no `docs/SPEC.md` exists for the package.
+
+### Preconditions
 
 - The workspace package exists in `pnpm-workspace.yaml`.
 - `docs/README.md` exists and references `SPEC.md`.
 - You have read the package source code sufficiently to describe its architecture.
 
-## Execution Steps
+### Steps
 
-1. **Read current source**: Understand the package's directory structure, key classes, interfaces, and exports.
+1. **Read current source**: Understand the package's directory structure, key classes, interfaces,
+   and exports.
 
-2. **Check existing SPEC.md**: Read `docs/SPEC.md` if it exists. Identify missing required sections.
-
-3. **Write or update required sections** (all are mandatory):
-
-   - **Scope**: What the package owns (2-4 sentences).
+2. **Write all required sections** (all mandatory):
+   - **Scope**: What the package owns (2–4 sentences).
    - **Boundaries**: What the package does NOT own and where those responsibilities live.
    - **Architecture Overview**: Layer structure, key components, design patterns used.
-   - **Type Ownership**: SSOT types this package defines. Table format: Type | Location | Purpose.
-   - **Public API Surface**: Exported classes, functions, types. Table format: Export | Kind | Description.
+   - **Type Ownership**: SSOT types this package defines. Table: Type | Location | Purpose.
+   - **Public API Surface**: Exported classes, functions, types. Table: Export | Kind | Description.
    - **Extension Points**: How consumers extend behavior (abstract classes, interfaces, strategies).
-   - **Error Taxonomy**: Error types with codes, categories, recoverability. Table format if applicable.
+   - **Error Taxonomy**: Error types with codes, categories, recoverability. Table if applicable.
    - **Test Strategy**: Current test files, scenario verification, coverage gaps.
-   - **Class Contract Registry**: Interface implementations, inheritance chains, and cross-package port consumers for this package.
+   - **Class Contract Registry**: Interface implementations, inheritance chains, cross-package port
+     consumers.
 
-4. **Write optional sections** (include when applicable):
+3. **Write applicable optional sections**:
+   - **Plugin/Hook Contract** — if the package has a plugin or hook system.
+   - **Event Architecture** — if the package emits or consumes events.
+   - **State Lifecycle** — if the package manages stateful objects with transitions.
+   - **Dependencies** — production dependencies and key peer contracts.
+   - **Configuration** — required and optional configuration options.
 
-   - **Plugin/Hook Contract**: If the package has a plugin or hook system.
-   - **Event Architecture**: If the package emits or consumes events.
-   - **State Lifecycle**: If the package manages stateful objects with transitions.
-   - **Dependencies**: Production dependencies and key peer contracts.
-   - **Configuration**: Required and optional configuration options.
+4. **Verify consistency**: Every type name, export symbol, and error class referenced in the spec
+   must exist in source.
 
-5. **Verify consistency**: Ensure SPEC.md content matches actual code.
-   - Type names in the ownership table must exist in source.
-   - Exported symbols in the API surface must exist in `index.ts`.
-   - Error classes in the taxonomy must exist in the error module.
+5. **Run harness scan**: `pnpm harness:scan:specs`.
 
-6. **Run harness scan**: `pnpm harness:scan:specs` to verify the spec is detected.
+---
+
+## Mode B — Incremental Update
+
+Use on every PR that changes package behavior, exports, types, or contracts. The spec is updated
+**before** implementation code is written (see Live Spec Policy).
+
+This mode is surgical: only sections affected by the change are touched. Unaffected sections are
+not rewritten.
+
+### Step 1 — Identify affected sections
+
+Use the table below to determine which sections need updating:
+
+| What is changing in this PR                    | Section(s) to update                    |
+| ---------------------------------------------- | --------------------------------------- |
+| New or removed public export                   | Public API Surface                      |
+| New or changed type or interface               | Type Ownership                          |
+| New class or changed `implements`/`extends`    | Class Contract Registry                 |
+| New or changed error type or code              | Error Taxonomy                          |
+| New or changed lifecycle event                 | State Lifecycle / Event Architecture    |
+| Changed behavioral semantics                   | Architecture Overview, relevant section |
+| New extension point (abstract class, callback) | Extension Points                        |
+| Changed configuration options                  | Configuration                           |
+| Changed test strategy or coverage              | Test Strategy                           |
+
+### Step 2 — Read the current SPEC sections
+
+Read only the sections identified in Step 1. Do not read sections that are not affected.
+
+### Step 3 — Write the delta
+
+For each affected section:
+
+- **New row in a table**: add the row. Do not renumber or reformat existing rows.
+- **Changed row**: edit that row only.
+- **Removed export or type**: delete the row. If a section becomes empty, state "None" or remove
+  the section heading if optional.
+- **Narrative paragraph**: edit the relevant sentence or paragraph. Do not rewrite the section.
+
+### Step 4 — Consistency check
+
+For every item added or changed in the spec:
+
+- Type names must exist (or will exist in the same PR) in source.
+- Export symbols must appear (or will appear) in `index.ts`.
+- Error classes must exist (or will exist) in the error module.
+
+### Step 5 — Commit the spec update with the implementation
+
+The spec change and the implementation change belong in the same commit or the same PR. Never
+split them into separate PRs unless the spec update is a drift recovery (see Mode C).
+
+---
+
+## Mode C — Drift Recovery
+
+Use when a SPEC.md has accumulated drift across multiple PRs that skipped updates.
+
+1. **Enumerate drift**: Run `pnpm harness:review -- --scope <pkg>` and read the current SPEC
+   section by section against the actual code.
+2. **List gaps**: Create a table of spec assertions that no longer match the code, and code
+   behaviors that are not in the spec.
+3. **Resolve each gap as a targeted incremental update** (Mode B, Step 3). Fix the spec to match
+   the current code — drift recovery corrects the spec to describe reality.
+4. **Re-run consistency check** (Mode B, Step 4) until zero gaps remain.
+5. **Run full conformance verification**: `pnpm --filter <pkg> build && pnpm --filter <pkg> test`.
+
+Drift recovery is a dedicated PR. Do not mix drift recovery with feature work.
+
+---
+
+## Required Sections Reference
+
+All nine sections below are mandatory in every complete SPEC.md:
+
+| #   | Section                 | Purpose                            |
+| --- | ----------------------- | ---------------------------------- |
+| 1   | Scope                   | What the package owns              |
+| 2   | Boundaries              | What it does not own               |
+| 3   | Architecture Overview   | Layer structure and key components |
+| 4   | Type Ownership          | SSOT types with locations          |
+| 5   | Public API Surface      | Exported symbols                   |
+| 6   | Extension Points        | How consumers extend the package   |
+| 7   | Error Taxonomy          | Error types and codes              |
+| 8   | Test Strategy           | Coverage and gaps                  |
+| 9   | Class Contract Registry | implements/extends inventory       |
+
+---
 
 ## Stop Conditions
 
-- SPEC.md contains fewer than 3 of the 8 required sections.
+- SPEC.md contains fewer than 3 of the 9 required sections (initial creation incomplete).
 - Type ownership table references types that do not exist in source.
 - Public API surface lists exports not present in `index.ts`.
 - SPEC.md describes architecture that contradicts actual code structure.
 - Class Contract Registry is inconsistent with `implements-audit` output.
+- Incremental update rewrote sections unaffected by the current change (scope creep).
 
 ## Checklist
 
-- [ ] Scope section defines ownership clearly
-- [ ] Boundaries section names concrete packages that own excluded responsibilities
+### Initial Creation
+
+- [ ] All 9 required sections present
+- [ ] Scope defines ownership clearly
+- [ ] Boundaries names concrete packages that own excluded responsibilities
 - [ ] Architecture overview includes layer structure or component diagram
-- [ ] Type ownership table lists all SSOT types with file locations
-- [ ] Public API surface covers primary exports (classes, factories, key types)
-- [ ] Extension points list abstract classes or interfaces consumers implement
+- [ ] Type ownership lists all SSOT types with file locations
+- [ ] Public API Surface covers primary exports
+- [ ] Extension Points lists abstract classes or interfaces consumers implement
 - [ ] Error taxonomy covers package-specific error types
 - [ ] Test strategy describes current coverage and gaps
 - [ ] Class Contract Registry covers all implements/extends in this package
-- [ ] All referenced types, exports, and errors exist in source code
+- [ ] All referenced types, exports, and errors exist in source
+- [ ] `pnpm harness:scan:specs` passes
+
+### Incremental Update
+
+- [ ] Affected sections identified using the lookup table
+- [ ] Only affected sections updated (no unrelated rewrites)
+- [ ] All new/changed items verifiable in source (or in the same PR)
+- [ ] Spec update committed in the same PR as implementation
 - [ ] `pnpm harness:scan:specs` passes
 
 ## Anti-Patterns
 
-- Writing a SPEC.md with only "Scope" and "Boundaries" (too minimal to be useful).
+- Treating SPEC.md as a one-time artifact — the spec is live and must evolve with every change.
+- Back-filling the spec after implementation — always update spec first.
+- Rewriting the whole document for a localized change — incremental updates only.
+- Writing a SPEC.md with only "Scope" and "Boundaries" (too minimal).
+- Writing aspirational architecture that does not match current code.
 - Duplicating implementation details that belong in code comments.
 - Listing every internal type in the ownership table (only SSOT types).
-- Writing aspirational architecture that does not match current code.
-- Copying SPEC.md content between packages without adjusting ownership.
 
 ## Related Harness Commands
 


### PR DESCRIPTION
## Summary

- Adds **Live Spec Policy** to `spec-workflow.md` — SPEC.md is never "done," it grows with every change to its package
- Refactors `spec-writing-standard` skill into three named modes: Initial Creation, Incremental Update, Drift Recovery
- Broadens `spec-first-development` skill trigger from "contract boundary changes" to any behavioral change

## What changed

**`spec-workflow.md` — new "Live Spec Policy" section:**
- Universal update mandate with a lookup table (what changed → which section to update)
- Incremental evolution rule: only affected sections change, never full document rewrite
- Spec-first invariant: spec update before or with implementation code, never after
- Spec drift is a process violation requiring a dedicated catch-up backlog item

**`spec-writing-standard/SKILL.md` — three modes:**
- Mode A: Initial Creation (existing workflow, preserved)
- Mode B: Incremental Update — surgical, section-targeted; includes the section-to-change lookup table and step-by-step guidance for adding/editing/removing rows without touching unrelated sections
- Mode C: Drift Recovery — enumerate gaps, resolve with Mode B, dedicated PR

**`spec-first-development/SKILL.md`:**
- Broadened "When to Use" from contract-boundary-only to any behavioral, export, type, error, event, or extension-point change
- Step 2 now delegates to `spec-writing-standard` Mode B for the incremental update
- Rule anchor updated to reference "Live Spec Policy"

## Test plan

Documentation-only change. No runnable code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)