### PR TITLE
docs(backlog): docs freshness audit + DOCS-001~006 backlogs

### DIFF
--- a/.agents/backlog/DOCS-001-content-transport-split-refs.md
+++ b/.agents/backlog/DOCS-001-content-transport-split-refs.md
@@ -1,0 +1,63 @@
+---
+title: 'DOCS-001: content 문서의 transport split 참조 갱신 (agent-transport/{tui,http,ws,mcp} → 독립 패키지)'
+status: todo
+created: 2026-06-16
+priority: high
+urgency: soon
+area: content/guide, content/examples, content/README.md, content/development
+depends_on: []
+---
+
+# DOCS-001: content transport split 참조 갱신
+
+## Problem
+
+beta.76에서 `agent-transport`가 lean core(`.`/`./headless`/`./testing`만 export)와 독립 패키지
+`@robota-sdk/agent-transport-{tui,http,ws,mcp}`로 분할됐으나, 다수 문서가 구 모놀리식 서브경로
+`@robota-sdk/agent-transport/{tui,http,ws,mcp}`를 그대로 사용한다(import 실패). 근거:
+`.design/docs-audit/2026-06-16/report-content-core-guides.md`, `report-content-examples-integrations.md`.
+
+대상:
+
+- `content/guide/architecture.md` (~14곳: 다이어그램/표/Dependency Flow)
+- `content/guide/sdk.md` (transport 표 ~357–380; `agent-transport/headless`만 유효)
+- `content/guide/cli.md` (~3, 5, 220: `agent-transport/tui`)
+- `content/README.md` (~189, 213)
+- `content/development/README.md` (~50 monorepo 트리)
+- `content/examples/http-transport.md` / `ws-transport.md` / `mcp-transport.md` (import 2곳씩)
+
+## Solution
+
+서브경로 import를 독립 패키지 root import로 교체(팩토리명 동일):
+`@robota-sdk/agent-transport/http` → `@robota-sdk/agent-transport-http` 등. `./headless`·`./testing`는
+유지. 다이어그램/표의 패키지 구조도 split 반영.
+
+## Completion Criteria
+
+- [ ] TC-01: 대상 문서에서 `@robota-sdk/agent-transport/(tui|http|ws|mcp)` 참조 0건 (rg)
+- [ ] TC-02: 각 transport example의 import가 실제 export(`agent-transport-*` root)와 일치
+- [ ] TC-03: architecture/sdk/README 다이어그램·표가 split 구조 반영
+- [ ] TC-04: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                                            |
+| ----- | ---------- | --------------------------------------------------- |
+| TC-01 | Doc/grep   | `rg "agent-transport/(tui\|http\|ws\|mcp)" content` |
+| TC-02 | Doc review | example import ↔ 패키지 package.json exports 대조   |
+| TC-03 | Doc review | 다이어그램/표 검토                                  |
+| TC-04 | Harness    | `pnpm harness:scan`                                 |
+
+## User Execution Test Scenarios
+
+content/examples/{http,ws,mcp}-transport.md는 사용자가 실행하는 코드 절차다. 수정 후 각 예제의
+import/팩토리 호출이 현재 패키지에서 resolve되는지 최소 빌드/타입 확인으로 검증한다(빈 임시 프로젝트
+또는 타입 체크). architecture/sdk/README의 다이어그램·표 변경은 prose라 Not applicable.
+
+## Tasks
+
+- [ ] 서브경로 → 독립 패키지 import 교체 → grep 0건 → harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/DOCS-002-content-phantom-api-refs.md
+++ b/.agents/backlog/DOCS-002-content-phantom-api-refs.md
@@ -1,0 +1,65 @@
+---
+title: 'DOCS-002: content 가이드의 존재하지 않는 패키지/API 참조 정리'
+status: todo
+created: 2026-06-16
+priority: high
+urgency: soon
+area: content/guide, content/examples, content/quickstart.md
+depends_on: []
+---
+
+# DOCS-002: content 존재하지 않는 패키지/API 참조 정리
+
+## Problem
+
+여러 가이드가 존재하지 않는 패키지/API를 현재형으로 기술해 따라하면 실패한다. 근거:
+`.design/docs-audit/2026-06-16/report-content-core-guides.md`, `report-content-examples-integrations.md`.
+
+- `content/guide/cli.md` (~305–347): 가공의 `@robota-sdk/plugin-{github,slack,jira,linear,notion}` +
+  `GitHubPlugin` + `agent.use(...)`. 실제: `@robota-sdk/agent-plugin`의 8개 플러그인, 생성자
+  `plugins: [...]` 등록. `Robota.use()` 없음.
+- `content/guide/migration.md` (~26, 227–243): 존재하지 않는 `@robota-sdk/agent-team`
+  (`createTeam`/`TeamContainer`/`agent.addTool()`) + 죽은 SPEC 링크.
+- `content/guide/local-llm.md` (~66–72): 존재하지 않는 `ROBOTA_PROVIDER/BASE_URL/MODEL/API_KEY`
+  환경변수 설정법. 실제: `robota --configure` / settings.json.
+- `content/examples/session-management.md`: `SessionStore` import/`new SessionStore()` — 미export.
+  실제: `createUserSessionStore()` / `createProjectSessionStore()`.
+- `content/quickstart.md` (~68–77): `createAgentRuntime({ provider })`가 필수 `cwd` 누락;
+  `const response = await session.submit(...)`는 오류(`submit()` → `Promise<void>`). 응답은
+  `complete` 이벤트 또는 `createQuery()`.
+
+## Solution
+
+각 항목을 실제 export/패턴으로 교체하거나, 미구현 기능은 "Planned"로 명확히 분리. 코드 샘플은
+실제 패키지 export와 일치하도록 수정.
+
+## Completion Criteria
+
+- [ ] TC-01: 위 문서에서 존재하지 않는 패키지명(`plugin-*`, `agent-team`) 및 API(`agent.use`,
+      `createAgent`, `SessionStore`, `ROBOTA_*` env) 참조 0건
+- [ ] TC-02: 교체된 심볼/옵션이 실제 소스 export와 일치(plugins 배열, createUserSessionStore,
+      createAgentRuntime cwd, submit void+complete 이벤트)
+- [ ] TC-03: 미구현(team 등)은 "Planned/future"로 표기 또는 제거
+- [ ] TC-04: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                                              |
+| ----- | ---------- | ----------------------------------------------------- |
+| TC-01 | Doc/grep   | 존재하지 않는 식별자 grep → 0건                       |
+| TC-02 | Doc review | 소스 export(`agent-plugin`, `agent-framework`)와 대조 |
+| TC-03 | Doc review | Planned 표기 확인                                     |
+| TC-04 | Harness    | `pnpm harness:scan`                                   |
+
+## User Execution Test Scenarios
+
+quickstart.md / session-management.md는 사용자 실행 절차다. 수정 후 해당 스니펫이 현재 API로
+타입체크/빌드되는지 확인. migration/local-llm/cli의 미구현·설정 서술은 prose/Planned라 Not applicable.
+
+## Tasks
+
+- [ ] phantom 참조 교체/Planned 표기 → grep 0건 → harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/DOCS-003-readme-accuracy.md
+++ b/.agents/backlog/DOCS-003-readme-accuracy.md
@@ -1,0 +1,63 @@
+---
+title: 'DOCS-003: README 정확도 갱신 (root + 패키지 + apps)'
+status: todo
+created: 2026-06-16
+priority: high
+urgency: soon
+area: README.md, packages/agent-core, packages/agent-framework, packages/agent-command, packages/agent-cli, apps/agent-server
+depends_on: []
+---
+
+# DOCS-003: README 정확도 갱신
+
+## Problem
+
+근거: `.design/docs-audit/2026-06-16/report-readmes.md`. 출하되지 않은 패키지 분할/가공 패키지명 등.
+
+- **root `README.md`**: 아키텍처 다이어그램·Packages 표가 beta.76 변경 누락(19개 중 ~6개만, transport
+  split·agent-session-analytics 등 부재).
+- **agent-core/README.md**: 출하 안 된 `@robota-sdk/agent-plugin-*` 분할 서술(실제 consolidated
+  `agent-plugin`); 비존재 복수형 `agent-sessions/agent-providers/agent-plugins/agent-sdk`;
+  private `agent-tool-mcp`를 설치 대상으로 제시.
+- **agent-framework/README.md**: 비존재 `@robota-sdk/agent-command-skills` import(실제 `agent-command`의
+  `./skills`); 개별 `agent-plugin-*` 나열; 구명 `agent-sdk`.
+- **agent-command/README.md**: 커맨드 인벤토리 stale — "20개"라 하나 실제 22개 export, `/preset`·
+  `/schedule` 누락.
+- **agent-cli/README.md**: 비존재 `@robota-sdk/agent-transport-headless`(실제 `agent-transport`의
+  `./headless`); `--model` 예시 구 모델 id.
+- **apps/agent-server/README.md**: 비존재 `@robota-sdk/agent-remote-server-core`.
+
+## Solution
+
+각 README를 실제 패키지/export에 맞춰 수정. root 표는 19개 공개 패키지 반영(또는 "curated subset"
+명시) + transport split·agent-session-analytics 추가. private 패키지를 설치 대상으로 제시하지 않음.
+
+## Completion Criteria
+
+- [ ] TC-01: 대상 README에서 비존재 패키지/심볼(`agent-plugin-*`, `agent-command-skills`,
+      `agent-transport-headless`, `agent-remote-server-core`, 복수형 명) 참조 0건
+- [ ] TC-02: agent-command README가 `/preset`·`/schedule` 포함, 카운트(22) 정정
+- [ ] TC-03: root README가 transport split + agent-session-analytics 반영(또는 subset 명시)
+- [ ] TC-04: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                                           |
+| ----- | ---------- | -------------------------------------------------- |
+| TC-01 | Doc/grep   | 비존재 식별자 grep → 0건                           |
+| TC-02 | Doc review | agent-command/src/index.ts export ↔ README 표 대조 |
+| TC-03 | Doc review | root 표/다이어그램 검토                            |
+| TC-04 | Harness    | `pnpm harness:scan`                                |
+
+## User Execution Test Scenarios
+
+Not applicable — README 정확도(설명/표/다이어그램) 갱신. 사용자 대면 런타임 동작 무변경.
+(코드 샘플 변경분이 있으면 해당 import만 타입 확인.)
+
+## Tasks
+
+- [ ] README별 비존재 참조 교체 + 인벤토리/표 정정 → grep 0건 → harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/DOCS-004-ko-docs-refresh.md
+++ b/.agents/backlog/DOCS-004-ko-docs-refresh.md
@@ -1,0 +1,56 @@
+---
+title: 'DOCS-004: content/ko 한국어 문서 최신화 (v2-era 재작성 + 끊긴 링크)'
+status: todo
+created: 2026-06-16
+priority: medium
+urgency: later
+area: content/ko
+depends_on: [DOCS-002]
+---
+
+# DOCS-004: content/ko 한국어 문서 최신화
+
+## Problem
+
+근거: `.design/docs-audit/2026-06-16/report-content-examples-integrations.md`.
+
+- `content/ko/getting-started/README.md`: 전체가 v2-era라 실행 불가 — 비존재 `@robota-sdk/anthropic`/
+  `openai`, 미export `createAgent`, 잘못된 옵션(`providers:` 문자열 `defaultModel`), 구 모델 id
+  `claude-sonnet-4-5`, 인라인 tool 리터럴. 현재 영어 getting-started와 한 세대 차이.
+- `content/ko/README.md`: `/ko/guide`·`/ko/examples`·`/ko/packages` 링크가 존재하지 않는 섹션을 가리킴.
+
+## Solution
+
+ko/getting-started를 현재 영어 `content/getting-started/README.md`(검증상 clean)에 맞춰 재작성
+(`new Robota({ aiProviders, defaultModel: {...} })`, `@robota-sdk/agent-provider/anthropic`,
+`createZodFunctionTool`, 모델 id `-4-6`). ko/README의 끊긴 링크는 해당 한국어 섹션 생성 또는 영어
+대응 문서로 연결.
+
+## Completion Criteria
+
+- [ ] TC-01: ko/getting-started가 현재 영어 getting-started의 API/옵션/모델 id와 일치
+- [ ] TC-02: ko/getting-started에 비존재 패키지/심볼(`@robota-sdk/anthropic`, `createAgent`) 0건
+- [ ] TC-03: ko/README의 끊긴 내부 링크 0건(존재 섹션 또는 영어 대응으로 연결)
+- [ ] TC-04: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                    |
+| ----- | ---------- | --------------------------- |
+| TC-01 | Doc review | 영어 getting-started와 대조 |
+| TC-02 | Doc/grep   | 비존재 식별자 grep → 0건    |
+| TC-03 | Doc review | 링크 대상 존재 확인         |
+| TC-04 | Harness    | `pnpm harness:scan`         |
+
+## User Execution Test Scenarios
+
+ko/getting-started는 사용자 실행 절차다. 수정 후 한국어 빠른시작 코드가 현재 API로 타입체크/빌드되는지
+확인(영어판과 동일 검증 경로). 링크 정정은 prose라 Not applicable.
+
+## Tasks
+
+- [ ] ko/getting-started 재작성 → ko/README 링크 정정 → grep/harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/DOCS-005-changelog-and-new-package-docs.md
+++ b/.agents/backlog/DOCS-005-changelog-and-new-package-docs.md
@@ -1,0 +1,52 @@
+---
+title: 'DOCS-005: changelog 최신화 + agent-session-analytics 문서화'
+status: todo
+created: 2026-06-16
+priority: medium
+urgency: later
+area: content/changelog, content/README.md, content/guide, content/development
+depends_on: []
+---
+
+# DOCS-005: changelog 최신화 + 신규 패키지 문서화
+
+## Problem
+
+근거: `.design/docs-audit/2026-06-16/report-content-core-guides.md`.
+
+- `content/changelog/README.md`: 최신 항목이 Beta 67(2026-05-23). ground truth는 beta.76. 누락:
+  transport split, `agent-session-analytics` 신규 패키지, 그 사이 릴리즈.
+- 신규 공개 패키지 `@robota-sdk/agent-session-analytics`가 `content/README.md`,
+  `content/guide/architecture.md`, `content/development/README.md`의 패키지 목록/다이어그램에 미문서화.
+
+## Solution
+
+changelog에 beta.68~76 핵심 변경(transport split, agent-session-analytics 신설, DQ-AUDIT 리팩터 등)
+요약 추가. 패키지 목록/아키텍처 다이어그램에 agent-session-analytics(세션 로그 분석) 등재.
+(transport split 자체의 본문 갱신은 DOCS-001과 중복되지 않게 changelog/목록 차원만.)
+
+## Completion Criteria
+
+- [ ] TC-01: changelog가 beta.76까지 반영(beta.68~76 항목 존재)
+- [ ] TC-02: agent-session-analytics가 README/architecture/development 패키지 목록에 등재
+- [ ] TC-03: `pnpm harness:scan` 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                                         |
+| ----- | ---------- | ------------------------------------------------ |
+| TC-01 | Doc review | changelog 최신 버전 = beta.76 확인               |
+| TC-02 | Doc/grep   | `rg "agent-session-analytics" content` 등재 확인 |
+| TC-03 | Harness    | `pnpm harness:scan`                              |
+
+## User Execution Test Scenarios
+
+Not applicable — changelog/패키지 목록(설명) 갱신. 사용자 대면 런타임 동작 무변경.
+
+## Tasks
+
+- [ ] changelog beta.68~76 추가 → agent-session-analytics 등재 → harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/DOCS-006-api-reference-disposition.md
+++ b/.agents/backlog/DOCS-006-api-reference-disposition.md
@@ -1,0 +1,67 @@
+---
+title: 'DOCS-006: content/api-reference 처리 방향 결정 (retire vs regenerate) + dead link 수정'
+status: todo
+created: 2026-06-16
+priority: medium
+urgency: later
+area: content/api-reference, scripts/docs, content/quickstart.md, apps/docs
+depends_on: []
+---
+
+# DOCS-006: api-reference 처리 방향 결정 + dead link
+
+## Problem
+
+근거: `.design/docs-audit/2026-06-16/report-content-generated-frozen.md`.
+
+`content/api-reference/`는 **stale + orphaned**:
+
+- 공개 19개 중 5개 디렉터리만 존재(그중 2개는 private: agent-playground, agent-tool-mcp). 16개 누락
+  (transport split, agent-session-analytics 포함).
+- 자동 생성기 `scripts/docs/docs-generator.js`는 `packages/*/src/index.ts`를 동적 스캔하나 `private`을
+  거르지 않음. 광고된 `pnpm typedoc:convert` 스크립트는 **존재하지 않고** 어떤 빌드에도 연결돼 있지 않음
+  (INFRA-BL-005에서 convert 단계 제거, 파이프라인이 Next.js로 이전). 라이브 docs 앱은
+  `EXCLUDED_DIRS={v2.0.0, api-reference, images, ko}`로 api-reference를 라우팅에서 제외 → 디스크의
+  5개 디렉터리는 stale leftover.
+- **dead link**: `content/quickstart.md:102`가 렌더되지 않는 `/api-reference`를 가리킴.
+
+## Decision Required
+
+api-reference는 자동 생성물이라 hand-edit 금지. 둘 중 하나를 사용자가 결정해야 함:
+
+- **옵션 A (권장) — 폐기(retire):** INFRA-BL-005 방향과 일치. `content/api-reference/`,
+  `scripts/docs/docs-generator.js`, `typedoc.json`, 죽은 `/api-reference` 링크 제거. 최저 비용.
+- **옵션 B — 복구·재생성:** `typedoc:convert` 스크립트 재도입 → 빌드 연결, 생성기가 `private` 스킵,
+  `/api-reference` 라우트 추가 + EXCLUDED_DIRS에서 제외, 19개 공개 패키지 전부 재생성.
+
+> 결정 후 해당 옵션만 구현한다. dead link 수정(quickstart.md)은 두 옵션 모두에 포함.
+
+## Completion Criteria
+
+- [ ] TC-01: 사용자가 옵션 A/B 중 선택(결정 기록)
+- [ ] TC-02: 선택 옵션 구현 (A: 디렉터리/생성기/typedoc.json/링크 제거 · B: 재생성+라우팅+private 스킵)
+- [ ] TC-03: `content/quickstart.md`의 `/api-reference` dead link 해소(제거 또는 유효 라우트)
+- [ ] TC-04: `pnpm harness:scan` + `apps/docs` 빌드 통과
+
+## Test Plan
+
+| TC-ID | Test Type  | Approach                                                     |
+| ----- | ---------- | ------------------------------------------------------------ |
+| TC-01 | Decision   | 사용자 승인 문구 기록                                        |
+| TC-02 | Build/Doc  | 옵션 A: 잔여 참조 0건 grep · 옵션 B: 19개 디렉터리 생성 확인 |
+| TC-03 | Doc review | quickstart 링크 검증                                         |
+| TC-04 | Build      | `apps/docs` build + `pnpm harness:scan`                      |
+
+## User Execution Test Scenarios
+
+옵션 B 채택 시: 사용자가 라이브 docs 사이트에서 `/api-reference` 경로를 열어 패키지 목록이 보이는지
+확인(브라우저). 옵션 A 채택 시: Not applicable(생성물·링크 제거, 런타임/사이트 동작 무변경 — 죽은 링크
+제거만).
+
+## Tasks
+
+- [ ] 옵션 결정(사용자) → 구현 → quickstart 링크 수정 → docs 빌드/harness:scan
+
+## Evidence Log
+
+(구현 후 작성)

