### PR TITLE
feat(analytics): source-attributed token usage + report + harness assertions (ANALYTICS-001 P1)

### DIFF
--- a/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
+++ b/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
@@ -1,12 +1,20 @@
 ---
 title: 'ANALYTICS-001: Record source-attributed token usage in the session log + reporting + test assertions'
-status: todo
+status: in-progress
 created: 2026-07-01
 priority: medium
 urgency: soon
-area: packages/agent-core, packages/agent-framework, packages/agent-session-analytics
+area: packages/agent-core, packages/agent-framework, packages/agent-session-analytics, packages/agent-interface-transport, packages/agent-cli
 depends_on: []
 ---
+
+> **Phase 1 delivered (2026-07-01):** the usage type + reducer + report + CLI + harness assertions, with
+> main-thread usage attributed today. **Phase 2 (remaining):** record _live_ subagent/background-task
+> usage into the main session log with its source so multi-source attribution is populated end-to-end
+> (the reducer/CLI/harness already consume it). Confirmed decisions: D1 minimal `IUsageSource` in
+> agent-interface-transport (the framework's `IExecutionOrigin` is a layer up and can't be imported into
+> the contract package); D2 single usage stream in the main session log; D3 `robota session analyze
+--usage` report; D4 harness `usageReport()`/`totalUsage()`.
 
 # Source-attributed token usage in the session log
 
@@ -72,4 +80,10 @@ framework can assert usage budgets so regressions in token consumption are caugh
   `/usage` or the documented report command) against the session.
 - Expected: the report lists token usage broken down by source (main thread vs each agent/background
   task) with totals and a clear "top consumer", matching what was run.
-- Evidence: _to be filled after implementation._
+- Evidence (Phase 1, agent-run): `agent-session-analytics` reducer unit tests (per-source breakdown,
+  percentages, top consumer, empty); `agent-cli` `session analyze --usage` integration test (prints the
+  source breakdown + top consumer); `agent-framework` `usage-assertion-functional` drives a REAL session
+  whose scripted provider reports usage and asserts `harness.usageReport()`/`totalUsage()` + a budget.
+  All green; lint 0 errors; `pnpm harness:scan` 39/39. **Live multi-source attribution (subagent /
+  background task usage written to the main log) is Phase 2** — until then a real session's report shows
+  main-thread usage (the subagent/background rows populate once Phase 2 records them).

--- a/packages/agent-cli/src/session-analyzer/__tests__/session-analyze-command.test.ts
+++ b/packages/agent-cli/src/session-analyzer/__tests__/session-analyze-command.test.ts
@@ -142,4 +142,54 @@ describe('runSessionAnalyze integration (OBS-001)', () => {
     const out = stdout.join('');
     expect(out).toMatch(/Analyzed 2 session/i);
   });
+
+  // ANALYTICS-001: --usage reports token usage broken down by source.
+  it('--usage reports per-source token usage with a top consumer', async () => {
+    const id = 'session_1781000005000_use';
+    const usageSnapshot = (total: number, source?: Record<string, unknown>): unknown => ({
+      kind: 'exact',
+      scope: 'turn',
+      totalTokens: total,
+      promptTokens: Math.round(total * 0.6),
+      completionTokens: total - Math.round(total * 0.6),
+      contextUsedTokens: total,
+      contextMaxTokens: 200_000,
+      contextUsedPercentage: 0,
+      costStatus: 'exact',
+      ...(source ? { source } : {}),
+    });
+    const record = {
+      id,
+      cwd: project,
+      createdAt: new Date(1_781_000_005_000).toISOString(),
+      updatedAt: new Date(1_781_000_006_000).toISOString(),
+      history: [
+        {
+          id: 'u1',
+          timestamp: new Date(1).toISOString(),
+          category: 'event',
+          type: 'usage-summary',
+          data: usageSnapshot(100),
+        },
+        {
+          id: 'u2',
+          timestamp: new Date(2).toISOString(),
+          category: 'event',
+          type: 'usage-summary',
+          data: usageSnapshot(400, { scope: 'background', id: 'bg-1', label: 'HARNESS-AND-CI' }),
+        },
+      ],
+    };
+    const dir = join(project, '.robota', 'sessions');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${id}.json`), JSON.stringify(record), 'utf8');
+
+    await run(['--usage']);
+
+    const out = stdout.join('');
+    expect(out).toContain('Token usage');
+    expect(out).toContain('HARNESS-AND-CI');
+    expect(out).toContain('main thread');
+    expect(out).toMatch(/top consumer: HARNESS-AND-CI/);
+  });
 });

--- a/packages/agent-cli/src/session-analyzer/session-analyze-command.ts
+++ b/packages/agent-cli/src/session-analyzer/session-analyze-command.ts
@@ -5,6 +5,8 @@
  *   robota session analyze                  — analyze the most recent session
  *   robota session analyze --last <n>       — aggregate the last N sessions
  *   robota session analyze --session <id>   — analyze a specific session by ID prefix
+ *   robota session analyze --usage          — token usage broken down by source (which agent /
+ *                                             background task burned the most tokens)
  *
  * This file only resolves session stores, parses args, and writes output. All timing analysis and
  * report formatting lives in the analytics package; record loading lives in agent-session (via the
@@ -22,6 +24,8 @@ import {
   analyzeSession,
   formatAggregateReport,
   formatSingleSession,
+  formatUsageReport,
+  summarizeUsageBySource,
 } from '@robota-sdk/agent-session-analytics';
 
 import type { TSessionAnalysisInput } from '@robota-sdk/agent-session-analytics';
@@ -29,11 +33,13 @@ import type { TSessionAnalysisInput } from '@robota-sdk/agent-session-analytics'
 interface ISessionAnalyzeArgs {
   last: number | undefined;
   sessionId: string | undefined;
+  usage: boolean;
 }
 
 function parseSessionAnalyzeArgs(argv: string[]): ISessionAnalyzeArgs {
   let last: number | undefined;
   let sessionId: string | undefined;
+  let usage = false;
 
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--last' && argv[i + 1]) {
@@ -43,10 +49,12 @@ function parseSessionAnalyzeArgs(argv: string[]): ISessionAnalyzeArgs {
     } else if (argv[i] === '--session' && argv[i + 1]) {
       sessionId = argv[i + 1];
       i++;
+    } else if (argv[i] === '--usage') {
+      usage = true;
     }
   }
 
-  return { last, sessionId };
+  return { last, sessionId, usage };
 }
 
 /**
@@ -77,6 +85,19 @@ export async function runSessionAnalyze(
       `No session files found in ${projectPaths(cwd).sessions} or ${userPaths().sessions}\n`,
     );
     process.exit(1);
+  }
+
+  if (args.usage) {
+    const target =
+      args.sessionId !== undefined
+        ? records.find((r) => r.id.includes(args.sessionId!))
+        : records[records.length - 1];
+    if (!target) {
+      process.stderr.write(`Session not found${args.sessionId ? `: ${args.sessionId}` : ''}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(formatUsageReport(summarizeUsageBySource(target)) + '\n');
+    return;
   }
 
   if (args.sessionId !== undefined) {

--- a/packages/agent-core/src/testing/scripted-provider.ts
+++ b/packages/agent-core/src/testing/scripted-provider.ts
@@ -12,10 +12,19 @@
 
 import type { IAIProvider, IRawProviderResponse, TUniversalMessage } from '../index.js';
 
-/** One scripted assistant turn: plain text or tool invocations. */
+/** ANALYTICS-001: optional token usage a scripted turn reports, so usage-based tests are possible. */
+export interface IScriptedTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** One scripted assistant turn: plain text or tool invocations, optionally reporting token usage. */
 export type TScriptedTurn =
-  | { text: string }
-  | { toolCalls: ReadonlyArray<{ name: string; args: Record<string, unknown> }> };
+  | { text: string; usage?: IScriptedTurnUsage }
+  | {
+      toolCalls: ReadonlyArray<{ name: string; args: Record<string, unknown> }>;
+      usage?: IScriptedTurnUsage;
+    };
 
 export interface IScriptedProvider {
   provider: IAIProvider;
@@ -39,6 +48,16 @@ export function createScriptedProvider(turns: readonly TScriptedTurn[]): IScript
         );
       }
       cursor += 1;
+      // ANALYTICS-001: surface declared usage in metadata so the real usage pipeline records it.
+      const usageMetadata = turn.usage
+        ? {
+            metadata: {
+              inputTokens: turn.usage.inputTokens,
+              outputTokens: turn.usage.outputTokens,
+              totalTokens: turn.usage.inputTokens + turn.usage.outputTokens,
+            },
+          }
+        : {};
       if ('text' in turn) {
         return {
           id: `scripted-${cursor}`,
@@ -46,6 +65,7 @@ export function createScriptedProvider(turns: readonly TScriptedTurn[]): IScript
           content: turn.text,
           state: 'complete',
           timestamp: new Date(),
+          ...usageMetadata,
         };
       }
       return {
@@ -54,6 +74,7 @@ export function createScriptedProvider(turns: readonly TScriptedTurn[]): IScript
         content: null,
         state: 'complete',
         timestamp: new Date(),
+        ...usageMetadata,
         toolCalls: turn.toolCalls.map((call, index) => ({
           id: `scripted-call-${cursor}-${index}`,
           type: 'function' as const,

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -58,6 +58,7 @@
     "@robota-sdk/agent-executor": "workspace:*",
     "@robota-sdk/agent-interface-transport": "workspace:*",
     "@robota-sdk/agent-session": "workspace:*",
+    "@robota-sdk/agent-session-analytics": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
     "zod": "^3.25.76"
   },

--- a/packages/agent-framework/src/testing/__tests__/usage-assertion-functional.test.ts
+++ b/packages/agent-framework/src/testing/__tests__/usage-assertion-functional.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ANALYTICS-001: token-usage assertions through the TEST-003 functional harness.
+ *
+ * Drives a REAL InteractiveSession with a scripted provider that reports token usage, then asserts
+ * the per-source usage breakdown and a budget — the mechanism that turns wrong/excessive token usage
+ * into a failing test.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { scriptedSession, type ScriptedSessionHarness } from '../index.js';
+
+const TEST_TIMEOUT = 20_000;
+
+let harness: ScriptedSessionHarness | undefined;
+
+afterEach(async () => {
+  await harness?.dispose();
+  harness = undefined;
+});
+
+describe('Token-usage assertions (ANALYTICS-001) via the scripted-session harness', () => {
+  it(
+    'reports per-source usage and supports a budget assertion',
+    async () => {
+      harness = scriptedSession({
+        turns: [
+          { text: 'first answer', usage: { inputTokens: 100, outputTokens: 40 } },
+          { text: 'second answer', usage: { inputTokens: 60, outputTokens: 20 } },
+        ],
+      });
+
+      await harness.submit('one');
+      await harness.submit('two');
+
+      const report = harness.usageReport();
+      // 140 + 80, all attributed to the main thread (no sub-sources in this run).
+      expect(report.totalTokens).toBe(220);
+      expect(report.bySource).toHaveLength(1);
+      expect(report.bySource[0]).toMatchObject({ label: 'main thread', percentage: 100 });
+      expect(report.topConsumer?.label).toBe('main thread');
+      expect(harness.totalUsage()).toBe(220);
+
+      // The budget gate: an over-budget session would fail here.
+      expect(harness.totalUsage()).toBeLessThanOrEqual(500);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'reports zero usage when the provider declares none',
+    async () => {
+      harness = scriptedSession({ turns: [{ text: 'no usage reported' }] });
+      await harness.submit('hi');
+      expect(harness.totalUsage()).toBe(0);
+      expect(harness.usageReport().bySource).toEqual([]);
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/packages/agent-framework/src/testing/scripted-session-harness.ts
+++ b/packages/agent-framework/src/testing/scripted-session-harness.ts
@@ -30,6 +30,7 @@ import {
   createReplayProvider,
   createRecordingProvider,
 } from '@robota-sdk/agent-core/testing';
+import { summarizeUsageBySource } from '@robota-sdk/agent-session-analytics';
 
 import { InteractiveSession } from '../interactive/index.js';
 import { createProjectSessionStore } from '../interactive/index.js';
@@ -48,6 +49,7 @@ import type {
   IToolSummary,
   TInteractiveEventName,
 } from '@robota-sdk/agent-interface-transport';
+import type { IUsageBySourceReport } from '@robota-sdk/agent-session-analytics';
 
 /** Options for {@link scriptedSession}. Provide exactly one of `turns`, `cassette`, or `record`. */
 export interface IScriptedSessionOptions {
@@ -331,6 +333,23 @@ export class ScriptedSessionHarness {
   sessionRecord(): IInteractiveSessionRecord | undefined {
     if (!this.sessionStore) return undefined;
     return this.sessionStore.load(this.session.getSession().getSessionId());
+  }
+
+  /**
+   * ANALYTICS-001: per-source token-usage breakdown for this session, computed from the recorded
+   * `usage-summary` history entries. Lets a test assert budgets — e.g. total usage ≤ N, or no single
+   * background task exceeds M — turning wrong/excessive token usage into a failing test.
+   */
+  usageReport(): IUsageBySourceReport {
+    return summarizeUsageBySource({
+      id: this.session.getSession().getSessionId(),
+      history: this.session.getFullHistory(),
+    });
+  }
+
+  /** Total tokens consumed across the whole session (ANALYTICS-001). */
+  totalUsage(): number {
+    return this.usageReport().totalTokens;
   }
 
   /** The real session-log directory the framework writes to (`{cwd}/.robota/logs`). */

--- a/packages/agent-interface-transport/src/index.ts
+++ b/packages/agent-interface-transport/src/index.ts
@@ -118,6 +118,7 @@ export type {
   IDiffLine,
   IToolSummary,
   IUsageSnapshot,
+  IUsageSource,
   TPermissionResultValue,
   TInteractivePermissionHandler,
   IContextFileRefreshedEvent,

--- a/packages/agent-interface-transport/src/session-contracts.ts
+++ b/packages/agent-interface-transport/src/session-contracts.ts
@@ -81,6 +81,20 @@ export interface IToolState {
   executionId?: string;
 }
 
+/**
+ * ANALYTICS-001: the execution unit a usage snapshot is attributed to, so session-log usage can be
+ * reported and asserted per source (main thread vs a specific subagent / background task). A minimal
+ * contract-layer descriptor — the framework's `IExecutionOrigin` lives a layer up and cannot be
+ * imported here; the two stay aligned by `scope`/`id`.
+ */
+export interface IUsageSource {
+  scope: 'main' | 'subagent' | 'background' | 'tool' | 'command' | 'skill';
+  /** Stable id of the source (e.g. the subagent / background-task id); omitted for the main thread. */
+  id?: string;
+  /** Human label for reports (e.g. the agent type or task title). */
+  label?: string;
+}
+
 export interface IUsageSnapshot {
   kind: 'exact' | 'estimated';
   scope: 'turn';
@@ -91,6 +105,8 @@ export interface IUsageSnapshot {
   contextMaxTokens: number;
   contextUsedPercentage: number;
   costStatus: 'unknown' | 'estimated' | 'exact';
+  /** ANALYTICS-001: which execution unit consumed these tokens. Defaults to the main thread. */
+  source?: IUsageSource;
 }
 
 /** Summary of a tool call extracted from history. */

--- a/packages/agent-session-analytics/docs/SPEC.md
+++ b/packages/agent-session-analytics/docs/SPEC.md
@@ -49,15 +49,17 @@ Reused (not owned): `TSessionAnalysisInput` is `Pick<IInteractiveSessionRecord, 
 
 ## Public API Surface
 
-| Export                          | Kind     | Description                                                 |
-| ------------------------------- | -------- | ----------------------------------------------------------- |
-| `analyzeSession(record)`        | function | Compute the timing report for one session record            |
-| `aggregateReports(reports)`     | function | Aggregate multiple single-session reports                   |
-| `computeTimingIntervals(hist)`  | function | Lower-level: classify a history array into timing intervals |
-| `gapMs(from, to)`               | function | Millisecond gap between two timestamps (string or Date)     |
-| `formatSingleSession(report)`   | function | Render a single-session report as text (returns string)     |
-| `formatAggregateReport(agg)`    | function | Render an aggregate report as text (returns string)         |
-| `TSessionAnalysisInput` + types | types    | See Type Ownership                                          |
+| Export                          | Kind     | Description                                                                                    |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `analyzeSession(record)`        | function | Compute the timing report for one session record                                               |
+| `aggregateReports(reports)`     | function | Aggregate multiple single-session reports                                                      |
+| `computeTimingIntervals(hist)`  | function | Lower-level: classify a history array into timing intervals                                    |
+| `gapMs(from, to)`               | function | Millisecond gap between two timestamps (string or Date)                                        |
+| `formatSingleSession(report)`   | function | Render a single-session report as text (returns string)                                        |
+| `formatAggregateReport(agg)`    | function | Render an aggregate report as text (returns string)                                            |
+| `summarizeUsageBySource(input)` | function | ANALYTICS-001: per-source token-usage breakdown from `usage-summary` history entries           |
+| `formatUsageReport(report)`     | function | Render the usage breakdown as text (returns string)                                            |
+| `TSessionAnalysisInput` + types | types    | See Type Ownership (incl. `TUsageAnalysisInput`, `IUsageBySourceReport`, `IUsageSourceTotals`) |
 
 ## Extension Points
 

--- a/packages/agent-session-analytics/src/__tests__/usage.test.ts
+++ b/packages/agent-session-analytics/src/__tests__/usage.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ANALYTICS-001: source-attributed token-usage reducer.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { summarizeUsageBySource } from '../usage.js';
+
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { IUsageSnapshot, IUsageSource } from '@robota-sdk/agent-interface-transport';
+
+let seq = 0;
+function usageEntry(total: number, source?: IUsageSource): IHistoryEntry<IUsageSnapshot> {
+  seq += 1;
+  const prompt = Math.round(total * 0.6);
+  const completion = total - prompt;
+  return {
+    id: `usage-${seq}`,
+    timestamp: new Date(1_700_000_000_000 + seq),
+    category: 'event',
+    type: 'usage-summary',
+    data: {
+      kind: 'exact',
+      scope: 'turn',
+      totalTokens: total,
+      promptTokens: prompt,
+      completionTokens: completion,
+      contextUsedTokens: total,
+      contextMaxTokens: 200_000,
+      contextUsedPercentage: 0,
+      costStatus: 'exact',
+      ...(source ? { source } : {}),
+    },
+  };
+}
+
+function chatEntry(): IHistoryEntry {
+  seq += 1;
+  return { id: `c-${seq}`, timestamp: new Date(seq), category: 'chat', type: 'user' };
+}
+
+describe('summarizeUsageBySource (ANALYTICS-001)', () => {
+  it('attributes snapshots with no source to the main thread', () => {
+    const report = summarizeUsageBySource({
+      id: 'sess-1',
+      history: [chatEntry(), usageEntry(100), usageEntry(50)],
+    });
+    expect(report.totalTokens).toBe(150);
+    expect(report.bySource).toHaveLength(1);
+    expect(report.bySource[0]).toMatchObject({
+      label: 'main thread',
+      totalTokens: 150,
+      turns: 2,
+      percentage: 100,
+    });
+    expect(report.topConsumer?.label).toBe('main thread');
+  });
+
+  it('breaks usage down by source and ranks the top consumer', () => {
+    const report = summarizeUsageBySource({
+      id: 'sess-2',
+      history: [
+        usageEntry(100), // main thread (no source)
+        usageEntry(300, { scope: 'background', id: 'bg-1', label: 'HARNESS-AND-CI' }),
+        usageEntry(100, { scope: 'subagent', id: 'a-1', label: 'reviewer' }),
+        usageEntry(200, { scope: 'background', id: 'bg-1', label: 'HARNESS-AND-CI' }),
+      ],
+    });
+
+    expect(report.totalTokens).toBe(700);
+    // sorted desc: background bg-1 (500) > main (100) == subagent (100) [stable by insertion]
+    expect(report.bySource[0]).toMatchObject({
+      label: 'HARNESS-AND-CI',
+      totalTokens: 500,
+      turns: 2,
+      percentage: 71.4,
+    });
+    expect(report.topConsumer?.source.id).toBe('bg-1');
+    // the background task is correctly aggregated across its two turns under one key
+    const keys = report.bySource.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('returns an empty breakdown when no usage was recorded', () => {
+    const report = summarizeUsageBySource({ id: 'sess-3', history: [chatEntry()] });
+    expect(report.totalTokens).toBe(0);
+    expect(report.bySource).toEqual([]);
+    expect(report.topConsumer).toBeUndefined();
+  });
+});

--- a/packages/agent-session-analytics/src/index.ts
+++ b/packages/agent-session-analytics/src/index.ts
@@ -13,4 +13,8 @@ export type {
 } from './types.js';
 
 export { analyzeSession, aggregateReports, computeTimingIntervals, gapMs } from './analyze.js';
-export { formatSingleSession, formatAggregateReport } from './report.js';
+export { formatSingleSession, formatAggregateReport, formatUsageReport } from './report.js';
+
+// ANALYTICS-001: source-attributed token-usage analysis.
+export { summarizeUsageBySource } from './usage.js';
+export type { TUsageAnalysisInput, IUsageSourceTotals, IUsageBySourceReport } from './usage.js';

--- a/packages/agent-session-analytics/src/report.ts
+++ b/packages/agent-session-analytics/src/report.ts
@@ -4,6 +4,39 @@
  */
 
 import type { IAggregateReport, ISessionTimingReport, ITimingInterval } from './types.js';
+import type { IUsageBySourceReport } from './usage.js';
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+/**
+ * ANALYTICS-001: render a per-source token-usage breakdown — which part of the session burned the
+ * most tokens. Pure; the caller owns writing it.
+ */
+export function formatUsageReport(report: IUsageBySourceReport): string {
+  const lines: string[] = [];
+  lines.push(`Token usage — session ${report.sessionId}`);
+  lines.push(
+    `  total ${fmtTokens(report.totalTokens)} (prompt ${fmtTokens(report.promptTokens)} · completion ${fmtTokens(report.completionTokens)})`,
+  );
+  if (report.bySource.length === 0) {
+    lines.push('  (no usage recorded)');
+    return lines.join('\n');
+  }
+  lines.push('  by source (most tokens first):');
+  for (const s of report.bySource) {
+    lines.push(
+      `    ${s.label.padEnd(24)} ${String(s.percentage).padStart(5)}%  ${fmtTokens(s.totalTokens).padStart(7)}  (${s.turns} turn${s.turns === 1 ? '' : 's'})`,
+    );
+  }
+  if (report.topConsumer) {
+    lines.push(`  top consumer: ${report.topConsumer.label} (${report.topConsumer.percentage}%)`);
+  }
+  return lines.join('\n');
+}
 
 function fmtMs(ms: number): string {
   if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;

--- a/packages/agent-session-analytics/src/usage.ts
+++ b/packages/agent-session-analytics/src/usage.ts
@@ -1,0 +1,127 @@
+/**
+ * ANALYTICS-001: source-attributed token-usage analysis over a session record.
+ *
+ * The main session history records one `usage-summary` history entry per turn (an `IUsageSnapshot`,
+ * created in agent-framework). This reducer aggregates those snapshots into a per-source breakdown —
+ * answering "which part of the session burned the most tokens?" — so it can be reported to the user
+ * and asserted by the testing framework (budget gates). Pure: no I/O, no process concerns.
+ */
+
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type {
+  IInteractiveSessionRecord,
+  IUsageSnapshot,
+  IUsageSource,
+} from '@robota-sdk/agent-interface-transport';
+
+/** The `type` of the per-turn usage history entry (agent-framework `createUsageSummaryEntry`). */
+const USAGE_SUMMARY_ENTRY_TYPE = 'usage-summary';
+
+/** SSOT-derived projection the usage reducer reads. */
+export type TUsageAnalysisInput = Pick<IInteractiveSessionRecord, 'id' | 'history'>;
+
+/** The main thread is the implicit source when a usage snapshot carries none. */
+const MAIN_THREAD_SOURCE: IUsageSource = { scope: 'main', label: 'main thread' };
+
+export interface IUsageSourceTotals {
+  /** Stable grouping key (`<scope>:<id>`). */
+  key: string;
+  source: IUsageSource;
+  label: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  /** How many usage snapshots (turns) were attributed to this source. */
+  turns: number;
+  /** Share of the session's total tokens, 0–100 (rounded to 1 decimal). */
+  percentage: number;
+}
+
+export interface IUsageBySourceReport {
+  sessionId: string;
+  totalTokens: number;
+  promptTokens: number;
+  completionTokens: number;
+  /** Per-source totals, sorted by `totalTokens` descending. */
+  bySource: IUsageSourceTotals[];
+  /** The single biggest token consumer, if any usage was recorded. */
+  topConsumer?: IUsageSourceTotals;
+}
+
+function sourceKey(source: IUsageSource): string {
+  return `${source.scope}:${source.id ?? ''}`;
+}
+
+function sourceLabel(source: IUsageSource): string {
+  return source.label ?? (source.id ? `${source.scope} ${source.id}` : source.scope);
+}
+
+function isUsageSummaryEntry(entry: IHistoryEntry): entry is IHistoryEntry<IUsageSnapshot> {
+  return (
+    entry.type === USAGE_SUMMARY_ENTRY_TYPE && typeof entry.data === 'object' && entry.data !== null
+  );
+}
+
+function roundPercentage(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 1000) / 10;
+}
+
+/**
+ * Aggregate a session's `usage-summary` entries into a per-source token breakdown.
+ *
+ * Usage snapshots with no `source` are attributed to the main thread. Sources are grouped by
+ * `<scope>:<id>`; the result is sorted by total tokens descending with the top consumer surfaced.
+ */
+export function summarizeUsageBySource(input: TUsageAnalysisInput): IUsageBySourceReport {
+  const totalsByKey = new Map<string, IUsageSourceTotals>();
+  let sessionPrompt = 0;
+  let sessionCompletion = 0;
+  let sessionTotal = 0;
+
+  for (const entry of input.history ?? []) {
+    if (!isUsageSummaryEntry(entry)) continue;
+    const snapshot = entry.data as IUsageSnapshot;
+    const source = snapshot.source ?? MAIN_THREAD_SOURCE;
+    const key = sourceKey(source);
+    const prompt = snapshot.promptTokens ?? 0;
+    const completion = snapshot.completionTokens ?? 0;
+    const total = snapshot.totalTokens;
+
+    sessionPrompt += prompt;
+    sessionCompletion += completion;
+    sessionTotal += total;
+
+    const existing = totalsByKey.get(key);
+    if (existing) {
+      existing.promptTokens += prompt;
+      existing.completionTokens += completion;
+      existing.totalTokens += total;
+      existing.turns += 1;
+    } else {
+      totalsByKey.set(key, {
+        key,
+        source,
+        label: sourceLabel(source),
+        promptTokens: prompt,
+        completionTokens: completion,
+        totalTokens: total,
+        turns: 1,
+        percentage: 0,
+      });
+    }
+  }
+
+  const bySource = [...totalsByKey.values()]
+    .map((totals) => ({ ...totals, percentage: roundPercentage(totals.totalTokens, sessionTotal) }))
+    .sort((left, right) => right.totalTokens - left.totalTokens);
+
+  return {
+    sessionId: input.id,
+    totalTokens: sessionTotal,
+    promptTokens: sessionPrompt,
+    completionTokens: sessionCompletion,
+    bySource,
+    ...(bySource[0] ? { topConsumer: bySource[0] } : {}),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -983,6 +983,9 @@ importers:
       '@robota-sdk/agent-session':
         specifier: workspace:*
         version: link:../agent-session
+      '@robota-sdk/agent-session-analytics':
+        specifier: workspace:*
+        version: link:../agent-session-analytics
       '@robota-sdk/agent-tools':
         specifier: workspace:*
         version: link:../agent-tools


### PR DESCRIPTION
세션 토큰 사용량을 **출처별로 조회/리포트**하고 **테스트로 단정**할 수 있게 — 사용자는 "어느 부분이 토큰을 많이 썼는지" 보고, 테스팅 프레임워크는 잘못된/과도한 사용을 잡아냄.

### 구현 (Phase 1)
- **agent-interface-transport**: 최소 `IUsageSource` + `IUsageSnapshot.source?` (framework의 `IExecutionOrigin`은 상위 레이어라 계약 패키지로 import 불가 → 최소 descriptor).
- **agent-session-analytics**: `summarizeUsageBySource()` — 세션의 `usage-summary` 히스토리 엔트리를 출처별 분해(총합·%·top consumer). `formatUsageReport()` 텍스트 렌더. 순수.
- **agent-cli**: `robota session analyze --usage` — 세션의 출처별 사용량 리포트 출력 (D3).
- **agent-core/testing**: scripted turn이 usage 보고 가능 → usage 기반 테스트 가능.
- **agent-framework/testing**: `harness.usageReport()`/`totalUsage()` (D4) — **실제 세션**에서 예산 단정("총 ≤ N", "단일 출처 ≤ M").

### 테스트
reducer 유닛(다중 출처/%/top/빈) · CLI `--usage` 통합 · **실세션 functional**(scripted usage → 예산 단정). lint 0, 전체 green, `harness:scan` 39/39.

### 남은 것 (Phase 2)
**라이브 subagent/background 사용량을 메인 세션로그에 출처와 함께 기록** — 그러면 실세션 리포트에 에이전트/백그라운드 행이 채워짐. 현재는 메인 스레드 사용량이 귀속됨. 백로그에 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)