### PR TITLE
INFRA-019: programmatic in-process agent driver (TEST-008 north star closed)

### DIFF
--- a/.agents/backlog/TEST-008-programmatic-agent-control-driver.md
+++ b/.agents/backlog/TEST-008-programmatic-agent-control-driver.md
@@ -1,6 +1,6 @@
 ---
 title: 'TEST-008: programmatic agent-control driver — fully drive the real CLI agent (north star)'
-status: todo
+status: largely-done
 created: 2026-06-28
 priority: high
 urgency: later
@@ -9,6 +9,23 @@ depends_on: [TEST-007]
 ---
 
 # Programmatic agent-control driver (final target shape)
+
+> **Status update (2026-06-28): north star reached.** All three enabling axes shipped:
+>
+> - **Replay provider** (provider axis) — `@robota-sdk/agent-provider-replay` / `ReplayProvider`
+>   (INFRA-017, done).
+> - **CLI replay flag** — `robota --session-log <path>` drives a deterministic conversation through the
+>   built binary (INFRA-018, done; unblocked SCREEN-010 TC-02/03).
+> - **Programmatic in-process driver** (transport axis) — `createProgrammaticAgent` +
+>   `ProgrammaticInteractionChannel` in `@robota-sdk/agent-transport/programmatic` (INFRA-019, done):
+>   `start`/`send`/`stop` drives a real `InteractiveSession` and reads assistant replies / tool calls /
+>   errors as data, no terminal.
+>
+> **Remaining (optional follow-up, not required for the north star):** the transport-agnostic CLI
+> **assembly factory** `createCliAgent(...)` — extract the CLI's exact preset/provider/command wiring so
+> the programmatic driver can run with production-parity composition (today it wires session +
+> commandModules directly). Invasive CLI-startup refactor; sequence when production-parity in-process
+> driving is actually needed (e.g. INFRA-016 testing-package scenarios). Tracked below under "What" #1.
 
 **North star (user-set, 2026-06-28):** the agent (Claude) must be able to **directly control and freely
 drive the real robota CLI agent at will** — boot it, send messages, run any command, observe streamed

