### PR TITLE
chore(release): bump to 3.0.0-beta.76

### DIFF
--- a/.changeset/dq-audit-002-ssot.md
+++ b/.changeset/dq-audit-002-ssot.md
@@ -1,0 +1,9 @@
+---
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-command': patch
+'@robota-sdk/agent-plugin': patch
+'@robota-sdk/agent-session': patch
+'@robota-sdk/agent-transport': patch
+---
+
+DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.

--- a/.changeset/dq-audit-003-interface-purity.md
+++ b/.changeset/dq-audit-003-interface-purity.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-interface-tui': patch
+'@robota-sdk/agent-transport-tui': patch
+---
+
+DQ-AUDIT-003 — restore agent-interface-tui to type-contracts only by removing its runtime type-guards (`isPickerInteraction`/`isConfirmInteraction`, which had zero call sites); narrow `TAnyTuiCommandInteraction` on its `onMissingArgs` discriminant instead. Documented the type-only downward references in agent-interface-transport.

--- a/.changeset/dq-audit-006-error-hygiene.md
+++ b/.changeset/dq-audit-006-error-hygiene.md
@@ -1,0 +1,8 @@
+---
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-provider': patch
+'@robota-sdk/agent-session': patch
+'@robota-sdk/agent-plugin': patch
+---
+
+DQ-AUDIT-006 — error/observability hygiene: replace raw `throw new Error()` on core-service and provider hot paths with typed `RobotaError` subclasses (`ConfigurationError`/`ValidationError`) so error-handling can branch on category/recoverable; surface fire-and-forget hook failures via `logger.warn` instead of silent `.catch(() => {})`; wire the error-handling plugin's `totalRetries`/`successfulRecoveries` stats to real counters.

--- a/.changeset/dq-audit-007-nits.md
+++ b/.changeset/dq-audit-007-nits.md
@@ -1,0 +1,6 @@
+---
+'@robota-sdk/agent-provider': patch
+'@robota-sdk/agent-core': patch
+---
+
+DQ-AUDIT-007 — remove the silent `model || 'gpt-4o-mini'` default in the OpenAI streaming handler (a missing model now throws `ConfigurationError` instead of substituting a vendor default); document `IAIProvider`'s universal (`chat`) vs raw (`generateResponse`) dual surface as intentional in the agent-core SPEC.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -70,7 +70,9 @@
     "robota-web": "0.1.0",
     "@robota-sdk/starter-nextjs": "0.0.1",
     "robota-www": "0.1.0",
-    "@robota-sdk/agent-preset": "3.0.0-beta.74"
+    "@robota-sdk/agent-preset": "3.0.0-beta.74",
+    "@robota-sdk/agent-session-analytics": "3.0.0-beta.75",
+    "@robota-sdk/agent-transport-tui": "3.0.0-beta.75"
   },
   "changesets": [
     "add-cli-provider-usage-visibility",
@@ -91,9 +93,16 @@
     "cmd-display-name-requires-permission",
     "collapse-command-transcripts",
     "context-ssot-token-estimation",
+    "dq-audit-002-ssot",
+    "dq-audit-003-interface-purity",
+    "dq-audit-004-session-analytics",
+    "dq-audit-005-transport-split",
+    "dq-audit-006-error-hygiene",
+    "dq-audit-007-nits",
     "edit-checkpointing",
     "every-aliens-pump",
     "fix-cli-diff-context-hunks",
+    "fix-cold-session-preset-model",
     "fix-context-capacity-guard",
     "fix-context-list-system-files",
     "fix-edit-diff-summary",

--- a/apps/agent-server/CHANGELOG.md
+++ b/apps/agent-server/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @robota-sdk/agent-server
 
+## 3.0.1-beta.32
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-command@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-provider@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76
+  - @robota-sdk/agent-playground@3.0.0-beta.76
+
 ## 3.0.1-beta.31
 
 ### Patch Changes

--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-server",
-  "version": "3.0.1-beta.31",
+  "version": "3.0.1-beta.32",
   "description": "Agent Server - AI provider proxy and Playground WebSocket server",
   "private": true,
   "keywords": [

--- a/apps/starter-nextjs/CHANGELOG.md
+++ b/apps/starter-nextjs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/starter-nextjs
 
+## 0.0.2-beta.8
+
+### Patch Changes
+
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-provider@3.0.0-beta.76
+
 ## 0.0.2-beta.7
 
 ### Patch Changes

--- a/apps/starter-nextjs/package.json
+++ b/apps/starter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/starter-nextjs",
-  "version": "0.0.2-beta.7",
+  "version": "0.0.2-beta.8",
   "private": true,
   "description": "Robota SDK — Next.js AI Chat starter template",
   "scripts": {

--- a/packages/agent-cli/CHANGELOG.md
+++ b/packages/agent-cli/CHANGELOG.md
@@ -1,5 +1,42 @@
 # @robota-sdk/agent-cli
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- c0a6287: Relocate session feature logic out of the CLI shell and the transport (DQ-AUDIT-004):
+
+  - Extract session-log timing analysis into the new `@robota-sdk/agent-session-analytics` package (pure analysis over canonical session records — no duplicate types, no file I/O). `agent-cli`'s `session analyze` command shrinks to thin wiring and loads records via the new `createUserSessionStore()` / existing `createProjectSessionStore()` framework facades.
+  - Move LLM-based session auto-naming (`generateSessionName`) from `agent-transport/tui` into `agent-framework` (session-lifecycle owner); the TUI transport now invokes it through the framework.
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-command@3.0.0-beta.76
+  - @robota-sdk/agent-transport@3.0.0-beta.76
+  - @robota-sdk/agent-transport-tui@3.0.0-beta.76
+  - @robota-sdk/agent-session-analytics@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-transport-ws@3.0.0-beta.76
+  - @robota-sdk/agent-provider@3.0.0-beta.76
+  - @robota-sdk/agent-subagent-runner@3.0.0-beta.76
+  - @robota-sdk/agent-preset@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-cli",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "AI coding assistant CLI built on Robota SDK",
   "type": "module",
   "bin": {

--- a/packages/agent-command/CHANGELOG.md
+++ b/packages/agent-command/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @robota-sdk/agent-command
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.
+- 576af62: Fix `ConfigurationError: Agent must be fully initialized before changing model configuration` when running `/preset` (or any live model re-apply) on a fresh interactive session before the first message. The Robota agent initialized lazily on the first `run()`, but `setModel` requires full initialization. `Session.applyModelOptions` now awaits the new idempotent `Robota.ensureReady()` before `setModel`, and the preset live-switch path (`applyPresetToSession` → `executePresetCommand`) is async end-to-end. Adds a real cold-session regression test (no mocked Robota).
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76
+  - @robota-sdk/agent-preset@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Consolidated command module implementations for Robota SDK CLI",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-core
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.
+- DQ-AUDIT-006 — error/observability hygiene: replace raw `throw new Error()` on core-service and provider hot paths with typed `RobotaError` subclasses (`ConfigurationError`/`ValidationError`) so error-handling can branch on category/recoverable; surface fire-and-forget hook failures via `logger.warn` instead of silent `.catch(() => {})`; wire the error-handling plugin's `totalRetries`/`successfulRecoveries` stats to real counters.
+- DQ-AUDIT-007 — remove the silent `model || 'gpt-4o-mini'` default in the OpenAI streaming handler (a missing model now throws `ConfigurationError` instead of substituting a vendor default); document `IAIProvider`'s universal (`chat`) vs raw (`generateResponse`) dual surface as intentional in the agent-core SPEC.
+- 576af62: Fix `ConfigurationError: Agent must be fully initialized before changing model configuration` when running `/preset` (or any live model re-apply) on a fresh interactive session before the first message. The Robota agent initialized lazily on the first `run()`, but `setModel` requires full initialization. `Session.applyModelOptions` now awaits the new idempotent `Robota.ensureReady()` before `setModel`, and the preset live-switch path (`applyPresetToSession` → `executePresetCommand`) is async end-to-end. Adds a real cold-session regression test (no mocked Robota).
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-core",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Complete AI agent implementation with unified core and tools functionality - conversation management, plugin system, and advanced agent features",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-executor/CHANGELOG.md
+++ b/packages/agent-executor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-executor
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-executor",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Composable runtime primitives for Robota background tasks and subagent orchestration",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-framework/CHANGELOG.md
+++ b/packages/agent-framework/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @robota-sdk/agent-framework
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- c0a6287: Relocate session feature logic out of the CLI shell and the transport (DQ-AUDIT-004):
+
+  - Extract session-log timing analysis into the new `@robota-sdk/agent-session-analytics` package (pure analysis over canonical session records — no duplicate types, no file I/O). `agent-cli`'s `session analyze` command shrinks to thin wiring and loads records via the new `createUserSessionStore()` / existing `createProjectSessionStore()` framework facades.
+  - Move LLM-based session auto-naming (`generateSessionName`) from `agent-transport/tui` into `agent-framework` (session-lifecycle owner); the TUI transport now invokes it through the framework.
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+- 576af62: Fix `ConfigurationError: Agent must be fully initialized before changing model configuration` when running `/preset` (or any live model re-apply) on a fresh interactive session before the first message. The Robota agent initialized lazily on the first `run()`, but `setModel` requires full initialization. `Session.applyModelOptions` now awaits the new idempotent `Robota.ensureReady()` before `setModel`, and the preset live-switch path (`applyPresetToSession` → `executePresetCommand`) is async end-to-end. Adds a real cold-session regression test (no mocked Robota).
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-session@3.0.0-beta.76
+  - @robota-sdk/agent-executor@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76
+  - @robota-sdk/agent-tools@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-framework",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Programmatic SDK for building AI agents with Robota — provides InteractiveSession, createQuery(), command APIs, permissions, hooks, and context loading",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-transport/CHANGELOG.md
+++ b/packages/agent-interface-transport/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-interface-transport
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-session@3.0.0-beta.76
+  - @robota-sdk/agent-executor@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-transport",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Transport contract interfaces for the Robota SDK (ITransportAdapter, IConfigurableTransport, ITransportConfig)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-tui/CHANGELOG.md
+++ b/packages/agent-interface-tui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-interface-tui
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-003 — restore agent-interface-tui to type-contracts only by removing its runtime type-guards (`isPickerInteraction`/`isConfirmInteraction`, which had zero call sites); narrow `TAnyTuiCommandInteraction` on its `onMissingArgs` discriminant instead. Documented the type-only downward references in agent-interface-transport.
+
 ## 3.0.0-beta.75
 
 ## 3.0.0-beta.74

--- a/packages/agent-interface-tui/package.json
+++ b/packages/agent-interface-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-tui",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "TUI interaction contract interfaces for the Robota SDK (ITuiPickerItem, ITuiCommandInteraction, ITuiPickerInteraction, ITuiConfirmInteraction)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-playground/CHANGELOG.md
+++ b/packages/agent-playground/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @robota-sdk/agent-playground
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-provider@3.0.0-beta.76
+  - @robota-sdk/agent-remote-client@3.0.0-beta.76
+  - @robota-sdk/agent-tools@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-playground",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Deployable Playground UI package (React implementation) for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-plugin
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.
+- DQ-AUDIT-006 — error/observability hygiene: replace raw `throw new Error()` on core-service and provider hot paths with typed `RobotaError` subclasses (`ConfigurationError`/`ValidationError`) so error-handling can branch on category/recoverable; surface fire-and-forget hook failures via `logger.warn` instead of silent `.catch(() => {})`; wire the error-handling plugin's `totalRetries`/`successfulRecoveries` stats to real counters.
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-plugin",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Consolidated plugin implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-preset/CHANGELOG.md
+++ b/packages/agent-preset/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-preset
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-preset/package.json
+++ b/packages/agent-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-preset",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Preset contract and resolver for the Robota SDK (IPreset, resolvePreset, listPresets, built-in presets)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider/CHANGELOG.md
+++ b/packages/agent-provider/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @robota-sdk/agent-provider
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-006 — error/observability hygiene: replace raw `throw new Error()` on core-service and provider hot paths with typed `RobotaError` subclasses (`ConfigurationError`/`ValidationError`) so error-handling can branch on category/recoverable; surface fire-and-forget hook failures via `logger.warn` instead of silent `.catch(() => {})`; wire the error-handling plugin's `totalRetries`/`successfulRecoveries` stats to real counters.
+- DQ-AUDIT-007 — remove the silent `model || 'gpt-4o-mini'` default in the OpenAI streaming handler (a missing model now throws `ConfigurationError` instead of substituting a vendor default); document `IAIProvider`'s universal (`chat`) vs raw (`generateResponse`) dual surface as intentional in the agent-core SPEC.
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-provider/package.json
+++ b/packages/agent-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Consolidated AI provider implementations for Robota SDK",
   "type": "module",
   "publishConfig": {

--- a/packages/agent-remote-client/CHANGELOG.md
+++ b/packages/agent-remote-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-remote-client
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-remote-client",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Remote client for calling a Robota agent over HTTP",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session-analytics/CHANGELOG.md
+++ b/packages/agent-session-analytics/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @robota-sdk/agent-session-analytics
+
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- c0a6287: Relocate session feature logic out of the CLI shell and the transport (DQ-AUDIT-004):
+
+  - Extract session-log timing analysis into the new `@robota-sdk/agent-session-analytics` package (pure analysis over canonical session records — no duplicate types, no file I/O). `agent-cli`'s `session analyze` command shrinks to thin wiring and loads records via the new `createUserSessionStore()` / existing `createProjectSessionStore()` framework facades.
+  - Move LLM-based session auto-naming (`generateSessionName`) from `agent-transport/tui` into `agent-framework` (session-lifecycle owner); the TUI transport now invokes it through the framework.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76

--- a/packages/agent-session-analytics/package.json
+++ b/packages/agent-session-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session-analytics",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Session-log timing analysis and reporting for the Robota SDK (analyzeSession, aggregateReports, report formatters)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session/CHANGELOG.md
+++ b/packages/agent-session/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @robota-sdk/agent-session
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.
+- DQ-AUDIT-006 — error/observability hygiene: replace raw `throw new Error()` on core-service and provider hot paths with typed `RobotaError` subclasses (`ConfigurationError`/`ValidationError`) so error-handling can branch on category/recoverable; surface fire-and-forget hook failures via `logger.warn` instead of silent `.catch(() => {})`; wire the error-handling plugin's `totalRetries`/`successfulRecoveries` stats to real counters.
+- 576af62: Fix `ConfigurationError: Agent must be fully initialized before changing model configuration` when running `/preset` (or any live model re-apply) on a fresh interactive session before the first message. The Robota agent initialized lazily on the first `run()`, but `setModel` requires full initialization. `Session.applyModelOptions` now awaits the new idempotent `Robota.ensureReady()` before `setModel`, and the preset live-switch path (`applyPresetToSession` → `executePresetCommand`) is async end-to-end. Adds a real cold-session regression test (no mocked Robota).
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Session and chat management for Robota SDK - multi-session support with independent workspaces",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-subagent-runner/CHANGELOG.md
+++ b/packages/agent-subagent-runner/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @robota-sdk/agent-subagent-runner
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-provider@3.0.0-beta.76
+  - @robota-sdk/agent-executor@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-subagent-runner/package.json
+++ b/packages/agent-subagent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-subagent-runner",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Child-process subagent runner for Robota SDK — optional package for running subagents in isolated child processes",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tool-mcp/CHANGELOG.md
+++ b/packages/agent-tool-mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-tool-mcp
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tool-mcp",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "MCP protocol tool implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tools/CHANGELOG.md
+++ b/packages/agent-tools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-tools
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tools",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Tool registry and implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-http/CHANGELOG.md
+++ b/packages/agent-transport-http/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @robota-sdk/agent-transport-http
+
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+### Patch Changes
+
+- @robota-sdk/agent-interface-transport@3.0.0-beta.76

--- a/packages/agent-transport-http/package.json
+++ b/packages/agent-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-http",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "HTTP (Hono) transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-mcp/CHANGELOG.md
+++ b/packages/agent-transport-mcp/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @robota-sdk/agent-transport-mcp
+
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+### Patch Changes
+
+- @robota-sdk/agent-interface-transport@3.0.0-beta.76

--- a/packages/agent-transport-mcp/package.json
+++ b/packages/agent-transport-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-mcp",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Model Context Protocol (MCP) server transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-tui/CHANGELOG.md
+++ b/packages/agent-transport-tui/CHANGELOG.md
@@ -1,0 +1,30 @@
+# @robota-sdk/agent-transport-tui
+
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+### Patch Changes
+
+- DQ-AUDIT-003 — restore agent-interface-tui to type-contracts only by removing its runtime type-guards (`isPickerInteraction`/`isConfirmInteraction`, which had zero call sites); narrow `TAnyTuiCommandInteraction` on its `onMissingArgs` discriminant instead. Documented the type-only downward references in agent-interface-transport.
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-interface-tui@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76

--- a/packages/agent-transport-tui/package.json
+++ b/packages/agent-transport-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-tui",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Terminal UI (React + Ink) transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-ws/CHANGELOG.md
+++ b/packages/agent-transport-ws/CHANGELOG.md
@@ -1,0 +1,27 @@
+# @robota-sdk/agent-transport-ws
+
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76

--- a/packages/agent-transport-ws/package.json
+++ b/packages/agent-transport-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-ws",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "WebSocket transport and protocol for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport/CHANGELOG.md
+++ b/packages/agent-transport/CHANGELOG.md
@@ -1,5 +1,37 @@
 # @robota-sdk/agent-transport
 
+## 3.0.0-beta.76
+
+### Minor Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+### Patch Changes
+
+- DQ-AUDIT-002 — consolidate duplicated domain data onto single owners: one model-pricing SSOT in agent-core (`MODEL_PRICES`/`lookupModelPrice`/`calculateModelCost`/`estimateBlendedCostPer1000`) consumed by agent-command and agent-plugin (drops two embedded/stale price tables); the `len/4` token estimator replaced by core `CONTEXT_ESTIMATE_CHARS_PER_TOKEN`; TUI `IContextState` derived from core `IContextWindowState`; dead pass-through re-exports removed from agent-session.
+- c0a6287: Relocate session feature logic out of the CLI shell and the transport (DQ-AUDIT-004):
+
+  - Extract session-log timing analysis into the new `@robota-sdk/agent-session-analytics` package (pure analysis over canonical session records — no duplicate types, no file I/O). `agent-cli`'s `session analyze` command shrinks to thin wiring and loads records via the new `createUserSessionStore()` / existing `createProjectSessionStore()` framework facades.
+  - Move LLM-based session auto-naming (`generateSessionName`) from `agent-transport/tui` into `agent-framework` (session-lifecycle owner); the TUI transport now invokes it through the framework.
+
+- Updated dependencies
+- Updated dependencies [c0a6287]
+- Updated dependencies [9df3a88]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [576af62]
+  - @robota-sdk/agent-core@3.0.0-beta.76
+  - @robota-sdk/agent-framework@3.0.0-beta.76
+  - @robota-sdk/agent-interface-transport@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Core transport package for Robota SDK — headless adapter, scripted-provider testing fixtures, and the transport registry",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-web-ui/CHANGELOG.md
+++ b/packages/agent-web-ui/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @robota-sdk/agent-web
 
+## 3.0.0-beta.76
+
+### Patch Changes
+
+- 9df3a88: Split the consolidated `@robota-sdk/agent-transport` package into per-concern transport packages (DQ-AUDIT-005) so unrelated heavy dependencies (React/Ink, ws, Hono, MCP SDK) no longer share one publishable unit and are not dragged into non-TUI consumers' graphs:
+
+  - `@robota-sdk/agent-transport` — lean core: headless adapter + `TransportRegistry` + scripted-provider testing fixtures (no external runtime deps).
+  - `@robota-sdk/agent-transport-tui` — React + Ink terminal UI.
+  - `@robota-sdk/agent-transport-ws` — WebSocket transport + protocol (`agent-web-ui` now depends only on this for WS types).
+  - `@robota-sdk/agent-transport-http` — Hono HTTP transport.
+  - `@robota-sdk/agent-transport-mcp` — MCP server transport.
+
+  The default transport-registry wiring (pre-registering `WsTransport`) moves to the CLI composition root, removing the core→ws edge.
+
+- Updated dependencies [9df3a88]
+  - @robota-sdk/agent-transport-ws@3.0.0-beta.76
+
 ## 3.0.0-beta.75
 
 ### Patch Changes

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-web-ui",
-  "version": "3.0.0-beta.75",
+  "version": "3.0.0-beta.76",
   "description": "Browser UI library for monitoring and controlling a running agent-cli session",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
Version bump for the beta.76 release. Rolls up all work since beta.75: design-quality audit remediation (DQ-AUDIT-001~007), cold-session /preset fix, and the new packages (agent-session-analytics, agent-transport-tui/-ws/-http/-mcp). Fixed group → all @robota-sdk/* → 3.0.0-beta.76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)