### PR TITLE
fix(tui): stop infinite render loop when drilling into a background task (SCREEN-014)

### DIFF
--- a/packages/agent-transport-tui/src/hooks/__tests__/use-tui-channel-stability.test.tsx
+++ b/packages/agent-transport-tui/src/hooks/__tests__/use-tui-channel-stability.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * SCREEN-014 regression: the workspace callbacks must keep a stable identity across re-renders.
+ *
+ * A fresh `readExecutionWorkspaceDetail` closure every render made App's detail-loading `useEffect`
+ * re-run on every render and `setState`-loop ("Maximum update depth exceeded") the moment a
+ * background entry was selected. This test pins the callbacks to a stable identity.
+ */
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, expect, it } from 'vitest';
+
+import { useTuiChannel } from '../useTuiChannel.js';
+
+import type { TuiInteractionChannel } from '../../TuiInteractionChannel.js';
+
+function makeFakeChannel(): TuiInteractionChannel {
+  const manager = {
+    history: [],
+    streamingText: '',
+    activeTools: [],
+    isThinking: false,
+    isAborting: false,
+    pendingPrompt: null,
+    executionWorkspaceSnapshot: null,
+    selectedExecutionEntryId: undefined,
+    contextState: { percentage: 0, usedTokens: 0, maxTokens: 100_000 },
+    addEntry: () => undefined,
+  };
+  const fake = {
+    onChange: null as (() => void) | null,
+    stateManager: manager,
+    isShuttingDown: false,
+    permissionRequest: null,
+    pendingUserAction: null,
+    getSession: () => ({}),
+    getRegistry: () => ({}),
+    getCommandEffectQueue: () => ({}),
+    handleInput: () => undefined,
+    abort: () => undefined,
+    cancelQueue: () => undefined,
+    shutdown: () => Promise.resolve(),
+    selectExecutionWorkspaceEntry: () => undefined,
+    readExecutionWorkspaceDetail: () => Promise.resolve({ entryId: 'x', records: [] }),
+  };
+  return fake as unknown as TuiInteractionChannel;
+}
+
+async function tick(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('useTuiChannel callback stability (SCREEN-014 regression)', () => {
+  it('keeps readExecutionWorkspaceDetail + selectExecutionWorkspaceEntry stable across re-renders', async () => {
+    const channel = makeFakeChannel();
+    const seen: Array<{ read: unknown; select: unknown }> = [];
+
+    function Probe(): React.ReactElement | null {
+      const state = useTuiChannel(channel);
+      seen.push({
+        read: state.readExecutionWorkspaceDetail,
+        select: state.selectExecutionWorkspaceEntry,
+      });
+      return null;
+    }
+
+    render(<Probe />);
+    await tick();
+
+    // Force a re-render the way the channel does on every state change.
+    channel.onChange?.();
+    channel.onChange?.();
+    await tick();
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    const first = seen[0]!;
+    const last = seen[seen.length - 1]!;
+    expect(last.read).toBe(first.read);
+    expect(last.select).toBe(first.select);
+  });
+});

--- a/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
+++ b/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
@@ -5,7 +5,7 @@
  * changes are minimal.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 import type { TuiInteractionChannel } from '../TuiInteractionChannel.js';
 import type { ICommandEffectQueue } from './command-effect-queue.js';
@@ -71,6 +71,19 @@ export function useTuiChannel(channel: TuiInteractionChannel): IInteractiveSessi
 
   const manager = channel.stateManager;
 
+  // SCREEN-014 fix: these are consumed in `useEffect` dependency arrays in App. `channel` is stable
+  // (created once), so memoize them — a fresh closure each render made the detail-loading effect
+  // re-run every render and `setState`-loop ("Maximum update depth exceeded") whenever a background
+  // entry was selected.
+  const selectExecutionWorkspaceEntry = useCallback(
+    (id: string) => channel.selectExecutionWorkspaceEntry(id),
+    [channel],
+  );
+  const readExecutionWorkspaceDetail = useCallback(
+    (id: string) => channel.readExecutionWorkspaceDetail(id),
+    [channel],
+  );
+
   return {
     interactiveSession: channel.getSession(),
     registry: channel.getRegistry(),
@@ -92,7 +105,7 @@ export function useTuiChannel(channel: TuiInteractionChannel): IInteractiveSessi
     handleAbort: () => channel.abort(),
     handleCancelQueue: () => channel.cancelQueue(),
     handleShutdown: (reason) => channel.shutdown({ reason }),
-    selectExecutionWorkspaceEntry: (id) => channel.selectExecutionWorkspaceEntry(id),
-    readExecutionWorkspaceDetail: (id) => channel.readExecutionWorkspaceDetail(id),
+    selectExecutionWorkspaceEntry,
+    readExecutionWorkspaceDetail,
   };
 }


### PR DESCRIPTION
배경 작업 하나를 선택해 진입하면 `Maximum update depth exceeded`가 무한 반복되던 크래시 수정.

### 원인
`useTuiChannel`이 `readExecutionWorkspaceDetail`(및 `selectExecutionWorkspaceEntry`)을 **매 렌더마다 새 클로저**로 반환. App의 detail-loading `useEffect`가 이 함수를 의존성 배열에 두고 있어서, 배경 엔트리가 선택되면 effect가 매 렌더마다 재실행 → `setIsExecutionDetailLoading` → 재렌더 → 새 클로저 → 무한 루프. SCREEN-014가 드릴인을 도달 가능하게 만들면서 드러난 기존 잠복 버그.

### 수정
`channel`은 한 번만 생성되어 안정적이므로 두 콜백을 `useCallback([channel])`로 메모이즈. detail effect 의존성이 안정화되어 선택/스냅샷 업데이트 시 1회만 실행.

### 회귀 테스트
`use-tui-channel-stability` — 채널 onChange 재렌더 전후로 두 콜백의 identity가 유지됨을 단언. TUI 전체 green(393), lint 0, PTY smoke 10/10, `harness:scan` 39/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)