### PR TITLE
chore(release): bump to 3.0.0-beta.70

### DIFF
--- a/.changeset/cli-b-ux-fixes-beta70.md
+++ b/.changeset/cli-b-ux-fixes-beta70.md
@@ -1,0 +1,7 @@
+---
+'@robota-sdk/agent-command': patch
+'@robota-sdk/agent-transport': patch
+'@robota-sdk/agent-framework': patch
+---
+
+CLI UX fixes: /context list full LLM context breakdown (CLI-B10), logo resize fix (CLI-B03), token estimates in context list (CLI-B04)

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -80,6 +80,7 @@
     "cjk-ime-cursor-position",
     "cli-001-002-lint-layer-separation",
     "cli-active-provider-validation",
+    "cli-b-ux-fixes-beta70",
     "cli-sdk-agent-feedback",
     "cli-status-bar-cleanup",
     "cli2-001-help-flag",

--- a/apps/agent-server/CHANGELOG.md
+++ b/apps/agent-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-server
 
+## 3.0.1-beta.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-command@3.0.0-beta.70
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-core@3.0.0-beta.70
+  - @robota-sdk/agent-provider@3.0.0-beta.70
+  - @robota-sdk/agent-playground@3.0.0-beta.70
+
 ## 3.0.1-beta.25
 
 ### Patch Changes

--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-server",
-  "version": "3.0.1-beta.25",
+  "version": "3.0.1-beta.26",
   "description": "Agent Server - AI provider proxy and Playground WebSocket server",
   "private": true,
   "keywords": [

--- a/apps/starter-nextjs/CHANGELOG.md
+++ b/apps/starter-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/starter-nextjs
 
+## 0.0.2-beta.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-provider@3.0.0-beta.70
+
 ## 0.0.2-beta.1
 
 ### Patch Changes

--- a/apps/starter-nextjs/package.json
+++ b/apps/starter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/starter-nextjs",
-  "version": "0.0.2-beta.1",
+  "version": "0.0.2-beta.2",
   "private": true,
   "description": "Robota SDK — Next.js AI Chat starter template",
   "scripts": {

--- a/packages/agent-cli/CHANGELOG.md
+++ b/packages/agent-cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-cli
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-command@3.0.0-beta.70
+  - @robota-sdk/agent-transport@3.0.0-beta.70
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-subagent-runner@3.0.0-beta.70
+  - @robota-sdk/agent-core@3.0.0-beta.70
+  - @robota-sdk/agent-provider@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-cli",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "AI coding assistant CLI built on Robota SDK",
   "type": "module",
   "bin": {

--- a/packages/agent-command/CHANGELOG.md
+++ b/packages/agent-command/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-command
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- CLI UX fixes: /context list full LLM context breakdown (CLI-B10), logo resize fix (CLI-B03), token estimates in context list (CLI-B04)
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Consolidated command module implementations for Robota SDK CLI",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-core
 
+## 3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ## 3.0.0-beta.68

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-core",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Complete AI agent implementation with unified core and tools functionality - conversation management, plugin system, and advanced agent features",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-executor/CHANGELOG.md
+++ b/packages/agent-executor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-executor
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-executor",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Composable runtime primitives for Robota background tasks and subagent orchestration",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-framework/CHANGELOG.md
+++ b/packages/agent-framework/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-framework
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- CLI UX fixes: /context list full LLM context breakdown (CLI-B10), logo resize fix (CLI-B03), token estimates in context list (CLI-B04)
+  - @robota-sdk/agent-core@3.0.0-beta.70
+  - @robota-sdk/agent-executor@3.0.0-beta.70
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.70
+  - @robota-sdk/agent-session@3.0.0-beta.70
+  - @robota-sdk/agent-tools@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-framework",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Programmatic SDK for building AI agents with Robota — provides InteractiveSession, createQuery(), command APIs, permissions, hooks, and context loading",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-transport/CHANGELOG.md
+++ b/packages/agent-interface-transport/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-interface-transport
 
+## 3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ## 3.0.0-beta.68

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-transport",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Transport contract interfaces for the Robota SDK (ITransportAdapter, IConfigurableTransport, ITransportConfig)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-tui/CHANGELOG.md
+++ b/packages/agent-interface-tui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-interface-tui
 
+## 3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ## 3.0.0-beta.68

--- a/packages/agent-interface-tui/package.json
+++ b/packages/agent-interface-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-tui",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "TUI interaction contract interfaces for the Robota SDK (ITuiPickerItem, ITuiCommandInteraction, ITuiPickerInteraction, ITuiConfirmInteraction)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-playground/CHANGELOG.md
+++ b/packages/agent-playground/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-playground
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+- @robota-sdk/agent-provider@3.0.0-beta.70
+- @robota-sdk/agent-tools@3.0.0-beta.70
+- @robota-sdk/agent-remote-client@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-playground",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Deployable Playground UI package (React implementation) for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-plugin
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-plugin",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Consolidated plugin implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider/CHANGELOG.md
+++ b/packages/agent-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-provider
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-provider/package.json
+++ b/packages/agent-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Consolidated AI provider implementations for Robota SDK",
   "type": "module",
   "publishConfig": {

--- a/packages/agent-remote-client/CHANGELOG.md
+++ b/packages/agent-remote-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-remote-client
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-remote-client",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Remote client for calling a Robota agent over HTTP",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session/CHANGELOG.md
+++ b/packages/agent-session/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-session
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Session and chat management for Robota SDK - multi-session support with independent workspaces",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-subagent-runner/CHANGELOG.md
+++ b/packages/agent-subagent-runner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-subagent-runner
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-core@3.0.0-beta.70
+  - @robota-sdk/agent-executor@3.0.0-beta.70
+  - @robota-sdk/agent-provider@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-subagent-runner/package.json
+++ b/packages/agent-subagent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-subagent-runner",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Child-process subagent runner for Robota SDK — optional package for running subagents in isolated child processes",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tool-mcp/CHANGELOG.md
+++ b/packages/agent-tool-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-tool-mcp
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+- @robota-sdk/agent-tools@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tool-mcp",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "MCP protocol tool implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tools/CHANGELOG.md
+++ b/packages/agent-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-tools
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tools",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Tool registry and implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport/CHANGELOG.md
+++ b/packages/agent-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-transport
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- CLI UX fixes: /context list full LLM context breakdown (CLI-B10), logo resize fix (CLI-B03), token estimates in context list (CLI-B04)
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.70
+  - @robota-sdk/agent-core@3.0.0-beta.70
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.70
+  - @robota-sdk/agent-interface-tui@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Consolidated transport package for Robota SDK — headless, HTTP, WebSocket, and MCP adapters",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-web-ui/CHANGELOG.md
+++ b/packages/agent-web-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-web
 
+## 3.0.0-beta.70
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-transport@3.0.0-beta.70
+
 ## 3.0.0-beta.69
 
 ### Patch Changes

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-web-ui",
-  "version": "3.0.0-beta.69",
+  "version": "3.0.0-beta.70",
   "description": "Browser UI library for monitoring and controlling a running agent-cli session",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
## Summary

- Version bump: `3.0.0-beta.69` → `3.0.0-beta.70`
- Includes changeset for CLI UX fixes: CLI-B03 (logo resize), CLI-B10 (/context list breakdown), CLI-B04 (token estimates)
- Generated by `pnpm changeset version`

## Test plan

- [x] `pnpm cli:dev --version` → `robota 3.0.0-beta.70` ✅
- [x] All package.json versions match 3.0.0-beta.70
- [x] CHANGELOG.md files updated for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)