### PR TITLE
feat(agent-core): CMD-004 PR-A — unified action contract + ask port

### DIFF
--- a/.agents/spec-docs/active/CMD-004-command-action-ui-separation.md
+++ b/.agents/spec-docs/active/CMD-004-command-action-ui-separation.md
@@ -1,5 +1,5 @@
 ---
-status: review-ready
+status: in-progress
 type: FLOW
 tags: [cli, typescript, websocket, async]
 ---
@@ -294,7 +294,7 @@ PTY for TUI render incl. masked + abort; harness scan for repo gates.
 
 ## Tasks
 
-- [ ] `.agents/tasks/CMD-004.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [x] `.agents/tasks/CMD-004.md` — created (GATE-IMPLEMENT). Tasks decomposed into PR-A…PR-D mapped to TC-01…TC-09.
 
 ## Evidence Log
 
@@ -311,3 +311,20 @@ PTY for TUI render incl. masked + abort; harness scan for repo gates.
 - Test Plan: `## Test Plan` present; one row per TC-N (TC-01..TC-09); each row has non-empty Test Type + Tool; manual row TC-09 carries a Notes justification (real-terminal render correctness not fully assertable headlessly).
 - Structure: `## Tasks` present with placeholder; `## Evidence Log` present and empty prior to this entry; no `## Status` or `## Classification` body sections.
 - TC-N count match: Completion Criteria = 9, Test Plan = 9 (9 = 9).
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-06-28
+
+**Status upgrade:** review-ready → approved
+
+- Prior gate: GATE-WRITE ✅ PASS above; input status `review-ready` (backlog/) matches the expected stage.
+- User explicit approval (verbatim): "2부터 하고 1도 바로 이어서 작업해" — answering the two-item prompt where item 1 was "approve Phase 1 implementation start (PR-A onward)"; the directive to execute item 1 authorizes implementation of this spec.
+- No Architecture Review, frontmatter `type`, or `tags` modified after approval.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-28
+
+**Status upgrade:** approved → in-progress
+
+- Prior gate: GATE-APPROVAL ✅ PASS above; input status `approved` (todo/) matches the expected stage.
+- Tasks file created: `.agents/tasks/CMD-004.md`, recorded in the `## Tasks` section.
+- Tasks correspond to Completion Criteria: PR-A→TC-01; PR-B→TC-05/06/07 + TC-04(part); PR-C→TC-04(masked/re-ask); PR-D→TC-02/03; final TC-08/TC-09 — ≥1 task per TC-N.
+- Tasks file includes a `## Test Plan / 검증` section (>50 chars) — satisfies the `test-plans` harness scan [AF-24].

