### PR TITLE
refactor(dag-nodes): integrate to workspace agent deps (INFRA-022)

### DIFF
--- a/.agents/spec-docs/done/INFRA-022-dag-nodes-published-agent-deps.md
+++ b/.agents/spec-docs/done/INFRA-022-dag-nodes-published-agent-deps.md
@@ -1,8 +1,18 @@
 ---
-status: draft
+status: done
 type: INFRA
 tags: [typescript]
 ---
+
+> **Done (2026-06-30) — integrated to workspace** (user chose integrate over decouple). The 7 absorbed
+> LLM/image node packages were re-pointed off the published `@robota-sdk/agent-*@3.0.0-beta.61` deps:
+> `@robota-sdk/agent-core` → `workspace:*`; the separate `@robota-sdk/agent-provider-<vendor>` deps →
+> the workspace `@robota-sdk/agent-provider` umbrella, imports switched to its subpaths
+> (`@robota-sdk/agent-provider/anthropic|openai|google|deepseek|qwen`). Added
+> `moduleResolution: "bundler"` to those node tsconfigs (subpath-exports resolution, matching agent-cli).
+> No more duplicate/published `agent-core`; the vulnerable `@anthropic-ai/sdk@0.80` path is gone, so the
+> tactical `pnpm.overrides` band-aid for it was **removed**. `pnpm build` + workspace `typecheck` +
+> dag-node/dag-cli/dag-framework tests + `pnpm audit --audit-level high` + `harness:scan` 39/39 all green.
 
 # INFRA-022: Re-point absorbed dag-node packages off published @robota-sdk/agent-\* deps
 

--- a/package.json
+++ b/package.json
@@ -194,8 +194,7 @@
       "form-data@<2.5.6": "^2.5.6",
       "form-data@^4.0.0": "^4.0.6",
       "postcss@<8.5.10": ">=8.5.10",
