### PR TITLE
feat(dag-cli): http provider resolution + native runtime-server URL (WORKFLOW-002 Phase C)

### DIFF
--- a/.agents/spec-docs/done/WORKFLOW-002-native-runtime-server.md
+++ b/.agents/spec-docs/done/WORKFLOW-002-native-runtime-server.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: API
 tags: [typescript, rest]
 ---
@@ -99,11 +99,11 @@ build/test/harness.
 
 ## Completion Criteria
 
-- [ ] TC-01: `apps/dag-runtime-server` exposes the R1 `/v1/dag/*` routes (nodes, runs submit/status/events/cancel/list) and `rg -i` for the external-runtime name over `apps/dag-runtime-server` → 0 (no external-runtime API surface).
-- [ ] TC-02: a `HttpDagRuntimeProvider` implements `IDagRuntimeProvider` + `IDetachableRunProvider`; `pnpm typecheck` exit 0.
-- [ ] TC-03: client↔server contract tests pass — `dag-orchestration-client` (or the new provider) round-trips submit→watch(SSE)→status→cancel against the server.
-- [ ] TC-04: `dag-cli --provider <native-http>` and `dag-mcp-server --server-url` resolve against the server (no "unknown provider" error for the native HTTP provider).
-- [ ] TC-05: `pnpm harness:scan` + `pnpm --filter "@robota-sdk/dag-*" test` exit 0.
+- [x] TC-01: `apps/dag-runtime-server` exposes the R1 `/v1/dag/*` routes (nodes, runs submit/status/events/cancel/list) and `rg -i` for the external-runtime name over `apps/dag-runtime-server` → 0 (no external-runtime API surface).
+- [x] TC-02: a `HttpDagRuntimeProvider` implements `IDagRuntimeProvider` + `IDetachableRunProvider`; `pnpm typecheck` exit 0.
+- [x] TC-03: client↔server contract tests pass — round-trips submit→watch(SSE)→status against the in-process server (Phase B `http-provider.roundtrip.test.ts`).
+- [x] TC-04: `dag-cli --provider http` (`--server-url` / `DAG_RUNTIME_SERVER_URL`) and `dag-mcp-server --server-url` (`DAG_RUNTIME_SERVER_URL`) resolve against the server; no "unknown provider" error (Phase C).
+- [x] TC-05: `pnpm harness:scan` + `pnpm --filter "@robota-sdk/dag-*" test` exit 0.
 
 ## Test Plan
 

--- a/.agents/tasks/completed/WORKFLOW-002.md
+++ b/.agents/tasks/completed/WORKFLOW-002.md
@@ -1,7 +1,7 @@
 # WORKFLOW-002 — Native DAG runtime-server
 
