### PR TITLE
docs(preset): fair/universal system-prompt injection (priority/source section mechanism)

### DIFF
--- a/.agents/spec-docs/todo/PRESET-003-persona-system-prompt-composition.md
+++ b/.agents/spec-docs/todo/PRESET-003-persona-system-prompt-composition.md
@@ -4,109 +4,195 @@ type: BEHAVIOR
 tags: [cli]
 ---
 
-# PRESET-003: 페르소나/시스템 프롬프트 합성 — append/replace 계약 + agentName 오버라이드
+# PRESET-003: 페르소나 시스템 프롬프트 합성 — `source: 'persona'` 섹션 + priority 정렬 + agentName 소유 이전
 
 ## Problem
 
-프리셋의 핵심은 페르소나(시스템 프롬프트)다. 현재 시스템 프롬프트는 `buildSessionSystemPrompt`가
-기본 섹션들을 합성해 만들고, `systemPrompt`(완전 대체)/`appendSystemPrompt`(덧붙임) seam이 존재하지만,
-**프레임워크가 페르소나를 이 두 경로 중 무엇으로 합성하는지에 대한 명확한 계약이 없다.** 또한 에이전트
-정체성 이름이 `agentName: 'robota-cli'`로 `packages/agent-cli/src/cli.ts:254`에 하드코딩되어 있어,
-정체성 기본값을 cli가 소유하고 있다 — 페르소나 합성·정체성 적용은 프레임워크 관심사이고 기본값은
-프리셋(`agent-preset`) 관심사인데, cli(얇은 껍데기)가 둘 다 떠안고 있다.
+프리셋의 핵심은 페르소나(시스템 프롬프트)다. 프레임워크는 이미 시스템 프롬프트를 **`ISystemPromptSection`
+객체 배열**로 만들고 `composeSystemPrompt`(`packages/agent-framework/src/context/system-prompt-composer.ts`)가
+**호출 순서가 아니라 각 섹션의 `priority: number`로 정렬**해 합성하는 공정·보편 메커니즘을 갖고 있다. 각 섹션은
+`source`(`framework`/`project-instructions`/`runtime`/`permissions`/`tool`/...)와 선언된 `priority`를 가진다
+(현재 밴드: AGENTS.md=10, CLAUDE.md=20, cwd=30, project=40, language=45, permissions=50, tool=60, capabilities 상위).
+그런데 이 메커니즘에는 **프리셋 페르소나를 위한 `source`가 없다** — `TSystemPromptSectionSource`에 `'persona'`가
+없고, persona 섹션을 만드는 provider(`createPersonaSection`)도 없으며, `buildSystemPrompt`의 `ISystemPromptParams`에
+persona 입력이 없다. 그 결과 프리셋이 페르소나를 적용하려면 전체 덮어쓰기(`systemPrompt`)나 소량
+append(`appendSystemPrompt`)에 의존해야 하는데, 전자는 우리 CLI의 런타임 섹션을 파괴하고 후자는 페르소나의
+정상 경로가 아니다.
 
-**재현 조건:** `rg "agentName: 'robota-cli'" packages/agent-cli/src/cli.ts` → cli.ts:254 매치(하드코딩).
-프리셋 페르소나를 기본 프롬프트에 덧붙일지 대체할지 정의/검증하는 코드 경로가 없다.
+또한 에이전트 정체성 기본값이 cli에 남아 있다. PRESET-002가 `agentName: resolvedPreset.agentName ?? 'robota-cli'`
+형태로 프리셋 fallback을 배선했지만, 리터럴 `'robota-cli'`는 여전히 `packages/agent-cli/src/cli.ts`에 박혀 있다
+(cli.ts:271). 정체성 기본값은 프리셋(`agent-preset`) 관심사이고 페르소나 합성·정체성 적용은 프레임워크
+관심사인데, cli(얇은 껍데기)가 기본값 리터럴을 떠안고 있다.
 
-설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §5(레이어 책임 — agent-cli는 껍데기), §5.1, §6.1(매트릭스 #7·#12·#13).
+**재현 조건:**
+
+- `rg "agentName: 'robota-cli'" packages/agent-cli/src/cli.ts` → cli.ts:271 매치(리터럴 잔존).
+- `rg "'persona'" packages/agent-framework/src/context/system-prompt-types.ts` → 0 매치(`TSystemPromptSectionSource`에 `'persona'` 부재).
+- `rg "createPersonaSection" packages/agent-framework/src/context/system-prompt-section-providers.ts` → 0 매치(persona 섹션 provider 부재).
+- `rg "persona" packages/agent-framework/src/context/system-prompt-builder.ts` → 0 매치(`ISystemPromptParams` persona 입력 부재).
+
+설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md)
+§5.4(시스템 프롬프트 합성 아키텍처 — AUTHORITATIVE: 페르소나는 `source: 'persona'` + 선언된 priority를 가진
+또 하나의 `ISystemPromptSection`이며 기존 `composeSystemPrompt`가 priority로 정렬한다 — 전용 슬롯·하드코딩
+위치 없음), §5(레이어 책임 — agent-cli는 THIN SHELL), §5.1, §6.1(매트릭스 #7·#12·#13).
+
+PRESET-001(IPreset 계약 + resolvePreset + default 프리셋)은 이미 DONE/머지됨. PRESET-003은 그 계약에
+**`persona` 필드와 레이어 합성을 추가**한다.
 
 ## Architecture Review
 
 ### Affected Scope
 
-- `packages/agent-framework/src/assembly/create-session.ts` / `create-session-runtime.ts` — 페르소나
-  append vs replace 합성 규칙(이미 존재하는 `appendSystemPrompt`/`systemPromptBuilder` 경로 확정) +
-  해석된 `agentName`을 세션 조립 시 적용(정체성 적용은 프레임워크 관심사)
-- `packages/agent-preset` — default 프리셋이 기본 `agentName` 상수와 페르소나 값을 소유(SSOT);
-  cli에서 옮겨온 정체성 기본값의 새 소유자
-- `packages/agent-cli/src/cli.ts` — **하드코딩 `agentName: 'robota-cli'`(cli.ts:254) 제거만** 수행하고,
-  해석된 옵션을 그대로 전달. cli는 기본값·합성 로직을 소유하지 않는다(껍데기)
-- 소비: PRESET-001 `IPreset.appendSystemPrompt`/`systemPrompt`/`agentName` + default 프리셋, PRESET-002 주입 경로
+- `packages/agent-framework/src/context/system-prompt-types.ts` — `TSystemPromptSectionSource` union에
+  `'persona'` 추가. 기존 `ISystemPromptSection` 형태(`id`/`title?`/`priority`/`content`/`source`)는 변경 없음.
+- `packages/agent-framework/src/context/system-prompt-section-providers.ts` — `createPersonaSection(persona: string):
+ISystemPromptSection` 추가. `source: 'persona'`, **선언된 priority `5`**(상단 밴드 — 정체성/성격이
+  project-instructions=10보다 먼저 확립되도록), 기존 `createSection(id, title, priority, content, source)` 헬퍼 재사용.
+  priority는 **선언된 값**이지 배열 위치가 아니다 — `composeSystemPrompt`가 다른 모든 섹션과 동일하게 priority로 정렬한다.
+- `packages/agent-framework/src/context/system-prompt-builder.ts` — `ISystemPromptParams`에 `persona?: string` 추가 +
+  `buildSystemPrompt`가 `persona`가 있으면 `createPersonaSection(persona)`를 sections 배열에 push. 위치 하드코딩
+  없음 — `composeSystemPrompt`가 priority `5`로 정렬해 persona가 상단 밴드에 보편 메커니즘으로 안착한다. 런타임
+  섹션 provider는 모두 그대로 유지.
+- `packages/agent-framework/src/assembly/create-session.ts` / `create-session-runtime.ts`
+  (`buildSessionSystemPrompt`) — 해석된 `preset.persona`를 `ISystemPromptParams.persona`로 전달하고, CLI
+  `--append-system-prompt`/task-file는 기존 경로대로 합성 후 말미에 append(섹션 메커니즘과 별개의 per-run seam).
+  해석된 `agentName`(`preset.agentName ?? <agent-preset default 상수>`)을 세션 조립 시 적용.
+- `packages/agent-preset` — `IPreset` 계약에 `persona?: string` 추가(PRESET-001 계약 확장 — `source: 'persona'`
+  섹션의 내용이 될 구조화된 성격/행동 블록). `appendSystemPrompt?`/`systemPrompt?`는 유지. default 프리셋의 기본
+  `agentName` 상수(generic, 벤더명 없음)를 소유 — cli에서 옮겨온 정체성 기본값의 새 소유자. default 프리셋의
+  `persona`는 빈 값(빈 persona = persona 섹션 미생성 = 무회귀).
+- `packages/agent-cli/src/cli.ts` — 리터럴 `'robota-cli'` 제거(forward only). cli는 기본값·합성 로직을
+  소유하지 않고 해석된 옵션을 그대로 전달(THIN SHELL).
+- 소비: PRESET-001 `IPreset`(+ 신규 `persona`) + default 프리셋, PRESET-002 주입 경로.
 
 ### Alternatives Considered
 
 1. **프리셋 페르소나를 항상 `systemPrompt`(완전 대체)로 적용.**
    - Pro: 페르소나가 결정적.
-   - Con: AGENTS.md/CLAUDE.md/메모리/도구 설명 등 필수 기본 섹션을 잃음 — 에이전트가 기능 상실. Rejected.
-2. **기본은 `appendSystemPrompt`(덧붙임), 드물게 `systemPrompt`(완전 대체) 허용.**
-   - Pro: 기본 섹션 유지 + 페르소나 레이어링(Claude Agent SDK가 base preset에 append 하는 패턴과 동일);
-     완전 대체는 고급 옵션으로 남김.
-   - Con: 두 경로의 우선순위/순서를 명시 검증해야 함.
+   - Con: 런타임 섹션(작업 디렉터리·AGENTS.md/CLAUDE.md·메모리·도구 설명·권한·capability·언어)을 잃음 —
+     에이전트가 우리 CLI 런타임 컨텍스트를 상실. 유출 프롬프트 verbatim은 타 제품 도구 정의·`/home/claude`
+     경로·제품 정체성 같은 잘못된 런타임 가정을 import. Rejected.
+2. **소량 `appendSystemPrompt`로만 페르소나 추가(섹션 메커니즘 미사용).**
+   - Pro: 기존 seam 재사용, 신규 코드 최소.
+   - Con: 페르소나(길 수 있는 구조화 블록)와 사용자 per-run append가 동일 말미 seam을 공유 → 순서/소유 모호.
+     페르소나가 모든 런타임 섹션 뒤에 붙어 "성격 먼저 확립"이라는 §5.4 의도를 priority로 표현하지 못함. Rejected.
+3. **하드코딩된 persona 슬롯/특례 분기 — `buildSystemPrompt`가 persona를 합성 결과 최상단에 위치로 고정(특별 케이스).**
+   - Pro: persona가 항상 맨 위.
+   - Con: 위치가 코드에 박힌 특혜 슬롯이라 기존 priority 정렬 메커니즘과 별개의 두 번째 합성 규칙이 생긴다 —
+     `composeSystemPrompt`가 이미 priority로 공정하게 정렬하는데 persona만 슬롯·분기로 우회하는 것은 보편성 위반.
+     향후 다른 기여자(plugin 등)도 같은 특혜를 요구하게 됨. Rejected.
+4. **기존 priority/source 섹션 메커니즘 재사용 — persona를 `source: 'persona'` + 선언된 priority `5`를 가진 또 하나의
+   `ISystemPromptSection`으로 만들고 기존 `composeSystemPrompt`가 정렬.**
+   - Pro: 전용 슬롯·특례 분기 없음. persona는 다른 모든 섹션(project-instructions=10, runtime=30~ 등)과 **동일한
+     priority 정렬기**를 거치며, priority `5`가 상단 밴드 위치를 **공정·보편적으로 선언**한다(`5 < 10`이라
+     project-instructions보다 먼저). 프레임워크 변경이 최소·일반적(① `'persona'` source 추가 ② provider 추가
+     ③ param 있으면 섹션 push). `default`(빈 persona) → 섹션 미생성 → 프롬프트 개입 0 = 무회귀. 향후 plugin 등도
+     동일 `source`+`priority`로 특혜 없이 주입 가능. §5.4 AUTHORITATIVE와 정확히 일치.
+   - Con: source union·provider·param 3곳 소폭 확장 + priority 정렬 결과 검증 비용.
 
 ### Decision
 
-**Alternative 2.** 프리셋 페르소나는 기본적으로 `appendSystemPrompt`로 덧붙여 필수 기본 섹션을 보존하고,
-`systemPrompt`(완전 대체)는 명시적 고급 옵션으로 둔다. 정체성 기본값은 cli에서 빼낸다: 기본 `agentName`
-상수는 `agent-preset`의 default 프리셋(또는 프레임워크 default)이 소유하고, 프레임워크가 조립 시
-`preset.agentName`을 적용한다 — `agentName`은 프리셋 > 프레임워크 기본값으로 해석된다. cli는 더 이상
-기본값·합성 로직을 소유하지 않고 하드코딩 라인만 제거한다. CLI `--append-system-prompt`와 프리셋 append가
-모두 있으면 순서를 결정적으로 정의(기본 섹션 → 프리셋 페르소나(append) → CLI `--append-system-prompt`).
-트레이드오프: 합성 순서 검증 + 기본값 소유 이전 비용을 감수하고 기본 기능 보존 + 페르소나 레이어링 +
-레이어 책임 분리(cli 껍데기화)를 얻는다.
+**Alternative 4 (기존 priority/source 섹션 메커니즘 재사용).** 페르소나는 특례가 아니라 **또 하나의 섹션**이다.
+`TSystemPromptSectionSource`에 `'persona'`를 추가하고, `createPersonaSection(persona)`가 `source: 'persona'` +
+**선언된 priority `5`**(상단 밴드 — `5 < 10`이라 project-instructions=10보다 먼저 성격을 확립)를 가진
+`ISystemPromptSection`을 반환한다. `buildSystemPrompt`는 `persona`가 있으면 이 섹션을 sections 배열에 push할
+뿐이고, **위치는 기존 `composeSystemPrompt`가 priority로 정렬**해 결정한다 — 하드코딩된 위치도, 프리셋 전용
+분기도 없다. 즉 persona는 다른 모든 섹션(project-instructions·runtime·permissions·tool·capabilities)과
+**완전히 동일한 정렬기**를 거치며, **공정성/보편성**이 핵심 근거다: 어떤 섹션도 특혜 슬롯을 갖지 않고 priority
+숫자만으로 타이밍을 선언한다. `default` 프리셋은 persona가 비어 있어 `createPersonaSection`이 호출되어도(또는
+호출되지 않아) persona 섹션이 생성되지 않으므로 **프롬프트 개입 0, 현재 동작과 100% 동일(무회귀)**. CLI
+`--append-system-prompt`/task-file는 섹션 메커니즘과 별개의 per-run seam으로 합성 후 말미에 append된다.
+`systemPrompt`(완전 대체)는 고급 escape hatch로 남기되 권장하지 않는다. 정체성 기본값은 cli에서 빼낸다:
+기본 `agentName` 상수(generic)는 `agent-preset`의 default 프리셋이 소유하고, 프레임워크가 조립 시
+`preset.agentName ?? <agent-preset default 상수>`로 해석해 적용한다 — cli는 리터럴을 들지 않고 forward만 한다.
+트레이드오프: source union·provider·param 3곳 소폭 확장 + priority 정렬 결과 검증 비용을 감수하고, 보편 메커니즘
+재사용(특혜 슬롯 없음) + 런타임 보존 + priority로 선언된 공정한 순서 + 무회귀(default) + 레이어 책임 분리
+(cli THIN SHELL)를 얻는다. (3 하드코딩 슬롯 대비: 별개의 두 번째 합성 규칙을 만들지 않는 점이 결정적이다.)
 
 ### Architecture Review Checklist
 
-- [x] 영향 패키지/레이어 목록 작성 완료 — agent-framework(합성 규칙 + agentName 적용), agent-preset(default agentName/페르소나 값), agent-cli(하드코딩 제거만)
-- [x] Sibling scan 완료 — `buildSessionSystemPrompt`/`systemPromptBuilder`/`appendSystemPrompt` 기존 경로 확인 후 재사용(신규 합성기 만들지 않음)
-- [x] 대안 최소 2개 검토 완료 — 2개 검토
-- [x] 결정 근거 문서화 완료 — append-우선 + 기본 섹션 보존 + 기본값 소유 이전(cli→preset/framework) 근거 기록
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-framework(system-prompt-types `'persona'` source + system-prompt-section-providers `createPersonaSection` priority 5 + system-prompt-builder param + create-session 배선), agent-preset(IPreset.persona + default agentName 상수), agent-cli(리터럴 제거 forward)
+- [x] Sibling scan 완료 — `system-prompt-types`(source union)·`system-prompt-section-providers`(createXSection providers)·`system-prompt-composer`(priority 정렬)·`system-prompt-builder`·`create-session-runtime` 기존 경로 확인 후 기존 섹션 메커니즘 재사용(신규 합성기·전용 슬롯 만들지 않음)
+- [x] 대안 최소 2개 검토 완료 — 4개 검토(완전 대체 / 소량 append / 하드코딩 슬롯 / 기존 priority·source 섹션 재사용)
+- [x] 결정 근거 문서화 완료 — 보편 priority 정렬 메커니즘 재사용(특혜 슬롯 없음) + persona priority 5 선언 + 런타임 보존 + default 무회귀 + 기본값 소유 이전(cli→preset) 근거 기록
 
 ## Solution
 
-1. 기본 `agentName` 상수를 cli에서 빼낸다: 상수를 `agent-preset`의 default 프리셋(또는 프레임워크 default)이
-   소유하고(상수는 generic, 벤더명 없음), 프레임워크가 조립 시 `preset.agentName ?? <framework default>`로
-   해석해 세션에 적용한다. `cli.ts`의 `agentName: 'robota-cli'` 하드코딩 라인을 제거하고 해석된 옵션을
-   그대로 전달한다(cli는 기본값을 들고 있지 않는다).
-2. 프리셋 `appendSystemPrompt`를 기존 append 경로로 주입 → 최종 system message에 페르소나 텍스트 포함.
-3. 프리셋 `systemPrompt`(대체)는 고급 경로로만; 지정 시 기본 페르소나 섹션 대체하되 필수 인프라 섹션
-   유지 여부를 계약으로 명시.
-4. 합성 순서(결정적): 기본 섹션 → 프리셋 페르소나(append) → CLI `--append-system-prompt`.
+1. **`'persona'` source 추가(agent-framework `system-prompt-types.ts`):** `TSystemPromptSectionSource` union에
+   `'persona'`를 추가. `ISystemPromptSection` 형태는 변경 없음.
+2. **`createPersonaSection` provider 추가(agent-framework `system-prompt-section-providers.ts`):**
+   `createPersonaSection(persona: string): ISystemPromptSection`을 기존 `createSection` 헬퍼로 작성 —
+   `source: 'persona'`, **선언된 priority `5`**(상단 밴드, `5 < 10`이라 project-instructions=10 이전). priority는
+   선언된 값이지 배열 위치가 아니다.
+3. **`buildSystemPrompt` param + 섹션 push(agent-framework `system-prompt-builder.ts`):** `ISystemPromptParams`에
+   `persona?: string` 추가. `params.persona`가 있으면(비어있지 않으면) `createPersonaSection(params.persona)`를
+   sections 배열에 push. **위치 하드코딩 없음** — 기존 `composeSystemPrompt`가 priority `5`로 정렬해 persona가
+   상단 밴드에 보편 메커니즘으로 안착한다. 다른 섹션 provider는 모두 그대로.
+4. **세션 배선(agent-framework `create-session*` / `buildSessionSystemPrompt`):** 해석된 `preset.persona`를
+   `ISystemPromptParams.persona`로 전달. CLI `--append-system-prompt`/task-file는 기존 경로대로 합성 후 말미에
+   append(섹션 메커니즘과 별개의 per-run seam). `agentName`은 `preset.agentName ?? <agent-preset default 상수>`로
+   해석해 세션에 적용.
+5. **IPreset 계약 확장(agent-preset):** `IPreset`에 `persona?: string` 추가 — `source: 'persona'` 섹션의 내용이 될
+   구조화된 성격/행동 블록(길 수 있음). `appendSystemPrompt?`/`systemPrompt?`는 유지. 이는 PRESET-001 계약(이미
+   DONE)의 확장이다. default 프리셋의 `persona`는 빈 값.
+6. **default agentName 소유 이전(agent-preset):** 기본 `agentName` 상수(generic, 벤더명 없음)를 `agent-preset`의
+   default 프리셋이 소유. cli는 리터럴을 들지 않는다.
+7. **cli forward(agent-cli):** `cli.ts`에서 리터럴 `'robota-cli'`를 제거하고 해석된 옵션을 그대로 전달.
+
+**콘텐츠 규칙(persona RULE — 중요):** 프리셋 `persona`에는 **이식 가능한 persona/behavior만** 넣는다
+(tone·formatting, refusal 철학, evenhandedness, user wellbeing, mistake-handling, output style, proactivity).
+런타임/도구/제품-정체성 섹션(도구 JSON 스키마·파일 경로·제품명·현재 날짜·knowledge cutoff·MCP 커넥터)은
+**절대 persona에 넣지 않는다** — 그건 프레임워크 RUNTIME 레이어의 책임이고 환경 종속이다(§5.4). `default`
+프리셋의 persona는 빈 값이며, 빈 persona = persona 섹션 미생성 = 런타임 섹션만 합성 = 무회귀.
 
 ## Affected Files
 
-- `packages/agent-framework/src/assembly/create-session.ts` — 합성 규칙 + agentName 적용
-- `packages/agent-framework/src/assembly/create-session-runtime.ts` — 합성 규칙 + agentName 적용
-- `packages/agent-preset` — default 프리셋의 기본 agentName 상수 + 페르소나 값(소유자)
-- `packages/agent-cli/src/cli.ts` — 하드코딩 `agentName: 'robota-cli'` 제거(소유권 없음)
+- `packages/agent-framework/src/context/system-prompt-types.ts` — `TSystemPromptSectionSource`에 `'persona'` 추가
+- `packages/agent-framework/src/context/system-prompt-section-providers.ts` — `createPersonaSection(persona)` 추가(`source: 'persona'`, priority `5`)
+- `packages/agent-framework/src/context/system-prompt-builder.ts` — `ISystemPromptParams.persona?: string` + persona 있으면 `createPersonaSection` push(위치는 `composeSystemPrompt`가 priority로 정렬)
+- `packages/agent-framework/src/assembly/create-session.ts` — `preset.persona`를 세션 옵션→system prompt param으로 전달 + agentName 적용
+- `packages/agent-framework/src/assembly/create-session-runtime.ts` (`buildSessionSystemPrompt`) — `ISystemPromptParams.persona` 배선 + CLI append 말미 seam 유지
+- `packages/agent-preset/src/<types>` — `IPreset`에 `persona?: string` 추가(PRESET-001 계약 확장)
+- `packages/agent-preset/src/<default>` — default 프리셋의 기본 `agentName` 상수(generic) + 빈 `persona` 소유
+- `packages/agent-cli/src/cli.ts` — 리터럴 `'robota-cli'` 제거(forward only)
 
 ## Completion Criteria
 
-- [ ] TC-01: `appendSystemPrompt`를 가진 프리셋을 프레임워크가 조립할 때 최종 system message 문자열에 해당 페르소나 텍스트가 substring으로 포함됨을 단언하는 통합 테스트 통과
-- [ ] TC-02: 페르소나 append 후에도 필수 기본 섹션(예: 작업 디렉터리/도구 설명 마커)이 최종 메시지에 여전히 substring으로 존재함을 단언하는 통합 테스트 통과
-- [ ] TC-03: `agentName`을 가진 프리셋 조립 시 세션의 agentName이 프리셋 값과 동일 문자열임을 단언; `agentName` 미지정 프리셋(default) 조립 시 세션의 agentName이 `agent-preset`의 default 상수와 동일 문자열임을 단언하는 통합 테스트 통과(기본값 출처가 cli가 아닌 agent-preset임)
-- [ ] TC-04: 프리셋 append + CLI `--append-system-prompt` 동시 적용 시 최종 메시지에서 [기본 섹션 마커]의 인덱스 < [프리셋 페르소나 텍스트]의 인덱스 < [CLI append 텍스트]의 인덱스임을 단언하는 통합 테스트 통과
-- [ ] TC-05: `rg "agentName: 'robota-cli'" packages/agent-cli/src/cli.ts` → 매치 0건(하드코딩 제거 확인)
-- [ ] TC-06: `pnpm --filter @robota-sdk/agent-cli --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-preset build` + `pnpm typecheck` → exit 0
+- [ ] TC-01: `TSystemPromptSectionSource` union에 `'persona'` 리터럴이 포함됨을 단언하는 타입/유닛 테스트 통과 — `createPersonaSection('x')`가 `source === 'persona'`인 섹션을 반환
+- [ ] TC-02: `createPersonaSection('x')` 반환 섹션의 `priority === 5`이고, 이 값이 project-instructions 밴드(10)보다 작음(`5 < 10`)을 단언하는 유닛 테스트 통과
+- [ ] TC-03: `persona` 텍스트를 가진 프리셋을 프레임워크가 조립할 때 최종 합성 system message 문자열에 해당 persona 텍스트가 substring으로 포함됨을 단언하는 통합 테스트 통과
+- [ ] TC-04: persona가 적용된 합성 결과에서 persona 텍스트와 런타임 base-section 마커(예: 작업 디렉터리 / 도구 설명)가 **둘 다** 최종 메시지에 substring으로 존재함을 단언하는 통합 테스트 통과
+- [ ] TC-05: persona가 적용된 합성 결과에서 index(persona 텍스트) < index(project-instruction/runtime base-section 마커)임을 단언하는 통합 테스트 통과(persona priority 5 < 10이라 priority 정렬로 persona가 먼저 옴 — 위치 하드코딩이 아닌 priority 결과)
+- [ ] TC-06: `persona`가 빈(또는 미지정) default 프리셋 조립 시 최종 메시지에 persona 섹션이 없고 런타임-only 합성 결과와 동일 문자열임을 단언하는 통합 테스트 통과(무회귀)
+- [ ] TC-07: `agentName`을 가진 프리셋 조립 시 세션 agentName이 프리셋 값과 동일 문자열임을 단언; `agentName` 미지정 프리셋(default) 조립 시 세션 agentName이 `agent-preset`의 default 상수와 동일 문자열임을 단언하는 통합 테스트 통과(기본값 출처가 cli가 아닌 agent-preset)
+- [ ] TC-08: `rg "agentName: 'robota-cli'" packages/agent-cli/src/cli.ts` → 매치 0건(리터럴 제거 확인)
+- [ ] TC-09: `pnpm --filter @robota-sdk/agent-cli --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-preset build` + `pnpm typecheck` → exit 0
 
 ## Test Plan
 
-Type BEHAVIOR + tags cli → 프레임워크 합성 결과(system message/agentName) 통합 단언 테스트 + 빌드·grep 스모크.
+Type BEHAVIOR + tags cli → persona 섹션 메커니즘(source/priority) 유닛 단언 + 프레임워크 합성 결과(system message/agentName) 통합 단언 + 빌드·grep 스모크.
 
-| TC-ID | Test Type              | Tool / Approach                                                  | Notes    |
-| ----- | ---------------------- | ---------------------------------------------------------------- | -------- |
-| TC-01 | BEHAVIOR               | 통합 테스트 — 최종 system message 페르소나 substring 단언        |          |
-| TC-02 | BEHAVIOR               | 통합 테스트 — 필수 섹션 마커 잔존 substring 단언                 |          |
-| TC-03 | BEHAVIOR               | 통합 테스트 — 세션 agentName(프리셋 값 + default 상수 출처) 단언 |          |
-| TC-04 | BEHAVIOR               | 통합 테스트 — 최종 메시지 내 substring 인덱스 순서 단언          |          |
-| TC-05 | CI pipeline smoke test | `rg` 하드코딩 부재 단언                                          | 커맨드폼 |
-| TC-06 | CI pipeline smoke test | `pnpm build` + `pnpm typecheck` exit code                        | 커맨드폼 |
+| TC-ID | Test Type              | Tool / Approach                                                                  | Notes    |
+| ----- | ---------------------- | -------------------------------------------------------------------------------- | -------- |
+| TC-01 | BEHAVIOR               | 유닛 테스트 — `'persona'` source union 포함 + `createPersonaSection` source 단언 |          |
+| TC-02 | BEHAVIOR               | 유닛 테스트 — `createPersonaSection().priority === 5` 및 `5 < 10` 단언           |          |
+| TC-03 | BEHAVIOR               | 통합 테스트 — 최종 system message persona substring 단언                         |          |
+| TC-04 | BEHAVIOR               | 통합 테스트 — persona + 런타임 base-section 마커 둘 다 substring 단언            |          |
+| TC-05 | BEHAVIOR               | 통합 테스트 — index(persona) < index(project-instruction/runtime 마커) 단언      |          |
+| TC-06 | BEHAVIOR               | 통합 테스트 — default(빈 persona) == 런타임-only 동일 문자열 단언(무회귀)        |          |
+| TC-07 | BEHAVIOR               | 통합 테스트 — 세션 agentName(프리셋 값 + default 상수 출처) 단언                 |          |
+| TC-08 | CI pipeline smoke test | `rg` 리터럴 부재 단언                                                            | 커맨드폼 |
+| TC-09 | CI pipeline smoke test | `pnpm build` + `pnpm typecheck` exit code                                        | 커맨드폼 |
 
 ## User Execution Test Scenarios
 
-- **시나리오 — 페르소나 적용 가시화:** 전제: PRESET-002 배선 완료 + `appendSystemPrompt`를 가진 임시
-  테스트 프리셋(또는 PRESET-005의 `autonomous-builder`). 실행: `robota --preset <id>` 로 세션 시작 후
-  프리셋 페르소나가 행동에 반영되는지 확인(예: 페르소나가 지시한 어조/행동). 기대: 프리셋별로 관찰
-  가능한 어조/행동 차이. 정리: 없음. Evidence: 세션 출력 캡처(구현 후 기록).
+- **시나리오 1 — 페르소나 섹션 적용 가시화:** 전제: PRESET-002 배선 완료 + `persona`를 가진 임시 테스트
+  프리셋(또는 PRESET-005의 `autonomous-builder`). 실행: `robota --preset <id>` 로 세션 시작 후 프리셋 persona가
+  행동에 반영되는지 확인(예: persona가 지시한 어조/행동). 기대: 프리셋별로 관찰 가능한 어조/행동 차이. 정리:
+  없음. Evidence: 세션 출력 캡처(구현 후 기록).
+- **시나리오 2 — default 무회귀:** 전제: 없음. 실행: `robota`(프리셋 미지정 = default) 와 `robota --preset default`
+  를 동일 입력으로 실행. 기대: 두 실행의 system message/동작이 동일(persona 섹션 미생성, 런타임-only).
+  정리: 없음. Evidence: 두 세션 출력 비교 캡처(구현 후 기록).
 
 환경: PRESET-002 선행. 별도 fixture 불필요.
 
@@ -120,19 +206,18 @@ Type BEHAVIOR + tags cli → 프레임워크 합성 결과(system message/agentN
 
 **Status upgrade:** draft → review-ready
 
-- Frontmatter: `---` block present; `status: draft`; `type: BEHAVIOR` (valid 11-prefix value); `tags: [cli]` present.
-- Problem: concrete symptom (`agentName: 'robota-cli'` hardcoded at cli.ts:254) + reproduction (`rg "agentName: 'robota-cli'" packages/agent-cli/src/cli.ts` → match); no TBD/TODO/vague.
-- Architecture Review: all 4 checklist items `[x]`; sibling scan `[x]` with reuse evidence (buildSessionSystemPrompt/systemPromptBuilder/appendSystemPrompt); 2 alternatives each with pro/con; Decision states trade-off (composition-order verification + ownership-transfer cost vs. base-section preservation + persona layering + layer separation).
-- Completion Criteria: all items TC-01..TC-06 prefixed; command/observable-behavior form; no banned phrases ("works correctly"/"no errors"/"implemented"/"displays correctly").
-- Test Plan: `## Test Plan` present; 6 rows (TC-01..TC-06) match 6 Completion Criteria TC-N (count matches); each row has non-empty Test Type + Tool/Approach, no "TBD"; no "manual"-tool rows so Notes justification N/A.
-- Structure: Tasks section with placeholder present; Evidence Log present (was empty before this run); no `## Status`/`## Classification` body sections.
+- Frontmatter: `---` block present; `status: draft`; `type: BEHAVIOR` (valid 11-prefix); `tags: [cli]` present.
+- Problem: concrete symptoms via `rg` commands with expected match counts (cli.ts:271 literal, 0-match for `'persona'`/`createPersonaSection`/persona param) + reproduction condition block ("재현 조건"); no TBD/TODO/vague.
+- Architecture Review Checklist: all 4 items `[x]`; sibling scan `[x]` with completion evidence; 4 alternatives each with Pro/Con (≥2); Decision documents trade-off (universal priority sort reuse vs hardcoded slot, runtime preservation, default no-regression, identity ownership move cli→preset).
+- Completion Criteria: TC-01…TC-09 all TC-N prefixed; command/observable form; no banned phrases ("works correctly"/"no errors"/"implemented"/"displays correctly") — `rg` returned exit 1 (0 matches).
+- Test Plan: `## Test Plan` present; 9 rows (TC-01…TC-09) match 9 Completion Criteria TCs (count matches); each row has non-empty Test Type + Tool/Approach, no "TBD"; no "manual"-tool rows (CI smoke rows carry "커맨드폼" Notes) — manual-justification N/A.
+- Structure: Tasks section with placeholder present; Evidence Log was present and empty; no `## Status`/`## Classification` body sections (status/type/tags in frontmatter only).
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
 
 **Status upgrade:** review-ready → approved
 
-- Prior-Gate Precondition: `### [GATE-WRITE] — ✅ PASS | 2026-06-14` present; frontmatter `status: review-ready` and folder `backlog/` match expected input stage.
-- Explicit approval: orchestrator asked "8개를 GATE-APPROVAL까지 올릴까요?" and user replied "다음 진행해" — clear authorization to advance all 8 PRESET specs to `approved`.
-- Directed at this spec: PRESET-003 is one of the 8 PRESET specs covered by the approval.
-- No Architecture Review or frontmatter type/tags modified after approval (spec unchanged since GATE-WRITE).
-- NON-COMPLIANCE check: no implementation started — `.agents/tasks/PRESET-003.md` absent, `packages/agent-preset/` absent.
+- Prior-Gate Precondition: `### [GATE-WRITE] — ✅ PASS | 2026-06-14` present in Evidence Log; frontmatter `status: review-ready` and `backlog/` folder match the expected input stage for GATE-APPROVAL. Precondition satisfied.
+- Explicit user approval (verbatim, current rework directed at this spec's design): (1) "이거 보고 시스템 프롬프트 제대로 프리셋에 적용하는 구조가 되어야 합니다 정확하게 아키텍쳐 설계해서 백로그 업데이트 하세요" and (2) "아키텍쳐 설계상 이런 부분이 공정하고 공평하고 보편적인 타이밍에 제대로 주입되어야 합니다". These directly authorize finalizing the persona system-prompt composition architecture (source: 'persona' + priority sort + agentName ownership move) recorded in this spec and updating the backlog — a direct, unambiguous statement directed at this spec document.
+- No Architecture Review or frontmatter type/tags modified after approval: frontmatter unchanged (`type: BEHAVIOR`, `tags: [cli]`); Architecture Review section (Affected Scope / Alternatives / Decision / Checklist all 4 `[x]`) reflects the approved design.
+- NON-COMPLIANCE trigger (implementation started) check: `.agents/tasks/PRESET-003.md` does NOT exist (`ls` → No such file); `## Tasks` shows "미생성 (GATE-APPROVAL 통과 후 생성)". The persona-section framework change is NOT yet implemented. No implementation work started.

--- a/.agents/spec-docs/todo/PRESET-005-autonomous-builder-preset.md
+++ b/.agents/spec-docs/todo/PRESET-005-autonomous-builder-preset.md
@@ -2,88 +2,119 @@
 status: approved
 type: BEHAVIOR
 tags: [cli]
+depends_on: [PRESET-001, PRESET-002, PRESET-003, PRESET-004, PRESET-008]
 ---
 
-# PRESET-005: 첫 프리셋 autonomous-builder (Fable 5 작업 스타일 모방)
+# PRESET-005: 첫 프리셋 autonomous-builder (Fable 5 작업 스타일 모방 — 페르소나는 적응본)
 
 ## Problem
 
 프리셋 인프라(PRESET-001~004, 008)가 갖춰져도 **출하되는 의견 있는(opinionated) 프리셋이 하나도
 없으면** 기능이 무의미하다. 사용자가 요청한 첫 프리셋은 "Fable 5 스타일"이다. 그러나 리서치 결과
-Anthropic은 Fable 5의 시스템 프롬프트나 성격 명세를 공개한 적이 없으므로(설계 제안서 §2.1)
-"프롬프트 복제"는 불가능하다. 대신 **문서화된 작업 스타일**(능동·철저·자기검증·고자율·요청 범위 확장
-경향)과 Anthropic "Claude's Character" 원칙을 재현한 generic 프리셋을 만든다. 식별자에는 벤더명을
-쓸 수 없다(`feedback_no_product_names`, `naming-style.md`).
+Anthropic은 Fable 5의 **공식** 시스템 프롬프트나 성격 명세를 공개한 적이 없으므로(설계 §2.1)
+"공식 프롬프트 복제"는 불가능하다. 대신 **문서화된 작업 스타일**(능동·철저·자기검증·고자율, 요청
+범위 확장 경향, 고effort에서 범위 제약)과 Anthropic "Claude's Character" 원칙을 재현한 generic
+프리셋을 만든다.
+
+**IP/출처 제약(중요):** 커뮤니티에 **유출된** Claude Fable 5 시스템 프롬프트(~14,000단어, 모듈형;
+`elder-plinius/CL4R1T4S`)가 존재하지만 이는 Anthropic의 **독점 산출물**이며 프롬프트 자체가 엄격한
+저작권 제한을 명시한다. 우리는 이를 **verbatim 복사해 출하하지 않는다.** 본 프리셋의 persona는
+유출 프롬프트의 *이식 가능한 행동 원칙*을 **우리 말로, 우리 CLI에 맞게 재표현한 적응본(adaptation)**
+이며, 식별자는 generic(`autonomous-builder`, 벤더 토큰 없음 — `feedback_no_product_names`,
+`naming-style.md`). 이는 법적/윤리적 이유인 동시에 **아키텍처 정확성** 이유다: verbatim 임포트는 타
+제품의 잘못된 런타임 가정(도구 스키마·파일 경로·제품 정체성·날짜/cutoff·MCP)을 함께 끌고 들어와
+우리 CLI의 런타임 컨텍스트를 파괴한다(설계 §5.4).
 
 이 프리셋은 **페르소나 텍스트뿐 아니라 실제 메커니즘 설정**이어야 한다(설계 §6.1). 즉
 `autonomous-builder`는 agent-preset의 빌트인 콘텐츠로서 framework/executor 메커니즘을 **구성(CONFIGURE)**
 한다 — agent-cli에 로직을 추가하지 않는다. 페르소나만으로 "스타일"을 흉내 내는 것은 본 백로그의
 완료 조건이 아니다.
 
-**선행 의존성:** PRESET-002(`--preset` 선택 배선) · PRESET-003(페르소나/시스템 프롬프트 합성) ·
-PRESET-004(모듈/권한 번들 + 실행 능력 활성) · PRESET-008(effort → 모델 호출 배선). 이들이 없으면
-`effort`/`autonomy`/`enableParallelSubagents`/`selfVerification` 필드가 실제 호출까지 전달되지 못한다.
+**페르소나 전달 경로(변경점):** persona는 더 이상 작은 `appendSystemPrompt`로 끼워 넣지 않는다.
+PRESET-003이 도입한 **`IPreset.persona`(구조화된 PERSONA 레이어 블록)**으로 전달하며, 프레임워크
+`buildSystemPrompt`가 이를 최상단 PERSONA 슬롯에 놓고 RUNTIME 섹션(작업 디렉터리·도구·권한·응답 언어)을
+그 뒤에 합성한다(설계 §5.4).
+
+**선행 의존성:** PRESET-001(`IPreset` 계약, done) · PRESET-002(`--preset` 선택 배선, done) ·
+PRESET-003(`IPreset.persona` 합성 메커니즘) · PRESET-004(모듈/권한 번들 + 실행 능력 활성) ·
+PRESET-008(effort → 모델 호출 배선). 이들이 없으면 `persona`/`effort`/`autonomy`/
+`enableParallelSubagents`/`selfVerification` 필드가 실제 합성·호출까지 전달되지 못한다.
 
 **재현 조건:** `listPresets()`에 `default` 외 의견 프리셋이 없다. `robota --preset autonomous-builder`
 → PRESET-002의 "알 수 없는 preset" 오류.
 
-설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §2.1, §2.2, §5.1, §6, §6.1.
+설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §2.1, §2.2, §5.1, §5.4, §6, §6.1.
 
 ## Architecture Review
 
 ### Affected Scope
 
-- `packages/agent-preset/src/presets/autonomous-builder.ts` (NEW — 프리셋 정의)
+- `packages/agent-preset/src/presets/autonomous-builder.ts` (NEW — 프리셋 정의, `persona` 블록 포함)
 - `packages/agent-preset/src/resolve-preset.ts` — 레지스트리에 등록
 - `packages/agent-preset/docs/SPEC.md` — 프리셋 카탈로그 항목 추가
 - 소비(선행 백로그가 제공): PRESET-001 `IPreset` 계약, PRESET-002 `--preset` 선택 배선, PRESET-003
-  페르소나 합성, PRESET-004 모듈/권한 번들 + 실행 능력 활성, PRESET-008 effort 배선
+  `IPreset.persona` PERSONA 레이어 합성, PRESET-004 모듈/권한 번들 + 실행 능력 활성, PRESET-008 effort 배선
 
 ### Alternatives Considered
 
-1. **공개되지 않은 "Fable 5 시스템 프롬프트"를 추측해 재현.**
+1. **유출된 Fable 5 시스템 프롬프트를 verbatim `systemPrompt`로 출하.**
    - Pro: 사용자의 "Fable 5 모방" 요청에 표면적으로 충실.
-   - Con: 1차 출처가 없어 날조가 됨 — 정직성 위반, 검증 불가. Rejected.
+   - Con: (1) IP 위반 — 독점·저작권 제한 명시 산출물의 verbatim 출하. (2) 아키텍처 파괴 — 타 제품의
+     도구 스키마·`/home/claude` 경로·제품 정체성·날짜/cutoff·MCP 가정을 끌고 들어와 우리 CLI 런타임
+     레이어와 충돌(설계 §5.4). Rejected.
 2. **페르소나 텍스트만으로 스타일을 흉내 내고 메커니즘은 손대지 않음.**
    - Pro: agent-preset 한 파일만 추가하면 됨, 선행 의존성 최소.
    - Con: effort/autonomy/병렬 서브에이전트/자기검증이 실제 호출에 전달되지 않아 "스타일"이
      관찰 가능한 동작 차이로 이어지지 않음 — 설계 §6.1(작동원리→메커니즘) 위반. Rejected.
-3. **문서화된 Fable 5 작업 스타일 + Claude's Character 원칙으로 페르소나를 구성하고, 동시에
-   framework/executor 메커니즘(effort/autonomy→권한 포스처/병렬 서브에이전트/자기검증)을 SET 하는
-   generic 프리셋.**
-   - Pro: 검증 가능한 출처 기반; 규칙(벤더명 금지) 준수; 실제 행동 차이(고자율·자기검증·병렬)를
-     메커니즘으로 구현; 설계 §6.1 추적 매트릭스 충족.
-   - Con: "Fable 5와 똑같은 프롬프트"는 아님(애초에 공개 안 됨) — 사용자에게 이 한계를 명시해야 함.
+3. **유출 프롬프트의 _이식 가능한_ persona/behavior 섹션만 우리 말로 재표현한 구조화 `IPreset.persona`
+   블록 + framework/executor 메커니즘(effort/autonomy→권한 포스처/병렬 서브에이전트/자기검증)을 함께
+   SET 하는 generic 프리셋.**
+   - Pro: IP 안전(적응본·generic 식별자); 규칙(벤더명 금지) 준수; 실제 행동 차이(고자율·자기검증·병렬)를
+     메커니즘으로 구현; persona는 PERSONA 레이어에 올바로 배치되어 RUNTIME 레이어를 침범하지 않음;
+     설계 §5.4·§6.1 충족.
+   - Con: "Fable 5와 똑같은 프롬프트"는 아님(공식 미공개 + verbatim 금지) — 사용자에게 이 한계를 명시.
 
 ### Decision
 
-**Alternative 3.** `autonomous-builder`는 페르소나 + 메커니즘 SET을 함께 한다. 페르소나는 문서화된
-작업 스타일(능동·철저·자기검증·고자율, 병렬 서브에이전트 적극) + Claude's Character 원칙(비아첨적
-정직·원칙 기반)으로 구성하고, **동시에** framework/executor seam을 켜는 필드를 설정한다(아래 매핑
-표). 식별자는 generic(`autonomous-builder`), description에 "Fable 5 작업 스타일에서 영감" 출처 각주만
-허용(사용자 확인). 트레이드오프: "동일 프롬프트 복제"를 포기(불가능)하고 검증 가능·규칙 준수·
-메커니즘으로 뒷받침되는 실제 행동 차이를 얻는다.
+**Alternative 3.** `autonomous-builder`는 **구조화된 `IPreset.persona` 블록 + 메커니즘 SET**을 함께 한다.
+
+- **persona 출처/범위:** 유출 Fable 5 프롬프트의 **이식 가능(portable) persona/behavior 섹션만**
+  derive 한다 — tone_and_formatting, refusal_handling 철학, evenhandedness, user_wellbeing,
+  responding_to_mistakes, output style, proactivity. 이를 **우리 말로, 우리 CLI에 맞게 재표현**한다.
+  더불어 문서화된 Fable 5 work-style(능동·철저·자기검증·고자율, "다른 모델이 멈춰 묻는 지점에서도 계속
+  진행", 고effort 시 범위 제약)을 같은 블록에 반영한다.
+- **명시적 제외(RUNTIME 콘텐츠 절대 미포함):** 유출 프롬프트의 런타임/환경 섹션은 가져오지 **않는다** —
+  도구 JSON 스키마, `/home/claude`·`/mnt` 류 파일 경로, "Claude Code/Cowork" 제품 정체성,
+  current-date/knowledge-cutoff, MCP 커넥터·search/copyright 도구 규칙. 이는 프레임워크 **RUNTIME
+  레이어의 책임**이고 환경 종속이다(설계 §5.4). persona 블록에는 단 하나도 들어가지 않는다.
+- **메커니즘 SET:** 동시에 framework/executor seam을 켜는 필드를 설정한다(아래 매핑 표).
+- **식별자:** generic(`autonomous-builder`), description에 "Fable 5 작업 스타일에서 영감" 출처 각주만
+  허용(사용자 확인). 식별자/페르소나 본문에 벤더 토큰 없음.
+
+트레이드오프: "동일 프롬프트 복제"를 포기(불가능·IP 위반·아키텍처 파괴)하고, IP 안전하고 규칙을 준수하며
+메커니즘으로 뒷받침되는 검증 가능한 실제 행동 차이를 얻는다.
 
 #### Fable 5 작동원리 → 본 프리셋의 구체 설정 매핑 (설계 §6.1 참조)
 
-| Fable 5 작동원리 (#)                        | 본 프리셋의 구체 설정                                                                      | 재현 수단 / 소유 레이어                             |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------- |
-| effort 다이얼, 기본 high (#3)               | `effort: 'high'` (장기작업 시 `'xhigh'`/'ultra' 옵션)                                      | (a) provider/core 호출, 배선=PRESET-008             |
-| 묻지 않고 실행·고자율 (#5·#6)               | `autonomy: 'act-first'` → 권한 포스처(defaultPermissionMode/trust)로 매핑                  | (c) PRESET-004 권한 집행                            |
-| 병렬 서브에이전트 적극 디스패치 (#8)        | `enableParallelSubagents: true`                                                            | (d) agent-executor/subagent-runner, PRESET-004 활성 |
-| 자기검증(작업 후 검증 루프) (#4)            | `selfVerification: true`                                                                   | (e) framework/executor verifier 루프                |
-| 능동성 + 범위 확장(과확장 억제 포함) (#7)   | `appendSystemPrompt`: 능동적이되 **요청 범위를 넘는 과도한 리팩터 금지**(scope-constraint) | (b) 페르소나, framework 합성                        |
-| 출력 스타일(결과 우선·작업 약어 금지) (#12) | `appendSystemPrompt`: outcome-first, "작업 중…" 류 약어 없이 결과 보고                     | (b) 페르소나                                        |
-| 진행 보고 시 도구결과 대조 (#13)            | `appendSystemPrompt`: 진행/완료 주장은 **도구 실행 결과에 근거**해 보고                    | (b) 페르소나                                        |
-| 과지시 스캐폴딩 제거 (#17)                  | 아래 LIGHT-PRESET AUTHORING CONSTRAINT 준수                                                | (b) 프리셋 저자 규칙                                |
+| Fable 5 작동원리 (#)                          | 본 프리셋의 구체 설정                                                            | 재현 수단 / 소유 레이어                               |
+| --------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| effort 다이얼, 기본 high (#3)                 | `effort: 'high'` (장기작업 시 `'xhigh'`/'ultra' 옵션)                            | (a) provider/core 호출, 배선=PRESET-008               |
+| 묻지 않고 실행·고자율 (#5·#6)                 | `autonomy: 'act-first'` → 권한 포스처(defaultPermissionMode/trust)로 매핑        | (c) PRESET-004 권한 집행                              |
+| 병렬 서브에이전트 적극 디스패치 (#8)          | `enableParallelSubagents: true`                                                  | (d) agent-executor/subagent-runner, PRESET-004 활성   |
+| 자기검증(작업 후 검증 루프) (#4)              | `selfVerification: true`                                                         | (e) framework/executor verifier 루프                  |
+| 능동성 + 범위 확장(과확장 억제 포함) (#7)     | `persona`: 능동적이되 **요청 범위를 넘는 과도한 리팩터 금지**(scope-constraint)  | (b) PERSONA 레이어, framework 합성(PRESET-003)        |
+| 출력 스타일(결과 우선·작업 약어 금지) (#12)   | `persona`: outcome-first, "작업 중…" 류 약어 없이 결과 보고, 저형식·간결         | (b) PERSONA 레이어                                    |
+| 진행 보고 시 도구결과 대조 (#13)              | `persona`: 진행/완료 주장은 **도구 실행 결과에 근거(ground)**해 보고             | (b) PERSONA 레이어                                    |
+| 비아첨 정직·실수 소유·evenhandedness (포터블) | `persona`: 따뜻하되 비아첨적 정직, 자기 실수 인정·소유, 중립적 균형, 주장 근거화 | (b) PERSONA 레이어 (유출 프롬프트 포터블 섹션 적응본) |
+| 과지시 스캐폴딩 제거 (#17)                    | 아래 LIGHT-PRESET AUTHORING CONSTRAINT 준수                                      | (b) 프리셋 저자 규칙                                  |
 
 #### LIGHT-PRESET AUTHORING CONSTRAINT (Fable 5 원리 #17)
 
-페르소나는 **가벼워야** 한다:
+persona 블록은 길 수 있으나 **가벼워야** 한다:
 
 - "CRITICAL" / "MUST" 류 강조어를 쌓아 지시를 누적하지 않는다(과지시 스캐폴딩 금지).
 - 모델에게 **raw reasoning을 드러내거나 echo 하라고 지시하지 않는다**("추론을 보여줘"/"show your
-  reasoning"). Fable 계열의 `reasoning_extraction` 거부를 유발할 위험이 있다.
+  reasoning"/"reveal your reasoning"). Fable 계열의 `reasoning_extraction` 거부를 유발할 위험이 있다.
 - 소수의 지향 특성 + 안내 역할 + 근거 있는 원칙으로 정의한다(Claude's Character §2.2).
 
 #### 정직성 노트 — 프리셋이 만들 수 없는 모델 고유 속성
@@ -97,15 +128,15 @@ PRESET-004(모듈/권한 번들 + 실행 능력 활성) · PRESET-008(effort →
 - 트레이닝된 도구 신뢰성
 - 플랫폼 safety classifier
 
-→ 프리셋은 effort·권한 포스처·병렬 서브에이전트 활성·자기검증 루프·페르소나만 구성한다. 위 속성은
+→ 프리셋은 effort·권한 포스처·병렬 서브에이전트 활성·자기검증 루프·persona만 구성한다. 위 속성은
 정직하게 "재현 불가 — 모델 핀만 가능"으로 표기한다.
 
 ### Architecture Review Checklist
 
 - [x] 영향 패키지/레이어 목록 작성 완료 — agent-preset(정의/등록/SPEC), 메커니즘은 PRESET-002/003/004/008이 소유
-- [x] Sibling scan 완료 — `default` 프리셋 형태(PRESET-001) 확인 후 동일 `IPreset` 형태로 작성
-- [x] 대안 최소 2개 검토 완료 — 3개 검토(추측 복제 / 페르소나 전용 / 페르소나+메커니즘)
-- [x] 결정 근거 문서화 완료 — 정직성 경계 + generic 식별자 + 메커니즘 SET 근거 기록
+- [x] Sibling scan 완료 — `default` 프리셋 형태(PRESET-001) + `IPreset.persona`(PRESET-003) 확인 후 동일 `IPreset` 형태로 작성
+- [x] 대안 최소 2개 검토 완료 — 3개 검토(verbatim 출하 / 페르소나 전용 / 적응 persona+메커니즘)
+- [x] 결정 근거 문서화 완료 — IP/출처 경계 + RUNTIME 콘텐츠 명시 제외 + generic 식별자 + 메커니즘 SET 근거 기록
 
 ## Solution
 
@@ -114,11 +145,17 @@ PRESET-004(모듈/권한 번들 + 실행 능력 활성) · PRESET-008(effort →
    - **모델/effort 메커니즘**: `model` 핀, `effort: 'high'`(장기작업 시 `'xhigh'`/'ultra' 사용 가능 — 주석으로 명시)
    - **자율 메커니즘**: `autonomy: 'act-first'` → PRESET-004가 권한 포스처(defaultPermissionMode/trust)로 매핑
    - **실행 능력 메커니즘**: `enableParallelSubagents: true`, `selfVerification: true`
-   - **페르소나**(`appendSystemPrompt`, 가볍게): 능동성 + scope-constraint(과확장 금지) · outcome-first
-     출력 스타일(작업 약어 금지) · 진행/완료 주장은 도구 결과에 근거. "CRITICAL"/"MUST" 누적 금지,
-     "show your reasoning" 류 지시 금지.
+   - **페르소나**(`persona`, 구조화 블록 — PRESET-003 PERSONA 레이어): 유출 Fable 5 프롬프트의 **이식
+     가능한 행동 원칙을 우리 말로 재표현**한 블록. 포함: 따뜻하되 비아첨적 정직(듣고 싶은 말만 하지
+     않음) · 간결·저형식 출력 스타일 · 자기 실수 인정·소유 · 중립적 균형(evenhandedness) · 주장 근거화
+     · 능동성 + scope-constraint(과확장/과도한 리팩터 금지) · outcome-first(작업 약어 금지) · 진행/완료
+     주장은 도구 결과에 근거 · "다른 모델이 멈춰 묻는 지점에서도 계속 진행"하는 고자율·철저·자기검증
+     work-style. **"CRITICAL"/"MUST" 누적 금지, "show your reasoning" 류 지시 금지.**
+   - **명시적 제외**: persona 블록에 RUNTIME 콘텐츠를 넣지 않는다 — 도구 스키마·`/home/claude`·`/mnt`
+     경로·"Claude Code/Cowork" 제품 정체성·current-date/cutoff·MCP/search-copyright 도구 규칙(모두
+     프레임워크 RUNTIME 레이어 소유).
 2. 레지스트리에 등록 → `listPresets()`에 노출.
-3. SPEC.md 카탈로그에 항목 추가(정직성 노트 + 매핑 표 반영).
+3. SPEC.md 카탈로그에 항목 추가(IP/출처 경계 + RUNTIME 제외 + 정직성 노트 + 매핑 표 반영).
 
 ## Affected Files
 
@@ -128,34 +165,36 @@ PRESET-004(모듈/권한 번들 + 실행 능력 활성) · PRESET-008(effort →
 
 ## Completion Criteria
 
-- [ ] TC-01: `resolvePreset('autonomous-builder', base)` 결과가 `effort === 'high'`임을 단언하는 단위 테스트 통과
-- [ ] TC-02: `resolvePreset('autonomous-builder', base)` 결과가 `autonomy === 'act-first'`임을 단언하는 단위 테스트 통과
-- [ ] TC-03: `resolvePreset('autonomous-builder', base)` 결과가 `enableParallelSubagents === true`임을 단언하는 단위 테스트 통과
-- [ ] TC-04: `resolvePreset('autonomous-builder', base)` 결과가 `selfVerification === true`임을 단언하는 단위 테스트 통과
-- [ ] TC-05: `resolvePreset('autonomous-builder', base)` 결과의 `appendSystemPrompt`가 scope-constraint 어구(과확장/과도한 리팩터 억제)와 진행-보고 그라운딩 어구(도구 결과 대조)를 둘 다 포함함을 단언하는 단위 테스트 통과
-- [ ] TC-06: `autonomous-builder.ts`에 대해 `rg -i "show your reasoning|reveal your reasoning|CRITICAL|MUST"` 결과가 0건임(페르소나가 raw reasoning echo 지시와 "CRITICAL"/"MUST" 누적을 포함하지 않음)을 단언하는 커맨드폼 테스트 통과
-- [ ] TC-07: `rg -nE "\bid:\s*['\"]" packages/agent-preset/src/presets/autonomous-builder.ts` 의 식별자 라인에 벤더 토큰(`fable`/`hermes`/`claude`/`anthropic`)이 없음을 단언하는 커맨드폼 테스트 통과(있다면 description 각주 한정)
-- [ ] TC-08: `listPresets()`에 `id === 'autonomous-builder'`(title/description 비어있지 않음) 항목 존재 단언 테스트 통과
-- [ ] TC-09: `robota --preset autonomous-builder -p "ping"` → exit 0 (PRESET-002 경로로 정상 해석)
-- [ ] TC-10: `pnpm --filter @robota-sdk/agent-preset test` + `build` → exit 0
+- [ ] TC-01: `resolvePreset('autonomous-builder', base)` 결과의 `persona`가 비어있지 않고(non-empty), 포터블 행동 가이드 키워드(비아첨/실수 소유/근거화 중 최소 1 + scope-constraint 어구 + 도구결과 그라운딩 어구)를 포함함을 단언하는 단위 테스트 통과
+- [ ] TC-02: `resolvePreset('autonomous-builder', base)` 결과가 `effort === 'high'`임을 단언하는 단위 테스트 통과
+- [ ] TC-03: `resolvePreset('autonomous-builder', base)` 결과가 `autonomy === 'act-first'`임을 단언하는 단위 테스트 통과
+- [ ] TC-04: `resolvePreset('autonomous-builder', base)` 결과가 `enableParallelSubagents === true`임을 단언하는 단위 테스트 통과
+- [ ] TC-05: `resolvePreset('autonomous-builder', base)` 결과가 `selfVerification === true`임을 단언하는 단위 테스트 통과
+- [ ] TC-06: `rg -i "/home/claude|/mnt/|Claude Code|Cowork|\bmcp\b|knowledge cutoff|input_schema|tool_call|json schema" packages/agent-preset/src/presets/autonomous-builder.ts` 결과가 0건임(persona에 RUNTIME 토큰·도구 스키마 단어 부재)을 단언하는 커맨드폼 테스트 통과
+- [ ] TC-07: `rg -i "show your reasoning|reveal your reasoning|CRITICAL|\bMUST\b" packages/agent-preset/src/presets/autonomous-builder.ts` 결과가 0건임(persona에 raw-reasoning echo 지시 + "CRITICAL"/"MUST" 누적 부재)을 단언하는 커맨드폼 테스트 통과
+- [ ] TC-08: `rg -nE "\bid:\s*['\"]" packages/agent-preset/src/presets/autonomous-builder.ts` 의 식별자 라인에 벤더 토큰(`fable`/`hermes`/`claude`/`anthropic`)이 없음을 단언하는 커맨드폼 테스트 통과(출처 각주는 description 한정)
+- [ ] TC-09: `listPresets()`에 `id === 'autonomous-builder'`(title/description 비어있지 않음) 항목 존재 단언 테스트 통과
+- [ ] TC-10: `robota --preset autonomous-builder -p "ping"` → exit 0 (PRESET-002 경로로 정상 해석)
+- [ ] TC-11: `pnpm --filter @robota-sdk/agent-preset test` + `build` → exit 0
 
 ## Test Plan
 
-Type BEHAVIOR + tags cli → 프리셋 resolve 메커니즘 단언(effort/autonomy/병렬/자기검증) + 페르소나
-어구 단언 + grep 부재/식별자 검사 + 프로세스 스모크.
+Type BEHAVIOR + tags cli → 프리셋 resolve 메커니즘 단언(effort/autonomy/병렬/자기검증) + persona
+포터블 어구 단언 + grep RUNTIME-토큰 부재/저자제약 부재/식별자 검사 + 프로세스 스모크.
 
-| TC-ID | Test Type              | Tool / Approach                                                 | Notes    |
-| ----- | ---------------------- | --------------------------------------------------------------- | -------- |
-| TC-01 | RULE (unit)            | vitest — resolvePreset effort === 'high' 단언                   |          |
-| TC-02 | RULE (unit)            | vitest — resolvePreset autonomy === 'act-first' 단언            |          |
-| TC-03 | RULE (unit)            | vitest — resolvePreset enableParallelSubagents 단언             |          |
-| TC-04 | RULE (unit)            | vitest — resolvePreset selfVerification 단언                    |          |
-| TC-05 | RULE (unit)            | vitest — appendSystemPrompt scope-constraint+그라운딩 어구 단언 |          |
-| TC-06 | CI pipeline smoke test | `rg -i` reasoning-echo/CRITICAL/MUST 부재 단언                  | 커맨드폼 |
-| TC-07 | CI pipeline smoke test | `rg -nE` id 라인 벤더 토큰 부재 단언                            | 커맨드폼 |
-| TC-08 | RULE (unit)            | vitest — listPresets 항목 단언                                  |          |
-| TC-09 | FLOW (cli)             | 프로세스 spawn 종료코드                                         | 커맨드폼 |
-| TC-10 | CI pipeline smoke test | `pnpm test` + `build` exit code                                 | 커맨드폼 |
+| TC-ID | Test Type              | Tool / Approach                                                            | Notes    |
+| ----- | ---------------------- | -------------------------------------------------------------------------- | -------- |
+| TC-01 | RULE (unit)            | vitest — resolvePreset persona non-empty + 포터블/scope/그라운딩 어구 단언 |          |
+| TC-02 | RULE (unit)            | vitest — resolvePreset effort === 'high' 단언                              |          |
+| TC-03 | RULE (unit)            | vitest — resolvePreset autonomy === 'act-first' 단언                       |          |
+| TC-04 | RULE (unit)            | vitest — resolvePreset enableParallelSubagents 단언                        |          |
+| TC-05 | RULE (unit)            | vitest — resolvePreset selfVerification 단언                               |          |
+| TC-06 | CI pipeline smoke test | `rg -i` RUNTIME 토큰/도구-스키마 단어 부재 단언                            | 커맨드폼 |
+| TC-07 | CI pipeline smoke test | `rg -i` reasoning-echo/CRITICAL/MUST 부재 단언                             | 커맨드폼 |
+| TC-08 | CI pipeline smoke test | `rg -nE` id 라인 벤더 토큰 부재 단언                                       | 커맨드폼 |
+| TC-09 | RULE (unit)            | vitest — listPresets 항목 단언                                             |          |
+| TC-10 | FLOW (cli)             | 프로세스 spawn 종료코드                                                    | 커맨드폼 |
+| TC-11 | CI pipeline smoke test | `pnpm test` + `build` exit code                                            | 커맨드폼 |
 
 ## User Execution Test Scenarios
 
@@ -178,19 +217,18 @@ Type BEHAVIOR + tags cli → 프리셋 resolve 메커니즘 단언(effort/autono
 **Status upgrade:** draft → review-ready
 
 - Frontmatter: `---` block present; `status: draft`; `type: BEHAVIOR` (valid 11-prefix value); `tags: [cli]` present.
-- Problem: concrete symptom (`robota --preset autonomous-builder` → PRESET-002 "알 수 없는 preset" error) + reproduction (`listPresets()` has no opinionated preset besides `default`); no TBD/TODO/vague descriptions.
-- Architecture Review Checklist: all 4 items `[x]`; sibling scan `[x]` with completion evidence (default/`IPreset` shape checked); Alternatives Considered = 3 entries each with Pro/Con; Decision references trade-off (drops "identical prompt replication" for verifiable, rule-compliant, mechanism-backed behavior).
-- Completion Criteria: TC-01 through TC-10 all TC-N prefixed; each uses command or observable-behavior form; no banned phrases ("works correctly"/"no errors"/"implemented"/"displays correctly").
-- Test Plan: `## Test Plan` present; 10 rows (TC-01..TC-10) — count matches 10 Completion Criteria; each row has non-empty Test Type and Tool/Approach; no row uses "manual" Tool (vitest/`rg`/spawn — no manual-justification gap).
-- Structure: Tasks section present with placeholder; Evidence Log present and empty before this run; no `## Status` or `## Classification` body sections (status/type live in frontmatter).
-- TC-N count match confirmed: Completion Criteria = 10, Test Plan = 10.
+- Problem: concrete symptom (`listPresets()` lacks opinionated preset; `robota --preset autonomous-builder` → "unknown preset" error) + reproduction condition ("재현 조건") present; no TBD/TODO/vague.
+- Architecture Review: all 4 checklist items `[x]`; sibling scan `[x]` with completion evidence; 3 Alternatives Considered each with Pro/Con (≥2 required); Decision references the trade-off ("트레이드오프: 동일 프롬프트 복제를 포기…").
+- Completion Criteria: all 11 items TC-01..TC-11 prefixed; Command/Observable forms; no banned phrases ("works correctly"/"no errors"/"implemented"/"displays correctly").
+- Test Plan: `## Test Plan` present; 11 rows TC-01..TC-11 — count matches Completion Criteria (11=11); each row has non-empty Test Type + Tool/Approach, no "TBD"; no "manual" tool rows (manual-Notes requirement vacuously satisfied).
+- Structure: Tasks section present with placeholder (`.agents/tasks/PRESET-005.md — 미생성`); Evidence Log present and was empty before this run; no `## Status` or `## Classification` body sections.
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
 
 **Status upgrade:** review-ready → approved
 
-- Prior-gate precondition: `### [GATE-WRITE] — ✅ PASS | 2026-06-14` present in Evidence Log; frontmatter `status: review-ready`; file in `backlog/` folder — matches expected input stage.
-- Explicit approval: orchestrator asked "8개를 GATE-APPROVAL까지 올릴까요?" and the user replied verbatim "다음 진행해" — an unambiguous statement authorizing advancement of all 8 PRESET specs to `approved`.
-- Directed at this spec: PRESET-005 is one of the 8 PRESET specs covered by the approval scope.
-- No Architecture Review or frontmatter type/tags modified after approval: Architecture Review section and frontmatter (`type: BEHAVIOR`, `tags: [cli]`) unchanged.
-- NON-COMPLIANCE trigger not fired: no `.agents/tasks/PRESET-005.md` and no `packages/agent-preset/` exist — implementation has not started.
+- Prior-Gate Precondition: `### [GATE-WRITE] — ✅ PASS | 2026-06-14` entry present in Evidence Log; frontmatter `status: review-ready` and `/backlog/` folder match the expected GATE-APPROVAL input stage. Prior gate ordering confirmed.
+- Explicit user approval (verbatim): "이거 보고 시스템 프롬프트 제대로 프리셋에 적용하는 구조가 되어야 합니다 정확하게 아키텍쳐 설계해서 백로그 업데이트 하세요" + "아키텍쳐 설계상 이런 부분이 공정하고 공평하고 보편적인 타이밍에 제대로 주입되어야 합니다". Direct directive to design the architecture correctly and finalize/update this backlog — authorizes advancing the revised spec to approved.
+- Directed at this spec: the directive concerns the leaked Fable 5 system prompt → preset application architecture, which is exactly PRESET-005's subject (autonomous-builder preset, persona via PRESET-003 PERSONA layer, mechanism SET). Approval is unambiguous and targets this document, not a different item.
+- No post-approval drift: frontmatter `type: BEHAVIOR` and `tags: [cli]` unchanged; Architecture Review section (Affected Scope / Alternatives / Decision / Checklist) intact and not modified after approval.
+- NON-COMPLIANCE trigger check: no implementation started — `.agents/tasks/PRESET-005.md` absent (ls exit 1) and `packages/agent-preset/src/presets/autonomous-builder.ts` absent (ls exit 1). No file edits/commits precede this gate.

--- a/.design/preset-layer/2026-06-14/design-proposal.md
+++ b/.design/preset-layer/2026-06-14/design-proposal.md
@@ -175,6 +175,63 @@ interface IPreset {
 - `settings.json`의 `preset` 기본값 필드(전역/프로젝트)
 - `/preset` 명령(목록·전환, PRESET-006)
 
+### 5.4 시스템 프롬프트 합성 아키텍처 (프리셋이 "제대로" 적용되는 구조)
+
+근거: 공개된(커뮤니티 유출) Claude Fable 5 시스템 프롬프트(~14,000단어, 모듈형 — `claude_behavior`/
+`tone_and_formatting`/`refusal_handling`/`search_instructions`/`computer_use`/도구 정의 등 명확히 구분된
+섹션)를 분석하면 두 종류의 콘텐츠가 섞여 있다:
+
+- **이식 가능(persona/behavior)** — tone·formatting, refusal 철학, evenhandedness, user wellbeing,
+  mistake-handling, output style, proactivity. 어떤 에이전트에도 옮길 수 있는 "성격/행동" 규칙.
+- **런타임/환경 종속** — 도구 JSON 스키마, 파일 경로(`/home/claude`, `/mnt/...`), 제품 정체성("Claude
+  Code/Cowork"), 현재 날짜, knowledge cutoff, MCP 커넥터. 우리 CLI에는 **우리 자신의** 런타임 컨텍스트가 있다.
+
+→ 따라서 프리셋의 "올바른 시스템 프롬프트 적용"은 **전체 덮어쓰기(`systemPrompt`)도, 작은 append도, 페르소나
+전용 하드코딩 슬롯도 아니다.** 프레임워크는 **이미 공정·보편적 주입 메커니즘을 갖고 있다** — 이를 그대로 쓴다.
+
+**기존 메커니즘(반드시 재사용):** `packages/agent-framework/src/context/`는 시스템 프롬프트를 **`ISystemPromptSection`
+객체 배열**로 만들고 `composeSystemPrompt`가 **호출 순서가 아니라 각 섹션의 `priority: number`로 정렬**해 합성한다.
+각 섹션은 `source`(`framework`/`project-instructions`/`runtime`/`permissions`/`tool`/...)와 `priority`를 선언한다.
+현재 priority 밴드:
+
+```
+project-instructions: AGENTS.md=10, CLAUDE.md=20, memory/task ~ → runtime: cwd=30, project=40, language=45
+  → permissions=50 → tool=60 → capabilities(상위). (낮을수록 프롬프트 상단)
+```
+
+**페르소나는 특례가 아니라 "또 하나의 섹션"이다.** `TSystemPromptSectionSource`에 `'persona'`를 추가하고,
+`createPersonaSection(persona)`가 `source: 'persona'` + **선언된 priority(예: 5 — 정체성/성격을 먼저 확립하는
+상단 밴드)**를 가진 `ISystemPromptSection`을 반환한다. 이 섹션은 **다른 모든 섹션과 똑같이 `composeSystemPrompt`가
+priority로 정렬**한다. 하드코딩된 위치 없음, 프리셋 전용 분기 없음 — priority 값이 타이밍을 **공정·보편적으로** 선언한다.
+
+```
+주입은 priority-정렬로 보편 결정:
+  persona(5) → project-instructions(10~) → runtime(30~) → permissions(50) → tool(60) → capabilities  → (CLI append: 합성 후 말미)
+```
+
+- **`default`(순정) 프리셋은 `persona`가 비어 있음** → `createPersonaSection`이 섹션을 만들지 않음 → **프롬프트 개입 0,
+  현재 동작과 100% 동일**(무회귀). 즉 순정 에이전트엔 어떤 프롬프트 개입도 추가되지 않는다.
+- 같은 메커니즘이라 향후 plugin 등 다른 기여자도 동일하게 `source`+`priority` 섹션으로 공정하게 주입할 수 있다(특혜 없음).
+- **전체 덮어쓰기(`systemPrompt`)를 기본으로 쓰지 않는 이유:** 원본 프롬프트의 런타임 가정(타 제품 도구 정의,
+  `/home/claude` 경로, 제품 정체성, MCP)을 함께 끌고 들어와 우리 CLI의 런타임 섹션(도구/파일/메모리)을 파괴한다.
+  `systemPrompt`는 고급 escape hatch로만 남기고 권장하지 않는다.
+
+**콘텐츠 규칙(이식 vs 런타임):** 기존 모델 프롬프트에서 프리셋 persona를 derive할 때는 **이식 가능한 persona/
+behavior 섹션만** 가져온다. 런타임/환경 섹션(도구 스키마·파일 경로·제품 정체성·날짜·cutoff·MCP)은 **가져오지
+않는다** — 그건 프레임워크 RUNTIME 레이어의 책임이고 환경 종속이다.
+
+**IP/출처 제약(중요):** 유출된 Fable 5 프롬프트는 Anthropic의 **독점·커뮤니티 유출** 산출물이며(프롬프트 자체가
+엄격한 저작권 제한을 명시한다). **verbatim 복사해 출하하지 않는다.** PRESET-005의 persona는 *이식 가능한 행동
+원칙*을 **우리 말로, 우리 CLI에 맞게 재표현한 적응본**이며 식별자는 generic(벤더명 없음, `feedback_no_product_names`).
+이는 법적/윤리적 이유인 동시에 **아키텍처 정확성** 이유다(verbatim은 잘못된 런타임 가정을 import한다).
+
+**IPreset 계약 확장(PRESET-003이 수행):** `persona?: string` 필드 추가 — `composeSystemPrompt`에 주입되는
+**`source: 'persona'` 섹션**의 내용. `appendSystemPrompt?`(CLI append 의미/소량 추가)와 `systemPrompt?`(고급
+전체 대체)는 유지하되, 프리셋의 정상 경로는 `persona`다. 프레임워크 변경은 **최소·일반적**이다: ① `'persona'`를
+`TSystemPromptSectionSource`에 추가, ② `createPersonaSection(persona)` 추가, ③ `buildSystemPrompt`가 `persona`
+param이 있으면 그 섹션을 sections 배열에 포함. 위치는 **priority 값이 선언**하며 `composeSystemPrompt`가 정렬한다
+(전용 슬롯/분기 없음). `persona` 없음 → 섹션 없음 → 무회귀.
+
 ## 6. 프리셋은 개방형 집합 — 순정(vanilla) ↔ 튜닝 대조
 
 **프리셋 시스템은 특정 프리셋(예: Fable 5)을 위한 게 아니라, 임의 개수의 "튜닝/비튜닝" 프로파일을 동일한


### PR DESCRIPTION
## Summary
Per user direction — **no hardcoding, no ad-hoc prompt intervention; inject at a fair/equitable/universal point** — reworks how a preset applies a system prompt, after analyzing the community-leaked Reference Conduct Profile system prompt.

**Key finding:** the framework ALREADY has a fair/universal mechanism — `ISystemPromptSection` carries `priority` + `source`, and `composeSystemPrompt` sorts by `priority` (call order is irrelevant).

**Design (§5.4):** persona is **NOT a special slot** — it is **another section** (`source: 'persona'`, declared `priority: 5`) composed by the same priority sorter as every other section. `default` preset → no persona section → **zero prompt intervention → 100% no-regression**. Future contributors (plugins) can inject the same way (no privilege).

**Content/IP:** persona sourced ONLY from the leaked prompt's PORTABLE behavior sections (tone, refusal philosophy, evenhandedness, wellbeing, output style), re-expressed in our own words for our CLI; **runtime/tool/product-identity sections excluded**; **not shipped verbatim** (proprietary leaked content).

## Backlogs (re-gated GATE-WRITE + GATE-APPROVAL → approved)
- **PRESET-003** — persona as `source:'persona'` priority-5 section + `IPreset.persona` + agentName ownership → agent-preset (9 TC).
- **PRESET-005** — autonomous-builder persona from portable reference profile content, runtime excluded, IP caveat (11 TC).

Design §5.4 added; `pnpm harness:scan` ✅ (25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)