### PR TITLE
chore(release): finalize 3.0.0-beta.76 release run record

### DIFF
--- a/.agents/release-runs/3.0.0-beta.76.md
+++ b/.agents/release-runs/3.0.0-beta.76.md
@@ -1,0 +1,53 @@
+# Release Run: 3.0.0-beta.76
+
+## State
+
+- Version: 3.0.0-beta.76
+- Branch: main
+- SHA: 510e0697c
+- PR: none
+- Target branch: main
+- Active gate: complete
+- Gate status: passed
+- Next action: none — release published and verified.
+- Stop condition: Stop if the active gate fails or stalls.
+
+## Publish Gate
+
+- Publish ready: yes
+- NPM auth verified: yes
+- Dry run passed: yes
+- OTP requested: yes
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
+
+## CI Triage Notes
+
+<!-- Append notes with pnpm harness:release:triage -- --version 3.0.0-beta.76 --pr <number> --check <name>. -->
+
+(none)
+
+## Final Report
+
+- Merged PRs:
+  - #781 — design-quality-audit-2026-06-14 (DQ audit findings captured as backlog)
+  - #782 — DQ-AUDIT-002 SSOT consolidation (model-pricing in agent-core)
+  - #783 — DQ-AUDIT-003 interface purity (delete unused interface-tui type guards)
+  - #784 — rule: design-first-not-cost-first (codify proper-architecture-over-cheap-fixes)
+  - #785 — DQ-AUDIT-004 session analytics (new @robota-sdk/agent-session-analytics)
+  - #786 — DQ-AUDIT-005 transport split (agent-transport-{tui,ws,http,mcp} + lean core)
+  - #787 — DQ-AUDIT-006 error hygiene
+  - #788 — DQ-AUDIT-007 nits
+  - #789 — fix: cold-session /preset model change (Robota.ensureReady seam + regression test)
+  - #790 — release: bump beta.76
+  - #791 — develop → main sync (release SHA 127e037dc)
+  - #792 — perfect DQ-AUDIT-001~007 + OBS-001 backlog completion processing
+  - #793 — develop → main sync (final)
+- Published version: 3.0.0-beta.76
+- Packages: 19 published @robota-sdk/\* packages — all verified at latest = beta = 3.0.0-beta.76 (19/19, mismatches: 0). The new packages agent-session-analytics and agent-transport-{tui,ws,http,mcp} are included.
+- Validation gates: passed (build, typecheck, lint, test green pre-merge; harness:scan 25/25; harness:release:check --publish passed; npm dry-run passed).
+- Publish notes: OTP-driven publish via `pnpm publish:beta` spanned three OTPs due to mid-run OTP expiry; the script is idempotent (skips already-published packages). A final-verification "dist-tag mismatch" report for agent-transport-mcp was a registry-propagation false positive — direct `npm dist-tag ls` confirmed beta.76 for both tags.
+- Skipped checks: none


### PR DESCRIPTION
Finalizes the `.agents/release-runs/3.0.0-beta.76.md` record after a successful publish.

- 19 `@robota-sdk/*` packages published and verified at `latest = beta = 3.0.0-beta.76` (19/19, mismatches: 0)
- Covers DQ-AUDIT-001~007, cold-session `/preset` fix, and transport/analytics package splits (PRs #781–#793)
- OTP requested: yes; publish spanned three OTPs (idempotent script); a final dist-tag-mismatch report for agent-transport-mcp was a registry-propagation false positive (confirmed beta.76 directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)