### PR TITLE
fix(harness): cover nested package groups in one-level package scans (INFRA-021)

### DIFF
--- a/.agents/spec-docs/done/INFRA-021-nested-package-scan-coverage.md
+++ b/.agents/spec-docs/done/INFRA-021-nested-package-scan-coverage.md
@@ -1,8 +1,17 @@
 ---
-status: draft
+status: done
 type: INFRA
 tags: [typescript]
 ---
+
+> **Done (2026-06-30).** Implemented directly under an explicit user go-ahead. Added the root-aware,
+> nesting-aware enumerator `scripts/harness/workspace-packages.mjs` (`listSpecPackageDirs` /
+> `listManifestPackageDirs`) and routed all five scans through it
+> (`check-spec-paths`, `check-spec-public-surface`, `check-spec-publish-claims`,
+> `scan-deprecated-markers`, `check-stub-markers`). The 21 `packages/dag-nodes/*` packages are now
+> covered and surfaced **no new findings** (the absorbed node SPECs/sources are clean for these checks).
+> Nested-coverage proof tests added to `check-spec-paths.test.mjs` and `check-stub-markers.test.mjs`.
+> `pnpm harness:scan` 39/39 green.
 
 # INFRA-021: Route one-level package scans through a nesting-aware enumerator
 

--- a/scripts/harness/__tests__/check-spec-paths.test.mjs
+++ b/scripts/harness/__tests__/check-spec-paths.test.mjs
@@ -61,4 +61,15 @@ describe('check-spec-paths', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].detail).toContain('packages/bar/src/gone.ts');
   });
+
+  it('covers nested package-group members (e.g. packages/dag-nodes/<name>)', async () => {
+    const root = await createFixture({
+      // The group container itself owns no SPEC.md — only its members do.
+      'packages/group/member/docs/SPEC.md': '- `src/ghost.ts` — deleted\n',
+    });
+    const findings = await findSpecPathFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toContain('src/ghost.ts');
+    expect(findings[0].file).toContain(path.join('group', 'member'));
+  });
 });

--- a/scripts/harness/__tests__/check-stub-markers.test.mjs
+++ b/scripts/harness/__tests__/check-stub-markers.test.mjs
@@ -52,4 +52,16 @@ describe('check-stub-markers', () => {
     });
     expect(await findStubMarkerFindings(root)).toHaveLength(0);
   });
+
+  it('covers nested package-group members (e.g. packages/dag-nodes/<name>)', async () => {
+    const root = await createFixture({
+      // The group container itself has no package.json — only its members do.
+      'packages/group/member/package.json': pkg('@robota-sdk/member'),
+      'packages/group/member/src/wip.ts':
+        "// TODO: Implement actual logic\nthrow new Error('Not implemented: member is unavailable');\n",
+    });
+    const findings = await findStubMarkerFindings(root);
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0].file).toContain(path.join('group', 'member', 'src', 'wip.ts'));
+  });
 });

--- a/scripts/harness/check-spec-paths.mjs
+++ b/scripts/harness/check-spec-paths.mjs
@@ -14,8 +14,10 @@
  * Exit code 0 = clean, 1 = findings.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+
