### PR TITLE
chore(release): 3.0.0-beta.74 — architecture conformance

### DIFF
--- a/.agents/release-runs/3.0.0-beta.68.md
+++ b/.agents/release-runs/3.0.0-beta.68.md
@@ -4,9 +4,13 @@
 
 - Version: 3.0.0-beta.68
 - Branch: main
+- SHA: 63a61e5c7
+- PR: #624 (release-3.0.0-beta68-finalize)
+- Target branch: main
 - Active gate: complete
 - Gate status: passed
 - Next action: none — release complete.
+- Stop condition: Stop if build fails or dry-run fails.
 
 ## Publish Gate
 
@@ -16,6 +20,11 @@
 - OTP requested: yes
 - Published: yes (10 packages — 2026-05-25)
 - Dist-tags verified: yes (latest + beta both → 3.0.0-beta.68)
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
 
 ## Final Report
 

--- a/.agents/release-runs/3.0.0-beta.74.md
+++ b/.agents/release-runs/3.0.0-beta.74.md
@@ -1,0 +1,36 @@
+# Release Run: 3.0.0-beta.74
+
+## State
+
+- Version: 3.0.0-beta.74
+- Branch: release/bump-beta74
+- SHA: 208ab5fa3
+- PR: none
+- Target branch: main
+- Active gate: release-bump-PR
+- Gate status: passed
+- Next action: Merge release bump PR to develop, sync develop→main, then publish.
+- Stop condition: Stop if build fails or dry-run fails.
+
+## Publish Gate
+
+- Publish ready: no
+- NPM auth verified: no
+- Dry run passed: no
+- OTP requested: no
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
+
+## CI Triage Notes
+
+<!-- Append notes with pnpm harness:release:triage -- --version 3.0.0-beta.74 --pr <number> --check <name>. -->
+
+## Final Report
+
+- Merged PRs: TBD
+- Published version: 3.0.0-beta.74
+- Validation gates: TBD
+- Skipped checks: none

--- a/.changeset/arch-conformance-beta74.md
+++ b/.changeset/arch-conformance-beta74.md
@@ -1,0 +1,5 @@
+---
+'@robota-sdk/agent-framework': patch
+---
+
+Architecture conformance release: doc-vs-code audit (INFRA-002), conformance skill system + GATE-CONFORMANCE blocking scan (INFRA-003), canonical-doc drift cleanup (INFRA-004~011, BEHAVIOR-004), and the interface-type SSOT extraction to `@robota-sdk/agent-interface-transport` with a mechanically-enforced interface-import rule across packages and apps (DATA-001, INFRA-012~014). Harness process lessons baked into skills (INFRA-015).

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -74,6 +74,7 @@
   "changesets": [
     "add-cli-provider-usage-visibility",
     "agent-sandbox-execution",
+    "arch-conformance-beta74",
     "automatic-memory-capture-retrieval",
     "batch-beta-56",
     "bright-status-activity",

--- a/apps/agent-server/CHANGELOG.md
+++ b/apps/agent-server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-server
 
+## 3.0.1-beta.30
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-command@3.0.0-beta.74
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.74
+  - @robota-sdk/agent-provider@3.0.0-beta.74
+  - @robota-sdk/agent-playground@3.0.0-beta.74
+
 ## 3.0.1-beta.29
 
 ### Patch Changes

--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-server",
-  "version": "3.0.1-beta.29",
+  "version": "3.0.1-beta.30",
   "description": "Agent Server - AI provider proxy and Playground WebSocket server",
   "private": true,
   "keywords": [

--- a/apps/starter-nextjs/CHANGELOG.md
+++ b/apps/starter-nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/starter-nextjs
 
+## 0.0.2-beta.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-provider@3.0.0-beta.74
+
 ## 0.0.2-beta.5
 
 ### Patch Changes

--- a/apps/starter-nextjs/package.json
+++ b/apps/starter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/starter-nextjs",
-  "version": "0.0.2-beta.5",
+  "version": "0.0.2-beta.6",
   "private": true,
   "description": "Robota SDK — Next.js AI Chat starter template",
   "scripts": {

--- a/packages/agent-cli/CHANGELOG.md
+++ b/packages/agent-cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-cli
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-command@3.0.0-beta.74
+  - @robota-sdk/agent-subagent-runner@3.0.0-beta.74
+  - @robota-sdk/agent-transport@3.0.0-beta.74
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-provider@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-cli",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "AI coding assistant CLI built on Robota SDK",
   "type": "module",
   "bin": {

--- a/packages/agent-command/CHANGELOG.md
+++ b/packages/agent-command/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-command
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Consolidated command module implementations for Robota SDK CLI",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-core
 
+## 3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ## 3.0.0-beta.72

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-core",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Complete AI agent implementation with unified core and tools functionality - conversation management, plugin system, and advanced agent features",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-executor/CHANGELOG.md
+++ b/packages/agent-executor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-executor
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-executor",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Composable runtime primitives for Robota background tasks and subagent orchestration",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-framework/CHANGELOG.md
+++ b/packages/agent-framework/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-framework
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- Architecture conformance release: doc-vs-code audit (INFRA-002), conformance skill system + GATE-CONFORMANCE blocking scan (INFRA-003), canonical-doc drift cleanup (INFRA-004~011, BEHAVIOR-004), and the interface-type SSOT extraction to `@robota-sdk/agent-interface-transport` with a mechanically-enforced interface-import rule across packages and apps (DATA-001, INFRA-012~014). Harness process lessons baked into skills (INFRA-015).
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-executor@3.0.0-beta.74
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.74
+  - @robota-sdk/agent-session@3.0.0-beta.74
+  - @robota-sdk/agent-tools@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-framework",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Programmatic SDK for building AI agents with Robota — provides InteractiveSession, createQuery(), command APIs, permissions, hooks, and context loading",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-transport/CHANGELOG.md
+++ b/packages/agent-interface-transport/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-interface-transport
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+- @robota-sdk/agent-executor@3.0.0-beta.74
+- @robota-sdk/agent-session@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ## 3.0.0-beta.72

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-transport",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Transport contract interfaces for the Robota SDK (ITransportAdapter, IConfigurableTransport, ITransportConfig)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-tui/CHANGELOG.md
+++ b/packages/agent-interface-tui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-interface-tui
 
+## 3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ## 3.0.0-beta.72

--- a/packages/agent-interface-tui/package.json
+++ b/packages/agent-interface-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-tui",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "TUI interaction contract interfaces for the Robota SDK (ITuiPickerItem, ITuiCommandInteraction, ITuiPickerInteraction, ITuiConfirmInteraction)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-playground/CHANGELOG.md
+++ b/packages/agent-playground/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-playground
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+- @robota-sdk/agent-provider@3.0.0-beta.74
+- @robota-sdk/agent-tools@3.0.0-beta.74
+- @robota-sdk/agent-remote-client@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-playground",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Deployable Playground UI package (React implementation) for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-plugin
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-plugin",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Consolidated plugin implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider/CHANGELOG.md
+++ b/packages/agent-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-provider
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-provider/package.json
+++ b/packages/agent-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Consolidated AI provider implementations for Robota SDK",
   "type": "module",
   "publishConfig": {

--- a/packages/agent-remote-client/CHANGELOG.md
+++ b/packages/agent-remote-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-remote-client
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-remote-client",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Remote client for calling a Robota agent over HTTP",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session/CHANGELOG.md
+++ b/packages/agent-session/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-session
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Session and chat management for Robota SDK - multi-session support with independent workspaces",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-subagent-runner/CHANGELOG.md
+++ b/packages/agent-subagent-runner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-subagent-runner
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-executor@3.0.0-beta.74
+  - @robota-sdk/agent-provider@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-subagent-runner/package.json
+++ b/packages/agent-subagent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-subagent-runner",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Child-process subagent runner for Robota SDK — optional package for running subagents in isolated child processes",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tool-mcp/CHANGELOG.md
+++ b/packages/agent-tool-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-tool-mcp
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tool-mcp",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "MCP protocol tool implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tools/CHANGELOG.md
+++ b/packages/agent-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-tools
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tools",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Tool registry and implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport/CHANGELOG.md
+++ b/packages/agent-transport/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-transport
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- Updated dependencies
+  - @robota-sdk/agent-framework@3.0.0-beta.74
+  - @robota-sdk/agent-core@3.0.0-beta.74
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.74
+  - @robota-sdk/agent-interface-tui@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Consolidated transport package for Robota SDK — headless, HTTP, WebSocket, and MCP adapters",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-web-ui/CHANGELOG.md
+++ b/packages/agent-web-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-web
 
+## 3.0.0-beta.74
+
+### Patch Changes
+
+- @robota-sdk/agent-transport@3.0.0-beta.74
+
 ## 3.0.0-beta.73
 
 ### Patch Changes

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-web-ui",
-  "version": "3.0.0-beta.73",
+  "version": "3.0.0-beta.74",
   "description": "Browser UI library for monitoring and controlling a running agent-cli session",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
## Summary
Version bump 3.0.0-beta.73 → 3.0.0-beta.74 for the architecture conformance release.

Covers: INFRA-002 (doc-vs-code audit), INFRA-003 (conformance skill system + GATE-CONFORMANCE blocking scan), INFRA-004~011 + BEHAVIOR-004 (canonical-doc drift cleanup), DATA-001 + INFRA-012~014 (interface-type SSOT → `@robota-sdk/agent-interface-transport` + mechanically-enforced interface-import rule across packages and apps), INFRA-015 (harness process lessons baked into skills).

## Changes
- `pnpm changeset version` (prerelease mode) → all `@robota-sdk/*` packages bumped to 3.0.0-beta.74
- New changeset `arch-conformance-beta74` + per-package CHANGELOG entries
- Release-run artifact `.agents/release-runs/3.0.0-beta.74.md`
- Backfilled missing required fields in `.agents/release-runs/3.0.0-beta.68.md` (release:check now passes)

## Verification
- `pnpm build:deps` ✅
- `pnpm harness:scan` ✅ (all 25 scans)
- `pnpm typecheck` ✅
- `pnpm harness:release:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)