### PR TITLE
chore(testing): align agent-testing exports with the source hint

### DIFF
--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": {
       "types": "./dist/node/index.d.ts",
+      "source": "./src/index.ts",
       "node": {
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs"


### PR DESCRIPTION
## Summary

Cosmetic follow-up surfaced during the INFRA-016 verification pass: `@robota-sdk/agent-testing`'s `exports` map lacked the `"source": "./src/index.ts"` hint that the published sibling `@robota-sdk/agent-transport` carries. This adds it for in-repo dev-resolution consistency.

- **No build/publish behavior change** — `source` only affects in-repo source resolution for dev consumers; `types`/`node`/`default` targets are unchanged.
- `pnpm harness:scan` 33/33.

Left open for review (not auto-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)