### PR TITLE
feat(preset): PRESET-008 — effort threaded to provider invocation (default high)

### DIFF
--- a/.agents/spec-docs/done/PRESET-008-effort-model-invocation-wiring.md
+++ b/.agents/spec-docs/done/PRESET-008-effort-model-invocation-wiring.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: BEHAVIOR
 tags: [typescript]
 ---
@@ -122,7 +122,7 @@ Type BEHAVIOR + tags `typescript` → 동작 검증은 unit/integration(요청 �
 
 ## Tasks
 
-- [ ] `.agents/tasks/PRESET-008.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [`.agents/tasks/PRESET-008.md`](../../tasks/completed/PRESET-008.md) — task breakdown (TC-01..TC-04), created at GATE-IMPLEMENT
 
 > depends_on: PRESET-001 (IPreset.effort 계약 — effort 필드와 resolvePreset 출력이 본 백로그의 입력 계약).
 
@@ -148,3 +148,37 @@ Type BEHAVIOR + tags `typescript` → 동작 검증은 unit/integration(요청 �
 - Directed at this spec: PRESET-008 is one of the 8 PRESET specs covered by the approval; not a clarifying-question answer or approval of an unrelated item.
 - No Architecture Review or frontmatter type/tags modified after approval.
 - NON-COMPLIANCE trigger clear: no `.agents/tasks/PRESET-008.md` and no `packages/agent-preset/` exist — implementation has not started.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+
+- Prior-gate precondition: `### [GATE-APPROVAL] — ✅ PASS | 2026-06-14` entry present in Evidence Log; spec at `status: in-progress` in `active/`.
+- Tasks file created: `.agents/tasks/PRESET-008.md` exists.
+- Tasks file path recorded in spec `## Tasks`: `[.agents/tasks/PRESET-008.md](../../tasks/completed/PRESET-008.md)`.
+- One task per TC-N: task file Plan lists TC-01, TC-02, TC-03, TC-04 — matches Completion Criteria TC-01..TC-04 (one per criterion).
+- Test Plan present: task file `## Test Plan` section ≈600 chars (≥50 required) describing thread path, per-provider mapping/no-op, and unit/build verification. [AF-24]
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+
+- Prior-gate precondition: `### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14` entry present in Evidence Log; frontmatter `status: in-progress` matches the expected input stage.
+- Task file completion: `.agents/tasks/PRESET-008.md` — all 4 tasks (TC-01, TC-02, TC-03, TC-04) marked `[x]`; none blocked or pending.
+- Build: `pnpm build:deps` → exit 0.
+- Tests: `pnpm --filter @robota-sdk/agent-core --filter @robota-sdk/agent-session --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-provider --filter @robota-sdk/agent-preset test` → exit 0 (agent-core 707/707, agent-session 63/63, agent-provider 554/554, agent-framework 932/932, agent-preset 22/22; all passing).
+- Typecheck: `pnpm typecheck` → exit 0.
+- Harness scan: `pnpm harness:scan` → exit 0.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+
+Per-TC verification (Completion Criteria all `[x]`; Test Plan evidence is authoritative — PRESET-008 ships no `## User Execution Test Scenarios` user preset, as effort is a provider-call wiring whose user-facing effect arrives with PRESET-005's preset):
+
+- TC-01 (resolved effort reaches native-effort provider request) — `[x]`. Verified via `pnpm --filter @robota-sdk/agent-provider test` (exit 0). Tests: `packages/agent-core/src/services/execution-round.test.ts:245` ("threads an explicit config.defaultModel.effort into chatOptions", asserts `effort: 'max'`) + `packages/agent-provider/src/openai/reasoning-effort.test.ts:74,89` ("TC-01: threads effort onto the OpenAI Responses reasoning.effort param" / low passthrough). Test Plan TC-01 row maps to these.
+- TC-02 (effort unset → default 'high' applied) — `[x]`. Verified via package test run (exit 0). Tests: `packages/agent-core/src/services/execution-round.test.ts:228` ("defaults effort to high in chatOptions when config.defaultModel.effort is unset", asserts `effort: 'high'`) + `packages/agent-provider/src/openai/reasoning-effort.test.ts:106` ("TC-02: an explicit high effort … yields reasoning.effort === high"). Test Plan TC-02 row maps to these.
+- TC-03 (no-native-effort provider ignores it w/o error + documented no-op) — `[x]`. Runtime half: `packages/agent-provider/src/deepseek/provider.test.ts:240` ("TC-03: ignores per-call effort without error and emits no effort param"; asserts request lacks `effort`/`reasoning_effort`) — package test exit 0. Doc half: `rg -n "Reasoning Effort" packages/agent-provider/docs/SPEC.md` → match at line 95 ("## Reasoning Effort (per-call)"). Test Plan TC-03 row maps to these.
+- TC-04 (build + typecheck exit 0 for changed packages) — `[x]`. `pnpm build:deps` → exit 0; `pnpm typecheck` → exit 0. Test Plan TC-04 row maps to these.
+
+Summary: all TC-01..TC-04 checked with matching Test Plan evidence; build/test/typecheck/harness:scan all exit 0. No User Execution Test Scenarios section applies (provider-call wiring; user-facing effect ships with PRESET-005).

--- a/.agents/tasks/completed/PRESET-008.md
+++ b/.agents/tasks/completed/PRESET-008.md
@@ -1,0 +1,17 @@
+# PRESET-008 — effort → 모델 호출 배선
+
+Spec: `.agents/spec-docs/active/PRESET-008-effort-model-invocation-wiring.md`
+
+## Plan (one task per Completion Criterion)
+
+- [x] TC-01: resolved effort reaches the provider request param (native-effort provider) — unit/integration
+- [x] TC-02: effort unset → default 'high' applied to provider request
+- [x] TC-03: provider without native effort ignores it without error + documented no-op (rg doc)
+- [x] TC-04: build + typecheck exit 0 for changed packages
+
+## Test Plan
+
+agent-framework threads resolved `effort` (default 'high' when unset) from session/assembly options into the
+provider invocation. agent-provider request builders map `effort` to the native param where supported
+(anthropic/openai), else a documented graceful no-op (deepseek/qwen) noted in provider SPEC/docs. Unit tests
+on provider request builders assert effort presence/default/absence (TC-01/02/03) + doc `rg` (TC-03). Build+typecheck (TC-04).

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   IToolSchema,
   IProviderOptions,
   IChatOptions,
+  TModelEffort,
   IProviderCapabilities,
   IProviderFunctionCallingCapability,
   IProviderNativeWebToolCapabilities,

--- a/packages/agent-core/src/interfaces/agent.ts
+++ b/packages/agent-core/src/interfaces/agent.ts
@@ -1,6 +1,11 @@
 import type { ICacheOptions } from './cache';
 import type { TUniversalMessageMetadata, TUniversalMessage } from './messages';
-import type { TProviderConfigValue, IAIProvider, TTextDeltaCallback } from './provider';
+import type {
+  TProviderConfigValue,
+  IAIProvider,
+  TTextDeltaCallback,
+  TModelEffort,
+} from './provider';
 import type { TMetadata, TConfigValue } from './types';
 import type { IModule } from '../abstracts/abstract-module';
 import type { IPluginContract, IPluginOptions, IPluginStats } from '../abstracts/abstract-plugin';
@@ -77,6 +82,8 @@ export interface IAgentConfig {
     maxTokens?: number;
     topP?: number;
     systemMessage?: string;
+    /** Reasoning-effort dial threaded to the provider request builder per call. */
+    effort?: TModelEffort;
   };
 
   // Tools and plugins

--- a/packages/agent-core/src/interfaces/index.ts
+++ b/packages/agent-core/src/interfaces/index.ts
@@ -36,6 +36,7 @@ export type {
   TJSONSchemaEnum,
   TParameterDefaultValue,
   IChatOptions,
+  TModelEffort,
   IProviderCapabilities,
   IProviderFunctionCallingCapability,
   IProviderNativeWebToolCapabilities,

--- a/packages/agent-core/src/interfaces/provider.ts
+++ b/packages/agent-core/src/interfaces/provider.ts
@@ -179,6 +179,17 @@ export interface IProviderNativeRawPayloadEvent {
 export type TProviderNativeRawPayloadCallback = (event: IProviderNativeRawPayloadEvent) => void;
 
 /**
+ * Reasoning-effort dial threaded per model invocation.
+ *
+ * Canonical SSOT for the effort union. `'high'` is the neutral default applied when
+ * a caller leaves effort unset; `'xhigh'` is the long-running ("ultra") tier and
+ * `'max'` the most exhaustive tier. Providers with a native reasoning-effort parameter
+ * map this value onto it (clamping to their supported range); providers without a
+ * native effort concept ignore it as a documented no-op.
+ */
+export type TModelEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/**
  * Options for AI provider chat requests
  */
 export interface IChatOptions extends IProviderSpecificOptions {
@@ -188,6 +199,12 @@ export interface IChatOptions extends IProviderSpecificOptions {
   maxTokens?: number;
   /** Temperature for response randomness (0-1) */
   temperature?: number;
+  /**
+   * Reasoning-effort dial for this invocation. Native-effort providers map it to their
+   * request parameter; providers without native effort ignore it (documented no-op).
+   * Threaded from session/model options; defaults to `'high'` at the framework→provider seam.
+   */
+  effort?: TModelEffort;
   /** Model to use for the request */
   model?: string;
   /** Callback for text deltas during streaming. When provided, the provider

--- a/packages/agent-core/src/services/execution-round-provider.ts
+++ b/packages/agent-core/src/services/execution-round-provider.ts
@@ -49,6 +49,9 @@ export async function callProviderWithCache(
 
   const chatOptions: IChatOptions = {
     model: config.defaultModel.model,
+    // Default the reasoning-effort dial to 'high' at the framework→provider seam so every
+    // model call carries an explicit effort (design §5.1 — neutral default 'high').
+    effort: config.defaultModel.effort ?? 'high',
     ...(config.defaultModel.maxTokens !== undefined && {
       maxTokens: config.defaultModel.maxTokens,
     }),

--- a/packages/agent-core/src/services/execution-round.test.ts
+++ b/packages/agent-core/src/services/execution-round.test.ts
@@ -224,6 +224,43 @@ describe('execution-round helpers', () => {
       expect(resolved.provider.chat).toHaveBeenCalled();
     });
 
+    // TC-02 (PRESET-008): effort defaults to 'high' at the framework→provider seam.
+    it('defaults effort to high in chatOptions when config.defaultModel.effort is unset', async () => {
+      const chat = vi.fn().mockResolvedValue({
+        role: 'assistant',
+        content: 'hi',
+        state: 'complete' as const,
+        timestamp: new Date(),
+      });
+      const resolved = createResolvedProviderInfo({ provider: { chat } });
+      const config = { name: 'test', defaultModel: { provider: 'openai', model: 'gpt-4' } };
+      await callProviderWithCache([], config as any, resolved);
+      expect(chat).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ effort: 'high' }),
+      );
+    });
+
+    // TC-01 (PRESET-008): an explicit effort threads through chatOptions unchanged.
+    it('threads an explicit config.defaultModel.effort into chatOptions', async () => {
+      const chat = vi.fn().mockResolvedValue({
+        role: 'assistant',
+        content: 'hi',
+        state: 'complete' as const,
+        timestamp: new Date(),
+      });
+      const resolved = createResolvedProviderInfo({ provider: { chat } });
+      const config = {
+        name: 'test',
+        defaultModel: { provider: 'openai', model: 'gpt-4', effort: 'max' },
+      };
+      await callProviderWithCache([], config as any, resolved);
+      expect(chat).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ effort: 'max' }),
+      );
+    });
+
     it('uses cached response when available', async () => {
       const config = { name: 'test', defaultModel: { provider: 'openai', model: 'gpt-4' } };
       const resolved = createResolvedProviderInfo();

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -17,6 +17,7 @@ import type {
   IToolWithEventService,
   IHookTypeExecutor,
   TPermissionMode,
+  TModelEffort,
   TToolArgs,
 } from '@robota-sdk/agent-core';
 import type {
@@ -127,6 +128,13 @@ export interface ICreateSessionOptions {
   deniedTools?: string[];
   /** Override the model from config. When set, takes precedence over config.provider.model. */
   model?: string;
+  /**
+   * Reasoning-effort dial for this session, threaded to the provider request builder.
+   * Resolved from a preset's `effort` (PRESET-008). When unset, the framework→provider
+   * seam defaults it to `'high'`. Native-effort providers map it onto their request
+   * parameter; providers without native effort ignore it as a documented no-op.
+   */
+  effort?: TModelEffort;
   /** Text to append to the generated system prompt. */
   appendSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -249,6 +249,7 @@ export function createSession(options: ICreateSessionOptions): ICreateSessionRes
     hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
     agentName: options.agentName,
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
+    ...(options.effort !== undefined ? { effort: options.effort } : {}),
   });
 
   wireSessionDeps(session, agentToolDeps, backgroundProcessToolDeps, backgroundTaskManager);

--- a/packages/agent-preset/src/preset-types.ts
+++ b/packages/agent-preset/src/preset-types.ts
@@ -3,8 +3,12 @@ import type { ICreateSessionOptions } from '@robota-sdk/agent-framework';
 /**
  * Effort dial passed through to the model invocation (mechanism, not persona text).
  * `'xhigh'` corresponds to the long-running ("ultra") tier; `'high'` is the neutral default.
+ *
+ * Reuses the framework's `ICreateSessionOptions['effort']` channel (which is the
+ * `agent-core` `TModelEffort` SSOT) so a resolved preset effort threads straight to the
+ * provider invocation seam (PRESET-008) without introducing a parallel union.
  */
-export type TPresetEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type TPresetEffort = NonNullable<ICreateSessionOptions['effort']>;
 
 /**
  * Behavioural autonomy posture. Drives the permission posture

--- a/packages/agent-provider/docs/SPEC.md
+++ b/packages/agent-provider/docs/SPEC.md
@@ -92,6 +92,22 @@ export class MyProvider implements IAIProvider {
 
 Custom providers do not need to depend on `@robota-sdk/agent-provider`.
 
+## Reasoning Effort (per-call)
+
+The framework threads a per-call reasoning-effort dial through `IChatOptions.effort`
+(`TModelEffort` = `'low' | 'medium' | 'high' | 'xhigh' | 'max'`, defaulting to `'high'` at
+the framework→provider seam). Each provider's request builder handles it as follows:
+
+| Provider              | Native effort support | Behavior                                                                                                                                                                            |
+| --------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI (Responses)    | Yes                   | Maps `effort` onto the Responses API `reasoning.effort` parameter. `'low'`/`'medium'`/`'high'` pass through; `'xhigh'`/`'max'` clamp to `'high'` (OpenAI's highest supported tier). |
+| Anthropic             | No (documented no-op) | The Anthropic Messages API exposes no per-request reasoning-effort enum, so `effort` is **ignored without error** — the built request carries no effort parameter.                  |
+| DeepSeek              | No (documented no-op) | Per-call `effort` is **ignored without error**; the built request has no effort parameter. (DeepSeek's static `reasoningEffort` constructor option is a separate, unrelated knob.)  |
+| Qwen / Gemma / Gemini | No (documented no-op) | No native per-request reasoning-effort parameter; `effort` is **ignored without error** (no effort key on the built request).                                                       |
+
+No-op providers must never throw on a populated `effort`; they simply omit it from the
+outgoing request so an effort-setting preset degrades gracefully.
+
 ## Dependencies
 
 | Package                  | Role                                                                  |

--- a/packages/agent-provider/src/deepseek/provider.test.ts
+++ b/packages/agent-provider/src/deepseek/provider.test.ts
@@ -234,6 +234,40 @@ describe('DeepSeekProvider', () => {
     ]);
   });
 
+  // TC-03 (runtime half): DeepSeek has no native per-call reasoning-effort param.
+  // A populated `effort` must complete without throwing AND must not appear on the
+  // built Chat Completions request. (The no-op is documented in agent-provider SPEC.md.)
+  it('TC-03: ignores per-call effort without error and emits no effort param', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'deepseek-key' });
+    const client = getClient(provider);
+    client.chat.completions.create.mockResolvedValue({
+      id: 'deepseek-effort-noop',
+      object: 'chat.completion',
+      created: 1,
+      model: 'deepseek-v4-flash',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'noop', refusal: null },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    } satisfies OpenAI.Chat.ChatCompletion);
+
+    const result = await provider.chat([createUserMessage('Hello')], {
+      model: 'deepseek-v4-flash',
+      effort: 'max',
+    });
+
+    expect(result.role).toBe('assistant');
+    const [requestParams] = client.chat.completions.create.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(requestParams).not.toHaveProperty('effort');
+    expect(requestParams).not.toHaveProperty('reasoning_effort');
+  });
+
   it('uses streaming assembly when text deltas are requested', async () => {
     const provider = new DeepSeekProvider({ apiKey: 'deepseek-key' });
     const client = getClient(provider);

--- a/packages/agent-provider/src/openai/reasoning-effort.test.ts
+++ b/packages/agent-provider/src/openai/reasoning-effort.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { OpenAIProvider } from './provider';
+import {
+  mapEffortToOpenAIReasoningEffort,
+  resolveOpenAIReasoningOptions,
+} from './reasoning-effort';
+
+import type { TUniversalMessage } from '@robota-sdk/agent-core';
+
+// Mock OpenAI SDK (mirror provider.test.ts so chat() never hits the network).
+vi.mock('openai', () => {
+  const MockOpenAI = vi.fn().mockImplementation(() => ({
+    chat: { completions: { create: vi.fn() } },
+    responses: { create: vi.fn() },
+  }));
+  return { default: MockOpenAI };
+});
+
+function createUserMessage(content: string): TUniversalMessage {
+  return { id: 'msg-1', state: 'complete' as const, role: 'user', content, timestamp: new Date() };
+}
+
+function getResponsesClient(provider: OpenAIProvider): {
+  responses: { create: ReturnType<typeof vi.fn> };
+} {
+  return (provider as unknown as { client: { responses: { create: ReturnType<typeof vi.fn> } } })
+    .client;
+}
+
+function stubResponsesResolve(create: ReturnType<typeof vi.fn>): void {
+  create.mockResolvedValue({
+    id: 'resp-effort',
+    model: 'gpt-4o',
+    output_text: 'ok',
+    output: [],
+    status: 'completed',
+  });
+}
+
+describe('PRESET-008 reasoning-effort wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mapEffortToOpenAIReasoningEffort', () => {
+    it('passes low/medium/high through and clamps xhigh/max to high', () => {
+      expect(mapEffortToOpenAIReasoningEffort('low')).toBe('low');
+      expect(mapEffortToOpenAIReasoningEffort('medium')).toBe('medium');
+      expect(mapEffortToOpenAIReasoningEffort('high')).toBe('high');
+      expect(mapEffortToOpenAIReasoningEffort('xhigh')).toBe('high');
+      expect(mapEffortToOpenAIReasoningEffort('max')).toBe('high');
+    });
+  });
+
+  describe('resolveOpenAIReasoningOptions', () => {
+    it('returns undefined when no effort and no static reasoning', () => {
+      expect(resolveOpenAIReasoningOptions(undefined, undefined)).toBeUndefined();
+    });
+
+    it('merges per-call effort over static reasoning, preserving other fields', () => {
+      expect(resolveOpenAIReasoningOptions({ summary: 'auto', effort: 'low' }, 'max')).toEqual({
+        summary: 'auto',
+        effort: 'high',
+      });
+    });
+  });
+
+  // TC-01: a call with effort set on a native-effort provider → the built request
+  // carries that effort value on reasoning.effort.
+  it('TC-01: threads effort onto the OpenAI Responses reasoning.effort param', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const client = getResponsesClient(provider);
+    stubResponsesResolve(client.responses.create);
+
+    await provider.chat([createUserMessage('Hello')], { model: 'gpt-4o', effort: 'max' });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoning: expect.objectContaining({ effort: 'high' }),
+      }),
+      undefined,
+    );
+  });
+
+  it('TC-01: passes a low effort straight through to reasoning.effort', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const client = getResponsesClient(provider);
+    stubResponsesResolve(client.responses.create);
+
+    await provider.chat([createUserMessage('Hello')], { model: 'gpt-4o', effort: 'low' });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoning: expect.objectContaining({ effort: 'low' }) }),
+      undefined,
+    );
+  });
+
+  // TC-02: the framework→provider seam defaults effort to 'high'. The provider faithfully
+  // maps whatever effort it receives; the default-application unit lives in agent-core
+  // (execution-round-provider) and is asserted there. Here we assert that the default
+  // 'high' a caller would receive maps to reasoning.effort === 'high'.
+  it('TC-02: an explicit high effort (the seam default) yields reasoning.effort === high', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const client = getResponsesClient(provider);
+    stubResponsesResolve(client.responses.create);
+
+    await provider.chat([createUserMessage('Hello')], { model: 'gpt-4o', effort: 'high' });
+
+    expect(client.responses.create).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoning: expect.objectContaining({ effort: 'high' }) }),
+      undefined,
+    );
+  });
+
+  it('TC-02: omits reasoning entirely when effort is unset and no static reasoning', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    const client = getResponsesClient(provider);
+    stubResponsesResolve(client.responses.create);
+
+    await provider.chat([createUserMessage('Hello')], { model: 'gpt-4o' });
+
+    const [requestParams] = client.responses.create.mock.calls[0] as [Record<string, unknown>];
+    expect(requestParams).not.toHaveProperty('reasoning');
+  });
+
+  // TC-03 (doc half): the graceful no-op for non-native providers is documented in the
+  // package SPEC. (The runtime no-op half is asserted in deepseek/provider.test.ts.)
+  it('TC-03: the per-provider effort no-op is documented in agent-provider SPEC.md', () => {
+    const specPath = join(__dirname, '..', '..', 'docs', 'SPEC.md');
+    const spec = readFileSync(specPath, 'utf8');
+    expect(spec).toMatch(/## Reasoning Effort/);
+    expect(spec).toMatch(/ignored without error/);
+    expect(spec).toMatch(/DeepSeek/);
+  });
+});

--- a/packages/agent-provider/src/openai/reasoning-effort.ts
+++ b/packages/agent-provider/src/openai/reasoning-effort.ts
@@ -1,0 +1,51 @@
+import type { IOpenAIResponsesReasoningOptions } from './types';
+import type { TModelEffort } from '@robota-sdk/agent-core';
+
+/**
+ * Map the framework's per-call reasoning-effort dial onto the OpenAI Responses API
+ * `reasoning.effort` parameter.
+ *
+ * OpenAI's native effort enum is `'low' | 'medium' | 'high'`. The framework union also
+ * carries the long-running tiers `'xhigh'` and `'max'`; both clamp to OpenAI's highest
+ * supported tier (`'high'`) since the Responses API has no stronger setting.
+ */
+export function mapEffortToOpenAIReasoningEffort(
+  effort: TModelEffort,
+): IOpenAIResponsesReasoningOptions['effort'] {
+  switch (effort) {
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+    case 'xhigh':
+    case 'max':
+      return 'high';
+    default: {
+      // Exhaustiveness guard — a new TModelEffort member must extend this mapping.
+      const exhaustive: never = effort;
+      return exhaustive;
+    }
+  }
+}
+
+/**
+ * Merge the per-call effort dial into the provider's static reasoning options.
+ *
+ * Per-call effort takes precedence over any static `reasoning.effort`; other static
+ * reasoning fields (e.g. `summary`) are preserved. Returns `undefined` when neither a
+ * per-call effort nor static reasoning options are present, so no `reasoning` key is
+ * emitted on the request.
+ */
+export function resolveOpenAIReasoningOptions(
+  staticReasoning: IOpenAIResponsesReasoningOptions | undefined,
+  effort: TModelEffort | undefined,
+): IOpenAIResponsesReasoningOptions | undefined {
+  if (effort === undefined) {
+    return staticReasoning;
+  }
+  return {
+    ...staticReasoning,
+    effort: mapEffortToOpenAIReasoningEffort(effort),
+  };
+}

--- a/packages/agent-provider/src/openai/responses-chat.ts
+++ b/packages/agent-provider/src/openai/responses-chat.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { buildOpenAIResponsesTextConfig } from './openai-request-format';
+import { resolveOpenAIReasoningOptions } from './reasoning-effort';
 import {
   convertToOpenAIResponsesInput,
   convertToOpenAIResponsesTools,
@@ -152,6 +153,12 @@ function buildResponsesRequestParams(
     input.providerOptions.strictTools,
   );
   const textConfig = buildOpenAIResponsesTextConfig(input.providerOptions);
+  // Native effort mapping: thread the per-call reasoning-effort dial onto the Responses
+  // API `reasoning.effort` parameter, merged with any static reasoning options.
+  const reasoning = resolveOpenAIReasoningOptions(
+    input.providerOptions.reasoning,
+    input.chatOptions?.effort,
+  );
   return {
     model,
     input: convertToOpenAIResponsesInput(input.messages),
@@ -163,8 +170,8 @@ function buildResponsesRequestParams(
       max_output_tokens: input.chatOptions.maxTokens,
     }),
     ...(textConfig !== undefined && { text: textConfig }),
-    ...(input.providerOptions.reasoning !== undefined && {
-      reasoning: input.providerOptions.reasoning,
+    ...(reasoning !== undefined && {
+      reasoning,
     }),
     ...(input.providerOptions.includeEncryptedReasoning === true && {
       include: ['reasoning.encrypted_content'],

--- a/packages/agent-session/src/session-components.ts
+++ b/packages/agent-session/src/session-components.ts
@@ -76,6 +76,7 @@ export function buildRobota(
       provider: provider.name,
       model,
       systemMessage,
+      ...(options.effort !== undefined && { effort: options.effort }),
     },
     systemMessage,
     tools: wrappedTools,

--- a/packages/agent-session/src/session-types.ts
+++ b/packages/agent-session/src/session-types.ts
@@ -17,6 +17,7 @@ import type {
   IToolWithEventService,
   TSessionEndReason,
   TPermissionMode,
+  TModelEffort,
   TToolArgs,
 } from '@robota-sdk/agent-core';
 import type { IHookTypeExecutor } from '@robota-sdk/agent-core';
@@ -105,4 +106,9 @@ export interface ISessionOptions {
   agentName?: string;
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
+  /**
+   * Reasoning-effort dial threaded to the Robota agent config and on to the provider
+   * request builder. When unset, the framework→provider seam defaults it to `'high'`.
+   */
+  effort?: TModelEffort;
 }


### PR DESCRIPTION
## Summary
Implements **PRESET-008** — a resolved `effort` reaches the provider request (most faithful reference profile lever).
- Seam: `agent-core` `IChatOptions.effort` (new `TModelEffort` SSOT); **default `'high'`** at `execution-round-provider`.
- OpenAI maps `effort → reasoning.effort` (xhigh/max→high). DeepSeek/Anthropic/Qwen/Gemma/Gemini = documented no-op.
- GATE-IMPLEMENT→VERIFY→COMPLETE PASS. core 707 + session 63 + provider 554 + framework 932 + preset 22 tests ✅ · scan ✅ (25) · no new dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)