### PR TITLE
feat(arch-003-p1): define IInteractionChannel + interaction types

### DIFF
--- a/.agents/backlog/completed/ARCH-003-p1-interaction-channel-contracts.md
+++ b/.agents/backlog/completed/ARCH-003-p1-interaction-channel-contracts.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-003-p1: Define IInteractionChannel + types in agent-framework'
-status: todo
+status: done
+done_at: 2026-05-31
 created: 2026-05-30
 priority: high
 urgency: soon

--- a/packages/agent-framework/src/command-api/command-module.ts
+++ b/packages/agent-framework/src/command-api/command-module.ts
@@ -1,6 +1,7 @@
 import type { ISystemCommand } from './contracts.js';
 import type { ICommandSource } from './types.js';
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import type { ICommandInteractionHint } from '../interaction/types.js';
 
 export type TCommandModuleSessionRequirement = 'agent-runtime';
 
@@ -16,4 +17,6 @@ export interface ICommandModule {
   readonly commandDescriptors?: readonly ICapabilityDescriptor[];
   /** Runtime facilities required by this module. */
   readonly sessionRequirements?: readonly TCommandModuleSessionRequirement[];
+  /** Interaction hints consumed by createInteractiveRuntime for disambiguation dialogs. */
+  readonly interactionHints?: Record<string, ICommandInteractionHint>;
 }

--- a/packages/agent-framework/src/index.ts
+++ b/packages/agent-framework/src/index.ts
@@ -586,6 +586,18 @@ export type {
   TContextReferenceStatus,
 } from './context/context-reference-inventory.js';
 
+// ── Interaction channel contracts ────────────────────────────
+export type { IInteractionChannel } from './interaction/IInteractionChannel.js';
+export type {
+  InteractionEvent,
+  IPermissionRequest,
+  IActionRequest,
+  IActionResponse,
+  IPickItem,
+  ICommandInfo,
+  ICommandInteractionHint,
+} from './interaction/types.js';
+
 // ── Permissions ─────────────────────────────────────────────
 export { promptForApproval } from './permissions/permission-prompt.js';
 

--- a/packages/agent-framework/src/interaction/IInteractionChannel.ts
+++ b/packages/agent-framework/src/interaction/IInteractionChannel.ts
@@ -1,0 +1,24 @@
+import type { InteractionEvent, IActionRequest, IActionResponse, ICommandInfo } from './types.js';
+
+export interface IInteractionChannel {
+  /** Framework registers input handler. Channel calls it when user submits text. */
+  onSubmit(handler: (text: string) => Promise<void>): void;
+
+  /** Framework pushes one-way display events. Fire-and-forget. */
+  write(event: InteractionEvent): void;
+
+  /**
+   * Framework requests user disambiguation. Channel decides HOW to present it
+   * (Ink dialog, web modal, programmatic preset). Resolves when user responds.
+   */
+  requestAction(action: IActionRequest): Promise<IActionResponse>;
+
+  /** Framework provides registered slash commands for autocomplete. */
+  setAvailableCommands(commands: ICommandInfo[]): void;
+
+  /** Signal whether session is busy (channel may disable input). */
+  setBusy(busy: boolean): void;
+
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/packages/agent-framework/src/interaction/index.ts
+++ b/packages/agent-framework/src/interaction/index.ts
@@ -1,0 +1,10 @@
+export type { IInteractionChannel } from './IInteractionChannel.js';
+export type {
+  InteractionEvent,
+  IPermissionRequest,
+  IActionRequest,
+  IActionResponse,
+  IPickItem,
+  ICommandInfo,
+  ICommandInteractionHint,
+} from './types.js';

--- a/packages/agent-framework/src/interaction/types.ts
+++ b/packages/agent-framework/src/interaction/types.ts
@@ -1,0 +1,45 @@
+/** One-way display events pushed by the framework to the channel. */
+export type InteractionEvent =
+  | { type: 'user-message'; text: string }
+  | { type: 'assistant-chunk'; chunk: string }
+  | { type: 'assistant-done'; fullText: string }
+  | { type: 'tool-call'; id: string; name: string; args: unknown }
+  | { type: 'tool-result'; id: string; name: string; result: unknown }
+  | { type: 'permission-request'; request: IPermissionRequest }
+  | { type: 'permission-resolved'; id: string; granted: boolean }
+  | { type: 'command-result'; name: string; output: string }
+  | { type: 'error'; error: Error };
+
+/** Framework-level permission request (id used to correlate with permission-resolved). */
+export interface IPermissionRequest {
+  id: string;
+  toolName: string;
+  toolArgs: unknown;
+}
+
+/** Request-response contract for disambiguation dialogs. */
+export type IActionRequest =
+  | { type: 'pick'; id: string; title: string; items: IPickItem[]; defaultIndex?: number }
+  | { type: 'confirm'; id: string; message: string; defaultValue?: boolean };
+
+export type IActionResponse =
+  | { type: 'pick'; item: IPickItem }
+  | { type: 'confirm'; confirmed: boolean }
+  | { type: 'cancelled' };
+
+export interface IPickItem {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+export interface ICommandInfo {
+  name: string;
+  description: string;
+  subcommands?: ICommandInfo[];
+}
+
+/** Declared by command modules; consumed by createInteractiveRuntime to call requestAction. */
+export type ICommandInteractionHint =
+  | { type: 'pick'; getItems(): IPickItem[] }
+  | { type: 'confirm'; message: string };


### PR DESCRIPTION
## Summary

- Adds `packages/agent-framework/src/interaction/` with contracts-only types:
  - `IInteractionChannel` — framework↔channel contract (onSubmit, write, requestAction, setAvailableCommands, setBusy, start, stop)
  - `InteractionEvent` — one-way display events (user-message, assistant-chunk, tool-call, permission-request, etc.)
  - `IActionRequest` / `IActionResponse` — disambiguation dialog protocol (pick, confirm, cancelled)
  - `IPickItem`, `ICommandInfo`, `ICommandInteractionHint` — supporting types
  - `IPermissionRequest` — framework-level permission request (id, toolName, toolArgs)
- Adds optional `interactionHints?: Record<string, ICommandInteractionHint>` to `ICommandModule`
- Exports all new types from `agent-framework` public API

## Done gate

- [x] `pnpm --filter @robota-sdk/agent-framework typecheck` passes
- [x] All new types exported from public API
- [x] `ICommandModule.interactionHints` optional field added
- [x] No implementation files (contracts only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)