### PR TITLE
feat(arch-003-p8b): TUI dialog tests — requestAction, CommandPicker, CommandConfirm

### DIFF
--- a/.agents/backlog/completed/ARCH-003-p8b-tui-dialog-tests.md
+++ b/.agents/backlog/completed/ARCH-003-p8b-tui-dialog-tests.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-003-p8b: TUI dialog tests (ink-testing-library)'
-status: todo
+status: done
 created: 2026-05-30
+completed: 2026-05-31
 priority: high
 urgency: soon
 area: packages/agent-transport

--- a/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.requestAction.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.requestAction.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for TuiInteractionChannel.requestAction() promise protocol.
+ *
+ * Tests the queue-based action resolution mechanism in isolation —
+ * no Ink rendering, no InteractiveSession, no real provider required.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@robota-sdk/agent-framework', async () => {
+  const actual = await vi.importActual<typeof import('@robota-sdk/agent-framework')>(
+    '@robota-sdk/agent-framework',
+  );
+  return {
+    ...actual,
+    InteractiveSession: vi.fn().mockImplementation(() => ({
+      getFullHistory: vi.fn().mockReturnValue([]),
+      setName: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue('test-id'),
+      isInitialized: false,
+      on: vi.fn(),
+      off: vi.fn(),
+    })),
+    CommandRegistry: vi.fn().mockImplementation(() => ({
+      addModule: vi.fn(),
+    })),
+  };
+});
+
+import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
+
+import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IActionRequest } from '@robota-sdk/agent-framework';
+
+function makeChannel(): TuiInteractionChannel {
+  return new TuiInteractionChannel({
+    cwd: '/tmp',
+    provider: {} as IAIProvider,
+  });
+}
+
+const PICK_ACTION: IActionRequest = {
+  type: 'pick',
+  id: 'mode',
+  title: '/mode',
+  items: [
+    { label: 'plan', value: 'plan' },
+    { label: 'default', value: 'default' },
+  ],
+};
+
+const CONFIRM_ACTION: IActionRequest = {
+  type: 'confirm',
+  id: 'exit',
+  message: 'Exit the session?',
+};
+
+describe('TuiInteractionChannel.requestAction', () => {
+  let channel: TuiInteractionChannel;
+
+  beforeEach(() => {
+    channel = makeChannel();
+  });
+
+  it('sets pendingAction when requestAction is called', () => {
+    void channel.requestAction(PICK_ACTION);
+    expect(channel.pendingAction).toMatchObject({ type: 'pick', id: 'mode' });
+  });
+
+  it('resolves pick response when resolveAction is called', async () => {
+    const responsePromise = channel.requestAction(PICK_ACTION);
+    channel.resolveAction({ type: 'pick', item: { label: 'plan', value: 'plan' } });
+    const response = await responsePromise;
+    expect(response).toEqual({ type: 'pick', item: { label: 'plan', value: 'plan' } });
+  });
+
+  it('clears pendingAction after resolveAction', async () => {
+    const responsePromise = channel.requestAction(PICK_ACTION);
+    channel.resolveAction({ type: 'cancelled' });
+    await responsePromise;
+    expect(channel.pendingAction).toBeNull();
+  });
+
+  it('resolves confirm response when resolveAction is called', async () => {
+    const responsePromise = channel.requestAction(CONFIRM_ACTION);
+    channel.resolveAction({ type: 'confirm', confirmed: true });
+    const response = await responsePromise;
+    expect(response).toEqual({ type: 'confirm', confirmed: true });
+  });
+
+  it('resolves cancelled when resolveAction is called with cancelled', async () => {
+    const responsePromise = channel.requestAction(PICK_ACTION);
+    channel.resolveAction({ type: 'cancelled' });
+    const response = await responsePromise;
+    expect(response).toEqual({ type: 'cancelled' });
+  });
+
+  it('queues multiple actions and processes them sequentially', async () => {
+    const p1 = channel.requestAction(PICK_ACTION);
+    const p2 = channel.requestAction(CONFIRM_ACTION);
+
+    // First action is pending immediately
+    expect(channel.pendingAction).toMatchObject({ type: 'pick' });
+
+    // Resolve first
+    channel.resolveAction({ type: 'pick', item: { label: 'plan', value: 'plan' } });
+    await p1;
+
+    // Second action becomes pending after first resolves
+    expect(channel.pendingAction).toMatchObject({ type: 'confirm' });
+
+    // Resolve second
+    channel.resolveAction({ type: 'confirm', confirmed: false });
+    const r2 = await p2;
+    expect(r2).toEqual({ type: 'confirm', confirmed: false });
+    expect(channel.pendingAction).toBeNull();
+  });
+
+  it('calls onChange when pendingAction changes', () => {
+    const onChange = vi.fn();
+    channel.onChange = onChange;
+    void channel.requestAction(PICK_ACTION);
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/agent-transport/src/tui/interactions/__tests__/CommandConfirm.test.tsx
+++ b/packages/agent-transport/src/tui/interactions/__tests__/CommandConfirm.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'vitest';
+
+import CommandConfirm from '../CommandConfirm.js';
+
+import type { ITuiConfirmInteraction } from '../../command-interaction.js';
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function makeInteraction(message: string): ITuiConfirmInteraction {
+  return { onMissingArgs: 'confirm', message };
+}
+
+describe('CommandConfirm', () => {
+  it('renders the message text', () => {
+    const { lastFrame } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit the session?')}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(lastFrame()).toContain('Exit the session?');
+  });
+
+  it('calls onConfirm when y is pressed', () => {
+    let confirmed = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {
+          confirmed = true;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('y');
+    expect(confirmed).toBe(true);
+  });
+
+  it('calls onConfirm when Y is pressed', () => {
+    let confirmed = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {
+          confirmed = true;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('Y');
+    expect(confirmed).toBe(true);
+  });
+
+  it('calls onConfirm on Enter', () => {
+    let confirmed = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {
+          confirmed = true;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('\r');
+    expect(confirmed).toBe(true);
+  });
+
+  it('calls onCancel when n is pressed', () => {
+    let cancelled = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {}}
+        onCancel={() => {
+          cancelled = true;
+        }}
+      />,
+    );
+    stdin.write('n');
+    expect(cancelled).toBe(true);
+  });
+
+  it('calls onCancel when N is pressed', () => {
+    let cancelled = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {}}
+        onCancel={() => {
+          cancelled = true;
+        }}
+      />,
+    );
+    stdin.write('N');
+    expect(cancelled).toBe(true);
+  });
+
+  it('calls onCancel on Escape', async () => {
+    let cancelled = false;
+    const { stdin } = render(
+      <CommandConfirm
+        commandName="exit"
+        interaction={makeInteraction('Exit?')}
+        onConfirm={() => {}}
+        onCancel={() => {
+          cancelled = true;
+        }}
+      />,
+    );
+    stdin.write('\x1b');
+    await delay(50);
+    expect(cancelled).toBe(true);
+  });
+});

--- a/packages/agent-transport/src/tui/interactions/__tests__/CommandPicker.test.tsx
+++ b/packages/agent-transport/src/tui/interactions/__tests__/CommandPicker.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect, vi } from 'vitest';
+
+import CommandPicker from '../CommandPicker.js';
+
+import type { ITuiPickerInteraction, ITuiPickerItem } from '../../command-interaction.js';
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function makeInteraction(items: ITuiPickerItem[]): ITuiPickerInteraction {
+  return {
+    onMissingArgs: 'picker',
+    getItems: () => items,
+  };
+}
+
+const ITEMS: ITuiPickerItem[] = [
+  { label: 'plan', value: 'plan', description: 'Plan mode' },
+  { label: 'default', value: 'default', description: 'Default mode' },
+  { label: 'auto', value: 'auto' },
+];
+
+describe('CommandPicker', () => {
+  it('renders all item labels', () => {
+    const { lastFrame } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('plan');
+    expect(frame).toContain('default');
+    expect(frame).toContain('auto');
+  });
+
+  it('highlights first item by default', () => {
+    const { lastFrame } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('▸ plan');
+  });
+
+  it('calls onSelect with first item on Enter', () => {
+    const onSelect = vi.fn();
+    const { stdin } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={onSelect}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('\r');
+    expect(onSelect).toHaveBeenCalledWith(ITEMS[0]);
+  });
+
+  it('moves highlight down on arrow-down then selects on Enter', async () => {
+    let selected: ITuiPickerItem | undefined;
+    const { stdin } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={(item) => {
+          selected = item;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    stdin.write('\x1B[B'); // ↓
+    await delay(50);
+    stdin.write('\r');
+    expect(selected).toEqual(ITEMS[1]);
+  });
+
+  it('calls onCancel on Escape', async () => {
+    let cancelled = false;
+    const { stdin } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={() => {}}
+        onCancel={() => {
+          cancelled = true;
+        }}
+      />,
+    );
+    stdin.write('\x1b');
+    await delay(50);
+    expect(cancelled).toBe(true);
+  });
+
+  it('calls onCancel on q', () => {
+    const onCancel = vi.fn();
+    const { stdin } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+    stdin.write('q');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('wraps highlight from last to first on arrow-down at bottom', async () => {
+    let selected: ITuiPickerItem | undefined;
+    const { stdin } = render(
+      <CommandPicker
+        commandName="mode"
+        interaction={makeInteraction(ITEMS)}
+        onSelect={(item) => {
+          selected = item;
+        }}
+        onCancel={() => {}}
+      />,
+    );
+    // Navigate to last item (index 2)
+    stdin.write('\x1B[B'); // ↓ to index 1
+    await delay(50);
+    stdin.write('\x1B[B'); // ↓ to index 2
+    await delay(50);
+    stdin.write('\x1B[B'); // ↓ wraps to index 0
+    await delay(50);
+    stdin.write('\r');
+    expect(selected).toEqual(ITEMS[0]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 3 new test files for the TUI dialog layer introduced in ARCH-003-p5
- `TuiInteractionChannel.requestAction.test.ts` (7 tests): pick/confirm/cancelled queue protocol, `pendingAction` state, `onChange` notification, sequential queue ordering
- `interactions/__tests__/CommandPicker.test.tsx` (7 tests): render, first-item highlight, Enter select, ↓ navigation, Esc/q cancel, wrap-around
- `interactions/__tests__/CommandConfirm.test.tsx` (7 tests): render, y/Y/Enter confirm, n/N/Esc cancel
- Total transport tests: 410 → 431

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-transport test` — 431/431 passed
- [x] No `InteractiveSession` or `createInteractiveRuntime` imports in test files
- [x] No `agent-cli` imports in test files
- [x] Pre-push harness passed (build, test, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)