### PR TITLE
feat(framework,session): runtime active-preset state (PRESET-011)

### DIFF
--- a/.agents/spec-docs/done/PRESET-011-runtime-active-preset-state.md
+++ b/.agents/spec-docs/done/PRESET-011-runtime-active-preset-state.md
@@ -1,0 +1,172 @@
+---
+status: done
+type: FLOW
+tags: [cli]
+---
+
+# PRESET-011: 런타임 active-preset 상태 seam (`get/setActivePresetId`)
+
+## Problem
+
+프리셋은 PRESET-002에서 **시작 시 1회** `resolvePreset`로 해석되어 세션 조립에 구워질 뿐,
+실행 중 세션에는 **"지금 어떤 프리셋이 활성인가"** 라는 런타임 상태가 존재하지 않는다.
+`ICommandSessionRuntime`에는 `getActivePresetId`/`setActivePresetId` seam이 없어서, `/preset` 명령
+(PRESET-006)이 활성 프리셋을 읽거나 전환할 곳이 없고, TUI 상태 표시줄도 활성 프리셋을 표시할
+데이터 원천이 없다. 라이브 전환 스택(PRESET-012/013/014)이 쌓일 토대가 비어 있다.
+
+**재현 조건:** `rg -n "getActivePresetId|setActivePresetId" packages/` → 0건. `ICommandSessionRuntime`
+(agent-framework `host-context.ts`)에 active-preset 메서드 없음. `Session`(agent-session)에 활성 프리셋
+필드 없음. `ISessionOptions`에 `activePresetId` 없음.
+
+본 백로그는 **순수 상태 추적**만 추가한다 — 활성 프리셋 id를 시작 시 PRESET-002 선택 결과로 초기화하고,
+읽기/쓰기 seam을 노출한다. **옵션 재적용(권한/모델/페르소나 등)은 하지 않는다** — 그것은 상위 레이어
+(PRESET-012/013/014)가 이 seam 위에 쌓는다. 설계 §7.1 참조.
+
+설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §5.3, §7.1.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-framework/src/command-api/host-context.ts` — `ICommandSessionRuntime`에 선택적
+  `getActivePresetId?()`/`setActivePresetId?(id)` 추가(`getModelId?` 등 기존 선택적 런타임 메서드와 동형)
+- `packages/agent-session/src/session-base.ts` — `SessionBase`에 `activePresetId` 상태 + getter/setter 구현
+- `packages/agent-session/src/session-types.ts` — `ISessionOptions`에 `activePresetId?: string` 추가
+- `packages/agent-session/src/session.ts` — 생성자에서 `this.activePresetId = options.activePresetId ?? 'default'`
+- `packages/agent-cli/src/startup/preset-selection.ts` — 선택된 프리셋 id를 노출(이미 `selectPresetId` 존재)
+- `packages/agent-cli/src/cli.ts` — 선택된 id를 세션 옵션(`activePresetId`)으로 전달(renderApp/runPrintMode 경로)
+
+### Alternatives Considered
+
+1. **command effect(`preset-switch-requested`)만 추가하고 런타임 상태는 두지 않음.**
+   - Pro: 세션 계약 변경 회피.
+   - Con: 활성 프리셋을 **읽을** 곳이 없어 `/preset` 목록의 active 마커·상태 표시줄 표시가 불가능. 전환은
+     요청할 수 있어도 현재 상태가 어디에도 없음 — 토대 부재. Rejected.
+2. **`ICommandSessionRuntime`에 선택적 `get/setActivePresetId` 추가 + `Session`에 상태 필드 + 시작 시 초기화.**
+   - Pro: 활성 프리셋이 런타임 상태로 존재 → 읽기(표시/목록 마커)·쓰기(전환) seam 확보; `getModelId?`/
+     `setPermissionMode` 등 기존 런타임 상태 패턴과 동형; 상위 라이브 전환 레이어의 토대.
+   - Con: 핵심 계약(`ICommandSessionRuntime`)에 메서드 2개 추가 — 그러나 선택적이라 기존 구현/목 무회귀.
+
+### Decision
+
+**Alternative 2.** `ICommandSessionRuntime`에 선택적 `getActivePresetId?()`/`setActivePresetId?(id)`를
+추가하고(`getModelId?` 동형), `SessionBase`/`Session`에 `activePresetId` 상태를 구현해 시작 시
+PRESET-002의 선택 id로 초기화한다. **재적용은 하지 않는다** — 순수 상태 추적. 선택적 시그니처라 기존
+구현·테스트 목은 무회귀(메서드 미구현 시 호출측이 fallback). 트레이드오프: 핵심 런타임 계약에 2개
+메서드를 추가하는 비용을 감수하고, 라이브 전환 스택 전체가 의존할 단일 상태 토대를 얻는다.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-framework(계약), agent-session(상태/구현/옵션), agent-cli(배선)
+- [x] Sibling scan 완료 — `getModelId?()`(선택적 런타임 getter), `get/setPermissionMode`(런타임 상태 mutate) 패턴 확인 후 동형 적용
+- [x] 대안 최소 2개 검토 완료 — 2개 검토(effect 전용 / 런타임 상태 seam)
+- [x] 결정 근거 문서화 완료 — 선택적 시그니처 무회귀 + 읽기/쓰기 토대 필요성 기록
+
+## Solution
+
+1. `ICommandSessionRuntime`(host-context.ts)에 `getActivePresetId?(): string`,
+   `setActivePresetId?(id: string): void` 추가(선택적, `getModelId?` 옆).
+2. `ISessionOptions`에 `activePresetId?: string` 추가.
+3. `SessionBase`에 `protected activePresetId` + `getActivePresetId()`/`setActivePresetId()` 구현
+   (`Session`이 필드를 초기화). `setActivePresetId`는 상태만 mutate(재적용 없음 — 상위 레이어 소유).
+4. `Session` 생성자: `this.activePresetId = options.activePresetId ?? 'default'`.
+5. agent-cli: `selectPresetId(args, settingsPreset)` 결과를 `activePresetId` 세션 옵션으로 전달
+   (renderApp + runPrintMode 경로). 기존 `resolveCliPreset`는 옵션 해석을 유지하고, 선택 id는 별도로 노출.
+
+## Affected Files
+
+- `packages/agent-framework/src/command-api/host-context.ts`
+- `packages/agent-session/src/session-base.ts`
+- `packages/agent-session/src/session-types.ts`
+- `packages/agent-session/src/session.ts`
+- `packages/agent-cli/src/startup/preset-selection.ts`
+- `packages/agent-cli/src/cli.ts`
+
+## Completion Criteria
+
+- [x] TC-01: `Session`을 `activePresetId: 'autonomous-builder'` 옵션으로 생성 후 `getActivePresetId()`가 `'autonomous-builder'`를 반환함을 단언하는 단위 테스트 통과
+- [x] TC-02: `activePresetId` 옵션 없이 생성한 `Session`의 `getActivePresetId()`가 `'default'`를 반환함을 단언하는 단위 테스트 통과
+- [x] TC-03: `setActivePresetId('careful-reviewer')` 호출 후 `getActivePresetId()`가 `'careful-reviewer'`로 바뀜을 단언하는 단위 테스트 통과(순수 상태 mutate — permissionMode/model 등은 변하지 않음을 함께 단언)
+- [x] TC-04: `ICommandSessionRuntime` 타입에 `getActivePresetId`/`setActivePresetId`가 선언되어 있음을 컴파일-단언(타입 테스트: 해당 메서드를 호출하는 함수가 typecheck 통과)
+- [x] TC-05: agent-cli 시작 경로에서 선택된 프리셋 id가 세션 옵션 `activePresetId`로 전달됨을 단언(`selectPresetId` 결과를 renderApp/runPrintMode `activePresetId`로 전달 — 코드 추적 + typecheck)
+- [x] TC-06: `pnpm --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-session --filter @robota-sdk/agent-cli build` + `pnpm typecheck` → exit 0
+- [x] TC-07: `pnpm --filter @robota-sdk/agent-session test` → exit 0 (기존 세션 테스트 무회귀)
+
+## Test Plan
+
+Type FLOW + tags cli → 런타임 상태 seam 단언(초기화/기본값/mutate-격리) + 타입 선언 컴파일-단언 +
+cli 배선 단언 + 빌드/타입체크/세션 테스트 스모크.
+
+| TC-ID | Test Type              | Tool / Approach                                              | Notes    |
+| ----- | ---------------------- | ------------------------------------------------------------ | -------- |
+| TC-01 | RULE (unit)            | vitest — Session getActivePresetId 초기값(옵션) 단언         |          |
+| TC-02 | RULE (unit)            | vitest — Session getActivePresetId 기본값 'default' 단언     |          |
+| TC-03 | RULE (unit)            | vitest — setActivePresetId mutate + 다른 상태 불변 단언      |          |
+| TC-04 | RULE (unit)            | vitest — ICommandSessionRuntime 메서드 호출 타입 컴파일-단언 |          |
+| TC-05 | RULE (unit)            | vitest — cli 선택 id → 세션 옵션 activePresetId 전달 단언    |          |
+| TC-06 | CI pipeline smoke test | `pnpm build` + `pnpm typecheck` exit code                    | 커맨드폼 |
+| TC-07 | CI pipeline smoke test | `pnpm --filter @robota-sdk/agent-session test` exit code     | 커맨드폼 |
+
+## User Execution Test Scenarios
+
+- **시나리오 — 시작 시 활성 프리셋 상태 초기화:** 전제: PRESET-002 완료 + 프로바이더 설정. 실행:
+  `robota --preset autonomous-builder` 로 세션 시작(비대화 `-p "ping"` 또는 TUI). 기대: 세션 런타임의
+  `getActivePresetId()`가 `'autonomous-builder'`(미지정 시 `'default'`)를 반환 — 이후 PRESET-006이 이
+  값을 읽어 표시/전환의 기준으로 삼는다. 정리: 없음. Evidence: 세션 런타임 상태 단언 테스트 + 시작 로그
+  (구현 후 기록).
+
+환경: PRESET-002 선행, 실제 프로바이더 키 필요(로컬 설정 사용).
+
+## Tasks
+
+- [x] [.agents/tasks/PRESET-011.md](../../tasks/PRESET-011.md) — task breakdown (TC-01..TC-07)
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter present (`status`, `type: FLOW` valid prefix, `tags: [cli]`). Problem states a concrete
+symptom (`rg -n "getActivePresetId|setActivePresetId" packages/` → 0; no runtime active-preset state)
+
+- reproduction condition. Architecture Review: 4 checklist items `[x]`; Sibling scan confirms
+  `getModelId?`/`get-setPermissionMode` runtime patterns; 2 Alternatives with Pro/Con; Decision records
+  the optional-signature no-regression trade-off + foundation rationale. Completion Criteria TC-01..TC-07
+  command-form/observable; Test Plan rows match TC set 1:1; no banned phrases.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** review-ready → approved
+Explicit user approval (verbatim): "승인 — 011부터 바닥부터 구현" — direct authorization of the layered
+decomposition (PRESET-011 → 012/013/014 → 006 re-scope) presented for confirmation, naming PRESET-011
+as the foundation to build first. The full live-switching decomposition was written into the design
+SSOT (§7.1) and confirmed. No post-approval drift: implementation not started at approval time.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/PRESET-011.md` created and linked from `## Tasks`. One task per Completion
+Criterion (TC-01..TC-07) plus contract/session/threading tasks. Test Plan section present (≥50 chars).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-session --filter
+@robota-sdk/agent-transport --filter @robota-sdk/agent-cli build` → exit 0. `pnpm --filter
+@robota-sdk/agent-session test` → exit 0, 66/66 tests (12 files, incl. 3 new active-preset cases),
+no regressions. `pnpm typecheck` → exit 0 (whole monorepo). `pnpm harness:scan` → exit 0, all 25 scans.
+`git status -- '*package.json' 'pnpm-lock.yaml'` → empty (no dependency/lockfile change).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] vitest `Session active preset state (PRESET-011) > TC-01: initializes activePresetId from options` PASS.
+- [GATE-COMPLETE: TC-02] vitest `TC-02: defaults activePresetId to 'default' when not provided` PASS.
+- [GATE-COMPLETE: TC-03] vitest `TC-03: setActivePresetId mutates state only — no option re-application` PASS — `getActivePresetId()` becomes `'careful-reviewer'`, `getPermissionMode()` unchanged from initial.
+- [GATE-COMPLETE: TC-04] `ICommandSessionRuntime` declares optional `getActivePresetId?(): string` (host-context.ts:75) + `setActivePresetId?(id: string): void` (:77); monorepo `pnpm typecheck` exit 0 proves the contract compiles and is consumable.
+- [GATE-COMPLETE: TC-05] cli threads `const selectedPresetId = selectPresetId(args, settingsPreset)` (cli.ts:147) into both `runPrintMode` options (`activePresetId: selectedPresetId`, cli.ts:247) and `renderApp` options (cli.ts:299); full path traced renderApp/runPrintMode → InteractiveSession → `createSession` (`activePresetId` forwarded, create-session.ts:251) → `new Session` → `ISessionOptions.activePresetId`. typecheck exit 0 across every intermediate options interface.
+- [GATE-COMPLETE: TC-06] build (framework/session/transport/cli) exit 0 + `pnpm typecheck` exit 0.
+- [GATE-COMPLETE: TC-07] `pnpm --filter @robota-sdk/agent-session test` exit 0 (66/66).
+- No-regression: `default` initialization preserves standard behaviour (TC-02); pure-state mutate proven by TC-03 (no permission re-application).

--- a/.agents/tasks/PRESET-011.md
+++ b/.agents/tasks/PRESET-011.md
@@ -1,0 +1,27 @@
+# PRESET-011: 런타임 active-preset 상태 seam — Task Breakdown
+
+Spec: `.agents/spec-docs/done/PRESET-011-runtime-active-preset-state.md`
+
+## Plan
+
+- [x] TC-01: `Session({activePresetId: 'autonomous-builder'})` → `getActivePresetId()` returns it
+- [x] TC-02: no option → `getActivePresetId()` returns `'default'`
+- [x] TC-03: `setActivePresetId('careful-reviewer')` mutates id; `getPermissionMode()` unchanged (pure state)
+- [x] TC-04: `ICommandSessionRuntime` declares `getActivePresetId?`/`setActivePresetId?` (typecheck pass)
+- [x] TC-05: cli selected id threaded into session options `activePresetId` (renderApp + runPrintMode paths)
+- [x] TC-06: framework/session/transport/cli build + `pnpm typecheck` exit 0
+- [x] TC-07: `pnpm --filter @robota-sdk/agent-session test` exit 0 (no regressions)
+- [x] Add optional contract methods to `ICommandSessionRuntime`
+- [x] Add `activePresetId` to `ISessionOptions` + `SessionBase` accessors + `Session` init
+- [x] Thread selected id through cli → renderApp/runPrintMode → createSession → Session
+
+## Test Plan
+
+Runtime active-preset STATE seam on the session: `ICommandSessionRuntime` optional
+`getActivePresetId`/`setActivePresetId`, `SessionBase` accessors mirroring the `permissionMode`
+pattern, `Session` initializing from `ISessionOptions.activePresetId` (default `'default'`), and the
+cli threading the startup-selected preset id through every intermediate options interface
+(renderApp/runPrintMode → InteractiveSession → createSession → Session). Verified by vitest unit
+assertions (init-from-option, default, pure-state mutate with permission-mode unchanged), monorepo
+typecheck (contract declaration), and build/session-test smoke. Pure state tracking — NO option
+re-application (PRESET-012/013/014 own that).

--- a/.design/preset-layer/2026-06-14/design-proposal.md
+++ b/.design/preset-layer/2026-06-14/design-proposal.md
@@ -300,6 +300,33 @@ param이 있으면 그 섹션을 sections 배열에 포함. 위치는 **priority
 권장 실행 순서: 001 → 002 → 003 → 004 → 008 → 005 → 006 → (009/010/007 선택, PRESET-005와 동형 콘텐츠).
 PRESET-009/010은 빌트인 튜닝 프리셋(콘텐츠)으로, 시스템(PRESET-001) 변경 없이 추가된다 — 프리셋이 개방형 집합임을 구체화.
 
+### 7.1 라이브 프리셋 전환 분해 (PRESET-006 재범위 + 신규 FLOW 스택)
+
+원래 PRESET-006(SCREEN)은 **세 가지 관심사**를 한 백로그에 묶고 있었다: (1) 런타임 active-preset
+상태, (2) 전환 시 프리셋 옵션의 **라이브 재적용**, (3) 발견/표시 UX. 그러나 현재 시스템에는 런타임
+active-preset 상태 자체가 없다 — 프리셋은 PRESET-002에서 **시작 시 1회** `resolvePreset`로 해석되어
+세션 조립에 구워질 뿐, `ICommandSessionRuntime`에 active id를 보관하거나 변경하는 seam이 없다.
+
+정석(canonical)은 **풀 라이브 적용**이다: `/preset <id>` 전환 시 해당 프리셋의 옵션(권한/모델/effort/
+페르소나/모듈/실행능력)이 실행 중 세션에 재적용된다. 범위가 크므로 **계층적 FLOW 스택**으로 분해해
+아래에서 위로 쌓는다. 각 레이어는 독립적으로 검증 가능하며, 옵션 그룹마다 재적용 메커니즘이 다르다.
+
+| ID         | 제목                                                                | type   | 우선순위 | 선행                         | 소유 seam                                                                                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------- | ------ | -------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PRESET-011 | 런타임 active-preset 상태 seam (`get/setActivePresetId`)            | FLOW   | high     | 001,002                      | agent-framework `ICommandSessionRuntime` 계약 + 런타임 구현. 시작 시 active id를 PRESET-002 해석 결과로 초기화. **순수 상태 추적**(재적용 없음) — 모든 상위 레이어의 토대                                                         |
+| PRESET-012 | 전환 시 권한/신뢰 포스처 라이브 재적용                              | FLOW   | medium   | 011,004                      | active id 변경 시 프리셋의 `permissionMode`/trust를 기존 `setPermissionMode` seam으로 즉시 재적용 (가장 쉬움 — 런타임 setter 존재)                                                                                                |
+| PRESET-013 | 전환 시 모델/effort 라이브 재적용                                   | FLOW   | medium   | 011,008                      | `model`/`effort`/`temperature`/`maxOutputTokens`를 기존 `provider-hot-swap-requested` effect 경로로 재적용                                                                                                                        |
+| PRESET-014 | 전환 시 페르소나/시스템 프롬프트 + 실행능력 라이브 재적용           | FLOW   | low      | 011,003                      | 시스템 프롬프트 재합성(persona 섹션) + `enabledCommandModules`/`enableParallelSubagents`/`selfVerification` 재적용. 세션 mid-flight 재합성 seam 필요 — 가장 복잡                                                                  |
+| PRESET-006 | 프리셋 발견/관리 UX — `/preset` 명령 + 목록 + TUI 활성 표시(재범위) | SCREEN | medium   | 011 (전환 효과: 012,013,014) | `/preset` 목록 + active 마커(`getActivePresetId` 읽기), `/preset <id>` 전환(검증 + `setActivePresetId` → 011~014 엔진 트리거), 상태 표시줄 active 표시. 명령/표시는 011만 있으면 착지 가능; **완전한 라이브 효과는 012~014 필요** |
+
+**라이브 전환 의존 순서:** 011 → {012, 013, 014} → 006. 012/013/014는 011 위에서 서로 독립이며 옵션
+그룹별로 점진 착지한다. PRESET-006의 `/preset` 명령은 011 착지 후 목록/표시/전환-상태변경을 제공하고,
+012~014가 누적될수록 전환의 **관찰 가능한 행동 효과**가 권한 → 모델/effort → 페르소나/능력 순으로 채워진다.
+
+**레이어 불변식 유지:** 모든 신규 seam은 agent-framework/executor/core/command가 소유한다. agent-cli는
+여전히 껍데기 — `/preset` 로직은 agent-command, 상태 표시는 agent-transport TUI, 재적용 엔진은
+framework/executor. cli에는 전환·재적용 로직을 두지 않는다.
+
 **레이어 불변식(모든 백로그 공통):** 기능 로직은 agent-preset/agent-framework/agent-executor/agent-core/agent-command가 소유한다. `agent-cli`는 `--preset` 파싱·`resolvePreset` 호출 결과 전달·활성 표시(껍데기)만 한다. cli에 해석·합성·권한·effort·서브에이전트 로직을 두지 않는다.
 
 ## 8. 영향 패키지 요약

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -22,7 +22,7 @@ import {
 } from '@robota-sdk/agent-framework';
 import { parseCliArgs, parseToolList, printHelp } from './utils/cli-args.js';
 import type { IParsedCliArgs } from './utils/cli-args.js';
-import { resolveCliPreset } from './startup/preset-selection.js';
+import { resolveCliPreset, selectPresetId } from './startup/preset-selection.js';
 import { DEFAULT_AGENT_NAME } from '@robota-sdk/agent-preset';
 import type { TResolvedPresetOptions } from '@robota-sdk/agent-preset';
 import {
@@ -142,6 +142,9 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
+  // PRESET-011: the selected preset id (same selection glue as resolveCliPreset) becomes the
+  // session's runtime active-preset state. Pure state — no option re-application here.
+  const selectedPresetId = selectPresetId(args, settingsPreset);
 
   const { commandHostAdapters, providerDefinitions, commandModules, startupUpdateNoticePromise } =
     buildCommandSetup(cwd, args, options, version, {
@@ -241,6 +244,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       { resumeSessionId, forkSession: args.forkSession },
       {
         agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
+        activePresetId: selectedPresetId,
         persona: resolvedPreset.persona,
         ...(resolvedPreset.permissionMode !== undefined
           ? { permissionMode: resolvedPreset.permissionMode }
@@ -292,6 +296,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     cliAdapter: createDefaultTuiCliAdapter({ providerDefinitions, reloadPluginCommandSource }),
     reloadPluginCommandSource,
     agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
+    activePresetId: selectedPresetId,
     persona: resolvedPreset.persona,
     ...(resolvedPreset.enableParallelSubagents !== undefined
       ? { enableParallelSubagents: resolvedPreset.enableParallelSubagents }

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -19,6 +19,8 @@ export interface IPrintModeSessionResolution {
 export interface IPrintModePresetOptions {
   /** Resolved agent name (preset value, else agent-preset DEFAULT_AGENT_NAME). */
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Resolved preset persona block composed as a `source: 'persona'` system-prompt section. */
   persona?: string;
   /** Resolved preset permission mode (overridden by an explicit CLI --permission-mode flag). */
@@ -74,6 +76,9 @@ export async function runPrintMode(
     appendSystemPrompt,
     ...(presetOptions.persona !== undefined ? { persona: presetOptions.persona } : {}),
     ...(presetOptions.agentName !== undefined ? { agentName: presetOptions.agentName } : {}),
+    ...(presetOptions.activePresetId !== undefined
+      ? { activePresetId: presetOptions.activePresetId }
+      : {}),
     ...(presetOptions.enableParallelSubagents !== undefined
       ? { enableParallelSubagents: presetOptions.enableParallelSubagents }
       : {}),

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -153,6 +153,8 @@ export interface ICreateSessionOptions {
   sandboxClient?: ISandboxClient;
   /** Name reported to the underlying Robota agent config. Defaults to 'agent'. */
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -248,6 +248,7 @@ export function createSession(options: ICreateSessionOptions): ICreateSessionRes
     sessionLogger: options.sessionLogger,
     hookTypeExecutors: hookTypeExecutors.length > 0 ? hookTypeExecutors : undefined,
     agentName: options.agentName,
+    ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
   });

--- a/packages/agent-framework/src/command-api/host-context.ts
+++ b/packages/agent-framework/src/command-api/host-context.ts
@@ -71,6 +71,10 @@ export interface ICommandSessionRuntime {
   setAutoCompactThreshold?(threshold: TAutoCompactThreshold): void;
   getSessionTokenUsage?(): { inputTokens: number; outputTokens: number } | undefined;
   getModelId?(): string | undefined;
+  /** Read the active preset id (PRESET-011 runtime state). */
+  getActivePresetId?(): string;
+  /** Set the active preset id (PRESET-011 runtime state — pure state, no option re-application). */
+  setActivePresetId?(id: string): void;
 }
 
 export interface ICommandSessionReplayValidationReport {

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -162,6 +162,7 @@ export async function createInteractiveSession(
     reversibleExecution: options.reversibleExecution,
     sandboxClient: options.sandboxClient,
     agentName: options.agentName,
+    ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
   });
@@ -280,6 +281,7 @@ export async function initializeInteractiveSessionAsync(
     ...(options.sandboxWorkspaceRoot ? { sandboxWorkspaceRoot: options.sandboxWorkspaceRoot } : {}),
     ...(deps.sandboxSnapshotId ? { sandboxSnapshotId: deps.sandboxSnapshotId } : {}),
     ...(options.agentName ? { agentName: options.agentName } : {}),
+    ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.enableParallelSubagents !== undefined
       ? { enableParallelSubagents: options.enableParallelSubagents }
       : {}),

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -87,6 +87,8 @@ export interface IInteractiveSessionStandardOptions {
   sandboxSnapshotId?: string;
   /** Name reported to the underlying Robota agent config. Defaults to 'agent'. */
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Preset execution capability: activate agent runtime + subagent/background dispatch. */
   enableParallelSubagents?: boolean;
   /** Preset execution capability: run a post-task self-verification step. */
@@ -186,6 +188,8 @@ export interface IInitOptions {
   sandboxSnapshotId?: string;
   /** Name reported to the underlying Robota agent config. Defaults to 'agent'. */
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Preset execution capability: activate agent runtime + subagent/background dispatch. */
   enableParallelSubagents?: boolean;
   /** Preset execution capability: run a post-task self-verification step. */

--- a/packages/agent-session/src/__tests__/active-preset-state.test.ts
+++ b/packages/agent-session/src/__tests__/active-preset-state.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the PRESET-011 runtime active-preset state on Session.
+ *
+ * The active preset id is pure runtime state: it is initialized from
+ * ISessionOptions.activePresetId (default 'default') and can be mutated via
+ * setActivePresetId without re-applying any preset options (permission mode etc.).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Session } from '../session.js';
+
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue('mock response'),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+      getFullHistory: vi.fn().mockReturnValue([]),
+      addHistoryEntry: vi.fn(),
+    })),
+  };
+});
+
+const MOCK_PROVIDER = {
+  name: 'mock-provider',
+  version: '1.0.0',
+  chat: vi.fn().mockResolvedValue({
+    role: 'assistant',
+    content: 'mock',
+    timestamp: new Date(),
+  }),
+  supportsTools: () => true,
+  validateConfig: () => true,
+};
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: () => ({ stop: vi.fn(), update: vi.fn() }),
+};
+
+describe('Session active preset state (PRESET-011)', () => {
+  it('TC-01: initializes activePresetId from options', () => {
+    const session = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+      activePresetId: 'autonomous-builder',
+    });
+
+    expect(session.getActivePresetId()).toBe('autonomous-builder');
+  });
+
+  it("TC-02: defaults activePresetId to 'default' when not provided", () => {
+    const session = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+    });
+
+    expect(session.getActivePresetId()).toBe('default');
+  });
+
+  it('TC-03: setActivePresetId mutates state only — no option re-application', () => {
+    const session = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+      permissionMode: 'acceptEdits',
+    });
+
+    const initialPermissionMode = session.getPermissionMode();
+    expect(session.getActivePresetId()).toBe('default');
+
+    session.setActivePresetId('careful-reviewer');
+
+    expect(session.getActivePresetId()).toBe('careful-reviewer');
+    // Pure state mutate: permission mode is unchanged (no re-application).
+    expect(session.getPermissionMode()).toBe(initialPermissionMode);
+  });
+});

--- a/packages/agent-session/src/session-base.ts
+++ b/packages/agent-session/src/session-base.ts
@@ -15,6 +15,7 @@ export abstract class SessionBase {
   protected abstract readonly permissionEnforcer: PermissionEnforcer;
   protected abstract readonly contextTracker: ContextWindowTracker;
   protected abstract permissionMode: TPermissionMode;
+  protected abstract activePresetId: string;
   protected abstract readonly sessionId: string;
   protected abstract readonly aiProvider: IAIProvider;
   protected abstract readonly toolSchemas: IToolSchema[];
@@ -30,6 +31,20 @@ export abstract class SessionBase {
   /** Change the active permission mode — future tool calls will use the new mode. */
   setPermissionMode(mode: TPermissionMode): void {
     this.permissionMode = mode;
+  }
+
+  /** Read the active preset id (PRESET-011 runtime state). */
+  getActivePresetId(): string {
+    return this.activePresetId;
+  }
+
+  /**
+   * Set the active preset id. PURE STATE — this only records which preset is active;
+   * it does not re-apply any preset options (permission/model/persona). Higher layers
+   * own re-application (PRESET-012/013/014).
+   */
+  setActivePresetId(id: string): void {
+    this.activePresetId = id;
   }
 
   getSessionId(): string {

--- a/packages/agent-session/src/session-types.ts
+++ b/packages/agent-session/src/session-types.ts
@@ -54,6 +54,8 @@ export interface ISessionOptions {
   permissionMode?: TPermissionMode;
   /** Default trust level — used to derive permissionMode if not given */
   defaultTrustLevel?: 'safe' | 'moderate' | 'full';
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Model name (for context window sizing and Robota config) */
   model?: string;
   /** Provider idle timeout in milliseconds for each model call */

--- a/packages/agent-session/src/session.ts
+++ b/packages/agent-session/src/session.ts
@@ -62,6 +62,7 @@ export class Session extends SessionBase {
   protected readonly permissionEnforcer: PermissionEnforcer;
   protected readonly contextTracker: ContextWindowTracker;
   protected permissionMode: TPermissionMode;
+  protected activePresetId: string;
   protected readonly sessionId: string;
   protected aiProvider: IAIProvider;
   protected readonly toolSchemas: IToolSchema[];
@@ -114,6 +115,7 @@ export class Session extends SessionBase {
       options.permissionMode ??
       (options.defaultTrustLevel ? TRUST_TO_MODE[options.defaultTrustLevel] : undefined) ??
       'default';
+    this.activePresetId = options.activePresetId ?? 'default';
     this.transcriptPath = options.sessionStore?.getFilePath?.(this.sessionId);
     this.log('session_init', {
       cwd: this.cwd,

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -40,6 +40,8 @@ export interface IHeadlessInteractionChannelOptions {
   systemPrompt?: string;
   /** Name reported to the underlying agent config (resolved by the CLI, e.g. preset agentName). */
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
   persona?: string;
   /** Preset execution capability: activate agent runtime + subagent/background dispatch. */
@@ -88,6 +90,9 @@ export class HeadlessInteractionChannel {
       commandHostAdapters: this.opts.commandHostAdapters,
       shellExec,
       agentName: this.opts.agentName,
+      ...(this.opts.activePresetId !== undefined
+        ? { activePresetId: this.opts.activePresetId }
+        : {}),
       ...(this.opts.enableParallelSubagents !== undefined
         ? { enableParallelSubagents: this.opts.enableParallelSubagents }
         : {}),

--- a/packages/agent-transport/src/tui/TuiInteractionChannel.ts
+++ b/packages/agent-transport/src/tui/TuiInteractionChannel.ts
@@ -66,6 +66,8 @@ export interface ITuiInteractionChannelOptions {
   language?: string;
   reloadPluginCommandSource?: (registry: CommandRegistry) => void;
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
   persona?: string;
   systemPrompt?: string;
@@ -142,6 +144,7 @@ export class TuiInteractionChannel implements IInteractionChannel {
       shellExec: opts.shellExec,
       language: opts.language,
       agentName: opts.agentName,
+      activePresetId: opts.activePresetId,
       persona: opts.persona,
       systemPrompt: opts.systemPrompt,
       appendSystemPrompt: opts.appendSystemPrompt,

--- a/packages/agent-transport/src/tui/render.tsx
+++ b/packages/agent-transport/src/tui/render.tsx
@@ -52,6 +52,8 @@ export interface IRenderOptions {
   cliAdapter: ITuiCliAdapter;
   reloadPluginCommandSource?: (registry: CommandRegistry) => void;
   agentName?: string;
+  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
+  activePresetId?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
   persona?: string;
   /** Preset execution capability: activate agent runtime + subagent/background dispatch. */
@@ -85,6 +87,7 @@ export function toChannelOptions(
     language: options.language,
     reloadPluginCommandSource: options.reloadPluginCommandSource,
     agentName: options.agentName,
+    activePresetId: options.activePresetId,
     persona: options.persona,
     enableParallelSubagents: options.enableParallelSubagents,
     selfVerification: options.selfVerification,


### PR DESCRIPTION
## Summary
Foundation layer (L1) for canonical live preset switching, per the approved §7.1 decomposition (011 → 012/013/014 → 006 re-scope).

Adds **runtime active-preset state** to the session:
- `ICommandSessionRuntime` gains optional `getActivePresetId?()` / `setActivePresetId?(id)` (mirrors existing optional `getModelId?`).
- `SessionBase` implements the accessors (mirroring the `permissionMode` pattern); `ISessionOptions.activePresetId` (default `'default'`); `Session` initializes from it.
- The cli threads the startup-selected preset id (`selectPresetId`) through `renderApp`/`runPrintMode` → `InteractiveSession` → `createSession` → `Session`.

**PURE STATE TRACKING** — `setActivePresetId` records the active id only; it does NOT re-apply any preset options. Permission/model/persona re-application is owned by the next layers (PRESET-012/013/014). Optional contract signature → existing impls and test mocks are unaffected (no regression).

## Verification
- build (framework/session/transport/cli) ✓ · `pnpm typecheck` ✓ (monorepo)
- `pnpm --filter @robota-sdk/agent-session test` ✓ (66/66, incl. 3 new active-preset cases)
- `pnpm harness:scan` ✓ (25/25) · no package.json/lockfile changes
- TC-03 proves pure-state mutate: `getActivePresetId()` changes while `getPermissionMode()` stays unchanged.

Spec `PRESET-011` → done with full gate evidence. Design SSOT §7.1 records the layered decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)