--- a/.agents/tasks/CMD-004.md
+++ b/.agents/tasks/CMD-004.md
@@ -1,0 +1,59 @@
+# CMD-004 — Separate interaction ACTION from UI (task breakdown)
+
+Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`
+Status: in-progress
+
+Phase 1, decomposed into 4 additive-then-delete PRs (each green typecheck + code-reviewed). Phase 2
+(WS + web-ui + multi-env broadcast) is tracked separately under the spec.
+
+## PR-A — action contract + ask port in `agent-core` (additive) → TC-01
+
+- [ ] Add `IActionOption`, `IActionRequest` (incl. `masked`/`allowEmpty`/`placeholder`/`maxVisible`),
+      `TActionResponse`, `IUserInteraction` to `agent-core` (pure types, zero-dep preserved).
+- [ ] Add ergonomic constructors + `isConfirmed` helper (`confirmAction`/`selectAction`/`multiSelectAction`/`textAction`).
+- [ ] Add `ask?: IUserInteraction['ask']` to `IToolExecutionContext` (reachable by tool source / CMD-005).
+- [ ] Export all from `agent-core` public surface.
+- [ ] Type test (TC-01): assert `IActionRequest` field set + `IUserInteraction.ask` exported.
+- [ ] Update `agent-core` `docs/SPEC.md` (Public API Surface + Type Ownership).
+- [ ] Leave old contracts (`agent-interface-transport`) untouched — additive only; build/typecheck green.
+
+## PR-B — wire `ask` + TUI renderer + migrate 6 simple commands → TC-04 (part), TC-05, TC-06 (part), TC-07
+
+- [ ] Inject `askHandler` into `InteractiveSession` (sibling to `permissionHandler`); thread through all
+      session-creation sites (TUI channel, `createInteractiveRuntime`, headless, programmatic).
+- [ ] Expose `ask` to commands as a narrow capability port (REFACTOR-006 pattern, not on base context).
+- [ ] Model-invocation guard: `invocationSource === 'model'` → ask resolves `{ cancelled }` (TC-07).
+- [ ] Build the TUI `pendingAction` Ink renderer (single/multi-select/confirm/masked); wire abort →
+      resolve-cancelled and input-gating while pending (TC-06).
+- [ ] programmatic + headless channels answer the unified action (TC-05).
+- [ ] Migrate the 6 Path-A commands (mode, preset, provider, language, exit, clear) to inline
+      `context.ask` (TC-04 single-select + confirm).
+
+## PR-C — migrate 13 provider wizard sites → TC-04 (masked + re-ask)
+
+- [ ] Convert `provider/*` returned-continuation wizards to sequential `await context.ask(...)`.
+- [ ] `masked` API-key entry; duplicate-name validation as a re-ask loop.
+- [ ] Tests: masked request + re-ask-on-invalid (TC-04).
+
+## PR-D — delete the old paths → TC-02, TC-03
+
+- [ ] Delete Path-A `interactionHints` + `buildActionRequest`/`resolveArgsFromResponse`.
+- [ ] Delete Path-B `ICommandResult.interaction`, `ICommandInteraction`, `TCommandInteractionPrompt`,
+      `ICommandChoicePromptOption`, `InteractivePrompt`/useSideEffects interaction path, dead
+      `CommandPicker`/`CommandConfirm`, and the dead `IPermissionRequest` event.
+- [ ] `pnpm -w typecheck` green in final state (TC-02); `rg` absence check (TC-03); `harness:scan` (TC-08).
+
+## Final → TC-08, TC-09
+
+- [ ] `pnpm harness:scan` → 33 scans pass (TC-08).
+- [ ] User Execution Test Scenario in a real TUI (`/preset` selection, `/provider add` masked field);
+      record evidence per the backlog done-gate (TC-09).
+
+## Test Plan / 검증
+
+Each PR runs its package build + tests and `pnpm -w typecheck` before opening; every PR that touches
+`.ts` passes the Pre-Merge Code-Review Gate (`/code-review`, all findings resolved) before merge. TC
+mapping: PR-A→TC-01; PR-B→TC-05/06/07 + TC-04(part); PR-C→TC-04(masked/re-ask); PR-D→TC-02/03; final
+gate TC-08 (`pnpm harness:scan`) and TC-09 (manual real-TUI scenario with recorded evidence). Type test
+for the contract (TC-01), vitest unit/integration via a mock `IUserInteraction` (TC-04/05/07), and a PTY
+test for TUI render incl. masked + abort (TC-06).

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -135,6 +135,10 @@ This package is the single source of truth (SSOT) for the following types:
 | `IContextTokenEstimateOptions`        | `context/estimation.ts`             | Options for `estimateContextTokensFromMessages()`: optional `providerUsage` floor and `callerFloor`                                                                                                                                                                                                                        |
 | `IMessageTokenUsage`                  | `context/token-usage.ts`            | Normalized token usage read from message metadata or provider usage payloads                                                                                                                                                                                                                                               |
 | `IHistoryEntry`                       | `interfaces/messages.ts`            | Rich history entry that wraps a message with category, type, and structured data fields. Fields: `id` (string), `timestamp` (Date), `category` ('chat' \| 'event'), `type` (string), `data` (varies by category/type)                                                                                                      |
+| `IActionRequest`                      | `interfaces/interaction.ts`         | UI-agnostic "ask the user" request (CMD-004). One shape covers confirm/single/multi/free-text/secret via `options` × `minSelect`/`maxSelect` × `allowFreeText` × `masked`. No function-valued fields (serialization-safe). SSOT lives in core so both command and tool sources reach it.                                   |
+| `IActionOption` / `IActionDefault`    | `interfaces/interaction.ts`         | One selectable option, and the pre-selected values / prefilled text for an action request.                                                                                                                                                                                                                                 |
+| `TActionResponse`                     | `interfaces/interaction.ts`         | Answer to an `IActionRequest`: `{ type: 'answer'; values; text? }` or `{ type: 'cancelled' }`.                                                                                                                                                                                                                             |
+| `IUserInteraction`                    | `interfaces/interaction.ts`         | Injected ask port — `ask(IActionRequest): Promise<TActionResponse>`. The single seam every interaction source uses; concurrency (broadcast, first-answer-wins, idempotent resolve) is owned by the implementation.                                                                                                         |
 
 Provider packages import these types. They must not re-declare them.
 
@@ -204,6 +208,25 @@ their own price tables. Prices are USD per 1,000,000 tokens.
 ### Tools
 
 NOTE: `ToolRegistry`, `FunctionTool`, `createFunctionTool`, `createZodFunctionTool`, and `OpenAPITool` have been moved to the tools layer. `MCPTool` and `RelayMcpTool` have been moved to the MCP-tool layer.
+
+### Interaction (CMD-004)
+
+UI-agnostic "ask the user" contract. The SSOT lives here so every interaction source reaches it:
+command execution (`ICommandHostContext`, agent-framework) and tool execution
+(`IToolExecutionContext.ask`, this package — model-issued questions, CMD-005). Transports render the
+request per-environment; the contract carries no function-valued fields (serialization-safe).
+
+| Export                                                                | Kind      | Description                                                                               |
+| --------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------- |
+| `IActionRequest` / `IActionOption` / `IActionDefault`                 | interface | The single action request shape, its options, and pre-selection/prefill                   |
+| `TActionResponse`                                                     | type      | `{ type: 'answer'; values; text? }` or `{ type: 'cancelled' }`                            |
+| `IUserInteraction`                                                    | interface | Injected ask port: `ask(IActionRequest): Promise<TActionResponse>`                        |
+| `confirmAction` / `selectAction` / `multiSelectAction` / `textAction` | function  | Ergonomic constructors for confirm / single / multi / free-text (incl. `masked`) requests |
+| `isConfirmed`                                                         | function  | Read a `confirmAction` answer as a boolean                                                |
+| `CONFIRM_YES` / `CONFIRM_NO`                                          | const     | Option values used by `confirmAction` / `isConfirmed`                                     |
+
+`IToolExecutionContext` gains an optional `ask?: IUserInteraction['ask']` — present when an interactive
+renderer is attached; a tool treats absence as "no human available" (never a silent guess).
 
 ### Permissions
 

--- a/packages/agent-core/src/interfaces/index.ts
+++ b/packages/agent-core/src/interfaces/index.ts
@@ -131,6 +131,25 @@ export type {
 
 export type { IToolFactory, IOpenAPIToolConfig, IMCPToolConfig } from './tool-integration';
 
+// Interaction action contract + ask port (CMD-004) — SSOT in agent-core so command and tool sources
+// both reach it.
+export type {
+  IActionOption,
+  IActionDefault,
+  IActionRequest,
+  TActionResponse,
+  IUserInteraction,
+} from './interaction';
+export {
+  confirmAction,
+  selectAction,
+  multiSelectAction,
+  textAction,
+  isConfirmed,
+  CONFIRM_YES,
+  CONFIRM_NO,
+} from './interaction-builders';
+
 export type {
   IEventService,
   IEventContext,

--- a/packages/agent-core/src/interfaces/interaction-builders.ts
+++ b/packages/agent-core/src/interfaces/interaction-builders.ts
@@ -1,0 +1,114 @@
+/**
+ * Ergonomic constructors for {@link IActionRequest} plus the {@link isConfirmed} response helper
+ * (CMD-004). The contract stays a single shape; these keep call sites readable so producers do not
+ * hand-assemble the field combinations for confirm / single / multi / text.
+ */
+
+import type { IActionDefault, IActionOption, IActionRequest, TActionResponse } from './interaction';
+
+/** Option value for the affirmative choice of a confirmation. */
+export const CONFIRM_YES = 'yes';
+/** Option value for the negative choice of a confirmation. */
+export const CONFIRM_NO = 'no';
+
+const CONFIRM_OPTIONS: readonly IActionOption[] = [
+  { value: CONFIRM_YES, label: 'Yes' },
+  { value: CONFIRM_NO, label: 'No' },
+];
+
+/** Build a yes/no confirmation action (two options, single selection). */
+export function confirmAction(
+  id: string,
+  message: string,
+  extra?: { description?: string; defaultYes?: boolean },
+): IActionRequest {
+  return {
+    id,
+    title: message,
+    description: extra?.description,
+    options: CONFIRM_OPTIONS,
+    maxSelect: 1,
+    default:
+      extra?.defaultYes === undefined
+        ? undefined
+        : { values: [extra.defaultYes ? CONFIRM_YES : CONFIRM_NO] },
+  };
+}
+
+/** Build a single-select action (optionally allowing a typed custom answer). */
+export function selectAction(
+  id: string,
+  title: string,
+  options: readonly IActionOption[],
+  extra?: {
+    description?: string;
+    allowFreeText?: boolean;
+    maxVisible?: number;
+    default?: IActionDefault;
+  },
+): IActionRequest {
+  return {
+    id,
+    title,
+    options,
+    maxSelect: 1,
+    description: extra?.description,
+    allowFreeText: extra?.allowFreeText,
+    maxVisible: extra?.maxVisible,
+    default: extra?.default,
+  };
+}
+
+/** Build a multi-select action (min/max selections; defaults: min 1, max = number of options). */
+export function multiSelectAction(
+  id: string,
+  title: string,
+  options: readonly IActionOption[],
+  extra?: {
+    description?: string;
+    minSelect?: number;
+    maxSelect?: number;
+    maxVisible?: number;
+    default?: IActionDefault;
+  },
+): IActionRequest {
+  return {
+    id,
+    title,
+    options,
+    minSelect: extra?.minSelect ?? 1,
+    maxSelect: extra?.maxSelect ?? options.length,
+    description: extra?.description,
+    maxVisible: extra?.maxVisible,
+    default: extra?.default,
+  };
+}
+
+/** Build a free-text action (optionally masked for secret entry such as an API key). */
+export function textAction(
+  id: string,
+  title: string,
+  extra?: {
+    description?: string;
+    masked?: boolean;
+    allowEmpty?: boolean;
+    placeholder?: string;
+    default?: IActionDefault;
+  },
+): IActionRequest {
+  return {
+    id,
+    title,
+    allowFreeText: true,
+    description: extra?.description,
+    masked: extra?.masked,
+    allowEmpty: extra?.allowEmpty,
+    placeholder: extra?.placeholder,
+    default: extra?.default,
+  };
+}
+
+/** True when the user answered a {@link confirmAction} affirmatively (selected "Yes"). */
+export function isConfirmed(response: TActionResponse): boolean {
+  return response.type === 'answer' && response.values.includes(CONFIRM_YES);
+}

