### PR TITLE
feat(agent-framework): createInteractiveRuntime factory (ARCH-003-p4)

### DIFF
--- a/packages/agent-framework/src/index.ts
+++ b/packages/agent-framework/src/index.ts
@@ -599,6 +599,9 @@ export type {
 } from './interaction/types.js';
 export { parseInput, isSlashCommand, tokeniseSlashCommand } from './interaction/input-parser.js';
 export type { ParsedInput } from './interaction/input-parser.js';
+export type { IInteractiveRuntime } from './interaction/InteractiveRuntime.js';
+export { createInteractiveRuntime } from './interaction/createInteractiveRuntime.js';
+export type { IInteractiveRuntimeOptions } from './interaction/createInteractiveRuntime.js';
 
 // ── Permissions ─────────────────────────────────────────────
 export { promptForApproval } from './permissions/permission-prompt.js';

--- a/packages/agent-framework/src/interaction/InteractiveRuntime.ts
+++ b/packages/agent-framework/src/interaction/InteractiveRuntime.ts
@@ -1,0 +1,4 @@
+export interface IInteractiveRuntime {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/packages/agent-framework/src/interaction/__tests__/MockInteractionChannel.ts
+++ b/packages/agent-framework/src/interaction/__tests__/MockInteractionChannel.ts
@@ -1,0 +1,57 @@
+import { vi } from 'vitest';
+
+import type { IInteractionChannel } from '../IInteractionChannel.js';
+import type { IActionRequest, IActionResponse, ICommandInfo, InteractionEvent } from '../types.js';
+
+export class MockInteractionChannel implements IInteractionChannel {
+  readonly events: InteractionEvent[] = [];
+  readonly writtenEvents: InteractionEvent[] = [];
+  readonly availableCommands: ICommandInfo[] = [];
+  busyState = false;
+  started = false;
+  stopped = false;
+
+  private submitHandler: ((text: string) => Promise<void>) | null = null;
+  private actionResponse: IActionResponse = { type: 'cancelled' };
+
+  onSubmit(handler: (text: string) => Promise<void>): void {
+    this.submitHandler = handler;
+  }
+
+  write(event: InteractionEvent): void {
+    this.events.push(event);
+    this.writtenEvents.push(event);
+  }
+
+  requestAction = vi.fn((_action: IActionRequest): Promise<IActionResponse> => {
+    return Promise.resolve(this.actionResponse);
+  });
+
+  setAvailableCommands(commands: ICommandInfo[]): void {
+    this.availableCommands.length = 0;
+    this.availableCommands.push(...commands);
+  }
+
+  setBusy(busy: boolean): void {
+    this.busyState = busy;
+  }
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+
+  /** Simulate user submitting text. */
+  async simulateSubmit(text: string): Promise<void> {
+    if (!this.submitHandler) throw new Error('No submit handler registered');
+    await this.submitHandler(text);
+  }
+
+  /** Set the response that requestAction will return. */
+  setActionResponse(response: IActionResponse): void {
+    this.actionResponse = response;
+  }
+}

--- a/packages/agent-framework/src/interaction/__tests__/createInteractiveRuntime.test.ts
+++ b/packages/agent-framework/src/interaction/__tests__/createInteractiveRuntime.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { createInteractiveRuntime } from '../createInteractiveRuntime.js';
+import { MockInteractionChannel } from './MockInteractionChannel.js';
+
+import type { IInteractiveSession } from '../../interactive/i-interactive-session.js';
+import type { ICommandModule } from '../../command-api/command-module.js';
+import type { ICommandListEntry } from '../../commands/index.js';
+import type { IInteractiveSessionEvents, TInteractiveEventName } from '../../interactive/types.js';
+
+type Handler = IInteractiveSessionEvents[TInteractiveEventName];
+
+function createMockSession(overrides: Partial<IInteractiveSession> = {}): IInteractiveSession & {
+  emitEvent<E extends TInteractiveEventName>(
+    event: E,
+    ...args: Parameters<IInteractiveSessionEvents[E]>
+  ): void;
+} {
+  const listeners: Partial<Record<TInteractiveEventName, Handler[]>> = {};
+
+  const session: IInteractiveSession = {
+    isInitialized: true,
+    submit: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    cancelQueue: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    isExecuting: vi.fn().mockReturnValue(false),
+    getPendingPrompt: vi.fn().mockReturnValue(null),
+    getMessages: vi.fn().mockReturnValue([]),
+    getContextState: vi.fn().mockReturnValue({
+      usedPercentage: 0,
+      usedTokens: 0,
+      maxTokens: 0,
+      remainingPercentage: 100,
+    }),
+    getSession: vi.fn().mockReturnValue({ getSessionId: () => 'test-id' }),
+    getCwd: vi.fn().mockReturnValue('/tmp'),
+    executeCommand: vi.fn().mockResolvedValue(null),
+    listCommands: vi.fn().mockReturnValue([] as ICommandListEntry[]),
+    on: vi.fn((event: TInteractiveEventName, handler: Handler) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event]!.push(handler);
+    }),
+    off: vi.fn((event: TInteractiveEventName, handler: Handler) => {
+      const arr = listeners[event];
+      if (arr) {
+        const idx = arr.indexOf(handler);
+        if (idx !== -1) arr.splice(idx, 1);
+      }
+    }),
+    listBackgroundTasks: vi.fn().mockReturnValue([]),
+    getBackgroundTask: vi.fn().mockReturnValue(undefined),
+    cancelBackgroundTask: vi.fn().mockResolvedValue(undefined),
+    closeBackgroundTask: vi.fn().mockResolvedValue(undefined),
+    sendBackgroundTask: vi.fn().mockResolvedValue(undefined),
+    readBackgroundTaskLog: vi.fn().mockResolvedValue({ entries: [], cursor: null }),
+    listBackgroundJobGroups: vi.fn().mockReturnValue([]),
+    getBackgroundJobGroup: vi.fn().mockReturnValue(undefined),
+    createBackgroundJobGroup: vi.fn().mockReturnValue({ groupId: 'g1', jobs: [] }),
+    waitBackgroundJobGroup: vi.fn().mockResolvedValue({ groupId: 'g1', jobs: [] }),
+    getExecutionWorkspaceSnapshot: vi.fn().mockReturnValue({ files: [] }),
+    listAgentDefinitions: vi.fn().mockReturnValue([]),
+    listAgentJobs: vi.fn().mockReturnValue([]),
+    spawnAgentJob: vi.fn().mockResolvedValue({ jobId: 'j1' }),
+    sendAgentJob: vi.fn().mockResolvedValue(undefined),
+    cancelAgentJob: vi.fn().mockResolvedValue(undefined),
+    closeAgentJob: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+
+  return Object.assign(session, {
+    emitEvent<E extends TInteractiveEventName>(
+      event: E,
+      ...args: Parameters<IInteractiveSessionEvents[E]>
+    ): void {
+      const handlers = listeners[event] ?? [];
+      for (const h of handlers) {
+        (h as (...a: unknown[]) => void)(...args);
+      }
+    },
+  });
+}
+
+function makeCommandModule(
+  name: string,
+  hints?: ICommandModule['interactionHints'],
+): ICommandModule {
+  return {
+    name,
+    interactionHints: hints,
+  };
+}
+
+describe('createInteractiveRuntime', () => {
+  let channel: MockInteractionChannel;
+  let session: ReturnType<typeof createMockSession>;
+
+  beforeEach(() => {
+    channel = new MockInteractionChannel();
+    session = createMockSession();
+  });
+
+  it('Given runtime started When channel.start() called Then channel.started is true', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+
+    await runtime.start();
+
+    expect(channel.started).toBe(true);
+  });
+
+  it('Given commands registered When started Then channel receives available commands', async () => {
+    vi.mocked(session.listCommands).mockReturnValue([
+      { name: 'help', description: 'Show help' },
+      { name: 'exit', description: 'Exit' },
+    ]);
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    expect(channel.availableCommands).toEqual([
+      { name: 'help', description: 'Show help' },
+      { name: 'exit', description: 'Exit' },
+    ]);
+  });
+
+  it('Given user message submitted Then session.submit called and user-message event written', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('hello world');
+
+    expect(session.submit).toHaveBeenCalledWith('hello world');
+    expect(channel.events[0]).toEqual({ type: 'user-message', text: 'hello world' });
+    expect(channel.busyState).toBe(true);
+  });
+
+  it('Given slash command with no hint When submitted Then executeCommand called directly', async () => {
+    vi.mocked(session.executeCommand).mockResolvedValue({
+      message: 'ok',
+      success: true,
+    });
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('/help');
+
+    expect(session.executeCommand).toHaveBeenCalledWith('help', '');
+    expect(channel.events[0]).toEqual({ type: 'command-result', name: 'help', output: 'ok' });
+  });
+
+  it('Given slash command with pick hint When submitted Then requestAction called and arg resolved', async () => {
+    channel.setActionResponse({ type: 'pick', item: { label: 'Plan', value: 'plan' } });
+    vi.mocked(session.executeCommand).mockResolvedValue({ message: 'switched', success: true });
+
+    const mod = makeCommandModule('mode', {
+      mode: {
+        type: 'pick',
+        getItems: () => [{ label: 'Plan', value: 'plan' }],
+      },
+    });
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [mod],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('/mode');
+
+    expect(channel.requestAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'pick', id: 'mode' }),
+    );
+    expect(session.executeCommand).toHaveBeenCalledWith('mode', 'plan');
+  });
+
+  it('Given slash command with confirm hint cancelled When submitted Then executeCommand not called', async () => {
+    channel.setActionResponse({ type: 'cancelled' });
+
+    const mod = makeCommandModule('exit', {
+      exit: { type: 'confirm', message: 'Exit?' },
+    });
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [mod],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('/exit');
+
+    expect(session.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('Given slash command with args already present When submitted Then no requestAction, direct execute', async () => {
+    channel.setActionResponse({ type: 'cancelled' });
+    vi.mocked(session.executeCommand).mockResolvedValue({ message: 'ok', success: true });
+
+    const mod = makeCommandModule('mode', {
+      mode: {
+        type: 'pick',
+        getItems: () => [{ label: 'Plan', value: 'plan' }],
+      },
+    });
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [mod],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('/mode plan');
+
+    expect(channel.requestAction).not.toHaveBeenCalled();
+    expect(session.executeCommand).toHaveBeenCalledWith('mode', 'plan');
+  });
+
+  it('Given unknown command executed When null returned Then error event written', async () => {
+    vi.mocked(session.executeCommand).mockResolvedValue(null);
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    await channel.simulateSubmit('/unknown');
+
+    expect(channel.events[0]).toMatchObject({ type: 'error' });
+  });
+
+  it('Given text_delta event When emitted Then assistant-chunk written', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    session.emitEvent('text_delta', 'hello ');
+    session.emitEvent('text_delta', 'world');
+
+    expect(channel.events).toContainEqual({ type: 'assistant-chunk', chunk: 'hello ' });
+    expect(channel.events).toContainEqual({ type: 'assistant-chunk', chunk: 'world' });
+  });
+
+  it('Given complete event When emitted Then assistant-done written and busy cleared', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+    channel.busyState = true;
+
+    session.emitEvent('text_delta', 'hi');
+    session.emitEvent('complete', {
+      response: 'hi',
+      history: [],
+      toolSummaries: [],
+      contextState: { usedPercentage: 0, usedTokens: 0, maxTokens: 0, remainingPercentage: 100 },
+    });
+
+    expect(channel.events).toContainEqual({ type: 'assistant-done', fullText: 'hi' });
+    expect(channel.busyState).toBe(false);
+  });
+
+  it('Given error event When emitted Then error written and busy cleared', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+    channel.busyState = true;
+
+    const err = new Error('oops');
+    session.emitEvent('error', err);
+
+    expect(channel.events).toContainEqual({ type: 'error', error: err });
+    expect(channel.busyState).toBe(false);
+  });
+
+  it('Given runtime stopped Then channel.stop called and events unwired', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+    await runtime.stop();
+
+    expect(channel.stopped).toBe(true);
+    expect(session.off).toHaveBeenCalledTimes(6);
+  });
+});

