### PR TITLE
feat(agent-session): ROOM-001 공유 트랜스크립트 멀티에이전트 Room primitive

### DIFF
--- a/.agents/backlog/completed/ROOM-001-shared-transcript-multi-agent-room.md
+++ b/.agents/backlog/completed/ROOM-001-shared-transcript-multi-agent-room.md
@@ -1,6 +1,7 @@
 ---
 title: 'ROOM-001: shared-transcript multi-agent Room primitive with a turn-selection hook'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: later
@@ -48,4 +49,24 @@ scope/priority at GATE-APPROVAL before design.
 - Prereq: consumer script assembling a room with 2 personas + 1 director (scripted or real provider).
 - Steps: run a 3-round exchange; dump the shared transcript.
 - Expected: one coherent transcript with correctly attributed speakers in director-chosen order.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (live, 2026-07-03).** GATE-APPROVAL: 사용자 승인 "설계+최소 코어 구현";
+  placement re-proposed per user direction (new agent-room package felt duplicative) and
+  re-confirmed as `packages/agent-session/src/room/` — agent-session now owns BOTH conversation
+  primitives (SPEC Scope rewritten first, spec-first). Design confirmed then implemented:
+  `Room` (shared transcript = core `ConversationStore`, append-only, speaker attribution via
+  `metadata.speaker`; `join`/`leave` with unique-name rules; `say()` for external turns;
+  sequential `run` loop with `maxTurns` safety cap, abort signal, unknown-speaker throw, one
+  run at a time) + `ITurnSelector` with `createRoundRobinSelector` (own scheduled counter —
+  external turns don't consume rounds), `createCallbackSelector`, `createDirectorSelector`
+  (decision via CORE-015 structured output constrained to members+END — supersedes the
+  CORE-011 tool workaround the backlog referenced, per CORE-015's own spec). Composition:
+  members pair with `retainHistory:false` (CORE-014); transcript re-rendered per turn (the
+  speech project's hand-rolled pattern made first-class). Unit/functional: 7 tests incl. the
+  deterministic 3-agent 6-turn round-robin exchange with fan-in ordering asserted per turn
+  ("saw N turns"), selector view growth, cap, attribution on store messages — agent-session
+  83/83 green; repo typecheck + 43 scans + doc-examples (53 blocks, incl. new README Room
+  example) green. Docs: SPEC "Room Contract" section, README Room section, llms.txt
+  capability line. Live User Execution (real Anthropic haiku): 2 personas + 1 director,
+  director-ordered debate — 4 coherent alternating turns (optimist/skeptic), both spoke,
+  END honored, store attribution intact. Follow-ons (unfiled by design, listed as non-goals):
+  transport fan-out, transcript persistence, mid-run join, parallel rooms.

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@ Three packages; the other `@robota-sdk/*` packages are optional assembly on top 
 - **Schema-enforced structured output** — `run(prompt, { output: zodSchema })` returns a validated typed object with provider-native mapping + bounded retry: [packages/agent-core/docs/SPEC.md](packages/agent-core/docs/SPEC.md) § Structured Output Contract
 - **Runtime tool validation** — zod schemas validate tool args before executors run: [packages/agent-tools/README.md](packages/agent-tools/README.md)
 - **Step control** — `maxExecutionRounds` (a round = one model call + its requested tool executions): [content/guide/building-agents.md](content/guide/building-agents.md) § Execution Contracts
+- **Multi-agent rooms** — N agents on one shared append-only transcript with pluggable turn selection (round-robin / callback / Director agent): [packages/agent-session/README.md](packages/agent-session/README.md) § Room
 - **Real-terminal E2E testing** — PTY runner: [packages/agent-testing/README.md](packages/agent-testing/README.md)
 
 ## Behavior contracts

--- a/packages/agent-session/README.md
+++ b/packages/agent-session/README.md
@@ -107,6 +107,51 @@ Note: `IPermissionEnforcerOptions` is an internal type and is not exported from 
 
 - **`Robota`** (agent-core): Raw agent — conversation + tools + plugins. No permissions, no hooks.
 - **`Session`** (this package): Wraps Robota with permissions, hooks, compaction, and persistence. Used by the CLI and SDK.
+- **`Room`** (this package): The multi-agent sibling — see below.
+
+## Room — shared-transcript multi-agent primitive
+
+N agents contribute **sequentially to one shared append-only transcript**, with a pluggable
+"who speaks next" policy — the opposite composition from subagents (isolation/parallel). Per-agent
+execution stays `Robota`; the room owns transcript fan-in and turn scheduling. Pair members with
+`retainHistory: false` — the room re-renders the transcript into every turn's input.
+
+```typescript
+import { Robota } from '@robota-sdk/agent-core';
+import { Room, createDirectorSelector, createRoundRobinSelector } from '@robota-sdk/agent-session';
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+declare const provider: IAIProvider;
+
+const makePersona = (name: string, persona: string) =>
+  new Robota({
+    name,
+    aiProviders: [provider],
+    defaultModel: { provider: provider.name, model: 'claude-haiku-4-5' },
+    systemMessage: persona,
+    retainHistory: false,
+  });
+
+const room = new Room({ topic: 'Should tests run before or after review?' });
+room.join({ name: 'optimist', agent: makePersona('optimist', 'You argue for benefits.') });
+room.join({ name: 'skeptic', agent: makePersona('skeptic', 'You probe for risks.') });
+
+// Deterministic policy…
+const transcript = await room.run({ selector: createRoundRobinSelector(2) });
+
+// …or a Director agent that picks the next speaker via structured output (or ends the talk)
+const director = makePersona('director', 'You moderate the debate.');
+await room.run({ selector: createDirectorSelector(director), maxTurns: 6 });
+
+for (const turn of transcript) {
+  console.log(`${turn.speaker}: ${turn.content}`);
+}
+```
+
+Selectors: `createRoundRobinSelector(rounds)` (join order; external `room.say()` turns do not
+consume rounds), `createCallbackSelector(fn)`, `createDirectorSelector(directorAgent)`. The
+selector returning `null` ends the run; `maxTurns` (default 20) is a safety cap. An unknown
+speaker name throws. See `docs/SPEC.md` § Room Contract for the full behavior contract.
 
 ### ISessionRecord
 

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -2,7 +2,16 @@
 
 ## Scope
 
-Owns the CLI session lifecycle for the Robota SDK. This package provides the `Session` class that wraps a `Robota` agent instance with permission-gated tool execution, hook-based lifecycle events, context window tracking, conversation compaction, and optional JSON file persistence via `SessionStore`. It is the primary runtime used by the CLI application (`agent-cli`) via the assembly layer (`agent-framework`).
+Owns the **conversation primitives** for the Robota SDK — two siblings:
+
+1. **`Session`** (single-agent): wraps a `Robota` agent instance with permission-gated tool
+   execution, hook-based lifecycle events, context window tracking, conversation compaction, and
+   optional JSON file persistence via `SessionStore`. The primary runtime used by the CLI
+   application (`agent-cli`) via the assembly layer (`agent-framework`).
+2. **`Room`** (multi-agent, ROOM-001): N agents contributing sequentially to ONE shared
+   append-only transcript with a pluggable turn-selection policy — the opposite composition from
+   subagents (isolation/parallel). A sibling primitive, not a rewrite: per-agent execution stays
+   `Robota`; the room owns transcript fan-in and turn scheduling. See the Room Contract section.
 
 ## Boundaries
 
@@ -367,6 +376,30 @@ No formal interface implementations. `PermissionEnforcer`, `ContextWindowTracker
 | `runHooks` (agent-core)           | `PermissionEnforcer`     | `src/permission-enforcer.ts`     |
 | `runHooks` (agent-core)           | `Session`                | `src/session.ts` (PostCompact)   |
 | `runHooks` (agent-core)           | `CompactionOrchestrator` | `src/compaction-orchestrator.ts` |
+
+## Room Contract (ROOM-001)
+
+Shared-transcript multi-agent primitive (`src/room/`). Minimal core; transport fan-out,
+transcript persistence, mid-run join/leave, and parallel rooms are tracked follow-ons.
+
+- **Transcript**: a core `ConversationStore` (append-only rule applies). Every committed turn is
+  an assistant message with `metadata.speaker` attribution; `getTranscript()` returns the
+  attributed view (`IRoomTranscriptEntry[]`), `getTranscriptMessages()` the raw store messages.
+- **Members**: unique names; `join` on an existing name and `leave` of an absent name throw.
+  Leaving keeps past turns (append-only).
+- **Turn loop** (`run`): strictly sequential — `selector.next(view)` picks a member name or
+  `null` to end; the room renders the transcript into the speaker's run input (persona + topic +
+  `name: content` log + speak-as instruction) and commits the response with attribution.
+  `maxTurns` (default 20) is a safety cap over the selector's termination; `signal` is checked
+  before each turn; an unknown speaker from the selector throws (no fallback). One `run` at a
+  time per room; `say(speaker, content)` appends an externally-produced turn (e.g. human input).
+- **Selectors**: `createRoundRobinSelector(rounds)` (join order), `createCallbackSelector(fn)`,
+  `createDirectorSelector(directorAgent)` — the director decides via CORE-015 schema-enforced
+  structured output constrained to member names + `END` (supersedes the CORE-011 tool-call
+  decision workaround referenced in the original backlog).
+- **Composition**: pair member/director agents with `retainHistory: false` (CORE-014) — the room
+  re-renders the shared transcript into every turn input, so instance history would duplicate it.
+  CORE-012's per-instance run queue keeps an agent reused across rooms serialized.
 
 ## Test Strategy
 

--- a/packages/agent-session/src/__tests__/room.test.ts
+++ b/packages/agent-session/src/__tests__/room.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Room — shared-transcript multi-agent primitive (ROOM-001).
+ *
+ * Covers: transcript fan-in ordering + attribution, turn-selector invocation order,
+ * join/leave rules, the deterministic 3-agent / 6-turn scripted exchange (functional row
+ * of the backlog test plan), and the unknown-speaker no-fallback throw.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { AbstractAIProvider, Robota } from '@robota-sdk/agent-core';
+import { Room } from '../room/room.js';
+import { createCallbackSelector, createRoundRobinSelector } from '../room/turn-selector.js';
+
+import type { IChatOptions, TUniversalMessage } from '@robota-sdk/agent-core';
+
+/** Provider that answers with a fixed prefix + the count of transcript lines it was shown. */
+class ScriptedSpeakerProvider extends AbstractAIProvider {
+  readonly name = 'scripted-speaker';
+  readonly version = '1.0.0';
+  constructor(private readonly speakerTag: string) {
+    super();
+  }
+  async chat(messages: TUniversalMessage[], _options?: IChatOptions): Promise<TUniversalMessage> {
+    const input = String(messages[messages.length - 1]?.content ?? '');
+    const seenTurns = input
+      .split('\n')
+      .filter((line) => /^(alice|bob|carol|human): /.test(line)).length;
+    return {
+      id: `m-${Math.random().toString(36).slice(2)}`,
+      role: 'assistant',
+      content: `${this.speakerTag} speaks (saw ${seenTurns} turns)`,
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+  }
+  override async *chatStream(): AsyncIterable<TUniversalMessage> {
+    yield await this.chat([]);
+  }
+}
+
+function makeAgent(tag: string): Robota {
+  return new Robota({
+    name: `agent-${tag}`,
+    aiProviders: [new ScriptedSpeakerProvider(tag)],
+    defaultModel: { provider: 'scripted-speaker', model: 'scripted' },
+    retainHistory: false,
+    logging: { level: 'silent', enabled: false },
+  });
+}
+
+describe('Room (ROOM-001)', () => {
+  it('completes a deterministic 3-agent, 6-turn round-robin exchange on one shared transcript', async () => {
+    const room = new Room({ topic: 'test exchange' });
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+    room.join({ name: 'bob', agent: makeAgent('bob') });
+    room.join({ name: 'carol', agent: makeAgent('carol') });
+
+    const transcript = await room.run({ selector: createRoundRobinSelector(2) });
+
+    expect(transcript).toHaveLength(6);
+    expect(transcript.map((t) => t.speaker)).toEqual([
+      'alice',
+      'bob',
+      'carol',
+      'alice',
+      'bob',
+      'carol',
+    ]);
+    // Fan-in ordering: each speaker saw exactly the turns committed before its own.
+    transcript.forEach((entry, index) => {
+      expect(entry.content).toBe(`${entry.speaker} speaks (saw ${index} turns)`);
+    });
+    // Attribution rides the append-only store messages.
+    const stored = room.getTranscriptMessages();
+    expect(stored).toHaveLength(6);
+    expect(stored.map((m) => m.metadata?.speaker)).toEqual([
+      'alice',
+      'bob',
+      'carol',
+      'alice',
+      'bob',
+      'carol',
+    ]);
+  });
+
+  it('invokes the selector with a growing view and stops on null', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+    const seenCounts: number[] = [];
+
+    await room.run({
+      selector: createCallbackSelector((view) => {
+        seenCounts.push(view.turnCount);
+        return view.turnCount >= 2 ? null : 'alice';
+      }),
+    });
+
+    expect(seenCounts).toEqual([0, 1, 2]);
+    expect(room.getTranscript()).toHaveLength(2);
+  });
+
+  it('enforces the maxTurns safety cap over a never-ending selector', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+
+    const transcript = await room.run({
+      selector: createCallbackSelector(() => 'alice'),
+      maxTurns: 3,
+    });
+
+    expect(transcript).toHaveLength(3);
+  });
+
+  it('throws (no fallback) when the selector picks an unknown speaker', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+
+    await expect(room.run({ selector: createCallbackSelector(() => 'mallory') })).rejects.toThrow(
+      'unknown speaker "mallory"',
+    );
+  });
+
+  it('join rejects duplicate names; leave rejects absent names; leaving keeps past turns', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+    expect(() => room.join({ name: 'alice', agent: makeAgent('alice') })).toThrow('already joined');
+
+    await room.run({ selector: createRoundRobinSelector(1) });
+    room.leave('alice');
+    expect(() => room.leave('alice')).toThrow('not in the room');
+    expect(room.getTranscript()).toHaveLength(1);
+    expect(room.getMembers()).toEqual([]);
+  });
+
+  it('say() appends an externally-produced turn with attribution', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+    room.say('human', 'Hello everyone');
+
+    const transcript = await room.run({ selector: createRoundRobinSelector(1) });
+
+    expect(transcript.map((t) => t.speaker)).toEqual(['human', 'alice']);
+    // Alice saw the human turn.
+    expect(transcript[1].content).toBe('alice speaks (saw 1 turns)');
+  });
+
+  it('rejects concurrent run() on the same room', async () => {
+    const room = new Room();
+    room.join({ name: 'alice', agent: makeAgent('alice') });
+
+    const first = room.run({ selector: createRoundRobinSelector(1) });
+    await expect(room.run({ selector: createRoundRobinSelector(1) })).rejects.toThrow(
+      'already in progress',
+    );
+    await first;
+  });
+});

--- a/packages/agent-session/src/index.ts
+++ b/packages/agent-session/src/index.ts
@@ -50,3 +50,20 @@ export type {
 // Session persistence
 export { SessionStore } from './session-store.js';
 export type { ISessionRecord, ISessionStore } from './session-store.js';
+
+// Room — shared-transcript multi-agent primitive (ROOM-001)
+export { Room } from './room/room.js';
+export {
+  createRoundRobinSelector,
+  createCallbackSelector,
+  createDirectorSelector,
+} from './room/turn-selector.js';
+export type {
+  IRoomMember,
+  IRoomOptions,
+  IRoomRunOptions,
+  IRoomTranscriptEntry,
+  IRoomView,
+  ITurnSelector,
+} from './room/types.js';
+export type { IDirectorSelectorOptions } from './room/turn-selector.js';

--- a/packages/agent-session/src/room/room.ts
+++ b/packages/agent-session/src/room/room.ts
@@ -1,0 +1,143 @@
+/**
+ * Room — shared-transcript multi-agent primitive (ROOM-001).
+ *
+ * Design: the shared transcript is a core `ConversationStore` (append-only rule applies;
+ * speaker attribution rides `metadata.speaker`). Each turn the room renders the transcript
+ * into a conversation log and passes it as the speaking agent's run input — the reference
+ * pattern the speech project hand-rolled (reconstruct context per call), made first-class.
+ */
+
+import { ConversationStore } from '@robota-sdk/agent-core';
+
+import type {
+  IRoomMember,
+  IRoomOptions,
+  IRoomRunOptions,
+  IRoomTranscriptEntry,
+  IRoomView,
+} from './types.js';
+
+const DEFAULT_MAX_TURNS = 20;
+const DEFAULT_MAX_TRANSCRIPT_MESSAGES = 1000;
+
+export class Room {
+  private readonly members = new Map<string, IRoomMember>();
+  private readonly store: ConversationStore;
+  private readonly entries: IRoomTranscriptEntry[] = [];
+  private readonly topic: string | undefined;
+  private running = false;
+
+  constructor(options: IRoomOptions = {}) {
+    this.topic = options.topic;
+    this.store = new ConversationStore(
+      options.maxTranscriptMessages ?? DEFAULT_MAX_TRANSCRIPT_MESSAGES,
+    );
+  }
+
+  /** Add a participant. Names are unique — joining an existing name is an error. */
+  join(member: IRoomMember): void {
+    if (this.members.has(member.name)) {
+      throw new Error(`Room: member "${member.name}" already joined`);
+    }
+    this.members.set(member.name, member);
+  }
+
+  /** Remove a participant. The transcript keeps their past turns (append-only). */
+  leave(name: string): void {
+    if (!this.members.delete(name)) {
+      throw new Error(`Room: member "${name}" is not in the room`);
+    }
+  }
+
+  getMembers(): string[] {
+    return Array.from(this.members.keys());
+  }
+
+  /** Attributed transcript so far (copy). */
+  getTranscript(): IRoomTranscriptEntry[] {
+    return [...this.entries];
+  }
+
+  /** The underlying append-only store messages (id/timestamp/metadata.speaker). */
+  getTranscriptMessages() {
+    return this.store.getMessages();
+  }
+
+  private view(): IRoomView {
+    return {
+      transcript: [...this.entries],
+      members: this.getMembers(),
+      turnCount: this.entries.length,
+    };
+  }
+
+  /**
+   * Run the sequential turn loop: selector picks a speaker (or `null` to end), the speaker's
+   * agent runs on the rendered transcript, and the response is committed to the shared
+   * transcript with speaker attribution. Turns are strictly sequential by construction.
+   */
+  async run(options: IRoomRunOptions): Promise<IRoomTranscriptEntry[]> {
+    if (this.running) {
+      throw new Error('Room: run() is already in progress on this room');
+    }
+    this.running = true;
+    try {
+      const maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS;
+      for (let turn = 0; turn < maxTurns; turn++) {
+        if (options.signal?.aborted) break;
+        const speaker = await options.selector.next(this.view());
+        if (speaker === null) break;
+        const member = this.members.get(speaker);
+        if (!member) {
+          throw new Error(
+            `Room: selector picked unknown speaker "${speaker}" (members: ${this.getMembers().join(', ')})`,
+          );
+        }
+        const content = await member.agent.run(this.renderTurnInput(member), {
+          ...(options.signal && { signal: options.signal }),
+        });
+        const entry = this.commitTurn(member.name, content);
+        options.onTurn?.(entry);
+      }
+      return this.getTranscript();
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Append an externally-produced turn (e.g. a human message) to the shared transcript. */
+  say(speaker: string, content: string): IRoomTranscriptEntry {
+    return this.commitTurn(speaker, content);
+  }
+
+  private commitTurn(speaker: string, content: string): IRoomTranscriptEntry {
+    this.store.addAssistantMessage(content, [], { speaker });
+    const messages = this.store.getMessages();
+    const message = messages[messages.length - 1];
+    const entry: IRoomTranscriptEntry = { speaker, content, message };
+    this.entries.push(entry);
+    return entry;
+  }
+
+  /** Render the shared transcript into the speaking agent's turn input. */
+  private renderTurnInput(member: IRoomMember): string {
+    const lines: string[] = [];
+    lines.push(`You are "${member.name}" in a multi-party conversation.`);
+    if (member.persona) lines.push(member.persona);
+    if (this.topic) lines.push(`Topic: ${this.topic}`);
+    lines.push('');
+    if (this.entries.length === 0) {
+      lines.push('The conversation has not started yet — you speak first.');
+    } else {
+      lines.push('Conversation so far:');
+      for (const entry of this.entries) {
+        lines.push(`${entry.speaker}: ${entry.content}`);
+      }
+    }
+    lines.push('');
+    lines.push(
+      `Respond with your next contribution as "${member.name}". Reply with the message content only — no name prefix.`,
+    );
+    return lines.join('\n');
+  }
+}

--- a/packages/agent-session/src/room/turn-selector.ts
+++ b/packages/agent-session/src/room/turn-selector.ts
@@ -1,0 +1,99 @@
+/**
+ * Built-in turn-selection policies (ROOM-001).
+ *
+ * The Director selector uses schema-enforced structured output (CORE-015) rather than the
+ * tool-call decision workaround — the ROOM-001 backlog's CORE-011 reference predates
+ * CORE-015, whose own spec supersedes the tool technique for fixed-schema answers.
+ */
+
+import type { IRoomView, ITurnSelector } from './types.js';
+import type { Robota } from '@robota-sdk/agent-core';
+
+/**
+ * Every member speaks once per round, in join order, for `rounds` rounds. Counts only the
+ * turns it schedules itself — externally-appended turns (`room.say`) do not consume rounds.
+ */
+export function createRoundRobinSelector(rounds: number): ITurnSelector {
+  let scheduled = 0;
+  return {
+    async next(view: IRoomView): Promise<string | null> {
+      if (view.members.length === 0) return null;
+      if (scheduled >= rounds * view.members.length) return null;
+      const speaker = view.members[scheduled % view.members.length];
+      scheduled += 1;
+      return speaker;
+    },
+  };
+}
+
+/** App-owned policy: return a member name, or `null` to end. */
+export function createCallbackSelector(
+  fn: (view: IRoomView) => Promise<string | null> | string | null,
+): ITurnSelector {
+  return {
+    async next(view: IRoomView): Promise<string | null> {
+      return fn(view);
+    },
+  };
+}
+
+const DIRECTOR_END = 'END';
+
+export interface IDirectorSelectorOptions {
+  /** Extra instruction line for the director (e.g. moderation style). */
+  instructions?: string;
+}
+
+/**
+ * A Director agent reads the transcript and picks the next speaker (the speech-project
+ * reference pattern). The decision is a schema-enforced structured answer constrained to
+ * the member names plus `"END"`. Pair the director with `retainHistory: false` — the full
+ * transcript is re-rendered into every decision prompt.
+ */
+export function createDirectorSelector(
+  director: Robota,
+  options: IDirectorSelectorOptions = {},
+): ITurnSelector {
+  return {
+    async next(view: IRoomView): Promise<string | null> {
+      if (view.members.length === 0) return null;
+      const prompt = renderDirectorPrompt(view, options.instructions);
+      const decision = (await director.run(prompt, {
+        output: {
+          name: 'turn_decision',
+          jsonSchema: {
+            type: 'object',
+            properties: {
+              next: {
+                type: 'string',
+                enum: [...view.members, DIRECTOR_END],
+                description: 'The member who should speak next, or END to finish.',
+              },
+            },
+            required: ['next'],
+          },
+        },
+      })) as { next: string };
+      return decision.next === DIRECTOR_END ? null : decision.next;
+    },
+  };
+}
+
+function renderDirectorPrompt(view: IRoomView, instructions?: string): string {
+  const lines: string[] = [];
+  lines.push('You direct a multi-party conversation. Decide who should speak next.');
+  if (instructions) lines.push(instructions);
+  lines.push(`Members: ${view.members.join(', ')}`);
+  lines.push('');
+  if (view.transcript.length === 0) {
+    lines.push('The conversation has not started yet.');
+  } else {
+    lines.push('Conversation so far:');
+    for (const entry of view.transcript) {
+      lines.push(`${entry.speaker}: ${entry.content}`);
+    }
+  }
+  lines.push('');
+  lines.push(`Pick the next speaker from the members, or "${DIRECTOR_END}" to finish.`);
+  return lines.join('\n');
+}

--- a/packages/agent-session/src/room/types.ts
+++ b/packages/agent-session/src/room/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Room — shared-transcript multi-agent primitive (ROOM-001).
+ *
+ * The opposite composition from subagents (isolation/parallel): N agents contribute
+ * sequentially to ONE shared append-only transcript, with a pluggable "who speaks next"
+ * policy. Per-agent execution stays `Robota`; the room owns transcript fan-in and turn
+ * scheduling.
+ */
+
+import type { Robota, TUniversalMessage } from '@robota-sdk/agent-core';
+
+/** A named participant. Pair with `retainHistory: false` agents — the room re-renders the
+ * shared transcript into every turn's input, so instance history would only duplicate it. */
+export interface IRoomMember {
+  /** Unique speaker name used for attribution and turn selection. */
+  name: string;
+  agent: Robota;
+  /** Optional persona line rendered into this member's turn input. */
+  persona?: string;
+}
+
+/** One committed turn on the shared transcript. */
+export interface IRoomTranscriptEntry {
+  speaker: string;
+  content: string;
+  /** The underlying append-only store message (id, timestamp, metadata.speaker). */
+  message: TUniversalMessage;
+}
+
+/** Read-only view handed to turn selectors. */
+export interface IRoomView {
+  transcript: readonly IRoomTranscriptEntry[];
+  /** Member names in join order. */
+  members: readonly string[];
+  /** Number of committed turns so far. */
+  turnCount: number;
+}
+
+/** Pluggable "who speaks next" policy. Return `null` to end the conversation. */
+export interface ITurnSelector {
+  next(view: IRoomView): Promise<string | null>;
+}
+
+export interface IRoomRunOptions {
+  selector: ITurnSelector;
+  /**
+   * Hard safety cap on turns for this run (the selector's `null` is the intended
+   * termination signal). Default 20.
+   */
+  maxTurns?: number;
+  /** Cooperative cancellation — checked before each turn. */
+  signal?: AbortSignal;
+  /** Called after each committed turn. */
+  onTurn?: (entry: IRoomTranscriptEntry) => void;
+}
+
+export interface IRoomOptions {
+  /** Optional topic line rendered at the top of every turn input. */
+  topic?: string;
+  /** Max messages retained by the shared transcript store (append-only). Default 1000. */
+  maxTranscriptMessages?: number;
+}


### PR DESCRIPTION
## 요약

Gap G3(P0) + speech 프로젝트의 실운영 워크어라운드(자체 ConversationStore + Director 루프)를 프리미티브화합니다. 승인 흐름: 제품방향 GATE-APPROVAL(설계+최소 코어) → 배치 재제안(신규 패키지 대신 **agent-session 서브모듈**, 사용자 의견 반영) → 설계 컨펌 → 구현.

## 변경 내용

- **agent-session이 대화 프리미티브 2종 소유** (SPEC Scope 먼저 재작성): 단일 에이전트 `Session` + 멀티에이전트 `Room`.
- **`Room`**: 공유 트랜스크립트 = core `ConversationStore`(append-only, `metadata.speaker` 귀속). `join`/`leave`(고유 이름 규칙), `say()`(외부/휴먼 턴), 순차 `run` 루프(maxTurns 안전 캡, abort signal, 미지 speaker throw — no fallback, 동시 run 가드). 매 턴 트랜스크립트를 대화록으로 렌더링해 speaker의 run 입력으로 주입 — `retainHistory:false`(CORE-014)와 자연 조합.
- **`ITurnSelector` 3종**: round-robin(자체 스케줄 카운터 — `say()` 턴이 라운드를 소모하지 않음) / callback / **Director** — CORE-015 structured output(멤버명+END enum 강제)으로 다음 발화자 결정. 백로그의 CORE-011 도구 우회 참조는 CORE-015 스펙이 대체(사유 evidence에 기록).
- Non-goals(후속): transport 팬아웃, 영속화, 런 중 join, 병렬 room.
- 문서: SPEC "Room Contract" 섹션, README Room 예제(doc-examples 스캔 컴파일 확인), llms.txt 역량 라인.

## 검증

- 단위/기능: 결정적 3-agent 6턴 round-robin 교환(턴별 fan-in ordering "saw N turns" 단언), selector view 성장, 캡, 귀속, join/leave, say, 동시 run 거부 — agent-session 83/83, repo typecheck + 43 스캔 + doc-examples(53블록) green.
- **User Execution (라이브, 실제 Anthropic)**: 2 페르소나 + 1 Director 토론 — Director가 optimist/skeptic을 번갈아 지정, 4턴 후 END, 일관된 귀속 트랜스크립트. 증거는 백로그에.

## 백로그

ROOM-001 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj