### PR TITLE
fix: Wave B — runtime bugs (WS-001, WEBUI-002, EVENT-001, PLUGIN-001)

### DIFF
--- a/.agents/backlog/PLUGIN-002-database-history-storage-stub.md
+++ b/.agents/backlog/PLUGIN-002-database-history-storage-stub.md
@@ -1,0 +1,61 @@
+---
+title: 'PLUGIN-002: DatabaseHistoryStorage is a consumed, nonfunctional stub (silent data loss)'
+status: todo
+created: 2026-06-27
+priority: medium
+urgency: soon
+area: packages/agent-plugin
+depends_on: []
+---
+
+# DatabaseHistoryStorage is a consumed, nonfunctional stub
+
+Surfaced while fixing PLUGIN-001 (which implemented the File/Remote `*Storage` classes).
+
+## What
+
+`packages/agent-plugin/src/conversation-history/storages/database-storage.ts` is a stub: every
+method logs "Database storage not fully implemented yet" and returns a stub value (save persists
+nothing, load returns `undefined`, etc.). It is **consumed** —
+`conversation-history-helpers.ts:118` returns `new DatabaseHistoryStorage(connectionString)`
+when a user selects the `database` history backend — so a user who configures database history
+silently loses all conversation data, same failure class as the File storages PLUGIN-001 fixed.
+
+Unlike the File/Remote storages, this one needs an external **DB driver decision** (Postgres
+via `pg`? SQLite via `better-sqlite3`? a generic adapter interface?) which is a real product/
+architecture choice, not a mechanical fill-in — hence a separate backlog.
+
+## Why
+
+A consumed storage that silently drops data is a data-loss bug; it must be implemented or the
+`database` option removed so users can't select a no-op backend.
+
+## Options (decide first)
+
+1. Implement against a chosen driver (e.g. Postgres `pg`) — add the dep, schema, migrations.
+2. Define a generic `IDatabaseDriver` adapter interface and let the consumer inject a driver
+   (keeps agent-plugin driver-free, matches the repo's DI philosophy).
+3. Remove the `database` backend option + `DatabaseHistoryStorage` export until a driver exists
+   (the helper falls back to an explicit error, not a silent stub).
+
+Recommended: option 2 (adapter interface) — keeps the package dependency-light and lets the
+app/CLI own the concrete driver. Confirm before implementing.
+
+## Done When
+
+- `database` history is either functional (round-trip persistence test) or the option is
+  removed and selecting it raises a clear error (no silent no-op).
+- The `database-storage` stub markers are gone; stub-marker scan (now catches
+  "placeholder for actual"; consider also extending for this phrasing) stays green.
+- SPEC updated (the table currently marks it a stub pending this item).
+
+## Test Plan
+
+- Round-trip persistence test against the chosen driver (or an in-memory adapter fake), OR a
+  test asserting the removed option errors clearly.
+
+## User Execution Test Scenarios
+
+1. Configure a plugin with `database` history, write and reload a conversation → it persists
+   (or the user gets an explicit "not available" error instead of silent loss). Evidence:
+   _to fill._

--- a/.agents/backlog/completed/EVENT-001-turn-source-event-contract-drift.md
+++ b/.agents/backlog/completed/EVENT-001-turn-source-event-contract-drift.md
@@ -1,12 +1,28 @@
 ---
 title: 'EVENT-001: Add turn_source to the interactive-session event contract (emitted but untyped)'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: medium
 urgency: soon
 area: packages/agent-interface-transport, packages/agent-framework
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `agent-interface-transport/session-contracts.ts`: added `export type TTurnSource =
+'user' | 'agent-wakeup'` and `turn_source: (source: TTurnSource) => void` to
+  `IInteractiveSessionEvents`; re-exported `TTurnSource` from the package index.
+- `agent-framework` controller now imports `TTurnSource` from the contract package (SSOT) and
+  re-exports it for compatibility; the local duplicate declaration was removed. The
+  `emit('turn_source', …)` call is now contract-backed, so consumers can `on('turn_source', …)`
+  type-safely.
+- WS forwarding: `turn_source` is intentionally not forwarded to WS clients (consistent with
+  other in-process-only events like `memory_event`/`compact`); the drift was the missing
+  contract entry, now fixed.
+- Verified: `pnpm build:deps` + `pnpm typecheck` PASS; `pnpm harness:scan` 30/30
+  (spec-public-surface + interface-imports PASS).
 
 # Add `turn_source` to the event contract
 

--- a/.agents/backlog/completed/PLUGIN-001-nonfunctional-exported-file-storages.md
+++ b/.agents/backlog/completed/PLUGIN-001-nonfunctional-exported-file-storages.md
@@ -1,12 +1,32 @@
 ---
 title: 'PLUGIN-001: Resolve exported-but-nonfunctional File*Storage stubs (+ close stub-marker scan gap)'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: high
 urgency: soon
 area: packages/agent-plugin, scripts/harness
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- Implemented the 3 File storages as write-through fs persistence (no buffered loss):
+  `FileHistoryStorage` (JSON map keyed by conversationId, Date revival), `FileUsageStorage`
+  (JSON array + conversationId/time-range filtering), `FileLogStorage` (append-only lines).
+- Implemented the 2 Remote storages against a generic JSON REST contract via `fetch`
+  (`RemoteUsageStorage` POST/GET/DELETE with bearer apiKey + headers + AbortSignal timeout;
+  `RemoteLogStorage` POST), both re-queueing the batch on failure (no silent loss).
+- Extended `check-stub-markers.mjs` STUB_MARKERS with `'placeholder for actual'` (the exact
+  shipped-stub phrasing); 0 remaining hits, scan passes. Deferred stubs that legitimately need
+  external decisions (DatabaseHistoryStorage → driver, network metrics) keep "not fully
+  implemented" wording and are intentionally not matched; DatabaseHistoryStorage is captured as
+  PLUGIN-002.
+- Tests: rewrote `FileHistoryStorage` tests to real round-trips; added `FileUsageStorage`,
+  `FileLogStorage`, `RemoteUsageStorage` (fetch-mocked) tests; updated `RemoteLogStorage` tests
+  to assert real POST + re-queue. agent-plugin **306 tests pass**.
+- Verified: `build:deps` OK, `typecheck` PASS, `lint` 0 errors, `harness:scan` 30/30. SPEC
+  updated (storage table + coverage gaps).
 
 # Resolve exported-but-nonfunctional File\*Storage stubs
 

--- a/.agents/backlog/completed/WEBUI-002-agent-web-ui-runtime-robustness.md
+++ b/.agents/backlog/completed/WEBUI-002-agent-web-ui-runtime-robustness.md
@@ -1,12 +1,23 @@
 ---
 title: 'WEBUI-002: agent-web-ui runtime robustness — render error state, guard JSON.parse, null-safety'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: medium
 urgency: soon
 area: packages/agent-web-ui
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `SessionMonitor.tsx`: render conversation only when `connected`; `error` now shows a
+  reasoned message ("Connection error — could not reach <url>…") instead of a blank view.
+- `ws-session-client.ts`: `JSON.parse` wrapped in try/catch; a malformed frame is surfaced as
+  a synthetic `protocol_error` via `onMessage` (no throw / no UI freeze).
+- `useWsSession.ts`: `user_message` content now uses `?? ''` (parity with the `messages` case).
+- Tests: new `ws-session-client.test.ts` (mocked WebSocket) — malformed frame → protocol_error
+  (no throw), well-formed frame passes through. 2 tests pass; typecheck + build clean.
 
 # agent-web-ui runtime robustness
 

--- a/.agents/backlog/completed/WS-001-unhandled-promise-rejection-ws-handler.md
+++ b/.agents/backlog/completed/WS-001-unhandled-promise-rejection-ws-handler.md
@@ -1,12 +1,22 @@
 ---
 title: 'WS-001: Handle promise rejections in agent-transport-ws message handler (no silent loss)'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: high
 urgency: soon
 area: packages/agent-transport-ws
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `ws-handler.ts`: `session.submit(...)` now `.catch((error: Error) => send protocol_error)`;
+  `session.executeCommand(...)` uses the two-arg `.then(onOk, onErr)` form sending a
+  `protocol_error` on rejection — mirroring `ws-background-messages.ts`.
+- Tests: added "submit rejection → protocol_error" and "command rejection → protocol_error"
+  (WS-001); fixed the mock `submit` to return a promise. `agent-transport-ws` 33 tests pass,
+  typecheck clean.
 
 # Handle promise rejections in the WS message handler
 

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -36,8 +36,11 @@ import type { ICommand, ICommandResult, ISkillExecutionResult } from '../command
 import type { ISkillActivationEvent } from '../commands/skill-activation-events.js';
 import type { IContextFileEntry } from '../context/context-file-tracker.js';
 import type { IContextWindowState, TToolArgs } from '@robota-sdk/agent-core';
+import type { TTurnSource } from '@robota-sdk/agent-interface-transport';
 import type { ICompactEvent } from '@robota-sdk/agent-session';
 import type { Session } from '@robota-sdk/agent-session';
+
+export type { TTurnSource };
 
 export interface IExecutionControllerCallbacks {
   getSession: () => Session;
@@ -48,9 +51,6 @@ export interface IExecutionControllerCallbacks {
   emit: <E extends string>(event: E, ...args: unknown[]) => void;
   persistSession: () => void;
 }
-
-/** Origin of a turn — distinguishes a human prompt from an agent-wakeup (FLOW-002). */
-export type TTurnSource = 'user' | 'agent-wakeup';
 
 /** Options threaded through submit/executePrompt for non-user turns (FLOW-002). */
 export interface ITurnOptions {

--- a/packages/agent-interface-transport/src/index.ts
+++ b/packages/agent-interface-transport/src/index.ts
@@ -110,6 +110,7 @@ export type {
   IInteractiveSession,
   IInteractiveSessionEvents,
   TInteractiveEventName,
+  TTurnSource,
   IExecutionResult,
   IToolState,
   IDiffLine,

--- a/packages/agent-interface-transport/src/session-contracts.ts
+++ b/packages/agent-interface-transport/src/session-contracts.ts
@@ -120,6 +120,9 @@ export interface IContextFileRefreshedEvent {
   filePath: string;
 }
 
+/** Origin of a turn — distinguishes a human prompt from an agent-wakeup re-entry (FLOW-002). */
+export type TTurnSource = 'user' | 'agent-wakeup';
+
 /** Events emitted by InteractiveSession. */
 export interface IInteractiveSessionEvents {
   text_delta: (delta: string) => void;
@@ -136,6 +139,8 @@ export interface IInteractiveSessionEvents {
   background_job_group_event: (event: TBackgroundJobGroupEvent) => void;
   execution_workspace_event: (event: IExecutionWorkspaceEvent) => void;
   user_message: (content: string) => void;
+  /** Emitted at the start of each turn with its origin (human prompt vs agent-wakeup, FLOW-002). */
+  turn_source: (source: TTurnSource) => void;
   /** Emitted when a context file (AGENTS.md or CLAUDE.md) is refreshed due to staleness. */
   context_file_refreshed: (event: IContextFileRefreshedEvent) => void;
   /** Emitted for every automatic-memory pipeline event (capture, approval, retrieval). */

--- a/packages/agent-plugin/docs/SPEC.md
+++ b/packages/agent-plugin/docs/SPEC.md
@@ -134,25 +134,25 @@ All types below are defined in `@robota-sdk/agent-plugin` and re-exported from `
 
 ### Storage / Utility Classes
 
-| Export                       | Kind  | Description                                      |
-| ---------------------------- | ----- | ------------------------------------------------ |
-| `MemoryHistoryStorage`       | class | In-memory `IHistoryStorage` implementation       |
-| `FileHistoryStorage`         | class | File-backed `IHistoryStorage` implementation     |
-| `DatabaseHistoryStorage`     | class | Database-backed `IHistoryStorage` implementation |
-| `ConsoleLogStorage`          | class | Console `ILogStorage` implementation             |
-| `FileLogStorage`             | class | File-backed `ILogStorage` implementation         |
-| `RemoteLogStorage`           | class | HTTP remote `ILogStorage` implementation         |
-| `SilentLogStorage`           | class | No-op `ILogStorage` implementation               |
-| `ConsoleLogFormatter`        | class | Console-style `ILogFormatter`                    |
-| `JsonLogFormatter`           | class | JSON `ILogFormatter`                             |
-| `MemoryUsageStorage`         | class | In-memory `IUsageStorage` implementation         |
-| `FileUsageStorage`           | class | File-backed `IUsageStorage` implementation       |
-| `RemoteUsageStorage`         | class | HTTP remote `IUsageStorage` implementation       |
-| `SilentUsageStorage`         | class | No-op `IUsageStorage` implementation             |
-| `MemoryPerformanceStorage`   | class | In-memory `IPerformanceStorage` implementation   |
-| `NodeSystemMetricsCollector` | class | Node.js `ISystemMetricsCollector` implementation |
-| `WebhookTransformer`         | class | Transforms agent events into `IWebhookPayload`   |
-| `WebhookHttpClient`          | class | Sends webhook requests with retry logic          |
+| Export                       | Kind  | Description                                                                         |
+| ---------------------------- | ----- | ----------------------------------------------------------------------------------- |
+| `MemoryHistoryStorage`       | class | In-memory `IHistoryStorage` implementation                                          |
+| `FileHistoryStorage`         | class | File-backed `IHistoryStorage` implementation                                        |
+| `DatabaseHistoryStorage`     | class | Database-backed `IHistoryStorage` — **stub** pending a driver decision (PLUGIN-002) |
+| `ConsoleLogStorage`          | class | Console `ILogStorage` implementation                                                |
+| `FileLogStorage`             | class | File-backed `ILogStorage` implementation                                            |
+| `RemoteLogStorage`           | class | HTTP remote `ILogStorage` implementation                                            |
+| `SilentLogStorage`           | class | No-op `ILogStorage` implementation                                                  |
+| `ConsoleLogFormatter`        | class | Console-style `ILogFormatter`                                                       |
+| `JsonLogFormatter`           | class | JSON `ILogFormatter`                                                                |
+| `MemoryUsageStorage`         | class | In-memory `IUsageStorage` implementation                                            |
+| `FileUsageStorage`           | class | File-backed `IUsageStorage` implementation                                          |
+| `RemoteUsageStorage`         | class | HTTP remote `IUsageStorage` implementation                                          |
+| `SilentUsageStorage`         | class | No-op `IUsageStorage` implementation                                                |
+| `MemoryPerformanceStorage`   | class | In-memory `IPerformanceStorage` implementation                                      |
+| `NodeSystemMetricsCollector` | class | Node.js `ISystemMetricsCollector` implementation                                    |
+| `WebhookTransformer`         | class | Transforms agent events into `IWebhookPayload`                                      |
+| `WebhookHttpClient`          | class | Sends webhook requests with retry logic                                             |
 
 ### Utility Functions
 
@@ -296,8 +296,10 @@ should catch `PluginError` at the agent execution boundary.
 ### Coverage Gaps
 
 - No tests for `WebhookTransformer` or `WebhookHttpClient` in isolation.
-- `FileUsageStorage` and `RemoteUsageStorage` lack dedicated test files.
 - `PerformancePlugin` file/remote/prometheus strategy paths are untested (not yet implemented).
+- `DatabaseHistoryStorage` is a stub (logs a warning, persists nothing) pending a driver
+  decision — tracked by PLUGIN-002. The File/Remote `*Storage` classes are now functional
+  with dedicated tests (PLUGIN-001).
 
 ## Class Contract Registry
 

--- a/packages/agent-plugin/src/conversation-history/__tests__/history-storages.test.ts
+++ b/packages/agent-plugin/src/conversation-history/__tests__/history-storages.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DatabaseHistoryStorage } from '../storages/database-storage';
 import { FileHistoryStorage } from '../storages/file-storage';
 import { MemoryHistoryStorage } from '../storages/memory-storage';
@@ -89,27 +92,51 @@ describe('DatabaseHistoryStorage', () => {
   });
 });
 
-describe('FileHistoryStorage', () => {
-  // Placeholder implementation - tests verify it does not throw
-  const storage = new FileHistoryStorage('/tmp/history.json');
+describe('FileHistoryStorage (PLUGIN-001: real persistence)', () => {
+  let dir: string;
+  let storage: FileHistoryStorage;
 
-  it('save does not throw', async () => {
-    await expect(storage.save('conv-1', entry)).resolves.toBeUndefined();
+  function freshStorage(): { dir: string; storage: FileHistoryStorage } {
+    const d = mkdtempSync(join(tmpdir(), 'robota-hist-'));
+    return { dir: d, storage: new FileHistoryStorage(join(d, 'history.json')) };
+  }
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
   });
 
-  it('load returns undefined', async () => {
-    expect(await storage.load('conv-1')).toBeUndefined();
+  it('persists and reloads an entry (round-trip with revived Dates)', async () => {
+    ({ dir, storage } = freshStorage());
+    await storage.save('conv-1', entry);
+    const loaded = await storage.load('conv-1');
+    expect(loaded).toBeDefined();
+    expect(loaded!.conversationId).toBe('conv-1');
+    expect(loaded!.startTime).toBeInstanceOf(Date);
+    expect(loaded!.messages[0]!.content).toBe('hello');
   });
 
-  it('list returns empty array', async () => {
+  it('survives a new storage instance pointed at the same file', async () => {
+    ({ dir, storage } = freshStorage());
+    const filePath = join(dir, 'history.json');
+    await new FileHistoryStorage(filePath).save('conv-1', entry);
+    const reopened = new FileHistoryStorage(filePath);
+    expect((await reopened.load('conv-1'))?.conversationId).toBe('conv-1');
+  });
+
+  it('returns undefined for a missing conversation and [] for an absent file', async () => {
+    ({ dir, storage } = freshStorage());
+    expect(await storage.load('missing')).toBeUndefined();
     expect(await storage.list()).toEqual([]);
   });
 
-  it('delete returns false', async () => {
+  it('lists, deletes, and clears', async () => {
+    ({ dir, storage } = freshStorage());
+    await storage.save('conv-1', entry);
+    await storage.save('conv-2', { ...entry, conversationId: 'conv-2' });
+    expect((await storage.list()).sort()).toEqual(['conv-1', 'conv-2']);
+    expect(await storage.delete('conv-1')).toBe(true);
     expect(await storage.delete('conv-1')).toBe(false);
-  });
-
-  it('clear does not throw', async () => {
-    await expect(storage.clear()).resolves.toBeUndefined();
+    await storage.clear();
+    expect(await storage.list()).toEqual([]);
   });
 });

--- a/packages/agent-plugin/src/conversation-history/storages/file-storage.ts
+++ b/packages/agent-plugin/src/conversation-history/storages/file-storage.ts
@@ -1,9 +1,16 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 import { createLogger, type ILogger, StorageError } from '@robota-sdk/agent-core';
 
 import type { IHistoryStorage, IConversationHistoryEntry } from '../types';
 
 /**
- * File storage implementation
+ * File-backed conversation history storage.
+ *
+ * All conversations are persisted as a single JSON object keyed by conversation
+ * id at `filePath`. Reads/writes are write-through (each mutation rewrites the
+ * file), so there is no buffered state to lose.
  */
 export class FileHistoryStorage implements IHistoryStorage {
   private filePath: string;
@@ -14,14 +21,30 @@ export class FileHistoryStorage implements IHistoryStorage {
     this.logger = createLogger('FileHistoryStorage');
   }
 
-  async save(conversationId: string, _entry: IConversationHistoryEntry): Promise<void> {
+  private async readAll(): Promise<Record<string, IConversationHistoryEntry>> {
     try {
-      // File operations would be implemented here
-      // This is a placeholder for actual file system operations
-      this.logger.warn('File storage not fully implemented yet', {
-        conversationId,
-        filePath: this.filePath,
-      });
+      const raw = await readFile(this.filePath, 'utf8');
+      const map = JSON.parse(raw) as Record<string, IConversationHistoryEntry>;
+      for (const entry of Object.values(map)) reviveHistoryEntry(entry);
+      return map;
+    } catch (error) {
+      if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {};
+      }
+      throw error;
+    }
+  }
+
+  private async writeAll(map: Record<string, IConversationHistoryEntry>): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(map), 'utf8');
+  }
+
+  async save(conversationId: string, entry: IConversationHistoryEntry): Promise<void> {
+    try {
+      const map = await this.readAll();
+      map[conversationId] = entry;
+      await this.writeAll(map);
     } catch (error) {
       throw new StorageError('Failed to save conversation to file', {
         conversationId,
@@ -33,12 +56,8 @@ export class FileHistoryStorage implements IHistoryStorage {
 
   async load(conversationId: string): Promise<IConversationHistoryEntry | undefined> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File storage not fully implemented yet', {
-        conversationId,
-        filePath: this.filePath,
-      });
-      return undefined;
+      const map = await this.readAll();
+      return map[conversationId];
     } catch (error) {
       throw new StorageError('Failed to load conversation from file', {
         conversationId,
@@ -50,11 +69,7 @@ export class FileHistoryStorage implements IHistoryStorage {
 
   async list(): Promise<string[]> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File storage not fully implemented yet', {
-        filePath: this.filePath,
-      });
-      return [];
+      return Object.keys(await this.readAll());
     } catch (error) {
       throw new StorageError('Failed to list conversations from file', {
         filePath: this.filePath,
@@ -65,12 +80,11 @@ export class FileHistoryStorage implements IHistoryStorage {
 
   async delete(conversationId: string): Promise<boolean> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File storage not fully implemented yet', {
-        conversationId,
-        filePath: this.filePath,
-      });
-      return false;
+      const map = await this.readAll();
+      if (!(conversationId in map)) return false;
+      delete map[conversationId];
+      await this.writeAll(map);
+      return true;
     } catch (error) {
       throw new StorageError('Failed to delete conversation from file', {
         conversationId,
@@ -82,15 +96,22 @@ export class FileHistoryStorage implements IHistoryStorage {
 
   async clear(): Promise<void> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File storage not fully implemented yet', {
-        filePath: this.filePath,
-      });
+      await this.writeAll({});
     } catch (error) {
       throw new StorageError('Failed to clear conversations from file', {
         filePath: this.filePath,
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+}
+
+/** Revive Date fields lost to JSON serialization (timestamps round-trip as ISO strings). */
+function reviveHistoryEntry(entry: IConversationHistoryEntry): void {
+  entry.startTime = new Date(entry.startTime);
+  entry.lastUpdated = new Date(entry.lastUpdated);
+  for (const message of entry.messages) {
+    const dated = message as { timestamp?: string | Date };
+    if (dated.timestamp) dated.timestamp = new Date(dated.timestamp);
   }
 }

--- a/packages/agent-plugin/src/logging/__tests__/logging-storages.test.ts
+++ b/packages/agent-plugin/src/logging/__tests__/logging-storages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConsoleLogStorage } from '../storages/console-storage';
 import { SilentLogStorage } from '../storages/silent-storage';
 import { RemoteLogStorage } from '../storages/remote-storage';
@@ -68,18 +68,28 @@ describe('SilentLogStorage', () => {
 
 describe('RemoteLogStorage', () => {
   let storage: RemoteLogStorage;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+  });
 
   afterEach(async () => {
     if (storage) await storage.close();
+    vi.unstubAllGlobals();
   });
 
-  it('batches logs and flushes when batch size reached', async () => {
+  it('POSTs the batch to the endpoint on flush', async () => {
     storage = new RemoteLogStorage('http://example.com/logs');
-    // Write entries below batch size (10)
     for (let i = 0; i < 5; i++) {
       await storage.write({ ...entry, message: `log-${i}` });
     }
-    // No error thrown
+    await storage.flush();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://example.com/logs',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 
   it('flushes on close', async () => {
@@ -88,8 +98,18 @@ describe('RemoteLogStorage', () => {
     await expect(storage.close()).resolves.toBeUndefined();
   });
 
-  it('flush with no pending logs is no-op', async () => {
+  it('flush with no pending logs is a no-op (no request)', async () => {
     storage = new RemoteLogStorage('http://example.com/logs');
+    await expect(storage.flush()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('re-queues the batch when the endpoint fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    storage = new RemoteLogStorage('http://example.com/logs');
+    await storage.write(entry);
+    await expect(storage.flush()).rejects.toThrow('Failed to send logs to remote endpoint');
+    // batch was re-queued, so a subsequent (now-ok) flush succeeds and sends it
     await expect(storage.flush()).resolves.toBeUndefined();
   });
 });

--- a/packages/agent-plugin/src/logging/storages/__tests__/file-storage.test.ts
+++ b/packages/agent-plugin/src/logging/storages/__tests__/file-storage.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileLogStorage } from '../file-storage';
+import type { ILogEntry } from '../../types';
+
+function makeEntry(message: string): ILogEntry {
+  return {
+    timestamp: new Date('2026-06-01T00:00:00.000Z'),
+    level: 'info',
+    message,
+  };
+}
+
+describe('FileLogStorage (PLUGIN-001: real persistence)', () => {
+  let dir: string;
+  let filePath: string;
+
+  function freshStorage(): FileLogStorage {
+    dir = mkdtempSync(join(tmpdir(), 'robota-log-'));
+    filePath = join(dir, 'app.log');
+    return new FileLogStorage(filePath);
+  }
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends each entry as a line to the file', async () => {
+    const storage = freshStorage();
+    await storage.write(makeEntry('first'));
+    await storage.write(makeEntry('second'));
+    const lines = readFileSync(filePath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('first');
+    expect(lines[1]).toContain('second');
+  });
+
+  it('flush/close resolve (write-through, nothing buffered)', async () => {
+    const storage = freshStorage();
+    await storage.write(makeEntry('x'));
+    await expect(storage.flush()).resolves.toBeUndefined();
+    await expect(storage.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent-plugin/src/logging/storages/file-storage.ts
+++ b/packages/agent-plugin/src/logging/storages/file-storage.ts
@@ -1,3 +1,6 @@
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 import { createLogger, type ILogger, PluginError } from '@robota-sdk/agent-core';
 
 import { JsonLogFormatter } from '../formatters';
@@ -5,7 +8,10 @@ import { JsonLogFormatter } from '../formatters';
 import type { ILogEntry, ILogStorage, ILogFormatter } from '../types';
 
 /**
- * File log storage (placeholder implementation)
+ * File-backed log storage.
+ *
+ * Each entry is formatted and appended as a single line. Appends are
+ * write-through, so `flush`/`close` have no buffered state to drain.
  */
 export class FileLogStorage implements ILogStorage {
   private filePath: string;
@@ -20,12 +26,8 @@ export class FileLogStorage implements ILogStorage {
 
   async write(entry: ILogEntry): Promise<void> {
     try {
-      // File writing would be implemented here
-      // This is a placeholder for actual file system operations
-      this.logger.warn('File logging not fully implemented yet', {
-        filePath: this.filePath,
-        entry: this.formatter.format(entry),
-      });
+      await mkdir(dirname(this.filePath), { recursive: true });
+      await appendFile(this.filePath, `${this.formatter.format(entry)}\n`, 'utf8');
     } catch (error) {
       throw new PluginError('Failed to write log to file', 'LoggingPlugin', {
         filePath: this.filePath,
@@ -35,12 +37,16 @@ export class FileLogStorage implements ILogStorage {
   }
 
   async flush(): Promise<void> {
-    // File flushing would be implemented here
-    this.logger.warn('File flush not fully implemented yet');
+    // Each write is appended immediately; nothing is buffered.
+    this.logger.debug('FileLogStorage.flush is a no-op (write-through)', {
+      filePath: this.filePath,
+    });
   }
 
   async close(): Promise<void> {
-    // File closing would be implemented here
-    this.logger.warn('File close not fully implemented yet');
+    // No long-lived file handle is held between writes.
+    this.logger.debug('FileLogStorage.close is a no-op (no open handle)', {
+      filePath: this.filePath,
+    });
   }
 }

--- a/packages/agent-plugin/src/logging/storages/remote-storage.ts
+++ b/packages/agent-plugin/src/logging/storages/remote-storage.ts
@@ -19,15 +19,17 @@ export class RemoteLogStorage implements ILogStorage {
   private formatter: ILogFormatter;
   private batchSize: number;
   private flushInterval: number;
+  private timeout: number;
   private pendingLogs: ILogEntry[] = [];
   private flushTimer: TTimerId | undefined;
   private logger: ILogger;
 
-  constructor(url: string, _options: { timeout?: number } = {}) {
+  constructor(url: string, options: { timeout?: number } = {}) {
     this.url = url;
     this.formatter = new JsonLogFormatter();
     this.batchSize = 10;
     this.flushInterval = 5000;
+    this.timeout = options.timeout ?? 0;
     this.logger = createLogger('RemoteLogStorage');
 
     // Start flush timer
@@ -55,14 +57,18 @@ export class RemoteLogStorage implements ILogStorage {
     this.pendingLogs = [];
 
     try {
-      // Remote sending would be implemented here
-      // This is a placeholder for actual HTTP requests
-      this.logger.warn('Remote logging not fully implemented yet', {
-        url: this.url,
-        logCount: logsToSend.length,
-        logs: logsToSend.map((log) => this.formatter.format(log)),
+      const response = await fetch(this.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ logs: logsToSend.map((log) => this.formatter.format(log)) }),
+        signal: this.timeout > 0 ? AbortSignal.timeout(this.timeout) : undefined,
       });
+      if (!response.ok) {
+        throw new Error(`Remote endpoint returned ${response.status}`);
+      }
     } catch (error) {
+      // Re-queue the failed batch so it is retried on the next flush (no silent loss).
+      this.pendingLogs = [...logsToSend, ...this.pendingLogs];
       throw new PluginError('Failed to send logs to remote endpoint', 'LoggingPlugin', {
         url: this.url,
         logCount: logsToSend.length,

--- a/packages/agent-plugin/src/usage/storages/__tests__/file-storage.test.ts
+++ b/packages/agent-plugin/src/usage/storages/__tests__/file-storage.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileUsageStorage } from '../file-storage';
+import type { IUsageStats } from '../../types';
+
+function makeStat(overrides: Partial<IUsageStats> = {}): IUsageStats {
+  return {
+    conversationId: 'conv-1',
+    timestamp: new Date('2026-06-01T00:00:00.000Z'),
+    provider: 'openai',
+    model: 'gpt',
+    tokensUsed: { input: 10, output: 5, total: 15 },
+    requestCount: 1,
+    duration: 100,
+    success: true,
+    ...overrides,
+  };
+}
+
+describe('FileUsageStorage (PLUGIN-001: real persistence)', () => {
+  let dir: string;
+
+  function freshStorage(): FileUsageStorage {
+    dir = mkdtempSync(join(tmpdir(), 'robota-usage-'));
+    return new FileUsageStorage(join(dir, 'usage.json'));
+  }
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('saves and reads back stats with revived timestamps', async () => {
+    const storage = freshStorage();
+    await storage.save(makeStat());
+    const all = await storage.getStats();
+    expect(all).toHaveLength(1);
+    expect(all[0]!.timestamp).toBeInstanceOf(Date);
+    expect(all[0]!.tokensUsed.total).toBe(15);
+  });
+
+  it('filters by conversationId and time range', async () => {
+    const storage = freshStorage();
+    await storage.save(makeStat({ conversationId: 'a' }));
+    await storage.save(makeStat({ conversationId: 'b' }));
+    await storage.save(
+      makeStat({ conversationId: 'a', timestamp: new Date('2026-01-01T00:00:00.000Z') }),
+    );
+
+    expect(await storage.getStats('a')).toHaveLength(2);
+    const ranged = await storage.getStats('a', {
+      start: new Date('2026-05-01T00:00:00.000Z'),
+      end: new Date('2026-07-01T00:00:00.000Z'),
+    });
+    expect(ranged).toHaveLength(1);
+  });
+
+  it('clears all stats; flush/close resolve (write-through)', async () => {
+    const storage = freshStorage();
+    await storage.save(makeStat());
+    await storage.clear();
+    expect(await storage.getStats()).toEqual([]);
+    await expect(storage.flush()).resolves.toBeUndefined();
+    await expect(storage.close()).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent-plugin/src/usage/storages/__tests__/remote-storage.test.ts
+++ b/packages/agent-plugin/src/usage/storages/__tests__/remote-storage.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { RemoteUsageStorage } from '../remote-storage';
+import type { IUsageStats } from '../../types';
+
+function makeStat(): IUsageStats {
+  return {
+    conversationId: 'conv-1',
+    timestamp: new Date('2026-06-01T00:00:00.000Z'),
+    provider: 'openai',
+    model: 'gpt',
+    tokensUsed: { input: 10, output: 5, total: 15 },
+    requestCount: 1,
+    duration: 100,
+    success: true,
+  };
+}
+
+describe('RemoteUsageStorage (PLUGIN-001: HTTP REST contract)', () => {
+  let storage: RemoteUsageStorage;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({ stats: [] }) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(async () => {
+    if (storage) await storage.close();
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the batch to the endpoint on flush', async () => {
+    // small batchSize so save triggers a flush
+    storage = new RemoteUsageStorage('http://example.com/usage', 'key', 0, {}, 1);
+    await storage.save(makeStat());
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://example.com/usage',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('re-queues the batch when the endpoint fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    storage = new RemoteUsageStorage('http://example.com/usage', '', 0, {}, 100);
+    await storage.save(makeStat());
+    await expect(storage.flush()).rejects.toThrow('Failed to send usage stats to remote endpoint');
+    // re-queued → a subsequent ok flush sends it
+    await expect(storage.flush()).resolves.toBeUndefined();
+  });
+
+  it('getStats parses the response and revives timestamps', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ stats: [makeStat()] }),
+    });
+    storage = new RemoteUsageStorage('http://example.com/usage', '', 0);
+    const stats = await storage.getStats('conv-1');
+    expect(stats).toHaveLength(1);
+    expect(stats[0]!.timestamp).toBeInstanceOf(Date);
+  });
+});

--- a/packages/agent-plugin/src/usage/storages/file-storage.ts
+++ b/packages/agent-plugin/src/usage/storages/file-storage.ts
@@ -1,3 +1,6 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 import { createLogger, type ILogger, StorageError } from '@robota-sdk/agent-core';
 
 import { aggregateUsageStats } from '../aggregate-usage-stats';
@@ -5,7 +8,11 @@ import { aggregateUsageStats } from '../aggregate-usage-stats';
 import type { IUsageStorage, IUsageStats, IAggregatedUsageStats } from '../types';
 
 /**
- * File storage implementation for usage statistics
+ * File-backed usage-statistics storage.
+ *
+ * Records are persisted as a single JSON array at `filePath`. Writes are
+ * write-through (each `save` rewrites the file), so `flush`/`close` have no
+ * buffered state to drain.
  */
 export class FileUsageStorage implements IUsageStorage {
   private filePath: string;
@@ -16,21 +23,30 @@ export class FileUsageStorage implements IUsageStorage {
     this.logger = createLogger('FileUsageStorage');
   }
 
+  private async readAll(): Promise<IUsageStats[]> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const stats = JSON.parse(raw) as IUsageStats[];
+      for (const stat of stats) stat.timestamp = new Date(stat.timestamp);
+      return stats;
+    } catch (error) {
+      if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private async writeAll(stats: IUsageStats[]): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(stats), 'utf8');
+  }
+
   async save(entry: IUsageStats): Promise<void> {
     try {
-      // File operations would be implemented here
-      // This is a placeholder for actual file system operations
-      this.logger.warn('File usage storage not fully implemented yet', {
-        filePath: this.filePath,
-        entry: {
-          timestamp: entry.timestamp.toISOString(),
-          provider: entry.provider,
-          model: entry.model,
-          tokens: entry.tokensUsed.total,
-          cost: entry.cost?.total,
-          success: entry.success,
-        },
-      });
+      const stats = await this.readAll();
+      stats.push(entry);
+      await this.writeAll(stats);
     } catch (error) {
       throw new StorageError('Failed to save usage stats to file', {
         filePath: this.filePath,
@@ -44,13 +60,14 @@ export class FileUsageStorage implements IUsageStorage {
     timeRange?: { start: Date; end: Date },
   ): Promise<IUsageStats[]> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File usage storage not fully implemented yet', {
-        filePath: this.filePath,
-        conversationId,
-        timeRange,
-      });
-      return [];
+      let stats = await this.readAll();
+      if (conversationId) {
+        stats = stats.filter((s) => s.conversationId === conversationId);
+      }
+      if (timeRange) {
+        stats = stats.filter((s) => s.timestamp >= timeRange.start && s.timestamp <= timeRange.end);
+      }
+      return stats;
     } catch (error) {
       throw new StorageError('Failed to load usage stats from file', {
         filePath: this.filePath,
@@ -74,11 +91,7 @@ export class FileUsageStorage implements IUsageStorage {
 
   async clear(): Promise<void> {
     try {
-      // File operations would be implemented here
-      this.logger.warn('File usage storage not fully implemented yet', {
-        filePath: this.filePath,
-        operation: 'clear',
-      });
+      await this.writeAll([]);
     } catch (error) {
       throw new StorageError('Failed to clear usage stats from file', {
         filePath: this.filePath,
@@ -88,30 +101,17 @@ export class FileUsageStorage implements IUsageStorage {
   }
 
   async flush(): Promise<void> {
-    try {
-      // File flushing would be implemented here
-      this.logger.warn('File usage storage flush not fully implemented yet', {
-        filePath: this.filePath,
-      });
-    } catch (error) {
-      throw new StorageError('Failed to flush usage stats to file', {
-        filePath: this.filePath,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    // Write-through storage: every save is persisted immediately, so there is no
+    // buffered state to flush. Method retained to satisfy IUsageStorage.
+    this.logger.debug('FileUsageStorage.flush is a no-op (write-through)', {
+      filePath: this.filePath,
+    });
   }
 
   async close(): Promise<void> {
-    try {
-      // File closing would be implemented here
-      this.logger.warn('File usage storage close not fully implemented yet', {
-        filePath: this.filePath,
-      });
-    } catch (error) {
-      throw new StorageError('Failed to close usage stats file', {
-        filePath: this.filePath,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    // No long-lived file handle is held between operations.
+    this.logger.debug('FileUsageStorage.close is a no-op (no open handle)', {
+      filePath: this.filePath,
+    });
   }
 }

--- a/packages/agent-plugin/src/usage/storages/remote-storage.ts
+++ b/packages/agent-plugin/src/usage/storages/remote-storage.ts
@@ -11,13 +11,20 @@ import { aggregateUsageStats } from '../aggregate-usage-stats';
 
 import type { IUsageStorage, IUsageStats, IAggregatedUsageStats } from '../types';
 
-const SAMPLE_SIZE = 3;
-
 /**
- * Remote storage implementation for usage statistics with batching
+ * Remote storage for usage statistics with batching.
+ *
+ * Uses a generic JSON REST contract against `apiUrl`:
+ * - `POST   {apiUrl}`  body `{ stats }` — persist a flushed batch
+ * - `GET    {apiUrl}?conversationId=&start=&end=` → `{ stats } | IUsageStats[]`
+ * - `DELETE {apiUrl}` — clear
+ * A bearer `apiKey` and extra `headers` are attached when provided.
  */
 export class RemoteUsageStorage implements IUsageStorage {
   private apiUrl: string;
+  private apiKey: string;
+  private timeout: number;
+  private headers: Record<string, string>;
   private batchSize: number;
   private flushInterval: number;
   private batch: IUsageStats[] = [];
@@ -26,13 +33,16 @@ export class RemoteUsageStorage implements IUsageStorage {
 
   constructor(
     apiUrl: string,
-    _apiKey: string,
-    _timeout: number,
-    _headers: Record<string, string> = {},
+    apiKey: string,
+    timeout: number,
+    headers: Record<string, string> = {},
     batchSize: number = 50,
     flushInterval: number = 60000, // 1 minute
   ) {
     this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+    this.timeout = timeout;
+    this.headers = headers;
     this.batchSize = batchSize;
     this.flushInterval = flushInterval;
     this.logger = createLogger('RemoteUsageStorage');
@@ -44,6 +54,18 @@ export class RemoteUsageStorage implements IUsageStorage {
         await this.flush();
       },
     );
+  }
+
+  private requestHeaders(): Record<string, string> {
+    return {
+      'content-type': 'application/json',
+      ...(this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {}),
+      ...this.headers,
+    };
+  }
+
+  private signal(): AbortSignal | undefined {
+    return this.timeout > 0 ? AbortSignal.timeout(this.timeout) : undefined;
   }
 
   async save(entry: IUsageStats): Promise<void> {
@@ -59,14 +81,24 @@ export class RemoteUsageStorage implements IUsageStorage {
     timeRange?: { start: Date; end: Date },
   ): Promise<IUsageStats[]> {
     try {
-      // Remote API call would be implemented here
-      this.logger.warn('Remote usage storage not fully implemented yet', {
-        endpoint: this.apiUrl,
-        operation: 'getStats',
-        conversationId,
-        timeRange,
+      const url = new URL(this.apiUrl);
+      if (conversationId) url.searchParams.set('conversationId', conversationId);
+      if (timeRange) {
+        url.searchParams.set('start', timeRange.start.toISOString());
+        url.searchParams.set('end', timeRange.end.toISOString());
+      }
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: this.requestHeaders(),
+        signal: this.signal(),
       });
-      return [];
+      if (!response.ok) {
+        throw new Error(`Remote endpoint returned ${response.status}`);
+      }
+      const body = (await response.json()) as IUsageStats[] | { stats: IUsageStats[] };
+      const stats = Array.isArray(body) ? body : body.stats;
+      for (const stat of stats) stat.timestamp = new Date(stat.timestamp);
+      return stats;
     } catch (error) {
       throw new StorageError('Failed to get usage stats from remote endpoint', {
         endpoint: this.apiUrl,
@@ -90,11 +122,14 @@ export class RemoteUsageStorage implements IUsageStorage {
 
   async clear(): Promise<void> {
     try {
-      // Remote API call would be implemented here
-      this.logger.warn('Remote usage storage not fully implemented yet', {
-        endpoint: this.apiUrl,
-        operation: 'clear',
+      const response = await fetch(this.apiUrl, {
+        method: 'DELETE',
+        headers: this.requestHeaders(),
+        signal: this.signal(),
       });
+      if (!response.ok) {
+        throw new Error(`Remote endpoint returned ${response.status}`);
+      }
     } catch (error) {
       throw new StorageError('Failed to clear usage stats from remote endpoint', {
         endpoint: this.apiUrl,
@@ -110,23 +145,17 @@ export class RemoteUsageStorage implements IUsageStorage {
     this.batch = [];
 
     try {
-      // Remote API call would be implemented here
-      // This is a placeholder for actual HTTP requests
-      this.logger.warn('Remote usage storage not fully implemented yet', {
-        endpoint: this.apiUrl,
-        operation: 'flush',
-        batchSize: statsToSend.length,
-        sample: statsToSend.slice(0, SAMPLE_SIZE).map((stat) => ({
-          timestamp: stat.timestamp.toISOString(),
-          provider: stat.provider,
-          model: stat.model,
-          tokens: stat.tokensUsed.total,
-          cost: stat.cost?.total,
-          success: stat.success,
-        })),
+      const response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: this.requestHeaders(),
+        body: JSON.stringify({ stats: statsToSend }),
+        signal: this.signal(),
       });
+      if (!response.ok) {
+        throw new Error(`Remote endpoint returned ${response.status}`);
+      }
     } catch (error) {
-      // Re-add failed batch to the beginning of current batch
+      // Re-queue the failed batch so it is retried on the next flush (no silent loss).
       this.batch = [...statsToSend, ...this.batch];
       throw new StorageError('Failed to send usage stats to remote endpoint', {
         endpoint: this.apiUrl,

--- a/packages/agent-plugin/usage.json
+++ b/packages/agent-plugin/usage.json
@@ -1,0 +1,29 @@
+[
+  {
+    "provider": "openai",
+    "model": "gpt-4",
+    "tokensUsed": { "input": 100, "output": 50, "total": 150 },
+    "requestCount": 1,
+    "duration": 500,
+    "success": true,
+    "timestamp": "2026-06-26T18:22:19.307Z"
+  },
+  {
+    "provider": "openai",
+    "model": "gpt-4",
+    "tokensUsed": { "input": 100, "output": 50, "total": 150 },
+    "requestCount": 1,
+    "duration": 500,
+    "success": true,
+    "timestamp": "2026-06-26T18:23:10.990Z"
+  },
+  {
+    "provider": "openai",
+    "model": "gpt-4",
+    "tokensUsed": { "input": 100, "output": 50, "total": 150 },
+    "requestCount": 1,
+    "duration": 500,
+    "success": true,
+    "timestamp": "2026-06-26T18:24:51.044Z"
+  }
+]

--- a/packages/agent-transport-ws/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-handler.test.ts
@@ -60,7 +60,7 @@ const backgroundJobGroup: IBackgroundJobGroupState = {
 function createMockSession() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
   return {
-    submit: vi.fn(),
+    submit: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn(),
     cancelQueue: vi.fn(),
     getMessages: vi.fn().mockReturnValue([{ role: 'user', content: 'hi' }]),
@@ -316,6 +316,26 @@ describe('WebSocket Transport Handler', () => {
     const { onMessage, sent } = setup();
     onMessage(JSON.stringify({ type: 'submit' }));
     expect(sent[0]).toEqual({ type: 'protocol_error', message: 'prompt is required' });
+  });
+
+  it('submit rejection surfaces a protocol_error (WS-001)', async () => {
+    const { onMessage, sent, session } = setup();
+    (session as unknown as { submit: ReturnType<typeof vi.fn> }).submit.mockRejectedValueOnce(
+      new Error('submit failed'),
+    );
+    onMessage(JSON.stringify({ type: 'submit', prompt: 'hello' }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(sent).toEqual([{ type: 'protocol_error', message: 'submit failed' }]);
+  });
+
+  it('command rejection surfaces a protocol_error (WS-001)', async () => {
+    const { onMessage, sent, session } = setup();
+    (
+      session as unknown as { executeCommand: ReturnType<typeof vi.fn> }
+    ).executeCommand.mockRejectedValueOnce(new Error('command failed'));
+    onMessage(JSON.stringify({ type: 'command', name: 'clear' }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(sent).toEqual([{ type: 'protocol_error', message: 'command failed' }]);
   });
 
   it('forwards InteractiveSession events to client', () => {

--- a/packages/agent-transport-ws/src/ws-handler.ts
+++ b/packages/agent-transport-ws/src/ws-handler.ts
@@ -226,21 +226,28 @@ function handleSessionControlMessage(
       send({ type: 'protocol_error', message: 'prompt is required' });
       return;
     }
-    session.submit(msg.prompt);
+    session.submit(msg.prompt).catch((error: Error) => {
+      send({ type: 'protocol_error', message: error.message });
+    });
   } else if (msg.type === 'command') {
     if (!msg.name) {
       send({ type: 'protocol_error', message: 'name is required' });
       return;
     }
-    session.executeCommand(msg.name, msg.args ?? '').then((result) => {
-      send({
-        type: 'command_result',
-        name: msg.name,
-        message: result?.message ?? `Unknown command: ${msg.name}`,
-        success: result?.success ?? false,
-        data: result?.data,
-      });
-    });
+    session.executeCommand(msg.name, msg.args ?? '').then(
+      (result) => {
+        send({
+          type: 'command_result',
+          name: msg.name,
+          message: result?.message ?? `Unknown command: ${msg.name}`,
+          success: result?.success ?? false,
+          data: result?.data,
+        });
+      },
+      (error: Error) => {
+        send({ type: 'protocol_error', message: error.message });
+      },
+    );
   } else if (msg.type === 'abort') {
     session.abort();
   } else {

--- a/packages/agent-web-ui/src/client/__tests__/ws-session-client.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/ws-session-client.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for WEBUI-002: a malformed server frame must not throw inside
+ * the WebSocket onmessage handler (which would freeze the UI) — it is surfaced as
+ * a protocol_error via the normal callback path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createWsSessionClient } from '../ws-session-client';
+import type { TServerMessage } from '../ws-session-client';
+
+interface IFakeSocket {
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  send: (data: string) => void;
+  close: () => void;
+}
+
+let lastSocket: IFakeSocket | null = null;
+
+class FakeWebSocket {
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    lastSocket = this as unknown as IFakeSocket;
+  }
+}
+
+describe('createWsSessionClient (WEBUI-002)', () => {
+  beforeEach(() => {
+    lastSocket = null;
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+  });
+  afterEach(() => {
+    delete (globalThis as unknown as { WebSocket?: unknown }).WebSocket;
+  });
+
+  it('surfaces a malformed frame as protocol_error instead of throwing', () => {
+    const messages: TServerMessage[] = [];
+    const client = createWsSessionClient('ws://localhost:7070', {
+      onMessage: (m) => messages.push(m),
+      onStatusChange: () => {},
+    });
+    client.connect();
+    expect(lastSocket).not.toBeNull();
+
+    // A non-JSON frame must not throw.
+    expect(() => lastSocket!.onmessage?.({ data: 'not json {{' })).not.toThrow();
+    expect(messages).toEqual([
+      { type: 'protocol_error', message: 'Malformed message from server (invalid JSON)' },
+    ]);
+  });
+
+  it('passes a well-formed frame through to onMessage', () => {
+    const messages: TServerMessage[] = [];
+    const client = createWsSessionClient('ws://localhost:7070', {
+      onMessage: (m) => messages.push(m),
+      onStatusChange: () => {},
+    });
+    client.connect();
+    lastSocket!.onmessage?.({ data: JSON.stringify({ type: 'thinking', isThinking: true }) });
+    expect(messages).toEqual([{ type: 'thinking', isThinking: true }]);
+  });
+});

--- a/packages/agent-web-ui/src/client/ws-session-client.ts
+++ b/packages/agent-web-ui/src/client/ws-session-client.ts
@@ -61,7 +61,18 @@ export function createWsSessionClient(
     ws.onmessage = (event: MessageEvent): void => {
       const data = event.data;
       if (typeof data !== 'string') return;
-      const msg = JSON.parse(data) as TServerMessage;
+      let msg: TServerMessage;
+      try {
+        msg = JSON.parse(data) as TServerMessage;
+      } catch {
+        // A malformed frame must not throw inside the handler (it would break the
+        // socket's message pump and freeze the UI). Surface it via the normal path.
+        callbacks.onMessage({
+          type: 'protocol_error',
+          message: 'Malformed message from server (invalid JSON)',
+        });
+        return;
+      }
       callbacks.onMessage(msg);
     };
 

--- a/packages/agent-web-ui/src/components/SessionMonitor.tsx
+++ b/packages/agent-web-ui/src/components/SessionMonitor.tsx
@@ -91,7 +91,14 @@ export function SessionMonitor({ wsUrl, className }: ISessionMonitorProps): Reac
           className={`flex flex-col overflow-hidden min-w-0 ${hasAgents ? 'flex-[2]' : 'flex-1'}`}
         >
           <div className="flex-1 overflow-hidden">
-            {status === 'disconnected' || status === 'connecting' ? (
+            {status === 'connected' ? (
+              <ConversationView
+                messages={messages}
+                activeTools={activeTools}
+                streamingText={streamingText}
+                isThinking={isThinking}
+              />
+            ) : (
               <div className="flex h-full items-center justify-center">
                 <div className="flex flex-col items-center gap-3 text-center px-8">
                   <div className="h-9 w-9 rounded-full border border-border/50 flex items-center justify-center">
@@ -100,17 +107,12 @@ export function SessionMonitor({ wsUrl, className }: ISessionMonitorProps): Reac
                   <p className="text-xs font-mono text-muted-foreground max-w-[260px] leading-relaxed">
                     {status === 'connecting'
                       ? `Connecting to ${url}…`
-                      : `Run robota to start the CLI (WS transport starts automatically).`}
+                      : status === 'error'
+                        ? `Connection error — could not reach ${url}. Check the CLI is running and the URL is correct.`
+                        : `Run robota to start the CLI (WS transport starts automatically).`}
                   </p>
                 </div>
               </div>
-            ) : (
-              <ConversationView
-                messages={messages}
-                activeTools={activeTools}
-                streamingText={streamingText}
-                isThinking={isThinking}
-              />
             )}
           </div>
 

--- a/packages/agent-web-ui/src/hooks/useWsSession.ts
+++ b/packages/agent-web-ui/src/hooks/useWsSession.ts
@@ -66,7 +66,10 @@ export function useWsSession(url: string): IWsSessionState {
         break;
       }
       case 'user_message': {
-        setMessages((prev) => [...prev, { id: nextId(), role: 'user', content: msg.content }]);
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: 'user', content: msg.content ?? '' },
+        ]);
         break;
       }
       case 'text_delta': {

--- a/scripts/harness/check-stub-markers.mjs
+++ b/scripts/harness/check-stub-markers.mjs
@@ -19,7 +19,14 @@ import path from 'node:path';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
-const STUB_MARKERS = ['TODO: Implement', 'Not implemented', 'NotImplementedError'];
+// "placeholder for actual" caught shipped, consumed storage classes that only
+// logged a warning and returned a stub value (silent data loss) — PLUGIN-001.
+const STUB_MARKERS = [
+  'TODO: Implement',
+  'Not implemented',
+  'NotImplementedError',
+  'placeholder for actual',
+];
 
 function walkSources(dir) {
   const files = [];


### PR DESCRIPTION
Fixes the 4 Wave-B runtime-bug backlogs (each verified, moved to completed/ with evidence).

- **WS-001**: WS handler surfaces promise rejections as `protocol_error` (submit `.catch`, command two-arg `.then`); was a floating promise / unhandled rejection.
- **WEBUI-002**: render connection-error state (was blank), guard `JSON.parse` (malformed frame no longer freezes UI), null-safe `user_message`. First tests for agent-web-ui.
- **EVENT-001**: `turn_source` added to `IInteractiveSessionEvents` (was emitted but untyped) — SSOT in the contract package, controller imports it.
- **PLUGIN-001**: implemented the consumed File/Remote `*Storage` stubs that silently dropped data (write-through fs + generic REST via fetch, 306 tests). Extended the stub-marker scan. `DatabaseHistoryStorage` (needs a driver decision) captured as **PLUGIN-002**.

Verification: `pnpm build:deps`, `pnpm typecheck`, `pnpm lint` 0 errors, `pnpm harness:scan` 30/30, affected package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)