### PR TITLE
feat(agent-core): CORE-015 스키마 강제 structured output — run(prompt, { output })

### DIFF
--- a/.agents/backlog/completed/CORE-015-first-class-structured-output.md
+++ b/.agents/backlog/completed/CORE-015-first-class-structured-output.md
@@ -1,7 +1,8 @@
 ---
 title: 'CORE-015: first-class schema-enforced structured output — run(prompt, { output: schema })'
-status: todo
+status: done
 created: 2026-07-03
+completed: 2026-07-03
 priority: high
 urgency: soon
 area: packages/agent-core, packages/agent-provider
@@ -45,4 +46,23 @@ as an assistant message?), retry budget surface, interaction with tools present 
 - Steps: request a 3-field structured report via the new API.
 - Expected: a parsed, schema-valid typed object (no manual JSON.parse, no tool-call plumbing);
   violation path observably retries.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live, 2026-07-03).** Temp consumer script (`tsx --conditions=source`, in
+  `packages/agent-cli`) called `run(prompt, { output: z.object({ title, score, summary }) })`
+  against the real Anthropic provider (`claude-haiku-4-5`). First live run returned an Anthropic
+  400 — `output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly
+set to false` — which unit mocks could not catch; fixed by recursive `closeObjectSchemas`
+  normalization at the Anthropic SDK seam (unit test updated to the closed-world expectation).
+  Rerun: typed report `{ title: "TypeScript Improves Large Codebase Maintainability", score: 78,
+summary: "..." }`, script's compile-time typed access + runtime range assertions passed, history
+  `user,assistant` (single attempt, append-only). Violation/retry path evidence (Test Plan
+  functional row): scripted-provider unit test — invalid → feedback turn containing the issues +
+  schema → valid on attempt 2; exhaustion throws `StructuredOutputError` (attempts capped at
+  `outputRetries`+1, provider untouched afterward). Suites: agent-core 801 (5 new structured-run +
+  9 structured-output unit + 29 moved converter tests), agent-provider 562 (anthropic
+  `output_config` ×2, gemini `responseSchema`, openai `mergeChatResponseFormat` ×5), full-repo
+  typecheck/lint/test + 42 harness scans + doc-examples (50 blocks, incl. the new README structured
+  output example) all green. Zod v3 gotcha institutionalized in code comment:
+  `IRunOptions & { output: S }` intersections silently knock out the typed overloads (deepPartial
+  variance), hence `TRunOptionsWithOutput<S> = Omit<IRunOptions, 'output'> & { output: S }` —
+  caught by the doc-examples scan, verified by an isolated tsc probe. ESLint base
+  `no-dupe-class-members` replaced with the TS-aware variant for legal method overloads.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,9 @@
       }
     ],
     "no-unused-vars": "off",
+    // ✅ TS method overloads are legal duplicate names; use the TS-aware rule instead
+    "no-dupe-class-members": "off",
+    "@typescript-eslint/no-dupe-class-members": "error",
     // ✅ 완화: 모듈 경계 타입을 선택적으로 변경
     "@typescript-eslint/explicit-module-boundary-types": "off", // 유지
     // ✅ 완화: TS 코멘트를 에러에서 경고로

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -69,6 +69,47 @@ agent.clearHistory();
 agent.setModel({ provider: 'openai', model: 'gpt-4o' });
 ```
 
+### Structured Output
+
+`run(input, { output })` returns a schema-validated object instead of a string. Zod schemas give a
+typed result; the schema is forwarded to the provider's native structured-output surface where one
+exists, and the response is always validated core-side with a bounded retry on violation
+(`outputRetries`, default 2). Exhausted retries throw `StructuredOutputError`.
+
+```typescript
+import { z } from 'zod';
+import { Robota } from '@robota-sdk/agent-core';
+import type { IAgentConfig } from '@robota-sdk/agent-core';
+
+declare const config: IAgentConfig;
+const agent = new Robota(config);
+
+const reportSchema = z.object({
+  title: z.string(),
+  score: z.number(),
+  summary: z.string(),
+});
+
+// Typed result: { title: string; score: number; summary: string }
+const report = await agent.run('Summarize the meeting as a report.', {
+  output: reportSchema,
+});
+
+// Streaming variant: deltas stream as usual; the validated object is the
+// generator's return value (the final { done: true, value } iterator result).
+const stream = agent.runStream('Summarize again.', { output: reportSchema });
+const iterator = stream[Symbol.asyncIterator]();
+let next = await iterator.next();
+while (!next.done) {
+  process.stdout.write(next.value);
+  next = await iterator.next();
+}
+const streamedReport = next.value;
+console.log(streamedReport.title);
+```
+
+A raw JSON-schema wrapper is also accepted: `{ output: { jsonSchema: { type: 'object', properties: { answer: { type: 'string' } }, required: ['answer'] } } }`.
+
 ### Execution Boundary Events
 
 `run()` accepts `onExecutionEvent` in run options. The execution loop emits provider-neutral events that higher layers can persist as append-only session provenance:

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -205,6 +205,20 @@ their own price tables. Prices are USD per 1,000,000 tokens.
 | `findProviderDefinition`                | function       | Resolve an injected provider definition by canonical type or alias                                                                                                                                                                                      |
 | `formatSupportedProviderTypes`          | function       | Format injected provider types and aliases for generic errors                                                                                                                                                                                           |
 
+### Schema (CORE-015)
+
+| Export                                                                                                    | Kind     | Description                                                                                                               |
+| --------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `zodToJsonSchema`                                                                                         | function | Zod → universal JSON-schema subset conversion (SSOT; moved from the tools package, which now imports it from core)        |
+| `extractEnumValues`                                                                                       | function | Safe Zod enum value extraction                                                                                            |
+| `hasValidationConstraints`                                                                                | function | Whether a Zod schema carries validation checks                                                                            |
+| `getSchemaTypeName`                                                                                       | function | Safe Zod type-name extraction                                                                                             |
+| `IZodSchema` / `IZodSchemaDef` / `IZodParseResult` / `ISchemaConversionOptions`                           | types    | Structural Zod compatibility types (no hard Zod version coupling in signatures)                                           |
+| `normalizeStructuredOutput`                                                                               | function | Normalize `IRunOptions.output` (Zod schema or `IJsonSchemaOutput`) into `IStructuredOutputSpec`                           |
+| `validateAgainstJsonSchema`                                                                               | function | Structural validation of a value against the universal JSON-schema subset                                                 |
+| `parseStructuredResponseText`                                                                             | function | Parse a model's final text into JSON (tolerates one fenced json code block; value is still strictly validated afterwards) |
+| `IJsonSchemaOutput` / `IStructuredOutputSpec` / `TStructuredOutputSchema` / `TStructuredOutputValidation` | types    | Structured output contract types                                                                                          |
+
 ### Tools
 
 NOTE: `ToolRegistry`, `FunctionTool`, `createFunctionTool`, `createZodFunctionTool`, and `OpenAPITool` have been moved to the tools layer. `MCPTool` and `RelayMcpTool` have been moved to the MCP-tool layer.
@@ -578,10 +592,13 @@ The execution loop supports cooperative cancellation via the standard `AbortSign
 | `IRunOptions`                | `signal?: AbortSignal`                       | Allows callers to cancel execution of `Robota.run()`                                                                                                                                                                                                                                   |
 | `IRunOptions`                | `onTextDelta?: TTextDeltaCallback`           | Per-run streaming callback forwarded through execution context                                                                                                                                                                                                                         |
 | `IRunOptions`                | `allowToolOnlyCompletion?: boolean`          | CORE-011: a turn ending in tool calls is a valid completion — skips the forced summary call (decision-agent pattern); the forced-summary path also honors an aborted signal                                                                                                            |
+| `IRunOptions`                | `output?: TStructuredOutputSchema`           | CORE-015: schema-enforced structured output — `run` resolves to the validated typed object instead of a string (see Structured Output Contract)                                                                                                                                        |
+| `IRunOptions`                | `outputRetries?: number`                     | CORE-015: validation-retry budget after the first attempt (default 2); only meaningful with `output`                                                                                                                                                                                   |
 | `IRunOptions`                | `onExecutionEvent?: TExecutionEventCallback` | Per-run replay event callback for provider/tool boundaries                                                                                                                                                                                                                             |
 | `IRunOptions`                | `maxExecutionRounds?: number`                | Maximum model/tool rounds for one run. `0` means unlimited.                                                                                                                                                                                                                            |
 | `IRunOptions`                | `maxSameToolInputs?: number`                 | Abort if the same tool is called with identical inputs N or more times in one run.                                                                                                                                                                                                     |
 | `IChatOptions`               | `signal?: AbortSignal`                       | Passed to provider `chat()` / `chatStream()` for cancelling calls                                                                                                                                                                                                                      |
+| `IChatOptions`               | `responseFormat` `json_schema` variant       | CORE-015: `{ type: 'json_schema', name?, schema }` carries the structured-output schema to provider native surfaces                                                                                                                                                                    |
 | `IAgentConfig`               | `timeout?: number`                           | Provider idle timeout in milliseconds for a model call                                                                                                                                                                                                                                 |
 | `IAgentConfig`               | `maxExecutionRounds?: number`                | Default maximum model/tool rounds for each run. `0` means unlimited.                                                                                                                                                                                                                   |
 | `IAgentConfig`               | `maxSameToolInputs?: number`                 | Config-level default for the identical-tool-input abort threshold.                                                                                                                                                                                                                     |
@@ -631,6 +648,33 @@ When `IToolExecutionBatchContext.mode` is `parallel`, `ToolExecutionService` enf
 ### Partial Content Preservation on Abort
 
 When abort occurs during provider streaming, the provider uses `streamWithAbort` which breaks out of the iteration loop on `signal.aborted`. The provider then returns partial content collected so far with `stopReason: 'aborted'`. `executeRound` commits this partial response via `commitAssistant('interrupted')` through the standard single commit path. The execution loop then exits via the `signal.aborted` check in ExecutionService. `robota.run()` always returns normally on abort — it does not throw.
