### PR TITLE
chore(backlog): TRANS-001 재스코프 — 보이스 도메인 G5 제거, 중립 운반 메커니즘만 유지

### DIFF
--- a/.agents/backlog/TRANS-001-payload-agnostic-transport.md
+++ b/.agents/backlog/TRANS-001-payload-agnostic-transport.md
@@ -1,5 +1,5 @@
 ---
-title: 'TRANS-001: payload-agnostic transport — binary/audio frames + custom event types (voice/multimodal direction)'
+title: 'TRANS-001: payload-agnostic transport — binary/opaque frames + custom event types'
 status: todo
 created: 2026-07-03
 priority: low
@@ -8,7 +8,7 @@ area: packages/agent-interface-transport, packages/agent-transport-ws
 depends_on: []
 ---
 
-# Payload-agnostic transport (+ audio adapter contracts follow-on)
+# Payload-agnostic transport
 
 Gap analysis G2/G5 (`.design/gap-analysis-realtime-voice-agent-app.md`, P1/P2 in its roadmap): the
 speech app's realtime channel carries mic audio chunks (up), TTS clips (down), captions, coaching
@@ -27,12 +27,16 @@ design pass must first re-verify what `agent-interface-transport` actually suppo
    that flow through the channel with type safety, instead of forking the protocol.
 3. **Separation**: the text-delta agent protocol becomes one profile ON the generic transport, not
    the transport itself (CMD-004 precedent: contracts below, per-environment behavior above).
-4. **Follow-on (G5, separate scope once 1–3 exist)**: `ISttAdapter`/`ITtsAdapter` contracts +
-   streaming audio types, so voice implementations (Deepgram/ElevenLabs class) can plug in as
-   community blocks — together these open the voice-agent app class on robota.
 
-Product-direction note: this is the "voice/multimodal direction" investment — confirm at
-GATE-APPROVAL before design.
+**Rescoped 2026-07-03 (owner decision, ROOM-001 principle)**: the former item 4 — G5
+`ISttAdapter`/`ITtsAdapter` contracts + streaming audio types ("open the voice-agent app class")
+— is REMOVED from robota scope. Voice/STT/TTS are app-domain contracts; putting them in the
+library is the same "finished product imitating an ingredient" class that withdrew ROOM-001.
+Items 1–3 remain: binary/opaque frames and consumer-declared event types are content-neutral
+carrier mechanics (a WebSocket-class ingredient) usable by ANY payload domain (files, images,
+audio, app events). Voice apps assemble their own adapters on top.
+
+Product-direction note: confirm scope/priority at GATE-APPROVAL before design.
 
 ## Test Plan
 
@@ -42,7 +46,8 @@ GATE-APPROVAL before design.
 
 ## User Execution Test Scenarios
 
-- Prereq: example app (or test rig) streaming an audio file as binary frames alongside a text turn.
-- Steps: run it over the ws transport; verify playback-side reassembly.
-- Expected: audio arrives intact and ordered alongside text events on one connection.
+- Prereq: example app (or test rig) streaming an arbitrary binary file as opaque frames alongside a
+  text turn (any payload domain — the transport must not know or care what the bytes are).
+- Steps: run it over the ws transport; verify receiver-side reassembly (byte-identical, ordered).
+- Expected: binary frames arrive intact and ordered alongside text events on one connection.
 - Evidence: _to fill at implementation._


### PR DESCRIPTION
## 요약

전면 재검토(ROOM-001 원칙: 라이브러리는 재료만)의 후속 조치입니다. 소유자 결정에 따라 TRANS-001에서 보이스 도메인 항목을 제거합니다.

## 변경 내용

- **제거 (사유 기록)**: 구 항목 4 — G5 `ISttAdapter`/`ITtsAdapter` 계약 + 스트리밍 오디오 타입("보이스 에이전트 앱 클래스 개방"). 보이스/STT/TTS는 앱 도메인 계약이며, 라이브러리에 넣으면 ROOM-001을 철회시킨 것과 같은 "재료를 흉내낸 완제품" 부류입니다.
- **유지**: 항목 1–3 (binary/opaque 프레임, 소비자 선언 이벤트 타입, text-delta의 프로파일화) — 어떤 payload 도메인(파일/이미지/오디오/앱 이벤트)에도 쓰이는 내용-중립 운반 메커니즘(WebSocket급 재료). 진행 여부는 기존대로 제품방향 GATE-APPROVAL.
- User Execution 시나리오도 오디오 특정에서 임의 바이너리로 중립화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj