### PR TITLE
feat(agent-command): CMD-004 PR-F — migrate /mode to inline context.ask

### DIFF
--- a/packages/agent-command/src/mode/__tests__/mode-command-module.test.ts
+++ b/packages/agent-command/src/mode/__tests__/mode-command-module.test.ts
@@ -140,4 +140,38 @@ describe('createModeCommandModule', () => {
     );
     expect(context.setPermissionMode).not.toHaveBeenCalled();
   });
+
+  it('asks the user to pick a mode when no arg is given and a renderer is attached (CMD-004)', async () => {
+    const executor = new SystemCommandExecutor([
+      ...(createModeCommandModule().systemCommands ?? []),
+    ]);
+    const context = createCommandHostContext();
+    const contextWithAsk: ICommandHostContext = {
+      ...context,
+      getUserInteraction: () => ({ ask: async () => ({ type: 'answer', values: ['plan'] }) }),
+    };
+
+    const result = await executor.execute('mode', contextWithAsk, '');
+
+    expect(result?.success).toBe(true);
+    expect(result?.message).toBe('Permission mode set to: plan');
+    expect(context.setPermissionMode).toHaveBeenCalledWith('plan');
+  });
+
+  it('reports the current mode when the user cancels the pick (CMD-004)', async () => {
+    const executor = new SystemCommandExecutor([
+      ...(createModeCommandModule().systemCommands ?? []),
+    ]);
+    const context = createCommandHostContext();
+    const contextWithAsk: ICommandHostContext = {
+      ...context,
+      getUserInteraction: () => ({ ask: async () => ({ type: 'cancelled' }) }),
+    };
+
+    const result = await executor.execute('mode', contextWithAsk, '');
+
+    expect(result?.success).toBe(true);
+    expect(result?.message).toBe('Current mode: default');
+    expect(context.setPermissionMode).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent-command/src/mode/mode-command-module.ts
+++ b/packages/agent-command/src/mode/mode-command-module.ts
@@ -7,11 +7,7 @@ import {
 import { executeModeCommand } from './mode-command.js';
 
 import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 
 export function createModeCommandEntry(): ICommand {
   return {
@@ -49,23 +45,10 @@ export class ModeCommandSource implements ICommandSource {
   }
 }
 
-const MODE_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  mode: {
-    type: 'pick',
-    getItems: () =>
-      buildPermissionModeSubcommands().map((sub) => ({
-        label: sub.name,
-        value: sub.name,
-        description: sub.description,
-      })),
-  },
-};
-
 export function createModeCommandModule(): ICommandModule {
   return {
     name: 'agent-command-mode',
     commandSources: [new ModeCommandSource()],
     systemCommands: [createModeSystemCommand()],
-    interactionHints: MODE_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/mode/mode-command.ts
+++ b/packages/agent-command/src/mode/mode-command.ts
@@ -1,4 +1,6 @@
+import { selectAction } from '@robota-sdk/agent-core';
 import {
+  buildPermissionModeSubcommands,
   formatInvalidPermissionModeMessage,
   isPermissionMode,
   parsePermissionModeArgument,
@@ -9,15 +11,36 @@ import {
 import type { ICommandHostContext } from '@robota-sdk/agent-framework';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-export function executeModeCommand(context: ICommandHostContext, args: string): ICommandResult {
-  const arg = parsePermissionModeArgument(args);
+/**
+ * Ask the user to pick a permission mode (CMD-004 inline ask). Returns the chosen mode name, or
+ * `undefined` when no interactive renderer is attached or the user cancelled — the caller then reports
+ * the current mode instead of changing it (never a silent guess).
+ */
+async function resolveModeViaAsk(context: ICommandHostContext): Promise<string | undefined> {
+  const ui = context.getUserInteraction?.();
+  if (!ui) return undefined;
+  const options = buildPermissionModeSubcommands().map((sub) => ({
+    value: sub.name,
+    label: sub.name,
+    description: sub.description,
+  }));
+  const response = await ui.ask(selectAction('mode', 'Select interaction mode', options));
+  return response.type === 'answer' ? response.values[0] : undefined;
+}
+
+export async function executeModeCommand(
+  context: ICommandHostContext,
+  args: string,
+): Promise<ICommandResult> {
+  let arg: string | undefined = parsePermissionModeArgument(args);
+
   if (arg === undefined) {
-    const mode = readCommandPermissionMode(context);
-    return {
-      message: `Current mode: ${mode}`,
-      success: true,
-      data: { mode },
-    };
+    arg = await resolveModeViaAsk(context);
+    if (arg === undefined) {
+      // No interactive answer — report the current mode without changing it.
+      const mode = readCommandPermissionMode(context);
+      return { message: `Current mode: ${mode}`, success: true, data: { mode } };
+    }
   }
 
   if (!isPermissionMode(arg)) {


### PR DESCRIPTION
**CMD-004 Phase 1, PR-F** — first command migrated onto the unified ask seam (proves contract→seam→renderer→wiring→command end-to-end). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

## Changes
- `executeModeCommand` is now async: with no arg it asks the user to pick a mode via `context.getUserInteraction()?.ask(selectAction(...))`, replacing the declarative `interactionHints` (removed from the module).
- **Backward-compatible**: no renderer attached (`getUserInteraction` → undefined) or user cancels → reports the current mode, exactly as before. So `/mode` now shows an interactive picker in the **TUI** (previously the Path-A hint only rendered for programmatic), with no regression elsewhere.

## Verification
- `mode-command-module.test.ts` (6 tests): existing report/set/invalid still pass (undefined port → report current); 2 new — pick-sets-mode and cancel-reports-current via an injected `getUserInteraction`.
- `agent-command` build + `tsc --noEmit` ✓; full suite **200/200**; `pnpm harness:scan` → 33/33 ✓.

Remaining: preset/language (same picker template), exit/clear (confirm), provider (wizard) — then delete the legacy paths (PR-H/I).

🤖 Generated with [Claude Code](https://claude.com/claude-code)