### PR TITLE
feat(analytics): live subagent/background usage attribution (ANALYTICS-001 P2)

### DIFF
--- a/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
+++ b/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
@@ -9,9 +9,13 @@ depends_on: []
 ---
 
 > **Phase 1 delivered (2026-07-01):** the usage type + reducer + report + CLI + harness assertions, with
-> main-thread usage attributed today. **Phase 2 (remaining):** record _live_ subagent/background-task
-> usage into the main session log with its source so multi-source attribution is populated end-to-end
-> (the reducer/CLI/harness already consume it). Confirmed decisions: D1 minimal `IUsageSource` in
+> main-thread usage attributed today. **Phase 2 wired (2026-07-01):** a finished subagent/background
+> agent task's total usage (`sumHistoryUsage`) flows `ISubagentJobResult.usage` →
+> `IBackgroundTaskResult.usage` → the session background tracker, which on completion appends a
+> **source-attributed `usage-summary`** (`scope: 'background'`, the task id/label) to the parent log —
+> so `--usage` / `harness.usageReport()` attribute those tokens to that task, not the main thread.
+> Remaining: a live end-to-end run (spawn a real background agent, see its row) for the User Execution
+> gate — the chain is unit-tested at each end + full suites green. Confirmed decisions: D1 minimal `IUsageSource` in
 > agent-interface-transport (the framework's `IExecutionOrigin` is a layer up and can't be imported into
 > the contract package); D2 single usage stream in the main session log; D3 `robota session analyze
 --usage` report; D4 harness `usageReport()`/`totalUsage()`.

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -158,7 +158,9 @@ export { AgentTemplates, type ITemplateApplicationResult } from './managers/agen
 export { ConversationHistory, ConversationStore } from './managers/conversation-history-manager';
 export {
   collectAssistantUsageMetadata,
+  sumHistoryUsage,
   type IAssistantUsageMetadata,
+  type ISessionUsageTotals,
 } from './services/execution-usage';
 
 // Core types