--- a/.agents/backlog/README.md
+++ b/.agents/backlog/README.md
@@ -719,6 +719,21 @@ beta.76 릴리즈 세션에서 **실제로 발생한** 마찰·실수를 스킬 
 | [LESSON-009](completed/LESSON-009-skill-registry-check-ssot.md) ✅       | unregistered-skill 검사를 skills/index.md(SSOT)로 교정                      | medium   |
 | [NAMING-001](completed/NAMING-001-subagent-hyphen-cleanup.md) ✅         | production 코드 금지 하이픈형 sub-agent → subagent 정리                     | medium   |
 
+### Docs Freshness Audit (2026-06-16)
+
+병렬 4-에이전트 감사(보고서: `.design/docs-audit/2026-06-16/`)에서 도출된 README·content 최신화 항목.
+ground truth: 19개 공개 패키지, 3.0.0-beta.76, beta.76 transport split + agent-session-analytics 신설.
+`content/v2.0.0/`(동결 아카이브)는 대상 외.
+
+| ID                                                     | 제목                                                            | 우선순위 |
+| ------------------------------------------------------ | --------------------------------------------------------------- | -------- |
+| [DOCS-001](DOCS-001-content-transport-split-refs.md)   | content transport split 참조 갱신 (서브경로 → 독립 패키지)      | high     |
+| [DOCS-002](DOCS-002-content-phantom-api-refs.md)       | content 가이드의 존재하지 않는 패키지/API 참조 정리             | high     |
+| [DOCS-003](DOCS-003-readme-accuracy.md)                | README 정확도 갱신 (root + 패키지 + apps)                       | high     |
+| [DOCS-004](DOCS-004-ko-docs-refresh.md)                | content/ko 한국어 문서 최신화 (v2-era 재작성 + 끊긴 링크)       | medium   |
+| [DOCS-005](DOCS-005-changelog-and-new-package-docs.md) | changelog 최신화 + agent-session-analytics 문서화               | medium   |
+| [DOCS-006](DOCS-006-api-reference-disposition.md)      | api-reference 처리 방향 결정 (retire vs regenerate) + dead link | medium   |
+
 ### Harness Audit Recommendations (rulebased-harness, 2026-06-15)
 
 rulebased-harness 감사(A등급, 55/57) 결과 도출된 보편성 강화 항목. AGENTS.md domain-free 설계를

--- a/.design/docs-audit/2026-06-16/SUMMARY.md
+++ b/.design/docs-audit/2026-06-16/SUMMARY.md
@@ -1,0 +1,27 @@
+# Docs Freshness Audit — Synthesis (2026-06-16)
+
+Four parallel agents audited READMEs and `content/` against ground truth (19 public `@robota-sdk/*`
+packages, 3.0.0-beta.76, beta.76 transport split + new agent-session-analytics).
+
+Reports:
+
+- [report-readmes.md](report-readmes.md)
+- [report-content-core-guides.md](report-content-core-guides.md)
+- [report-content-examples-integrations.md](report-content-examples-integrations.md)
+- [report-content-generated-frozen.md](report-content-generated-frozen.md)
+
+## Cross-cutting themes → backlogs
+
+| Theme                                                                  | Backlog  | Priority |
+| ---------------------------------------------------------------------- | -------- | -------- |
+| Transport split: `agent-transport/{tui,http,ws,mcp}` → standalone pkgs | DOCS-001 | high     |
+| Phantom packages / non-existent APIs in content guides                 | DOCS-002 | high     |
+| README accuracy (root + package + apps)                                | DOCS-003 | high     |
+| content/ko v2-era stale + broken links                                 | DOCS-004 | medium   |
+| changelog stale (beta.67→76) + agent-session-analytics undocumented    | DOCS-005 | medium   |
+| api-reference orphaned/stale — retire vs regenerate (decision) + link  | DOCS-006 | medium   |
+
+## Excluded (no action)
+
+- `content/v2.0.0/` — intentional frozen archive, banner-marked, excluded from the live Next.js site.
+- `content/api-reference/*.md` individual files — AUTO-GENERATED; never hand-edit (see DOCS-006).

