### PR TITLE
chore(release): finalize 3.0.0-beta.74 release-run

### DIFF
--- a/.agents/release-runs/3.0.0-beta.74.md
+++ b/.agents/release-runs/3.0.0-beta.74.md
@@ -5,19 +5,21 @@
 - Version: 3.0.0-beta.74
 - Branch: release/bump-beta74
 - SHA: 208ab5fa3
-- PR: none
+- PR: #748 (release/bump-beta74 → develop), #749 (develop → main)
 - Target branch: main
-- Active gate: release-bump-PR
+- Active gate: complete
 - Gate status: passed
-- Next action: Merge release bump PR to develop, sync develop→main, then publish.
+- Next action: none — release complete.
 - Stop condition: Stop if build fails or dry-run fails.
 
 ## Publish Gate
 
-- Publish ready: no
-- NPM auth verified: no
-- Dry run passed: no
-- OTP requested: no
+- Publish ready: yes
+- NPM auth verified: yes (jungyoun — 2026-06-14)
+- Dry run passed: yes (13 packages — 2026-06-14)
+- OTP requested: yes
+- Published: yes (13 packages — 2026-06-14)
+- Dist-tags verified: yes (latest + beta both → 3.0.0-beta.74)
 
 ## Long-Running Watchers
 
@@ -30,7 +32,9 @@
 
 ## Final Report
 
-- Merged PRs: TBD
+- Merged PRs: #748 (bump → develop), #749 (develop → main release)
 - Published version: 3.0.0-beta.74
-- Validation gates: TBD
+- Published packages: 13 (@robota-sdk/agent-cli, agent-command, agent-core, agent-executor, agent-framework, agent-interface-transport, agent-interface-tui, agent-plugin, agent-provider, agent-session, agent-subagent-runner, agent-tools, agent-transport)
+- Excluded packages: @robota-sdk/agent-web-ui, agent-playground (private)
+- Validation gates: npm auth ✅ · build ✅ · dry-run ✅ · publish ✅ · dist-tags ✅ (latest + beta)
 - Skipped checks: none


### PR DESCRIPTION
Records the publish result for 3.0.0-beta.74 (13 packages published, latest + beta dist-tags verified).

Bookkeeping only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)