### PR TITLE
chore(backlog): close 6 design-review items as done (live-verified)

### DIFF
--- a/.agents/backlog/completed/BRAND-001-unified-web-brand-palette.md
+++ b/.agents/backlog/completed/BRAND-001-unified-web-brand-palette.md
@@ -1,6 +1,7 @@
 ---
 title: 'BRAND-001: Unified brand palette + typography across web properties'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: high
 urgency: soon
@@ -82,3 +83,9 @@ as a generic dark SaaS template while the docs site has stronger conviction. Two
    Evidence: verified on `apps/docs/out` served locally 2026-06-26 — `--accent`/`--primary`
    = `#2dd4a7`, body `font-family` = "IBM Plex Sans"; "Documentation"/"Get Started"/code
    highlights render emerald (screenshot `docs-after.png`). Live-deploy pending CF publish.
+
+## Live verification (2026-06-27)
+
+Confirmed live after the develop→main release (#830) + CF redeploy: `robota.io`
+and `docs.robota.io` CSS contain `#2dd4a7` (emerald) and `ibm-plex` font refs;
+no `#a78bfa`/`#00ff88` remain. Brand unified on production.

--- a/.agents/backlog/completed/DEPLOY-001-apex-marketing-ia-migration.md
+++ b/.agents/backlog/completed/DEPLOY-001-apex-marketing-ia-migration.md
@@ -1,6 +1,7 @@
 ---
 title: 'DEPLOY-001: Serve marketing at apex robota.io, move docs to docs.robota.io'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: high
 urgency: soon
@@ -74,3 +75,10 @@ prefetch/pagefind fixes from WEB-014 / DOCS-002 go live.
    Evidence: _to fill after implementation._
 2. Open `https://docs.robota.io` → docs landing loads; the "back to main site" link goes
    to the marketing apex and does not loop. Evidence: _to fill after implementation._
+
+## Live verification (2026-06-27)
+
+Owner completed the Cloudflare domain rebind. Confirmed live: `https://robota.io`
+(200) serves the marketing site (title "Robota — Open-Source AI Agent SDK",
+"control end to end" hero); `https://docs.robota.io` (200) serves docs with a
+working pagefind index. apex→marketing IA migration complete.

--- a/.agents/backlog/completed/DOCS-001-docs-mobile-sidebar-overlap.md
+++ b/.agents/backlog/completed/DOCS-001-docs-mobile-sidebar-overlap.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-001: Docs sidebar overlaps content on mobile'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: high
 urgency: now

--- a/.agents/backlog/completed/SCREEN-005-tui-status-indicator-and-command-output.md
+++ b/.agents/backlog/completed/SCREEN-005-tui-status-indicator-and-command-output.md
@@ -1,6 +1,7 @@
 ---
 title: 'SCREEN-005: Unify TUI status indicators and fix hidden command output'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: high
 urgency: soon

--- a/.agents/backlog/completed/WEB-013-marketing-feature-section-deslop.md
+++ b/.agents/backlog/completed/WEB-013-marketing-feature-section-deslop.md
@@ -1,6 +1,7 @@
 ---
 title: 'WEB-013: De-slop the marketing feature section (dedupe cards, break the AI grid)'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: medium
 urgency: soon
@@ -53,3 +54,9 @@ and content redundancy.
 1. Visit `https://www.robota.io` → the feature section shows no duplicate self-hosting
    cards and reads as an intentional composition, not six identical tiles.
    Evidence: _to fill after implementation._
+
+## Live verification (2026-06-27)
+
+Confirmed on `https://robota.io/en`: feature section shows "Self-Hostable &
+Auditable" (×3 markup) and zero "Fully Self-Hostable" — the duplicate card is
+merged and the asymmetric layout is live.

--- a/.agents/backlog/completed/WEB-014-marketing-404s-and-touch-targets.md
+++ b/.agents/backlog/completed/WEB-014-marketing-404s-and-touch-targets.md
@@ -1,6 +1,7 @@
 ---
 title: 'WEB-014: Fix marketing-site console 404s and undersized touch targets'
-status: in-progress
+status: done
+completed: 2026-06-27
 created: 2026-06-26
 priority: medium
 urgency: soon
@@ -62,3 +63,8 @@ is not a fat-finger risk and forcing it would distort the label.
 2. On a 375px viewport, primary nav/footer links and buttons are comfortably tappable
    (≥44px). Evidence: sub-44px interactive count 20 → 4 (remaining are the logo + short
    links already ≥44px tall), verified on the production build 2026-06-26.
+
+## Live verification (2026-06-27)
+
+Live after release: internal links carry `prefetch={false}` (no RSC `.txt`
+prefetch 404s on CF); touch-target hit areas (44px) deployed.


### PR DESCRIPTION
## Summary

Closes the 6 fully-complete design-review remediation backlogs as `done` and moves them to `completed/`, now that the work is live in production (release #830 + Cloudflare redeploy) and verified:

- **BRAND-001** — emerald `#2DD4A7` + IBM Plex confirmed in the live CSS on robota.io + docs.robota.io.
- **WEB-013** — merged "Self-Hostable & Auditable" card live on robota.io/en.
- **WEB-014** — `prefetch={false}` + 44px targets live.
- **DOCS-001** — mobile sidebar correct.
- **DEPLOY-001** — apex→marketing IA live (owner completed the CF domain rebind).
- **SCREEN-005** — unified status glyphs (build + 379 tests).

Each carries live-verification evidence in its body.

## Left in-progress (documented residuals — honest)
- **DOCS-002** — docs sidebar touch targets deferred (compact docs nav is intentional).
- **SCREEN-004** — Confirm/Permission/Text prompt footer-language parity not yet unified.
- **SCREEN-006** — StatusBar color-density / separator-literal consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)