### PR TITLE
fix(harness): revive CLI import-layering rule as agent-executor (HARNESS-011)

### DIFF
--- a/.agents/backlog/completed/HARNESS-011-ci-green-baseline.md
+++ b/.agents/backlog/completed/HARNESS-011-ci-green-baseline.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-011: CI green baseline — stop normalizing red runs'
-status: todo
+status: done
 created: 2026-06-11
 priority: critical
 urgency: now
@@ -72,3 +72,19 @@ Not applicable — CI/infra change; evidence is green pipeline runs on the PR.
   `IBackgroundTaskRunner`). Decide whether composition-root wiring is a documented
   exception or must route through an agent-framework re-export, then update the pattern.
   The test currently pins the legacy-name behavior so revival is deliberate.
+
+## Progress update (2026-06-13) — CLOSED
+
+- Remaining decision resolved (spec `HARNESS-011-agent-executor-import-rule`, user-approved):
+  the dead `cli-agent-runtime-import` rule is revived as **`cli-agent-executor-import`**
+  targeting `@robota-sdk/agent-executor` under `packages/agent-cli/src/`, with exactly two
+  composition-root exemptions carrying reason strings (`cli.ts` — concrete runner wiring;
+  `modes/print-mode.ts` — type-only runner contract). Exemptions are reported on every scan
+  run, never silent. Framework re-export routing rejected (no-pass-through rule).
+- Rationale + exemption policy documented in `.agents/project-structure.md`
+  §Composition-Root Exemption.
+- Evidence: `pnpm harness:scan` → all 22 scans passed with the revived rule active;
+  scan unit tests 5/5 (violation fixture flagged, exemption fixtures pass with reasons,
+  legacy `agent-runtime` name fully retired).
+- All HARNESS-011 scope items now complete: aggregation (1-2), stale-path fixes (3-4),
+  this rule revival. CI green baseline achieved — any red run means a NEW problem.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -77,3 +77,18 @@ Rules:
 - Implementation packages (`agent-transport` with subpaths `/tui`, `/headless`, `/ws`, `/http`, `/mcp`; `agent-provider` with subpaths `/anthropic`, `/openai`, etc.) depend on the corresponding `agent-interface-*` package, not on `agent-framework`, for interface types.
 - `agent-framework` depends on `agent-interface-*` packages to consume the contracts it needs.
 - Do not place interface packages in `agent-core` — `agent-core` is zero-deps and owns foundational primitives only.
+
+## Composition-Root Exemption (Import-Layering Scans)
+
+`agent-cli` must not import `@robota-sdk/agent-executor` directly — it consumes SDK
+workspace projections through `agent-framework`. The single permitted exception is the
+**composition root**: the app assembly point may wire concrete implementations (e.g.
+`cli.ts` wiring `createDefaultBackgroundTaskRunners`, `modes/print-mode.ts` consuming the
+type-only `IBackgroundTaskRunner` contract). Routing these through an `agent-framework`
+re-export is NOT an alternative — it would violate the no-pass-through-re-exports rule
+above.
+
+Enforced by the `cli-agent-executor-import` rule in
+`scripts/harness/check-background-workspace-conformance.mjs`. Every exemption entry MUST
+carry a reason string and is reported (never silent) on each scan run; composition-root
+wiring is the only valid exemption category. (HARNESS-011)

--- a/.agents/spec-docs/active/HARNESS-011-agent-executor-import-rule.md
+++ b/.agents/spec-docs/active/HARNESS-011-agent-executor-import-rule.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: in-progress
 type: RULE
 tags: [harness, typescript]
 ---
