### PR TITLE
test: TEST-009 Phases 2-3 + close (IAgentDriver flows + TUI flag rendering)

### DIFF
--- a/.agents/backlog/completed/TEST-009-agent-cli-feature-coverage.md
+++ b/.agents/backlog/completed/TEST-009-agent-cli-feature-coverage.md
@@ -1,7 +1,8 @@
 ---
 title: 'TEST-009: agent-cli feature coverage on the INFRA-020 test foundation'
-status: in-progress
+status: done
 created: 2026-06-28
+completed: 2026-06-28
 priority: high
 urgency: soon
 area: packages/agent-cli, packages/agent-transport, packages/agent-testing
@@ -90,7 +91,36 @@ Headless flag matrix via `startCli` + scripted provider (`scripted-e2e.test.ts`)
 - (`--goal` / `--goal-max-iterations`, output formats, `-c`/`--fork-session` resume already covered.)
 - Evidence: agent-cli suite 145 pass (+4); typecheck + `pnpm harness:scan` 33/33.
 
-Phases 2–4 follow as separate PRs.
+### Phase 2 — ✅ done | 2026-06-28
+
+Conversation + slash flows via `IAgentDriver` (`programmatic-flows.test.ts`, agent-transport, 3 tests):
+
+- multi-turn conversation context carried across `send`s (second request carries the prior turn).
+- a slash command (`/ping`, inline module) surfaces a `command-result` event through the driver.
+- the full `requestAction` → `queueAction` path: a hinted `/danger` runs when confirmed via
+  `queueAction`, and is cancelled when the queue is empty — the end-to-end disambiguation path the
+  unit test only covered at the channel level.
+
+### Phase 3 — ✅ done | 2026-06-28
+
+Interactive-TUI flag effect via PTY (`flag-tui.ptytest.ts`, agent-transport-tui, 2 tests):
+
+- `--permission-mode plan` / `acceptEdits` render in the status bar — a CLI flag's _rendered_ effect,
+  complementing Phase 1's request/output assertions. (Boot/help/exit/handoff/replay/scrollback remain
+  covered by the existing `*.ptytest.ts`.)
+
+### Phase 4 — feedback loop | 2026-06-28
+
+One finding surfaced and was resolved in-loop without an in-test hack: `--allowed-tools` is an
+auto-approve list (not a hard allowlist) — the test asserts the correct semantics; no framework change
+needed. No further enrichment outstanding.
+
+## Closure (2026-06-28)
+
+Representative coverage delivered across all four phase areas, validating the INFRA-020 foundation is
+ergonomic for real feature tests (headless flag matrix, in-process conversation/slash flows,
+cross-fidelity, and interactive-TUI rendering). Per-flag / per-command coverage can grow incrementally
+using these established patterns; the foundation + patterns are the durable deliverable. Marking done.
 
 ## Test Plan
 

--- a/packages/agent-transport-tui/src/__tests__/pty/flag-tui.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/flag-tui.ptytest.ts
@@ -1,0 +1,56 @@
+/**
+ * TEST-009 Phase 3: a CLI flag's interactive-TUI effect, observed through a real PTY.
+ *
+ * The headless flag matrix (Phase 1) asserts request/output effects; this asserts the *rendered*
+ * effect a flag has on the live TUI. `--permission-mode <mode>` is shown in the status bar whenever it
+ * is not the default — so booting with `plan` / `acceptEdits` must render that mode. Runs in the
+ * dedicated PTY project against the BUILT robota binary (`pnpm --filter @robota-sdk/agent-cli build`).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { spawnTui, writeTuiProviderSettings } from './pty-driver.js';
+
+import type { IPtySession } from './pty-driver.js';
+
+describe('CLI flag → TUI rendering through a real PTY (TEST-009 Phase 3)', () => {
+  let projectDir: string;
+  let session: IPtySession | undefined;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'robota-flagtui-'));
+    writeTuiProviderSettings(projectDir);
+  });
+
+  afterEach(() => {
+    session?.kill();
+    session = undefined;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('--permission-mode plan renders the plan mode in the status bar', async () => {
+    session = spawnTui({
+      projectDir,
+      homeDir: join(projectDir, 'home'),
+      args: ['--permission-mode', 'plan'],
+    });
+    await session.waitFor(/Type a message or \/help/);
+    await session.waitFor(/plan/, 15_000);
+    expect(session.snapshot()).toContain('plan');
+  }, 60_000);
+
+  it('--permission-mode acceptEdits renders that mode in the status bar', async () => {
+    session = spawnTui({
+      projectDir,
+      homeDir: join(projectDir, 'home'),
+      args: ['--permission-mode', 'acceptEdits'],
+    });
+    await session.waitFor(/Type a message or \/help/);
+    await session.waitFor(/acceptEdits/, 15_000);
+    expect(session.snapshot()).toContain('acceptEdits');
+  }, 60_000);
+});

--- a/packages/agent-transport/src/__tests__/programmatic/programmatic-flows.test.ts
+++ b/packages/agent-transport/src/__tests__/programmatic/programmatic-flows.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TEST-009 Phase 2: conversation + slash-command flows driven through `IAgentDriver`.
+ *
+ * Exercises the in-process driver (`createProgrammaticAgent`) against the REAL framework loop with the
+ * scripted provider: multi-turn context, a slash command producing a `command-result`, and the full
+ * `requestAction` → `queueAction` disambiguation path (which the unit test only covered at the channel
+ * level). All assertions read the shared `InteractionEvent` stream the contract exposes.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createProgrammaticAgent } from '../../programmatic/index.js';
+
+import type { ICommandModule } from '@robota-sdk/agent-framework';
+import type { IAgentDriver, InteractionEvent } from '@robota-sdk/agent-interface-transport';
+
+function commandResults(
+  events: readonly InteractionEvent[],
+): Array<{ name: string; output: string }> {
+  return events
+    .filter(
+      (e): e is Extract<InteractionEvent, { type: 'command-result' }> =>
+        e.type === 'command-result',
+    )
+    .map((e) => ({ name: e.name, output: e.output }));
+}
+
+/** A read-only `/ping` command that returns a fixed result — no host adapters needed. */
+const PING_MODULE: ICommandModule = {
+  name: 'ping',
+  systemCommands: [
+    {
+      name: 'ping',
+      description: 'test ping',
+      userInvocable: true,
+      safety: 'read-only',
+      requiresPermission: false,
+      execute: () => ({ message: 'PONG', success: true }),
+    },
+  ],
+};
+
+/** A `/danger` command gated by a confirm interaction hint — drives the requestAction path. */
+const CONFIRM_MODULE: ICommandModule = {
+  name: 'danger',
+  systemCommands: [
+    {
+      name: 'danger',
+      description: 'requires confirmation',
+      userInvocable: true,
+      safety: 'read-only',
+      requiresPermission: false,
+      execute: () => ({ message: 'DANGER_RAN', success: true }),
+    },
+  ],
+  interactionHints: { danger: { type: 'confirm', message: 'Are you sure?' } },
+};
+
+describe('IAgentDriver conversation + slash flows (TEST-009 Phase 2)', () => {
+  let cwd: string;
+  let driver: IAgentDriver | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'robota-flows-'));
+  });
+  afterEach(async () => {
+    await driver?.stop();
+    driver = undefined;
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('carries multi-turn conversation context across sends', async () => {
+    const scripted = createScriptedProvider([{ text: 'NOTED_42' }, { text: 'IT_WAS_42' }]);
+    driver = createProgrammaticAgent({ provider: scripted.provider, cwd });
+    await driver.start();
+
+    await driver.send('Remember the number 42');
+    expect(driver.lastAssistantText()).toBe('NOTED_42');
+
+    await driver.send('What number?');
+    expect(driver.lastAssistantText()).toBe('IT_WAS_42');
+    expect(driver.assistantReplies()).toEqual(['NOTED_42', 'IT_WAS_42']);
+
+    // The second request must carry the prior turn (real session context).
+    const second = (scripted.requests[1] ?? []).map((m) => String(m.content)).join('\n');
+    expect(second).toContain('Remember the number 42');
+    expect(second).toContain('NOTED_42');
+  });
+
+  it('runs a slash command and surfaces a command-result event', async () => {
+    const scripted = createScriptedProvider([{ text: 'unused' }]);
+    driver = createProgrammaticAgent({
+      provider: scripted.provider,
+      cwd,
+      commandModules: [PING_MODULE],
+    });
+    await driver.start();
+
+    await driver.send('/ping');
+    expect(commandResults(driver.events)).toEqual([{ name: 'ping', output: 'PONG' }]);
+  });
+
+  it('drives the requestAction path: queueAction confirms a hinted command; empty queue cancels it', async () => {
+    const scripted = createScriptedProvider([{ text: 'unused' }, { text: 'unused' }]);
+    driver = createProgrammaticAgent({
+      provider: scripted.provider,
+      cwd,
+      commandModules: [CONFIRM_MODULE],
+    });
+    await driver.start();
+
+    // Confirmed → the command runs (requestAction resolved from the queue).
+    driver.queueAction({ type: 'confirm', confirmed: true });
+    await driver.send('/danger');
+    expect(commandResults(driver.events).some((c) => c.output === 'DANGER_RAN')).toBe(true);
+
+    // Empty queue → requestAction resolves `cancelled` → the command does NOT run again.
+    const before = commandResults(driver.events).length;
+    await driver.send('/danger');
+    expect(commandResults(driver.events).length).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Completes **TEST-009** on the INFRA-020 foundation.

- **Phase 2** (`programmatic-flows.test.ts`, +3): multi-turn conversation context, a slash command → `command-result` via the driver, and the full `requestAction`→`queueAction` disambiguation path through `IAgentDriver` (the end-to-end path the unit test only covered at the channel level).
- **Phase 3** (`flag-tui.ptytest.ts`, +2): `--permission-mode plan`/`acceptEdits` render in the status bar — a CLI flag's *rendered* TUI effect, via PTY. (Boot/help/exit/handoff/replay/scrollback stay covered by existing ptytests.)
- **Phase 4**: the `--allowed-tools` finding (auto-approve, not hard allowlist) was resolved in-loop — correct semantics asserted, no framework change.

Representative coverage now spans all four phase areas — the foundation is validated for real feature tests. TEST-009 → done, archived.

## Verification
- agent-transport **41** (+3), tui `test:pty` **8** (+2); `pnpm harness:scan` **33/33**

🤖 Generated with [Claude Code](https://claude.com/claude-code)