--- a/.agents/spec-docs/done/INFRA-019-programmatic-in-process-driver.md
+++ b/.agents/spec-docs/done/INFRA-019-programmatic-in-process-driver.md
@@ -1,0 +1,233 @@
+---
+status: draft
+type: INFRA
+tags: [transport, testing]
+---
+
+# INFRA-019: Programmatic in-process agent driver (IInteractionChannel adapter)
+
+Final TEST-008 increment. Adds a **programmatic `IInteractionChannel` adapter** and a thin
+**in-process driver** so the real agent can be driven structurally — send a message, await the turn,
+read assistant replies / tool calls / errors as data — with no terminal, no PTY, no scraping. This
+closes the north star: "the agent can be driven at will, in-process, structured."
+
+## Problem
+
+The framework already exposes the binding seam — `createInteractiveRuntime({ channel, ... })` consumes
+any `IInteractionChannel` and wires it to a real `InteractiveSession` (real provider, real command
+modules, real tool loop). Two adapters exist today:
+
+- `TuiInteractionChannel` (agent-transport-tui) — Ink/React, direct-wiring, terminal-bound.
+- `HeadlessInteractionChannel` (agent-transport) — one-shot print runner, not interactive-structured.
+
+There is **no programmatic adapter** — nothing that lets a caller (a test, an automation, an embedding
+app) push a message in-process and read back the structured `InteractionEvent` stream the contract
+already defines. The `requestAction` contract doc explicitly reserves a "programmatic preset" adapter
+slot for exactly this. Until it exists, driving the agent requires a terminal (PTY scraping, INFRA-018)
+— the slowest, least structured form.
+
+Reproduction: there is no way, in a unit test or an embedding host, to do
+`driver.send('hi'); const reply = driver.lastAssistantText();` against the real framework session.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-transport/src/programmatic/` — NEW: `ProgrammaticInteractionChannel` (implements
+  `IInteractionChannel` via the documented one-way `write()` event protocol + an action-response
+  queue) and `createProgrammaticAgent` (wraps `createInteractiveRuntime` + the channel; exposes
+  `start/send/stop` + structured accessors).
+- `packages/agent-transport/src/index.ts` — export the adapter + driver; add a `./programmatic`
+  subpath in `package.json` exports.
+- `packages/agent-transport/src/__tests__/programmatic/` — NEW: an in-process test using the
+  deterministic scripted provider (`@robota-sdk/agent-core/testing`) proving structured driving
+  against the REAL `InteractiveSession` (no mocks of the framework loop).
+
+agent-transport already depends on exactly the right packages (agent-core, agent-framework,
+agent-interface-transport) — no new dependency.
+
+### Alternatives Considered
+
+**Alt A (chosen): programmatic adapter + thin driver over `createInteractiveRuntime`, in agent-transport**
+
+- Pro: smallest correct seam — reuses the existing port (`IInteractionChannel`) and the existing
+  binding (`createInteractiveRuntime`). The driver is a thin convenience over the production
+  event protocol; no framework change. Lives in transport core (production), so the (future) testing
+  package consumes it test→production, never the reverse.
+- Con: the driver awaits turn completion via the event stream / `submit()` resolution; multi-call
+  turns (tool loops) are naturally handled by `submit()` awaiting the whole turn.
+
+**Alt B: a full transport-agnostic CLI assembly factory (`createCliAgent`) extracted from agent-cli**
+
+- Pro: production-parity wiring (exact preset/provider/command composition the CLI uses) reusable
+  in-process.
+- Con: an invasive refactor of the CLI startup path; **not required** to close the north star — the
+  programmatic driver already drives the real framework session with real command modules and a real
+  provider. Sequenced to a follow-up backlog item, not dropped.
+
+### Decision
+
+Alt A. Ship the programmatic adapter + in-process driver in agent-transport, proven against the real
+`InteractiveSession` with the scripted provider. The CLI assembly-factory extraction (production-parity
+in-process wiring) is sequenced to a follow-up (recorded in the backlog), not in scope here.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — agent-transport (adapter + driver + test); no new deps
+- [x] Sibling scan 완료 — `createInteractiveRuntime` is the sole channel-binding seam; existing
+      adapters (Tui/Headless) confirm the port shape; the programmatic slot is reserved by the contract
+- [x] 대안 최소 2개 검토 완료 (A thin driver over the port / B full CLI assembly-factory extraction)
+- [x] 결정 근거 문서화 완료 (smallest correct seam, reuses port + binding, production placement, test→prod)
+
+## Solution
+
+1. **`ProgrammaticInteractionChannel implements IInteractionChannel`** (agent-transport/programmatic):
+   - `onSubmit(handler)` stores the framework's submit handler; `submit(text)` invokes it (the
+     programmatic "user types").
+   - `write(event)` appends to an in-memory `InteractionEvent[]` log (the structured output).
+   - `requestAction(action)` resolves from a FIFO queue of pre-supplied `TActionResponse`s; if the
+     queue is empty it resolves `{ type: 'cancelled' }` (a safe default the framework already handles)
+     — so a driver run never blocks on an un-answered disambiguation.
+   - `setAvailableCommands`/`setBusy`/`start`/`stop` track simple state (`availableCommands`, `busy`,
+     `started`/`stopped`).
+2. **`createProgrammaticAgent(options)`** — wraps `createInteractiveRuntime({ channel, commandModules,
+provider, cwd, sessionStore })`:
+   - `start()` → `runtime.start()`.
+   - `send(text)` → `await channel.submit(text)` (resolves when the turn completes, since
+     `InteractiveSession.submit` awaits the whole turn; busy is cleared on `complete`).
+   - structured accessors: `events` (the full `InteractionEvent[]`), `assistantReplies()`
+     (`assistant-done` fullTexts), `lastAssistantText()`, `toolCalls()` (`tool-call` events),
+     `errors()`.
+   - `queueAction(response)` to pre-answer the next disambiguation.
+   - `stop()` → `runtime.stop()`.
+3. **Exports** — add `ProgrammaticInteractionChannel`, `createProgrammaticAgent`, and their option/types
+   to agent-transport's index + a `./programmatic` subpath.
+4. **In-process test** — with `createScriptedProvider([...])` and a temp cwd, build the driver, `start`,
+   `send` a message, and assert the recorded assistant reply is captured as structured data; cover a
+   tool-call turn and a queued `requestAction`. The framework loop (session, tool exec, persistence)
+   runs unmocked.
+
+## Affected Files
+
+- `packages/agent-transport/src/programmatic/ProgrammaticInteractionChannel.ts` (NEW)
+- `packages/agent-transport/src/programmatic/createProgrammaticAgent.ts` (NEW)
+- `packages/agent-transport/src/programmatic/index.ts` (NEW)
+- `packages/agent-transport/src/index.ts`, `packages/agent-transport/package.json` (export + subpath)
+- `packages/agent-transport/src/__tests__/programmatic/programmatic-driver.test.ts` (NEW)
+- `packages/agent-transport/docs/SPEC.md` (document the new programmatic surface)
+- `packages/agent-framework/src/interaction/createInteractiveRuntime.ts` — added `permissionMode` to
+  `IInteractiveRuntimeOptions` (parity with TUI/headless) and made `assistant-done` carry the
+  authoritative `result.response` (correct for non-streaming providers). Scope note appended at
+  GATE-VERIFY — a justified, minimal framework change surfaced during implementation, not a new design.
+
+## Completion Criteria
+
+- [x] TC-01: `createProgrammaticAgent({ provider: scripted, cwd })` starts and binds a real
+      `InteractiveSession` via `createInteractiveRuntime` (no mocks of the framework loop).
+- [x] TC-02: `await driver.send('hello')` drives a real turn; the scripted assistant reply is captured —
+      `driver.lastAssistantText()` equals the scripted text and `driver.events` contains the
+      `user-message` then `assistant-done` events in order.
+- [x] TC-03: a tool-call turn is captured as structured data — `driver.toolCalls()` contains the `Edit`
+      tool-call event and the real tool loop mutated the file on disk (not mocked).
+- [x] TC-04: `channel.queueAction({...})` pre-answers a disambiguation `requestAction`; with an empty
+      queue, `requestAction` resolves `{ type: 'cancelled' }` (driver never deadlocks).
+- [x] TC-05: `pnpm --filter @robota-sdk/agent-transport typecheck` + `build` exit 0; agent-transport
+      suite 38 pass; framework suite 1021 pass; `pnpm harness:scan` 33/33 (incl. dependency-direction +
+      capability-placement + docs-structure for the new subpath).
+
+## Test Plan
+
+Test strategy derived from type=INFRA, tags=[transport,testing]: in-process functional tests against
+the real framework loop with a deterministic provider + harness scans.
+
+| TC-ID | Test Type | Tool / Approach                                                            | Notes                               |
+| ----- | --------- | -------------------------------------------------------------------------- | ----------------------------------- |
+| TC-01 | automated | vitest: build driver with scripted provider + temp cwd, assert start binds | Real `InteractiveSession`, no mocks |
+| TC-02 | automated | vitest: `send` a message, assert captured assistant reply + event order    | Structured in-process driving       |
+| TC-03 | automated | vitest: scripted tool-call turn, assert `toolCalls()` captured             | Real tool loop                      |
+| TC-04 | automated | vitest: queued + empty `requestAction` → resolved / cancelled              | No deadlock on disambiguation       |
+| TC-05 | automated | `pnpm typecheck` + `build` + `pnpm harness:scan`                           | Must exit 0 / all scans green       |
+
+## User Execution Test Scenarios
+
+- Prereq: agent-transport built; a deterministic provider (the scripted provider, or a real provider
+  key for a live run).
+- Steps (in-process, e.g. a Node script or test):
+  `const driver = createProgrammaticAgent({ provider, cwd, commandModules }); await driver.start();
+await driver.send('hello'); console.log(driver.lastAssistantText()); await driver.stop();`
+- Expected: the assistant reply prints with no terminal/PTY involved; `driver.events` holds the full
+  structured `InteractionEvent` stream (user-message, assistant chunks/done, tool calls) for assertion.
+- Evidence: `programmatic-driver.test.ts` is the automated form of this scenario — it constructs the
+  driver, `start()`s it, `send()`s a message, and asserts `lastAssistantText()` / `events` /
+  `toolCalls()` against the real framework loop (scripted provider) with no terminal. TC-01/02 prove the
+  send→reply round-trip; TC-03 proves a tool turn mutates a real file and surfaces as data; all 3 pass.
+
+## Tasks
+
+- [x] `.agents/tasks/completed/INFRA-019.md` — archived (GATE-COMPLETE).
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-28
+
+- Frontmatter `type: INFRA`, `tags: [transport, testing]`; Problem w/ reproduction; Architecture
+  Review 4/4 — 2 alternatives (A thin driver over the port / B CLI assembly-factory) + decision;
+  TC-01–05 + matching Test Plan; Tasks placeholder; empty result Evidence Log.
+- Result: PASS → `draft` → `review-ready` → `backlog/`.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-28
+
+- User authorized driving the final TEST-008 increment to completion ("이어서 끝까지 진행해", following
+  the offer to take INFRA-019 — the programmatic adapter — to close "마음대로 제어"). Scoped (engineering
+  decision, stated to the user) to the programmatic adapter + in-process driver; the CLI
+  assembly-factory extraction is sequenced to a follow-up backlog item, not dropped.
+- No Architecture Review / type / tags changed after approval.
+- Result: PASS → `review-ready` → `approved` → `todo/`.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-28
+
+- Tasks file `.agents/tasks/INFRA-019.md` created; T1–T4 map to TC-01–05.
+- Result: PASS → `approved` → `in-progress` → `active/`.
+
+### Implementation note (2026-06-28)
+
+Two minimal `createInteractiveRuntime` (agent-framework) changes surfaced during implementation —
+justified, not new design:
+
+1. **`permissionMode` on `IInteractiveRuntimeOptions`** — the production runtime path created the
+   session without a permission mode, so a programmatically-driven tool turn (TC-03) could not run
+   tools deterministically. Added the option (parity with the TUI/headless channels) and threaded it
+   to the `InteractiveSession`; the driver exposes it as `permissionMode`.
+2. **`assistant-done` carries `result.response`** — the event previously reported only the accumulated
+   `text_delta` stream, which a non-streaming provider (the scripted provider) does not fully emit
+   (TC-02/03 saw `''`/`'\n\n'`). It now prefers the authoritative `result.response` from the execution
+   result, falling back to the deltas. Correct for both streaming and non-streaming providers; the
+   existing `createInteractiveRuntime` tests (which emit `response` on `complete`) stay green.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-06-28
+
+- Prior gate: GATE-IMPLEMENT ✅ PASS; status `in-progress` in `active/`.
+- T1–T4 complete; agent-transport typecheck + build exit 0 (new `programmatic/index` entry emitted);
+  agent-transport suite 38 pass (3 new INFRA-019 tests); agent-framework suite 1021 pass (runtime
+  change regression-clean); framework lint 0 errors; `pnpm harness:scan` 33/33.
+- Result: PASS → `in-progress` → `verifying`.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-06-28
+
+- **TC-01** ✅ `createProgrammaticAgent` binds a real `InteractiveSession` via `createInteractiveRuntime`
+  (no framework-loop mocks) and starts.
+- **TC-02** ✅ `send('hello')` → `lastAssistantText()` = `'DRIVEN_ANSWER_42'`; `events` carry
+  `user-message` before `assistant-done`; scripted provider saw the driven message.
+- **TC-03** ✅ scripted `Edit` turn ran the real tool loop (file mutated `Hello`→`Goodbye` on disk) and
+  surfaced in `toolCalls()`; final reply `'edit done'`.
+- **TC-04** ✅ queued `confirm` answered; empty queue resolved `{ type: 'cancelled' }` (no deadlock).
+- **TC-05** ✅ transport typecheck + build exit 0; transport 38 pass; framework 1021 pass;
+  `harness:scan` 33/33.
+
+All Completion Criteria `[x]`; every Test Plan row has a test reference. Tasks archived to
+`.agents/tasks/completed/INFRA-019.md`. Result: PASS → `verifying` → `done`; `active/` → `done/`.
+
+**TEST-008 north star closed.** The agent can now be driven at will across all three axes: the replay
+provider (INFRA-017), the CLI `--session-log` flag (INFRA-018), and the in-process programmatic driver
+(INFRA-019). Sequenced follow-up: the transport-agnostic CLI assembly factory (`createCliAgent`) for
+production-parity in-process wiring — recorded in the backlog, not required to close the north star.

--- a/.agents/tasks/completed/INFRA-019.md
+++ b/.agents/tasks/completed/INFRA-019.md
@@ -1,0 +1,26 @@
+# INFRA-019 Tasks — Programmatic in-process agent driver
+
+Spec: `.agents/spec-docs/active/INFRA-019-programmatic-in-process-driver.md`
+
+## Tasks
+
+- [ ] T1 (TC-01): `ProgrammaticInteractionChannel implements IInteractionChannel` in
+      `packages/agent-transport/src/programmatic/` — `onSubmit`/`submit`, `write` → event buffer,
+      `requestAction` → FIFO response queue (empty → `cancelled`), `setAvailableCommands`/`setBusy`/
+      `start`/`stop` state.
+- [ ] T2 (TC-02/03/04): `createProgrammaticAgent` wrapping `createInteractiveRuntime` — `start`,
+      `send` (awaits the turn), `stop`, structured accessors (`events`, `assistantReplies`,
+      `lastAssistantText`, `toolCalls`, `errors`), `queueAction`. Export both + a `./programmatic`
+      subpath; document in `docs/SPEC.md`.
+- [ ] T3 (TC-02/03/04): in-process test `programmatic-driver.test.ts` using the scripted provider +
+      temp cwd against the REAL `InteractiveSession` — assistant reply captured, event order, tool-call
+      turn, queued/empty `requestAction`.
+- [ ] T4 (TC-05): `pnpm --filter @robota-sdk/agent-transport typecheck` + `build` + suite green;
+      `pnpm harness:scan` 33/33.
+
+## Test Plan
+
+In-process vitest functional tests in agent-transport against the real framework loop
+(`createInteractiveRuntime` + real `InteractiveSession`) driven by the deterministic scripted provider
+(`@robota-sdk/agent-core/testing`); harness:scan as the structural guard. Each TC shows evidence in the
+spec Evidence Log before GATE-VERIFY.

--- a/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
+++ b/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
@@ -13,7 +13,7 @@ import type { ICommandModule } from '../command-api/command-module.js';
 import type { IInteractiveSession } from '../interactive/i-interactive-session.js';
 import type { IInteractiveSessionStore } from '../interactive/session-persistence.js';
 import type { IInteractiveSessionEvents } from '../interactive/types.js';
-import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
 
 export interface IInteractiveRuntimeOptions {
   channel: IInteractionChannel;
@@ -24,6 +24,8 @@ export interface IInteractiveRuntimeOptions {
   cwd?: string;
   /** Session store for persistence. */
   sessionStore?: IInteractiveSessionStore;
+  /** Permission mode for tool execution (parity with the TUI/headless channels). */
+  permissionMode?: TPermissionMode;
   /** Test escape hatch — skips session creation when supplied. */
   _testSession?: IInteractiveSession;
 }
@@ -68,8 +70,11 @@ function wireSessionEvents(session: IInteractiveSession, channel: IInteractionCh
     channel.write({ type: 'assistant-chunk', chunk: delta });
   };
 
-  const onComplete: IInteractiveSessionEvents['complete'] = () => {
-    channel.write({ type: 'assistant-done', fullText });
+  const onComplete: IInteractiveSessionEvents['complete'] = (result) => {
+    // Prefer the authoritative final response from the execution result; fall back to the
+    // accumulated stream deltas (e.g. if a result is unavailable). This keeps assistant-done
+    // correct for both streaming and non-streaming providers.
+    channel.write({ type: 'assistant-done', fullText: result?.response ?? fullText });
     fullText = '';
     channel.setBusy(false);
   };
@@ -169,10 +174,16 @@ export function createInteractiveRuntime(options: IInteractiveRuntimeOptions): I
       if (_testSession) {
         session = _testSession;
       } else {
-        const { provider, cwd, sessionStore } = options;
+        const { provider, cwd, sessionStore, permissionMode } = options;
         if (!provider) throw new Error('createInteractiveRuntime: provider is required');
         if (!cwd) throw new Error('createInteractiveRuntime: cwd is required');
-        session = new InteractiveSession({ provider, cwd, sessionStore, commandModules });
+        session = new InteractiveSession({
+          provider,
+          cwd,
+          sessionStore,
+          commandModules,
+          permissionMode,
+        });
       }
 
       unwireEvents = wireSessionEvents(session, channel);

--- a/packages/agent-transport/docs/SPEC.md
+++ b/packages/agent-transport/docs/SPEC.md
@@ -7,6 +7,10 @@ split by concern; this package owns only the **dependency-free core**:
 
 - Headless transport (`/headless`): non-interactive print/JSON/stream-json runner — `HeadlessInteractionChannel`, `createHeadlessRunner`, `PrintTerminal`, `promptInput`, `createHeadlessTransport`.
 - Transport registry (root): `TransportRegistry` — settings-backed enable/disable of `IConfigurableTransport` instances.
+- Programmatic driver (`/programmatic`): an in-process `IInteractionChannel` adapter
+  (`ProgrammaticInteractionChannel`) + `createProgrammaticAgent` driver — drive the real agent
+  structurally (`start`/`send`/`stop`, read assistant replies / tool calls / errors as data) with no
+  terminal, no PTY, no scraping.
 - Testing fixtures (`/testing`): `createScriptedProvider` deterministic provider for transport/CLI tests.
 
 The per-concern transport implementations live in their own packages: `@robota-sdk/agent-transport-tui`
@@ -36,7 +40,20 @@ agent-transport/src
     print-terminal.ts           ← PrintTerminal, promptInput
   testing/
     scripted-provider.ts        ← createScriptedProvider (test-only, via /testing subpath)
+  programmatic/
+    ProgrammaticInteractionChannel.ts ← in-process IInteractionChannel adapter (event buffer + action queue)
+    createProgrammaticAgent.ts  ← driver over createInteractiveRuntime (start/send/stop + accessors)
 ```
+
+### Programmatic driving
+
+`createProgrammaticAgent({ provider, cwd, commandModules?, sessionStore?, permissionMode? })` wires a
+`ProgrammaticInteractionChannel` to a real `InteractiveSession` via `createInteractiveRuntime`.
+`send(text)` pushes a user submission and awaits the whole turn; the channel records the framework's
+one-way `InteractionEvent` stream into `events`, which the driver exposes as `assistantReplies()`,
+`lastAssistantText()`, `toolCalls()`, and `errors()`. `queueAction(response)` pre-answers a
+disambiguation `requestAction` (an empty queue resolves `{ type: 'cancelled' }`, so a run never
+deadlocks). This is the in-process form of "drive the agent at will" (TEST-008).
 
 ### Headless lifecycle
 
@@ -46,12 +63,14 @@ is selected by the runner options.
 
 ## 4. Type Ownership
 
-| Type                                 | File                                         | Description                                  |
-| ------------------------------------ | -------------------------------------------- | -------------------------------------------- |
-| `IHeadlessInteractionChannelOptions` | `src/headless/HeadlessInteractionChannel.ts` | Constructor options for the headless channel |
-| `IHeadlessRunnerOptions`             | `src/headless/headless-runner.ts`            | Options for `createHeadlessRunner`           |
-| `TOutputFormat`                      | `src/headless/headless-runner.ts`            | `'text' \| 'json' \| 'stream-json'`          |
-| `IHeadlessTransportOptions`          | `src/headless/headless-transport.ts`         | Options for `createHeadlessTransport`        |
+| Type                                 | File                                          | Description                                  |
+| ------------------------------------ | --------------------------------------------- | -------------------------------------------- |
+| `IHeadlessInteractionChannelOptions` | `src/headless/HeadlessInteractionChannel.ts`  | Constructor options for the headless channel |
+| `IHeadlessRunnerOptions`             | `src/headless/headless-runner.ts`             | Options for `createHeadlessRunner`           |
+| `TOutputFormat`                      | `src/headless/headless-runner.ts`             | `'text' \| 'json' \| 'stream-json'`          |
+| `IHeadlessTransportOptions`          | `src/headless/headless-transport.ts`          | Options for `createHeadlessTransport`        |
+| `ICreateProgrammaticAgentOptions`    | `src/programmatic/createProgrammaticAgent.ts` | Options for `createProgrammaticAgent`        |
+| `IProgrammaticAgent`                 | `src/programmatic/createProgrammaticAgent.ts` | The in-process driver surface                |
 
 ## 5. Public API Surface
 
