### PR TITLE
feat(agent-transport): CMD-004 PR-E — ask seam for programmatic/headless

### DIFF
--- a/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
+++ b/packages/agent-framework/src/interaction/createInteractiveRuntime.ts
@@ -178,6 +178,10 @@ export function createInteractiveRuntime(options: IInteractiveRuntimeOptions): I
           sessionStore,
           commandModules,
           permissionMode,
+          // CMD-004: route command asks to the channel's unified renderer when it implements one;
+          // otherwise resolve cancelled (never block a non-interactive run on an un-answered ask).
+          askHandler: (request) =>
+            channel.askUser?.(request) ?? Promise.resolve({ type: 'cancelled' as const }),
         });
       }
 

--- a/packages/agent-interface-transport/src/interaction-contracts.ts
+++ b/packages/agent-interface-transport/src/interaction-contracts.ts
@@ -5,6 +5,13 @@
  * SSOT shared by agent-framework (createInteractiveRuntime) and agent-transport channels.
  */
 
+// CMD-004 unified action contract (SSOT in agent-core). Aliased so the new `TActionResponse` does not
+// clash with this module's legacy `TActionResponse` (removed once all channels migrate, PR-H).
+import type {
+  IActionRequest,
+  TActionResponse as TUserActionResponse,
+} from '@robota-sdk/agent-core';
+
 /** Framework-level permission request (id used to correlate with permission-resolved). */
 export interface IPermissionRequest {
   id: string;
@@ -63,6 +70,13 @@ export interface IInteractionChannel {
    * (Ink dialog, web modal, programmatic preset). Resolves when user responds.
    */
   requestAction(action: TActionRequest): Promise<TActionResponse>;
+
+  /**
+   * CMD-004 unified ask: request a structured answer (confirm/select/multi/text). Optional during the
+   * additive migration; the channel renders it per-environment and resolves when the user answers (or
+   * cancels). The legacy `requestAction` above is removed once every channel implements this (PR-H).
+   */
+  askUser?(request: IActionRequest): Promise<TUserActionResponse>;
 
   /** Framework provides registered slash commands for autocomplete. */
   setAvailableCommands(commands: ICommandInfo[]): void;

--- a/packages/agent-transport/src/__tests__/programmatic/programmatic-ask-user.test.ts
+++ b/packages/agent-transport/src/__tests__/programmatic/programmatic-ask-user.test.ts
@@ -1,0 +1,42 @@
+/**
+ * CMD-004 PR-E: ProgrammaticInteractionChannel.askUser() — the unified ask path on the programmatic
+ * channel. FIFO from the pre-supplied queue; empty queue → cancelled (never blocks a headless run).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { ProgrammaticInteractionChannel } from '../../programmatic/ProgrammaticInteractionChannel.js';
+
+import type { IActionRequest } from '@robota-sdk/agent-core';
+
+const REQUEST: IActionRequest = {
+  id: 'q',
+  title: 'Pick',
+  options: [{ value: 'a', label: 'A' }],
+  maxSelect: 1,
+};
+
+describe('ProgrammaticInteractionChannel.askUser', () => {
+  it('resolves cancelled when no answer is queued', async () => {
+    const channel = new ProgrammaticInteractionChannel();
+    expect(await channel.askUser(REQUEST)).toEqual({ type: 'cancelled' });
+  });
+
+  it('resolves queued answers FIFO, then cancelled once drained', async () => {
+    const channel = new ProgrammaticInteractionChannel();
+    channel.queueUserAction({ type: 'answer', values: ['a'] });
+    channel.queueUserAction({ type: 'cancelled' });
+    expect(await channel.askUser(REQUEST)).toEqual({ type: 'answer', values: ['a'] });
+    expect(await channel.askUser(REQUEST)).toEqual({ type: 'cancelled' });
+    expect(await channel.askUser(REQUEST)).toEqual({ type: 'cancelled' });
+  });
+
+  it('keeps the legacy requestAction queue independent of the ask queue', async () => {
+    const channel = new ProgrammaticInteractionChannel();
+    channel.queueUserAction({ type: 'answer', values: ['a'] });
+    // legacy requestAction has its own (empty) queue → cancelled, unaffected by queueUserAction
+    expect(await channel.requestAction({ type: 'confirm', id: 'x', message: 'ok?' })).toEqual({
+      type: 'cancelled',
+    });
+    expect(await channel.askUser(REQUEST)).toEqual({ type: 'answer', values: ['a'] });
+  });
+});

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -91,6 +91,8 @@ export class HeadlessInteractionChannel {
       cwd: this.opts.cwd,
       provider: this.opts.provider,
       permissionMode: this.opts.permissionMode ?? 'bypassPermissions',
+      // CMD-004: headless has no interactive renderer — an ask resolves cancelled (never a silent guess).
+      askHandler: () => Promise.resolve({ type: 'cancelled' as const }),
       maxTurns: this.opts.maxTurns,
       sessionStore: this.opts.sessionStore,
       resumeSessionId: this.opts.resumeSessionId,

--- a/packages/agent-transport/src/programmatic/ProgrammaticInteractionChannel.ts
+++ b/packages/agent-transport/src/programmatic/ProgrammaticInteractionChannel.ts
@@ -11,12 +11,18 @@
  */
 
 import type {
+  IActionRequest,
+  TActionResponse as TUserActionResponse,
+} from '@robota-sdk/agent-core';
+import type {
   IInteractionChannel,
   ICommandInfo,
   InteractionEvent,
   TActionRequest,
   TActionResponse,
 } from '@robota-sdk/agent-interface-transport';
+// CMD-004 unified action contract (SSOT in agent-core). Aliased to avoid clashing with the legacy
+// interface-transport TActionRequest/TActionResponse used by the requestAction path above.
 
 export class ProgrammaticInteractionChannel implements IInteractionChannel {
   /** Full structured event stream pushed by the framework, in order. */
@@ -29,6 +35,7 @@ export class ProgrammaticInteractionChannel implements IInteractionChannel {
 
   private submitHandler: ((text: string) => Promise<void>) | null = null;
   private readonly actionResponses: TActionResponse[] = [];
+  private readonly userActionResponses: TUserActionResponse[] = [];
 
   // ── IInteractionChannel ──────────────────────────────────────
 
@@ -47,6 +54,14 @@ export class ProgrammaticInteractionChannel implements IInteractionChannel {
    */
   async requestAction(_action: TActionRequest): Promise<TActionResponse> {
     return this.actionResponses.shift() ?? { type: 'cancelled' };
+  }
+
+  /**
+   * CMD-004 unified ask. Resolves from the pre-supplied queue (FIFO); an empty queue resolves
+   * `{ type: 'cancelled' }` so a programmatic run never blocks on an un-answered question.
+   */
+  async askUser(_request: IActionRequest): Promise<TUserActionResponse> {
+    return this.userActionResponses.shift() ?? { type: 'cancelled' };
   }
 
   setAvailableCommands(commands: ICommandInfo[]): void {
@@ -80,5 +95,10 @@ export class ProgrammaticInteractionChannel implements IInteractionChannel {
   /** Pre-answer the next `requestAction` disambiguation. */
   queueAction(response: TActionResponse): void {
     this.actionResponses.push(response);
+  }
+
+  /** Pre-answer the next `askUser` (CMD-004 unified ask). */
+  queueUserAction(response: TUserActionResponse): void {
+    this.userActionResponses.push(response);
   }
 }


### PR DESCRIPTION
**CMD-004 Phase 1, PR-E** — completes the ask-seam wiring for non-TUI environments (TUI was PR-D). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

## Changes
- `IInteractionChannel.askUser?(IActionRequest): Promise<TActionResponse>` — optional during the additive migration (agent-core contract; aliased to avoid the legacy `TActionResponse` clash).
- `ProgrammaticInteractionChannel.askUser` — FIFO from a pre-supplied queue (`queueUserAction`); empty queue → `cancelled` (never blocks a programmatic run). Independent of the legacy `requestAction` queue.
- `createInteractiveRuntime` injects `askHandler: req => channel.askUser?.(req) ?? cancelled` into its session (programmatic + remote paths).
- `HeadlessInteractionChannel` resolves asks `cancelled` (no interactive renderer — never a silent guess).

After this, a command calling `context.ask` works in every environment: TUI renders the dialog (PR-D), programmatic answers from its queue, headless cancels. Command migration onto `context.ask` is PR-F/G.

## Verification
- `programmatic-ask-user.test.ts` (3 tests) — cancelled-when-empty, FIFO, queue independence (TC-05 new path).
- Builds: agent-core/interface-transport/framework/transport ✓; `tsc --noEmit` (transport, framework) ✓.
- agent-transport 41→44, agent-framework 1025 tests ✓. `pnpm harness:scan` → 33/33 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)