### PR TITLE
docs: Wave D — doc/SPEC sync (DOCAUDIT-005, DOCSYNC-001, README-001, WEB-019)

### DIFF
--- a/.agents/backlog/completed/DOCAUDIT-005-stale-provider-api-references.md
+++ b/.agents/backlog/completed/DOCAUDIT-005-stale-provider-api-references.md
@@ -1,12 +1,28 @@
 ---
 title: 'DOCAUDIT-005: Fix stale provider API references in docs/SPEC after provider consolidation'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: medium
 urgency: soon
 area: content, packages/agent-framework, packages/agent-provider
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `content/quickstart.md`: the broken `createOpenAIProvider` import/usage replaced with
+  `new OpenAIProvider({ apiKey })` (OpenAI ships a class, not a convenience factory). The
+  Anthropic snippet (`createAnthropicProvider`) was already correct (re-exported from root).
+- `agent-framework/docs/SPEC.md`: 2 stale `agent-provider-anthropic` / `agent-provider-openai/
+google/bytedance` references updated to the consolidated package + sub-paths (lines 1851, 2294).
+- `agent-provider/docs/SPEC.md`: added an "Other provider sub-paths" section documenting each
+  sub-path's real exports (class + `create*ProviderDefinition`; only Anthropic has a convenience
+  factory) — removing the false implication that all expose an Anthropic-style factory.
+- Left untouched (intentional, NOT stale): `content/guide/migration.md` and the release notes,
+  which legitimately reference the old `agent-provider-*` names to document the migration/history.
+- Verified: factories named in the new table all exist; `pnpm harness:scan` 32/32
+  (spec-public-surface + docs-structure pass); `createOpenAIProvider` gone from the quickstart.
 
 # Fix stale provider API references after provider consolidation
 

--- a/.agents/backlog/completed/DOCSYNC-001-agent-framework-spec-readme-drift.md
+++ b/.agents/backlog/completed/DOCSYNC-001-agent-framework-spec-readme-drift.md
@@ -1,12 +1,23 @@
 ---
 title: 'DOCSYNC-001: Reconcile agent-framework SPEC↔README public-API drift (createAgentRuntime)'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: low
 urgency: later
 area: packages/agent-framework
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `agent-framework/README.md`: added `createAgentRuntime()` to the intro summary and a new
+  "Headless / multi-session runtime" Quick-Start subsection with a minimal example
+  (`createAgentRuntime({ cwd, provider }).createSession({})`), matching the SPEC's "primary
+  public API" claim. README references: 0 → present.
+- Confirmed the API against source: `createAgentRuntime(config: IAgentRuntimeConfig): IAgentRuntime`
+  with `createSession()` composing `InteractiveSession`s.
+- Verified: docs structure validation passes.
 
 # Reconcile agent-framework SPEC ↔ README public-API drift
 

--- a/.agents/backlog/completed/README-001-stub-readmes-transport-packages.md
+++ b/.agents/backlog/completed/README-001-stub-readmes-transport-packages.md
@@ -1,12 +1,21 @@
 ---
 title: 'README-001: Flesh out stub READMEs for published transport packages'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: low
 urgency: later
 area: packages/agent-transport-http, packages/agent-transport-mcp
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `agent-transport-http/README.md` + `agent-transport-mcp/README.md` expanded from 9-line stubs
+  to full READMEs: purpose, install, a runnable usage snippet using only real exports
+  (`createAgentRoutes({ sessionFactory })`, `createAgentMcpServer({ name, version, session })`),
+  and an exports table verified against `src/index.ts` + the option interfaces.
+- Verified: docs structure validation passes; snippets use existing exports only.
 
 # Flesh out stub READMEs for published transport packages
 

--- a/.agents/backlog/completed/WEB-019-hide-undeployed-playground-link.md
+++ b/.agents/backlog/completed/WEB-019-hide-undeployed-playground-link.md
@@ -1,12 +1,23 @@
 ---
 title: 'WEB-019: Hide undeployed playground link in docs; reconcile playground subdomain'
-status: todo
+status: done
+completed: 2026-06-27
 created: 2026-06-27
 priority: medium
 urgency: soon
 area: apps/docs, apps/www
 depends_on: []
 ---
+
+## Evidence Log (2026-06-27)
+
+- `apps/docs/src/components/Header.tsx`: the live `Playground → https://playground.robota.io`
+  nav item (undeployed subdomain) is commented out with a note to restore alongside WEB-005
+  using the canonical `play.robota.io` (matching the marketing site), resolving the
+  playground/play subdomain inconsistency.
+- Added an explicit `external?: boolean` type to `NAV_LINKS` so the `.external` branch still
+  typechecks with no external entry present.
+- Verified: `apps/docs` typecheck passes; no live `playground.robota.io` link remains in docs.
 
 # Hide undeployed playground link in docs; reconcile playground subdomain
 

--- a/apps/docs/src/components/Header.tsx
+++ b/apps/docs/src/components/Header.tsx
@@ -6,14 +6,17 @@ import { useLocale } from 'next-intl';
 import { ThemeToggle } from './ThemeToggle';
 import { SearchButton } from './SearchButton';
 
-const NAV_LINKS = [
+const NAV_LINKS: { labelKey: string; href: string; external?: boolean }[] = [
   { labelKey: 'Getting Started', href: 'getting-started' },
   { labelKey: 'Guide', href: 'guide' },
   { labelKey: 'Examples', href: 'examples' },
   { labelKey: 'Packages', href: 'packages' },
   { labelKey: 'Changelog', href: 'changelog' },
   { labelKey: 'Development', href: 'development' },
-  { labelKey: 'Playground', href: 'https://playground.robota.io', external: true },
+  // WEB-019: Playground is temporarily hidden until the hosted playground ships (the
+  // subdomain is not yet deployed). Restore alongside WEB-005 using the canonical
+  // `play.robota.io` subdomain (matching the marketing site), not `playground.robota.io`.
+  // { labelKey: 'Playground', href: 'https://play.robota.io', external: true },
 ];
 
 export function Header() {

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -79,13 +79,14 @@ console.log(response);
 
 ## Switch providers
 
-Swap `createAnthropicProvider` with any other supported provider — no other code changes required:
+Swap `createAnthropicProvider` with any other supported provider — no other code changes required.
+OpenAI is constructed directly via its provider class:
 
 ```typescript
-import { createOpenAIProvider } from '@robota-sdk/agent-provider';
+import { OpenAIProvider } from '@robota-sdk/agent-provider';
 
 const query = createQuery({
-  provider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
+  provider: new OpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
 });
 ```
 

--- a/packages/agent-framework/README.md
+++ b/packages/agent-framework/README.md
@@ -1,6 +1,6 @@
 # @robota-sdk/agent-framework
 
-Programmatic SDK for building AI agents with Robota. Provides `InteractiveSession` as the central client-facing API, `createQuery()` for one-shot use, session management, SDK-owned command/common APIs, permissions, hooks, streaming, context loading, bounded prompt file references, and context reference inventory.
+Programmatic SDK for building AI agents with Robota. Provides `InteractiveSession` as the central client-facing API, `createQuery()` for one-shot use, `createAgentRuntime()` as a composition factory for headless and multi-session consumers, session management, SDK-owned command/common APIs, permissions, hooks, streaming, context loading, bounded prompt file references, and context reference inventory.
 
 This is the **assembly layer** of the Robota ecosystem — it composes lower-level packages (`agent-core`, `agent-tools`, `agent-session`, `agent-provider`) into a cohesive SDK.
 
@@ -34,6 +34,25 @@ const queryWithOptions = createQuery({
 });
 
 const detailedResponse = await queryWithOptions('Analyze the code');
+```
+
+### Headless / multi-session runtime
+
+For headless or multi-session consumers, `createAgentRuntime()` builds a composition root that
+spawns `InteractiveSession`s sharing one configuration (provider, cwd, command modules, session
+store, transports):
+
+```typescript
+import { createAgentRuntime } from '@robota-sdk/agent-framework';
+import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
+
+const runtime = createAgentRuntime({
+  cwd: process.cwd(),
+  provider: new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY }),
+});
+
+// Each call composes a fresh InteractiveSession that inherits the runtime config.
+const session = runtime.createSession({});
 ```
 
 ## Features

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -1848,7 +1848,7 @@ Each module's placement is determined by "Is this used only in the SDK, or is it
 - **agent-session**: Removed existing SessionManager/ChatInstance (zero consumers, no-op persistence), replaced with Session/SessionStore from agent-framework
 - **agent-tools**: Added 8 built-in tools in `builtins/` directory (Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch), added `IToolInvocationResult` type
 - **agent-core**: Added `permissions/` and `hooks/` directories
-- **agent-provider-anthropic**: Multi-block content handling (text + tool_use), streaming `chatWithStreaming`, `onTextDelta` support
+- **agent-provider (`./anthropic` sub-path)**: Multi-block content handling (text + tool_use), streaming `chatWithStreaming`, `onTextDelta` support
 
 ## Hook Type Executors (SDK-Specific)
 
@@ -2285,10 +2285,10 @@ Subagent transcript logs must include session initialization, prompts, tool call
 
 ## Unconnected Packages (Future Integration Targets)
 
-| Package                                    | Current State | Integration Direction                                               |
-| ------------------------------------------ | ------------- | ------------------------------------------------------------------- |
-| **agent-tool-mcp**                         | Unconnected   | Connect when MCP server is configured in InteractiveSession options |
-| **agent-team**                             | Unconnected   | Replace agent-tool.ts with agent-team delegation pattern            |
-| **agent-event-service**                    | Unconnected   | Publish Session lifecycle events                                    |
-| **agent-plugin-\***                        | Unconnected   | Inject plugins during Session/Robota creation                       |
-| **agent-provider-openai/google/bytedance** | Unconnected   | Consumer passes provider to InteractiveSession({ cwd, provider })   |
+| Package                                                              | Current State | Integration Direction                                               |
+| -------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------- |
+| **agent-tool-mcp**                                                   | Unconnected   | Connect when MCP server is configured in InteractiveSession options |
+| **agent-team**                                                       | Unconnected   | Replace agent-tool.ts with agent-team delegation pattern            |
+| **agent-event-service**                                              | Unconnected   | Publish Session lifecycle events                                    |
+| **agent-plugin-\***                                                  | Unconnected   | Inject plugins during Session/Robota creation                       |
+| **agent-provider (`./openai`, `./gemini`, `./bytedance` sub-paths)** | Unconnected   | Consumer passes provider to InteractiveSession({ cwd, provider })   |

--- a/packages/agent-provider/docs/SPEC.md
+++ b/packages/agent-provider/docs/SPEC.md
@@ -49,6 +49,24 @@ Re-exports all provider classes, factory functions, and types from all providers
 
 `createAnthropicProvider` returns `IAIProvider` (typed as `AnthropicProvider` at runtime). This is the recommended way to instantiate the provider when a concrete class reference is not required.
 
+### Other provider sub-paths
+
+Unlike Anthropic, the remaining providers do **not** ship a `create<Name>Provider` convenience
+factory — instantiate them with `new <Name>Provider({ apiKey })`. Each sub-path exports its
+provider class plus a `create<Name>ProviderDefinition()` for use with provider registries, and
+provider-specific `DEFAULT_*` constants.
+
+| Sub-path      | Class (instantiate via `new`) | Definition factory                 | Notes                                          |
+| ------------- | ----------------------------- | ---------------------------------- | ---------------------------------------------- |
+| `./openai`    | `OpenAIProvider`              | `createOpenAIProviderDefinition`   | OpenAI-compatible base; `./openai/loggers` too |
+| `./deepseek`  | `DeepSeekProvider`            | `createDeepSeekProviderDefinition` | OpenAI-compatible endpoint                     |
+| `./gemini`    | `GeminiProvider`              | `createGeminiProviderDefinition`   | also implements `IImageGenerationProvider`     |
+| `./gemma`     | `GemmaProvider`               | `createGemmaProviderDefinition`    | local models (LM Studio / OpenAI-compatible)   |
+| `./qwen`      | `QwenProvider`                | `createQwenProviderDefinition`     | OpenAI-compatible endpoint                     |
+| `./bytedance` | `BytedanceProvider`           | —                                  | `IVideoGenerationProvider` (video, internal)   |
+
+`./google` is a deprecated compatibility alias re-exporting `./gemini`.
+
 ### Internal (not exported)
 
 `src/shared/openai-compatible/` contains the OpenAI-compatible protocol implementation used by openai, deepseek, gemma, and qwen sub-modules. It is not a public export.

--- a/packages/agent-transport-http/README.md
+++ b/packages/agent-transport-http/README.md
@@ -1,9 +1,45 @@
 # @robota-sdk/agent-transport-http
 
-HTTP transport (Hono) for the Robota SDK.
+HTTP transport (built on [Hono](https://hono.dev)) for the Robota SDK. It exposes a running
+`IInteractiveSession` over HTTP routes so a browser, another service, or any HTTP client can
+drive an agent session.
 
-```typescript
-import { createHttpTransport, createAgentRoutes } from '@robota-sdk/agent-transport-http';
+## Installation
+
+```bash
+npm install @robota-sdk/agent-transport-http
+# or
+pnpm add @robota-sdk/agent-transport-http
 ```
 
-See [docs/SPEC.md](./docs/SPEC.md) for the full contract.
+## Usage
+
+`createAgentRoutes` builds the agent route handlers from a `sessionFactory` that resolves an
+`IInteractiveSession` per request (e.g. by auth token or session id). `createHttpTransport`
+wraps them as a mountable transport with an optional `basePath`.
+
+```typescript
+import { createAgentRoutes } from '@robota-sdk/agent-transport-http';
+import { Hono } from 'hono';
+
+const app = new Hono();
+app.route(
+  '/agent',
+  createAgentRoutes({
+    // Resolve (or create) the session for this request.
+    sessionFactory: (c) => resolveSessionForRequest(c),
+  }),
+);
+```
+
+## Exports
+
+| Symbol                  | Kind      | Description                                               |
+| ----------------------- | --------- | --------------------------------------------------------- |
+| `createHttpTransport`   | function  | `(options?: IHttpTransportOptions)` — mountable transport |
+| `createAgentRoutes`     | function  | `(options: IAgentRoutesOptions)` — Hono agent routes      |
+| `IHttpTransportOptions` | interface | `{ basePath?: string }`                                   |
+| `IAgentRoutesOptions`   | interface | `{ sessionFactory: TSessionFactory }`                     |
+| `TSessionFactory`       | type      | Resolves an `IInteractiveSession` per request             |
+
+See [docs/SPEC.md](./docs/SPEC.md) for the full contract and route surface.

--- a/packages/agent-transport-mcp/README.md
+++ b/packages/agent-transport-mcp/README.md
@@ -1,9 +1,43 @@
 # @robota-sdk/agent-transport-mcp
 
-Model Context Protocol (MCP) server transport for the Robota SDK.
+Model Context Protocol (MCP) server transport for the Robota SDK. It exposes a running
+`IInteractiveSession` as an MCP server so MCP-aware clients (e.g. Claude Desktop, IDE
+integrations) can drive the agent and call its system commands as MCP tools.
+
+## Installation
+
+```bash
+npm install @robota-sdk/agent-transport-mcp
+# or
+pnpm add @robota-sdk/agent-transport-mcp
+```
+
+## Usage
+
+`createAgentMcpServer` builds an MCP server from an `IInteractiveSession`. By default each
+system command is registered as a separate MCP tool (`exposeCommands`). `createMcpTransport`
+wraps it for the SDK's transport registry.
 
 ```typescript
-import { createMcpTransport, createAgentMcpServer } from '@robota-sdk/agent-transport-mcp';
+import { createAgentMcpServer } from '@robota-sdk/agent-transport-mcp';
+
+const server = createAgentMcpServer({
+  name: 'robota-agent',
+  version: '1.0.0',
+  session, // an IInteractiveSession
+  exposeCommands: true,
+});
+
+// Connect `server` to your MCP stdio/SSE transport of choice.
 ```
+
+## Exports
+
+| Symbol                 | Kind      | Description                                               |
+| ---------------------- | --------- | --------------------------------------------------------- |
+| `createAgentMcpServer` | function  | `(options: IAgentMcpOptions)` — MCP server for a session  |
+| `createMcpTransport`   | function  | `(options: IMcpTransportOptions)` — SDK transport wrapper |
+| `IAgentMcpOptions`     | interface | `{ name, version, session, exposeCommands? }`             |
+| `IMcpTransportOptions` | interface | Transport-registry options                                |
 
 See [docs/SPEC.md](./docs/SPEC.md) for the full contract.


### PR DESCRIPTION
Implements the 4 Wave-D doc-sync backlogs (each verified, moved to completed/ with evidence).

- **DOCAUDIT-005**: fixed the broken `createOpenAIProvider` quickstart import (`new OpenAIProvider`), 2 stale `agent-provider-*` names in the agent-framework SPEC, and documented each agent-provider sub-path's real exports. Migration/release-note historical references left intact.
- **DOCSYNC-001**: documented `createAgentRuntime()` in the agent-framework README (SPEC↔README parity).
- **README-001**: fleshed out the 9-line stub READMEs for agent-transport-http/mcp with real-export usage.
- **WEB-019**: hid the undeployed `playground.robota.io` nav link in docs (restore via WEB-005 on canonical `play.robota.io`).

Verification: `pnpm harness:scan` 32/32, `apps/docs` typecheck, docs-structure validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)