### PR TITLE
docs(agent-provider): DOCS-016 baseURL 게이트웨이 역량을 타입 표면에 명시

### DIFF
--- a/.agents/backlog/completed/DOCS-016-capability-jsdoc-type-surface.md
+++ b/.agents/backlog/completed/DOCS-016-capability-jsdoc-type-surface.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-016: adoption-critical capabilities on the type surface — baseURL gateway JSDoc + provider table reframing'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: high
 urgency: soon
@@ -44,4 +45,23 @@ never goes stale for the consumer.
 - Steps: in an IDE, hover `baseURL` on `OpenAIProvider` options; follow only that JSDoc to configure
   a gateway endpoint with a non-OpenAI slug.
 - Expected: gateway streaming + tool calling works from the hover text alone.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live, 2026-07-03).** `IOpenAIProviderOptions.baseURL` now carries
+  adoption-decision-grade JSDoc (gateways/Azure/vLLM/Ollama/LM Studio, apiSurface switch to
+  chat-completions, verbatim slug pass-through, Vercel AI Gateway @example) — verified present in
+  the built package `.d.ts` (`dist/node` + `dist/browser`), which is what a consumer's IDE hover
+  reads. Mirrored on gemma/qwen/deepseek `baseURL` (OpenAI-compatible framing) and anthropic
+  `baseURL` (Messages-protocol framing + pointer to the OpenAI provider for OpenAI-protocol
+  gateways). Provider tables reframed to protocol/endpoint-surface in
+  `packages/agent-provider/README.md` (+ new "AI Gateway / any OpenAI-compatible endpoint"
+  example; fixed the Gemma example's wrong option names `baseUrl`/`model` →
+  `baseURL`/`defaultModel`, masked from the doc scan by the options index signature) and
+  `content/guide/providers.md` (protocol-client narrative, "Through an AI gateway" section,
+  gateway pointer in the overview callout). Live User Execution: temp consumer script in
+  `packages/agent-playground` following ONLY the new JSDoc recipe — `OpenAIProvider` +
+  OpenAI-compatible endpoint baseURL (DashScope compatible-mode, same protocol class as a
+  gateway) + non-OpenAI slug `qwen-plus` (TEST_QWEN_KEY) → PASS: streaming (7 deltas) + tool
+  call (`get_weather` executed) + final answer. doc-examples scan 51 blocks green;
+  `pnpm docs:build` green — required fixing a pre-existing breakage absorbed into scope:
+  `scripts/docs/prepare-docs.js` still checked the removed `.vitepress/dist` path after the
+  docs app's VitePress→Next.js migration (now checks `apps/docs/out`). DOCS-014 owns the
+  run/runStream behavior-contract JSDoc (cross-referenced, not duplicated).

--- a/content/guide/providers.md
+++ b/content/guide/providers.md
@@ -16,15 +16,23 @@ All providers implement the same `IAIProvider` interface. You can pass any provi
 
 ## Provider Overview
 
