### PR TITLE
chore(release): finalize 3.0.0-beta.75 release-run

### DIFF
--- a/.agents/release-runs/3.0.0-beta.75.md
+++ b/.agents/release-runs/3.0.0-beta.75.md
@@ -1,0 +1,38 @@
+# Release Run: 3.0.0-beta.75
+
+## State
+
+- Version: 3.0.0-beta.75
+- Branch: main
+- SHA: 9c2556a53aae
+- PR: none
+- Target branch: main
+- Active gate: publish
+- Gate status: passed
+- Next action: Publish with OTP via pnpm publish:beta.
+- Stop condition: Stop if the active gate fails or stalls.
+
+## Publish Gate
+
+- Publish ready: yes
+- NPM auth verified: yes
+- Dry run passed: yes
+- OTP requested: yes
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
+
+## CI Triage Notes
+
+<!-- Append notes with pnpm harness:release:triage -- --version 3.0.0-beta.75 --pr <number> --check <name>. -->
+
+## Final Report
+
+- Merged PRs: #762 #763 #764 #765 #766 #767 #768 #769 #770 #771 #772 #773 #774 (feature/fix PRs), #775 (bump), #776 (develop → main release)
+- Published version: 3.0.0-beta.75
+- Published packages: 14 (all @robota-sdk/\* incl. new agent-preset) — latest=3.0.0-beta.75, beta=3.0.0-beta.75 (verified)
+- Validation gates: harness:verify:release (build:deps + scan + test + typecheck + lint, 0 errors) PASS; release:check --publish PASS; dry-run PASS
+- Highlights: agent preset system (PRESET-001~017), live preset switching, CTX-001 (accurate context estimate), HIST-001 (append-only conversation history)
+- Skipped checks: none


### PR DESCRIPTION
Records the completed 3.0.0-beta.75 release: 14 @robota-sdk packages published, `latest` and `beta` dist-tags both at 3.0.0-beta.75 (verified). Includes the agent preset system (PRESET-001~017), live preset switching, CTX-001 (accurate context estimate), and HIST-001 (append-only conversation history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)