--- a/packages/agent-core/src/interfaces/interaction.test.ts
+++ b/packages/agent-core/src/interfaces/interaction.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONFIRM_NO,
+  CONFIRM_YES,
+  confirmAction,
+  isConfirmed,
+  multiSelectAction,
+  selectAction,
+  textAction,
+} from '../index.js';
+
+import type { IActionRequest, IUserInteraction, TActionResponse } from '../index.js';
+
+// TC-01 (CMD-004): the unified action contract + ask port are exported from agent-core's public
+// surface and carry the full field set. Importing the symbols above from '../index.js' is itself the
+// "exported from agent-core" assertion (the module fails to load otherwise).
+
+describe('CMD-004 interaction contract (agent-core SSOT)', () => {
+  it('IActionRequest carries the full field set (compile + shape)', () => {
+    // Type-level coverage: every documented field is assignable. A dropped field would fail to compile.
+    const request: IActionRequest = {
+      id: 'demo',
+      title: 'Pick',
+      description: 'desc',
+      options: [{ value: 'a', label: 'A', description: 'opt a' }],
+      minSelect: 1,
+      maxSelect: 2,
+      allowFreeText: true,
+      masked: true,
+      allowEmpty: true,
+      placeholder: 'type…',
+      maxVisible: 6,
+      default: { values: ['a'], text: 'x' },
+    };
+    expect(request.options).toHaveLength(1);
+    expect(request.masked).toBe(true);
+    expect(request.allowEmpty).toBe(true);
+  });
+
+  it('confirmAction → two options, single-select; isConfirmed reads the answer', () => {
+    const req = confirmAction('exit', 'Exit the session?');
+    expect(req.options?.map((o) => o.value)).toEqual([CONFIRM_YES, CONFIRM_NO]);
+    expect(req.maxSelect).toBe(1);
+
+    const yes: TActionResponse = { type: 'answer', values: [CONFIRM_YES] };
+    const no: TActionResponse = { type: 'answer', values: [CONFIRM_NO] };
+    const cancelled: TActionResponse = { type: 'cancelled' };
+    expect(isConfirmed(yes)).toBe(true);
+    expect(isConfirmed(no)).toBe(false);
+    expect(isConfirmed(cancelled)).toBe(false);
+  });
+
+  it('selectAction → single-select with optional free text', () => {
+    const req = selectAction('mode', 'Select mode', [{ value: 'm', label: 'M' }], {
+      allowFreeText: true,
+    });
+    expect(req.maxSelect).toBe(1);
+    expect(req.allowFreeText).toBe(true);
+  });
+
+  it('multiSelectAction → defaults min 1 / max = option count', () => {
+    const options = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+    ];
+    const req = multiSelectAction('tags', 'Pick tags', options);
+    expect(req.minSelect).toBe(1);
+    expect(req.maxSelect).toBe(3);
+  });
+
+  it('textAction → free-text, optionally masked (secret entry)', () => {
+    const req = textAction('apiKey', 'Enter API key', { masked: true, placeholder: 'sk-…' });
+    expect(req.allowFreeText).toBe(true);
+    expect(req.masked).toBe(true);
+    expect(req.options).toBeUndefined();
+  });
+
+  it('IUserInteraction.ask resolves to a TActionResponse (port shape)', async () => {
+    const port: IUserInteraction = {
+      ask: (request) => Promise.resolve({ type: 'answer', values: [request.id] }),
+    };
+    const res = await port.ask(confirmAction('ok', 'OK?'));
+    expect(res.type).toBe('answer');
+    if (res.type === 'answer') expect(res.values).toEqual(['ok']);
+  });
+});

--- a/packages/agent-core/src/interfaces/interaction.ts
+++ b/packages/agent-core/src/interfaces/interaction.ts
@@ -1,0 +1,76 @@
+/**
+ * UI-agnostic "ask the user" contract (CMD-004).
+ *
+ * The SSOT for the interaction action lives in agent-core so every interaction *source* can reach it:
+ * command execution (`ICommandHostContext`, agent-framework) AND tool execution
+ * (`IToolExecutionContext`, agent-core, for model-issued questions — CMD-005). These are pure types
+ * with no runtime dependency, so the contract crosses a serialization/transport boundary unchanged
+ * (no function-valued fields).
+ *
+ * A single shape covers every interaction kind, parameterised by fields rather than split into
+ * variants:
+ * - confirm    → two options, `maxSelect` 1
+ * - single     → options, `maxSelect` 1
+ * - multi      → options, `maxSelect` > 1
+ * - free text  → no options, `allowFreeText` true
+ * - secret     → free text with `masked` true
+ */
+
+/** One predefined option the user can choose. */
+export interface IActionOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+/** Pre-selected option values and/or prefilled free text for an action request. */
+export interface IActionDefault {
+  values?: readonly string[];
+  text?: string;
+}
+
+/** One request for the user to answer. See the module doc for how the fields encode each kind. */
+export interface IActionRequest {
+  /** Correlation key; the ask port resolves a given id exactly once (idempotent, first-answer wins). */
+  id: string;
+  title: string;
+  description?: string;
+  /** Predefined options. Empty/omitted ⇒ pure free-text entry. */
+  options?: readonly IActionOption[];
+  /** Minimum selections required (default 1). */
+  minSelect?: number;
+  /** Maximum selections allowed (default 1 ⇒ single; > 1 ⇒ multi). */
+  maxSelect?: number;
+  /** Allow a typed custom answer in addition to / instead of the options. */
+  allowFreeText?: boolean;
+  /** Free-text entry is masked (secret entry such as an API key); the renderer hides input. */
+  masked?: boolean;
+  /** Allow submitting empty free text. */
+  allowEmpty?: boolean;
+  /** Placeholder shown in the free-text field. */
+  placeholder?: string;
+  /** Maximum options shown before scrolling (renderer hint). */
+  maxVisible?: number;
+  /** Pre-selected option values and/or prefilled free text. */
+  default?: IActionDefault;
+}
+
+/**
+ * The user's answer to an {@link IActionRequest}. `answer` carries the selected option values and/or
+ * the typed text; `cancelled` means the user dismissed the request, or no interactive renderer was
+ * available to answer it.
+ */
+export type TActionResponse =
+  | { type: 'answer'; values: readonly string[]; text?: string }
+  | { type: 'cancelled' };
+
+/**
+ * The injected "ask the user" port — a single seam reachable by every interaction source (command
+ * execution now; tool execution for model-issued questions later) and rendered per-environment by each
+ * transport. The concurrency model (broadcast to attached interactive channels, first answer wins,
+ * later answers for an already-resolved `id` ignored) is owned by the port implementation, not the
+ * contract.
+ */
+export interface IUserInteraction {
+  ask(request: IActionRequest): Promise<TActionResponse>;
+}

