### PR TITLE
feat(agent-command): CMD-004 PR-G — migrate /preset and /language to inline ask

### DIFF
--- a/packages/agent-command/src/language/__tests__/language-command-module.test.ts
+++ b/packages/agent-command/src/language/__tests__/language-command-module.test.ts
@@ -102,4 +102,20 @@ describe('createLanguageCommandModule', () => {
     expect(result?.success).toBe(false);
     expect(result?.message).toBe('Usage: language <code> (e.g., ko, en, ja, zh)');
   });
+
+  it('asks the user to pick a language when none is provided (CMD-004)', async () => {
+    const executor = new SystemCommandExecutor([
+      ...(createLanguageCommandModule().systemCommands ?? []),
+    ]);
+    const contextWithAsk: ICommandHostContext = {
+      ...commandHostContext,
+      getUserInteraction: () => ({ ask: async () => ({ type: 'answer', values: ['ko'] }) }),
+    };
+
+    const result = await executor.execute('language', contextWithAsk, '');
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.language).toBe('ko');
+    expect(result?.effects).toEqual([{ type: 'language-change-requested', language: 'ko' }]);
+  });
 });

--- a/packages/agent-command/src/language/language-command-module.ts
+++ b/packages/agent-command/src/language/language-command-module.ts
@@ -7,11 +7,7 @@ import {
 import { executeLanguageCommand } from './language-command.js';
 
 import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 
 export function createLanguageCommandEntry(): ICommand {
   return {
@@ -49,23 +45,10 @@ export class LanguageCommandSource implements ICommandSource {
   }
 }
 
-const LANGUAGE_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  language: {
-    type: 'pick',
-    getItems: () =>
-      buildLanguageCommandSubcommands().map((sub) => ({
-        label: `${sub.name}  ${sub.description ?? ''}`.trimEnd(),
-        value: sub.name,
-        description: sub.description,
-      })),
-  },
-};
-
 export function createLanguageCommandModule(): ICommandModule {
   return {
     name: 'agent-command-language',
     commandSources: [new LanguageCommandSource()],
     systemCommands: [createLanguageSystemCommand()],
-    interactionHints: LANGUAGE_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/language/language-command.ts
+++ b/packages/agent-command/src/language/language-command.ts
@@ -1,18 +1,44 @@
-import { formatLanguageUsageMessage, parseLanguageArgument } from '@robota-sdk/agent-framework';
+import { selectAction } from '@robota-sdk/agent-core';
+import {
+  buildLanguageCommandSubcommands,
+  formatLanguageUsageMessage,
+  parseLanguageArgument,
+} from '@robota-sdk/agent-framework';
 
 import type { ICommandHostContext } from '@robota-sdk/agent-framework';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-export function executeLanguageCommand(
-  _context: ICommandHostContext,
+/**
+ * Ask the user to pick a language (CMD-004 inline ask). Returns a validated language, or `undefined`
+ * when no interactive renderer is attached or the user cancelled — the caller then shows usage.
+ */
+async function resolveLanguageViaAsk(context: ICommandHostContext): Promise<string | undefined> {
+  const ui = context.getUserInteraction?.();
+  if (!ui) return undefined;
+  const options = buildLanguageCommandSubcommands().map((sub) => ({
+    value: sub.name,
+    label: sub.name,
+    description: sub.description,
+  }));
+  const response = await ui.ask(selectAction('language', 'Select language', options));
+  const picked = response.type === 'answer' ? response.values[0] : undefined;
+  return picked === undefined ? undefined : parseLanguageArgument(picked);
+}
+
+export async function executeLanguageCommand(
+  context: ICommandHostContext,
   args: string,
-): ICommandResult {
-  const language = parseLanguageArgument(args);
+): Promise<ICommandResult> {
+  let language = parseLanguageArgument(args);
+
   if (language === undefined) {
-    return {
-      message: formatLanguageUsageMessage(),
-      success: false,
-    };
+    language = await resolveLanguageViaAsk(context);
+    if (language === undefined) {
+      return {
+        message: formatLanguageUsageMessage(),
+        success: false,
+      };
+    }
   }
 
   return {

--- a/packages/agent-command/src/preset/__tests__/preset-command-module.test.ts
+++ b/packages/agent-command/src/preset/__tests__/preset-command-module.test.ts
@@ -135,4 +135,40 @@ describe('preset command module', () => {
     }
     expect(setActivePresetId).not.toHaveBeenCalled();
   });
+
+  it('CMD-004: asks the user to pick a preset when none is given, then switches', async () => {
+    const setActivePresetId = vi.fn();
+    const setPermissionMode = vi.fn();
+    const applyModelOptions = vi.fn();
+    const runtime = createSessionRuntime({
+      setActivePresetId,
+      setPermissionMode,
+      applyModelOptions,
+    });
+    const context = createCommandHostContext(runtime, {
+      getUserInteraction: () => ({
+        ask: async () => ({ type: 'answer', values: ['careful-reviewer'] }),
+      }),
+    });
+
+    const result = await executePresetCommand(context, '');
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Switched to preset: careful-reviewer');
+    expect(setActivePresetId).toHaveBeenCalledWith('careful-reviewer');
+  });
+
+  it('CMD-004: shows the preset list when the pick is cancelled', async () => {
+    const setActivePresetId = vi.fn();
+    const runtime = createSessionRuntime({ setActivePresetId });
+    const context = createCommandHostContext(runtime, {
+      getUserInteraction: () => ({ ask: async () => ({ type: 'cancelled' }) }),
+    });
+
+    const result = await executePresetCommand(context, '');
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Available presets:');
+    expect(setActivePresetId).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent-command/src/preset/preset-command-module.ts
+++ b/packages/agent-command/src/preset/preset-command-module.ts
@@ -3,11 +3,7 @@ import { listPresets } from '@robota-sdk/agent-preset';
 import { executePresetCommand } from './preset-command.js';
 
 import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 
 const PRESET_COMMAND_DESCRIPTION = 'List presets or switch the active preset';
 const PRESET_ARGUMENT_HINT = 'list | <preset-id>';
@@ -57,23 +53,10 @@ export class PresetCommandSource implements ICommandSource {
   }
 }
 
-const PRESET_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  preset: {
-    type: 'pick',
-    getItems: () =>
-      buildPresetSubcommands().map((sub) => ({
-        label: sub.name,
-        value: sub.name,
-        description: sub.description,
-      })),
-  },
-};
-
 export function createPresetCommandModule(): ICommandModule {
   return {
     name: 'agent-command-preset',
     commandSources: [new PresetCommandSource()],
     systemCommands: [createPresetSystemCommand()],
-    interactionHints: PRESET_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/preset/preset-command.ts
+++ b/packages/agent-command/src/preset/preset-command.ts
@@ -1,3 +1,4 @@
+import { selectAction } from '@robota-sdk/agent-core';
 import { applyPresetToSession } from '@robota-sdk/agent-framework';
 import { getPreset, listPresets, resolvePreset } from '@robota-sdk/agent-preset';
 
@@ -29,19 +30,47 @@ function formatUnknownPresetMessage(id: string): string {
   return `Unknown preset: ${id}. Available: ${ids}`;
 }
 
+/** The `/preset` (or `/preset list`) listing result. */
+function presetListResult(context: ICommandHostContext): ICommandResult {
+  const active = readActivePresetId(context);
+  return {
+    message: formatPresetList(active),
+    success: true,
+    data: { presets: listPresets(), active },
+  };
+}
+
+/**
+ * Ask the user to pick a preset (CMD-004 inline ask). Returns the chosen id, or `undefined` when no
+ * interactive renderer is attached or the user cancelled — the caller then shows the preset list.
+ */
+async function resolvePresetViaAsk(context: ICommandHostContext): Promise<string | undefined> {
+  const ui = context.getUserInteraction?.();
+  if (!ui) return undefined;
+  const options = listPresets().map((preset) => ({
+    value: preset.id,
+    label: preset.id,
+    description: preset.description,
+  }));
+  const response = await ui.ask(selectAction('preset', 'Select a preset', options));
+  return response.type === 'answer' ? response.values[0] : undefined;
+}
+
 export async function executePresetCommand(
   context: ICommandHostContext,
   args: string,
 ): Promise<ICommandResult> {
-  const id = args.trim().split(/\s+/)[0];
+  let id: string | undefined = args.trim().split(/\s+/)[0];
 
-  if (id === undefined || id.length === 0 || id === 'list') {
-    const active = readActivePresetId(context);
-    return {
-      message: formatPresetList(active),
-      success: true,
-      data: { presets: listPresets(), active },
-    };
+  if (id === 'list') {
+    return presetListResult(context);
+  }
+
+  if (id === undefined || id.length === 0) {
+    id = await resolvePresetViaAsk(context);
+    if (id === undefined) {
+      return presetListResult(context);
+    }
   }
 
   if (getPreset(id) === undefined) {


### PR DESCRIPTION
**CMD-004 Phase 1, PR-G** — migrates the two remaining single-select command pickers onto the unified ask seam (same template as PR-F's /mode). Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

## Changes
- `executePresetCommand` / `executeLanguageCommand`: with no arg, ask the user to pick via `context.getUserInteraction()?.ask(selectAction(...))`. Removed `interactionHints` from both modules.
- **Backward-compatible**: no renderer (`getUserInteraction` → undefined) or cancel → `/preset` shows its list, `/language` shows usage — unchanged. `/preset list` stays an explicit list. Both now show an interactive picker in the **TUI**.

## Verification
- preset 6/6 (4 existing + pick-switches + cancel-lists), language 4/4 (3 existing + pick-sets-effect).
- `agent-command` `tsc --noEmit` ✓; full suite **203/203**; `pnpm harness:scan` → 33/33 ✓.

Remaining: exit/clear (confirm — needs the headless "no human → proceed" semantics), provider (wizard), then delete the legacy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)