### PR TITLE
docs: DOCS-017 루트 llms.txt 소비자 에이전트 맵 + link-rot 스캔

### DIFF
--- a/.agents/backlog/HARNESS-021-background-workspace-conformance-test-drift.md
+++ b/.agents/backlog/HARNESS-021-background-workspace-conformance-test-drift.md
@@ -1,0 +1,41 @@
+---
+title: 'HARNESS-021: check-background-workspace-conformance unit tests drifted — 5/5 failing on develop'
+status: todo
+created: 2026-07-03
+priority: medium
+urgency: soon
+area: scripts/harness
+depends_on: []
+---
+
+# background-workspace-conformance test drift
+
+Found during DOCS-017 (2026-07-03): `pnpm exec vitest run
+scripts/harness/__tests__/check-background-workspace-conformance.test.mjs` fails 5/5 **on a clean
+develop tree** (verified via `git stash` → rerun → same failures). Every assertion receives MORE
+findings than expected — the scan appears to emit extra finding entries against the test fixtures
+(likely scanner logic or fixture drift after a HARNESS-011-era refactor), so either the scan is
+over-reporting in production too, or the tests no longer describe its intended contract.
+
+Not caught earlier because the root `pnpm test` runs per-package suites only; the
+`scripts/harness/__tests__/` suite runs via `verify-change.mjs` selection, which only includes
+files listed for the touched scan — a full-suite run of this directory is not on any green path.
+
+## What
+
+1. Diagnose: run the failing tests, diff actual vs expected findings, decide which side drifted
+   (scan over-reporting = fix scan; contract change = fix tests).
+2. Fix the drifted side; all 5 green.
+3. Consider adding the harness test directory to a blocking path (CI or pre-push) so suite-wide
+   drift cannot sit silent again — mechanism over prose.
+
+## Test Plan
+
+- `pnpm exec vitest run scripts/harness/__tests__/` fully green; harness scan output unchanged for
+  a clean tree (or intentionally corrected, documented in the scan header).
+
+## User Execution Test Scenarios
+
+- Not applicable beyond the mechanical suite run (dev-tooling fix); evidence = green run recorded
+  at implementation.
+- Evidence: _to fill at implementation._

--- a/.agents/backlog/completed/DOCS-017-llms-txt-consumer-map.md
+++ b/.agents/backlog/completed/DOCS-017-llms-txt-consumer-map.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-017: root llms.txt — a consumer-agent map (identity, minimal set, capability matrix, behavior contracts)'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: soon
@@ -45,4 +46,20 @@ listed paths exist (same class as the done-evidence path check) prevents rot.
 - Steps: let it read llms.txt first; record its conclusions.
 - Expected: no O1/O2-class misunderstanding — it identifies the library-collection identity, the
   3-package minimal set, and gateway support without user correction.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live fresh-agent run, 2026-07-03).** Root `llms.txt` written per the report's
+  outline as a thin index (identity one-liner killing O2; 3-package minimal embedding set;
+  capability matrix with owner-doc links incl. gateway-via-baseURL, structured output,
+  maxExecutionRounds; behavior contracts linking SPEC/guide sections from CORE-011/012 +
+  DOCS-014; type/example paths — facts stay in owner docs, no duplication). Rot prevention
+  mechanized: new `llms-txt` harness scan (`scripts/harness/check-llms-txt.mjs`) fails on a
+  missing file or any dangling repo-relative markdown link (21 links resolve; registered in
+  run-all-scans — 43 scans total — + verify-change test selection + 4 unit tests). User
+  Execution: a FRESH agent session (no prior repo knowledge, AGENTS.md/CLAUDE.md forbidden)
+  was given the report's exact task class ("evaluate robota for embedded orchestration via
+  Vercel AI Gateway with anthropic/\* slugs") with llms.txt as the entry point — its recorded
+  conclusions: identity = "not a coding-agent product... library collection; agent-cli is
+  merely a reference app" (no O2), minimal set = the exact 3 packages, gateway = "yes —
+  protocol client, not a vendor lock" citing the baseURL JSDoc + providers guide (no O1),
+  verdict "Suitable". Zero misunderstandings, zero user corrections. Side discovery filed
+  separately: HARNESS-021 (background-workspace-conformance unit tests 5/5 failing on clean
+  develop — pre-existing, out of this item's scope).

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,40 @@
+# Robota SDK
+
+> A composable TypeScript **library collection** for building AI agents — strict types,
+> multi-provider, plugin/event architecture. It is not a coding-agent product:
+> `@robota-sdk/agent-cli` is a reference app assembled FROM these libraries, and you embed the
+> libraries directly the same way.
+
+This file is a map for agent consumers evaluating or embedding robota. Facts live in their owner
+documents — follow the links; do not infer capabilities from package counts or quickstart defaults.
+(`AGENTS.md`/`CLAUDE.md` are contributor-harness docs, not consumer docs.)
+
+## Minimal embedding set
+
+Three packages; the other `@robota-sdk/*` packages are optional assembly on top of them.
+
+- [packages/agent-core/README.md](packages/agent-core/README.md): `Robota` class — `run`/`runStream`, conversation history, plugins, structured output
+- [packages/agent-provider/README.md](packages/agent-provider/README.md): providers as protocol clients (OpenAI / Anthropic Messages / Google GenAI surfaces)
+- [packages/agent-tools/README.md](packages/agent-tools/README.md): zod-validated function tools + built-in CLI tools
+
+## Capabilities
+
+- **OpenAI-compatible gateway via `baseURL`** — any gateway (Vercel AI Gateway, LiteLLM, OpenRouter), Azure, vLLM, Ollama, LM Studio; non-OpenAI model slugs pass through verbatim; streaming + tool calling included. Owner JSDoc: [packages/agent-provider/src/openai/types.ts](packages/agent-provider/src/openai/types.ts); guide: [content/guide/providers.md](content/guide/providers.md)
+- **Streaming** — `runStream()` or per-run `onTextDelta`: [content/guide/building-agents.md](content/guide/building-agents.md)
+- **Schema-enforced structured output** — `run(prompt, { output: zodSchema })` returns a validated typed object with provider-native mapping + bounded retry: [packages/agent-core/docs/SPEC.md](packages/agent-core/docs/SPEC.md) § Structured Output Contract
+- **Runtime tool validation** — zod schemas validate tool args before executors run: [packages/agent-tools/README.md](packages/agent-tools/README.md)
+- **Step control** — `maxExecutionRounds` (a round = one model call + its requested tool executions): [content/guide/building-agents.md](content/guide/building-agents.md) § Execution Contracts
+- **Real-terminal E2E testing** — PTY runner: [packages/agent-testing/README.md](packages/agent-testing/README.md)
+
+## Behavior contracts
+
+- **Run concurrency** — per-instance FIFO serialization; concurrent `run()` calls never interleave history: [packages/agent-core/docs/SPEC.md](packages/agent-core/docs/SPEC.md) § Run Concurrency Contract
+- **History lifetime & cost** — append-only, full history sent every call; `clearHistory()` resets, systemMessage re-applies: [content/guide/building-agents.md](content/guide/building-agents.md) § History lifetime & cost
+- **`destroy()`** — sequential cleanup, throws on first failing step: [content/guide/building-agents.md](content/guide/building-agents.md) § Execution Contracts
+- **Tool-only turns** — `allowToolOnlyCompletion: true` makes a tool call a valid completion (decision agents, no summary-call tax): [content/guide/building-agents.md](content/guide/building-agents.md) § Decision agents
+
+## Types & examples
+
+- Type declarations ship inside each npm package (`dist/**/*.d.ts`) — the hover docs above are in them. Repo sources: [packages/agent-core/src/index.ts](packages/agent-core/src/index.ts), [packages/agent-provider/src/index.ts](packages/agent-provider/src/index.ts), [packages/agent-tools/src/index.ts](packages/agent-tools/src/index.ts)
+- Quickstart: [content/quickstart.md](content/quickstart.md) (includes the AI-gateway path)
+- Runnable examples: [examples/express](examples/express), [examples/discord-bot](examples/discord-bot), [examples/batch-processor](examples/batch-processor)

--- a/scripts/harness/__tests__/check-llms-txt.test.mjs
+++ b/scripts/harness/__tests__/check-llms-txt.test.mjs
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractLocalLinks } from '../check-llms-txt.mjs';
+
+describe('extractLocalLinks', () => {
+  it('extracts repo-relative markdown link targets', () => {
+    const markdown =
+      '- [core](packages/agent-core/README.md): x\n- [guide](content/guide/providers.md)';
+    expect(extractLocalLinks(markdown)).toEqual([
+      'packages/agent-core/README.md',
+      'content/guide/providers.md',
+    ]);
+  });
+
+  it('ignores http(s) links and pure anchors', () => {
+    const markdown = '[npm](https://npmjs.com/x) [sec](#section) [ok](llms.txt)';
+    expect(extractLocalLinks(markdown)).toEqual(['llms.txt']);
+  });
+
+  it('strips anchor fragments from local targets', () => {
+    expect(extractLocalLinks('[spec](packages/agent-core/docs/SPEC.md#run-concurrency)')).toEqual([
+      'packages/agent-core/docs/SPEC.md',
+    ]);
+  });
+
+  it('returns an empty list when there are no links', () => {
+    expect(extractLocalLinks('# no links here')).toEqual([]);
+  });
+});

--- a/scripts/harness/check-llms-txt.mjs
+++ b/scripts/harness/check-llms-txt.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * llms.txt link-rot scan (DOCS-017).
+ *
+ * The root `llms.txt` is the consumer-agent map (llmstxt.org convention): a thin index whose value
+ * is entirely in its links. A moved/renamed owner document silently turns the map into the exact
+ * misdirection it was written to prevent, so every repo-relative markdown link in it must resolve.
+ *
+ * Findings:
+ *   - llms.txt missing at the repository root
+ *   - a markdown link target (non-http) that does not exist on disk
+ *
+ * Exit code 0 = map is intact, 1 = missing file or dangling link.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const LLMS_TXT = 'llms.txt';
+
+const LINK_PATTERN = /\[[^\]]*\]\(([^)]+)\)/g;
+
+/** Extract repo-relative link targets (http(s) and anchors are out of scope). */
+export function extractLocalLinks(markdown) {
+  const targets = [];
+  for (const match of markdown.matchAll(LINK_PATTERN)) {
+    const target = match[1].trim();
+    if (/^https?:\/\//.test(target) || target.startsWith('#')) continue;
+    targets.push(target.split('#')[0]);
+  }
+  return targets;
+}
+
+export async function main() {
+  const filePath = path.join(WORKSPACE_ROOT, LLMS_TXT);
+  let markdown;
+  try {
+    markdown = await fs.readFile(filePath, 'utf8');
+  } catch {
+    // allow-fallback: absence of the map file IS the finding this scan reports
+    process.stdout.write(`llms-txt scan failed: ${LLMS_TXT} is missing at the repository root.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const dangling = [];
+  const targets = extractLocalLinks(markdown);
+  for (const target of targets) {
+    try {
+      await fs.access(path.join(WORKSPACE_ROOT, target));
+    } catch {
+      // allow-fallback: a non-resolving path IS the finding this scan reports
+      dangling.push(target);
+    }
+  }
+
+  if (dangling.length > 0) {
+    process.stdout.write('llms-txt scan failed — dangling links in llms.txt:\n');
+    for (const target of dangling) {
+      process.stdout.write(`  - ${target}\n`);
+    }
+    process.stdout.write('Update the link to the moved/renamed owner document.\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(`llms-txt scan passed (${targets.length} links resolve).\n`);
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -82,6 +82,7 @@ const SCAN_COMMANDS = [
   { name: 'test-module-mocks', command: ['node', 'scripts/harness/check-test-module-mocks.mjs'] },
   { name: 'backlog-placement', command: ['node', 'scripts/harness/check-backlog-placement.mjs'] },
   { name: 'doc-examples', command: ['node', 'scripts/harness/check-doc-examples.mjs'] },
+  { name: 'llms-txt', command: ['node', 'scripts/harness/check-llms-txt.mjs'] },
   { name: 'orphan-exports', command: ['node', 'scripts/harness/check-orphan-exports.mjs'] },
   { name: 'deps', command: ['node', 'scripts/harness/check-dependency-direction.mjs'] },
   {

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -67,6 +67,7 @@ function runRepositoryCheck(check, dryRun) {
           'scripts/harness/__tests__/check-test-module-mocks.test.mjs',
           'scripts/harness/__tests__/check-backlog-placement.test.mjs',
           'scripts/harness/__tests__/check-doc-examples.test.mjs',
+          'scripts/harness/__tests__/check-llms-txt.test.mjs',
         ],
         WORKSPACE_ROOT,
         dryRun,


### PR DESCRIPTION
## 요약

발견성 리포트 §2(P2)를 이행합니다. 라이브러리 평가는 이제 AI 에이전트가 수행하며, 그 에이전트의 첫 프로브(`ls packages/` → 41개 플랫 패키지, README 퀵스타트)가 오해 O1/O2를 만들었습니다. 루트 `llms.txt`(llmstxt.org 규약)가 그 오류 유발 경로를 대체합니다.

## 변경 내용

- **`llms.txt`**: 정체성 한 줄(O2 차단: 라이브러리 컬렉션, agent-cli는 레퍼런스 앱) / 최소 임베딩 3종 세트 / 역량 매트릭스(gateway baseURL·structured output·step control, owner 문서 링크) / 행동 계약(CORE-011/012 + DOCS-014 산출물 링크) / 타입·예제 경로. 사실은 owner 문서에만 — thin index.
- **rot 방지 기계화**: 신규 `llms-txt` 하네스 스캔 — 파일 부재/깨진 상대링크에서 실패 (21개 링크 검증, run-all-scans 등록으로 총 43개 스캔, verify-change 연결 + 단위 테스트 4개).

## 검증 (User Execution — 리포트의 시나리오 그대로)

리포지토리 사전 지식이 없는 **신선한 에이전트 세션**에 llms.txt를 입구로 리포트와 동일한 평가 과제("Vercel AI Gateway + anthropic/* 슬러그로 임베디드 오케스트레이션 평가")를 실행:
- 정체성: "not a coding-agent product — library collection; agent-cli is merely a reference app" (O2 없음)
- 최소 세트: 정확히 3개 패키지 식별
- 게이트웨이: "protocol client, not a vendor lock" — baseURL JSDoc + providers 가이드 인용 (O1 없음)
- 평결: Suitable. **사용자 교정 0회.** 전체 기록은 백로그 evidence에.

## 부수 발견

HARNESS-021 신규 백로그: `check-background-workspace-conformance` 단위 테스트가 클린 develop에서 5/5 실패(기존 결함, 이 PR 범위 밖 — 진단·수정·차단 경로 편입 필요).

## 백로그

DOCS-017 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj