### PR TITLE
feat(agent-framework): CMD-004 PR-B — ask seam (askHandler + getUserInteraction)

### DIFF
--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -390,7 +390,20 @@ dependency cycle). Fields and the group each drives:
 `setParallelSubagentsEnabled?(enabled)` (`src/command-api/host-context.ts`).
 
 **Optional `ICommandHostContext` methods**: `applyPersona?(persona)`,
-`applyCommandModuleSelection?(enabled, disabled)`, `applySelfVerification?(enabled)`.
+`applyCommandModuleSelection?(enabled, disabled)`, `applySelfVerification?(enabled)`,
+`getUserInteraction?()`.
+
+**Ask seam (CMD-004)**: consumers provide an `askHandler` callback (`IUserInteraction['ask']`, SSOT in
+`@robota-sdk/agent-core`) to `InteractiveSession` options — the interaction sibling of
+`permissionHandler`. The session exposes it to command modules as a narrow capability via
+`ICommandHostContext.getUserInteraction(): IUserInteraction | undefined`, which returns `undefined`
+when no interactive renderer is attached (headless/automation) — a command treats absence as "no human
+available", never a silent guess. `createUserInteractionPort()`
+(`src/interaction/user-interaction-port.ts`) wraps the handler with the model-invocation guard: a
+command invoked by the model runs inside an executing turn, so the port resolves `cancelled` instead of
+blocking on a human prompt (a model-issued interactive ask is CMD-005's separate turn-suspension
+design). Transports render the `IActionRequest` per-environment; the contract carries no function-valued
+fields (serialization-safe for remote transports).
 
 **`createSelfVerificationSection()`** (`src/context/system-prompt-section-providers.ts`) composes a
 verify-before-done system-prompt section with `source: 'self-verification'` at **priority 6** — between