+
+## Structured Output Contract (CORE-015)
+
+`run(input, { output })` returns a schema-validated object instead of a string; `runStream` streams
+text deltas as usual and delivers the validated object as the generator's **return value** (read it
+from the final `{ done: true, value }` iterator result).
+
+- **Accepted schemas**: a Zod schema (validated via `safeParse`, return typed `z.infer<S>` on the
+  `Robota` class surface) or an explicit `IJsonSchemaOutput` wrapper carrying the universal
+  JSON-schema subset (validated structurally by `validateAgainstJsonSchema`). Both normalize to
+  `IStructuredOutputSpec` — one internal representation (SSOT).
+- **Provider mapping**: the schema is forwarded as `IChatOptions.responseFormat =
+{ type: 'json_schema', name, schema }`. Providers with a native structured-output surface map it
+  natively (OpenAI `response_format.json_schema`, Anthropic `output_config.format`, Gemini
+  `responseSchema` + JSON mime type); providers without one ignore it — the core-side enforcement
+  loop below is the universal contract either way.
+- **Enforcement loop**: the final response text is parsed (`parseStructuredResponseText`, tolerant
+  of one fenced json block) and validated core-side on every run. A violation triggers a retry
+  turn whose input contains the validation issues plus the schema, bounded by `outputRetries`
+  (default 2 retries after the first attempt). Exhaustion throws `StructuredOutputError`
+  (`issues`, `attempts`).
+- **History**: every attempt — including retry feedback turns — is a real conversation turn
+  committed through the standard append-only history path. Structured output never edits history.
+- **Tools**: tools may run within a structured turn; validation applies to the final assistant
+  text after tool rounds complete.
+- **Interface note**: the structured overloads are visible on `Robota` directly; through the
+  generic `IAgent` interface `run` remains `Promise<string>`-typed.
 
 ## Run Concurrency Contract (CORE-012)
 

--- a/packages/agent-core/src/core/robota-execution.ts
+++ b/packages/agent-core/src/core/robota-execution.ts
@@ -4,9 +4,13 @@
  * Extracted from robota.ts to keep the main class under 300 lines.
  */
 import { AGENT_EVENTS } from '../agents/constants';
+import { parseStructuredResponseText } from '../schema/structured-output';
+import { StructuredOutputError } from '../utils/errors';
 
 import type { TUniversalMessage, IAgentConfig, IRunOptions } from '../interfaces/agent';
 import type { IAgentEventData } from '../interfaces/event-service';
+import type { TConfigValue } from '../interfaces/types';
+import type { IStructuredOutputSpec } from '../schema/structured-output';
 import type { ExecutionService } from '../services/execution-service';
 import type { IExecutionContext } from '../services/execution-types';
 import type { ILogger } from '../utils/logger';
@@ -50,6 +54,7 @@ export async function robotaRun(
   deps: IRobotaExecutionDeps,
   input: string,
   options: IRunOptions = {},
+  configOverrides?: Partial<IAgentConfig>,
 ): Promise<string> {
   try {
     deps.emitAgentEvent(AGENT_EVENTS.EXECUTION_START, {});
@@ -63,7 +68,7 @@ export async function robotaRun(
     });
 
     const messages = deps.getHistory();
-    const executionConfig: IAgentConfig = { ...deps.config };
+    const executionConfig: IAgentConfig = { ...deps.config, ...configOverrides };
 
     const result = await deps
       .getExecutionService()
@@ -105,6 +110,7 @@ export async function* robotaRunStream(
   deps: IRobotaExecutionDeps,
   input: string,
   options: IRunOptions = {},
+  configOverrides?: Partial<IAgentConfig>,
 ): AsyncGenerator<string, void, undefined> {
   try {
     deps.emitAgentEvent(AGENT_EVENTS.EXECUTION_START, {});
@@ -118,7 +124,7 @@ export async function* robotaRunStream(
     });
 
     const messages = deps.getHistory();
-    const executionConfig: IAgentConfig = { ...deps.config };
+    const executionConfig: IAgentConfig = { ...deps.config, ...configOverrides };
 
     const stream = deps.getExecutionService().executeStream(input, messages, executionConfig, {
       conversationId: deps.conversationId,
@@ -142,4 +148,128 @@ export async function* robotaRunStream(
   } finally {
     deps.emitAgentEvent(AGENT_EVENTS.EXECUTION_COMPLETE, {});
   }
+}
+
+/** Config override that routes the structured-output schema to the provider surface. */
+function structuredConfigOverrides(spec: IStructuredOutputSpec): Partial<IAgentConfig> {
+  return {
+    responseFormat: {
+      type: 'json_schema',
+      // The universal JSON-schema subset is plain JSON data; the interface merely
+      // lacks an index signature, hence the widening cast.
+      schema: spec.jsonSchema as unknown as Record<string, TConfigValue>,
+      name: spec.name,
+    },
+  };
+}
+
+function buildRetryFeedbackInput(spec: IStructuredOutputSpec, issues: string[]): string {
+  return [
+    'Your previous response did not match the required JSON schema.',
+    'Validation issues:',
+    ...issues.map((issue) => `- ${issue}`),
+    '',
+    'Respond with ONLY a JSON object (no prose, no code fences) matching this JSON schema:',
+    JSON.stringify(spec.jsonSchema),
+  ].join('\n');
+}
+
+/**
+ * Execute a schema-enforced structured turn (CORE-015). Each attempt is a full
+ * conversation turn (history stays append-only); a validation failure feeds the
+ * issues back as the next attempt's input, bounded by `outputRetries`.
+ * @internal
+ */
+export async function robotaRunStructured(
+  deps: IRobotaExecutionDeps,
+  input: string,
+  options: IRunOptions,
+  spec: IStructuredOutputSpec,
+): Promise<unknown> {
+  const maxAttempts = (options.outputRetries ?? 2) + 1;
+  const overrides = structuredConfigOverrides(spec);
+  let attemptInput = input;
+  let lastIssues: string[] = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const responseText = await robotaRun(deps, attemptInput, options, overrides);
+    const outcome = validateStructuredText(spec, responseText);
+    if (outcome.success) {
+      return outcome.value;
+    }
+    lastIssues = outcome.issues;
+    deps.logger.debug('Structured output validation failed', {
+      attempt,
+      maxAttempts,
+      issues: lastIssues,
+    });
+    if (attempt < maxAttempts) {
+      attemptInput = buildRetryFeedbackInput(spec, lastIssues);
+    }
+  }
+
+  throw new StructuredOutputError(
+    `response failed schema validation after ${maxAttempts} attempt(s)`,
+    lastIssues,
+    maxAttempts,
+  );
+}
+
+/**
+ * Streaming variant of the structured turn: text deltas stream as usual (retried
+ * attempts stream too) and the validated object is the generator's return value.
+ * @internal
+ */
+export async function* robotaRunStreamStructured(
+  deps: IRobotaExecutionDeps,
+  input: string,
+  options: IRunOptions,
+  spec: IStructuredOutputSpec,
+): AsyncGenerator<string, unknown, undefined> {
+  const maxAttempts = (options.outputRetries ?? 2) + 1;
+  const overrides = structuredConfigOverrides(spec);
+  let attemptInput = input;
+  let lastIssues: string[] = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let responseText = '';
+    for await (const chunk of robotaRunStream(deps, attemptInput, options, overrides)) {
+      responseText += chunk;
+      yield chunk;
+    }
+    const outcome = validateStructuredText(spec, responseText);
+    if (outcome.success) {
+      return outcome.value;
+    }
+    lastIssues = outcome.issues;
+    deps.logger.debug('Structured output validation failed (stream)', {
+      attempt,
+      maxAttempts,
+      issues: lastIssues,
+    });
+    if (attempt < maxAttempts) {
+      attemptInput = buildRetryFeedbackInput(spec, lastIssues);
+    }
+  }
+
+  throw new StructuredOutputError(
+    `response failed schema validation after ${maxAttempts} attempt(s)`,
+    lastIssues,
+    maxAttempts,
+  );
+}
+
+function validateStructuredText(
+  spec: IStructuredOutputSpec,
+  responseText: string,
+): { success: true; value: unknown } | { success: false; issues: string[] } {
+  const parsed = parseStructuredResponseText(responseText);
+  if (!parsed.success) {
+    return { success: false, issues: [parsed.issue] };
+  }
+  const validated = spec.validate(parsed.value);
+  if (validated.success) {
+    return { success: true, value: validated.value };
+  }
+  return { success: false, issues: validated.issues };
 }

--- a/packages/agent-core/src/core/robota.test.ts
+++ b/packages/agent-core/src/core/robota.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { z } from 'zod';
 import { Robota } from './robota';
 import type { IAgentConfig, IRunOptions } from '../interfaces/agent';
 import { AbstractAIProvider } from '../abstracts/abstract-ai-provider';
@@ -7,7 +8,7 @@ import { AbstractTool } from '../abstracts/abstract-tool';
 import type { IToolSchema, IChatOptions } from '../interfaces/provider';
 import type { IToolExecutionContext, IToolResult, TToolParameters } from '../interfaces/tool';
 import type { TUniversalMessage } from '../interfaces/messages';
-import { ConfigurationError } from '../utils/errors';
+import { ConfigurationError, StructuredOutputError } from '../utils/errors';
 
 // Mock AI Provider that tracks calls
 class TrackingProvider extends AbstractAIProvider {
@@ -442,6 +443,134 @@ describe('Robota Core', () => {
       }
 
       await expect(queuedRun).resolves.toBe('Response to: Queued behind stream');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Structured output (CORE-015)
+  // ----------------------------------------------------------------
+  describe('structured output', () => {
+    // Provider that returns scripted response texts in order, recording chat options.
+    class ScriptedTextProvider extends TrackingProvider {
+      constructor(private readonly responses: string[]) {
+        super();
+      }
+
+      override async chat(
+        messages: TUniversalMessage[],
+        options?: IChatOptions,
+      ): Promise<TUniversalMessage> {
+        this.chatCalls.push({ messages, options });
+        const content = this.responses[this.chatCalls.length - 1];
+        if (content === undefined) {
+          throw new Error('ScriptedTextProvider ran out of scripted responses');
+        }
+        return {
+          id: `scripted-${this.chatCalls.length}`,
+          role: 'assistant',
+          content,
+          state: 'complete' as const,
+          timestamp: new Date(),
+        };
+      }
+    }
+
+    const reportSchema = z.object({ title: z.string(), score: z.number() });
+
+    it('returns the validated typed object and forwards json_schema to the provider', async () => {
+      const provider = new ScriptedTextProvider(['{"title": "ok", "score": 42}']);
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const report = await robota.run('Give me a report.', { output: reportSchema });
+
+      expect(report).toEqual({ title: 'ok', score: 42 });
+      const chatOptions = provider.chatCalls[0].options;
+      expect(chatOptions?.responseFormat).toEqual(expect.objectContaining({ type: 'json_schema' }));
+    });
+
+    it('retries with validation feedback and succeeds on the second attempt', async () => {
+      const provider = new ScriptedTextProvider([
+        '{"title": "missing score"}',
+        '{"title": "ok", "score": 7}',
+      ]);
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const report = await robota.run('Give me a report.', { output: reportSchema });
+
+      expect(report).toEqual({ title: 'ok', score: 7 });
+      expect(provider.chatCalls).toHaveLength(2);
+      // The retry turn feeds the validation issues back to the model.
+      const retryMessages = provider.chatCalls[1].messages;
+      const retryInput = retryMessages[retryMessages.length - 1];
+      expect(String(retryInput.content)).toContain('did not match the required JSON schema');
+      expect(String(retryInput.content)).toContain('score');
+    });
+
+    it('throws StructuredOutputError when the retry budget is exhausted', async () => {
+      const provider = new ScriptedTextProvider(['not json', 'still not json']);
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      await expect(
+        robota.run('Give me a report.', { output: reportSchema, outputRetries: 1 }),
+      ).rejects.toThrow(StructuredOutputError);
+      expect(provider.chatCalls).toHaveLength(2);
+    });
+
+    it('accepts an explicit JSON-schema wrapper', async () => {
+      const provider = new ScriptedTextProvider(['{"answer": "yes"}']);
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const result = await robota.run('Answer.', {
+        output: {
+          jsonSchema: {
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+          },
+          name: 'answer_schema',
+        },
+      });
+
+      expect(result).toEqual({ answer: 'yes' });
+    });
+
+    it('returns the validated object as the runStream generator return value', async () => {
+      class ScriptedStreamProvider extends TrackingProvider {
+        override async *chatStream(
+          messages: TUniversalMessage[],
+          options?: IChatOptions,
+        ): AsyncIterable<TUniversalMessage> {
+          this.chatCalls.push({ messages, options });
+          yield {
+            id: 'chunk-1',
+            role: 'assistant',
+            content: '{"title": "streamed",',
+            state: 'complete' as const,
+            timestamp: new Date(),
+          };
+          yield {
+            id: 'chunk-2',
+            role: 'assistant',
+            content: ' "score": 3}',
+            state: 'complete' as const,
+            timestamp: new Date(),
+          };
+        }
+      }
+      const provider = new ScriptedStreamProvider();
+      const robota = new Robota(createConfig({ aiProviders: [provider] }));
+
+      const stream = robota.runStream('Give me a report.', { output: reportSchema });
+      const iterator = stream[Symbol.asyncIterator]();
+      const chunks: string[] = [];
+      let next = await iterator.next();
+      while (!next.done) {
+        chunks.push(next.value);
+        next = await iterator.next();
+      }
+
+      expect(chunks.join('')).toBe('{"title": "streamed", "score": 3}');
+      expect(next.value).toEqual({ title: 'streamed', score: 3 });
     });
   });
 

--- a/packages/agent-core/src/core/robota.ts
+++ b/packages/agent-core/src/core/robota.ts
@@ -7,7 +7,13 @@ import {
   buildOwnerPath,
   createModuleEventEmitter,
 } from './robota-events';
-import { robotaRun, robotaRunStream, type IRobotaExecutionDeps } from './robota-execution';
+import {
+  robotaRun,
+  robotaRunStream,
+  robotaRunStructured,
+  robotaRunStreamStructured,
+  type IRobotaExecutionDeps,
+} from './robota-execution';
 import {
   getHistory,
   getFullHistory,
@@ -24,17 +30,26 @@ import { AIProviders } from '../managers/ai-provider-manager';
 import { ConversationHistory } from '../managers/conversation-history-manager';
 import { ModuleRegistry } from '../managers/module-registry';
 import { Tools } from '../managers/tool-manager';
+import { normalizeStructuredOutput } from '../schema/structured-output';
 import { createLogger, setGlobalLogLevel, type ILogger } from '../utils/logger';
 
 import type { RobotaConfigManager } from './robota-config-manager';
 import type { IModelConfig, IConfigurationSnapshot } from './robota-types';
 import type { AbstractTool, IToolWithEventService } from '../abstracts/abstract-tool';
-import type { TUniversalMessage, IAgentConfig, IRunOptions, IAgent } from '../interfaces/agent';
+import type {
+  TUniversalMessage,
+  IAgentConfig,
+  IRunOptions,
+  IAgent,
+  TRunOptionsWithOutput,
+} from '../interfaces/agent';
 import type { IEventService, IAgentEventData } from '../interfaces/event-service';
 import type { IHistoryEntry } from '../interfaces/messages';
 import type { IAIProvider } from '../interfaces/provider';
 import type { EventEmitterPlugin } from '../plugins/event-emitter-plugin';
+import type { IJsonSchemaOutput } from '../schema/structured-output';
 import type { ExecutionService } from '../services/execution-service';
+import type { ZodType, TypeOf } from 'zod';
 
 const ID_RADIX = 36;
 const ID_RANDOM_LENGTH = 9;
@@ -143,24 +158,51 @@ export class Robota
    * concurrent `run`/`runStream` calls on the same instance are serialized on an internal queue —
    * a call issued while another is in flight waits its turn (its `signal` is honored while queued).
    * Interleaved histories are therefore impossible by construction.
+   *
+   * Structured output (CORE-015): with `options.output` set the promise resolves to the validated
+   * object (typed `z.infer<S>` for a Zod schema) instead of a string. Note the structured typing
+   * is visible on `Robota` directly; through the generic `IAgent` interface the return type stays
+   * `Promise<string>`.
    */
-  async run(input: string, options: IRunOptions = {}): Promise<string> {
+  run<S extends ZodType>(input: string, options: TRunOptionsWithOutput<S>): Promise<TypeOf<S>>;
+  run(input: string, options: TRunOptionsWithOutput<IJsonSchemaOutput>): Promise<unknown>;
+  run(input: string, options?: IRunOptions): Promise<string>;
+  async run(input: string, options: IRunOptions = {}): Promise<unknown> {
     return this.enqueueRun(options.signal, async () => {
       await this.ensureFullyInitialized();
+      if (options.output) {
+        const spec = normalizeStructuredOutput(options.output);
+        return robotaRunStructured(this.executionDeps(), input, options, spec);
+      }
       return robotaRun(this.executionDeps(), input, options);
     });
   }
 
+  runStream<S extends ZodType>(
+    input: string,
+    options: TRunOptionsWithOutput<S>,
+  ): AsyncGenerator<string, TypeOf<S>, undefined>;
+  runStream(
+    input: string,
+    options: TRunOptionsWithOutput<IJsonSchemaOutput>,
+  ): AsyncGenerator<string, unknown, undefined>;
+  runStream(input: string, options?: IRunOptions): AsyncGenerator<string, void, undefined>;
   async *runStream(
     input: string,
     options: IRunOptions = {},
-  ): AsyncGenerator<string, void, undefined> {
+  ): AsyncGenerator<string, unknown, undefined> {
     // Serialized like run(): the queue slot is held until the stream is fully consumed
     // (return or throw), because the conversation history is being written throughout.
     const release = await this.acquireRunSlot(options.signal);
     try {
       await this.ensureFullyInitialized();
+      if (options.output) {
+        const spec = normalizeStructuredOutput(options.output);
+        // The validated object is the generator's return value (CORE-015).
+        return yield* robotaRunStreamStructured(this.executionDeps(), input, options, spec);
+      }
       yield* robotaRunStream(this.executionDeps(), input, options);
+      return undefined;
     } finally {
       release();
     }

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -8,6 +8,31 @@ export * from './interfaces';
 export * from './abstracts';
 export * from './utils';
 
+// Schema utilities: Zod→JSON-schema conversion (SSOT) + structured output (CORE-015)
+export {
+  zodToJsonSchema,
+  extractEnumValues,
+  hasValidationConstraints,
+  getSchemaTypeName,
+} from './schema/zod-to-json-schema';
+export type {
+  IZodSchema,
+  IZodSchemaDef,
+  IZodParseResult,
+  ISchemaConversionOptions,
+} from './schema/zod-schema-types';
+export {
+  normalizeStructuredOutput,
+  validateAgainstJsonSchema,
+  parseStructuredResponseText,
+} from './schema/structured-output';
+export type {
+  IJsonSchemaOutput,
+  IStructuredOutputSpec,
+  TStructuredOutputSchema,
+  TStructuredOutputValidation,
+} from './schema/structured-output';
+
 // Provider integration types
 export type {
   IToolSchema,

--- a/packages/agent-core/src/interfaces/agent.ts
+++ b/packages/agent-core/src/interfaces/agent.ts
@@ -12,6 +12,7 @@ import type { IModule } from '../abstracts/abstract-module';
 import type { IPluginContract, IPluginOptions, IPluginStats } from '../abstracts/abstract-plugin';
 import type { IToolWithEventService } from '../abstracts/abstract-tool';
 import type { IEventService, IOwnerPathSegment } from '../interfaces/event-service';
+import type { TStructuredOutputSchema } from '../schema/structured-output';
 import type { TUtilLogLevel } from '../utils/logger';
 
 export type {
@@ -198,7 +199,30 @@ export interface IRunOptions {
    * The run result's content may be empty; consumers read the outcome from the tool results.
    */
   allowToolOnlyCompletion?: boolean;
+  /**
+   * Schema-enforced structured output (CORE-015). Accepts a Zod schema or an explicit
+   * `{ jsonSchema }` wrapper. `run` then resolves to the validated, typed object instead of a
+   * string: the schema is forwarded to the provider's native structured-output surface where one
+   * exists, and the final response is always parsed and validated core-side; a violation triggers
+   * a bounded retry with the validation issues fed back as the next turn's input. Every attempt is
+   * a real conversation turn (history stays append-only). Exhausted retries throw
+   * `StructuredOutputError`.
+   */
+  output?: TStructuredOutputSchema;
+  /**
+   * Retry budget for structured output validation failures — the number of additional attempts
+   * after the first (default 2). Only meaningful with `output` set.
+   */
+  outputRetries?: number;
 }
+
+/**
+ * Run options whose `output` is pinned to a concrete schema type (CORE-015).
+ * Built with `Omit` rather than an intersection on `output` because Zod v3 object
+ * schemas are not assignable to intersections containing themselves (deepPartial
+ * variance), which would silently knock out the typed overloads.
+ */
+export type TRunOptionsWithOutput<TOutput> = Omit<IRunOptions, 'output'> & { output: TOutput };
 
 export type TExecutionEventData = Record<string, unknown>;
 
@@ -275,8 +299,11 @@ export interface IExtendedRunContext {
  * Response format configuration
  */
 export interface IResponseFormatConfig {
-  type?: 'text' | 'json_object';
+  type?: 'text' | 'json_object' | 'json_schema';
+  /** JSON schema payload; required when `type` is `'json_schema'` (CORE-015). */
   schema?: Record<string, TConfigValue>;
+  /** Schema name forwarded to provider native structured-output surfaces. */
+  name?: string;
 }
 
 /**

--- a/packages/agent-core/src/interfaces/provider.ts
+++ b/packages/agent-core/src/interfaces/provider.ts
@@ -217,8 +217,10 @@ export interface IChatOptions extends IProviderSpecificOptions {
   signal?: AbortSignal;
   /** Provider-native hosted web tools requested for this call */
   nativeWebTools?: IProviderNativeWebToolRequest;
-  /** Request structured output from the provider. */
-  responseFormat?: { type: 'text' | 'json_object' };
+  /** Request structured output from the provider (CORE-015: `json_schema` carries the schema). */
+  responseFormat?:
+    | { type: 'text' | 'json_object' }
+    | { type: 'json_schema'; name?: string; schema: Record<string, unknown> };
 }
 
 /**

--- a/packages/agent-core/src/schema/structured-output.test.ts
+++ b/packages/agent-core/src/schema/structured-output.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import {
+  normalizeStructuredOutput,
+  parseStructuredResponseText,
+  validateAgainstJsonSchema,
+} from './structured-output';
+
+import type { IToolSchema } from '../interfaces/provider';
+
+const reportJsonSchema: IToolSchema['parameters'] = {
+  type: 'object',
+  properties: {
+    title: { type: 'string' },
+    score: { type: 'number', minimum: 0, maximum: 100 },
+    tags: { type: 'array', items: { type: 'string' } },
+    level: { type: 'string', enum: ['low', 'high'] },
+  },
+  required: ['title', 'score'],
+};
+
+describe('normalizeStructuredOutput', () => {
+  it('normalizes a Zod schema: converts to JSON schema and validates via safeParse', () => {
+    const spec = normalizeStructuredOutput(z.object({ title: z.string(), score: z.number() }));
+
+    expect(spec.jsonSchema.type).toBe('object');
+    expect(spec.jsonSchema.properties.title).toEqual({ type: 'string' });
+    expect(spec.jsonSchema.required).toEqual(['title', 'score']);
+
+    expect(spec.validate({ title: 'ok', score: 1 })).toEqual({
+      success: true,
+      value: { title: 'ok', score: 1 },
+    });
+
+    const failed = spec.validate({ title: 'ok' });
+    expect(failed.success).toBe(false);
+    if (!failed.success) {
+      expect(failed.issues.join('\n')).toContain('score');
+    }
+  });
+
+  it('normalizes an explicit JSON-schema wrapper and validates structurally', () => {
+    const spec = normalizeStructuredOutput({ jsonSchema: reportJsonSchema, name: 'report' });
+
+    expect(spec.name).toBe('report');
+    expect(spec.validate({ title: 't', score: 10 }).success).toBe(true);
+
+    const failed = spec.validate({ title: 't', score: 'not-a-number' });
+    expect(failed.success).toBe(false);
+    if (!failed.success) {
+      expect(failed.issues[0]).toContain('expected number');
+    }
+  });
+});
+
+describe('validateAgainstJsonSchema', () => {
+  it('reports missing required properties', () => {
+    expect(validateAgainstJsonSchema(reportJsonSchema, { score: 1 }, '$')).toEqual([
+      '$.title: required property missing',
+    ]);
+  });
+
+  it('reports unexpected additional properties when additionalProperties is unset', () => {
+    const issues = validateAgainstJsonSchema(
+      reportJsonSchema,
+      { title: 't', score: 1, extra: true },
+      '$',
+    );
+    expect(issues).toEqual(['$.extra: unexpected additional property']);
+  });
+
+  it('validates nested arrays, enums, and numeric bounds', () => {
+    const issues = validateAgainstJsonSchema(
+      reportJsonSchema,
+      { title: 't', score: 101, tags: ['a', 5], level: 'medium' },
+      '$',
+    );
+    expect(issues).toEqual([
+      '$.score: value 101 is above maximum 100',
+      '$.tags[1]: expected string, got number',
+      '$.level: value "medium" is not one of the allowed enum values',
+    ]);
+  });
+
+  it('rejects non-object roots', () => {
+    expect(validateAgainstJsonSchema(reportJsonSchema, [1, 2], '$')).toEqual([
+      '$: expected object, got array',
+    ]);
+  });
+});
+
+describe('parseStructuredResponseText', () => {
+  it('parses plain JSON', () => {
+    expect(parseStructuredResponseText('{"a": 1}')).toEqual({ success: true, value: { a: 1 } });
+  });
+
+  it('parses a fenced ```json block but still returns the raw value for validation', () => {
+    expect(parseStructuredResponseText('```json\n{"a": 1}\n```')).toEqual({
+      success: true,
+      value: { a: 1 },
+    });
+  });
+
+  it('returns a typed failure for non-JSON text', () => {
+    const result = parseStructuredResponseText('The answer is 42.');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issue).toContain('not valid JSON');
+    }
+  });
+});

--- a/packages/agent-core/src/schema/structured-output.ts
+++ b/packages/agent-core/src/schema/structured-output.ts
@@ -1,0 +1,233 @@
+/**
+ * Structured output normalization and validation (CORE-015).
+ *
+ * `run(input, { output })` accepts either a Zod schema or an explicit JSON-schema
+ * wrapper. Both normalize to one internal representation (`IStructuredOutputSpec`)
+ * that carries the JSON schema for the provider's native structured-output surface
+ * and a validate function for the core-side enforcement loop. The enforcement loop
+ * is the universal contract: providers with a native surface enforce early, and for
+ * providers without one the bounded validate-and-retry loop still guarantees the
+ * returned object matches the schema.
+ */
+
+import { zodToJsonSchema } from './zod-to-json-schema';
+
+import type { IZodSchema } from './zod-schema-types';
+import type { IToolSchema, IParameterSchema } from '../interfaces/provider';
+
+/** Explicit raw-JSON-schema form of `IRunOptions.output`. */
+export interface IJsonSchemaOutput {
+  /** JSON Schema (object root, universal subset) the response must match. */
+  jsonSchema: IToolSchema['parameters'];
+  /** Optional schema name forwarded to provider native surfaces. */
+  name?: string;
+}
+
+/** Accepted `IRunOptions.output` values: a Zod schema or an explicit JSON-schema wrapper. */
+export type TStructuredOutputSchema = IZodSchema | IJsonSchemaOutput;
+
+export type TStructuredOutputValidation =
+  | { success: true; value: unknown }
+  | { success: false; issues: string[] };
+
+/** Internal SSOT representation every `output` value normalizes to. */
+export interface IStructuredOutputSpec {
+  name: string;
+  jsonSchema: IToolSchema['parameters'];
+  validate(value: unknown): TStructuredOutputValidation;
+}
+
+function isZodSchema(output: TStructuredOutputSchema): output is IZodSchema {
+  return (
+    typeof (output as IZodSchema).safeParse === 'function' &&
+    typeof (output as IZodSchema).parse === 'function'
+  );
+}
+
+function formatZodError(error: unknown): string[] {
+  if (error && typeof error === 'object' && 'issues' in error) {
+    const issues = (error as { issues: unknown }).issues;
+    if (Array.isArray(issues)) {
+      return issues.map((issue) => {
+        if (issue && typeof issue === 'object' && 'message' in issue) {
+          const path = Array.isArray((issue as { path?: unknown[] }).path)
+            ? (issue as { path: unknown[] }).path.join('.')
+            : '';
+          const message = String((issue as { message: unknown }).message);
+          return path ? `${path}: ${message}` : message;
+        }
+        return String(issue);
+      });
+    }
+  }
+  return [String(error)];
+}
+
+/** Normalize an accepted `output` value into the internal spec. */
+export function normalizeStructuredOutput(output: TStructuredOutputSchema): IStructuredOutputSpec {
+  if (isZodSchema(output)) {
+    return {
+      name: 'structured_output',
+      jsonSchema: zodToJsonSchema(output),
+      validate: (value) => {
+        const result = output.safeParse(value);
+        if (result.success) {
+          return { success: true, value: result.data };
+        }
+        return { success: false, issues: formatZodError(result.error) };
+      },
+    };
+  }
+  const { jsonSchema, name } = output;
+  return {
+    name: name ?? 'structured_output',
+    jsonSchema,
+    validate: (value) => {
+      const issues = validateAgainstJsonSchema(jsonSchema, value, '$');
+      return issues.length === 0 ? { success: true, value } : { success: false, issues };
+    },
+  };
+}
+
+/**
+ * Validate a value against the universal JSON-schema subset used by tool
+ * parameters (`IParameterSchema`). Covers type, required, enum, items, nested
+ * properties, and numeric bounds — the full expressible surface of the subset.
+ */
+export function validateAgainstJsonSchema(
+  schema: IToolSchema['parameters'] | IParameterSchema,
+  value: unknown,
+  path: string,
+): string[] {
+  const issues: string[] = [];
+  const kind = schema.type;
+
+  switch (kind) {
+    case 'object': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return [`${path}: expected object, got ${describeType(value)}`];
+      }
+      const record = value as Record<string, unknown>;
+      const required = 'required' in schema ? (schema.required ?? []) : [];
+      for (const key of required) {
+        if (!(key in record)) {
+          issues.push(`${path}.${key}: required property missing`);
+        }
+      }
+      const properties = schema.properties ?? {};
+      for (const [key, propertySchema] of Object.entries(properties)) {
+        if (key in record) {
+          issues.push(...validateAgainstJsonSchema(propertySchema, record[key], `${path}.${key}`));
+        }
+      }
+      const additional = schema.additionalProperties;
+      if (additional === undefined || additional === false) {
+        for (const key of Object.keys(record)) {
+          if (!(key in properties)) {
+            issues.push(`${path}.${key}: unexpected additional property`);
+          }
+        }
+      } else if (typeof additional === 'object') {
+        for (const [key, entry] of Object.entries(record)) {
+          if (!(key in properties)) {
+            issues.push(...validateAgainstJsonSchema(additional, entry, `${path}.${key}`));
+          }
+        }
+      }
+      return issues;
+    }
+
+    case 'array': {
+      if (!Array.isArray(value)) {
+        return [`${path}: expected array, got ${describeType(value)}`];
+      }
+      const items = 'items' in schema ? schema.items : undefined;
+      if (items) {
+        value.forEach((entry, index) => {
+          issues.push(...validateAgainstJsonSchema(items, entry, `${path}[${index}]`));
+        });
+      }
+      return issues;
+    }
+
+    case 'string': {
+      if (typeof value !== 'string') {
+        return [`${path}: expected string, got ${describeType(value)}`];
+      }
+      if ('enum' in schema && schema.enum && !schema.enum.some((entry) => entry === value)) {
+        issues.push(
+          `${path}: value ${JSON.stringify(value)} is not one of the allowed enum values`,
+        );
+      }
+      if ('pattern' in schema && schema.pattern && !new RegExp(schema.pattern).test(value)) {
+        issues.push(`${path}: value does not match pattern ${schema.pattern}`);
+      }
+      return issues;
+    }
+
+    case 'number':
+    case 'integer': {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        return [`${path}: expected number, got ${describeType(value)}`];
+      }
+      if (kind === 'integer' && !Number.isInteger(value)) {
+        issues.push(`${path}: expected integer, got non-integer number`);
+      }
+      if ('minimum' in schema && schema.minimum !== undefined && value < schema.minimum) {
+        issues.push(`${path}: value ${value} is below minimum ${schema.minimum}`);
+      }
+      if ('maximum' in schema && schema.maximum !== undefined && value > schema.maximum) {
+        issues.push(`${path}: value ${value} is above maximum ${schema.maximum}`);
+      }
+      if ('enum' in schema && schema.enum && !schema.enum.some((entry) => entry === value)) {
+        issues.push(`${path}: value ${value} is not one of the allowed enum values`);
+      }
+      return issues;
+    }
+
+    case 'boolean': {
+      if (typeof value !== 'boolean') {
+        return [`${path}: expected boolean, got ${describeType(value)}`];
+      }
+      return issues;
+    }
+
+    case 'null': {
+      if (value !== null) {
+        return [`${path}: expected null, got ${describeType(value)}`];
+      }
+      return issues;
+    }
+
+    default:
+      return [`${path}: unsupported schema type ${String(kind)}`];
+  }
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Parse the model's final text into a JSON value. Tolerates a fenced
+ * ```json code block wrapper (providers without native enforcement commonly
+ * emit one); the parsed value is still strictly schema-validated afterwards.
+ */
+export function parseStructuredResponseText(
+  text: string,
+): { success: true; value: unknown } | { success: false; issue: string } {
+  const trimmed = text.trim();
+  const fenced = /^```(?:json)?\s*\n([\s\S]*?)\n?```$/.exec(trimmed);
+  const candidate = fenced ? fenced[1] : trimmed;
+  try {
+    return { success: true, value: JSON.parse(candidate) };
+  } catch (error) {
+    // allow-fallback: converts JSON.parse failure into a typed failure result feeding the bounded retry loop
+    return {
+      success: false,
+      issue: `response is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}

--- a/packages/agent-core/src/schema/zod-schema-types.ts
+++ b/packages/agent-core/src/schema/zod-schema-types.ts
@@ -1,0 +1,46 @@
+/**
+ * Zod schema compatibility types (CORE-015).
+ *
+ * Structural stand-ins for Zod schemas so the converter and structured-output
+ * surfaces accept real Zod schemas (ZodObject<...>, ZodType) without coupling
+ * public signatures to a concrete Zod version. Widened to `unknown` where needed
+ * so actual Zod schemas are structurally assignable without casts at call sites.
+ *
+ * SSOT note: moved here from the tools package (dependency direction is
+ * tools → core, and the run(`output`) pipeline needs the conversion inside core).
+ */
+
+import type { TUniversalValue } from '../interfaces/types';
+
+export interface IZodParseResult {
+  success: boolean;
+  data?: unknown;
+  error?: unknown;
+}
+
+export interface IZodSchemaDef {
+  typeName?: string;
+  innerType?: IZodSchema;
+  valueType?: IZodSchema;
+  checks?: Array<{ kind: string; value?: TUniversalValue }>;
+  shape?: () => Record<string, IZodSchema>;
+  type?: IZodSchema;
+  values?: TUniversalValue[];
+  description?: string;
+  unknownKeys?: 'passthrough' | 'strip' | 'strict';
+}
+
+export interface IZodSchema {
+  parse(value: unknown): unknown;
+  safeParse(value: unknown): IZodParseResult;
+  _def?: IZodSchemaDef;
+}
+
+/**
+ * Schema conversion options
+ */
+export interface ISchemaConversionOptions {
+  includeDescription?: boolean;
+  strictTypes?: boolean;
+  allowAdditionalProperties?: boolean;
+}

--- a/packages/agent-core/src/schema/zod-to-json-schema.test.ts
+++ b/packages/agent-core/src/schema/zod-to-json-schema.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import type { IZodSchema, IZodSchemaDef } from '../implementations/function-tool/types';
+import type { IZodSchema, IZodSchemaDef } from './zod-schema-types';
 import {
   zodToJsonSchema,
   extractEnumValues,
   hasValidationConstraints,
   getSchemaTypeName,
-} from '../implementations/function-tool/schema-converter';
+} from './zod-to-json-schema';
 
 /**
  * Create a mock Zod schema definition.

--- a/packages/agent-core/src/schema/zod-to-json-schema.ts
+++ b/packages/agent-core/src/schema/zod-to-json-schema.ts
@@ -1,23 +1,15 @@
 /**
- * FunctionTool - Schema conversion utilities for Facade pattern
+ * Zod → JSON Schema conversion (SSOT).
  *
- * REASON: Complex Zod to JSON schema conversion requires isolated utility functions
- * ALTERNATIVES_CONSIDERED:
- * 1. Keep conversion logic in main class (violates single responsibility)
- * 2. Use third-party library (adds external dependency)
- * 3. Manual conversion each time (code duplication)
- * 4. Runtime type checking only (loses compile-time safety)
- * 5. Remove Zod support (breaks backward compatibility)
- * TODO: Consider caching conversion results for performance
+ * Owned by agent-core (CORE-015): the structured-output run pipeline and the
+ * tools package both convert Zod schemas to the universal JSON-schema subset
+ * (`IToolSchema['parameters']`), so the single converter lives at the bottom of
+ * the dependency graph. The tools package imports these functions from core.
  */
 
-import type { IZodSchema, ISchemaConversionOptions } from './types';
-import type {
-  IToolSchema,
-  IParameterSchema,
-  TJSONSchemaEnum,
-  TUniversalValue,
-} from '@robota-sdk/agent-core';
+import type { IZodSchema, ISchemaConversionOptions } from './zod-schema-types';
+import type { IToolSchema, IParameterSchema, TJSONSchemaEnum } from '../interfaces/provider';
+import type { TUniversalValue } from '../interfaces/types';
 
 /**
  * Convert Zod schema to JSON Schema format with safe undefined handling

--- a/packages/agent-core/src/services/execution-round-provider.ts
+++ b/packages/agent-core/src/services/execution-round-provider.ts
@@ -5,6 +5,8 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { buildChatResponseFormat } from './execution-service-helpers';
+
 import type { IResolvedProviderInfo, IExecutionRoundState } from './execution-types';
 import type { IAgentConfig, IAssistantMessage } from '../interfaces/agent';
 import type { IToolCall, TUniversalMessage } from '../interfaces/messages';
@@ -59,9 +61,10 @@ export async function callProviderWithCache(
       temperature: config.defaultModel.temperature,
     }),
     ...(resolved.availableTools.length > 0 && { tools: resolved.availableTools }),
-    ...(config.responseFormat?.type
-      ? { responseFormat: { type: config.responseFormat.type } }
-      : {}),
+    ...(() => {
+      const responseFormat = buildChatResponseFormat(config.responseFormat);
+      return responseFormat ? { responseFormat } : {};
+    })(),
     ...overrides,
   };
   const providerChat = resolved.provider.chat.bind(resolved.provider) as TProviderChat;

--- a/packages/agent-core/src/services/execution-service-helpers.ts
+++ b/packages/agent-core/src/services/execution-service-helpers.ts
@@ -11,11 +11,40 @@ import { type ConversationStore } from '../managers/conversation-history-manager
 
 import type { ExecutionEventEmitter } from './execution-event-emitter';
 import type { TPluginWithHooks } from './plugin-hook-dispatcher';
-import type { IAgentConfig, IAssistantMessage, IToolMessage } from '../interfaces/agent';
+import type {
+  IAgentConfig,
+  IAssistantMessage,
+  IResponseFormatConfig,
+  IToolMessage,
+} from '../interfaces/agent';
 import type { IAIProviderManager } from '../interfaces/manager';
 import type { IToolManager } from '../interfaces/manager';
 import type { TUniversalMessage } from '../interfaces/messages';
+import type { IChatOptions } from '../interfaces/provider';
 import type { ILogger } from '../utils/logger';
+
+/**
+ * Map the config-level response format onto provider chat options (CORE-015:
+ * `json_schema` requires the schema payload; `text`/`json_object` carry type only).
+ */
+export function buildChatResponseFormat(
+  responseFormat: IResponseFormatConfig | undefined,
+): IChatOptions['responseFormat'] | undefined {
+  if (!responseFormat?.type) {
+    return undefined;
+  }
+  if (responseFormat.type === 'json_schema') {
+    if (!responseFormat.schema) {
+      throw new Error("responseFormat.schema is required when type is 'json_schema'.");
+    }
+    return {
+      type: 'json_schema',
+      schema: responseFormat.schema,
+      ...(responseFormat.name && { name: responseFormat.name }),
+    };
+  }
+  return { type: responseFormat.type };
+}
 
 /**
  * Resolve the current AI provider and available tools from managers.

--- a/packages/agent-core/src/services/execution-stream.ts
+++ b/packages/agent-core/src/services/execution-stream.ts
@@ -1,3 +1,4 @@
+import { buildChatResponseFormat } from './execution-service-helpers';
 import { executeStreamToolCalls } from './execution-stream-tools';
 import { callPluginHook } from './plugin-hook-dispatcher';
 import { ConfigurationError } from '../utils/errors';
@@ -121,9 +122,10 @@ export async function* executeStream(
     const chatOptions: IChatOptions = {
       model: config.defaultModel.model,
       ...(config.tools && config.tools.length > 0 && { tools: tools.getTools() }),
-      ...(config.responseFormat?.type
-        ? { responseFormat: { type: config.responseFormat.type } }
-        : {}),
+      ...(() => {
+        const responseFormat = buildChatResponseFormat(config.responseFormat);
+        return responseFormat ? { responseFormat } : {};
+      })(),
     };
 
     logger.debug('[EXECUTION-SERVICE] Final chatOptions has tools:', {

--- a/packages/agent-core/src/utils/errors.ts
+++ b/packages/agent-core/src/utils/errors.ts
@@ -73,6 +73,29 @@ export class ValidationError extends RobotaError {
 }
 
 /**
+ * Structured output validation exhausted its retry budget (CORE-015).
+ *
+ * Thrown by `run(input, { output })` when the model's final response still fails
+ * schema validation after the configured number of retries. `issues` holds the
+ * validation messages from the last attempt; `attempts` is the total number of
+ * provider turns spent (initial + retries).
+ */
+export class StructuredOutputError extends RobotaError {
+  readonly code = 'STRUCTURED_OUTPUT_ERROR';
+  readonly category = 'provider' as const;
+  readonly recoverable = true;
+
+  constructor(
+    message: string,
+    public readonly issues: string[],
+    public readonly attempts: number,
+    context?: TErrorContextData,
+  ) {
+    super(`Structured Output Error: ${message}`, context);
+  }
+}
+
+/**
  * Provider related errors
  */
 export class ProviderError extends RobotaError {

--- a/packages/agent-framework/src/tools/agent-tool.ts
+++ b/packages/agent-framework/src/tools/agent-tool.ts
@@ -36,7 +36,7 @@ import type {
   ISubagentSpawnRequest,
 } from '../subagents/index.js';
 import type { IToolExecutionContext } from '@robota-sdk/agent-core';
-import type { IZodSchema } from '@robota-sdk/agent-tools';
+import type { IZodSchema } from '@robota-sdk/agent-core';
 
 export const AGENT_TOOL_DESCRIPTION = [
   'Creates delegated subagent jobs in isolated contexts.',

--- a/packages/agent-framework/src/tools/background-process-tool.ts
+++ b/packages/agent-framework/src/tools/background-process-tool.ts
@@ -2,7 +2,7 @@ import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import { z } from 'zod';
 
 import type { IBackgroundTaskManager, TBackgroundPrimitive } from '../background-tasks/index.js';
-import type { IZodSchema } from '@robota-sdk/agent-tools';
+import type { IZodSchema } from '@robota-sdk/agent-core';
 
 const DEFAULT_PROCESS_TIMEOUT_MS = 120_000;
 

--- a/packages/agent-framework/src/tools/command-execution-tool.ts
+++ b/packages/agent-framework/src/tools/command-execution-tool.ts
@@ -8,7 +8,7 @@ import {
 
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
 import type { ICommandResult } from '../commands/index.js';
-import type { IZodSchema } from '@robota-sdk/agent-tools';
+import type { IZodSchema } from '@robota-sdk/agent-core';
 
 interface ICommandExecutionArgs {
   command: string;

--- a/packages/agent-framework/src/tools/model-command-tool-projection.ts
+++ b/packages/agent-framework/src/tools/model-command-tool-projection.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
 import type { ICommandResult } from '../commands/index.js';
-import type { IZodSchema } from '@robota-sdk/agent-tools';
+import type { IZodSchema } from '@robota-sdk/agent-core';
 
 export const MODEL_COMMAND_TOOL_PREFIX = 'robota_command_' as const;
 export const PROVIDER_SAFE_TOOL_NAME_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;

--- a/packages/agent-provider/src/anthropic/__tests__/provider.test.ts
+++ b/packages/agent-provider/src/anthropic/__tests__/provider.test.ts
@@ -342,6 +342,67 @@ describe('AnthropicProvider', () => {
       expect(result.metadata?.outputTokens).toBe(20);
     });
 
+    it('maps json_schema responseFormat onto output_config.format (CORE-015)', async () => {
+      const apiResponse = makeTextResponse('{"title": "ok"}');
+      mockClient.messages.create.mockResolvedValue(makeStreamEvents(apiResponse));
+
+      const messages: TUniversalMessage[] = [
+        {
+          id: 'msg-1',
+          state: 'complete' as const,
+          role: 'user',
+          content: 'Report please',
+          timestamp: new Date(),
+        },
+      ];
+      const schema = {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+      };
+      await provider.chat(messages, {
+        model: 'claude-3-opus-20240229',
+        responseFormat: { type: 'json_schema', name: 'report', schema },
+      });
+
+      // Anthropic requires closed-world objects: additionalProperties is forced false.
+      expect(mockClient.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          output_config: {
+            format: {
+              type: 'json_schema',
+              schema: {
+                type: 'object',
+                properties: { title: { type: 'string' } },
+                required: ['title'],
+                additionalProperties: false,
+              },
+            },
+          },
+        }),
+        undefined,
+      );
+    });
+
+    it('omits output_config for non-json_schema response formats', async () => {
+      const apiResponse = makeTextResponse('plain');
+      mockClient.messages.create.mockResolvedValue(makeStreamEvents(apiResponse));
+
+      const messages: TUniversalMessage[] = [
+        {
+          id: 'msg-1',
+          state: 'complete' as const,
+          role: 'user',
+          content: 'Hi',
+          timestamp: new Date(),
+        },
+      ];
+      await provider.chat(messages, { model: 'claude-3-opus-20240229' });
+
+      const params = mockClient.messages.create.mock.calls[0][0] as Record<string, unknown>;
+      expect(params).not.toHaveProperty('output_config');
+    });
+
     it('emits native Anthropic request and ordered stream event payloads', async () => {
       const apiResponse = makeTextResponse('Hello there!');
       mockClient.messages.create.mockResolvedValue(makeStreamEvents(apiResponse));

--- a/packages/agent-provider/src/anthropic/provider.ts
+++ b/packages/agent-provider/src/anthropic/provider.ts
@@ -131,6 +131,7 @@ export class AnthropicProvider extends AbstractAIProvider {
       ...(systemPrompt && { system: systemPrompt }),
       ...(options?.temperature !== undefined && { temperature: options.temperature }),
       ...(allTools.length > 0 && { tools: allTools }),
+      ...buildOutputConfig(options),
     };
 
     // Always use streaming to avoid Anthropic SDK's 10-minute non-streaming timeout.
@@ -199,6 +200,7 @@ export class AnthropicProvider extends AbstractAIProvider {
       messages: anthropicMessages,
       max_tokens: options?.maxTokens || getModelMaxOutput(options.model as string),
       stream: true,
+      ...buildOutputConfig(options),
     };
 
     if (options?.temperature !== undefined) {
@@ -323,4 +325,62 @@ export class AnthropicProvider extends AbstractAIProvider {
       }
     }
   }
+}
+
+/**
+ * Map a `json_schema` response format onto Anthropic's native structured-output
+ * surface (`output_config.format`, CORE-015). Other formats have no Anthropic
+ * equivalent and rely on the core-side validation loop.
+ */
+function buildOutputConfig(
+  options: IChatOptions | undefined,
+): Pick<Anthropic.MessageCreateParams, 'output_config'> | Record<string, never> {
+  if (options?.responseFormat?.type !== 'json_schema') {
+    return {};
+  }
+  return {
+    output_config: {
+      format: {
+        type: 'json_schema',
+        schema: closeObjectSchemas(options.responseFormat.schema) as Record<string, unknown>,
+      },
+    },
+  };
+}
+
+/**
+ * Anthropic's structured-output surface rejects open-world objects: every
+ * `object` node must carry an explicit `additionalProperties: false`. The
+ * universal schema subset leaves it unset (closed by convention), so close
+ * every object node recursively at this SDK seam. The consumer's original
+ * schema still governs core-side validation.
+ */
+function closeObjectSchemas(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(closeObjectSchemas);
+  }
+  if (typeof node !== 'object' || node === null) {
+    return node;
+  }
+  const record = node as Record<string, unknown>;
+  const closed: Record<string, unknown> = { ...record };
+  if (record.properties && typeof record.properties === 'object') {
+    closed.properties = Object.fromEntries(
+      Object.entries(record.properties as Record<string, unknown>).map(([key, value]) => [
+        key,
+        closeObjectSchemas(value),
+      ]),
+    );
+  }
+  if (record.items && typeof record.items === 'object') {
+    closed.items = closeObjectSchemas(record.items);
+  }
+  if (record.additionalProperties && typeof record.additionalProperties === 'object') {
+    // Schema-valued additionalProperties (record types) pass through recursed;
+    // Anthropic may reject them — surfaced as a provider error, not masked here.
+    closed.additionalProperties = closeObjectSchemas(record.additionalProperties);
+  } else if (record.type === 'object') {
+    closed.additionalProperties = false;
+  }
+  return closed;
 }

--- a/packages/agent-provider/src/gemini/execution-helpers.ts
+++ b/packages/agent-provider/src/gemini/execution-helpers.ts
@@ -131,6 +131,13 @@ function buildGenerateContentRequest(
   if (systemInstruction) {
     config.systemInstruction = systemInstruction;
   }
+  // CORE-015: map json_schema onto Gemini's native structured-output surface.
+  if (options?.responseFormat?.type === 'json_schema') {
+    config.responseMimeType = 'application/json';
+    config.responseSchema = options.responseFormat.schema;
+  } else if (options?.responseFormat?.type === 'json_object') {
+    config.responseMimeType = 'application/json';
+  }
   return {
     model,
     contents,

--- a/packages/agent-provider/src/gemini/genai-transport.test.ts
+++ b/packages/agent-provider/src/gemini/genai-transport.test.ts
@@ -102,6 +102,34 @@ describe('GeminiProvider @google/genai transport', () => {
     });
   });
 
+  it('maps json_schema responseFormat onto responseSchema + JSON mime type (CORE-015)', async () => {
+    generateContentMock.mockResolvedValue({
+      candidates: [{ content: { parts: [{ text: '{"title": "ok"}' }] } }],
+    });
+    const { GeminiProvider } = await import('./provider');
+
+    const provider = new GeminiProvider({ apiKey: 'test-key' });
+    const schema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+    };
+    await provider.chat([createUserMessage('report please')], {
+      model: 'gemini-3-flash-preview',
+      responseFormat: { type: 'json_schema', name: 'report', schema },
+    });
+
+    expect(generateContentMock).toHaveBeenCalledWith({
+      model: 'gemini-3-flash-preview',
+      contents: [{ role: 'user', parts: [{ text: 'report please' }] }],
+      config: {
+        responseModalities: ['TEXT'],
+        responseMimeType: 'application/json',
+        responseSchema: schema,
+      },
+    });
+  });
+
   it('uses provider defaultModel when chat options omit model', async () => {
     generateContentMock.mockResolvedValue({
       candidates: [{ content: { parts: [{ text: 'done' }] } }],

--- a/packages/agent-provider/src/openai/__tests__/request-format.test.ts
+++ b/packages/agent-provider/src/openai/__tests__/request-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildOpenAIChatResponseFormat, mergeChatResponseFormat } from '../openai-request-format';
+
+import type { IOpenAIProviderOptions } from '../types';
+
+const providerOptions: IOpenAIProviderOptions = { apiKey: 'test-key' };
+
+describe('mergeChatResponseFormat (CORE-015)', () => {
+  it('returns provider options untouched when no chat responseFormat is set', () => {
+    expect(mergeChatResponseFormat(providerOptions, undefined)).toBe(providerOptions);
+  });
+
+  it('carries a json_schema chat option with its schema payload into jsonSchema', () => {
+    const schema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+    };
+    const merged = mergeChatResponseFormat(providerOptions, {
+      type: 'json_schema',
+      name: 'report',
+      schema,
+    });
+
+    expect(merged.responseFormat).toBe('json_schema');
+    expect(merged.jsonSchema).toEqual({ name: 'report', schema });
+  });
+
+  it('defaults the schema name when omitted', () => {
+    const merged = mergeChatResponseFormat(providerOptions, {
+      type: 'json_schema',
+      schema: { type: 'object', properties: {} },
+    });
+    expect(merged.jsonSchema?.name).toBe('structured_output');
+  });
+
+  it('maps text/json_object formats without a schema payload', () => {
+    expect(mergeChatResponseFormat(providerOptions, { type: 'json_object' }).responseFormat).toBe(
+      'json_object',
+    );
+    expect(mergeChatResponseFormat(providerOptions, { type: 'text' }).responseFormat).toBe('text');
+  });
+
+  it('composes with buildOpenAIChatResponseFormat into response_format json_schema', () => {
+    const schema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+    };
+    const format = buildOpenAIChatResponseFormat(
+      mergeChatResponseFormat(providerOptions, { type: 'json_schema', name: 'report', schema }),
+    );
+    expect(format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'report', schema },
+    });
+  });
+});

--- a/packages/agent-provider/src/openai/chat-completions-chat.ts
+++ b/packages/agent-provider/src/openai/chat-completions-chat.ts
@@ -1,7 +1,7 @@
 import { RateLimitError } from '@robota-sdk/agent-core';
 
 import { convertToOpenAIMessages, convertToOpenAITools } from './message-converter';
-import { buildOpenAIChatResponseFormat } from './openai-request-format';
+import { buildOpenAIChatResponseFormat, mergeChatResponseFormat } from './openai-request-format';
 import { assembleOpenAIStream } from './streaming/stream-assembler';
 import { observeProviderNativeRawPayloadStream } from '../shared/openai-compatible/index.js';
 
@@ -127,9 +127,7 @@ function buildChatRequestParams(
   }
 
   const responseFormat = buildOpenAIChatResponseFormat(
-    input.chatOptions?.responseFormat?.type !== undefined
-      ? { ...input.providerOptions, responseFormat: input.chatOptions.responseFormat.type }
-      : input.providerOptions,
+    mergeChatResponseFormat(input.providerOptions, input.chatOptions?.responseFormat),
   );
   return {
     model,

--- a/packages/agent-provider/src/openai/openai-request-format.ts
+++ b/packages/agent-provider/src/openai/openai-request-format.ts
@@ -3,6 +3,7 @@ import type {
   IOpenAIResponsesTextFormatJsonSchema,
 } from './responses-types';
 import type { IOpenAIProviderOptions, TOpenAIProviderOptionValue } from './types';
+import type { IChatOptions } from '@robota-sdk/agent-core';
 
 export interface IOpenAIChatTextFormatText {
   type: 'text';
@@ -26,6 +27,31 @@ export type TOpenAIChatResponseFormat =
   | IOpenAIChatTextFormatText
   | IOpenAIChatTextFormatJsonObject
   | IOpenAIChatTextFormatJsonSchema;
+
+/**
+ * Merge a per-call `IChatOptions.responseFormat` onto the provider options (CORE-015).
+ * A `json_schema` chat option carries its schema payload into `jsonSchema`; the
+ * provider-level `jsonSchema` option remains as-is for `text`/`json_object`.
+ */
+export function mergeChatResponseFormat(
+  providerOptions: IOpenAIProviderOptions,
+  responseFormat: IChatOptions['responseFormat'],
+): IOpenAIProviderOptions {
+  if (responseFormat?.type === undefined) {
+    return providerOptions;
+  }
+  if (responseFormat.type === 'json_schema') {
+    return {
+      ...providerOptions,
+      responseFormat: 'json_schema',
+      jsonSchema: {
+        name: responseFormat.name ?? 'structured_output',
+        schema: responseFormat.schema as Record<string, TOpenAIProviderOptionValue>,
+      },
+    };
+  }
+  return { ...providerOptions, responseFormat: responseFormat.type };
+}
 
 export function buildOpenAIChatResponseFormat(
   options: IOpenAIProviderOptions,

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -124,7 +124,6 @@ Recent file tool updates keep write/edit behavior atomic and make Edit tool resu
 | `createZodFunctionTool`  | Factory with Zod validation and JSON Schema conversion     |
 | `OpenAPITool`            | Tool generated from OpenAPI specification                  |
 | `createOpenAPITool`      | Factory for creating OpenAPI tools                         |
-| `zodToJsonSchema`        | Converts Zod schemas to JSON Schema format                 |
 | `IToolInvocationResult`  | Result type for built-in CLI tool invocations              |
 | `ISandboxClient`         | Provider-neutral sandbox execution port                    |
 | `IWorkspaceManifest`     | Declarative sandbox workspace setup contract               |

--- a/packages/agent-tools/docs/SPEC.md
+++ b/packages/agent-tools/docs/SPEC.md
@@ -24,7 +24,6 @@ implementations/
   function-tool.ts      -- FunctionTool: JS function tool with Zod schema validation
   function-tool/
     index.ts            -- Re-exports FunctionTool, createFunctionTool, createZodFunctionTool
-    schema-converter.ts -- zodToJsonSchema: converts Zod schemas to JSON Schema
     parameter-validator.ts -- validateToolParameters / getValidationErrors / validateParameterType
     types.ts            -- FunctionTool-specific types
 types/
@@ -54,7 +53,7 @@ builtins/
 
 - **Registry** -- `ToolRegistry` provides central tool registration, lookup, and schema management.
 - **Factory** -- `createFunctionTool` and `createZodFunctionTool` provide ergonomic tool construction.
-- **Adapter** -- `zodToJsonSchema` adapts Zod schemas into the JSON Schema format expected by AI providers; `E2BSandboxClient` adapts E2B-compatible sandbox instances to `ISandboxClient`.
+- **Adapter** -- `E2BSandboxClient` adapts E2B-compatible sandbox instances to `ISandboxClient`. (Zod-to-JSON-schema conversion is owned by the core package as the schema SSOT; this package imports it.)
 - **Ports and adapters** -- `ISandboxClient` separates tool execution intent, workspace preparation, and provider-owned snapshot hydration from the concrete execution plane.
 - **Declarative workspace setup** -- `IWorkspaceManifest` describes fresh-session sandbox files, directories, Git repositories, and future ephemeral storage mounts without putting manifest algorithms in SDK or CLI layers.
 
@@ -109,7 +108,6 @@ Types owned by this package (SSOT):
 | `FunctionTool`                          | Class    | JS function tool with Zod schema validation                    |
 | `createFunctionTool`                    | Function | Factory for creating function tools                            |
 | `createZodFunctionTool`                 | Function | Factory with Zod validation and conversion                     |
-| `zodToJsonSchema`                       | Function | Converts Zod schemas to JSON Schema format                     |
 | `IToolInvocationResult`                 | Type     | Result shape for CLI tool invocations                          |
 | `E2BSandboxClient`                      | Class    | Adapter for E2B-compatible sandbox instances and snapshots     |
 | `InMemorySandboxClient`                 | Class    | Deterministic sandbox client for tests                         |
@@ -187,7 +185,7 @@ This is the inner result type used by built-in tools. It is serialized to JSON a
 
 ## Error Taxonomy
 
-This package does not define a custom error hierarchy. Built-in tools return errors via the `IToolInvocationResult.error` field rather than throwing. Schema conversion errors from `zodToJsonSchema` are thrown as standard `Error` instances.
+This package does not define a custom error hierarchy. Built-in tools return errors via the `IToolInvocationResult.error` field rather than throwing.
 
 `classifyFetchError` in `web-fetch-tool.ts` maps network-layer errors (Node.js `ErrnoException` codes and `AbortError`) to human-readable strings; it does not throw. Path traversal violations detected by `checkPathWithinCwd` in `path-guard.ts` are returned as a serialized `IToolInvocationResult` error string rather than thrown exceptions.
 
@@ -225,7 +223,6 @@ None. `FunctionTool` implements its interface directly (`implements IFunctionToo
 | `src/__tests__/sandbox-tools.test.ts`      | Unit  | Sandbox client contracts, sandbox-aware tools, E2B adapter behavior, and snapshot/restore paths |
 | `src/__tests__/workspace-manifest.test.ts` | Unit  | Workspace manifest path validation and generic sandbox application                              |
 | `src/__tests__/function-tool.test.ts`      | Unit  | FunctionTool creation, execution, schema validation                                             |
-| `src/__tests__/schema-converter.test.ts`   | Unit  | Zod-to-JSON-Schema conversion                                                                   |
 | `src/__tests__/tool-registry.test.ts`      | Unit  | ToolRegistry registration, lookup, listing                                                      |
 
 ### Gaps

--- a/packages/agent-tools/src/browser.ts
+++ b/packages/agent-tools/src/browser.ts
@@ -11,13 +11,9 @@ export {
   createFunctionTool,
   createZodFunctionTool,
 } from './implementations/function-tool';
-export { zodToJsonSchema } from './implementations/function-tool/schema-converter';
+// zodToJsonSchema and the Zod compatibility types moved to @robota-sdk/agent-core (CORE-015 SSOT).
 export type {
-  IZodSchema,
-  IZodParseResult,
-  IZodSchemaDef,
   IFunctionToolValidationOptions,
-  ISchemaConversionOptions,
   IFunctionToolExecutionMetadata,
   IFunctionToolResult,
 } from './implementations/function-tool/types';

--- a/packages/agent-tools/src/implementations/function-tool.ts
+++ b/packages/agent-tools/src/implementations/function-tool.ts
@@ -1,9 +1,8 @@
-import { ToolExecutionError, ValidationError } from '@robota-sdk/agent-core';
+import { ToolExecutionError, ValidationError, zodToJsonSchema } from '@robota-sdk/agent-core';
 
 import { getValidationErrors, validateToolParameters } from './function-tool/parameter-validator';
-import { zodToJsonSchema } from './function-tool/schema-converter';
 
-import type { IZodSchema } from './function-tool/types';
+import type { IZodSchema } from '@robota-sdk/agent-core';
 import type {
   IFunctionTool,
   IToolResult,

--- a/packages/agent-tools/src/implementations/function-tool/index.ts
+++ b/packages/agent-tools/src/implementations/function-tool/index.ts
@@ -3,23 +3,14 @@
  *
  * This module provides a clean interface for function tool functionality
  * with proper separation of concerns and type safety.
+ *
+ * Zod compatibility types and schema conversion utilities moved to
+ * @robota-sdk/agent-core (CORE-015 SSOT) — import them from core.
  */
 
 // Core types
 export type {
-  IZodSchema,
-  IZodParseResult,
-  IZodSchemaDef,
   IFunctionToolValidationOptions,
-  ISchemaConversionOptions,
   IFunctionToolExecutionMetadata,
   IFunctionToolResult,
 } from './types';
-
-// Schema conversion utilities
-export {
-  zodToJsonSchema,
-  extractEnumValues,
-  hasValidationConstraints,
-  getSchemaTypeName,
-} from './schema-converter';

--- a/packages/agent-tools/src/implementations/function-tool/types.ts
+++ b/packages/agent-tools/src/implementations/function-tool/types.ts
@@ -1,34 +1,7 @@
 import type { TToolParameters, TUniversalValue } from '@robota-sdk/agent-core';
 
-/**
- * Zod schema compatibility types
- *
- * Widened to `unknown` so that actual Zod schemas (ZodObject<...>) are structurally
- * assignable without `as unknown as IZodSchema` casts at call sites.
- */
-export interface IZodParseResult {
-  success: boolean;
-  data?: unknown;
-  error?: unknown;
-}
-
-export interface IZodSchemaDef {
-  typeName?: string;
-  innerType?: IZodSchema;
-  valueType?: IZodSchema;
-  checks?: Array<{ kind: string; value?: TUniversalValue }>;
-  shape?: () => Record<string, IZodSchema>;
-  type?: IZodSchema;
-  values?: TUniversalValue[];
-  description?: string;
-  unknownKeys?: 'passthrough' | 'strip' | 'strict';
-}
-
-export interface IZodSchema {
-  parse(value: unknown): unknown;
-  safeParse(value: unknown): IZodParseResult;
-  _def?: IZodSchemaDef;
-}
+// Zod compatibility types and schema conversion moved to @robota-sdk/agent-core (CORE-015 SSOT):
+// IZodSchema, IZodSchemaDef, IZodParseResult, ISchemaConversionOptions, zodToJsonSchema.
 
 /**
  * Parameter type validation options
@@ -37,15 +10,6 @@ export interface IFunctionToolValidationOptions {
   strict?: boolean;
   allowUnknown?: boolean;
   validateTypes?: boolean;
-}
-
-/**
- * Schema conversion options
- */
-export interface ISchemaConversionOptions {
-  includeDescription?: boolean;
-  strictTypes?: boolean;
-  allowAdditionalProperties?: boolean;
 }
 
 /**

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -37,13 +37,9 @@ export {
   createFunctionTool,
   createZodFunctionTool,
 } from './implementations/function-tool';
-export { zodToJsonSchema } from './implementations/function-tool/schema-converter';
+// zodToJsonSchema and the Zod compatibility types moved to @robota-sdk/agent-core (CORE-015 SSOT).
 export type {
-  IZodSchema,
-  IZodParseResult,
-  IZodSchemaDef,
   IFunctionToolValidationOptions,
-  ISchemaConversionOptions,
   IFunctionToolExecutionMetadata,
   IFunctionToolResult,
 } from './implementations/function-tool/types';


### PR DESCRIPTION
## 요약

Gap 분석 G1(P0, "거의 모든 앱이 필요")을 해결합니다. `run(input, { output: schema })`가 문자열 대신 **검증된 typed 객체**를 반환합니다 (승인된 설계: run 옵션 output + 변환기 SSOT core 이동).

## 변경 내용

- **Agent API**: `run` 오버로드 — Zod 스키마면 `z.infer<S>` typed 반환, raw JSON-schema 래퍼(`{ jsonSchema }`)도 수용. `runStream`은 delta를 그대로 스트리밍하고 검증된 객체를 generator **return 값**으로 전달.
- **스키마 SSOT**: `zodToJsonSchema` + Zod 호환 타입들을 agent-tools → agent-core `src/schema/`로 이동 (의존 방향 tools→core 준수, tools/framework는 core에서 import; pass-through 재수출 없음).
- **Provider native 매핑**: OpenAI `response_format.json_schema` / Anthropic `output_config.format`(closed-world 정규화: 모든 object 노드에 `additionalProperties:false` 강제) / Gemini `responseSchema`+JSON mime.
- **보편 계약**: provider native 여부와 무관하게 core-side 파싱+검증 → 위반 시 이슈+스키마를 피드백으로 bounded 재시도(`outputRetries`, 기본 2) → 소진 시 `StructuredOutputError`. 모든 시도는 append-only 히스토리의 실제 턴.
- **ESLint**: TS 메서드 오버로드는 합법이므로 base `no-dupe-class-members` → `@typescript-eslint/no-dupe-class-members`.
- 문서: SPEC(Structured Output Contract 섹션 + 테이블 행), README structured output 예제(doc-examples 스캔으로 typecheck됨), tools SPEC/README에서 이동 반영.

## 라이브 실행이 잡은 버그 2건

1. **Anthropic 400**: native surface가 object 스키마에 `additionalProperties:false` 명시를 요구 — mock으로는 불가능한 발견. seam 정규화로 수정.
2. **Zod v3 오버로드 무력화**: `IRunOptions & { output: S }` intersection이 ZodObject의 deepPartial variance로 typed 오버로드를 조용히 탈락시킴 — doc-examples 스캔이 잡음. `TRunOptionsWithOutput<S> = Omit<IRunOptions,'output'> & { output: S }`로 수정.

## 검증

- agent-core 801 / agent-tools 143 / agent-provider 562 / 전체 repo 테스트·typecheck·lint green, 42 하네스 스캔 + doc-examples(50블록) 통과.
- **User Execution (라이브)**: 실제 Anthropic provider로 3-field typed report 획득 (`score: 78`), 증거는 백로그 문서에 기록.

## 백로그

CORE-015 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj