### PR TITLE
feat(arch-003-p8a): extend createInteractiveRuntime test suite

### DIFF
--- a/.agents/backlog/completed/ARCH-003-p8a-framework-interaction-tests.md
+++ b/.agents/backlog/completed/ARCH-003-p8a-framework-interaction-tests.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p8a: Framework interaction tests (no PTY)'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-framework

--- a/.agents/backlog/completed/CLI-040-tui-mode-tests.md
+++ b/.agents/backlog/completed/CLI-040-tui-mode-tests.md
@@ -1,7 +1,8 @@
 ---
 title: 'CLI-040: TUI 모드 기본 테스트 추가'
-status: todo
+status: superseded
 created: 2026-05-24
+completed: 2026-05-31
 priority: high
 category: test
 ---

--- a/.agents/backlog/completed/CLI-041-missing-test-coverage.md
+++ b/.agents/backlog/completed/CLI-041-missing-test-coverage.md
@@ -1,7 +1,8 @@
 ---
 title: 'CLI-041: diagnose, init, web-fetch, web-search 테스트 커버리지'
-status: todo
+status: superseded
 created: 2026-05-24
+completed: 2026-05-31
 priority: medium
 category: test
 ---

--- a/packages/agent-framework/src/interaction/__tests__/createInteractiveRuntime.test.ts
+++ b/packages/agent-framework/src/interaction/__tests__/createInteractiveRuntime.test.ts
@@ -312,4 +312,79 @@ describe('createInteractiveRuntime', () => {
     expect(channel.stopped).toBe(true);
     expect(session.off).toHaveBeenCalledTimes(6);
   });
+
+  it('Given user message submitted When complete emitted Then setBusy called true then false', async () => {
+    const busyCalls: boolean[] = [];
+    const originalSetBusy = channel.setBusy.bind(channel);
+    vi.spyOn(channel, 'setBusy').mockImplementation((v) => {
+      busyCalls.push(v);
+      originalSetBusy(v);
+    });
+
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    const submitPromise = channel.simulateSubmit('hello');
+    session.emitEvent('complete', {
+      response: 'hi',
+      history: [],
+      toolSummaries: [],
+      contextState: { usedPercentage: 0, usedTokens: 0, maxTokens: 0, remainingPercentage: 100 },
+    });
+    await submitPromise;
+
+    expect(busyCalls).toEqual([true, false]);
+  });
+
+  it('Given tool_start event When emitted Then tool-call event written', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    session.emitEvent('tool_start', {
+      toolName: 'bash',
+      executionId: 'exec-1',
+      firstArg: 'ls',
+      isRunning: true,
+    });
+
+    expect(channel.events).toContainEqual({
+      type: 'tool-call',
+      id: 'exec-1',
+      name: 'bash',
+      args: 'ls',
+    });
+  });
+
+  it('Given tool_end event When emitted Then tool-result event written', async () => {
+    const runtime = createInteractiveRuntime({
+      channel,
+      commandModules: [],
+      _testSession: session,
+    });
+    await runtime.start();
+
+    session.emitEvent('tool_end', {
+      toolName: 'bash',
+      executionId: 'exec-1',
+      firstArg: 'ls',
+      isRunning: false,
+      result: 'success',
+      toolResultData: 'file.txt',
+    });
+
+    expect(channel.events).toContainEqual({
+      type: 'tool-result',
+      id: 'exec-1',
+      name: 'bash',
+      result: 'file.txt',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds 3 new tests to `createInteractiveRuntime.test.ts`: `setBusy` sequential signalling (true → false), `tool_start → tool-call` event mapping, `tool_end → tool-result` event mapping
- Total: 12 → 15 tests in the interaction test suite (866 total framework tests, all passing)
- Marks `CLI-040` and `CLI-041` as superseded — `tui-mode.ts` was replaced by `TuiInteractionChannel` in ARCH-003-p5; original test coverage concerns are addressed by the new architecture's test suite

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-framework test` — 866/866 passed
- [x] No PTY, no Ink, no real provider in test setup (all tests use mocked session + MockInteractionChannel)
- [x] Pre-push harness passed (build, test, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)