### PR TITLE
feat(command,transport): /preset discovery + live switch UX (PRESET-006)

### DIFF
--- a/.agents/spec-docs/done/PRESET-006-preset-discovery-ux.md
+++ b/.agents/spec-docs/done/PRESET-006-preset-discovery-ux.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: SCREEN
 tags: [cli]
 ---
@@ -55,6 +55,11 @@ tags: [cli]
 2. 기본 명령 모듈에 등록.
 3. TUI `SessionStatusBar`에 활성 프리셋 id 표시(기존 provider/model 표시 옆).
 
+> **재범위(설계 §7.1):** 본 스펙은 PRESET-011~014(라이브 전환 엔진) 착지 후 그 seam 위에 구현된다.
+> `/preset <id>` 전환은 `getPreset(id)` 검증 → `resolvePreset(id)` → `applyPresetToSession(context, id,
+resolved)`(권한·모델/effort·페르소나 라이브 재적용)로 동작하고, 활성 마커/상태표시줄은 PRESET-011
+> `getActivePresetId`를 읽는다. 명령 모듈/실행능력 전환은 PRESET-015(연기)까지 보류.
+
 ## Affected Files
 
 - `packages/agent-command/src/preset/preset-command-module.ts` (NEW)
@@ -64,11 +69,11 @@ tags: [cli]
 
 ## Completion Criteria
 
-- [ ] TC-01: `/preset` 실행 시 출력에 `listPresets()`의 모든 id가 포함되고 활성 프리셋에 마커가 표시됨을 단언하는 통합 테스트 통과
-- [ ] TC-02: `/preset autonomous-builder` 실행 후 활성 프리셋 상태가 `autonomous-builder`로 바뀜을 단언하는 통합 테스트 통과
-- [ ] TC-03: TUI 렌더 스냅샷/단위 테스트에서 상태 표시줄 출력에 활성 프리셋 id 문자열이 포함됨을 단언
-- [ ] TC-04: `/preset __nope__` → 사용 가능한 id 목록과 함께 거부 메시지 출력(전환되지 않음)을 단언하는 통합 테스트 통과
-- [ ] TC-05: `pnpm --filter @robota-sdk/agent-command --filter @robota-sdk/agent-transport build` + `pnpm typecheck` → exit 0
+- [x] TC-01: `/preset` 실행 시 출력에 `listPresets()`의 모든 id가 포함되고 활성 프리셋에 마커가 표시됨을 단언하는 통합 테스트 통과
+- [x] TC-02: `/preset autonomous-builder` 실행 후 활성 프리셋 상태가 `autonomous-builder`로 바뀜을 단언하는 통합 테스트 통과
+- [x] TC-03: TUI 렌더 스냅샷/단위 테스트에서 상태 표시줄 출력에 활성 프리셋 id 문자열이 포함됨을 단언
+- [x] TC-04: `/preset __nope__` → 사용 가능한 id 목록과 함께 거부 메시지 출력(전환되지 않음)을 단언하는 통합 테스트 통과
+- [x] TC-05: `pnpm --filter @robota-sdk/agent-command --filter @robota-sdk/agent-transport build` + `pnpm typecheck` → exit 0
 
 ## Test Plan
 
@@ -94,7 +99,7 @@ Type SCREEN + tags cli → 명령 출력/TUI 렌더 단언 + 빌드 스모크.
 
 ## Tasks
 
-- [ ] `.agents/tasks/PRESET-006.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [x] [.agents/tasks/PRESET-006.md](../../tasks/PRESET-006.md) — task breakdown (TC-01..TC-05)
 
 ## Evidence Log
 
@@ -116,3 +121,33 @@ Explicit approval: orchestrator asked "8개를 GATE-APPROVAL까지 올릴까요?
 Directed at this spec: PRESET-006 is one of the 8 PRESET specs covered by the batch approval.
 No post-approval changes: Architecture Review and frontmatter (`type: SCREEN`, `tags: [cli]`) unchanged after approval.
 NON-COMPLIANCE trigger clear: no `.agents/tasks/PRESET-006.md`, no `packages/agent-preset/`, no `packages/agent-command/src/preset/` — implementation not started.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/PRESET-006.md` created and linked from `## Tasks`. One task per Completion
