### PR TITLE
feat(framework,session): live enableParallelSubagents gate (PRESET-016)

### DIFF
--- a/.agents/spec-docs/done/PRESET-016-parallel-subagents-gate.md
+++ b/.agents/spec-docs/done/PRESET-016-parallel-subagents-gate.md
@@ -1,0 +1,171 @@
+---
+status: done
+type: FLOW
+tags: [cli]
+---
+
+# PRESET-016: 전환 시 `enableParallelSubagents` 라이브 게이팅
+
+## Problem
+
+라이브 전환 엔진은 권한·모델/effort·페르소나·명령모듈(PRESET-012~015)을 재적용하지만, 프리셋의
+`enableParallelSubagents`는 전환 시 반영되지 않는다. agent runtime(`SubagentManager`)은 조립 시
+`if (options.enableAgentRuntime || options.enableParallelSubagents)`로 **한 번만** 구성되어 세션에
+구워진다(`wireSessionDeps`→`storeAgentToolDeps`). 런타임에 토글하는 seam이 없다.
+
+**핵심 제약(회귀 금지):** 미구성 세션에서 parallel을 라이브로 켜려면 `SubagentManager`/백그라운드
+인프라를 새로 구성해야 하는데, 이를 위해 **항상 구성(always-construct)** 하면 모든 세션(기본/비프리셋
+경로 포함)이 자원 비용을 부담 → **회귀**다. 따라서 본 백로그는 **런타임 게이트**만 추가한다: agent
+tool이 이미 구성된 세션에서 dispatch 시점에 게이트 플래그를 검사한다. 시작 시 미구성 세션에서
+parallel을 켜는 것은 다음 세션부터 반영(문서화).
+
+**재현 조건:** `rg -n "setParallelSubagentsEnabled|isParallelSubagentsEnabled" packages/` → 0건.
+`IAgentToolDeps`/`ICommandSessionRuntime`에 parallel 게이트 없음.
+
+**범위(설계 §7.1):** `enableParallelSubagents` 게이팅만. 명령 모듈은 PRESET-015(done), `selfVerification`
+기능 구현은 PRESET-017.
+
+설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §7.1 (PRESET-016).
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-session/src/session-base.ts` — mutable `parallelSubagentsEnabled`(기본 true) +
+  `getParallelSubagentsEnabled()`/`setParallelSubagentsEnabled(bool)`(`getActivePresetId` 패턴)
+- `packages/agent-session/src/session.ts` — 필드 선언
+- `packages/agent-framework/src/tools/agent-tool.ts` — `IAgentToolDeps.isParallelSubagentsEnabled?: () => boolean`; `createAgentTool` execute 진입부에서 게이트 검사(비활성 시 dispatch 없이 비활성 결과 반환)
+- `packages/agent-framework/src/assembly/create-session-runtime.ts` — `wireSessionDeps`가 `agentToolDeps.isParallelSubagentsEnabled = () => session.getParallelSubagentsEnabled()` 배선
+- `packages/agent-framework/src/command-api/host-context.ts` — `ICommandSessionRuntime.setParallelSubagentsEnabled?(enabled)`
+- `packages/agent-framework/src/command-api/preset/preset-application.ts` — `IPresetApplicationOptions.enableParallelSubagents?` + 오케스트레이터 재적용
+
+### Alternatives Considered
+
+1. **always-construct + 런타임 게이트.**
+   - Pro: 미구성 세션도 라이브로 켤 수 있음.
+   - Con: 모든 세션이 agent runtime 구성 비용 부담 → 기본/비프리셋 경로 회귀. Rejected.
+2. **런타임 게이트만(구성된 세션에서 dispatch 시점 검사), 미구성 세션은 다음 세션 반영.**
+   - Pro: 기본 경로 무회귀(가산적); 구성된 세션에서 enable/disable 라이브; agent tool 존재 시에만 의미.
+   - Con: 시작 시 미구성 세션에서 라이브로 켜는 것은 불가(문서화된 한계).
+
+### Decision
+
+**Alternative 2.** 세션에 mutable `parallelSubagentsEnabled`(기본 true = 현 동작) + getter/setter를 두고,
+agent tool execute가 deps의 게이트 predicate를 검사해 비활성 시 dispatch 없이 비활성 결과를 반환한다.
+`wireSessionDeps`가 predicate를 세션 플래그에 배선. `ICommandSessionRuntime.setParallelSubagentsEnabled?`로
+노출하고 오케스트레이터가 재적용. 기본값 true라 기존 동작 무회귀. 미구성 세션 한계는 문서화. 트레이드오프:
+미구성 세션 라이브-켜기를 포기하고, 기본 경로 무회귀 + dispatch 시점 저위험 게이트를 얻는다.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-session(플래그), agent-framework(agent-tool 게이트/배선/계약/오케스트레이터)
+- [x] Sibling scan 완료 — `getActivePresetId`(mutable 세션 상태) + PRESET-013 `applyModelOptions` 런타임 seam 패턴 확인 후 동일 적용
+- [x] 대안 최소 2개 검토 완료 — 2개(always-construct / 런타임 게이트)
+- [x] 결정 근거 문서화 완료 — 기본 경로 무회귀 우선 + 미구성 세션 한계 문서화 근거 기록
+
+## Solution
+
+1. `SessionBase`: `protected parallelSubagentsEnabled` 추가; `getParallelSubagentsEnabled()`/`setParallelSubagentsEnabled(enabled)`. `Session` 생성자: `this.parallelSubagentsEnabled = options.enableParallelSubagents ?? true` (기본 true = 현 동작).
+2. `IAgentToolDeps.isParallelSubagentsEnabled?: () => boolean`. `createAgentTool` execute 진입부: `if (deps.isParallelSubagentsEnabled && !deps.isParallelSubagentsEnabled()) return <비활성 ToolResult>` (dispatch 안 함).
+3. `wireSessionDeps`: `if (agentToolDeps) agentToolDeps.isParallelSubagentsEnabled = () => session.getParallelSubagentsEnabled()`.
+4. `ICommandSessionRuntime.setParallelSubagentsEnabled?(enabled)`; SessionBase가 구현.
+5. `IPresetApplicationOptions.enableParallelSubagents?`; 오케스트레이터: 있으면 `context.getSession().setParallelSubagentsEnabled?.(value)` + applied 기록.
+
+## Affected Files
+
+- `packages/agent-session/src/session-base.ts`
+- `packages/agent-session/src/session.ts`
+- `packages/agent-framework/src/tools/agent-tool.ts`
+- `packages/agent-framework/src/assembly/create-session-runtime.ts`
+- `packages/agent-framework/src/command-api/host-context.ts`
+- `packages/agent-framework/src/command-api/preset/preset-application.ts`
+- `packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts`
+- `packages/agent-session/src/__tests__/` (게이트 플래그 단위 테스트)
+
+## Completion Criteria
+
+- [x] TC-01: `Session`을 `enableParallelSubagents: false`로 생성 시 `getParallelSubagentsEnabled() === false`, 미지정 시 `true`(기본)임을 단언하는 단위 테스트 통과
+- [x] TC-02: `setParallelSubagentsEnabled(false)` 후 `getParallelSubagentsEnabled() === false`로 바뀜을 단언하는 단위 테스트 통과
+- [x] TC-03: `createAgentTool({ ...deps, isParallelSubagentsEnabled: () => false })`의 tool execute 호출 시 subagentManager dispatch 없이 비활성 결과를 반환함을 단언하는 단위 테스트 통과(예: spawn/runner 미호출 spy)
+- [x] TC-04: 게이트가 `() => true`(또는 predicate 미설정)일 때는 기존대로 dispatch가 진행됨을 단언하는 단위 테스트 통과
+- [x] TC-05: `applyPresetToSession(ctx, id, { enableParallelSubagents: false })` 호출 시 런타임 `setParallelSubagentsEnabled`가 `false`로 호출되고 결과 `applied`에 `'enableParallelSubagents'`가 포함됨을 단언하는 단위 테스트 통과
+- [x] TC-06: 모델 필드 없음/미지정 시 `setParallelSubagentsEnabled` 미호출 + `skipped` 포함, 그리고 미구현 컨텍스트에서 예외 없음을 단언하는 단위 테스트 통과
+- [x] TC-07: `pnpm --filter @robota-sdk/agent-session --filter @robota-sdk/agent-framework build` + `test` + `pnpm typecheck` → exit 0 (무회귀); `harness:scan` 통과
+
+## Test Plan
+
+Type FLOW + tags cli → 세션 게이트 플래그(기본/토글) + agent tool dispatch 게이트(비활성 미dispatch/활성
+dispatch) + 오케스트레이터 재적용(적용/건너뜀/optional 안전) + 빌드/테스트/타입체크/스캔 스모크.
+
+| TC-ID | Test Type              | Tool / Approach                                      | Notes    |
+| ----- | ---------------------- | ---------------------------------------------------- | -------- |
+| TC-01 | RULE (unit)            | vitest — Session 게이트 기본값/옵션 단언             |          |
+| TC-02 | RULE (unit)            | vitest — setParallelSubagentsEnabled 토글 단언       |          |
+| TC-03 | RULE (unit)            | vitest — agent tool 비활성 시 미dispatch 단언        |          |
+| TC-04 | RULE (unit)            | vitest — 활성/미설정 시 dispatch 진행 단언           |          |
+| TC-05 | RULE (unit)            | vitest — applyPresetToSession 재적용 + applied 단언  |          |
+| TC-06 | RULE (unit)            | vitest — 미지정 skipped + optional 안전 단언         |          |
+| TC-07 | CI pipeline smoke test | `pnpm build` + `test` + `typecheck` + `harness:scan` | 커맨드폼 |
+
+## User Execution Test Scenarios
+
+- **시나리오 — 전환 시 parallel 토글(006 경로):** 전제: PRESET-011 완료 + agent runtime 구성된 세션
+  (`--preset autonomous-builder` 등). 실행: `enableParallelSubagents:false`인 프리셋으로 `/preset` 전환 후
+  서브에이전트 유발 작업. 기대: 전환 후 Agent 도구 호출이 비활성 결과로 처리(dispatch 안 함). `true`
+  프리셋으로 되돌리면 재개. 본 백로그 단독으로는 단위 테스트로 검증. 정리: 없음. Evidence: dispatch
+  spy 단언(구현 후 기록).
+
+환경: PRESET-011 선행. 시작 시 runtime 미구성 세션에서 라이브 켜기는 다음 세션 반영(문서화된 한계).
+
+## Tasks
+
+- [x] [.agents/tasks/PRESET-016.md](../../tasks/PRESET-016.md) — task breakdown (TC-01..TC-07)
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter present (`status`, `type: FLOW`, `tags: [cli]`). Problem states the symptom (agent runtime
+built once at assembly; no live toggle; `rg` → 0), the non-regression constraint (no always-construct),
+and the scope (parallel-only; 015 done, 017 split). Architecture Review: 4 checklist items `[x]`; Sibling
+scan cites `getActivePresetId` + PRESET-013 runtime-seam pattern; 2 Alternatives with Pro/Con; Decision
+records default-true non-regression + the documented unbuilt-session limitation. Completion Criteria
+TC-01..TC-07 command-form/observable; Test Plan rows match TC set 1:1.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** review-ready → approved
+Explicit user approval (verbatim): "나머지도 다 진행해" — directs completion of the remaining preset
+backlogs, combined with the standing "정석대로 / 범위가 크면 별도 flow 백로그로 분산" directive
+authorizing the 015→015/016/017 split; PRESET-016 (parallel-subagents gate) is the next piece. No
+post-approval drift: implementation not started at approval time.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/PRESET-016.md` created and linked. One task per Completion Criterion
+(TC-01..TC-07) plus session/agent-tool/wiring/orchestrator tasks. Test Plan present (≥50 chars).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-session --filter @robota-sdk/agent-framework build` →
+exit 0. `pnpm --filter @robota-sdk/agent-session --filter @robota-sdk/agent-framework test` → exit 0
+(agent-session 14 files / 71 incl. new gate cases; agent-framework 99 files / 960 incl. agent-tool gate +
+orchestrator cases), no regressions. `pnpm typecheck` → exit 0 (monorepo). `pnpm harness:scan` → exit 0,
+25/25. No package.json/lockfile change, no new dependency.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] agent-session vitest (`parallel-subagents-gate.test.ts`) — `enableParallelSubagents:false` → `getParallelSubagentsEnabled()===false`; default → `true`.
+- [GATE-COMPLETE: TC-02] vitest — `setParallelSubagentsEnabled(false)` → getter `false`.
+- [GATE-COMPLETE: TC-03] agent-framework vitest (`agent-tool.test.ts`) — gate `() => false` → tool execute returns the disabled JSON result, subagentManager `spawn`/`createSubagentSession` NOT called (single + batch).
+- [GATE-COMPLETE: TC-04] vitest — gate `() => true` / predicate omitted → dispatch proceeds (`spawn` called once, `success:true`).
+- [GATE-COMPLETE: TC-05] agent-framework vitest (`preset-application.test.ts`) — `applyPresetToSession({enableParallelSubagents:false})` → `setParallelSubagentsEnabled(false)` + `applied` contains 'enableParallelSubagents'.
+- [GATE-COMPLETE: TC-06] vitest — omitted → not called, in `skipped`; runtime without the method → no throw.
+- [GATE-COMPLETE: TC-07] builds + tests + `pnpm typecheck` + `pnpm harness:scan` all exit 0.
+- Disabled result shape: the agent-tool executor returns `Promise<string>` (JSON via `stringifyAgentX`); the gate returns a new `stringifyParallelSubagentsDisabled()` matching the existing error-result shape (no throw). Non-regression: gate defaults to enabled and is a no-op when the predicate is undefined.

--- a/.agents/tasks/PRESET-016.md
+++ b/.agents/tasks/PRESET-016.md
@@ -1,0 +1,28 @@
+# PRESET-016: 전환 시 enableParallelSubagents 라이브 게이팅 — Task Breakdown
+
+Spec: `.agents/spec-docs/done/PRESET-016-parallel-subagents-gate.md`
+
+## Plan
+
+- [x] TC-01: `Session({enableParallelSubagents:false})` → getter false; default → true
+- [x] TC-02: `setParallelSubagentsEnabled(false)` → getter false
+- [x] TC-03: agent tool with `isParallelSubagentsEnabled: () => false` → no dispatch, disabled result
+- [x] TC-04: gate `() => true` / unset → dispatch proceeds (spawn spy called)
+- [x] TC-05: `applyPresetToSession(..., { enableParallelSubagents:false })` → `setParallelSubagentsEnabled(false)` + applied
+- [x] TC-06: omitted → not called + in skipped; runtime without method → no throw
+- [x] TC-07: agent-session + agent-framework build + test + typecheck + harness:scan pass
+- [x] SessionBase gate flag (default true) + get/set; ISessionOptions.enableParallelSubagents
+- [x] IAgentToolDeps gate predicate + agent-tool execute gate + disabled result
+- [x] wireSessionDeps predicate wiring; ICommandSessionRuntime seam + orchestrator group
+
+## Test Plan
+
+Live runtime gate for `enableParallelSubagents` (NOT always-construct — default path unchanged). The
+session holds a mutable `parallelSubagentsEnabled` (default `true` = current behavior); the agent tool's
+executor refuses dispatch (returns a JSON disabled result via `stringifyParallelSubagentsDisabled`, no
+throw) when the deps gate predicate returns false; `wireSessionDeps` binds the predicate to the session
+flag (only present when the agent runtime was built at assembly). `ICommandSessionRuntime.
+setParallelSubagentsEnabled?` exposes it; `applyPresetToSession` re-applies the group. Verified by
+session unit tests (default/toggle), agent-tool dispatch-gate tests (refused vs. proceeds, single+batch),
+orchestrator spy tests (applied/skip/optional-safe), and build/test/typecheck/scan smoke. Sessions started
+without the runtime can't live-enable parallel (documented; next session). selfVerification → PRESET-017.

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -259,6 +259,11 @@ export function wireSessionDeps(
   backgroundTaskManager: IBackgroundTaskManager,
 ): void {
   if (agentToolDeps) agentToolDeps.parentSessionId = session.getSessionId();
+  // PRESET-016: wire the runtime gate to the session's live flag so a preset switch can
+  // enable/disable subagent dispatch on this already-constructed session.
+  if (agentToolDeps) {
+    agentToolDeps.isParallelSubagentsEnabled = () => session.getParallelSubagentsEnabled();
+  }
   if (backgroundProcessToolDeps) backgroundProcessToolDeps.parentSessionId = session.getSessionId();
   storeSessionBackgroundTaskManager(session, backgroundTaskManager);
   if (agentToolDeps) storeAgentToolDeps(session, agentToolDeps);

--- a/packages/agent-framework/src/command-api/host-context.ts
+++ b/packages/agent-framework/src/command-api/host-context.ts
@@ -89,6 +89,8 @@ export interface ICommandSessionRuntime {
   getActivePresetId?(): string;
   /** Set the active preset id (PRESET-011 runtime state — pure state, no option re-application). */
   setActivePresetId?(id: string): void;
+  /** Toggle subagent dispatch live for the running session (PRESET-016 runtime gate). */
+  setParallelSubagentsEnabled?(enabled: boolean): void;
 }
 
 export interface ICommandSessionReplayValidationReport {

--- a/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
+++ b/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
@@ -18,6 +18,7 @@ interface IRuntimeSpies {
   applyModelOptions?: ReturnType<typeof vi.fn>;
   applyPersona?: ReturnType<typeof vi.fn>;
   applyCommandModuleSelection?: ReturnType<typeof vi.fn>;
+  setParallelSubagentsEnabled?: ReturnType<typeof vi.fn>;
 }
 
 /**
@@ -28,12 +29,15 @@ interface IRuntimeSpies {
  * `includeApplyPersona: false` omits the optional `applyPersona` to exercise the PRESET-014
  * optional path (TC-05). `includeApplyCommandModuleSelection: false` omits the optional
  * `applyCommandModuleSelection` to exercise the PRESET-015 optional path (TC-06).
+ * `includeSetParallelSubagentsEnabled: false` omits the optional `setParallelSubagentsEnabled` to
+ * exercise the PRESET-016 optional path (TC-06).
  */
 function createContext(
   includeActivePreset = true,
   includeApplyModelOptions = true,
   includeApplyPersona = true,
   includeApplyCommandModuleSelection = true,
+  includeSetParallelSubagentsEnabled = true,
 ): {
   context: ICommandHostContext;
   spies: IRuntimeSpies;
@@ -68,6 +72,12 @@ function createContext(
     const applyModelOptions = vi.fn();
     runtime.applyModelOptions = applyModelOptions;
     spies.applyModelOptions = applyModelOptions;
+  }
+
+  if (includeSetParallelSubagentsEnabled) {
+    const setParallelSubagentsEnabled = vi.fn();
+    runtime.setParallelSubagentsEnabled = setParallelSubagentsEnabled;
+    spies.setParallelSubagentsEnabled = setParallelSubagentsEnabled;
   }
 
   const context: ICommandHostContext = {
@@ -232,6 +242,35 @@ describe('applyPresetToSession command-module group (PRESET-015)', () => {
     expect(spies.applyCommandModuleSelection).toBeUndefined();
     expect(() =>
       applyPresetToSession(context, 'careful-reviewer', { enabledCommandModules: ['a'] }),
+    ).not.toThrow();
+  });
+});
+
+describe('applyPresetToSession parallel-subagents gate (PRESET-016)', () => {
+  it('TC-05: enableParallelSubagents:false → setParallelSubagentsEnabled(false), applied lists it', () => {
+    const { context, spies } = createContext();
+    const result = applyPresetToSession(context, 'careful-reviewer', {
+      enableParallelSubagents: false,
+    });
+
+    expect(spies.setParallelSubagentsEnabled).toHaveBeenCalledWith(false);
+    expect(result.applied).toContain('enableParallelSubagents');
+  });
+
+  it('TC-06: omitted → not called, group skipped', () => {
+    const { context, spies } = createContext();
+    const result = applyPresetToSession(context, 'x', {});
+
+    expect(spies.setParallelSubagentsEnabled).not.toHaveBeenCalled();
+    expect(result.skipped).toContain('enableParallelSubagents');
+    expect(result.applied).not.toContain('enableParallelSubagents');
+  });
+
+  it('TC-06b: runtime without setParallelSubagentsEnabled still applies safely (optional chaining)', () => {
+    const { context, spies } = createContext(true, true, true, true, false);
+    expect(spies.setParallelSubagentsEnabled).toBeUndefined();
+    expect(() =>
+      applyPresetToSession(context, 'careful-reviewer', { enableParallelSubagents: true }),
     ).not.toThrow();
   });
 });

--- a/packages/agent-framework/src/command-api/preset/preset-application.ts
+++ b/packages/agent-framework/src/command-api/preset/preset-application.ts
@@ -27,6 +27,8 @@ export interface IPresetApplicationOptions {
   enabledCommandModules?: readonly string[];
   /** PRESET-015 — denylist of command-module names to remove from the live session. */
   disabledCommandModules?: readonly string[];
+  /** PRESET-016 — runtime gate toggle for subagent dispatch on the live session. */
+  enableParallelSubagents?: boolean;
 }
 
 /** Outcome of {@link applyPresetToSession}: which option groups were re-applied vs. skipped. */
@@ -47,8 +49,9 @@ export interface IPresetApplicationResult {
  * group (`model`/`effort`/`temperature`/`maxOutputTokens`) via the runtime's optional
  * `applyModelOptions`. PRESET-014 re-applies the `persona` group via the host context's optional
  * `applyPersona` seam. PRESET-015 re-applies the command-module selection group via the host
- * context's optional `applyCommandModuleSelection` seam. Groups absent from `options` are left
- * untouched and reported under `skipped`.
+ * context's optional `applyCommandModuleSelection` seam. PRESET-016 toggles the parallel-subagents
+ * runtime gate via the runtime's optional `setParallelSubagentsEnabled` seam. Groups absent from
+ * `options` are left untouched and reported under `skipped`.
  */
 export function applyPresetToSession(
   context: ICommandHostContext,
@@ -104,6 +107,15 @@ export function applyPresetToSession(
     applied.push('commandModules');
   } else {
     skipped.push('commandModules');
+  }
+
+  // PRESET-016 parallel-subagents gate — toggled via the runtime's optional
+  // setParallelSubagentsEnabled seam (live gate on an already-constructed session).
+  if (options.enableParallelSubagents !== undefined) {
+    context.getSession().setParallelSubagentsEnabled?.(options.enableParallelSubagents);
+    applied.push('enableParallelSubagents');
+  } else {
+    skipped.push('enableParallelSubagents');
   }
 
   return { applied, skipped };

--- a/packages/agent-framework/src/tools/__tests__/agent-tool.test.ts
+++ b/packages/agent-framework/src/tools/__tests__/agent-tool.test.ts
@@ -1177,4 +1177,110 @@ describe('Agent tool', () => {
       expect.not.objectContaining({ isForkWorker: true }),
     );
   });
+
+  // PRESET-016: runtime gate consulted at dispatch time. A spy SubagentManager lets us assert
+  // dispatch is refused (no spawn) when the gate predicate returns false.
+  function makeManagerSpy(): ISubagentManager {
+    return {
+      spawn: vi.fn().mockResolvedValue({
+        id: 'agent_gate_1',
+        type: 'Explore',
+        label: 'Explore',
+        parentSessionId: 'session_parent',
+        status: 'running',
+        mode: 'background',
+        depth: 1,
+        cwd: '/workspace',
+        promptPreview: 'Gate task',
+        updatedAt: '2026-06-14T00:00:00.000Z',
+      }),
+      wait: vi.fn().mockResolvedValue({ jobId: 'agent_gate_1', output: 'gate output' }),
+      list: vi.fn(),
+      get: vi.fn(),
+      cancel: vi.fn(),
+      close: vi.fn(),
+      send: vi.fn(),
+      shutdown: vi.fn(),
+    };
+  }
+
+  it('TC-03: gate disabled → returns disabled result without dispatching', async () => {
+    const subagentManager = makeManagerSpy();
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+        isParallelSubagentsEnabled: () => false,
+      }),
+    );
+
+    const toolResult = await tool.execute({ prompt: 'Gate task', subagent_type: 'Explore' });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).not.toHaveBeenCalled();
+    expect(createSubagentSession).not.toHaveBeenCalled();
+    expect(result['success']).toBe(false);
+    expect(result['requestedJobCount']).toBe(0);
+    expect(result['startedJobCount']).toBe(0);
+    expect(result['error']).toContain('Parallel subagents are disabled');
+  });
+
+  it('TC-03b: gate disabled also refuses batch jobs without dispatching', async () => {
+    const subagentManager = makeManagerSpy();
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+        isParallelSubagentsEnabled: () => false,
+      }),
+    );
+
+    const toolResult = await tool.execute({
+      jobs: [{ prompt: 'Developer analysis', subagent_type: 'Explore' }],
+    });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).not.toHaveBeenCalled();
+    expect(result['error']).toContain('Parallel subagents are disabled');
+  });
+
+  it('TC-04: gate enabled → dispatch proceeds normally', async () => {
+    const subagentManager = makeManagerSpy();
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+        isParallelSubagentsEnabled: () => true,
+      }),
+    );
+
+    const toolResult = await tool.execute({ prompt: 'Gate task', subagent_type: 'Explore' });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).toHaveBeenCalledTimes(1);
+    expect(subagentManager.wait).toHaveBeenCalledWith('agent_gate_1');
+    expect(result['success']).toBe(true);
+    expect(result['output']).toBe('gate output');
+  });
+
+  it('TC-04b: no gate predicate → dispatch proceeds (default behavior unchanged)', async () => {
+    const subagentManager = makeManagerSpy();
+    const tool = createAgentTool(
+      makeDeps({
+        cwd: '/workspace',
+        parentSessionId: 'session_parent',
+        subagentManager,
+        // isParallelSubagentsEnabled intentionally omitted
+      }),
+    );
+
+    const toolResult = await tool.execute({ prompt: 'Gate task', subagent_type: 'Explore' });
+    const result = parseToolResult(toolResult);
+
+    expect(subagentManager.spawn).toHaveBeenCalledTimes(1);
+    expect(result['success']).toBe(true);
+  });
 });

--- a/packages/agent-framework/src/tools/agent-tool-output.ts
+++ b/packages/agent-framework/src/tools/agent-tool-output.ts
@@ -18,6 +18,28 @@ export function stringifyUnknownAgentType(agentType: string): string {
   });
 }
 
+/**
+ * PRESET-016 — terminal result returned when the runtime gate refuses subagent dispatch.
+ * No job is started, so all counts are zero and `success` is false.
+ */
+export function stringifyParallelSubagentsDisabled(): string {
+  return JSON.stringify({
+    success: false,
+    mode: 'single',
+    requestedJobCount: 0,
+    startedJobCount: 0,
+    failedJobCount: 0,
+    output: '',
+    error: 'Parallel subagents are disabled for the active preset.',
+    provenance: {
+      source: 'agent-tool-single',
+      requestedJobCount: 0,
+      startedJobCount: 0,
+      failedJobCount: 0,
+    },
+  });
+}
+
 export function stringifyAgentSuccess(result: ISubagentJobResult): string {
   const worktreePath = result.metadata?.['worktreePath'];
   const branchName = result.metadata?.['branchName'];

--- a/packages/agent-framework/src/tools/agent-tool.ts
+++ b/packages/agent-framework/src/tools/agent-tool.ts
@@ -19,6 +19,7 @@ import { runManagedAgentBatch } from './agent-tool-batch.js';
 import {
   stringifyAgentError,
   stringifyAgentSuccess,
+  stringifyParallelSubagentsDisabled,
   stringifyUnknownAgentType,
 } from './agent-tool-output.js';
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
@@ -126,6 +127,8 @@ export interface IAgentToolDeps extends IInProcessSubagentRunnerDeps {
   customAgentRegistry?: (name: string) => IAgentDefinition | undefined;
   /** Model-visible and command-visible agent definitions available to this session. */
   agentDefinitions?: IAgentDefinition[];
+  /** PRESET-016 — runtime gate; when present and returns false, subagent dispatch is refused. */
+  isParallelSubagentsEnabled?: () => boolean;
 }
 
 /**
@@ -246,6 +249,11 @@ export function createAgentTool(deps: IAgentToolDeps): ReturnType<typeof createZ
     async (params, context) => {
       const args = params as TAgentArgs;
       const toolCallId = (context as IToolExecutionContext | undefined)?.executionId;
+      // PRESET-016 runtime gate: refuse dispatch without spawning anything when the active preset
+      // has disabled parallel subagents on this (already-constructed) session.
+      if (deps.isParallelSubagentsEnabled !== undefined && !deps.isParallelSubagentsEnabled()) {
+        return stringifyParallelSubagentsDisabled();
+      }
       if (Array.isArray(args.jobs) && args.jobs.length > 0) {
         return runManagedAgentBatch({
           jobs: args.jobs as TAgentJobArgs[],

--- a/packages/agent-session/src/__tests__/parallel-subagents-gate.test.ts
+++ b/packages/agent-session/src/__tests__/parallel-subagents-gate.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the PRESET-016 parallel-subagents runtime gate on Session.
+ *
+ * The flag is pure runtime state: it is initialized from
+ * ISessionOptions.enableParallelSubagents (default true = current behavior) and can be mutated via
+ * setParallelSubagentsEnabled without re-applying any other preset options. The agent-tool dispatch
+ * gate consults this flag at dispatch time (covered in agent-framework tests).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Session } from '../session.js';
+
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue('mock response'),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+      getFullHistory: vi.fn().mockReturnValue([]),
+      addHistoryEntry: vi.fn(),
+    })),
+  };
+});
+
+const MOCK_PROVIDER = {
+  name: 'mock-provider',
+  version: '1.0.0',
+  chat: vi.fn().mockResolvedValue({
+    role: 'assistant',
+    content: 'mock',
+    timestamp: new Date(),
+  }),
+  supportsTools: () => true,
+  validateConfig: () => true,
+};
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: () => ({ stop: vi.fn(), update: vi.fn() }),
+};
+
+describe('Session parallel-subagents gate (PRESET-016)', () => {
+  it('TC-01: initializes parallelSubagentsEnabled from options; defaults to true', () => {
+    const disabled = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+      enableParallelSubagents: false,
+    });
+    expect(disabled.getParallelSubagentsEnabled()).toBe(false);
+
+    const defaulted = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+    });
+    expect(defaulted.getParallelSubagentsEnabled()).toBe(true);
+  });
+
+  it('TC-02: setParallelSubagentsEnabled(false) flips the live flag', () => {
+    const session = new Session({
+      tools: [],
+      provider: MOCK_PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL as never,
+    });
+
+    expect(session.getParallelSubagentsEnabled()).toBe(true);
+    session.setParallelSubagentsEnabled(false);
+    expect(session.getParallelSubagentsEnabled()).toBe(false);
+    session.setParallelSubagentsEnabled(true);
+    expect(session.getParallelSubagentsEnabled()).toBe(true);
+  });
+});

--- a/packages/agent-session/src/session-base.ts
+++ b/packages/agent-session/src/session-base.ts
@@ -17,6 +17,7 @@ export abstract class SessionBase {
   protected abstract readonly contextTracker: ContextWindowTracker;
   protected abstract permissionMode: TPermissionMode;
   protected abstract activePresetId: string;
+  protected abstract parallelSubagentsEnabled: boolean;
   protected abstract readonly sessionId: string;
   protected abstract readonly aiProvider: IAIProvider;
   protected abstract readonly toolSchemas: IToolSchema[];
@@ -46,6 +47,16 @@ export abstract class SessionBase {
    */
   setActivePresetId(id: string): void {
     this.activePresetId = id;
+  }
+
+  /** Whether subagent dispatch is currently allowed for this session (PRESET-016 runtime gate). */
+  getParallelSubagentsEnabled(): boolean {
+    return this.parallelSubagentsEnabled;
+  }
+
+  /** Toggle subagent dispatch live. Only effective if the agent runtime was built at assembly. */
+  setParallelSubagentsEnabled(enabled: boolean): void {
+    this.parallelSubagentsEnabled = enabled;
   }
 
   getSessionId(): string {

--- a/packages/agent-session/src/session-types.ts
+++ b/packages/agent-session/src/session-types.ts
@@ -56,6 +56,11 @@ export interface ISessionOptions {
   defaultTrustLevel?: 'safe' | 'moderate' | 'full';
   /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
   activePresetId?: string;
+  /**
+   * Whether subagent dispatch is allowed for this session (PRESET-016 runtime gate). Defaults to
+   * true (current behavior). Only meaningful when the agent runtime was built at assembly.
+   */
+  enableParallelSubagents?: boolean;
   /** Model name (for context window sizing and Robota config) */
   model?: string;
   /** Provider idle timeout in milliseconds for each model call */

--- a/packages/agent-session/src/session.ts
+++ b/packages/agent-session/src/session.ts
@@ -63,6 +63,7 @@ export class Session extends SessionBase {
   protected readonly contextTracker: ContextWindowTracker;
   protected permissionMode: TPermissionMode;
   protected activePresetId: string;
+  protected parallelSubagentsEnabled: boolean;
   protected readonly sessionId: string;
   protected aiProvider: IAIProvider;
   protected readonly toolSchemas: IToolSchema[];
@@ -116,6 +117,9 @@ export class Session extends SessionBase {
       (options.defaultTrustLevel ? TRUST_TO_MODE[options.defaultTrustLevel] : undefined) ??
       'default';
     this.activePresetId = options.activePresetId ?? 'default';
+    // PRESET-016: default true preserves the current behavior — subagent dispatch is allowed
+    // unless a preset explicitly disables it.
+    this.parallelSubagentsEnabled = options.enableParallelSubagents ?? true;
     this.transcriptPath = options.sessionStore?.getFilePath?.(this.sessionId);
     this.log('session_init', {
       cwd: this.cwd,


### PR DESCRIPTION
## Summary
Second piece of the split epic (015 modules ✓, **016 parallel**, 017 selfVerification next).

Runtime GATE for `enableParallelSubagents` — **not** always-construct (which would regress every session's resource cost):
- `SessionBase`: mutable `parallelSubagentsEnabled` (default `true` = current behavior) + get/set; `ISessionOptions.enableParallelSubagents`.
- `agent-tool`: `IAgentToolDeps.isParallelSubagentsEnabled` predicate; the executor refuses dispatch (returns a JSON disabled result via `stringifyParallelSubagentsDisabled`, no throw) when it returns false. `wireSessionDeps` binds the predicate to the session flag.
- `ICommandSessionRuntime.setParallelSubagentsEnabled?` seam; `applyPresetToSession` re-applies the group.

The gate only matters when the agent runtime was built at assembly; sessions started without it can't live-enable parallel (documented). Default-enabled + no-op when the predicate is unset → **zero regression**.

## Verification
- agent-session + agent-framework build ✓ · test ✓ (session 71, framework 960) · `pnpm typecheck` ✓ · `pnpm harness:scan` ✓ (25/25)
- no package.json/lockfile change

Spec `PRESET-016` → done with full gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)