### PR TITLE
feat(agent-cli): wire cli directly to renderApp — remove TuiTransport middleman (ARCH-003-p6)

### DIFF
--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -24,7 +24,7 @@ import {
   handleProviderConfigurationArgs,
   runInteractiveProviderSetup,
 } from './startup/provider-startup.js';
-import { TuiTransport, createDefaultTuiCliAdapter } from '@robota-sdk/agent-transport/tui';
+import { renderApp, createDefaultTuiCliAdapter } from '@robota-sdk/agent-transport/tui';
 import { createDefaultTransportRegistry } from '@robota-sdk/agent-transport';
 import { createDefaultBackgroundTaskRunners } from '@robota-sdk/agent-executor';
 import {
@@ -157,7 +157,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     return;
   }
 
-  const tuiTransport = new TuiTransport({
+  await renderApp({
     cwd,
     provider,
     providerOverride: args.provider,
@@ -186,6 +186,5 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     reloadPluginCommandSource,
     agentName: 'robota-cli',
   });
-  await tuiTransport.start();
   process.exit(0);
 }

--- a/packages/agent-transport/src/tui/index.ts
+++ b/packages/agent-transport/src/tui/index.ts
@@ -1,8 +1,9 @@
 export { TuiTransport } from './tui-transport.js';
+export { renderApp } from './render.js';
+export type { IRenderOptions } from './render.js';
 export type { ITuiCliAdapter } from './tui-cli-adapter.js';
 export type { IDefaultTuiCliAdapterOptions } from './create-default-tui-cli-adapter.js';
 export { createDefaultTuiCliAdapter } from './create-default-tui-cli-adapter.js';
-export type { IRenderOptions } from './render.js';
 export type {
   TOnMissingArgsAction,
   ITuiPickerItem,


### PR DESCRIPTION
## Summary

- `cli.ts` now imports `renderApp` from `@robota-sdk/agent-transport/tui` directly — no more `TuiTransport` instantiation
- Exports `renderApp` from the `./tui` entry point
- `TuiTransport` is preserved for external consumers but `cli.ts` no longer needs it

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-cli typecheck` — clean
- [x] `pnpm cli:dev --help` works
- [x] `pnpm --filter @robota-sdk/agent-cli test` — 67 passed
- [x] pre-push harness verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)