--- a/packages/agent-core/src/interfaces/tool.ts
+++ b/packages/agent-core/src/interfaces/tool.ts
@@ -1,4 +1,5 @@
 import type { IEventService, IOwnerPathSegment } from './event-service';
+import type { IUserInteraction } from './interaction';
 import type { IToolSchema } from './provider';
 import type { TContextData, TLoggerData, TToolParameters, TUniversalValue } from './types';
 
@@ -131,6 +132,14 @@ export interface IToolExecutionContext {
    * Owner-bound instances must not be layered across different owners.
    */
   baseEventService?: IEventService;
+
+  /**
+   * Injected "ask the user" port (CMD-004). Present when an interactive renderer is attached, letting
+   * a tool solicit a structured answer from the user (the model-issued question seam consumed by
+   * CMD-005). Absent in non-interactive contexts; a tool that asks must treat absence as "no human
+   * available" (never a silent guess).
+   */
+  ask?: IUserInteraction['ask'];
 }
 
 /**


### PR DESCRIPTION
**CMD-004 Phase 1, PR-A** (additive). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

Adds the UI-agnostic "ask the user" contract to **agent-core** so every interaction source can reach it — command execution now, tool execution (CMD-005) later.

## Changes
- `interfaces/interaction.ts` — `IActionRequest` (single shape: `options` × `minSelect`/`maxSelect` × `allowFreeText` × `masked`), `IActionOption`, `IActionDefault`, `TActionResponse`, `IUserInteraction` ask port. No function-valued fields (serialization-safe for Phase-2 WS).
- `interfaces/interaction-builders.ts` — `confirmAction`/`selectAction`/`multiSelectAction`/`textAction` + `isConfirmed` + `CONFIRM_YES`/`CONFIRM_NO`.
- `interfaces/tool.ts` — `IToolExecutionContext.ask?` (optional; reachable by the tool source).
- exports wired in `interfaces/index.ts`; `agent-core` SPEC updated (Type Ownership + Public API Surface).

**Additive only** — the old `agent-interface-transport` contracts are untouched; they are migrated and removed in PR-B…PR-D.

## Verification
- TC-01: `interfaces/interaction.test.ts` (6 tests) — contract shape + builders + ask port; exported from agent-core public surface.
- `pnpm --filter @robota-sdk/agent-core build` ✓; full agent-core test 742/742 ✓.
- `pnpm harness:scan` → 33/33 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)