### PR TITLE
fix(agent-core): append-only conversation history — remove 100-message cap (HIST-001)

### DIFF
--- a/.agents/spec-docs/done/HIST-001-append-only-conversation-history.md
+++ b/.agents/spec-docs/done/HIST-001-append-only-conversation-history.md
@@ -1,0 +1,157 @@
+---
+status: done
+type: BEHAVIOR
+tags: [cli]
+---
+
+# HIST-001: 대화 히스토리 append-only — 개수 기반(100) 절단 제거
+
+## Problem
+
+라이브 에이전트 대화 히스토리가 **채팅 메시지 100개를 넘으면 가장 오래된 메시지를 조용히 버린다.**
+`SimpleConversationHistory.addMessage`가 매 추가마다 `applyMessageLimit()`를 호출하고, 이 메서드는
+`maxMessages`(=100) 초과 시 `nonSystem.slice(-available)`로 오래된 비시스템 메시지를 `entries`에서
+삭제한다(`conversation-store-history.ts`). 라이브 경로 확정: `robota.ts` `new ConversationHistory()` →
+`DEFAULT_MAX_MESSAGES_PER_CONVERSATION = 100` → `new ConversationStore(100)` →
+`SimpleConversationHistory({ maxMessages: 100 })`.
+
+이는 **개수 기반 절단**으로, 토큰/크기 무관하게 발생한다 — 작은 도구 호출이 많은 세션은 토큰 사용이
+1%여도 메시지 100개를 넘으면 초기 대화가 사라진다. 모델이 초기 맥락을 "잊는" 심각한 정확성 버그다.
+
+이는 같은 코드베이스의 문서화된 설계와 **정면 모순**한다:
+
+- `conversation-store.ts`: "History is append-only", "History records everything — text is always
+  preserved. Context savings is compaction's responsibility, not history's."
+- 메모리 원칙 `feedback_history_append_only`: 히스토리는 append-only + read-only, edit/delete 없음.
+
+올바른 컨텍스트 관리는 **크기 기반 compaction**이다(`compaction-orchestrator` → `session-history-ops`가
+`clearHistory()` 후 `[Context Summary]` 주입; 토큰 83.5%에서 auto, 또는 manual). 개수 절단은 이를
+우회해 요약 없이 정보를 잃는다.
+
+**재현 조건:** `DEFAULT_MAX_MESSAGES_PER_CONVERSATION === 100`이고 `applyMessageLimit`가 `addMessage`에서
+호출됨. 101번째 채팅 메시지 추가 시 가장 오래된 비시스템 메시지가 `getMessages()`에서 사라진다.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-core/src/managers/conversation-history-manager.ts` — `DEFAULT_MAX_MESSAGES_PER_CONVERSATION` 100 → 0(무제한·append-only)
+- `packages/agent-core/src/managers/conversation-store.ts` — `ConversationStore` 생성자 기본값 100 → 0
+- (테스트) `packages/agent-core/src/managers/conversation-store-history.test.ts` 또는 신규 — append-only 보존 단언
+
+> `applyMessageLimit` 메커니즘 자체는 보존하되(명시적 opt-in용, `maxMessages > 0`), **라이브 기본값을
+> 무제한(0)** 으로 바꿔 개수 절단을 끈다. `maxMessages <= 0`이면 `applyMessageLimit`는 early-return(무동작).
+
+### Alternatives Considered
+
+1. **100 캡을 더 큰 수로 상향.**
+   - Con: 여전히 개수 기반 절단 — 큰 수도 결국 잘림; 원칙(모든 데이터 보존) 위배. Rejected.
+2. **라이브 기본값을 무제한(0)으로 하여 append-only, 크기 기반 compaction이 컨텍스트 관리.**
+   - Pro: 문서화된 설계·메모리 원칙 충족; 정보 손실 없음; 컨텍스트는 요약(compaction)으로 경계; `maxMessages`
+     메커니즘은 명시 opt-in으로 유지(무회귀).
+   - Con: compaction이 꺼져 있고 메시지가 극단적으로 많으면 메모리 증가 — 그러나 auto-compact 기본 ON,
+     이전(데이터 소실)보다 훨씬 안전.
+
+### Decision
+
+**Alternative 2.** 라이브 대화 히스토리 기본을 무제한(append-only)으로. 개수 기반 절단 OFF. 컨텍스트는
+크기 기반 auto/manual compaction(요약)으로만 관리. `applyMessageLimit`는 명시적 `maxMessages > 0` opt-in
+시에만 동작(예: 격리된 bounded 버퍼). 트레이드오프: 이론적 메모리 증가를 감수하고, 모든 데이터 보존 +
+문서화된 append-only 설계 일치 + 모델의 맥락 손실 제거.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-core(conversation manager/store)
+- [x] Sibling scan 완료 — compaction-orchestrator/session-history-ops(요약 기반 컨텍스트 관리), conversation-store 주석(append-only 의도) 확인
+- [x] 대안 최소 2개 검토 완료 — 2개(캡 상향 / 무제한)
+- [x] 결정 근거 문서화 완료 — 문서/원칙 일치 + 데이터 보존 + compaction 위임 근거 기록
+
+## Solution
+
+1. `DEFAULT_MAX_MESSAGES_PER_CONVERSATION` 100 → 0 (주석: 0 = 무제한·append-only; 컨텍스트는 크기 기반 compaction이 관리).
+2. `ConversationStore` 생성자 기본값 100 → 0 (동일 주석).
+3. 테스트: 기본(무제한) 스토어가 100개 초과(예: 150개) 메시지를 모두 보존; 명시적 `maxMessages > 0`은 여전히 trim(메커니즘 보존).
+
+## Affected Files
+
+- `packages/agent-core/src/managers/conversation-history-manager.ts`
+- `packages/agent-core/src/managers/conversation-store.ts`
+- `packages/agent-core/src/managers/conversation-store-history.test.ts` (신규 또는 확장)
+
+## Completion Criteria
+
+- [x] TC-01: 기본 `ConversationStore`(무제한)에 150개 채팅 메시지 추가 후 `getMessages().length === 150`(가장 오래된 것 포함 모두 보존)임을 단언하는 단위 테스트 통과
+- [x] TC-02: `DEFAULT_MAX_MESSAGES_PER_CONVERSATION === 0`이고 `new ConversationHistory()`(기본)로 얻은 스토어가 150개 메시지를 모두 보존함을 단언하는 단위 테스트 통과
+- [x] TC-03: 명시적 `new ConversationStore(3)`은 여전히 최근 메시지만 유지(메커니즘 opt-in 보존)함을 단언하는 단위 테스트 통과
+- [x] TC-04: `pnpm --filter @robota-sdk/agent-core build` + `test` + `pnpm typecheck` → exit 0 (기존 테스트 무회귀); `harness:scan` 통과
+
+## Test Plan
+
+Type BEHAVIOR + tags cli → append-only 보존(무제한 기본) + opt-in trim 유지 단위 테스트 + 빌드/테스트/타입체크/스캔.
+
+| TC-ID | Test Type              | Tool / Approach                                      | Notes    |
+| ----- | ---------------------- | ---------------------------------------------------- | -------- |
+| TC-01 | RULE (unit)            | vitest — 무제한 스토어 150개 보존 단언               |          |
+| TC-02 | RULE (unit)            | vitest — 기본 매니저 경로 150개 보존 단언            |          |
+| TC-03 | RULE (unit)            | vitest — 명시적 캡(3)은 trim 유지 단언               |          |
+| TC-04 | CI pipeline smoke test | `pnpm build` + `test` + `typecheck` + `harness:scan` | 커맨드폼 |
+
+## User Execution Test Scenarios
+
+- **시나리오 — 장기 세션 맥락 보존:** 전제: 프로바이더 설정. 실행: `robota`로 도구 호출이 많은 긴 작업을
+  진행해 채팅 메시지가 100개를 넘기게 한 뒤, 초기 대화에서 언급한 사실을 다시 질문. 기대: 모델이 초기
+  맥락을 여전히 알고 답함(개수 절단으로 잊지 않음). 컨텍스트가 커지면 크기 기반 compaction이 요약으로 처리.
+  정리: 없음. Evidence: 100+ 메시지 후 초기 사실 회상 확인(구현 후 기록).
+
+환경: 실제 프로바이더 키 필요(로컬). 단위 테스트로 보존 로직 검증.
+
+## Tasks
+
+- [x] [.agents/tasks/HIST-001.md](../../tasks/HIST-001.md) — task breakdown (TC-01..TC-04)
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter present (`status`, `type: BEHAVIOR`, `tags: [cli]`). Problem documents the exact silent
+100-message drop (`applyMessageLimit` on every `addMessage`), the confirmed live path
+(`robota.ts` → `DEFAULT_MAX_MESSAGES_PER_CONVERSATION=100` → ConversationStore → SimpleConversationHistory),
+and the contradiction with the code's own append-only comments + `feedback_history_append_only`.
+Architecture Review: 4 checklist items `[x]`; Sibling scan cites compaction-orchestrator/session-history-ops;
+2 Alternatives with Con/Pro; Decision records data-preservation + compaction-delegation. Completion
+Criteria TC-01..TC-04 command-form/observable; Test Plan rows match TC set 1:1.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** review-ready → approved
+Explicit user approval (verbatim): "100개 제한 문제는 큰 오류입니다. … 모든 데이터는 보존되어야 하고
+context로 처리되어야 … context가 많아지면 사이즈에 따라 자동 또는 수동 compact를 해야 하는 일이지 100개
+같은 제한으로 자르는 것은 심각한 오류입니다" — directly authorizes removing the count-based cap and managing
+context by size-based compaction. Reinforced by the standing `feedback_history_append_only` principle. No
+post-approval drift.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** approved → in-progress
+Task file `.agents/tasks/HIST-001.md` created and linked. One task per Completion Criterion (TC-01..TC-04)
+plus the two default-change tasks. Test Plan present (≥50 chars).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** in-progress → verifying
+All tasks `[x]`. `pnpm --filter @robota-sdk/agent-core build` → exit 0. agent-core test → exit 0, 48 files
+(incl. 3 new append-only cases). Dependent packages `pnpm --filter agent-session --filter agent-framework
+--filter agent-executor test` → exit 0 (14/99/11 files), no regressions. `pnpm typecheck` → exit 0
+(monorepo). `pnpm harness:scan` → exit 0, 25/25. No package.json/lockfile change.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-14
+
+**Status upgrade:** verifying → done
+Per-TC:
+
+- [GATE-COMPLETE: TC-01] agent-core vitest (`conversation-history-manager.test.ts`) — default `ConversationStore` retains all 150 messages; `messages[0].content === 'message 0'` (oldest preserved).
+- [GATE-COMPLETE: TC-02] vitest — `new ConversationHistory().getConversationStore(...)` (the live manager path) retains all 150 messages.
+- [GATE-COMPLETE: TC-03] vitest — `new ConversationStore(3)` still trims to the last 3 (`['m3','m4','m5']`) — explicit opt-in bounded buffer preserved.
+- [GATE-COMPLETE: TC-04] agent-core build + test + dependent-package tests + `pnpm typecheck` + `pnpm harness:scan` all exit 0; no test asserted the former 100-drop, so no regressions.
+- Behavior: the live conversation history is now append-only (count cap off by default); context size is managed solely by size-based compaction (auto at 83.5% / manual), which summarizes rather than dropping. Matches the documented design and `feedback_history_append_only`.

--- a/.agents/tasks/HIST-001.md
+++ b/.agents/tasks/HIST-001.md
@@ -1,0 +1,24 @@
+# HIST-001: 대화 히스토리 append-only — Task Breakdown
+
+Spec: `.agents/spec-docs/done/HIST-001-append-only-conversation-history.md`
+
+## Plan
+
+- [x] TC-01: default (unbounded) `ConversationStore` retains 150 messages (oldest preserved)
+- [x] TC-02: default `ConversationHistory` manager path is unbounded (150 retained)
+- [x] TC-03: explicit positive cap (3) still trims (opt-in bounded buffer preserved)
+- [x] TC-04: agent-core build + test + `pnpm typecheck` + `harness:scan` pass (no regressions)
+- [x] `DEFAULT_MAX_MESSAGES_PER_CONVERSATION` 100 → 0 (unbounded/append-only)
+- [x] `ConversationStore` constructor default 100 → 0
+
+## Test Plan
+
+The live agent conversation history silently dropped the oldest messages once chat-message count
+exceeded 100 (`SimpleConversationHistory.applyMessageLimit` on every `addMessage`), losing context
+independent of token usage — contradicting the documented append-only design and `feedback_history_
+append_only`. Fix: default the live conversation store/manager to unbounded (0 = no count cap), so
+history records everything and context size is managed solely by size-based compaction (which
+summarizes via `clearHistory()` + `[Context Summary]`, auto at 83.5% or manual). The `applyMessageLimit`
+mechanism is preserved for explicit `maxMessages > 0` opt-in (bounded buffers). Verified by unit tests
+(150-message retention on the default store and the default manager path; explicit cap still trims) and
+build/test/typecheck/scan across agent-core and its dependents — no regressions.

--- a/packages/agent-core/src/managers/conversation-history-manager.test.ts
+++ b/packages/agent-core/src/managers/conversation-history-manager.test.ts
@@ -10,6 +10,39 @@ import {
   createSystemMessage,
 } from './conversation-history-manager';
 
+describe('ConversationStore append-only retention (HIST-001)', () => {
+  it('TC-01: default (unbounded) store preserves every message past the former 100 cap', () => {
+    const session = new ConversationStore();
+    for (let i = 0; i < 150; i++) {
+      session.addUserMessage(`message ${i}`);
+    }
+    const messages = session.getMessages();
+    expect(messages).toHaveLength(150);
+    // The oldest message is retained (no count-based truncation).
+    expect(messages[0].content).toBe('message 0');
+  });
+
+  it('TC-02: the default ConversationHistory manager path is also unbounded (append-only)', () => {
+    const history = new ConversationHistory();
+    const store = history.getConversationStore('conv-append-only');
+    for (let i = 0; i < 150; i++) {
+      store.addUserMessage(`m${i}`);
+    }
+    expect(store.getMessages()).toHaveLength(150);
+    expect(store.getMessages()[0].content).toBe('m0');
+  });
+
+  it('TC-03: an explicit positive cap still trims (opt-in bounded buffer preserved)', () => {
+    const session = new ConversationStore(3);
+    for (let i = 0; i < 6; i++) {
+      session.addUserMessage(`m${i}`);
+    }
+    const messages = session.getMessages();
+    expect(messages).toHaveLength(3);
+    expect(messages.map((m) => m.content)).toEqual(['m3', 'm4', 'm5']);
+  });
+});
+
 describe('ConversationStore', () => {
   describe('addToolMessageWithId', () => {
     it('should add tool message successfully with unique toolCallId', () => {

--- a/packages/agent-core/src/managers/conversation-history-manager.ts
+++ b/packages/agent-core/src/managers/conversation-history-manager.ts
@@ -41,7 +41,12 @@ export { ConversationStore } from './conversation-store';
 
 export type { IProviderApiMessage } from './conversation-store';
 
-const DEFAULT_MAX_MESSAGES_PER_CONVERSATION = 100;
+/**
+ * 0 = unbounded (append-only). Conversation history must preserve every message; context size is
+ * managed by size-based compaction (which summarizes), never by count-based truncation. A positive
+ * value is an explicit opt-in for a bounded buffer only.
+ */
+const DEFAULT_MAX_MESSAGES_PER_CONVERSATION = 0;
 const DEFAULT_MAX_CONVERSATIONS = 50;
 
 /** Interface for managing conversation history. @public */

--- a/packages/agent-core/src/managers/conversation-store.ts
+++ b/packages/agent-core/src/managers/conversation-store.ts
@@ -47,7 +47,10 @@ export class ConversationStore implements IConversationHistory {
   private history: SimpleConversationHistory;
   private pendingAssistant: IStreamingState | null = null;
 
-  constructor(maxMessages: number = 100) {
+  // `maxMessages` defaults to 0 = unbounded (append-only). History records everything; context size
+  // is managed by size-based compaction, never by count-based truncation. A positive value is an
+  // explicit opt-in for a bounded buffer only.
+  constructor(maxMessages: number = 0) {
     this.history = new SimpleConversationHistory({ maxMessages });
   }
 


### PR DESCRIPTION
## Problem (user-reported)
The live agent conversation history **silently dropped the oldest messages** once chat-message count exceeded **100** (`SimpleConversationHistory.applyMessageLimit`, called on every `addMessage`). This is **count-based truncation** independent of token size — so a session with many small tool calls could lose early context even at ~1% token usage, and the model "forgets" earlier conversation.

This contradicts:
- the code's own comments — `conversation-store.ts`: *"History is append-only … records everything; context savings is compaction's responsibility, not history's"*;
- the project principle that history is append-only (no edit/delete).

Confirmed live path: `robota.ts new ConversationHistory()` → `DEFAULT_MAX_MESSAGES_PER_CONVERSATION=100` → `new ConversationStore(100)` → `SimpleConversationHistory({maxMessages:100})`.

## Fix
Default the live conversation store + manager to **unbounded (0 = no count cap)**. History records everything; context size is managed **solely by size-based compaction** (auto at 83.5% / manual `/compact`), which **summarizes** (`clearHistory()` + `[Context Summary]`) rather than dropping. The `applyMessageLimit` mechanism stays available for explicit `maxMessages > 0` opt-in (bounded buffers).

## Verification
- agent-core build ✓ · test ✓ (incl. TC-01/02 150-message retention on default store + manager path, TC-03 explicit cap still trims)
- agent-session / agent-framework / agent-executor tests ✓ · `pnpm typecheck` ✓ · `pnpm harness:scan` ✓ (25/25)
- No test asserted the former 100-drop → no regressions.

Spec `HIST-001` → done with full gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)