### PR TITLE
chore(backlog): complete TERM-002/003/004 (terminal-handoff feature)

### DIFF
--- a/.agents/backlog/completed/TERM-002-tui-terminal-handoff-impl.md
+++ b/.agents/backlog/completed/TERM-002-tui-terminal-handoff-impl.md
@@ -1,7 +1,8 @@
 ---
 title: 'TERM-002: TUI implements the terminal-handoff port (thin suspend/resume)'
-status: in-progress
+status: done
 created: 2026-06-27
+completed: 2026-06-28
 priority: high
 urgency: soon
 area: packages/agent-transport-tui
@@ -108,3 +109,11 @@ TEST-007 PTY harness.
   keystrokes (`CHILD_GOT:[hello-from-pty]`), `runWithTerminal` returns, and the App resumes
   (`RESUMED exit=0`); full cycle ≈1.3s. Controller unit tests (`terminal-handoff-controller.test.ts`,
   4 tests) and the full TUI suite (393 tests) stay green; `pnpm harness:scan` green.
+
+### Closure (2026-06-28)
+
+Done-gate satisfied — own evidence is the automated restore-after-handoff PTY smoke, and the consumer
+user-execution scenarios are now closed (TERM-003 `/shell`, TERM-004 `/editor`). Re-ran at closure:
+`terminal-handoff-pty-e2e.test.ts` (resume, no hang) ✓ and `terminal-handoff.ptytest.ts` TC-04/TC-01
+(committed `<Static>` history not re-printed after a `/shell` handoff) ✓. Marking done. The further
+async-background bridge (TERM-005) and Windows support (TERM-007) remain as separate future items.

--- a/.agents/backlog/completed/TERM-003-shell-escape-command.md
+++ b/.agents/backlog/completed/TERM-003-shell-escape-command.md
@@ -1,7 +1,8 @@
 ---
 title: 'TERM-003: drop-to-shell command (hand the terminal to an interactive subshell)'
-status: in-progress
+status: done
 created: 2026-06-27
+completed: 2026-06-28
 priority: medium
 urgency: soon
 area: packages/agent-framework, packages/agent-cli
@@ -63,3 +64,9 @@ agent should not drive) without killing the session. Today there is no way to do
   frame redraws (clean resume, no hang) — the whole path: CLI → command pipeline → injected
   `TerminalHandoffController` → handoff. (A user-typed command is not permission-gated; that gate is
   for model/agent-invoked actions.)
+
+### Closure (2026-06-28)
+
+Done-gate satisfied. Re-ran the scenarios at closure: `command-handoff-pty-e2e.test.ts` `/shell`
+(real TTY) ✓ and `terminal-handoff.ptytest.ts` TC-09 (built binary `/shell` on the real terminal) ✓.
+Marking done.

--- a/.agents/backlog/completed/TERM-004-editor-prompt-composition.md
+++ b/.agents/backlog/completed/TERM-004-editor-prompt-composition.md
@@ -1,7 +1,8 @@
 ---
 title: 'TERM-004: compose prompts/messages in $EDITOR via terminal handoff'
-status: in-progress
+status: done
 created: 2026-06-27
+completed: 2026-06-28
 priority: medium
 urgency: later
 area: packages/agent-framework, packages/agent-cli
@@ -49,3 +50,8 @@ standard solution and reuses TERM-001.
 the inherited TTY: the typed text (`composed-in-editor`) round-trips back as the command result and
 the App resumes cleanly. Framework functional test (fake handoff/editor) + this PTY E2E +
 `pnpm harness:scan` green.
+
+### Closure (2026-06-28)
+
+Done-gate satisfied. Re-ran the scenario at closure: `command-handoff-pty-e2e.test.ts` `/editor`
+(real TTY, scripted `$EDITOR` round-trip) ✓. Marking done.


### PR DESCRIPTION
## Summary

Close out the terminal-handoff feature backlogs — all implemented and PTY-verified, with recorded automated evidence re-run at closure:

- **TERM-002** (TUI terminal-handoff port) — restore-after-handoff PTY smoke + the 30s-hang fix; TC-04/01 (no `<Static>` re-print after `/shell`) ✓.
- **TERM-003** (`/shell`) — real-TTY command-handoff E2E + built-binary TC-09 ✓.
- **TERM-004** (`/editor`) — real-TTY `$EDITOR` round-trip E2E ✓.

Status → done + moved to `backlog/completed/`. TERM-005 (async background bridge) and TERM-007 (Windows) remain as separate future items. `pnpm harness:scan` 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)