### PR TITLE
feat(dag): SSE run-progress stream on the native runtime server (WORKFLOW-002 A)

### DIFF
--- a/apps/dag-runtime-server/docs/SPEC.md
+++ b/apps/dag-runtime-server/docs/SPEC.md
@@ -56,9 +56,9 @@ worker loop, and serves the app via `@hono/node-server`.
 | `POST /v1/dag/run-drafts/:draftId/nodes/:nodeId/reset` | `resetRunDraftNodeResult`                       |
 | `PUT /v1/dag/run-drafts/:draftId/nodes/:nodeId/result` | `overwriteRunDraftNodeResult`                   |
 
-A `GET /v1/dag/runs/:id/events` SSE stream + an `HttpDagRuntimeProvider` (for the `--provider http`
-path) are tracked follow-on surface (the streaming endpoint needs a run-progress source beyond
-`IDagOrchestrationPort`).
+| `GET /v1/dag/runs/:id/events` (SSE) | `progressSource` run-progress stream |
+
+An `HttpDagRuntimeProvider` (for the `--provider http` path) is the remaining follow-on surface.
 
 ## Type Ownership
 

--- a/apps/dag-runtime-server/src/__tests__/app.contract.test.ts
+++ b/apps/dag-runtime-server/src/__tests__/app.contract.test.ts
@@ -4,6 +4,8 @@ import { createDagFramework } from '@robota-sdk/dag-framework';
 
 import { createDagRuntimeServer } from '../app.js';
 
+import type { IRunProgressSource } from '../app.js';
+import type { TRunProgressEvent } from '@robota-sdk/dag-core';
 import type { IDagFramework } from '@robota-sdk/dag-framework';
 import type { Hono } from 'hono';
 
@@ -60,8 +62,66 @@ describe('dag-runtime-server contract', () => {
     expect(res.status).not.toBe(404);
   });
 
+  it('GET /v1/dag/runs/:id/events is 501 when no progress source is wired', async () => {
+    const res = await app.request('/v1/dag/runs/run-1/events');
+    expect(res.status).toBe(501);
+  });
+
   it('unknown route is a 404 (no external-runtime surface)', async () => {
     const res = await app.request('/external-runtime-unknown');
     expect(res.status).toBe(404);
+  });
+});
+
+describe('dag-runtime-server SSE progress stream', () => {
+  it('streams a run’s progress events and closes on a terminal event', async () => {
+    // A fake progress source that, once subscribed, emits one matching terminal event next tick.
+    const source: IRunProgressSource = {
+      subscribe(listener: (event: TRunProgressEvent) => void): () => void {
+        queueMicrotask(() => {
+          listener({
+            dagRunId: 'run-1',
+            eventType: 'execution.completed',
+            occurredAt: '2026-06-30T00:00:00.000Z',
+          });
+        });
+        return () => undefined;
+      },
+    };
+    const app = createDagRuntimeServer({} as never, source);
+
+    const res = await app.request('/v1/dag/runs/run-1/events');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type') ?? '').toContain('text/event-stream');
+    const body = await res.text();
+    expect(body).toContain('event: open');
+    expect(body).toContain('event: execution.completed');
+  });
+
+  it('ignores progress events for other runs', async () => {
+    const source: IRunProgressSource = {
+      subscribe(listener: (event: TRunProgressEvent) => void): () => void {
+        queueMicrotask(() => {
+          // An event for a DIFFERENT run, then the terminal event for ours.
+          listener({
+            dagRunId: 'other-run',
+            eventType: 'task.started',
+            occurredAt: '2026-06-30T00:00:00.000Z',
+            taskRunId: 't1',
+            nodeId: 'n1',
+          });
+          listener({
+            dagRunId: 'run-1',
+            eventType: 'execution.completed',
+            occurredAt: '2026-06-30T00:00:01.000Z',
+          });
+        });
+        return () => undefined;
+      },
+    };
+    const app = createDagRuntimeServer({} as never, source);
+    const body = await (await app.request('/v1/dag/runs/run-1/events')).text();
+    expect(body).not.toContain('other-run');
+    expect(body).toContain('event: execution.completed');
   });
 });

--- a/apps/dag-runtime-server/src/app.ts
+++ b/apps/dag-runtime-server/src/app.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
 
 import type { IDagBuildInput } from '@robota-sdk/dag-builder';
 import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
-import type { IDagDefinition } from '@robota-sdk/dag-core';
+import type { IDagDefinition, TRunProgressEvent } from '@robota-sdk/dag-core';
 import type {
   IDagOrchestrationAssetUploadRequest,
   IDagOrchestrationCostMetaPreviewRequest,
@@ -23,12 +24,28 @@ function reply(c: Context, response: IDagOrchestrationHttpResponse): Response {
   return c.json(response.payload, response.status as ContentfulStatusCode);
 }
 
+/** A run-progress source the SSE stream subscribes to (structurally the framework's progress bus). */
+export interface IRunProgressSource {
+  subscribe(listener: (event: TRunProgressEvent) => void): () => void;
+}
+
+/** A run progress event is terminal when the whole execution has finished (success or failure). */
+function isTerminalProgressEvent(event: TRunProgressEvent): boolean {
+  return event.eventType === 'execution.completed' || event.eventType === 'execution.failed';
+}
+
 /**
  * Native DAG runtime HTTP server (WORKFLOW-002). Maps the `/v1/dag/*` route surface onto an
  * `IDagOrchestrationPort` — typically `createDagFramework().client` (the in-process implementation).
  * No external-runtime API surface; every handler is a uniform route → port-method → JSON-response mapping.
+ *
+ * When a `progressSource` is supplied, `GET /v1/dag/runs/:id/events` streams that run's progress as
+ * Server-Sent Events; without one, that route answers 501.
  */
-export function createDagRuntimeServer(port: IDagOrchestrationPort): Hono {
+export function createDagRuntimeServer(
+  port: IDagOrchestrationPort,
+  progressSource?: IRunProgressSource,
+): Hono {
   const app = new Hono();
 
   // --- Node catalog ---
@@ -82,6 +99,39 @@ export function createDagRuntimeServer(port: IDagOrchestrationPort): Hono {
   app.get('/v1/dag/runs/:id/result', async (c) =>
     reply(c, await port.getRunResult(c.req.param('id'))),
   );
+
+  // --- Run progress stream (SSE) ---
+  app.get('/v1/dag/runs/:id/events', (c) => {
+    const runId = c.req.param('id');
+    if (!progressSource) {
+      return c.json({ error: 'progress streaming is not available on this server' }, 501);
+    }
+    return streamSSE(c, async (stream) => {
+      // Serialize writes so the terminal event flushes before the stream closes.
+      let writeChain = stream.writeSSE({
+        event: 'open',
+        data: JSON.stringify({ dagRunId: runId }),
+      });
+      await new Promise<void>((resolve) => {
+        // `unsubscribe` is assigned synchronously; the listener only runs on later events.
+        const unsubscribe = progressSource.subscribe((event) => {
+          if (event.dagRunId !== runId) return;
+          writeChain = writeChain.then(() =>
+            stream.writeSSE({ event: event.eventType, data: JSON.stringify(event) }),
+          );
+          if (isTerminalProgressEvent(event)) {
+            unsubscribe();
+            writeChain.then(resolve, resolve);
+          }
+        });
+        stream.onAbort(() => {
+          unsubscribe();
+          resolve();
+        });
+      });
+      await writeChain;
+    });
+  });
 
   // --- Published-workflow run (start a published definition directly) ---
   app.post('/v1/dag/definitions/:dagId/start', async (c) => {

--- a/apps/dag-runtime-server/src/server.ts
+++ b/apps/dag-runtime-server/src/server.ts
@@ -25,7 +25,10 @@ export async function startDagRuntimeServer(
 
   const framework = await createDagFramework();
   await framework.start();
-  const app = createDagRuntimeServer(framework.client);
+  const app = createDagRuntimeServer(
+    framework.client,
+    framework.internals.execution.runProgressEventBus,
+  );
   const server = serve({ fetch: app.fetch, port });
 
   return {


### PR DESCRIPTION
## Summary

WORKFLOW-002 phase A — adds the server-side run-progress SSE stream to the native DAG runtime server. (The client `HttpDagRuntimeProvider` and `--provider http` CLI resolution are the follow-up phases B/C.)

## Changes

- `GET /v1/dag/runs/:id/events` — when `createDagRuntimeServer(port, progressSource)` is given a progress source (the framework's `runProgressEventBus`, wired in `startDagRuntimeServer`), the route streams that run's progress as SSE and closes on a terminal `execution.completed`/`execution.failed` event; without a source it answers 501.
- Writes are serialized so the terminal event flushes before the stream closes.
- Contract tests: 501 without a source, streaming + terminal close, and run-id filtering (events for other runs ignored).

## Verification

`pnpm harness:scan` 39/39; dag-runtime-server contract tests 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)