### PR TITLE
fix(naming): NAMING-001 sub-agent -> subagent in source comments/prompts

### DIFF
--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -717,6 +717,7 @@ beta.76 릴리즈 세션에서 **실제로 발생한** 마찰·실수를 스킬 
 | [LESSON-007](completed/LESSON-007-gh-delete-branch-guard.md) ✅          | gh pr merge --delete-branch 차단 가드 — branch-guard 훅에 기계적 강제       | high     |
 | [LESSON-008](completed/LESSON-008-delete-branch-guard-precision.md) ✅   | --delete-branch 가드 정밀화 — 주석/별도 세그먼트 false-positive 제거        | medium   |
 | [LESSON-009](completed/LESSON-009-skill-registry-check-ssot.md) ✅       | unregistered-skill 검사를 skills/index.md(SSOT)로 교정                      | medium   |
+| [NAMING-001](completed/NAMING-001-subagent-hyphen-cleanup.md) ✅         | production 코드 금지 하이픈형 sub-agent → subagent 정리                     | medium   |
 
 ### Harness Audit Recommendations (rulebased-harness, 2026-06-15)
 

--- a/.agents/backlog/completed/NAMING-001-subagent-hyphen-cleanup.md
+++ b/.agents/backlog/completed/NAMING-001-subagent-hyphen-cleanup.md
@@ -1,0 +1,76 @@
+---
+title: 'NAMING-001: production 코드의 금지 하이픈형 sub-agent → subagent 정리'
+status: done
+created: 2026-06-15
+completed: 2026-06-15
+priority: medium
+urgency: now
+area: packages/agent-core, packages/agent-framework
+depends_on: []
+---
+
+# NAMING-001: sub-agent 하이픈형 정리
+
+## Problem (하네스 검증에서 발견)
+
+규칙대로 하네스 전체를 검증하던 중 `harness:cleanup`이 production 코드 3곳에서 금지된 하이픈형
+`sub-agent`를 탐지(`forbidden-agent-term`). naming-style.md는 `main agent`/`sub-agent`/
+`parent-agent`/`child-agent` 등 계층 함의 명명을 금지하며, 프로젝트 표준은 비하이픈 `subagent`다.
+
+대상(전부 **주석/문서 prose/LLM 프롬프트 문자열** — 식별자·타입·API 계약 아님 → 동작 무영향):
+
+- `packages/agent-core/src/hooks/types.ts:52` — 주석
+- `packages/agent-framework/src/tools/agent-tool.ts:2,6` — 주석
+- `packages/agent-framework/src/hooks/agent-executor.ts:2,21` — 주석
+- `packages/agent-framework/src/assembly/subagent-prompts.ts:35` — 프롬프트 문자열 "sub-agents"
+  (cleanup 정규식 `\bsub-agent\b`엔 안 잡히나 같은 문자열 안에서 `subagent`와 혼용되어 일관성상 정리)
+
+범위 외(보고만): `apps/blog/src/content/.../*.md` 의 "sub-agent"는 일반 개념 설명 prose로,
+우리 에이전트 정체성 명명이 아니므로 본 작업 대상에서 제외.
+
+## Solution
+
+위 코드/프롬프트의 `sub-agent(s)` → `subagent(s)`로 교체(의미 동일, 주석/문자열만). 식별자·export·
+타입명 변경 없음.
+
+## Completion Criteria
+
+- [x] TC-01: agent-core·agent-framework src의 `\bsub-agent\b` 0건 (rg 검증)
+- [x] TC-02: `harness:cleanup`의 `forbidden-agent-term` 0건 (현 3 → 0)
+- [x] TC-03: 영향 패키지 typecheck + build 통과 (식별자 무변경 → 동작 불변)
+- [x] TC-04: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type   | Approach                                          |
+| ----- | ----------- | ------------------------------------------------- |
+| TC-01 | Code review | `rg "\bsub-agent\b" packages/*/src` → 0건         |
+| TC-02 | Integration | `pnpm harness:cleanup` → forbidden-agent-term 0건 |
+| TC-03 | Build       | agent-core·agent-framework typecheck + build      |
+| TC-04 | Harness     | `pnpm harness:scan` 통과                          |
+
+## User Execution Test Scenarios
+
+Not applicable — 주석/문자열 명명 정리. 사용자 대면 런타임 동작 무변경(식별자·계약 불변).
+
+## Tasks
+
+- [x] sub-agent → subagent 교체 → typecheck/build → cleanup/scan 검증
+
+## Evidence Log
+
+### 구현 완료 — 2026-06-15
+
+- **교체(주석/문자열만, 식별자·타입·export 불변):**
+  - `agent-core/src/hooks/types.ts:52` 주석 sub-agent → subagent
+  - `agent-framework/src/tools/agent-tool.ts:2,6` 주석 sub-agent → subagent
+  - `agent-framework/src/hooks/agent-executor.ts:2,21` 주석 sub-agent → subagent
+  - `agent-framework/src/assembly/subagent-prompts.ts:35` 프롬프트 "sub-agents" → "subagents"(일관성)
+- **TC-01:** `rg "\bsub-agent\b" packages/*/src apps/*/src` → blog .md 제외 **0건**.
+- **TC-02:** `pnpm harness:cleanup` `forbidden-agent-term` **3 → 0**.
+- **TC-03:** agent-core·agent-framework **typecheck exit 0**, **build exit 0**(식별자 무변경 → 동작 불변).
+- **TC-04:** `pnpm harness:scan` **26/26 passed**.
+- 범위 외: `apps/blog/src/content/.../how-coding-agent-works.md`의 "sub-agent" 3건은 일반 개념
+  설명 prose(우리 에이전트 정체성 명명 아님)라 제외.
+
+User Execution Test Scenario gate: Not applicable — 주석/문자열 명명 정리(런타임·계약 불변).

--- a/packages/agent-core/src/hooks/types.ts
+++ b/packages/agent-core/src/hooks/types.ts
@@ -49,7 +49,7 @@ export interface IPromptHookDefinition {
   model?: string;
 }
 
-/** Agent hook — delegates to a sub-agent */
+/** Agent hook — delegates to a subagent */
 export interface IAgentHookDefinition {
   type: 'agent';
   agent: string;

--- a/packages/agent-framework/src/assembly/subagent-prompts.ts
+++ b/packages/agent-framework/src/assembly/subagent-prompts.ts
@@ -32,7 +32,7 @@ Do not use emojis.`;
  * Returns the fork worker suffix for context:fork skill workers.
  */
 export function getForkWorkerSuffix(): string {
-  return `You are a worker subagent executing a specific task. Do NOT spawn sub-agents; execute directly. Keep your report under 500 words. Use this structure:
+  return `You are a worker subagent executing a specific task. Do NOT spawn subagents; execute directly. Keep your report under 500 words. Use this structure:
 - Scope: What was requested
 - Result: What was done
 - Key files: Relevant file paths (absolute)

--- a/packages/agent-framework/src/hooks/agent-executor.ts
+++ b/packages/agent-framework/src/hooks/agent-executor.ts
@@ -1,5 +1,5 @@
 /**
- * Agent hook executor — delegates to a sub-agent session.
+ * Agent hook executor — delegates to a subagent session.
  *
  * Creates a subagent session with maxTurns and timeout limits,
  * runs hook input as the initial prompt, and parses the result.
@@ -18,7 +18,7 @@ import type {
   THookDefinition,
 } from '@robota-sdk/agent-core';
 
-/** Default maximum turns for the sub-agent session. */
+/** Default maximum turns for the subagent session. */
 const DEFAULT_MAX_TURNS = 50;
 
 /** Default timeout in seconds. */

--- a/packages/agent-framework/src/tools/agent-tool.ts
+++ b/packages/agent-framework/src/tools/agent-tool.ts
@@ -1,9 +1,9 @@
 /**
- * AgentTool — spawn a sub-agent with isolated context.
+ * AgentTool — spawn a subagent with isolated context.
  *
  * Uses `SubagentManager` with an in-process runner to assemble a child Session
  * with filtered tools, model resolution, and framework system prompt. The
- * sub-agent shares the same config and context but has its own conversation
+ * subagent shares the same config and context but has its own conversation
  * history.
  *
  * Each call to `createAgentTool(deps)` returns a fresh tool instance with deps


### PR DESCRIPTION
harness 검증 중 cleanup이 잡은 금지 하이픈형 `sub-agent`(naming-style) 3개 파일 정리. 전부 주석/JSDoc + LLM 프롬프트 문자열 — 식별자·타입·export·계약 무변경. forbidden-agent-term 3→0, typecheck+build 통과, harness:scan 26/26. blog .md 일반 개념 prose는 범위 외.