### PR TITLE
fix: ERR-001 네트워크 에러 표면화 + TUI 프로세스 생존

### DIFF
--- a/.agents/backlog/completed/ERR-001-network-error-surfacing-and-liveness.md
+++ b/.agents/backlog/completed/ERR-001-network-error-surfacing-and-liveness.md
@@ -1,6 +1,7 @@
 ---
 title: 'ERR-001: transient network errors — surface clearly to the user, never kill or freeze the TUI'
-status: todo
+status: done
+completed: 2026-07-03
 created: 2026-07-03
 priority: high
 urgency: soon
@@ -83,4 +84,28 @@ layer's job.
 - Expected: a clearly-styled error explains the network failure (not a silent stop, not a stack
   trace, not a dead UI); any partial answer stays visible marked interrupted; the input prompt is
   immediately usable; the post-restore prompt round-trips normally; the process never exits.
-- Evidence: _to fill at implementation (live run — capability-absence claims require a probe)._
+- Evidence: **PASS (live PTY run, real binary + real provider + real mid-stream cut,
+  2026-07-03).** Implementation per the reviewed design, G1–G3 (G4 auto-retry stays out of
+  scope): **G1** — `agent-cli/src/process-guards.ts` (product-owned per the Library Neutrality
+  Rule): TUI-mode-only `unhandledRejection` + `uncaughtException` guards routing into the live
+  session via new `InteractiveSession.reportBackgroundError` (humanize → `metadata.kind:'error'`
+  entry → `'error'` event), stderr as final surface; `bin.ts` IME fallback defers via
+  `areTuiProcessGuardsActive`; headless keeps fail-fast; the library-level `unhandledRejection`
+  handler previously hiding in `render.tsx` was REMOVED (neutrality violation — raw stderr writes
+  corrupting the Ink frame) and replaced with a neutral `onChannelReady` seam the product wires.
+  **G2** — framework commits partial streamed text as an interrupted assistant entry before
+  clearing stream state (new `getStreamingText` ctx capability) and marks error entries
+  `metadata.kind:'error'`; TUI renders a styled ✖ error block (humanized message + "session is
+  still alive" affordance, no stack trace) + transient post-error strip; channel now passes the
+  Error object into state. **G3** — 15s dead-air stall hint ("network may be stalled — Esc to
+  interrupt") driven by a provider-activity-reset timer, cleared on turn end. Tests: TUI reducer
+  5 (error lifecycle + fake-timer stall), framework functional 2 (mid-stream ECONNRESET → partial
+  preserved + humanized marked entry + NEXT submit succeeds; reportBackgroundError → marked entry
+  - event + session usable), process-guards 4 (idempotent install, session routing, stderr last
+    resort, headless-inactive) — full repo suite + 43 scans + doc-examples green. **User Execution
+    (live)**: local RST proxy in front of the real Anthropic API; real built binary in a PTY with an
+    isolated HOME profile; turn 1's stream cut mid-answer → `styled block: true | humanized: true |
+no stack trace: true`; proxy restored → turn 2 "RECOVERED" round-tripped; process alive
+    throughout. Guide (`error-handling.md`), framework SPEC (Turn Error Surfacing & Liveness), CLI
+    SPEC (Process Survival Boundary) synced. Follow-on G4 (bounded auto-retry) intentionally not
+    filed here — capture on demand per the backlog's own note.

--- a/content/guide/error-handling.md
+++ b/content/guide/error-handling.md
@@ -257,6 +257,19 @@ the key when multiple providers are registered.
 
 ---
 
+## Interactive Failures: What the User Sees (ERR-001)
+
+In the interactive TUI a failed turn is surfaced, never swallowed and never fatal:
+
+- Any partially streamed answer stays visible, marked _(interrupted)_ — it is committed to
+  history before stream state clears.
+- The failure renders as a styled error block (humanized message — e.g. network failures say so
+  plainly) plus a note that the session is still alive; the input prompt is immediately usable.
+- If the provider goes silent mid-turn, the status area hints after ~15s that the connection may
+  be stalled (Esc interrupts); the 120s provider idle timeout remains the hard stop.
+- Errors outside the turn boundary (background tasks, un-caught promises) route through the same
+  path — in interactive mode the process itself never exits on them.
+
 ## The error Event Footgun
 
 `InteractiveSession` extends Node.js `EventEmitter`. In Node.js, an `'error'` event

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -1675,6 +1675,18 @@ passing values into the public entry point rather than by subclassing or monkey-
 The CLI does not expose plugin hooks at the binary level. Plugin lifecycle is owned by
 `@robota-sdk/agent-framework` through the plugin command adapter.
 
+## Process Survival Boundary (ERR-001 G1)
+
+Interactive TUI mode must never die on a transient failure. `src/process-guards.ts`
+(product-owned per the Library Neutrality Rule — transports install no process policy) installs
+last-resort `unhandledRejection`/`uncaughtException` handlers when the TUI starts: errors route
+into the live session via `InteractiveSession.reportBackgroundError` (humanized, styled error
+block, session log) and the process stays alive; if routing itself fails, stderr is the final
+surface. `bin.ts`'s IME-aware `uncaughtException` fallback defers to these guards when active
+(`areTuiProcessGuardsActive`). Headless/print mode installs nothing and keeps the fail-fast
+exit-code contract. Each async subsystem still owns terminating its promises — the guards are the
+boundary of last resort, not the primary handler.
+
 ## Error Taxonomy
 
 | Error class           | Trigger                                                                           | Handling                                                                                                                                                                                                              | Exit code     |

--- a/packages/agent-cli/src/__tests__/process-guards.test.ts
+++ b/packages/agent-cli/src/__tests__/process-guards.test.ts
@@ -1,0 +1,80 @@
+/**
+ * ERR-001 G1 — TUI process survival boundary: unhandled rejections and uncaught
+ * exceptions route into the live session instead of killing the process; without a
+ * live channel they fall back to stderr; headless mode (guards not installed) keeps
+ * bin.ts fail-fast semantics via areTuiProcessGuardsActive().
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  areTuiProcessGuardsActive,
+  installTuiProcessGuards,
+  setLiveChannel,
+} from '../process-guards.js';
+
+function listenerCount(event: 'unhandledRejection' | 'uncaughtException'): number {
+  return process.listeners(event as 'uncaughtException').length;
+}
+
+describe('process guards (ERR-001 G1)', () => {
+  const baseRejection = listenerCount('unhandledRejection');
+  const baseException = listenerCount('uncaughtException');
+  let stderrSpy: ReturnType<typeof vi.fn>;
+  let originalWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    stderrSpy = vi.fn().mockReturnValue(true);
+    originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = stderrSpy as unknown as typeof process.stderr.write;
+  });
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  it('is inactive until installed (headless keeps fail-fast)', () => {
+    expect(areTuiProcessGuardsActive()).toBe(false);
+  });
+
+  it('installs both handlers exactly once (idempotent)', () => {
+    installTuiProcessGuards();
+    installTuiProcessGuards();
+
+    expect(areTuiProcessGuardsActive()).toBe(true);
+    expect(listenerCount('unhandledRejection')).toBe(baseRejection + 1);
+    expect(listenerCount('uncaughtException')).toBe(baseException + 1);
+  });
+
+  it('routes an unhandled rejection into the live session and keeps the process alive', () => {
+    installTuiProcessGuards();
+    const reportBackgroundError = vi.fn();
+    setLiveChannel({ getSession: () => ({ reportBackgroundError }) });
+
+    const handler = process.listeners('unhandledRejection').slice(-1)[0] as (
+      reason: unknown,
+    ) => void;
+    handler(new Error('socket hang up'));
+
+    expect(reportBackgroundError).toHaveBeenCalledTimes(1);
+    expect((reportBackgroundError.mock.calls[0][0] as Error).message).toBe('socket hang up');
+    expect(reportBackgroundError.mock.calls[0][1]).toBe('unhandled rejection');
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to stderr when routing into the session itself fails (last resort)', () => {
+    installTuiProcessGuards();
+    setLiveChannel({
+      getSession: () => ({
+        reportBackgroundError: () => {
+          throw new Error('render broken');
+        },
+      }),
+    });
+
+    const handler = process.listeners('uncaughtException').slice(-1)[0] as (err: unknown) => void;
+    handler(new Error('boom'));
+
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(String(stderrSpy.mock.calls[0][0])).toContain('uncaught exception: boom');
+  });
+});

--- a/packages/agent-cli/src/bin.ts
+++ b/packages/agent-cli/src/bin.ts
@@ -8,6 +8,7 @@
  * tsdown.config.ts and runs before any module imports are loaded.
  */
 import { startCli } from './cli.js';
+import { areTuiProcessGuardsActive } from './process-guards.js';
 
 // Last-resort crash prevention for IME-related errors only.
 // Korean IME in raw mode can cause errors that escape React/Ink.
@@ -28,7 +29,10 @@ process.on('uncaughtException', (err) => {
     );
     return;
   }
-  // Re-throw non-IME errors — let them crash normally
+  // ERR-001 G1: in interactive TUI mode the product-level guards own process survival —
+  // they render the error into the live session; re-throwing here would kill the TUI.
+  if (areTuiProcessGuardsActive()) return;
+  // Re-throw non-IME errors — headless/print mode keeps normal crash behavior
   throw err;
 });
 

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -32,6 +32,7 @@ import {
   runInteractiveProviderSetup,
 } from './startup/provider-startup.js';
 import { renderApp, createDefaultTuiCliAdapter } from '@robota-sdk/agent-transport-tui';
+import { installTuiProcessGuards, setLiveChannel } from './process-guards.js';
 import { TransportRegistry } from '@robota-sdk/agent-transport';
 import { WsTransport } from '@robota-sdk/agent-transport-ws';
 import { createDefaultBackgroundTaskRunners } from '@robota-sdk/agent-executor';
@@ -288,12 +289,15 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   warnIfTerminalAppOnMacOS(terminal);
+  // ERR-001 G1: interactive mode only — the process must survive transient failures.
+  installTuiProcessGuards();
   if (isFirstRun()) {
     printFirstRunWelcome(terminal);
     markOnboarded();
   }
 
   await renderApp({
+    onChannelReady: (channel) => setLiveChannel(channel),
     cwd,
     provider,
     providerOverride: args.provider,

--- a/packages/agent-cli/src/process-guards.ts
+++ b/packages/agent-cli/src/process-guards.ts
@@ -1,0 +1,68 @@
+/**
+ * Process survival boundary for the interactive TUI (ERR-001 G1).
+ *
+ * On Node 20+ an unhandled rejection terminates the process, and the previous
+ * `uncaughtException` guard re-threw everything non-IME — any async path outside the turn
+ * boundary (background tasks, catalog refresh, persistence) hitting a transient network
+ * error could kill the whole TUI. In interactive mode the product installs these
+ * last-resort guards: the error is routed into the live session (humanized, styled error
+ * block, session log) and the process stays alive. Headless/print mode installs nothing
+ * and keeps its fail-fast exit-code contract.
+ *
+ * This is deliberately product-owned (agent-cli), not library-owned — see the Library
+ * Neutrality Rule in .agents/project-structure.md. Each async subsystem should still
+ * terminate its own promises; this boundary is the last resort, not the primary handler.
+ */
+
+/** The surface the guards need from the live TUI channel. */
+export interface IGuardableChannel {
+  getSession(): { reportBackgroundError(error: Error, source?: string): void };
+}
+
+let liveChannel: IGuardableChannel | null = null;
+let guardsInstalled = false;
+
+/** bin.ts consults this so its own uncaughtException fallback keeps fail-fast semantics
+ * whenever the TUI guards are NOT active (headless/print mode). */
+export function areTuiProcessGuardsActive(): boolean {
+  return guardsInstalled;
+}
+
+/** Track the current live channel (session switches re-create it). */
+export function setLiveChannel(channel: IGuardableChannel): void {
+  liveChannel = channel;
+}
+
+function routeProcessError(error: Error, source: string): void {
+  try {
+    if (liveChannel) {
+      liveChannel.getSession().reportBackgroundError(error, source);
+      return;
+    }
+  } catch {
+    // allow-fallback: this guard IS the last-resort boundary — if rendering into the session itself fails, stderr below is the only remaining surface (ERR-001 G1)
+    /* fall through to stderr */
+  }
+  process.stderr.write(`\n[robota] ${source}: ${error.message}\n`);
+}
+
+/**
+ * Install the interactive-mode guards. Idempotent. Never masks errors silently — every
+ * routed error is visible in the transcript (styled block) and the session log.
+ */
+export function installTuiProcessGuards(): void {
+  if (guardsInstalled) return;
+  guardsInstalled = true;
+
+  process.on('unhandledRejection', (reason) => {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    routeProcessError(error, 'unhandled rejection');
+  });
+
+  // Note: bin.ts installed its IME-aware uncaughtException handler first; it checks
+  // areTuiProcessGuardsActive() and defers to this handler instead of re-throwing.
+  process.on('uncaughtException', (err) => {
+    const error = err instanceof Error ? err : new Error(String(err));
+    routeProcessError(error, 'uncaught exception');
+  });
+}

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -442,6 +442,21 @@ non-error (skipped / empty defaults), but an EXISTING file that fails to parse t
 Callers can detect `source === 'env-default'` and read `sourceEnvVar` to render a one-line
 startup notice naming provider/model/env-var — never the key value.
 
+## Turn Error Surfacing & Liveness (ERR-001)
+
+Layered contract: classification lives in the provider (typed errors), humanization in this
+package (`humanizeApiError`, SSOT), turn recovery in the interactive controller, rendering in each
+transport, and process survival in the product assembly.
+
+- A failed turn commits any partially streamed answer to history as an **interrupted assistant
+  entry** before the stream state clears — a mid-stream failure never evaporates the partial text.
+- The error history entry is humanized and machine-marked with `metadata.kind: 'error'` so
+  transports can render a styled error block instead of a plain system note.
+- `InteractiveSession.reportBackgroundError(error, source?)` surfaces errors from OUTSIDE the turn
+  boundary (background tasks, catalog refresh, un-caught promises) through the same humanize →
+  marked-entry → `'error'` event path; the session stays fully usable. Product assemblies route
+  process-level guards here (agent-cli SPEC → Process Survival Boundary).
+
 ## Error Taxonomy
 
 The package defines two named `Error` subclasses: `ProviderConfigError` (missing/unusable

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -270,6 +270,94 @@ describe('InteractiveSession — User Behavior Scenarios', () => {
     expect(errorMsg).toBeDefined();
   });
 
+  // ── Scenario: ERR-001 — mid-stream failure surfacing + liveness ─
+
+  it('ERR-001: mid-stream failure preserves the partial answer, marks a styled error entry, and the next submit succeeds', async () => {
+    const mockSession = createMockSession();
+    const controllableRun = createControllableRun();
+    mockSession.run.mockImplementationOnce(controllableRun.run);
+
+    const session = new InteractiveSession({
+      session: mockSession as never,
+      cwd: '/tmp',
+    });
+    let errorReceived: Error | null = null;
+    session.on('error', (err) => {
+      errorReceived = err;
+    });
+
+    const exec = session.submit('first');
+    await controllableRun.started;
+    // Stream a partial answer, then drop the connection mid-stream.
+    (
+      session as unknown as { execCtrl: { handleTextDelta(delta: string): void } }
+    ).execCtrl.handleTextDelta('partial answ');
+    controllableRun.reject(new Error('read ECONNRESET'));
+    await exec;
+
+    expect(errorReceived!.message).toBe('read ECONNRESET');
+    const history = session.getFullHistory();
+    // (1) The partial answer is preserved as an interrupted assistant entry — not evaporated.
+    const partial = history.find(
+      (e) =>
+        e.category === 'chat' &&
+        (e.data as { role?: string }).role === 'assistant' &&
+        (e.data as { content?: string }).content === 'partial answ',
+    );
+    expect(partial).toBeDefined();
+    expect((partial!.data as { state?: string }).state).toBe('interrupted');
+    // (2) The error entry is humanized AND machine-marked for styled rendering.
+    const errorEntry = history.find(
+      (e) =>
+        e.category === 'chat' &&
+        (e.data as { metadata?: { kind?: string } }).metadata?.kind === 'error',
+    );
+    expect(errorEntry).toBeDefined();
+    expect((errorEntry!.data as { content?: string }).content).toContain(
+      'Network connection failed',
+    );
+    // (3) Liveness: the session accepts and completes the NEXT prompt.
+    await session.submit('second');
+    const assistant = session
+      .getMessages()
+      .filter((m) => m.role === 'assistant')
+      .map((m) => m.content);
+    expect(assistant).toContain('mock response');
+  });
+
+  it('ERR-001 G1: reportBackgroundError surfaces an out-of-turn error into history and events', async () => {
+    const session = new InteractiveSession({
+      session: createMockSession() as never,
+      cwd: '/tmp',
+    });
+    let errorReceived: Error | null = null;
+    session.on('error', (err) => {
+      errorReceived = err;
+    });
+
+    session.reportBackgroundError(
+      new Error('getaddrinfo ENOTFOUND api.example.com'),
+      'background task',
+    );
+
+    expect(errorReceived!.message).toContain('ENOTFOUND');
+    const entry = session
+      .getFullHistory()
+      .find(
+        (e) =>
+          e.category === 'chat' &&
+          (e.data as { metadata?: { kind?: string } }).metadata?.kind === 'error',
+      );
+    expect(entry).toBeDefined();
+    expect((entry!.data as { content?: string }).content).toContain('Network connection failed');
+    expect((entry!.data as { metadata?: { source?: string } }).metadata?.source).toBe(
+      'background task',
+    );
+    // Session stays usable.
+    await session.submit('after');
+    expect(session.getMessages().some((m) => m.content === 'mock response')).toBe(true);
+  });
+
   // ── Scenario: Tool execution tracking ─────────────────────────
 
   it('getActiveTools returns empty array after execution completes', async () => {

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -218,6 +218,7 @@ export class SessionExecutionController {
         beginEditCheckpointTurn: (p) => this.histTracker.beginEditCheckpointTurn(p),
         flushStreaming: () => this.flushStreaming(),
         clearStreaming: () => this.clearStreaming(),
+        getStreamingText: () => this.streamingText,
         onWorkspaceUpdated: () => this.emitExecutionWorkspaceUpdated('main_thread'),
         onComplete: (result: IExecutionResult) => {
           this.callbacks.emit('complete', result);

--- a/packages/agent-framework/src/interactive/interactive-session-prompt.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-prompt.ts
@@ -40,6 +40,8 @@ export interface IPromptTurnContext {
   beginEditCheckpointTurn: (prompt: string) => Promise<void>;
   flushStreaming: () => void;
   clearStreaming: () => void;
+  /** Accumulated streamed text of the in-flight turn (ERR-001: preserved on error). */
+  getStreamingText: () => string;
   onComplete: (result: IExecutionResult) => void;
   onInterrupted: (result: IExecutionResult) => void;
   onError: (err: Error) => void;
@@ -109,10 +111,23 @@ export async function executePromptTurn(
       ctx.onInterrupted(result);
     } else {
       pushToolSummaryToHistory({ activeTools: ctx.getActiveTools(), history });
+      // ERR-001: a mid-stream failure must not evaporate the partial answer — commit it
+      // to history marked interrupted before clearing the stream buffer.
+      const partial = ctx.getStreamingText();
       ctx.clearStreaming();
+      if (partial.trim().length > 0) {
+        const partialMessage = createAssistantMessage(partial);
+        partialMessage.state = 'interrupted';
+        history.push(messageToHistoryEntry(partialMessage));
+      }
       const errObj = err instanceof Error ? err : new Error(String(err));
       const errMsg = humanizeApiError(errObj);
-      history.push(messageToHistoryEntry(createSystemMessage(`Error: ${errMsg}`)));
+      // metadata.kind lets transports render a styled error block instead of a plain system note.
+      history.push(
+        messageToHistoryEntry(
+          createSystemMessage(`Error: ${errMsg}`, { metadata: { kind: 'error' } }),
+        ),
+      );
       ctx.onError(errObj);
     }
   }

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -19,6 +19,7 @@ import {
 import { GoalController, buildGoalContinuationPrompt } from '../goal/index.js';
 import { createUserInteractionPort } from '../interaction/user-interaction-port.js';
 import { retrieveAgentToolDeps } from '../tools/agent-tool.js';
+import { humanizeApiError } from '../utils/error-humanizer.js';
 
 import type { IInteractiveSession } from './i-interactive-session.js';
 import type { ITurnOptions } from './interactive-session-execution-controller.js';
@@ -541,6 +542,22 @@ export class InteractiveSession
       retrieveSessionBackgroundTaskManager(this.session) ??
       retrieveAgentToolDeps(this.session)?.backgroundTaskManager
     );
+  }
+
+  /**
+   * Surface an error that happened OUTSIDE the turn boundary (background task, catalog
+   * refresh, persistence, un-caught promise) into the conversation (ERR-001 G1). The entry
+   * carries `metadata.kind: 'error'` so transports render it as a styled error block, and the
+   * 'error' event drives transport error state. The session stays fully usable.
+   */
+  reportBackgroundError(error: Error, source = 'background'): void {
+    const message = humanizeApiError(error);
+    this.histTracker.append(
+      messageToHistoryEntry(
+        createSystemMessage(`Error: ${message}`, { metadata: { kind: 'error', source } }),
+      ),
+    );
+    this.emit('error', error);
   }
 
   private async captureSandboxSnapshot(): Promise<void> {

--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -122,6 +122,8 @@ function AppInner(
     streamingText,
     activeTools,
     isThinking,
+    lastErrorMessage,
+    isStalled,
     isAborting,
     isShuttingDown,
     pendingPrompt,
@@ -484,6 +486,18 @@ function AppInner(
                   activeTools={activeTools}
                   isThinking={isThinking}
                 />
+                {isStalled && (
+                  <Text color="yellow">
+                    ⚠ Still waiting on the provider — the network may be stalled. Esc to interrupt.
+                  </Text>
+                )}
+              </Box>
+            )}
+            {!isThinking && lastErrorMessage && (
+              <Box marginBottom={1}>
+                <Text color="red">
+                  ✖ Last turn failed — the session is alive; type your next prompt when ready.
+                </Text>
               </Box>
             )}
             <BackgroundTaskPanel

--- a/packages/agent-transport-tui/src/MessageList.tsx
+++ b/packages/agent-transport-tui/src/MessageList.tsx
@@ -145,6 +145,28 @@ function ToolMessage({ message }: { message: TUniversalMessage }): React.ReactEl
   );
 }
 
+/** ERR-001 G2: a failed turn renders as a styled error block, not a plain system note. */
+function ErrorEntryBlock({ message }: { message: TUniversalMessage }): React.ReactElement {
+  const content = (message.content ?? '').replace(/^Error:\s*/, '');
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box>
+        <Text color="red" bold>
+          ✖ Error:{' '}
+        </Text>
+      </Box>
+      <Box marginLeft={2} flexDirection="column">
+        <Text color="red" wrap="wrap">
+          {content}
+        </Text>
+        <Text dimColor wrap="wrap">
+          The session is still alive — type your next prompt when ready.
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
 const MessageItem = React.memo(function MessageItem({
   message,
 }: {
@@ -152,6 +174,10 @@ const MessageItem = React.memo(function MessageItem({
 }): React.ReactElement {
   if (isToolMessage(message)) {
     return <ToolMessage message={message} />;
+  }
+
+  if (message.role === 'system' && message.metadata?.kind === 'error') {
+    return <ErrorEntryBlock message={message} />;
   }
 
   const content = message.content ?? '';

--- a/packages/agent-transport-tui/src/TuiInteractionChannel.ts
+++ b/packages/agent-transport-tui/src/TuiInteractionChannel.ts
@@ -413,8 +413,8 @@ export class TuiInteractionChannel implements IInteractionChannel {
       manager.onComplete(result);
       manager.syncHistory(session.getFullHistory());
     };
-    const onError = (): void => {
-      manager.onError();
+    const onError = (error: Error): void => {
+      manager.onError(error);
       manager.syncHistory(session.getFullHistory());
     };
     const onCompact = (): void => {

--- a/packages/agent-transport-tui/src/__tests__/tui-state-manager.error-stall.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/tui-state-manager.error-stall.test.ts
@@ -1,0 +1,73 @@
+/**
+ * ERR-001 G2/G3 — TUI error-state reducer: last-error message lifecycle and the
+ * dead-air stall hint timer.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TuiStateManager } from '../tui-state-manager';
+
+describe('TuiStateManager — error state (ERR-001 G2)', () => {
+  it('records the error message on onError and clears it when the next turn starts', () => {
+    const manager = new TuiStateManager();
+
+    manager.onError(new Error('connection reset'));
+    expect(manager.lastErrorMessage).toBe('connection reset');
+    expect(manager.isThinking).toBe(false);
+
+    manager.onThinking(true);
+    expect(manager.lastErrorMessage).toBeNull();
+  });
+
+  it('falls back to a generic message when no Error object arrives', () => {
+    const manager = new TuiStateManager();
+    manager.onError();
+    expect(manager.lastErrorMessage).toBe('Unknown error');
+  });
+});
+
+describe('TuiStateManager — dead-air stall hint (ERR-001 G3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flags isStalled after 15s of thinking with no provider activity', () => {
+    const manager = new TuiStateManager();
+    manager.onThinking(true);
+    expect(manager.isStalled).toBe(false);
+
+    vi.advanceTimersByTime(15_000);
+    expect(manager.isStalled).toBe(true);
+  });
+
+  it('provider activity (text delta) resets the timer — no stall flag', () => {
+    const manager = new TuiStateManager();
+    manager.onThinking(true);
+
+    vi.advanceTimersByTime(10_000);
+    manager.onTextDelta('still alive');
+    vi.advanceTimersByTime(10_000);
+    expect(manager.isStalled).toBe(false);
+
+    vi.advanceTimersByTime(5_000);
+    expect(manager.isStalled).toBe(true);
+  });
+
+  it('clears the stall flag and timer when the turn ends (thinking false / error)', () => {
+    const manager = new TuiStateManager();
+    manager.onThinking(true);
+    vi.advanceTimersByTime(15_000);
+    expect(manager.isStalled).toBe(true);
+
+    manager.onThinking(false);
+    expect(manager.isStalled).toBe(false);
+
+    manager.onThinking(true);
+    manager.onError(new Error('boom'));
+    vi.advanceTimersByTime(20_000);
+    expect(manager.isStalled).toBe(false);
+  });
+});

--- a/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
+++ b/packages/agent-transport-tui/src/hooks/useTuiChannel.ts
@@ -28,6 +28,10 @@ export interface IInteractiveSessionState {
   activeTools: IToolState[];
   isThinking: boolean;
   isAborting: boolean;
+  /** ERR-001 G2: humanized message of the last failed turn (null once the next turn starts). */
+  lastErrorMessage: string | null;
+  /** ERR-001 G3: no provider activity for a while during a turn — connection may be stalled. */
+  isStalled: boolean;
   isShuttingDown: boolean;
   pendingPrompt: string | null;
   executionWorkspaceSnapshot: IExecutionWorkspaceSnapshot | null;
@@ -94,6 +98,8 @@ export function useTuiChannel(channel: TuiInteractionChannel): IInteractiveSessi
     activeTools: manager.activeTools,
     isThinking: manager.isThinking,
     isAborting: manager.isAborting,
+    lastErrorMessage: manager.lastErrorMessage,
+    isStalled: manager.isStalled,
     isShuttingDown: channel.isShuttingDown,
     pendingPrompt: manager.pendingPrompt,
     executionWorkspaceSnapshot: manager.executionWorkspaceSnapshot,

--- a/packages/agent-transport-tui/src/render.tsx
+++ b/packages/agent-transport-tui/src/render.tsx
@@ -61,6 +61,11 @@ export interface IRenderOptions {
   enableParallelSubagents?: boolean;
   /** Preset execution capability: run a post-task self-verification step. */
   selfVerification?: boolean;
+  /**
+   * Called with each live channel (including session-switch re-creations). Lets the embedding
+   * product wire process-level concerns (ERR-001 G1: error routing into the live session).
+   */
+  onChannelReady?: (channel: TuiInteractionChannel) => void;
 }
 
 /** Map render options to TuiInteractionChannel constructor options. */
@@ -96,12 +101,8 @@ export function toChannelOptions(
 }
 
 export async function renderApp(options: IRenderOptions): Promise<void> {
-  process.on('unhandledRejection', (reason) => {
-    process.stderr.write(`\n[UNHANDLED REJECTION] ${reason}\n`);
-    if (reason instanceof Error) {
-      process.stderr.write(`${reason.stack}\n`);
-    }
-  });
+  // ERR-001 / Library Neutrality Rule: NO process-level error policy here — process survival
+  // is the product assembly's boundary (agent-cli installs the guards via onChannelReady).
 
   // TERM-002: one terminal-handoff controller per process (one Ink instance / App). Shared across
   // channel re-creations (session switch) so the handoff capability survives a session swap.
@@ -109,11 +110,16 @@ export async function renderApp(options: IRenderOptions): Promise<void> {
 
   // Single-owner lifecycle (CLI-B12): render.tsx supplies only the factory;
   // App creates, replaces, and stops channels exclusively through React state.
-  const createChannel = (resumeSessionId?: string): TuiInteractionChannel =>
-    new TuiInteractionChannel({
+  const createChannel = (resumeSessionId?: string): TuiInteractionChannel => {
+    const channel = new TuiInteractionChannel({
       ...toChannelOptions(options, resumeSessionId),
       terminalHandoff: handoffController,
     });
+    // Expose each live channel (incl. session-switch re-creations) to the embedding product,
+    // e.g. for process-level error routing (ERR-001 G1).
+    options.onChannelReady?.(channel);
+    return channel;
+  };
 
   const instance = render(
     <App

--- a/packages/agent-transport-tui/src/tui-state-manager.ts
+++ b/packages/agent-transport-tui/src/tui-state-manager.ts
@@ -17,6 +17,9 @@ import type {
 
 /** Debounce interval for streaming text notify (limits renderMarkdown frequency) */
 const STREAMING_DEBOUNCE_MS = 300;
+/** ERR-001 G3: with no provider activity for this long while thinking, hint that the
+ * connection may be stalled (well under the 120s provider idle timeout). */
+const STALL_HINT_MS = 15_000;
 /**
  * TUI view of the core context-window state. The token fields are derived from the agent-core
  * SSOT (`IContextWindowState`) via `Pick` so they stay structurally tied to it; `percentage` is an
@@ -62,6 +65,10 @@ export class TuiStateManager {
   contextState: TContextState = { percentage: 0, usedTokens: 0, maxTokens: 0 };
   executionWorkspaceSnapshot: IExecutionWorkspaceSnapshot | null = null;
   selectedExecutionEntryId: string | undefined;
+  /** ERR-001 G2: humanized message of the last failed turn; cleared when the next turn starts. */
+  lastErrorMessage: string | null = null;
+  /** ERR-001 G3: no stream/tool activity for STALL_HINT_MS while thinking. */
+  isStalled = false;
 
   /** Called after any state change. React hook sets this to trigger re-render. */
   onChange: (() => void) | null = null;
@@ -69,6 +76,27 @@ export class TuiStateManager {
   // ── Internal ──────────────────────────────────────────────────
   private streamBuf = '';
   private debouncedStreamNotify = createDebouncedNotify(() => this.notify(), STREAMING_DEBOUNCE_MS);
+  private stallTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** (Re)start the dead-air timer — any provider activity proves the connection is alive. */
+  private armStallTimer(): void {
+    this.clearStallTimer();
+    this.stallTimer = setTimeout(() => {
+      this.stallTimer = null;
+      this.isStalled = true;
+      this.notify();
+    }, STALL_HINT_MS);
+  }
+
+  private clearStallTimer(): void {
+    if (this.stallTimer) {
+      clearTimeout(this.stallTimer);
+      this.stallTimer = null;
+    }
+    if (this.isStalled) {
+      this.isStalled = false;
+    }
+  }
 
   private notify(): void {
     this.onChange?.();
@@ -77,12 +105,14 @@ export class TuiStateManager {
   // ── Event handlers (InteractiveSession → state) ───────────────
 
   onTextDelta = (delta: string): void => {
+    if (this.isThinking) this.armStallTimer();
     this.streamBuf += delta;
     this.streamingText = this.streamBuf;
     this.debouncedStreamNotify.schedule();
   };
 
   onToolStart = (state: IToolState): void => {
+    if (this.isThinking) this.armStallTimer();
     this.activeTools = [...this.activeTools, state];
     this.notify();
   };
@@ -106,9 +136,12 @@ export class TuiStateManager {
       this.streamBuf = '';
       this.streamingText = '';
       this.activeTools = [];
+      this.lastErrorMessage = null;
+      this.armStallTimer();
     } else {
       this.isAborting = false;
       this.activeTools = [];
+      this.clearStallTimer();
     }
     this.notify();
   };
@@ -116,6 +149,7 @@ export class TuiStateManager {
   onComplete = (result: IExecutionResult): void => {
     // Tool summary is now in messages (pushed by InteractiveSession)
     // Clear streaming display
+    this.clearStallTimer();
     this.debouncedStreamNotify.flush();
     this.streamBuf = '';
     this.streamingText = '';
@@ -130,6 +164,7 @@ export class TuiStateManager {
 
   onInterrupted = (): void => {
     // Tool summary is now in messages
+    this.clearStallTimer();
     this.debouncedStreamNotify.flush();
     this.streamBuf = '';
     this.streamingText = '';
@@ -137,8 +172,11 @@ export class TuiStateManager {
     this.notify();
   };
 
-  onError = (): void => {
-    // Tool summary is now in messages
+  onError = (error?: Error): void => {
+    // The partial answer is preserved as an interrupted history entry by the framework
+    // (ERR-001); clearing the local stream buffer here no longer loses it.
+    this.clearStallTimer();
+    this.lastErrorMessage = error?.message ?? 'Unknown error';
     this.debouncedStreamNotify.flush();
     this.streamBuf = '';
     this.streamingText = '';


### PR DESCRIPTION
## 요약

사용자 요구사항 — "에러가 났을 때 사용자에게 제대로 인지시키고, 에러가 나더라도 프로그램이 멈추거나 죽으면 안 된다" — 의 구현입니다 (PR #913에서 승인된 설계의 G1–G3; G4 자동 재시도는 설계대로 범위 밖).

## 변경 내용

**G1 — 프로세스 생존 (제품 소유, Library Neutrality Rule 준수)**
- `agent-cli/src/process-guards.ts` 신설: TUI 모드 한정 `unhandledRejection`/`uncaughtException` 가드 — 라이브 세션으로 라우팅(humanize→styled block→세션 로그), 최후 표면은 stderr. headless는 fail-fast 유지.
- `render.tsx`(라이브러리)에 숨어 있던 프로세스 핸들러 제거(중립성 위반 + raw stderr가 Ink 프레임 파손) → 중립적 `onChannelReady` seam으로 대체, 제품이 배선.
- `bin.ts` IME 폴백은 가드 활성 시 양보(`areTuiProcessGuardsActive`).

**G2 — 실패 렌더링**
- framework: 부분 스트림 텍스트를 지우기 전에 interrupted assistant 엔트리로 커밋(답이 증발하지 않음), 에러 엔트리에 `metadata.kind:'error'` 기계 마킹, 신설 `InteractiveSession.reportBackgroundError`(턴 밖 에러도 같은 경로).
- TUI: ✖ styled 에러 블록(humanized 메시지 + "세션 살아있음" 안내, 스택트레이스 없음) + 일시적 사후 에러 스트립.

**G3 — dead-air**: 15초 무활동 시 "provider 대기 중 — 네트워크 정체 가능, Esc로 중단" 힌트 (활동마다 리셋).

## 검증

- 단위/기능 11개 신규: TUI 리듀서 5(fake-timer 스톨 포함) / framework 2(미드-스트림 ECONNRESET → 부분 보존+마킹 엔트리+**다음 submit 성공**) / process-guards 4. 전체 repo + 43 스캔 green.
- **User Execution (라이브)**: 실제 빌드 바이너리를 PTY로 구동, 실제 Anthropic API 앞에 RST 프록시 — 답변 스트리밍 중 소켓 절단 → `styled block: true | humanized: true | no stack trace: true`, 프록시 복구 후 두 번째 프롬프트 "RECOVERED" 왕복, 프로세스 생존. 증거는 백로그에.

## 문서

guide error-handling / framework SPEC(Turn Error Surfacing & Liveness) / CLI SPEC(Process Survival Boundary) 동기화.

## 백로그

ERR-001 done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj