### PR TITLE
fix(tui): revert IME blank line to normal flow for remount stability

### DIFF
--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -472,10 +472,8 @@ function AppInner(
         sessionName={sessionName}
         history={history}
       />
-      {/* Blank line for Korean IME — absolute to avoid extending output height. */}
-      <Box position="absolute">
-        <Text> </Text>
-      </Box>
+      {/* Blank line for Korean IME — normal flow ensures it persists across remounts. */}
+      <Text> </Text>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- `<Box position="absolute"><Text> </Text></Box>` → `<Text> </Text>` (normal flow)
- `position="absolute"` caused the blank line to disappear after `AppInner` remount (e.g. `/resume` session switch via key change)
- Normal flow `<Text>` is always rendered reliably regardless of remount

## Trade-off

Korean IME candidate window moves 1 row further from the input (cursor 2 rows below bottom border instead of 1). This is the original pre-`d879c76` behavior, accepted as a better trade-off than the disappearing blank line.

## Test plan

- [x] typecheck passes
- [x] Blank line persists after `/resume` session switch
- [x] Blank line persists after other UI state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)