-| Provider                  | Import path                            | Extra install       | Auth method         | Representative model |
-| ------------------------- | -------------------------------------- | ------------------- | ------------------- | -------------------- |
-| Anthropic                 | `@robota-sdk/agent-provider/anthropic` | `@anthropic-ai/sdk` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6`  |
-| OpenAI                    | `@robota-sdk/agent-provider/openai`    | `openai`            | `OPENAI_API_KEY`    | `gpt-4o`             |
-| Gemini                    | `@robota-sdk/agent-provider/gemini`    | `@google/genai`     | `GEMINI_API_KEY`    | `gemini-2.0-flash`   |
-| DeepSeek                  | `@robota-sdk/agent-provider/deepseek`  | `openai`            | `DEEPSEEK_API_KEY`  | `deepseek-v4-flash`  |
-| Qwen (Alibaba)            | `@robota-sdk/agent-provider/qwen`      | `openai`            | `DASHSCOPE_API_KEY` | `qwen-plus`          |
-| Gemma / OpenAI-compatible | `@robota-sdk/agent-provider/gemma`     | `openai`            | varies              | any local model      |
+Each provider is a **protocol client**, not a model-vendor lock: it speaks an API surface, and any
+endpoint speaking that surface works via `baseURL` — AI gateways (Vercel AI Gateway, LiteLLM,
+OpenRouter), Azure, vLLM, Ollama, LM Studio. Model slugs pass through verbatim, so routing
+`anthropic/claude-*` or `meta-llama/*` through an OpenAI-protocol gateway is a one-line config.
 
+| Provider                  | Import path                            | API surface it speaks                                                           | Auth method                       |
+| ------------------------- | -------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------- |
+| OpenAI                    | `@robota-sdk/agent-provider/openai`    | OpenAI API — official or ANY compatible endpoint (gateways, Azure, vLLM, local) | `OPENAI_API_KEY` (or gateway key) |
+| Anthropic                 | `@robota-sdk/agent-provider/anthropic` | Anthropic Messages API                                                          | `ANTHROPIC_API_KEY`               |
+| Gemini                    | `@robota-sdk/agent-provider/gemini`    | Google GenAI API                                                                | `GEMINI_API_KEY`                  |
+| DeepSeek                  | `@robota-sdk/agent-provider/deepseek`  | OpenAI-compatible (DeepSeek endpoint default)                                   | `DEEPSEEK_API_KEY`                |
+| Qwen (Alibaba)            | `@robota-sdk/agent-provider/qwen`      | OpenAI-compatible (DashScope endpoint default)                                  | `DASHSCOPE_API_KEY`               |
+| Gemma / OpenAI-compatible | `@robota-sdk/agent-provider/gemma`     | OpenAI-compatible (bring your own endpoint)                                     | varies                            |
+
+> **AI gateways (Vercel AI Gateway, LiteLLM, OpenRouter):** Use the `OpenAIProvider` with the
+> gateway's `baseURL` and a gateway model slug — see [Through an AI gateway](#through-an-ai-gateway).
+>
 > **Local models (Ollama, LM Studio, llama.cpp):** Use the `GemmaProvider` with a custom
 > `baseURL`. See [Local LLM Setup](./local-llm.md) for a step-by-step guide.
 
@@ -52,13 +60,13 @@ const provider = new AnthropicProvider({
 
 ### Configuration options
 
-| Option     | Type        | Required                       | Description                       |
-| ---------- | ----------- | ------------------------------ | --------------------------------- |
-| `apiKey`   | `string`    | Yes (unless `client` provided) | Anthropic API key                 |
-| `client`   | `Anthropic` | No                             | Pre-built Anthropic SDK client    |
-| `baseURL`  | `string`    | No                             | Custom API endpoint               |
-| `timeout`  | `number`    | No                             | Request timeout in milliseconds   |
-| `executor` | `IExecutor` | No                             | Remote or local executor override |
+| Option     | Type        | Required                       | Description                                                    |
+| ---------- | ----------- | ------------------------------ | -------------------------------------------------------------- |
+| `apiKey`   | `string`    | Yes (unless `client` provided) | Anthropic API key                                              |
+| `client`   | `Anthropic` | No                             | Pre-built Anthropic SDK client                                 |
+| `baseURL`  | `string`    | No                             | Any Anthropic-Messages-API-compatible endpoint (proxy/gateway) |
+| `timeout`  | `number`    | No                             | Request timeout in milliseconds                                |
+| `executor` | `IExecutor` | No                             | Remote or local executor override                              |
 
 ### With a pre-built client
 
@@ -78,8 +86,9 @@ const provider = new AnthropicProvider({ client });
 
 ## OpenAI
 
-GPT and o-series models. Native support for JSON mode, structured outputs, and
-the Responses API.
+The OpenAI **protocol** client. Official OpenAI models (GPT and o-series) with native JSON mode,
+structured outputs, and the Responses API — and, via `baseURL`, any OpenAI-compatible endpoint:
+AI gateways, Azure OpenAI, vLLM, Ollama, LM Studio.
 
 ### Install
 
@@ -104,13 +113,34 @@ const provider = new OpenAIProvider({
 | `apiKey`         | `string`                                   | Yes (unless `client` provided) | OpenAI API key                                                                                |
 | `client`         | `OpenAI`                                   | No                             | Pre-built OpenAI SDK client                                                                   |
 | `organization`   | `string`                                   | No                             | OpenAI organization ID                                                                        |
-| `baseURL`        | `string`                                   | No                             | Custom endpoint (e.g. Azure, proxies)                                                         |
+| `baseURL`        | `string`                                   | No                             | Any OpenAI-compatible endpoint — gateways, Azure, vLLM, local                                 |
 | `timeout`        | `number`                                   | No                             | Request timeout in milliseconds                                                               |
 | `apiSurface`     | `'responses' \| 'chat-completions'`        | No                             | API surface to use (default: `responses` for OpenAI, `chat-completions` for custom endpoints) |
 | `responseFormat` | `'text' \| 'json_object' \| 'json_schema'` | No                             | Response format                                                                               |
 | `reasoning`      | `IOpenAIResponsesReasoningOptions`         | No                             | Reasoning effort for o-series models                                                          |
 | `strictTools`    | `boolean`                                  | No                             | Enable strict function parameter validation                                                   |
 | `executor`       | `IExecutor`                                | No                             | Remote or local executor override                                                             |
+
+### Through an AI gateway
+
+Point `baseURL` at any OpenAI-compatible gateway and use the gateway's model slug — non-OpenAI
+models route through the same provider. Streaming and tool calling work unchanged; the slug is
+passed to the endpoint verbatim.
+
+```typescript
+import { OpenAIProvider } from '@robota-sdk/agent-provider/openai';
+
+// Vercel AI Gateway serving an Anthropic model
+const provider = new OpenAIProvider({
+  apiKey: process.env.AI_GATEWAY_API_KEY!,
+  baseURL: 'https://ai-gateway.vercel.sh/v1',
+  defaultModel: 'anthropic/claude-sonnet-4-5',
+});
+```
+
+The same pattern covers LiteLLM (`http://localhost:4000/v1`), OpenRouter
+(`https://openrouter.ai/api/v1`), and Azure OpenAI deployments. Setting `baseURL` switches the
+default `apiSurface` to `chat-completions` for endpoint compatibility.
 
 ### JSON output
 

--- a/packages/agent-provider/README.md
+++ b/packages/agent-provider/README.md
@@ -10,15 +10,20 @@ npm install @robota-sdk/agent-provider
 
 ## Available Providers
 
-| Provider  | Sub-path      | Models                              |
-| --------- | ------------- | ----------------------------------- |
-| Anthropic | `./anthropic` | Claude 3.5, Claude 4.x              |
-| OpenAI    | `./openai`    | GPT-4o, GPT-4, o1, o3               |
-| DeepSeek  | `./deepseek`  | DeepSeek-V3, DeepSeek-R1            |
-| Google    | `./gemini`    | Gemini 2.0, Gemini 1.5              |
-| Gemma     | `./gemma`     | Gemma 3 (local / OpenAI-compatible) |
-| Qwen      | `./qwen`      | Qwen 2.5, QwQ                       |
-| Bytedance | `./bytedance` | Doubao                              |
+Providers are protocol clients, not model-vendor locks: each one speaks an API surface, and any
+endpoint that speaks the same surface works via `baseURL` — AI gateways (Vercel AI Gateway,
+LiteLLM, OpenRouter), Azure, vLLM, Ollama, LM Studio. Gateway model slugs (e.g.
+`anthropic/claude-*` through an OpenAI-protocol gateway) pass through verbatim.
+
+| Provider  | Sub-path      | API surface it speaks                                                                                                                   |
+| --------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI    | `./openai`    | OpenAI API (Responses + Chat Completions) — official OpenAI or ANY OpenAI-compatible endpoint: gateways, Azure, vLLM, Ollama, LM Studio |
+| Anthropic | `./anthropic` | Anthropic Messages API (Claude models; Messages-compatible proxies via `baseURL`)                                                       |
+| Google    | `./gemini`    | Google GenAI API (Gemini models)                                                                                                        |
+| DeepSeek  | `./deepseek`  | OpenAI-compatible (DeepSeek endpoint by default; any compatible endpoint via `baseURL`)                                                 |
+| Qwen      | `./qwen`      | OpenAI-compatible (DashScope endpoint by default; any compatible endpoint via `baseURL`)                                                |
+| Gemma     | `./gemma`     | OpenAI-compatible (bring your own endpoint — local or hosted)                                                                           |
+| Bytedance | `./bytedance` | OpenAI-compatible (Doubao/Ark endpoint by default)                                                                                      |
 
 ## Quick Start
 
@@ -45,6 +50,21 @@ import { OpenAIProvider } from '@robota-sdk/agent-provider/openai';
 const provider = new OpenAIProvider({ apiKey: process.env.OPENAI_API_KEY });
 ```
 
+### AI Gateway / any OpenAI-compatible endpoint
+
+Set `baseURL` on the OpenAI provider to route through a gateway or a self-hosted server. Non-OpenAI
+model slugs pass through verbatim; streaming and tool calling work over the same protocol.
+
+```typescript
+import { OpenAIProvider } from '@robota-sdk/agent-provider/openai';
+
+const provider = new OpenAIProvider({
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+  baseURL: 'https://ai-gateway.vercel.sh/v1',
+  defaultModel: 'anthropic/claude-sonnet-4-5',
+});
+```
+
 ### DeepSeek
 
 ```typescript
@@ -66,7 +86,10 @@ const provider = new GeminiProvider({ apiKey: process.env.GOOGLE_API_KEY ?? '' }
 ```typescript
 import { GemmaProvider } from '@robota-sdk/agent-provider/gemma';
 
-const provider = new GemmaProvider({ baseUrl: 'http://localhost:11434/v1', model: 'gemma3' });
+const provider = new GemmaProvider({
+  baseURL: 'http://localhost:11434/v1',
+  defaultModel: 'gemma3',
+});
 ```
 
 ## Root Export

--- a/packages/agent-provider/src/anthropic/types.ts
+++ b/packages/agent-provider/src/anthropic/types.ts
@@ -39,7 +39,11 @@ export interface IAnthropicProviderOptions {
   timeout?: number;
 
   /**
-   * API base URL
+   * API base URL (default: Anthropic's official endpoint).
+   * Point this at any Anthropic-Messages-API-compatible endpoint — e.g. a
+   * proxy/gateway that speaks the Messages protocol. For OpenAI-protocol
+   * gateways (Vercel AI Gateway, LiteLLM, OpenRouter) use the OpenAI provider's
+   * `baseURL` with a gateway model slug instead.
    */
   baseURL?: string;
 

