### PR TITLE
feat(agent-preset): file-based external preset loading (PRESET-007)

### DIFF
--- a/.agents/spec-docs/done/PRESET-007-user-authored-external-presets.md
+++ b/.agents/spec-docs/done/PRESET-007-user-authored-external-presets.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: FLOW
 tags: [cli]
 ---
@@ -63,11 +63,11 @@ tags: [cli]
 
 ## Completion Criteria
 
-- [ ] TC-01: 임시 디렉터리에 유효한 프리셋 JSON 1개 배치 후 로딩 시 `listPresets()`에 해당 id가 포함됨을 단언하는 통합 테스트 통과
-- [ ] TC-02: 스키마 위반 프리셋 파일은 건너뛰고(해당 id 미등록) 나머지 로딩은 계속됨을 단언하는 통합 테스트 통과
-- [ ] TC-03: 외부 프리셋 id가 빌트인과 충돌 시 정의된 정책(덮어쓰기 또는 거부)대로 동작함을 단언하는 통합 테스트 통과
-- [ ] TC-04: 외부 프리셋이 하나도 없을 때 `listPresets()`가 빌트인만 반환(무회귀)함을 단언하는 통합 테스트 통과
-- [ ] TC-05: `pnpm --filter @robota-sdk/agent-preset test` + `build` → exit 0
+- [x] TC-01: 임시 디렉터리에 유효한 프리셋 JSON 1개 배치 후 로딩 시 `listPresets()`에 해당 id가 포함됨을 단언하는 통합 테스트 통과
+- [x] TC-02: 스키마 위반 프리셋 파일은 건너뛰고(해당 id 미등록) 나머지 로딩은 계속됨을 단언하는 통합 테스트 통과
+- [x] TC-03: 외부 프리셋 id가 빌트인과 충돌 시 정의된 정책(덮어쓰기 또는 거부)대로 동작함을 단언하는 통합 테스트 통과
+- [x] TC-04: 외부 프리셋이 하나도 없을 때 `listPresets()`가 빌트인만 반환(무회귀)함을 단언하는 통합 테스트 통과
+- [x] TC-05: `pnpm --filter @robota-sdk/agent-preset test` + `build` → exit 0
 
 ## Test Plan
 
@@ -91,7 +91,7 @@ Type FLOW + tags cli → 파일 로딩/검증/병합 통합 테스트(임시 디
 
 ## Tasks
 
-- [ ] `.agents/tasks/PRESET-007.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [x] [.agents/tasks/PRESET-007.md](../../tasks/PRESET-007.md) — task breakdown (TC-01..TC-05)
 
 ## Evidence Log
 
@@ -114,3 +114,32 @@ Explicit approval: orchestrator asked "8개를 GATE-APPROVAL까지 올릴까요?
 Directed at this spec: PRESET-007 is one of the 8 PRESET specs covered by the approval — OK.
 No post-approval changes: Architecture Review and frontmatter (type FLOW / tags [cli]) unchanged after approval — OK.
 NON-COMPLIANCE triggers cleared: `.agents/tasks/PRESET-007.md` does not exist; `packages/agent-preset/` does not exist — no implementation work started before this gate ran.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/PRESET-007.md` created and linked from `## Tasks`. One task per Completion
+Criterion (TC-01..TC-05) plus registry/validator/loader/cli tasks. Test Plan present (≥50 chars).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-preset --filter @robota-sdk/agent-cli build` → exit 0.
+`pnpm --filter @robota-sdk/agent-preset --filter @robota-sdk/agent-cli test` → exit 0 (agent-preset 2
+files/55 incl. 10 new external-loading cases; agent-cli 20 files/158). Existing `resolve-preset.test.ts`
+(45) stays green — mutable external registry starts empty and new tests `clearExternalPresets()` for
+isolation, so the exact built-in list + unknown-id message assertions are intact. `pnpm typecheck` →
+exit 0. `pnpm harness:scan` → exit 0, all 25 scans. No package.json/lockfile change, no new dependency
+(manual type-guard validation, not Zod).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] agent-preset vitest (`load-external-presets.test.ts`) — valid preset JSON in a temp dir → `loadExternalPresetsFromDir` registers it; `listPresets()` includes its id; `loaded` contains it.
+- [GATE-COMPLETE: TC-02] vitest — a schema-violating file is skipped (recorded in `errors`, absent from `listPresets()`); a valid sibling in the same dir still loads.
+- [GATE-COMPLETE: TC-03] vitest — external preset with id `default` (built-in collision) → rejected (`reason: collides with built-in preset`); a single built-in `default` survives.
+- [GATE-COMPLETE: TC-04] vitest — non-existent/empty dir → `loaded` empty, `listPresets()` returns exactly the built-ins (no regression).
+- [GATE-COMPLETE: TC-05] agent-preset build + test exit 0; plus `validateExternalPreset` units (bogus `effort` rejected, minimal valid accepted, missing required field rejected, unknown keys dropped).
+- Boundary note: the validator types untrusted JSON as `unknown` + narrowing (correct strict-TS pattern at a data boundary; same precedent as agent-framework `config-loader.ts`) — eslint emits `unknown` warnings only, no errors, all harness gates pass.

--- a/.agents/tasks/PRESET-007.md
+++ b/.agents/tasks/PRESET-007.md
@@ -1,0 +1,26 @@
+# PRESET-007: 사용자 작성/외부 프리셋 로딩 — Task Breakdown
+
+Spec: `.agents/spec-docs/done/PRESET-007-user-authored-external-presets.md`
+
+## Plan
+
+- [x] TC-01: valid preset JSON in a dir → `loadExternalPresetsFromDir` → `listPresets()` includes its id
+- [x] TC-02: schema-violating file skipped (in `errors`, not registered); valid sibling still loads
+- [x] TC-03: external id colliding with a built-in → rejected (built-in wins; reported in errors)
+- [x] TC-04: no/empty external dir → `listPresets()` returns built-ins only (no regression)
+- [x] TC-05: agent-preset build + test exit 0
+- [x] resolve-preset registry refactor (BUILT_IN_PRESETS + externalPresets + allPresets + register/clear)
+- [x] preset-validation.ts manual type-guard validator (no Zod)
+- [x] load-external-presets.ts (fs loader, default `~/.robota/presets`)
+- [x] agent-cli thin startup call to `loadExternalPresets()`
+
+## Test Plan
+
+File-based external preset loading merged with the built-in registry. agent-preset gains a sync
+registration seam (`registerExternalPresets`/`clearExternalPresets`) over `[...BUILT_IN_PRESETS,
+...externalPresets]`, a manual type-guard `validateExternalPreset` (no new dep), and `loadExternalPresets`
+(scans `~/.robota/presets/*.json`, validates, registers; per-file errors collected, run continues). id
+conflict policy: external cannot override a built-in id (rejected). agent-cli invokes the loader once at
+startup before resolution (thin shell). Verified by agent-preset integration tests (temp-dir fixtures:
+load/skip-invalid/collision/no-regression) + validator units, with registry isolation (clearExternalPresets)
+keeping the existing resolve-preset suite green, plus build/test/typecheck/scan smoke.

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -23,7 +23,7 @@ import {
 import { parseCliArgs, parseToolList, printHelp } from './utils/cli-args.js';
 import type { IParsedCliArgs } from './utils/cli-args.js';
 import { resolveCliPreset, selectPresetId } from './startup/preset-selection.js';
-import { DEFAULT_AGENT_NAME } from '@robota-sdk/agent-preset';
+import { DEFAULT_AGENT_NAME, loadExternalPresets } from '@robota-sdk/agent-preset';
 import type { TResolvedPresetOptions } from '@robota-sdk/agent-preset';
 import {
   ensureConfig,
@@ -134,6 +134,13 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // the preset's module-selection delta can reach createDefaultCommandModules.
   const userSettings = readSettings(getUserSettingsPath());
   const settingsPreset = typeof userSettings.preset === 'string' ? userSettings.preset : undefined;
+  // PRESET-007: register user-authored external presets (~/.robota/presets/*.json) into the
+  // shared registry before resolution so `--preset <id>` and `/preset` can see them. Per-file
+  // load/validation problems are non-fatal and surfaced as warnings; the run still proceeds.
+  const externalPresetLoad = loadExternalPresets();
+  for (const { file, error } of externalPresetLoad.errors) {
+    terminal.writeError(`Skipped external preset "${file}": ${error}`);
+  }
   let resolvedPreset: TResolvedPresetOptions;
   try {
     resolvedPreset = resolveCliPreset(args, settingsPreset);

--- a/packages/agent-preset/src/__tests__/load-external-presets.test.ts
+++ b/packages/agent-preset/src/__tests__/load-external-presets.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadExternalPresetsFromDir } from '../load-external-presets.js';
+import { validateExternalPreset } from '../preset-validation.js';
+import { clearExternalPresets, listPresets } from '../resolve-preset.js';
+
+/** Create a fresh unique temp directory for a single test case. */
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'robota-presets-'));
+}
+
+/** Write a JSON preset file into `dir` and return nothing. */
+function writePreset(dir: string, fileName: string, value: unknown): void {
+  writeFileSync(join(dir, fileName), JSON.stringify(value), 'utf8');
+}
+
+describe('loadExternalPresetsFromDir', () => {
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    clearExternalPresets();
+  });
+
+  afterEach(() => {
+    clearExternalPresets();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('TC-01: loads a valid external preset and includes it in listPresets()', () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    writePreset(dir, 'my-style.json', {
+      id: 'my-style',
+      title: 'My Style',
+      description: 'A personal style preset.',
+      persona: 'Be concise and proactive.',
+    });
+
+    const result = loadExternalPresetsFromDir(dir);
+
+    expect(result.loaded).toContain('my-style');
+    expect(result.errors).toEqual([]);
+    expect(listPresets().some((preset) => preset.id === 'my-style')).toBe(true);
+  });
+
+  it('TC-02: skips a schema-violating preset, loads the valid one, and reports the error', () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    writePreset(dir, 'good.json', {
+      id: 'good-style',
+      title: 'Good Style',
+      description: 'A valid preset.',
+    });
+    // Missing required `title` plus a bogus effort — must be rejected.
+    writePreset(dir, 'bad.json', {
+      id: 'bad-style',
+      description: 'Invalid preset.',
+      effort: 'bogus',
+    });
+
+    const result = loadExternalPresetsFromDir(dir);
+
+    expect(result.loaded).toContain('good-style');
+    expect(result.loaded).not.toContain('bad-style');
+    expect(result.errors.some((entry) => entry.file === 'bad.json')).toBe(true);
+    expect(listPresets().some((preset) => preset.id === 'good-style')).toBe(true);
+    expect(listPresets().some((preset) => preset.id === 'bad-style')).toBe(false);
+  });
+
+  it('TC-03: rejects an external preset whose id collides with a built-in', () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    writePreset(dir, 'default.json', {
+      id: 'default',
+      title: 'Hijacked Default',
+      description: 'Attempts to override the built-in default.',
+      persona: 'Should never apply.',
+    });
+
+    const result = loadExternalPresetsFromDir(dir);
+
+    expect(result.loaded).not.toContain('default');
+    expect(result.errors.some((entry) => entry.error === 'collides with built-in preset')).toBe(
+      true,
+    );
+    // The built-in default survives and remains the only `default` entry.
+    const defaults = listPresets().filter((preset) => preset.id === 'default');
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0]?.title).toBe('Default');
+  });
+
+  it('TC-04: a non-existent directory returns empty and listPresets() is unchanged', () => {
+    const baseline = listPresets();
+    const missingDir = join(makeTempDir(), 'does-not-exist');
+
+    const result = loadExternalPresetsFromDir(missingDir);
+
+    expect(result.loaded).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(listPresets()).toEqual(baseline);
+  });
+
+  it('TC-04: an empty directory returns empty loaded and only the built-ins remain', () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    const baseline = listPresets();
+
+    const result = loadExternalPresetsFromDir(dir);
+
+    expect(result.loaded).toEqual([]);
+    expect(listPresets()).toEqual(baseline);
+  });
+
+  it('directory creation helper does not interfere with nested dir reads', () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    mkdirSync(join(dir, 'nested'));
+    writePreset(dir, 'top.json', {
+      id: 'top-style',
+      title: 'Top',
+      description: 'Top-level preset only.',
+    });
+
+    const result = loadExternalPresetsFromDir(dir);
+
+    expect(result.loaded).toEqual(['top-style']);
+  });
+});
+
+describe('validateExternalPreset', () => {
+  beforeEach(() => {
+    clearExternalPresets();
+  });
+
+  afterEach(() => {
+    clearExternalPresets();
+  });
+
+  it('rejects a preset with a bogus effort value', () => {
+    const result = validateExternalPreset({
+      id: 'x',
+      title: 'X',
+      description: 'd',
+      effort: 'bogus',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/^effort: /);
+    }
+  });
+
+  it('accepts a minimal valid preset', () => {
+    const result = validateExternalPreset({ id: 'min', title: 'Min', description: 'minimal' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.preset.id).toBe('min');
+      expect(result.preset.title).toBe('Min');
+      expect(result.preset.description).toBe('minimal');
+    }
+  });
+
+  it('rejects a missing required field', () => {
+    const result = validateExternalPreset({ id: 'x', description: 'no title' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/^title: /);
+    }
+  });
+
+  it('drops unrecognised keys from the built preset', () => {
+    const result = validateExternalPreset({
+      id: 'x',
+      title: 'X',
+      description: 'd',
+      unknownKey: 'ignored',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect('unknownKey' in result.preset).toBe(false);
+    }
+  });
+});

--- a/packages/agent-preset/src/index.ts
+++ b/packages/agent-preset/src/index.ts
@@ -16,6 +16,29 @@ export { defaultPreset } from './presets/default.js';
 
 export { autonomousBuilderPreset } from './presets/autonomous-builder.js';
 
-export { DEFAULT_AGENT_NAME, resolvePreset, listPresets, getPreset } from './resolve-preset.js';
+export {
+  DEFAULT_AGENT_NAME,
+  resolvePreset,
+  listPresets,
+  getPreset,
+  registerExternalPresets,
+  clearExternalPresets,
+} from './resolve-preset.js';
 
-export type { IPresetSummary, IResolvePresetContext } from './resolve-preset.js';
+export type {
+  IPresetSummary,
+  IResolvePresetContext,
+  IPresetRegistrationResult,
+} from './resolve-preset.js';
+
+export {
+  loadExternalPresets,
+  loadExternalPresetsFromDir,
+  defaultExternalPresetDir,
+} from './load-external-presets.js';
+
+export type { IExternalPresetLoadResult } from './load-external-presets.js';
+
+export { validateExternalPreset } from './preset-validation.js';
+
+export type { TPresetValidationResult } from './preset-validation.js';

--- a/packages/agent-preset/src/load-external-presets.ts
+++ b/packages/agent-preset/src/load-external-presets.ts
@@ -1,0 +1,76 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { validateExternalPreset } from './preset-validation.js';
+import { registerExternalPresets } from './resolve-preset.js';
+
+import type { IPreset } from './preset-types.js';
+
+/** Outcome of an external-preset load: which ids loaded and per-file load/validation errors. */
+export interface IExternalPresetLoadResult {
+  loaded: readonly string[];
+  errors: readonly { file: string; error: string }[];
+}
+
+/** Conventional external-preset directory: `~/.robota/presets`. */
+export function defaultExternalPresetDir(): string {
+  return join(homedir(), '.robota', 'presets');
+}
+
+/**
+ * Load, validate, and register every `*.json` external preset from `dir`.
+ *
+ * A missing directory yields an empty result (no error). Each file is JSON-parsed and validated;
+ * a parse or validation failure is recorded as a per-file error and skipped — the remaining files
+ * still load. Validated presets are registered via {@link registerExternalPresets}; registry
+ * rejections (built-in id collision or duplicate id) are folded into `errors` against their file.
+ */
+export function loadExternalPresetsFromDir(dir: string): IExternalPresetLoadResult {
+  if (!existsSync(dir)) {
+    return { loaded: [], errors: [] };
+  }
+
+  const errors: { file: string; error: string }[] = [];
+  const validPresets: IPreset[] = [];
+  // Track which file each validated preset id came from so registry rejections map back to a file.
+  const fileById = new Map<string, string>();
+
+  const jsonFiles = readdirSync(dir).filter((name) => name.endsWith('.json'));
+  for (const name of jsonFiles) {
+    const filePath = join(dir, name);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+    } catch (error) {
+      // allow-fallback: a malformed file is reported per-file and skipped, not silently swallowed
+      errors.push({ file: name, error: error instanceof Error ? error.message : String(error) });
+      continue;
+    }
+
+    const result = validateExternalPreset(parsed);
+    if (!result.ok) {
+      errors.push({ file: name, error: result.error });
+      continue;
+    }
+
+    validPresets.push(result.preset);
+    fileById.set(result.preset.id, name);
+  }
+
+  const registration = registerExternalPresets(validPresets);
+  for (const rejection of registration.rejected) {
+    errors.push({ file: fileById.get(rejection.id) ?? rejection.id, error: rejection.reason });
+  }
+
+  return { loaded: registration.registered, errors };
+}
+
+/**
+ * Load external presets from the conventional directory (or `options.dir` when given).
+ * Thin wrapper over {@link loadExternalPresetsFromDir}.
+ */
+export function loadExternalPresets(options?: { dir?: string }): IExternalPresetLoadResult {
+  const dir = options?.dir ?? defaultExternalPresetDir();
+  return loadExternalPresetsFromDir(dir);
+}

