### PR TITLE
chore(infra): INFRA-023 라이브 검증 스크립트 거처 scratch/ + 배치 가드 스캔

### DIFF
--- a/.agents/backlog/completed/INFRA-023-scratch-workspace-for-live-verification.md
+++ b/.agents/backlog/completed/INFRA-023-scratch-workspace-for-live-verification.md
@@ -1,0 +1,66 @@
+---
+title: 'INFRA-023: scratch/ workspace — the one home for live-verification scripts, with a guard against temp files in packages/'
+status: done
+completed: 2026-07-04
+created: 2026-07-03
+priority: medium
+urgency: now
+area: scratch/, scripts/harness, .agents/rules
+depends_on: []
+---
+
+# Live-verification script home
+
+Owner question (2026-07-03): "왜 라이브러리 속에 이상한 넘버링이 되어 있는 파일을 만들었는가?"
+During the goal loop, disposable User-Execution scripts (`err-001-proxy.mjs`,
+`core-016-user-execution.ts`, …) were repeatedly placed INSIDE library package roots because pnpm's
+strict, script-location-relative ESM resolution cannot resolve `@robota-sdk/*` imports from the
+scratchpad or `/tmp`. Deletion discipline kept them out of every commit, but discipline is not a
+mechanism — one `git add -A` accident away, and the working tree the owner watches shows unknown
+numbered files inside libraries.
+
+## What (approved recommendation)
+
+1. **`scratch/` workspace package** at repo root (NOT under `packages/` — dev tooling tier, not a
+   library; Library Neutrality Rule untouched): COMMITTED skeleton (`package.json` `private: true`
+   name `robota-scratch`, `workspace:*` deps on core/provider/tools/session/framework/testing,
+   `tsconfig.json`, `README.md`, `.gitignore`) with **`src/` contents gitignored** — scripts run
+   but can never be committed. Committing the skeleton with pinned deps keeps `pnpm-lock.yaml`
+   importers stable (`--frozen-lockfile` CI safe); a fully-ignored directory would fork the
+   lockfile per machine.
+2. Workspace registration (`pnpm-workspace.yaml` + root `package.json` `workspaces`, aligned per
+   the workspace-drift scan) and harness-scope exclusion (same mechanism as examples in
+   `scripts/harness/shared.mjs`).
+3. **Guard scan** (mechanism over prose): temp-pattern files (`*-user-execution.*`, `*-proxy.mjs`,
+   `*-mode.txt`) under `packages/**` or `apps/**` fail the scan.
+4. One-line convention in `.agents/rules/backlog-execution.md`: User-Execution scripts live in
+   `scratch/src/`.
+
+## Test Plan
+
+- `pnpm install` lockfile-clean; a sample script in `scratch/src/` importing `@robota-sdk/agent-core`
+  runs via `tsx --conditions=source`; `git status` stays clean with scripts present; guard scan
+  fails on a planted `packages/agent-core/x-user-execution.ts` and passes clean; full
+  `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+- Prereq: repo as-is.
+- Steps: write a script in `scratch/src/` that constructs a Robota with a real provider key and
+  runs one turn; check `git status`; plant a temp-named file in a package root and run the scan.
+- Expected: script resolves deps and runs; git stays clean; the scan blocks the planted file.
+- Evidence: **PASS (live, 2026-07-04).** Implemented as approved: `scratch/` root workspace
+  package (committed skeleton — `private: true` `robota-scratch`, `workspace:*` deps on
+  core/provider/tools/session/framework/testing + zod, tsconfig with `customConditions:
+['source']`, README, `.gitignore src/*` with a kept `.gitkeep`); registered in
+  pnpm-workspace.yaml + root `workspaces` (drift scan green) and excluded from harness scopes
+  alongside examples (`shared.mjs`). Guard mechanized: new `temp-script-placement` scan (44
+  scans total) fails on `*-user-execution.*` / `*-proxy.mjs` / `*-mode.txt` under `packages/**`
+  or `apps/**` (+2 unit tests in the harness suite, 223 green; verify-change wired). Convention
+  recorded once in `.agents/rules/backlog-execution.md` § User Execution rule. User Execution
+  (scenario as written): a `scratch/src/` script constructing a Robota with the REAL Anthropic
+  key resolved all `@robota-sdk/*` imports and answered `SCRATCH-OK`; `git status` showed zero
+  scratch/src entries with the script present; a planted
+  `packages/agent-core/x-099-user-execution.ts` failed the scan (exit 1) and full
+  `pnpm harness:scan` is green after removal. Lockfile stable (committed skeleton deps —
+  `pnpm install` no-churn).

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -102,6 +102,11 @@ Every backlog that changes runnable user-facing behavior, command behavior, TUI/
 workflow behavior must include a `## User Execution Test Scenarios` section before implementation
 starts.
 
+**Script home (INFRA-023)**: disposable live-verification scripts (evidence runs, repro probes)
+live in `scratch/src/` — a gitignored workspace home whose committed skeleton resolves
+`@robota-sdk/*` imports. Never park them inside `packages/` or `apps/`; the
+`temp-script-placement` harness scan blocks temp-pattern files there.
+
 User execution test scenarios are separate from the agent's engineering test plan:
 
 - The engineering test plan covers unit, integration, type, harness, CI, build, and internal

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
     "packages/dag-nodes/*",
     "apps/*",
     "examples/*",
-    "examples/capabilities/*"
+    "examples/capabilities/*",
+    "scratch"
   ],
   "volta": {
     "node": "22.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2928,6 +2928,40 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
 
+  scratch:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../packages/agent-core
+      '@robota-sdk/agent-framework':
+        specifier: workspace:*
+        version: link:../packages/agent-framework
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../packages/agent-provider
+      '@robota-sdk/agent-session':
+        specifier: workspace:*
+        version: link:../packages/agent-session
+      '@robota-sdk/agent-testing':
+        specifier: workspace:*
+        version: link:../packages/agent-testing
+      '@robota-sdk/agent-tools':
+        specifier: workspace:*
+        version: link:../packages/agent-tools
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.21
+      tsx:
+        specifier: ^4.6.0
+        version: 4.22.4
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
 packages:
 
   /@actions/core@1.11.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
   # scripts/harness/shared.mjs listWorkspaceScopes — and are private (never published).
   - 'examples/*'
   - 'examples/capabilities/*'
+  # dev-tooling tier: disposable live-verification scripts (src/ gitignored)
+  - 'scratch'

--- a/scratch/.gitignore
+++ b/scratch/.gitignore
@@ -1,0 +1,3 @@
+# Everything under src/ is disposable live-verification tooling — never committed.
+src/*
+!src/.gitkeep

--- a/scratch/README.md
+++ b/scratch/README.md
@@ -1,0 +1,13 @@
+# robota-scratch
+
+The ONE home for disposable **live-verification scripts** (backlog User Execution evidence runs,
+repro probes). See `.agents/rules/backlog-execution.md`.
+
+- `src/` contents are **gitignored** — nothing written here can be committed.
+- The committed skeleton declares `workspace:*` deps on the main packages, so scripts resolve
+  `@robota-sdk/*` imports without ever touching a library directory
+  (pnpm ESM resolution is script-location-relative).
+- Run: `pnpm --filter robota-scratch run run src/my-probe.ts`
+  (or from the repo root: `pnpm exec tsx --conditions=source scratch/src/my-probe.ts`).
+- A harness scan (`temp-script-placement`) fails if temp-pattern files
+  (`*-user-execution.*`, `*-proxy.mjs`, `*-mode.txt`) appear under `packages/**` or `apps/**`.

--- a/scratch/package.json
+++ b/scratch/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "robota-scratch",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Disposable live-verification (User Execution) scripts. src/ contents are gitignored — nothing here is ever committed or published.",
+  "type": "module",
+  "scripts": {
+    "run": "tsx --conditions=source"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-framework": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
+    "@robota-sdk/agent-session": "workspace:*",
+    "@robota-sdk/agent-testing": "workspace:*",
+    "@robota-sdk/agent-tools": "workspace:*",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.6.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/scratch/tsconfig.json
+++ b/scratch/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "customConditions": ["source"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/harness/__tests__/check-temp-script-placement.test.mjs
+++ b/scripts/harness/__tests__/check-temp-script-placement.test.mjs
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { findParkedTempScripts } from '../check-temp-script-placement.mjs';
+
+async function createFixture(files) {
+  const root = await mkdtemp(path.join(tmpdir(), 'robota-temp-script-'));
+  for (const relativePath of files) {
+    const target = path.join(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, '// temp\n', 'utf8');
+  }
+  return root;
+}
+
+describe('findParkedTempScripts (INFRA-023)', () => {
+  it('flags temp-pattern files parked under packages/ and apps/', async () => {
+    const root = await createFixture([
+      'packages/agent-core/core-099-user-execution.ts',
+      'packages/agent-cli/err-099-proxy.mjs',
+      'apps/docs/x-mode.txt',
+    ]);
+
+    expect(findParkedTempScripts(root)).toEqual([
+      'apps/docs/x-mode.txt',
+      'packages/agent-cli/err-099-proxy.mjs',
+      'packages/agent-core/core-099-user-execution.ts',
+    ]);
+  });
+
+  it('ignores scratch/, node_modules, and dist output', async () => {
+    const root = await createFixture([
+      'scratch/src/core-099-user-execution.ts',
+      'packages/agent-core/node_modules/x/y-user-execution.ts',
+      'packages/agent-core/dist/z-user-execution.js',
+      'packages/agent-core/src/robota.ts',
+    ]);
+
+    expect(findParkedTempScripts(root)).toEqual([]);
+  });
+});

--- a/scripts/harness/check-temp-script-placement.mjs
+++ b/scripts/harness/check-temp-script-placement.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Temp-script placement guard (INFRA-023).
+ *
+ * Disposable live-verification scripts (backlog User Execution probes) belong in `scratch/src/`
+ * (gitignored) — never inside library/app trees. During the 2026-07 goal loop such scripts were
+ * repeatedly parked in package roots because of pnpm's script-location-relative ESM resolution;
+ * deletion discipline kept them out of commits, but discipline is not a mechanism. This scan is.
+ *
+ * Findings: a file matching a temp pattern (`*-user-execution.*`, `*-proxy.mjs`, `*-mode.txt`)
+ * anywhere under `packages/` or `apps/`.
+ *
+ * Exit code 0 = no temp scripts parked in product/library trees, 1 = violation found.
+ */
+
+import path from 'node:path';
+import { globSync } from 'node:fs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+export const TEMP_PATTERNS = ['*-user-execution.*', '*-proxy.mjs', '*-mode.txt'];
+
+/** List temp-pattern files under packages/ and apps/ (node_modules/dist excluded). */
+export function findParkedTempScripts(root = WORKSPACE_ROOT) {
+  const found = [];
+  for (const tier of ['packages', 'apps']) {
+    for (const pattern of TEMP_PATTERNS) {
+      for (const entry of globSync(`${tier}/**/${pattern}`, { cwd: root })) {
+        if (entry.includes('node_modules/') || entry.includes('/dist/')) continue;
+        found.push(entry);
+      }
+    }
+  }
+  return found.sort();
+}
+
+export async function main() {
+  const parked = findParkedTempScripts();
+  if (parked.length > 0) {
+    process.stdout.write(
+      'temp-script-placement scan failed — disposable scripts parked in library/app trees:\n',
+    );
+    for (const file of parked) {
+      process.stdout.write(`  - ${file}\n`);
+    }
+    process.stdout.write(
+      'Move live-verification scripts to scratch/src/ (see scratch/README.md).\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write('temp-script-placement scan passed.\n');
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -83,6 +83,10 @@ const SCAN_COMMANDS = [
   { name: 'backlog-placement', command: ['node', 'scripts/harness/check-backlog-placement.mjs'] },
   { name: 'doc-examples', command: ['node', 'scripts/harness/check-doc-examples.mjs'] },
   { name: 'llms-txt', command: ['node', 'scripts/harness/check-llms-txt.mjs'] },
+  {
+    name: 'temp-script-placement',
+    command: ['node', 'scripts/harness/check-temp-script-placement.mjs'],
+  },
   { name: 'orphan-exports', command: ['node', 'scripts/harness/check-orphan-exports.mjs'] },
   { name: 'deps', command: ['node', 'scripts/harness/check-dependency-direction.mjs'] },
   {

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -122,6 +122,11 @@ export async function listWorkspaceScopes() {
     if (rootName === 'examples') {
       continue;
     }
+    // `scratch` is the dev-tooling home for disposable live-verification scripts
+    // (INFRA-023): committed skeleton only, src/ gitignored — not a scannable scope.
+    if (rootName === 'scratch') {
+      continue;
+    }
     if (!(await pathExists(path.join(WORKSPACE_ROOT, rootName)))) {
       continue;
     }

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -68,6 +68,7 @@ function runRepositoryCheck(check, dryRun) {
           'scripts/harness/__tests__/check-backlog-placement.test.mjs',
           'scripts/harness/__tests__/check-doc-examples.test.mjs',
           'scripts/harness/__tests__/check-llms-txt.test.mjs',
+          'scripts/harness/__tests__/check-temp-script-placement.test.mjs',
         ],
         WORKSPACE_ROOT,
         dryRun,


### PR DESCRIPTION
## 요약

소유자 질문("왜 라이브러리 속에 넘버링된 파일을 만들었는가")의 구조적 해결입니다. 승인된 추천안 그대로: 삭제-규율을 메커니즘으로 대체합니다.

## 변경 내용

- **`scratch/` 루트 워크스페이스 패키지** (packages/ 밖 — 라이브러리 티어 아님, Library Neutrality 무접촉): 커밋되는 스켈레톤(`private: true`, 주요 패키지 `workspace:*` 의존, source-conditions tsconfig, README) + **`src/` 내용물 gitignore**(.gitkeep만 유지). 스켈레톤 커밋 + 의존 고정이라 lockfile importer가 안정적(`--frozen-lockfile` CI 안전).
- 워크스페이스 등록(yaml+package.json 정렬 — drift 스캔 green), examples와 동일 방식으로 하네스 스코프 제외.
- **신규 `temp-script-placement` 스캔(총 44개)**: `*-user-execution.*`/`*-proxy.mjs`/`*-mode.txt`가 `packages/`·`apps/` 아래 존재하면 실패 (+단위 테스트 2, 하네스 스위트 223 green, verify-change 연결).
- 관례를 `.agents/rules/backlog-execution.md`에 한 줄 명시 (소유 문서 1곳).

## 검증 (User Execution — 시나리오 그대로 라이브)

1. `scratch/src/` 스크립트가 실제 Anthropic 키로 Robota 1턴 실행 → `SCRATCH-OK` (모든 `@robota-sdk/*` import 해석).
2. 스크립트가 존재하는 상태에서 `git status` → scratch/src 항목 0개.
3. `packages/agent-core/x-099-user-execution.ts`를 심자 스캔 실패(exit 1), 제거 후 44개 스캔 전부 green.

## 백로그

INFRA-023 생성 + done + `completed/` 이동 (같은 커밋).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj