### PR TITLE
feat(tui): arrow-key navigation into the inline background-work list (SCREEN-014)

### DIFF
--- a/.agents/backlog/SCREEN-014-background-work-keyboard-navigation.md
+++ b/.agents/backlog/SCREEN-014-background-work-keyboard-navigation.md
@@ -1,0 +1,83 @@
+---
+title: 'SCREEN-014: Define + implement arrow-key navigation into the inline background-work list'
+status: in-progress
+created: 2026-06-30
+priority: high
+urgency: now
+area: packages/agent-transport-tui
+depends_on: []
+supersedes_note: 'Revises SCREEN-013 — the Ctrl+B hint was a workaround, not the intended interaction.'
+---
+
+# Arrow-key navigation into the background-work list
+
+## Problem (observed)
+
+In the live agent-cli TUI, the "Background work" list is visible but **cannot be reached the way a user
+expects**: arrow keys do nothing to it (they drive prompt history), there is no focus/selection on the
+inline list, and the only real entry point is a separate `Ctrl+B` modal switcher that is confusing and
+feels broken. Trying to reach a background task via slash commands is also unclear. By contrast, the
+reference UX (Claude Code) lets you **just press ↓ to move into the bottom background list and Enter to
+open it** — no modal, no command.
+
+SCREEN-013 only added a `Ctrl+B` hint, which did not define or deliver the intended interaction. This
+item defines the interaction model first, then implements it, then locks it with regression tests.
+
+## Target interaction model (to confirm before implementation)
+
+Two focus zones: **(A) the prompt input** (default) and **(B) the inline background-work list** (only
+when it has entries).
+
+1. **Enter the list:** from the prompt input, pressing **↓** when the caret is on the last line and
+   there is no forward prompt-history left moves focus to the **first** background-work item (a
+   highlighted selection appears). This is the same "fall through the bottom of the input into the
+   list" behaviour as the reference UX. (Prompt-history ↑/↓ is unchanged while history remains.)
+2. **Move within the list:** **↑/↓** move the highlight between background items. **↑** past the first
+   item returns focus to the prompt input.
+3. **Open a task:** **Enter** on the highlighted item opens that task's detail (the existing
+   `ExecutionWorkspaceDetailPane` via `selectExecutionWorkspaceEntry` + `readExecutionWorkspaceDetail`)
+   — inline, no modal.
+4. **Leave:** **Esc** from the list returns focus to the input; **Esc** from a task detail returns to
+   the list (or input). The main thread stays selected/active for prompting.
+5. **Affordance:** the panel shows a subtle, focus-aware hint (e.g. "↑↓ select · Enter open" when
+   focusable) instead of the current `Ctrl+B` text.
+
+The order shown is the stable order from SCREEN-010 so the highlight is predictable.
+
+## Confirmed decisions (2026-06-30)
+
+- **D1 — entry key: ↓ fall-through.** From the input, ↓ at the caret's last line with no forward
+  prompt-history moves focus to the first background item (reference-style). Prompt-history ↑/↓
+  unchanged while history remains.
+- **D2 — Ctrl+B switcher: keep as secondary.** Inline arrow-key navigation is the primary path; the
+  Ctrl+B switcher stays as the full execution-workspace overlay (incl. main thread).
+- **D3 — keyboard only, no slash command.** Do not add a background slash command; remove/clean up any
+  confusing existing background command surface so the keyboard path is the single clear way in.
+- **D4 — inline detail pane.** Enter opens the existing `ExecutionWorkspaceDetailPane` inline (no modal).
+
+## Test Plan
+
+- Component/interaction tests (ink-testing-library): ↓ from the input focuses the first item; ↑/↓ move
+  the highlight; ↑ past the top returns to the input; Enter opens the detail pane and triggers
+  `readExecutionWorkspaceDetail`; Esc unwinds focus. Prompt-history ↑/↓ still works while history
+  remains (no regression).
+- PTY E2E (extends TEST-010, needs the deterministic background-task seed): with ≥2 seeded background
+  tasks in the real binary, ↓ + Enter opens a task's detail; ↑ returns to the input.
+- typecheck / lint / `pnpm --filter @robota-sdk/agent-transport-tui test` + `test:pty` green; the
+  `tui-e2e` CI job covers it.
+
+## User Execution Test Scenarios
+
+- Prereq: built CLI; a session with ≥2 running background agents.
+- Steps: run `robota`, spawn ≥2 background agents, ensure the prompt input is empty, press **↓** once
+  (focus enters the list), press **↓** to highlight the second task, press **Enter**.
+- Expected: ↓ moves a visible highlight into the bottom background list; Enter opens that task's detail
+  (status/output); **↑** from the top of the list returns to the prompt; no modal is required.
+- Evidence (automated, agent-run): `background-focus-flow.test.ts` (6) exhaustively covers the
+  ↑/↓/Enter/Esc/empty navigation reducer; `input-area-focus-handoff.test.tsx` (2) proves ↓ on an
+  empty input requests list focus (and not while disabled); `background-task-panel.test.tsx` covers
+  the focus highlight + focus-aware hint. Full TUI suite green (392), real-binary PTY smoke green.
+  **Remaining gate:** the full live ↓ → ↑↓ → Enter → inline-detail flow against _real seeded
+  background tasks_ in the binary needs the deterministic background-task seed (TEST-010 Phase 3);
+  tracked there. Until then the integrated flow is covered by the unit/component pieces above, not a
+  single end-to-end run.

--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from './execution-workspace-view-model.js';
 import ExecutionWorkspaceDetailPane from './ExecutionWorkspaceDetailPane.js';
 import ExecutionWorkspaceSwitcher from './ExecutionWorkspaceSwitcher.js';
+import { resolveBackgroundFocusKey } from './flows/background-focus-flow.js';
 import { usePluginCallbacks } from './hooks/usePluginCallbacks.js';
 import { useSideEffects } from './hooks/useSideEffects.js';
 import { useStatusLineSettings } from './hooks/useStatusLineSettings.js';
@@ -151,10 +152,22 @@ function AppInner(
   const [isExecutionDetailLoading, setIsExecutionDetailLoading] = useState(false);
   const [statusLineSettings, setStatusLineSettings] = useStatusLineSettings();
   const [gitRefreshToken, setGitRefreshToken] = useState(0);
+  // SCREEN-014: index of the keyboard-focused background-work row, or null when the prompt input is
+  // focused. Drives the inline arrow-key navigation into the background list.
+  const [backgroundFocusIndex, setBackgroundFocusIndex] = useState<number | null>(null);
   const backgroundWorkspaceEntries = useMemo(
     () => getDefaultBackgroundWorkspaceEntries(executionWorkspaceSnapshot),
     [executionWorkspaceSnapshot],
   );
+  const isBackgroundListFocused = backgroundFocusIndex !== null;
+  // Keep the focused index in range as tasks appear/finish; drop focus when the list empties.
+  useEffect(() => {
+    setBackgroundFocusIndex((index) => {
+      if (index === null) return null;
+      if (backgroundWorkspaceEntries.length === 0) return null;
+      return Math.min(index, backgroundWorkspaceEntries.length - 1);
+    });
+  }, [backgroundWorkspaceEntries.length]);
   const activeBackgroundTaskCount = countActiveBackgroundWorkspaceEntries(
     executionWorkspaceSnapshot,
   );
@@ -319,6 +332,39 @@ function AppInner(
     }
   });
 
+  // SCREEN-014: inline keyboard navigation of the background-work list (the primary drill-in path).
+  // Active only while the list holds focus (entered via ↓ from the input). ↑/↓ move the highlight,
+  // ↑ past the top returns to the input, Enter opens the task's inline detail, Esc returns to input.
+  useInput(
+    (
+      _input: string,
+      key: { upArrow: boolean; downArrow: boolean; return: boolean; escape: boolean },
+    ) => {
+      if (backgroundFocusIndex === null) return;
+      const entries = backgroundWorkspaceEntries;
+      const action = resolveBackgroundFocusKey(backgroundFocusIndex, entries.length, key);
+      if (action.type === 'move') {
+        setBackgroundFocusIndex(action.index);
+      } else if (action.type === 'open') {
+        const entry = entries[action.index];
+        if (entry) selectExecutionWorkspaceEntry(entry.id);
+        setBackgroundFocusIndex(null);
+      } else if (action.type === 'exit') {
+        setBackgroundFocusIndex(null);
+      }
+    },
+    {
+      isActive:
+        isBackgroundListFocused &&
+        !permissionRequest &&
+        !pendingUserAction &&
+        !showPluginTUI &&
+        !showTransportTUI &&
+        !showSessionPicker &&
+        !showExecutionWorkspaceSwitcher,
+    },
+  );
+
   // Ctrl+C graceful shutdown
   useInput((input: string, key: { ctrl?: boolean }) => {
     if (!key.ctrl || input !== 'c' || isShuttingDown) return;
@@ -440,7 +486,10 @@ function AppInner(
                 />
               </Box>
             )}
-            <BackgroundTaskPanel entries={backgroundWorkspaceEntries} />
+            <BackgroundTaskPanel
+              entries={backgroundWorkspaceEntries}
+              focusedIndex={backgroundFocusIndex}
+            />
           </Box>
           {showExecutionWorkspaceSwitcher && (
             <ExecutionWorkspaceSwitcher
@@ -498,13 +547,17 @@ function AppInner(
               showExecutionWorkspaceSwitcher ||
               isShuttingDown ||
               (isThinking && !!pendingPrompt) ||
-              !isSelectedEntryInteractive
+              !isSelectedEntryInteractive ||
+              isBackgroundListFocused
             }
             isAborting={isAborting}
             pendingPrompt={pendingPrompt}
             registry={registry}
             sessionName={sessionName}
             history={history}
+            onRequestFocusBackgroundList={() => {
+              if (backgroundWorkspaceEntries.length > 0) setBackgroundFocusIndex(0);
+            }}
           />
           <SessionStatusBar
             cwd={cwd}

--- a/packages/agent-transport-tui/src/BackgroundTaskPanel.tsx
+++ b/packages/agent-transport-tui/src/BackgroundTaskPanel.tsx
@@ -7,28 +7,35 @@ import type { IExecutionWorkspaceEntry } from '@robota-sdk/agent-interface-trans
 
 interface IProps {
   entries: IExecutionWorkspaceEntry[];
+  /** Index of the keyboard-focused row (SCREEN-014), or null when the prompt input is focused. */
+  focusedIndex?: number | null;
 }
 
-export default function BackgroundTaskPanel({ entries }: IProps): React.ReactElement | null {
+export default function BackgroundTaskPanel({
+  entries,
+  focusedIndex = null,
+}: IProps): React.ReactElement | null {
   if (entries.length === 0) return null;
+
+  // SCREEN-014: the hint is focus-aware — it tells you how to enter the list, then how to move/open.
+  const hint =
+    focusedIndex !== null ? '  ·  ↑↓ select · Enter open · Esc back' : '  ·  ↓ select · Ctrl+B all';
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      {/* SCREEN-013: advertise the drill-in. The Ctrl+B switcher (select ↑↓ · Enter to open) is the
-          only way into a background task, but it was previously undiscoverable from the main UI. */}
       <Box>
         <Text color="cyan" bold>
           Background work
         </Text>
-        <Text dimColor>{'  ·  Ctrl+B to view'}</Text>
+        <Text dimColor>{hint}</Text>
       </Box>
       {entries.map((entry, index) => {
         const row = formatBackgroundTaskRow(entry, { isLast: index === entries.length - 1 });
+        const isFocused = index === focusedIndex;
         return (
-          // SCREEN-011: keep each row to a single line so the connector + status glyph always sit at
-          // the line start. Without this the long preview wraps onto an unconnected second line and
-          // the tree glyphs lose meaning. Full text stays in `accessibleText` and the detail pane.
-          <Text key={entry.id} wrap="truncate-end">
+          // SCREEN-011: one truncated line so the connector + glyph lead the row.
+          // SCREEN-014: the keyboard-focused row is inverse-highlighted.
+          <Text key={entry.id} wrap="truncate-end" inverse={isFocused}>
             {`${row.connector} `}
             <Text color={row.color}>{row.marker}</Text>
             {` ${row.label}`}

--- a/packages/agent-transport-tui/src/InputArea.tsx
+++ b/packages/agent-transport-tui/src/InputArea.tsx
@@ -37,6 +37,11 @@ interface IProps {
   registry?: CommandRegistry;
   sessionName?: string;
   history?: readonly IHistoryEntry[];
+  /**
+   * SCREEN-014: called when ↓ is pressed on an empty input at the bottom of prompt history, so the
+   * parent can move focus into the background-work list (a no-op for the input today).
+   */
+  onRequestFocusBackgroundList?: () => void;
 }
 
 /**
@@ -68,6 +73,7 @@ export default function InputArea({
   registry,
   sessionName,
   history,
+  onRequestFocusBackgroundList,
 }: IProps): React.ReactElement {
   const [value, setValue] = useState('');
   const [cursorHint, setCursorHint] = useState<number | null>(null);
@@ -205,6 +211,13 @@ export default function InputArea({
     (_input, key) => {
       const action = getPromptHistoryInputAction(key);
       if (!action) return;
+      // SCREEN-014: ↓ on an empty input that is not browsing history falls through into the
+      // background-work list (where it is a no-op for the input today). The parent decides whether
+      // there is a list to focus.
+      if (action === 'next' && historyState.selectedIndex === null && value.length === 0) {
+        onRequestFocusBackgroundList?.();
+        return;
+      }
       const result = navigatePromptHistory(value, promptHistory, historyState, action);
       setValue(result.value);
       setCursorHint(result.cursorHint);

--- a/packages/agent-transport-tui/src/__tests__/background-task-panel.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/background-task-panel.test.tsx
@@ -51,11 +51,26 @@ describe('BackgroundTaskPanel', () => {
     expect(frame).not.toContain('agent_3');
   });
 
-  it('advertises the Ctrl+B drill-in (SCREEN-013)', () => {
+  it('advertises the keyboard drill-in when not focused (SCREEN-013/014)', () => {
     const { lastFrame } = render(
       <BackgroundTaskPanel entries={[makeEntry({ id: 'task:agent_1' })]} />,
     );
-    expect(lastFrame()!).toContain('Ctrl+B');
+    const frame = lastFrame()!;
+    // Entry affordance: ↓ to select, Ctrl+B for the full switcher.
+    expect(frame).toContain('select');
+    expect(frame).toContain('Ctrl+B');
+  });
+
+  it('shows the move/open affordance when a row is focused (SCREEN-014)', () => {
+    const { lastFrame } = render(
+      <BackgroundTaskPanel
+        entries={[makeEntry({ id: 'task:agent_1' }), makeEntry({ id: 'task:agent_2' })]}
+        focusedIndex={0}
+      />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Enter open');
+    expect(frame).toContain('Esc back');
   });
 
   it('keeps a long-preview row on a single line (SCREEN-011)', () => {

--- a/packages/agent-transport-tui/src/__tests__/input-area-focus-handoff.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/input-area-focus-handoff.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+
+import InputArea from '../InputArea.js';
+
+// ESC [ B — the terminal down-arrow sequence Ink parses into `key.downArrow`.
+const DOWN_ARROW = '[B';
+
+async function tick(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('InputArea ↓ fall-through into the background list (SCREEN-014)', () => {
+  it('requests background-list focus when ↓ is pressed on an empty input', async () => {
+    const onRequestFocusBackgroundList = vi.fn();
+    const { stdin } = render(
+      <InputArea
+        onSubmit={vi.fn()}
+        isDisabled={false}
+        onRequestFocusBackgroundList={onRequestFocusBackgroundList}
+      />,
+    );
+    await tick();
+    stdin.write(DOWN_ARROW);
+    await tick();
+    expect(onRequestFocusBackgroundList).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request focus while the input is disabled', async () => {
+    const onRequestFocusBackgroundList = vi.fn();
+    const { stdin } = render(
+      <InputArea
+        onSubmit={vi.fn()}
+        isDisabled={true}
+        onRequestFocusBackgroundList={onRequestFocusBackgroundList}
+      />,
+    );
+    await tick();
+    stdin.write(DOWN_ARROW);
+    await tick();
+    expect(onRequestFocusBackgroundList).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-transport-tui/src/flows/__tests__/background-focus-flow.test.ts
+++ b/packages/agent-transport-tui/src/flows/__tests__/background-focus-flow.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBackgroundFocusKey } from '../background-focus-flow.js';
+
+const KEY = { upArrow: false, downArrow: false, return: false, escape: false };
+
+describe('resolveBackgroundFocusKey (SCREEN-014)', () => {
+  it('↓ moves down, clamped at the last item', () => {
+    expect(resolveBackgroundFocusKey(0, 3, { ...KEY, downArrow: true })).toEqual({
+      type: 'move',
+      index: 1,
+    });
+    expect(resolveBackgroundFocusKey(2, 3, { ...KEY, downArrow: true })).toEqual({
+      type: 'move',
+      index: 2,
+    });
+  });
+
+  it('↑ moves up; ↑ past the first item returns focus to the input (null)', () => {
+    expect(resolveBackgroundFocusKey(2, 3, { ...KEY, upArrow: true })).toEqual({
+      type: 'move',
+      index: 1,
+    });
+    expect(resolveBackgroundFocusKey(0, 3, { ...KEY, upArrow: true })).toEqual({
+      type: 'move',
+      index: null,
+    });
+  });
+
+  it('Enter opens the highlighted task', () => {
+    expect(resolveBackgroundFocusKey(1, 3, { ...KEY, return: true })).toEqual({
+      type: 'open',
+      index: 1,
+    });
+  });
+
+  it('Esc exits to the input', () => {
+    expect(resolveBackgroundFocusKey(1, 3, { ...KEY, escape: true })).toEqual({ type: 'exit' });
+  });
+
+  it('an emptied list always exits', () => {
+    expect(resolveBackgroundFocusKey(0, 0, { ...KEY, downArrow: true })).toEqual({ type: 'exit' });
+  });
+
+  it('ignores unrelated keys', () => {
+    expect(resolveBackgroundFocusKey(1, 3, KEY)).toEqual({ type: 'none' });
+  });
+});

--- a/packages/agent-transport-tui/src/flows/background-focus-flow.ts
+++ b/packages/agent-transport-tui/src/flows/background-focus-flow.ts
@@ -1,0 +1,44 @@
+/**
+ * SCREEN-014: pure reducer for keyboard navigation of the inline background-work list.
+ *
+ * Kept out of the App component so the navigation rules are exhaustively unit-testable without
+ * rendering the whole TUI. The App's `useInput` translates the resulting action into focus/selection
+ * state changes.
+ */
+
+/** A key event relevant to background-list navigation (subset of Ink's key object). */
+export interface IBackgroundFocusKey {
+  upArrow: boolean;
+  downArrow: boolean;
+  return: boolean;
+  escape: boolean;
+}
+
+export type TBackgroundFocusAction =
+  | { type: 'move'; index: number | null } // null = focus returns to the prompt input
+  | { type: 'open'; index: number } // open the highlighted task's inline detail
+  | { type: 'exit' } // leave the list, focus the prompt input
+  | { type: 'none' }; // unhandled key — ignore
+
+/**
+ * Resolve a keypress while the background list holds focus.
+ *
+ * - ↑ moves up; ↑ past the first item returns focus to the input (`move` to `null`).
+ * - ↓ moves down, clamped at the last item.
+ * - Enter opens the highlighted task.
+ * - Esc (or an emptied list) exits to the input.
+ */
+export function resolveBackgroundFocusKey(
+  current: number,
+  entryCount: number,
+  key: IBackgroundFocusKey,
+): TBackgroundFocusAction {
+  if (entryCount <= 0) return { type: 'exit' };
+  if (key.upArrow) return { type: 'move', index: current > 0 ? current - 1 : null };
+  if (key.downArrow) {
+    return { type: 'move', index: current < entryCount - 1 ? current + 1 : current };
+  }
+  if (key.return) return { type: 'open', index: Math.min(Math.max(current, 0), entryCount - 1) };
+  if (key.escape) return { type: 'exit' };
+  return { type: 'none' };
+}


### PR DESCRIPTION
SCREEN-013(Ctrl+B 힌트)이 의도한 상호작용이 아니었습니다. Claude Code처럼 **방향키로 하단 배경 목록에 진입 → Enter로 드릴인**하는 모델을 시나리오로 정의(사용자 확인)하고 구현합니다.

### 확정 설계
- **D1** ↓ fall-through (빈 입력에서 ↓ → 목록 첫 항목 포커스)
- **D2** Ctrl+B 스위처는 보조로 유지, 인라인이 주경로
- **D3** 키보드 전용 (새 슬래시 명령 추가 안 함)
- **D4** Enter → 기존 인라인 ExecutionWorkspaceDetailPane

### 구현
- InputArea: 빈 입력 + 히스토리 바닥에서 ↓ → `onRequestFocusBackgroundList`.
- App: `backgroundFocusIndex` 포커스 상태 + 순수 reducer `resolveBackgroundFocusKey` 기반 useInput. 목록 포커스 중 입력 비활성화. Enter→엔트리 선택(기존 상세 페인 표시). 작업 증감 시 인덱스 클램프.
- BackgroundTaskPanel: 포커스 행 inverse 하이라이트 + 포커스-aware 힌트(↓ select / ↑↓ select · Enter open · Esc back).

### 테스트 (회귀 방지)
- reducer 6 (↑↓/Enter/Esc/빈목록/무관키 전수) · ↓ fall-through 2 · 패널 포커스 힌트 2.
- TUI 전체 green(392), lint 0 errors, `harness:scan` 39/39, 실바이너리 PTY smoke green.
- 실제 시드된 배경작업으로의 ↓→Enter 전체 라이브 E2E는 TEST-010 Phase 3(결정적 시드) follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)