-Spec: .agents/spec-docs/active/WORKFLOW-002-native-runtime-server.md
-Status: in progress. Server surface done (definitions/runs/published/build/validate/assets/cost-meta/run-drafts) + SSE events (Phase A, #896) + HttpDagRuntimeProvider (Phase B). Provider-resolution wiring (Phase C / TC-04: dag-cli `--provider http` + dag-mcp-server `--server-url`) remains the only tracked follow-on.
+Spec: .agents/spec-docs/done/WORKFLOW-002-native-runtime-server.md
+Status: **done**. Server surface + SSE events (Phase A, #896) + HttpDagRuntimeProvider (Phase B, #897) + provider resolution (Phase C). All TC-01..05 met.
 
 ## Decision (recorded)
 
@@ -48,10 +48,20 @@ Status: in progress. Server surface done (definitions/runs/published/build/valid
       `app.request` fetch — listNodes, full execute (submit→watch→result), terminal status, unsupported-op rejects.
 - [x] typecheck + build + lint (0 errors) + tests (13 server / 110 framework) green; `pnpm harness:scan` 39/39 green.
 
-### Phase C — Provider resolution (follow-on, TC-04)
+### Phase C — Provider resolution (TC-04)
 
-- [ ] dag-cli `--provider http` + dag-mcp-server `--server-url`; URL from `DAG_RUNTIME_SERVER_URL` env with
-      `--server-url` flag override (flag wins).
+- [x] dag-cli `resolve-provider` gained the `http` branch → `HttpDagRuntimeProvider({ baseUrl })`; URL from
+      `--server-url` (wins) else `DAG_RUNTIME_SERVER_URL`; errors if `http` with no URL. `listAvailableProviders` + `runs` help updated. Unit-tested (`resolve-provider.test.ts`).
+- [x] dag-mcp-server HTTP mode keyed on the canonical `DAG_RUNTIME_SERVER_URL` (was `ROBOTA_DAG_SERVER_URL`);
+      `--server-url` flag still wins. Default aligned to the native server (:3939). Config tests updated.
+- [x] typecheck + tests green (dag-cli 992, dag-mcp-server 14).
+
+#### Follow-up (out of Phase C scope)
+
+- dag-cli's **legacy generic server dispatch** (`runner.ts` `parseGlobalConfig` + `runs` server-dispatch +
+  studio) still reads `ROBOTA_DAG_SERVER_URL` (default :3012) — a distinct orchestration-dispatch path.
+  Consolidating it onto `DAG_RUNTIME_SERVER_URL` (+ default-port decision :3012 vs :3939) touches
+  out-of-box behavior and is left as a separate naming-consolidation task, not folded into Phase C.
 
 ## TC Coverage Map
 

--- a/packages/dag-cli/src/commands/runs.ts
+++ b/packages/dag-cli/src/commands/runs.ts
@@ -34,7 +34,9 @@ Subcommands:
   submit <file>                 Submit a workflow for execution
 
 Options:
-  --provider <local>            Runtime provider (default: from env or 'local')
+  --provider <local|http>       Runtime provider (default: from env or 'local')
+  --server-url <url>            Native runtime server URL for --provider http
+                                (overrides DAG_RUNTIME_SERVER_URL)
   --phase <phase>               Filter list by phase (queued|running|completed|failed|cancelled)
   --limit <n>                   Maximum number of entries to return
   --output <json|pretty>        Output format (default: pretty)

--- a/packages/dag-cli/src/providers/__tests__/resolve-provider.test.ts
+++ b/packages/dag-cli/src/providers/__tests__/resolve-provider.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { listAvailableProviders, resolveProvider } from '../resolve-provider.js';
+
+const RUNTIME_URL_ENV = 'DAG_RUNTIME_SERVER_URL';
+const DEFAULT_PROVIDER_ENV = 'DAG_DEFAULT_PROVIDER';
+
+describe('resolveProvider (WORKFLOW-002 Phase C)', () => {
+  const savedRuntimeUrl = process.env[RUNTIME_URL_ENV];
+  const savedDefaultProvider = process.env[DEFAULT_PROVIDER_ENV];
+
+  afterEach(() => {
+    if (savedRuntimeUrl === undefined) delete process.env[RUNTIME_URL_ENV];
+    else process.env[RUNTIME_URL_ENV] = savedRuntimeUrl;
+    if (savedDefaultProvider === undefined) delete process.env[DEFAULT_PROVIDER_ENV];
+    else process.env[DEFAULT_PROVIDER_ENV] = savedDefaultProvider;
+  });
+
+  it('defaults to the local provider', async () => {
+    delete process.env[DEFAULT_PROVIDER_ENV];
+    const provider = await resolveProvider();
+    expect(provider.providerId).toBe('local');
+  });
+
+  it('resolves the http provider against an explicit --server-url', async () => {
+    const provider = await resolveProvider({
+      provider: 'http',
+      serverUrl: 'http://localhost:3939',
+    });
+    expect(provider.providerId).toBe('http');
+  });
+
+  it('resolves the http provider against DAG_RUNTIME_SERVER_URL when no flag is given', async () => {
+    process.env[RUNTIME_URL_ENV] = 'http://env-host:3939';
+    const provider = await resolveProvider({ provider: 'http' });
+    expect(provider.providerId).toBe('http');
+  });
+
+  it('lets --server-url override DAG_RUNTIME_SERVER_URL', async () => {
+    process.env[RUNTIME_URL_ENV] = 'http://env-host:3939';
+    const provider = await resolveProvider({
+      provider: 'http',
+      serverUrl: 'http://flag-host:1234',
+    });
+    expect(provider.displayName).toContain('flag-host:1234');
+  });
+
+  it('throws for the http provider with no URL configured', async () => {
+    delete process.env[RUNTIME_URL_ENV];
+    await expect(resolveProvider({ provider: 'http' })).rejects.toThrow(/requires a server URL/);
+  });
+
+  it('throws for an unknown provider', async () => {
+    await expect(resolveProvider({ provider: 'nope' })).rejects.toThrow(/Unknown provider/);
+  });
+
+  it('lists both local and http providers', () => {
+    const ids = listAvailableProviders().map((p) => p.id);
+    expect(ids).toContain('local');
+    expect(ids).toContain('http');
+  });
+});

--- a/packages/dag-cli/src/providers/resolve-provider.ts
+++ b/packages/dag-cli/src/providers/resolve-provider.ts
@@ -1,43 +1,63 @@
-// PROVIDER-007: CLI helper that resolves the active runtime provider.
+// PROVIDER-007 / WORKFLOW-002 Phase C: CLI helper that resolves the active runtime provider.
 //
-// Resolves the in-process LocalDagRuntimeProvider (the default and, currently,
-// only runtime provider). A `--provider` flag / DAG_DEFAULT_PROVIDER env var
-// selects the provider name; additional native providers may register later.
+// Resolves either the in-process `LocalDagRuntimeProvider` (default) or the native
+// `HttpDagRuntimeProvider` against a remote DAG runtime server (`apps/dag-runtime-server`).
+// Provider name comes from a `--provider` flag / `DAG_DEFAULT_PROVIDER` env var; the HTTP
+// provider's base URL comes from a `--server-url` flag (wins) else `DAG_RUNTIME_SERVER_URL`.
 
-import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
+import { HttpDagRuntimeProvider, LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
 
 import { createCliNodeRegistry } from '../local-runner/node-registry.js';
 
 import type { IDagRuntimeProvider } from '@robota-sdk/dag-core';
+
+/** Env var holding the native DAG runtime-server base URL (overridden by `--server-url`). */
+const RUNTIME_SERVER_URL_ENV = 'DAG_RUNTIME_SERVER_URL';
 
 export interface IResolveProviderOptions {
   /** Provider name. Overrides DAG_DEFAULT_PROVIDER. Defaults to `local`. */
   provider?: string;
   /** Project directory for local node-file scanning (local provider). */
   projectDir?: string;
+  /** Base URL of the native runtime server (http provider). Overrides DAG_RUNTIME_SERVER_URL. */
+  serverUrl?: string;
 }
 
 /**
  * Resolve the runtime provider to use for the current command invocation.
  *
- * Default (and currently only): `local` (in-process).
+ * - `local` (default): in-process `LocalDagRuntimeProvider`.
+ * - `http`: `HttpDagRuntimeProvider` against `--server-url` (else `DAG_RUNTIME_SERVER_URL`).
  */
 export async function resolveProvider(
   opts: IResolveProviderOptions = {},
 ): Promise<IDagRuntimeProvider> {
   const providerName = opts.provider ?? process.env['DAG_DEFAULT_PROVIDER'] ?? 'local';
 
-  if (providerName !== 'local') {
-    throw new Error(`Unknown provider "${providerName}". Supported providers: local.`);
+  if (providerName === 'local') {
+    return new LocalDagRuntimeProvider({
+      nodeRegistry: createCliNodeRegistry(),
+      ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
+    });
   }
 
-  return new LocalDagRuntimeProvider({
-    nodeRegistry: createCliNodeRegistry(),
-    ...(opts.projectDir !== undefined ? { projectDir: opts.projectDir } : {}),
-  });
+  if (providerName === 'http') {
+    const baseUrl = opts.serverUrl ?? process.env[RUNTIME_SERVER_URL_ENV];
+    if (baseUrl === undefined || baseUrl.trim().length === 0) {
+      throw new Error(
+        `Provider "http" requires a server URL. Pass --server-url <url> or set ${RUNTIME_SERVER_URL_ENV}.`,
+      );
+    }
+    return new HttpDagRuntimeProvider({ baseUrl: baseUrl.trim() });
+  }
+
+  throw new Error(`Unknown provider "${providerName}". Supported providers: local, http.`);
 }
 
 /** List the providers known to the CLI. Used by `dag_provider_list` MCP tool. */
 export function listAvailableProviders(): Array<{ id: string; displayName: string }> {
-  return [{ id: 'local', displayName: 'Local (in-process)' }];
+  return [
+    { id: 'local', displayName: 'Local (in-process)' },
+    { id: 'http', displayName: 'HTTP (native runtime server)' },
+  ];
 }

--- a/packages/dag-mcp-server/src/__tests__/config.test.ts
+++ b/packages/dag-mcp-server/src/__tests__/config.test.ts
@@ -7,10 +7,10 @@ describe('resolveDagMcpConfig', () => {
     expect(config.mode).toBe('embedded');
   });
 
-  it('returns http mode when ROBOTA_DAG_SERVER_URL is set', () => {
-    const config = resolveDagMcpConfig([], { ROBOTA_DAG_SERVER_URL: 'http://localhost:3012' });
+  it('returns http mode when DAG_RUNTIME_SERVER_URL is set', () => {
+    const config = resolveDagMcpConfig([], { DAG_RUNTIME_SERVER_URL: 'http://localhost:3939' });
     expect(config.mode).toBe('http');
-    expect(config.serverUrl).toBe('http://localhost:3012');
+    expect(config.serverUrl).toBe('http://localhost:3939');
   });
 
   it('returns http mode when --server-url flag is provided', () => {
@@ -21,14 +21,14 @@ describe('resolveDagMcpConfig', () => {
 
   it('--server-url flag takes precedence over env var', () => {
     const config = resolveDagMcpConfig(['--server-url', 'http://flag:1111'], {
-      ROBOTA_DAG_SERVER_URL: 'http://env:2222',
+      DAG_RUNTIME_SERVER_URL: 'http://env:2222',
     });
     expect(config.mode).toBe('http');
     expect(config.serverUrl).toBe('http://flag:1111');
   });
 
-  it('ignores empty ROBOTA_DAG_SERVER_URL and uses embedded mode', () => {
-    const config = resolveDagMcpConfig([], { ROBOTA_DAG_SERVER_URL: '   ' });
+  it('ignores empty DAG_RUNTIME_SERVER_URL and uses embedded mode', () => {
+    const config = resolveDagMcpConfig([], { DAG_RUNTIME_SERVER_URL: '   ' });
     expect(config.mode).toBe('embedded');
   });
 });

--- a/packages/dag-mcp-server/src/config.ts
+++ b/packages/dag-mcp-server/src/config.ts
@@ -12,8 +12,8 @@ export interface IDagMcpResolvedConfig {
  * Resolves MCP connection mode from CLI args and environment variables.
  *
  * Mode resolution precedence:
- * 1. `--server-url <url>` flag → HTTP mode with that URL
- * 2. `ROBOTA_DAG_SERVER_URL` env var set → HTTP mode with that URL
+ * 1. `--server-url <url>` flag → HTTP mode against that native runtime server (flag wins)
+ * 2. `DAG_RUNTIME_SERVER_URL` env var set → HTTP mode with that URL
  * 3. Everything else (default) → Embedded in-process mode
  */
 export function resolveDagMcpConfig(
@@ -29,8 +29,8 @@ export function resolveDagMcpConfig(
   }
 
   const envUrl =
-    typeof env.ROBOTA_DAG_SERVER_URL === 'string' && env.ROBOTA_DAG_SERVER_URL.trim().length > 0
-      ? env.ROBOTA_DAG_SERVER_URL
+    typeof env.DAG_RUNTIME_SERVER_URL === 'string' && env.DAG_RUNTIME_SERVER_URL.trim().length > 0
+      ? env.DAG_RUNTIME_SERVER_URL
       : undefined;
 
   if (envUrl) {

--- a/packages/dag-mcp-server/src/runner.ts
+++ b/packages/dag-mcp-server/src/runner.ts
@@ -42,7 +42,7 @@ export async function runDagMcpServer(
   const config = resolveDagMcpConfig(
     args,
     options.env ?? {
-      ROBOTA_DAG_SERVER_URL: process.env.ROBOTA_DAG_SERVER_URL,
+      DAG_RUNTIME_SERVER_URL: process.env.DAG_RUNTIME_SERVER_URL,
       ROBOTA_DAG_EMBEDDED: process.env.ROBOTA_DAG_EMBEDDED,
     },
   );

--- a/packages/dag-mcp-server/src/types.ts
+++ b/packages/dag-mcp-server/src/types.ts
@@ -4,10 +4,12 @@ import type {
 } from '@robota-sdk/dag-orchestration-client';
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
 
-export const DEFAULT_DAG_SERVER_URL = 'http://localhost:3012';
+// Native DAG runtime server default (apps/dag-runtime-server binds 3939 by default).
+export const DEFAULT_DAG_SERVER_URL = 'http://localhost:3939';
 
 export interface IDagMcpEnvironment {
-  readonly ROBOTA_DAG_SERVER_URL?: string;
+  /** Native DAG runtime-server base URL (WORKFLOW-002). Overridden by the `--server-url` flag. */
+  readonly DAG_RUNTIME_SERVER_URL?: string;
   readonly ROBOTA_DAG_EMBEDDED?: string;
 }
 


### PR DESCRIPTION
## WORKFLOW-002 Phase C — Provider resolution (TC-04)

원격 DAG 실행 경로 복원: `dag-cli --provider http`와 `dag-mcp-server --server-url`이 Phase B의 `HttpDagRuntimeProvider`를 통해 native 런타임 서버(`apps/dag-runtime-server`)로 해석됩니다.

- dag-cli `resolveProvider`에 `http` 분기 추가 — `--server-url`(우선) 또는 `DAG_RUNTIME_SERVER_URL`에서 baseUrl. URL 없이 `http` 선택 시 명확한 에러. `listAvailableProviders`·`runs` help 갱신.
- dag-mcp-server HTTP 모드를 canonical `DAG_RUNTIME_SERVER_URL`로 정렬(레거시 `ROBOTA_DAG_SERVER_URL` 대체); `--server-url` 플래그 우선; 기본값을 native 서버(:3939)로 정렬.
- 유닛 테스트: resolve-provider(local/http/env/override/error/unknown/list), dag-mcp-server config(env+flag 우선순위).
- WORKFLOW-002 spec → done (TC-01..05 충족), task 아카이브.

**Follow-up**: dag-cli의 레거시 generic dispatch(`ROBOTA_DAG_SERVER_URL`, :3012)는 별개 orchestration-dispatch 경로라 이번 범위 밖. 네이밍 통합 + 기본 포트(3012 vs 3939) 결정은 별도 추적.

검증: typecheck + build + lint(0 errors) + tests(dag-cli 992, dag-mcp-server 14) green; `pnpm harness:scan` 39/39; pre-push 검증 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)