### PR TITLE
chore(governance): architecture-audit follow-up — INFRA-024/025 backlogs + preset rule consumers

### DIFF
--- a/.agents/backlog/INFRA-024-dep-kind-conformance.md
+++ b/.agents/backlog/INFRA-024-dep-kind-conformance.md
@@ -1,0 +1,51 @@
+---
+title: 'INFRA-024: dep-kind conformance — runtime value imports must be dependencies/peerDependencies, never devDependencies-only'
+status: todo
+created: 2026-07-04
+priority: high
+urgency: now
+area: packages/agent-cli, scripts/harness
+depends_on: []
+---
+
+# Dep-kind conformance
+
+Architecture audit finding F1 (2026-07-04): `packages/agent-cli/src/cli.ts:38` value-imports
+`createDefaultBackgroundTaskRunners` from `@robota-sdk/agent-executor` at runtime, but
+agent-cli declares agent-executor only in **devDependencies**. The published CLI (beta)
+currently resolves it by hoisting accident (agent-framework's regular dep) and can break
+under strictly-isolated installs. The composition-root exemption permits the _import_, not
+the dep misclassification. Neither the `deps` nor `dependency-direction` scan checks dep
+KIND — direction-only checking is why this sat silent.
+
+## What
+
+1. **Fix**: move `@robota-sdk/agent-executor` from devDependencies to dependencies in
+   `packages/agent-cli/package.json` (type-only imports like `print-mode.ts` remain valid
+   against devDeps). Lockfile refresh.
+2. **Mechanize (`dep-kind` scan)**: for every workspace package, a non-type import of a
+   `@robota-sdk/*` module in production source (src/, excluding tests/testing surfaces)
+   must resolve to `dependencies` or `peerDependencies`. Known false-positive classes from
+   the audit probe must be excluded by construction: JSDoc example lines (`* import ...`),
+   generated-code string literals (line does not start with `import`), and type-only
+   imports. Allowlist with mandatory reason strings, reported never silent (harness
+   convention).
+3. **Prove the mechanism** (lesson-to-harness step 9): the scan FAILS on the pre-fix
+   agent-cli state and PASSES after the dep move — recorded in evidence.
+4. Wire into `pnpm harness:scan` + unit tests in the harness suite (fixture packages).
+
+## Test Plan
+
+- Harness unit tests: fixture with (a) value import declared only in devDeps → finding;
+  (b) type-only import in devDeps → clean; (c) peerDependencies value import → clean;
+  (d) JSDoc/string-literal mention → clean.
+- Full `pnpm harness:scan` green after fix; scan red when the dep move is reverted (prove).
+- `pnpm --filter @robota-sdk/agent-cli build` + CLI smoke (`--version`) green after the
+  lockfile refresh.
+
+## User Execution Test Scenarios
+
+Not applicable — packaging/harness-tooling change with no user-facing behavior delta
+(the CLI already resolves the module in this workspace; the defect only manifests at
+isolated install time, which is not reachable pre-publish). Engineering evidence: the
+prove-the-mechanism red/green run in the Test Plan.

--- a/.agents/backlog/INFRA-025-interface-transport-contract-ssot.md
+++ b/.agents/backlog/INFRA-025-interface-transport-contract-ssot.md
@@ -1,0 +1,44 @@
+---
+title: 'INFRA-025: interface-transport contract SSOT — stop type-importing from implementation packages'
+status: todo
+created: 2026-07-04
+priority: medium
+urgency: later
+area: packages/agent-interface-transport, packages/agent-executor, packages/agent-session
+depends_on: []
+---
+
+# Interface-transport contract SSOT
+
+Architecture audit finding F2 (2026-07-04): `agent-interface-transport` — the pure
+contract SSOT per the Interface Package Rule — type-imports from implementation packages:
+`TBackgroundTaskStatus`/`IBackgroundTaskError` from `@robota-sdk/agent-executor`
+(`background-group-contracts.ts`, `session-contracts.ts`, `workspace-contracts.ts`) and
+`ICompactEvent` from `@robota-sdk/agent-session` (`session-contracts.ts`). Type-only, so
+no runtime coupling — but the contract package cannot be consumed without pulling two
+implementation packages into the install tree, and for exactly these types the
+"implementations depend on contracts" direction is inverted.
+
+## What (spec-first — contract change, design confirmation required before implementation)
+
+1. Relocate the transport-facing contract types (`TBackgroundTaskStatus`,
+   `IBackgroundTaskError`, `ICompactEvent` — audit the full import surface for others) into
+   `agent-interface-transport` as their SSOT.
+2. Reverse the edges: `agent-executor` and `agent-session` import (or re-export for their
+   own consumers, within the no-pass-through rule) the contract types from
+   `agent-interface-transport`.
+3. Target state: `agent-interface-transport` deps shrink toward `agent-core`-only (or
+   zero); document the final dependency posture in the Interface Package Rule.
+4. Update SPEC.md of all three packages (type ownership tables) + typecheck-driven sweep of
+   all importers.
+
+## Test Plan
+
+- Full repo typecheck (the relocation is type-SSOT movement; tsc catches every importer).
+- `interface-imports` + `deps` + `dependency-direction` scans green.
+- No runtime behavior change expected — full test suite green as regression evidence.
+
+## User Execution Test Scenarios
+
+Not applicable — type-ownership relocation with no runnable behavior change; evidence is
+the Test Plan (typecheck + suites + scans).

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -133,7 +133,8 @@ re-export `agent-framework`.
 
 - Dependency edge: `agent-preset → agent-framework` (consumes option types as SSOT, e.g.
   `ICreateSessionOptions['permissionMode']`). This is the package's only workspace dependency.
-- `agent-cli` depends on both `agent-preset` (resolver) and `agent-framework` (assembly entry); the
+- Consumers: `agent-cli` depends on both `agent-preset` (resolver) and `agent-framework` (assembly
+  entry); `agent-command` consumes the resolver/list surface for the `/preset` command module. The
   reverse edges (`agent-framework → agent-preset`, `agent-preset → agent-cli`) must never exist.
 - The edge is derived dynamically from `package.json` by
   `scripts/harness/check-dependency-direction.mjs`; keeping the dependency one-way is sufficient for


### PR DESCRIPTION
## Accepted recommendation

Follow-up unit from the user-approved 2026-07-04 agent-* architecture audit ("좋아"). Governance-only: two backlog files + one rule-doc line.

- **INFRA-024** (high/now): agent-cli runtime value import of `createDefaultBackgroundTaskRunners` sits against a devDependencies-only declaration — dep move + a new `dep-kind` scan (value import ⇒ dependencies/peerDependencies) with the audit's three false-positive classes excluded by construction. Will be executed next as its own PR.
- **INFRA-025** (medium/later): `agent-interface-transport` type-imports contract types from implementation packages (executor/session) — contract-SSOT relocation, spec-first with design confirmation before implementation.
- **Preset Package Rule**: records `agent-command` (/preset module) as an actual consumer — doc drift only, no forbidden edge involved.

## Verification

- 44 harness scans green (backlog-placement satisfied: both files todo, root).
- User execution test scenario: not applicable — governance/backlog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj