### PR TITLE
fix(context): abolish usedTokens pre-storage, unify token estimation to SSOT

### DIFF
--- a/packages/agent-command/src/background/__tests__/background-command-module.test.ts
+++ b/packages/agent-command/src/background/__tests__/background-command-module.test.ts
@@ -28,6 +28,7 @@ function createSessionRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => false,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-command/src/compact/__tests__/compact-command-module.test.ts
+++ b/packages/agent-command/src/compact/__tests__/compact-command-module.test.ts
@@ -36,6 +36,7 @@ function createRuntime(beforeCount = 10, afterCount = 3): ICommandSessionRuntime
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => 0.835,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-command/src/context/__tests__/context-command-module.test.ts
+++ b/packages/agent-command/src/context/__tests__/context-command-module.test.ts
@@ -76,6 +76,7 @@ function createRuntime(
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => state.threshold,
     getFullHistory: () => history,
+    getHistory: () => [],
     setAutoCompactThreshold: (threshold) => {
       state.threshold = threshold;
     },

--- a/packages/agent-command/src/context/context-command.ts
+++ b/packages/agent-command/src/context/context-command.ts
@@ -12,7 +12,7 @@ import {
   writeAutoCompactThresholdSetting,
 } from '@robota-sdk/agent-framework';
 
-import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { IHistoryEntry, TUniversalMessage } from '@robota-sdk/agent-core';
 import type {
   ICommandHostContext,
   ICommandResult,
@@ -65,14 +65,14 @@ export async function executeContextCommand(
   const autoCompactThreshold = readAutoCompactThreshold(context);
   const autoCompactThresholdSource = readAutoCompactThresholdSource(context);
   const history = context.getSession().getFullHistory();
-  const analysis = analyzeHistory(history);
+  const display = buildToolDisplayList(history);
   const references = listCommandContextReferences(context);
   return {
     message: [
       `Context: ${state.usedTokens.toLocaleString()} / ${state.maxTokens.toLocaleString()} tokens (${Math.round(state.usedPercentage)}%)`,
       formatAutoCompactLine(autoCompactThreshold, autoCompactThresholdSource),
       formatContextReferenceSummary(references),
-      `History: ${analysis.turnCount} turn${analysis.turnCount !== 1 ? 's' : ''}`,
+      `History: ${display.turnCount} turn${display.turnCount !== 1 ? 's' : ''}`,
     ].join('\n'),
     success: true,
     data: {
@@ -304,20 +304,23 @@ function formatContextReferenceLine(reference: IContextReferenceItem): string {
 interface IToolResultSummary {
   toolName: string;
   displayArg: string;
-  tokens: number;
 }
 
-interface IHistoryAnalysis {
-  turnCount: number;
-  userCount: number;
+interface IMessageTokensByRole {
+  systemTokens: number;
   userTokens: number;
-  assistantCount: number;
+  userCount: number;
   assistantTokens: number;
+  assistantCount: number;
+  toolTokens: number;
+  toolCallCount: number;
+  totalTokens: number;
+}
+
+interface IToolDisplayList {
+  turnCount: number;
   toolResults: IToolResultSummary[];
   totalToolCallCount: number;
-  totalToolTokens: number;
-  systemTokens: number;
-  totalTokens: number;
 }
 
 function parseToolCallArgs(argsJson: string): Record<string, unknown> | null {
@@ -337,7 +340,44 @@ function extractFirstToolArg(argsJson: string): string {
   return raw.length > TOOL_ARG_MAX_LEN ? `${raw.slice(0, TOOL_ARG_MAX_LEN)}…` : raw;
 }
 
-function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
+function computeMessageTokensByRole(rawMessages: TUniversalMessage[]): IMessageTokensByRole {
+  let systemTokens = 0;
+  let userTokens = 0;
+  let userCount = 0;
+  let assistantTokens = 0;
+  let assistantCount = 0;
+  let toolTokens = 0;
+  let toolCallCount = 0;
+
+  for (const msg of rawMessages) {
+    const t = Math.ceil(JSON.stringify(msg).length / CHARS_PER_TOKEN);
+    if (msg.role === 'system') {
+      systemTokens += t;
+    } else if (msg.role === 'user') {
+      userTokens += t;
+      userCount++;
+    } else if (msg.role === 'assistant') {
+      assistantTokens += t;
+      assistantCount++;
+    } else if (msg.role === 'tool') {
+      toolTokens += t;
+      toolCallCount++;
+    }
+  }
+
+  return {
+    systemTokens,
+    userTokens,
+    userCount,
+    assistantTokens,
+    assistantCount,
+    toolTokens,
+    toolCallCount,
+    totalTokens: systemTokens + userTokens + assistantTokens + toolTokens,
+  };
+}
+
+function buildToolDisplayList(history: IHistoryEntry[]): IToolDisplayList {
   type TToolCallEntry = { name: string; firstArg: string };
   const toolCallMap = new Map<string, TToolCallEntry>();
 
@@ -354,57 +394,28 @@ function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
     }
   }
 
-  let userCount = 0;
-  let userTokens = 0;
-  let assistantCount = 0;
-  let assistantTokens = 0;
-  let systemTokens = 0;
+  let turnCount = 0;
   let totalToolCallCount = 0;
-  let totalToolTokens = 0;
-  // For display only: group by toolName:displayArg (keeps last call's token count per key)
   const toolDisplayMap = new Map<string, IToolResultSummary>();
 
   for (const entry of history) {
     if (entry.category !== 'chat') continue;
     if (entry.type === 'user') {
-      const data = entry.data as { content?: string };
-      userCount++;
-      userTokens += estimateTokens((data.content ?? '').length);
-    } else if (entry.type === 'system') {
-      const data = entry.data as { content?: string };
-      systemTokens += estimateTokens((data.content ?? '').length);
-    } else if (entry.type === 'assistant') {
-      const data = entry.data as { content?: string | null; toolCalls?: unknown[] };
-      assistantCount++;
-      assistantTokens += estimateTokens(
-        (data.content ?? '').length + (data.toolCalls ? JSON.stringify(data.toolCalls).length : 0),
-      );
+      turnCount++;
     } else if (entry.type === 'tool') {
-      const data = entry.data as { content?: string; toolCallId?: string };
+      const data = entry.data as { toolCallId?: string };
       const tc = toolCallMap.get(data.toolCallId ?? '');
       const toolName = tc?.name ?? 'tool';
       const displayArg = tc?.firstArg ?? '';
-      const tokens = estimateTokens((data.content ?? '').length);
-      // Accumulate ALL tool call tokens (no deduplication) for accurate total
       totalToolCallCount++;
-      totalToolTokens += tokens;
-      // Track for display grouping (last call per toolName:arg wins for display)
-      toolDisplayMap.set(`${toolName}:${displayArg}`, { toolName, displayArg, tokens });
+      toolDisplayMap.set(`${toolName}:${displayArg}`, { toolName, displayArg });
     }
   }
 
-  const toolResults = [...toolDisplayMap.values()];
   return {
-    turnCount: userCount,
-    userCount,
-    userTokens,
-    assistantCount,
-    assistantTokens,
-    toolResults,
+    turnCount,
+    toolResults: [...toolDisplayMap.values()],
     totalToolCallCount,
-    totalToolTokens,
-    systemTokens,
-    totalTokens: userTokens + assistantTokens + totalToolTokens + systemTokens,
   };
 }
 
@@ -422,45 +433,45 @@ function formatFullContextBreakdown(context: ICommandHostContext): ICommandResul
   const state = readCommandContextState(context);
   const autoCompactThreshold = readAutoCompactThreshold(context);
   const autoCompactThresholdSource = readAutoCompactThresholdSource(context);
-  const history = context.getSession().getFullHistory();
-  const analysis = analyzeHistory(history);
+  const rawMessages = context.getSession().getHistory();
+  const msgTokens = computeMessageTokensByRole(rawMessages);
+  const display = buildToolDisplayList(context.getSession().getFullHistory());
   const references = listCommandContextReferences(context);
 
   const systemRefs = references.filter((r) => r.loadType === 'system');
   const manualRefs = references.filter((r) => r.loadType === 'manual');
   const promptRefs = references.filter((r) => r.loadType === 'prompt-reference');
 
-  const systemTokens = systemRefs.reduce((s, r) => s + estimateTokens(r.byteLength), 0);
+  const systemRefTokens = systemRefs.reduce((s, r) => s + estimateTokens(r.byteLength), 0);
   const manualTokens = manualRefs.reduce((s, r) => s + estimateTokens(r.byteLength), 0);
   const promptRefTokens = promptRefs.reduce((s, r) => s + estimateTokens(r.byteLength), 0);
 
   const convTurnLabel =
-    analysis.turnCount === 0
+    display.turnCount === 0
       ? 'Conversation history — 0 turns'
-      : `Conversation history — ${analysis.turnCount} turn${analysis.turnCount !== 1 ? 's' : ''} | ~${analysis.totalTokens.toLocaleString()} tokens`;
+      : `Conversation history — ${display.turnCount} turn${display.turnCount !== 1 ? 's' : ''} | ~${msgTokens.totalTokens.toLocaleString()} tokens`;
 
-  const toolResultLines = analysis.toolResults.map(
-    (t) =>
-      `${t.toolName}${t.displayArg ? `: ${t.displayArg}` : ''} — ~${t.tokens.toLocaleString()} tokens`,
+  const toolResultLines = display.toolResults.map(
+    (t) => `${t.toolName}${t.displayArg ? `: ${t.displayArg}` : ''}`,
   );
 
-  const uniqueToolCount = analysis.toolResults.length;
-  const totalToolCallCount = analysis.totalToolCallCount;
+  const uniqueToolCount = display.toolResults.length;
+  const totalToolCallCount = display.totalToolCallCount;
   const toolResultsLabel =
     totalToolCallCount === 0
       ? 'Tool results (0): (none)'
       : uniqueToolCount < totalToolCallCount
-        ? `Tool results (${uniqueToolCount} unique / ${totalToolCallCount} calls, ~${analysis.totalToolTokens.toLocaleString()} tokens):`
-        : `Tool results (${uniqueToolCount}):`;
+        ? `Tool results (${uniqueToolCount} unique / ${totalToolCallCount} calls, ~${msgTokens.toolTokens.toLocaleString()} tokens):`
+        : `Tool results (${uniqueToolCount}, ~${msgTokens.toolTokens.toLocaleString()} tokens):`;
 
   const conversationLines: string[] =
-    analysis.turnCount === 0
+    display.turnCount === 0
       ? []
       : [
-          `User (${analysis.userCount}): ~${analysis.userTokens.toLocaleString()} tokens`,
-          `Assistant (${analysis.assistantCount}): ~${analysis.assistantTokens.toLocaleString()} tokens`,
-          ...(analysis.systemTokens > 0
-            ? [`System messages: ~${analysis.systemTokens.toLocaleString()} tokens`]
+          `User (${msgTokens.userCount}): ~${msgTokens.userTokens.toLocaleString()} tokens`,
+          `Assistant (${msgTokens.assistantCount}): ~${msgTokens.assistantTokens.toLocaleString()} tokens`,
+          ...(msgTokens.systemTokens > 0
+            ? [`System messages: ~${msgTokens.systemTokens.toLocaleString()} tokens`]
             : []),
           totalToolCallCount > 0
             ? [toolResultsLabel, ...toolResultLines.map((l) => `  ${l}`)].join('\n')
@@ -468,7 +479,7 @@ function formatFullContextBreakdown(context: ICommandHostContext): ICommandResul
         ];
 
   const convSection =
-    analysis.turnCount === 0
+    display.turnCount === 0
       ? `${convTurnLabel}:\n  (none)`
       : [`${convTurnLabel}:`, ...conversationLines.map((l) => `  ${l}`)].join('\n');
 
@@ -478,7 +489,7 @@ function formatFullContextBreakdown(context: ICommandHostContext): ICommandResul
     '',
     formatSection(
       'System prompt (active every turn)',
-      systemTokens,
+      systemRefTokens,
       systemRefs.map(formatContextReferenceLine),
     ),
     '',
@@ -498,7 +509,7 @@ function formatFullContextBreakdown(context: ICommandHostContext): ICommandResul
     message,
     data: {
       references,
-      history: { turnCount: analysis.turnCount, toolResults: analysis.toolResults },
+      history: { turnCount: display.turnCount, toolResults: display.toolResults },
     },
   };
 }

--- a/packages/agent-command/src/context/context-command.ts
+++ b/packages/agent-command/src/context/context-command.ts
@@ -314,6 +314,9 @@ interface IHistoryAnalysis {
   assistantCount: number;
   assistantTokens: number;
   toolResults: IToolResultSummary[];
+  totalToolCallCount: number;
+  totalToolTokens: number;
+  systemTokens: number;
   totalTokens: number;
 }
 
@@ -355,7 +358,11 @@ function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
   let userTokens = 0;
   let assistantCount = 0;
   let assistantTokens = 0;
-  const toolResultMap = new Map<string, IToolResultSummary>();
+  let systemTokens = 0;
+  let totalToolCallCount = 0;
+  let totalToolTokens = 0;
+  // For display only: group by toolName:displayArg (keeps last call's token count per key)
+  const toolDisplayMap = new Map<string, IToolResultSummary>();
 
   for (const entry of history) {
     if (entry.category !== 'chat') continue;
@@ -363,6 +370,9 @@ function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
       const data = entry.data as { content?: string };
       userCount++;
       userTokens += estimateTokens((data.content ?? '').length);
+    } else if (entry.type === 'system') {
+      const data = entry.data as { content?: string };
+      systemTokens += estimateTokens((data.content ?? '').length);
     } else if (entry.type === 'assistant') {
       const data = entry.data as { content?: string | null; toolCalls?: unknown[] };
       assistantCount++;
@@ -375,12 +385,15 @@ function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
       const toolName = tc?.name ?? 'tool';
       const displayArg = tc?.firstArg ?? '';
       const tokens = estimateTokens((data.content ?? '').length);
-      toolResultMap.set(`${toolName}:${displayArg}`, { toolName, displayArg, tokens });
+      // Accumulate ALL tool call tokens (no deduplication) for accurate total
+      totalToolCallCount++;
+      totalToolTokens += tokens;
+      // Track for display grouping (last call per toolName:arg wins for display)
+      toolDisplayMap.set(`${toolName}:${displayArg}`, { toolName, displayArg, tokens });
     }
   }
 
-  const toolResults = [...toolResultMap.values()];
-  const toolTokens = toolResults.reduce((s, t) => s + t.tokens, 0);
+  const toolResults = [...toolDisplayMap.values()];
   return {
     turnCount: userCount,
     userCount,
@@ -388,7 +401,10 @@ function analyzeHistory(history: IHistoryEntry[]): IHistoryAnalysis {
     assistantCount,
     assistantTokens,
     toolResults,
-    totalTokens: userTokens + assistantTokens + toolTokens,
+    totalToolCallCount,
+    totalToolTokens,
+    systemTokens,
+    totalTokens: userTokens + assistantTokens + totalToolTokens + systemTokens,
   };
 }
 
@@ -428,18 +444,27 @@ function formatFullContextBreakdown(context: ICommandHostContext): ICommandResul
       `${t.toolName}${t.displayArg ? `: ${t.displayArg}` : ''} — ~${t.tokens.toLocaleString()} tokens`,
   );
 
+  const uniqueToolCount = analysis.toolResults.length;
+  const totalToolCallCount = analysis.totalToolCallCount;
+  const toolResultsLabel =
+    totalToolCallCount === 0
+      ? 'Tool results (0): (none)'
+      : uniqueToolCount < totalToolCallCount
+        ? `Tool results (${uniqueToolCount} unique / ${totalToolCallCount} calls, ~${analysis.totalToolTokens.toLocaleString()} tokens):`
+        : `Tool results (${uniqueToolCount}):`;
+
   const conversationLines: string[] =
     analysis.turnCount === 0
       ? []
       : [
           `User (${analysis.userCount}): ~${analysis.userTokens.toLocaleString()} tokens`,
           `Assistant (${analysis.assistantCount}): ~${analysis.assistantTokens.toLocaleString()} tokens`,
-          analysis.toolResults.length > 0
-            ? [
-                `Tool results (${analysis.toolResults.length}):`,
-                ...toolResultLines.map((l) => `  ${l}`),
-              ].join('\n')
-            : `Tool results (0): (none)`,
+          ...(analysis.systemTokens > 0
+            ? [`System messages: ~${analysis.systemTokens.toLocaleString()} tokens`]
+            : []),
+          totalToolCallCount > 0
+            ? [toolResultsLabel, ...toolResultLines.map((l) => `  ${l}`)].join('\n')
+            : toolResultsLabel,
         ];
 
   const convSection =

--- a/packages/agent-command/src/help/__tests__/help-command-module.test.ts
+++ b/packages/agent-command/src/help/__tests__/help-command-module.test.ts
@@ -20,6 +20,7 @@ function createCommandSessionRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => false,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-command/src/help/__tests__/help-command.test.ts
+++ b/packages/agent-command/src/help/__tests__/help-command.test.ts
@@ -23,6 +23,7 @@ function createCommandSessionRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => false,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-command/src/plugin/__tests__/plugin-command-module.test.ts
+++ b/packages/agent-command/src/plugin/__tests__/plugin-command-module.test.ts
@@ -41,6 +41,7 @@ function createCommandSessionRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => false,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-command/src/session/__tests__/session-command-module.test.ts
+++ b/packages/agent-command/src/session/__tests__/session-command-module.test.ts
@@ -20,6 +20,7 @@ function createRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => false,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-framework/src/command-api/__tests__/command-api.test.ts
+++ b/packages/agent-framework/src/command-api/__tests__/command-api.test.ts
@@ -95,6 +95,7 @@ function createCommandSessionRuntime(): ICommandSessionRuntime {
     getSessionAllowedTools: () => [],
     getAutoCompactThreshold: () => 0.8,
     getFullHistory: () => [],
+    getHistory: () => [],
   };
 }
 

--- a/packages/agent-framework/src/command-api/host-context.ts
+++ b/packages/agent-framework/src/command-api/host-context.ts
@@ -23,7 +23,12 @@ import type {
 import type { IMemoryEvent, IMemoryReference } from '../memory/automatic-memory-types.js';
 import type { ISubagentJobState } from '../subagents/index.js';
 import type { TAutoCompactThreshold } from './context/context-command-api.js';
-import type { IContextWindowState, IHistoryEntry, TPermissionMode } from '@robota-sdk/agent-core';
+import type {
+  IContextWindowState,
+  IHistoryEntry,
+  TPermissionMode,
+  TUniversalMessage,
+} from '@robota-sdk/agent-core';
 import type { ISessionReplayValidationResult } from '@robota-sdk/agent-session';
 
 export interface ICommandListEntry {
@@ -67,6 +72,7 @@ export interface ICommandSessionRuntime {
   getSessionAllowedTools(): readonly string[];
   getAutoCompactThreshold(): number | false;
   getFullHistory(): IHistoryEntry[];
+  getHistory(): TUniversalMessage[];
   setAutoCompactThreshold?(threshold: TAutoCompactThreshold): void;
   getSessionTokenUsage?(): { inputTokens: number; outputTokens: number } | undefined;
   getModelId?(): string | undefined;

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-resume-context.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-resume-context.test.ts
@@ -150,7 +150,7 @@ describe('RESUME-001: session resume context recovery', () => {
       expect(mockSession.syncContextFromHistory).toHaveBeenCalled();
     });
 
-    it('syncContextFromHistory() is called for sessions with usedTokens field (new format)', () => {
+    it('syncContextFromHistory() is called for sessions with messages', () => {
       const mockSession = createMockSession({ sessionId: 'new-session' });
       const mockStore = createMockSessionStore({
         'new-session': {
@@ -162,7 +162,6 @@ describe('RESUME-001: session resume context recovery', () => {
             { id: 'm1', role: 'user', content: 'hello', state: 'complete', timestamp: new Date() },
           ],
           history: [],
-          usedTokens: 12_000, // stored for analytics, not used for restoration
         },
       });
 
@@ -173,7 +172,6 @@ describe('RESUME-001: session resume context recovery', () => {
         resumeSessionId: 'new-session',
       });
 
-      // Same single method regardless of whether usedTokens is in record
       expect(mockSession.syncContextFromHistory).toHaveBeenCalled();
     });
 
@@ -292,8 +290,8 @@ describe('RESUME-001: session resume context recovery', () => {
     });
   });
 
-  describe('usedTokens is persisted when saving session (for analytics)', () => {
-    it('save() call includes usedTokens field', async () => {
+  describe('session save does not persist usedTokens', () => {
+    it('save() call does not include usedTokens field', async () => {
       const mockSession = createMockSession({ sessionId: 'save-test' });
       mockSession.getContextState.mockReturnValue({
         usedTokens: 8_000,
@@ -314,7 +312,7 @@ describe('RESUME-001: session resume context recovery', () => {
 
       expect(mockStore.save).toHaveBeenCalled();
       const savedRecord = mockStore.save.mock.calls[0]?.[0] as Record<string, unknown>;
-      expect(savedRecord?.['usedTokens']).toBe(8_000);
+      expect(Object.prototype.hasOwnProperty.call(savedRecord, 'usedTokens')).toBe(false);
     });
   });
 });

--- a/packages/agent-framework/src/interactive/interactive-session-persistence.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-persistence.ts
@@ -104,7 +104,6 @@ function buildInteractiveSessionRecord(
     history: input.history,
     systemPrompt: input.session.getSystemMessage(),
     toolSchemas: input.session.getToolSchemas(),
-    usedTokens: input.session.getContextState().usedTokens,
     ...(input.sandboxSnapshotId !== undefined
       ? { sandboxSnapshotId: input.sandboxSnapshotId }
       : {}),

--- a/packages/agent-framework/src/interactive/interactive-session-restore.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-restore.ts
@@ -45,7 +45,6 @@ export function loadSessionRecord(
   memoryEvents: IMemoryEvent[];
   usedMemoryReferences: IMemoryReference[];
   contextReferences: IContextReferenceItem[];
-  usedTokens: number;
   sandboxSnapshotId: string | undefined;
 } {
   const record = sessionStore.load(resumeSessionId);
@@ -62,7 +61,6 @@ export function loadSessionRecord(
       memoryEvents: [],
       usedMemoryReferences: [],
       contextReferences: [],
-      usedTokens: 0,
       sandboxSnapshotId: undefined,
     };
   }
@@ -76,7 +74,6 @@ export function loadSessionRecord(
   const memoryEvents = record.memoryEvents ?? [];
   const usedMemoryReferences = record.usedMemoryReferences ?? [];
   const contextReferences = record.contextReferences ?? [];
-  const usedTokens = record.usedTokens ?? 0;
   const sandboxSnapshotId = record.sandboxSnapshotId;
   const { backgroundTasks, backgroundTaskEvents } = reconcileRestoredBackgroundTasks(
     restoredBackgroundTasks,
@@ -107,7 +104,6 @@ export function loadSessionRecord(
     memoryEvents,
     usedMemoryReferences,
     contextReferences,
-    usedTokens,
     sandboxSnapshotId,
   };
 }

--- a/packages/agent-framework/src/interactive/session-persistence.ts
+++ b/packages/agent-framework/src/interactive/session-persistence.ts
@@ -40,7 +40,6 @@ export interface IInteractiveSessionRecord {
   memoryEvents?: IMemoryEvent[];
   usedMemoryReferences?: IMemoryReference[];
   contextReferences?: IContextReferenceItem[];
-  usedTokens?: number;
   sandboxSnapshotId?: string;
 }
 

--- a/packages/agent-session/src/__tests__/session-compaction.test.ts
+++ b/packages/agent-session/src/__tests__/session-compaction.test.ts
@@ -141,16 +141,27 @@ describe('Session compaction', () => {
     const session = createSession({
       onCompactEvent: (event: ICompactEvent) => compactEvents.push(event),
     });
+    // Content long enough so serialized JSON estimate is clearly non-zero regardless of context window.
     mockHistory = [
-      { role: 'user', content: 'hello', metadata: { inputTokens: 70, outputTokens: 10 } },
-      { role: 'assistant', content: 'hi', metadata: { inputTokens: 90_000, outputTokens: 10_000 } },
+      {
+        role: 'user',
+        content: 'x'.repeat(130),
+        metadata: { inputTokens: 70, outputTokens: 10 },
+      },
+      {
+        role: 'assistant',
+        content: 'x'.repeat(130),
+        metadata: { inputTokens: 90_000, outputTokens: 10_000 },
+      },
     ];
 
     await session.compact();
 
     expect(compactEvents).toHaveLength(1);
     expect(compactEvents[0].trigger).toBe('manual');
-    expect(compactEvents[0].before.usedPercentage).toBeGreaterThan(0);
+    // Check usedTokens (raw count) rather than usedPercentage, which rounds to 0 for tiny messages
+    // against a large context window (e.g., 200k).
+    expect(compactEvents[0].before.usedTokens).toBeGreaterThan(0);
     expect(compactEvents[0].after.usedPercentage).toBeGreaterThanOrEqual(0);
   });
 
@@ -214,10 +225,15 @@ describe('Session compaction', () => {
     // Create session with a small context window to trigger compaction easily
     const session = createSession({ contextMaxTokens: 100 });
 
-    // Seed history with metadata that shows high token usage
+    // Seed history with large enough content so the serialized JSON estimate exceeds the threshold.
+    // Two messages with 130-char content each → ~420 JSON chars → 105 estimated tokens > 83.5% of 100.
     mockHistory = [
-      { role: 'user', content: 'hello', metadata: { inputTokens: 90, outputTokens: 10 } },
-      { role: 'assistant', content: 'response', metadata: { inputTokens: 90, outputTokens: 10 } },
+      { role: 'user', content: 'x'.repeat(130), metadata: { inputTokens: 90, outputTokens: 10 } },
+      {
+        role: 'assistant',
+        content: 'x'.repeat(130),
+        metadata: { inputTokens: 90, outputTokens: 10 },
+      },
     ];
 
     // run() should trigger auto-compact at the START (before processing the message)
@@ -241,9 +257,18 @@ describe('Session compaction', () => {
       onCompactEvent: (event: ICompactEvent) => compactEvents.push(event),
     });
 
+    // Two messages with 130-char content → serialized JSON exceeds contextMaxTokens (100 tokens cap = 100%)
     mockHistory = [
-      { role: 'user', content: 'hello', metadata: { inputTokens: 90, outputTokens: 10 } },
-      { role: 'assistant', content: 'response', metadata: { inputTokens: 90, outputTokens: 10 } },
+      {
+        role: 'user',
+        content: 'x'.repeat(130),
+        metadata: { inputTokens: 90, outputTokens: 10 },
+      },
+      {
+        role: 'assistant',
+        content: 'x'.repeat(130),
+        metadata: { inputTokens: 90, outputTokens: 10 },
+      },
     ];
 
     await session.run('next question');
@@ -256,8 +281,9 @@ describe('Session compaction', () => {
   it('auto-compact uses a configured threshold', async () => {
     const session = createSession({ contextMaxTokens: 100, autoCompactThreshold: 0.5 });
 
+    // Single message with 130-char content → serialized JSON ~208 chars → 52 tokens → 52% > 50% threshold
     mockHistory = [
-      { role: 'user', content: 'hello', metadata: { inputTokens: 40, outputTokens: 20 } },
+      { role: 'user', content: 'x'.repeat(130), metadata: { inputTokens: 40, outputTokens: 20 } },
     ];
 
     await session.run('next question');
@@ -286,8 +312,9 @@ describe('Session compaction', () => {
     const session = createSession({ contextMaxTokens: 100, autoCompactThreshold: false });
     session.setAutoCompactThreshold(0.5);
 
+    // Single message with 130-char content → serialized JSON ~208 chars → 52 tokens → 52% > 50% threshold
     mockHistory = [
-      { role: 'user', content: 'hello', metadata: { inputTokens: 40, outputTokens: 20 } },
+      { role: 'user', content: 'x'.repeat(130), metadata: { inputTokens: 40, outputTokens: 20 } },
     ];
 
     await session.run('next question');

--- a/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
+++ b/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
@@ -93,6 +93,7 @@ describe('Session provider callback isolation', () => {
 
     expect(snapshots.length).toBeGreaterThanOrEqual(2);
     expect(snapshots[0]?.usedTokens).toBeGreaterThan(0);
-    expect(snapshots.at(-1)?.usedTokens).toBe(15);
+    // usedTokens reflects serialized JSON estimate of the conversation, not provider-reported tokens.
+    expect(snapshots.at(-1)?.usedTokens).toBeGreaterThan(0);
   });
 });

--- a/packages/agent-session/src/context-window-tracker.test.ts
+++ b/packages/agent-session/src/context-window-tracker.test.ts
@@ -26,7 +26,7 @@ function assistantMessage(inputTokens: number, outputTokens: number): TUniversal
 }
 
 describe('ContextWindowTracker', () => {
-  it('includes metadata-free prompt text even when previous provider usage exists', () => {
+  it('estimates tokens from serialized JSON — large user message dominates estimate', () => {
     const tracker = new ContextWindowTracker('claude-haiku-4-5', 200_000);
 
     tracker.updateFromHistory([assistantMessage(1_000, 100), userMessage('x'.repeat(320_000))]);

--- a/packages/agent-session/src/context-window-tracker.ts
+++ b/packages/agent-session/src/context-window-tracker.ts
@@ -4,7 +4,7 @@
  * Extracted from Session to separate context monitoring from conversation management.
  */
 
-import { estimateContextTokensFromMessages, getModelContextWindow } from '@robota-sdk/agent-core';
+import { estimateSerializedContextTokens, getModelContextWindow } from '@robota-sdk/agent-core';
 
 import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
 
@@ -69,7 +69,7 @@ export class ContextWindowTracker {
    * execution guards reason about the same effective token state.
    */
   updateFromHistory(history: TUniversalMessage[]): void {
-    this.contextUsedTokens = estimateContextTokensFromMessages(history).usedTokens;
+    this.contextUsedTokens = estimateSerializedContextTokens(history);
   }
 
   /** Reset token tracking */


### PR DESCRIPTION
## Summary

- **문제**: 상태바의 토큰 수(104,739)와 `/context list` 항목 합계(~66,481)가 불일치
- **원인**: `estimateContextTokensFromMessages()`가 마지막 메시지의 API 보고 토큰 수를 사용했고, `/context list`는 다른 계산 경로를 사용함
- **해결**: `ContextWindowTracker.updateFromHistory`를 `estimateSerializedContextTokens()` 단일 경로로 통일 (`Math.ceil(JSON.stringify(messages).length / 4)`)

## Changes

- `ContextWindowTracker.updateFromHistory`: provider-reported tokens 제거 → serialized JSON 추정만 사용
- `IInteractiveSessionRecord.usedTokens` 필드 제거: persist했지만 resume 시 `syncContextFromHistory()`가 즉시 덮어쓰던 dead code
- `ICommandSessionRuntime.getHistory(): TUniversalMessage[]` 추가: `/context list`가 role별 토큰 분석을 직접 계산할 수 있도록
- `/context` summary view: 삭제된 `analyzeHistory` 대신 `buildToolDisplayList` 사용
- 테스트 업데이트: compaction 테스트들이 provider-reported 토큰 대신 serialized 추정으로 임계값 초과하도록 content를 충분히 길게 조정

## Test plan

- [x] `pnpm --filter @robota-sdk/agent-session test` — 60/60 통과
- [x] `pnpm --filter @robota-sdk/agent-framework test` — 881/881 통과
- [x] `pnpm --filter @robota-sdk/agent-command test` — 168/168 통과
- [x] `pnpm test` — 전체 패키지 모두 통과
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)