-      "dompurify@<3.4.11": ">=3.4.11",
-      "@anthropic-ai/sdk@<0.91.1": ">=0.91.1"
+      "dompurify@<3.4.11": ">=3.4.11"
     },
     "auditConfig": {
       "ignoreCves": [

--- a/packages/dag-nodes/gemini-image-edit/package.json
+++ b/packages/dag-nodes/gemini-image-edit/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-google": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/gemini-image-edit/src/runtime-core.test.ts
+++ b/packages/dag-nodes/gemini-image-edit/src/runtime-core.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IPortBinaryValue } from '@robota-sdk/dag-core';
 import type { IImageGenerationResult, TProviderMediaResult } from '@robota-sdk/agent-core';
 import { GeminiImageRuntime, isImageBinaryValue } from './runtime-core.js';
-import { GoogleProvider } from '@robota-sdk/agent-provider-google';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
 
 // Mock GoogleProvider so no real API calls are made
-vi.mock('@robota-sdk/agent-provider-google', () => ({
+vi.mock('@robota-sdk/agent-provider/google', () => ({
   GoogleProvider: vi
     .fn()
     .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({

--- a/packages/dag-nodes/gemini-image-edit/src/runtime-core.ts
+++ b/packages/dag-nodes/gemini-image-edit/src/runtime-core.ts
@@ -5,7 +5,7 @@ import {
   type IPortBinaryValue,
   type TResult,
 } from '@robota-sdk/dag-core';
-import { GoogleProvider } from '@robota-sdk/agent-provider-google';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
 import type { IImageGenerationProvider, IImageGenerationResult } from '@robota-sdk/agent-core';
 import {
   normalizeImageOutput,

--- a/packages/dag-nodes/gemini-image-edit/tsconfig.json
+++ b/packages/dag-nodes/gemini-image-edit/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/instant-node/package.json
+++ b/packages/dag-nodes/instant-node/package.json
@@ -43,12 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-anthropic": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-openai": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-google": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-deepseek": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-qwen": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/instant-node/src/__tests__/index.test.ts
+++ b/packages/dag-nodes/instant-node/src/__tests__/index.test.ts
@@ -6,23 +6,23 @@ vi.mock('@robota-sdk/agent-core', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-anthropic', () => ({
+vi.mock('@robota-sdk/agent-provider/anthropic', () => ({
   AnthropicProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-openai', () => ({
+vi.mock('@robota-sdk/agent-provider/openai', () => ({
   OpenAIProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-google', () => ({
+vi.mock('@robota-sdk/agent-provider/google', () => ({
   GoogleProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-deepseek', () => ({
+vi.mock('@robota-sdk/agent-provider/deepseek', () => ({
   DeepSeekProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-qwen', () => ({
+vi.mock('@robota-sdk/agent-provider/qwen', () => ({
   QwenProvider: vi.fn().mockImplementation(() => ({})),
 }));
 

--- a/packages/dag-nodes/instant-node/src/index.ts
+++ b/packages/dag-nodes/instant-node/src/index.ts
@@ -10,11 +10,11 @@ import {
   type TResult,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
-import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
-import { GoogleProvider } from '@robota-sdk/agent-provider-google';
-import { DeepSeekProvider } from '@robota-sdk/agent-provider-deepseek';
-import { QwenProvider } from '@robota-sdk/agent-provider-qwen';
+import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
+import { OpenAIProvider } from '@robota-sdk/agent-provider/openai';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
+import { DeepSeekProvider } from '@robota-sdk/agent-provider/deepseek';
+import { QwenProvider } from '@robota-sdk/agent-provider/qwen';
 import { z } from 'zod';
 
 export type TInstantNodeProvider = 'anthropic' | 'openai' | 'gemini' | 'deepseek' | 'qwen';

--- a/packages/dag-nodes/instant-node/tsconfig.json
+++ b/packages/dag-nodes/instant-node/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/llm-text-anthropic/package.json
+++ b/packages/dag-nodes/llm-text-anthropic/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-anthropic": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/llm-text-anthropic/src/index.test.ts
+++ b/packages/dag-nodes/llm-text-anthropic/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock('@robota-sdk/agent-core', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-anthropic', () => ({
+vi.mock('@robota-sdk/agent-provider/anthropic', () => ({
   AnthropicProvider: vi.fn(),
 }));
 

--- a/packages/dag-nodes/llm-text-anthropic/src/index.ts
+++ b/packages/dag-nodes/llm-text-anthropic/src/index.ts
@@ -10,7 +10,7 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { AnthropicProvider } from '@robota-sdk/agent-provider-anthropic';
+import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
 import { z } from 'zod';
 
 const DEFAULT_ANTHROPIC_LLM_MODEL = 'claude-sonnet-4-6';

--- a/packages/dag-nodes/llm-text-anthropic/tsconfig.json
+++ b/packages/dag-nodes/llm-text-anthropic/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/llm-text-deepseek/package.json
+++ b/packages/dag-nodes/llm-text-deepseek/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-deepseek": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/llm-text-deepseek/src/index.test.ts
+++ b/packages/dag-nodes/llm-text-deepseek/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock('@robota-sdk/agent-core', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-deepseek', () => ({
+vi.mock('@robota-sdk/agent-provider/deepseek', () => ({
   DeepSeekProvider: vi.fn(),
 }));
 

--- a/packages/dag-nodes/llm-text-deepseek/src/index.ts
+++ b/packages/dag-nodes/llm-text-deepseek/src/index.ts
@@ -10,7 +10,7 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { DeepSeekProvider } from '@robota-sdk/agent-provider-deepseek';
+import { DeepSeekProvider } from '@robota-sdk/agent-provider/deepseek';
 import { z } from 'zod';
 
 const DEFAULT_DEEPSEEK_LLM_MODEL = 'deepseek-v4-flash';

--- a/packages/dag-nodes/llm-text-deepseek/tsconfig.json
+++ b/packages/dag-nodes/llm-text-deepseek/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/llm-text-gemini/package.json
+++ b/packages/dag-nodes/llm-text-gemini/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-google": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/llm-text-gemini/src/index.test.ts
+++ b/packages/dag-nodes/llm-text-gemini/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock('@robota-sdk/agent-core', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-google', () => ({
+vi.mock('@robota-sdk/agent-provider/google', () => ({
   GoogleProvider: vi.fn(),
 }));
 

--- a/packages/dag-nodes/llm-text-gemini/src/index.ts
+++ b/packages/dag-nodes/llm-text-gemini/src/index.ts
@@ -10,7 +10,7 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { GoogleProvider } from '@robota-sdk/agent-provider-google';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
 import { z } from 'zod';
 
 const DEFAULT_GEMINI_LLM_MODEL = 'gemini-2.0-flash';

--- a/packages/dag-nodes/llm-text-gemini/tsconfig.json
+++ b/packages/dag-nodes/llm-text-gemini/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/llm-text-openai/package.json
+++ b/packages/dag-nodes/llm-text-openai/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-openai": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/llm-text-openai/src/index.test.ts
+++ b/packages/dag-nodes/llm-text-openai/src/index.test.ts
@@ -11,7 +11,7 @@ vi.mock('@robota-sdk/agent-core', () => ({
 }));
 
 // Mock OpenAIProvider
-vi.mock('@robota-sdk/agent-provider-openai', () => ({
+vi.mock('@robota-sdk/agent-provider/openai', () => ({
   OpenAIProvider: vi.fn(),
 }));
 

--- a/packages/dag-nodes/llm-text-openai/src/index.ts
+++ b/packages/dag-nodes/llm-text-openai/src/index.ts
@@ -10,7 +10,7 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { OpenAIProvider } from '@robota-sdk/agent-provider-openai';
+import { OpenAIProvider } from '@robota-sdk/agent-provider/openai';
 import { z } from 'zod';
 
 const DEFAULT_OPENAI_LLM_MODEL = 'gpt-4o-mini';

--- a/packages/dag-nodes/llm-text-openai/tsconfig.json
+++ b/packages/dag-nodes/llm-text-openai/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/packages/dag-nodes/llm-text-qwen/package.json
+++ b/packages/dag-nodes/llm-text-qwen/package.json
@@ -43,8 +43,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@robota-sdk/agent-core": "3.0.0-beta.61",
-    "@robota-sdk/agent-provider-qwen": "3.0.0-beta.61",
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",
     "zod": "^3.24.4"

--- a/packages/dag-nodes/llm-text-qwen/src/index.test.ts
+++ b/packages/dag-nodes/llm-text-qwen/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock('@robota-sdk/agent-core', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-qwen', () => ({
+vi.mock('@robota-sdk/agent-provider/qwen', () => ({
   QwenProvider: vi.fn(),
 }));
 

--- a/packages/dag-nodes/llm-text-qwen/src/index.ts
+++ b/packages/dag-nodes/llm-text-qwen/src/index.ts
@@ -10,7 +10,7 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import { Robota } from '@robota-sdk/agent-core';
-import { QwenProvider } from '@robota-sdk/agent-provider-qwen';
+import { QwenProvider } from '@robota-sdk/agent-provider/qwen';
 import { z } from 'zod';
 
 const DEFAULT_QWEN_LLM_MODEL = 'qwen-plus';

--- a/packages/dag-nodes/llm-text-qwen/tsconfig.json
+++ b/packages/dag-nodes/llm-text-qwen/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "downlevelIteration": true,
     "lib": ["ES2022"],
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,6 @@ overrides:
   form-data@^4.0.0: ^4.0.6
   postcss@<8.5.10: '>=8.5.10'
   dompurify@<3.4.11: '>=3.4.11'
-  '@anthropic-ai/sdk@<0.91.1': '>=0.91.1'
 
 importers:
 
@@ -2088,11 +2087,11 @@ importers:
   packages/dag-nodes/gemini-image-edit:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-google':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2240,23 +2239,11 @@ importers:
   packages/dag-nodes/instant-node:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-anthropic':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      '@robota-sdk/agent-provider-deepseek':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      '@robota-sdk/agent-provider-google':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61)
-      '@robota-sdk/agent-provider-openai':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      '@robota-sdk/agent-provider-qwen':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2289,11 +2276,11 @@ importers:
   packages/dag-nodes/llm-text-anthropic:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-anthropic':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2326,11 +2313,11 @@ importers:
   packages/dag-nodes/llm-text-deepseek:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-deepseek':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2363,11 +2350,11 @@ importers:
   packages/dag-nodes/llm-text-gemini:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-google':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2400,11 +2387,11 @@ importers:
   packages/dag-nodes/llm-text-openai:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-openai':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -2437,11 +2424,11 @@ importers:
   packages/dag-nodes/llm-text-qwen:
     dependencies:
       '@robota-sdk/agent-core':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61
-      '@robota-sdk/agent-provider-qwen':
-        specifier: 3.0.0-beta.61
-        version: 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core
@@ -6772,107 +6759,6 @@ packages:
 
   /@radix-ui/rect@1.1.2:
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
-    dev: false
-
-  /@robota-sdk/agent-core@3.0.0-beta.61:
-    resolution: {integrity: sha512-34CL4d5z7zM1taNGZRdHsDU2EWpXm8XPWUTVuH9Q9XlY1gPDT8+Z32GNkr+Jwyg7GbrR8h56ROzmZXnaLve8ig==}
-    dependencies:
-      jssha: 3.3.1
-      zod: 3.25.76
-    dev: false
-
-  /@robota-sdk/agent-provider-anthropic@3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76):
-    resolution: {integrity: sha512-WJ4jHYKHLUIaZH5uTCpCUvJ/hkrS8w9+0oH9xt0koIkC4XttCUH/i2aDvzSXaKyOnP4HB/zhxTC95x0RVJbLxw==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    transitivePeerDependencies:
-      - zod
-    dev: false
-
-  /@robota-sdk/agent-provider-deepseek@3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76):
-    resolution: {integrity: sha512-s4ASRfU5PFom7lEKV+MnIThMQ19af5v1qTHgg8uSfM3zAEr3ztNonYEIxSxaiunzslUqD4iqdPaHX+l27bbXQw==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-      '@robota-sdk/agent-provider-openai-compatible': 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      openai: 4.104.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-      - zod
-    dev: false
-
-  /@robota-sdk/agent-provider-gemini@3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61):
-    resolution: {integrity: sha512-cyXgoYkF9qIB5ZrANap7DZ1dejsHCG4+cY2COd2q6rH/WjzmSvyYVajxZeRLK+3Bk2mx0UqS/xnHrBfycfkfQA==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0)
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@robota-sdk/agent-provider-google@3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61):
-    resolution: {integrity: sha512-7S6QiTl7SV1wcJxtzvAuqJcq2s6hUaGgrpMDIqHobAIKezp6eV9BLJ2YrDhURBgg9kE5E+qT8sS0A7MpMgDm+g==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-      '@robota-sdk/agent-provider-gemini': 3.0.0-beta.61(@modelcontextprotocol/sdk@1.29.0)(@robota-sdk/agent-core@3.0.0-beta.61)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@robota-sdk/agent-provider-openai-compatible@3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76):
-    resolution: {integrity: sha512-Hl2LFF9HCBzCVpwuJu/8aCQDskGiZ7m33mVeDeqkGgDu1yAyhWzb2rfZ3GEdWIEjFGL/Hnfjur/jtEryeJ8Hqg==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-      openai: 4.104.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-      - zod
-    dev: false
-
-  /@robota-sdk/agent-provider-openai@3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76):
-    resolution: {integrity: sha512-f/r8ruz7A5JstOuvyqYQjw2VymYj0mgG9qVLwNH3ckVEXDlmL/yBU2FVqqgUz9FFAeB2mTA6JRluYIyhMAi2Vw==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-      '@robota-sdk/agent-provider-openai-compatible': 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      openai: 4.104.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-      - zod
-    dev: false
-
-  /@robota-sdk/agent-provider-qwen@3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76):
-    resolution: {integrity: sha512-p87RF1r/HRfrXOFbzMWny71NeV411FBVxaDwABH9EgFtn5/7FwklGhFDzOXaitQlBmqpJriI9DC4xLQnH/XTkw==}
-    peerDependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-    dependencies:
-      '@robota-sdk/agent-core': 3.0.0-beta.61
-      '@robota-sdk/agent-provider-openai-compatible': 3.0.0-beta.61(@robota-sdk/agent-core@3.0.0-beta.61)(zod@3.25.76)
-      openai: 4.104.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-      - zod
     dev: false
 
   /@rolldown/binding-android-arm64@1.0.3:


### PR DESCRIPTION
## Summary

Implements INFRA-022 (integrate, per decision). The 7 absorbed LLM/image node packages depended on **published, pinned** `@robota-sdk/agent-core@3.0.0-beta.61` + separate `@robota-sdk/agent-provider-<vendor>` packages that are not workspace members — incomplete monorepo integration, version freeze/drift, duplicate `agent-core` installs, and the path the `@anthropic-ai/sdk` override patched over.

## Changes

- `@robota-sdk/agent-core` dep → `workspace:*`.
- `@robota-sdk/agent-provider-<vendor>` deps → the workspace `@robota-sdk/agent-provider` umbrella; imports switched to its subpaths (`/anthropic`, `/openai`, `/google`, `/deepseek`, `/qwen`).
- Added `moduleResolution: "bundler"` to those node tsconfigs (subpath-exports resolution, matching agent-cli).
- **Removed** the now-unnecessary `@anthropic-ai/sdk` `pnpm.overrides` band-aid — the vulnerable `0.80` path is gone (workspace `agent-provider` uses `^0.91.1`).

## Verification

No published-beta `agent-core` left in the tree. `pnpm build` + workspace `typecheck` + dag-node/dag-cli/dag-framework tests + `pnpm audit --audit-level high` (exit 0, override removed) + `pnpm harness:scan` 39/39 all green. INFRA-022 → `done/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)