### PR TITLE
fix(license): make LICENSE detectable as AGPL-3.0 on GitHub

### DIFF
--- a/.agents/backlog/CI-001-flaky-headless-provider-failure-test.md
+++ b/.agents/backlog/CI-001-flaky-headless-provider-failure-test.md
@@ -1,0 +1,42 @@
+---
+title: 'Fix flaky CI test — agent-transport headless provider failure (CLI-064 TC-02)'
+status: todo
+---
+
+# Fix flaky CI test — agent-transport headless provider failure (CLI-064 TC-02)
+
+## What
+
+`packages/agent-transport/src/headless/__tests__/headless-provider-failure.integration.test.ts`
+→ "headless provider failure exit codes (CLI-064) > **TC-02: json format exits 1 with subtype
+error and error_code api_error**" fails intermittently in the `compat-node18` CI job, while
+passing reliably when run in isolation locally.
+
+## Why
+
+The failure is a flake, not a real regression:
+
+- Reproduced green locally on develop/main: `pnpm --filter @robota-sdk/agent-transport test -- --run src/headless/__tests__/headless-provider-failure.integration.test.ts` → 2 passed.
+- It only fails inside the full parallel `pnpm -r run test --coverage` matrix in CI.
+- The same `compat-node18` job has failed on unrelated sync-to-main PRs (AGPL relicense,
+  DOCFIX) — i.e. it is a recurring flake, independent of the PR content.
+
+It blocks/red-flags otherwise-clean PRs (observed on PR #816, a www-copy-only change) and
+erodes trust in CI signal.
+
+## Likely causes to investigate
+
+- Shared/global state across concurrently-running vitest projects (env vars, stdout/stderr
+  capture, process exit code interception) in the headless integration harness.
+- Timing/ordering assumption in the JSON-format assertion (error_code `api_error`, subtype
+  `error`) that only surfaces under load.
+
+## Done When
+
+- Root cause identified and fixed (deterministic isolation of the headless run / assertion).
+- The test passes reliably under the full `pnpm -r run test --coverage` run, including in the
+  `compat-node18` job, across multiple consecutive CI runs.
+
+## User Execution Test Scenarios
+
+1. Re-run the `compat-node18` CI job 3+ times on an unrelated PR → no flaky failure of TC-02.

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,5 @@
 Copyright (C) 2024-2026 Robota
-
-Robota is dual-licensed. You may use, copy, modify, and distribute this software
-under the terms of EITHER:
-
-  (1) the GNU Affero General Public License, version 3.0 (AGPL-3.0), the full
-      text of which is reproduced below; OR
-
-  (2) a commercial license from Robota, for use in proprietary/closed-source
-      products or where the AGPL-3.0 obligations are not acceptable. See
-      LICENSE-COMMERCIAL.md and LICENSING.md for details and how to obtain one.
-
-If you did not obtain a commercial license, your use is governed by the AGPL-3.0.
-
-SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
-
-================================================================================
+Dual-licensed: GNU AGPL-3.0 (full text below) OR a commercial license — see LICENSING.md.
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007


### PR DESCRIPTION
## Problem

GitHub's repo license badge showed **"unknown"**. GitHub uses the `licensee` gem, which matches the `LICENSE` file against known license templates above a ~98% similarity threshold. Our `LICENSE` had a 17-line custom dual-license preamble before the verbatim AGPL-3.0 text, dropping similarity below the threshold → not detected.

## Fix

Reduce the preamble to a copyright line + a one-line dual-license pointer, leaving the verbatim GNU AGPL-3.0 text as the bulk of the file. `licensee` strips the leading copyright line and the single short notice is negligible against ~660 lines of AGPL text, so the badge now resolves to **AGPL-3.0**.

This is the standard dual-license pattern (Grafana, Cal.com, Plausible, Sidekiq): the OSI license text lives in `LICENSE`; the dual/commercial track is documented separately.

**Dual licensing is unchanged** — still documented in `LICENSING.md`, `LICENSE-COMMERCIAL.md`, and the `package.json` SPDX expression `AGPL-3.0-only OR LicenseRef-Commercial`.

## Also

- Tracks the recurring flaky `compat-node18` test (agent-transport CLI-064 TC-02) as backlog **CI-001** — it passes in isolation locally and on CI re-run; it is not a real regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)