### PR TITLE
fix(analytics): forward child-process subagent token usage over IPC (ANALYTICS-001 P2)

### DIFF
--- a/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
+++ b/.agents/backlog/ANALYTICS-001-source-attributed-token-usage-in-session-log.md
@@ -1,6 +1,6 @@
 ---
 title: 'ANALYTICS-001: Record source-attributed token usage in the session log + reporting + test assertions'
-status: in-progress
+status: done
 created: 2026-07-01
 priority: medium
 urgency: soon
@@ -19,11 +19,20 @@ depends_on: []
 > - `BackgroundTaskManager`; a completed background agent task reports `usage` and the test asserts the
 >   parent log gains a `scope:'background'` `usage-summary` and that `summarizeUsageBySource` attributes
 >   the full total to `background:<taskId>` (label = agentType) as the top consumer — the production
->   chain, not a mock of it (`interactive-session-background-tasks.test.ts`). Remaining only: a keyed
->   live CLI run against a real provider (no API keys in this env) — the code path is now exercised
->   end-to-end by the regression test. Confirmed decisions: D1 minimal `IUsageSource` in
->   agent-interface-transport (the framework's `IExecutionOrigin` is a layer up and can't be imported into
->   the contract package); D2 single usage stream in the main session log; D3 `robota session analyze
+>   chain, not a mock of it (`interactive-session-background-tasks.test.ts`).
+>
+> **Phase 2 gap found + fixed by a LIVE CLI run (2026-07-02):** a real `robota -p … --preset
+autonomous-builder` run (Anthropic claude-sonnet-4-6) that spawned a `general-purpose` subagent showed
+> `session analyze --usage` attributing 100% to the main thread — the subagent's tokens were missing.
+> Root cause: the CLI uses the **child-process** subagent runner (`agent-subagent-runner`), whose worker
+> only sent `output` over IPC and dropped usage; only the in-process runner captured it. Fix: the worker
+> now forwards `sumHistoryUsage(session.getFullHistory())` in the `result` IPC message → the runner
+> carries it onto `ISubagentJobResult.usage` → the existing tracker chain attributes it. Re-run proof:
+> `main thread 87.1% (32.5K) · general-purpose 12.9% (4.8K)`. Regression-guarded by a fixture usage-mode
+> test (`child-process-subagent-runner.test.ts`). **User Execution gate: satisfied by this live run.**
+> Confirmed decisions: D1 minimal `IUsageSource` in
+> agent-interface-transport (the framework's `IExecutionOrigin` is a layer up and can't be imported into
+> the contract package); D2 single usage stream in the main session log; D3 `robota session analyze
 --usage` report; D4 harness `usageReport()`/`totalUsage()`.
 
 # Source-attributed token usage in the session log
@@ -94,6 +103,13 @@ framework can assert usage budgets so regressions in token consumption are caugh
   percentages, top consumer, empty); `agent-cli` `session analyze --usage` integration test (prints the
   source breakdown + top consumer); `agent-framework` `usage-assertion-functional` drives a REAL session
   whose scripted provider reports usage and asserts `harness.usageReport()`/`totalUsage()` + a budget.
-  All green; lint 0 errors; `pnpm harness:scan` 39/39. **Live multi-source attribution (subagent /
-  background task usage written to the main log) is Phase 2** — until then a real session's report shows
-  main-thread usage (the subagent/background rows populate once Phase 2 records them).
+  All green; lint 0 errors; `pnpm harness:scan` 39/39.
+- Evidence (Phase 2, LIVE agent-run 2026-07-02): `robota -p "Use the Agent tool … spawn a general-purpose
+subagent …" --preset autonomous-builder` against a real Anthropic provider (claude-sonnet-4-6) in a
+  throwaway cwd, then `robota session analyze --usage` on that session. First run exposed a real gap
+  (report showed `main thread 100%` — subagent tokens dropped by the child-process runner's IPC). After
+  fixing the worker to forward `sumHistoryUsage(...)` over IPC, the re-run report read:
+  `main thread 87.1% (32.5K, 1 turn) · general-purpose 12.9% (4.8K, 1 turn) · top consumer: main thread`
+  — i.e. the subagent's tokens are now attributed to its own source, matching what was run. **User
+  Execution gate satisfied.** Guarded against regression by the child-process runner usage-mode fixture
+  test.

--- a/packages/agent-subagent-runner/src/__tests__/child-process-subagent-runner.test.ts
+++ b/packages/agent-subagent-runner/src/__tests__/child-process-subagent-runner.test.ts
@@ -98,6 +98,25 @@ describe('ChildProcessSubagentRunner', () => {
   );
 
   it(
+    'propagates the child worker token usage into the subagent result (ANALYTICS-001 P2)',
+    async () => {
+      const runner = new ChildProcessSubagentRunner(createDeps(), {
+        workerPath: FIXTURE_WORKER,
+        execArgv: [],
+        env: { ROBOTA_FIXTURE_MODE: 'usage' },
+      });
+
+      const handle = runner.start(createJob());
+      const result = await handle.result;
+
+      // The worker forwards sumHistoryUsage(...) over IPC; the runner must carry it onto the result
+      // so the background-task tracker can attribute those tokens to this subagent's source.
+      expect(result.usage).toEqual({ promptTokens: 300, completionTokens: 120, totalTokens: 420 });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
     'emits text and tool progress messages from the child worker',
     async () => {
       const events: TBackgroundTaskRunnerEvent[] = [];

--- a/packages/agent-subagent-runner/src/__tests__/fixtures/subagent-worker-fixture.mjs
+++ b/packages/agent-subagent-runner/src/__tests__/fixtures/subagent-worker-fixture.mjs
@@ -16,6 +16,15 @@ process.on('message', (message) => {
       process.send?.({ type: 'text_delta', delta: 'partial ' });
       process.send?.({ type: 'tool_end', toolName: 'Read', success: true });
     }
+    if (process.env.ROBOTA_FIXTURE_MODE === 'usage') {
+      process.send?.({
+        type: 'result',
+        output: `completed:${jobId}`,
+        usage: { promptTokens: 300, completionTokens: 120, totalTokens: 420 },
+      });
+      setTimeout(() => process.exit(0), 0);
+      return;
+    }
     process.send?.({ type: 'result', output: `completed:${jobId}` });
     setTimeout(() => process.exit(0), 0);
     return;

--- a/packages/agent-subagent-runner/src/child-process-subagent-ipc.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-ipc.ts
@@ -1,4 +1,4 @@
-import type { TPermissionMode, TToolArgs } from '@robota-sdk/agent-core';
+import type { ISessionUsageTotals, TPermissionMode, TToolArgs } from '@robota-sdk/agent-core';
 import type {
   ISerializableProviderProfile,
   ISubagentSpawnRequest,
@@ -64,6 +64,8 @@ export interface ISubagentWorkerToolEndMessage {
 export interface ISubagentWorkerResultMessage {
   type: 'result';
   output: string;
+  /** ANALYTICS-001 (Phase 2): total token usage of the subagent run, forwarded to the parent. */
+  usage?: ISessionUsageTotals;
 }
 
 export interface ISubagentWorkerErrorMessage {

--- a/packages/agent-subagent-runner/src/child-process-subagent-runner-result.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-runner-result.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   isSubagentWorkerChildMessage,
+  type ISubagentWorkerResultMessage,
   type ISubagentWorkerStartPayload,
   type TSubagentWorkerWireValue,
 } from './child-process-subagent-ipc.js';
@@ -89,13 +90,13 @@ class ChildProcessSubagentResultController {
     this.rejectOnce(new BackgroundTaskError('crash', formatEarlyExitMessage(code, signal)));
   };
 
-  private readonly resolveOnce = (output: string): void => {
+  private readonly resolveOnce = (result: ISubagentWorkerResultMessage): void => {
     if (this.settled) return;
     this.settled = true;
     this.clearTimers();
     this.cleanup();
     const { runtime, resolveTranscriptPath } = this.options;
-    this.resolve(toSubagentResult(runtime.job, output, resolveTranscriptPath));
+    this.resolve(toSubagentResult(runtime.job, result, resolveTranscriptPath));
   };
 
   private readonly rejectOnce = (error: Error): void => {
@@ -148,14 +149,17 @@ function createTimeoutTimer(
 
 function toSubagentResult(
   job: ISubagentJobStart,
-  output: string,
+  result: ISubagentWorkerResultMessage,
   resolveTranscriptPath: (job: ISubagentJobStart) => string | undefined,
 ): ISubagentJobResult {
   const transcriptPath = resolveTranscriptPath(job);
   return {
     jobId: job.jobId,
-    output,
+    output: result.output,
     ...(transcriptPath ? { metadata: { transcriptPath, logPath: transcriptPath } } : {}),
+    // ANALYTICS-001 (Phase 2): carry the subagent's forwarded token usage so the background-task
+    // tracker can attribute it to this agent as a source in the parent log.
+    ...(result.usage ? { usage: result.usage } : {}),
   };
 }
 

--- a/packages/agent-subagent-runner/src/child-process-subagent-transport.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-transport.ts
@@ -5,6 +5,7 @@ import {
 } from '@robota-sdk/agent-executor';
 
 import type {
+  ISubagentWorkerResultMessage,
   TSubagentWorkerChildMessage,
   TSubagentWorkerParentMessage,
 } from './child-process-subagent-ipc.js';
@@ -21,7 +22,7 @@ export interface IChildProcessRuntime {
 export function handleWorkerMessage(
   message: TSubagentWorkerChildMessage,
   startWorker: () => void,
-  resolveOnce: (output: string) => void,
+  resolveOnce: (result: ISubagentWorkerResultMessage) => void,
   rejectOnce: (error: Error) => void,
   emit?: (event: TBackgroundTaskRunnerEvent) => void,
 ): void {
@@ -30,7 +31,7 @@ export function handleWorkerMessage(
       startWorker();
       break;
     case 'result':
-      resolveOnce(message.output);
+      resolveOnce(message);
       break;
     case 'error':
       rejectOnce(new BackgroundTaskError('runner', message.message));

--- a/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
@@ -1,3 +1,4 @@
+import { sumHistoryUsage } from '@robota-sdk/agent-core';
 import { createProviderFromProfile } from '@robota-sdk/agent-executor';
 import {
   createDefaultTools,
@@ -41,6 +42,18 @@ function sendChildMessage(message: TSubagentWorkerChildMessage): void {
   }
 }
 
+/** Best-effort total token usage of the finished subagent session; never throws. */
+function readSessionUsage(
+  finishedSession: ReturnType<typeof createSubagentSession>,
+): ReturnType<typeof sumHistoryUsage> {
+  try {
+    return sumHistoryUsage(finishedSession.getFullHistory());
+  } catch {
+    // allow-fallback: usage capture is auxiliary — history read failure must not fail the subagent run
+    return undefined;
+  }
+}
+
 async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<void> {
   try {
     const provider = createProviderFromProfile(
@@ -70,7 +83,10 @@ async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<v
       sendChildMessage({ type: 'cancelled', reason: 'Subagent worker cancelled' });
       return;
     }
-    sendChildMessage({ type: 'result', output });
+    // ANALYTICS-001 (Phase 2): forward the subagent's total token usage so the parent log can
+    // attribute it to this agent as a source. Best-effort — usage capture must never fail the run.
+    const usage = readSessionUsage(session);
+    sendChildMessage({ type: 'result', output, ...(usage ? { usage } : {}) });
   } catch (error) {
     // allow-fallback: child process must report errors to parent via IPC, not crash silently
     if (cancelled) {


### PR DESCRIPTION
## 요약

ANALYTICS-001 Phase 2의 **실전 갭을 라이브 실행으로 발견하고 수정**한다.

실제 `robota -p "Agent 툴로 general-purpose 서브에이전트 스폰…" --preset autonomous-builder` 실행(실 Anthropic claude-sonnet-4-6) 후 `robota session analyze --usage`를 돌려보니 **main thread 100%** 로만 나오고 서브에이전트 토큰이 누락됐다.

### 원인

CLI는 **child-process 서브에이전트 러너**(`agent-subagent-runner`)를 쓴다. 그 worker는 IPC `result` 메시지에 `output`만 실어 보내고 usage를 버렸다 — Phase 2에서 usage를 캡처한 건 in-process 러너뿐이었다. 그래서 tracker 체인에 usage가 도달하지 못했다.

### 수정

- worker: `session.run` 후 `sumHistoryUsage(session.getFullHistory())`를 계산해 `result` IPC 메시지에 실어 전달(best-effort, 실패해도 run을 깨지 않음).
- IPC 타입: `ISubagentWorkerResultMessage.usage?`(agent-core `ISessionUsageTotals` 재사용 = SSOT).
- transport / result controller: `resolveOnce`가 result 메시지를 그대로 받아 `ISubagentJobResult.usage`로 전달 → 기존 `IBackgroundTaskResult.usage` → 트래커 → 부모 로그 소스 귀속 체인이 동작.

### 재실행 증명

```
Token usage — session …
  total 37.3K (prompt 37.1K · completion 149)
  by source (most tokens first):
    main thread               87.1%    32.5K  (1 turn)
    general-purpose           12.9%     4.8K  (1 turn)
  top consumer: main thread (87.1%)
```

서브에이전트(`general-purpose`) 토큰이 자기 소스로 정확히 귀속된다.

## 회귀 방지

`child-process-subagent-runner.test.ts`에 fixture usage-mode 테스트 추가 — worker가 usage를 IPC로 보내면 러너 결과의 `usage`로 전파되는지 단언. 누가 이 IPC 전파를 깨면 실패한다.

## 검증

- agent-subagent-runner 13/13 green, typecheck 통과, lint 0 errors, `pnpm harness:scan` 39/39.
- ANALYTICS-001 백로그 **done** 처리(User Execution 게이트: 이 라이브 실행으로 충족).

🤖 Generated with [Claude Code](https://claude.com/claude-code)