### PR TITLE
chore(backlog): ROOM-001 철회 기록 — 라이브러리는 재료만, 완제품 금지

### DIFF
--- a/.agents/backlog/completed/ROOM-001-shared-transcript-multi-agent-room.md
+++ b/.agents/backlog/completed/ROOM-001-shared-transcript-multi-agent-room.md
@@ -1,6 +1,7 @@
 ---
 title: 'ROOM-001: shared-transcript multi-agent Room primitive with a turn-selection hook'
-status: todo
+status: wontfix
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: later
@@ -49,3 +50,23 @@ scope/priority at GATE-APPROVAL before design.
 - Steps: run a 3-round exchange; dump the shared transcript.
 - Expected: one coherent transcript with correctly attributed speakers in director-chosen order.
 - Evidence: _to fill at implementation._
+
+## Resolution: wontfix (2026-07-03, architectural decision by owner)
+
+Implemented once (PR #925, closed unmerged) and **withdrawn on owner review**: a `Room` class
+owning the turn loop — with persona fields, a Director selector, and library-rendered prompts —
+is not a building block; it is _a finished product imitating an ingredient_ ("재료를 흉내낸
+완제품"). robota is an assembly system: the app owns its main loop and its prompts.
+
+The raw ingredients this use case needs ALREADY exist and are each neutral:
+
+- standalone `ConversationStore` (agent-core, exported) + `metadata.speaker` attribution — the
+  shared append-only transcript;
+- `retainHistory: false` (CORE-014) — per-call context reconstruction;
+- structured output (CORE-015) — a director-style decision, when an app wants one;
+- per-instance run serialization (CORE-012) — transcript integrity.
+
+The speech project assembling exactly these into their own room loop is the composition working
+as intended, not a gap. If anything ships later, it is an **example/guide showing the assembly**
+(examples are allowed to be products) — to be proposed as its own backlog item, not revived as a
+library primitive.


### PR DESCRIPTION
## 요약

소유자 아키텍처 리뷰에 따라 ROOM-001(Room primitive)을 철회합니다. PR #925는 미머지 상태로 폐기했고, 이 PR은 백로그를 wontfix로 사유와 함께 기록합니다.

## 사유 (백로그 Resolution에 상세 기록)

턴 루프를 소유한 Room 클래스 + persona 필드 + Director selector + 라이브러리가 렌더링하는 프롬프트는 **조립 재료가 아니라 재료를 흉내낸 완제품**입니다. robota는 조립 시스템이고, 앱의 메인 루프와 프롬프트는 앱의 소유입니다.

이 use-case에 필요한 재료는 이미 전부 존재하며 각각 중립적입니다: standalone `ConversationStore` + `metadata.speaker` 귀속 / `retainHistory:false`(CORE-014) / structured output(CORE-015) / run 직렬화(CORE-012). speech 프로젝트가 이것들을 조립해 자체 룸을 만든 것이 곧 의도된 합성입니다. 향후 남길 게 있다면 조립법을 보여주는 example/가이드(별도 백로그 제안)뿐입니다.

## 백로그

ROOM-001 wontfix + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj