### PR TITLE
chore: release develop → main (complete TEST-007 + TEST-008 backlogs)

### DIFF
--- a/.agents/backlog/completed/TEST-007-reusable-pty-tui-e2e-harness.md
+++ b/.agents/backlog/completed/TEST-007-reusable-pty-tui-e2e-harness.md
@@ -1,7 +1,8 @@
 ---
 title: 'TEST-007: reusable PTY-driven TUI E2E harness (terminal-handoff scenarios + consolidation)'
-status: in-progress
+status: done
 created: 2026-06-28
+completed: 2026-06-28
 priority: high
 urgency: soon
 area: packages/agent-transport-tui
@@ -133,6 +134,13 @@ first new consumers. The `python3`-based exploration is deleted (node-pty is the
 - **Throwaway removed:** `scripts/verify-handoff-pty.{tsx,py}` deleted (node-pty is the repo standard).
 - Gates: TUI typecheck clean; full TUI suite 393 tests pass; `test:pty` 3 tests pass;
   `pnpm harness:scan` 33/33 green.
+
+### Closure note (2026-06-28)
+
+All "Done When" criteria met. Follow-up **INFRA-016** later relocated the shared harness from
+`agent-transport-tui/src/__tests__/pty/spawn-pty.ts` into the published `@robota-sdk/agent-testing`
+package (`spawnPty`/`spawnPtyFixture`); `agent-transport-tui` now consumes it as a devDependency. The
+re-pointed PTY suites stay green (`test:pty` 6, pty-e2e 5). Marking done.
 
 ## User Execution Test Scenarios
 

--- a/.agents/backlog/completed/TEST-008-programmatic-agent-control-driver.md
+++ b/.agents/backlog/completed/TEST-008-programmatic-agent-control-driver.md
@@ -1,7 +1,8 @@
 ---
 title: 'TEST-008: programmatic agent-control driver — fully drive the real CLI agent (north star)'
-status: largely-done
+status: done
 created: 2026-06-28
+completed: 2026-06-28
 priority: high
 urgency: later
 area: packages/agent-cli, packages/agent-provider (assembly factory + programmatic adapter + replay provider; consumed by the testing package)
@@ -176,4 +177,29 @@ transport-agnostic assembly factory + CLI opt-in.
   back through the committed conversation.
 - Expected: the conversation runs deterministically end-to-end with no network/model key; committed
   turns sit in scrollback, input pinned; matches a real session's behavior.
-- Evidence: _to be filled after implementation._
+- Evidence (2026-06-28): delivered and verified across all three axes; the scenario's automated form
+  is INFRA-018's PTY E2E `replay-conversation.ptytest.ts` — it boots the **built** CLI with
+  `--session-log <fixture>` (replay provider, no model key), sends a message, and asserts the recorded
+  assistant reply renders then **commits to `<Static>` scrollback** while the input stays pinned
+  (`lastIndexOf('Type a message') > indexOf('REPLAYED_ANSWER_42')`) — exactly this scenario. The
+  in-process axis is covered by INFRA-019's `createProgrammaticAgent` (`programmatic-driver.test.ts`,
+  3 tests) driving the real framework loop with structured event capture. Spec docs:
+  `.agents/spec-docs/done/INFRA-017/018/019`.
+
+## Closure (2026-06-28)
+
+North star reached. All three enabling axes shipped and merged to `main`:
+
+- **INFRA-017** — `@robota-sdk/agent-provider-replay` / `ReplayProvider` (provider axis).
+- **INFRA-018** — `robota --session-log <path>` deterministic conversation through the built binary
+  (CLI axis; closed SCREEN-010 TC-02/03 on the real binary).
+- **INFRA-019** — `createProgrammaticAgent` + `ProgrammaticInteractionChannel` in
+  `@robota-sdk/agent-transport/programmatic` (in-process transport axis).
+
+The recording substrate is the session log (resume-complete ⟹ replay-complete; no parallel cassette
+format). The one remaining bullet from "What" — a shared `createCliAgent` assembly factory — was
+**explicitly cancelled by the user** ([[feedback_no_shared_cli_factory]]): `agent-cli` is just one
+assembled product among many (agent-cli-2, embedded hosts), so its preset/provider/command wiring is
+that product's internal concern, not a reusable factory. The reusable layer already exists in
+`agent-framework` (`createInteractiveRuntime`) + `agent-transport` (`createProgrammaticAgent`).
+Nothing outstanding — marking done.


### PR DESCRIPTION
## Summary

Archive the two backlogs delivered by the recent INFRA-017/018/019 + INFRA-016 work:

- **TEST-007** — reusable PTY harness (done; relocated to `@robota-sdk/agent-testing` by INFRA-016).
- **TEST-008** — programmatic agent-control driver / north star (done across all three axes; optional `createCliAgent` factory cancelled per the no-shared-CLI-factory directive).

Docs/backlog-only change: status → done + moved to `backlog/completed/`. `pnpm harness:scan` 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)