### PR TITLE
refactor(transport): import interface types from agent-interface-transport (INFRA-012, INFRA-010 L2)

### DIFF
--- a/.agents/spec-docs/done/INFRA-012-migrate-transport-interface-imports.md
+++ b/.agents/spec-docs/done/INFRA-012-migrate-transport-interface-imports.md
@@ -1,0 +1,153 @@
+---
+status: done
+type: INFRA
+tags: [typescript]
+---
+
+# INFRA-012: Migrate agent-transport interface-type imports to agent-interface-transport (INFRA-010 L2)
+
+> Source: INFRA-002 finding **AF-14**. Layer 2 of the INFRA-010 refactor (L1 = DATA-001, done). The user
+> directed a proper, by-the-book fix.
+
+## Problem
+
+DATA-001 (L1) relocated the transport-facing interface-type SSOT into `@robota-sdk/agent-interface-transport`,
+with `agent-framework` re-exporting them. `agent-transport` still imports those types from
+`@robota-sdk/agent-framework` (across ~74 files), so the Interface Package Rule (AF-14) — implementation
+packages take interface types from `agent-interface-*`, not from `agent-framework` — is still violated at
+the import sites even though the SSOT moved.
+
+**This backlog is Layer 2:** repoint `agent-transport`'s **type** imports of the moved closure from
+`@robota-sdk/agent-framework` to `@robota-sdk/agent-interface-transport`. Runtime-value imports
+(classes/functions/consts) and `TInteractiveSessionOptions` (intentionally retained in framework by L1)
+stay imported from `@robota-sdk/agent-framework`.
+
+**Reproduction condition:** `rg -l "from '@robota-sdk/agent-framework'" packages/agent-transport/src` →
+74 files; many import moved interface types (e.g. `IInteractiveSession`) that now have their SSOT in
+`agent-interface-transport`.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-transport/src/**` — repoint type imports of the moved set to `agent-interface-transport`.
+- No package.json change needed (`agent-transport` already depends on `agent-interface-transport`).
+- NOT changed: `agent-framework` (keeps re-exporting), `agent-interface-transport` (L1), the rule/guard (L3).
+
+### Moved-type set (import from agent-interface-transport)
+
+The types exported by `agent-interface-transport/src/index.ts` (the L1 closure), e.g. `IInteractiveSession`,
+`ICommand`, `ICommandResult`, `ICommandListEntry`, `ICommandPluginAdapter`, `ICommandInteraction`,
+`IToolState`, `IUsageSnapshot`, `TPermissionResultValue`, `IInteractionChannel`, `IActionRequest`,
+`IExecutionWorkspaceEntry`/`*Snapshot`/`*Filter`, `IInteractiveSessionStore`, `IResumableSessionSummary`,
+`TCommandEffect`, `IExecutionResult`, the background-group + workspace + event + capability contracts, etc.
+
+### Retained-in-framework set (keep importing from agent-framework)
+
+Runtime values: `InteractiveSession` (class), `CommandRegistry` (class), `readSettings`, `writeSettings`,
+`getUserSettingsPath`, `createProjectSessionStore`, `tokeniseSlashCommand`, `isSlashCommand`,
+`isStatusLineCommandSettingsPatch`, `listResumableSessionSummaries`, `DEFAULT_STATUS_LINE_COMMAND_SETTINGS`;
+and the type `TInteractiveSessionOptions` (+ its construction closure) which L1 deliberately left in framework.
+
+### Alternatives Considered
+
+1. **Leave imports pointing at framework (rely on re-export).** Pro: zero change. Con: AF-14 stays violated
+   at the import sites — the whole point of L2. Rejected.
+2. **Repoint only the type imports of the moved set; keep runtime + TInteractiveSessionOptions from framework.**
+   Pro: makes the contract boundary real for the relocated types; reviewable per-file. Con: must split mixed
+   imports carefully. Chosen.
+
+### Decision
+
+Alternative 2. Split each `agent-transport` import: moved interface types → `agent-interface-transport`;
+runtime values + `TInteractiveSessionOptions` → `agent-framework`. `import type` stays `import type`.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-transport/src only; framework/interface-transport unchanged
+- [x] Sibling scan 완료 — moved-type set taken verbatim from agent-interface-transport index (L1 output); runtime/retained set enumerated
+- [x] 대안 최소 2개 검토 완료 — 2 alternatives above
+- [x] 결정 근거 문서화 완료 — Decision records the type-vs-runtime split
+
+## Solution
+
+For each `agent-transport/src` file importing from `@robota-sdk/agent-framework`: move the symbols that are
+in the moved-type set into an `import type { … } from '@robota-sdk/agent-interface-transport'` statement;
+leave runtime values and `TInteractiveSessionOptions` importing from `@robota-sdk/agent-framework`. Then
+build + typecheck + test agent-transport (and dependents), and confirm dep-direction + conformance green.
+
+## Affected Files
+
+- `packages/agent-transport/src/**` (import-source repointing only)
+
+## Completion Criteria
+
+- [x] TC-01: No `agent-transport/src` file imports a moved interface type from `@robota-sdk/agent-framework`
+      — `rg` shows the moved types (e.g. `IInteractiveSession`, `ICommand`, `ICommandResult`, `TCommandEffect`)
+      are imported from `@robota-sdk/agent-interface-transport`, not `@robota-sdk/agent-framework`, in agent-transport.
+- [x] TC-02: Runtime values (`InteractiveSession`, `CommandRegistry`, `readSettings`, …) and
+      `TInteractiveSessionOptions` are still imported from `@robota-sdk/agent-framework` (not broken).
+- [x] TC-03: `pnpm build`, `pnpm typecheck`, `pnpm test` green for affected packages;
+      `node scripts/harness/check-dependency-direction.mjs` + `pnpm harness:conformance` exit 0.
+
+## Test Plan
+
+| TC-ID | Test Type                     | Tool / Approach                                                                          | Notes            |
+| ----- | ----------------------------- | ---------------------------------------------------------------------------------------- | ---------------- |
+| TC-01 | CI pipeline smoke test        | `rg` over agent-transport/src: moved types come from interface-transport                 | Command-form     |
+| TC-02 | Build/typecheck assertion     | `pnpm --filter @robota-sdk/agent-transport typecheck` (runtime imports resolve)          | re-export intact |
+| TC-03 | CI pipeline smoke + dep check | `pnpm build`/`typecheck`/`test`; `check-dependency-direction.mjs`; `harness:conformance` | full green gate  |
+
+## Tasks
+
+- [x] [`.agents/tasks/completed/INFRA-012.md`](../../tasks/completed/INFRA-012.md) — archived at GATE-COMPLETE; tasks TC-01/TC-02/TC-03 + Test Plan all `[x]`
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter: starts with `---`; `status: draft`; `type: INFRA` (valid 11-prefix value); `tags: [typescript]` present.
+Problem: concrete symptom (`rg -l "from '@robota-sdk/agent-framework'" packages/agent-transport/src` → 74 files, verified; rule AF-14 violated at import sites); reproduction condition present; no TBD/TODO/vague single-sentence.
+Architecture Review: all 4 checklist items `[x]`; sibling scan `[x]` with completion evidence (moved-type set taken verbatim from agent-interface-transport L1 index); 2 alternatives with pro/con each; Decision references the type-vs-runtime split trade-off.
+Completion Criteria: TC-01/TC-02/TC-03 all TC-N prefixed; command/observable form; no banned vague terms ("works correctly", "no errors", "implemented", "displays correctly").
+Test Plan: `## Test Plan` present; 3 rows for 3 TC-Ns (count matches); each row has non-empty Test Type + Tool/Approach; no "TBD"; no "manual" tool rows requiring Notes justification.
+Structure: Tasks section present with placeholder; Evidence Log present and empty before this entry; no `## Status` or `## Classification` body sections.
+Cross-check: dependency `@robota-sdk/agent-interface-transport: workspace:*` confirmed in agent-transport package.json; `agent-interface-transport/src/index.ts` (L1 SSOT) exists.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** review-ready → approved
+Explicit approval present: user approved the INFRA-010 3-layer decomposition (DATA-001 → INFRA-012 → INFRA-013) with "승인", directed a proper/by-the-book fix ("정석으로 제대로 수정"), and repeatedly directed continued execution ("진행해", "계속 이어서 진행해"). "승인" and "진행해" are both on the skill's explicit-approval list.
+Direct & unambiguous to this spec: the approval covers the INFRA-010 decomposition that names INFRA-012 as Layer 2; spec body confirms ("Layer 2 of the INFRA-010 refactor (L1 = DATA-001, done). The user directed a proper, by-the-book fix.").
+No post-approval drift: frontmatter (`status: review-ready`, `type: INFRA`, `tags: [typescript]`) and Architecture Review checklist (all `[x]`) unchanged since GATE-WRITE.
+NON-COMPLIANCE check: not triggered — `## Tasks` shows `.agents/tasks/INFRA-012.md` is 미생성 (no tasks file, no implementation commits before this gate).
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Tasks file created: `.agents/tasks/INFRA-012.md` exists (created at this gate).
+Path recorded in spec: `## Tasks` now links `.agents/tasks/INFRA-012.md` (replaced the 미생성 placeholder).
+Tasks correspond to Completion Criteria (≥1 per TC-N): TC-01 (split moved interface types → agent-interface-transport import), TC-02 (retain runtime values + TInteractiveSessionOptions from agent-framework), TC-03 (build/typecheck/test + dep-direction + harness:conformance green) — 3 tasks for 3 TC-Ns.
+Test Plan present ≥50 chars [AF-24]: tasks file includes a `## Test Plan` section with TC-01/TC-02/TC-03 verification approaches (well over 50 chars), satisfying the test-plans harness scan requirement.
+NON-COMPLIANCE check: not triggered — tasks file created at this gate, no implementation commits precede it.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+Tasks completion: all 3 tasks in `.agents/tasks/INFRA-012.md` (TC-01/TC-02/TC-03) marked `[x]`; none blocked or pending.
+Build/test (orchestrator-verified, re-confirmed): `pnpm build` pass; `pnpm typecheck` exit 0 (all packages); agent-transport tests 473/473 pass; only `packages/agent-transport/src/**` changed; package.json / pnpm-lock.yaml untouched.
+TC-01 (re-run `rg`): no moved interface type (IInteractiveSession, ICommandResult, TCommandEffect, IToolState, ICommand) is imported from `@robota-sdk/agent-framework` in agent-transport/src — `rg` returned NONE; moved types are sourced from `@robota-sdk/agent-interface-transport`. The 25 files still importing from agent-framework carry only runtime values, `TInteractiveSessionOptions`, and `IBackgroundTask*` types (verified NOT exported by agent-interface-transport's index — outside the L1 moved closure, correctly retained).
+TC-02: runtime values (`InteractiveSession`, `CommandRegistry`, `readSettings`, `writeSettings`, `tokeniseSlashCommand`, `isSlashCommand`) and the type `TInteractiveSessionOptions` confirmed still imported from `@robota-sdk/agent-framework`; typecheck exit 0 proves re-export boundary intact.
+TC-03 (re-run): `node scripts/harness/check-dependency-direction.mjs` exit 0 ("No dependency direction violations found"); `pnpm harness:conformance` exit 0 with `dependencyDirection: pass`, `conformant: true`; no unresolved P0.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Scope note: spec has no `## User Execution Test Scenarios` section → User-Execution done-gate is N/A for this item (INFRA-010 L2 import-migration). Test Plan evidence (build/typecheck/test/dep-direction/conformance green) is the applicable evidence class and was captured at GATE-VERIFY; re-confirmed below.
+**[GATE-COMPLETE: TC-01]** Checkbox `[x]`. Verified — `rg` over `packages/agent-transport/src` shows moved interface types (`IInteractiveSession`, `ICommand`, `ICommandResult`, `TCommandEffect`, `IToolState`) sourced from `@robota-sdk/agent-interface-transport`; none imported from `@robota-sdk/agent-framework` (GATE-VERIFY `rg` returned NONE). Test ref: Test Plan TC-01 command-form `rg` check (CI pipeline smoke).
+**[GATE-COMPLETE: TC-02]** Checkbox `[x]`. Verified — runtime values (`InteractiveSession`, `CommandRegistry`, `readSettings`, `writeSettings`, `tokeniseSlashCommand`, `isSlashCommand`) and type `TInteractiveSessionOptions` still imported from `@robota-sdk/agent-framework`; `pnpm --filter @robota-sdk/agent-transport typecheck` exit 0 proves re-export boundary intact. Test ref: Test Plan TC-02 build/typecheck assertion.
+**[GATE-COMPLETE: TC-03]** Checkbox `[x]`. Verified — `pnpm build`/`typecheck`/`test` green for affected packages (agent-transport 473/473); `node scripts/harness/check-dependency-direction.mjs` exit 0; `pnpm harness:conformance` exit 0 (`dependencyDirection: pass`, `conformant: true`, no unresolved P0). Test ref: Test Plan TC-03 CI smoke + dependency gate.
+Spec `## Completion Criteria`: TC-01/TC-02/TC-03 all `[x]`. `## Test Plan`: all 3 TC rows carry command-form test references (no silent unaddressed TC).
+Artifact actions: tasks file archived `.agents/tasks/INFRA-012.md` → `.agents/tasks/completed/INFRA-012.md` (all 3 tasks `[x]`); `## Tasks` section updated to the archived path.
+**Summary:** All 3 TC-N checked with matching evidence; Test Plan fully referenced; tasks archived. GATE-COMPLETE PASS — status upgrade verifying → done authorized (frontmatter/folder move performed by backlog-pipeline, not this guard).

--- a/.agents/tasks/completed/INFRA-012.md
+++ b/.agents/tasks/completed/INFRA-012.md
@@ -1,0 +1,50 @@
+---
+title: Migrate agent-transport interface-type imports to agent-interface-transport (INFRA-010 L2)
+status: in-progress
+priority: high
+created: 2026-06-14
+spec: .agents/spec-docs/todo/INFRA-012-migrate-transport-interface-imports.md
+packages:
+  - agent-transport
+---
+
+# INFRA-012 — agent-transport interface-type import migration (L2)
+
+Repoint `agent-transport`'s **type** imports of the moved closure from `@robota-sdk/agent-framework`
+to `@robota-sdk/agent-interface-transport`. Runtime-value imports and `TInteractiveSessionOptions`
+stay imported from `@robota-sdk/agent-framework`. See spec for the full moved-type / retained-set lists.
+
+## Tasks
+
+- [x] **TC-01** — In every `packages/agent-transport/src/**` file, split each
+      `@robota-sdk/agent-framework` import so that moved interface types (e.g. `IInteractiveSession`,
+      `ICommand`, `ICommandResult`, `ICommandListEntry`, `ICommandPluginAdapter`, `ICommandInteraction`,
+      `IToolState`, `IUsageSnapshot`, `TPermissionResultValue`, `IInteractionChannel`, `IActionRequest`,
+      `IExecutionWorkspaceEntry`/`*Snapshot`/`*Filter`, `IInteractiveSessionStore`,
+      `IResumableSessionSummary`, `TCommandEffect`, `IExecutionResult`, and the rest of the L1 closure)
+      are imported via `import type { … } from '@robota-sdk/agent-interface-transport'`.
+      Verify: `rg` over `agent-transport/src` shows the moved types sourced from
+      `agent-interface-transport`, not `agent-framework`.
+- [x] **TC-02** — Keep runtime values (`InteractiveSession`, `CommandRegistry`, `readSettings`,
+      `writeSettings`, `getUserSettingsPath`, `createProjectSessionStore`, `tokeniseSlashCommand`,
+      `isSlashCommand`, `isStatusLineCommandSettingsPatch`, `listResumableSessionSummaries`,
+      `DEFAULT_STATUS_LINE_COMMAND_SETTINGS`) and the type `TInteractiveSessionOptions` imported from
+      `@robota-sdk/agent-framework`. Verify these still resolve (re-export intact) via
+      `pnpm --filter @robota-sdk/agent-transport typecheck`.
+- [x] **TC-03** — Run the full green gate for affected packages: `pnpm build`, `pnpm typecheck`,
+      `pnpm test`, plus `node scripts/harness/check-dependency-direction.mjs` and
+      `pnpm harness:conformance` — all exit 0.
+
+## Test Plan
+
+Verification maps 1:1 to the spec's Completion Criteria and Test Plan rows:
+
+- **TC-01** — Command-form check: `rg` over `packages/agent-transport/src` confirms moved interface
+  types are imported from `@robota-sdk/agent-interface-transport` and no longer from
+  `@robota-sdk/agent-framework`. No moved type may remain pointed at framework.
+- **TC-02** — Build/typecheck assertion: `pnpm --filter @robota-sdk/agent-transport typecheck` proves
+  runtime values + `TInteractiveSessionOptions` still resolve from `@robota-sdk/agent-framework`
+  (re-export boundary intact, nothing broken by the split).
+- **TC-03** — CI smoke + dependency gate: `pnpm build`, `pnpm typecheck`, `pnpm test` for affected
+  packages all pass; `node scripts/harness/check-dependency-direction.mjs` and
+  `pnpm harness:conformance` both exit 0, confirming dep-direction and architecture conformance stay green.

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -16,10 +16,10 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
-  IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TShellExecFn,
 } from '@robota-sdk/agent-framework';
+import type { IInteractiveSessionStore } from '@robota-sdk/agent-interface-transport';
 
 export interface IHeadlessInteractionChannelOptions {
   cwd: string;

--- a/packages/agent-transport/src/headless/__tests__/headless-runner-initialization.test.ts
+++ b/packages/agent-transport/src/headless/__tests__/headless-runner-initialization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 import { createHeadlessRunner } from '../headless-runner.js';
 
 describe('createHeadlessRunner initialization', () => {

--- a/packages/agent-transport/src/headless/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport/src/headless/__tests__/headless-runner.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { IExecutionResult } from '@robota-sdk/agent-framework';
-import type { TBackgroundJobGroupEvent } from '@robota-sdk/agent-framework';
+import type {
+  IExecutionResult,
+  IInteractiveSession,
+  TBackgroundJobGroupEvent,
+} from '@robota-sdk/agent-interface-transport';
 import type { TBackgroundTaskEvent } from '@robota-sdk/agent-framework';
 import { createHeadlessRunner } from '../headless-runner.js';
 

--- a/packages/agent-transport/src/headless/__tests__/headless-transport.test.ts
+++ b/packages/agent-transport/src/headless/__tests__/headless-transport.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHeadlessTransport } from '../headless-transport.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { IExecutionResult } from '@robota-sdk/agent-framework';
+import type { IExecutionResult, IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(): IInteractiveSession {
   return {

--- a/packages/agent-transport/src/headless/headless-runner.ts
+++ b/packages/agent-transport/src/headless/headless-runner.ts
@@ -1,6 +1,6 @@
 import { executeSlashCommandIfPresent, subscribeStreamJsonEvents } from './headless-stream-json.js';
 
-import type { IInteractiveSession, IExecutionResult } from '@robota-sdk/agent-framework';
+import type { IExecutionResult, IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 export type TOutputFormat = 'text' | 'json' | 'stream-json';
 

--- a/packages/agent-transport/src/headless/headless-stream-json.ts
+++ b/packages/agent-transport/src/headless/headless-stream-json.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
+import type { TBackgroundTaskEvent } from '@robota-sdk/agent-framework';
 import type {
-  IInteractiveSession,
-  IExecutionResult,
   ICommandResult,
+  IExecutionResult,
+  IInteractiveSession,
   TBackgroundJobGroupEvent,
-  TBackgroundTaskEvent,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 type TSlashCommandExecution =
   | { readonly kind: 'not-slash' }

--- a/packages/agent-transport/src/headless/headless-transport.ts
+++ b/packages/agent-transport/src/headless/headless-transport.ts
@@ -8,8 +8,7 @@
 import { createHeadlessRunner } from './headless-runner.js';
 
 import type { TOutputFormat } from './headless-runner.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession, ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 
 export interface IHeadlessTransportOptions {
   /** Output format: 'text', 'json', or 'stream-json'. */

--- a/packages/agent-transport/src/http/__tests__/http-transport.test.ts
+++ b/packages/agent-transport/src/http/__tests__/http-transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createHttpTransport } from '../http-transport.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(): IInteractiveSession {
   return {

--- a/packages/agent-transport/src/http/__tests__/routes.test.ts
+++ b/packages/agent-transport/src/http/__tests__/routes.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createAgentRoutes } from '../routes.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(overrides?: Record<string, unknown>) {
   return {

--- a/packages/agent-transport/src/http/http-transport.ts
+++ b/packages/agent-transport/src/http/http-transport.ts
@@ -7,8 +7,7 @@
 
 import { createAgentRoutes } from './routes.js';
 
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession, ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 import type { Hono } from 'hono';
 
 export interface IHttpTransportOptions {

--- a/packages/agent-transport/src/http/routes.ts
+++ b/packages/agent-transport/src/http/routes.ts
@@ -8,7 +8,7 @@
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 import type { Context } from 'hono';
 
 /** Callback that resolves an IInteractiveSession from the request context. */

--- a/packages/agent-transport/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/agent-transport/src/mcp/__tests__/mcp-server.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { createAgentMcpServer } from '../mcp-server.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(commands?: Array<{ name: string; description: string }>) {
   return {

--- a/packages/agent-transport/src/mcp/__tests__/mcp-transport.test.ts
+++ b/packages/agent-transport/src/mcp/__tests__/mcp-transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createMcpTransport } from '../mcp-transport.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(): IInteractiveSession {
   return {

--- a/packages/agent-transport/src/mcp/mcp-server.ts
+++ b/packages/agent-transport/src/mcp/mcp-server.ts
@@ -9,7 +9,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
-import type { IInteractiveSession, IExecutionResult } from '@robota-sdk/agent-framework';
+import type { IExecutionResult, IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 export interface IAgentMcpOptions {
   /** Name for the MCP server. */

--- a/packages/agent-transport/src/mcp/mcp-transport.ts
+++ b/packages/agent-transport/src/mcp/mcp-transport.ts
@@ -8,8 +8,7 @@
 import { createAgentMcpServer } from './mcp-server.js';
 
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession, ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 
 export interface IMcpTransportOptions {
   /** Name for the MCP server. */

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -11,9 +11,9 @@ import { readSettings, writeSettings, type TSettingsData } from '@robota-sdk/age
 import { WsTransport } from './ws/index.js';
 
 import type { TUniversalValue } from '@robota-sdk/agent-core';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
 import type {
   IConfigurableTransport,
+  IInteractiveSession,
   ITransportConfig,
   ITransportEntry,
 } from '@robota-sdk/agent-interface-transport';

--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -31,11 +31,11 @@ import type { ITuiCliAdapter } from './tui-cli-adapter.js';
 import type { TuiInteractionChannel } from './TuiInteractionChannel.js';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
 import type {
+  IExecutionDetailPage,
   IInteractiveSession,
   IInteractiveSessionStore,
-  IExecutionDetailPage,
-} from '@robota-sdk/agent-framework';
-import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transport';
+  ITransportRegistryView,
+} from '@robota-sdk/agent-interface-transport';
 
 interface IProps {
   cwd: string;

--- a/packages/agent-transport/src/tui/BackgroundTaskPanel.tsx
+++ b/packages/agent-transport/src/tui/BackgroundTaskPanel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { formatBackgroundTaskRow } from './background-task-row-format.js';
 
-import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-framework';
+import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-interface-transport';
 
 interface IProps {
   entries: IExecutionWorkspaceEntry[];

--- a/packages/agent-transport/src/tui/ExecutionWorkspaceDetailPane.tsx
+++ b/packages/agent-transport/src/tui/ExecutionWorkspaceDetailPane.tsx
@@ -10,7 +10,7 @@ import type {
   IExecutionDetailPage,
   IExecutionWorkspaceEntry,
   TExecutionDetailRecordKind,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 const MAX_VISIBLE_DETAIL_RECORDS = 12;
 

--- a/packages/agent-transport/src/tui/ExecutionWorkspaceSwitcher.tsx
+++ b/packages/agent-transport/src/tui/ExecutionWorkspaceSwitcher.tsx
@@ -14,7 +14,7 @@ import {
 import type {
   IExecutionWorkspaceEntry,
   IExecutionWorkspaceSnapshot,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 const MAX_VISIBLE_WORKSPACE_ENTRIES = 8;
 

--- a/packages/agent-transport/src/tui/InputArea.tsx
+++ b/packages/agent-transport/src/tui/InputArea.tsx
@@ -25,7 +25,8 @@ import { expandPasteLabels } from './utils/paste-labels.js';
 import WaveText from './WaveText.js';
 
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
-import type { CommandRegistry, ICommand } from '@robota-sdk/agent-framework';
+import type { CommandRegistry } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 
 interface IProps {
   onSubmit: (value: string) => void;

--- a/packages/agent-transport/src/tui/InteractivePrompt.tsx
+++ b/packages/agent-transport/src/tui/InteractivePrompt.tsx
@@ -5,9 +5,9 @@ import ListPicker from './ListPicker.js';
 import TextPrompt from './TextPrompt.js';
 
 import type {
-  TCommandInteractionPrompt as TInteractivePrompt,
   ICommandChoicePromptOption as IChoicePromptOption,
-} from '@robota-sdk/agent-framework';
+  TCommandInteractionPrompt as TInteractivePrompt,
+} from '@robota-sdk/agent-interface-transport';
 
 interface IInteractivePromptProps {
   prompt: TInteractivePrompt;

--- a/packages/agent-transport/src/tui/PluginTUI.tsx
+++ b/packages/agent-transport/src/tui/PluginTUI.tsx
@@ -20,7 +20,7 @@ import {
 import TextPrompt from './TextPrompt.js';
 
 import type { IMenuSelectItem } from './MenuSelect.js';
-import type { ICommandPluginAdapter } from '@robota-sdk/agent-framework';
+import type { ICommandPluginAdapter } from '@robota-sdk/agent-interface-transport';
 
 type TScreenId =
   | 'main'

--- a/packages/agent-transport/src/tui/SessionPicker.tsx
+++ b/packages/agent-transport/src/tui/SessionPicker.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import ListPicker from './ListPicker.js';
 
-import type { IResumableSessionSummary } from '@robota-sdk/agent-framework';
+import type { IResumableSessionSummary } from '@robota-sdk/agent-interface-transport';
 
 const SESSION_ID_DISPLAY_LENGTH = 8;
 const SESSION_PREVIEW_DISPLAY_LENGTH = 60;

--- a/packages/agent-transport/src/tui/SessionStatusBar.tsx
+++ b/packages/agent-transport/src/tui/SessionStatusBar.tsx
@@ -4,7 +4,7 @@ import StatusBar from './StatusBar.js';
 import { useTuiCliAdapter } from './tui-cli-adapter-context.js';
 
 import type { TPermissionMode } from '@robota-sdk/agent-core';
-import type { IStatusLineCommandSettings } from '@robota-sdk/agent-framework';
+import type { IStatusLineCommandSettings } from '@robota-sdk/agent-interface-transport';
 
 interface IProps {
   cwd: string;

--- a/packages/agent-transport/src/tui/SlashAutocomplete.tsx
+++ b/packages/agent-transport/src/tui/SlashAutocomplete.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useStdout } from 'ink';
 import React, { useState, useEffect } from 'react';
 
-import type { ICommand } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 
 interface IProps {
   /** Filtered list of commands to display */

--- a/packages/agent-transport/src/tui/StreamingIndicator.tsx
+++ b/packages/agent-transport/src/tui/StreamingIndicator.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { renderMarkdown } from './render-markdown.js';
 import ToolDiffBlock from './ToolDiffBlock.js';
 
-import type { IToolState } from '@robota-sdk/agent-framework';
+import type { IToolState } from '@robota-sdk/agent-interface-transport';
 
 function getToolStyle(t: IToolState): {
   color: string;

--- a/packages/agent-transport/src/tui/TransportTUI.tsx
+++ b/packages/agent-transport/src/tui/TransportTUI.tsx
@@ -7,8 +7,8 @@
 import { Box, Text, useInput } from 'ink';
 import React, { useState, useCallback } from 'react';
 
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
 import type {
+  IInteractiveSession,
   ITransportEntry,
   ITransportRegistryView,
 } from '@robota-sdk/agent-interface-transport';

--- a/packages/agent-transport/src/tui/TuiInteractionChannel.ts
+++ b/packages/agent-transport/src/tui/TuiInteractionChannel.ts
@@ -22,27 +22,27 @@ import type { ISessionInitPoller, TSessionInitFailure } from './flows/session-in
 import type { IPermissionRequest } from './types.js';
 import type { IAIProvider, TPermissionMode, TSessionEndReason } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
-import type { IInteractionChannel } from '@robota-sdk/agent-framework';
-import type {
-  InteractionEvent,
-  IActionRequest,
-  IActionResponse,
-  ICommandInfo,
-} from '@robota-sdk/agent-framework';
 import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
-  IInteractiveSession,
-  IInteractiveSessionStore,
   TSubagentRunnerFactory,
-  IExecutionWorkspaceEvent,
-  IExecutionDetailPage,
-  IExecutionResult,
   TShellExecFn,
 } from '@robota-sdk/agent-framework';
-import type { TPermissionResultValue } from '@robota-sdk/agent-framework';
-import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transport';
+import type {
+  IActionRequest,
+  IActionResponse,
+  ICommandInfo,
+  IExecutionDetailPage,
+  IExecutionResult,
+  IExecutionWorkspaceEvent,
+  IInteractionChannel,
+  IInteractiveSession,
+  IInteractiveSessionStore,
+  ITransportRegistryView,
+  InteractionEvent,
+  TPermissionResultValue,
+} from '@robota-sdk/agent-interface-transport';
 
 const SESSION_INIT_POLL_MS = 200;
 const SESSION_INIT_TIMEOUT_MS = 15000;

--- a/packages/agent-transport/src/tui/UsageSummaryEntry.tsx
+++ b/packages/agent-transport/src/tui/UsageSummaryEntry.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'ink';
 import React from 'react';
 
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
-import type { IUsageSnapshot } from '@robota-sdk/agent-framework';
+import type { IUsageSnapshot } from '@robota-sdk/agent-interface-transport';
 
 const TOKEN_COMPACT_THRESHOLD = 1000;
 

--- a/packages/agent-transport/src/tui/__tests__/PluginTUI.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/PluginTUI.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi } from 'vitest';
 import PluginTUI from '../PluginTUI.js';
-import type { ICommandPluginAdapter } from '@robota-sdk/agent-framework';
+import type { ICommandPluginAdapter } from '@robota-sdk/agent-interface-transport';
 
 function mockCallbacks(): ICommandPluginAdapter {
   return {

--- a/packages/agent-transport/src/tui/__tests__/SlashAutocomplete.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/SlashAutocomplete.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'vitest';
 import SlashAutocomplete from '../SlashAutocomplete.js';
-import type { ICommand } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 
 // ink-testing-library fixes stdout.columns = 100
 // outer box chrome = 4 → rowWidth = 96 in tests

--- a/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.display-contract.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.display-contract.test.ts
@@ -68,7 +68,7 @@ import {
 import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 
 import type { IAIProvider, IHistoryEntry } from '@robota-sdk/agent-core';
-import type { IExecutionResult } from '@robota-sdk/agent-framework';
+import type { IExecutionResult } from '@robota-sdk/agent-interface-transport';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.lifecycle.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.lifecycle.test.ts
@@ -53,8 +53,11 @@ vi.mock('@robota-sdk/agent-framework', async () => {
 import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 
 import type { IAIProvider } from '@robota-sdk/agent-core';
-import type { IExecutionResult, IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transport';
+import type {
+  IExecutionResult,
+  IInteractiveSession,
+  ITransportRegistryView,
+} from '@robota-sdk/agent-interface-transport';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.requestAction.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/TuiInteractionChannel.requestAction.test.ts
@@ -29,7 +29,7 @@ vi.mock('@robota-sdk/agent-framework', async () => {
 import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 
 import type { IAIProvider } from '@robota-sdk/agent-core';
-import type { IActionRequest } from '@robota-sdk/agent-framework';
+import type { IActionRequest } from '@robota-sdk/agent-interface-transport';
 
 function makeChannel(): TuiInteractionChannel {
   return new TuiInteractionChannel({

--- a/packages/agent-transport/src/tui/__tests__/background-task-panel.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/background-task-panel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from 'ink-testing-library';
-import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-framework';
+import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-interface-transport';
 import BackgroundTaskPanel from '../BackgroundTaskPanel.js';
 
 function makeEntry(overrides: Partial<IExecutionWorkspaceEntry>): IExecutionWorkspaceEntry {

--- a/packages/agent-transport/src/tui/__tests__/background-task-row-format.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/background-task-row-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-framework';
+import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-interface-transport';
 import { formatBackgroundTaskRow } from '../background-task-row-format.js';
 
 function makeEntry(overrides: Partial<IExecutionWorkspaceEntry>): IExecutionWorkspaceEntry {

--- a/packages/agent-transport/src/tui/__tests__/channel-factory-integration.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/channel-factory-integration.test.ts
@@ -20,7 +20,7 @@ import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 
 import type { ITuiCliAdapter } from '../tui-cli-adapter.js';
 import type { TUniversalMessage } from '@robota-sdk/agent-core';
-import type { IInteractiveSessionStore } from '@robota-sdk/agent-framework';
+import type { IInteractiveSessionStore } from '@robota-sdk/agent-interface-transport';
 
 const RESTORE_DEADLINE_MS = 10_000;
 const POLL_MS = 50;

--- a/packages/agent-transport/src/tui/__tests__/execution-workspace-switcher.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/execution-workspace-switcher.test.tsx
@@ -4,7 +4,7 @@ import { render } from 'ink-testing-library';
 import type {
   IExecutionWorkspaceEntry,
   IExecutionWorkspaceSnapshot,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 import ExecutionWorkspaceSwitcher from '../ExecutionWorkspaceSwitcher.js';
 import ExecutionWorkspaceDetailPane from '../ExecutionWorkspaceDetailPane.js';
 

--- a/packages/agent-transport/src/tui/__tests__/execution-workspace-view-model.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/execution-workspace-view-model.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type {
   IExecutionWorkspaceEntry,
   IExecutionWorkspaceSnapshot,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 import {
   countActiveBackgroundWorkspaceEntries,
   formatExecutionDetailRecord,

--- a/packages/agent-transport/src/tui/__tests__/fixtures/provider-setup-prompt-driver.tsx
+++ b/packages/agent-transport/src/tui/__tests__/fixtures/provider-setup-prompt-driver.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import InteractivePrompt from '../../InteractivePrompt.js';
 
 import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
-import type { TCommandInteractionPrompt as TInteractivePrompt } from '@robota-sdk/agent-framework';
+import type { TCommandInteractionPrompt as TInteractivePrompt } from '@robota-sdk/agent-interface-transport';
 
 const openaiDefaults = {
   apiKey: '$ENV:OPENAI_API_KEY',

--- a/packages/agent-transport/src/tui/__tests__/input-area-flow.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/input-area-flow.test.ts
@@ -13,7 +13,7 @@ import {
   resolveTabCompletion,
   shouldSubmitInput,
 } from '../flows/input-area-flow.js';
-import type { ICommand } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 import {
   createAssistantMessage,
   createSystemMessage,

--- a/packages/agent-transport/src/tui/__tests__/session-switch-channel.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/session-switch-channel.test.tsx
@@ -28,7 +28,7 @@ import type { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 import type {
   IInteractiveSessionRecord,
   IInteractiveSessionStore,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 const TICK_MS = 30;
 const FRAME_DEADLINE_MS = 3000;

--- a/packages/agent-transport/src/tui/__tests__/slash-routing-effects.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/slash-routing-effects.test.ts
@@ -9,7 +9,10 @@ import {
   BundlePluginLoader,
   PluginCommandSource,
 } from '@robota-sdk/agent-framework';
-import type { ICommandInteraction, IInteractiveSession } from '@robota-sdk/agent-framework';
+import type {
+  ICommandInteraction,
+  IInteractiveSession,
+} from '@robota-sdk/agent-interface-transport';
 import { TuiStateManager } from '../tui-state-manager.js';
 import { applySystemCommandResult } from '../hooks/useSlashRouting.js';
 import { CommandEffectQueue } from '../hooks/command-effect-queue.js';

--- a/packages/agent-transport/src/tui/__tests__/tui-state-manager.test.ts
+++ b/packages/agent-transport/src/tui/__tests__/tui-state-manager.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { TuiStateManager } from '../tui-state-manager.js';
-import type { IToolState, IExecutionResult } from '@robota-sdk/agent-framework';
+import type { IExecutionResult, IToolState } from '@robota-sdk/agent-interface-transport';
 
 function makeResult(overrides?: Partial<IExecutionResult>): IExecutionResult {
   return {

--- a/packages/agent-transport/src/tui/background-task-row-format.ts
+++ b/packages/agent-transport/src/tui/background-task-row-format.ts
@@ -1,6 +1,6 @@
 import { formatExecutionWorkspaceEntryRow } from './execution-workspace-view-model.js';
 
-import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-framework';
+import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-interface-transport';
 
 export interface IBackgroundTaskRow {
   connector: '├' | '└';

--- a/packages/agent-transport/src/tui/execution-workspace-view-model.ts
+++ b/packages/agent-transport/src/tui/execution-workspace-view-model.ts
@@ -3,7 +3,7 @@ import type {
   IExecutionWorkspaceEntry,
   IExecutionWorkspaceSnapshot,
   TExecutionWorkspaceStatus,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 const ACTIVE_STATUSES: readonly TExecutionWorkspaceStatus[] = [
   'active',

--- a/packages/agent-transport/src/tui/flows/input-area-flow.ts
+++ b/packages/agent-transport/src/tui/flows/input-area-flow.ts
@@ -1,7 +1,7 @@
 import { isSlashCommand, tokeniseSlashCommand } from '@robota-sdk/agent-framework';
 
 import type { IHistoryEntry, TUniversalValue } from '@robota-sdk/agent-core';
-import type { ICommand } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 
 export interface IAutocompleteInputKey {
   upArrow?: boolean;

--- a/packages/agent-transport/src/tui/hooks/command-effect-handler.ts
+++ b/packages/agent-transport/src/tui/hooks/command-effect-handler.ts
@@ -3,7 +3,10 @@ import { isStatusLineCommandSettingsPatch } from '@robota-sdk/agent-framework';
 
 import type { ITuiCliAdapter } from '../tui-cli-adapter.js';
 import type { IHistoryEntry, TSessionEndReason } from '@robota-sdk/agent-core';
-import type { TCommandEffect, TStatusLineCommandSettingsPatch } from '@robota-sdk/agent-framework';
+import type {
+  TCommandEffect,
+  TStatusLineCommandSettingsPatch,
+} from '@robota-sdk/agent-interface-transport';
 
 export interface ICommandEffectHandlerDeps {
   addEntry: (entry: IHistoryEntry) => void;

--- a/packages/agent-transport/src/tui/hooks/command-effect-queue.ts
+++ b/packages/agent-transport/src/tui/hooks/command-effect-queue.ts
@@ -1,4 +1,4 @@
-import type { ICommandInteraction, TCommandEffect } from '@robota-sdk/agent-framework';
+import type { ICommandInteraction, TCommandEffect } from '@robota-sdk/agent-interface-transport';
 
 export type TQueuedCommandState =
   | {

--- a/packages/agent-transport/src/tui/hooks/side-effects-types.ts
+++ b/packages/agent-transport/src/tui/hooks/side-effects-types.ts
@@ -2,9 +2,9 @@ import type { ICommandEffectQueue } from './command-effect-queue.js';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { InteractiveSession } from '@robota-sdk/agent-framework';
 import type {
-  TCommandInteractionPrompt as TInteractivePrompt,
   IStatusLineCommandSettings as TStatusLineSettings,
-} from '@robota-sdk/agent-framework';
+  TCommandInteractionPrompt as TInteractivePrompt,
+} from '@robota-sdk/agent-interface-transport';
 
 export type { TInteractivePrompt, TStatusLineSettings };
 

--- a/packages/agent-transport/src/tui/hooks/useAutocomplete.ts
+++ b/packages/agent-transport/src/tui/hooks/useAutocomplete.ts
@@ -5,7 +5,8 @@
 
 import React, { useState, useMemo } from 'react';
 
-import type { CommandRegistry, ICommand } from '@robota-sdk/agent-framework';
+import type { CommandRegistry } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
 
 /** Parse input to determine autocomplete state */
 function parseSlashInput(value: string): {

--- a/packages/agent-transport/src/tui/hooks/usePluginCallbacks.ts
+++ b/packages/agent-transport/src/tui/hooks/usePluginCallbacks.ts
@@ -8,7 +8,7 @@
 
 import { useMemo } from 'react';
 
-import type { ICommandPluginAdapter } from '@robota-sdk/agent-framework';
+import type { ICommandPluginAdapter } from '@robota-sdk/agent-interface-transport';
 
 function createNoOpPluginAdapter(): ICommandPluginAdapter {
   return {

--- a/packages/agent-transport/src/tui/hooks/usePluginScreenData.ts
+++ b/packages/agent-transport/src/tui/hooks/usePluginScreenData.ts
@@ -6,7 +6,7 @@
 import { useState, useEffect } from 'react';
 
 import type { IMenuSelectItem } from '../MenuSelect.js';
-import type { ICommandPluginAdapter } from '@robota-sdk/agent-framework';
+import type { ICommandPluginAdapter } from '@robota-sdk/agent-interface-transport';
 
 export function usePluginScreenData(
   screen: string,

--- a/packages/agent-transport/src/tui/hooks/useSideEffects.ts
+++ b/packages/agent-transport/src/tui/hooks/useSideEffects.ts
@@ -8,7 +8,7 @@ import { useTuiCliAdapter } from '../tui-cli-adapter-context.js';
 import type { IUseSideEffectsOptions, IUseSideEffectsResult } from './side-effects-types.js';
 import type { TInteractivePrompt } from './side-effects-types.js';
 import type { TSessionEndReason } from '@robota-sdk/agent-core';
-import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-framework';
+import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 const EXIT_DELAY_MS = 500;
 

--- a/packages/agent-transport/src/tui/hooks/useSlashRouting.ts
+++ b/packages/agent-transport/src/tui/hooks/useSlashRouting.ts
@@ -8,12 +8,12 @@ import { useCallback } from 'react';
 
 import type { TuiStateManager } from '../tui-state-manager.js';
 import type { ICommandEffectQueue } from './command-effect-queue.js';
+import type { CommandRegistry } from '@robota-sdk/agent-framework';
 import type {
-  IInteractiveSession,
-  CommandRegistry,
   ICommandResult,
+  IInteractiveSession,
   TCommandEffect,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 export function useSlashRouting(
   interactiveSession: IInteractiveSession,

--- a/packages/agent-transport/src/tui/hooks/useStatusLineSettings.ts
+++ b/packages/agent-transport/src/tui/hooks/useStatusLineSettings.ts
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useTuiCliAdapter } from '../tui-cli-adapter-context.js';
 
 import type { TUniversalValue } from '@robota-sdk/agent-core';
-import type { IStatusLineCommandSettings } from '@robota-sdk/agent-framework';
+import type { IStatusLineCommandSettings } from '@robota-sdk/agent-interface-transport';
 
 function readStatusLineSettings(
   settings: Record<string, TUniversalValue>,

--- a/packages/agent-transport/src/tui/hooks/useTuiChannel.ts
+++ b/packages/agent-transport/src/tui/hooks/useTuiChannel.ts
@@ -13,10 +13,10 @@ import type { IPermissionRequest } from '../types.js';
 import type { IHistoryEntry, TSessionEndReason } from '@robota-sdk/agent-core';
 import type { InteractiveSession, CommandRegistry } from '@robota-sdk/agent-framework';
 import type {
-  IToolState,
-  IExecutionWorkspaceSnapshot,
   IExecutionDetailPage,
-} from '@robota-sdk/agent-framework';
+  IExecutionWorkspaceSnapshot,
+  IToolState,
+} from '@robota-sdk/agent-interface-transport';
 
 export interface IInteractiveSessionState {
   interactiveSession: InteractiveSession;

--- a/packages/agent-transport/src/tui/plugin-tui-handlers.ts
+++ b/packages/agent-transport/src/tui/plugin-tui-handlers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { IMenuSelectItem } from './MenuSelect.js';
-import type { ICommandPluginAdapter } from '@robota-sdk/agent-framework';
+import type { ICommandPluginAdapter } from '@robota-sdk/agent-interface-transport';
 
 interface IConfirmState {
   message: string;

--- a/packages/agent-transport/src/tui/render.tsx
+++ b/packages/agent-transport/src/tui/render.tsx
@@ -15,13 +15,15 @@ import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
   ICommandModule,
-  IInteractiveSession,
-  IInteractiveSessionStore,
   TSubagentRunnerFactory,
   TShellExecFn,
   CommandRegistry,
 } from '@robota-sdk/agent-framework';
-import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transport';
+import type {
+  IInteractiveSession,
+  IInteractiveSessionStore,
+  ITransportRegistryView,
+} from '@robota-sdk/agent-interface-transport';
 
 export interface IRenderOptions {
   cwd: string;

--- a/packages/agent-transport/src/tui/tui-cli-adapter.ts
+++ b/packages/agent-transport/src/tui/tui-cli-adapter.ts
@@ -1,9 +1,9 @@
 import type { TUniversalValue } from '@robota-sdk/agent-core';
+import type { CommandRegistry } from '@robota-sdk/agent-framework';
 import type {
-  TStatusLineCommandSettingsPatch,
   IStatusLineCommandSettings,
-  CommandRegistry,
-} from '@robota-sdk/agent-framework';
+  TStatusLineCommandSettingsPatch,
+} from '@robota-sdk/agent-interface-transport';
 
 export interface ITuiCliAdapter {
   getUserSettingsPath(): string;

--- a/packages/agent-transport/src/tui/tui-state-manager.ts
+++ b/packages/agent-transport/src/tui/tui-state-manager.ts
@@ -10,10 +10,10 @@
 
 import type { IContextWindowState, IHistoryEntry } from '@robota-sdk/agent-core';
 import type {
-  IToolState,
   IExecutionResult,
   IExecutionWorkspaceSnapshot,
-} from '@robota-sdk/agent-framework';
+  IToolState,
+} from '@robota-sdk/agent-interface-transport';
 
 /** Max messages kept in rendering state */
 const MAX_RENDERED_MESSAGES = 100;

--- a/packages/agent-transport/src/tui/tui-transport.ts
+++ b/packages/agent-transport/src/tui/tui-transport.ts
@@ -1,8 +1,10 @@
 import { renderApp, type IRenderOptions } from './render.js';
 
 import type { TUniversalValue } from '@robota-sdk/agent-core';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
+import type {
+  IConfigurableTransport,
+  IInteractiveSession,
+} from '@robota-sdk/agent-interface-transport';
 
 export class TuiTransport implements IConfigurableTransport<IInteractiveSession> {
   readonly name = 'tui';

--- a/packages/agent-transport/src/ws/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport/src/ws/__tests__/ws-handler.test.ts
@@ -6,15 +6,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { createWsHandler } from '../ws-handler.js';
 import type { TServerMessage } from '../ws-protocol.js';
 import type {
-  IBackgroundTaskLogPage,
-  IBackgroundTaskState,
+  IBackgroundJobGroupState,
   IExecutionWorkspaceEvent,
   IExecutionWorkspaceSnapshot,
   IInteractiveSession,
-  IBackgroundJobGroupState,
   TBackgroundJobGroupEvent,
-  TBackgroundTaskEvent,
   TExecutionWorkspaceUpdateCause,
+} from '@robota-sdk/agent-interface-transport';
+import type {
+  IBackgroundTaskLogPage,
+  IBackgroundTaskState,
+  TBackgroundTaskEvent,
 } from '@robota-sdk/agent-framework';
 
 const backgroundTask: IBackgroundTaskState = {

--- a/packages/agent-transport/src/ws/__tests__/ws-transport.test.ts
+++ b/packages/agent-transport/src/ws/__tests__/ws-transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createWsTransport } from '../ws-transport.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 function createMockSession(): IInteractiveSession {
   return {

--- a/packages/agent-transport/src/ws/ws-background-messages.ts
+++ b/packages/agent-transport/src/ws/ws-background-messages.ts
@@ -1,5 +1,5 @@
 import type { TBackgroundControlAction, TClientMessage, TServerMessage } from './ws-protocol.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
 export function handleBackgroundQueryMessage(
   session: IInteractiveSession,

--- a/packages/agent-transport/src/ws/ws-handler.ts
+++ b/packages/agent-transport/src/ws/ws-handler.ts
@@ -14,14 +14,14 @@ import {
 } from './ws-background-messages.js';
 
 import type { TClientMessage, TServerMessage } from './ws-protocol.js';
+import type { TBackgroundTaskEvent } from '@robota-sdk/agent-framework';
 import type {
-  IInteractiveSession,
   IExecutionResult,
   IExecutionWorkspaceEvent,
-  TBackgroundJobGroupEvent,
-  TBackgroundTaskEvent,
+  IInteractiveSession,
   IToolState,
-} from '@robota-sdk/agent-framework';
+  TBackgroundJobGroupEvent,
+} from '@robota-sdk/agent-interface-transport';
 
 export interface IWsHandlerOptions {
   /** IInteractiveSession to expose. */

--- a/packages/agent-transport/src/ws/ws-protocol.ts
+++ b/packages/agent-transport/src/ws/ws-protocol.ts
@@ -1,18 +1,20 @@
 import type {
   InteractiveSession,
-  ICommandResult,
-  IBackgroundJobGroupState,
   IBackgroundTaskInput,
   IBackgroundTaskListFilter,
   IBackgroundTaskLogCursor,
   IBackgroundTaskLogPage,
   IBackgroundTaskState,
+  TBackgroundTaskEvent,
+} from '@robota-sdk/agent-framework';
+import type {
+  IBackgroundJobGroupState,
+  ICommandResult,
   IExecutionResult,
   IExecutionWorkspaceSnapshot,
   IToolState,
   TBackgroundJobGroupEvent,
-  TBackgroundTaskEvent,
-} from '@robota-sdk/agent-framework';
+} from '@robota-sdk/agent-interface-transport';
 
 export type TBackgroundControlAction = 'cancel' | 'close' | 'send';
 

--- a/packages/agent-transport/src/ws/ws-transport-configurable.ts
+++ b/packages/agent-transport/src/ws/ws-transport-configurable.ts
@@ -11,8 +11,10 @@ import { createWsHandler } from './ws-handler.js';
 
 import type { TServerMessage } from './ws-protocol.js';
 import type { TUniversalValue } from '@robota-sdk/agent-core';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
+import type {
+  IConfigurableTransport,
+  IInteractiveSession,
+} from '@robota-sdk/agent-interface-transport';
 
 const DEFAULT_PORT = 7070;
 const DEFAULT_MAX_RETRIES = 20;

--- a/packages/agent-transport/src/ws/ws-transport.ts
+++ b/packages/agent-transport/src/ws/ws-transport.ts
@@ -8,8 +8,7 @@
 import { createWsHandler } from './ws-handler.js';
 
 import type { TServerMessage } from './ws-protocol.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-framework';
-import type { ITransportAdapter } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession, ITransportAdapter } from '@robota-sdk/agent-interface-transport';
 
 export interface IWsTransportOptions {
   /** Send a JSON message to the connected WebSocket client. */


### PR DESCRIPTION
**INFRA-010 Layer 2.** Repoints agent-transport's interface-TYPE imports (70 files) from `@robota-sdk/agent-framework` to `@robota-sdk/agent-interface-transport` (their SSOT since DATA-001). Runtime values + `TInteractiveSessionOptions` still come from agent-framework. AF-14 is now real at the import sites for the relocated contract types. No package.json/lockfile change.

**Green (local):** build, typecheck, test (transport 473/473), check-dependency-direction, harness:conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)