### PR TITLE
feat(agent-core): CORE-012 run() 동시성 계약 — 인스턴스 내부 FIFO 런 큐

### DIFF
--- a/.agents/backlog/completed/CORE-012-run-concurrency-contract.md
+++ b/.agents/backlog/completed/CORE-012-run-concurrency-contract.md
@@ -1,7 +1,8 @@
 ---
 title: 'CORE-012: Robota.run() concurrency contract — serialize concurrent runs or state the contract'
-status: todo
+status: done
 created: 2026-07-03
+completed: 2026-07-03
 priority: high
 urgency: soon
 area: packages/agent-core
@@ -43,4 +44,15 @@ double-queue).
 - Steps: run it; inspect the resulting history order.
 - Expected: strictly sequential turn blocks (or a documented thrown error), never interleaved
   messages.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live, 2026-07-03).** Implemented option 1 (internal FIFO run queue, approved
+  design). Temp consumer script (`tsx --conditions=source`, script placed in `packages/agent-cli`
+  because agent-core has zero agent-package deps) fired two un-awaited `run()` calls on one
+  `Robota` instance against the real Anthropic provider (`claude-haiku-4-5`, key from
+  `packages/agent-cli/.env`). Output: responses `"ALPHA"`/`"BETA"`, history order
+  `user(ALPHA ask), assistant(ALPHA), user(BETA ask), assistant(BETA)` — strictly sequential,
+  script's own role-order + queue-order assertions passed. Unit: 3 new tests in
+  `packages/agent-core/src/core/robota.test.ts` (`run concurrency` describe: sequential history +
+  queued run sees prior exchange; queued-abort throws `Run aborted while queued` without a provider
+  call; `runStream` holds the slot until fully consumed) — agent-core 758/758 green. Regression:
+  agent-framework suite 1033/1033 green (InteractiveSession queueing, no double-queue deadlock).
+  Contract documented in JSDoc (`run`/`runStream`) + SPEC.md "Run Concurrency Contract (CORE-012)".

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -632,6 +632,27 @@ When `IToolExecutionBatchContext.mode` is `parallel`, `ToolExecutionService` enf
 
 When abort occurs during provider streaming, the provider uses `streamWithAbort` which breaks out of the iteration loop on `signal.aborted`. The provider then returns partial content collected so far with `stopReason: 'aborted'`. `executeRound` commits this partial response via `commitAssistant('interrupted')` through the standard single commit path. The execution loop then exits via the `signal.aborted` check in ExecutionService. `robota.run()` always returns normally on abort — it does not throw.
 
+## Run Concurrency Contract (CORE-012)
+
+One `Robota` instance owns one conversation history, so concurrent executions on the same instance
+would interleave history writes. The instance therefore serializes runs internally:
+
+- `run()` and `runStream()` share a single FIFO run slot per instance. A call made while another
+  run is in flight waits for the earlier run to complete, then executes — callers may fire
+  concurrent calls without external locking and still get strictly sequential history
+  (`user₁, assistant₁, user₂, assistant₂ …`). The queued run's provider request includes the
+  completed earlier exchange.
+- `runStream()` acquires the slot when iteration starts and holds it until the stream is fully
+  consumed (or the generator is closed early via `return()`/`break`, which releases through the
+  same `finally` path). An abandoned, never-consumed generator does not hold the slot because the
+  generator body has not started.
+- If a queued call's `IRunOptions.signal` is already aborted when its turn arrives, it throws
+  `Run aborted while queued behind another run on this instance` without touching the provider or
+  history. An abort during an in-flight run keeps the existing abort semantics above (returns
+  normally, never throws).
+- The queue is per-instance. Cross-instance coordination is out of scope; separate instances remain
+  fully concurrent.
+
 This ensures:
 
 - The partial response is saved in conversation history for the next turn

--- a/packages/agent-core/src/core/robota.test.ts
+++ b/packages/agent-core/src/core/robota.test.ts
@@ -345,6 +345,107 @@ describe('Robota Core', () => {
   });
 
   // ----------------------------------------------------------------
+  // Run concurrency contract (CORE-012)
+  // ----------------------------------------------------------------
+  describe('run concurrency', () => {
+    it('should serialize concurrent run() calls into strictly sequential history', async () => {
+      class SlowProvider extends TrackingProvider {
+        override async chat(
+          messages: TUniversalMessage[],
+          options?: IChatOptions,
+        ): Promise<TUniversalMessage> {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return super.chat(messages, options);
+        }
+      }
+      const provider = new SlowProvider();
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const [first, second] = await Promise.all([
+        robota.run('First concurrent'),
+        robota.run('Second concurrent'),
+      ]);
+
+      expect(first).toBe('Response to: First concurrent');
+      expect(second).toBe('Response to: Second concurrent');
+
+      const history = robota.getHistory();
+      expect(history.map((message) => ({ role: message.role, content: message.content }))).toEqual([
+        { role: 'user', content: 'First concurrent' },
+        { role: 'assistant', content: 'Response to: First concurrent' },
+        { role: 'user', content: 'Second concurrent' },
+        { role: 'assistant', content: 'Response to: Second concurrent' },
+      ]);
+
+      // The queued run must see the completed first exchange, not a partial one.
+      const secondCall = provider.chatCalls[1];
+      expect(
+        secondCall.messages.some(
+          (message) =>
+            message.role === 'assistant' && message.content === 'Response to: First concurrent',
+        ),
+      ).toBe(true);
+    });
+
+    it('should reject a queued run whose signal aborts while waiting', async () => {
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      class GatedProvider extends TrackingProvider {
+        override async chat(
+          messages: TUniversalMessage[],
+          options?: IChatOptions,
+        ): Promise<TUniversalMessage> {
+          await firstGate;
+          return super.chat(messages, options);
+        }
+      }
+      const provider = new GatedProvider();
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const firstRun = robota.run('Holds the slot');
+      const controller = new AbortController();
+      const queuedRun = robota.run('Aborted while queued', { signal: controller.signal });
+      const queuedFailure = expect(queuedRun).rejects.toThrow('Run aborted while queued');
+
+      controller.abort();
+      releaseFirst();
+
+      await expect(firstRun).resolves.toBe('Response to: Holds the slot');
+      await queuedFailure;
+      // The aborted run must never reach the provider.
+      expect(provider.chatCalls).toHaveLength(1);
+    });
+
+    it('should hold the run slot until runStream is fully consumed', async () => {
+      const provider = new TrackingProvider();
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const iterator = robota.runStream('Stream first')[Symbol.asyncIterator]();
+      await iterator.next(); // stream is now mid-consumption and owns the slot
+
+      let queuedCompleted = false;
+      const queuedRun = robota.run('Queued behind stream').then((response) => {
+        queuedCompleted = true;
+        return response;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(queuedCompleted).toBe(false);
+      expect(provider.chatCalls).toHaveLength(1);
+
+      // Drain the stream — completion releases the slot to the queued run.
+      let next = await iterator.next();
+      while (!next.done) {
+        next = await iterator.next();
+      }
+
+      await expect(queuedRun).resolves.toBe('Response to: Queued behind stream');
+    });
+  });
+
+  // ----------------------------------------------------------------
   // Streaming
   // ----------------------------------------------------------------
   describe('runStream', () => {

--- a/packages/agent-core/src/core/robota.ts
+++ b/packages/agent-core/src/core/robota.ts
@@ -138,17 +138,59 @@ export class Robota
     await this.ensureFullyInitialized();
   }
 
+  /**
+   * Concurrency contract (CORE-012): a Robota instance owns ONE conversation history, so
+   * concurrent `run`/`runStream` calls on the same instance are serialized on an internal queue —
+   * a call issued while another is in flight waits its turn (its `signal` is honored while queued).
+   * Interleaved histories are therefore impossible by construction.
+   */
   async run(input: string, options: IRunOptions = {}): Promise<string> {
-    await this.ensureFullyInitialized();
-    return robotaRun(this.executionDeps(), input, options);
+    return this.enqueueRun(options.signal, async () => {
+      await this.ensureFullyInitialized();
+      return robotaRun(this.executionDeps(), input, options);
+    });
   }
 
   async *runStream(
     input: string,
     options: IRunOptions = {},
   ): AsyncGenerator<string, void, undefined> {
-    await this.ensureFullyInitialized();
-    yield* robotaRunStream(this.executionDeps(), input, options);
+    // Serialized like run(): the queue slot is held until the stream is fully consumed
+    // (return or throw), because the conversation history is being written throughout.
+    const release = await this.acquireRunSlot(options.signal);
+    try {
+      await this.ensureFullyInitialized();
+      yield* robotaRunStream(this.executionDeps(), input, options);
+    } finally {
+      release();
+    }
+  }
+
+  /** Tail of the internal run queue (CORE-012). */
+  private runQueueTail: Promise<void> = Promise.resolve();
+
+  /** Wait for the previous run to settle, then hold the slot until `release` is called. */
+  private async acquireRunSlot(signal: AbortSignal | undefined): Promise<() => void> {
+    const previous = this.runQueueTail;
+    let release: () => void = () => {};
+    this.runQueueTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    if (signal?.aborted) {
+      release();
+      throw new Error('Run aborted while queued behind another run on this instance');
+    }
+    return release;
+  }
+
+  private async enqueueRun<T>(signal: AbortSignal | undefined, task: () => Promise<T>): Promise<T> {
+    const release = await this.acquireRunSlot(signal);
+    try {
+      return await task();
+    } finally {
+      release();
+    }
   }
 
   private executionDeps(): IRobotaExecutionDeps {


### PR DESCRIPTION
## 요약

외부 도입 피드백(§3.2)에서 지적된 `run()` 동시성 무방비 문제를 해결합니다. 하나의 `Robota` 인스턴스에서 동시에 발사된 `run()`/`runStream()` 호출이 이제 내부 FIFO 런 큐로 직렬화됩니다 (승인된 설계: 내부 큐 기본).

## 변경 내용

- `Robota.run()`/`runStream()`: 인스턴스당 하나의 런 슬롯을 공유. 실행 중인 런이 있으면 큐에서 대기 후 순차 실행 — 히스토리 인터리빙 원천 차단.
- 큐 대기 중 signal이 abort되면 provider/히스토리를 건드리지 않고 `Run aborted while queued behind another run on this instance` throw.
- `runStream`은 스트림이 완전히 소비될 때까지 슬롯을 보유 (early break/return 시 finally로 해제).
- JSDoc 동시성 계약 + SPEC.md "Run Concurrency Contract (CORE-012)" 섹션 추가.

## 검증

- 신규 단위 테스트 3개 (순차 히스토리 + 큐 런이 이전 교환을 봄 / 큐 abort / runStream 슬롯 보유) — agent-core 758/758 green.
- 회귀: agent-framework 1033/1033 green (InteractiveSession 큐잉 이중 큐 데드락 없음).
- **User Execution (라이브)**: 실제 Anthropic provider로 두 개의 un-awaited `run()` 발사 → 엄격한 순차 히스토리 확인. 증거는 백로그 문서에 기록.

## 백로그

CORE-012 done 처리 + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj