### PR TITLE
feat(framework): selfVerification system-prompt section (PRESET-017)

### DIFF
--- a/.agents/spec-docs/done/PRESET-017-self-verification-section.md
+++ b/.agents/spec-docs/done/PRESET-017-self-verification-section.md
@@ -1,0 +1,177 @@
+---
+status: done
+type: FLOW
+tags: [cli]
+---
+
+# PRESET-017: selfVerification 시스템 프롬프트 자기검증 섹션 (라이브 적용)
+
+## Problem
+
+프리셋의 `selfVerification` 플래그는 타입으로만 존재하고 **어디서도 소비되지 않는다**(미구현 기능).
+페르소나 텍스트의 자기검증 지시(PRESET-005/009)는 이미 동작하지만, `selfVerification` **메커니즘**은
+아무 동작이 없다 → 전환 시 재적용할 대상도 없다.
+
+**결정(사용자 승인):** `selfVerification=true`일 때 framework가 시스템 프롬프트에 간결한 "완료 전 도구
+결과로 검증" **섹션을 주입**한다 — persona와 **동일한 priority/source 섹션 메커니즘**(하드코딩 슬롯
+아님, 우선순위 정렬로 위치 결정). 그리고 persona(PRESET-014)와 동일하게 **라이브 재적용** 가능하게 한다.
+
+**재현 조건:** `rg -n "self-verification|createSelfVerificationSection|applySelfVerification" packages/` → 0건.
+`TSystemPromptSectionSource`에 자기검증 source 없음. `selfVerification`은 `buildSystemPrompt`에서 미사용.
+
+**범위(설계 §7.1):** 시스템 프롬프트 자기검증 섹션 + 라이브 적용. 결정적 검증 루프(lint/test 실행 등)는
+본 백로그가 아니다(별도 기능 — 채택 시 추후 설계).
+
+설계 근거: [.design/preset-layer/2026-06-14/design-proposal.md](../../../.design/preset-layer/2026-06-14/design-proposal.md) §5.4, §7.1 (PRESET-017).
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-framework/src/context/system-prompt-types.ts` — `TSystemPromptSectionSource`에 `'self-verification'` 추가
+- `packages/agent-framework/src/context/system-prompt-section-providers.ts` — `createSelfVerificationSection()`(고정 영어 콘텐츠, source `'self-verification'`, priority 6 = persona(5) 직후·AGENTS.md(10) 이전)
+- `packages/agent-framework/src/context/system-prompt-builder.ts` — `ISystemPromptParams.selfVerification?: boolean`; true·non-undefined일 때 섹션 합성
+- `packages/agent-framework/src/assembly/create-session-runtime.ts` — 클로저에 mutable `currentSelfVerification`(persona와 동형) + `rebuildSystemMessage` overrides에 `selfVerification?` 추가; per-build로 buildPrompt에 전달
+- `packages/agent-framework/src/interactive/interactive-session.ts` — `applySelfVerification(enabled)`(재합성 → `updateSystemMessage`, applyPersona와 동형)
+- `packages/agent-framework/src/command-api/host-context.ts` — `ICommandHostContext.applySelfVerification?(enabled)`
+- `packages/agent-framework/src/command-api/preset/preset-application.ts` — `IPresetApplicationOptions.selfVerification?` + 오케스트레이터 재적용
+- (배선) `selfVerification`이 `ICreateSessionOptions` → `buildSystemPrompt` params까지 도달하도록 확인/연결
+
+### Alternatives Considered
+
+1. **하드코딩 슬롯으로 자기검증 문구를 시스템 프롬프트 특정 위치에 삽입.**
+   - Pro: 단순.
+   - Con: 공정·보편 타이밍 주입 원칙 위반(하드코딩 금지) — persona가 이미 priority/source 메커니즘 사용. Rejected.
+2. **persona와 동일한 priority/source 섹션 메커니즘으로 자기검증 섹션 합성 + 라이브 재적용(PRESET-014 동형).**
+   - Pro: 공정·보편 주입(정렬로 위치 결정); persona 재합성 seam 재사용으로 라이브 토글; 기본(미설정) 무회귀.
+   - Con: source enum + 섹션 provider + 클로저 mutable 1개 추가.
+
+### Decision
+
+**Alternative 2.** `selfVerification=true`이면 `createSelfVerificationSection()`을 `composeSystemPrompt`가
+priority 6으로 정렬해 합성한다(하드코딩 슬롯 아님). create-session-runtime 클로저가 mutable
+`currentSelfVerification`을 추적해(persona와 동형) 라이브 토글 시 재합성+`updateSystemMessage`로 반영하고,
+이후 staleness 재합성에서도 최신 값을 유지. `ICommandHostContext.applySelfVerification?`로 노출하고
+오케스트레이터가 재적용. 기본(미설정/false)은 섹션 없음 → 무회귀. 트레이드오프: source/섹션/클로저 추가
+비용을 감수하고, 공정한 주입 메커니즘 + 라이브 토글 + persona와 일관된 구조를 얻는다.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-framework(context 합성/런타임 클로저/host seam/오케스트레이터)
+- [x] Sibling scan 완료 — `createPersonaSection`(priority/source 섹션) + PRESET-014 `applyPersona`/`rebuildSystemMessage` mutable 패턴 확인 후 동형 적용
+- [x] 대안 최소 2개 검토 완료 — 2개(하드코딩 슬롯 / priority-source 섹션)
+- [x] 결정 근거 문서화 완료 — 공정 주입 메커니즘 + persona 동형 재사용 + 무회귀 근거 기록
+
+#### 자기검증 섹션 콘텐츠 제약 (persona 저자 규칙 준용)
+
+- 영어, 간결. "CRITICAL"/"MUST" 누적 금지, "show your reasoning" 류 지시 금지.
+- 내용: 완료를 보고하기 전 이번 세션의 **도구 실행 결과로** 작업을 검증하고, 검증되지 않은 것은 그렇게 말하라.
+
+## Solution
+
+1. `TSystemPromptSectionSource`에 `'self-verification'`.
+2. `createSelfVerificationSection()`: `createSection('preset-self-verification', undefined, 6, <영어 콘텐츠>, 'self-verification')`.
+3. `ISystemPromptParams.selfVerification?: boolean`; `buildSystemPrompt`이 true일 때 섹션 append(`appendOptionalSection` 패턴).
+4. create-session-runtime: `let currentSelfVerification = options.selfVerification`; `rebuildSystemMessage(agents, claude, overrides?: { persona?; selfVerification? })` — `overrides.selfVerification !== undefined`면 `currentSelfVerification` 갱신; per-build로 `selfVerification: currentSelfVerification` 전달.
+5. interactive-session: `applySelfVerification(enabled)` — 재합성(`{ selfVerification: enabled }`) → `updateSystemMessage`.
+6. `ICommandHostContext.applySelfVerification?(enabled)`; orchestrator: 있으면 `context.applySelfVerification?.(value)` + applied 기록.
+7. `selfVerification`이 `ICreateSessionOptions` → buildSystemPrompt params까지 도달하도록 배선 확인/연결.
+
+## Affected Files
+
+- `packages/agent-framework/src/context/system-prompt-types.ts`
+- `packages/agent-framework/src/context/system-prompt-section-providers.ts`
+- `packages/agent-framework/src/context/system-prompt-builder.ts`
+- `packages/agent-framework/src/assembly/create-session-runtime.ts`
+- `packages/agent-framework/src/interactive/interactive-session.ts`
+- `packages/agent-framework/src/command-api/host-context.ts`
+- `packages/agent-framework/src/command-api/preset/preset-application.ts`
+- `packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts`
+- `packages/agent-framework/src/context/__tests__/` (섹션/빌더 테스트)
+
+## Completion Criteria
+
+- [x] TC-01: `buildSystemPrompt({ ...params, selfVerification: true })` 결과에 자기검증 섹션 문구(예: "verify"/"tool result" 어구)가 포함되고, `selfVerification: false`/미지정 시 포함되지 않음을 단언하는 단위 테스트 통과
+- [x] TC-02: `createSelfVerificationSection()`의 `source === 'self-verification'`, `priority === 6`, content 비어있지 않음을 단언하는 단위 테스트 통과
+- [x] TC-03: `rebuildSystemMessage(a, c, { selfVerification: true })` 결과에 섹션 포함; 이후 override 없이 `rebuildSystemMessage(a2, c2)` 호출해도 섹션 유지(mutable 지속)를 단언하는 단위 테스트 통과
+- [x] TC-04: `applyPresetToSession(ctx, id, { selfVerification: true })` 호출 시 `ctx.applySelfVerification`가 `true`로 호출되고 `applied`에 `'selfVerification'` 포함을 단언하는 단위 테스트 통과(spy)
+- [x] TC-05: `selfVerification` 미지정 시 `applySelfVerification` 미호출 + `skipped` 포함, 미구현 컨텍스트에서 예외 없음을 단언하는 단위 테스트 통과
+- [x] TC-06: `createSelfVerificationSection().content`에 `rg -i "CRITICAL|MUST|show your reasoning"` 0건(자기검증 콘텐츠 저자 규칙) + Hangul 0건을 단언하는 커맨드폼/단위 테스트 통과
+- [x] TC-07: `pnpm --filter @robota-sdk/agent-framework build` + `test` + `pnpm typecheck` → exit 0 (무회귀); `harness:scan` 통과
+
+## Test Plan
+
+Type FLOW + tags cli → 섹션 provider(source/priority/콘텐츠 규칙) + 빌더(true 시 포함/false 시 미포함) +
+런타임 클로저(override 반영/지속) + 오케스트레이터(적용/건너뜀/optional 안전) + 빌드/테스트/타입체크/스캔.
+
+| TC-ID | Test Type              | Tool / Approach                                             | Notes    |
+| ----- | ---------------------- | ----------------------------------------------------------- | -------- |
+| TC-01 | RULE (unit)            | vitest — buildSystemPrompt 섹션 포함/미포함 단언            |          |
+| TC-02 | RULE (unit)            | vitest — createSelfVerificationSection source/priority 단언 |          |
+| TC-03 | RULE (unit)            | vitest — rebuild override 반영 + 지속 단언                  |          |
+| TC-04 | RULE (unit)            | vitest — applyPresetToSession 재적용 + applied 단언         |          |
+| TC-05 | RULE (unit)            | vitest — 미지정 skipped + optional 안전 단언                |          |
+| TC-06 | CI pipeline smoke test | `rg -i` CRITICAL/MUST/reasoning + Hangul 부재 단언          | 커맨드폼 |
+| TC-07 | CI pipeline smoke test | `pnpm build` + `test` + `typecheck` + `harness:scan`        | 커맨드폼 |
+
+## User Execution Test Scenarios
+
+- **시나리오 — 전환 시 자기검증 섹션 토글(006 경로):** 전제: PRESET-011 완료. 실행: `selfVerification:true`
+  프리셋으로 `/preset` 전환. 기대: 시스템 프롬프트에 자기검증 섹션이 라이브로 추가됨(이후 호출 반영);
+  `false` 프리셋으로 되돌리면 섹션 제거. 본 백로그 단독으로는 빌더/재합성/오케스트레이터 단위 테스트로 검증.
+  정리: 없음. Evidence: 재합성 문자열 단언 + applySelfVerification spy(구현 후 기록).
+
+환경: PRESET-011 선행.
+
+## Tasks
+
+- [x] [.agents/tasks/PRESET-017.md](../../tasks/PRESET-017.md) — task breakdown (TC-01..TC-07)
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter present (`status`, `type: FLOW`, `tags: [cli]`). Problem states the symptom (`selfVerification`
+consumed nowhere; `rg` → 0), records the user-approved decision (system-prompt self-verification section
+via the persona-style priority/source mechanism), and scopes out the deterministic verification loop.
+Architecture Review: 4 checklist items `[x]`; Sibling scan cites `createPersonaSection` + PRESET-014
+`applyPersona`/`rebuildSystemMessage` mutable pattern; 2 Alternatives with Pro/Con; Decision records the
+fair-injection mechanism + no-regression default + persona-author content rules. Completion Criteria
+TC-01..TC-07 command-form/observable; Test Plan rows match TC set 1:1.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** review-ready → approved
+Explicit user approval (verbatim): the AskUserQuestion answer "시스템 프롬프트 자기검증 섹션 (추천)" —
+directly chooses the system-prompt section approach for `selfVerification` over the seam-only and
+deterministic-loop alternatives, on top of the standing "나머지도 다 진행해" directive. No post-approval
+drift: implementation not started at approval time.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/PRESET-017.md` created and linked. One task per Completion Criterion
+(TC-01..TC-07) plus source/provider/builder/runtime/orchestrator tasks. Test Plan present (≥50 chars).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-framework build` → exit 0. `pnpm --filter
+@robota-sdk/agent-framework test` → exit 0, 99 files / 970 (incl. new builder/section/runtime +
+orchestrator cases), no regressions. `pnpm typecheck` → exit 0 (monorepo). `pnpm harness:scan` → exit 0,
+25/25. No package.json/lockfile change.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] framework vitest (`system-prompt-builder.test.ts`) — `selfVerification:true` → output contains the verify/tool-results section; false/omitted → absent.
+- [GATE-COMPLETE: TC-02] vitest — `createSelfVerificationSection()` → `source==='self-verification'`, `priority===6`, non-empty content.
+- [GATE-COMPLETE: TC-03] vitest (`rebuild-system-message-persona.test.ts`) — `rebuildSystemMessage(a,c,{selfVerification:true})` includes the section; a later override-less rebuild keeps it (mutable persistence).
+- [GATE-COMPLETE: TC-04] framework vitest (`preset-application.test.ts`) — `applyPresetToSession({selfVerification:true})` → `applySelfVerification(true)` + `applied` contains 'selfVerification'.
+- [GATE-COMPLETE: TC-05] vitest — omitted → not called, in `skipped`; context without `applySelfVerification` → no throw.
+- [GATE-COMPLETE: TC-06] `rg -i "CRITICAL|MUST|show your reasoning"` on the section provider → no match in the self-verification content; `rg -P "\p{Hangul}"` → exit 1 (English-only). Asserted in TC-06 unit + command-form.
+- [GATE-COMPLETE: TC-07] framework build + test + `pnpm typecheck` + `pnpm harness:scan` all exit 0.
+- Mechanism note: the section is composed by `composeSystemPrompt`'s priority sort (priority 6, between persona=5 and AGENTS.md=10), NOT a hardcoded slot — the fair/universal injection the user required. Live toggling mirrors PRESET-014 persona (mutable closure + `updateSystemMessage`). Default (unset/false) adds no section → no regression. The deterministic verification loop (running lint/tests) is explicitly out of scope (separate feature).

--- a/.agents/tasks/PRESET-017.md
+++ b/.agents/tasks/PRESET-017.md
@@ -1,0 +1,28 @@
+# PRESET-017: selfVerification 시스템 프롬프트 자기검증 섹션 — Task Breakdown
+
+Spec: `.agents/spec-docs/done/PRESET-017-self-verification-section.md`
+
+## Plan
+
+- [x] TC-01: `buildSystemPrompt({selfVerification:true})` includes the section; false/omitted → absent
+- [x] TC-02: `createSelfVerificationSection()` → source 'self-verification', priority 6, non-empty
+- [x] TC-03: `rebuildSystemMessage(a,c,{selfVerification:true})` includes it; later override-less rebuild persists it
+- [x] TC-04: `applyPresetToSession(..., {selfVerification:true})` → `applySelfVerification(true)` + applied
+- [x] TC-05: omitted → not called + in skipped; context without method → no throw
+- [x] TC-06: section content has no CRITICAL/MUST/show-your-reasoning + no Hangul
+- [x] TC-07: framework build + test + typecheck + harness:scan pass
+- [x] source enum + section provider (priority 6, English content)
+- [x] builder composes section when true; runtime closure mutable currentSelfVerification (PRESET-014 mirror)
+- [x] InteractiveSession.applySelfVerification + host seam + orchestrator group
+
+## Test Plan
+
+selfVerification becomes a system-prompt section composed by the SAME priority/source mechanism as
+persona (priority 6, source 'self-verification' — sorted by `composeSystemPrompt`, not hardcoded),
+included only when the flag is true. The create-session-runtime closure tracks a mutable
+`currentSelfVerification` (mirroring PRESET-014 persona) so a live switch recomposes + persists; exposed
+via `ICommandHostContext.applySelfVerification?` and re-applied by `applyPresetToSession`. The section
+content is concise English (verify against tool results before reporting done), with no CRITICAL/MUST/
+reasoning-echo and no Hangul. Verified by builder/section/runtime unit tests, orchestrator spy tests, a
+content-constraint assertion, and build/test/typecheck/scan smoke. Default (unset/false) adds no section
+→ no regression. The deterministic verification loop (running lint/tests) remains a separate feature.

--- a/packages/agent-framework/src/__tests__/system-prompt-builder.test.ts
+++ b/packages/agent-framework/src/__tests__/system-prompt-builder.test.ts
@@ -2,7 +2,10 @@ import type { TPermissionMode } from '@robota-sdk/agent-core';
 import { describe, it, expect } from 'vitest';
 
 import { buildSystemPrompt } from '../context/system-prompt-builder.js';
-import { createPersonaSection } from '../context/system-prompt-section-providers.js';
+import {
+  createPersonaSection,
+  createSelfVerificationSection,
+} from '../context/system-prompt-section-providers.js';
 
 import type { ISystemPromptParams } from '../context/system-prompt-builder.js';
 
@@ -196,6 +199,42 @@ describe('buildSystemPrompt', () => {
       expect(withEmpty).toBe(withoutField);
       expect(withBlank).toBe(withoutField);
       expect(withoutField).not.toContain('PERSONA_MARK');
+    });
+  });
+
+  describe('PRESET-017 self-verification section', () => {
+    it('TC-01: selfVerification:true injects a verify-before-done directive into the prompt', () => {
+      const result = buildSystemPrompt({ ...BASE_PARAMS, selfVerification: true });
+      expect(result).toMatch(/verify/i);
+      expect(result).toMatch(/tool results?/i);
+    });
+
+    it('TC-01: selfVerification false/omitted produces no self-verification section', () => {
+      const omitted = buildSystemPrompt({ ...BASE_PARAMS });
+      const disabled = buildSystemPrompt({ ...BASE_PARAMS, selfVerification: false });
+      const sectionContent = createSelfVerificationSection().content;
+      expect(omitted).not.toContain(sectionContent);
+      expect(disabled).not.toContain(sectionContent);
+      expect(disabled).toBe(omitted);
+    });
+
+    it('TC-02: createSelfVerificationSection has source "self-verification", priority 6, non-empty content', () => {
+      const section = createSelfVerificationSection();
+      expect(section.source).toBe('self-verification');
+      expect(section.priority).toBe(6);
+      expect(section.content.trim().length).toBeGreaterThan(0);
+    });
+
+    it('TC-02: section priority 6 sorts after persona (5) and before AGENTS.md (10)', () => {
+      const section = createSelfVerificationSection();
+      expect(section.priority).toBeGreaterThan(createPersonaSection('x').priority);
+      expect(section.priority).toBeLessThan(10);
+    });
+
+    it('TC-06: section content avoids heavy emphasis cues and contains no Hangul', () => {
+      const { content } = createSelfVerificationSection();
+      expect(content).not.toMatch(/CRITICAL|MUST|show your reasoning/i);
+      expect(content).not.toMatch(/\p{Script=Hangul}/u);
     });
   });
 

--- a/packages/agent-framework/src/assembly/__tests__/rebuild-system-message-persona.test.ts
+++ b/packages/agent-framework/src/assembly/__tests__/rebuild-system-message-persona.test.ts
@@ -27,6 +27,11 @@ function personaOnlyBuilder(params: ISystemPromptParams): string {
   return `PROMPT[persona=${params.persona ?? '<none>'}]`;
 }
 
+/** A stub prompt builder that surfaces the selfVerification flag, so tests assert on it. */
+function selfVerificationOnlyBuilder(params: ISystemPromptParams): string {
+  return `PROMPT[selfVerification=${params.selfVerification ?? '<none>'}]`;
+}
+
 function makeOptions(persona?: string): ICreateSessionOptions {
   return {
     config: {
@@ -40,6 +45,40 @@ function makeOptions(persona?: string): ICreateSessionOptions {
     systemPromptBuilder: personaOnlyBuilder,
     ...(persona !== undefined ? { persona } : {}),
   };
+}
+
+function makeSelfVerificationOptions(selfVerification?: boolean): ICreateSessionOptions {
+  return {
+    config: {
+      defaultTrustLevel: 'safe',
+      provider: { name: 'test', model: 'test-model', apiKey: undefined },
+      permissions: { allow: [], deny: [] },
+      env: {},
+    },
+    context: { agentsMd: 'A0', claudeMd: 'C0' },
+    terminal: NOOP_TERMINAL,
+    systemPromptBuilder: selfVerificationOnlyBuilder,
+    ...(selfVerification !== undefined ? { selfVerification } : {}),
+  };
+}
+
+function buildSelfVerificationRebuilder(
+  selfVerification?: boolean,
+): (
+  agentsMd: string,
+  claudeMd: string,
+  overrides?: { persona?: string; selfVerification?: boolean },
+) => string {
+  const { rebuildSystemMessage } = buildSessionSystemPrompt(
+    makeSelfVerificationOptions(selfVerification),
+    '/workspace',
+    [],
+    undefined,
+    undefined,
+    [],
+    [],
+  );
+  return rebuildSystemMessage;
 }
 
 function buildRebuilder(
@@ -71,5 +110,21 @@ describe('rebuildSystemMessage persona override (PRESET-014)', () => {
     // Staleness refresh passes no override — the latest persona must persist.
     const result = rebuild('A2', 'C2');
     expect(result).toContain('NEW_PERSONA_X');
+  });
+});
+
+describe('rebuildSystemMessage selfVerification override (PRESET-017)', () => {
+  it('TC-03: a selfVerification override is reflected in the rebuilt system message', () => {
+    const rebuild = buildSelfVerificationRebuilder();
+    const result = rebuild('A1', 'C1', { selfVerification: true });
+    expect(result).toContain('selfVerification=true');
+  });
+
+  it('TC-03: a later override-less rebuild retains the previously overridden flag', () => {
+    const rebuild = buildSelfVerificationRebuilder(false);
+    rebuild('A1', 'C1', { selfVerification: true });
+    // Staleness refresh passes no override — the latest flag must persist.
+    const result = rebuild('A2', 'C2');
+    expect(result).toContain('selfVerification=true');
   });
 });

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -127,14 +127,14 @@ export interface ISystemPromptResult {
   rebuildSystemMessage: (
     agentsMd: string,
     claudeMd: string,
-    overrides?: { persona?: string },
+    overrides?: { persona?: string; selfVerification?: boolean },
   ) => string;
 }
 
 /**
- * Build the persona-free static system-prompt params shared by the initial build and every
- * rebuild. Persona is composed separately per-build (PRESET-014) so the mutable persona always
- * takes precedence over these static params.
+ * Build the static system-prompt params shared by the initial build and every rebuild. Persona
+ * (PRESET-014) and selfVerification (PRESET-017) are composed separately per-build so their mutable
+ * closure values always take precedence over these static params.
  */
 function buildStaticPromptParams(
   options: ICreateSessionOptions,
@@ -146,7 +146,7 @@ function buildStaticPromptParams(
     disableModelInvocation?: boolean;
   }>,
   agentDefinitions: IAgentDefinition[],
-): Omit<ISystemPromptParams, 'persona'> {
+): Omit<ISystemPromptParams, 'persona' | 'selfVerification'> {
   return {
     agentsMd: options.context.agentsMd,
     claudeMd: options.context.claudeMd,
@@ -213,8 +213,14 @@ export function buildSessionSystemPrompt(
   // staleness rebuilds (no override) must keep the most recently applied persona.
   let currentPersona = options.persona;
 
-  // Persona is composed per-build (initial + each rebuild) so the mutable persona always wins;
-  // it is therefore excluded from these static (persona-free) params.
+  // PRESET-017: selfVerification is mutable for the lifetime of this closure, mirroring persona. A
+  // live preset switch can toggle the verify-before-done section mid-session (via
+  // `rebuildSystemMessage(..., { selfVerification })`); later staleness rebuilds (no override) must
+  // keep the most recently applied value.
+  let currentSelfVerification = options.selfVerification;
+
+  // Persona/selfVerification are composed per-build (initial + each rebuild) so the mutable closure
+  // values always win; they are therefore excluded from these static params.
   const staticPromptParams = buildStaticPromptParams(
     options,
     cwd,
@@ -225,6 +231,7 @@ export function buildSessionSystemPrompt(
   const systemMessage = buildPrompt({
     ...staticPromptParams,
     ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
+    ...(currentSelfVerification !== undefined ? { selfVerification: currentSelfVerification } : {}),
   });
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`
@@ -233,16 +240,24 @@ export function buildSessionSystemPrompt(
   const rebuildSystemMessage = (
     newAgentsMd: string,
     newClaudeMd: string,
-    overrides?: { persona?: string },
+    overrides?: { persona?: string; selfVerification?: boolean },
   ): string => {
     // PRESET-014: a persona override mutates the retained persona so subsequent rebuilds
     // (e.g. staleness refresh, which passes no override) keep the latest applied persona.
     if (overrides?.persona !== undefined) {
       currentPersona = overrides.persona;
     }
+    // PRESET-017: a selfVerification override mutates the retained flag the same way, so later
+    // override-less rebuilds keep the latest applied value.
+    if (overrides?.selfVerification !== undefined) {
+      currentSelfVerification = overrides.selfVerification;
+    }
     const rebuilt = buildPrompt({
       ...staticPromptParams,
       ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
+      ...(currentSelfVerification !== undefined
+        ? { selfVerification: currentSelfVerification }
+        : {}),
       agentsMd: newAgentsMd,
       claudeMd: newClaudeMd,
     });

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -86,8 +86,9 @@ export interface ICreateSessionOptions {
    */
   enableParallelSubagents?: boolean;
   /**
-   * Preset execution capability: when true the agent runs a post-task self-verification
-   * step. Threaded onto the assembly options so executor/framework can consume it.
+   * Preset execution capability: when true the framework composes a verify-before-done
+   * self-verification section into the system prompt (PRESET-017), as a normal
+   * priority-sorted `source: 'self-verification'` section.
    */
   selfVerification?: boolean;
   /** Callback when a tool starts or finishes execution — enables real-time tool display in UI */
@@ -166,11 +167,12 @@ export interface ICreateSessionResult {
    * Rebuild the system message using updated context strings.
    * Called by staleness detection when AGENTS.md or CLAUDE.md files change between turns.
    * PRESET-014: an optional `overrides.persona` re-applies a preset persona to the live prompt;
-   * the override is retained for subsequent (override-less) rebuilds.
+   * PRESET-017: an optional `overrides.selfVerification` toggles the verify-before-done section.
+   * Either override is retained for subsequent (override-less) rebuilds.
    */
   rebuildSystemMessage: (
     agentsMd: string,
     claudeMd: string,
-    overrides?: { persona?: string },
+    overrides?: { persona?: string; selfVerification?: boolean },
   ) => string;
 }

--- a/packages/agent-framework/src/command-api/host-context.ts
+++ b/packages/agent-framework/src/command-api/host-context.ts
@@ -106,6 +106,8 @@ export interface ICommandHostContext {
   getSession(): ICommandSessionRuntime;
   /** PRESET-014 — re-apply a preset persona to the live system prompt. */
   applyPersona?(persona: string): void;
+  /** PRESET-017 — toggle the verify-before-done self-verification section on the live prompt. */
+  applySelfVerification?(enabled: boolean): void;
   /** PRESET-015 — re-apply command-module selection to the live session. */
   applyCommandModuleSelection?(
     enabled: readonly string[] | undefined,

--- a/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
+++ b/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
@@ -19,6 +19,7 @@ interface IRuntimeSpies {
   applyPersona?: ReturnType<typeof vi.fn>;
   applyCommandModuleSelection?: ReturnType<typeof vi.fn>;
   setParallelSubagentsEnabled?: ReturnType<typeof vi.fn>;
+  applySelfVerification?: ReturnType<typeof vi.fn>;
 }
 
 /**
@@ -30,7 +31,8 @@ interface IRuntimeSpies {
  * optional path (TC-05). `includeApplyCommandModuleSelection: false` omits the optional
  * `applyCommandModuleSelection` to exercise the PRESET-015 optional path (TC-06).
  * `includeSetParallelSubagentsEnabled: false` omits the optional `setParallelSubagentsEnabled` to
- * exercise the PRESET-016 optional path (TC-06).
+ * exercise the PRESET-016 optional path (TC-06). `includeApplySelfVerification: false` omits the
+ * optional `applySelfVerification` to exercise the PRESET-017 optional path (TC-05).
  */
 function createContext(
   includeActivePreset = true,
@@ -38,6 +40,7 @@ function createContext(
   includeApplyPersona = true,
   includeApplyCommandModuleSelection = true,
   includeSetParallelSubagentsEnabled = true,
+  includeApplySelfVerification = true,
 ): {
   context: ICommandHostContext;
   spies: IRuntimeSpies;
@@ -111,6 +114,12 @@ function createContext(
     const applyCommandModuleSelection = vi.fn();
     context.applyCommandModuleSelection = applyCommandModuleSelection;
     spies.applyCommandModuleSelection = applyCommandModuleSelection;
+  }
+
+  if (includeApplySelfVerification) {
+    const applySelfVerification = vi.fn();
+    context.applySelfVerification = applySelfVerification;
+    spies.applySelfVerification = applySelfVerification;
   }
 
   return { context, spies };
@@ -271,6 +280,33 @@ describe('applyPresetToSession parallel-subagents gate (PRESET-016)', () => {
     expect(spies.setParallelSubagentsEnabled).toBeUndefined();
     expect(() =>
       applyPresetToSession(context, 'careful-reviewer', { enableParallelSubagents: true }),
+    ).not.toThrow();
+  });
+});
+
+describe('applyPresetToSession self-verification group (PRESET-017)', () => {
+  it('TC-04: selfVerification:true → applySelfVerification(true), applied lists it', () => {
+    const { context, spies } = createContext();
+    const result = applyPresetToSession(context, 'careful-reviewer', { selfVerification: true });
+
+    expect(spies.applySelfVerification).toHaveBeenCalledWith(true);
+    expect(result.applied).toContain('selfVerification');
+  });
+
+  it('TC-05: omitted → not called, group skipped', () => {
+    const { context, spies } = createContext();
+    const result = applyPresetToSession(context, 'x', {});
+
+    expect(spies.applySelfVerification).not.toHaveBeenCalled();
+    expect(result.skipped).toContain('selfVerification');
+    expect(result.applied).not.toContain('selfVerification');
+  });
+
+  it('TC-05: context without applySelfVerification still applies safely (optional chaining)', () => {
+    const { context, spies } = createContext(true, true, true, true, true, false);
+    expect(spies.applySelfVerification).toBeUndefined();
+    expect(() =>
+      applyPresetToSession(context, 'careful-reviewer', { selfVerification: true }),
     ).not.toThrow();
   });
 });

--- a/packages/agent-framework/src/command-api/preset/preset-application.ts
+++ b/packages/agent-framework/src/command-api/preset/preset-application.ts
@@ -29,6 +29,8 @@ export interface IPresetApplicationOptions {
   disabledCommandModules?: readonly string[];
   /** PRESET-016 — runtime gate toggle for subagent dispatch on the live session. */
   enableParallelSubagents?: boolean;
+  /** PRESET-017 — toggle the verify-before-done self-verification section on the live prompt. */
+  selfVerification?: boolean;
 }
 
 /** Outcome of {@link applyPresetToSession}: which option groups were re-applied vs. skipped. */
@@ -50,8 +52,10 @@ export interface IPresetApplicationResult {
  * `applyModelOptions`. PRESET-014 re-applies the `persona` group via the host context's optional
  * `applyPersona` seam. PRESET-015 re-applies the command-module selection group via the host
  * context's optional `applyCommandModuleSelection` seam. PRESET-016 toggles the parallel-subagents
- * runtime gate via the runtime's optional `setParallelSubagentsEnabled` seam. Groups absent from
- * `options` are left untouched and reported under `skipped`.
+ * runtime gate via the runtime's optional `setParallelSubagentsEnabled` seam. PRESET-017 toggles
+ * the verify-before-done self-verification section via the host context's optional
+ * `applySelfVerification` seam. Groups absent from `options` are left untouched and reported under
+ * `skipped`.
  */
 export function applyPresetToSession(
   context: ICommandHostContext,
@@ -116,6 +120,15 @@ export function applyPresetToSession(
     applied.push('enableParallelSubagents');
   } else {
     skipped.push('enableParallelSubagents');
+  }
+
+  // PRESET-017 self-verification group — toggled via the host context's optional
+  // applySelfVerification seam (recomposes the live system prompt).
+  if (options.selfVerification !== undefined) {
+    context.applySelfVerification?.(options.selfVerification);
+    applied.push('selfVerification');
+  } else {
+    skipped.push('selfVerification');
   }
 
   return { applied, skipped };

--- a/packages/agent-framework/src/context/system-prompt-builder.ts
+++ b/packages/agent-framework/src/context/system-prompt-builder.ts
@@ -8,6 +8,7 @@ import {
   createProjectMemorySection,
   createProjectSection,
   createResponseLanguageSection,
+  createSelfVerificationSection,
   createTaskContextSection,
   createToolDescriptionSection,
   createWorkingDirectorySection,
@@ -24,6 +25,11 @@ export interface ISystemPromptParams {
    * composed as a `source: 'persona'` section with priority 5; empty/undefined adds no section.
    */
   persona?: string;
+  /**
+   * PRESET-017: when true, a concise verify-before-done directive is composed as a
+   * `source: 'self-verification'` section with priority 6; false/undefined adds no section.
+   */
+  selfVerification?: boolean;
   /** Concatenated AGENTS.md content (may be empty string) */
   agentsMd: string;
   /** Concatenated CLAUDE.md content (may be empty string) */
@@ -98,6 +104,10 @@ export function buildSystemPrompt(params: ISystemPromptParams): string {
     params.persona !== undefined && params.persona.trim().length > 0
       ? createPersonaSection(params.persona)
       : undefined,
+  );
+  appendOptionalSection(
+    sections,
+    params.selfVerification === true ? createSelfVerificationSection() : undefined,
   );
   appendOptionalSection(sections, createAgentsMdSection(params.agentsMd));
   appendOptionalSection(sections, createClaudeMdSection(params.claudeMd));

--- a/packages/agent-framework/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-framework/src/context/system-prompt-section-providers.ts
@@ -26,6 +26,30 @@ export function createPersonaSection(persona: string): ISystemPromptSection {
   return createSection('preset-persona', undefined, 5, persona, 'persona');
 }
 
+/**
+ * PRESET-017: a concise verify-before-done directive injected when a preset enables
+ * `selfVerification`. The content must stay English, brief, and avoid heavy emphasis cues.
+ */
+const SELF_VERIFICATION_CONTENT =
+  "Before you report a task complete, verify your work against this session's tool " +
+  'results — re-run the relevant checks and confirm the outcome matches what was asked. ' +
+  'If something is not yet verified, say so plainly rather than implying it is done.';
+
+/**
+ * PRESET-017: when a preset enables selfVerification, inject a concise verify-before-done
+ * section as a normal priority-sorted section (priority 6 = just after persona=5, before
+ * AGENTS.md=10), never a hardcoded slot.
+ */
+export function createSelfVerificationSection(): ISystemPromptSection {
+  return createSection(
+    'preset-self-verification',
+    undefined,
+    6,
+    SELF_VERIFICATION_CONTENT,
+    'self-verification',
+  );
+}
+
 export function createWorkingDirectorySection(cwd?: string): ISystemPromptSection | undefined {
   if (!cwd) return undefined;
   return createSection('runtime-cwd', 'Working Directory', 30, `\`${cwd}\``, 'runtime');

--- a/packages/agent-framework/src/context/system-prompt-types.ts
+++ b/packages/agent-framework/src/context/system-prompt-types.ts
@@ -1,6 +1,7 @@
 export type TSystemPromptSectionSource =
   | 'framework'
   | 'persona'
+  | 'self-verification'
   | 'project-instructions'
   | 'runtime'
   | 'permissions'

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -52,13 +52,14 @@ export interface ICreatedInteractiveSession {
   claudeFileEntries: IContextFileEntry[];
   /**
    * Rebuilds the system message given updated agentsMd and claudeMd strings. PRESET-014: an
-   * optional `overrides.persona` re-applies a preset persona to the live prompt and is retained
-   * for subsequent (override-less) rebuilds.
+   * optional `overrides.persona` re-applies a preset persona to the live prompt; PRESET-017: an
+   * optional `overrides.selfVerification` toggles the verify-before-done section. Either override
+   * is retained for subsequent (override-less) rebuilds.
    */
   rebuildSystemMessage: (
     agentsMd: string,
     claudeMd: string,
-    overrides?: { persona?: string },
+    overrides?: { persona?: string; selfVerification?: boolean },
   ) => string;
 }
 

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -386,6 +386,22 @@ export class InteractiveSession
   }
 
   /**
+   * PRESET-017: toggle the verify-before-done self-verification section on the live system prompt.
+   * Recomposes the system message from the currently tracked AGENTS.md/CLAUDE.md entries plus the
+   * new selfVerification flag, then propagates it to the session. No-op before init, when the
+   * rebuild closure is not yet available.
+   */
+  applySelfVerification(enabled: boolean): void {
+    if (this.rebuildSystemMessage === null) return;
+    const currentAgents = this.agentsFileEntries.map((e) => e.content).join('\n\n');
+    const currentClaude = this.claudeFileEntries.map((e) => e.content).join('\n\n');
+    const msg = this.rebuildSystemMessage(currentAgents, currentClaude, {
+      selfVerification: enabled,
+    });
+    this.getSessionOrThrow().updateSystemMessage(msg);
+  }
+
+  /**
    * PRESET-015: re-apply a preset's command-module selection to the live session by delegating to
    * the skill router, which re-filters the session-start module set and rebuilds the executor.
    */


### PR DESCRIPTION
## Summary
Final piece of the split epic (015 modules ✓, 016 parallel ✓, **017 selfVerification**).

`selfVerification` was a typed-but-unused flag. Per the chosen approach, it now injects a concise verify-before-done **section** into the system prompt via the **same priority/source mechanism as persona** — priority 6, source `'self-verification'`, positioned by `composeSystemPrompt`'s sort (NOT a hardcoded slot).

- Live-re-appliable, mirroring PRESET-014 persona: the `create-session-runtime` closure tracks a mutable `currentSelfVerification`; `ICommandHostContext.applySelfVerification` recomposes + `updateSystemMessage`; `applyPresetToSession` re-applies the group.
- Section content is concise English (verify against this session's tool results before reporting done); no `CRITICAL`/`MUST`/reasoning-echo, no Hangul.
- Default (unset/false) adds no section → **no regression**.

The deterministic verification loop (actually running lint/tests) remains a separate feature, explicitly out of scope.

## Verification
- framework build ✓ · test ✓ (99 files / 970) · `pnpm typecheck` ✓ · `pnpm harness:scan` ✓ (25/25)
- no package.json/lockfile change

Spec `PRESET-017` → done with full gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)