--- a/packages/agent-preset/src/preset-validation.ts
+++ b/packages/agent-preset/src/preset-validation.ts
@@ -1,0 +1,224 @@
+import type {
+  IPreset,
+  TPresetAutonomy,
+  TPresetEffort,
+  TPresetPermissionMode,
+  TPresetTrustLevel,
+  TResolvedPresetOptions,
+} from './preset-types.js';
+
+/** Result of {@link validateExternalPreset}: the validated preset, or a single error message. */
+export type TPresetValidationResult = { ok: true; preset: IPreset } | { ok: false; error: string };
+
+/** Runtime membership list for {@link TPresetEffort}. */
+const EFFORT_VALUES: readonly TPresetEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+/** Runtime membership list for {@link TPresetAutonomy}. */
+const AUTONOMY_VALUES: readonly TPresetAutonomy[] = ['ask-first', 'act-first', 'balanced'];
+
+/** Runtime membership list for {@link TPresetPermissionMode}. */
+const PERMISSION_MODE_VALUES: readonly TPresetPermissionMode[] = [
+  'plan',
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+];
+
+/** Runtime membership list for {@link TPresetTrustLevel}. */
+const TRUST_LEVEL_VALUES: readonly TPresetTrustLevel[] = ['safe', 'moderate', 'full'];
+
+/** Narrowing guard: `value` is a non-null, non-array object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Narrowing guard: `value` is an array whose every element is a string. */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+/** Validate the string-typed optional fields onto `options`; return the first error, if any. */
+function validateStringFields(
+  value: Record<string, unknown>,
+  options: TResolvedPresetOptions,
+): string | undefined {
+  const fields: readonly [string, unknown, (v: string) => void][] = [
+    ['persona', value.persona, (v) => (options.persona = v)],
+    ['systemPrompt', value.systemPrompt, (v) => (options.systemPrompt = v)],
+    ['appendSystemPrompt', value.appendSystemPrompt, (v) => (options.appendSystemPrompt = v)],
+    ['agentName', value.agentName, (v) => (options.agentName = v)],
+    ['model', value.model, (v) => (options.model = v)],
+    ['language', value.language, (v) => (options.language = v)],
+  ];
+  for (const [field, raw, assign] of fields) {
+    if (raw === undefined) {
+      continue;
+    }
+    if (typeof raw !== 'string') {
+      return `${field}: expected a string`;
+    }
+    assign(raw);
+  }
+  return undefined;
+}
+
+/** Validate the number- and boolean-typed optional fields onto `options`; return the first error. */
+function validateScalarFields(
+  value: Record<string, unknown>,
+  options: TResolvedPresetOptions,
+): string | undefined {
+  const numbers: readonly [string, unknown, (v: number) => void][] = [
+    ['temperature', value.temperature, (v) => (options.temperature = v)],
+    ['maxOutputTokens', value.maxOutputTokens, (v) => (options.maxOutputTokens = v)],
+  ];
+  for (const [field, raw, assign] of numbers) {
+    if (raw === undefined) {
+      continue;
+    }
+    if (typeof raw !== 'number' || Number.isNaN(raw)) {
+      return `${field}: expected a number`;
+    }
+    assign(raw);
+  }
+
+  const booleans: readonly [string, unknown, (v: boolean) => void][] = [
+    [
+      'enableParallelSubagents',
+      value.enableParallelSubagents,
+      (v) => (options.enableParallelSubagents = v),
+    ],
+    ['selfVerification', value.selfVerification, (v) => (options.selfVerification = v)],
+  ];
+  for (const [field, raw, assign] of booleans) {
+    if (raw === undefined) {
+      continue;
+    }
+    if (typeof raw !== 'boolean') {
+      return `${field}: expected a boolean`;
+    }
+    assign(raw);
+  }
+  return undefined;
+}
+
+/** Validate the enum-typed optional fields onto `options`; return the first error, if any. */
+function validateEnumFields(
+  value: Record<string, unknown>,
+  options: TResolvedPresetOptions,
+): string | undefined {
+  if (value.effort !== undefined) {
+    if (!EFFORT_VALUES.includes(value.effort as TPresetEffort)) {
+      return `effort: expected one of ${EFFORT_VALUES.join(', ')}`;
+    }
+    options.effort = value.effort as TPresetEffort;
+  }
+
+  if (value.autonomy !== undefined) {
+    if (!AUTONOMY_VALUES.includes(value.autonomy as TPresetAutonomy)) {
+      return `autonomy: expected one of ${AUTONOMY_VALUES.join(', ')}`;
+    }
+    options.autonomy = value.autonomy as TPresetAutonomy;
+  }
+
+  const modes: readonly [string, unknown, (v: TPresetPermissionMode) => void][] = [
+    ['permissionMode', value.permissionMode, (v) => (options.permissionMode = v)],
+    [
+      'defaultPermissionMode',
+      value.defaultPermissionMode,
+      (v) => (options.defaultPermissionMode = v),
+    ],
+  ];
+  for (const [field, raw, assign] of modes) {
+    if (raw === undefined) {
+      continue;
+    }
+    if (!PERMISSION_MODE_VALUES.includes(raw as TPresetPermissionMode)) {
+      return `${field}: expected one of ${PERMISSION_MODE_VALUES.join(', ')}`;
+    }
+    assign(raw as TPresetPermissionMode);
+  }
+
+  if (value.defaultTrustLevel !== undefined) {
+    if (!TRUST_LEVEL_VALUES.includes(value.defaultTrustLevel as TPresetTrustLevel)) {
+      return `defaultTrustLevel: expected one of ${TRUST_LEVEL_VALUES.join(', ')}`;
+    }
+    options.defaultTrustLevel = value.defaultTrustLevel as TPresetTrustLevel;
+  }
+  return undefined;
+}
+
+/** Validate the string-array optional fields onto `options`; return the first error, if any. */
+function validateArrayFields(
+  value: Record<string, unknown>,
+  options: TResolvedPresetOptions,
+): string | undefined {
+  const arrays: readonly [string, unknown, (v: readonly string[]) => void][] = [
+    ['allowedTools', value.allowedTools, (v) => (options.allowedTools = v)],
+    ['deniedTools', value.deniedTools, (v) => (options.deniedTools = v)],
+    [
+      'enabledCommandModules',
+      value.enabledCommandModules,
+      (v) => (options.enabledCommandModules = v),
+    ],
+    [
+      'disabledCommandModules',
+      value.disabledCommandModules,
+      (v) => (options.disabledCommandModules = v),
+    ],
+  ];
+  for (const [field, raw, assign] of arrays) {
+    if (raw === undefined) {
+      continue;
+    }
+    if (!isStringArray(raw)) {
+      return `${field}: expected an array of strings`;
+    }
+    assign(raw);
+  }
+  return undefined;
+}
+
+/**
+ * Manually validate an unknown value as an {@link IPreset} (no schema library).
+ *
+ * Required fields: non-empty `id`, `title`, `description` strings. Every other field is
+ * optional and is validated only when present; an unrecognised field is dropped (the built
+ * preset carries the recognised fields only, never unknown keys). On the first failed check
+ * returns `{ ok: false, error: '<field>: <reason>' }`.
+ */
+export function validateExternalPreset(value: unknown): TPresetValidationResult {
+  if (!isPlainObject(value)) {
+    return { ok: false, error: 'preset: expected a non-null object' };
+  }
+
+  const requiredStrings: readonly ['id' | 'title' | 'description', unknown][] = [
+    ['id', value.id],
+    ['title', value.title],
+    ['description', value.description],
+  ];
+  for (const [field, raw] of requiredStrings) {
+    if (typeof raw !== 'string' || raw.length === 0) {
+      return { ok: false, error: `${field}: expected a non-empty string` };
+    }
+  }
+
+  // Accumulate recognised optional fields here, then spread onto the identity triple so the
+  // built preset never carries unknown keys.
+  const options: TResolvedPresetOptions = {};
+  const error =
+    validateStringFields(value, options) ??
+    validateScalarFields(value, options) ??
+    validateEnumFields(value, options) ??
+    validateArrayFields(value, options);
+  if (error !== undefined) {
+    return { ok: false, error };
+  }
+
+  const preset: IPreset = {
+    id: value.id as string,
+    title: value.title as string,
+    description: value.description as string,
+    ...options,
+  };
+  return { ok: true, preset };
+}

