### PR TITLE
fix(license): canonical AGPL-3.0 text for GitHub detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-Copyright (C) 2024-2026 Robota
-Dual-licensed: GNU AGPL-3.0 (full text below) OR a commercial license — see LICENSING.md.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
@@ -636,8 +633,8 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
## Problem

The repo license still showed **"Unknown / Unknown licenses found"** after the previous attempt. Root cause confirmed by diffing against the template GitHub's `licensee` uses (choosealicense): our AGPL body matched it almost exactly (one wrapped line), but the **extra lines prepended to LICENSE** (a custom copyright line + a dual-license pointer paragraph) pushed the match below the detection threshold.

GitHub's own docs (*Licensing a repository → Detecting a license*) state that extra text in the LICENSE file prevents detection. The AGPL projects GitHub cites (Grafana, Mastodon, Nextcloud) all use the raw license text with no additions.

## Fix

Replace `LICENSE` with the **byte-exact** choosealicense AGPL-3.0 template (`diff -q` clean). GitHub will now detect and display **AGPL-3.0**.

Dual-licensing is unchanged — it remains documented in `LICENSING.md`, `LICENSE-COMMERCIAL.md`, and the `package.json` SPDX expression `AGPL-3.0-only OR LicenseRef-Commercial`, which is also where the Robota copyright is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)