+Criterion (TC-01..TC-05) plus command-module / dependency / TUI tasks. Test Plan present (≥50 chars).
+Built on the merged PRESET-011~014 live-switching engine (re-scope note in Solution).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-command --filter @robota-sdk/agent-transport build` →
+exit 0. `pnpm --filter @robota-sdk/agent-command --filter @robota-sdk/agent-transport test` → exit 0
+(agent-command 25 files incl. 4 new preset-command cases; agent-transport 61 files incl. TC-03 status
+bar cases). `pnpm typecheck` → exit 0 (monorepo). `pnpm harness:scan` → exit 0, all 25 scans incl. the
+`deps` dependency-direction check (new agent-command → agent-preset edge is one-way, no cycle). The
+`@robota-sdk/agent-preset` dependency + lockfile entry were added surgically (+3 lockfile lines, 0
+deletions; `pnpm install --frozen-lockfile` clean).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] agent-command vitest (`preset-command-module.test.ts`) — `/preset` output contains every `listPresets()` id with a `*` marker on the active one (mock `getActivePresetId`).
+- [GATE-COMPLETE: TC-02] vitest — `/preset <id>` → `success: true`, drives `applyPresetToSession` (mock `setActivePresetId`/`setPermissionMode` called); `data.preset === id`.
+- [GATE-COMPLETE: TC-03] agent-transport vitest (`status-bar.test.tsx`) — StatusBar shows the active preset id + `Preset:` label when non-default; hidden for `'default'`/undefined.
+- [GATE-COMPLETE: TC-04] vitest — `/preset __nope__` → `success: false`, message lists available ids, no switch (setActivePresetId not called with the bad id).
+- [GATE-COMPLETE: TC-05] agent-command + agent-transport build + `pnpm typecheck` exit 0.
+- Dependency direction: `node scripts/harness/check-dependency-direction.mjs` → exit 0 ("No dependency direction violations found"); agent-command → agent-preset is one-way.

--- a/.agents/tasks/PRESET-006.md
+++ b/.agents/tasks/PRESET-006.md
@@ -1,0 +1,25 @@
+# PRESET-006: 프리셋 발견/관리 UX (/preset + TUI 표시) — Task Breakdown
+
+Spec: `.agents/spec-docs/done/PRESET-006-preset-discovery-ux.md`
+
+## Plan
+
+- [x] TC-01: `/preset` output lists every `listPresets()` id + marks the active one
+- [x] TC-02: `/preset <id>` switches active preset (drives `applyPresetToSession` → set active/permission/model/persona)
+- [x] TC-03: TUI status bar shows the active preset id (hidden when 'default'/unset)
+- [x] TC-04: `/preset __nope__` → rejection with available ids, no switch
+- [x] TC-05: agent-command + agent-transport build + `pnpm typecheck` exit 0
+- [x] `createPresetCommandModule()` (agent-command) mirroring mode command; registered in default modules
+- [x] agent-command → agent-preset dependency (one-way; dependency-direction check passes)
+- [x] TUI `PresetText` in StatusBar/SessionStatusBar + App.tsx active-preset extraction
+
+## Test Plan
+
+User-facing `/preset` discovery + live switch + TUI active display, built on PRESET-011..014.
+`/preset` (no args) lists presets with an active marker (read via `getActivePresetId`); `/preset <id>`
+validates via `getPreset`, then `resolvePreset(id)` → `applyPresetToSession` (live permission/model/
+effort/persona re-apply); unknown id is rejected with the available list (no switch). The TUI status bar
+renders the active preset id when non-default (mirrors the `Mode:` display). Verified by agent-command
+command-module integration tests (list+marker, switch, reject), agent-transport status-bar render tests,
+monorepo typecheck/build, and `harness:scan` (incl. one-way dependency-direction for the new
+agent-command → agent-preset edge). Module/execution-capability switching is deferred to PRESET-015.

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-framework": "workspace:*",
-    "@robota-sdk/agent-interface-transport": "workspace:*"
+    "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/agent-preset": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.19.21",

--- a/packages/agent-command/src/default/__tests__/default-command-modules.test.ts
+++ b/packages/agent-command/src/default/__tests__/default-command-modules.test.ts
@@ -40,14 +40,15 @@ describe('createDefaultCommandModules — PRESET-004 module-selection delta', ()
 
   it('TC-04: neither enabled nor disabled given → full default set unchanged (no-regression)', () => {
     const names = moduleNames(baseOptions);
-    // No-regression: the default set length is the documented 20 modules.
-    expect(names).toHaveLength(20);
+    // No-regression: the default set length is the documented 21 modules.
+    expect(names).toHaveLength(21);
     expect(names).toEqual([
       'agent-command-skills',
       'agent-command-help',
       'agent-command-agent',
       'agent-command-permissions',
       'agent-command-mode',
+      'agent-command-preset',
       'agent-command-language',
       'agent-command-background',
       'agent-command-memory',

--- a/packages/agent-command/src/default/default-command-modules.ts
+++ b/packages/agent-command/src/default/default-command-modules.ts
@@ -9,6 +9,7 @@ import { createMemoryCommandModule } from '../memory/index.js';
 import { createModeCommandModule } from '../mode/index.js';
 import { createPermissionsCommandModule } from '../permissions/index.js';
 import { createPluginCommandModule } from '../plugin/index.js';
+import { createPresetCommandModule } from '../preset/index.js';
 import { createProviderCommandModule } from '../provider/index.js';
 import { createResetCommandModule } from '../reset/index.js';
 import { createRewindCommandModule } from '../rewind/index.js';
@@ -75,6 +76,7 @@ export function createDefaultCommandModules({
     createAgentCommandModule(),
     createPermissionsCommandModule(),
     createModeCommandModule(),
+    createPresetCommandModule(),
     createLanguageCommandModule(),
     createBackgroundCommandModule(),
     createMemoryCommandModule(),

--- a/packages/agent-command/src/index.ts
+++ b/packages/agent-command/src/index.ts
@@ -10,6 +10,7 @@ export * from './memory/index.js';
 export * from './mode/index.js';
 export * from './permissions/index.js';
 export * from './plugin/index.js';
+export * from './preset/index.js';
 export * from './provider/index.js';
 export * from './reset/index.js';
 export * from './rewind/index.js';

--- a/packages/agent-command/src/preset/__tests__/preset-command-module.test.ts
+++ b/packages/agent-command/src/preset/__tests__/preset-command-module.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { listPresets } from '@robota-sdk/agent-preset';
+import type { ICommandHostContext, ICommandSessionRuntime } from '@robota-sdk/agent-framework';
+import { createPresetCommandModule, executePresetCommand } from '../index.js';
+
+function createSessionRuntime(overrides?: Partial<ICommandSessionRuntime>): ICommandSessionRuntime {
+  return {
+    clearHistory: () => undefined,
+    compact: async () => undefined,
+    getContextState: () => ({
+      maxTokens: 100,
+      usedTokens: 10,
+      usedPercentage: 10,
+      remainingPercentage: 90,
+    }),
+    getPermissionMode: () => 'default',
+    setPermissionMode: () => undefined,
+    getSessionId: () => 'session_1',
+    getMessageCount: () => 0,
+    getSessionAllowedTools: () => [],
+    getAutoCompactThreshold: () => false,
+    getFullHistory: () => [],
+    getHistory: () => [],
+    ...overrides,
+  };
+}
+
+function createCommandHostContext(
+  runtime: ICommandSessionRuntime,
+  overrides?: Partial<ICommandHostContext>,
+): ICommandHostContext {
+  return {
+    getSession: () => runtime,
+    getContextState: () => ({
+      maxTokens: 100,
+      usedTokens: 10,
+      usedPercentage: 10,
+      remainingPercentage: 90,
+    }),
+    getAutoCompactThreshold: () => 0.8,
+    compactContext: async () => undefined,
+    getCwd: () => '/workspace',
+    listEditCheckpoints: () => [],
+    restoreEditCheckpoint: async () => ({
+      target: {
+        id: 'checkpoint_1',
+        sessionId: 'session_1',
+        sequence: 1,
+        prompt: 'edit',
+        createdAt: '2026-05-03T00:00:00.000Z',
+        fileCount: 0,
+      },
+      restoredCheckpointCount: 1,
+      restoredFileCount: 0,
+      removedCheckpointCount: 0,
+    }),
+    rollbackEditCheckpoint: async () => ({
+      target: {
+        id: 'checkpoint_1',
+        sessionId: 'session_1',
+        sequence: 1,
+        prompt: 'edit',
+        createdAt: '2026-05-03T00:00:00.000Z',
+        fileCount: 0,
+      },
+      restoredCheckpointCount: 1,
+      restoredFileCount: 0,
+      removedCheckpointCount: 0,
+    }),
+    getUsedMemoryReferences: () => [],
+    recordMemoryEvent: () => undefined,
+    listBackgroundTasks: () => [],
+    readBackgroundTaskLog: async (taskId) => ({ taskId, lines: [] }),
+    cancelBackgroundTask: async () => undefined,
+    closeBackgroundTask: async () => undefined,
+    ...overrides,
+  };
+}
+
+describe('preset command module', () => {
+  it('exposes a single preset system command (structure)', () => {
+    const module = createPresetCommandModule();
+    expect(module.systemCommands?.map((command) => command.name)).toContain('preset');
+  });
+
+  it('TC-01: lists every preset and marks the active one', () => {
+    const runtime = createSessionRuntime({ getActivePresetId: () => 'autonomous-builder' });
+    const context = createCommandHostContext(runtime);
+
+    const result = executePresetCommand(context, '');
+
+    expect(result.success).toBe(true);
+    for (const preset of listPresets()) {
+      expect(result.message).toContain(preset.id);
+    }
+    // The active preset is marked with the `* ` prefix.
+    expect(result.message).toContain('* autonomous-builder');
+    expect(result.message).not.toContain('* default');
+    expect(result.data?.active).toBe('autonomous-builder');
+  });
+
+  it('TC-02: switches to a valid preset and drives the live re-apply seams', () => {
+    const setActivePresetId = vi.fn();
+    const setPermissionMode = vi.fn();
+    const applyModelOptions = vi.fn();
+    const runtime = createSessionRuntime({
+      setActivePresetId,
+      setPermissionMode,
+      applyModelOptions,
+    });
+    const context = createCommandHostContext(runtime);
+
+    const result = executePresetCommand(context, 'careful-reviewer');
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Switched to preset: careful-reviewer');
+    expect(result.data?.preset).toBe('careful-reviewer');
+    expect(setActivePresetId).toHaveBeenCalledWith('careful-reviewer');
+    // careful-reviewer resolves autonomy ask-first → default permission posture (PRESET-012)
+    // and effort high → applyModelOptions (PRESET-013).
+    expect(setPermissionMode).toHaveBeenCalledWith('default');
+    expect(applyModelOptions).toHaveBeenCalledWith(expect.objectContaining({ effort: 'high' }));
+  });
+
+  it('TC-04: rejects an unknown preset id without switching', () => {
+    const setActivePresetId = vi.fn();
+    const runtime = createSessionRuntime({ setActivePresetId });
+    const context = createCommandHostContext(runtime);
+
+    const result = executePresetCommand(context, '__nope__');
+
+    expect(result.success).toBe(false);
+    for (const preset of listPresets()) {
+      expect(result.message).toContain(preset.id);
+    }
+    expect(setActivePresetId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-command/src/preset/index.ts
+++ b/packages/agent-command/src/preset/index.ts
@@ -1,0 +1,6 @@
+export {
+  createPresetCommandEntry,
+  createPresetCommandModule,
+  PresetCommandSource,
+} from './preset-command-module.js';
+export { executePresetCommand } from './preset-command.js';

--- a/packages/agent-command/src/preset/preset-command-module.ts
+++ b/packages/agent-command/src/preset/preset-command-module.ts
@@ -1,0 +1,79 @@
+import { listPresets } from '@robota-sdk/agent-preset';
+
+import { executePresetCommand } from './preset-command.js';
+
+import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
+import type {
+  ICommand,
+  ICommandInteractionHint,
+  ICommandSource,
+} from '@robota-sdk/agent-interface-transport';
+
+const PRESET_COMMAND_DESCRIPTION = 'List presets or switch the active preset';
+const PRESET_ARGUMENT_HINT = 'list | <preset-id>';
+
+/** Build one subcommand per registered preset id (mirrors the permission-mode subcommands). */
+function buildPresetSubcommands(source = 'preset'): ICommand[] {
+  return listPresets().map((preset) => ({
+    name: preset.id,
+    description: preset.description,
+    source,
+  }));
+}
+
+export function createPresetCommandEntry(): ICommand {
+  return {
+    name: 'preset',
+    displayName: 'Agent Preset',
+    description: PRESET_COMMAND_DESCRIPTION,
+    source: 'preset',
+    argumentHint: PRESET_ARGUMENT_HINT,
+    subcommands: buildPresetSubcommands('preset'),
+    modelInvocable: false,
+  };
+}
+
+function createPresetSystemCommand(): ISystemCommand {
+  const entry = createPresetCommandEntry();
+  return {
+    name: entry.name,
+    displayName: entry.displayName,
+    description: entry.description,
+    requiresPermission: false,
+    userInvocable: true,
+    modelInvocable: false,
+    argumentHint: entry.argumentHint,
+    subcommands: entry.subcommands,
+    lifecycle: 'inline',
+    execute: executePresetCommand,
+  };
+}
+
+export class PresetCommandSource implements ICommandSource {
+  readonly name = 'preset';
+
+  getCommands(): ICommand[] {
+    return [createPresetCommandEntry()];
+  }
+}
+
+const PRESET_INTERACTION_HINTS: Record<string, ICommandInteractionHint> = {
+  preset: {
+    type: 'pick',
+    getItems: () =>
+      buildPresetSubcommands().map((sub) => ({
+        label: sub.name,
+        value: sub.name,
+        description: sub.description,
+      })),
+  },
+};
+
+export function createPresetCommandModule(): ICommandModule {
+  return {
+    name: 'agent-command-preset',
+    commandSources: [new PresetCommandSource()],
+    systemCommands: [createPresetSystemCommand()],
+    interactionHints: PRESET_INTERACTION_HINTS,
+  };
+}

--- a/packages/agent-command/src/preset/preset-command.ts
+++ b/packages/agent-command/src/preset/preset-command.ts
@@ -1,0 +1,58 @@
+import { applyPresetToSession } from '@robota-sdk/agent-framework';
+import { getPreset, listPresets, resolvePreset } from '@robota-sdk/agent-preset';
+
+import type { ICommandHostContext } from '@robota-sdk/agent-framework';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
+
+/** Default active preset id reported when the runtime has no recorded active preset. */
+const DEFAULT_ACTIVE_PRESET_ID = 'default';
+
+/** Read the active preset id from the session, defaulting when the optional seam is absent. */
+function readActivePresetId(context: ICommandHostContext): string {
+  return context.getSession().getActivePresetId?.() ?? DEFAULT_ACTIVE_PRESET_ID;
+}
+
+/** Build the `/preset` listing: one line per preset, marking the active one with a `*` prefix. */
+function formatPresetList(active: string): string {
+  const lines = listPresets().map((preset) => {
+    const marker = preset.id === active ? '* ' : '  ';
+    return `${marker}${preset.id} — ${preset.title}: ${preset.description}`;
+  });
+  return ['Available presets:', ...lines].join('\n');
+}
+
+/** Build the rejection message for an unknown preset id, listing the valid ids. */
+function formatUnknownPresetMessage(id: string): string {
+  const ids = listPresets()
+    .map((preset) => preset.id)
+    .join(', ');
+  return `Unknown preset: ${id}. Available: ${ids}`;
+}
+
+export function executePresetCommand(context: ICommandHostContext, args: string): ICommandResult {
+  const id = args.trim().split(/\s+/)[0];
+
+  if (id === undefined || id.length === 0 || id === 'list') {
+    const active = readActivePresetId(context);
+    return {
+      message: formatPresetList(active),
+      success: true,
+      data: { presets: listPresets(), active },
+    };
+  }
+
+  if (getPreset(id) === undefined) {
+    return {
+      message: formatUnknownPresetMessage(id),
+      success: false,
+    };
+  }
+
+  const resolved = resolvePreset(id);
+  applyPresetToSession(context, id, resolved);
+  return {
+    message: `Switched to preset: ${id}`,
+    success: true,
+    data: { preset: id },
+  };
+}

--- a/packages/agent-transport/src/tui/App.tsx
+++ b/packages/agent-transport/src/tui/App.tsx
@@ -350,10 +350,12 @@ function AppInner(
   // Session may not be initialized yet
   let permissionMode: TPermissionMode = props.permissionMode ?? 'default';
   let sessionId = '';
+  let activePresetId: string | undefined;
   try {
     // allow-fallback: session initializes asynchronously; use defaults until ready
     const session = interactiveSession.getSession();
     permissionMode = session.getPermissionMode();
+    activePresetId = session.getActivePresetId?.();
     sessionId = session.getSessionId();
   } catch {
     // allow-fallback: session initializes asynchronously; use defaults until ready
@@ -481,6 +483,7 @@ function AppInner(
         sessionName={sessionName}
         settings={statusLineSettings}
         activeAgentLabel={activeAgentLabel}
+        activePresetId={activePresetId}
         gitRefreshToken={gitRefreshToken}
       />
     </Box>

--- a/packages/agent-transport/src/tui/SessionStatusBar.tsx
+++ b/packages/agent-transport/src/tui/SessionStatusBar.tsx
@@ -20,6 +20,7 @@ interface IProps {
   sessionName?: string;
   settings: IStatusLineCommandSettings;
   activeAgentLabel?: string;
+  activePresetId?: string;
   gitRefreshToken?: number;
 }
 
@@ -37,6 +38,7 @@ export default function SessionStatusBar({
   sessionName,
   settings,
   activeAgentLabel,
+  activePresetId,
   gitRefreshToken,
 }: IProps): React.ReactElement | null {
   const cliAdapter = useTuiCliAdapter();
@@ -65,6 +67,7 @@ export default function SessionStatusBar({
       gitBranch={gitBranch}
       showGitBranch={settings.gitBranch}
       activeAgentLabel={activeAgentLabel}
+      activePresetId={activePresetId}
     />
   );
 }

--- a/packages/agent-transport/src/tui/StatusBar.tsx
+++ b/packages/agent-transport/src/tui/StatusBar.tsx
@@ -26,6 +26,7 @@ interface IProps {
   gitBranch?: string;
   showGitBranch?: boolean;
   activeAgentLabel?: string;
+  activePresetId?: string;
 }
 
 interface IStatusLeftProps {
@@ -42,6 +43,7 @@ interface IStatusLeftProps {
   sessionName?: string;
   gitBranch?: string;
   showGitBranch: boolean;
+  activePresetId?: string;
 }
 
 /** Return the color for the context percentage indicator */
@@ -106,6 +108,21 @@ function shouldShowPermissionMode(permissionMode: TPermissionMode): boolean {
   return permissionMode !== 'default';
 }
 
+function PresetText({ activePresetId }: { activePresetId: string }): React.ReactElement {
+  return (
+    <>
+      <Text color="cyan" bold>
+        Preset:
+      </Text>{' '}
+      <Text>{activePresetId}</Text>
+    </>
+  );
+}
+
+function shouldShowActivePreset(activePresetId: string | undefined): activePresetId is string {
+  return activePresetId !== undefined && activePresetId !== 'default';
+}
+
 function ProviderText({
   modelName,
   providerDisplayName,
@@ -127,6 +144,8 @@ function StatusLeft(props: IStatusLeftProps): React.ReactElement {
   const shouldShowGitBranch =
     props.showGitBranch && props.gitBranch !== undefined && props.gitBranch.length > 0;
   const showPermissionMode = shouldShowPermissionMode(props.permissionMode);
+  const activePresetId = props.activePresetId;
+  const showActivePreset = shouldShowActivePreset(activePresetId);
   return (
     <Text>
       <StatusActivityText
@@ -139,6 +158,12 @@ function StatusLeft(props: IStatusLeftProps): React.ReactElement {
         <>
           {'  |  '}
           <ModeText permissionMode={props.permissionMode} />
+        </>
+      )}
+      {showActivePreset && (
+        <>
+          {'  |  '}
+          <PresetText activePresetId={activePresetId} />
         </>
       )}
       {props.sessionName && (
@@ -181,6 +206,7 @@ export default function StatusBar({
   gitBranch,
   showGitBranch = true,
   activeAgentLabel,
+  activePresetId,
 }: IProps): React.ReactElement {
   return (
     <Box paddingLeft={1} paddingRight={1} justifyContent="space-between">
@@ -198,6 +224,7 @@ export default function StatusBar({
         sessionName={sessionName}
         gitBranch={gitBranch}
         showGitBranch={showGitBranch}
+        activePresetId={activePresetId}
       />
       {activeAgentLabel !== undefined && (
         <Text color="yellow" bold>

--- a/packages/agent-transport/src/tui/__tests__/status-bar.test.tsx
+++ b/packages/agent-transport/src/tui/__tests__/status-bar.test.tsx
@@ -155,4 +155,23 @@ describe('StatusBar', () => {
     const frame = lastFrame()!;
     expect(frame).not.toContain('feat/status-line');
   });
+
+  it('TC-03: shows the active preset id when set and non-default', () => {
+    const { lastFrame } = render(<StatusBar {...baseProps} activePresetId="autonomous-builder" />);
+    const frame = lastFrame()!;
+    expect(frame).toContain('Preset:');
+    expect(frame).toContain('autonomous-builder');
+  });
+
+  it('TC-03: hides the default active preset', () => {
+    const { lastFrame } = render(<StatusBar {...baseProps} activePresetId="default" />);
+    const frame = lastFrame()!;
+    expect(frame).not.toContain('Preset:');
+  });
+
+  it('TC-03: hides the preset label when no active preset is provided', () => {
+    const { lastFrame } = render(<StatusBar {...baseProps} activePresetId={undefined} />);
+    const frame = lastFrame()!;
+    expect(frame).not.toContain('Preset:');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       '@robota-sdk/agent-interface-transport':
         specifier: workspace:*
         version: link:../agent-interface-transport
+      '@robota-sdk/agent-preset':
+        specifier: workspace:*
+        version: link:../agent-preset
     devDependencies:
       '@types/node':
         specifier: ^22.19.21


### PR DESCRIPTION
## Summary
L3 of the §7.1 live-switching stack — the user-facing layer tying PRESET-011~014 together.

- **agent-command**: new `createPresetCommandModule()` (mirrors `/mode`). `/preset` lists presets with an active marker (read via `getActivePresetId`); `/preset <id>` validates via `getPreset`, then `resolvePreset(id)` → `applyPresetToSession` (live permission/model/effort/persona re-apply); unknown id is rejected with the available list (no switch). New **one-way** dependency `agent-command → agent-preset` (dependency-direction check passes; lockfile updated surgically +3/0).
- **agent-transport TUI**: `StatusBar`/`SessionStatusBar` render the active preset id (`PresetText`, shown only when non-default), sourced from `session.getActivePresetId` via `App.tsx`.

agent-cli stays a thin shell. Command-module / execution-capability switching is deferred to PRESET-015.

## Verification
- agent-command + agent-transport build ✓ · test ✓ (command 25 files incl. 4 preset cases; transport 61 files incl. TC-03)
- `pnpm typecheck` ✓ · `pnpm harness:scan` ✓ (25/25, incl. dependency-direction) · lockfile frozen-install clean

Spec `PRESET-006` → done with full gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)