@@ -84,7 +84,20 @@ wiring` / `composition root — type-only runner contract`).
    import fails; exempt files pass; clean tree passes.
 3. `.agents/project-structure.md`: one paragraph defining the composition-root exemption
    (what qualifies, reason-string requirement).
-4. Verify `pnpm harness:scan` 23/23 (with HARNESS-002) green on develop.
+4. Verify `pnpm harness:scan` green on develop (22/22 at this item's merge time;
+   HARNESS-002 adds its scan separately).
+
+_Extension during implementation (within the parent HARNESS-011 scope this spec closes):
+running the full harness unit suite for TC-03 surfaced 3 pre-existing failing tests of the
+SAME defect class this spec exists to fix — (a) `check-command-layering.mjs` carried another
+dead legacy-name pattern (`@robota-sdk/agent-sessions`, plural; the real package is
+`agent-session`) so its violation fixture matched nothing; (b) two
+`check-capability-placement` fixtures predated the `workspace-package-not-documented`
+check and omitted `agent-framework` from the fixture structure doc. Both repaired here
+(pattern retargeted to the singular name with subpath support — zero live findings,
+agent-cli has no real agent-session imports; fixture doc row added). HARNESS-011 item 4
+("failing harness unit tests must be repaired") is the parent scope authorizing this;
+harness suite now 184/184._
 
 ## Affected Files
 
@@ -117,7 +130,7 @@ wiring` / `composition root — type-only runner contract`).
 
 ## Tasks
 
-- [ ] `.agents/tasks/HARNESS-011R.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [ ] `.agents/tasks/HARNESS-011R.md` — T1~T6 (TC-01~TC-05 매핑 + wrap-up)
 
 ## Evidence Log
 
@@ -141,3 +154,13 @@ wiring` / `composition root — type-only runner contract`).
 - No Architecture Review or frontmatter type/tags modified after the approval request: only post-GATE-WRITE changes were the guard's GATE-WRITE Evidence Log entry, the frontmatter status upgrade draft → review-ready, and prettier formatting at commit cd5b1053a (released in PR #705); verified the commit is a 133-line new-file addition for this spec.
 - NON-COMPLIANCE trigger checked — no implementation started before this gate: `.agents/tasks/HARNESS-011R.md` absent; scan rule still carries the legacy `cli-agent-runtime-import` type and legacy package name in `scripts/harness/check-background-workspace-conformance.mjs:70` and `scripts/harness/__tests__/check-background-workspace-conformance.test.mjs:61`; no commits to `scripts/harness/` or `.agents/project-structure.md` for this spec since the approval request (only afdca8b66, 2026-06-12, the earlier HARNESS-011 items 1–2 fix predating this spec).
 - Prior gate evidence present: [GATE-WRITE] ✅ PASS entry (2026-06-13) exists in this Evidence Log; frontmatter `status: review-ready` matches the gate's entry state.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** approved → in-progress
