### PR TITLE
docs(rules): 라이브러리 중립성 규칙 명문화 — packages/는 보편·중립, apps/는 프로덕트

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -53,6 +53,28 @@ apps/
 └── dag-runtime-server/     # Native DAG runtime HTTP server (`/v1/dag/*` over Hono); serves dag-framework's IDagOrchestrationPort, native runtime surface, no external-runtime API (WORKFLOW-002)
 ```
 
+## Library Neutrality Rule (packages/ vs apps/)
+
+Everything under `packages/` is a **library and must be universal and neutral** — usable by any
+consumer for any payload/application domain:
+
+- No app main loops: a library must not own the consumer's orchestration loop. If a class "runs
+  the show" and the app merely configures it, it is a finished product imitating an ingredient
+  (ROOM-001 withdrawal, 2026-07-03).
+- No library-authored prompt content: model-facing text in `packages/` is limited to
+  mechanism-level enforcement strings (schema-violation feedback, round-limit notices). Anything
+  that shapes an application's voice, persona, or conversation style belongs to the consumer.
+- No application-domain concepts in library types: fields/interfaces like persona, room, topic,
+  STT/TTS adapters are app-domain contracts (TRANS-001 rescope) — libraries ship content-neutral
+  mechanics that any domain can carry.
+- `apps/` is the product tier and plays by product rules (opinionated UX, domain concepts, its own
+  prompts). `examples/` may likewise be full products — that is their job. `packages/agent-cli` is
+  the sanctioned reference product assembled FROM the libraries (its preset/persona surface is
+  product behavior, not library behavior).
+
+When a use case seems to need a domain feature in a library, the answer is: verify the neutral
+ingredients exist, then show the assembly in `examples/` or a guide.
+
 ## Planned Packages (Not Yet Created)
 
 The following packages are planned but do not yet exist on disk. Do not attempt to import from them.


### PR DESCRIPTION
## 요약

소유자 원칙을 규칙 SSOT(`.agents/project-structure.md`)에 명문화합니다: **packages/ 아래 모든 라이브러리는 보편적이고 중립적이어야 하며, apps/ 경로만 프로덕트 기준을 갖습니다.**

## 규칙 내용

- 앱 메인 루프 소유 금지 — 라이브러리가 오케스트레이션 루프를 소유하면 "재료를 흉내낸 완제품" (ROOM-001 철회 사례 인용)
- 라이브러리 작성 프롬프트 금지 — 허용선은 메커니즘 강제 문자열(스키마 위반 피드백, 라운드 한계 고지)뿐
- 라이브러리 타입에 앱 도메인 개념 금지 (persona/room/topic/STT·TTS 어댑터 — TRANS-001 재스코프 사례 인용)
- apps/·examples/는 완제품 허용; packages/agent-cli는 승인된 참조 프로덕트
- 도메인 기능이 필요해 보이면: 중립 재료 존재 확인 → examples/가이드로 조립법 제시

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj