### PR TITLE
fix(harness): HARNESS-021 conformance 테스트 픽스처 드리프트 수리 + 하네스 스위트 CI 편입

### DIFF
--- a/.agents/backlog/completed/HARNESS-021-background-workspace-conformance-test-drift.md
+++ b/.agents/backlog/completed/HARNESS-021-background-workspace-conformance-test-drift.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-021: check-background-workspace-conformance unit tests drifted — 5/5 failing on develop'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: medium
 urgency: soon
@@ -38,4 +39,14 @@ files listed for the touched scan — a full-suite run of this directory is not 
 
 - Not applicable beyond the mechanical suite run (dev-tooling fix); evidence = green run recorded
   at implementation.
-- Evidence: _to fill at implementation._
+- Evidence: **PASS (2026-07-03).** Diagnosis: the SCAN was correct and passing against the real
+  tree; the TEST FIXTURES had drifted — the beta.76 transport split moved the TUI channel to
+  `packages/agent-transport-tui/`, the scan's expected paths were updated, but `baselineFiles`
+  in the test still created the files at the old `packages/agent-transport/src/tui/` paths, so
+  every fixture run produced 4 extra "missing-cli-\*" findings (5/5 assertions failed). Fix:
+  fixture paths updated to the post-split layout — 5/5 green, scan behavior unchanged (contract
+  intact; the tests were stale, not the scan). Mechanism against recurrence (item 3): new root
+  `harness:test` script runs the FULL `scripts/harness/__tests__/` suite (27 files / 221 tests
+  green) and a blocking step was added to the CI quality job — per-scan test selection
+  (verify-change) remains for local speed, but suite-wide drift can no longer sit silent.
+  43 harness scans green.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
         if: github.base_ref != 'main'
         run: pnpm harness:verify -- --base-ref origin/${{ github.base_ref }} --skip-build --skip-record-check
 
+      # HARNESS-021: the harness scans' own unit suite runs in full — per-scan test selection
+      # (verify-change) cannot see suite-wide drift, which let 5 stale fixtures sit silent.
+      - name: Harness scan test suite
+        if: github.base_ref != 'main'
+        run: pnpm harness:test
+
   security-audit:
     name: security audit
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "readme:cleanup": "node scripts/docs/copy-readme.cjs cleanup",
     "readme:validate": "node scripts/docs/validate-readmes.js",
     "harness:scan": "node scripts/harness/run-all-scans.mjs",
+    "harness:test": "vitest run scripts/harness/__tests__",
     "harness:conformance": "node scripts/harness/check-architecture-conformance.mjs",
     "harness:scan:done-evidence": "node scripts/harness/check-done-evidence.mjs",
     "harness:scan:task-archival": "node scripts/harness/check-task-archival.mjs",

--- a/scripts/harness/__tests__/check-background-workspace-conformance.test.mjs
+++ b/scripts/harness/__tests__/check-background-workspace-conformance.test.mjs
@@ -25,9 +25,9 @@ const baselineFiles = {
     'export class BackgroundTaskManager {}\n',
   'packages/agent-framework/src/background-tasks/execution-workspace-projection.ts':
     'export function createExecutionWorkspaceSnapshot() { return { entries: [] }; }\n',
-  'packages/agent-transport/src/tui/TuiInteractionChannel.ts':
+  'packages/agent-transport-tui/src/TuiInteractionChannel.ts':
     'session.getExecutionWorkspaceSnapshot(); session.on("execution_workspace_event", () => {}); session.readExecutionWorkspaceDetail("main");\n',
-  'packages/agent-transport/src/tui/tui-state-manager.ts':
+  'packages/agent-transport-tui/src/tui-state-manager.ts':
     'export class TuiStateManager { syncExecutionWorkspaceSnapshot() {} }\n',
   '.agents/specs/architecture-map/agent-system.md':
     '| Background workspace/read model                   | `agent-framework` + `agent-executor`              | CLI renders projections only. |\n',
@@ -104,7 +104,7 @@ describe('findBackgroundWorkspaceConformanceFindings', () => {
   it('flags missing SDK snapshot consumption in the TUI channel', async () => {
     const root = await createFixture({
       ...baselineFiles,
-      'packages/agent-transport/src/tui/TuiInteractionChannel.ts':
+      'packages/agent-transport-tui/src/TuiInteractionChannel.ts':
         'session.getFullHistory(); session.readExecutionWorkspaceDetail("main");\n',
     });
 


### PR DESCRIPTION
## 요약

DOCS-017 검증 중 발견된 기존 결함(클린 develop에서 5/5 실패)의 수리입니다.

## 진단

**스캔은 정상, 테스트가 스테일**: beta.76 transport 분리로 스캔의 기대 경로는 `agent-transport-tui/`로 갱신됐지만 테스트 픽스처(`baselineFiles`)는 구 경로(`agent-transport/src/tui/`)에 파일을 생성 → 매 실행마다 "missing-cli-*" 파인딩 4건이 추가돼 5/5 단언 실패. 실제 트리에 대한 스캔 동작은 계속 올바랐음.

## 변경 내용

- 픽스처 경로를 분리 후 레이아웃으로 갱신 → 5/5 green (스캔 로직 무변경 — 계약 유지).
- **재발 방지 기계화** (backlog item 3): 루트 `harness:test` 스크립트 신설(하네스 테스트 전체 27파일/221테스트) + CI quality 잡에 차단 스텝 추가. verify-change의 per-scan 선택은 로컬 속도용으로 유지 — 스위트 전체 드리프트가 다시는 조용히 앉아있을 수 없음.

## 검증

- `pnpm harness:test` 27/27 파일, 221/221 green; 43 하네스 스캔 green.

## 백로그

HARNESS-021 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj