### PR TITLE
docs(backlog): CMD-004 action/UI separation + CMD-005 question dialog tool

### DIFF
--- a/.agents/backlog/CMD-004-command-action-ui-separation.md
+++ b/.agents/backlog/CMD-004-command-action-ui-separation.md
@@ -1,0 +1,83 @@
+---
+title: 'CMD-004: separate command interaction ACTION from UI (environment-agnostic, multi-transport)'
+status: todo
+created: 2026-06-28
+priority: high
+urgency: soon
+area: packages/agent-interface-transport, packages/agent-framework, packages/agent-command, packages/agent-transport-tui, packages/agent-transport, packages/agent-cli, packages/agent-web-ui
+depends_on: []
+---
+
+# Separate command interaction ACTION from UI
+
+The foundation refactor: an interactive command's **action** (the request "ask the user to pick /
+confirm / choose multiple / type a value") must be **UI-agnostic**, and **how it is rendered is each
+environment's job** (Ink TUI dialog, web modal, programmatic answer). Design this cleanly and
+completely; the question-dialog tool (CMD-005) then migrates onto it.
+
+## Motivation
+
+The same `InteractiveSession` can be driven from **multiple environments at once** — e.g. a remote web
+client showing a web UI **and** a terminal TUI rendering simultaneously over the same session. So an
+interaction is fundamentally **one action** ("the agent/command needs an answer from the user"), and
+the **UI is per-environment**. Coupling the action to a specific renderer (TUI) breaks the moment a
+second environment is attached.
+
+The seam partly exists — `IInteractionChannel.requestAction(TActionRequest): Promise<TActionResponse>`
+(agent-interface-transport) is already the action↔UI port, with the TUI channel rendering it as an Ink
+dialog and the programmatic channel answering from a queue. But:
+
+- The action contract is narrow: only `pick` (single, no free-text) and `confirm`. No multi-select, no
+  "choose an option **or** type your own" (the shape the agent actually needs).
+- `requestAction` is only triggered by **command interaction hints** in `createInteractiveRuntime`; the
+  **agent (model) cannot issue an action** itself (that gap is CMD-005).
+- Some assembled command modules reach into host adapters / TUI-specific behavior rather than
+  expressing their interaction purely as a UI-agnostic action (coupling signal observed across
+  `agent-command` modules: schedule, compact, context, memory, mode, preset, shell, reset, background).
+
+## Goal (design completely before implementing)
+
+A clean, complete design where:
+
+- The **interaction action contract** is the SSOT in `agent-interface-transport`, generalized to cover
+  single-select (with optional free-text entry), multi-select, and confirm — and is the ONLY thing a
+  command/agent produces for an interaction.
+- Every transport provides a **rendering adapter** for that contract (TUI Ink dialog, web modal,
+  programmatic queue/auto-answer); no command knows which UI renders it.
+- Assembled commands are **audited and decoupled**: any command currently bound to TUI rendering or
+  TUI-only host behavior expresses its interaction as an action through the channel port instead.
+- The design accounts for **multi-environment concurrency** (≥1 channel attached to one session): which
+  environment(s) render an action and how a single answer resolves it.
+
+## Open Design Questions (resolve during the design/GATE-WRITE phase)
+
+1. **Action contract shape**: exact `TActionRequest`/`TActionResponse` extension for single-select +
+   free-text and multi-select (min/max selections, validation, default, cancel). One unified `ask`
+   action vs. distinct variants.
+2. **Who issues actions**: command interaction hints (today) vs. the agent/model (CMD-005) vs. both —
+   one routing path through the channel port.
+3. **Multi-environment concurrency**: with web + TUI on one session, does every attached channel render
+   the action? First-to-answer wins? Designated primary? How are the others dismissed?
+4. **Command decoupling**: per-command audit — which `agent-command` modules are TUI/host-coupled, and
+   the target shape (host-adapter port vs. pure action) for each.
+5. **Headless / no-UI**: how an action resolves when no interactive renderer is attached (programmatic
+   queue, default, or terminal error) — consistent with the existing `cancelled` semantics.
+6. **Relationship to existing contracts**: how this generalizes `requestAction` + `interactionHints`
+   without breaking the TUI/programmatic channels already built (pre-release — interfaces may change).
+
+## Affected Scope (preliminary)
+
+- `agent-interface-transport` — generalize the action contract (SSOT).
+- `agent-framework` — `createInteractiveRuntime` action routing; command interaction wiring.
+- `agent-command` — decouple coupled modules to action-only interactions.
+- `agent-transport-tui` — Ink dialog rendering adapter for the generalized contract.
+- `agent-transport` — programmatic adapter; `agent-cli` — composition wiring.
+- `agent-web-ui` / `agent-web` — web modal rendering adapter (so web + TUI can both render).
+
+## Notes
+
+- Idea captured per the backlog process; **design is intentionally deferred** — this item is the
+  problem + intent. The complete design happens in its own design/GATE-WRITE pass before implementation.
+- CMD-005 (model-invocable question dialog + migration) depends on this foundation.
+- Respect layering ([[code-quality.md Layered Assembly]], no shared product factory): the action
+  contract is a lower-layer interface; UI rendering is per-transport; agent-cli only composes.

--- a/.agents/backlog/CMD-005-agent-question-dialog-tool.md
+++ b/.agents/backlog/CMD-005-agent-question-dialog-tool.md
@@ -1,0 +1,63 @@
+---
+title: 'CMD-005: model-invocable question dialog tool (single-select + free-text, multi-select) on the CMD-004 action layer'
+status: todo
+created: 2026-06-28
+priority: high
+urgency: soon
+area: packages/agent-interface-transport, packages/agent-framework, packages/agent-tools, packages/agent-cli, packages/agent-transport-tui, packages/agent-web-ui
+depends_on: [CMD-004]
+---
+
+# Model-invocable question dialog tool
+
+Let the **agent (model) ask the user a question mid-conversation** — exactly like the assistant's own
+AskUserQuestion dialog: choose one of the offered options **or type a custom answer**, and a
+**multi-select** variant. Built on the CMD-004 action/UI separation, then **migrate the existing dialog
+interactions onto it**.
+
+## Motivation
+
+Today the agent cannot solicit a structured answer from the user; only slash-command interaction hints
+trigger a dialog (`requestAction`), and only as single-`pick`/`confirm`. We want the agent to issue a
+question as a **UI-agnostic action** that any attached environment renders its own way (TUI Ink dialog,
+web modal) — and resolve to a structured answer fed back to the model. This is the natural consumer of
+CMD-004's generalized action contract.
+
+## Goal (after CMD-004 is designed)
+
+- A **model-invocable tool** (AskUserQuestion-equivalent) that issues a question **action** through the
+  interaction channel and returns the user's answer to the model.
+- Supports **single-select with free-text** (pick an option or type your own) and **multi-select**.
+- UI-agnostic: the tool produces an action; each environment (TUI/web/programmatic) renders it via its
+  CMD-004 rendering adapter. Works when web + TUI are attached to the same session simultaneously.
+- **Migrate** existing dialog/`requestAction` usages (command interaction hints, etc.) onto the
+  generalized CMD-004 contract so there is one interaction path, not two.
+
+## Open Design Questions (resolve during the design/GATE-WRITE phase)
+
+1. **Tool surface**: the tool's schema (how the model declares options, multi-select, free-text-allowed,
+   min/max, header/labels) and where the tool lives (`agent-tools` vs. an interaction-layer tool vs. a
+   command). Must stay provider-neutral.
+2. **Answer flow**: how the structured answer (selected option(s) and/or typed text) returns to the
+   model as a tool result; how cancellation is represented.
+3. **Permission/safety**: is asking the user gated, and how it behaves under each permission mode.
+4. **Headless / no-UI**: behavior when no interactive renderer is attached (print mode, automation) —
+   programmatic answer, default, or a clear tool error; never a silent guess.
+5. **Migration scope**: enumerate current dialog/`requestAction` call sites and move each to the new
+   contract; remove the narrow `pick`/`confirm`-only path once migrated (pre-release — no compat debt).
+
+## Affected Scope (preliminary)
+
+- `agent-tools` (or interaction layer) — the model-invocable question tool.
+- `agent-interface-transport` / `agent-framework` — action issuance from the agent + result routing
+  (built on CMD-004).
+- `agent-transport-tui` / `agent-web-ui` — render single-select+free-text and multi-select dialogs.
+- `agent-cli` — compose the tool into the product; migrate existing dialog usages.
+
+## Notes
+
+- **Blocked on CMD-004** (the action/UI separation must be designed first). This item is captured now so
+  the migration is planned alongside the foundation.
+- Mirrors the assistant's own AskUserQuestion affordance (single-select/free-text + multi-select) as the
+  target UX.
+- Design deferred — this is the problem + intent; complete design happens in its own GATE-WRITE pass.


### PR DESCRIPTION
Two sequenced backlogs (design deferred per request — capture now, design later):
- **CMD-004** (foundation): separate an interaction's UI-agnostic ACTION from per-environment UI rendering (TUI/web/programmatic) — one session driven from web+TUI at once; generalize the action contract (single-select+free-text, multi-select, confirm); audit/decouple TUI-coupled commands.
- **CMD-005** (depends on CMD-004): model-invocable question dialog tool (single-select+free-text, multi-select) on the new action layer + migrate existing dialog/requestAction usages.

Docs-only. harness:scan 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)