### PR TITLE
chore(release): 3.0.0-beta.68 finalize

### DIFF
--- a/.agents/release-runs/3.0.0-beta.68.md
+++ b/.agents/release-runs/3.0.0-beta.68.md
@@ -1,0 +1,26 @@
+# Release Run: 3.0.0-beta.68
+
+## State
+
+- Version: 3.0.0-beta.68
+- Branch: main
+- Active gate: complete
+- Gate status: passed
+- Next action: none — release complete.
+
+## Publish Gate
+
+- Publish ready: yes
+- NPM auth verified: yes (jungyoun — 2026-05-25)
+- Dry run passed: yes
+- OTP requested: yes
+- Published: yes (10 packages — 2026-05-25)
+- Dist-tags verified: yes (latest + beta both → 3.0.0-beta.68)
+
+## Final Report
+
+- Merged PRs: #622 (cjk-cursor-positioning), #623 (backlog-archive-beta68)
+- Published version: 3.0.0-beta.68
+- Published packages: 10 (@robota-sdk/agent-core, agent-plugin, agent-provider, agent-session, agent-tools, agent-framework, agent-command, agent-subagent-runner, agent-transport, agent-cli)
+- Excluded packages: @robota-sdk/action, plugin-github, plugin-jira, plugin-linear, plugin-notion, plugin-slack (name TBD, not ready)
+- Validation gates: npm auth ✅ · build ✅ · dry-run ✅ · publish ✅ · dist-tags ✅

--- a/apps/action/package.json
+++ b/apps/action/package.json
@@ -17,5 +17,6 @@
     "typescript": "^5.3.3",
     "vitest": "^1.6.1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -46,5 +46,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/plugin-jira/package.json
+++ b/packages/plugin-jira/package.json
@@ -46,5 +46,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/plugin-linear/package.json
+++ b/packages/plugin-linear/package.json
@@ -46,5 +46,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/plugin-notion/package.json
+++ b/packages/plugin-notion/package.json
@@ -46,5 +46,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/plugin-slack/package.json
+++ b/packages/plugin-slack/package.json
@@ -46,5 +46,6 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
## Summary

- Mark `@robota-sdk/action`, `plugin-github/jira/linear/notion/slack` as `private: true` — name TBD, not ready for publish
- Record release run for 3.0.0-beta.68

🤖 Generated with [Claude Code](https://claude.com/claude-code)