--- a/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
+++ b/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
@@ -1,0 +1,193 @@
+import { parseInput } from './input-parser.js';
+import { InteractiveSession } from '../interactive/index.js';
+
+import type { IInteractionChannel } from './IInteractionChannel.js';
+import type { IInteractiveRuntime } from './InteractiveRuntime.js';
+import type {
+  IActionRequest,
+  IActionResponse,
+  ICommandInteractionHint,
+  ICommandInfo,
+} from './types.js';
+import type { ICommandModule } from '../command-api/command-module.js';
+import type { IInteractiveSession } from '../interactive/i-interactive-session.js';
+import type { IInteractiveSessionStore } from '../interactive/session-persistence.js';
+import type { IInteractiveSessionEvents } from '../interactive/types.js';
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+export interface IInteractiveRuntimeOptions {
+  channel: IInteractionChannel;
+  commandModules: readonly ICommandModule[];
+  /** Provider for session creation (production path). */
+  provider?: IAIProvider;
+  /** Working directory for session creation. */
+  cwd?: string;
+  /** Session store for persistence. */
+  sessionStore?: IInteractiveSessionStore;
+  /** Test escape hatch — skips session creation when supplied. */
+  _testSession?: IInteractiveSession;
+}
+
+function buildActionRequest(commandName: string, hint: ICommandInteractionHint): IActionRequest {
+  if (hint.type === 'pick') {
+    return {
+      type: 'pick',
+      id: commandName,
+      title: `/${commandName}`,
+      items: hint.getItems(),
+    };
+  }
+  return {
+    type: 'confirm',
+    id: commandName,
+    message: hint.message,
+  };
+}
+
+function resolveArgsFromResponse(
+  hint: ICommandInteractionHint,
+  response: IActionResponse,
+): string[] | null {
+  if (response.type === 'cancelled') return null;
+  if (hint.type === 'pick' && response.type === 'pick') return [response.item.value];
+  if (hint.type === 'confirm' && response.type === 'confirm') return [];
+  return null;
+}
+
+function commandsToCommandInfo(
+  commands: ReturnType<IInteractiveSession['listCommands']>,
+): ICommandInfo[] {
+  return commands.map((c) => ({ name: c.name, description: c.description }));
+}
+
+function wireSessionEvents(session: IInteractiveSession, channel: IInteractionChannel): () => void {
+  let fullText = '';
+
+  const onDelta: IInteractiveSessionEvents['text_delta'] = (delta) => {
+    fullText += delta;
+    channel.write({ type: 'assistant-chunk', chunk: delta });
+  };
+
+  const onComplete: IInteractiveSessionEvents['complete'] = () => {
+    channel.write({ type: 'assistant-done', fullText });
+    fullText = '';
+    channel.setBusy(false);
+  };
+
+  const onToolStart: IInteractiveSessionEvents['tool_start'] = (state) => {
+    channel.write({
+      type: 'tool-call',
+      id: state.executionId ?? state.toolName,
+      name: state.toolName,
+      args: state.firstArg,
+    });
+  };
+
+  const onToolEnd: IInteractiveSessionEvents['tool_end'] = (state) => {
+    channel.write({
+      type: 'tool-result',
+      id: state.executionId ?? state.toolName,
+      name: state.toolName,
+      result: state.toolResultData ?? state.result,
+    });
+  };
+
+  const onError: IInteractiveSessionEvents['error'] = (error) => {
+    channel.setBusy(false);
+    channel.write({ type: 'error', error });
+  };
+
+  const onInterrupted: IInteractiveSessionEvents['interrupted'] = () => {
+    channel.setBusy(false);
+  };
+
+  session.on('text_delta', onDelta);
+  session.on('complete', onComplete);
+  session.on('tool_start', onToolStart);
+  session.on('tool_end', onToolEnd);
+  session.on('error', onError);
+  session.on('interrupted', onInterrupted);
+
+  return () => {
+    session.off('text_delta', onDelta);
+    session.off('complete', onComplete);
+    session.off('tool_start', onToolStart);
+    session.off('tool_end', onToolEnd);
+    session.off('error', onError);
+    session.off('interrupted', onInterrupted);
+  };
+}
+
+export function createInteractiveRuntime(options: IInteractiveRuntimeOptions): IInteractiveRuntime {
+  const { channel, commandModules, _testSession } = options;
+
+  let session: IInteractiveSession | null = null;
+  let unwireEvents: (() => void) | null = null;
+
+  const interactionHints: Record<string, ICommandInteractionHint> = {};
+  for (const mod of commandModules) {
+    if (mod.interactionHints) {
+      Object.assign(interactionHints, mod.interactionHints);
+    }
+  }
+
+  async function handleSubmit(text: string): Promise<void> {
+    if (!session) return;
+    const parsed = parseInput(text);
+
+    if (parsed.type === 'user-message') {
+      channel.write({ type: 'user-message', text });
+      channel.setBusy(true);
+      await session.submit(text);
+      return;
+    }
+
+    const { name, args } = parsed;
+    const hint = interactionHints[name];
+
+    let resolvedArgs = args;
+    if (hint && args.length === 0) {
+      const response = await channel.requestAction(buildActionRequest(name, hint));
+      const fromResponse = resolveArgsFromResponse(hint, response);
+      if (fromResponse === null) return; // cancelled
+      resolvedArgs = fromResponse;
+    }
+
+    const result = await session.executeCommand(name, resolvedArgs.join(' '));
+    if (result) {
+      channel.write({ type: 'command-result', name, output: result.message });
+    } else {
+      channel.write({
+        type: 'error',
+        error: new Error(`Unknown command "/${name}". Type /help for help.`),
+      });
+    }
+  }
+
+  return {
+    async start(): Promise<void> {
+      if (_testSession) {
+        session = _testSession;
+      } else {
+        const { provider, cwd, sessionStore } = options;
+        if (!provider) throw new Error('createInteractiveRuntime: provider is required');
+        if (!cwd) throw new Error('createInteractiveRuntime: cwd is required');
+        session = new InteractiveSession({ provider, cwd, sessionStore, commandModules });
+      }
+
+      unwireEvents = wireSessionEvents(session, channel);
+
+      const commands = session.listCommands();
+      channel.setAvailableCommands(commandsToCommandInfo(commands));
+      channel.onSubmit(handleSubmit);
+      await channel.start();
+    },
+
+    async stop(): Promise<void> {
+      unwireEvents?.();
+      await channel.stop();
+      await session?.shutdown();
+      session = null;
+    },
+  };
+}

