### PR TITLE
chore(harness): close out shipped items — live-TUI evidence, gate completion, archival

### DIFF
--- a/.agents/backlog/CMD-004-command-action-ui-separation.md
+++ b/.agents/backlog/CMD-004-command-action-ui-separation.md
@@ -1,12 +1,22 @@
 ---
 title: 'CMD-004: separate command interaction ACTION from UI (environment-agnostic, multi-transport)'
-status: todo
+status: in-progress
 created: 2026-06-28
 priority: high
 urgency: soon
 area: packages/agent-interface-transport, packages/agent-framework, packages/agent-command, packages/agent-transport-tui, packages/agent-transport, packages/agent-cli, packages/agent-web-ui
 depends_on: []
 ---
+
+> **Phase 1 delivered (2026-06-28 ~ 2026-06-30)** via the CMD-004 spec/task pipeline (task archived at
+> `.agents/tasks/completed/CMD-004.md`, spec at `.agents/spec-docs/done/CMD-004-*.md`): PRs A–I + the
+> final legacy deletion (#887, removing `IInteractionChannel.requestAction` / `ICommandResult.interaction`
+> across 5 packages) + TC-09 real-binary PTY evidence (#888). `askUser` is now the single UI-agnostic
+> action seam; TUI + programmatic channels render it per-environment; TC-01..TC-09 evidence is in the
+> spec's Evidence Log. **CMD-005 is unblocked.**
+>
+> **This item stays open for Phase 2 only:** the WS + web-ui **multi-environment broadcast** (two
+> attached environments rendering the same ask simultaneously) — per the completed task's closing note.
 
 # Separate command interaction ACTION from UI
 

--- a/.agents/backlog/SCREEN-010-background-work-stable-ordering.md
+++ b/.agents/backlog/SCREEN-010-background-work-stable-ordering.md
@@ -1,6 +1,6 @@
 ---
 title: 'SCREEN-010: Background work list keeps reordering — give it a stable order'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: medium
 urgency: soon
@@ -41,4 +41,9 @@ switcher so they never disagree.
   reshuffling on each activity tick); only newly spawned tasks appear, appended at the end.
 - Evidence: Engineering — `execution-workspace-projection.test.ts` › "orders background tasks by
   startedAt, not by lastActivityAt" passes: the entry order is invariant when `lastActivityAt` is
-  reshuffled across snapshots. Live-TUI confirmation (watch ≥3 streaming agents ~20s) pending a user run.
+  reshuffled across snapshots.
+- Evidence (LIVE, agent-run 2026-07-02): real TUI in a PTY (tsx source, real Anthropic
+  claude-sonnet-4-6, `--preset autonomous-builder`); the model spawned 3 background agents via the
+  `agent` command tool (`parallel --wait`). 8 panel snapshots over ~21s of live streaming all read
+  `A1 A2 A3` top-to-bottom — the order stayed invariant even as A2 flipped `running → completed`
+  mid-run while A1/A3 kept streaming. Scenario executed as written (≥3 agents, ~20s watch).

--- a/.agents/backlog/SCREEN-011-background-work-single-line-rows.md
+++ b/.agents/backlog/SCREEN-011-background-work-single-line-rows.md
@@ -1,6 +1,6 @@
 ---
 title: 'SCREEN-011: Background work rows wrap to two lines, orphaning the tree connector'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: medium
 urgency: soon
@@ -44,4 +44,9 @@ Render each background row as exactly **one terminal line**: set the row `<Text>
   with `…` rather than wrapping onto an unconnected second line.
 - Evidence: Engineering — `background-task-panel.test.tsx` › "keeps a long-preview row on a single
   line (SCREEN-011)" passes: a row with a >1-width preview renders exactly one line that still begins
-  with `└ ⟳`. Live-TUI confirmation in an 80-col terminal pending a user run.
+  with `└ ⟳`.
+- Evidence (LIVE, agent-run 2026-07-02): real TUI in an 80-column PTY (real Anthropic provider); one
+  background agent was given a >200-char prompt. Every panel row rendered as exactly one line —
+  `├ ⟳ A1 agent · running · agent · general-purpose · Write one very long senten…` — truncated with
+  `…` at the terminal edge; no row wrapped onto an unconnected second line. Scenario executed as
+  written (long prompt, 80-col terminal).

--- a/.agents/backlog/SCREEN-012-humanize-model-command-tool-names.md
+++ b/.agents/backlog/SCREEN-012-humanize-model-command-tool-names.md
@@ -1,6 +1,6 @@
 ---
 title: 'SCREEN-012: Tool display shows internal robota_command_* id instead of the command name'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: medium
 urgency: soon
@@ -48,4 +48,9 @@ so the value stays SSOT. Display becomes `⟳ agent(parallel --wait "…")`.
 - Expected: the row reads `⟳ agent(...)` (the command name), not `robota_command_agent(...)`.
 - Evidence: Engineering — `humanize-tool-name.test.ts` passes (`robota_command_agent` → `agent`,
   hash-suffixed → body, non-command names unchanged); `StreamingIndicator`/`MessageList` now call
-  `humanizeToolName`. Live-TUI confirmation (model invokes a command-tool) pending a user run.
+  `humanizeToolName`.
+- Evidence (LIVE, agent-run 2026-07-02): real TUI in a PTY (real Anthropic provider); the model
+  invoked the projected `agent` command tool. The `Tools:` list read
+  `⟳ agent(parallel --wait A1=general-purpose:"Write one v...")` — the humanized command name; the
+  raw `robota_command_agent…` id never appeared in the rendered tool row (it appeared only inside the
+  user's own echoed prompt text). Scenario executed as written.

--- a/.agents/backlog/SCREEN-013-background-work-selectable-drill-in.md
+++ b/.agents/backlog/SCREEN-013-background-work-selectable-drill-in.md
@@ -1,6 +1,6 @@
 ---
 title: 'SCREEN-013: No way to select or enter a background task from the TUI'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: high
 urgency: soon
@@ -48,5 +48,10 @@ Use the same stable order as SCREEN-010 so the switcher selection is predictable
   `Enter` opens its detail view showing the task's status/output; `Esc` returns to the main thread.
 - Evidence: Engineering — `background-task-panel.test.tsx` › "advertises the Ctrl+B drill-in
   (SCREEN-013)" passes: the panel renders the `Ctrl+B` hint. The `Ctrl+B` handler + switcher +
-  `ExecutionWorkspaceDetailPane` already exist and are wired in `App.tsx`. Live-TUI confirmation
-  (Ctrl+B → ↑↓ → Enter → detail) pending a user run.
+  `ExecutionWorkspaceDetailPane` already exist and are wired in `App.tsx`.
+- Evidence (LIVE, agent-run 2026-07-02): real TUI in a PTY (real Anthropic provider) with 3 live
+  background agents. `Ctrl+B` opened the "Execution workspace" switcher listing main thread + A1/A2/A3
+  with the `Ctrl+B Close ↑↓ Navigate Enter Switch Esc Close` footer; `↓↓` moved the `>` selection to
+  `> ● A1 agent · running…`; `Enter` switched to A1 — the status bar showed `[A1]` and the main pane
+  rendered A1's live transcript; `Esc` returned to the prompt. Notably this worked **mid-turn** (while
+  the parent turn was still streaming). Scenario executed as written.

--- a/.agents/backlog/SCREEN-014-background-work-keyboard-navigation.md
+++ b/.agents/backlog/SCREEN-014-background-work-keyboard-navigation.md
@@ -1,6 +1,6 @@
 ---
 title: 'SCREEN-014: Define + implement arrow-key navigation into the inline background-work list'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: high
 urgency: now
@@ -77,7 +77,11 @@ The order shown is the stable order from SCREEN-010 so the highlight is predicta
   ↑/↓/Enter/Esc/empty navigation reducer; `input-area-focus-handoff.test.tsx` (2) proves ↓ on an
   empty input requests list focus (and not while disabled); `background-task-panel.test.tsx` covers
   the focus highlight + focus-aware hint. Full TUI suite green (392), real-binary PTY smoke green.
-  **Remaining gate:** the full live ↓ → ↑↓ → Enter → inline-detail flow against _real seeded
-  background tasks_ in the binary needs the deterministic background-task seed (TEST-010 Phase 3);
-  tracked there. Until then the integrated flow is covered by the unit/component pieces above, not a
-  single end-to-end run.
+- Evidence (LIVE end-to-end, agent-run 2026-07-02): real TUI in a PTY (real Anthropic provider) with
+  a real background agent spawned by the model — no seed needed. On the idle empty input, **↓**
+  flipped the panel hint to `↑↓ select · Enter open · Esc back` (focus entered the inline list);
+  **Enter** opened that entry inline — the status bar showed `[tides]` and the main pane rendered the
+  task's live transcript (`… Tides are the periodic rise and fall of sea levels …`); **Esc/↑**
+  restored the prompt and the unfocused `↓ select · Ctrl+B all` hint. The full live
+  ↓ → highlight → Enter → inline-detail → back flow ran as a single end-to-end session — the
+  previously-remaining gate is closed.

--- a/.agents/backlog/TEST-010-ci-maintained-tui-e2e-gate.md
+++ b/.agents/backlog/TEST-010-ci-maintained-tui-e2e-gate.md
@@ -1,6 +1,6 @@
 ---
 title: 'TEST-010: CI-maintained TUI PTY E2E gate (background-work drill-in self-verification)'
-status: in-progress
+status: done
 created: 2026-06-30
 priority: high
 urgency: soon
@@ -48,5 +48,7 @@ workspace`), then `Esc` closes it. This verifies the SCREEN-013 App-level `Ctrl+
   `test:pty` run + the green `tui-e2e` CI job, recorded below.
 - Evidence: Agent ran `pnpm --filter @robota-sdk/agent-transport-tui test:pty` locally — **10 tests /
   7 files green**, including the new `background-work-switcher.ptytest.ts` which drives `Ctrl+B` in the
-  real binary and asserts the execution-workspace switcher opens. CI evidence: the new `tui-e2e` job's
-  green run on the PR (recorded after merge).
+  real binary and asserts the execution-workspace switcher opens.
+- CI evidence (recorded 2026-07-02): the `tui-e2e` job has run green as a **blocking** check on every
+  PR since it landed — PR #902 (first run) through #903, #904, #905, #906, #907, #908, #909 (e.g.
+  2m46s–3m14s per run). The gate is live and maintained.

--- a/.agents/backlog/WORKFLOW-004-workflows-build-subcommand.md
+++ b/.agents/backlog/WORKFLOW-004-workflows-build-subcommand.md
@@ -1,0 +1,46 @@
+---
+title: 'WORKFLOW-004: workflows build subcommand (LLM-assisted DAG authoring from the agent CLI)'
+status: todo
+created: 2026-07-02
+priority: medium
+urgency: backlog
+area: packages/agent-command-workflows, packages/agent-framework
+depends_on: []
+---
+
+# `workflows build` subcommand
+
+Deferred from WORKFLOW-003 (its TC-01 scope note): the `workflows` command module shipped
+`list` / `catalog` / `validate` / `run`, but **`build`** — generating or scaffolding a `.dag.json`
+workflow with model assistance — was deferred because it needs an **LLM-integration design decision**:
+how an `ICommandModule` reaches the session's model provider.
+
+## What
+
+1. **Design decision first:** the seam by which a command module invokes the session's provider
+   (e.g. a host-context capability like the existing `getAgentJobCapability()` pattern vs a
+   command-prompt effect) — decide, spec, and confirm before implementation.
+2. `workflows build <name|description>`: produce a valid workflow file (node graph over the
+   `dag-framework` catalog), validate it with the existing `validate` path, and write it to
+   `.dag/workflows/`.
+3. Tests: module dispatch + a scripted-provider functional test that builds a small workflow and
+   validates it; no `@robota-sdk/dag-cli` import (WORKFLOW-003 TC-02 boundary holds).
+
+## Notes
+
+- Additive to `packages/agent-command-workflows` — no re-architecting of the shipped subcommands.
+- Follow the spec-first pipeline (GATE-WRITE onward) since this adds a model-facing product surface.
+
+## Test Plan
+
+- Module dispatch test for `build`; functional test with a scripted provider producing a small DAG;
+  `validate` accepts the produced file; boundary `rg` stays 0; typecheck/lint/harness green.
+
+## User Execution Test Scenarios
+
+- Prereq: built CLI in a project with `.dag/workflows/`.
+- Steps: run `robota`, invoke `/workflows build` with a short description, then `/workflows validate`
+  and `/workflows run` on the produced file.
+- Expected: a valid workflow file is created, validates cleanly, and runs (or reports a clear,
+  actionable error); the file appears in `/workflows list`.
+- Evidence: _to fill at implementation._

--- a/.agents/spec-docs/done/TERM-008-cross-platform-shell-execution.md
+++ b/.agents/spec-docs/done/TERM-008-cross-platform-shell-execution.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags: [typescript, cross-platform, windows, shell, tools]
 ---
@@ -121,3 +121,50 @@ shell + syntax hint) is the mitigation. Tracked here so the tradeoff is visible.
   actually spawns `powershell.exe` and executes. Evidence: **first run green** (PR #900, 1m34s). The
   interactive `/shell` drop-to-shell + IME on real Windows Terminal is not CI-exercisable and remains a
   manual Windows-Terminal pass tracked under TERM-007.
+
+## Tasks
+
+Archived: `.agents/tasks/completed/TERM-008.md` (all phases `[x]`).
+
+## Evidence Log
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-02
+
+Tasks file: all phases/checkboxes `[x]` (Phase 1 resolver SSOT + tests; Phase 2 three-site rewire +
+permission/TUI/assembly extension; Phase 3 functional coverage; Phase 4 verify) — none blocked.
+Build: `pnpm --filter agent-core --filter agent-tools --filter agent-command --filter
+agent-command-workflows --filter agent-cli build` → 0 errors. Tests (same filters, 2026-07-02 on
+develop): agent-core 752/54, agent-tools 163/12, agent-command 210/28, agent-cli 146/18 — all pass.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-07-02
+
+Resolver per-platform correctness. Test: `packages/agent-core/src/utils/platform-shell.test.ts`
+(posix `$SHELL`/`/bin/sh`/bash-vs-sh kind; win32 PowerShell default + `cmd.exe`/`pwsh.exe` overrides;
+`ROBOTA_SHELL` precedence; OS-family naming). Ran in the agent-core suite above — pass. Windows is
+additionally executed for real on `windows-latest` by the blocking `windows-shell` CI job (green since
+PR #900 and on every PR after).
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-07-02
+
+Shell tool OS-aware description. Test: `packages/agent-tools/src/builtins/__tests__` shell-tool suite —
+registers `Shell` + `Bash` alias, description embeds resolved `label` + `syntaxHint`, POSIX exec
+round-trip (`echo` → stdout + exit code). Ran in the agent-tools suite above — pass.
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-07-02
+
+Three sites consume the one resolver. Verified by tests over each site: shell tool (agent-tools),
+hook `command-executor` (agent-core hooks suite), interactive `resolveShell()` (agent-command suite —
+delegates to the core resolver). All in the suites above — pass.
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-07-02
+
+POSIX behavior unchanged. Exec round-trip (agent-tools) + agent-command drop-to-shell regression both
+pass in the suites above; `agent-framework` `shell-tool-functional.test.ts` drives a REAL
+InteractiveSession through both `Shell` and the `Bash` alias end-to-end (framework suite 1031/115
+green, 2026-07-01).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-02
+
+All 4 TCs verified with test references (no skips). Tasks archived to
+`.agents/tasks/completed/TERM-008.md`; spec `active/` → `done/`; frontmatter `status: done`.
+`pnpm harness:scan` 39/39 green.

--- a/.agents/spec-docs/done/WORKFLOW-003-workflows-command.md
+++ b/.agents/spec-docs/done/WORKFLOW-003-workflows-command.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: FLOW
 tags: [cli]
 ---
@@ -103,7 +103,7 @@ No manual rows.
 
 ## Tasks
 
-- [x] `.agents/tasks/WORKFLOW-003.md` — 작성 완료.
+- [x] Archived: `.agents/tasks/completed/WORKFLOW-003.md` (all phases `[x]`).
 
 ## Evidence Log
 
@@ -118,3 +118,42 @@ review-ready → approved. User approved the direction verbatim: "당연히 /wor
 ### [GATE-IMPLEMENT] — ✅ PASS | 2026-06-30
 
 approved → in-progress. `.agents/tasks/WORKFLOW-003.md` created; spec Tasks updated; spec pointer in tasks file; phased tasks cover TC-01..TC-05; Test Plan in tasks file.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-02
+
+Tasks file: all phases `[x]` (bridge package skeleton, command module + subcommand executors, agent-cli
+composition, verify) — none blocked. Build: `pnpm --filter agent-command-workflows --filter agent-cli
+build` (with siblings) → 0 errors. Tests (2026-07-02, develop): agent-command-workflows 9/1, agent-cli
+146/18 — pass.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-07-02
+
+`workflows` `ICommandModule` in `packages/agent-command-workflows` with canonical slash-free name and
+`list`/`catalog`/`validate`/`run` subcommands. Test: the module suite (9 tests) covers presence +
+dispatch. The deferred `build` subcommand follow-on is now tracked as
+`backlog/WORKFLOW-004-workflows-build-subcommand.md` (was noted as "tracked" but had no item).
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-07-02
+
+`rg -rln "@robota-sdk/dag-cli" packages/agent-*/src` → 0 files; `rg '"@robota-sdk/dag-cli"'
+packages/agent-*/package.json` → 0 (the only textual hit is the package's own SPEC.md sentence stating
+it does NOT depend on dag-cli).
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-07-02
+
+agent-cli registers the module in `command-setup.ts`; the 4 dispatch tests pass inside the
+agent-command-workflows/agent-cli suites run at GATE-VERIFY.
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-07-02
+
+`pnpm --filter @robota-sdk/agent-command-workflows typecheck` and `pnpm --filter
+@robota-sdk/agent-cli typecheck` both exit 0 (run 2026-07-02); agent-cli test 146 pass.
+
+### [GATE-COMPLETE: TC-05] — ✅ PASS | 2026-07-02
+
+`pnpm harness:scan` → all 39 scans pass (was 38 at authoring; the scan count grew since — still exit 0).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-02
+
+All 5 TCs verified with test references (no skips). Tasks archived to
+`.agents/tasks/completed/WORKFLOW-003.md`; spec `active/` → `done/`; frontmatter `status: done`.

--- a/.agents/tasks/completed/TERM-008.md
+++ b/.agents/tasks/completed/TERM-008.md
@@ -1,7 +1,9 @@
 # TERM-008 — Cross-platform shell execution (Shell tool + shared resolver)
 
-Spec: .agents/spec-docs/active/TERM-008-cross-platform-shell-execution.md
-Status: implemented; verifying. Carved from TERM-007 item 1 (shell selection / hardcoded `sh`).
+Spec: .agents/spec-docs/done/TERM-008-cross-platform-shell-execution.md
+Status: completed — GATE-VERIFY + GATE-COMPLETE passed 2026-07-02 (TC-01..04 evidence in the spec
+Evidence Log; suites re-run green on develop; `windows-shell` CI gate blocking on every PR). Carved
+from TERM-007 item 1 (shell selection / hardcoded `sh`).
 
 ## Decision (recorded)
 

--- a/.agents/tasks/completed/WORKFLOW-003.md
+++ b/.agents/tasks/completed/WORKFLOW-003.md
@@ -1,6 +1,6 @@
 # WORKFLOW-003 — `/workflows` agent-cli command
 
-Spec: .agents/spec-docs/active/WORKFLOW-003-workflows-command.md
+Spec: .agents/spec-docs/done/WORKFLOW-003-workflows-command.md
 Status: done (list/catalog/validate/run) — build subcommand deferred (needs LLM-integration design: how a command module reaches the session provider). Committed incrementally; harness green.
 
 ## Decision (recorded)


### PR DESCRIPTION
## 요약

이미 머지된 작업들(PR #901–#904, #887–#890, #900)의 **상태 마감**. 백로그/스펙/태스크의 SSOT가 실제와 어긋나 있던 드리프트를 정리한다. 규칙(done gate)대로 evidence 없이 done 처리하지 않았다 — 부족한 evidence는 **라이브 실행으로 직접 채웠다**.

## 라이브-TUI evidence (agent 직접 실행, 2026-07-02)

실제 TUI를 PTY에서 구동(실 Anthropic provider, 모델이 `agent` 명령 tool로 background agent 3개 스폰)해 각 시나리오를 문서 그대로 실행:

| 항목 | 라이브 확인 | 상태 |
|------|------------|------|
| SCREEN-010 | ~21초 스트리밍 동안 8개 스냅샷 전부 `A1 A2 A3` 순서 불변 (A2가 running→completed 전환돼도) | done |
| SCREEN-011 | 80컬럼에서 >200자 프롬프트 행이 단일 라인 + `…` 잘림, 줄바꿈 없음 | done |
| SCREEN-012 | `Tools:`가 `⟳ agent(parallel --wait …)` — raw `robota_command_agent…` 미노출 | done |
| SCREEN-013 | Ctrl+B switcher → `>` 선택 이동 → Enter로 `[A1]` 전환 + 인라인 상세 → Esc 복귀 (**턴 진행 중에도** 동작) | done |
| SCREEN-014 | 빈 입력에서 ↓ → 힌트 `↑↓ select · Enter open · Esc back`로 전환(포커스 진입) → Enter → `[tides]` 인라인 상세 → Esc/↑ 복귀 — 남아있던 "실 태스크 대상 단일 e2e" 게이트 닫힘 | done |
| TEST-010 | `tui-e2e` blocking 게이트가 PR #902–#909 전부 green | done |

## 게이트 완료 + 아카이브

- **TERM-008 / WORKFLOW-003 spec**: GATE-VERIFY(전 태스크 `[x]` + build 0 errors + 스위트 재실행 green: core 752, tools 163, command 210, cmd-workflows 9, cli 146) + GATE-COMPLETE(TC별 테스트 참조, skip 없음) 기록 → `active/` → `done/`, 태스크 파일 `tasks/completed/`로 아카이브.
- **CMD-004 백로그**: done이 아니라 **in-progress로 정정** — 완료 태스크의 종결 노트대로 Phase 2(WS + web-ui 멀티환경 브로드캐스트)만 남기고 Phase 1 delivered 기록.
- **WORKFLOW-004 신규**: WORKFLOW-003에서 deferred된 `workflows build` 서브커맨드 후속 — "tracked follow-on"이라 적혀 있었으나 실제 항목이 없어서 생성.

## 검증

- `pnpm harness:scan` 39/39 green (docs-structure 포함).
- 코드 변경 없음(문서/상태만). TC-02 경계 재검증: `packages/agent-*/src` 내 dag-cli import 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)