### PR TITLE
feat(dag-framework): HttpDagRuntimeProvider over /v1/dag/* (WORKFLOW-002 Phase B)

### DIFF
--- a/.agents/tasks/WORKFLOW-002.md
+++ b/.agents/tasks/WORKFLOW-002.md
@@ -1,7 +1,7 @@
 # WORKFLOW-002 — Native DAG runtime-server
 
 Spec: .agents/spec-docs/active/WORKFLOW-002-native-runtime-server.md
-Status: done (full uniform route surface: definitions/runs/published/build/validate/assets/cost-meta/run-drafts). SSE events + HttpDagRuntimeProvider + provider-resolution (TC-04) remain as tracked follow-on (streaming needs a run-progress source beyond IDagOrchestrationPort).
+Status: in progress. Server surface done (definitions/runs/published/build/validate/assets/cost-meta/run-drafts) + SSE events (Phase A, #896) + HttpDagRuntimeProvider (Phase B). Provider-resolution wiring (Phase C / TC-04: dag-cli `--provider http` + dag-mcp-server `--server-url`) remains the only tracked follow-on.
 
 ## Decision (recorded)
 
@@ -30,15 +30,38 @@ Status: done (full uniform route surface: definitions/runs/published/build/valid
 - [x] typecheck + build + test (3 passing) green; `pnpm harness:scan` 38/38 green (new app documented in
       project-structure + capability-placement pattern).
 
+### Phase A — SSE progress stream (#896)
+
+- [x] `GET /v1/dag/runs/:id/events` streams a run's progress as Server-Sent Events from an injected
+      `IRunProgressSource` (the framework's `runProgressEventBus`); 501 when no source is wired.
+      Write-chain serialization flushes the terminal event before the stream closes.
+
+### Phase B — HttpDagRuntimeProvider
+
+- [x] `HttpDagRuntimeProvider implements IDetachableRunProvider` (`packages/dag-framework`) — drives a
+      remote native server over `/v1/dag/*`: `submitRun` (createRun+startRun), `watchRun` (SSE +
+      terminal-poll race, so attaching to an already-finished run can't hang), `getRunStatus`, `listNodes`.
+      `cancelRun`/`listRuns` reject plainly (no server endpoint) rather than fake success.
+- [x] Shared `run-result-mapping.ts` SSOT (`isTerminalStatus`/`collectOutputsFromTaskRuns`/`extractFinalText`/
+      `extractRunError`/`mapRunToResult`); `LocalDagRuntimeProvider` refactored to consume it (duplicates removed).
+- [x] Round-trip test (`apps/dag-runtime-server`): `HttpDagRuntimeProvider` against the in-process server via
+      `app.request` fetch — listNodes, full execute (submit→watch→result), terminal status, unsupported-op rejects.
+- [x] typecheck + build + lint (0 errors) + tests (13 server / 110 framework) green; `pnpm harness:scan` 39/39 green.
+
+### Phase C — Provider resolution (follow-on, TC-04)
+
+- [ ] dag-cli `--provider http` + dag-mcp-server `--server-url`; URL from `DAG_RUNTIME_SERVER_URL` env with
+      `--server-url` flag override (flag wins).
+
 ## TC Coverage Map
 
-| TC                                    | Covered by                         |
-| ------------------------------------- | ---------------------------------- |
-| TC-01 (R1 routes, external-runtime 0) | Phase 1, Phase 2                   |
-| TC-02 (provider/port impl typechecks) | Phase 1, Phase 3                   |
-| TC-03 (client↔server round-trip)      | Phase 2                            |
-| TC-04 (provider resolution)           | follow-on (HttpDagRuntimeProvider) |
-| TC-05 (harness + dag tests)           | Phase 3                            |
+| TC                                    | Covered by                          |
+| ------------------------------------- | ----------------------------------- |
+| TC-01 (R1 routes, external-runtime 0) | Phase 1, Phase 2                    |
+| TC-02 (provider/port impl typechecks) | Phase 1, Phase 3                    |
+| TC-03 (client↔server round-trip)      | Phase 2, Phase B (provider e2e)     |
+| TC-04 (provider resolution)           | Phase C (follow-on: CLI/MCP wiring) |
+| TC-05 (harness + dag tests)           | Phase 3                             |
 
 ## Test Plan / 검증
 

--- a/apps/dag-runtime-server/src/__tests__/http-provider.roundtrip.test.ts
+++ b/apps/dag-runtime-server/src/__tests__/http-provider.roundtrip.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { toDagWorkflowFile } from '@robota-sdk/dag-builder';
+import { createDagFramework, HttpDagRuntimeProvider } from '@robota-sdk/dag-framework';
+
+import { createDagRuntimeServer } from '../app.js';
+
+import type { IDagDefinition, IDagWorkflowFile } from '@robota-sdk/dag-core';
+import type { IDagFramework } from '@robota-sdk/dag-framework';
+
+// A single-node DAG: one InputNode emitting its configured text on the `text` output port.
+// InputNode has no inputs and always succeeds, so the run reaches a terminal state quickly —
+// exactly the race (run finishes before the watcher subscribes) the provider must tolerate.
+const SINGLE_INPUT_DEFINITION: IDagDefinition = {
+  dagId: 'http-roundtrip',
+  version: 1,
+  status: 'published',
+  nodes: [{ nodeId: 'in', nodeType: 'input', dependsOn: [], config: { text: 'hello-http' } }],
+  edges: [],
+};
+
+function buildWorkflowFile(): IDagWorkflowFile {
+  return toDagWorkflowFile(SINGLE_INPUT_DEFINITION).workflowFile;
+}
+
+describe('HttpDagRuntimeProvider round-trip against the in-process server', () => {
+  let framework: IDagFramework;
+  let provider: HttpDagRuntimeProvider;
+
+  beforeEach(async () => {
+    framework = await createDagFramework();
+    await framework.start();
+    const app = createDagRuntimeServer(
+      framework.client,
+      framework.internals.execution.runProgressEventBus,
+    );
+    // Route the provider's HTTP + SSE traffic into the in-process Hono app instead of a real socket.
+    const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) =>
+      app.request(input as string, init)) as typeof fetch;
+    provider = new HttpDagRuntimeProvider({ baseUrl: 'http://dag.test', fetch: fetchImpl });
+  });
+
+  afterEach(async () => {
+    await framework.stop();
+  });
+
+  it('lists the node catalog over the native route', async () => {
+    const nodes = await provider.listNodes();
+    expect(Array.isArray(nodes)).toBe(true);
+    expect(nodes.some((n) => n.nodeType === 'input')).toBe(true);
+  });
+
+  it('executes a DAG end-to-end (submit → watch → result)', async () => {
+    const events: string[] = [];
+    const result = await provider.execute(
+      buildWorkflowFile(),
+      { text: 'hello-http' },
+      { onProgress: (e) => events.push(e.type) },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    // The InputNode's `text` output (the run input, runtime-priority) reached the mapped result —
+    // proof the payload flowed submit → execute → result over HTTP. The output key embeds the
+    // recovered node id, so assert on the value rather than a brittle exact key.
+    const textOutputs = Object.entries(result.outputs)
+      .filter(([key]) => key.endsWith('.text'))
+      .map(([, value]) => value);
+    expect(textOutputs).toContain('hello-http');
+  });
+
+  it('submitRun returns a runId whose status becomes terminal', async () => {
+    const runId = await provider.submitRun(buildWorkflowFile(), { text: 'status-check' });
+    expect(typeof runId).toBe('string');
+    expect(runId.length).toBeGreaterThan(0);
+
+    // Watch to completion, then the status must be a terminal `completed`.
+    await provider.watchRun(runId, () => undefined);
+    const status = await provider.getRunStatus(runId);
+    expect(status.runId).toBe(runId);
+    expect(status.phase).toBe('completed');
+    expect(status.result?.ok).toBe(true);
+  });
+
+  it('rejects unsupported detachable operations rather than faking success', async () => {
+    await expect(provider.cancelRun('run-x')).rejects.toThrow(/not supported/);
+    await expect(provider.listRuns()).rejects.toThrow(/not supported/);
+  });
+});

--- a/packages/dag-framework/src/http-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/http-dag-runtime-provider.ts
@@ -1,0 +1,292 @@
+// HTTP runtime provider: drives a remote native DAG runtime server (apps/dag-runtime-server) over its
+// `/v1/dag/*` surface. The first implementation of `IDetachableRunProvider` — submit a run, watch its
+// progress over the SSE stream, query status, and read the final result. Mirrors LocalDagRuntimeProvider
+// behaviour via the shared run-result mapping (no per-provider drift).
+
+import { fromDagWorkflowFile } from '@robota-sdk/dag-builder';
+import { DagOrchestrationHttpClient } from '@robota-sdk/dag-orchestration-client';
+
+import { isTerminalStatus, mapRunToResult } from './run-result-mapping.js';
+
+import type {
+  IDagNodeManifest,
+  IDagRun,
+  IDagRunStatus,
+  IDagRuntimeExecuteOptions,
+  IDagRunSummary,
+  IDagRuntimeProgressEvent,
+  IDagRuntimeResult,
+  IDagWorkflowFile,
+  IDetachableRunProvider,
+  IListRunsOptions,
+  ITaskRun,
+  TDagRunStatus,
+  TPortPayload,
+  TRunPhase,
+  TRunProgressEvent,
+} from '@robota-sdk/dag-core';
+
+export interface IHttpDagRuntimeProviderOptions {
+  /** Base URL of the native DAG runtime server, e.g. `http://localhost:3939`. */
+  readonly baseUrl: string;
+  /** Fetch implementation (defaults to the global `fetch`); injectable for tests. */
+  readonly fetch?: typeof fetch;
+}
+
+interface IRunDataPayload {
+  readonly data?: {
+    readonly dagRunId?: string;
+    readonly dagRun?: IDagRun;
+    readonly taskRuns?: ITaskRun[];
+    readonly items?: IDagNodeManifest[];
+  };
+}
+
+/** Delay between run-status polls while watching a run for terminal completion. */
+const TERMINAL_POLL_INTERVAL_MS = 50;
+
+/** Map a persisted DAG run status to the runtime-provider lifecycle phase. */
+function toRunPhase(status: TDagRunStatus): TRunPhase {
+  if (status === 'success') return 'completed';
+  if (status === 'created') return 'queued';
+  return status;
+}
+
+/** Resolve after `ms`, or early if the signal aborts. */
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+/** Parse a single SSE frame (`event: <name>\ndata: <json>`) into its event name + data payload. */
+function parseSseFrame(frame: string): { event: string; data: string } | undefined {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event:')) event = line.slice('event:'.length).trim();
+    else if (line.startsWith('data:')) dataLines.push(line.slice('data:'.length).trim());
+  }
+  if (dataLines.length === 0) return undefined;
+  return { event, data: dataLines.join('\n') };
+}
+
+/** Translate a server run-progress event into the runtime-provider progress contract. */
+function emitRuntimeProgress(
+  event: TRunProgressEvent,
+  onProgress: (event: IDagRuntimeProgressEvent) => void,
+  startTimes: Map<string, number>,
+): void {
+  if (event.eventType === 'task.started') {
+    startTimes.set(event.nodeId, Date.now());
+    onProgress({ type: 'node_start', nodeId: event.nodeId });
+  } else if (event.eventType === 'task.completed') {
+    const startedAt = startTimes.get(event.nodeId);
+    onProgress({
+      type: 'node_complete',
+      nodeId: event.nodeId,
+      durationMs: startedAt !== undefined ? Date.now() - startedAt : undefined,
+    });
+  } else if (event.eventType === 'task.failed') {
+    const startedAt = startTimes.get(event.nodeId);
+    onProgress({
+      type: 'node_error',
+      nodeId: event.nodeId,
+      durationMs: startedAt !== undefined ? Date.now() - startedAt : undefined,
+      error: event.error.message ?? event.error.code,
+    });
+  }
+}
+
+export class HttpDagRuntimeProvider implements IDetachableRunProvider {
+  public readonly providerId = 'http';
+  public readonly displayName: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly client: DagOrchestrationHttpClient;
+
+  public constructor(options: IHttpDagRuntimeProviderOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = options.fetch ?? fetch;
+    this.displayName = `HTTP (${this.baseUrl})`;
+    this.client = new DagOrchestrationHttpClient({ baseUrl: this.baseUrl, fetch: this.fetchImpl });
+  }
+
+  public async listNodes(): Promise<IDagNodeManifest[]> {
+    const response = await this.client.listNodes();
+    if (!response.ok) {
+      throw new Error(`listNodes failed (HTTP ${response.status})`);
+    }
+    return (response.payload as IRunDataPayload).data?.items ?? [];
+  }
+
+  public async execute(
+    dag: IDagWorkflowFile,
+    inputs: Record<string, unknown>,
+    options?: IDagRuntimeExecuteOptions,
+  ): Promise<IDagRuntimeResult> {
+    const runId = await this.submitRun(dag, inputs);
+    return this.watchRun(runId, options?.onProgress ?? (() => undefined), options?.signal);
+  }
+
+  public async submitRun(dag: IDagWorkflowFile, inputs: Record<string, unknown>): Promise<string> {
+    const definition = fromDagWorkflowFile(dag);
+    const created = await this.client.createRun({ definition, input: inputs as TPortPayload });
+    if (!created.ok) {
+      throw new Error(`createRun failed (HTTP ${created.status})`);
+    }
+    const dagRunId = (created.payload as IRunDataPayload).data?.dagRunId;
+    if (dagRunId === undefined) {
+      throw new Error('createRun did not return a dagRunId');
+    }
+    const started = await this.client.startRun(dagRunId);
+    if (!started.ok) {
+      throw new Error(`startRun failed (HTTP ${started.status})`);
+    }
+    return dagRunId;
+  }
+
+  public async watchRun(
+    runId: string,
+    onProgress: (event: IDagRuntimeProgressEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<IDagRuntimeResult> {
+    const startMs = Date.now();
+    // The progress bus is live-only: a run that finished before we subscribe emits no terminal event,
+    // so the stream alone could hang. Race the live stream against a terminal-status poll — whichever
+    // observes completion first wins, then abort the loser. This makes attaching to an already-finished
+    // run (the detachable-run reconnect case) safe.
+    const watchAbort = new AbortController();
+    const forwardAbort = (): void => watchAbort.abort();
+    if (signal?.aborted) watchAbort.abort();
+    else signal?.addEventListener('abort', forwardAbort, { once: true });
+    try {
+      await Promise.race([
+        this.consumeProgressStream(runId, onProgress, watchAbort.signal),
+        this.pollUntilTerminal(runId, watchAbort.signal),
+      ]);
+    } finally {
+      watchAbort.abort();
+      signal?.removeEventListener('abort', forwardAbort);
+    }
+
+    const result = await this.client.getRunResult(runId);
+    if (!result.ok) {
+      throw new Error(`getRunResult failed (HTTP ${result.status})`);
+    }
+    const data = (result.payload as IRunDataPayload).data;
+    if (data?.dagRun === undefined) {
+      throw new Error('getRunResult response did not include the run state');
+    }
+    return mapRunToResult(data.dagRun, data.taskRuns ?? [], Date.now() - startMs);
+  }
+
+  public async getRunStatus(runId: string): Promise<IDagRunStatus> {
+    const response = await this.client.getRunStatus(runId);
+    if (!response.ok) {
+      throw new Error(`getRunStatus failed (HTTP ${response.status})`);
+    }
+    const dagRun = (response.payload as IRunDataPayload).data?.dagRun;
+    if (dagRun === undefined) {
+      throw new Error('getRunStatus response did not include the run state');
+    }
+    const status: IDagRunStatus = { runId, phase: toRunPhase(dagRun.status) };
+    if (dagRun.startedAt !== undefined) status.startedAt = dagRun.startedAt;
+    if (isTerminalStatus(dagRun.status)) {
+      const taskRuns = (response.payload as IRunDataPayload).data?.taskRuns ?? [];
+      status.result = mapRunToResult(dagRun, taskRuns, 0);
+    }
+    return status;
+  }
+
+  public cancelRun(_runId: string): Promise<void> {
+    // The orchestration surface exposes no run-cancel endpoint yet; surface that plainly rather than
+    // pretend success.
+    return Promise.reject(
+      new Error(
+        'cancelRun is not supported by the HTTP runtime provider (no server cancel endpoint)',
+      ),
+    );
+  }
+
+  public listRuns(_options?: IListRunsOptions): Promise<IDagRunSummary[]> {
+    // The orchestration surface exposes no run-listing endpoint yet; surface that plainly rather
+    // than return an empty list that would read as "no runs exist".
+    return Promise.reject(
+      new Error(
+        'listRuns is not supported by the HTTP runtime provider (no server run-listing endpoint)',
+      ),
+    );
+  }
+
+  /** Poll the run's status until it reaches a terminal state (or the watch is aborted). */
+  private async pollUntilTerminal(runId: string, signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      const response = await this.client.getRunStatus(runId);
+      if (response.ok) {
+        const dagRun = (response.payload as IRunDataPayload).data?.dagRun;
+        if (dagRun !== undefined && isTerminalStatus(dagRun.status)) return;
+      }
+      await delay(TERMINAL_POLL_INTERVAL_MS, signal);
+    }
+  }
+
+  /** Consume the run's SSE progress stream until it closes (terminal event or abort). */
+  private async consumeProgressStream(
+    runId: string,
+    onProgress: (event: IDagRuntimeProgressEvent) => void,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/v1/dag/runs/${encodeURIComponent(runId)}/events`,
+      {
+        signal,
+      },
+    );
+    // No stream available (e.g. 501): the caller still reads the final result via getRunResult.
+    if (!response.ok || response.body === null) return;
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const startTimes = new Map<string, number>();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let separator = buffer.indexOf('\n\n');
+        while (separator !== -1) {
+          const frame = buffer.slice(0, separator);
+          buffer = buffer.slice(separator + 2);
+          const parsed = parseSseFrame(frame);
+          if (parsed !== undefined && parsed.event !== 'open') {
+            emitRuntimeProgress(
+              JSON.parse(parsed.data) as TRunProgressEvent,
+              onProgress,
+              startTimes,
+            );
+          }
+          separator = buffer.indexOf('\n\n');
+        }
+      }
+    } catch (err) {
+      // allow-fallback: an abort is the normal stop signal once the terminal state is observed
+      // out-of-band (the polling branch won the race); only non-abort errors are real failures.
+      if (signal.aborted) return;
+      throw err;
+    }
+  }
+}

--- a/packages/dag-framework/src/index.ts
+++ b/packages/dag-framework/src/index.ts
@@ -17,6 +17,9 @@ export type {
 export { LocalDagRuntimeProvider } from './local-dag-runtime-provider.js';
 export type { ILocalDagRuntimeProviderOptions } from './local-dag-runtime-provider.js';
 
+export { HttpDagRuntimeProvider } from './http-dag-runtime-provider.js';
+export type { IHttpDagRuntimeProviderOptions } from './http-dag-runtime-provider.js';
+
 export { DagPromptBackend } from './adapters/prompt-backend.js';
 export { LocalFsAssetStore } from './adapters/local-fs-asset-store.js';
 export { createExecutionComposition } from './composition/create-execution-composition.js';

--- a/packages/dag-framework/src/local-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/local-dag-runtime-provider.ts
@@ -37,6 +37,12 @@ import { fromDagWorkflowFile } from '@robota-sdk/dag-builder';
 
 import { createDefaultNodeRegistrySync } from './default-node-registry.js';
 import { createExecutionComposition } from './composition/create-execution-composition.js';
+import {
+  collectOutputsFromTaskRuns,
+  extractFinalText,
+  extractRunError,
+  isTerminalStatus,
+} from './run-result-mapping.js';
 
 const LOCAL_WORKER_ID = 'local-dag-runtime-provider';
 const LOCAL_LEASE_DURATION_MS = 60_000;
@@ -45,12 +51,6 @@ const LOCAL_MAX_ATTEMPTS = 1;
 const LOCAL_DEFAULT_TIMEOUT_MS = 300_000;
 const WORKER_IDLE_POLL_DELAY_MS = 10;
 const MAX_WORKER_ITERATIONS = 10_000;
-
-const TERMINAL_STATUSES = new Set(['success', 'failed', 'cancelled']);
-
-function isTerminalStatus(status: string): boolean {
-  return TERMINAL_STATUSES.has(status);
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -302,54 +302,6 @@ async function runDagOnce(
   } finally {
     unsubscribe();
   }
-}
-
-function collectOutputsFromTaskRuns(taskRuns: ITaskRun[]): Record<string, unknown> {
-  const outputs: Record<string, unknown> = {};
-  for (const taskRun of taskRuns) {
-    const snapshot = parseOutputSnapshot(taskRun.outputSnapshot);
-    for (const [k, v] of Object.entries(snapshot)) {
-      outputs[`${taskRun.nodeId}.${k}`] = v;
-    }
-  }
-  return outputs;
-}
-
-function parseOutputSnapshot(snapshot: string | undefined): Record<string, unknown> {
-  if (!snapshot) return {};
-  try {
-    const parsed = JSON.parse(snapshot) as unknown;
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-    return {};
-  } catch {
-    // allow-fallback: outputSnapshot is advisory display data; malformed JSON is skipped gracefully
-    return {};
-  }
-}
-
-function extractFinalText(taskRuns: ITaskRun[]): string | undefined {
-  for (let i = taskRuns.length - 1; i >= 0; i--) {
-    const taskRun = taskRuns[i];
-    if (!taskRun || taskRun.status !== 'success') continue;
-    const snapshot = parseOutputSnapshot(taskRun.outputSnapshot);
-    for (const val of Object.values(snapshot)) {
-      if (typeof val === 'string') return val;
-    }
-  }
-  return undefined;
-}
-
-function extractRunError(taskRuns: ITaskRun[]): string | undefined {
-  for (let i = taskRuns.length - 1; i >= 0; i--) {
-    const taskRun = taskRuns[i];
-    if (!taskRun) continue;
-    if (taskRun.status === 'failed' && taskRun.errorMessage) {
-      return `${taskRun.nodeId}: ${taskRun.errorMessage}`;
-    }
-  }
-  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/dag-framework/src/run-result-mapping.ts
+++ b/packages/dag-framework/src/run-result-mapping.ts
@@ -1,0 +1,79 @@
+// Shared mapping from a terminal run's persisted state (dagRun + taskRuns) to the runtime-provider
+// result contract. Used by both LocalDagRuntimeProvider and HttpDagRuntimeProvider so the two stay
+// behaviourally identical (single source — no per-provider drift).
+
+import type { IDagRun, IDagRuntimeResult, ITaskRun } from '@robota-sdk/dag-core';
+
+const TERMINAL_STATUSES = new Set(['success', 'failed', 'cancelled']);
+
+/** A DAG run has reached a terminal lifecycle state (no further transitions). */
+export function isTerminalStatus(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+function parseOutputSnapshot(snapshot: string | undefined): Record<string, unknown> {
+  if (!snapshot) return {};
+  let parsed: unknown;
+  // allow-fallback: outputSnapshot is advisory display data; malformed JSON is skipped gracefully
+  try {
+    parsed = JSON.parse(snapshot);
+  } catch {
+    return {};
+  } // allow-fallback: malformed advisory display data is skipped
+  if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Flatten every task run's output snapshot into `{ "<nodeId>.<key>": value }`. */
+export function collectOutputsFromTaskRuns(taskRuns: ITaskRun[]): Record<string, unknown> {
+  const outputs: Record<string, unknown> = {};
+  for (const taskRun of taskRuns) {
+    const snapshot = parseOutputSnapshot(taskRun.outputSnapshot);
+    for (const [k, v] of Object.entries(snapshot)) {
+      outputs[`${taskRun.nodeId}.${k}`] = v;
+    }
+  }
+  return outputs;
+}
+
+/** The last successful task's first string output — a best-effort "final text" of the run. */
+export function extractFinalText(taskRuns: ITaskRun[]): string | undefined {
+  for (let i = taskRuns.length - 1; i >= 0; i--) {
+    const taskRun = taskRuns[i];
+    if (!taskRun || taskRun.status !== 'success') continue;
+    const snapshot = parseOutputSnapshot(taskRun.outputSnapshot);
+    for (const val of Object.values(snapshot)) {
+      if (typeof val === 'string') return val;
+    }
+  }
+  return undefined;
+}
+
+/** The last failed task's error, prefixed with its node id. */
+export function extractRunError(taskRuns: ITaskRun[]): string | undefined {
+  for (let i = taskRuns.length - 1; i >= 0; i--) {
+    const taskRun = taskRuns[i];
+    if (!taskRun) continue;
+    if (taskRun.status === 'failed' && taskRun.errorMessage) {
+      return `${taskRun.nodeId}: ${taskRun.errorMessage}`;
+    }
+  }
+  return undefined;
+}
+
+/** Map a terminal run (dagRun + taskRuns) to the `IDagRuntimeResult` contract. */
+export function mapRunToResult(
+  dagRun: IDagRun,
+  taskRuns: ITaskRun[],
+  durationMs: number,
+): IDagRuntimeResult {
+  const ok = dagRun.status === 'success';
+  return {
+    ok,
+    outputs: collectOutputsFromTaskRuns(taskRuns),
+    durationMs,
+    error: ok ? undefined : extractRunError(taskRuns),
+  };
+}


### PR DESCRIPTION
## WORKFLOW-002 Phase B — HttpDagRuntimeProvider

원격 native DAG runtime 서버(`apps/dag-runtime-server`)를 `/v1/dag/*` 표면으로 구동하는 `IDetachableRunProvider` 구현. `LocalDagRuntimeProvider`의 HTTP 짝.

### 구현
- `HttpDagRuntimeProvider`: `submitRun`(createRun+startRun) · `watchRun` · `getRunStatus` · `listNodes`.
- `watchRun`이 라이브 SSE 스트림과 terminal-status 폴링을 **race** — progress bus가 live-only라 워처 구독 전에 끝난 run은 terminal 이벤트를 받지 못함. "이미 끝난 run에 attach"(detachable-run 재연결) 케이스가 멈추지 않도록 보장.
- `cancelRun`/`listRuns`는 서버 엔드포인트 부재를 솔직하게 reject — 가짜 성공/빈 목록 금지.
- `run-result-mapping.ts`를 공유 SSOT로 추출, `LocalDagRuntimeProvider`가 이를 소비하도록 리팩토링(중복 헬퍼 제거)해 두 provider drift 방지.

### 테스트 / 검증
- 라운드트립 테스트(`apps/dag-runtime-server`): provider가 `app.request` fetch로 in-process Hono 서버 구동 — listNodes, full execute(submit→watch→result), terminal status, unsupported-op reject.
- typecheck + build + lint(0 errors) + tests(13 server / 110 framework) green.
- `pnpm harness:scan` 39/39 green. pre-push `harness:verify` green.

### 남은 것
- Phase C (provider resolution): dag-cli `--provider http` + dag-mcp-server `--server-url` — 별도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)