### PR TITLE
chore: version packages — 3.0.0-beta.71

### DIFF
--- a/.changeset/context-ssot-token-estimation.md
+++ b/.changeset/context-ssot-token-estimation.md
@@ -1,0 +1,18 @@
+---
+'@robota-sdk/agent-cli': patch
+'@robota-sdk/agent-command': patch
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-executor': patch
+'@robota-sdk/agent-framework': patch
+'@robota-sdk/agent-interface-transport': patch
+'@robota-sdk/agent-interface-tui': patch
+'@robota-sdk/agent-plugin': patch
+'@robota-sdk/agent-provider': patch
+'@robota-sdk/agent-session': patch
+'@robota-sdk/agent-subagent-runner': patch
+'@robota-sdk/agent-tools': patch
+'@robota-sdk/agent-transport': patch
+'@robota-sdk/agent-web-ui': patch
+---
+
+fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -88,6 +88,7 @@
     "cmd-003-tui-command-interaction",
     "cmd-display-name-requires-permission",
     "collapse-command-transcripts",
+    "context-ssot-token-estimation",
     "edit-checkpointing",
     "every-aliens-pump",
     "fix-cli-diff-context-hunks",

--- a/apps/agent-server/CHANGELOG.md
+++ b/apps/agent-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-server
 
+## 3.0.1-beta.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-command@3.0.0-beta.71
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+  - @robota-sdk/agent-provider@3.0.0-beta.71
+  - @robota-sdk/agent-playground@3.0.0-beta.71
+
 ## 3.0.1-beta.26
 
 ### Patch Changes

--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-server",
-  "version": "3.0.1-beta.26",
+  "version": "3.0.1-beta.27",
   "description": "Agent Server - AI provider proxy and Playground WebSocket server",
   "private": true,
   "keywords": [

--- a/apps/starter-nextjs/CHANGELOG.md
+++ b/apps/starter-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/starter-nextjs
 
+## 0.0.2-beta.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+  - @robota-sdk/agent-provider@3.0.0-beta.71
+
 ## 0.0.2-beta.2
 
 ### Patch Changes

--- a/apps/starter-nextjs/package.json
+++ b/apps/starter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/starter-nextjs",
-  "version": "0.0.2-beta.2",
+  "version": "0.0.2-beta.3",
   "private": true,
   "description": "Robota SDK — Next.js AI Chat starter template",
   "scripts": {

--- a/packages/agent-cli/CHANGELOG.md
+++ b/packages/agent-cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @robota-sdk/agent-cli
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-command@3.0.0-beta.71
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+  - @robota-sdk/agent-provider@3.0.0-beta.71
+  - @robota-sdk/agent-subagent-runner@3.0.0-beta.71
+  - @robota-sdk/agent-transport@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-cli",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "AI coding assistant CLI built on Robota SDK",
   "type": "module",
   "bin": {

--- a/packages/agent-command/CHANGELOG.md
+++ b/packages/agent-command/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-command
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Consolidated command module implementations for Robota SDK CLI",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-core
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+
 ## 3.0.0-beta.70
 
 ## 3.0.0-beta.69

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-core",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Complete AI agent implementation with unified core and tools functionality - conversation management, plugin system, and advanced agent features",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-executor/CHANGELOG.md
+++ b/packages/agent-executor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-executor
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-executor",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Composable runtime primitives for Robota background tasks and subagent orchestration",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-framework/CHANGELOG.md
+++ b/packages/agent-framework/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-framework
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-executor@3.0.0-beta.71
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.71
+  - @robota-sdk/agent-session@3.0.0-beta.71
+  - @robota-sdk/agent-tools@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-framework",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Programmatic SDK for building AI agents with Robota — provides InteractiveSession, createQuery(), command APIs, permissions, hooks, and context loading",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-transport/CHANGELOG.md
+++ b/packages/agent-interface-transport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-interface-transport
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+
 ## 3.0.0-beta.70
 
 ## 3.0.0-beta.69

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-transport",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Transport contract interfaces for the Robota SDK (ITransportAdapter, IConfigurableTransport, ITransportConfig)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-tui/CHANGELOG.md
+++ b/packages/agent-interface-tui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-interface-tui
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+
 ## 3.0.0-beta.70
 
 ## 3.0.0-beta.69

--- a/packages/agent-interface-tui/package.json
+++ b/packages/agent-interface-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-tui",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "TUI interaction contract interfaces for the Robota SDK (ITuiPickerItem, ITuiCommandInteraction, ITuiPickerInteraction, ITuiConfirmInteraction)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-playground/CHANGELOG.md
+++ b/packages/agent-playground/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-playground
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-provider@3.0.0-beta.71
+  - @robota-sdk/agent-tools@3.0.0-beta.71
+  - @robota-sdk/agent-remote-client@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-playground",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Deployable Playground UI package (React implementation) for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-plugin
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-plugin",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Consolidated plugin implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider/CHANGELOG.md
+++ b/packages/agent-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-provider
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-provider/package.json
+++ b/packages/agent-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Consolidated AI provider implementations for Robota SDK",
   "type": "module",
   "publishConfig": {

--- a/packages/agent-remote-client/CHANGELOG.md
+++ b/packages/agent-remote-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-remote-client
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-remote-client",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Remote client for calling a Robota agent over HTTP",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session/CHANGELOG.md
+++ b/packages/agent-session/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-session
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Session and chat management for Robota SDK - multi-session support with independent workspaces",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-subagent-runner/CHANGELOG.md
+++ b/packages/agent-subagent-runner/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-subagent-runner
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-executor@3.0.0-beta.71
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+  - @robota-sdk/agent-provider@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-subagent-runner/package.json
+++ b/packages/agent-subagent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-subagent-runner",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Child-process subagent runner for Robota SDK — optional package for running subagents in isolated child processes",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tool-mcp/CHANGELOG.md
+++ b/packages/agent-tool-mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-tool-mcp
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-tools@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tool-mcp",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "MCP protocol tool implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tools/CHANGELOG.md
+++ b/packages/agent-tools/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-tools
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tools",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Tool registry and implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport/CHANGELOG.md
+++ b/packages/agent-transport/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-transport
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-core@3.0.0-beta.71
+  - @robota-sdk/agent-framework@3.0.0-beta.71
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.71
+  - @robota-sdk/agent-interface-tui@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Consolidated transport package for Robota SDK — headless, HTTP, WebSocket, and MCP adapters",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-web-ui/CHANGELOG.md
+++ b/packages/agent-web-ui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-web
 
+## 3.0.0-beta.71
+
+### Patch Changes
+
+- fix(context): unify token estimation to single SSOT — status bar and /context list now use the same serialized JSON estimate
+- Updated dependencies
+  - @robota-sdk/agent-transport@3.0.0-beta.71
+
 ## 3.0.0-beta.70
 
 ### Patch Changes

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-web-ui",
-  "version": "3.0.0-beta.70",
+  "version": "3.0.0-beta.71",
   "description": "Browser UI library for monitoring and controlling a running agent-cli session",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
## Summary
- Version bump all packages to `3.0.0-beta.71`
- Includes fix: unify token estimation to single SSOT — status bar and `/context list` now use the same serialized JSON estimate
- Removes `usedTokens` pre-stored value from session persistence (dead code)

## Test plan
- [x] `pnpm build` passes
- [x] `robota --version` → `3.0.0-beta.71`

🤖 Generated with [Claude Code](https://claude.com/claude-code)