+
+- Tasks file created: `.agents/tasks/HARNESS-011R.md` exists on branch `feat/harness-011r-executor-import-rule` (untracked working-tree file, 6 tasks T1–T6, spec back-reference and Test Plan SSOT pointer present).
+- Tasks file path recorded: `## Tasks` section of this spec lists `.agents/tasks/HARNESS-011R.md` — T1~T6 (TC-01~TC-05 매핑 + wrap-up).
+- Tasks ↔ Completion Criteria correspondence: T1↔TC-01 (rule retarget + non-exempt fixture fails), T2↔TC-02 (per-file exemptions with reason strings + exempt fixtures pass), T3↔TC-03 (`pnpm harness:scan` green on develop), T4↔TC-04 (legacy `@robota-sdk/agent-runtime` retired from rule + test), T5↔TC-05 (`.agents/project-structure.md` composition-root exemption doc) — at least one task per TC-N, all 5 covered; T6 is wrap-up (tests green, PR, archive) with no TC mapping required. Note: tasks file uses the actual file path `src/modes/print-mode.ts` (verified on disk; spec's `src/print-mode.ts` shorthand refers to the same file) — correspondence intact.
+- NON-COMPLIANCE trigger checked — no implementation commits before tasks file: `scripts/harness/check-background-workspace-conformance.mjs:70` still carries the legacy `cli-agent-runtime-import` rule with pattern `@robota-sdk/agent-runtime`; branch diff vs develop contains only the spec move todo/ → active/ and the new tasks file; last commits touching `scripts/harness/` or `.agents/project-structure.md` predate this spec (550cdcd80 / 8099b117f, HARNESS-012/005/013/014).
+- Prior gate evidence present: [GATE-WRITE] and [GATE-APPROVAL] ✅ PASS entries (2026-06-13) exist above; frontmatter `status: approved` matches the entry state for this gate.

--- a/.agents/spec-docs/done/HARNESS-011-agent-executor-import-rule.md
+++ b/.agents/spec-docs/done/HARNESS-011-agent-executor-import-rule.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: RULE
 tags: [harness, typescript]
 ---
@@ -107,30 +107,30 @@ harness suite now 184/184._
 
 ## Completion Criteria
 
-- [ ] TC-01: fixture — a non-exempt agent-cli file importing
+- [x] TC-01: fixture — a non-exempt agent-cli file importing
       `@robota-sdk/agent-executor` → scan fails naming file + rule
-- [ ] TC-02: exempt files (`cli.ts`, `print-mode.ts`) with their current imports → scan
+- [x] TC-02: exempt files (`cli.ts`, `print-mode.ts`) with their current imports → scan
       passes, exemptions reported with reasons
-- [ ] TC-03: `pnpm harness:scan` green on clean develop with the revived rule active (all
+- [x] TC-03: `pnpm harness:scan` green on clean develop with the revived rule active (all
       scans pass)
-- [ ] TC-04: scan unit test no longer references `@robota-sdk/agent-runtime` (legacy name
+- [x] TC-04: scan unit test no longer references `@robota-sdk/agent-runtime` (legacy name
       fully retired from rule + test)
-- [ ] TC-05: `.agents/project-structure.md` documents the composition-root exemption with
+- [x] TC-05: `.agents/project-structure.md` documents the composition-root exemption with
       the reason-string requirement
 
 ## Test Plan
 
-| TC-ID | Test Type   | Tool / Approach                                  | Notes                                                                 |
-| ----- | ----------- | ------------------------------------------------ | --------------------------------------------------------------------- |
-| TC-01 | unit        | vitest — fixture violation file                  | failure naming                                                        |
-| TC-02 | unit        | vitest — exemption fixtures mirroring real files | exemption + reason output                                             |
-| TC-03 | integration | `pnpm harness:scan` on develop                   | aggregate green                                                       |
-| TC-04 | unit        | grep + test assertions                           | legacy name retired                                                   |
-| TC-05 | manual      | project-structure.md diff review                 | doc prose — verified by direct read at GATE-COMPLETE, not automatable |
+| TC-ID | Test Type   | Tool / Approach                                  | Notes                                                                                                                                                                                                                                                |
+| ----- | ----------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TC-01 | unit        | vitest — fixture violation file                  | Test: `scripts/harness/__tests__/check-background-workspace-conformance.test.mjs > findBackgroundWorkspaceConformanceFindings > flags direct CLI imports from agent-executor in non-exempt files (HARNESS-011)`                                      |
+| TC-02 | unit        | vitest — exemption fixtures mirroring real files | Test: `scripts/harness/__tests__/check-background-workspace-conformance.test.mjs > findBackgroundWorkspaceConformanceFindings > exempts the composition root with documented reasons (HARNESS-011)`; live scan exit 0 with both exemptions + reasons |
+| TC-03 | integration | `pnpm harness:scan` on develop                   | Live run 2026-06-13: "all 22 scans passed", exit 0 (no dedicated test file — aggregate integration command is the test)                                                                                                                              |
+| TC-04 | unit        | grep + test assertions                           | `grep -n "agent-runtime"` over rule + test files → zero hits (exit 1); legacy-pinning test replaced by the two HARNESS-011 cases in `check-background-workspace-conformance.test.mjs`                                                                |
+| TC-05 | manual      | project-structure.md diff review                 | Skip (no automated test): doc prose — verified by direct read at GATE-COMPLETE 2026-06-13, `.agents/project-structure.md:81-94` §Composition-Root Exemption                                                                                          |
 
 ## Tasks
 
-- [ ] `.agents/tasks/HARNESS-011R.md` — T1~T6 (TC-01~TC-05 매핑 + wrap-up)
+- [x] `.agents/tasks/completed/HARNESS-011R.md` — archived at GATE-COMPLETE (T1~T6 complete, TC-01~TC-05 매핑)
 
 ## Evidence Log
 
@@ -164,3 +164,61 @@ harness suite now 184/184._
 - Tasks ↔ Completion Criteria correspondence: T1↔TC-01 (rule retarget + non-exempt fixture fails), T2↔TC-02 (per-file exemptions with reason strings + exempt fixtures pass), T3↔TC-03 (`pnpm harness:scan` green on develop), T4↔TC-04 (legacy `@robota-sdk/agent-runtime` retired from rule + test), T5↔TC-05 (`.agents/project-structure.md` composition-root exemption doc) — at least one task per TC-N, all 5 covered; T6 is wrap-up (tests green, PR, archive) with no TC mapping required. Note: tasks file uses the actual file path `src/modes/print-mode.ts` (verified on disk; spec's `src/print-mode.ts` shorthand refers to the same file) — correspondence intact.
 - NON-COMPLIANCE trigger checked — no implementation commits before tasks file: `scripts/harness/check-background-workspace-conformance.mjs:70` still carries the legacy `cli-agent-runtime-import` rule with pattern `@robota-sdk/agent-runtime`; branch diff vs develop contains only the spec move todo/ → active/ and the new tasks file; last commits touching `scripts/harness/` or `.agents/project-structure.md` predate this spec (550cdcd80 / 8099b117f, HARNESS-012/005/013/014).
 - Prior gate evidence present: [GATE-WRITE] and [GATE-APPROVAL] ✅ PASS entries (2026-06-13) exist above; frontmatter `status: approved` matches the entry state for this gate.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** in-progress → verifying
+
+- All tasks complete: `.agents/tasks/HARNESS-011R.md` T1–T5 all `[x]` (verified by direct read). T6 (wrap-up) unchecked but every component independently verified per the established CLI-063..073 GATE-VERIFY interpretation (precedent confirmed by direct read of the CLI-069 done-spec GATE-VERIFY entry, which adjudicated its open wrap-up task the same way): PR #714 OPEN (`gh pr view 714 --json state,headRefName,baseRefName`: state OPEN, head `feat/harness-011r-executor-import-rule` → base `develop`) with CI green on `gh pr checks 714` — build pass (31s), quality pass (26s), security audit pass (8s), Cloudflare Pages pass; compat-node18 and release-grade verification "skipping" (skipped by design on feature PRs); backlog closure recorded at `.agents/backlog/completed/HARNESS-011-ci-green-baseline.md` (`status: done`, "Progress update (2026-06-13) — CLOSED" present; User Execution Test Scenarios section states "Not applicable — CI/infra change; evidence is green pipeline runs on the PR") — met
+- No tasks blocked or pending: tasks file contains no blocked markers; only T6 wrap-up remains open as adjudicated above — met
+- Build passes (mapped): this item has no package build (scope is `scripts/harness/` + `.agents/project-structure.md`); mapped verification ran instead — `pnpm harness:scan` → "all 22 scans passed" with the revived `cli-agent-executor-import` rule active; direct `node scripts/harness/check-background-workspace-conformance.mjs` → exit 0, "background workspace conformance scan passed." with both exemptions reported with reasons ("exempted: packages/agent-cli/src/cli.ts [cli-agent-executor-import] — composition root — concrete runner wiring" / "exempted: packages/agent-cli/src/modes/print-mode.ts [cli-agent-executor-import] — composition root — type-only runner contract") — met
+- Tests pass (mapped): `npx vitest run scripts/harness/__tests__/` → 20 files / 184 tests passed (184/184, includes the 3 pre-existing same-class repairs noted in the Solution's in-Decision extension: command-layering singular-name retarget + 2 capability-placement fixtures); legacy name retired — `grep agent-runtime` over the rule file and its unit test returns zero hits; `.agents/project-structure.md:81` contains the `## Composition-Root Exemption (Import-Layering Scans)` section — met
+- Validity: on branch `feat/harness-011r-executor-import-rule`; `git status --porcelain` shows only `.agents/evals/lessons/*` modifications, nothing under `scripts/harness/`, `.agents/project-structure.md`, or `.agents/tasks/` — scan/test evidence reflects the PR #714 head state.
+
+Completion Criteria checkboxes remain unchecked by design: TC-N validation belongs to GATE-COMPLETE.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-01 `[x]` in ## Completion Criteria — confirmed.
+- Command: `npx vitest run scripts/harness/__tests__/check-background-workspace-conformance.test.mjs`
+- Output: `Test Files 1 passed (1)`, `Tests 5 passed (5)` — includes `flags direct CLI imports from agent-executor in non-exempt files (HARNESS-011)`, which asserts a non-exempt agent-cli fixture importing `@robota-sdk/agent-executor` produces a finding naming the file and the `cli-agent-executor-import` rule. Exit code 0.
+- Test reference recorded in ## Test Plan row TC-01.
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-02 `[x]` in ## Completion Criteria — confirmed.
+- Command (unit): same vitest run as TC-01 — test `exempts the composition root with documented reasons (HARNESS-011)` passed (5/5, exit 0).
+- Command (live): `node scripts/harness/check-background-workspace-conformance.mjs`
+- Output: `exempted: packages/agent-cli/src/cli.ts [cli-agent-executor-import] — composition root — concrete runner wiring` / `exempted: packages/agent-cli/src/modes/print-mode.ts [cli-agent-executor-import] — composition root — type-only runner contract` / `background workspace conformance scan passed.` Exit code 0 — exempt files pass with reasons reported.
+- Test reference recorded in ## Test Plan row TC-02.
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-03 `[x]` in ## Completion Criteria — confirmed.
+- Command: `pnpm harness:scan` (on develop-based branch, clean tree for harness paths)
+- Output: scan summary lists 22 checks all `✓` (consistency … docs-structure) ending `all 22 scans passed`, with `background-workspace` (the revived rule's scan) green. Exit code 0 (verified via `pnpm harness:scan > /dev/null 2>&1; echo $?` → 0).
+- Test Plan row TC-03 notes the live integration run as the test (aggregate command, no dedicated test file).
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-04 `[x]` in ## Completion Criteria — confirmed.
+- Command: `grep -n "agent-runtime" scripts/harness/check-background-workspace-conformance.mjs scripts/harness/__tests__/check-background-workspace-conformance.test.mjs`
+- Output: no matches, grep exit code 1 — legacy `@robota-sdk/agent-runtime` fully retired from rule and test.
+- Test assertions: the legacy-name-pinning test no longer exists; test-name listing (`grep "it("`) shows the two HARNESS-011 cases plus three unrelated conformance cases — all 5 pass (exit 0).
+- Test reference recorded in ## Test Plan row TC-04.
+
+### [GATE-COMPLETE: TC-05] — ✅ PASS | 2026-06-13
+
+- Checkbox: TC-05 `[x]` in ## Completion Criteria — confirmed.
+- Action: direct read of `.agents/project-structure.md` lines 81–94 — section `## Composition-Root Exemption (Import-Layering Scans)` present; defines the composition root as the single permitted exemption category (cli.ts concrete runner wiring, modes/print-mode.ts type-only contract), rejects the framework re-export route as a no-pass-through violation, and states "Every exemption entry MUST carry a reason string and is reported (never silent) on each scan run" — exemption category + reason-string requirement both documented.
+- Test Plan row TC-05 carries the explicit skip reason (doc prose, manual direct-read verification — not automatable).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-13
+
+**Status upgrade:** verifying → done
+
+- All 5 Completion Criteria checkboxes `[x]` with one `[GATE-COMPLETE: TC-N]` evidence entry each (commands, observed output, exit codes recorded above).
+- ## Test Plan: all 5 rows updated — TC-01/TC-02/TC-04 with test file + test name references, TC-03 with the live integration command result, TC-05 with an explicit skip reason. No TC-N silently unaddressed.
+- Tasks file archived: `.agents/tasks/completed/HARNESS-011R.md` exists with T1–T6 all `[x]`; original `.agents/tasks/HARNESS-011R.md` removed (verified absent); spec ## Tasks section points at the archived path.
+- Backlog closure (done gate): `.agents/backlog/completed/HARNESS-011-ci-green-baseline.md` — `status: done` (line 3), `## Progress update (2026-06-13) — CLOSED` present; User Execution Test Scenarios section states "Not applicable — CI/infra change; evidence is green pipeline runs on the PR" — done-gate satisfied without user execution scenarios per the backlog itself.
+- Prior gate evidence chain intact: GATE-WRITE, GATE-APPROVAL, GATE-IMPLEMENT, GATE-VERIFY all ✅ PASS (2026-06-13) above; frontmatter `status: verifying` matches this gate's entry state.

--- a/.agents/tasks/HARNESS-011R.md
+++ b/.agents/tasks/HARNESS-011R.md
@@ -1,0 +1,28 @@
+# Tasks — HARNESS-011(잔여): revive the dead CLI import-layering rule as agent-executor
+
+Spec: `.agents/spec-docs/active/HARNESS-011-agent-executor-import-rule.md`
+Test Plan SSOT: the spec's TC table.
+
+- [x] T1 (TC-01): retarget the rule in
+      `scripts/harness/check-background-workspace-conformance.mjs` —
+      `cli-agent-executor-import`, pattern `@robota-sdk/agent-executor` under
+      `packages/agent-cli/src/`; fixture test: a non-exempt file with the import → scan
+      fails naming file + rule.
+- [x] T2 (TC-02): per-file exemptions with reason strings —
+      `src/cli.ts` (composition root — concrete runner wiring) and
+      `src/modes/print-mode.ts` (composition root — type-only runner contract); exempt
+      fixtures pass and the exemptions are reported with reasons.
+- [x] T3 (TC-03): `pnpm harness:scan` green on clean develop with the revived rule active.
+- [x] T4 (TC-04): legacy `@robota-sdk/agent-runtime` name fully retired from the rule and
+      its unit test (the legacy-pinning test replaced).
+- [x] T5 (TC-05): `.agents/project-structure.md` documents the composition-root exemption
+      with the reason-string requirement.
+- [ ] T6: wrap-up — harness unit tests green; PR to develop (squash); backlog progress
+      updated + moved to completed/ (HARNESS-011 fully closed).
+
+## Test Plan
+
+Authoritative TC table: `.agents/spec-docs/active/HARNESS-011-agent-executor-import-rule.md`
+(## Test Plan). Summary: TC-01/02/04 via check-background-workspace-conformance.test.mjs
+fixtures; TC-03 via live `pnpm harness:scan`; TC-05 SPEC/doc diff review at GATE-COMPLETE.
+User Execution Test Scenarios: N/A per backlog (CI/infra) — evidence is green scans.

--- a/.agents/tasks/completed/HARNESS-011R.md
+++ b/.agents/tasks/completed/HARNESS-011R.md
@@ -17,7 +17,7 @@ Test Plan SSOT: the spec's TC table.
       its unit test (the legacy-pinning test replaced).
 - [x] T5 (TC-05): `.agents/project-structure.md` documents the composition-root exemption
       with the reason-string requirement.
-- [ ] T6: wrap-up — harness unit tests green; PR to develop (squash); backlog progress
+- [x] T6: wrap-up — harness unit tests green; PR to develop (squash); backlog progress
       updated + moved to completed/ (HARNESS-011 fully closed).
 
 ## Test Plan

--- a/scripts/harness/__tests__/check-background-workspace-conformance.test.mjs
+++ b/scripts/harness/__tests__/check-background-workspace-conformance.test.mjs
@@ -5,7 +5,10 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { findBackgroundWorkspaceConformanceFindings } from '../check-background-workspace-conformance.mjs';
+import {
+  findBackgroundWorkspaceConformanceFindings,
+  findUsedExemptions,
+} from '../check-background-workspace-conformance.mjs';
 
 async function createFixture(files) {
   const root = await mkdtemp(path.join(tmpdir(), 'robota-background-workspace-'));
@@ -41,28 +44,43 @@ describe('findBackgroundWorkspaceConformanceFindings', () => {
     expect(findings).toEqual([]);
   });
 
-  it('flags direct CLI imports from agent-runtime', async () => {
-    // The rule's pattern still targets the legacy '@robota-sdk/agent-runtime' name and is
-    // therefore dead against current '@robota-sdk/agent-executor' imports — reviving it
-    // requires an architecture decision on the CLI composition root's two real
-    // agent-executor imports (tracked in HARNESS-011). This test pins the implemented
-    // behavior so the rule's revival is a deliberate change, not an accident.
+  it('flags direct CLI imports from agent-executor in non-exempt files (HARNESS-011)', async () => {
     const root = await createFixture({
       ...baselineFiles,
-      'packages/agent-cli/src/background/runtime-import.ts':
-        'import { BackgroundTaskManager } from "@robota-sdk/agent-runtime";\n',
+      'packages/agent-cli/src/background/executor-import.ts':
+        'import { BackgroundTaskManager } from "@robota-sdk/agent-executor";\n',
     });
 
     const findings = await findBackgroundWorkspaceConformanceFindings(root);
 
     expect(findings).toEqual([
       {
-        file: 'packages/agent-cli/src/background/runtime-import.ts',
-        type: 'cli-agent-runtime-import',
+        file: 'packages/agent-cli/src/background/executor-import.ts',
+        type: 'cli-agent-executor-import',
         detail:
           'agent-cli must not import agent-executor directly; consume SDK workspace projections.',
       },
     ]);
+  });
+
+  it('exempts the composition root with documented reasons (HARNESS-011)', async () => {
+    const root = await createFixture({
+      ...baselineFiles,
+      'packages/agent-cli/src/cli.ts':
+        'import { createDefaultBackgroundTaskRunners } from "@robota-sdk/agent-executor";\n',
+      'packages/agent-cli/src/modes/print-mode.ts':
+        'import type { IBackgroundTaskRunner } from "@robota-sdk/agent-executor";\n',
+    });
+
+    const findings = await findBackgroundWorkspaceConformanceFindings(root);
+    expect(findings).toEqual([]);
+
+    const exemptions = await findUsedExemptions(root);
+    expect(exemptions).toHaveLength(2);
+    for (const exemption of exemptions) {
+      expect(exemption.type).toBe('cli-agent-executor-import');
+      expect(exemption.reason).toContain('composition root');
+    }
   });
 
   it('flags CLI-owned retention policy', async () => {

--- a/scripts/harness/__tests__/check-capability-placement.test.mjs
+++ b/scripts/harness/__tests__/check-capability-placement.test.mjs
@@ -33,6 +33,7 @@ function packageJson(name, extra = {}) {
 const projectStructure = [
   'packages/',
   '- agent-cli',
+  '- agent-framework',
   '- agent-sdk',
   '- agent-command-*',
   '- agent-provider-*',

--- a/scripts/harness/check-background-workspace-conformance.mjs
+++ b/scripts/harness/check-background-workspace-conformance.mjs
@@ -67,9 +67,15 @@ const REQUIRED_FILES = [
 
 const CLI_FORBIDDEN_PATTERNS = [
   {
-    type: 'cli-agent-runtime-import',
-    pattern: /from\s+['"]@robota-sdk\/agent-runtime(?:\/[^'"]*)?['"]/,
+    type: 'cli-agent-executor-import',
+    pattern: /from\s+['"]@robota-sdk\/agent-executor(?:\/[^'"]*)?['"]/,
     detail: 'agent-cli must not import agent-executor directly; consume SDK workspace projections.',
+    // HARNESS-011: composition-root exemptions — the app assembly point may wire
+    // concrete runners; every entry requires a reason string (.agents/project-structure.md).
+    exemptions: {
+      'packages/agent-cli/src/cli.ts': 'composition root — concrete runner wiring',
+      'packages/agent-cli/src/modes/print-mode.ts': 'composition root — type-only runner contract',
+    },
   },
   {
     type: 'cli-background-registry-owner',
@@ -164,10 +170,16 @@ async function findRequiredFileFindings(root) {
 
 async function findCliForbiddenFindings(root) {
   const findings = [];
+  const exemptionsUsed = [];
   for (const file of await walkFiles(root, 'packages/agent-cli/src')) {
     const content = await fs.readFile(path.join(root, file), 'utf8');
     for (const check of CLI_FORBIDDEN_PATTERNS) {
       if (!check.pattern.test(content)) {
+        continue;
+      }
+      const exemptionReason = check.exemptions?.[file];
+      if (exemptionReason !== undefined) {
+        exemptionsUsed.push({ file, type: check.type, reason: exemptionReason });
         continue;
       }
       findings.push({
@@ -177,16 +189,28 @@ async function findCliForbiddenFindings(root) {
       });
     }
   }
-  return findings;
+  return { findings, exemptionsUsed };
 }
 
 export async function findBackgroundWorkspaceConformanceFindings(root = WORKSPACE_ROOT) {
-  return [...(await findRequiredFileFindings(root)), ...(await findCliForbiddenFindings(root))];
+  const cli = await findCliForbiddenFindings(root);
+  return [...(await findRequiredFileFindings(root)), ...cli.findings];
+}
+
+/** Exemptions actually used in this tree (reported, never silent). */
+export async function findUsedExemptions(root = WORKSPACE_ROOT) {
+  return (await findCliForbiddenFindings(root)).exemptionsUsed;
 }
 
 export async function main() {
   const findings = await findBackgroundWorkspaceConformanceFindings(WORKSPACE_ROOT);
   if (findings.length === 0) {
+    const exemptions = await findUsedExemptions(WORKSPACE_ROOT);
+    for (const exemption of exemptions) {
+      process.stdout.write(
+        `  exempted: ${exemption.file} [${exemption.type}] — ${exemption.reason}\n`,
+      );
+    }
     process.stdout.write('background workspace conformance scan passed.\n');
     return;
   }

--- a/scripts/harness/check-command-layering.mjs
+++ b/scripts/harness/check-command-layering.mjs
@@ -61,7 +61,7 @@ const CLI_UI_FORBIDDEN_PATTERNS = [
 const CLI_FORBIDDEN_PATTERNS = [
   {
     type: 'cli-agent-sessions-import',
-    pattern: /from\s+['"]@robota-sdk\/agent-sessions['"]/,
+    pattern: /from\s+['"]@robota-sdk\/agent-session(?:\/[^'"]*)?['"]/,
     detail:
       'agent-cli must not import @robota-sdk/agent-session; use SDK-owned session persistence APIs.',
   },


### PR DESCRIPTION
## Summary

HARNESS-011 final item — the `cli-agent-runtime-import` forbidden-pattern rule targeted the legacy `@robota-sdk/agent-runtime` name and has been dead since the rename: any `agent-executor` import in agent-cli passed the scan silently.

- Rule revived as **`cli-agent-executor-import`** with exactly two composition-root exemptions, each carrying a reason string and **reported on every scan run** (never silent): `cli.ts` (concrete runner wiring) and `modes/print-mode.ts` (type-only `IBackgroundTaskRunner`). Framework re-export routing rejected — it would violate the no-pass-through rule.
- Exemption policy documented in `.agents/project-structure.md` §Composition-Root Exemption (composition root = the only valid category)
- Same defect class repaired in the same sweep (parent scope: HARNESS-011 item 4 — failing harness unit tests): `check-command-layering.mjs`'s dead plural `agent-sessions` pattern retargeted to the real `agent-session` name (zero live findings), and two `check-capability-placement` fixtures updated for the `workspace-package-not-documented` check

This closes HARNESS-011 entirely (aggregation, stale paths, and rule revival all done).

## Verification

- Harness unit suite **184/184** (was 3 pre-existing failures); violation fixture flagged, exemption fixtures pass with reasons, legacy names fully retired
- `pnpm harness:scan` — **all 22 scans green** with the revived rule active; exemptions printed with reasons
- Live exemption report: `cli.ts` + `print-mode.ts` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)