### PR TITLE
feat: IAgentDriver client contract + shared accessors (INFRA-020 Phase 1)

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -21,7 +21,7 @@ packages/
 ├── agent-interface-*/           # Interface/contract packages: pure type contracts with no implementation (e.g. agent-interface-transport)
 ├── agent-transport/             # Transport core: headless adapter + transport registry + scripted-provider testing fixtures (pure TS)
 ├── agent-transport-*/           # Per-concern transport implementations: agent-transport-tui (React/Ink), -ws (WebSocket), -http (Hono), -mcp (MCP)
-├── agent-testing/               # Cross-cutting test harness: real-PTY E2E driver (spawnPty/spawnPtyFixture); zero @robota-sdk deps, consumed as devDependency
+├── agent-testing/               # General test framework: domain-free test-environment tooling (PTY runner spawnPty/spawnPtyFixture); zero @robota-sdk deps, devDependency. Charter+placement rule in its SPEC (contracts→agent-interface-*, doubles→owner /testing, drivers→owning module)
 └── agent-plugin/                # Plugins: conversation-history, logging, usage, performance, execution-analytics, error-handling, limits, event-emitter, webhook
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)

--- a/.agents/spec-docs/active/INFRA-020-test-architecture-foundation.md
+++ b/.agents/spec-docs/active/INFRA-020-test-architecture-foundation.md
@@ -1,0 +1,226 @@
+---
+status: draft
+type: INFRA
+tags: [architecture, testing, transport]
+---
+
+# INFRA-020: Test architecture foundation — client-side interaction contract + disciplined test framework
+
+Lock the **foundation** the test suite will scale on top of. The test count is small today only
+because testing is at an early stage; it must grow large, so the structure decided now is what every
+future test inherits. Judged on architecture alone (rework cost and "existing pattern" explicitly set
+aside; pre-release, so interfaces in any package may change — [[feedback_no_backward_compat]]).
+
+## Problem
+
+Test infrastructure is shaped by convenience, not by the domain's seams:
+
+1. **The client side of the interaction seam is unmodeled.** `IInteractionChannel`
+   (`agent-interface-transport`) is the **framework-side** port (the framework writes events to a
+   channel, reads submits). Its **dual — the client side** (submit input, observe the event stream) —
+   has **three real implementers** but no shared contract: the in-process programmatic driver
+   (`createProgrammaticAgent`/`IProgrammaticAgent`, agent-transport), the remote client
+   (`agent-remote-client`), and the (to-be-built) built-binary driver. Each reinvents the same
+   "drive + observe" shape; scenarios cannot be written once and run across drivers; the client
+   surface drifts per implementer.
+
+2. **The test framework package has no charter, so it risks becoming a grab-bag.**
+   `@robota-sdk/agent-testing` (INFRA-016) currently holds one PTY primitive but its name implies "all
+   testing"; without a written charter + placement rule, unrelated cross-layer test code will accrete
+   and dependency/ownership lines blur.
+
+Reproduction: there is no `IAgentDriver` type to write a driver-agnostic scenario against; and
+`agent-testing` has no SPEC charter saying what does and does not belong in it.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-interface-transport/src/interaction-contracts.ts` (+ index) — add the client-side
+  `IAgentDriver` contract (dual of `IInteractionChannel`) + shared **pure accessors** over the
+  `InteractionEvent` stream.
+- `packages/agent-transport/src/programmatic/` — `createProgrammaticAgent` returns `IAgentDriver`;
+  `IProgrammaticAgent` is **replaced** (not aliased) by the shared contract; accessors delegate to the
+  shared helpers (no per-adapter filter logic).
+- `packages/agent-testing/` — keep the package as the **general test framework/environment**; write
+  its SPEC **charter + placement rule**. The generic PTY runner stays here. No move, no rename.
+- `packages/agent-cli/` — a built-binary `IAgentDriver` adapter (spawns the robota binary via the
+  agent-testing PTY runner, parses `--output-format stream-json` into `InteractionEvent`s); whole-binary
+  E2E lives here.
+- `packages/agent-transport-tui/` — rendering tests keep consuming agent-testing's PTY runner; only
+  terminal-specific assertions (Ink frames/scrollback) live here.
+- (Future, not in this spec) `agent-remote-client` — its client implements `IAgentDriver`.
+
+### The two pillars
+
+**Pillar 1 — model the client-side interaction port (`IAgentDriver`).** The interaction seam has two
+sides; only one is modeled. The dual is a **production** contract (remote-client + embedding apps are
+non-test clients), not test-only — so it is NOT speculative generality: ≥3 real implementers. It lives
+next to `IInteractionChannel` in `agent-interface-transport` (interaction-contract SSOT):
+
+```ts
+interface IAgentDriver {
+  start(): Promise<void>;
+  send(text: string): Promise<void>; // serial: awaits the turn
+  queueAction(response: TActionResponse): void;
+  readonly events: readonly InteractionEvent[];
+  stop(): Promise<void>;
+}
+// Pure shared accessors over the stream — implemented ONCE, reused by every adapter:
+//   assistantReplies(events) / lastAssistantText(events) / toolCalls(events) / errors(events)
+```
+
+Accessors are pure functions of `events` → live in the contract package, reused by every adapter; the
+per-adapter filter duplication INFRA-019's review flagged becomes structurally impossible.
+
+**Pillar 2 — agent-testing is the disciplined general test framework.** Keep the package and name; a
+"test framework/environment" is a cohesive single purpose (like vitest/testing-library). Cohesion is
+guaranteed by a written **placement rule** (its SPEC), not by the name. The generic PTY runner is
+general test-environment tooling → stays here. Dependency-clean: agent-testing has **zero `@robota-sdk`
+runtime deps**, so any consumer (agent-cli, agent-transport-tui) can depend down onto it with no cycle.
+
+**Placement rule (governing principle — written into agent-testing's SPEC):**
+
+- **Contracts** (interfaces) → the relevant `agent-interface-*` package. (Never in agent-testing.)
+- **Test doubles** for a contract X → X's owning package `./testing` (canonical fake, no divergent
+  forks): scripted provider (agent-core), scripted-session (agent-framework).
+- **Driver adapters** → the module owning what they drive: in-process → agent-transport; built CLI
+  binary → agent-cli (its own artifact, consistent with no shared CLI factory); remote →
+  agent-remote-client.
+- **Domain-free test-environment tooling with no other home** (PTY runner, future scenario helpers) →
+  `agent-testing`. **No re-export hub** ([[feedback_sdk_not_reexport_all]]): it does not re-export the
+  doubles/adapters; authors import those from their owners.
+- A module's **own feature tests** live in that module.
+
+### Alternatives Considered
+
+- **Alt A — agent-testing as an undisciplined bucket.** Rejected: accretes cross-layer code; ownership
+  blurs. (The fix is the placement rule, not deletion.)
+- **Alt B — rename to `agent-pty-harness` / move PTY into agent-transport-tui.** Rejected: "harness" is
+  internal repo jargon, wrong for a public general test package; and moving PTY into the TUI couples a
+  domain-free primitive to a UI module and forces agent-cli to import PTY from the TUI (against the
+  consumer set / dependency direction).
+- **Alt C — no client contract; each driver keeps its own shape.** Rejected: the client side is a real
+  port with ≥3 implementers; leaving it unmodeled guarantees drift and blocks write-once-run-anywhere
+  scenarios — the exact scale problem this foundation must prevent.
+- **Alt D (chosen) — `IAgentDriver` in the interface package + agent-testing kept as the disciplined
+  general framework (charter + placement rule) + adapters in owning modules.**
+
+### Decision
+
+Alt D. Contradiction-free against every standing invariant: interface package owns contracts; adapters
+in owning modules; agent-core stays zero-dep (contract is types-only, agent-testing has zero
+`@robota-sdk` deps); agent-cli owns its own driver (no shared CLI factory); test doubles co-locate with
+contracts; no re-export hub; no cycle. Minimal structure that scales: one driving contract, one written
+rule for where each kind of test artifact lives.
+
+### Resolved decisions (user, GATE-APPROVAL)
+
+1. **Package name**: `@robota-sdk/agent-testing` (kept — the general test framework).
+2. **Contract name**: `IAgentDriver`.
+3. **Interfaces in other packages may change** as needed (pre-release): `IProgrammaticAgent` is
+   replaced by `IAgentDriver`; shared interaction types may be unified across both sides of the seam.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — `IInteractionChannel` is the only interaction port; its client dual is
+      missing; the PTY runner is the only cross-cutting domain-free test util
+- [x] 대안 최소 2개 검토 완료 (A bucket / B harness-rename+move / C no-contract / D chosen)
+- [x] 결정 근거 문서화 완료 (real client-side port; cohesion via placement rule not name; dependency-clean leaf)
+
+## Solution (phased; each phase = one PR)
+
+1. **Phase 1 — contract + programmatic conformance + framework charter.**
+   `IAgentDriver` + pure accessors in `agent-interface-transport`; `createProgrammaticAgent` returns
+   `IAgentDriver` (replace `IProgrammaticAgent`, accessors delegate to shared helpers); write
+   `agent-testing` SPEC charter + placement rule.
+2. **Phase 2 — agent-cli built-binary driver + cross-fidelity proof.**
+   A built-binary `IAgentDriver` in agent-cli (agent-testing PTY runner + stream-json parse); one
+   scenario runs on BOTH the programmatic and binary drivers with identical observations; relocate
+   whole-binary CLI E2E into agent-cli; keep TUI rendering PTY tests in agent-transport-tui.
+3. **(Separate item) TEST-009 rewrite** — agent-cli feature coverage: scenarios target `IAgentDriver`;
+   in-process via `startCli`/programmatic, real-binary via the binary driver; cross-fidelity where
+   valuable.
+
+## Affected Files
+
+- `packages/agent-interface-transport/src/interaction-contracts.ts` (+ index export)
+- `packages/agent-transport/src/programmatic/*`
+- `packages/agent-testing/docs/SPEC.md` (charter + placement rule)
+- `packages/agent-cli/**` (binary driver + whole-binary E2E)
+- `packages/agent-transport-tui/**` (rendering tests unchanged consumption)
+- `.agents/project-structure.md` (agent-testing description)
+
+## Completion Criteria
+
+- [ ] TC-01: `IAgentDriver` + pure accessors exported from `agent-interface-transport`; an accessor
+      unit test over a synthetic `InteractionEvent[]` passes; typecheck green.
+- [ ] TC-02: `createProgrammaticAgent` returns `IAgentDriver`; `IProgrammaticAgent` removed; accessors
+      delegate to the shared helpers (no per-adapter filter duplication); agent-transport suite green.
+- [ ] TC-03: `agent-testing/docs/SPEC.md` states the general-framework charter + placement rule; the
+      PTY runner stays; `harness:scan` specs/docs-structure green.
+- [ ] TC-04: a built-binary `IAgentDriver` in agent-cli drives the real robota binary via stream-json;
+      one shared scenario passes identically on the programmatic AND binary drivers (cross-fidelity).
+- [ ] TC-05: `agent-transport-tui` rendering PTY tests stay green consuming agent-testing.
+- [ ] TC-06: repo-wide typecheck + `pnpm harness:scan` 33/33; no dependency cycle introduced.
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach                                                                    | Notes               |
+| ----- | --------- | ---------------------------------------------------------------------------------- | ------------------- |
+| TC-01 | automated | accessor unit test over a synthetic event array + typecheck                        | pure accessors      |
+| TC-02 | automated | agent-transport programmatic suite against `IAgentDriver`                          | conformance, no dup |
+| TC-03 | automated | SPEC charter present; `harness:scan` specs/docs-structure                          | discipline written  |
+| TC-04 | automated | one scenario via programmatic AND agent-cli binary driver → identical observations | cross-fidelity      |
+| TC-05 | automated | agent-transport-tui `test:pty` green                                               | no regression       |
+| TC-06 | automated | `pnpm typecheck` + `pnpm harness:scan`                                             | structural gates    |
+
+## User Execution Test Scenarios
+
+Foundational test architecture; product value is a scalable, drift-free test surface. Validated by the
+conformance + cross-fidelity tests running green — the same scenario observed identically in-process and
+against the built binary is the executable proof the contract is real and the foundation holds.
+Evidence: _per-phase, filled as each PR lands._
+
+## Tasks
+
+- [ ] `.agents/tasks/INFRA-020.md` — created at GATE-IMPLEMENT.
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-06-28
+
+- Frontmatter `type: INFRA`, `tags: [architecture, testing, transport]`; Problem w/ reproduction;
+  Architecture Review 4/4 — 4 alternatives + decision; TC-01–06 + matching Test Plan; Tasks
+  placeholder; empty result Evidence Log.
+- Result: PASS → `draft` → `review-ready` → `backlog/`.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-28
+
+- The design was developed and refined directly with the user across several turns (client-side port
+  insight; dependency-direction argument for the leaf; "harness" naming correction). User resolved the
+  three open decisions: package name `@robota-sdk/agent-testing` (kept), contract `IAgentDriver`,
+  interfaces in any package may change (pre-release). Approval given to proceed phase-by-phase.
+- No Architecture Review / type / tags changed after approval.
+- Result: PASS → `review-ready` → `approved` → `todo/`.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-28
+
+- Tasks file `.agents/tasks/INFRA-020.md` created; Phase 1 (T1–T4) → TC-01/02/03/06, Phase 2 (T5–T7)
+  → TC-04/05/06.
+- Result: PASS → `approved` → `in-progress` → `active/`.
+
+### Phase 1 — ✅ complete (PR pending) | 2026-06-28
+
+- **TC-01**: `IAgentDriver` + `IToolCallObservation` + pure accessors (`readAssistantReplies` /
+  `readLastAssistantText` / `readToolCalls` / `readErrors`) added to `agent-interface-transport`
+  (`interaction-contracts.ts`, exported from index). `interaction-accessors.test.ts` (5 tests) +
+  type test pass; interface-transport suite 10 pass.
+- **TC-02**: `createProgrammaticAgent` now returns `IAgentDriver`; `IProgrammaticAgent` removed;
+  accessors delegate to the shared `read*` helpers (no per-adapter filters). agent-transport suite 38
+  pass. `programmatic-driver.test.ts` imports `IAgentDriver` from the contract SSOT.
+- **TC-03**: `agent-testing/docs/SPEC.md` rewritten with the general-framework charter + placement-rule
+  table; project-structure.md description updated. No re-export hub.
+- **TC-06**: full monorepo build + repo-wide typecheck green; `pnpm harness:scan` 33/33.
+- Phase 2 (TC-04/05 — agent-cli binary driver + cross-fidelity) follows in the next PR.

--- a/.agents/tasks/INFRA-020.md
+++ b/.agents/tasks/INFRA-020.md
@@ -1,0 +1,34 @@
+# INFRA-020 Tasks — Test architecture foundation
+
+Spec: `.agents/spec-docs/active/INFRA-020-test-architecture-foundation.md`
+
+## Phase 1 — contract + programmatic conformance + framework charter (PR 1)
+
+- [ ] T1 (TC-01): add `IAgentDriver` (client-side interaction contract) + pure accessors
+      (`assistantReplies`/`lastAssistantText`/`toolCalls`/`errors` over `InteractionEvent[]`) to
+      `agent-interface-transport`; export from index. Accessor unit test over a synthetic event array.
+- [ ] T2 (TC-02): `createProgrammaticAgent` returns `IAgentDriver`; remove `IProgrammaticAgent`;
+      accessors delegate to the shared helpers (no per-adapter filter logic). agent-transport suite green.
+- [ ] T3 (TC-03): `agent-testing/docs/SPEC.md` — write the general-framework charter + placement rule;
+      keep the PTY runner; update `.agents/project-structure.md` description.
+- [ ] T4 (TC-06): repo-wide typecheck + `pnpm harness:scan` 33/33; no cycle.
+
+## Phase 2 — agent-cli built-binary driver + cross-fidelity (PR 2)
+
+- [ ] T5 (TC-04): built-binary `IAgentDriver` in agent-cli (agent-testing PTY runner + `--output-format
+  stream-json` parse → `InteractionEvent`s); one shared scenario passes identically on the
+      programmatic AND binary drivers.
+- [ ] T6 (TC-05): relocate whole-binary CLI E2E into agent-cli; agent-transport-tui rendering PTY tests
+      stay green consuming agent-testing.
+- [ ] T7 (TC-06): typecheck + `pnpm harness:scan` 33/33.
+
+## Follow-up (separate item)
+
+- [ ] TEST-009 rewrite: agent-cli feature coverage targeting `IAgentDriver` (in-process via
+      `startCli`/programmatic, real-binary via the binary driver).
+
+## Test Plan
+
+Per spec Test Plan (TC-01–06): accessor unit test, programmatic conformance suite, SPEC charter +
+harness:scan, cross-fidelity scenario (programmatic vs binary), TUI rendering no-regression, repo
+typecheck + scan. Evidence recorded in the spec Evidence Log before GATE-VERIFY.

--- a/packages/agent-interface-transport/src/__tests__/contracts.test.ts
+++ b/packages/agent-interface-transport/src/__tests__/contracts.test.ts
@@ -11,6 +11,7 @@ import type {
   IConfigurableTransport,
   IExecutionResult,
   IExecutionWorkspaceEntry,
+  IAgentDriver,
   IInteractionChannel,
   IInteractiveSession,
   IInteractiveSessionStore,
@@ -46,6 +47,8 @@ describe('agent-interface-transport contract surface', () => {
 
   it('exports the interaction-channel contracts', () => {
     expectTypeOf<IInteractionChannel>().toHaveProperty('requestAction');
+    expectTypeOf<IAgentDriver>().toHaveProperty('send');
+    expectTypeOf<IAgentDriver>().toHaveProperty('events');
     expectTypeOf<TActionRequest>().not.toBeNever();
   });
 

--- a/packages/agent-interface-transport/src/__tests__/interaction-accessors.test.ts
+++ b/packages/agent-interface-transport/src/__tests__/interaction-accessors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  readAssistantReplies,
+  readErrors,
+  readLastAssistantText,
+  readToolCalls,
+} from '../index.js';
+
+import type { InteractionEvent } from '../index.js';
+
+/**
+ * INFRA-020 TC-01: the shared pure accessors over an InteractionEvent stream. These are the single
+ * home for "what counts as a reply / tool call / error"; every IAgentDriver implementer delegates here.
+ */
+describe('interaction-event accessors (INFRA-020)', () => {
+  const err = new Error('boom');
+  const events: InteractionEvent[] = [
+    { type: 'user-message', text: 'hi' },
+    { type: 'assistant-chunk', chunk: 'par' },
+    { type: 'assistant-chunk', chunk: 'tial' },
+    { type: 'tool-call', id: 't1', name: 'Bash', args: { command: 'ls' } },
+    { type: 'tool-result', id: 't1', name: 'Bash', result: 'ok' },
+    { type: 'assistant-done', fullText: 'first reply' },
+    { type: 'user-message', text: 'again' },
+    { type: 'error', error: err },
+    { type: 'assistant-done', fullText: 'second reply' },
+  ];
+
+  it('readAssistantReplies returns completed replies in order', () => {
+    expect(readAssistantReplies(events)).toEqual(['first reply', 'second reply']);
+  });
+
+  it('readLastAssistantText returns the most recent reply', () => {
+    expect(readLastAssistantText(events)).toBe('second reply');
+    expect(readLastAssistantText([])).toBeUndefined();
+  });
+
+  it('readToolCalls returns tool-call observations', () => {
+    expect(readToolCalls(events)).toEqual([{ id: 't1', name: 'Bash', args: { command: 'ls' } }]);
+  });
+
+  it('readErrors returns surfaced errors', () => {
+    expect(readErrors(events)).toEqual([err]);
+  });
+
+  it('accessors are pure (do not mutate the input)', () => {
+    const snapshot = [...events];
+    readAssistantReplies(events);
+    readToolCalls(events);
+    readErrors(events);
+    expect(events).toEqual(snapshot);
+  });
+});

--- a/packages/agent-interface-transport/src/index.ts
+++ b/packages/agent-interface-transport/src/index.ts
@@ -40,6 +40,8 @@ export type {
 // ── Interaction-channel contracts ────────────────────────────
 export type {
   IInteractionChannel,
+  IAgentDriver,
+  IToolCallObservation,
   ITerminalHandoff,
   InteractionEvent,
   IPermissionRequest,
@@ -48,6 +50,13 @@ export type {
   IPickItem,
   ICommandInfo,
   TCommandInteractionHint,
+} from './interaction-contracts.js';
+// Shared pure accessors over an InteractionEvent stream (values, not types).
+export {
+  readAssistantReplies,
+  readLastAssistantText,
+  readToolCalls,
+  readErrors,
 } from './interaction-contracts.js';
 
 // ── Session-event payload contracts ──────────────────────────

--- a/packages/agent-interface-transport/src/interaction-contracts.ts
+++ b/packages/agent-interface-transport/src/interaction-contracts.ts
@@ -74,6 +74,82 @@ export interface IInteractionChannel {
   stop(): Promise<void>;
 }
 
+/** A tool invocation observed from the interaction event stream. */
+export interface IToolCallObservation {
+  id: string;
+  name: string;
+  args: unknown;
+}
+
+/**
+ * Client-side interaction contract — the **dual** of {@link IInteractionChannel}. Where
+ * `IInteractionChannel` is what the framework *writes to*, `IAgentDriver` is what a **client** uses to
+ * *drive* the agent and *observe* its event stream. Implemented by the in-process programmatic driver,
+ * the remote client, and a built-binary test driver. Production-grade (embedding apps + the remote
+ * client are non-test clients), so it lives next to the framework-side port as the same seam's other
+ * face.
+ *
+ * Observation accessors are NOT methods that each adapter re-implements: an implementer exposes the raw
+ * {@link events} stream and delegates the accessors to the shared `read*` helpers below, so the
+ * filter/derivation logic exists exactly once.
+ */
+export interface IAgentDriver {
+  /** Start the underlying session/transport. Idempotent — a second call is a no-op. */
+  start(): Promise<void>;
+  /**
+   * Submit a user message. When called serially (await each `send`), resolves after the turn
+   * completes; a `send` issued mid-turn is queued and resolves once that queued turn runs.
+   */
+  send(text: string): Promise<void>;
+  /** Pre-answer the next disambiguation `requestAction`. */
+  queueAction(response: TActionResponse): void;
+  /** The structured event stream observed from the agent, in order. */
+  readonly events: readonly InteractionEvent[];
+  /** Every completed assistant reply (`assistant-done` fullTexts), in order. */
+  assistantReplies(): string[];
+  /** The most recent completed assistant reply, or `undefined` if none yet. */
+  lastAssistantText(): string | undefined;
+  /** Tool-call observations captured during the run. */
+  toolCalls(): IToolCallObservation[];
+  /** Errors surfaced by the framework during the run. */
+  errors(): Error[];
+  /** Stop the underlying session/transport. */
+  stop(): Promise<void>;
+}
+
+// ── Shared pure accessors over an InteractionEvent stream ────────────────────────────────
+// The single home for "what counts as a reply / tool call / error". Every IAgentDriver implementer
+// delegates to these; no adapter re-implements the discriminated-union filters.
+
+/** Completed assistant replies (`assistant-done` fullTexts), in order. */
+export function readAssistantReplies(events: readonly InteractionEvent[]): string[] {
+  return events
+    .filter(
+      (e): e is Extract<InteractionEvent, { type: 'assistant-done' }> =>
+        e.type === 'assistant-done',
+    )
+    .map((e) => e.fullText);
+}
+
+/** The most recent completed assistant reply, or `undefined`. */
+export function readLastAssistantText(events: readonly InteractionEvent[]): string | undefined {
+  return readAssistantReplies(events).at(-1);
+}
+
+/** Tool-call observations, in order. */
+export function readToolCalls(events: readonly InteractionEvent[]): IToolCallObservation[] {
+  return events
+    .filter((e): e is Extract<InteractionEvent, { type: 'tool-call' }> => e.type === 'tool-call')
+    .map((e) => ({ id: e.id, name: e.name, args: e.args }));
+}
+
+/** Errors surfaced in the stream, in order. */
+export function readErrors(events: readonly InteractionEvent[]): Error[] {
+  return events
+    .filter((e): e is Extract<InteractionEvent, { type: 'error' }> => e.type === 'error')
+    .map((e) => e.error);
+}
+
 /**
  * Terminal-handoff capability — a transport may optionally hand the real terminal to a child process
  * (interactive input + output via the real TTY) and restore its display afterward.

--- a/packages/agent-testing/docs/SPEC.md
+++ b/packages/agent-testing/docs/SPEC.md
@@ -2,19 +2,37 @@
 
 ## Scope
 
-Cross-cutting test harness for the Robota SDK. Owns test infrastructure that is genuinely shared across
-packages and has no natural home in any single package's `./testing` contract surface.
+The general **test framework / environment** for the Robota SDK (INFRA-020). It owns domain-free
+test-environment tooling that has no other home — currently the PTY runner, and future shared scenario
+helpers. Cohesion comes from the **placement rule** below (a written charter), not from the broad word
+"testing": this package is deliberately NOT a catch-all bucket.
 
 Current surface:
 
-- **PTY harness** (TEST-007): `spawnPty` / `spawnPtyFixture` — drive any command (or a TSX fixture) in
+- **PTY runner** (TEST-007): `spawnPty` / `spawnPtyFixture` — drive any command (or a TSX fixture) in
   a real pseudo-terminal so Ink renders and reads input exactly as in a user terminal. Per-key paced
   input, marker/exit waiting, ANSI-stripped snapshots.
 
 This package is published (`@robota-sdk/*` scope) so any package — or an external consumer — can import
-the harness as a `devDependency`. It deliberately does **not** absorb the per-package `./testing`
-contract surfaces (`agent-core/testing`, `agent-framework/testing`, `agent-transport/testing`), which
-remain each package's own SSOT.
+the tooling as a `devDependency`.
+
+## Charter & placement rule (INFRA-020)
+
+What lives **here**: domain-free test-environment tooling with no single-package owner (the PTY runner;
+future cross-cutting scenario helpers). Zero `@robota-sdk` runtime deps, so any package can depend down
+onto it without a cycle.
+
+What lives **elsewhere** (and must NOT move here):
+
+| Artifact                                                      | Home                                     | Example                                                                                        |
+| ------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Contracts / interfaces (incl. the client-side `IAgentDriver`) | the relevant `agent-interface-*` package | `IAgentDriver` → `agent-interface-transport`                                                   |
+| Test doubles for a contract X                                 | X's owning package `./testing`           | scripted provider → `agent-core/testing`; scripted-session → `agent-framework/testing`         |
+| Driver adapters (implement `IAgentDriver`)                    | the module owning what they drive        | in-process → `agent-transport`; built CLI binary → `agent-cli`; remote → `agent-remote-client` |
+| A module's own feature tests                                  | that module                              | agent-cli features → `agent-cli`                                                               |
+
+**No re-export hub**: this package does not re-export the doubles/adapters above; authors import those
+from their owners directly (avoids a pass-through layer).
 
 ## Boundaries
 

--- a/packages/agent-transport/src/__tests__/programmatic/programmatic-driver.test.ts
+++ b/packages/agent-transport/src/__tests__/programmatic/programmatic-driver.test.ts
@@ -17,12 +17,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   createProgrammaticAgent,
   ProgrammaticInteractionChannel,
-  type IProgrammaticAgent,
 } from '../../programmatic/index.js';
+
+import type { IAgentDriver } from '@robota-sdk/agent-interface-transport';
 
 describe('programmatic in-process agent driver (INFRA-019)', () => {
   let cwd: string;
-  let driver: IProgrammaticAgent | undefined;
+  let driver: IAgentDriver | undefined;
 
   beforeEach(() => {
     cwd = mkdtempSync(join(tmpdir(), 'robota-programmatic-'));

--- a/packages/agent-transport/src/programmatic/createProgrammaticAgent.ts
+++ b/packages/agent-transport/src/programmatic/createProgrammaticAgent.ts
@@ -1,21 +1,29 @@
 /**
- * createProgrammaticAgent — a thin in-process driver over the real framework session (INFRA-019).
+ * createProgrammaticAgent — the in-process implementation of the client-side agent contract
+ * (`IAgentDriver`, INFRA-020; introduced as the programmatic driver in INFRA-019).
  *
  * Wraps `createInteractiveRuntime` with a {@link ProgrammaticInteractionChannel} so a caller can drive
  * the real agent structurally: `start()`, `send(text)` (awaits the whole turn), then read assistant
- * replies / tool calls / errors as data — no terminal, no PTY, no scraping. This is the in-process
- * form of "drive the agent at will" (TEST-008).
+ * replies / tool calls / errors as data — no terminal, no PTY, no scraping. The observation accessors
+ * delegate to the shared `read*` helpers in `@robota-sdk/agent-interface-transport`, so the
+ * filter/derivation logic is not re-implemented here.
  */
 
 import { createInteractiveRuntime } from '@robota-sdk/agent-framework';
+import {
+  readAssistantReplies,
+  readErrors,
+  readLastAssistantText,
+  readToolCalls,
+} from '@robota-sdk/agent-interface-transport';
 
 import { ProgrammaticInteractionChannel } from './ProgrammaticInteractionChannel.js';
 
 import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
 import type { ICommandModule, IInteractiveRuntime } from '@robota-sdk/agent-framework';
 import type {
+  IAgentDriver,
   IInteractiveSessionStore,
-  InteractionEvent,
   TActionResponse,
 } from '@robota-sdk/agent-interface-transport';
 
@@ -32,34 +40,11 @@ export interface ICreateProgrammaticAgentOptions {
   permissionMode?: TPermissionMode;
 }
 
-export interface IProgrammaticAgent {
-  /** The structured event stream pushed by the framework, in order. */
-  readonly events: readonly InteractionEvent[];
-  /** Start the runtime and bind a real `InteractiveSession`. Idempotent — a second call is a no-op. */
-  start(): Promise<void>;
-  /**
-   * Push a user message and await the turn. When called serially (await each `send`), this resolves
-   * after the whole turn completes. A `send` issued while a turn is still executing is queued by the
-   * session and resolves immediately; its reply lands in `events` once that queued turn runs.
-   */
-  send(text: string): Promise<void>;
-  /** Pre-answer the next disambiguation `requestAction`. */
-  queueAction(response: TActionResponse): void;
-  /** Every completed assistant reply (`assistant-done` fullTexts), in order. */
-  assistantReplies(): string[];
-  /** The most recent completed assistant reply, or `undefined` if none yet. */
-  lastAssistantText(): string | undefined;
-  /** Tool-call events captured during the run. */
-  toolCalls(): Array<{ id: string; name: string; args: unknown }>;
-  /** Errors surfaced by the framework during the run. */
-  errors(): Error[];
-  /** Stop the runtime and shut down the session. */
-  stop(): Promise<void>;
-}
-
-export function createProgrammaticAgent(
-  options: ICreateProgrammaticAgentOptions,
-): IProgrammaticAgent {
+/**
+ * Construct an in-process {@link IAgentDriver} bound to a real `InteractiveSession`. The returned
+ * driver's accessors are the shared `read*` helpers applied to the captured event stream.
+ */
+export function createProgrammaticAgent(options: ICreateProgrammaticAgentOptions): IAgentDriver {
   const channel = new ProgrammaticInteractionChannel();
   const runtime: IInteractiveRuntime = createInteractiveRuntime({
     channel,
@@ -70,14 +55,7 @@ export function createProgrammaticAgent(
     permissionMode: options.permissionMode,
   });
 
-  /** Events of a given type, narrowed to the matching member of the InteractionEvent union. */
-  const byType = <T extends InteractionEvent['type']>(
-    type: T,
-  ): Array<Extract<InteractionEvent, { type: T }>> =>
-    channel.events.filter((e): e is Extract<InteractionEvent, { type: T }> => e.type === type);
-
   let started = false;
-  const assistantReplies = (): string[] => byType('assistant-done').map((e) => e.fullText);
 
   return {
     events: channel.events,
@@ -88,11 +66,10 @@ export function createProgrammaticAgent(
     },
     send: (text: string): Promise<void> => channel.submit(text),
     queueAction: (response: TActionResponse): void => channel.queueAction(response),
-    assistantReplies,
-    lastAssistantText: (): string | undefined => assistantReplies().at(-1),
-    toolCalls: (): Array<{ id: string; name: string; args: unknown }> =>
-      byType('tool-call').map((e) => ({ id: e.id, name: e.name, args: e.args })),
-    errors: (): Error[] => byType('error').map((e) => e.error),
+    assistantReplies: (): string[] => readAssistantReplies(channel.events),
+    lastAssistantText: (): string | undefined => readLastAssistantText(channel.events),
+    toolCalls: () => readToolCalls(channel.events),
+    errors: (): Error[] => readErrors(channel.events),
     stop: (): Promise<void> => runtime.stop(),
   };
 }

--- a/packages/agent-transport/src/programmatic/index.ts
+++ b/packages/agent-transport/src/programmatic/index.ts
@@ -1,6 +1,5 @@
 export { ProgrammaticInteractionChannel } from './ProgrammaticInteractionChannel.js';
 export { createProgrammaticAgent } from './createProgrammaticAgent.js';
-export type {
-  ICreateProgrammaticAgentOptions,
-  IProgrammaticAgent,
-} from './createProgrammaticAgent.js';
+export type { ICreateProgrammaticAgentOptions } from './createProgrammaticAgent.js';
+// The driver's return type is the shared client contract `IAgentDriver`; import it from its SSOT
+// `@robota-sdk/agent-interface-transport` (not re-exported here, to avoid a pass-through layer).


### PR DESCRIPTION
## Summary

INFRA-020 Phase 1 — the test-architecture foundation. Models the **client side** of the interaction seam (the dual of `IInteractionChannel`) as a production contract, so the growing test suite has one canonical drive+observe API.

- **agent-interface-transport**: `IAgentDriver` (start/send/queueAction/events/stop + accessor methods) + `IToolCallObservation` + pure `read*` helpers (`readAssistantReplies`/`readLastAssistantText`/`readToolCalls`/`readErrors`) — the single home for the discriminated-union derivations.
- **agent-transport**: `createProgrammaticAgent` returns `IAgentDriver`; `IProgrammaticAgent` removed; accessors delegate to the shared helpers (no per-adapter filter duplication).
- **agent-testing**: SPEC rewritten as the disciplined general test framework — charter + placement rule (contracts→`agent-interface-*`, doubles→owner `./testing`, drivers→owning module, no re-export hub).

## Verification
- agent-interface-transport **10** tests (+ new accessor suite) + agent-transport **38** pass
- full monorepo build + repo-wide typecheck green; `pnpm harness:scan` **33/33**

Phase 2 (agent-cli built-binary `IAgentDriver` + cross-fidelity proof) follows; the INFRA-020 spec closes after Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)