--- a/packages/agent-provider/src/deepseek/types.ts
+++ b/packages/agent-provider/src/deepseek/types.ts
@@ -26,6 +26,11 @@ export interface IDeepSeekProviderOptions {
   [key: string]: TDeepSeekProviderOptionValue;
 
   apiKey?: string;
+  /**
+   * API base URL (default: DeepSeek's OpenAI-compatible endpoint).
+   * Any OpenAI-compatible server works — gateways (LiteLLM, OpenRouter), vLLM,
+   * Ollama, LM Studio; model ids are passed through verbatim.
+   */
   baseURL?: string;
   timeout?: number;
   defaultModel?: string;

--- a/packages/agent-provider/src/gemma/types.ts
+++ b/packages/agent-provider/src/gemma/types.ts
@@ -18,6 +18,11 @@ export interface IGemmaProviderOptions {
   [key: string]: TGemmaProviderOptionValue;
 
   apiKey?: string;
+  /**
+   * API base URL of the OpenAI-compatible endpoint serving the model.
+   * Works with gateways (LiteLLM, OpenRouter), vLLM, Ollama, LM Studio, or any
+   * other chat-completions server; model ids are passed through verbatim.
+   */
   baseURL?: string;
   timeout?: number;
   defaultModel?: string;

--- a/packages/agent-provider/src/openai/types.ts
+++ b/packages/agent-provider/src/openai/types.ts
@@ -66,7 +66,31 @@ export interface IOpenAIProviderOptions {
   timeout?: number;
 
   /**
-   * API base URL (default: 'https://api.openai.com/v1')
+   * API base URL (default: `'https://api.openai.com/v1'`).
+   *
+   * Point this at ANY OpenAI-compatible endpoint — this provider is a protocol
+   * client, not an OpenAI-vendor lock:
+   *
+   * - AI gateways: Vercel AI Gateway, LiteLLM, OpenRouter, …
+   * - Hosted compatibles: Azure OpenAI, Groq, Together, …
+   * - Local/self-hosted: vLLM, Ollama, LM Studio, …
+   *
+   * Setting `baseURL` switches the default {@link apiSurface} to
+   * `'chat-completions'` for broad endpoint compatibility (official OpenAI calls
+   * default to the Responses API). Model slugs are passed through verbatim, so
+   * gateway-namespaced ids like `anthropic/claude-sonnet-4-5` or
+   * `meta-llama/llama-3.1-70b` work as `defaultModel`/`model` values — streaming
+   * and tool calling ride the same chat-completions protocol.
+   *
+   * @example
+   * ```ts
+   * // Vercel AI Gateway with a non-OpenAI model slug
+   * createOpenAIProvider({
+   *   apiKey: process.env.AI_GATEWAY_API_KEY,
+   *   baseURL: 'https://ai-gateway.vercel.sh/v1',
+   *   defaultModel: 'anthropic/claude-sonnet-4-5',
+   * });
+   * ```
    */
   baseURL?: string;
 

--- a/packages/agent-provider/src/qwen/types.ts
+++ b/packages/agent-provider/src/qwen/types.ts
@@ -217,6 +217,11 @@ export interface IQwenProviderOptions {
   [key: string]: TQwenProviderOptionValue;
 
   apiKey?: string;
+  /**
+   * API base URL (default: DashScope's OpenAI-compatible endpoint).
+   * Any OpenAI-compatible server works — gateways (LiteLLM, OpenRouter), vLLM,
+   * Ollama, LM Studio; model ids are passed through verbatim.
+   */
   baseURL?: string;
   responsesBaseURL?: string;
   timeout?: number;

--- a/scripts/docs/prepare-docs.js
+++ b/scripts/docs/prepare-docs.js
@@ -34,12 +34,12 @@ function executeCommand(command, options = {}) {
 async function main() {
   log('🚀 Starting documentation build preparation...');
 
-  // 1. Build documentation (copy-docs.js + vitepress build + copy-public.js)
+  // 1. Build documentation (next build + pagefind index)
   log('🔨 Building documentation...');
   executeCommand('pnpm run build', { cwd: DOCS_DIR });
 
-  // 2. Check build results
-  const distDir = path.join(DOCS_DIR, '.vitepress/dist');
+  // 2. Check build results (Next.js static export output)
+  const distDir = path.join(DOCS_DIR, 'out');
   const files = fs.readdirSync(distDir);
   log(`📁 Generated files: ${files.join(', ')}`);
 


### PR DESCRIPTION
## 요약

발견성 리포트 P1/P5(오해 O1: "robota는 AI 게이트웨이를 못 쓴다")를 해결합니다. 소비자(특히 AI 에이전트)가 실제로 읽는 신뢰 순서 — `.d.ts` > tests > source > README — 의 최상단에 게이트웨이 역량을 배치합니다.

## 변경 내용

- **`IOpenAIProviderOptions.baseURL` JSDoc**: 어떤 OpenAI-호환 엔드포인트든 동작(게이트웨이/Azure/vLLM/Ollama/LM Studio), `apiSurface` 자동 전환, 모델 슬러그 verbatim 통과, Vercel AI Gateway @example — 빌드된 `.d.ts`(node+browser)에 실림을 확인.
- gemma/qwen/deepseek(OpenAI-호환 framing) + anthropic(Messages 프로토콜 framing) `baseURL`에도 미러링.
- **Provider 테이블 재구성**: 모델-벤더 나열("GPT-4o, o1, o3") → 프로토콜/엔드포인트 표면 framing (`packages/agent-provider/README.md` + `content/guide/providers.md`), 게이트웨이 예제 섹션 신설.
- 발견 결함 수정: Gemma README 예제의 잘못된 옵션명(`baseUrl`/`model` → `baseURL`/`defaultModel`; index signature 때문에 스캔이 못 잡던 것), docs 앱 Next.js 이관 후 방치된 `prepare-docs.js`의 `.vitepress/dist` 스테일 경로(→ `apps/docs/out`).

## 검증

- 빌드 산출물 `.d.ts`에서 JSDoc 확인, doc-examples 51블록 + 42 하네스 스캔 + `pnpm docs:build` green.
- **User Execution (라이브)**: 새 JSDoc 레시피만 따라 `OpenAIProvider` + OpenAI-호환 엔드포인트(DashScope compatible-mode) + 비-OpenAI 슬러그 `qwen-plus` → 스트리밍(7 deltas) + tool calling 성공. 증거는 백로그에 기록.

## 백로그

DOCS-016 done + `completed/` 이동 (같은 커밋). run/runStream 행동 계약 JSDoc은 DOCS-014 소유(중복 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj