### PR TITLE
fix(framework): system prompt names the active permission mode, not a trust label (CLI-072)

### DIFF
--- a/.agents/backlog/completed/CLI-072-permission-denial-mode-name.md
+++ b/.agents/backlog/completed/CLI-072-permission-denial-mode-name.md
@@ -1,6 +1,6 @@
 ---
 title: 'CLI-072: Permission-denial feedback names mode "moderate" while running under plan mode'
-status: todo
+status: done
 created: 2026-06-11
 priority: low
 urgency: later
@@ -35,4 +35,19 @@ explanations are accurate.
 
 - Steps: `robota -p "edit some file" --dry-run`; read the explanation.
 - Expected observable result: explanation references plan mode, not another mode name.
-- Evidence: (fill after implementation)
+- Evidence (2026-06-13, real binary + real Anthropic provider, isolated HOME,
+  `--dry-run` → permission mode `plan`):
+
+  ```
+  $ robota -p "What is your current permission mode? Answer with just the mode name." --dry-run
+  plan
+  ```
+
+  Root cause confirmed and fixed: the system prompt injected `Trust level: moderate`
+  (config default, a separate axis) — replaced with `- **Permission mode:** <active mode>`
+  fed from the session's own resolution (`options.permissionMode ??
+TRUST_TO_MODE[defaultTrustLevel] ?? 'default'`). A dry-run edit request explanation now
+  describes plan-mode restrictions without misnaming the mode; the edit stays blocked
+  (file unchanged). CI tests: `packages/agent-framework/src/__tests__/
+system-prompt-builder.test.ts` (CLI-072 mode interpolation over the full union +
+  no Trust-level label).

--- a/.agents/spec-docs/active/CLI-072-permission-mode-in-system-prompt.md
+++ b/.agents/spec-docs/active/CLI-072-permission-mode-in-system-prompt.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: in-progress
 type: BEHAVIOR
 tags: [cli, typescript]
 ---
@@ -105,7 +105,7 @@ is removed; if no other consumer remains, the constant is deleted (no-deprecated
 
 ## Tasks
 
-- [ ] `.agents/tasks/CLI-072.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [ ] `.agents/tasks/CLI-072.md` — T1~T5 (TC-01~TC-04 매핑 + wrap-up)
 
 ## Evidence Log
 
@@ -128,3 +128,12 @@ is removed; if no other consumer remains, the constant is deleted (no-deprecated
 - Direct, unambiguous, directed at this spec: the approval responds to the batch request that explicitly includes CLI-072's design summary; it is not an answer to a clarifying question, not silence, and not approval of a different item. The earlier release instruction ("머지하고 main 릴리스 진행해줘", executed as docs-only release PR #705) was correctly not treated as design approval.
 - No Architecture Review or frontmatter type/tags modified after approval: the spec file has exactly one commit (cd5b1053a, the GATE-WRITE batch); the only post-GATE-WRITE changes were the guard's Evidence Log entry, the frontmatter status upgrade draft → review-ready, and prettier formatting — all prior to approval. Frontmatter remains `type: BEHAVIOR`, `tags: [cli, typescript]`.
 - NON-COMPLIANCE trigger (implementation before this gate) not present: `.agents/tasks/CLI-072.md` does not exist (`ls` → No such file or directory); `git status --porcelain -- packages/agent-framework packages/agent-core` is clean; last commit touching `system-prompt-section-providers.ts` is the unrelated REFACTOR-024 rename (8cac18921).
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** approved → in-progress
+
+- Tasks file created: `.agents/tasks/CLI-072.md` exists (`ls -la` → 1666 bytes, created 2026-06-13).
+- Tasks file path recorded in `## Tasks`: the spec's Tasks section lists `.agents/tasks/CLI-072.md` — T1~T5 (TC-01~TC-04 매핑 + wrap-up).
+- Tasks correspond to Completion Criteria (one task per TC-N): T1 ↔ TC-01 (permission-mode line rendered, no `Trust level:` under mode `plan`); T2 ↔ TC-02 (parameterized interpolation over the `TPermissionMode` union); T3 ↔ TC-03 (prompt-assembly regression, `trustLevel` → `permissionMode`, full framework suite green, orphaned `TRUST_LEVEL_LABELS` deletion); T4 ↔ TC-04 (framework SPEC.md documents the line change); T5 = wrap-up (verify/PR/scenario evidence) beyond the TC minimum.
+- NON-COMPLIANCE trigger (implementation commits without tasks file) not present: branch `feat/cli-072-permission-mode-prompt` has only spec/tasks doc changes; `git status --porcelain -- packages/agent-framework packages/agent-core` is clean; last commit touching `system-prompt-section-providers.ts` remains the unrelated REFACTOR-024 rename (8cac18921).

--- a/.agents/spec-docs/done/CLI-072-permission-mode-in-system-prompt.md
+++ b/.agents/spec-docs/done/CLI-072-permission-mode-in-system-prompt.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: BEHAVIOR
 tags: [cli, typescript]
 ---
@@ -85,27 +85,27 @@ is removed; if no other consumer remains, the constant is deleted (no-deprecated
 
 ## Completion Criteria
 
-- [ ] TC-01: with permission mode `plan`, the generated system prompt contains
+- [x] TC-01: with permission mode `plan`, the generated system prompt contains
       `Permission mode: plan` and does NOT contain `Trust level:`
-- [ ] TC-02: each `TPermissionMode` value is interpolated verbatim (parameterized over the
+- [x] TC-02: each `TPermissionMode` value is interpolated verbatim (parameterized over the
       mode union — no hardcoded subset)
-- [ ] TC-03: full prompt-assembly regression — other sections unchanged
+- [x] TC-03: full prompt-assembly regression — other sections unchanged
       (`pnpm --filter @robota-sdk/agent-framework test` green)
-- [ ] TC-04: framework SPEC.md documents the section's permission-mode line and the removal
+- [x] TC-04: framework SPEC.md documents the section's permission-mode line and the removal
       of the trust-level line
 
 ## Test Plan
 
-| TC-ID | Test Type | Tool / Approach                                     | Notes                                                                 |
-| ----- | --------- | --------------------------------------------------- | --------------------------------------------------------------------- |
-| TC-01 | unit      | vitest — section provider with mode `plan`          | positive + negative content assertion                                 |
-| TC-02 | unit      | vitest — parameterized over `TPermissionMode` union | exhaustive via type-derived list                                      |
-| TC-03 | unit      | vitest — existing prompt assembly suite             | regression                                                            |
-| TC-04 | manual    | SPEC.md diff review                                 | doc prose — verified by direct read at GATE-COMPLETE, not automatable |
+| TC-ID | Test Type | Tool / Approach                                     | Notes                                                                                                                                                                                                                            |
+| ----- | --------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TC-01 | unit      | vitest — section provider with mode `plan`          | Test written: `packages/agent-framework/src/__tests__/system-prompt-builder.test.ts > includes the active permission mode and no trust-level label (CLI-072)` — positive `- **Permission mode:** plan` + negative `Trust level:` |
+| TC-02 | unit      | vitest — parameterized over `TPermissionMode` union | Test written: `packages/agent-framework/src/__tests__/system-prompt-builder.test.ts > interpolates every TPermissionMode value verbatim (CLI-072 TC-02)` — all 4 union values (plan/default/acceptEdits/bypassPermissions)       |
+| TC-03 | unit      | vitest — existing prompt assembly suite             | Test written: full `@robota-sdk/agent-framework` suite (92 files / 912 tests green at GATE-COMPLETE); `TRUST_LEVEL_LABELS` grep over `packages/agent-framework/src` → zero hits (deleted)                                        |
+| TC-04 | manual    | SPEC.md diff review                                 | Test skipped (doc prose, not automatable): verified by direct read at GATE-COMPLETE — `packages/agent-framework/docs/SPEC.md:1003` "Permission Mode section (CLI-072)" bullet                                                    |
 
 ## Tasks
 
-- [ ] `.agents/tasks/CLI-072.md` — T1~T5 (TC-01~TC-04 매핑 + wrap-up)
+- [x] `.agents/tasks/completed/CLI-072.md` — archived at GATE-COMPLETE (T1~T5 complete, TC-01~TC-04 매핑)
 
 ## Evidence Log
 
@@ -137,3 +137,53 @@ is removed; if no other consumer remains, the constant is deleted (no-deprecated
 - Tasks file path recorded in `## Tasks`: the spec's Tasks section lists `.agents/tasks/CLI-072.md` — T1~T5 (TC-01~TC-04 매핑 + wrap-up).
 - Tasks correspond to Completion Criteria (one task per TC-N): T1 ↔ TC-01 (permission-mode line rendered, no `Trust level:` under mode `plan`); T2 ↔ TC-02 (parameterized interpolation over the `TPermissionMode` union); T3 ↔ TC-03 (prompt-assembly regression, `trustLevel` → `permissionMode`, full framework suite green, orphaned `TRUST_LEVEL_LABELS` deletion); T4 ↔ TC-04 (framework SPEC.md documents the line change); T5 = wrap-up (verify/PR/scenario evidence) beyond the TC minimum.
 - NON-COMPLIANCE trigger (implementation commits without tasks file) not present: branch `feat/cli-072-permission-mode-prompt` has only spec/tasks doc changes; `git status --porcelain -- packages/agent-framework packages/agent-core` is clean; last commit touching `system-prompt-section-providers.ts` remains the unrelated REFACTOR-024 rename (8cac18921).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** in-progress → verifying
+
+- All tasks complete: `.agents/tasks/CLI-072.md` T1–T4 all `[x]` (verified by direct read). T5 (wrap-up) unchecked but every component independently verified per the established CLI-063..070 GATE-VERIFY interpretation (precedent confirmed by direct read of the CLI-069 and CLI-070 done-spec GATE-VERIFY entries): PR #712 OPEN (`gh pr view 712 --json state,headRefName,baseRefName`: state OPEN, head `feat/cli-072-permission-mode-prompt` → base `develop`) with CI green on `gh pr checks 712` — build pass (1m28s), quality pass (50s), security audit pass (6s), Cloudflare Pages pass; compat-node18 and release-grade verification "skipping" (skipped by design on feature PRs); backlog evidence recorded in `.agents/backlog/completed/CLI-072-permission-denial-mode-name.md` (`status: done`, User Execution Test Scenario Evidence filled: 2026-06-13 real binary + real Anthropic provider, isolated HOME, `--dry-run` → permission mode `plan`, mode question answered `plan`, dry-run edit explanation describes plan-mode restrictions without misnaming the mode, edit stays blocked) — met
+- No tasks blocked or pending: tasks file contains no blocked markers (grep for "blocked" → no hits); only T5 wrap-up remains open as adjudicated above — met
+- Build passes for affected package: `pnpm --filter @robota-sdk/agent-framework build` → "Build complete in 853ms" (ESM bundles, no errors) — met
+- Tests pass for affected package: `pnpm --filter @robota-sdk/agent-framework test` → 92 files / 912 tests passed, including the CLI-072 assertions in `src/__tests__/system-prompt-builder.test.ts` (parameterized `- **Permission mode:** ${mode}` over the union at line 76-77; explicit `plan` and `acceptEdits` content assertions at lines 83-88) — met
+- Note on approved scope: `ISystemPromptParams.trustLevel` → `permissionMode` replacement and `TRUST_LEVEL_LABELS` deletion match the approved Decision (Alternative 1 incl. no-deprecated cleanup); five test files migrated from trustLevel values to TRUST_TO_MODE-equivalent permissionMode values, all green in the 912-test run above.
+- Validity: on branch `feat/cli-072-permission-mode-prompt`; `git status --porcelain` shows only `.agents/evals/lessons/*` modifications, nothing under `packages/agent-framework` or `.agents/tasks` — build/test evidence reflects the PR #712 head state.
+
+Completion Criteria checkboxes remain unchecked by design: TC-N validation belongs to GATE-COMPLETE.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-01 is `[x]` in `## Completion Criteria`.
+- Command: `npx vitest run src/__tests__/system-prompt-builder.test.ts` (cwd `packages/agent-framework`).
+- Observed output: `Test Files 1 passed (1)`, `Tests 26 passed (26)`; exit code 0.
+- Test reference: `packages/agent-framework/src/__tests__/system-prompt-builder.test.ts > includes the active permission mode and no trust-level label (CLI-072)` (line 82) — asserts `buildSystemPrompt({ permissionMode: 'plan' })` contains `- **Permission mode:** plan` and does NOT contain `Trust level:` (positive + negative content assertion, verified by direct read of the test source).
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-02 is `[x]` in `## Completion Criteria`.
+- Command: `npx vitest run src/__tests__/system-prompt-builder.test.ts` (cwd `packages/agent-framework`) — same run as TC-01.
+- Observed output: `Tests 26 passed (26)`; exit code 0.
+- Test reference: `packages/agent-framework/src/__tests__/system-prompt-builder.test.ts > interpolates every TPermissionMode value verbatim (CLI-072 TC-02)` (line 73) — parameterized loop over `const modes: TPermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions']` (the full `TPermissionMode` union, no hardcoded subset), asserting `- **Permission mode:** ${mode}` verbatim and no `Trust level:` for each mode (verified by direct read of the test source).
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-03 is `[x]` in `## Completion Criteria`.
+- Command: `pnpm --filter @robota-sdk/agent-framework test`.
+- Observed output: `Test Files 92 passed (92)`, `Tests 912 passed (912)`, duration 2.64s; exit code 0 — full prompt-assembly regression green, other sections unchanged.
+- Orphan cleanup confirmed: `grep -rn "TRUST_LEVEL_LABELS" packages/agent-framework/src` → zero hits, exit code 1 — constant deleted per the no-deprecated rule.
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-04 is `[x]` in `## Completion Criteria`.
+- Action: direct read of `packages/agent-framework/docs/SPEC.md` (manual doc verification per Test Plan — not automatable).
+- Observed: line 1003, "Context Loading (SDK-Specific)" section, bullet "**Permission Mode section (CLI-072)**" — documents that `buildSystemPrompt()` renders `- **Permission mode:** <mode>` from `ISystemPromptParams.permissionMode` (the active `TPermissionMode` resolved as `options.permissionMode ?? TRUST_TO_MODE[config.defaultTrustLevel] ?? 'default'`), that the former `Trust level:` line is removed, and that `TRUST_LEVEL_LABELS` is deleted.
+- Test Plan row marked as explicit skip (doc prose) with the direct-read reference above.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** verifying → done
+
+- All 4 Completion Criteria checkboxes are `[x]` (TC-01–TC-04), each backed by a `[GATE-COMPLETE: TC-N]` evidence entry above with exact command, observed output, and exit code.
+- `## Test Plan` updated: TC-01/TC-02/TC-03 rows carry test references (file path + test name / full-suite run + grep), TC-04 row carries an explicit skip reason (doc prose, direct read at `docs/SPEC.md:1003`). No TC-N is silently unaddressed.
+- Tasks file archived: `.agents/tasks/completed/CLI-072.md` exists with T1–T5 all `[x]`; the un-archived path `.agents/tasks/CLI-072.md` no longer exists (`ls` → No such file or directory, exit 1). The spec `## Tasks` section points at the archived path.
+- User-execution corroboration (done-gate): `.agents/backlog/completed/CLI-072-permission-denial-mode-name.md` is `status: done` with real-provider evidence (2026-06-13, real binary + real Anthropic provider, isolated HOME): `robota -p "What is your current permission mode? ..." --dry-run` → answer `plan`; dry-run edit explanation describes plan-mode restrictions without misnaming the mode and the edit stays blocked.

--- a/.agents/tasks/CLI-072.md
+++ b/.agents/tasks/CLI-072.md
@@ -1,0 +1,27 @@
+# Tasks — CLI-072: System prompt reports the actual permission mode
+
+Spec: `.agents/spec-docs/active/CLI-072-permission-mode-in-system-prompt.md`
+Test Plan SSOT: the spec's TC table.
+
+- [x] T1 (TC-01): `createPermissionSection` takes the active `TPermissionMode` and renders
+      `- **Permission mode:** <mode>`; under mode `plan` the generated prompt contains
+      `Permission mode: plan` and no `Trust level:` line.
+- [x] T2 (TC-02): every `TPermissionMode` value interpolates verbatim (parameterized test
+      over the union — no hardcoded subset).
+- [x] T3 (TC-03): prompt-assembly regression — `ISystemPromptParams.trustLevel` replaced by
+      `permissionMode`; `create-session-runtime` feeds the session's own resolution
+      (`options.permissionMode ?? TRUST_TO_MODE[config.defaultTrustLevel] ?? 'default'` —
+      mirrors agent-session); full framework suite green; `TRUST_LEVEL_LABELS` deleted if
+      orphaned (no-deprecated rule).
+- [x] T4 (TC-04): framework SPEC.md documents the permission-mode line + trust-level line
+      removal.
+- [ ] T5: wrap-up — framework test/typecheck/lint/build green; PR to develop (squash);
+      backlog scenario evidence + move to completed/.
+
+## Test Plan
+
+Authoritative TC table: `.agents/spec-docs/active/CLI-072-permission-mode-in-system-prompt.md`
+(## Test Plan). Summary: TC-01/02 via section-provider unit tests (mode interpolation,
+negative Trust-level assertion); TC-03 via full suite + builder test updates; TC-04 SPEC.md
+diff review at GATE-COMPLETE. User-execution scenario: `robota -p "edit a file" --dry-run`
+explanation references plan mode (scripted-provider request capture or real run).

--- a/.agents/tasks/completed/CLI-072.md
+++ b/.agents/tasks/completed/CLI-072.md
@@ -15,7 +15,7 @@ Test Plan SSOT: the spec's TC table.
       orphaned (no-deprecated rule).
 - [x] T4 (TC-04): framework SPEC.md documents the permission-mode line + trust-level line
       removal.
-- [ ] T5: wrap-up — framework test/typecheck/lint/build green; PR to develop (squash);
+- [x] T5: wrap-up — framework test/typecheck/lint/build green; PR to develop (squash);
       backlog scenario evidence + move to completed/.
 
 ## Test Plan

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -1000,6 +1000,7 @@ Resolved provider fields:
 - **Rationale**: AGENTS.md/CLAUDE.md walk-up discovery is for local development environments only
 - **Implementation**: Directory traversal from cwd to root, project type/language detection, `.robota/memory/MEMORY.md` startup memory loading, active task context loading, system prompt assembly
 - **Response Language**: `IResolvedConfig.language` (from settings.json `language` field) is rendered as neutral metadata by `buildSystemPrompt()`. Persists across compaction because system message is preserved.
+- **Permission Mode section (CLI-072)**: `buildSystemPrompt()` renders `- **Permission mode:** <mode>` from `ISystemPromptParams.permissionMode` — the ACTIVE `TPermissionMode` resolved exactly as agent-session does (`options.permissionMode ?? TRUST_TO_MODE[config.defaultTrustLevel] ?? 'default'`), so the prompt always names the mode the permission gate enforces. The former `Trust level:` line (a separate axis that defaulted to `moderate` and misled the model under `--permission-mode plan`) is removed; `TRUST_LEVEL_LABELS` is deleted.
 - **Compact Instructions**: Extracts "Compact Instructions" section from CLAUDE.md and passes to Session for compaction
 - **Skill Discovery Paths**: Skills are discovered from `.agents/skills/*/SKILL.md` (project), `.claude/skills/*/SKILL.md`, `.claude/commands/*.md`, and `~/.robota/skills/*/SKILL.md`. Used by conditional SDK skill metadata injection when `/skills` is model-invocable, and by `@robota-sdk/agent-command-skills` for virtual skill command palette metadata.
 

--- a/packages/agent-framework/src/__tests__/cross-package-hooks.test.ts
+++ b/packages/agent-framework/src/__tests__/cross-package-hooks.test.ts
@@ -362,7 +362,7 @@ describe('Cross-package: BundlePlugin -> system prompt', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'unknown', language: 'unknown' },
       skills: plugins[0]!.skills.map((s) => ({
         name: s.name,
@@ -432,7 +432,7 @@ describe('Cross-package: BundlePlugin -> system prompt', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'unknown', language: 'unknown' },
       skills: allSkills,
     });

--- a/packages/agent-framework/src/__tests__/cross-package-skills.test.ts
+++ b/packages/agent-framework/src/__tests__/cross-package-skills.test.ts
@@ -73,7 +73,7 @@ describe('Cross-package: skill discovery -> system prompt', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: ['bash: Execute shell commands'],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'node', language: 'typescript' },
       skills: invocable.map((cmd) => ({
         name: cmd.name,
@@ -137,7 +137,7 @@ describe('Cross-package: skill discovery -> system prompt', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'unknown', language: 'unknown' },
       skills: invocable.map((cmd) => ({
         name: cmd.name,
@@ -300,7 +300,7 @@ describe('Cross-package: BundlePlugin -> CLI commands', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'unknown', language: 'unknown' },
       skills,
     });

--- a/packages/agent-framework/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/agent-framework/src/__tests__/e2e-scenarios.test.ts
@@ -108,7 +108,7 @@ describe('E2E: Skill lifecycle', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: ['bash: Execute shell commands'],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'node', language: 'typescript' },
       skills: modelSkills.map((cmd) => ({
         name: cmd.name,
@@ -157,7 +157,7 @@ describe('E2E: Skill lifecycle', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'unknown', language: 'unknown' },
       skills: modelSkills.map((cmd) => ({
         name: cmd.name,
@@ -617,7 +617,7 @@ describe('E2E: CommandRegistry aggregation', () => {
       agentsMd: '',
       claudeMd: '',
       toolDescriptions: [],
-      trustLevel: 'moderate',
+      permissionMode: 'default',
       projectInfo: { type: 'node', language: 'typescript' },
       skills: modelSkills,
     });

--- a/packages/agent-framework/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-framework/src/__tests__/system-prompt-builder.test.ts
@@ -1,3 +1,4 @@
+import type { TPermissionMode } from '@robota-sdk/agent-core';
 import { describe, it, expect } from 'vitest';
 
 import { buildSystemPrompt } from '../context/system-prompt-builder.js';
@@ -8,7 +9,7 @@ const BASE_PARAMS: ISystemPromptParams = {
   agentsMd: '',
   claudeMd: '',
   toolDescriptions: [],
-  trustLevel: 'moderate',
+  permissionMode: 'default',
   projectInfo: {
     type: 'node',
     name: 'my-project',
@@ -69,12 +70,22 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('Read: read file contents');
   });
 
-  it('includes trust level', () => {
-    const resultSafe = buildSystemPrompt({ ...BASE_PARAMS, trustLevel: 'safe' });
-    expect(resultSafe).toContain('- **Trust level:** safe');
+  it('interpolates every TPermissionMode value verbatim (CLI-072 TC-02)', () => {
+    const modes: TPermissionMode[] = ['plan', 'default', 'acceptEdits', 'bypassPermissions'];
+    for (const mode of modes) {
+      const prompt = buildSystemPrompt({ ...BASE_PARAMS, permissionMode: mode });
+      expect(prompt).toContain(`- **Permission mode:** ${mode}`);
+      expect(prompt).not.toContain('Trust level:');
+    }
+  });
 
-    const resultFull = buildSystemPrompt({ ...BASE_PARAMS, trustLevel: 'full' });
-    expect(resultFull).toContain('- **Trust level:** full');
+  it('includes the active permission mode and no trust-level label (CLI-072)', () => {
+    const resultPlan = buildSystemPrompt({ ...BASE_PARAMS, permissionMode: 'plan' });
+    expect(resultPlan).toContain('- **Permission mode:** plan');
+    expect(resultPlan).not.toContain('Trust level:');
+
+    const resultAccept = buildSystemPrompt({ ...BASE_PARAMS, permissionMode: 'acceptEdits' });
+    expect(resultAccept).toContain('- **Permission mode:** acceptEdits');
   });
 
   it('includes response language as metadata when provided', () => {

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -1,3 +1,4 @@
+import { TRUST_TO_MODE } from '@robota-sdk/agent-core';
 import { SubagentManager, BackgroundTaskManager } from '@robota-sdk/agent-executor';
 
 import { fireSubagentLifecycleHook } from './background-task-hooks.js';
@@ -161,7 +162,10 @@ export function buildSessionSystemPrompt(
     memoryMd: options.context.memoryMd,
     taskContext: options.context.taskContext,
     toolDescriptions: resolvedToolDescriptions,
-    trustLevel: options.config.defaultTrustLevel,
+    // CLI-072: the prompt names the mode the gate enforces — same resolution
+    // as agent-session (explicit mode, else trust-level mapping, else default).
+    permissionMode:
+      options.permissionMode ?? TRUST_TO_MODE[options.config.defaultTrustLevel] ?? 'default',
     projectInfo: options.projectInfo ?? { type: 'unknown', language: 'unknown' },
     cwd,
     language: options.config.language,

--- a/packages/agent-framework/src/context/__tests__/task-context-system-prompt.test.ts
+++ b/packages/agent-framework/src/context/__tests__/task-context-system-prompt.test.ts
@@ -8,7 +8,7 @@ const BASE_PARAMS: ISystemPromptParams = {
   agentsMd: '',
   claudeMd: '',
   toolDescriptions: [],
-  trustLevel: 'moderate',
+  permissionMode: 'default',
   projectInfo: {
     type: 'node',
     name: 'my-project',

--- a/packages/agent-framework/src/context/system-prompt-builder.ts
+++ b/packages/agent-framework/src/context/system-prompt-builder.ts
@@ -12,10 +12,10 @@ import {
   createWorkingDirectorySection,
 } from './system-prompt-section-providers.js';
 
-import type { ICapabilityDescriptor } from '../capabilities/types.js';
-import type { TTrustLevel } from '../types.js';
 import type { IProjectInfo } from './project-detector.js';
 import type { ISystemPromptSection } from './system-prompt-types.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import type { TPermissionMode } from '@robota-sdk/agent-core';
 
 export interface ISystemPromptParams {
   /** Concatenated AGENTS.md content (may be empty string) */
@@ -28,8 +28,8 @@ export interface ISystemPromptParams {
   taskContext?: string;
   /** Human-readable tool descriptions, one per entry */
   toolDescriptions: string[];
-  /** Active trust level governing permission checks */
-  trustLevel: TTrustLevel;
+  /** Active permission mode — the value the permission gate enforces */
+  permissionMode: TPermissionMode;
   /** Detected project metadata */
   projectInfo: IProjectInfo;
   /** Current working directory */
@@ -94,7 +94,7 @@ export function buildSystemPrompt(params: ISystemPromptParams): string {
   appendOptionalSection(sections, createWorkingDirectorySection(params.cwd));
   sections.push(createProjectSection(params.projectInfo));
   appendOptionalSection(sections, createResponseLanguageSection(params.language));
-  sections.push(createPermissionSection(params.trustLevel));
+  sections.push(createPermissionSection(params.permissionMode));
   appendOptionalSection(sections, createToolDescriptionSection(params.toolDescriptions));
   sections.push(...createCapabilitySections(buildCapabilityDescriptors(params)));
 

--- a/packages/agent-framework/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-framework/src/context/system-prompt-section-providers.ts
@@ -1,13 +1,8 @@
-import type { ICapabilityDescriptor } from '../capabilities/types.js';
-import type { TTrustLevel } from '../types.js';
 import type { IProjectInfo } from './project-detector.js';
 import type { ISystemPromptSection } from './system-prompt-types.js';
+import type { ICapabilityDescriptor } from '../capabilities/types.js';
+import type { TPermissionMode } from '@robota-sdk/agent-core';
 
-const TRUST_LEVEL_LABELS: Record<TTrustLevel, string> = {
-  safe: 'safe',
-  moderate: 'moderate',
-  full: 'full',
-};
 const PROJECT_MEMORY_PRIORITY = Number('25');
 const TASK_CONTEXT_PRIORITY = Number('27');
 
@@ -43,12 +38,17 @@ export function createProjectSection(info: IProjectInfo): ISystemPromptSection {
   return createSection('runtime-project', 'Current Project', 40, lines.join('\n'), 'runtime');
 }
 
-export function createPermissionSection(trustLevel: TTrustLevel): ISystemPromptSection {
+/**
+ * CLI-072: the prompt names the ACTIVE permission mode — the same value the
+ * permission gate enforces — so the model's explanations can never quote a
+ * stale trust-level label.
+ */
+export function createPermissionSection(permissionMode: TPermissionMode): ISystemPromptSection {
   return createSection(
     'permission-mode',
     'Permission Mode',
     50,
-    `- **Trust level:** ${TRUST_LEVEL_LABELS[trustLevel]}`,
+    `- **Permission mode:** ${permissionMode}`,
     'permissions',
   );
 }


### PR DESCRIPTION
## Summary

CLI-072 — under `--dry-run` (permission mode `plan`) the model explained denials as "permission mode is set to **moderate**". Root cause confirmed: the system prompt injected `Trust level: moderate` (the config-default trust axis), the only mode-like label the model ever saw.

- `createPermissionSection` now renders `- **Permission mode:** <mode>` from the ACTIVE `TPermissionMode`
- `ISystemPromptParams.trustLevel` → `permissionMode`; `create-session-runtime` resolves it exactly as agent-session does (`options.permissionMode ?? TRUST_TO_MODE[config.defaultTrustLevel] ?? 'default'`) — prompt and gate can never disagree
- `TRUST_LEVEL_LABELS` deleted (no remaining consumers); prompt tests migrated and extended (full mode-union interpolation + negative Trust-level assertion)
- SPEC documents the section contract

## Verification

- framework 912/912, typecheck 0 errors (framework + agent-cli + agent-transport consumers), lint clean, builds complete
- Real-provider scenario (`--dry-run`): "What is your current permission mode?" → **`plan`** (previously "moderate"); dry-run edit stays blocked, file unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)