### PR TITLE
chore(governance): prior-approval rule for novel practices + CORE-017 backlog

### DIFF
--- a/.agents/backlog/CORE-017-run-options-dead-field-audit.md
+++ b/.agents/backlog/CORE-017-run-options-dead-field-audit.md
@@ -1,0 +1,55 @@
+---
+title: 'CORE-017: IRunOptions dead-field audit — stream/toolChoice unthreaded; every advertised run option must work or fail loudly'
+status: todo
+created: 2026-07-04
+priority: high
+urgency: soon
+area: packages/agent-core
+depends_on: []
+---
+
+# IRunOptions dead-field audit
+
+Follow-on from the CORE-016 external bug report (`.design/bug-report-maxtokens-2026-07-03.md`
+제안 3 — silent-ignore mitigation, generalized). CORE-016 fixed `maxTokens`/`temperature`, but a
+grep sweep of `robota-execution.ts` + `execution-*.ts` for `options.stream` / `options.toolChoice`
+/ `context.toolChoice` returns EMPTY — `IRunOptions.stream` and `IRunOptions.toolChoice` are
+advertised on the public interface yet never threaded into any execution context or provider call.
+Same defect class the report exposed: a typed, documented option the runtime silently ignores.
+
+## What
+
+1. **Full-surface audit**: for every field on `IRunOptions`, trace the threading path
+   (buildRunContext / runStream inline context → `IExecutionContext` →
+   `buildFullExecutionContext` → provider call sites, per the CORE-011/CORE-016 lesson: the
+   helper is the easy-to-miss seam). Produce a table: field → threaded? → consumer.
+2. **Policy — no silent ignores**: each dead field must be either (a) wired end-to-end with
+   regression tests (CORE-016 pattern: mock provider asserts chatOptions), or (b) removed from
+   the interface. This repo is unreleased with a no-backward-compat, no-deprecated policy —
+   removal is a first-class option; a warning log is NOT an acceptable terminal state.
+3. **Regression guard**: for every field kept, a threading assertion test (run + runStream);
+   consider a type-level or test-level exhaustiveness check over `keyof IRunOptions` so a future
+   field cannot ship unthreaded.
+
+## Known dead fields (verified 2026-07-03 by grep)
+
+- `stream` — no reads anywhere in execution services.
+- `toolChoice` — no reads anywhere in execution services.
+- (Audit may find more; the table in item 1 is the deliverable that proves completeness.)
+
+## Test Plan
+
+- Unit: threading assertions per kept field (mock provider records chatOptions), run × runStream.
+- Exhaustiveness: test iterating `keyof IRunOptions` against the audited table.
+- Full core suite + typecheck + harness scans green.
+
+## User Execution Test Scenarios
+
+- Prereq: consumer script in `scratch/src/` with a real provider key
+  (`packages/agent-cli/.env` ANTHROPIC_API_KEY).
+- Steps: for each kept-and-wired field, one live call demonstrating the option observably
+  changes provider behavior (e.g. `toolChoice` forcing/suppressing a tool call); for each
+  removed field, `tsc` rejection of the removed option in a consumer snippet.
+- Expected: every advertised option has an observable effect; no option compiles yet silently
+  no-ops.
+- Evidence: (record after execution)

--- a/.agents/backlog/completed/INFRA-023-scratch-workspace-for-live-verification.md
+++ b/.agents/backlog/completed/INFRA-023-scratch-workspace-for-live-verification.md
@@ -61,6 +61,7 @@ numbered files inside libraries.
   (scenario as written): a `scratch/src/` script constructing a Robota with the REAL Anthropic
   key resolved all `@robota-sdk/*` imports and answered `SCRATCH-OK`; `git status` showed zero
   scratch/src entries with the script present; a planted
+  <!-- evidence-superseded: deliberately transient probe file planted to prove the scan fires, removed in the same run; the durable guard is scripts/harness/__tests__/check-temp-script-placement.test.mjs -->
   `packages/agent-core/x-099-user-execution.ts` failed the scan (exit 1) and full
   `pnpm harness:scan` is green after removal. Lockfile stable (committed skeleton deps —
   `pnpm install` no-churn).

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -34,6 +34,23 @@ The agent must stop and present options to the user when ANY of the following ho
 - The decision changes a published or externally visible contract.
 - The decision requires business, legal, or strategic judgment (e.g., telemetry opt-in consent,
   third-party service selection).
+- The change introduces a practice this repository has not used before — a new workflow, tooling
+  convention, file-placement pattern, or verification approach with no existing rule, skill, or
+  precedent to point to.
+- The change touches repository-wide policy files — lint configuration (`.eslintrc*`), CI
+  workflows (`.github/workflows/`), git hooks, or workspace topology (root directories,
+  `pnpm-workspace.yaml`, root `package.json` scripts) — even when the change is bundled inside an
+  already-approved backlog. Backlog approval covers the backlog's stated scope, not policy files
+  it happens to pass through. Backlog wording such as "consider adding X" authorizes evaluation
+  and a recommendation, not the change itself.
+- The change edits, moves, or deletes a user-authored document (a file the user personally wrote,
+  e.g. reports or notes under `.design/`), unless the user has already given disposition for that
+  document.
+
+**Disclosure is not approval.** Mentioning a policy-file change or novel practice in a PR
+description, commit message, or backlog note does not substitute for asking first. Approval must
+be obtained before the change lands (2026-07-03 trust audit: three such changes shipped with
+PR-body disclosure only; all required retroactive review).
 
 **Never write "사용자 결정 필요" without first presenting a concrete recommendation.** Every
 open decision in a backlog item must include the agent's recommendation and the reasoning behind it.

--- a/.design/bug-report-maxtokens-2026-07-03.md
+++ b/.design/bug-report-maxtokens-2026-07-03.md
@@ -92,3 +92,8 @@ PR #933에서 수정됨. 원인: (1) `executeStream`(runStream 경로)의 chat o
 `IExecutionContext` 경유로 두 provider 호출 지점 모두에 전달(오버라이드 우선).
 회귀 테스트가 이 리포트의 매트릭스 4조합 전부를 mock provider로 단언하며, 라이브 재현
 (무제한 13,501자 vs cap 50에서 238/211자)은 `CORE-016` 백로그 evidence에 기록.
+
+제안 3(silent-ignore 완화)은 일반화하여 후속 백로그 `CORE-017`
+(`.agents/backlog/CORE-017-run-options-dead-field-audit.md`)로 등록: 동일 결함 부류로
+`IRunOptions.stream`/`toolChoice`가 스레딩되지 않는 죽은 필드임을 grep으로 확인했으며,
+모든 공개 run 옵션은 동작하거나 제거되어야 한다는 정책으로 전수 감사 예정.


### PR DESCRIPTION
## Accepted recommendation

Trust-audit (2026-07-03) follow-up, per user's three directives:

1. **① Bug-report review → backlog**: `.design/bug-report-maxtokens-2026-07-03.md` fully reviewed. 제안 1/2 are covered by CORE-016 (PR #933). 제안 3 (silent-ignore mitigation) generalized: grep verified `IRunOptions.stream` and `IRunOptions.toolChoice` are unthreaded dead fields — filed **CORE-017** (todo): full IRunOptions threading audit; every advertised option must work or be removed (no-backward-compat repo — removal is first-class; warning logs are not a terminal state).
2. **② Retroactive policy reviews (user-approved)**: eslint `no-dupe-class-members` → `@typescript-eslint` variant, and CI `harness:test` blocking step — both reviewed individually and retained with retroactive approval. No file changes needed.
3. **③ Rule institutionalization**: `rules/backlog-execution.md` § Agent Decision Authority now requires PRIOR approval for (a) practices with no repo precedent, (b) repo-wide policy files (lint config, CI workflows, hooks, workspace topology) even inside approved backlogs, (c) user-authored document edits/moves. **Disclosure in a PR body is not approval.** Mirrored in session memory.

Also: INFRA-023 evidence reference to the deliberately transient probe file annotated `evidence-superseded` (done-evidence scan was red on develop).

## Verification

- `pnpm harness:scan` 44/44 green (done-evidence fixed), `pnpm harness:test` 223 green, `pnpm typecheck` green, `pnpm lint` 0 errors.
- User execution test scenario: **not applicable** — governance/rule/backlog-only change, no runnable user-facing behavior (per backlog-execution.md).

## Residual risks

- None functional. CORE-017 is filed, not implemented — the dead fields remain until that backlog runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj