### PR TITLE
docs: DOCS-014 adoption-path 퀵스타트 + 행동 계약 명문화

### DIFF
--- a/.agents/backlog/completed/DOCS-014-adoption-path-quickstarts-and-contracts.md
+++ b/.agents/backlog/completed/DOCS-014-adoption-path-quickstarts-and-contracts.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-014: adoption-path docs — gateway quickstart, decision-agent pattern, execution/history contracts, agent-testing positioning'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: soon
@@ -49,4 +50,25 @@ Positioning:
 - Prereq: a fresh consumer following only the new gateway quickstart.
 - Steps: set up baseURL + non-OpenAI slug per the doc; run the snippet.
 - Expected: first-try streaming + tool call success without reading source.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live, 2026-07-03).** All seven items landed with one owner each:
+  (1) gateway quickstart — `content/quickstart.md` "Through an AI gateway" block + cross-link to
+  the providers guide section (DOCS-016 landed the reference section; the quickstart now surfaces
+  it on the adoption path); (2) decision-agent pattern — `content/guide/building-agents.md`
+  "Decision agents — the tool call IS the answer" section documenting CORE-011
+  `allowToolOnlyCompletion` as the intended pattern (supersedes the execute-callback workaround)
+  with a structured-output cross-pointer; (3) `maxExecutionRounds` semantics — JSDoc on
+  `IRunOptions` (round = one model call + its requested tool executions; not a tool-count or
+  conversation limit; 0 = uncapped) + `IAgentConfig` mirror + guide "Execution rounds" section;
+  (4) run/runStream concurrency contract — guide "Concurrency" section (JSDoc/SPEC landed with
+  CORE-012); (5) history lifetime & cost — guide "History lifetime & cost" section (accumulates,
+  full history sent every call, `clearHistory()` + CORE-010 systemMessage re-injection,
+  instance-per-conversation guidance, append-only/no-edit by design); (6) `destroy()` —
+  guide "destroy()" section documenting the CURRENT sequential/throw-on-first-failure contract
+  (CORE-013 will update it when it lands); (7) `@robota-sdk/agent-testing` README created
+  (none existed): what-layer-it-tests positioning table (unit fakes vs provider-replay vs
+  real-PTY E2E), spawnPty example with the outputOffset/waitForSince cumulative-transcript
+  pitfall baked in. Live User Execution (TEST_QWEN_KEY): (A) gateway quickstart recipe —
+  OpenAI provider + compatible endpoint + non-OpenAI slug → first-try streaming (7 deltas) +
+  tool call PASS; (B) the guide's decision-agent snippet → `decision='billing'` via tool-only
+  completion PASS. doc-examples scan 52 blocks (incl. new agent-testing README), docs:build,
+  42 harness scans green.

--- a/content/guide/building-agents.md
+++ b/content/guide/building-agents.md
@@ -235,6 +235,46 @@ const response = await agent.run(
 
 These are used by `agent-framework` to assemble the CLI agent, but can also be used independently.
 
+### Decision agents — the tool call IS the answer
+
+For router/orchestrator/classifier agents, the useful output is a tool call, not prose. By default
+a turn that ends in tool calls triggers one extra model call to produce a text summary; set
+`allowToolOnlyCompletion: true` to make the tool call itself a valid completion and skip that
+one-call tax. Read the decision from your tool's executor (or the run's execution events) — the
+returned text may be empty.
+
+```typescript
+import { z } from 'zod';
+import { Robota } from '@robota-sdk/agent-core';
+import { createZodFunctionTool } from '@robota-sdk/agent-tools';
+
+let decision: string | undefined;
+const routeTool = createZodFunctionTool(
+  'route',
+  'Choose the team that should handle the ticket',
+  z.object({ team: z.enum(['billing', 'bugs', 'sales']) }),
+  async (args) => {
+    decision = String(args.team);
+    return { success: true, data: `routed to ${String(args.team)}` };
+  },
+);
+
+const router = new Robota({
+  name: 'Router',
+  aiProviders: [provider],
+  defaultModel: { provider: 'anthropic', model: 'claude-haiku-4-5' },
+  tools: [routeTool],
+});
+
+await router.run('Ticket: "I was charged twice this month."', {
+  allowToolOnlyCompletion: true,
+});
+// decision === 'billing' — no summary call was made
+```
+
+For a fixed-schema JSON answer (rather than a routing decision), prefer structured output:
+`run(prompt, { output: schema })` returns a validated typed object directly.
+
 ## Plugins
 
 Plugins hook into the agent lifecycle to add cross-cutting concerns.
