### PR TITLE
fix(tui): remove corner chars from input top border

### DIFF
--- a/packages/agent-transport/src/tui/InputArea.tsx
+++ b/packages/agent-transport/src/tui/InputArea.tsx
@@ -237,9 +237,9 @@ export default function InputArea({
       const label = ` "${sessionName}" `;
       const rightPad = 2;
       const leftLen = Math.max(0, innerWidth - label.length - rightPad);
-      return { left: '┌' + '─'.repeat(leftLen), label, right: '─'.repeat(rightPad) + '┐' };
+      return { left: '─'.repeat(leftLen), label, right: '─'.repeat(rightPad) };
     }
-    return { left: '┌' + '─'.repeat(innerWidth), label: '', right: '┐' };
+    return { left: '─'.repeat(innerWidth), label: '', right: '' };
   })();
 
   return (


### PR DESCRIPTION
After SCREEN-001, the hand-drawn top border still had `┌` and `┐` corner characters. Replaced with `─` so the top line is a plain horizontal line matching the bottom border.