### PR TITLE
docs: DOCS-018 루트 README — 라이브러리 정체성 우선 + 계층 패키지 테이블

### DIFF
--- a/.agents/backlog/completed/DOCS-018-root-readme-identity-first.md
+++ b/.agents/backlog/completed/DOCS-018-root-readme-identity-first.md
@@ -1,6 +1,7 @@
 ---
 title: 'DOCS-018: root README restructure — library identity first, layered package table, resolve the dag scope contradiction'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: later
@@ -39,4 +40,19 @@ user correction to reverse). Verified contradiction: README:108 still says the D
 - Prereq: a fresh evaluator (agent session or person) given only the root README's first screen.
 - Steps: ask "what is robota and what is the minimal package set to embed it?"
 - Expected: answers "library collection / core+provider+tools", not "a coding CLI product".
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (fresh-agent run, 2026-07-03).** README restructured library-identity-first:
+  (1) first sentence = composable TypeScript library collection; agent-cli explicitly framed as
+  a reference app built FROM the libraries (aligned with the Library Neutrality Rule
+  institutionalized the same day in project-structure.md); llms.txt pointer added for agent
+  evaluators; embed quickstart (3-package minimal set) now leads, createQuery next, CLI +
+  screenshot moved below. (2) Package table split into three layers — "Start here (embedding)"
+  (core/provider/tools first, same fact source as llms.txt), "App assembly", "Products &
+  transports" (agent-testing added; provider row reframed to protocol clients per DOCS-016).
+  (3) Stale DAG sentence fixed: repository scope now states dag-_/dag-node-_ live HERE (engine
+  absorbed back, external-runtime-decoupled) — the "moved to a separate robota-dag repository"
+  contradiction removed. (4) Gateway variant cross-referenced to the quickstart (DOCS-014 owner),
+  one line only — no duplication. Verified: doc-examples scan 52 blocks (README ts blocks
+  compile), llms-txt scan, 43 harness scans, docs:build all green. User Execution: a FRESH agent
+  session shown ONLY the README's first ~60 lines answered "not a coding-CLI product — composable
+  TypeScript library collection… agent-cli serving only as a reference app" and named exactly
+  `agent-core + agent-provider + agent-tools` — the O2 misunderstanding does not reproduce.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,16 @@
-# Robota - AI Agent Framework
+# Robota — Composable AI Agent Libraries
 
-A TypeScript framework for building AI agents with multi-provider support, tool calling, and extensible plugin architecture.
+Robota is a **composable TypeScript library collection for building AI agents** — strict types,
+multi-provider, tool calling, and an extensible plugin/event architecture. You assemble agents
+from neutral building blocks; `@robota-sdk/agent-cli` (an AI coding assistant) is a **reference
+app built from these same libraries**, not the product itself.
 
-![Robota CLI](https://raw.githubusercontent.com/woojubb/robota/main/content/images/cli-demo.png)
+> Evaluating with an AI agent? Start at [`llms.txt`](./llms.txt) — the consumer map (identity,
+> minimal package set, capability matrix, behavior contracts).
 
-## Quick Start
+## Quick Start — Embed the Library
 
-### CLI — AI Coding Assistant
-
-```bash
-# Try it now (no install needed)
-npx @robota-sdk/agent-cli
-
-# Or install globally for persistent use
-npm install -g @robota-sdk/agent-cli
-robota
-```
-
-> **Beta**: Robota is currently `3.0.0-beta`. Core features are stable but APIs may change before 1.0. See [CHANGELOG.md](./CHANGELOG.md) for upgrade notes.
-
-> **macOS users**: Korean/CJK IME input may crash macOS Terminal.app. Use **[iTerm2](https://iterm2.com/)** instead. This is a known Ink + Terminal.app issue shared with Claude Code.
-
-### SDK — Programmatic Usage
-
-```typescript
-import { createQuery } from '@robota-sdk/agent-framework';
-import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
-
-const query = createQuery({
-  provider: new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY }),
-});
-const response = await query('List all TypeScript files in src/');
-```
-
-### Core — Build Custom Agents
+The minimal set is three packages: `agent-core` + `agent-provider` + `agent-tools`.
 
 ```typescript
 import { Robota } from '@robota-sdk/agent-core';
@@ -52,17 +29,54 @@ const agent = new Robota({
 const response = await agent.run('Hello!');
 ```
 
+Any OpenAI-compatible endpoint works too — AI gateways, Azure, vLLM, local servers — via the
+OpenAI provider's `baseURL` (see the [quickstart's gateway section](./content/quickstart.md)).
+
+### Higher-level assembly — `createQuery`
+
+`agent-framework` assembles CLI tools, permissions, and config/context loading on top:
+
+```typescript
+import { createQuery } from '@robota-sdk/agent-framework';
+import { AnthropicProvider } from '@robota-sdk/agent-provider/anthropic';
+
+const query = createQuery({
+  provider: new AnthropicProvider({ apiKey: process.env.ANTHROPIC_API_KEY }),
+});
+const response = await query('List all TypeScript files in src/');
+```
+
+### Reference app — the CLI coding assistant
+
+```bash
+# Try the reference product built from these libraries (no install needed)
+npx @robota-sdk/agent-cli
+
+# Or install globally
+npm install -g @robota-sdk/agent-cli
+robota
+```
+
+![Robota CLI](https://raw.githubusercontent.com/woojubb/robota/main/content/images/cli-demo.png)
+
+> **Beta**: Robota is currently `3.0.0-beta`. Core features are stable but APIs may change before 1.0. See [CHANGELOG.md](./CHANGELOG.md) for upgrade notes.
+
+> **macOS users**: Korean/CJK IME input may crash macOS Terminal.app. Use **[iTerm2](https://iterm2.com/)** instead. This is a known Ink + Terminal.app issue shared with Claude Code.
+
 ## Architecture
 
+Libraries below, products on top. Everything under `packages/` is universal and neutral; apps and
+the reference CLI are opinionated assemblies OF the libraries.
+
 ```
-agent-cli                       ← Interactive terminal AI coding assistant
-agent-transport-{tui,http,ws,mcp} ← Standalone transports (split in beta.76); agent-transport = lean core
+agent-cli                       ← Reference product: terminal AI coding assistant
+agent-transport-{tui,http,ws,mcp} ← Standalone transports; agent-transport = lean core
   ↓
 agent-framework        ← Assembly layer: InteractiveSession, createQuery(), config/context loading
   ↓
 agent-session          ← Session lifecycle: permissions, hooks, compaction
 agent-tools            ← Tool infrastructure + 8 built-in tools
-agent-provider         ← Consolidated AI providers (sub-paths: /anthropic, /openai, /gemini, …)
+agent-provider         ← Protocol clients (sub-paths: /anthropic, /openai, /gemini, …)
 agent-plugin           ← 8 consolidated lifecycle plugins
   ↓
 agent-core             ← Foundation: Robota engine, abstractions, plugin contracts
@@ -70,27 +84,40 @@ agent-core             ← Foundation: Robota engine, abstractions, plugin contr
 
 ## Packages
 
-| Package                                                                                                        | Description                                                                             |
-| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| [`@robota-sdk/agent-core`](https://www.npmjs.com/package/@robota-sdk/agent-core)                               | Core agent runtime, abstractions, and plugin system                                     |
-| [`@robota-sdk/agent-tools`](https://www.npmjs.com/package/@robota-sdk/agent-tools)                             | Tool registry, FunctionTool, and 8 built-in tools                                       |
-| [`@robota-sdk/agent-session`](https://www.npmjs.com/package/@robota-sdk/agent-session)                         | Session with permissions, hooks, and compaction                                         |
-| [`@robota-sdk/agent-framework`](https://www.npmjs.com/package/@robota-sdk/agent-framework)                     | Assembly layer with config/context loading and query()                                  |
-| [`@robota-sdk/agent-provider`](https://www.npmjs.com/package/@robota-sdk/agent-provider)                       | Consolidated AI providers (Anthropic, OpenAI, Gemini, DeepSeek, Gemma, Qwen, ByteDance) |
-| [`@robota-sdk/agent-cli`](https://www.npmjs.com/package/@robota-sdk/agent-cli)                                 | Interactive terminal AI coding assistant                                                |
-| [`@robota-sdk/agent-command`](https://www.npmjs.com/package/@robota-sdk/agent-command)                         | Slash command modules (`/agent`, `/help`, `/provider`, `/preset`, `/schedule`, …)       |
-| [`@robota-sdk/agent-plugin`](https://www.npmjs.com/package/@robota-sdk/agent-plugin)                           | 8 consolidated lifecycle plugins (logging, usage, limits, performance, webhook, …)      |
-| [`@robota-sdk/agent-executor`](https://www.npmjs.com/package/@robota-sdk/agent-executor)                       | Execution engine for the agentic loop                                                   |
-| [`@robota-sdk/agent-preset`](https://www.npmjs.com/package/@robota-sdk/agent-preset)                           | Named agent profiles (preset system)                                                    |
-| [`@robota-sdk/agent-subagent-runner`](https://www.npmjs.com/package/@robota-sdk/agent-subagent-runner)         | Subagent dispatch runner                                                                |
-| [`@robota-sdk/agent-session-analytics`](https://www.npmjs.com/package/@robota-sdk/agent-session-analytics)     | Session log timing analysis (new in beta.76)                                            |
-| [`@robota-sdk/agent-interface-transport`](https://www.npmjs.com/package/@robota-sdk/agent-interface-transport) | Transport type contracts (zero deps)                                                    |
-| [`@robota-sdk/agent-interface-tui`](https://www.npmjs.com/package/@robota-sdk/agent-interface-tui)             | TUI interaction type contracts (zero deps)                                              |
-| [`@robota-sdk/agent-transport`](https://www.npmjs.com/package/@robota-sdk/agent-transport)                     | Lean transport core (`/headless`, `/testing`)                                           |
-| [`@robota-sdk/agent-transport-tui`](https://www.npmjs.com/package/@robota-sdk/agent-transport-tui)             | TUI transport (Ink/React) — standalone (split in beta.76)                               |
-| [`@robota-sdk/agent-transport-http`](https://www.npmjs.com/package/@robota-sdk/agent-transport-http)           | HTTP/REST transport — standalone (split in beta.76)                                     |
-| [`@robota-sdk/agent-transport-ws`](https://www.npmjs.com/package/@robota-sdk/agent-transport-ws)               | WebSocket transport — standalone (split in beta.76)                                     |
-| [`@robota-sdk/agent-transport-mcp`](https://www.npmjs.com/package/@robota-sdk/agent-transport-mcp)             | MCP transport — standalone (split in beta.76)                                           |
+**Start here (embedding)** — the minimal set:
+
+| Package                                                                                  | Description                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [`@robota-sdk/agent-core`](https://www.npmjs.com/package/@robota-sdk/agent-core)         | `Robota` engine: run/runStream, history, structured output, plugins                                                      |
+| [`@robota-sdk/agent-provider`](https://www.npmjs.com/package/@robota-sdk/agent-provider) | Provider protocol clients (Anthropic, OpenAI + any OpenAI-compatible endpoint, Gemini, DeepSeek, Gemma, Qwen, ByteDance) |
+| [`@robota-sdk/agent-tools`](https://www.npmjs.com/package/@robota-sdk/agent-tools)       | Tool registry, zod-validated function tools, 8 built-in tools                                                            |
+
+**App assembly** — add when you need sessions, permissions, or plugins:
+
+| Package                                                                                                    | Description                                                                        |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [`@robota-sdk/agent-framework`](https://www.npmjs.com/package/@robota-sdk/agent-framework)                 | Assembly layer with config/context loading and `createQuery()`                     |
+| [`@robota-sdk/agent-session`](https://www.npmjs.com/package/@robota-sdk/agent-session)                     | Session with permissions, hooks, and compaction                                    |
+| [`@robota-sdk/agent-plugin`](https://www.npmjs.com/package/@robota-sdk/agent-plugin)                       | 8 consolidated lifecycle plugins (logging, usage, limits, performance, webhook, …) |
+| [`@robota-sdk/agent-executor`](https://www.npmjs.com/package/@robota-sdk/agent-executor)                   | Execution engine for the agentic loop                                              |
+| [`@robota-sdk/agent-subagent-runner`](https://www.npmjs.com/package/@robota-sdk/agent-subagent-runner)     | Subagent dispatch runner                                                           |
+| [`@robota-sdk/agent-session-analytics`](https://www.npmjs.com/package/@robota-sdk/agent-session-analytics) | Session log timing analysis                                                        |
+| [`@robota-sdk/agent-testing`](https://www.npmjs.com/package/@robota-sdk/agent-testing)                     | Real-PTY E2E test harness                                                          |
+
+**Products & transports** — the reference CLI and its interaction surfaces:
+
+| Package                                                                                                        | Description                                                                       |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [`@robota-sdk/agent-cli`](https://www.npmjs.com/package/@robota-sdk/agent-cli)                                 | Reference product: interactive terminal AI coding assistant                       |
+| [`@robota-sdk/agent-command`](https://www.npmjs.com/package/@robota-sdk/agent-command)                         | Slash command modules (`/agent`, `/help`, `/provider`, `/preset`, `/schedule`, …) |
+| [`@robota-sdk/agent-preset`](https://www.npmjs.com/package/@robota-sdk/agent-preset)                           | Named agent profiles (preset system)                                              |
+| [`@robota-sdk/agent-interface-transport`](https://www.npmjs.com/package/@robota-sdk/agent-interface-transport) | Transport type contracts (zero deps)                                              |
+| [`@robota-sdk/agent-interface-tui`](https://www.npmjs.com/package/@robota-sdk/agent-interface-tui)             | TUI interaction type contracts (zero deps)                                        |
+| [`@robota-sdk/agent-transport`](https://www.npmjs.com/package/@robota-sdk/agent-transport)                     | Lean transport core (`/headless`, `/testing`)                                     |
+| [`@robota-sdk/agent-transport-tui`](https://www.npmjs.com/package/@robota-sdk/agent-transport-tui)             | TUI transport (Ink/React)                                                         |
+| [`@robota-sdk/agent-transport-http`](https://www.npmjs.com/package/@robota-sdk/agent-transport-http)           | HTTP/REST transport                                                               |
+| [`@robota-sdk/agent-transport-ws`](https://www.npmjs.com/package/@robota-sdk/agent-transport-ws)               | WebSocket transport                                                               |
+| [`@robota-sdk/agent-transport-mcp`](https://www.npmjs.com/package/@robota-sdk/agent-transport-mcp)             | MCP transport                                                                     |
 
 ## Documentation
 
@@ -104,9 +131,10 @@ Full documentation at **[robota.io](https://robota.io)**
 
 ## Repository Scope
 
-This repository now owns the Robota agent SDK, CLI, providers, transports, playground, and related
-apps. The DAG product line has moved to a separate `robota-dag` repository; use that repository for
-DAG source, issues, docs, and releases once its remote URL is published.
+This repository owns the Robota agent SDK, providers, transports, the reference CLI, related apps —
+and the **DAG orchestration line** (`packages/dag-*`, `@robota-sdk/dag-node-*`): the DAG engine was
+absorbed back into this monorepo (external-runtime-decoupled) and is developed here alongside the
+agent libraries.
 
 ## Development
 


### PR DESCRIPTION
## 요약

발견성 리포트 §3.2(P3, 오해 O2 원인)를 이행합니다. 같은 날 명문화된 Library Neutrality Rule과 같은 방향의 문서 작업입니다.

## 변경 내용

1. 첫 문장 = **composable TypeScript library collection**; agent-cli는 이 라이브러리들로 조립한 **reference app**으로 명시. 임베드 퀵스타트(3-패키지 최소 세트)가 선두, createQuery 다음, CLI+스크린샷은 아래로. 에이전트 평가자용 llms.txt 포인터 추가.
2. 패키지 테이블 3계층 분리: **Start here (embedding)** core/provider/tools → **App assembly** → **Products & transports** (agent-testing 추가, provider 행은 DOCS-016의 프로토콜 클라이언트 framing).
3. **스테일 DAG 문장 수정**: "별도 robota-dag 리포로 이동" ↔ 실제 15개 dag-* 패키지 존재 모순 제거 — 엔진 재흡수(외부 런타임 분리) 현실 반영.
4. 게이트웨이 변형은 퀵스타트(DOCS-014 소유)로 한 줄 크로스링크만 — 중복 없음.

## 검증

- doc-examples 52블록(README ts 블록 컴파일) + llms-txt 스캔 + 43 하네스 스캔 + docs:build green.
- **User Execution**: 신선한 에이전트에게 README 첫 ~60줄만 제공 → "not a coding-CLI product — composable TypeScript library collection… agent-cli serving only as a reference app" + 정확히 `core+provider+tools` 3종 지목. O2 재현 안 됨. 증거는 백로그에.

## 백로그

DOCS-018 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj