### PR TITLE
chore(backlog): mark ARCH-003-p4 through p7 as done

### DIFF
--- a/.agents/backlog/completed/ARCH-003-p4-create-interactive-runtime.md
+++ b/.agents/backlog/completed/ARCH-003-p4-create-interactive-runtime.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p4: createInteractiveRuntime factory in agent-framework'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-framework

--- a/.agents/backlog/completed/ARCH-003-p5-tui-interaction-channel.md
+++ b/.agents/backlog/completed/ARCH-003-p5-tui-interaction-channel.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p5: TuiInteractionChannel in agent-transport/tui'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-transport

--- a/.agents/backlog/completed/ARCH-003-p6-wire-agent-cli.md
+++ b/.agents/backlog/completed/ARCH-003-p6-wire-agent-cli.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p6: Wire agent-cli composition root'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-cli

--- a/.agents/backlog/completed/ARCH-003-p7-headless-interaction-channel.md
+++ b/.agents/backlog/completed/ARCH-003-p7-headless-interaction-channel.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p7: HeadlessInteractionChannel in agent-transport/headless'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-transport, packages/agent-cli


### PR DESCRIPTION
## Summary

- Marks ARCH-003-p4, p5, p6, p7 backlog files as `status: done`
- Moves all four files from `backlog/` to `backlog/completed/`
- PRs #639, #640, #641, #642 delivered the corresponding implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)