### PR TITLE
feat(agent-transport-tui): CMD-004 PR-C — unified action renderer

### DIFF
--- a/packages/agent-transport-tui/src/MultiSelectList.tsx
+++ b/packages/agent-transport-tui/src/MultiSelectList.tsx
@@ -1,0 +1,89 @@
+/**
+ * Multi-select checklist (CMD-004): arrow-key navigation, Space toggles, Enter confirms once the
+ * selection count is within [minSelect, maxSelect], Esc cancels. Used by PendingActionPrompt for an
+ * IActionRequest whose `maxSelect` > 1.
+ */
+
+import { Box, Text, useInput } from 'ink';
+import React, { useState } from 'react';
+
+import type { IActionOption } from '@robota-sdk/agent-core';
+
+export interface IMultiSelectListProps {
+  title: string;
+  description?: string;
+  options: readonly IActionOption[];
+  minSelect: number;
+  maxSelect: number;
+  defaultValues?: readonly string[];
+  onConfirm: (values: string[]) => void;
+  onCancel: () => void;
+}
+
+export default function MultiSelectList({
+  title,
+  description,
+  options,
+  minSelect,
+  maxSelect,
+  defaultValues,
+  onConfirm,
+  onCancel,
+}: IMultiSelectListProps): React.ReactElement {
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set(defaultValues ?? []));
+
+  const toggle = (value: string): void => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else if (next.size < maxSelect) {
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setCursor((c) => (c <= 0 ? options.length - 1 : c - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => (c >= options.length - 1 ? 0 : c + 1));
+    } else if (input === ' ') {
+      const option = options[cursor];
+      if (option !== undefined) toggle(option.value);
+    } else if (key.return) {
+      if (selected.size >= minSelect) onConfirm([...selected]);
+    } else if (key.escape) {
+      onCancel();
+    }
+  });
+
+  const canConfirm = selected.size >= minSelect;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="yellow" paddingX={1}>
+      <Text color="yellow" bold>
+        {title}
+      </Text>
+      {description !== undefined && description.length > 0 && <Text dimColor>{description}</Text>}
+      {options.map((option, index) => {
+        const isCursor = index === cursor;
+        const isChecked = selected.has(option.value);
+        return (
+          <Text key={option.value} color={isCursor ? 'cyan' : undefined}>
+            {isCursor ? '> ' : '  '}
+            {isChecked ? '[x] ' : '[ ] '}
+            {option.label}
+          </Text>
+        );
+      })}
+      <Text dimColor>
+        {' ↑↓ Navigate  Space Toggle  Enter Confirm'}
+        {canConfirm ? '' : ` (min ${minSelect})`}
+        {'  Esc Cancel'}
+      </Text>
+    </Box>
+  );
+}

--- a/packages/agent-transport-tui/src/MultiSelectList.tsx
+++ b/packages/agent-transport-tui/src/MultiSelectList.tsx
@@ -2,6 +2,10 @@
  * Multi-select checklist (CMD-004): arrow-key navigation, Space toggles, Enter confirms once the
  * selection count is within [minSelect, maxSelect], Esc cancels. Used by PendingActionPrompt for an
  * IActionRequest whose `maxSelect` > 1.
+ *
+ * Note: unlike ListPicker, this renders all options without a scroll viewport — `IActionRequest`'s
+ * optional `maxVisible` hint is not yet honored here (multi-select lists are typically short). Adding a
+ * viewport is a follow-up if long multi-select lists appear.
  */
 
 import { Box, Text, useInput } from 'ink';

--- a/packages/agent-transport-tui/src/PendingActionPrompt.tsx
+++ b/packages/agent-transport-tui/src/PendingActionPrompt.tsx
@@ -1,0 +1,103 @@
+/**
+ * PendingActionPrompt (CMD-004) — the TUI renderer for the unified `IActionRequest`. It derives the
+ * presentation from the request's fields (not a kind switch):
+ * - no options                → free-text (TextPrompt, honoring `masked`/`placeholder`/`allowEmpty`)
+ * - options, `maxSelect` > 1   → multi-select checklist (MultiSelectList)
+ * - options, `maxSelect` <= 1  → single-select list (ListPicker); with `allowFreeText`, a synthetic
+ *                                "Type a custom answer…" entry switches to a text field
+ *
+ * It always resolves the caller's `onAnswer` with a `TActionResponse` (answer or cancelled).
+ */
+
+import { Box, Text } from 'ink';
+import React, { useState } from 'react';
+
+import ListPicker from './ListPicker.js';
+import MultiSelectList from './MultiSelectList.js';
+import TextPrompt from './TextPrompt.js';
+
+import type { IActionOption, IActionRequest, TActionResponse } from '@robota-sdk/agent-core';
+
+interface IPendingActionPromptProps {
+  request: IActionRequest;
+  onAnswer: (response: TActionResponse) => void;
+}
+
+/** Synthetic option value for the "type a custom answer" affordance on a single-select with free text. */
+const FREE_TEXT_VALUE = '__free_text__';
+
+export default function PendingActionPrompt({
+  request,
+  onAnswer,
+}: IPendingActionPromptProps): React.ReactElement {
+  const [freeTextMode, setFreeTextMode] = useState(false);
+
+  const options = request.options ?? [];
+  const hasOptions = options.length > 0;
+  const maxSelect = request.maxSelect ?? 1;
+  const cancel = (): void => onAnswer({ type: 'cancelled' });
+
+  // Pure free-text (no options) — or the user chose "type a custom answer" on a single-select.
+  if (!hasOptions || freeTextMode) {
+    return (
+      <TextPrompt
+        key={`text:${request.id}`}
+        title={request.title}
+        description={request.description}
+        placeholder={request.placeholder}
+        allowEmpty={request.allowEmpty}
+        masked={request.masked}
+        onSubmit={(value) => onAnswer({ type: 'answer', values: [], text: value })}
+        onCancel={freeTextMode ? () => setFreeTextMode(false) : cancel}
+      />
+    );
+  }
+
+  // Multi-select.
+  if (maxSelect > 1) {
+    return (
+      <MultiSelectList
+        title={request.title}
+        description={request.description}
+        options={options}
+        minSelect={request.minSelect ?? 1}
+        maxSelect={maxSelect}
+        defaultValues={request.default?.values}
+        onConfirm={(values) => onAnswer({ type: 'answer', values })}
+        onCancel={cancel}
+      />
+    );
+  }
+
+  // Single-select, optionally with a "type your own" entry.
+  const pickerItems: IActionOption[] = request.allowFreeText
+    ? [...options, { value: FREE_TEXT_VALUE, label: 'Type a custom answer…' }]
+    : [...options];
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>{request.title}</Text>
+      {request.description !== undefined && request.description.length > 0 && (
+        <Text dimColor>{request.description}</Text>
+      )}
+      <ListPicker<IActionOption>
+        items={pickerItems}
+        maxVisible={request.maxVisible}
+        renderItem={(option, isSelected) => (
+          <Text color={isSelected ? 'cyan' : undefined}>
+            {isSelected ? '> ' : '  '}
+            {option.label}
+          </Text>
+        )}
+        onSelect={(option) => {
+          if (option.value === FREE_TEXT_VALUE) {
+            setFreeTextMode(true);
+          } else {
+            onAnswer({ type: 'answer', values: [option.value] });
+          }
+        }}
+        onCancel={cancel}
+      />
+    </Box>
+  );
+}

--- a/packages/agent-transport-tui/src/PendingActionPrompt.tsx
+++ b/packages/agent-transport-tui/src/PendingActionPrompt.tsx
@@ -23,8 +23,11 @@ interface IPendingActionPromptProps {
   onAnswer: (response: TActionResponse) => void;
 }
 
-/** Synthetic option value for the "type a custom answer" affordance on a single-select with free text. */
-const FREE_TEXT_VALUE = '__free_text__';
+/**
+ * Synthetic "type a custom answer" entry for a single-select with free text. Routed by object identity
+ * (reference equality), not by a magic value — so it can never collide with a real option's `value`.
+ */
+const FREE_TEXT_OPTION: IActionOption = { value: '', label: 'Type a custom answer…' };
 
 export default function PendingActionPrompt({
   request,
@@ -69,9 +72,9 @@ export default function PendingActionPrompt({
     );
   }
 
-  // Single-select, optionally with a "type your own" entry.
+  // Single-select, optionally with a "type your own" entry (routed by identity, see FREE_TEXT_OPTION).
   const pickerItems: IActionOption[] = request.allowFreeText
-    ? [...options, { value: FREE_TEXT_VALUE, label: 'Type a custom answer…' }]
+    ? [...options, FREE_TEXT_OPTION]
     : [...options];
 
   return (
@@ -90,7 +93,7 @@ export default function PendingActionPrompt({
           </Text>
         )}
         onSelect={(option) => {
-          if (option.value === FREE_TEXT_VALUE) {
+          if (option === FREE_TEXT_OPTION) {
             setFreeTextMode(true);
           } else {
             onAnswer({ type: 'answer', values: [option.value] });

--- a/packages/agent-transport-tui/src/__tests__/PendingActionPrompt.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/PendingActionPrompt.test.tsx
@@ -1,0 +1,107 @@
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import PendingActionPrompt from '../PendingActionPrompt.js';
+
+import type { IActionRequest } from '@robota-sdk/agent-core';
+
+const delay = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 20));
+const ESC = String.fromCharCode(27);
+const DOWN = `${ESC}[B`;
+const ENTER = '\r';
+
+describe('PendingActionPrompt (CMD-004 unified action renderer)', () => {
+  it('single-select: renders options and answers with the chosen value', async () => {
+    const onAnswer = vi.fn();
+    const request: IActionRequest = {
+      id: 'mode',
+      title: 'Select mode',
+      options: [
+        { value: 'plan', label: 'Plan' },
+        { value: 'default', label: 'Default' },
+      ],
+      maxSelect: 1,
+    };
+    const { stdin, lastFrame } = render(
+      <PendingActionPrompt request={request} onAnswer={onAnswer} />,
+    );
+    expect(lastFrame()).toContain('Select mode');
+    expect(lastFrame()).toContain('Plan');
+
+    stdin.write(DOWN);
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+    expect(onAnswer).toHaveBeenCalledWith({ type: 'answer', values: ['default'] });
+  });
+
+  it('multi-select (maxSelect>1): toggles with Space and confirms with Enter', async () => {
+    const onAnswer = vi.fn();
+    const request: IActionRequest = {
+      id: 'tags',
+      title: 'Pick tags',
+      options: [
+        { value: 'a', label: 'Alpha' },
+        { value: 'b', label: 'Beta' },
+        { value: 'c', label: 'Gamma' },
+      ],
+      minSelect: 1,
+      maxSelect: 3,
+    };
+    const { stdin, lastFrame } = render(
+      <PendingActionPrompt request={request} onAnswer={onAnswer} />,
+    );
+    expect(lastFrame()).toContain('[ ] Alpha');
+
+    stdin.write(' ');
+    await delay();
+    expect(lastFrame()).toContain('[x] Alpha');
+    stdin.write(DOWN);
+    await delay();
+    stdin.write(' ');
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+    expect(onAnswer).toHaveBeenCalledWith({ type: 'answer', values: ['a', 'b'] });
+  });
+
+  it('free-text with masked: hides input and answers with typed text', async () => {
+    const onAnswer = vi.fn();
+    const request: IActionRequest = {
+      id: 'apiKey',
+      title: 'Enter API key',
+      allowFreeText: true,
+      masked: true,
+    };
+    const { stdin, lastFrame } = render(
+      <PendingActionPrompt request={request} onAnswer={onAnswer} />,
+    );
+    expect(lastFrame()).toContain('Enter API key');
+
+    stdin.write('sk-secret');
+    await delay();
+    expect(lastFrame()).not.toContain('sk-secret');
+    expect(lastFrame()).toContain('*'.repeat('sk-secret'.length));
+    stdin.write(ENTER);
+    await delay();
+    expect(onAnswer).toHaveBeenCalledWith({ type: 'answer', values: [], text: 'sk-secret' });
+  });
+
+  it('Esc cancels the request (resolves cancelled)', async () => {
+    const onAnswer = vi.fn();
+    const request: IActionRequest = {
+      id: 'exit',
+      title: 'Exit?',
+      options: [
+        { value: 'yes', label: 'Yes' },
+        { value: 'no', label: 'No' },
+      ],
+      maxSelect: 1,
+    };
+    const { stdin } = render(<PendingActionPrompt request={request} onAnswer={onAnswer} />);
+    stdin.write(ESC);
+    await delay();
+    expect(onAnswer).toHaveBeenCalledWith({ type: 'cancelled' });
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/PendingActionPrompt.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/PendingActionPrompt.test.tsx
@@ -104,4 +104,28 @@ describe('PendingActionPrompt (CMD-004 unified action renderer)', () => {
     await delay();
     expect(onAnswer).toHaveBeenCalledWith({ type: 'cancelled' });
   });
+
+  it('single-select + allowFreeText: "type a custom answer" opens text; Esc returns to picker (not cancel)', async () => {
+    const onAnswer = vi.fn();
+    const request: IActionRequest = {
+      id: 'provider',
+      title: 'Select provider',
+      options: [{ value: 'openai', label: 'OpenAI' }],
+      maxSelect: 1,
+      allowFreeText: true,
+    };
+    const { stdin, lastFrame } = render(
+      <PendingActionPrompt request={request} onAnswer={onAnswer} />,
+    );
+    expect(lastFrame()).toContain('Type a custom answer');
+
+    stdin.write(DOWN); // move to the synthetic "type a custom answer" entry
+    await delay();
+    stdin.write(ENTER); // enter free-text mode
+    await delay();
+    stdin.write(ESC); // Esc here returns to the picker, does NOT cancel the request
+    await delay();
+    expect(onAnswer).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('OpenAI'); // back at the picker
+  });
 });


### PR DESCRIPTION
**CMD-004 Phase 1, PR-C** (additive — the TUI renderer for the unified action). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

Renders the agent-core `IActionRequest` (PR-A) in the TUI, deriving the presentation from fields (no kind switch):
- no options → free-text `TextPrompt` (honors `masked`/`placeholder`/`allowEmpty`)
- options + `maxSelect` > 1 → new `MultiSelectList` checklist (Space toggle, Enter confirm within min/max, Esc cancel)
- options + `maxSelect` <= 1 → `ListPicker`; with `allowFreeText`, a synthetic "Type a custom answer…" entry switches to a text field

Always resolves `onAnswer` with a `TActionResponse` (answer/cancelled). Reuses the existing `ListPicker`/`TextPrompt`; mirrors the Path-B `InteractivePrompt`.

**Additive** — the component is not yet wired into the channel/App (next PR injects `askHandler` and renders `pendingUserAction` + input gating). Nothing changes behaviorally until then.

## Verification
- TC-06 (component level): `__tests__/PendingActionPrompt.test.tsx` (4 tests, ink-testing-library) — single-select chosen value, multi-select Space/Enter, masked free-text hides input + answers text, Esc → cancelled.
- `pnpm --filter @robota-sdk/agent-transport-tui build` ✓; `tsc --noEmit` ✓.
- `pnpm harness:scan` → 33/33 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)