### PR TITLE
feat(agent-transport-tui): CMD-004 PR-D — wire ask seam end-to-end in TUI

### DIFF
--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -19,6 +19,7 @@ import { useTuiChannel } from './hooks/useTuiChannel.js';
 import InputArea from './InputArea.js';
 import InteractivePrompt from './InteractivePrompt.js';
 import { EntryItem } from './MessageList.js';
+import PendingActionPrompt from './PendingActionPrompt.js';
 import PermissionPrompt from './PermissionPrompt.js';
 import PluginTUI from './PluginTUI.js';
 import SessionPicker from './SessionPicker.js';
@@ -129,6 +130,7 @@ function AppInner(
     selectExecutionWorkspaceEntry,
     readExecutionWorkspaceDetail,
     permissionRequest,
+    pendingUserAction,
     contextState,
     handleSubmit: baseHandleSubmit,
     handleAbort,
@@ -274,6 +276,7 @@ function AppInner(
     if (!key.escape || !isThinking) return;
     if (
       permissionRequest ||
+      pendingUserAction ||
       showPluginTUI ||
       showTransportTUI ||
       showSessionPicker ||
@@ -287,7 +290,14 @@ function AppInner(
   // Ctrl+B toggles the execution workspace switcher.
   useInput((input: string, key: { ctrl?: boolean }) => {
     if (!key.ctrl || input !== 'b') return;
-    if (permissionRequest || showPluginTUI || showSessionPicker || isShuttingDown) return;
+    if (
+      permissionRequest ||
+      pendingUserAction ||
+      showPluginTUI ||
+      showSessionPicker ||
+      isShuttingDown
+    )
+      return;
     setShowExecutionWorkspaceSwitcher((shown) => !shown);
   });
 
@@ -296,6 +306,7 @@ function AppInner(
     if (!key.escape || isThinking) return;
     if (
       permissionRequest ||
+      pendingUserAction ||
       showPluginTUI ||
       showTransportTUI ||
       showSessionPicker ||
@@ -451,6 +462,12 @@ function AppInner(
               onCancel={handleInteractionCancel}
             />
           )}
+          {pendingUserAction && (
+            <PendingActionPrompt
+              request={pendingUserAction}
+              onAnswer={(response) => channel.resolveUserAction(response)}
+            />
+          )}
           {showPluginTUI && (
             <PluginTUI
               callbacks={pluginCallbacks}
@@ -485,6 +502,7 @@ function AppInner(
             onCancelQueue={handleCancelQueue}
             isDisabled={
               !!permissionRequest ||
+              !!pendingUserAction ||
               showPluginTUI ||
               showTransportTUI ||
               showSessionPicker ||

--- a/packages/agent-transport-tui/src/TuiInteractionChannel.ts
+++ b/packages/agent-transport-tui/src/TuiInteractionChannel.ts
@@ -26,6 +26,12 @@ import type { TerminalHandoffController } from './terminal-handoff-controller.js
 import type { IPendingPermissionRequest } from './types.js';
 import type { IAIProvider, TPermissionMode, TSessionEndReason } from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
+// CMD-004 unified action contract (SSOT in agent-core). Aliased to avoid clashing with the legacy
+// interface-transport `TActionResponse` still used by the (dead, removed in PR-H) requestAction path.
+import type {
+  IActionRequest,
+  TActionResponse as TUserActionResponse,
+} from '@robota-sdk/agent-core';
 import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
@@ -101,8 +107,18 @@ export class TuiInteractionChannel implements IInteractionChannel {
   }> = [];
   private processingAction = false;
 
+  // CMD-004 unified ask path (parallel to the legacy actionQueue above; that legacy path is removed
+  // in PR-H). Backs askHandler → InteractiveSession; rendered by App's PendingActionPrompt.
+  private userActionQueue: Array<{
+    request: IActionRequest;
+    resolve: (response: TUserActionResponse) => void;
+  }> = [];
+  private processingUserAction = false;
+
   permissionRequest: IPendingPermissionRequest | null = null;
   pendingAction: TActionRequest | null = null;
+  /** CMD-004: the action currently awaiting a user answer, or null. Read by App to render the dialog. */
+  pendingUserAction: IActionRequest | null = null;
   availableCommands: ICommandInfo[] = [];
   isShuttingDown = false;
   sessionName: string | undefined;
@@ -144,6 +160,7 @@ export class TuiInteractionChannel implements IInteractionChannel {
       permissionMode: opts.permissionMode,
       maxTurns: opts.maxTurns,
       permissionHandler: (toolName, toolArgs) => this.handlePermissionRequest(toolName, toolArgs),
+      askHandler: (request) => this.askUser(request),
       sessionStore: opts.sessionStore,
       resumeSessionId: opts.resumeSessionId,
       forkSession: opts.forkSession,
@@ -242,17 +259,20 @@ export class TuiInteractionChannel implements IInteractionChannel {
 
   abort(): void {
     this.stateManager.setAborting(true);
+    this.cancelAllUserActions();
     this.interactiveSession.abort();
   }
 
   cancelQueue(): void {
     this.interactiveSession.cancelQueue();
+    this.cancelAllUserActions();
     this.stateManager.setPendingPrompt(null);
   }
 
   async shutdown(options?: { reason?: TSessionEndReason }): Promise<void> {
     if (this.isShuttingDown) return;
     this.isShuttingDown = true;
+    this.cancelAllUserActions();
     this.stateManager.addEntry(messageToHistoryEntry(createSystemMessage('Shutting down...')));
     this.onChange?.();
     await this.interactiveSession.shutdown({
@@ -288,6 +308,53 @@ export class TuiInteractionChannel implements IInteractionChannel {
     this.onChange?.();
     pending.resolve(response);
     this.processNextAction();
+  }
+
+  // ── CMD-004 unified ask path ─────────────────────────────────
+
+  /** Framework's `askHandler` entry point: queue the request and resolve when the user answers. */
+  async askUser(request: IActionRequest): Promise<TUserActionResponse> {
+    return new Promise<TUserActionResponse>((resolve) => {
+      this.userActionQueue.push({ request, resolve });
+      this.processNextUserAction();
+    });
+  }
+
+  /** Called by App's PendingActionPrompt when the user answers (or cancels) the pending action. */
+  resolveUserAction(response: TUserActionResponse): void {
+    const pending = this.userActionQueue[0];
+    if (!pending) return;
+    this.userActionQueue.shift();
+    this.processingUserAction = false;
+    this.pendingUserAction = null;
+    this.onChange?.();
+    pending.resolve(response);
+    this.processNextUserAction();
+  }
+
+  private processNextUserAction(): void {
+    if (this.processingUserAction) return;
+    const next = this.userActionQueue[0];
+    if (!next) {
+      this.pendingUserAction = null;
+      this.onChange?.();
+      return;
+    }
+    this.processingUserAction = true;
+    this.pendingUserAction = next.request;
+    this.onChange?.();
+  }
+
+  /** Resolve every queued/in-flight ask as cancelled (abort, shutdown). */
+  private cancelAllUserActions(): void {
+    const queued = this.userActionQueue;
+    this.userActionQueue = [];
+    this.processingUserAction = false;
+    this.pendingUserAction = null;
+    for (const pending of queued) {
+      pending.resolve({ type: 'cancelled' });
+    }
+    this.onChange?.();
   }
 
   async handleInput(input: string): Promise<void> {

--- a/packages/agent-transport-tui/src/__tests__/TuiInteractionChannel.askUser.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/TuiInteractionChannel.askUser.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for TuiInteractionChannel.askUser() — the CMD-004 unified ask path (parallel to the
+ * legacy requestAction path). Queue resolution + abort cancellation in isolation; no Ink render.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@robota-sdk/agent-framework', async () => {
+  const actual = await vi.importActual<typeof import('@robota-sdk/agent-framework')>(
+    '@robota-sdk/agent-framework',
+  );
+  return {
+    ...actual,
+    InteractiveSession: vi.fn().mockImplementation(() => ({
+      getFullHistory: vi.fn().mockReturnValue([]),
+      setName: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue('test-id'),
+      isInitialized: false,
+      on: vi.fn(),
+      off: vi.fn(),
+      cancelQueue: vi.fn(),
+      abort: vi.fn(),
+    })),
+    CommandRegistry: vi.fn().mockImplementation(() => ({
+      addModule: vi.fn(),
+    })),
+  };
+});
+
+import { TuiInteractionChannel } from '../TuiInteractionChannel.js';
+
+import type { IAIProvider, IActionRequest } from '@robota-sdk/agent-core';
+
+function makeChannel(): TuiInteractionChannel {
+  return new TuiInteractionChannel({ cwd: '/tmp', provider: {} as IAIProvider });
+}
+
+const SELECT: IActionRequest = {
+  id: 'mode',
+  title: 'Select mode',
+  options: [
+    { value: 'plan', label: 'Plan' },
+    { value: 'default', label: 'Default' },
+  ],
+  maxSelect: 1,
+};
+
+const CONFIRM: IActionRequest = {
+  id: 'exit',
+  title: 'Exit?',
+  options: [
+    { value: 'yes', label: 'Yes' },
+    { value: 'no', label: 'No' },
+  ],
+  maxSelect: 1,
+};
+
+describe('TuiInteractionChannel.askUser', () => {
+  let channel: TuiInteractionChannel;
+
+  beforeEach(() => {
+    channel = makeChannel();
+  });
+
+  it('sets pendingUserAction when askUser is called', () => {
+    void channel.askUser(SELECT);
+    expect(channel.pendingUserAction).toMatchObject({ id: 'mode' });
+  });
+
+  it('resolves the answer when resolveUserAction is called, then clears pendingUserAction', async () => {
+    const promise = channel.askUser(SELECT);
+    channel.resolveUserAction({ type: 'answer', values: ['default'] });
+    const response = await promise;
+    expect(response).toEqual({ type: 'answer', values: ['default'] });
+    expect(channel.pendingUserAction).toBeNull();
+  });
+
+  it('resolves cancelled', async () => {
+    const promise = channel.askUser(SELECT);
+    channel.resolveUserAction({ type: 'cancelled' });
+    expect(await promise).toEqual({ type: 'cancelled' });
+  });
+
+  it('queues multiple asks and processes them sequentially', async () => {
+    const p1 = channel.askUser(SELECT);
+    const p2 = channel.askUser(CONFIRM);
+    expect(channel.pendingUserAction).toMatchObject({ id: 'mode' });
+
+    channel.resolveUserAction({ type: 'answer', values: ['plan'] });
+    await p1;
+    expect(channel.pendingUserAction).toMatchObject({ id: 'exit' });
+
+    channel.resolveUserAction({ type: 'answer', values: ['no'] });
+    expect(await p2).toEqual({ type: 'answer', values: ['no'] });
+    expect(channel.pendingUserAction).toBeNull();
+  });
+
+  it('cancelQueue() resolves every in-flight/queued ask as cancelled', async () => {
+    const p1 = channel.askUser(SELECT);
+    const p2 = channel.askUser(CONFIRM);
+    channel.cancelQueue();
+    expect(await p1).toEqual({ type: 'cancelled' });
+    expect(await p2).toEqual({ type: 'cancelled' });
+    expect(channel.pendingUserAction).toBeNull();
+  });
+
+  it('abort() resolves an in-flight ask as cancelled', async () => {
+    const promise = channel.askUser(SELECT);
+    channel.abort();
+    expect(await promise).toEqual({ type: 'cancelled' });
+  });
+
+  it('calls onChange when pendingUserAction changes', () => {
+    const onChange = vi.fn();
+    channel.onChange = onChange;
+    void channel.askUser(SELECT);
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/session-switch-channel.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/session-switch-channel.test.tsx
@@ -56,6 +56,7 @@ interface IFakeChannel {
   onChange: (() => void) | null;
   isShuttingDown: boolean;
   permissionRequest: null;
+  pendingUserAction: null;
   start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
   handleInput: ReturnType<typeof vi.fn>;
@@ -95,6 +96,7 @@ function createFakeChannel(createdFor: string | undefined): IFakeChannel {
     onChange: null,
     isShuttingDown: false,
     permissionRequest: null,
+    pendingUserAction: null,
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
     handleInput: vi.fn(async () => {}),

--- a/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
+++ b/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
@@ -10,7 +10,7 @@ import { useState, useEffect } from 'react';
 import type { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 import type { ICommandEffectQueue } from './command-effect-queue.js';
 import type { IPendingPermissionRequest } from '../types.js';
-import type { IHistoryEntry, TSessionEndReason } from '@robota-sdk/agent-core';
+import type { IActionRequest, IHistoryEntry, TSessionEndReason } from '@robota-sdk/agent-core';
 import type { InteractiveSession, CommandRegistry } from '@robota-sdk/agent-framework';
 import type {
   IExecutionDetailPage,
@@ -33,6 +33,8 @@ export interface IInteractiveSessionState {
   executionWorkspaceSnapshot: IExecutionWorkspaceSnapshot | null;
   selectedExecutionEntryId?: string;
   permissionRequest: IPendingPermissionRequest | null;
+  /** CMD-004: the unified action awaiting a user answer, or null. */
+  pendingUserAction: IActionRequest | null;
   contextState: { percentage: number; usedTokens: number; maxTokens: number };
   handleSubmit: (input: string) => Promise<void>;
   handleAbort: () => void;
@@ -84,6 +86,7 @@ export function useTuiChannel(channel: TuiInteractionChannel): IInteractiveSessi
     executionWorkspaceSnapshot: manager.executionWorkspaceSnapshot,
     selectedExecutionEntryId: manager.selectedExecutionEntryId,
     permissionRequest: channel.permissionRequest,
+    pendingUserAction: channel.pendingUserAction ?? null,
     contextState: manager.contextState,
     handleSubmit: (input) => channel.handleInput(input),
     handleAbort: () => channel.abort(),


### PR DESCRIPTION
**CMD-004 Phase 1, PR-D** — connects the pieces from PR-A/B/C so the ask path works end-to-end in the TUI. Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

## Changes
- `TuiInteractionChannel.askUser(IActionRequest): Promise<TActionResponse>` — queue + `pendingUserAction` + `resolveUserAction` + `cancelAllUserActions` (parallel to the legacy `requestAction` path, which is removed in PR-H). Injects `askHandler: req => this.askUser(req)` into its `InteractiveSession`.
- Abort/cancel/shutdown (`abort()`, `cancelQueue()`, `shutdown()`) resolve every in-flight/queued ask as `cancelled` so a command awaiting `context.ask` unwinds.
- `useTuiChannel` exposes `pendingUserAction`; `App.tsx` renders `PendingActionPrompt` and gates input + ESC/Ctrl-B handlers while an action is pending.

Now functional: a command that calls `context.ask(...)` renders the unified dialog in the TUI and receives the answer. (Programmatic/headless wiring = PR-E; command migration = PR-F/G.)

## Verification
- `__tests__/TuiInteractionChannel.askUser.test.ts` (7 tests) — queue/resolve/sequential/cancelQueue+abort cancellation/onChange.
- Caught + fixed a regression: the fake channel in `session-switch-channel.test.tsx` has no `pendingUserAction` (→ `undefined`); switched the input-gate to a truthy check (`!!pendingUserAction`, matching `permissionRequest`) and `?? null` in the hook.
- Full `agent-transport-tui` suite: **404/404**. `tsc --noEmit` ✓. `pnpm harness:scan` → 33/33 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)