--- a/packages/agent-preset/src/resolve-preset.ts
+++ b/packages/agent-preset/src/resolve-preset.ts
@@ -30,19 +30,76 @@ const AUTONOMY_TO_PERMISSION_MODE: Record<TPresetAutonomy, TPresetPermissionMode
  */
 export const DEFAULT_AGENT_NAME = 'robota-cli';
 
-/** Registry of built-in presets. */
-const PRESETS: readonly IPreset[] = [
+/** Registry of built-in presets. Built-ins always win on id conflict and cannot be overridden. */
+const BUILT_IN_PRESETS: readonly IPreset[] = [
   defaultPreset,
   autonomousBuilderPreset,
   carefulReviewerPreset,
   neutralExecutorPreset,
 ];
 
+/**
+ * Module-level mutable registry of user-authored external presets (PRESET-007).
+ * Populated by {@link registerExternalPresets}; the sync readers iterate
+ * `[...BUILT_IN_PRESETS, ...externalPresets]` so external presets merge with the built-ins.
+ */
+const externalPresets: IPreset[] = [];
+
+/** The merged preset registry: built-ins first, then registered external presets. */
+function allPresets(): readonly IPreset[] {
+  return [...BUILT_IN_PRESETS, ...externalPresets];
+}
+
 /** Lightweight `{ id, title, description }` view of a preset for discovery/UX. */
 export interface IPresetSummary {
   id: string;
   title: string;
   description: string;
+}
+
+/** Outcome of {@link registerExternalPresets}: which ids registered and which were rejected. */
+export interface IPresetRegistrationResult {
+  registered: readonly string[];
+  rejected: readonly { id: string; reason: string }[];
+}
+
+/**
+ * Register user-authored external presets into the module-level registry.
+ *
+ * Conflict policy: an external preset whose id matches a BUILT-IN preset is rejected
+ * (`'collides with built-in preset'`) — built-ins always win. An external preset whose id
+ * matches an already-registered external preset is rejected (`'duplicate preset id'`) — first
+ * registration wins. All other presets are appended and counted as registered.
+ *
+ * @returns the ids that registered and the `{ id, reason }` of each rejection.
+ */
+export function registerExternalPresets(presets: readonly IPreset[]): IPresetRegistrationResult {
+  const builtInIds = new Set(BUILT_IN_PRESETS.map((preset) => preset.id));
+  const registered: string[] = [];
+  const rejected: { id: string; reason: string }[] = [];
+
+  for (const preset of presets) {
+    if (builtInIds.has(preset.id)) {
+      rejected.push({ id: preset.id, reason: 'collides with built-in preset' });
+      continue;
+    }
+    if (externalPresets.some((existing) => existing.id === preset.id)) {
+      rejected.push({ id: preset.id, reason: 'duplicate preset id' });
+      continue;
+    }
+    externalPresets.push(preset);
+    registered.push(preset.id);
+  }
+
+  return { registered, rejected };
+}
+
+/**
+ * Remove every registered external preset, leaving only the built-ins.
+ * Used at startup before a fresh re-load and for test isolation.
+ */
+export function clearExternalPresets(): void {
+  externalPresets.length = 0;
 }
 
 /**
@@ -56,12 +113,12 @@ export interface IResolvePresetContext {
 
 /** Return the `{ id, title, description }` summary of every registered preset. */
 export function listPresets(): readonly IPresetSummary[] {
-  return PRESETS.map(({ id, title, description }) => ({ id, title, description }));
+  return allPresets().map(({ id, title, description }) => ({ id, title, description }));
 }
 
 /** Look up a registered preset by id, or `undefined` if none matches. */
 export function getPreset(id: string): IPreset | undefined {
-  return PRESETS.find((preset) => preset.id === id);
+  return allPresets().find((preset) => preset.id === id);
 }
 
 /** Strip the identity triple from a preset, leaving only resolvable option overrides. */
@@ -101,7 +158,9 @@ export function resolvePreset(
 ): TResolvedPresetOptions {
   const preset = getPreset(id);
   if (!preset) {
-    const available = PRESETS.map((p) => p.id).join(', ');
+    const available = allPresets()
+      .map((p) => p.id)
+      .join(', ');
     throw new Error(`Unknown preset: "${id}". Available presets: ${available}.`);
   }
 


### PR DESCRIPTION
## Summary
Load user-authored presets from `~/.robota/presets/*.json`, merged with the built-in registry.

- **resolve-preset**: registry refactor — `BUILT_IN_PRESETS` const + mutable `externalPresets`; sync readers iterate both; `registerExternalPresets`/`clearExternalPresets` seam. **id-conflict policy: external cannot override a built-in id** (rejected + reported); external duplicate → first wins.
- **preset-validation**: manual type-guard `validateExternalPreset` (no Zod — keeps agent-preset dependency-light; untrusted JSON typed as `unknown` + narrowing, the strict-TS boundary pattern).
- **load-external-presets**: fs loader (default `~/.robota/presets`); per-file JSON-parse/validation errors collected and skipped, the run continues.
- **agent-cli**: thin startup call to `loadExternalPresets()` before resolution (so `--preset <id>` and `/preset` see user presets). No feature logic in the cli.

## Verification
- agent-preset + agent-cli build ✓ · test ✓ (agent-preset 55/2 files incl. 10 new external-loading cases; agent-cli 158/20)
- existing `resolve-preset.test.ts` stays green (registry isolation via `clearExternalPresets`)
- `pnpm typecheck` ✓ · `pnpm harness:scan` ✓ (25/25) · no package.json/lockfile change, no new dependency

Spec `PRESET-007` → done with full gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)