--- a/.design/docs-audit/2026-06-16/report-content-core-guides.md
+++ b/.design/docs-audit/2026-06-16/report-content-core-guides.md
@@ -1,0 +1,55 @@
+# Docs Audit Report — content/ core guides (2026-06-16)
+
+Scope: content/getting-started, guide (~14), development, changelog, top-level content/\*.md. Excluded:
+v2.0.0 (frozen), api-reference (generated), examples/integrations/plugins/ko (other agents).
+
+## Summary
+
+Reviewed 19 files. **8 stale**, 10 clean, 1 frozen snapshot accepted as-is.
+
+## Findings
+
+### HIGH
+
+- **Transport split not reflected (widespread).** beta.76 split `agent-transport` into a lean core
+  (only `./headless` + `./testing` remain) + standalone `@robota-sdk/agent-transport-{tui,http,ws,mcp}`.
+  Docs still use old monolithic subpaths `agent-transport/{tui,http,ws,mcp}`:
+  - `content/guide/architecture.md` — ~14 refs (Mermaid diagram, Package Roles, Dependency Flow,
+    React/Ink table, Transport Layer table, "Changes from v2.0.0").
+  - `content/guide/sdk.md` — transport table ~357–380 + "Assembly vs Direct Usage"; only
+    `agent-transport/headless` still valid.
+  - `content/guide/cli.md` — lines ~3, 5, 220 (`agent-transport/tui` → `@robota-sdk/agent-transport-tui`).
+  - `content/README.md` — lines ~189, 213.
+  - `content/development/README.md` — line ~50 monorepo tree.
+- **Fictional plugin packages + non-existent API — `content/guide/cli.md` (~305–347).** Claims
+  `@robota-sdk/plugin-{github,slack,jira,linear,notion}` with `GitHubPlugin` etc. via
+  `agent.use(new GitHubPlugin())`. None exist; `Robota` has no `.use()`. Real: the 8 plugins in
+  `@robota-sdk/agent-plugin`, registered via constructor `plugins: [...]`.
+- **Incorrect quickstart — `content/quickstart.md` (~68–77).** `createAgentRuntime({ provider })`
+  omits required `cwd`; `const response = await session.submit(...)` is wrong — `submit()` returns
+  `Promise<void>` (interactive-session.ts). Reply comes via the `complete` event or `createQuery()`.
+
+### MEDIUM
+
+- **`content/guide/migration.md`** — presents non-existent `@robota-sdk/agent-team` as current 3.0.0
+  (~26, 227–243) with `createTeam`/`TeamContainer`/`createAssignTaskRelayTool`/`agent.addTool()` +
+  dead link to `packages/agent-team/docs/SPEC.md`. No such package.
+- **`content/guide/local-llm.md` (~66–72)** — documents `ROBOTA_PROVIDER/BASE_URL/MODEL/API_KEY`
+  env-var config that does not exist. Real config: `robota --configure` / settings.json.
+- **`content/changelog/README.md`** — latest entry Beta 67 (2026-05-23); ground truth beta.76. Missing
+  transport split + agent-session-analytics entries.
+- **`agent-session-analytics` (new public package) undocumented** in README.md, architecture.md,
+  development/README.md package lists/diagrams.
+
+## Clean files (verified against source)
+
+getting-started/README.md, guide/README.md, building-agents.md, providers.md, embedding.md,
+plugins.md, error-handling.md (12 error classes confirmed), context-management.md,
+permissions-and-hooks.md. `release-2026-05-02.md` is a frozen Beta 59 snapshot (old names historically
+correct — accept).
+
+## Caveat
+
+Built `packages/*/src` is minified; some exact strings (SessionManager, `complete` payload field,
+specific model IDs) couldn't be string-confirmed. Findings rest on package.json `exports`, package
+existence/absence, and un-minified declarations.

--- a/.design/docs-audit/2026-06-16/report-content-examples-integrations.md
+++ b/.design/docs-audit/2026-06-16/report-content-examples-integrations.md
@@ -1,0 +1,65 @@
+# Docs Audit Report — content/ examples, integrations, plugins, ko (2026-06-16)
+
+Scope: content/examples (12), integrations (1), plugins (1), ko (2). Verified imports/symbols/options
+against packages/\*/src + package.json exports at 3.0.0-beta.76.
+
+## Summary
+
+16 files. **5 with findings (4 high)**, 11 clean.
+Top themes: (1) transport split not reflected in 3 transport examples; (2) Korean docs v2-era stale;
+(3) `SessionStore` symbol removed; (4) github-action self-contradicts; (5) plugin event names wrong.
+
+## Findings
+
+### content/ko/getting-started/README.md — HIGH (entirely v2-era; won't run)
+
+- `import { Anthropic } from '@robota-sdk/anthropic'` / `'@robota-sdk/openai'` — packages don't exist.
+  Current: `@robota-sdk/agent-provider/anthropic` exporting `AnthropicProvider`.
+- `createAgent({ providers, defaultModel: 'claude-sonnet-4-5' })` — `createAgent` not exported. Current:
+  `new Robota({ name, aiProviders: [...], defaultModel: { provider, model, systemMessage } })`.
+- Wrong options (`providers:` → `aiProviders:`; string `defaultModel` → object); inline tool literal →
+  `createZodFunctionTool` from `@robota-sdk/agent-tools`; model id `claude-sonnet-4-5` → `-4-6`.
+- Fix: rewrite to mirror current English getting-started, or remove + redirect.
+
+### content/ko/README.md — MEDIUM
+
+- Broken links `/ko/guide`, `/ko/examples`, `/ko/packages` (lines ~8–10) — only README.md +
+  getting-started/ exist under ko. Fix: create sections or point to English.
+
+### content/examples/http-transport.md — HIGH
+
+- Imports `createHttpTransport`/`createAgentRoutes` from `@robota-sdk/agent-transport/http` (removed
+  subpath). Real: `@robota-sdk/agent-transport-http` root. Fix: change both imports.
+
+### content/examples/ws-transport.md — HIGH
+
+- Imports from `@robota-sdk/agent-transport/ws` (removed). Real: `@robota-sdk/agent-transport-ws`
+  (`createWsTransport`, `createWsHandler`). Fix: change both imports.
+
+### content/examples/mcp-transport.md — HIGH
+
+- Imports from `@robota-sdk/agent-transport/mcp` (removed). Real: `@robota-sdk/agent-transport-mcp`
+  (`createMcpTransport`, `createAgentMcpServer`). Fix: change both imports.
+
+### content/examples/session-management.md — HIGH
+
+- `import { InteractiveSession, SessionStore }` + `new SessionStore()` — `SessionStore` not exported by
+  agent-framework; only `createProjectSessionStore`/`createUserSessionStore`. Everything else valid.
+  Fix: replace with `createUserSessionStore()`.
+
+### content/integrations/github-action.md — MEDIUM
+
+- Self-contradictory: declares action "Not yet available" (~1–3) but presents `uses: robota-sdk/action@v1`
+  as shipped (~47–121). Fix: fence Quick Start/Inputs/Outputs under "Planned (future)" or remove until shipped.
+
+### content/plugins/README.md — LOW
+
+- Event names colon-style `execution:start`/`tool:call`/`error` (line ~20) don't exist. Real
+  `TExecutionEventName` uses dot/prefixed: `tool.beforeExecute`, `tool.afterExecute`, `tool.success`,
+  `error.occurred`, `execution.hierarchy`. Fix: use real names or describe generically.
+
+## Clean files (11)
+
+examples/README.md, basic-conversation.md, multi-provider.md, streaming.md, one-shot-query.md,
+tool-calling.md, interactive-mode.md, print-mode.md. Vendor names (Anthropic/OpenAI/Gemini/LM Studio)
+are legitimate external references. No `sub-agent` hyphen in scope.

--- a/.design/docs-audit/2026-06-16/report-content-generated-frozen.md
+++ b/.design/docs-audit/2026-06-16/report-content-generated-frozen.md
@@ -1,0 +1,50 @@
+# Docs Audit Report — api-reference (generated) + v2.0.0 (frozen) (2026-06-16)
+
+## api-reference coverage
+
+**Covered (5 subdirs in content/api-reference/):** agent-cli, agent-core, agent-playground (PRIVATE),
+agent-tool-mcp (PRIVATE), agent-tools. No top-level index. ~244–249 files.
+
+**MISSING (16 of 19 public packages):** agent-command, agent-executor, agent-framework,
+agent-interface-transport, agent-interface-tui, agent-plugin, agent-preset, agent-provider,
+agent-session, **agent-session-analytics (NEW)**, agent-subagent-runner, agent-transport,
+**agent-transport-{http,mcp,tui,ws} (NEW split)**. Only 3 of 5 covered dirs are actually public; 2 are
+private and should not appear in public API reference. Covered set predates the beta.76 split.
+
+**Generator wiring — ORPHANED:**
+
+- `scripts/docs/docs-generator.js` dynamically scans `packages/*/src/index.ts` (no static list), so a
+  fresh run would cover all packages — but it never reads `"private": true`, so it would wrongly
+  include private packages. Per-run config: `typedoc.json` (repo root).
+- The advertised `pnpm typedoc:convert` script **does not exist** in package.json; nothing invokes
+  `docs-generator.js`. Task `completed/INFRA-BL-005-docs-build-diet.md` removed the convert step and
+  planned to delete `content/api-reference/`, `content/v2.0.0/`, `typedoc.json`. Docs app is now
+  Next.js (`apps/docs`), and both `apps/docs/src/lib/content.ts` and `sidebar.ts` set
+  `EXCLUDED_DIRS = {'v2.0.0','api-reference','images','ko'}` — api-reference is neither regenerated nor
+  published. The 5 dirs on disk are stale leftovers.
+
+**Recommended fix (DECISION REQUIRED — pick one; never hand-edit generated .md):**
+
+1. _Retire (matches INFRA-BL-005 direction):_ delete `content/api-reference/`, `docs-generator.js`,
+   `typedoc.json`, and the dead `/api-reference` link in quickstart.md. **(recommended — lowest cost,
+   aligns with the already-chosen Next.js diet.)**
+2. _Restore & regenerate:_ re-add a `typedoc:convert` script → `node scripts/docs/docs-generator.js`,
+   wire it into the build, make the generator skip `"private": true`, build an `/api-reference`
+   route + remove from EXCLUDED_DIRS, regenerate all 19 public dirs.
+
+**Concrete bug:** `content/quickstart.md:102` links to `/api-reference` ("full TypeScript API docs"),
+which is in EXCLUDED_DIRS and does not render — dead link in the live site.
+
+## v2.0.0 frozen status
+
+- Confirmed intentional frozen archive. `content/v2.0.0/README.md`: `title: Robota SDK (v2.0.0)` +
+  banner "archived documentation … for the latest, see current documentation (/)". Banner repeated in
+  6 landing READMEs across 310 files.
+- Excluded from live site (in EXCLUDED_DIRS of content.ts + sidebar.ts). No improper "current" links —
+  only prose "Changes from v2.0.0" migration notes. **No action; do not modify.**
+
+## Summary
+
+api-reference is stale + orphaned (5 dirs, missing 16/19 incl. transport split + agent-session-analytics;
+generator not wired into any build; app excludes it). Decision: retire (recommended) vs regenerate+rewire.
+v2.0.0 is a correctly frozen archive — leave as-is. One concrete dead link: quickstart.md:102 → /api-reference.

--- a/.design/docs-audit/2026-06-16/report-readmes.md
+++ b/.design/docs-audit/2026-06-16/report-readmes.md
@@ -1,0 +1,65 @@
+# Docs Audit Report — READMEs (2026-06-16)
+
+Scope: root `README.md`, `packages/*/README.md` (25), `apps/*/README.md` (3). Ground truth: 19 public
+`@robota-sdk/*` packages, version 3.0.0-beta.76, beta.76 transport split + new agent-session-analytics.
+
+## Summary
+
+- Reviewed: 26 READMEs. Stale: **6**. Placeholder/empty: 0 (new packages all have real content).
+- Dominant theme: references to **package splits that never shipped** (`agent-plugin-*`,
+  `agent-command-*` are consolidated into single `agent-plugin` / `agent-command`) + a few phantom
+  package names. The transport split IS correctly reflected in transport READMEs.
+
+## Findings
+
+### packages/agent-cli/README.md
+
+- **high** — Dependency table lists non-existent `@robota-sdk/agent-transport-headless` (line ~538).
+  Headless folded into `@robota-sdk/agent-transport` (`./headless` sub-path). Fix: replace with
+  `agent-transport` + note `./headless`.
+- **low** — `--model` example uses `claude-opus-4-7` while doc elsewhere uses `claude-sonnet-4-6`
+  (line ~135). Fix: align example model id.
+
+### packages/agent-core/README.md
+
+- **medium** — "What Moved Out in v3" + architecture describe a per-plugin package split that did not
+  ship; plugins ship consolidated in `@robota-sdk/agent-plugin`. Evidence: `@robota-sdk/agent-plugin-*`
+  (line ~133), "8 extracted packages" (line ~106). Fix: → `@robota-sdk/agent-plugin`.
+- **low** — Architecture diagram uses non-existent plurals `agent-sessions/agent-providers/agent-plugins/agent-sdk`
+  (lines ~103–108). Fix: singular real names + `agent-framework`.
+- **low** — Presents `@robota-sdk/agent-tool-mcp` (private/unpublished) as installable (line ~132).
+
+### packages/agent-framework/README.md
+
+- **high** — Code sample imports non-existent `@robota-sdk/agent-command-skills` (lines ~238, ~261).
+  Skills module lives in consolidated `@robota-sdk/agent-command` (`./skills`). Fix: → `agent-command`.
+- **medium** — Lists individual plugin packages `agent-plugin-conversation-history…webhook` (line ~433)
+  that don't exist. Fix: "consolidated `@robota-sdk/agent-plugin` exports all 8 plugins".
+- **low** — Prose uses `agent-command-*` (lines ~43, 213) and old name `agent-sdk` for this package
+  (lines ~343, 345, 382). Fix: `agent-command`, `agent-framework`.
+
+### packages/agent-command/README.md
+
+- **medium** — Command inventory stale: claims "All 20 factory functions" but package now exports 22
+  modules; missing `/preset` and `/schedule` (verified: src/index.ts exports preset, schedule). Fix:
+  add both + update count.
+
+### README.md (root)
+
+- **medium** — Architecture diagram + Packages table omit beta.76 changes; table lists only ~6 of 19
+  public packages (no transport split, no agent-session-analytics/preset/command/plugin/executor/
+  subagent-runner/interface packages). Fix: add new packages (or mark table as curated subset) +
+  update diagram.
+
+### apps/agent-server/README.md
+
+- **high** — References non-existent `@robota-sdk/agent-remote-server-core` (line ~14); only
+  `@robota-sdk/agent-remote-client` (private) exists. Fix: correct to actual location or describe
+  in-app implementation.
+
+## Clean files (17)
+
+agent-session-analytics, agent-transport, agent-transport-{http,mcp,tui,ws}, agent-executor,
+agent-interface-transport, agent-interface-tui, agent-plugin, agent-preset, agent-provider,
+agent-session, agent-subagent-runner, agent-tools, apps/blog, apps/starter-nextjs. No vendor-name or
+`sub-agent` hyphen violations. Transport split correctly documented in transport READMEs.


### PR DESCRIPTION
병렬 4-에이전트로 README·content/ 최신화 감사 → 보고서 4종(.design/docs-audit/2026-06-16/) → 백로그 6건 종합.

| ID | 테마 | 우선 |
|----|------|------|
| DOCS-001 | content transport split 참조 갱신(서브경로→독립 패키지) | high |
| DOCS-002 | 존재하지 않는 패키지/API(plugin-*, agent-team, .use(), SessionStore, ROBOTA_* env, submit void) | high |
| DOCS-003 | README 정확도(root 표·agent-core/framework/command/cli·agent-server) | high |
| DOCS-004 | content/ko v2-era 재작성 + 끊긴 링크 | medium |
| DOCS-005 | changelog beta.67→76 + agent-session-analytics 문서화 | medium |
| DOCS-006 | api-reference 처리 결정(retire 권장 vs regenerate) + dead link | medium |

이 PR은 **보고서·백로그 생성만**(실제 문서 수정은 각 DOCS 백로그 실행 시). content/v2.0.0(동결) 제외, api-reference(자동생성) hand-edit 금지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)