@@ -69,6 +88,15 @@ is selected by the runner options.
 | `createHeadlessTransport`            | function   | Returns `ITransportAdapter & { getExitCode(): number }` wrapping `createHeadlessRunner`                  |
 | `IHeadlessTransportOptions`          | interface  | Options for `createHeadlessTransport`                                                                    |
 
+### `/programmatic`
+
+| Export                            | Kind      | Description                                                                                       |
+| --------------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| `ProgrammaticInteractionChannel`  | class     | In-process `IInteractionChannel` adapter: buffers `InteractionEvent`s, FIFO action-response queue |
+| `createProgrammaticAgent`         | function  | Driver over `createInteractiveRuntime`: `start`/`send`/`stop` + structured accessors              |
+| `ICreateProgrammaticAgentOptions` | interface | `{ provider, cwd, commandModules?, sessionStore?, permissionMode? }`                              |
+| `IProgrammaticAgent`              | interface | Driver surface: `events`, `send`, `assistantReplies`, `lastAssistantText`, `toolCalls`, `errors`  |
+
 ### `/testing`
 
 | Export                                | Kind     | Description                                                      |
@@ -78,10 +106,10 @@ is selected by the runner options.
 
 ### Root (`@robota-sdk/agent-transport`)
 
-| Export                        | Kind  | Description                                                          |
-| ----------------------------- | ----- | -------------------------------------------------------------------- |
-| `TransportRegistry`           | class | Settings-backed enable/disable registry of `IConfigurableTransport`s |
-| (plus `/headless` re-exports) |       | The root barrel also re-exports the headless surface                 |
+| Export                                          | Kind  | Description                                                          |
+| ----------------------------------------------- | ----- | -------------------------------------------------------------------- |
+| `TransportRegistry`                             | class | Settings-backed enable/disable registry of `IConfigurableTransport`s |
+| (plus `/headless` + `/programmatic` re-exports) |       | The root barrel also re-exports the headless + programmatic surfaces |
 
 ## 6. Extension Points
 

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -41,6 +41,18 @@
         "import": "./dist/node/testing/index.js",
         "require": "./dist/node/testing/index.cjs"
       }
+    },
+    "./programmatic": {
+      "types": "./dist/node/programmatic/index.d.ts",
+      "source": "./src/programmatic/index.ts",
+      "node": {
+        "import": "./dist/node/programmatic/index.js",
+        "require": "./dist/node/programmatic/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/programmatic/index.js",
+        "require": "./dist/node/programmatic/index.cjs"
+      }
     }
   },
   "repository": {

--- a/packages/agent-transport/src/__tests__/programmatic/programmatic-driver.test.ts
+++ b/packages/agent-transport/src/__tests__/programmatic/programmatic-driver.test.ts
@@ -1,0 +1,106 @@
+/**
+ * INFRA-019: in-process programmatic driving of the REAL agent.
+ *
+ * Drives `createProgrammaticAgent` (→ `createInteractiveRuntime` → a real `InteractiveSession`) with
+ * the deterministic scripted provider. No terminal, no PTY, no mocks of the framework loop: a message
+ * is pushed in-process and the structured `InteractionEvent` stream is asserted as data. This is the
+ * in-process form of "drive the agent at will" (TEST-008 north star).
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createProgrammaticAgent,
+  ProgrammaticInteractionChannel,
+  type IProgrammaticAgent,
+} from '../../programmatic/index.js';
+
+describe('programmatic in-process agent driver (INFRA-019)', () => {
+  let cwd: string;
+  let driver: IProgrammaticAgent | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'robota-programmatic-'));
+  });
+
+  afterEach(async () => {
+    await driver?.stop();
+    driver = undefined;
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('TC-01/02: send() drives a real turn and the scripted assistant reply is captured as data', async () => {
+    const scripted = createScriptedProvider([{ text: 'DRIVEN_ANSWER_42' }]);
+    driver = createProgrammaticAgent({ provider: scripted.provider, cwd });
+
+    await driver.start();
+    await driver.send('hello');
+
+    // TC-02: the reply is captured structurally — no terminal involved.
+    expect(driver.lastAssistantText()).toBe('DRIVEN_ANSWER_42');
+    expect(driver.assistantReplies()).toEqual(['DRIVEN_ANSWER_42']);
+
+    // Event order: the user message is recorded before the assistant completion.
+    const types = driver.events.map((e) => e.type);
+    expect(types).toContain('user-message');
+    expect(types).toContain('assistant-done');
+    expect(types.indexOf('user-message')).toBeLessThan(types.indexOf('assistant-done'));
+    expect(driver.errors()).toEqual([]);
+
+    // The scripted provider saw exactly the driven message.
+    const firstRequest = scripted.requests[0] ?? [];
+    const contents = firstRequest.map((m) => String(m.content));
+    expect(contents.some((c) => c.includes('hello'))).toBe(true);
+  });
+
+  it('TC-03: a scripted tool-call turn runs the real tool loop and is captured in toolCalls()', async () => {
+    const target = join(cwd, 'greet.txt');
+    writeFileSync(target, 'Hello, world\n', 'utf8');
+
+    const scripted = createScriptedProvider([
+      {
+        toolCalls: [
+          { name: 'Edit', args: { filePath: target, oldString: 'Hello', newString: 'Goodbye' } },
+        ],
+      },
+      { text: 'edit done' },
+    ]);
+    driver = createProgrammaticAgent({
+      provider: scripted.provider,
+      cwd,
+      permissionMode: 'bypassPermissions',
+    });
+
+    await driver.start();
+    await driver.send('change the greeting');
+
+    // The real tool loop executed: the file on disk was mutated.
+    expect(readFileSync(target, 'utf8')).toBe('Goodbye, world\n');
+    // The tool call surfaced as structured data.
+    const calls = driver.toolCalls();
+    expect(calls.some((c) => c.name === 'Edit')).toBe(true);
+    expect(driver.lastAssistantText()).toBe('edit done');
+  });
+
+  it('TC-04: queueAction pre-answers a requestAction; empty queue resolves to cancelled', async () => {
+    const scripted = createScriptedProvider([{ text: 'noop' }]);
+    driver = createProgrammaticAgent({ provider: scripted.provider, cwd });
+    await driver.start();
+
+    // Exercise the request/response contract in isolation (the framework only calls requestAction
+    // for command interaction hints — the same FIFO queue the driver's queueAction feeds).
+    const channel = new ProgrammaticInteractionChannel();
+
+    channel.queueAction({ type: 'confirm', confirmed: true });
+    const answered = await channel.requestAction({ type: 'confirm', id: 'x', message: 'ok?' });
+    expect(answered).toEqual({ type: 'confirm', confirmed: true });
+
+    const defaulted = await channel.requestAction({ type: 'confirm', id: 'y', message: 'ok?' });
+    expect(defaulted).toEqual({ type: 'cancelled' });
+  });
+});

--- a/packages/agent-transport/src/index.ts
+++ b/packages/agent-transport/src/index.ts
@@ -1,2 +1,3 @@
 export * from './headless/index.js';
+export * from './programmatic/index.js';
 export { TransportRegistry } from './transport-registry.js';

--- a/packages/agent-transport/src/programmatic/ProgrammaticInteractionChannel.ts
+++ b/packages/agent-transport/src/programmatic/ProgrammaticInteractionChannel.ts
@@ -1,0 +1,84 @@
+/**
+ * ProgrammaticInteractionChannel — an in-process IInteractionChannel adapter (INFRA-019).
+ *
+ * The "programmatic preset" adapter slot reserved by the interaction contract: instead of an Ink TUI
+ * or a print runner, this channel lets a caller push a message in-process and read back the structured
+ * `InteractionEvent` stream the framework already emits. It uses the documented one-way `write()`
+ * protocol consumed by `createInteractiveRuntime` (not the TUI's direct-wiring path).
+ *
+ * Production transport adapter — lives in transport core. Tests and automation consume it; it never
+ * depends on test code.
+ */
+
+import type {
+  IInteractionChannel,
+  ICommandInfo,
+  InteractionEvent,
+  TActionRequest,
+  TActionResponse,
+} from '@robota-sdk/agent-interface-transport';
+
+export class ProgrammaticInteractionChannel implements IInteractionChannel {
+  /** Full structured event stream pushed by the framework, in order. */
+  readonly events: InteractionEvent[] = [];
+
+  availableCommands: ICommandInfo[] = [];
+  busy = false;
+  started = false;
+  stopped = false;
+
+  private submitHandler: ((text: string) => Promise<void>) | null = null;
+  private readonly actionResponses: TActionResponse[] = [];
+
+  // ── IInteractionChannel ──────────────────────────────────────
+
+  onSubmit(handler: (text: string) => Promise<void>): void {
+    this.submitHandler = handler;
+  }
+
+  write(event: InteractionEvent): void {
+    this.events.push(event);
+  }
+
+  /**
+   * Resolves from the pre-supplied response queue (FIFO). With an empty queue it resolves
+   * `{ type: 'cancelled' }` — a safe default the framework already handles — so a programmatic run
+   * never blocks on an un-answered disambiguation.
+   */
+  async requestAction(_action: TActionRequest): Promise<TActionResponse> {
+    return this.actionResponses.shift() ?? { type: 'cancelled' };
+  }
+
+  setAvailableCommands(commands: ICommandInfo[]): void {
+    this.availableCommands = commands;
+  }
+
+  setBusy(busy: boolean): void {
+    this.busy = busy;
+  }
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+
+  // ── Programmatic driving surface ─────────────────────────────
+
+  /** Push a user submission into the framework (the programmatic "user types and presses enter"). */
+  async submit(text: string): Promise<void> {
+    if (!this.submitHandler) {
+      throw new Error(
+        'ProgrammaticInteractionChannel: no submit handler registered — start the runtime first',
+      );
+    }
+    await this.submitHandler(text);
+  }
+
+  /** Pre-answer the next `requestAction` disambiguation. */
+  queueAction(response: TActionResponse): void {
+    this.actionResponses.push(response);
+  }
+}

--- a/packages/agent-transport/src/programmatic/createProgrammaticAgent.ts
+++ b/packages/agent-transport/src/programmatic/createProgrammaticAgent.ts
@@ -1,0 +1,100 @@
+/**
+ * createProgrammaticAgent — a thin in-process driver over the real framework session (INFRA-019).
+ *
+ * Wraps `createInteractiveRuntime` with a {@link ProgrammaticInteractionChannel} so a caller can drive
+ * the real agent structurally: `start()`, `send(text)` (awaits the whole turn), then read assistant
+ * replies / tool calls / errors as data — no terminal, no PTY, no scraping. This is the in-process
+ * form of "drive the agent at will" (TEST-008).
+ */
+
+import { createInteractiveRuntime } from '@robota-sdk/agent-framework';
+
+import { ProgrammaticInteractionChannel } from './ProgrammaticInteractionChannel.js';
+
+import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
+import type { ICommandModule, IInteractiveRuntime } from '@robota-sdk/agent-framework';
+import type {
+  IInteractiveSessionStore,
+  InteractionEvent,
+  TActionResponse,
+} from '@robota-sdk/agent-interface-transport';
+
+export interface ICreateProgrammaticAgentOptions {
+  /** Provider that answers the agent loop (e.g. a real provider, or the scripted provider in tests). */
+  provider: IAIProvider;
+  /** Working directory for session creation. */
+  cwd: string;
+  /** Slash-command modules to register (defaults to none). */
+  commandModules?: readonly ICommandModule[];
+  /** Optional session store for persistence. */
+  sessionStore?: IInteractiveSessionStore;
+  /** Permission mode for tool execution (e.g. `'bypassPermissions'` for unattended driving). */
+  permissionMode?: TPermissionMode;
+}
+
+export interface IProgrammaticAgent {
+  /** The structured event stream pushed by the framework, in order. */
+  readonly events: readonly InteractionEvent[];
+  /** Start the runtime and bind a real `InteractiveSession`. */
+  start(): Promise<void>;
+  /** Push a user message and await the turn to completion. */
+  send(text: string): Promise<void>;
+  /** Pre-answer the next disambiguation `requestAction`. */
+  queueAction(response: TActionResponse): void;
+  /** Every completed assistant reply (`assistant-done` fullTexts), in order. */
+  assistantReplies(): string[];
+  /** The most recent completed assistant reply, or `undefined` if none yet. */
+  lastAssistantText(): string | undefined;
+  /** Tool-call events captured during the run. */
+  toolCalls(): Array<{ id: string; name: string; args: unknown }>;
+  /** Errors surfaced by the framework during the run. */
+  errors(): Error[];
+  /** Stop the runtime and shut down the session. */
+  stop(): Promise<void>;
+}
+
+export function createProgrammaticAgent(
+  options: ICreateProgrammaticAgentOptions,
+): IProgrammaticAgent {
+  const channel = new ProgrammaticInteractionChannel();
+  const runtime: IInteractiveRuntime = createInteractiveRuntime({
+    channel,
+    commandModules: options.commandModules ?? [],
+    provider: options.provider,
+    cwd: options.cwd,
+    ...(options.sessionStore ? { sessionStore: options.sessionStore } : {}),
+    ...(options.permissionMode ? { permissionMode: options.permissionMode } : {}),
+  });
+
+  return {
+    events: channel.events,
+    start: (): Promise<void> => runtime.start(),
+    send: (text: string): Promise<void> => channel.submit(text),
+    queueAction: (response: TActionResponse): void => channel.queueAction(response),
+    assistantReplies: (): string[] =>
+      channel.events
+        .filter(
+          (e): e is Extract<InteractionEvent, { type: 'assistant-done' }> =>
+            e.type === 'assistant-done',
+        )
+        .map((e) => e.fullText),
+    lastAssistantText: (): string | undefined => {
+      const replies = channel.events.filter(
+        (e): e is Extract<InteractionEvent, { type: 'assistant-done' }> =>
+          e.type === 'assistant-done',
+      );
+      return replies.at(-1)?.fullText;
+    },
+    toolCalls: (): Array<{ id: string; name: string; args: unknown }> =>
+      channel.events
+        .filter(
+          (e): e is Extract<InteractionEvent, { type: 'tool-call' }> => e.type === 'tool-call',
+        )
+        .map((e) => ({ id: e.id, name: e.name, args: e.args })),
+    errors: (): Error[] =>
+      channel.events
+        .filter((e): e is Extract<InteractionEvent, { type: 'error' }> => e.type === 'error')
+        .map((e) => e.error),
+    stop: (): Promise<void> => runtime.stop(),
+  };
+}

--- a/packages/agent-transport/src/programmatic/index.ts
+++ b/packages/agent-transport/src/programmatic/index.ts
@@ -1,0 +1,6 @@
+export { ProgrammaticInteractionChannel } from './ProgrammaticInteractionChannel.js';
+export { createProgrammaticAgent } from './createProgrammaticAgent.js';
+export type {
+  ICreateProgrammaticAgentOptions,
+  IProgrammaticAgent,
+} from './createProgrammaticAgent.js';

--- a/packages/agent-transport/tsdown.config.ts
+++ b/packages/agent-transport/tsdown.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'headless/index': 'src/headless/index.ts',
     'testing/index': 'src/testing/index.ts',
+    'programmatic/index': 'src/programmatic/index.ts',
   },
   format: ['esm', 'cjs'],
   outDir: 'dist/node',


### PR DESCRIPTION
## Summary

Closes the TEST-008 north star transport axis: drive the real agent **structurally, in-process** — no terminal, no PTY, no scraping.

- **`ProgrammaticInteractionChannel`** (`@robota-sdk/agent-transport/programmatic`) — an in-process `IInteractionChannel` adapter (the "programmatic preset" slot the contract reserves): buffers the framework's `InteractionEvent` stream, FIFO action-response queue (empty → `cancelled`, never deadlocks).
- **`createProgrammaticAgent`** — thin driver over `createInteractiveRuntime` + a real `InteractiveSession`: `start`/`send`/`stop` plus structured accessors (`events`, `assistantReplies`, `lastAssistantText`, `toolCalls`, `errors`) and `queueAction`.
- **`createInteractiveRuntime`** (agent-framework): `permissionMode` added to `IInteractiveRuntimeOptions` (parity with the TUI/headless channels); `assistant-done` now carries the authoritative `result.response` (correct for non-streaming providers).

## TEST-008 north star — reached

All three axes now ship: replay provider (INFRA-017), CLI `--session-log` flag (INFRA-018), and the in-process programmatic driver (INFRA-019). Optional follow-up recorded in the backlog: the transport-agnostic `createCliAgent` assembly factory for production-parity in-process wiring.

## Verification

- agent-transport **38** tests pass (3 new INFRA-019), agent-framework **1021**, agent-transport-tui **394**
- full monorepo build + repo-wide typecheck green
- `pnpm harness:scan` **33/33**

🤖 Generated with [Claude Code](https://claude.com/claude-code)