--- a/packages/agent-framework/src/command-api/host-context.ts
+++ b/packages/agent-framework/src/command-api/host-context.ts
@@ -27,6 +27,7 @@ import type { TAutoCompactThreshold } from './context/context-command-api.js';
 import type {
   IContextWindowState,
   IHistoryEntry,
+  IUserInteraction,
   TModelEffort,
   TPermissionMode,
   TUniversalMessage,
@@ -108,6 +109,13 @@ export interface ICommandHostContext {
   clearConversationHistory?(): void;
   validateCurrentSessionReplayLog?(): ICommandSessionReplayValidationReport;
   getAgentJobCapability?(): IAgentJobHostContext | undefined;
+  /**
+   * CMD-004: the injected "ask the user" port, or undefined when no interactive renderer is attached.
+   * A command solicits a structured answer via `getUserInteraction()?.ask(request)`; absence means no
+   * human is available (headless/automation, or a model-invoked command) — the command must handle it
+   * as a cancellation, never a silent guess.
+   */
+  getUserInteraction?(): IUserInteraction | undefined;
   getSession(): ICommandSessionRuntime;
   /** PRESET-014 — re-apply a preset persona to the live system prompt. */
   applyPersona?(persona: string): void;

--- a/packages/agent-framework/src/interaction/user-interaction-port.test.ts
+++ b/packages/agent-framework/src/interaction/user-interaction-port.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createUserInteractionPort } from './user-interaction-port.js';
+
+import type { TCommandInvocationSource } from '../command-api/host-context.js';
+import type { IActionRequest, TActionResponse } from '@robota-sdk/agent-core';
+
+const request: IActionRequest = { id: 'q', title: 'Pick' };
+const answer: TActionResponse = { type: 'answer', values: ['x'] };
+
+describe('createUserInteractionPort (CMD-004 ask seam)', () => {
+  it('returns undefined when no ask handler is attached (no interactive renderer)', () => {
+    expect(createUserInteractionPort(undefined, () => 'user')).toBeUndefined();
+  });
+
+  it('delegates to the handler for user-invoked commands', async () => {
+    const handler = vi.fn(async () => answer);
+    const port = createUserInteractionPort(handler, () => 'user');
+    if (!port) throw new Error('expected a port');
+    const res = await port.ask(request);
+    expect(handler).toHaveBeenCalledWith(request);
+    expect(res).toEqual(answer);
+  });
+
+  it('resolves cancelled WITHOUT calling the handler for model-invoked commands (TC-07 deadlock guard)', async () => {
+    const handler = vi.fn(async () => answer);
+    const port = createUserInteractionPort(handler, () => 'model');
+    if (!port) throw new Error('expected a port');
+    const res = await port.ask(request);
+    expect(res).toEqual({ type: 'cancelled' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('re-reads the invocation source on each ask (not captured once)', async () => {
+    const handler = vi.fn(async () => answer);
+    let source: TCommandInvocationSource = 'user';
+    const port = createUserInteractionPort(handler, () => source);
+    if (!port) throw new Error('expected a port');
+    expect((await port.ask(request)).type).toBe('answer');
+    source = 'model';
+    expect((await port.ask(request)).type).toBe('cancelled');
+  });
+});

--- a/packages/agent-framework/src/interaction/user-interaction-port.ts
+++ b/packages/agent-framework/src/interaction/user-interaction-port.ts
@@ -1,0 +1,29 @@
+/**
+ * Builds the guarded "ask the user" port for a session (CMD-004).
+ *
+ * Kept as a pure function (separate from the InteractiveSession god-class) so the model-invocation
+ * guard is unit-testable without constructing a session.
+ */
+
+import type { TCommandInvocationSource } from '../command-api/host-context.js';
+import type { IUserInteraction, TActionResponse } from '@robota-sdk/agent-core';
+
+/**
+ * Return the injected ask port, or `undefined` when no ask handler is attached (headless/automation —
+ * callers treat absence as "no human available", never a silent guess).
+ *
+ * When the active command was invoked by the model, the port resolves `cancelled` instead of asking:
+ * a model-invoked command runs inside an executing turn, where blocking on a human prompt would
+ * deadlock. (Letting the model issue an interactive ask is CMD-005's separate turn-suspension design.)
+ */
+export function createUserInteractionPort(
+  handler: IUserInteraction['ask'] | undefined,
+  getInvocationSource: () => TCommandInvocationSource,
+): IUserInteraction | undefined {
+  if (!handler) return undefined;
+  const cancelled: TActionResponse = { type: 'cancelled' };
+  return {
+    ask: (request) =>
+      getInvocationSource() === 'model' ? Promise.resolve(cancelled) : handler(request),
+  };
+}

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -22,9 +22,9 @@ import type {
   IAIProvider,
   IContextWindowState,
   IToolWithEventService,
+  IUserInteraction,
   TToolArgs,
 } from '@robota-sdk/agent-core';
-import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type { ITerminalHandoff } from '@robota-sdk/agent-interface-transport';
 import type { ICompactEvent } from '@robota-sdk/agent-session';
 import type { Session } from '@robota-sdk/agent-session';

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -24,6 +24,7 @@ import type {
   IToolWithEventService,
   TToolArgs,
 } from '@robota-sdk/agent-core';
+import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type { ITerminalHandoff } from '@robota-sdk/agent-interface-transport';
 import type { ICompactEvent } from '@robota-sdk/agent-session';
 import type { Session } from '@robota-sdk/agent-session';
@@ -72,6 +73,12 @@ export interface IInteractiveSessionStandardOptions {
    * `canHandoffTerminal === false` for transports with no interactive TTY (headless).
    */
   terminalHandoff?: ITerminalHandoff;
+  /**
+   * CMD-004: transport-provided "ask the user" handler. When present, commands can solicit a
+   * structured answer (confirm/select/multi/text) through the interaction channel. Absent for
+   * non-interactive transports — the session then treats an ask as `cancelled`, never a silent guess.
+   */
+  askHandler?: IUserInteraction['ask'];
   /** Model-visible command descriptors derived from the composed command executor. */
   commandDescriptors?: readonly ICapabilityDescriptor[];
   /** Provider definitions for hot-swap via /provider switch. */
@@ -126,6 +133,8 @@ export interface IInteractiveSessionInjectedOptions {
   commandHostAdapters?: ICommandHostAdapters;
   /** TERM-001: transport-provided terminal-handoff capability (see standard options). */
   terminalHandoff?: ITerminalHandoff;
+  /** CMD-004: transport-provided "ask the user" handler (see standard options). */
+  askHandler?: IUserInteraction['ask'];
 }
 
 /** Union of standard and injected construction options. */

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -17,6 +17,7 @@ import {
   readProviderSettings,
 } from '../command-api/provider/provider-factory.js';
 import { GoalController, buildGoalContinuationPrompt } from '../goal/index.js';
+import { createUserInteractionPort } from '../interaction/user-interaction-port.js';
 import { retrieveAgentToolDeps } from '../tools/agent-tool.js';
 
 import type { IInteractiveSession } from './i-interactive-session.js';
@@ -46,6 +47,7 @@ import type {
   TUniversalMessage,
   TSessionEndReason,
   IProviderDefinition,
+  IUserInteraction,
 } from '@robota-sdk/agent-core';
 import type { ISession } from '@robota-sdk/agent-core';
 import type {
@@ -97,6 +99,8 @@ export class InteractiveSession
   private currentTurnSource: TTurnSource = 'user';
   /** TERM-001: transport-provided terminal-handoff capability (undefined when none). */
   private readonly terminalHandoff?: ITerminalHandoff;
+  /** CMD-004: transport-provided "ask the user" handler (undefined when no interactive renderer). */
+  private readonly askHandler?: IUserInteraction['ask'];
   /** TERM-001: guards handoff exclusivity (one handoff at a time). */
   private terminalHandoffActive = false;
 
@@ -105,6 +109,7 @@ export class InteractiveSession
     this.sessionStore = options.sessionStore;
     this.sessionName = options.sessionName;
     this.terminalHandoff = options.terminalHandoff;
+    this.askHandler = options.askHandler;
     this.cwd = ('cwd' in options ? options.cwd : undefined) ?? '';
     this.resumeSessionId = options.resumeSessionId;
     this.forkSession = options.forkSession ?? false;
@@ -444,6 +449,15 @@ export class InteractiveSession
 
   getAgentJobCapability(): IAgentJobHostContext {
     return this;
+  }
+
+  /**
+   * CMD-004: the injected "ask the user" port, or undefined when no interactive renderer is attached
+   * (headless/automation) — a command must treat absence as "no human available", never a silent
+   * guess. The model-invocation guard lives in {@link createUserInteractionPort}.
+   */
+  getUserInteraction(): IUserInteraction | undefined {
+    return createUserInteractionPort(this.askHandler, () => this.getCommandInvocationSource());
   }
 
   /**


### PR DESCRIPTION
**CMD-004 Phase 1, PR-B** (additive — the framework ask seam). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

Wires the agent-core `IUserInteraction` ask port (PR-A) into the session so command modules can reach it. The channel/TUI renderer wiring and command migration follow in subsequent PRs.

## Changes
- `InteractiveSession` options gain `askHandler?: IUserInteraction['ask']` (sibling to `permissionHandler`), stored on the session.
- `ICommandHostContext.getUserInteraction(): IUserInteraction | undefined` — narrow capability (REFACTOR-006 pattern), not piled onto the base context. `undefined` when no interactive renderer is attached → command treats it as "no human available", never a silent guess.
- `createUserInteractionPort()` (`src/interaction/user-interaction-port.ts`) — pure helper applying the **model-invocation guard**: a model-invoked command runs inside an executing turn, so the port resolves `cancelled` instead of deadlocking on a human prompt.
- agent-framework SPEC updated.

**Additive** — no consumers wired yet; nothing changes behaviorally until the channels inject `askHandler` and commands call `getUserInteraction()`.

## Verification
- TC-07: `src/interaction/user-interaction-port.test.ts` (4 tests) — undefined-without-handler, user delegation, model-guard cancelled (handler not called), source re-read per ask.
- `pnpm --filter @robota-sdk/agent-framework build` ✓; `tsc --noEmit` ✓; full agent-framework test 1025/1025 ✓.
- `pnpm harness:scan` → 33/33 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)