### PR TITLE
feat(agent-command): CMD-004 PR-H — migrate /exit and /clear to inline confirm

### DIFF
--- a/packages/agent-command/src/exit/__tests__/exit-command-module.test.ts
+++ b/packages/agent-command/src/exit/__tests__/exit-command-module.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
+import type { ICommandHostContext } from '@robota-sdk/agent-framework';
 import {
   ExitCommandSource,
   createExitCommandEntry,
   createExitCommandModule,
   executeExitCommand,
 } from '../index.js';
+
+function contextWithAnswer(value: string): ICommandHostContext {
+  return {
+    getUserInteraction: () => ({ ask: async () => ({ type: 'answer', values: [value] }) }),
+  } as unknown as ICommandHostContext;
+}
 
 describe('exit command module', () => {
   it('provides command metadata and executable registration from one module', () => {
@@ -23,13 +30,25 @@ describe('exit command module', () => {
     expect(module.commandSources?.flatMap((source) => source.getCommands())).toEqual([entry]);
   });
 
-  it('returns the session exit effect without owning process exit', () => {
-    const result = executeExitCommand({} as never, '');
+  it('proceeds to exit with no renderer attached (no human to confirm)', async () => {
+    const result = await executeExitCommand({} as never, '');
 
     expect(result).toEqual({
       success: true,
       message: 'Exit requested.',
       effects: [{ type: 'session-exit-requested' }],
     });
+  });
+
+  it('confirms before exiting and proceeds on yes (CMD-004)', async () => {
+    const result = await executeExitCommand(contextWithAnswer('yes'), '');
+    expect(result.effects).toEqual([{ type: 'session-exit-requested' }]);
+  });
+
+  it('cancels the exit when the user declines (CMD-004)', async () => {
+    const result = await executeExitCommand(contextWithAnswer('no'), '');
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Exit cancelled.');
+    expect(result.effects).toBeUndefined();
   });
 });

--- a/packages/agent-command/src/exit/exit-command-module.ts
+++ b/packages/agent-command/src/exit/exit-command-module.ts
@@ -3,11 +3,7 @@ import { EXIT_COMMAND_DESCRIPTION } from '@robota-sdk/agent-framework';
 import { executeExitCommand } from './exit-command.js';
 
 import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 
 export function createExitCommandEntry(): ICommand {
   return {
@@ -41,15 +37,10 @@ export class ExitCommandSource implements ICommandSource {
   }
 }
 
-const EXIT_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  exit: { type: 'confirm', message: 'Exit the session?' },
-};
-
 export function createExitCommandModule(): ICommandModule {
   return {
     name: 'agent-command-exit',
     commandSources: [new ExitCommandSource()],
     systemCommands: [createExitSystemCommand()],
-    interactionHints: EXIT_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/exit/exit-command.ts
+++ b/packages/agent-command/src/exit/exit-command.ts
@@ -1,9 +1,23 @@
+import { confirmAction, isConfirmed } from '@robota-sdk/agent-core';
 import { createSessionExitRequestedEffect } from '@robota-sdk/agent-framework';
 
 import type { ICommandHostContext } from '@robota-sdk/agent-framework';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-export function executeExitCommand(_context: ICommandHostContext, _args: string): ICommandResult {
+export async function executeExitCommand(
+  context: ICommandHostContext,
+  _args: string,
+): Promise<ICommandResult> {
+  // Confirm only when an interactive renderer is attached. With no human (headless/automation) the
+  // user explicitly invoked /exit, so proceed — the confirm is an interactive safety prompt, not a gate.
+  const ui = context.getUserInteraction?.();
+  if (ui) {
+    const response = await ui.ask(confirmAction('exit', 'Exit the session?'));
+    if (!isConfirmed(response)) {
+      return { success: true, message: 'Exit cancelled.' };
+    }
+  }
+
   return {
     success: true,
     message: 'Exit requested.',

--- a/packages/agent-command/src/session/__tests__/session-command-module.test.ts
+++ b/packages/agent-command/src/session/__tests__/session-command-module.test.ts
@@ -201,6 +201,44 @@ describe('createSessionCommandModule', () => {
     });
   });
 
+  it('CMD-004: confirms before clearing and proceeds on yes', async () => {
+    const clearConversationHistory = vi.fn();
+    const context = {
+      ...createCommandContext(),
+      clearConversationHistory,
+      getUserInteraction: () => ({
+        ask: async () => ({ type: 'answer' as const, values: ['yes'] }),
+      }),
+    };
+    const executor = new SystemCommandExecutor([
+      ...(createSessionCommandModule().systemCommands ?? []),
+    ]);
+
+    const result = await executor.execute('clear', context, '');
+
+    expect(clearConversationHistory).toHaveBeenCalledTimes(1);
+    expect(result?.effects).toEqual([{ type: 'conversation-history-cleared' }]);
+  });
+
+  it('CMD-004: cancels the clear when the user declines', async () => {
+    const clearConversationHistory = vi.fn();
+    const context = {
+      ...createCommandContext(),
+      clearConversationHistory,
+      getUserInteraction: () => ({
+        ask: async () => ({ type: 'answer' as const, values: ['no'] }),
+      }),
+    };
+    const executor = new SystemCommandExecutor([
+      ...(createSessionCommandModule().systemCommands ?? []),
+    ]);
+
+    const result = await executor.execute('clear', context, '');
+
+    expect(clearConversationHistory).not.toHaveBeenCalled();
+    expect(result?.message).toBe('Clear cancelled.');
+  });
+
   it('falls back to runtime clearHistory when the host has not implemented the richer API', async () => {
     const runtime = createRuntime();
     const context = {

--- a/packages/agent-command/src/session/session-command-module.ts
+++ b/packages/agent-command/src/session/session-command-module.ts
@@ -15,11 +15,7 @@ import {
 } from './session-command.js';
 
 import type { ICommandModule, ISystemCommand } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 
 export function createClearCommandEntry(): ICommand {
   return {
@@ -155,10 +151,6 @@ export class SessionCommandSource implements ICommandSource {
   }
 }
 
-const SESSION_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  clear: { type: 'confirm', message: 'Clear conversation history?' },
-};
-
 export function createSessionCommandModule(): ICommandModule {
   return {
     name: 'agent-command-session',
@@ -170,6 +162,5 @@ export function createSessionCommandModule(): ICommandModule {
       createCostSystemCommand(),
       createValidateSessionSystemCommand(),
     ],
-    interactionHints: SESSION_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/session/session-command.ts
+++ b/packages/agent-command/src/session/session-command.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { confirmAction, isConfirmed } from '@robota-sdk/agent-core';
 import {
   RENAME_COMMAND_USAGE,
   clearConversationHistory,
@@ -19,7 +20,19 @@ import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 export const CLEAR_COMMAND_MESSAGE = 'Conversation cleared.';
 
-export function executeClearCommand(context: ICommandHostContext, _args: string): ICommandResult {
+export async function executeClearCommand(
+  context: ICommandHostContext,
+  _args: string,
+): Promise<ICommandResult> {
+  // Confirm only when an interactive renderer is attached; with no human the explicit /clear proceeds.
+  const ui = context.getUserInteraction?.();
+  if (ui) {
+    const response = await ui.ask(confirmAction('clear', 'Clear conversation history?'));
+    if (!isConfirmed(response)) {
+      return { success: true, message: 'Clear cancelled.' };
+    }
+  }
+
   clearConversationHistory(context);
   return {
     success: true,

--- a/packages/agent-transport-tui/src/__tests__/pty/tui-pty.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/tui-pty.ptytest.ts
@@ -48,11 +48,15 @@ describe('TUI through a real PTY (CLI-074)', () => {
     expect(session.snapshot()).not.toContain('[Pasted text');
   }, 60_000);
 
-  it('TC-08: /exit reaches process exit within 10s', async () => {
+  it('TC-08: /exit confirms then reaches process exit within 10s', async () => {
     session = spawnTui({ projectDir, homeDir: join(projectDir, 'home') });
     await session.waitFor(/Type a message or \/help/);
 
     await session.sendKeys('/exit');
+    await session.pressEnter();
+
+    // CMD-004: /exit now asks for confirmation; answer Yes (the default-highlighted option).
+    await session.waitFor(/Exit the session\?/);
     await session.pressEnter();
 
     const exitCode = await session.expectExit(10_000);

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -91,8 +91,9 @@ export class HeadlessInteractionChannel {
       cwd: this.opts.cwd,
       provider: this.opts.provider,
       permissionMode: this.opts.permissionMode ?? 'bypassPermissions',
-      // CMD-004: headless has no interactive renderer — an ask resolves cancelled (never a silent guess).
-      askHandler: () => Promise.resolve({ type: 'cancelled' as const }),
+      // CMD-004: headless has no interactive renderer, so it injects no askHandler — the session's
+      // getUserInteraction() returns undefined and each command applies its explicit no-human path
+      // (e.g. /mode reports current, /exit and /clear proceed — never a silent guess).
       maxTurns: this.opts.maxTurns,
       sessionStore: this.opts.sessionStore,
       resumeSessionId: this.opts.resumeSessionId,


### PR DESCRIPTION
**CMD-004 Phase 1, PR-H** — migrates the two confirm commands onto the unified ask seam. Spec: `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md`.

## Changes
- `executeExitCommand` / `executeClearCommand` are now async: they confirm via `context.getUserInteraction()?.ask(confirmAction(...))` when a renderer is attached, replacing their `interactionHints` (removed from both modules).
- **Confirm semantics**: confirmed → proceed; declined → cancel; **no renderer (headless/automation) → proceed** — the user explicitly invoked `/exit`/`/clear`; the confirm is an interactive safety prompt, not a gate.
- `HeadlessInteractionChannel` no longer injects `askHandler`, so `getUserInteraction()` returns `undefined` in headless and each command takes its explicit no-human path (never a silent guess). This refines PR-E's headless choice (cancelled-port conflated "no human" with "user declined"). No behavior change for mode/preset/language (undefined → report/list/usage, same as before).
- So `/exit` and `/clear` gain a confirm dialog in the **TUI** (previously immediate).

## Verification
- exit 4/4 (no-renderer proceeds + confirm-yes + decline), session 30/30 (existing clear + confirm-yes + decline).
- `agent-command` `tsc --noEmit` ✓; full suite **207/207**; agent-transport 44/44; agent-cli scripted-e2e 12/12 (headless path); `pnpm harness:scan` → 33/33 ✓.

Remaining: provider (interactionHint + 13-site wizard), then delete legacy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)