--- a/packages/agent-core/src/services/__tests__/execution-usage.test.ts
+++ b/packages/agent-core/src/services/__tests__/execution-usage.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { sumHistoryUsage } from '../execution-usage';
+
+import type { IHistoryEntry } from '../../interfaces/messages';
+
+function assistantEntry(id: string, inputTokens: number, outputTokens: number): IHistoryEntry {
+  return {
+    id,
+    timestamp: new Date(),
+    category: 'chat',
+    type: 'assistant',
+    data: { role: 'assistant', content: 'x', metadata: { inputTokens, outputTokens } },
+  };
+}
+
+describe('sumHistoryUsage (ANALYTICS-001 Phase 2)', () => {
+  it('sums assistant token usage across a sub-session history', () => {
+    const totals = sumHistoryUsage([
+      assistantEntry('a1', 100, 40),
+      { id: 'e1', timestamp: new Date(), category: 'event', type: 'tool-start' },
+      assistantEntry('a2', 60, 20),
+    ]);
+    expect(totals).toEqual({ promptTokens: 160, completionTokens: 60, totalTokens: 220 });
+  });
+
+  it('returns undefined when no usage is reported', () => {
+    expect(
+      sumHistoryUsage([{ id: 'u', timestamp: new Date(), category: 'chat', type: 'user' }]),
+    ).toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/services/execution-usage.ts
+++ b/packages/agent-core/src/services/execution-usage.ts
@@ -1,6 +1,39 @@
 import { readTokenUsageFromMessage } from '../context/token-usage';
+import { chatEntryToMessage, isChatEntry } from '../interfaces/messages';
 
-import type { TUniversalMessage } from '../interfaces/messages';
+import type { IHistoryEntry, TUniversalMessage } from '../interfaces/messages';
+
+/** Aggregate token totals over a whole session/sub-session history. */
+export interface ISessionUsageTotals {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * ANALYTICS-001 (Phase 2): sum assistant token usage across a history timeline — used to capture a
+ * subagent / background task's total usage so it can be attributed to its source in the parent log.
+ * Returns undefined when no usage was reported (so callers can skip recording an empty entry).
+ */
+export function sumHistoryUsage(
+  history: readonly IHistoryEntry[],
+): ISessionUsageTotals | undefined {
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let found = false;
+  for (const entry of history) {
+    if (!isChatEntry(entry) || entry.data === undefined) continue;
+    const message = chatEntryToMessage(entry);
+    if (message.role !== 'assistant') continue;
+    const usage = collectAssistantUsageMetadata(message);
+    if (!usage) continue;
+    found = true;
+    promptTokens += usage.inputTokens;
+    completionTokens += usage.outputTokens;
+  }
+  if (!found) return undefined;
+  return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens };
+}
 
 export interface IAssistantUsageMetadata {
   inputTokens: number;

--- a/packages/agent-executor/src/background-tasks/types.ts
+++ b/packages/agent-executor/src/background-tasks/types.ts
@@ -135,6 +135,13 @@ export type TBackgroundTaskRequest =
   | IProcessBackgroundTaskRequest
   | IScheduledBackgroundTaskRequest;
 
+/** ANALYTICS-001 (Phase 2): token usage a completed task/subagent consumed, for source attribution. */
+export interface IBackgroundTaskUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
 export interface IBackgroundTaskResult {
   taskId: string;
   kind: TBackgroundTaskKind;
@@ -142,6 +149,8 @@ export interface IBackgroundTaskResult {
   exitCode?: number;
   signalCode?: string;
   metadata?: Record<string, TBackgroundPrimitive>;
+  /** ANALYTICS-001 (Phase 2): total token usage of an agent task, attributed to it in the parent log. */
+  usage?: IBackgroundTaskUsage;
 }
 
 export interface IBackgroundTaskState {

--- a/packages/agent-executor/src/subagents/subagent-manager.ts
+++ b/packages/agent-executor/src/subagents/subagent-manager.ts
@@ -231,5 +231,6 @@ function toBackgroundResult(result: ISubagentJobResult): IBackgroundTaskResult {
     kind: 'agent',
     output: result.output,
     metadata: result.metadata,
+    ...(result.usage ? { usage: result.usage } : {}),
   };
 }

--- a/packages/agent-executor/src/subagents/types.ts
+++ b/packages/agent-executor/src/subagents/types.ts
@@ -79,6 +79,8 @@ export interface ISubagentJobResult {
   jobId: string;
   output: string;
   metadata?: Record<string, TBackgroundPrimitive>;
+  /** ANALYTICS-001 (Phase 2): total token usage of the subagent run. */
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
 }
 
 export interface ISubagentJobStart {

--- a/packages/agent-framework/src/interactive/interactive-session-background-tracker.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-background-tracker.ts
@@ -4,6 +4,7 @@
  * integration without owning the session or store directly.
  */
 
+import { createSourceUsageSummaryEntry } from './interactive-session-execution.js';
 import {
   BackgroundJobOrchestrator,
   createBackgroundGroupExecutionEntryId,
@@ -29,6 +30,7 @@ import type {
   TBackgroundTaskEvent,
   TExecutionWorkspaceUpdateCause,
 } from '../background-tasks/index.js';
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { Session } from '@robota-sdk/agent-session';
 
 export interface IBackgroundTrackerState {
@@ -57,6 +59,8 @@ export class SessionBackgroundTaskTracker {
     private readonly onWake?: (instruction: string, taskId: string) => void,
     // FLOW-003: append a user-visible system note (e.g. a missed-wake notice) to history.
     private readonly appendSystemNote?: (message: string) => void,
+    // ANALYTICS-001 (Phase 2): append a structured history entry (a source-attributed usage summary).
+    private readonly appendHistoryEntry?: (entry: IHistoryEntry) => void,
   ) {}
 
   subscribe(session: Session): void {
@@ -263,8 +267,27 @@ export class SessionBackgroundTaskTracker {
   private recordTaskEvent(event: TBackgroundTaskEvent): void {
     this.backgroundTasks = this.getTaskSnapshots();
     this.backgroundTaskEvents.push(event);
+    this.recordCompletedTaskUsage(event);
     this.persistSession();
     this.onChanged('background_task', getTaskEventEntryId(event));
+  }
+
+  /**
+   * ANALYTICS-001 (Phase 2): when a background agent task completes with token usage, append a
+   * source-attributed usage-summary to the parent history so the usage report attributes those tokens
+   * to that task (not the main thread).
+   */
+  private recordCompletedTaskUsage(event: TBackgroundTaskEvent): void {
+    if (event.type !== 'background_task_completed') return;
+    const usage = event.task.result?.usage;
+    if (!usage || usage.totalTokens <= 0) return;
+    this.appendHistoryEntry?.(
+      createSourceUsageSummaryEntry(usage, {
+        scope: 'background',
+        id: event.task.id,
+        label: event.task.agentType ?? event.task.label,
+      }),
+    );
   }
 
   private recordGroupEvent(event: TBackgroundJobGroupEvent, _sessionId: string): void {

--- a/packages/agent-framework/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution.ts
@@ -24,6 +24,7 @@ import type { IContextReferenceItem } from '../context/context-reference-invento
 import type { IPromptFileReferenceRecord } from '../context/prompt-file-references.js';
 import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { IUsageSource } from '@robota-sdk/agent-interface-transport';
 
 export interface IPreparedPromptInput {
   modelInput: string;
@@ -121,6 +122,29 @@ export function createUsageSummaryEntry(usage: IUsageSnapshot): IHistoryEntry<IU
     type: 'usage-summary',
     data: usage,
   };
+}
+
+/**
+ * ANALYTICS-001 (Phase 2): build a usage-summary entry attributed to a non-main source (a subagent /
+ * background task) so the parent session log can report token usage per source. Context fields are
+ * not meaningful for a child run and are left at 0; the usage reducer only reads the token totals.
+ */
+export function createSourceUsageSummaryEntry(
+  totals: { promptTokens: number; completionTokens: number; totalTokens: number },
+  source: IUsageSource,
+): IHistoryEntry<IUsageSnapshot> {
+  return createUsageSummaryEntry({
+    kind: 'exact',
+    scope: 'turn',
+    totalTokens: totals.totalTokens,
+    promptTokens: totals.promptTokens,
+    completionTokens: totals.completionTokens,
+    contextUsedTokens: 0,
+    contextMaxTokens: 0,
+    contextUsedPercentage: 0,
+    costStatus: 'exact',
+    source,
+  });
 }
 
 export async function preparePromptInput(

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -130,6 +130,7 @@ export class InteractiveSession
       () => this.persistCurrentSession(),
       (instruction, taskId) => this.requestWakeup(instruction, taskId),
       (message) => this.histTracker.append(messageToHistoryEntry(createSystemMessage(message))),
+      (entry) => this.histTracker.append(entry),
     );
 
     this.histTracker = new SessionHistoryTracker(

--- a/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
@@ -1,3 +1,5 @@
+import { sumHistoryUsage } from '@robota-sdk/agent-core';
+
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
 import { createSubagentSession } from '../assembly/create-subagent-session.js';
 
@@ -102,6 +104,18 @@ function emitToolExecutionEvent(job: ISubagentJobStart, event: TSubagentToolExec
   });
 }
 
+/** Best-effort total token usage of a finished subagent session; never throws. */
+function readSubagentUsage(
+  session: ReturnType<typeof createSubagentSession>,
+): ReturnType<typeof sumHistoryUsage> {
+  try {
+    return sumHistoryUsage(session.getFullHistory());
+  } catch {
+    // allow-fallback: usage capture is auxiliary — a failure to read history must not fail the subagent run
+    return undefined;
+  }
+}
+
 export function createInProcessSubagentRunner(deps: IInProcessSubagentRunnerDeps): ISubagentRunner {
   return {
     start(job: ISubagentJobStart): ISubagentJobHandle {
@@ -130,10 +144,12 @@ export function createInProcessSubagentRunner(deps: IInProcessSubagentRunnerDeps
 
       return {
         jobId: job.jobId,
-        result: session.run(job.request.prompt).then((output) => ({
-          jobId: job.jobId,
-          output,
-        })),
+        result: session.run(job.request.prompt).then((output) => {
+          // ANALYTICS-001 (Phase 2): capture the subagent's total token usage so the parent log can
+          // attribute it to this agent as a source. Best-effort — never let usage capture fail the run.
+          const usage = readSubagentUsage(session);
+          return { jobId: job.jobId, output, ...(usage ? { usage } : {}) };
+        }),
         cancel: () => {
           session.abort();
           return Promise.resolve();

--- a/packages/agent-playground/src/contexts/__tests__/playground-context.test.tsx
+++ b/packages/agent-playground/src/contexts/__tests__/playground-context.test.tsx
@@ -80,7 +80,8 @@ vi.mock('../../lib/playground/robota-executor', () => ({
   PlaygroundExecutor: executorMocks.MockPlaygroundExecutor,
 }));
 
-vi.mock('@robota-sdk/agent-core', () => ({
+vi.mock('@robota-sdk/agent-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-core')>()),
   DefaultEventService: eventServiceMocks.DefaultEventService,
   SilentLogger: loggerMocks,
 }));


### PR DESCRIPTION
## 요약 (ANALYTICS-001 Phase 2)

Phase 1은 메인 스레드 토큰 사용량만 `usage-summary`로 세션 로그에 기록했다. Phase 2는 **완료된 subagent / background task의 토큰 사용량을 그 소스(source)로 귀속**시켜 부모 세션 로그에 기록한다. 이제 `robota session analyze --usage` / `harness.usageReport()`가 해당 토큰을 메인 스레드가 아니라 그 task에 정확히 귀속한다.

## 데이터 흐름

```
subagent 세션 종료
  → sumHistoryUsage(session.getFullHistory())   (agent-core, best-effort)
  → ISubagentJobResult.usage                     (agent-executor)
  → IBackgroundTaskResult.usage                  (agent-executor)
  → SessionBackgroundTaskTracker.recordCompletedTaskUsage
  → createSourceUsageSummaryEntry(totals, { scope:'background', id, label })
  → 부모 세션 로그에 source-attributed usage-summary append (append-only)
  → Phase 1 reducer / CLI / harness 가 소비
```

## 변경

- **agent-core**: `sumHistoryUsage(history) → ISessionUsageTotals | undefined` — (서브)세션 history의 assistant 토큰 총합. 사용량이 없으면 `undefined`. 비-chat/`data` 없는 엔트리는 스킵.
- **agent-executor**: `ISubagentJobResult.usage`, `IBackgroundTaskResult.usage` 타입 추가; `subagent-manager`가 결과로 전파.
- **agent-framework**: `in-process-subagent-runner`가 종료 시 usage를 best-effort로 읽어 결과에 첨부(실패해도 run을 깨지 않음); background tracker가 완료 이벤트에서 source-attributed `usage-summary`를 부모 로그에 append.

## 테스트 / 검증

- `sumHistoryUsage` 유닛 테스트 2개(합산 / 사용량 없음 → undefined).
- 전체 스위트 green (agent-core / agent-executor / agent-framework), lint 0, `pnpm harness:scan` 39/39, build 통과.
- **추가 수정**: develop에 이미 있던 깨진 테스트 1건 동봉 — TERM-008의 `resolvePlatformShell`가 추가되며 `agent-playground` playground-context 테스트의 하드코딩 `vi.mock('@robota-sdk/agent-core')`가 stale해져 실패하던 것을 `importOriginal` 스프레드로 수정(모든 push를 막던 develop breakage).

## 남은 작업 (별도)

실제 background agent를 띄워 `--usage` 리포트에 그 행이 뜨는 라이브 end-to-end 실행(User Execution 게이트). 체인은 양 끝단 모두 유닛 테스트됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)