@@ -332,6 +372,17 @@ const history = agent.getHistory(); // TUniversalMessage[]
 agent.clearHistory();
 ```
 
+### History lifetime & cost
+
+History **accumulates for the lifetime of the instance and the full history is sent to the
+provider on every call** — token cost grows with every turn until you act:
+
+- `clearHistory()` resets the conversation. The `systemMessage` from config is not lost — it is
+  re-applied as the log head on the next run.
+- One `Robota` instance = one conversation. For independent requests (for example one per HTTP
+  request), create an instance per conversation instead of sharing one.
+- History is append-only and read-only: there is no edit/delete API by design.
+
 ### Message State
 
 Messages have a `state` field that tracks completion:
@@ -352,6 +403,36 @@ During streaming, `ConversationStore` manages a streaming buffer internally:
 3. `commitAssistant(state, metadata)` — commits the buffer to history as a confirmed message
 
 This is a single path — both normal completion (`'complete'`) and abort (`'interrupted'`) use the same `commitAssistant` call with different state values. History is append-only and read-only; text content is always preserved. The CLI's `onTextDelta` callback is preserved as a passthrough for real-time display.
+
+## Execution Contracts
+
+Behavior guarantees of `run()`/`runStream()` that matter in production hosts.
+
+### Execution rounds
+
+A **round** is one model call plus the execution of every tool call that reply requested; a reply
+with no tool calls ends the loop (a plain Q&A turn is exactly 1 round). `maxExecutionRounds` caps
+rounds within one `run()` — it is not a tool-count limit and not a conversation-turn limit. Set it
+per run or as a config default; `0` means no cap.
+
+```typescript
+await agent.run('Research this topic and summarize.', { maxExecutionRounds: 5 });
+```
+
+### Concurrency
+
+One instance owns one conversation history, so concurrent `run()`/`runStream()` calls on the same
+instance are **serialized on an internal FIFO queue** — fire-and-forget calls are safe and always
+produce sequential history, never interleaved messages. A queued call whose `AbortSignal` fires
+while waiting throws without touching the provider or history. `runStream()` holds its queue slot
+until the stream is fully consumed. Separate instances are fully concurrent.
+
+### destroy()
+
+`destroy()` disposes modules, plugin subscriptions, and event emitters **sequentially, and throws
+on the first failing step** — steps after the failure do not run. Call it when the instance's
+lifecycle ends (server shutdown, session close); after a throw the instance should be considered
+unusable and discarded.
 
 ## Error Handling
 

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -92,6 +92,25 @@ const query = createQuery({
 
 Supported providers: Anthropic, OpenAI, Google Gemini, DeepSeek, Qwen, and any OpenAI-compatible endpoint (LM Studio, Ollama).
 
+**Through an AI gateway** (Vercel AI Gateway, LiteLLM, OpenRouter): use the OpenAI provider with the
+gateway's `baseURL` and a gateway model slug — non-OpenAI models included. Streaming and tool
+calling work first-try over the same protocol:
+
+```typescript
+import { OpenAIProvider } from '@robota-sdk/agent-provider';
+
+const query = createQuery({
+  provider: new OpenAIProvider({
+    apiKey: process.env.AI_GATEWAY_API_KEY,
+    baseURL: 'https://ai-gateway.vercel.sh/v1',
+    defaultModel: 'anthropic/claude-sonnet-4-5',
+  }),
+});
+```
+
+See [Providers Reference — Through an AI gateway](./guide/providers.md#through-an-ai-gateway) for
+LiteLLM/OpenRouter/Azure variants.
+
 ## Deploy to Vercel
 
 The starter template includes a one-click Deploy button. Set `ANTHROPIC_API_KEY` as an environment variable in the Vercel dashboard and deploy — no additional configuration needed.

--- a/packages/agent-core/src/interfaces/agent.ts
+++ b/packages/agent-core/src/interfaces/agent.ts
@@ -126,6 +126,10 @@ export interface IAgentConfig {
 
   // Performance and limits
   timeout?: number;
+  /**
+   * Default maximum execution rounds per run (round = one model call + its requested tool
+   * executions; see `IRunOptions.maxExecutionRounds` for the full semantics). 0 = no cap.
+   */
   maxExecutionRounds?: number;
   maxSameToolInputs?: number;
   retryAttempts?: number;
@@ -186,8 +190,12 @@ export interface IRunOptions {
   /** Per-run replay event callback for provider/tool execution boundaries. */
   onExecutionEvent?: TExecutionEventCallback;
   /**
-   * Maximum model/tool rounds for this run.
-   * Use 0 for no core round cap.
+   * Maximum execution rounds for this run. A **round** is one provider (model) call plus the
+   * execution of every tool call that reply requested; a reply with no tool calls ends the loop,
+   * so a plain Q&A turn is exactly 1 round. This caps model/tool cycles within ONE `run()` — it is
+   * not a tool-count limit and not a multi-turn conversation limit. When the cap is hit the run
+   * stops after the current round. Use 0 for no core round cap. Defaults to
+   * `IAgentConfig.maxExecutionRounds`.
    */
   maxExecutionRounds?: number;
   /** Max times the same tool may be called with identical input before aborting. Unset = no limit. */

--- a/packages/agent-testing/README.md
+++ b/packages/agent-testing/README.md
@@ -1,0 +1,69 @@
+# Agent Testing
+
+Test framework/environment tooling for the Robota SDK — currently a **PTY runner** that drives a
+real command (or a TSX fixture) in a genuine pseudo-terminal.
+
+## What layer does this test?
+
+This package is for **real-binary / real-terminal E2E**: your CLI or Ink UI runs in an actual PTY,
+renders real frames, and receives input keystroke-by-keystroke exactly as a user terminal delivers
+it (burst writes get bundled by terminals as a bracketed paste — the exact failure mode this
+harness exists to catch).
+
+| You want to test…                                           | Use                                                     |
+| ----------------------------------------------------------- | ------------------------------------------------------- |
+| Agent/tool/plugin logic in isolation                        | Plain vitest + hand-rolled fake providers               |
+| Deterministic agent runs without live API calls             | `@robota-sdk/agent-provider-replay` (scripted provider) |
+| A terminal app end-to-end: rendering, key input, exit codes | **this package** (`spawnPty` / `spawnPtyFixture`)       |
+
+If you are not spawning a process that draws to a terminal, you do not need this package.
+
+## Installation
+
+```bash
+npm install -D @robota-sdk/agent-testing
+```
+
+## Usage
+
+```typescript
+import { spawnPty } from '@robota-sdk/agent-testing';
+
+const session = spawnPty({
+  command: 'node',
+  args: ['./dist/cli.js', '--name', 'fixture'],
+  cwd: process.cwd(),
+});
+
+// Assert only on output that arrives AFTER a mark — the stripped output is a
+// cumulative transcript (old frames + the echo of your own typing also match).
+const mark = session.outputOffset();
+await session.sendKeys('hello');
+await session.pressEnter();
+await session.waitForSince(mark, /assistant:/i);
+
+const exitMark = session.outputOffset();
+await session.sendKeys('/exit');
+await session.pressEnter();
+const code = await session.expectExit();
+console.log(code, session.snapshotSince(exitMark));
+```
+
+`spawnPtyFixture` runs a TSX fixture through the `tsx/esm` import hook (no build step) — the
+pattern used for focused source-level E2E of Ink components.
+
+## Key session APIs
+
+| Member                               | Purpose                                                           |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `sendKeys(text)`                     | Type per-key (default 35ms/key) to avoid bracketed-paste bundling |
+| `pressEnter()` / `write(data)`       | Single keystroke / verbatim bytes for control sequences           |
+| `outputOffset()`                     | Mark the cumulative transcript before acting                      |
+| `waitForSince(mark, pattern)`        | Wait for output that arrived after the mark (ANSI-stripped)       |
+| `snapshotSince(mark)` / `snapshot()` | Stripped output after the mark / full stripped output             |
+| `expectExit()` / `raw()`             | Wait for exit with timeout / raw un-stripped output               |
+
+## Links
+
+- [npm](https://www.npmjs.com/package/@robota-sdk/agent-testing)
+- [GitHub](https://github.com/woojubb/robota)


### PR DESCRIPTION
## 요약

Speech 도입 피드백 §3.6–3.7, §5의 결론 — "기능 추가보다 이 네 가지의 계약 명문화가 다음 도입자의 경험을 가장 크게 바꿀 것" — 을 이행합니다. 7개 항목 전부 단일 소유자로 배치.

## 변경 내용

1. **게이트웨이 퀵스타트**: `content/quickstart.md`에 "Through an AI gateway" 블록 + providers 가이드 크로스링크.
2. **Decision-agent 패턴**: `building-agents.md`에 CORE-011 `allowToolOnlyCompletion`을 공식 패턴으로 문서화 (execute-callback 우회 기법 대체) + structured output 포인터.
3. **`maxExecutionRounds` 의미론**: JSDoc(IRunOptions/IAgentConfig) — round = 모델 호출 1회 + 그 응답이 요청한 tool 실행 전부; tool-count/대화-턴 제한이 아님 — + 가이드 섹션.
4. **동시성 계약**: 가이드 "Concurrency" 섹션 (JSDoc/SPEC은 CORE-012에서 완료).
5. **히스토리 수명·비용**: 누적 + 매 호출 전체 전송, `clearHistory()` + systemMessage 재주입, 대화당 인스턴스 권장, append-only by design.
6. **`destroy()` 계약**: 현재 동작(순차 정리, 첫 실패에서 throw) 명문화 — CORE-013이 landing하면 갱신.
7. **agent-testing README 신설** (기존에 없었음): 계층 포지셔닝 표(unit fake / provider-replay / real-PTY E2E) + cumulative-transcript 함정이 반영된 spawnPty 예제.

## 검증

- doc-examples 스캔 52블록(신규 agent-testing README 포함) + docs:build + 42 하네스 스캔 green.
- **User Execution (라이브, TEST_QWEN_KEY)**: (A) 게이트웨이 퀵스타트 레시피 → first-try 스트리밍(7 deltas)+tool call PASS, (B) 가이드의 decision-agent 스니펫 → tool-only completion으로 `decision='billing'` PASS.

## 백로그

DOCS-014 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj