### PR TITLE
feat(agent-command): migrate provider wizard to CMD-004 inline ask (PR-I)

### DIFF
--- a/packages/agent-command/src/provider/__tests__/org-policy.test.ts
+++ b/packages/agent-command/src/provider/__tests__/org-policy.test.ts
@@ -8,6 +8,7 @@ import type {
   TProviderSettingsDocument,
 } from '@robota-sdk/agent-framework';
 import { createProviderCommandModule } from '../provider-command-module.js';
+import { scriptedContext } from './scripted-interaction.js';
 
 const providerDefinitions: readonly IProviderDefinition[] = [
   {
@@ -62,7 +63,8 @@ function createExecutor(
   return new SystemCommandExecutor([...(module.systemCommands ?? [])]);
 }
 
-const session = {} as ICommandHostContext;
+/** Context with no interactive renderer attached (headless/automation). */
+const headlessContext = {} as ICommandHostContext;
 
 describe('org policy enforcement in provider commands', () => {
   afterEach(() => {
@@ -83,7 +85,7 @@ describe('org policy enforcement in provider commands', () => {
 
     const result = await createExecutor(adapter, orgPolicy).execute(
       'provider',
-      session,
+      headlessContext,
       'switch openai',
     );
 
@@ -105,7 +107,7 @@ describe('org policy enforcement in provider commands', () => {
 
     const result = await createExecutor(adapter, orgPolicy).execute(
       'provider',
-      session,
+      headlessContext,
       'switch openai',
     );
 
@@ -128,12 +130,14 @@ describe('org policy enforcement in provider commands', () => {
     });
     const orgPolicy: IOrgPolicy = { requireApiKeyFromEnv: true, adminContact: 'sec@example.com' };
 
-    const listed = await createExecutor(adapter, orgPolicy).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const editRequested = await selected?.interaction?.submit('edit');
     // Anthropic has 2 setup steps: apiKey then model
-    const modelPrompt = await editRequested?.interaction?.submit('sk-plaintext-key');
-    const completed = await modelPrompt?.interaction?.submit('claude-sonnet-4-6');
+    const { context } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['edit'] },
+      { type: 'answer', values: [], text: 'sk-plaintext-key' },
+      { type: 'answer', values: [], text: 'claude-sonnet-4-6' },
+    ]);
+    const completed = await createExecutor(adapter, orgPolicy).execute('provider', context, 'list');
 
     expect(completed?.success).toBe(false);
     expect(completed?.message).toContain('environment variable references');
@@ -154,11 +158,13 @@ describe('org policy enforcement in provider commands', () => {
     });
     const orgPolicy: IOrgPolicy = { requireApiKeyFromEnv: true };
 
-    const listed = await createExecutor(adapter, orgPolicy).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const editRequested = await selected?.interaction?.submit('edit');
-    const modelPrompt = await editRequested?.interaction?.submit('$ENV:ORG_TEST_KEY');
-    const completed = await modelPrompt?.interaction?.submit('claude-opus-4-5');
+    const { context } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['edit'] },
+      { type: 'answer', values: [], text: '$ENV:ORG_TEST_KEY' },
+      { type: 'answer', values: [], text: 'claude-opus-4-5' },
+    ]);
+    const completed = await createExecutor(adapter, orgPolicy).execute('provider', context, 'list');
 
     expect(completed?.success).toBe(true);
   });

--- a/packages/agent-command/src/provider/__tests__/provider-command-module.test.ts
+++ b/packages/agent-command/src/provider/__tests__/provider-command-module.test.ts
@@ -7,6 +7,7 @@ import type {
   TProviderSettingsDocument,
 } from '@robota-sdk/agent-framework';
 import { createProviderCommandModule } from '../provider-command-module.js';
+import { scriptedContext } from './scripted-interaction.js';
 
 const providerDefinitions: readonly IProviderDefinition[] = [
   {
@@ -93,7 +94,8 @@ function createExecutor(adapter: IProviderCommandSettingsAdapter): SystemCommand
   return new SystemCommandExecutor([...(module.systemCommands ?? [])]);
 }
 
-const session = {} as ICommandHostContext;
+/** Context with no interactive renderer attached (headless/automation). */
+const headlessContext = {} as ICommandHostContext;
 
 describe('createProviderCommandModule', () => {
   it('contributes /provider metadata and executable command from the provider package', () => {
@@ -107,7 +109,7 @@ describe('createProviderCommandModule', () => {
     expect(module.systemCommands?.map((command) => command.name)).toEqual(['provider']);
   });
 
-  it('lists provider profiles from injected merged settings', async () => {
+  it('asks the user to pick a provider profile from injected merged settings', async () => {
     const { adapter } = createSettingsAdapter({
       currentProvider: 'openai',
       providers: {
@@ -116,18 +118,37 @@ describe('createProviderCommandModule', () => {
       },
     });
 
-    const result = await createExecutor(adapter).execute('provider', session, 'list');
+    const { context, requests } = scriptedContext([{ type: 'cancelled' }]);
+    const result = await createExecutor(adapter).execute('provider', context, 'list');
+
+    expect(result?.success).toBe(true);
+    const picker = requests[0];
+    expect(picker?.title).toBe('Select provider profile');
+    expect(picker?.options?.map((option) => option.label)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('* openai'),
+        expect.stringContaining('anthropic'),
+      ]),
+    );
+  });
+
+  it('returns a plain text list when no interactive renderer is attached', async () => {
+    const { adapter } = createSettingsAdapter({
+      currentProvider: 'openai',
+      providers: {
+        openai: { type: 'openai', model: 'supergemma4-26b-uncensored-v2' },
+        anthropic: { type: 'anthropic', model: 'claude-sonnet-4-6' },
+      },
+    });
+
+    const result = await createExecutor(adapter).execute('provider', headlessContext, 'list');
 
     expect(result?.success).toBe(true);
     expect(result?.message).toContain('* openai');
     expect(result?.message).toContain('anthropic');
-    expect(result?.interaction?.prompt).toMatchObject({
-      kind: 'choice',
-      title: 'Select provider profile',
-    });
   });
 
-  it('opens a provider profile picker from /provider without CLI-owned routing', async () => {
+  it('opens a provider profile action menu from /provider after picking a profile', async () => {
     const { adapter } = createSettingsAdapter({
       currentProvider: 'openai',
       providers: {
@@ -136,14 +157,15 @@ describe('createProviderCommandModule', () => {
       },
     });
 
-    const result = await createExecutor(adapter).execute('provider', session, '');
-    const selected = await result?.interaction?.submit('anthropic');
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'cancelled' },
+    ]);
+    const result = await createExecutor(adapter).execute('provider', context, '');
 
-    expect(result?.message).toContain('* openai');
-    expect(selected?.interaction?.prompt).toMatchObject({
-      kind: 'choice',
-      title: 'Provider profile: anthropic',
-    });
+    expect(result?.success).toBe(true);
+    expect(requests[0]?.title).toBe('Select provider profile');
+    expect(requests[1]?.title).toBe('Provider profile: anthropic');
   });
 
   it('switches provider immediately via /provider switch without confirmation dialog', async () => {
@@ -158,9 +180,12 @@ describe('createProviderCommandModule', () => {
       {},
     );
 
-    const result = await createExecutor(adapter).execute('provider', session, 'switch openai');
+    const result = await createExecutor(adapter).execute(
+      'provider',
+      headlessContext,
+      'switch openai',
+    );
 
-    expect(result?.interaction).toBeUndefined();
     expect(result?.message).toBe(
       'Switched to openai (supergemma4-26b-uncensored-v2). History preserved.',
     );
@@ -182,16 +207,17 @@ describe('createProviderCommandModule', () => {
       {},
     );
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('openai');
-    const switchRequested = await selected?.interaction?.submit('switch');
+    const { context } = scriptedContext([
+      { type: 'answer', values: ['openai'] },
+      { type: 'answer', values: ['switch'] },
+    ]);
+    const result = await createExecutor(adapter).execute('provider', context, 'list');
 
-    expect(switchRequested?.message).toBe(
+    expect(result?.message).toBe(
       'Switched to openai (supergemma4-26b-uncensored-v2). History preserved.',
     );
-    expect(switchRequested?.interaction).toBeUndefined();
     expect(readTarget().currentProvider).toBe('openai');
-    expect(switchRequested?.effects).toEqual([
+    expect(result?.effects).toEqual([
       { type: 'provider-hot-swap-requested', profileName: 'openai' },
     ]);
   });
@@ -211,19 +237,19 @@ describe('createProviderCommandModule', () => {
       {},
     );
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const editRequested = await selected?.interaction?.submit('edit');
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['edit'] },
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: 'claude-opus-4-5' },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
-    expect(editRequested?.interaction?.prompt).toMatchObject({
-      kind: 'text',
-      title: 'anthropic API key',
-      placeholder: '(unchanged)',
-      masked: true,
-    });
-
-    const modelPrompt = await editRequested?.interaction?.submit('');
-    const completed = await modelPrompt?.interaction?.submit('claude-opus-4-5');
+    const apiKeyRequest = requests[2];
+    expect(apiKeyRequest?.title).toBe('anthropic API key');
+    expect(apiKeyRequest?.allowFreeText).toBe(true);
+    expect(apiKeyRequest?.placeholder).toBe('(unchanged)');
+    expect(apiKeyRequest?.masked).toBe(true);
 
     expect(readTarget()).toMatchObject({
       providers: {
@@ -252,16 +278,15 @@ describe('createProviderCommandModule', () => {
       },
     });
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('openai');
-    const duplicateRequested = await selected?.interaction?.submit('duplicate');
-    const completed = await duplicateRequested?.interaction?.submit('');
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: ['openai'] },
+      { type: 'answer', values: ['duplicate'] },
+      { type: 'answer', values: [], text: '' },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
-    expect(duplicateRequested?.interaction?.prompt).toMatchObject({
-      kind: 'text',
-      title: 'Duplicate openai as',
-      placeholder: 'openai-copy',
-    });
+    expect(requests[2]?.title).toBe('Duplicate openai as');
+    expect(requests[2]?.placeholder).toBe('openai-copy');
     expect(readTarget()).toMatchObject({
       providers: {
         'openai-copy': {
@@ -292,10 +317,12 @@ describe('createProviderCommandModule', () => {
       },
     );
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const deleteRequested = await selected?.interaction?.submit('delete');
-    const completed = await deleteRequested?.interaction?.submit('yes');
+    const { context } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['delete'] },
+      { type: 'answer', values: ['yes'] },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
     expect(completed?.message).toBe('Provider profile deleted: anthropic.');
     expect(readTarget()).toEqual({
@@ -324,16 +351,15 @@ describe('createProviderCommandModule', () => {
       },
     );
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const deleteRequested = await selected?.interaction?.submit('delete');
-    const replacementPrompt = await deleteRequested?.interaction?.submit('yes');
-    const completed = await replacementPrompt?.interaction?.submit('openai');
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['delete'] },
+      { type: 'answer', values: ['yes'] },
+      { type: 'answer', values: ['openai'] },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
-    expect(replacementPrompt?.interaction?.prompt).toMatchObject({
-      kind: 'choice',
-      title: 'Replacement provider for anthropic',
-    });
+    expect(requests[3]?.title).toBe('Replacement provider for anthropic');
     expect(readTarget()).toEqual({
       currentProvider: 'openai',
       providers: {
@@ -361,30 +387,32 @@ describe('createProviderCommandModule', () => {
       {},
     );
 
-    const listed = await createExecutor(adapter).execute('provider', session, 'list');
-    const selected = await listed?.interaction?.submit('anthropic');
-    const deleteRequested = await selected?.interaction?.submit('delete');
+    const { context } = scriptedContext([
+      { type: 'answer', values: ['anthropic'] },
+      { type: 'answer', values: ['delete'] },
+    ]);
+    const result = await createExecutor(adapter).execute('provider', context, 'list');
 
-    expect(deleteRequested?.success).toBe(false);
-    expect(deleteRequested?.message).toContain('not stored in the active write target');
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('not stored in the active write target');
   });
 
   it('owns provider setup flow and writes settings after generic prompt submissions', async () => {
     const { adapter, readTarget } = createSettingsAdapter({}, {});
-    const first = await createExecutor(adapter).execute('provider', session, 'add openai');
 
-    expect(first?.interaction?.prompt).toMatchObject({
-      kind: 'text',
-      title: 'OpenAI-compatible base URL',
-      description:
-        '  Setup help: Official: OpenAI-compatible local server docs - https://lmstudio.ai/docs/developer',
-      placeholder: 'http://localhost:1234/v1',
-      allowEmpty: true,
-    });
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'add openai');
 
-    const second = await first?.interaction?.submit('');
-    const third = await second?.interaction?.submit('');
-    const completed = await third?.interaction?.submit('');
+    expect(requests[0]?.title).toBe('OpenAI-compatible base URL');
+    expect(requests[0]?.description).toBe(
+      '  Setup help: Official: OpenAI-compatible local server docs - https://lmstudio.ai/docs/developer',
+    );
+    expect(requests[0]?.placeholder).toBe('http://localhost:1234/v1');
+    expect(requests[0]?.allowEmpty).toBe(true);
 
     expect(readTarget()).toMatchObject({
       currentProvider: 'openai',
@@ -406,6 +434,35 @@ describe('createProviderCommandModule', () => {
     ]);
   });
 
+  it('asks the user to pick a provider type when /provider add is called without one', async () => {
+    const { adapter, readTarget } = createSettingsAdapter({}, {});
+
+    const { context, requests } = scriptedContext([
+      { type: 'answer', values: ['openai'] },
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+    ]);
+    const completed = await createExecutor(adapter).execute('provider', context, 'add');
+
+    expect(requests[0]?.title).toBe('Select provider');
+    expect(requests[0]?.options?.map((option) => option.value)).toEqual(['openai', 'anthropic']);
+    expect(readTarget()).toMatchObject({
+      currentProvider: 'openai',
+      providers: { openai: { type: 'openai' } },
+    });
+    expect(completed?.success).toBe(true);
+  });
+
+  it('reports usage for /provider add without a type when no renderer is attached', async () => {
+    const { adapter } = createSettingsAdapter({}, {});
+
+    const result = await createExecutor(adapter).execute('provider', headlessContext, 'add');
+
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain('Usage: provider add <type>');
+  });
+
   it('creates another profile when provider type already exists', async () => {
     const { adapter, readTarget } = createSettingsAdapter(
       {
@@ -421,11 +478,13 @@ describe('createProviderCommandModule', () => {
       },
       {},
     );
-    const first = await createExecutor(adapter).execute('provider', session, 'add openai');
-    const second = await first?.interaction?.submit('');
-    const third = await second?.interaction?.submit('');
 
-    await third?.interaction?.submit('');
+    const { context } = scriptedContext([
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+      { type: 'answer', values: [], text: '' },
+    ]);
+    await createExecutor(adapter).execute('provider', context, 'add openai');
 
     expect(readTarget()).toMatchObject({
       currentProvider: 'openai-2',
@@ -465,7 +524,7 @@ describe('createProviderCommandModule', () => {
     });
     const result = await new SystemCommandExecutor([...(module.systemCommands ?? [])]).execute(
       'provider',
-      session,
+      headlessContext,
       'test openai',
     );
 

--- a/packages/agent-command/src/provider/__tests__/provider-command-module.test.ts
+++ b/packages/agent-command/src/provider/__tests__/provider-command-module.test.ts
@@ -317,13 +317,16 @@ describe('createProviderCommandModule', () => {
       },
     );
 
-    const { context } = scriptedContext([
+    const { context, requests } = scriptedContext([
       { type: 'answer', values: ['anthropic'] },
       { type: 'answer', values: ['delete'] },
       { type: 'answer', values: ['yes'] },
     ]);
     const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
+    // The confirm prompt must actually be issued — guards against a silent drop of the
+    // confirmation step that would still "delete and pass".
+    expect(requests[2]?.title).toBe('Delete provider profile anthropic?');
     expect(completed?.message).toBe('Provider profile deleted: anthropic.');
     expect(readTarget()).toEqual({
       currentProvider: 'openai',
@@ -359,6 +362,8 @@ describe('createProviderCommandModule', () => {
     ]);
     const completed = await createExecutor(adapter).execute('provider', context, 'list');
 
+    // The confirm precedes the replacement picker — assert both so neither step can be dropped silently.
+    expect(requests[2]?.title).toBe('Delete provider profile anthropic?');
     expect(requests[3]?.title).toBe('Replacement provider for anthropic');
     expect(readTarget()).toEqual({
       currentProvider: 'openai',
@@ -413,6 +418,13 @@ describe('createProviderCommandModule', () => {
     );
     expect(requests[0]?.placeholder).toBe('http://localhost:1234/v1');
     expect(requests[0]?.allowEmpty).toBe(true);
+    // All three setup steps must be asked in order — a dropped step would otherwise be hidden by the
+    // scripted double returning the surplus answers to whatever remains.
+    expect(requests.map((request) => request.title)).toEqual([
+      'OpenAI-compatible base URL',
+      'OpenAI-compatible model',
+      'OpenAI-compatible API key',
+    ]);
 
     expect(readTarget()).toMatchObject({
       currentProvider: 'openai',

--- a/packages/agent-command/src/provider/__tests__/scripted-interaction.ts
+++ b/packages/agent-command/src/provider/__tests__/scripted-interaction.ts
@@ -1,0 +1,28 @@
+import type { IActionRequest, IUserInteraction, TActionResponse } from '@robota-sdk/agent-core';
+import type { ICommandHostContext } from '@robota-sdk/agent-framework';
+
+/**
+ * Build a command host context whose `getUserInteraction().ask` replays a scripted sequence of
+ * responses (CMD-004 test double). Each `ask` records the request it received (so tests can assert on
+ * the rendered action shape) and returns the next scripted answer; once the script is exhausted it
+ * returns `{ type: 'cancelled' }`, mirroring a user dismissing the prompt.
+ */
+export function scriptedContext(answers: readonly TActionResponse[]): {
+  context: ICommandHostContext;
+  requests: IActionRequest[];
+} {
+  const requests: IActionRequest[] = [];
+  let index = 0;
+  const ui: IUserInteraction = {
+    ask: (request) => {
+      requests.push(request);
+      const answer = answers[index];
+      index += 1;
+      return Promise.resolve(answer ?? { type: 'cancelled' });
+    },
+  };
+  const context = {
+    getUserInteraction: () => ui,
+  } as Partial<ICommandHostContext> as ICommandHostContext;
+  return { context, requests };
+}

--- a/packages/agent-command/src/provider/provider-command-execution.ts
+++ b/packages/agent-command/src/provider/provider-command-execution.ts
@@ -1,30 +1,38 @@
-import { findProviderDefinition, formatSupportedProviderTypes } from '@robota-sdk/agent-core';
+import {
+  findProviderDefinition,
+  formatSupportedProviderTypes,
+  selectAction,
+} from '@robota-sdk/agent-core';
 import { testProviderProfileCommand } from '@robota-sdk/agent-framework';
 
 import { buildProviderSwitch } from './provider-command-profile-operations.js';
-import { createProviderProfileSelectionInteraction } from './provider-command-profile.js';
-import { createSetupFlow, createProviderSetupInteraction } from './provider-command-setup.js';
+import { askProviderProfileSelection } from './provider-command-profile.js';
+import { createSetupFlow, runProviderAddSetup } from './provider-command-setup.js';
 import { formatProviderSetupChoiceLabel } from './provider-setup-flow.js';
 
+import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type {
+  ICommandHostContext,
   IProviderCommandModuleOptions,
   IProviderProfileSettings,
 } from '@robota-sdk/agent-framework';
-import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 export async function executeProviderCommand(
+  context: ICommandHostContext,
   args: string,
   options: IProviderCommandModuleOptions,
 ): Promise<ICommandResult> {
+  const ui = context.getUserInteraction?.();
   const settings = options.settings.readMergedSettings();
   const trimmedArgs = args.trim();
   if (trimmedArgs.length === 0) {
-    return buildProviderProfilePicker(settings.currentProvider, settings.providers, options);
+    return buildProviderProfilePicker(ui, settings.currentProvider, settings.providers, options);
   }
   const [subcommand = 'current', profileArg] = trimmedArgs.split(/\s+/);
 
   if (subcommand === 'list') {
-    return buildProviderProfilePicker(settings.currentProvider, settings.providers, options);
+    return buildProviderProfilePicker(ui, settings.currentProvider, settings.providers, options);
   }
   if (subcommand === 'current' || subcommand === '') {
     return {
@@ -36,7 +44,7 @@ export async function executeProviderCommand(
     return buildProviderSwitch(settings.providers, profileArg, options);
   }
   if (subcommand === 'test') {
-    return await testProviderProfileCommand(
+    return testProviderProfileCommand(
       settings.currentProvider,
       settings.providers,
       profileArg,
@@ -44,7 +52,7 @@ export async function executeProviderCommand(
     );
   }
   if (subcommand === 'add') {
-    return buildProviderSetup(profileArg, options);
+    return buildProviderSetup(ui, profileArg, options);
   }
 
   return {
@@ -53,20 +61,20 @@ export async function executeProviderCommand(
   };
 }
 
+/**
+ * List the provider profiles. With an interactive renderer attached, drive the inline profile picker
+ * (CMD-004); without one (headless/automation) or with no profiles, return the formatted list as text.
+ */
 function buildProviderProfilePicker(
+  ui: IUserInteraction | undefined,
   currentProvider: string | undefined,
   providers: Record<string, IProviderProfileSettings> | undefined,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
-  const message = formatProviderList(currentProvider, providers);
-  if (Object.keys(providers ?? {}).length === 0) {
-    return { message, success: true };
+): Promise<ICommandResult> | ICommandResult {
+  if (!ui || Object.keys(providers ?? {}).length === 0) {
+    return { message: formatProviderList(currentProvider, providers), success: true };
   }
-  return {
-    message,
-    success: true,
-    interaction: createProviderProfileSelectionInteraction(currentProvider, providers, options),
-  };
+  return askProviderProfileSelection(ui, currentProvider, providers, options);
 }
 
 function formatProviderList(
@@ -104,16 +112,24 @@ function formatCurrentProvider(
   ].join('\n');
 }
 
+/**
+ * Configure a provider profile. With an explicit `type`, run the setup wizard directly; without one,
+ * ask the user to pick a provider type first (CMD-004). Without an interactive renderer, setup cannot
+ * proceed — return usage text instead of a silent guess.
+ */
 function buildProviderSetup(
+  ui: IUserInteraction | undefined,
   type: string | undefined,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> | ICommandResult {
   if (type === undefined || type.length === 0) {
-    return {
-      message: 'Provider setup requested. Select a provider to continue.',
-      success: true,
-      interaction: createProviderSelectionInteraction(options),
-    };
+    if (!ui) {
+      return {
+        message: `Usage: provider add <type>. Supported: ${formatSupportedProviderTypes(options.providerDefinitions)}`,
+        success: false,
+      };
+    }
+    return askProviderSetupType(ui, options);
   }
   if (findProviderDefinition(options.providerDefinitions, type) === undefined) {
     return {
@@ -121,34 +137,35 @@ function buildProviderSetup(
       success: false,
     };
   }
-  return {
-    message: `Provider setup requested: ${type}`,
-    success: true,
-    interaction: createProviderSetupInteraction(createSetupFlow(type, options), options),
-  };
+  if (!ui) {
+    return {
+      message: `Provider setup for "${type}" requires an interactive session.`,
+      success: false,
+    };
+  }
+  return runProviderAddSetup(ui, createSetupFlow(type, options), options);
 }
 
-function createProviderSelectionInteraction(
+async function askProviderSetupType(
+  ui: IUserInteraction,
   options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: {
-      kind: 'choice' as const,
-      title: 'Select provider',
-      options: options.providerDefinitions.map((definition) => ({
-        value: definition.type,
-        label: formatProviderSetupChoiceLabel(definition),
-      })),
-      maxVisible: 6,
-    },
-    submit: (value: string) => {
-      const flow = createSetupFlow(value, options);
-      return {
-        message: `Provider setup requested: ${value}`,
-        success: true,
-        interaction: createProviderSetupInteraction(flow, options),
-      };
-    },
-    cancel: () => ({ message: 'Provider setup cancelled.', success: true }),
-  };
+): Promise<ICommandResult> {
+  const typeOptions = options.providerDefinitions.map((definition) => ({
+    value: definition.type,
+    label: formatProviderSetupChoiceLabel(definition),
+  }));
+  const response = await ui.ask(
+    selectAction('provider-type', 'Select provider', typeOptions, { maxVisible: 6 }),
+  );
+  if (response.type !== 'answer' || response.values[0] === undefined) {
+    return { message: 'Provider setup cancelled.', success: true };
+  }
+  const type = response.values[0];
+  if (findProviderDefinition(options.providerDefinitions, type) === undefined) {
+    return {
+      message: `Usage: provider add <type>. Supported: ${formatSupportedProviderTypes(options.providerDefinitions)}`,
+      success: false,
+    };
+  }
+  return runProviderAddSetup(ui, createSetupFlow(type, options), options);
 }

--- a/packages/agent-command/src/provider/provider-command-module.ts
+++ b/packages/agent-command/src/provider/provider-command-module.ts
@@ -6,11 +6,7 @@ import type {
   IProviderCommandSettingsAdapter,
   ISystemCommand as TSystemCommand,
 } from '@robota-sdk/agent-framework';
-import type {
-  ICommand,
-  TCommandInteractionHint,
-  ICommandSource,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommand, ICommandSource } from '@robota-sdk/agent-interface-transport';
 export type { IProviderCommandModuleOptions, IProviderCommandSettingsAdapter };
 
 function buildProviderSubcommands(): ICommand[] {
@@ -56,21 +52,10 @@ function createProviderSystemCommand(options: IProviderCommandModuleOptions): TS
     modelInvocable: false,
     argumentHint: entry.argumentHint,
     subcommands: entry.subcommands,
-    execute: async (_session, args) => executeProviderCommand(args, options),
+    lifecycle: 'inline',
+    execute: (context, args) => executeProviderCommand(context, args, options),
   };
 }
-
-const PROVIDER_INTERACTION_HINTS: Record<string, TCommandInteractionHint> = {
-  provider: {
-    type: 'pick',
-    getItems: () =>
-      buildProviderSubcommands().map((sub) => ({
-        label: sub.name,
-        value: sub.name,
-        description: sub.description,
-      })),
-  },
-};
 
 export function createProviderCommandModule(
   options: IProviderCommandModuleOptions,
@@ -79,6 +64,5 @@ export function createProviderCommandModule(
     name: 'agent-command-provider',
     commandSources: [new ProviderCommandSource()],
     systemCommands: [createProviderSystemCommand(options)],
-    interactionHints: PROVIDER_INTERACTION_HINTS,
   };
 }

--- a/packages/agent-command/src/provider/provider-command-profile-lifecycle.ts
+++ b/packages/agent-command/src/provider/provider-command-profile-lifecycle.ts
@@ -1,3 +1,4 @@
+import { confirmAction, isConfirmed, selectAction, textAction } from '@robota-sdk/agent-core';
 import {
   deleteProviderProfile,
   sanitizeProviderProfileName,
@@ -6,48 +7,47 @@ import {
 
 import { formatProviderChoiceLabel } from './provider-command-profile-operations.js';
 
+import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type { IProviderCommandModuleOptions } from '@robota-sdk/agent-framework';
-import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-const YES = 'yes';
 const MAX_DUPLICATE_PROFILE_SUFFIX = 1000;
 const PROVIDER_RESTART_EFFECT = {
   type: 'session-restart-requested',
   reason: 'other',
 } as const;
 
-export function buildProviderDuplicate(
+export async function buildProviderDuplicate(
+  ui: IUserInteraction,
   profileName: string,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> {
   const settings = options.settings.readMergedSettings();
   if (!settings.providers?.[profileName]) {
     return { message: `Provider profile "${profileName}" was not found.`, success: false };
   }
   const defaultName = suggestDuplicateProfileName(profileName, Object.keys(settings.providers));
-  return {
-    message: `Provider duplicate requested: ${profileName}`,
-    success: true,
-    interaction: createProviderDuplicateInteraction(profileName, defaultName, options),
-  };
-}
-
-function createProviderDuplicateInteraction(
-  profileName: string,
-  defaultName: string,
-  options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: {
-      kind: 'text',
-      title: `Duplicate ${profileName} as`,
-      placeholder: defaultName,
-      allowEmpty: true,
-      validate: (value) => validateDuplicateProfileName(value, defaultName, options),
-    },
-    submit: (value) => completeProviderDuplicate(profileName, value, defaultName, options),
-    cancel: () => ({ message: 'Provider duplicate cancelled.', success: true }),
-  };
+  let errorMessage: string | undefined;
+  for (;;) {
+    const response = await ui.ask(
+      textAction('provider-duplicate', `Duplicate ${profileName} as`, {
+        description: errorMessage,
+        placeholder: defaultName,
+        allowEmpty: true,
+      }),
+    );
+    if (response.type === 'cancelled') {
+      return { message: 'Provider duplicate cancelled.', success: true };
+    }
+    const value = response.text ?? '';
+    // Re-ask on validation failure, surfacing the reason (CMD-004 re-ask loop replaces the closure).
+    const validationMessage = validateDuplicateProfileName(value, defaultName, options);
+    if (validationMessage !== undefined) {
+      errorMessage = validationMessage;
+      continue;
+    }
+    return completeProviderDuplicate(profileName, value, defaultName, options);
+  }
 }
 
 function validateDuplicateProfileName(
@@ -90,10 +90,11 @@ function completeProviderDuplicate(
   };
 }
 
-export function buildProviderDelete(
+export async function buildProviderDelete(
+  ui: IUserInteraction,
   profileName: string,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> {
   const settings = options.settings.readMergedSettings();
   const providers = settings.providers ?? {};
   if (!providers[profileName]) {
@@ -108,40 +109,20 @@ export function buildProviderDelete(
       success: false,
     };
   }
-  return {
-    message: `Provider delete requested: ${profileName}`,
-    success: true,
-    interaction: createProviderDeleteConfirmationInteraction(profileName, options),
-  };
+  const response = await ui.ask(
+    confirmAction('provider-delete', `Delete provider profile ${profileName}?`),
+  );
+  if (!isConfirmed(response)) {
+    return { message: 'Provider delete cancelled.', success: true };
+  }
+  return confirmProviderDelete(ui, profileName, options);
 }
 
-function createProviderDeleteConfirmationInteraction(
+async function confirmProviderDelete(
+  ui: IUserInteraction,
   profileName: string,
   options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: {
-      kind: 'choice',
-      title: `Delete provider profile ${profileName}?`,
-      options: [
-        { value: YES, label: 'Yes' },
-        { value: 'no', label: 'No' },
-      ],
-    },
-    submit: (value) => {
-      if (value !== YES) {
-        return { message: 'Provider delete cancelled.', success: true };
-      }
-      return confirmProviderDelete(profileName, options);
-    },
-    cancel: () => ({ message: 'Provider delete cancelled.', success: true }),
-  };
-}
-
-function confirmProviderDelete(
-  profileName: string,
-  options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> {
   const settings = options.settings.readMergedSettings();
   if (settings.currentProvider !== profileName) {
     options.settings.writeTargetSettings(
@@ -155,21 +136,20 @@ function confirmProviderDelete(
       value: name,
       label: formatProviderChoiceLabel(name, profile, settings.currentProvider),
     }));
-  return {
-    message: `Select a replacement provider before deleting ${profileName}.`,
-    success: true,
-    interaction: {
-      prompt: {
-        kind: 'choice',
-        title: `Replacement provider for ${profileName}`,
-        options: replacementOptions,
+  const response = await ui.ask(
+    selectAction(
+      'provider-delete-replacement',
+      `Replacement provider for ${profileName}`,
+      replacementOptions,
+      {
         maxVisible: 8,
       },
-      submit: (replacementName) =>
-        completeActiveProviderDelete(profileName, replacementName, options),
-      cancel: () => ({ message: 'Provider delete cancelled.', success: true }),
-    },
-  };
+    ),
+  );
+  if (response.type !== 'answer' || response.values[0] === undefined) {
+    return { message: 'Provider delete cancelled.', success: true };
+  }
+  return completeActiveProviderDelete(profileName, response.values[0], options);
 }
 
 function completeActiveProviderDelete(

--- a/packages/agent-command/src/provider/provider-command-profile-operations.ts
+++ b/packages/agent-command/src/provider/provider-command-profile-operations.ts
@@ -6,19 +6,16 @@ import {
   upsertProviderProfile,
 } from '@robota-sdk/agent-framework';
 
-import {
-  createProviderSetupInteraction,
-  toProviderSetupStepPrompt,
-} from './provider-command-setup.js';
-import { createProviderSetupFlow, submitProviderSetupValue } from './provider-setup-flow.js';
+import { runProviderSetupAsk } from './provider-command-setup.js';
+import { createProviderSetupFlow } from './provider-setup-flow.js';
 
-import type { IProviderSetupFlowState } from './provider-setup-flow.js';
+import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type {
   IProviderCommandModuleOptions,
   IProviderProfileSettings,
   IProviderSetupInput,
 } from '@robota-sdk/agent-framework';
-import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 export function formatProviderChoiceLabel(
   name: string,
@@ -69,10 +66,11 @@ export function buildProviderSwitch(
   };
 }
 
-export function buildProviderEdit(
+export async function buildProviderEdit(
+  ui: IUserInteraction,
   profileName: string,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> {
   const settings = options.settings.readMergedSettings();
   const profile = settings.providers?.[profileName];
   if (!profile) {
@@ -81,20 +79,22 @@ export function buildProviderEdit(
   if (!profile.type) {
     return { message: `Provider profile "${profileName}" is missing type.`, success: false };
   }
+  let flow;
   try {
-    const flow = createProviderSetupFlow(profile.type, options.providerDefinitions, {
+    flow = createProviderSetupFlow(profile.type, options.providerDefinitions, {
       profileName,
       setCurrent: false,
       initialValues: getProviderProfileSetupValues(profile),
     });
-    return {
-      message: `Provider edit requested: ${profileName}`,
-      success: true,
-      interaction: createProviderEditInteraction(flow, profileName, options),
-    };
   } catch (error) {
     return { message: error instanceof Error ? error.message : String(error), success: false };
   }
+  return runProviderSetupAsk(
+    ui,
+    flow,
+    (input) => completeProviderEdit(input, profileName, options),
+    'Provider edit cancelled.',
+  );
 }
 
 function getProviderProfileSetupValues(profile: IProviderProfileSettings): {
@@ -106,42 +106,6 @@ function getProviderProfileSetupValues(profile: IProviderProfileSettings): {
     ...(typeof profile.model === 'string' ? { model: profile.model } : {}),
     ...(typeof profile.apiKey === 'string' ? { apiKey: profile.apiKey } : {}),
     ...(typeof profile.baseURL === 'string' ? { baseURL: profile.baseURL } : {}),
-  };
-}
-
-function createProviderEditInteraction(
-  flow: IProviderSetupFlowState,
-  profileName: string,
-  options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: toProviderSetupStepPrompt(flow),
-    submit: (value) => submitProviderEditInteractionValue(flow, profileName, value, options),
-    cancel: () => ({ message: 'Provider edit cancelled.', success: true }),
-  };
-}
-
-function submitProviderEditInteractionValue(
-  flow: IProviderSetupFlowState,
-  profileName: string,
-  value: string,
-  options: IProviderCommandModuleOptions,
-): ICommandResult {
-  const result = submitProviderSetupValue(flow, value);
-  if (result.status === 'error') {
-    return {
-      message: result.message,
-      success: false,
-      interaction: createProviderEditInteraction(flow, profileName, options),
-    };
-  }
-  if (result.status === 'complete') {
-    return completeProviderEdit(result.input, profileName, options);
-  }
-  return {
-    message: '',
-    success: true,
-    interaction: createProviderEditInteraction(result.state, profileName, options),
   };
 }
 

--- a/packages/agent-command/src/provider/provider-command-profile.ts
+++ b/packages/agent-command/src/provider/provider-command-profile.ts
@@ -1,3 +1,4 @@
+import { selectAction } from '@robota-sdk/agent-core';
 import { testProviderProfileCommand } from '@robota-sdk/agent-framework';
 
 import {
@@ -10,11 +11,12 @@ import {
   formatProviderChoiceLabel,
 } from './provider-command-profile-operations.js';
 
+import type { IUserInteraction } from '@robota-sdk/agent-core';
 import type {
   IProviderCommandModuleOptions,
   IProviderProfileSettings,
 } from '@robota-sdk/agent-framework';
-import type { ICommandInteraction, ICommandResult } from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 const ACTION_SWITCH = 'switch';
 const ACTION_EDIT = 'edit';
@@ -23,64 +25,57 @@ const ACTION_DUPLICATE = 'duplicate';
 const ACTION_DELETE = 'delete';
 const ACTION_CANCEL = 'cancel';
 
-export function createProviderProfileSelectionInteraction(
+/**
+ * Ask the user to pick a provider profile, then drive its action menu (CMD-004 inline ask). Replaces
+ * the legacy `ICommandInteraction` choice→submit continuation chain — the picker's own option list is
+ * the rendered profile list, so the caller no longer prepends a separate list message.
+ */
+export async function askProviderProfileSelection(
+  ui: IUserInteraction,
   currentProvider: string | undefined,
   providers: Record<string, IProviderProfileSettings> | undefined,
   options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: {
-      kind: 'choice',
-      title: 'Select provider profile',
-      options: Object.entries(providers ?? {}).map(([name, profile]) => ({
-        value: name,
-        label: formatProviderChoiceLabel(name, profile, currentProvider),
-      })),
-      maxVisible: 8,
-    },
-    submit: (value) => buildProviderProfileActionMenu(value, options),
-    cancel: () => ({ message: 'Provider profile selection cancelled.', success: true }),
-  };
+): Promise<ICommandResult> {
+  const profileOptions = Object.entries(providers ?? {}).map(([name, profile]) => ({
+    value: name,
+    label: formatProviderChoiceLabel(name, profile, currentProvider),
+  }));
+  const response = await ui.ask(
+    selectAction('provider-profile', 'Select provider profile', profileOptions, { maxVisible: 8 }),
+  );
+  if (response.type !== 'answer' || response.values[0] === undefined) {
+    return { message: 'Provider profile selection cancelled.', success: true };
+  }
+  return askProviderProfileAction(ui, response.values[0], options);
 }
 
-function buildProviderProfileActionMenu(
+async function askProviderProfileAction(
+  ui: IUserInteraction,
   profileName: string,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
+): Promise<ICommandResult> {
   const settings = options.settings.readMergedSettings();
   if (!settings.providers?.[profileName]) {
     return { message: `Provider profile "${profileName}" was not found.`, success: false };
   }
-  return {
-    message: `Provider profile selected: ${profileName}`,
-    success: true,
-    interaction: createProviderProfileActionInteraction(profileName, options),
-  };
-}
-
-function createProviderProfileActionInteraction(
-  profileName: string,
-  options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: {
-      kind: 'choice',
-      title: `Provider profile: ${profileName}`,
-      options: [
-        { value: ACTION_SWITCH, label: 'Switch' },
-        { value: ACTION_EDIT, label: 'Edit' },
-        { value: ACTION_TEST, label: 'Test' },
-        { value: ACTION_DUPLICATE, label: 'Duplicate' },
-        { value: ACTION_DELETE, label: 'Delete' },
-        { value: ACTION_CANCEL, label: 'Cancel' },
-      ],
-    },
-    submit: (value) => executeProviderProfileAction(profileName, value, options),
-    cancel: () => ({ message: 'Provider profile action cancelled.', success: true }),
-  };
+  const response = await ui.ask(
+    selectAction('provider-profile-action', `Provider profile: ${profileName}`, [
+      { value: ACTION_SWITCH, label: 'Switch' },
+      { value: ACTION_EDIT, label: 'Edit' },
+      { value: ACTION_TEST, label: 'Test' },
+      { value: ACTION_DUPLICATE, label: 'Duplicate' },
+      { value: ACTION_DELETE, label: 'Delete' },
+      { value: ACTION_CANCEL, label: 'Cancel' },
+    ]),
+  );
+  if (response.type !== 'answer' || response.values[0] === undefined) {
+    return { message: 'Provider profile action cancelled.', success: true };
+  }
+  return executeProviderProfileAction(ui, profileName, response.values[0], options);
 }
 
 async function executeProviderProfileAction(
+  ui: IUserInteraction,
   profileName: string,
   action: string,
   options: IProviderCommandModuleOptions,
@@ -90,18 +85,18 @@ async function executeProviderProfileAction(
     case ACTION_SWITCH:
       return buildProviderSwitch(settings.providers, profileName, options);
     case ACTION_EDIT:
-      return buildProviderEdit(profileName, options);
+      return buildProviderEdit(ui, profileName, options);
     case ACTION_TEST:
-      return await testProviderProfileCommand(
+      return testProviderProfileCommand(
         settings.currentProvider,
         settings.providers,
         profileName,
         options,
       );
     case ACTION_DUPLICATE:
-      return buildProviderDuplicate(profileName, options);
+      return buildProviderDuplicate(ui, profileName, options);
     case ACTION_DELETE:
-      return buildProviderDelete(profileName, options);
+      return buildProviderDelete(ui, profileName, options);
     case ACTION_CANCEL:
       return { message: 'Provider profile action cancelled.', success: true };
     default:

--- a/packages/agent-command/src/provider/provider-command-setup.ts
+++ b/packages/agent-command/src/provider/provider-command-setup.ts
@@ -1,3 +1,4 @@
+import { textAction } from '@robota-sdk/agent-core';
 import { buildProviderSetupPatch, mergeProviderPatch } from '@robota-sdk/agent-framework';
 
 import {
@@ -5,19 +6,15 @@ import {
   formatProviderSetupHelpLinks,
   getProviderSetupStep,
   submitProviderSetupValue,
-  validateProviderSetupValue,
 } from './provider-setup-flow.js';
 
 import type { IProviderSetupFlowState } from './provider-setup-flow.js';
+import type { IActionRequest, IUserInteraction } from '@robota-sdk/agent-core';
 import type {
   IProviderCommandModuleOptions,
   IProviderSetupInput,
 } from '@robota-sdk/agent-framework';
-import type {
-  ICommandInteraction,
-  ICommandResult,
-  TCommandInteractionPrompt,
-} from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 const PROVIDER_RESTART_EFFECT = {
   type: 'session-restart-requested',
@@ -33,62 +30,70 @@ export function createSetupFlow(
   });
 }
 
-export function createProviderSetupInteraction(
+/** Build the per-step `IActionRequest` for the current setup step (CMD-004 inline ask). */
+function toProviderSetupStepRequest(
   flow: IProviderSetupFlowState,
-  options: IProviderCommandModuleOptions,
-): ICommandInteraction {
-  return {
-    prompt: toProviderSetupStepPrompt(flow),
-    submit: (value) => submitProviderSetupInteractionValue(flow, value, options),
-    cancel: () => ({ message: 'Provider setup cancelled.', success: true }),
-  };
-}
-
-export function toProviderSetupStepPrompt(
-  flow: IProviderSetupFlowState,
-): TCommandInteractionPrompt {
+  errorMessage?: string,
+): IActionRequest {
   const step = getProviderSetupStep(flow);
   const placeholder =
     step.masked === true && step.defaultValue !== undefined ? '(unchanged)' : step.defaultValue;
-  return {
-    kind: 'text',
-    title: step.title,
-    ...toProviderSetupPromptDescription(flow),
-    ...(placeholder !== undefined ? { placeholder } : {}),
-    ...(step.defaultValue !== undefined ? { allowEmpty: true } : {}),
-    ...(step.masked !== undefined ? { masked: step.masked } : {}),
-    validate: (value) => validateProviderSetupValue(step, value),
-  };
+  const helpLinks = formatProviderSetupHelpLinks(flow.setupHelpLinks);
+  const description =
+    [errorMessage, helpLinks.length > 0 ? helpLinks : undefined]
+      .filter((part): part is string => part !== undefined && part.length > 0)
+      .join('\n') || undefined;
+  return textAction(`provider-setup-${step.key}`, step.title, {
+    description,
+    placeholder,
+    allowEmpty: step.defaultValue !== undefined,
+    masked: step.masked,
+  });
 }
 
-function toProviderSetupPromptDescription(
+/**
+ * Drive the setup-step engine through inline `ui.ask` calls (CMD-004), re-asking the same step when a
+ * step fails validation (the error is surfaced in the request description). The `complete` sink differs
+ * between the add and edit paths.
+ */
+export async function runProviderSetupAsk(
+  ui: IUserInteraction,
   flow: IProviderSetupFlowState,
-): { description: string } | Record<string, never> {
-  const description = formatProviderSetupHelpLinks(flow.setupHelpLinks);
-  return description.length > 0 ? { description } : {};
+  complete: (input: IProviderSetupInput) => ICommandResult,
+  cancelMessage: string,
+): Promise<ICommandResult> {
+  let state = flow;
+  let errorMessage: string | undefined;
+  for (;;) {
+    const response = await ui.ask(toProviderSetupStepRequest(state, errorMessage));
+    if (response.type === 'cancelled') {
+      return { message: cancelMessage, success: true };
+    }
+    const result = submitProviderSetupValue(state, response.text ?? '');
+    if (result.status === 'error') {
+      errorMessage = result.message;
+      continue;
+    }
+    if (result.status === 'complete') {
+      return complete(result.input);
+    }
+    state = result.state;
+    errorMessage = undefined;
+  }
 }
 
-function submitProviderSetupInteractionValue(
+/** Run the `/provider add` setup wizard inline. */
+export function runProviderAddSetup(
+  ui: IUserInteraction,
   flow: IProviderSetupFlowState,
-  value: string,
   options: IProviderCommandModuleOptions,
-): ICommandResult {
-  const result = submitProviderSetupValue(flow, value);
-  if (result.status === 'error') {
-    return {
-      message: result.message,
-      success: false,
-      interaction: createProviderSetupInteraction(flow, options),
-    };
-  }
-  if (result.status === 'complete') {
-    return completeProviderSetup(result.input, options);
-  }
-  return {
-    message: '',
-    success: true,
-    interaction: createProviderSetupInteraction(result.state, options),
-  };
+): Promise<ICommandResult> {
+  return runProviderSetupAsk(
+    ui,
+    flow,
+    (input) => completeProviderSetup(input, options),
+    'Provider setup cancelled.',
+  );
 }
 
 function completeProviderSetup(


### PR DESCRIPTION
## CMD-004 PR-I — provider wizard migration

Converts the multi-step provider wizard (the hardest CMD-004 site) from the legacy `ICommandResult.interaction` continuation chain to the unified **ask seam** (`context.getUserInteraction()?.ask(IActionRequest)`).

### What changed
- **Profile picker + action menu** (`provider-command-profile.ts`): inline `selectAction`; the picker's option list *is* the rendered profile list, so no separate text message is prepended.
- **Setup wizard** (`provider-command-setup.ts`): `runProviderSetupAsk` re-ask loop drives the pure step engine, surfacing validation errors in the request `description`. Preserves **masked** API-key entry (`(unchanged)` placeholder) and help-link descriptions. The pure engine (`provider-setup-flow.ts`) is untouched.
- **Edit / duplicate / delete / replacement** (`-operations.ts`, `-lifecycle.ts`): async inline ask; `confirmAction`/`isConfirmed` for the delete confirm, `selectAction` for the replacement picker, re-ask loops for duplicate-name validation.
- **Module** (`provider-command-module.ts`): `lifecycle: 'inline'`, threads `ICommandHostContext`, drops `interactionHints`.

### Headless / no-renderer behavior
When `getUserInteraction()` returns `undefined` (headless/automation, or model-invoked), each path takes its explicit no-human branch: `list`/`current` return text, `add` reports usage — never a silent guess.

### Tests
- Rewrote the provider suite to drive a **scripted `getUserInteraction()` double** (`__tests__/scripted-interaction.ts`) instead of `.submit()` continuation chains.
- Added absent-renderer coverage (text list, usage on `add`).
- `org-policy.test.ts` updated to the same double.
- 210/210 agent-command tests green; typecheck + lint + all 33 harness scans pass; downstream (agent-cli, agent-transport, agent-transport-tui) typecheck clean.

Part of the CMD-004 additive-then-delete sequence. Legacy deletion follows in the final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)