--- a/packages/agent-framework/src/interaction/index.ts
+++ b/packages/agent-framework/src/interaction/index.ts
@@ -10,3 +10,6 @@ export type {
 } from './types.js';
 export { parseInput, isSlashCommand, tokeniseSlashCommand } from './input-parser.js';
 export type { ParsedInput } from './input-parser.js';
+export type { IInteractiveRuntime } from './InteractiveRuntime.js';
+export { createInteractiveRuntime } from './createInteractiveRuntime.js';
+export type { IInteractiveRuntimeOptions } from './createInteractiveRuntime.js';


### PR DESCRIPTION
## Summary

- Adds `IInteractiveRuntime` interface (`start` / `stop`) in `interaction/InteractiveRuntime.ts`
- Adds `createInteractiveRuntime(options)` factory wiring `IInteractionChannel` ↔ `InteractiveSession`
  - User-message path: writes `user-message` event → `session.submit()`
  - Slash-command path: looks up `interactionHints` → calls `channel.requestAction()` for disambiguation → `session.executeCommand()`
  - Event bridge: `text_delta` → `assistant-chunk`, `complete` → `assistant-done`, `tool_start/end` → `tool-call/tool-result`, `error`/`interrupted` → clears busy
- Exports `IInteractiveRuntime`, `createInteractiveRuntime`, `IInteractiveRuntimeOptions` from package root
- Adds `MockInteractionChannel` test helper and 12 unit tests covering all routing paths

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-framework typecheck` — clean
- [x] `pnpm --filter @robota-sdk/agent-framework test` — 863 passed (12 new)
- [x] pre-push harness verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)