### PR TITLE
docs(readme): every README example now typechecks — new doc-examples gate (DOCS-015)

### DIFF
--- a/.agents/backlog/DOCS-019-content-doc-examples-onboarding.md
+++ b/.agents/backlog/DOCS-019-content-doc-examples-onboarding.md
@@ -1,0 +1,37 @@
+---
+title: 'DOCS-019: onboard content/ guide code blocks (517 blocks, 70 files) to the doc-examples typecheck gate'
+status: todo
+created: 2026-07-03
+priority: medium
+urgency: later
+area: content/, scripts/harness
+depends_on: []
+---
+
+# content/ doc-example onboarding
+
+Split from DOCS-015 (recorded, not silent): the doc-examples typecheck gate
+(`scripts/harness/check-doc-examples.mjs`, in `pnpm harness:scan`) covers the root README + all
+packages/x/README.md (49 blocks green, 5 explicit fragments). The content/ guide corpus is 10x
+larger — **517 ts blocks across 70 files** — and onboarding it (fixing/marking every failure) is its
+own effort with the mechanism already built.
+
+## What
+
+1. Extend `listReadmeFiles()` (or a corpus option) to include `content/**/*.md` — possibly per-batch
+   (guide/ first) so each PR stays reviewable.
+2. Triage every failing block: fix real API drift; mark intentional fragments with
+   `<!-- doc-example-skip: <reason> -->`; batch per directory with suites green.
+3. Also honor DOCS-014/016 outcomes so fixed examples document the CURRENT contracts, not the old.
+
+## Test Plan
+
+- Per batch: `node scripts/harness/check-doc-examples.mjs` exit 0 with the batch included; final:
+  full content/ in scope, `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+- Prereq: fresh strict-TS consumer project.
+- Steps: paste 3 randomly-chosen content/ guide examples; compile.
+- Expected: all compile without edits.
+- Evidence: _to fill at implementation._

--- a/.agents/backlog/completed/DOCS-015-readme-example-compile-fix-and-ci-typecheck.md
+++ b/.agents/backlog/completed/DOCS-015-readme-example-compile-fix-and-ci-typecheck.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-015: README quickstart does not compile (defaultModel.systemMessage) — fix + CI typecheck for doc examples'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: high
 urgency: now
@@ -38,4 +39,20 @@ of drift — the front-door example confirming the distrust is the worst possibl
 - Prereq: fresh consumer project with strict TS.
 - Steps: paste the root README Core quickstart verbatim; compile.
 - Expected: compiles and runs without edits.
-- Evidence: _to fill at implementation._
+- Evidence (agent-run 2026-07-03): the new `doc-examples` scan (registered in `pnpm harness:scan`,
+  which CI's quality gate runs) extracts every ts block from the root README + all packages/x
+  READMEs and typechecks them against workspace SOURCE types (strict, es2023, jsx). Initial run
+  exposed **29 broken blocks beyond the reported one** (first pass showed only 1 — a syntax error was
+  suppressing all semantic diagnostics): nonexistent option fields (`LoggingPlugin backend→strategy`,
+  `UsagePlugin storage→strategy`, `createHeadlessTransport format→outputFormat+prompt`,
+  `createHttpTransport port→basePath`, `LimitsPlugin maxTokensPerMinute→strategy/maxTokens`),
+  wrong arities (`createZodFunctionTool` object→4 positional args, command-module factories
+  hostAdapters→0 args / provider module 1 required options arg), wrong type names
+  (`IInteractiveSessionOptions→TInteractiveSessionOptions`), wrong ctor param
+  (`TuiTransport(adapter)→IRenderOptions`), fictional APIs (`createSubagentSession({parentSession})`,
+  `WebhookPlugin({url,secret})→endpoints[]`), missing required fields (`createAgentRuntime cwd`,
+  streaming `stream: true`), and the reported `defaultModel.systemMessage` (3 spots). All fixed to
+  the real contracts; 5 intentional fragments carry explicit `doc-example-skip` markers (reported,
+  never silent). Final: **49 blocks typechecked green, 5 skips**. Root-README paste-compile scenario
+  is exactly what the gate executes on every scan. Scope note: content/ (517 blocks / 70 files) split
+  to DOCS-019 — the mechanism is ready; onboarding that corpus is its own effort.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ const agent = new Robota({
   defaultModel: {
     provider: 'anthropic',
     model: 'claude-sonnet-4-6',
-    systemMessage: 'You are a helpful assistant.',
   },
+  systemMessage: 'You are a helpful assistant.',
 });
 
 const response = await agent.run('Hello!');

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -24,6 +24,7 @@ import { createAgentRuntime } from '@robota-sdk/agent-framework';
 import { createAnthropicProvider } from '@robota-sdk/agent-provider';
 
 const runtime = createAgentRuntime({
+  cwd: process.cwd(),
   provider: createAnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY }),
 });
 const session = runtime.createSession({ permissionMode: 'bypassPermissions' });

--- a/packages/agent-command/README.md
+++ b/packages/agent-command/README.md
@@ -16,12 +16,15 @@ import {
   createModeCommandModule,
   createProviderCommandModule,
 } from '@robota-sdk/agent-command';
+import type { IProviderCommandModuleOptions } from '@robota-sdk/agent-command';
+
+declare const providerOptions: IProviderCommandModuleOptions;
 
 // Register commands with a CommandRegistry (owned by agent-framework)
 const modules = [
-  createAgentCommandModule(hostAdapters),
-  createModeCommandModule(hostAdapters),
-  createProviderCommandModule(hostAdapters),
+  createAgentCommandModule(),
+  createModeCommandModule(),
+  createProviderCommandModule(providerOptions),
 ];
 ```
 
@@ -58,8 +61,8 @@ Each command is exposed via a factory function that returns an `ICommandModule`:
 ```typescript
 import { createExitCommandModule, createHelpCommandModule } from '@robota-sdk/agent-command';
 
-const exitCmd = createExitCommandModule(hostAdapters);
-const helpCmd = createHelpCommandModule(hostAdapters);
+const exitCmd = createExitCommandModule();
+const helpCmd = createHelpCommandModule();
 ```
 
 All command factory functions are re-exported from the root entry point (21 command modules plus the

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -22,8 +22,8 @@ const agent = new Robota({
   defaultModel: {
     provider: 'anthropic',
     model: 'claude-sonnet-4-6',
-    systemMessage: 'You are a helpful assistant.',
   },
+  systemMessage: 'You are a helpful assistant.',
 });
 
 const response = await agent.run('Hello, world!');
@@ -52,6 +52,10 @@ console.log(response);
 ## Robota API
 
 ```typescript
+import { Robota } from '@robota-sdk/agent-core';
+import type { IAgentConfig } from '@robota-sdk/agent-core';
+
+declare const config: IAgentConfig;
 const agent = new Robota(config);
 
 // Send a message (executes tool calls automatically)
@@ -85,15 +89,15 @@ Provider-specific SDK payload capture remains provider-owned. Providers may call
 
 ## IAgentConfig
 
-| Field                        | Type                       | Description                    |
-| ---------------------------- | -------------------------- | ------------------------------ |
-| `name`                       | `string`                   | Agent name                     |
-| `aiProviders`                | `IAIProvider[]`            | One or more provider instances |
-| `defaultModel.provider`      | `string`                   | Provider name                  |
-| `defaultModel.model`         | `string`                   | Model identifier               |
-| `defaultModel.systemMessage` | `string?`                  | System prompt                  |
-| `tools`                      | `IToolWithEventService[]?` | Tools the agent can call       |
-| `plugins`                    | `IPluginContract[]?`       | Plugins for lifecycle hooks    |
+| Field                   | Type                       | Description                    |
+| ----------------------- | -------------------------- | ------------------------------ |
+| `name`                  | `string`                   | Agent name                     |
+| `aiProviders`           | `IAIProvider[]`            | One or more provider instances |
+| `defaultModel.provider` | `string`                   | Provider name                  |
+| `defaultModel.model`    | `string`                   | Model identifier               |
+| `systemMessage`         | `string?`                  | System prompt (top-level)      |
+| `tools`                 | `IToolWithEventService[]?` | Tools the agent can call       |
+| `plugins`               | `IPluginContract[]?`       | Plugins for lifecycle hooks    |
 
 ## Architecture
 

--- a/packages/agent-framework/README.md
+++ b/packages/agent-framework/README.md
@@ -114,22 +114,20 @@ The SDK is **pure TypeScript with no React dependency**. The CLI is a thin TUI-o
 
 ```typescript
 import { InteractiveSession, createProjectSessionStore } from '@robota-sdk/agent-framework';
-import type { IInteractiveSessionOptions } from '@robota-sdk/agent-framework';
+import type { IAIProvider } from '@robota-sdk/agent-core';
 
+declare const provider: IAIProvider;
 const cwd = process.cwd();
 const sessionStore = createProjectSessionStore(cwd);
 
 const session = new InteractiveSession({
-  config,
-  context,
-  projectInfo,
+  cwd,
+  provider,
   sessionStore, // SDK-owned project-local persistence facade
-  resumeSessionId, // Session ID to restore, including sandbox snapshot when available
-  forkSession, // Session ID to fork from (optional)
+  resumeSessionId: 'sess_123', // Session ID to restore, incl. sandbox snapshot (optional)
+  forkSession: false, // Fork the resumed session into a new one (optional)
   permissionMode: 'default',
   maxTurns: 10,
-  cwd,
-  permissionHandler: async (toolName, toolArgs) => ({ allowed: true }),
 });
 
 // Subscribe to events
@@ -166,7 +164,7 @@ await session.submit('Explain this code');
 await session.submit('Explain @AGENTS.md and @docs/SPEC.md');
 
 // Submit with display override (shown in UI) and raw input (for hook matching)
-await session.submit(fullPrompt, '/audit', '/rulebased-harness:audit');
+await session.submit('full expanded prompt…', '/audit', '/rulebased-harness:audit');
 
 // Execute slash commands through the command layer. With the skills command module composed,
 // `/audit src/index.ts` is normalized by SDK to command "skills" with args "audit src/index.ts".
@@ -207,8 +205,9 @@ session.getSession(); // Session
 
 ```typescript
 import { SystemCommandExecutor, createSystemCommands } from '@robota-sdk/agent-framework';
-import type { ICommandResult } from '@robota-sdk/agent-framework';
+import type { ICommandResult, ICommandHostContext } from '@robota-sdk/agent-framework';
 
+declare const session: ICommandHostContext;
 const executor = new SystemCommandExecutor(); // starts empty unless commands are supplied
 
 // Execute a command
@@ -333,6 +332,8 @@ import {
 
 SDK sessions can receive a provider-neutral sandbox client. When provided, Bash, Read, Write, and Edit use the sandbox execution plane instead of the host process/filesystem:
 
+<!-- doc-example-skip: requires the optional e2b dependency -->
+
 ```typescript
 import { InteractiveSession } from '@robota-sdk/agent-framework';
 import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
@@ -369,13 +370,12 @@ When `sessionStore` and a snapshot-capable `sandboxClient` are both provided, `I
 
 ```typescript
 import { createSubagentSession } from '@robota-sdk/agent-framework';
+import type { ISubagentOptions } from '@robota-sdk/agent-framework';
 
-const subSession = createSubagentSession({
-  parentSession: session,
-  agentDefinition: 'explore',
-  prompt: 'Analyze the test coverage gaps',
-});
-const result = await subSession.run();
+// agentDefinition, parentConfig/parentContext/parentTools, provider, terminal, …
+declare const options: ISubagentOptions;
+const subSession = createSubagentSession(options);
+const result = await subSession.run('Analyze the test coverage gaps');
 ```
 
 ### Agent Definitions
@@ -433,18 +433,16 @@ Manages plugin installation and uninstallation:
 `@robota-sdk/agent-plugin` plugins are **consumer opt-in** — they are not built into the CLI or SDK by default. Application consumers register plugins at composition time by passing plugin instances to the SDK assembly API.
 
 ```typescript
-import { InteractiveSession } from '@robota-sdk/agent-framework';
-import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
-import { ConversationHistoryPlugin } from '@robota-sdk/agent-plugin';
-import { LoggingPlugin } from '@robota-sdk/agent-plugin';
+import { Robota } from '@robota-sdk/agent-core';
+import { ConversationHistoryPlugin, LoggingPlugin } from '@robota-sdk/agent-plugin';
+import type { IAgentConfig } from '@robota-sdk/agent-core';
 
-const session = new InteractiveSession({
-  cwd: process.cwd(),
-  config,
-  context,
+declare const base: IAgentConfig;
+const agent = new Robota({
+  ...base,
   plugins: [
-    new ConversationHistoryPlugin({ maxMessages: 100 }),
-    new LoggingPlugin({ level: 'info' }),
+    new ConversationHistoryPlugin({ storage: 'memory' }),
+    new LoggingPlugin({ strategy: 'console', level: 'info' }),
   ],
 });
 ```

--- a/packages/agent-plugin/README.md
+++ b/packages/agent-plugin/README.md
@@ -26,13 +26,15 @@ npm install @robota-sdk/agent-plugin
 ```typescript
 import { Robota } from '@robota-sdk/agent-core';
 import { ConversationHistoryPlugin, LoggingPlugin, UsagePlugin } from '@robota-sdk/agent-plugin';
+import type { IAgentConfig } from '@robota-sdk/agent-core';
 
+declare const base: IAgentConfig; // name, aiProviders, defaultModel, …
 const agent = new Robota({
-  // ...provider config...
+  ...base,
   plugins: [
     new ConversationHistoryPlugin({ storage: 'memory' }),
-    new LoggingPlugin({ backend: 'console', level: 'info' }),
-    new UsagePlugin({ storage: 'memory' }),
+    new LoggingPlugin({ strategy: 'console', level: 'info' }),
+    new UsagePlugin({ strategy: 'memory' }),
   ],
 });
 ```
@@ -44,7 +46,10 @@ const agent = new Robota({
 Persists conversation history across sessions.
 
 ```typescript
-new ConversationHistoryPlugin({ storage: 'memory' | 'file' | 'database' });
+import { ConversationHistoryPlugin } from '@robota-sdk/agent-plugin';
+
+// storage: 'memory' | 'file' | 'database'
+new ConversationHistoryPlugin({ storage: 'memory' });
 ```
 
 ### LoggingPlugin
@@ -52,10 +57,10 @@ new ConversationHistoryPlugin({ storage: 'memory' | 'file' | 'database' });
 Logs agent activity to one or more backends.
 
 ```typescript
-new LoggingPlugin({
-  backend: 'console' | 'file' | 'remote' | 'silent',
-  level: 'info' | 'debug' | 'warn' | 'error',
-});
+import { LoggingPlugin } from '@robota-sdk/agent-plugin';
+
+// strategy: 'console' | 'file' | 'remote' | 'silent'
+new LoggingPlugin({ strategy: 'console', level: 'info' });
 ```
 
 ### UsagePlugin
@@ -63,7 +68,10 @@ new LoggingPlugin({
 Tracks token usage and estimates cost.
 
 ```typescript
-new UsagePlugin({ storage: 'memory' | 'file' | 'remote' | 'silent' });
+import { UsagePlugin } from '@robota-sdk/agent-plugin';
+
+// strategy: 'memory' | 'file' | 'remote' | 'silent'
+new UsagePlugin({ strategy: 'memory' });
 ```
 
 ### LimitsPlugin
@@ -71,7 +79,10 @@ new UsagePlugin({ storage: 'memory' | 'file' | 'remote' | 'silent' });
 Enforces rate limits and usage quotas.
 
 ```typescript
-new LimitsPlugin({ maxTokensPerMinute: 100000, maxRequestsPerMinute: 60 });
+import { LimitsPlugin } from '@robota-sdk/agent-plugin';
+
+// strategy: 'token-bucket' | 'sliding-window' | 'fixed-window' | 'none'
+new LimitsPlugin({ strategy: 'token-bucket', maxTokens: 100000, maxRequests: 60 });
 ```
 
 ### WebhookPlugin
@@ -79,7 +90,9 @@ new LimitsPlugin({ maxTokensPerMinute: 100000, maxRequestsPerMinute: 60 });
 Fires HTTP webhooks on agent lifecycle events with optional HMAC signing.
 
 ```typescript
-new WebhookPlugin({ url: 'https://example.com/hook', secret: 'my-secret' });
+import { WebhookPlugin } from '@robota-sdk/agent-plugin';
+
+new WebhookPlugin({ endpoints: [{ url: 'https://example.com/hook' }] });
 ```
 
 ## Dependencies

--- a/packages/agent-provider/README.md
+++ b/packages/agent-provider/README.md
@@ -58,7 +58,7 @@ const provider = new DeepSeekProvider({ apiKey: process.env.DEEPSEEK_API_KEY });
 ```typescript
 import { GeminiProvider } from '@robota-sdk/agent-provider/gemini';
 
-const provider = new GeminiProvider({ apiKey: process.env.GOOGLE_API_KEY });
+const provider = new GeminiProvider({ apiKey: process.env.GOOGLE_API_KEY ?? '' });
 ```
 
 ### Local / OpenAI-compatible

--- a/packages/agent-remote-client/README.md
+++ b/packages/agent-remote-client/README.md
@@ -12,6 +12,7 @@ This package is used internally within the Robota monorepo via workspace referen
 
 ```typescript
 import { RemoteExecutor } from '@robota-sdk/agent-remote-client';
+import { createUserMessage } from '@robota-sdk/agent-core';
 
 const executor = new RemoteExecutor({
   serverUrl: 'https://my-agent-server.example.com',
@@ -23,14 +24,15 @@ const executor = new RemoteExecutor({
 const response = await executor.executeChat({
   provider: 'anthropic',
   model: 'claude-opus-4-5',
-  messages: [{ role: 'user', content: 'Hello' }],
+  messages: [createUserMessage('Hello')],
 });
 
 // Streaming (SSE)
 for await (const chunk of executor.executeChatStream({
   provider: 'anthropic',
   model: 'claude-opus-4-5',
-  messages: [{ role: 'user', content: 'Hello' }],
+  messages: [createUserMessage('Hello')],
+  stream: true,
 })) {
   process.stdout.write(chunk.content ?? '');
 }

--- a/packages/agent-session/README.md
+++ b/packages/agent-session/README.md
@@ -12,6 +12,11 @@ npm install @robota-sdk/agent-session @robota-sdk/agent-core
 
 ```typescript
 import { Session } from '@robota-sdk/agent-session';
+import type { IAIProvider, IToolWithEventService, ITerminalOutput } from '@robota-sdk/agent-core';
+
+declare const tools: IToolWithEventService[];
+declare const provider: IAIProvider;
+declare const terminal: ITerminalOutput;
 
 const session = new Session({
   tools,

--- a/packages/agent-subagent-runner/README.md
+++ b/packages/agent-subagent-runner/README.md
@@ -24,12 +24,18 @@ agent-cli
 ## Usage
 
 ```typescript
-import { createChildProcessSubagentRunnerFactory } from '@robota-sdk/agent-subagent-runner';
+import {
+  createChildProcessSubagentRunnerFactory,
+  getDefaultSubagentWorkerPath,
+} from '@robota-sdk/agent-subagent-runner';
+import type { IProviderDefinitionConfig } from '@robota-sdk/agent-core';
+
+declare const providerConfig: IProviderDefinitionConfig;
 
 const factory = createChildProcessSubagentRunnerFactory({
+  workerPath: getDefaultSubagentWorkerPath(), // the bundled worker entry point
   providerConfig,
-  logsDir,
-  // workerPath is optional — defaults to the bundled worker entry point
+  logsDir: '.robota/logs',
 });
 ```
 

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -18,16 +18,14 @@ Peer dependency: `@robota-sdk/agent-core`
 import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import { z } from 'zod';
 
-const weatherTool = createZodFunctionTool({
-  name: 'get_weather',
-  description: 'Get current weather for a city',
-  schema: z.object({
+const weatherTool = createZodFunctionTool(
+  'get_weather',
+  'Get current weather for a city',
+  z.object({
     city: z.string().describe('City name'),
   }),
-  handler: async ({ city }) => ({
-    data: JSON.stringify({ city, temperature: 22, condition: 'sunny' }),
-  }),
-});
+  async (args) => JSON.stringify({ city: args['city'], temperature: 22, condition: 'sunny' }),
+);
 ```
 
 ### Use Built-in Tools
@@ -35,7 +33,9 @@ const weatherTool = createZodFunctionTool({
 ```typescript
 import { bashTool, readTool, globTool, grepTool } from '@robota-sdk/agent-tools';
 import { Robota } from '@robota-sdk/agent-core';
+import type { IAIProvider } from '@robota-sdk/agent-core';
 
+declare const provider: IAIProvider;
 const agent = new Robota({
   name: 'DevAgent',
   aiProviders: [provider],
@@ -71,6 +71,8 @@ Factory exports (`createBashTool`, `createReadTool`, `createWriteTool`, `createE
 
 `ISandboxClient` is the provider-neutral execution-plane port used by sandbox-aware built-in tools:
 
+<!-- doc-example-skip: requires the optional e2b dependency -->
+
 ```typescript
 import { E2BSandboxClient, createBashTool, createReadTool } from '@robota-sdk/agent-tools';
 import { Sandbox } from 'e2b';
@@ -87,6 +89,8 @@ The package does not depend on E2B directly. `E2BSandboxClient` adapts an E2B-co
 ### Workspace Manifests
 
 `IWorkspaceManifest` declares the fresh sandbox workspace before a session starts. Paths are workspace-relative and cannot escape the target root.
+
+<!-- doc-example-skip: requires the optional e2b dependency -->
 
 ```typescript
 import { applyWorkspaceManifest, E2BSandboxClient } from '@robota-sdk/agent-tools';

--- a/packages/agent-transport-http/README.md
+++ b/packages/agent-transport-http/README.md
@@ -18,6 +18,8 @@ pnpm add @robota-sdk/agent-transport-http
 `IInteractiveSession` per request (e.g. by auth token or session id). `createHttpTransport`
 wraps them as a mountable transport with an optional `basePath`.
 
+<!-- doc-example-skip: requires the host app's hono dependency -->
+
 ```typescript
 import { createAgentRoutes } from '@robota-sdk/agent-transport-http';
 import { Hono } from 'hono';

--- a/packages/agent-transport-mcp/README.md
+++ b/packages/agent-transport-mcp/README.md
@@ -20,7 +20,9 @@ wraps it for the SDK's transport registry.
 
 ```typescript
 import { createAgentMcpServer } from '@robota-sdk/agent-transport-mcp';
+import type { IInteractiveSession } from '@robota-sdk/agent-framework';
 
+declare const session: IInteractiveSession;
 const server = createAgentMcpServer({
   name: 'robota-agent',
   version: '1.0.0',

--- a/packages/agent-transport/README.md
+++ b/packages/agent-transport/README.md
@@ -25,7 +25,7 @@ npm install @robota-sdk/agent-transport
 ```typescript
 import { createHeadlessTransport } from '@robota-sdk/agent-transport/headless';
 
-const transport = createHeadlessTransport({ format: 'text' });
+const transport = createHeadlessTransport({ outputFormat: 'text', prompt: 'Hello!' });
 ```
 
 ### WebSocket
@@ -41,7 +41,7 @@ const transport = new WsTransport({ port: 3001 });
 ```typescript
 import { createHttpTransport } from '@robota-sdk/agent-transport-http';
 
-const transport = createHttpTransport({ port: 8080 });
+const transport = createHttpTransport({ basePath: '/agent' }); // mount on your own server
 ```
 
 ### MCP
@@ -49,16 +49,17 @@ const transport = createHttpTransport({ port: 8080 });
 ```typescript
 import { createMcpTransport } from '@robota-sdk/agent-transport-mcp';
 
-const transport = createMcpTransport({ name: 'my-agent' });
+const transport = createMcpTransport({ name: 'my-agent', version: '1.0.0' });
 ```
 
 ### TUI (Ink/React)
 
 ```typescript
 import { TuiTransport } from '@robota-sdk/agent-transport-tui';
-import type { ITuiCliAdapter } from '@robota-sdk/agent-transport-tui';
+import type { IRenderOptions } from '@robota-sdk/agent-transport-tui';
 
-const transport = new TuiTransport(adapter);
+declare const options: IRenderOptions;
+const transport = new TuiTransport(options);
 ```
 
 > React and Ink dependencies are confined to the `./tui` sub-path. Importing from
@@ -78,6 +79,8 @@ import { TuiTransport } from '@robota-sdk/agent-transport-tui';
 ```
 
 Root import re-exports all transports:
+
+<!-- doc-example-skip: intentional ellipsis fragment (import surface overview, not runnable) -->
 
 ```typescript
 import { createHeadlessTransport, WsTransport, TuiTransport, ... } from '@robota-sdk/agent-transport';

--- a/packages/agent-web-ui/README.md
+++ b/packages/agent-web-ui/README.md
@@ -56,6 +56,7 @@ React hook that manages the WebSocket connection and reconstructs conversation s
 ```typescript
 import { useWsSession } from '@robota-sdk/agent-web-ui';
 
+declare const url: string;
 const { status, messages, activeTools, streamingText, isThinking, send } = useWsSession(url);
 ```
 

--- a/scripts/harness/__tests__/check-doc-examples.test.mjs
+++ b/scripts/harness/__tests__/check-doc-examples.test.mjs
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractBlocks } from '../check-doc-examples.mjs';
+
+describe('extractBlocks', () => {
+  it('extracts ts and typescript fenced blocks with indices', () => {
+    const md = 'intro\n```ts\nconst a = 1;\n```\ntext\n```typescript\nconst b = 2;\n```\n';
+    const blocks = extractBlocks(md);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ index: 0, code: 'const a = 1;\n', skipReason: null });
+    expect(blocks[1].code).toBe('const b = 2;\n');
+  });
+
+  it('captures the skip marker on the line directly above the fence', () => {
+    const md = 'x\n<!-- doc-example-skip: needs optional dep -->\n```ts\nbroken(\n```\n';
+    expect(extractBlocks(md)[0].skipReason).toBe('needs optional dep');
+  });
+
+  it('ignores non-ts fences and markers not adjacent to a fence', () => {
+    const md =
+      '<!-- doc-example-skip: far away -->\n\nprose\n```bash\nls\n```\n```ts\nconst x = 1;\n```\n';
+    const blocks = extractBlocks(md);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].skipReason).toBeNull();
+  });
+});

--- a/scripts/harness/check-doc-examples.mjs
+++ b/scripts/harness/check-doc-examples.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+/**
+ * Doc-example typecheck scan (DOCS-015).
+ *
+ * The first code a consumer meets — README quickstarts — shipped uncompilable for an unknown time
+ * (`defaultModel.systemMessage`, a field that does not exist on `IAgentConfig.defaultModel`), and
+ * doc examples had no gate at all, so drift between examples and the real types was invisible.
+ * External discoverability feedback showed consumers (especially AI agents) trust `.d.ts` over
+ * README precisely because of this class of drift.
+ *
+ * This scan extracts every ```ts / ```typescript fenced block from the root README and each
+ * packages/x/README.md and typechecks them against the WORKSPACE SOURCE types (strict). A block
+ * that is intentionally a fragment (pseudo-code, elided context) must carry an explicit opt-out
+ * marker on the line directly above its fence:
+ *
+ *   <!-- doc-example-skip: <reason> -->
+ *
+ * Silent skips do not exist; the marker count is reported. content/ guide pages are a tracked
+ * follow-on (larger corpus, same mechanism) — see the DOCS-015 backlog evidence.
+ *
+ * Exit code 0 = all doc examples typecheck, 1 = drift found.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'node:fs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const OUT_DIR = path.join(WORKSPACE_ROOT, 'node_modules/.cache/doc-examples');
+
+const FENCE_PATTERN = /(^|\n)([^\n]*)\n```(ts|typescript)\n([\s\S]*?)```/g;
+const SKIP_PATTERN = /<!--\s*doc-example-skip:\s*(.+?)\s*-->/;
+
+/** README files under scan: root + every packages/x/README.md. */
+export function listReadmeFiles(root = WORKSPACE_ROOT) {
+  const files = ['README.md'];
+  for (const entry of globSync('packages/*/README.md', { cwd: root })) {
+    files.push(entry);
+  }
+  return files.sort();
+}
+
+/** Extract ts blocks with their skip-marker state. */
+export function extractBlocks(markdown) {
+  const blocks = [];
+  let index = 0;
+  for (const match of markdown.matchAll(FENCE_PATTERN)) {
+    const precedingLine = match[2] ?? '';
+    const skip = SKIP_PATTERN.exec(precedingLine);
+    blocks.push({
+      index: index++,
+      code: match[4],
+      skipReason: skip ? skip[1] : null,
+    });
+  }
+  return blocks;
+}
+
+function buildTsconfig(dir) {
+  return {
+    compilerOptions: {
+      strict: true,
+      noEmit: true,
+      target: 'es2022',
+      module: 'esnext',
+      moduleResolution: 'bundler',
+      lib: ['es2023', 'dom'],
+      types: ['node'],
+      skipLibCheck: true,
+      jsx: 'react-jsx',
+      customConditions: ['source'],
+      baseUrl: WORKSPACE_ROOT,
+      paths: {
+        '@robota-sdk/*': ['packages/*/src/index.ts'],
+        '@robota-sdk/agent-provider/*': ['packages/agent-provider/src/*/index.ts'],
+        '@robota-sdk/agent-transport/*': ['packages/agent-transport/src/*/index.ts'],
+      },
+    },
+    include: [path.join(dir, '*.ts')],
+  };
+}
+
+export async function main() {
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const manifest = [];
+  let skipped = 0;
+  for (const relative of listReadmeFiles()) {
+    const markdown = readFileSync(path.join(WORKSPACE_ROOT, relative), 'utf8');
+    for (const block of extractBlocks(markdown)) {
+      if (block.skipReason) {
+        skipped += 1;
+        continue;
+      }
+      const slug = relative.replace(/[^a-zA-Z0-9]+/g, '_');
+      const fileName = `${slug}__${block.index}.ts`;
+      writeFileSync(path.join(OUT_DIR, fileName), block.code, 'utf8');
+      manifest.push({ fileName, source: `${relative} (block #${block.index + 1})` });
+    }
+  }
+
+  writeFileSync(path.join(OUT_DIR, 'tsconfig.json'), JSON.stringify(buildTsconfig(OUT_DIR)));
+
+  let output = '';
+  let failed = false;
+  try {
+    execFileSync('pnpm', ['exec', 'tsc', '-p', path.join(OUT_DIR, 'tsconfig.json')], {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    failed = true;
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+
+  if (!failed) {
+    process.stdout.write(
+      `doc-examples scan passed (${manifest.length} blocks typechecked, ${skipped} marked skip).\n`,
+    );
+    return;
+  }
+
+  process.stdout.write('doc-examples scan failed — README code blocks do not typecheck:\n');
+  const bySource = new Map();
+  for (const line of output.split('\n')) {
+    const match = /doc-examples[\\/](\S+?\.ts)\((\d+),\d+\): (error TS\d+: .*)/.exec(line);
+    if (!match) continue;
+    const entry = manifest.find((m) => m.fileName === match[1]);
+    const source = entry ? entry.source : match[1];
+    if (!bySource.has(source)) bySource.set(source, []);
+    bySource.get(source).push(`line ${match[2]}: ${match[3]}`);
+  }
+  for (const [source, errors] of bySource) {
+    process.stdout.write(`  - ${source}\n`);
+    for (const error of errors.slice(0, 3)) process.stdout.write(`      ${error}\n`);
+  }
+  if (bySource.size === 0) {
+    process.stdout.write('  (errors outside the extracted blocks — raw tsc output follows)\n');
+    for (const line of output.split('\n').filter(Boolean).slice(0, 10)) {
+      process.stdout.write(`      ${line}\n`);
+    }
+  }
+  process.stdout.write(
+    'Fix the example to match the real types, or mark an intentional fragment with ' +
+      '<!-- doc-example-skip: <reason> --> on the line above the fence.\n',
+  );
+  process.exitCode = 1;
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -81,6 +81,7 @@ const SCAN_COMMANDS = [
   { name: 'task-archival', command: ['node', 'scripts/harness/check-task-archival.mjs'] },
   { name: 'test-module-mocks', command: ['node', 'scripts/harness/check-test-module-mocks.mjs'] },
   { name: 'backlog-placement', command: ['node', 'scripts/harness/check-backlog-placement.mjs'] },
+  { name: 'doc-examples', command: ['node', 'scripts/harness/check-doc-examples.mjs'] },
   { name: 'orphan-exports', command: ['node', 'scripts/harness/check-orphan-exports.mjs'] },
   { name: 'deps', command: ['node', 'scripts/harness/check-dependency-direction.mjs'] },
   {

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -66,6 +66,7 @@ function runRepositoryCheck(check, dryRun) {
           'scripts/harness/__tests__/check-task-archival.test.mjs',
           'scripts/harness/__tests__/check-test-module-mocks.test.mjs',
           'scripts/harness/__tests__/check-backlog-placement.test.mjs',
+          'scripts/harness/__tests__/check-doc-examples.test.mjs',
         ],
         WORKSPACE_ROOT,
         dryRun,


### PR DESCRIPTION
## 요약 (DOCS-015, high/now)

발견가능성 리포트가 지적한 "README 첫 예제가 컴파일되지 않는" 버그를 수정하고, **문서 예제 타입체크 게이트**를 하네스에 추가한다.

## 게이트가 드러낸 것

지적된 1건(`defaultModel.systemMessage` — 존재하지 않는 필드, 3곳)은 빙산의 일각이었다. 새 게이트 첫 실행에서 **추가 29개 블록의 드리프트** 발견 (첫 패스는 1건만 보였는데, 구문 에러 1개가 전체 의미 진단을 가리고 있었음 — 파서에 이 함정 대응 포함):

- 존재하지 않는 옵션 필드: `LoggingPlugin backend→strategy`, `UsagePlugin storage→strategy`, `createHeadlessTransport format→outputFormat+prompt`, `createHttpTransport port→basePath`, `LimitsPlugin maxTokensPerMinute→…` 등
- 잘못된 시그니처: `createZodFunctionTool` 객체→위치 인자 4개, command 모듈 팩토리들 인자 0개(provider만 옵션 1개 필수)
- 잘못된 타입명/생성자: `IInteractiveSessionOptions→T…`, `TuiTransport(adapter)→IRenderOptions`
- 가공의 API: `createSubagentSession({parentSession})`, `WebhookPlugin({url,secret})→endpoints[]`
- 필수 필드 누락: `createAgentRuntime cwd`, streaming `stream: true`, subagent-runner `workerPath`("optional" 서술도 거짓)

전부 실제 계약으로 수정. 의도적 fragment 5개는 명시적 `<!-- doc-example-skip: reason -->` 마커(무언 스킵 없음, 개수 리포트됨).

## 메커니즘

`scripts/harness/check-doc-examples.mjs` — 루트 README + 전체 packages/x README의 ts 블록을 추출해 워크스페이스 **소스 타입** 기준 strict 타입체크. `pnpm harness:scan` 등록(42개 스캔) → CI quality 게이트에서 매 PR 실행. 유닛 테스트 3종 + verify-change 목록 편입.

## 스코프 기록

content/ 코퍼스(517블록/70파일)는 **DOCS-019**로 명시 분리 — 메커니즘은 완성, 온보딩은 별도 작업량.

최종: **49블록 green / 5 skip**, `harness:scan` 42/42. DOCS-015 evidence 기록 후 done/아카이브.

🤖 Generated with [Claude Code](https://claude.com/claude-code)