### PR TITLE
fix(tui): remove blank line between input and status bar

### DIFF
--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -456,8 +456,6 @@ function AppInner(
         sessionName={sessionName}
         history={history}
       />
-      {/* Blank line for Korean IME — normal flow ensures it persists across remounts. */}
-      <Text> </Text>
       <SessionStatusBar
         cwd={cwd}
         permissionMode={permissionMode}


### PR DESCRIPTION
Removes the `<Text> </Text>` IME spacing line that became a visible gap after SCREEN-002 moved the status bar below the input. User confirmed removal is acceptable (spec-gate waiver).