### PR TITLE
refactor(transport): single React owner for TuiInteractionChannel lifecycle (CLI-B12)

### DIFF
--- a/.agents/backlog/completed/CLI-B12-tui-channel-lifecycle-architecture.md
+++ b/.agents/backlog/completed/CLI-B12-tui-channel-lifecycle-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI-B12: TuiInteractionChannel 생명주기 — React 외부 생성으로 인한 구조적 사각지대'
-status: todo
+status: done
 created: 2026-05-31
 priority: high
 urgency: soon
@@ -102,7 +102,20 @@ CLI-B11 테스트에서 직접 사용할 수 있게 한다.
 
 ## 완료 기준
 
-- [ ] 설계안 확정 (사용자 컨펌)
-- [ ] 채널 생명주기 소유자가 단일화됨
-- [ ] `TuiInteractionChannel` 또는 동등한 인터페이스를 외부 테스트에서 사용 가능
-- [ ] CLI-B11의 TC-A ~ TC-E가 이 구조 위에서 안정적으로 동작
+- [x] 설계안 확정 (사용자 컨펌) — Option A, 2026-06-13 "승인함" (스펙 GATE-APPROVAL 증거)
+- [x] 채널 생명주기 소유자가 단일화됨 — `App` React state가 유일한 소유자:
+      `useState(() => createChannel(resumeSessionId))` 초기 생성, 전환 시
+      `void old.stop()` 후 교체; `render.tsx`는 팩토리만 전달 (채널 생성 코드 제거)
+- [x] `TuiInteractionChannel` 또는 동등한 인터페이스를 외부 테스트에서 사용 가능 —
+      패키지 내 테스트가 팩토리 seam + 실제 채널 경로
+      (`channel-factory-integration.test.ts`)로 검증; 공개 export 없이 해결
+- [x] CLI-B11의 TC-A ~ TC-E가 이 구조 위에서 안정적으로 동작 —
+      `session-switch-channel.test.tsx` 4/4 + 통합 2/2 green (TC-D는 팩토리 필수화로
+      대체 — CLI-B12 스펙 Solution 3)
+
+## Evidence (2026-06-13)
+
+- `pnpm --filter @robota-sdk/agent-transport test` — 61 files / 473 tests green
+- typecheck 0 errors (transport + agent-cli), lint clean, build complete
+- 재빌드 실 바이너리 PTY 시나리오 (단일 소유 구조):
+  `Context: 0% → 6% (11.9K/200K) → 16% (31.8K/200K)` 연속 /resume 전환

--- a/.agents/spec-docs/active/CLI-B12-channel-lifecycle-react-ownership.md
+++ b/.agents/spec-docs/active/CLI-B12-channel-lifecycle-react-ownership.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: in-progress
 type: INFRA
 tags: [cli, typescript, react]
 ---
@@ -101,7 +101,13 @@ props.createChannel(id), sessionId: id })`. Remove the `channel` prop from `IApp
       per mount (mock factory call count = 1 on initial render)
 - [ ] TC-02: session switch stops the old channel before the new channel becomes active
       (ordering observable via spied `stop()` vs factory invocation order)
-- [ ] TC-03: CLI-B11 TC-A/B/C/E assertions still pass unchanged on the new structure
+- [ ] TC-03: CLI-B11 TC-A/B/C/E assertions still pass on the new structure. _Correction
+      during implementation (within the approved Decision): "unchanged" holds for the
+      asserted contracts (factory receives the selected id, one new channel per switch, old
+      stopped / active never stopped, real-store restoration), but the suite was
+      mechanically adapted to the new channel source — the initial channel is now factory
+      call 1 (`undefined`), so switch calls shift to nth 2..4 and the old B11 TC-D
+      no-factory fallback test is deleted as specified by this spec's Solution step 3._
 - [ ] TC-04: `App` no longer accepts a `channel` prop and `createChannel` is required —
       typecheck fails for the old call shape (`pnpm --filter @robota-sdk/agent-transport typecheck` exits 0 on new code)
 - [ ] TC-05: real TUI boots and `/resume` session switch shows Context > 0% (PTY or
@@ -122,7 +128,7 @@ props.createChannel(id), sessionId: id })`. Remove the `channel` prop from `IApp
 
 ## Tasks
 
-- [ ] `.agents/tasks/CLI-B12.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [ ] `.agents/tasks/CLI-B12.md` — T1~T7 (TC-01~TC-06 매핑 + wrap-up)
 
 ## Evidence Log
 
@@ -151,3 +157,12 @@ props.createChannel(id), sessionId: id })`. Remove the `channel` prop from `IApp
 - Non-approval messages correctly excluded: "머지하고 main 릴리스 진행해줘" (release instruction, executed as docs-only release PR #705) and "그래서 뭐?" (clarifying question) were not counted as design approval.
 - No Architecture Review or frontmatter type/tags modified after the approval request: git history for this file contains a single commit (`cd5b1053a`, GATE-WRITE batch); only post-GATE-WRITE changes were the GATE-WRITE Evidence Log entry, frontmatter status draft → review-ready, and prettier formatting; working tree clean.
 - NON-COMPLIANCE check (no implementation before this gate): `.agents/tasks/CLI-B12.md` does not exist; `packages/agent-transport` working tree clean; latest commit touching `src/tui` is `5dc0c9649` (CLI-074, prior item) — no CLI-B12 implementation work started.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** approved → in-progress
+
+- Tasks file created: `.agents/tasks/CLI-B12.md` exists (verified by direct read; present as untracked file on branch `feat/cli-b12-channel-react-ownership`).
+- Tasks file path recorded in `## Tasks`: spec's Tasks section lists `.agents/tasks/CLI-B12.md` — T1~T7 (TC-01~TC-06 매핑 + wrap-up).
+- Tasks correspond to Completion Criteria (one task per TC-N): T1→TC-01 (useState lazy-initializer channel creation, render.tsx construction removed), T2→TC-02 (old channel stop ordering before new channel active), T3→TC-03 (CLI-B11 TC-A/B/C/E regression hold), T4→TC-04 (IAppProps drops `channel`, `createChannel` required, typecheck/build), T5→TC-05 (real-store integration / PTY /resume Context > 0%), T6→TC-06 (docs/SPEC.md single-owner lifecycle contract) — all 6 TC-N covered; T7 is wrap-up (test/typecheck/lint/build + PR + backlog completion), additive beyond the minimum.
+- NON-COMPLIANCE check (tasks file before implementation): `git status` shows only spec move (todo → active), the new tasks file, and unrelated evals lessons; `packages/agent-transport/src/tui/App.tsx` and `render.tsx` untouched; latest commit touching `src/tui` is `0c472a40f` (CLI-B11 #706, prerequisite merge) — no CLI-B12 implementation commits exist.

--- a/.agents/spec-docs/done/CLI-B12-channel-lifecycle-react-ownership.md
+++ b/.agents/spec-docs/done/CLI-B12-channel-lifecycle-react-ownership.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags: [cli, typescript, react]
 ---
@@ -96,39 +96,39 @@ props.createChannel(id), sessionId: id })`. Remove the `channel` prop from `IApp
 
 ## Completion Criteria
 
-- [ ] TC-01: `render.tsx` contains no `TuiInteractionChannel` construction; the initial
+- [x] TC-01: `render.tsx` contains no `TuiInteractionChannel` construction; the initial
       channel is created by `App`'s `useState` initializer via the factory, exactly once
       per mount (mock factory call count = 1 on initial render)
-- [ ] TC-02: session switch stops the old channel before the new channel becomes active
+- [x] TC-02: session switch stops the old channel before the new channel becomes active
       (ordering observable via spied `stop()` vs factory invocation order)
-- [ ] TC-03: CLI-B11 TC-A/B/C/E assertions still pass on the new structure. _Correction
+- [x] TC-03: CLI-B11 TC-A/B/C/E assertions still pass on the new structure. _Correction
       during implementation (within the approved Decision): "unchanged" holds for the
       asserted contracts (factory receives the selected id, one new channel per switch, old
       stopped / active never stopped, real-store restoration), but the suite was
       mechanically adapted to the new channel source — the initial channel is now factory
       call 1 (`undefined`), so switch calls shift to nth 2..4 and the old B11 TC-D
       no-factory fallback test is deleted as specified by this spec's Solution step 3._
-- [ ] TC-04: `App` no longer accepts a `channel` prop and `createChannel` is required —
+- [x] TC-04: `App` no longer accepts a `channel` prop and `createChannel` is required —
       typecheck fails for the old call shape (`pnpm --filter @robota-sdk/agent-transport typecheck` exits 0 on new code)
-- [ ] TC-05: real TUI boots and `/resume` session switch shows Context > 0% (PTY or
+- [x] TC-05: real TUI boots and `/resume` session switch shows Context > 0% (PTY or
       real-store integration evidence)
-- [ ] TC-06: `docs/SPEC.md` documents single-owner channel lifecycle (created/replaced/
+- [x] TC-06: `docs/SPEC.md` documents single-owner channel lifecycle (created/replaced/
       stopped only via App state)
 
 ## Test Plan
 
-| TC-ID | Test Type   | Tool / Approach                                                      | Notes                                                                 |
-| ----- | ----------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| TC-01 | unit        | vitest + ink-testing-library, mock factory, initial-render assertion | factory called once, no eager channel in render.tsx (grep + test)     |
-| TC-02 | unit        | vitest, spied `stop()` + factory order assertion                     | old stopped before new active                                         |
-| TC-03 | unit        | re-run CLI-B11 suite on new structure                                | regression hold                                                       |
-| TC-04 | integration | `pnpm --filter @robota-sdk/agent-transport typecheck` + build        | old prop shape removed                                                |
-| TC-05 | integration | PTY driver (CLI-074) or real-store integration test                  | restored context > 0 end to end                                       |
-| TC-06 | manual      | SPEC.md diff review                                                  | doc prose — reviewed at GATE-COMPLETE by direct read, not automatable |
+| TC-ID | Test Type   | Tool / Approach                                                      | Notes / Test Reference (GATE-COMPLETE)                                                                                                                                                                                                            |
+| ----- | ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TC-01 | unit        | vitest + ink-testing-library, mock factory, initial-render assertion | Test: `packages/agent-transport/src/tui/__tests__/session-switch-channel.test.tsx > App session-switch channel ownership (CLI-B11) > "TC-01 (B11) / TC-01 (B12): the factory is the sole channel source"` + grep `render.tsx` (no channel passed) |
+| TC-02 | unit        | vitest, spied `stop()` + factory order assertion                     | Test: same file > `"TC-03 (B11) / TC-02 (B12): the previous channel is stopped before the new one becomes active"`                                                                                                                                |
+| TC-03 | unit        | re-run CLI-B11 suite on new structure                                | Test: `session-switch-channel.test.tsx` full suite (4/4) + `packages/agent-transport/src/tui/__tests__/channel-factory-integration.test.ts` (2/2)                                                                                                 |
+| TC-04 | integration | `pnpm --filter @robota-sdk/agent-transport typecheck` + build        | Verified: typecheck exit 0 + `App.tsx:40-58` `IProps` read (required `createChannel`, no `channel`) + suite test `"TC-04 (B12): App renders from the factory alone — no channel prop exists"`                                                     |
+| TC-05 | integration | PTY driver (CLI-074) or real-store integration test                  | Test: `channel-factory-integration.test.ts` (2/2 green) + PTY rebuilt-binary evidence recorded in `.agents/backlog/completed/CLI-B12-tui-channel-lifecycle-architecture.md` (Context 0% → 6% → 16%)                                               |
+| TC-06 | manual      | SPEC.md diff review                                                  | Skip (no automated test): doc prose, not automatable — manually verified at GATE-COMPLETE by direct read of `packages/agent-transport/docs/SPEC.md:109-111` §TUI lifecycle single-owner paragraph (CLI-B12)                                       |
 
 ## Tasks
 
-- [ ] `.agents/tasks/CLI-B12.md` — T1~T7 (TC-01~TC-06 매핑 + wrap-up)
+- [x] `.agents/tasks/completed/CLI-B12.md` — archived at GATE-COMPLETE (T1~T7 complete, TC-01~TC-06 매핑)
 
 ## Evidence Log
 
@@ -166,3 +166,59 @@ props.createChannel(id), sessionId: id })`. Remove the `channel` prop from `IApp
 - Tasks file path recorded in `## Tasks`: spec's Tasks section lists `.agents/tasks/CLI-B12.md` — T1~T7 (TC-01~TC-06 매핑 + wrap-up).
 - Tasks correspond to Completion Criteria (one task per TC-N): T1→TC-01 (useState lazy-initializer channel creation, render.tsx construction removed), T2→TC-02 (old channel stop ordering before new channel active), T3→TC-03 (CLI-B11 TC-A/B/C/E regression hold), T4→TC-04 (IAppProps drops `channel`, `createChannel` required, typecheck/build), T5→TC-05 (real-store integration / PTY /resume Context > 0%), T6→TC-06 (docs/SPEC.md single-owner lifecycle contract) — all 6 TC-N covered; T7 is wrap-up (test/typecheck/lint/build + PR + backlog completion), additive beyond the minimum.
 - NON-COMPLIANCE check (tasks file before implementation): `git status` shows only spec move (todo → active), the new tasks file, and unrelated evals lessons; `packages/agent-transport/src/tui/App.tsx` and `render.tsx` untouched; latest commit touching `src/tui` is `0c472a40f` (CLI-B11 #706, prerequisite merge) — no CLI-B12 implementation commits exist.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** in-progress → verifying
+
+- All tasks complete: `.agents/tasks/CLI-B12.md` T1–T6 `[x]`. T7 (wrap-up: PR + backlog completed/) unchecked but every component independently verified per the established CLI-063/064/065/066/B11 GATE-VERIFY interpretation: PR #707 OPEN (`feat/cli-b12-channel-react-ownership` → `develop`, "refactor(transport): single React owner for TuiInteractionChannel lifecycle (CLI-B12)") with all CI checks green on `gh pr checks 707` — build pass (1m28s), quality pass (54s), security audit pass (6s), Cloudflare Pages pass; compat-node18 and release-grade verification report "skipping" by workflow design on feature PRs (same pattern as B11 PR #706); backlog evidence recorded in `.agents/backlog/completed/CLI-B12-tui-channel-lifecycle-architecture.md` (frontmatter `status: done`; all 4 완료 기준 `[x]` with evidence — Option A 승인, App React state sole owner, factory seam + `channel-factory-integration.test.ts`, B11 suite 4/4 + integration 2/2 with TC-D replaced per Solution step 3).
+- No tasks blocked or pending: tasks file contains no blocked markers; only T7 wrap-up remains open as adjudicated above. The TC-03 italic correction note (suite mechanically adapted: initial channel = factory call 1 with `undefined`, switch calls shift to nth 2..4, B11 TC-D fallback test deleted as specified in Solution step 3) is a documented in-Decision correction per the CLI-066/B11 correction-note precedent, not a blocked/divergent task.
+- Implementation conformance spot-check (fresh-read this gate): `render.tsx` contains no eager `new TuiInteractionChannel` + `channel` prop — only the factory definition (`render.tsx:93-94`) passed as `createChannel` (`render.tsx:99`); `App.tsx` `useState` lazy initializer calls `props.createChannel(props.resumeSessionId)` (`App.tsx:63-68`); `onSessionSwitch` runs `void sessionState.channel.stop()` before `setSessionState` with the new channel (`App.tsx:86-87`); `IProps` has required `createChannel` and no `channel` field (`App.tsx:40-58`).
+- Build passes: `pnpm --filter @robota-sdk/agent-transport build` fresh-run this gate — "Build complete in 710ms" (38 files, 481.93 kB), exit 0. Repo-wide build (including type-level consumer `agent-cli`) green via PR #707 CI build job (pass, 1m28s).
+- Tests pass: `pnpm --filter @robota-sdk/agent-transport test` fresh-run this gate — **61 files passed / 473 tests passed**, 0 failures, exit 0 (matches the expected 61/473 from the B11 baseline carried onto the new structure).
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-01 is `[x]` in `## Completion Criteria`.
+- Command: `npx vitest run src/tui/__tests__/session-switch-channel.test.tsx` (cwd `packages/agent-transport`) — test `App session-switch channel ownership (CLI-B11) > TC-01 (B11) / TC-01 (B12): the factory is the sole channel source — once at mount, once per switch with the selected sessionId` ✓ passed (1064ms), suite 4/4, exit 0.
+- Grep: `rg -n "TuiInteractionChannel|createChannel|channel" packages/agent-transport/src/tui/render.tsx` — `new TuiInteractionChannel(...)` appears only inside the `createChannel` factory body (`render.tsx:93-94`), passed as `createChannel` prop (`render.tsx:99`); no constructed channel is passed to `App` (no `channel` prop anywhere in the file).
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-02 is `[x]` in `## Completion Criteria`.
+- Command: same suite run — test `App session-switch channel ownership (CLI-B11) > TC-03 (B11) / TC-02 (B12): the previous channel is stopped before the new one becomes active` ✓ passed (999ms), exit 0. Ordering asserted via mock `invocationCallOrder` (spied `stop()` before factory invocation for the new channel).
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-03 is `[x]` in `## Completion Criteria`.
+- Command 1: `npx vitest run src/tui/__tests__/session-switch-channel.test.tsx` — **4 tests passed (4)**, 0 failures, exit 0 (TC-01/TC-02/TC-04/TC-05 names listed in output; B11 contracts hold on the new structure per the spec's documented in-Decision adaptation note — initial channel is factory call 1, B11 TC-D fallback test deleted per Solution step 3).
+- Command 2: `npx vitest run src/tui/__tests__/channel-factory-integration.test.ts` — **2 tests passed (2)**, 0 failures, exit 0 (real-store restoration path on the new structure).
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-04 is `[x]` in `## Completion Criteria`.
+- Command: `pnpm --filter @robota-sdk/agent-transport typecheck` — `tsc --noEmit` completed with no output, exit 0.
+- Direct read `App.tsx:40-58`: `IProps` declares `createChannel: (resumeSessionId?: string) => TuiInteractionChannel` as required (JSDoc "Sole channel source (CLI-B12)"); no `channel` field exists in `IProps` — the old call shape cannot typecheck.
+- Corroborating test: same suite — `TC-04 (B12): App renders from the factory alone — no channel prop exists` ✓ passed (582ms).
+
+### [GATE-COMPLETE: TC-05] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-05 is `[x]` in `## Completion Criteria`.
+- Command: `npx vitest run src/tui/__tests__/channel-factory-integration.test.ts` — 2/2 passed, exit 0 (real-store integration: restored context end to end on the single-owner structure).
+- PTY evidence (direct read): `.agents/backlog/completed/CLI-B12-tui-channel-lifecycle-architecture.md` "## Evidence (2026-06-13)" records the rebuilt-binary PTY scenario on the single-owner structure: `Context: 0% → 6% (11.9K/200K) → 16% (31.8K/200K)` across consecutive `/resume` switches — Context > 0% after switch, satisfying the criterion.
+
+### [GATE-COMPLETE: TC-06] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-06 is `[x]` in `## Completion Criteria`.
+- Manual verification (direct read, per Test Plan skip reason — doc prose, not automatable): `packages/agent-transport/docs/SPEC.md:109-111` — section `### TUI lifecycle` contains the paragraph "**Single channel owner (CLI-B12):** `renderApp()` does NOT construct a channel. It passes only a `createChannel(resumeSessionId?)` factory … `App` creates the initial `TuiInteractionChannel` … in its `useState` lazy initializer and replaces it on every session switch — the old channel is stopped (`void channel.stop()`) before the replacement becomes active. … The channel lifecycle is therefore exactly the React state lifecycle: created, replaced, and stopped exclusively through `App` state, with no second owner outside React." — documents created/replaced/stopped only via App state, exactly as the criterion requires.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** verifying → done
+
+- All 6 Completion Criteria checkboxes `[x]`, each with a matching `[GATE-COMPLETE: TC-N]` Evidence entry above (exact command, observed output, exit code).
+- `## Test Plan` updated this gate: TC-01–TC-05 rows carry explicit test file + test name references; TC-06 row carries an explicit skip reason (doc prose, manually verified by direct read of `SPEC.md:109-111`).
+- No TC-N silently unaddressed: 6/6 rows resolved (5 test references, 1 documented manual skip).
+- Tasks file archived: `.agents/tasks/completed/CLI-B12.md` exists (verified by `ls` + direct read) with T1–T7 all `[x]`; `.agents/tasks/CLI-B12.md` no longer exists at the active path.
+- `## Tasks` section reflects the archived path: spec lists `.agents/tasks/completed/CLI-B12.md` — archived at GATE-COMPLETE (T1~T7 complete, TC-01~TC-06 매핑).
+- Fresh test evidence this gate: session-switch suite 4/4 + channel-factory integration 2/2 + typecheck exit 0, all run 2026-06-13.

--- a/.agents/tasks/CLI-B12.md
+++ b/.agents/tasks/CLI-B12.md
@@ -1,0 +1,29 @@
+# Tasks — CLI-B12: TuiInteractionChannel lifecycle — single React owner (Option A)
+
+Spec: `.agents/spec-docs/active/CLI-B12-channel-lifecycle-react-ownership.md`
+Test Plan SSOT: the spec's TC table.
+
+- [x] T1 (TC-01): `App.tsx` — channel created in the `useState` lazy initializer via the
+      required `createChannel` prop; `render.tsx` no longer constructs a channel (grep +
+      mock-factory initial-render test: factory called exactly once per mount).
+- [x] T2 (TC-02): `onSessionSwitch` stops the old channel before the new channel becomes
+      active (spied `stop()` vs factory invocation order assertion).
+- [x] T3 (TC-03): CLI-B11 suite TC-A/B/C/E assertions pass unchanged on the new structure
+      (TC-D replaced per spec — factory now mandatory).
+- [x] T4 (TC-04): `IAppProps` drops `channel` and requires `createChannel`;
+      `pnpm --filter @robota-sdk/agent-transport typecheck` exits 0; build green.
+- [x] T5 (TC-05): end-to-end restored context — real-store integration suite green
+      (channel-factory-integration.test.ts) and/or PTY /resume scenario shows Context > 0%.
+- [x] T6 (TC-06): `docs/SPEC.md` documents single-owner channel lifecycle
+      (created/replaced/stopped only via App state; render.tsx supplies only the factory).
+- [ ] T7: wrap-up — full package test/typecheck/lint/build green; PR to develop (squash);
+      backlog `.agents/backlog/CLI-B12-*.md` completion criteria checked + moved to
+      completed/ with evidence.
+
+## Test Plan
+
+Authoritative TC table: `.agents/spec-docs/active/CLI-B12-channel-lifecycle-react-ownership.md`
+(## Test Plan). Summary: TC-01/02/03 via the updated
+`session-switch-channel.test.tsx` (mock factory, initial render + switch ordering);
+TC-04 via typecheck/build; TC-05 via `channel-factory-integration.test.ts` + PTY
+/resume scenario; TC-06 via SPEC.md diff review at GATE-COMPLETE.

--- a/.agents/tasks/completed/CLI-B12.md
+++ b/.agents/tasks/completed/CLI-B12.md
@@ -16,7 +16,7 @@ Test Plan SSOT: the spec's TC table.
       (channel-factory-integration.test.ts) and/or PTY /resume scenario shows Context > 0%.
 - [x] T6 (TC-06): `docs/SPEC.md` documents single-owner channel lifecycle
       (created/replaced/stopped only via App state; render.tsx supplies only the factory).
-- [ ] T7: wrap-up — full package test/typecheck/lint/build green; PR to develop (squash);
+- [x] T7: wrap-up — full package test/typecheck/lint/build green; PR to develop (squash);
       backlog `.agents/backlog/CLI-B12-*.md` completion criteria checked + moved to
       completed/ with evidence.
 

--- a/packages/agent-transport/docs/SPEC.md
+++ b/packages/agent-transport/docs/SPEC.md
@@ -108,7 +108,7 @@ src/
 
 ### TUI lifecycle
 
-`renderApp()` creates a `TuiInteractionChannel` (which owns `InteractiveSession`, `CommandRegistry`, and `TuiStateManager` creation) and then mounts the Ink `App` component. `App` subscribes to channel state via the `useTuiChannel` hook, which calls `channel.onChange` on each state change. User input is forwarded to `channel.handleInput()`; slash commands that need disambiguation call `channel.requestAction()`, which queues a pick/confirm dialog rendered by `App` and resolved via `channel.resolveAction()`.
+**Single channel owner (CLI-B12):** `renderApp()` does NOT construct a channel. It passes only a `createChannel(resumeSessionId?)` factory to the Ink `App` component; `App` creates the initial `TuiInteractionChannel` (which owns `InteractiveSession`, `CommandRegistry`, and `TuiStateManager` creation) in its `useState` lazy initializer and replaces it on every session switch — the old channel is stopped (`void channel.stop()`) before the replacement becomes active. Channel construction is side-effect-free; I/O starts only in `AppInner`'s effect via `channel.start()`. The channel lifecycle is therefore exactly the React state lifecycle: created, replaced, and stopped exclusively through `App` state, with no second owner outside React. `App` subscribes to channel state via the `useTuiChannel` hook, which calls `channel.onChange` on each state change. User input is forwarded to `channel.handleInput()`; slash commands that need disambiguation call `channel.requestAction()`, which queues a pick/confirm dialog rendered by `App` and resolved via `channel.resolveAction()`.
 
 ### TUI session-init polling
 

--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -39,8 +39,11 @@ import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transpo
 
 interface IProps {
   cwd: string;
-  channel: TuiInteractionChannel;
-  createChannel?: (resumeSessionId?: string) => TuiInteractionChannel;
+  /**
+   * Sole channel source (CLI-B12): App owns the channel lifecycle in React state.
+   * The initial channel and every session-switch replacement come from this factory.
+   */
+  createChannel: (resumeSessionId?: string) => TuiInteractionChannel;
   providerOverride?: string | undefined;
   providerType?: string | undefined;
   modelId?: string;
@@ -55,10 +58,15 @@ interface IProps {
 }
 
 export default function App(props: IProps): React.ReactElement {
+  // Lazy initializer: channel construction is side-effect-free (object wiring only);
+  // I/O starts in AppInner's effect via channel.start(). Runs once per mount.
   const [sessionState, setSessionState] = useState<{
     channel: TuiInteractionChannel;
     sessionId: string | undefined;
-  }>({ channel: props.channel, sessionId: props.resumeSessionId });
+  }>(() => ({
+    channel: props.createChannel(props.resumeSessionId),
+    sessionId: props.resumeSessionId,
+  }));
   const [showInitialSessionPicker, setShowInitialSessionPicker] = useState(
     props.showSessionPickerOnStart ?? false,
   );
@@ -73,10 +81,10 @@ export default function App(props: IProps): React.ReactElement {
         resumeSessionId={sessionState.sessionId}
         onSessionSwitch={(sessionId) => {
           setShowInitialSessionPicker(false);
-          const oldChannel = sessionState.channel;
-          const newChannel = props.createChannel ? props.createChannel(sessionId) : props.channel;
-          setSessionState({ channel: newChannel, sessionId });
-          void oldChannel.stop();
+          // Stop the old channel BEFORE the new one becomes active so it can
+          // never receive events addressed to the new session (CLI-B12).
+          void sessionState.channel.stop();
+          setSessionState({ channel: props.createChannel(sessionId), sessionId });
         }}
       />
     </TuiCliAdapterProvider>
@@ -84,7 +92,10 @@ export default function App(props: IProps): React.ReactElement {
 }
 
 function AppInner(
-  props: IProps & { onSessionSwitch: (sessionId: string) => void },
+  props: IProps & {
+    channel: TuiInteractionChannel;
+    onSessionSwitch: (sessionId: string) => void;
+  },
 ): React.ReactElement {
   const cwd = props.cwd;
   const { channel } = props;

--- a/packages/agent-transport/src/tui/__tests__/session-switch-channel.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/session-switch-channel.test.tsx
@@ -1,10 +1,13 @@
 /**
- * CLI-B11 TC-01/03/04/05: session-switch channel ownership at the App boundary.
+ * CLI-B11 TC-01/03/05 + CLI-B12 TC-01/02/04: session-switch channel ownership
+ * at the App boundary.
  *
  * The 2026-05-31 context-loss bug lived between render.tsx, App.tsx and
  * TuiInteractionChannel — InteractiveSession-level tests stayed green through it.
  * These tests render the REAL App with a mocked createChannel factory and drive
  * switches through the real SessionPicker, pinning the factory-call contract.
+ * Since CLI-B12 the factory is the SOLE channel source: App creates the initial
+ * channel in its useState initializer and replaces it on every switch.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -163,12 +166,10 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
   let cwd: string;
   let created: IFakeChannel[];
   let createChannel: ReturnType<typeof vi.fn>;
-  let initialChannel: IFakeChannel;
 
   beforeEach(() => {
     cwd = mkdtempSync(join(tmpdir(), 'robota-b11-'));
     created = [];
-    initialChannel = createFakeChannel(undefined);
     createChannel = vi.fn((resumeSessionId?: string) => {
       const fake = createFakeChannel(resumeSessionId);
       created.push(fake);
@@ -180,15 +181,14 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  function renderApp(options?: { withFactory?: boolean; sessionIds?: string[] }) {
+  function renderApp(options?: { sessionIds?: string[] }) {
     const ids = options?.sessionIds ?? ['session-aaaaaaaa', 'session-bbbbbbbb'];
     const records = ids.map((id) => sessionRecord(id, cwd));
     const store = createFakeStore(records);
     const instance = render(
       <App
         cwd={cwd}
-        channel={asChannel(initialChannel)}
-        {...(options?.withFactory === false ? {} : { createChannel })}
+        createChannel={createChannel}
         sessionStore={store}
         showSessionPickerOnStart
         cliAdapter={createCliAdapter(join(cwd, 'settings.json'))}
@@ -197,21 +197,28 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     return { ...instance, records };
   }
 
-  it('TC-01: selecting a session in the picker calls createChannel exactly once with that sessionId', async () => {
+  it('TC-01 (B11) / TC-01 (B12): the factory is the sole channel source — once at mount, once per switch with the selected sessionId', async () => {
     const { stdin, lastFrame } = renderApp();
     await tick();
     expect(lastFrame()).toContain('Select a session to resume');
 
+    // CLI-B12 TC-01: initial channel from the useState initializer, exactly once.
+    expect(createChannel).toHaveBeenCalledTimes(1);
+    expect(createChannel).toHaveBeenNthCalledWith(1, undefined);
+
     stdin.write('\r'); // select first item (newest first — equal timestamps keep list order)
     await tick();
 
-    expect(createChannel).toHaveBeenCalledTimes(1);
-    expect(createChannel).toHaveBeenCalledWith('session-aaaaaaaa');
+    // CLI-B11 TC-A: the switch asks the factory for exactly one channel with the id.
+    expect(createChannel).toHaveBeenCalledTimes(2);
+    expect(createChannel).toHaveBeenNthCalledWith(2, 'session-aaaaaaaa');
   });
 
-  it('TC-03: the previous channel is stopped on switch and the new channel is started', async () => {
+  it('TC-03 (B11) / TC-02 (B12): the previous channel is stopped before the new one becomes active', async () => {
     const { stdin } = renderApp();
     await tick();
+    const initialChannel = created[0]!;
+    expect(initialChannel.start).toHaveBeenCalled();
 
     stdin.write('\r');
     await tick();
@@ -219,23 +226,29 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     // Old channel released: stopped by the switch handler and by the unmounting
     // AppInner's effect cleanup (stop() is idempotent by contract).
     expect(initialChannel.stop).toHaveBeenCalled();
-    expect(created).toHaveLength(1);
-    const newChannel = created[0]!;
+    expect(created).toHaveLength(2);
+    const newChannel = created[1]!;
     expect(newChannel.start).toHaveBeenCalled();
     expect(newChannel.stop).not.toHaveBeenCalled();
+
+    // CLI-B12 TC-02 ordering: old stop() was invoked BEFORE the factory built
+    // the replacement channel (stop-before-active contract).
+    const stopOrder = initialChannel.stop.mock.invocationCallOrder[0]!;
+    const replacementOrder = createChannel.mock.invocationCallOrder[1]!;
+    expect(stopOrder).toBeLessThan(replacementOrder);
   });
 
-  it('TC-04: without a createChannel prop, the switch falls back to props.channel and does not crash', async () => {
-    const { stdin, lastFrame } = renderApp({ withFactory: false });
+  it('TC-04 (B12): App renders from the factory alone — no channel prop exists', async () => {
+    // The old no-factory fallback (B11 TC-D) is deleted with CLI-B12: createChannel
+    // is required and `channel` is no longer a prop (enforced at the type level —
+    // passing one is a compile error). This pins the runtime half: a render with
+    // only the factory boots, starts the initial channel, and keeps rendering.
+    const { lastFrame } = renderApp();
     await tick();
 
-    stdin.write('\r');
-    await tick();
-
-    expect(createChannel).not.toHaveBeenCalled();
-    // Fallback keeps the initial channel active; the app keeps rendering.
     expect(lastFrame()).toBeTruthy();
-    expect(initialChannel.start).toHaveBeenCalled();
+    expect(createChannel).toHaveBeenCalledTimes(1);
+    expect(created[0]!.start).toHaveBeenCalled();
   });
 
   it('TC-05: consecutive switches A→B→C create one channel per switch and stop each prior channel', async () => {
@@ -246,11 +259,16 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     touch(records, 'aaaaaaaa-1111', '2026-06-13T01:00:00.000Z'); // A on top
     await waitForFrame(lastFrame, (f) => f.includes('Select a session to resume'));
 
+    // Mount creates the initial channel (factory call 1, undefined).
+    expect(createChannel).toHaveBeenNthCalledWith(1, undefined);
+    const channelInitial = created[0]!;
+
     // Switch 1: pick A (top) from the startup picker.
     stdin.write('\r');
-    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 1);
-    expect(createChannel).toHaveBeenNthCalledWith(1, 'aaaaaaaa-1111');
-    const channelA = created[0]!;
+    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 2);
+    expect(createChannel).toHaveBeenNthCalledWith(2, 'aaaaaaaa-1111');
+    expect(channelInitial.stop).toHaveBeenCalled();
+    const channelA = created[1]!;
 
     // Switch 2: reopen the picker via a queued session-picker-requested effect,
     // drained by a submit on the active channel (real /resume drain path).
@@ -262,10 +280,10 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     await waitForFrame(lastFrame, (f) => f.includes('> bbbbbbbb'));
     await tick(); // settle: let the reopened picker's useInput subscription attach
     stdin.write('\r');
-    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 2);
-    expect(createChannel).toHaveBeenNthCalledWith(2, 'bbbbbbbb-2222');
+    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 3);
+    expect(createChannel).toHaveBeenNthCalledWith(3, 'bbbbbbbb-2222');
     expect(channelA.stop).toHaveBeenCalled();
-    const channelB = created[1]!;
+    const channelB = created[2]!;
     expect(channelB.start).toHaveBeenCalled();
 
     // Switch 3: same drill from B to C.
@@ -277,13 +295,13 @@ describe('App session-switch channel ownership (CLI-B11)', () => {
     await waitForFrame(lastFrame, (f) => f.includes('> cccccccc'));
     await tick(); // settle: let the reopened picker's useInput subscription attach
     stdin.write('\r');
-    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 3);
-    expect(createChannel).toHaveBeenNthCalledWith(3, 'cccccccc-3333');
+    await waitForFrame(lastFrame, () => createChannel.mock.calls.length === 4);
+    expect(createChannel).toHaveBeenNthCalledWith(4, 'cccccccc-3333');
     expect(channelB.stop).toHaveBeenCalled();
 
-    const channelC = created[2]!;
+    const channelC = created[3]!;
     expect(channelC.start).toHaveBeenCalled();
     expect(channelC.stop).not.toHaveBeenCalled();
-    expect(createChannel).toHaveBeenCalledTimes(3);
+    expect(createChannel).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/agent-transport/src/tui/render.tsx
+++ b/packages/agent-transport/src/tui/render.tsx
@@ -88,15 +88,14 @@ export async function renderApp(options: IRenderOptions): Promise<void> {
     }
   });
 
+  // Single-owner lifecycle (CLI-B12): render.tsx supplies only the factory;
+  // App creates, replaces, and stops channels exclusively through React state.
   const createChannel = (resumeSessionId?: string): TuiInteractionChannel =>
     new TuiInteractionChannel(toChannelOptions(options, resumeSessionId));
-
-  const channel = createChannel(options.resumeSessionId);
 
   const instance = render(
     <App
       cwd={options.cwd}
-      channel={channel}
       createChannel={createChannel}
       providerOverride={options.providerOverride}
       providerType={options.providerType}


### PR DESCRIPTION
## Summary

CLI-B12 (Option A, user-approved): the channel lifecycle gets exactly one owner — `App` React state.

- `App` creates the initial channel in its `useState` lazy initializer via the now-**required** `createChannel` factory; replaces it on every session switch, stopping the old channel **before** the new one becomes active
- `render.tsx` no longer constructs a channel — it supplies only the factory (the two-owner split that produced the CLI-B11 context-loss bug class is gone by construction)
- `channel` prop deleted (unreleased project — no backward compat); construction stays side-effect-free, I/O starts in `AppInner`'s effect via `channel.start()`
- CLI-B11 suite adapted to the single-source contract (initial channel = factory call 1 with `undefined`; switch calls shift to nth 2..4); B11 TC-D no-factory fallback test deleted per spec; B12 TC-02 stop-before-active ordering asserted via mock invocation order
- SPEC.md §TUI lifecycle documents the single-owner contract

## Verification

- `pnpm --filter @robota-sdk/agent-transport test` — 61 files / 473 tests green
- typecheck 0 errors (transport **and** agent-cli consumer), lint clean, builds complete
- Rebuilt-binary PTY scenario: `Context: 0% → 6% (11.9K/200K) → 16% (31.8K/200K)` across consecutive `/resume` switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)