+import { listSpecPackageDirs } from './workspace-packages.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
@@ -24,17 +26,11 @@ const REPO_PATH_PATTERN =
   /packages\/[\w-]+\/(?:src|scripts|bin)\/[\w\-./]+\.(?:tsx|ts|mjs|cjs)(?!\w)/g;
 
 function listSpecFiles(root) {
-  const packagesDir = path.join(root, 'packages');
-  if (!existsSync(packagesDir)) return [];
-  const specs = [];
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const specPath = path.join(packagesDir, entry.name, 'docs', 'SPEC.md');
-    if (existsSync(specPath)) {
-      specs.push({ packageDir: path.join(packagesDir, entry.name), specPath });
-    }
-  }
-  return specs;
+  // Nesting-aware: covers depth-1 packages and nested group members (e.g. packages/dag-nodes/<name>).
+  return listSpecPackageDirs(root).map((packageDir) => ({
+    packageDir,
+    specPath: path.join(packageDir, 'docs', 'SPEC.md'),
+  }));
 }
 
 export async function findSpecPathFindings(root = WORKSPACE_ROOT) {

--- a/scripts/harness/check-spec-public-surface.mjs
+++ b/scripts/harness/check-spec-public-surface.mjs
@@ -23,6 +23,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { listSpecPackageDirs } from './workspace-packages.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
@@ -72,15 +74,12 @@ function publicApiIdentifiers(specText) {
 
 export async function findPublicSurfaceFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
-  if (!existsSync(packagesDir)) return findings;
 
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const pkgDir = path.join(packagesDir, entry.name);
+  // Nesting-aware: covers depth-1 packages and nested group members (e.g. packages/dag-nodes/<name>).
+  for (const pkgDir of listSpecPackageDirs(root)) {
     const specPath = path.join(pkgDir, 'docs', 'SPEC.md');
     const srcDir = path.join(pkgDir, 'src');
-    if (!existsSync(specPath) || !existsSync(srcDir)) continue;
+    if (!existsSync(srcDir)) continue;
 
     const idents = publicApiIdentifiers(readFileSync(specPath, 'utf8'));
     if (idents.length === 0) continue;

--- a/scripts/harness/check-spec-publish-claims.mjs
+++ b/scripts/harness/check-spec-publish-claims.mjs
@@ -12,8 +12,10 @@
  * Exit code 0 = clean, 1 = findings.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+
+import { listSpecPackageDirs } from './workspace-packages.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
@@ -22,15 +24,12 @@ const NEGATED = /\b(not|never|un-?published|internal|private|do(?:es)? not)\b/i;
 
 export async function findPublishClaimFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
-  if (!existsSync(packagesDir)) return findings;
 
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const pkgDir = path.join(packagesDir, entry.name);
+  // Nesting-aware: covers depth-1 packages and nested group members (e.g. packages/dag-nodes/<name>).
+  for (const pkgDir of listSpecPackageDirs(root)) {
     const specPath = path.join(pkgDir, 'docs', 'SPEC.md');
     const pkgJsonPath = path.join(pkgDir, 'package.json');
-    if (!existsSync(specPath) || !existsSync(pkgJsonPath)) continue;
+    if (!existsSync(pkgJsonPath)) continue;
 
     const isPrivate = JSON.parse(readFileSync(pkgJsonPath, 'utf8')).private === true;
     if (!isPrivate) continue;

--- a/scripts/harness/check-stub-markers.mjs
+++ b/scripts/harness/check-stub-markers.mjs
@@ -17,6 +17,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { listManifestPackageDirs } from './workspace-packages.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 // "placeholder for actual" caught shipped, consumed storage classes that only
@@ -47,14 +49,10 @@ function walkSources(dir) {
 
 export async function findStubMarkerFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
-  if (!existsSync(packagesDir)) return findings;
 
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const packageDir = path.join(packagesDir, entry.name);
+  // Nesting-aware: covers depth-1 packages and nested group members (e.g. packages/dag-nodes/<name>).
+  for (const packageDir of listManifestPackageDirs(root)) {
     const pkgPath = path.join(packageDir, 'package.json');
-    if (!existsSync(pkgPath)) continue;
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
     if (pkg.private === true) continue;
 

--- a/scripts/harness/scan-deprecated-markers.mjs
+++ b/scripts/harness/scan-deprecated-markers.mjs
@@ -17,6 +17,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { listManifestPackageDirs } from './workspace-packages.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 const DEPRECATED_MARKER = '@deprecated';
@@ -40,14 +42,10 @@ function walkSources(dir) {
 
 export function findDeprecatedMarkerFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
-  if (!existsSync(packagesDir)) return findings;
 
-  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const packageDir = path.join(packagesDir, entry.name);
+  // Nesting-aware: covers depth-1 packages and nested group members (e.g. packages/dag-nodes/<name>).
+  for (const packageDir of listManifestPackageDirs(root)) {
     const pkgPath = path.join(packageDir, 'package.json');
-    if (!existsSync(pkgPath)) continue;
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
     if (pkg.private === true) continue;
 

--- a/scripts/harness/workspace-packages.mjs
+++ b/scripts/harness/workspace-packages.mjs
@@ -1,0 +1,56 @@
+/**
+ * Root-aware, nesting-aware enumeration of workspace package directories under `packages/`.
+ *
+ * Several harness scans used a one-level `readdirSync('packages')` loop and therefore silently
+ * skipped NESTED package groups (e.g. `packages/dag-nodes/<name>`) — under-covering those packages
+ * (INFRA-021; the same defect class guarded for build/CI globs by check-nested-package-glob-coverage).
+ * This is the single owner of "what package directories exist", parameterized by `root` so the scans
+ * and their fixture-based tests share it.
+ *
+ * A depth-1 directory under `packages/` that carries the requested marker is a package; a depth-1
+ * directory WITHOUT it is treated as a group container and recursed exactly one level.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage']);
+
+function childDirs(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && !SKIP_DIRS.has(entry.name) && !entry.name.startsWith('.'),
+    )
+    .map((entry) => path.join(dir, entry.name));
+}
+
+/**
+ * List package directories under `<root>/packages`, including nested group members. `hasMarker(dir)`
+ * decides whether a directory is a package (e.g. it owns `docs/SPEC.md`, or a `package.json`). A
+ * depth-1 directory that is not itself a package is recursed one level to find nested members.
+ */
+export function listPackageDirs(root, hasMarker) {
+  const packagesDir = path.join(root, 'packages');
+  const dirs = [];
+  for (const dir of childDirs(packagesDir)) {
+    if (hasMarker(dir)) {
+      dirs.push(dir);
+      continue;
+    }
+    for (const nested of childDirs(dir)) {
+      if (hasMarker(nested)) dirs.push(nested);
+    }
+  }
+  return dirs;
+}
+
+/** Package directories that own a `docs/SPEC.md`. */
+export function listSpecPackageDirs(root) {
+  return listPackageDirs(root, (dir) => existsSync(path.join(dir, 'docs', 'SPEC.md')));
+}
+
+/** Package directories that own a `package.json`. */
+export function listManifestPackageDirs(root) {
+  return listPackageDirs(root, (dir) => existsSync(path.join(dir, 'package.json')));
+}


### PR DESCRIPTION
## Summary

Implements INFRA-021: five harness scans enumerated workspace packages with a one-level `readdirSync('packages')` loop and silently skipped nested package groups (`packages/dag-nodes/*`), so the 21 absorbed node packages (which ship `docs/SPEC.md`) went unchecked. Same defect class as the build/CI globs guarded by `check-nested-package-glob-coverage`.

## Changes

- **`scripts/harness/workspace-packages.mjs`** (new single owner) — root-aware, nesting-aware `listSpecPackageDirs` / `listManifestPackageDirs` (depth-1 packages + members of group containers).
- Route all five scans through it: `check-spec-paths`, `check-spec-public-surface`, `check-spec-publish-claims`, `scan-deprecated-markers`, `check-stub-markers`.
- Newly-covered node packages surface **no new findings** (clean).
- Nested-coverage **proof tests** added to `check-spec-paths.test.mjs` and `check-stub-markers.test.mjs` (a stub/ghost in `packages/<group>/<member>` is now caught — it was not before).
- INFRA-021 spec → `done/`.

## Verification

`pnpm harness:scan` 39/39 green; harness scan tests pass (incl. the two new nested-coverage cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)