### PR TITLE
feat(arch-003-p7): HeadlessInteractionChannel — session lifecycle out of print-mode

### DIFF
--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -1,12 +1,7 @@
-import { execSync } from 'node:child_process';
 import type { IAIProvider } from '@robota-sdk/agent-core';
-import {
-  InteractiveSession,
-  type ICommandHostAdapters,
-  type ICommandModule,
-} from '@robota-sdk/agent-framework';
+import type { ICommandHostAdapters, ICommandModule } from '@robota-sdk/agent-framework';
 import type { createProjectSessionStore } from '@robota-sdk/agent-framework';
-import { createHeadlessTransport } from '@robota-sdk/agent-transport/headless';
+import { HeadlessInteractionChannel } from '@robota-sdk/agent-transport/headless';
 import type { IBackgroundTaskRunner } from '@robota-sdk/agent-executor';
 import type { createChildProcessSubagentRunnerFactory } from '@robota-sdk/agent-subagent-runner';
 import type { IParsedCliArgs } from '../utils/cli-args.js';
@@ -39,12 +34,10 @@ export async function runPrintMode(
 
   const appendSystemPrompt = buildAppendSystemPrompt(cwd, args);
 
-  const shellExec = (command: string) =>
-    execSync(command, { timeout: 5000, encoding: 'utf-8', stdio: 'pipe' }).trimEnd();
-
-  const session = new InteractiveSession({
+  const channel = new HeadlessInteractionChannel({
     cwd,
     provider,
+    outputFormat: args.outputFormat ?? 'text',
     permissionMode: args.permissionMode ?? 'bypassPermissions',
     maxTurns: args.maxTurns,
     sessionStore: args.noSessionPersistence ? undefined : sessionStore,
@@ -62,16 +55,8 @@ export async function runPrintMode(
     subagentRunnerFactory,
     commandModules,
     commandHostAdapters,
-    shellExec,
-    agentName: 'robota-cli',
   });
 
-  const transport = createHeadlessTransport({
-    outputFormat: args.outputFormat ?? 'text',
-    prompt,
-  });
-  session.attachTransport(transport);
-  await transport.start();
-  await session.shutdown({ reason: 'prompt_input_exit', message: 'Headless transport complete' });
-  process.exit(transport.getExitCode());
+  await channel.run(prompt);
+  process.exit(channel.getExitCode());
 }

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -1,0 +1,84 @@
+/**
+ * HeadlessInteractionChannel — owns session lifecycle for non-interactive (print) mode.
+ *
+ * Mirrors TuiInteractionChannel's ownership pattern: session creation lives here,
+ * not in the caller. print-mode.ts constructs this and calls run().
+ */
+
+import { execSync } from 'node:child_process';
+
+import { InteractiveSession } from '@robota-sdk/agent-framework';
+
+import { createHeadlessRunner, type TOutputFormat } from './headless-runner.js';
+
+import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
+import type {
+  IBackgroundTaskRunner,
+  ICommandHostAdapters,
+  ICommandModule,
+  IInteractiveSessionStore,
+  TSubagentRunnerFactory,
+  TShellExecFn,
+} from '@robota-sdk/agent-framework';
+
+export interface IHeadlessInteractionChannelOptions {
+  cwd: string;
+  provider: IAIProvider;
+  outputFormat: TOutputFormat;
+  permissionMode?: TPermissionMode;
+  maxTurns?: number;
+  sessionStore?: IInteractiveSessionStore;
+  sessionName?: string;
+  bare?: boolean;
+  allowedTools?: string[];
+  appendSystemPrompt?: string;
+  systemPrompt?: string;
+  backgroundTaskRunners?: IBackgroundTaskRunner[];
+  subagentRunnerFactory?: TSubagentRunnerFactory;
+  commandModules?: readonly ICommandModule[];
+  commandHostAdapters?: ICommandHostAdapters;
+  shellExec?: TShellExecFn;
+}
+
+export class HeadlessInteractionChannel {
+  private readonly opts: IHeadlessInteractionChannelOptions;
+  private exitCode = 0;
+
+  constructor(options: IHeadlessInteractionChannelOptions) {
+    this.opts = options;
+  }
+
+  async run(prompt: string): Promise<void> {
+    const shellExec: TShellExecFn =
+      this.opts.shellExec ??
+      ((command: string) =>
+        execSync(command, { timeout: 5000, encoding: 'utf-8', stdio: 'pipe' }).trimEnd());
+
+    const session = new InteractiveSession({
+      cwd: this.opts.cwd,
+      provider: this.opts.provider,
+      permissionMode: this.opts.permissionMode ?? 'bypassPermissions',
+      maxTurns: this.opts.maxTurns,
+      sessionStore: this.opts.sessionStore,
+      sessionName: this.opts.sessionName,
+      bare: this.opts.bare || undefined,
+      allowedTools: this.opts.allowedTools,
+      appendSystemPrompt: this.opts.appendSystemPrompt,
+      ...(this.opts.systemPrompt ? { systemPrompt: this.opts.systemPrompt } : {}),
+      backgroundTaskRunners: this.opts.backgroundTaskRunners,
+      subagentRunnerFactory: this.opts.subagentRunnerFactory,
+      commandModules: this.opts.commandModules,
+      commandHostAdapters: this.opts.commandHostAdapters,
+      shellExec,
+      agentName: 'robota-cli',
+    });
+
+    const runner = createHeadlessRunner({ session, outputFormat: this.opts.outputFormat });
+    this.exitCode = await runner.run(prompt);
+    await session.shutdown({ reason: 'prompt_input_exit', message: 'Headless transport complete' });
+  }
+
+  getExitCode(): number {
+    return this.exitCode;
+  }
+}

--- a/packages/agent-transport/src/headless/index.ts
+++ b/packages/agent-transport/src/headless/index.ts
@@ -4,3 +4,5 @@ export { createHeadlessRunner } from './headless-runner.js';
 export type { IHeadlessRunnerOptions, TOutputFormat } from './headless-runner.js';
 export { createHeadlessTransport } from './headless-transport.js';
 export type { IHeadlessTransportOptions } from './headless-transport.js';
+export { HeadlessInteractionChannel } from './HeadlessInteractionChannel.js';
+export type { IHeadlessInteractionChannelOptions } from './HeadlessInteractionChannel.js';


### PR DESCRIPTION
## Summary

- Introduces `HeadlessInteractionChannel` in `packages/agent-transport/src/headless/`
- The class owns `InteractiveSession` creation for non-interactive (print) mode, mirroring the `TuiInteractionChannel` ownership pattern from ARCH-003-p5
- `print-mode.ts` no longer constructs `InteractiveSession` directly — it delegates to the channel

## Changes

- **new** `HeadlessInteractionChannel` — encapsulates session creation, headless runner, and exit code tracking
- **updated** `packages/agent-transport/src/headless/index.ts` — exports `HeadlessInteractionChannel` and `IHeadlessInteractionChannelOptions`
- **updated** `packages/agent-cli/src/modes/print-mode.ts` — replaced `new InteractiveSession()` + `createHeadlessTransport()` with `new HeadlessInteractionChannel(opts).run(prompt)`

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-transport typecheck` — passes
- [x] `pnpm --filter @robota-sdk/agent-cli typecheck` — passes
- [x] Pre-push harness: build, test (410 passed), lint, typecheck all green
- [x] CLI smoke check: `pnpm cli:dev --version` returns expected version

🤖 Generated with [Claude Code](https://claude.com/claude-code)