### PR TITLE
chore(release): mark 3.0.0-beta.71 complete — 10 packages published

### DIFF
--- a/.agents/release-runs/3.0.0-beta.71.md
+++ b/.agents/release-runs/3.0.0-beta.71.md
@@ -1,0 +1,39 @@
+# Release Run: 3.0.0-beta.71
+
+## State
+
+- Version: 3.0.0-beta.71
+- Branch: develop
+- SHA: b519d6aeeec2
+- PR: #661 (fix/context-list-ssot-token-count), #662 (chore/release-3.0.0-beta.71)
+- Target branch: main
+- Active gate: complete
+- Gate status: passed
+- Next action: none — release complete.
+- Stop condition: n/a
+
+## Publish Gate
+
+- Publish ready: yes
+- NPM auth verified: yes (jungyoun — 2026-05-31)
+- Dry run passed: yes
+- OTP requested: yes
+- Published: yes (10 packages — 2026-05-31)
+- Dist-tags verified: yes (latest + beta both → 3.0.0-beta.71)
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
+
+## CI Triage Notes
+
+<!-- Append notes with pnpm harness:release:triage -- --version 3.0.0-beta.71 --pr <number> --check <name>. -->
+
+## Final Report
+
+- Merged PRs: #661 (fix/context-list-ssot-token-count — context token SSOT unification), #662 (chore/release-3.0.0-beta.71 — version bump)
+- Published version: 3.0.0-beta.71
+- Published packages: 10 (@robota-sdk/agent-core, agent-plugin, agent-provider, agent-session, agent-tools, agent-framework, agent-command, agent-subagent-runner, agent-transport, agent-cli)
+- Validation gates: npm auth ✅ · build ✅ · dry-run ✅ · publish ✅ · dist-tags ✅
+- Skipped checks: none


### PR DESCRIPTION
## Summary
- Records release-run artifact for `3.0.0-beta.71`
- All 10 packages published to npm with `latest` and `beta` dist-tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)