### PR TITLE
fix(infra): INFRA-024 — dep-kind conformance scan; runtime imports moved out of devDeps

### DIFF
--- a/.agents/backlog/completed/INFRA-024-dep-kind-conformance.md
+++ b/.agents/backlog/completed/INFRA-024-dep-kind-conformance.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-024: dep-kind conformance — runtime value imports must be dependencies/peerDependencies, never devDependencies-only'
-status: todo
+status: done
+completed: 2026-07-04
 created: 2026-07-04
 priority: high
 urgency: now
@@ -49,3 +50,24 @@ Not applicable — packaging/harness-tooling change with no user-facing behavior
 (the CLI already resolves the module in this workspace; the defect only manifests at
 isolated install time, which is not reachable pre-publish). Engineering evidence: the
 prove-the-mechanism red/green run in the Test Plan.
+
+## Evidence (engineering verification, 2026-07-04)
+
+- **Prove (red → green)**: the new scan run against the PRE-fix tree failed with exit 1,
+  naming the audit finding — `@robota-sdk/agent-cli imports @robota-sdk/agent-executor
+(packages/agent-cli/src/cli.ts)` — **and swept the class**: 49 additional findings in
+  `@robota-sdk/dag-cli`, which declared ALL 19 of its runtime `@robota-sdk/dag-*` imports
+  as devDependencies (`private: false`, ships a `robota-dag` bin — same latent break at
+  publish time). After moving agent-executor (agent-cli) and the 18 flagged dag modules
+  (dag-cli) to `dependencies` (dag-api stays devDeps — type-only), the scan passes with
+  exit 0. Lockfile refreshed (`pnpm install`, workspace-field moves only).
+- Mechanism: `scripts/harness/check-dep-kind.mjs`, wired as the `dep-kind` scan (45 scans
+  total); allowlist requires reason strings and reports on every run (empty today).
+- Fixture tests: 4 cases in `scripts/harness/__tests__/check-dep-kind.test.mjs`
+  (devDeps-only value import flagged; type-only + peerDeps clean; JSDoc/string-literal/
+  test-surface exclusions; undeclared imports left to the deps scan) — harness suite 235
+  green.
+- Builds + smoke: both CLI binaries build and execute post-move (`robota 3.0.0-beta.76`;
+  `robota-dag` loads and reports its structured usage error — all runtime imports
+  resolve). agent-cli 150 / dag-cli 992 tests green; repo typecheck 0 errors; lint 0
+  errors; 45 harness scans green.

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -55,6 +55,7 @@
     "@robota-sdk/agent-command": "workspace:*",
     "@robota-sdk/agent-command-workflows": "workspace:*",
     "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-executor": "workspace:*",
     "@robota-sdk/agent-framework": "workspace:*",
     "@robota-sdk/agent-preset": "workspace:*",
     "@robota-sdk/agent-provider": "workspace:*",
@@ -74,7 +75,6 @@
   },
   "devDependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
-    "@robota-sdk/agent-executor": "workspace:*",
     "@robota-sdk/agent-interface-transport": "workspace:*",
     "@types/marked": "^6.0.0",
     "@types/ws": "^8.18.1",

--- a/packages/dag-cli/package.json
+++ b/packages/dag-cli/package.json
@@ -59,15 +59,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@anthropic-ai/sdk": "^0.91.1",
-    "openai": "^4.104.0",
     "@google/genai": "^1.52.0",
-    "zod": "^3.24.4"
-  },
-  "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@robota-sdk/dag-adapters-local": "workspace:*",
-    "@robota-sdk/dag-api": "workspace:*",
     "@robota-sdk/dag-builder": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-framework": "workspace:*",
@@ -85,6 +80,11 @@
     "@robota-sdk/dag-node-llm-text-router": "workspace:*",
     "@robota-sdk/dag-node-mcp-tool": "workspace:*",
     "@robota-sdk/dag-orchestration-client": "workspace:*",
+    "openai": "^4.104.0",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@robota-sdk/dag-api": "workspace:*",
     "tsdown": "^0.22.2"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       '@robota-sdk/agent-core':
         specifier: workspace:*
         version: link:../agent-core
+      '@robota-sdk/agent-executor':
+        specifier: workspace:*
+        version: link:../agent-executor
       '@robota-sdk/agent-framework':
         specifier: workspace:*
         version: link:../agent-framework
@@ -896,9 +899,6 @@ importers:
       '@homebridge/node-pty-prebuilt-multiarch':
         specifier: ^0.13.1
         version: 0.13.1
-      '@robota-sdk/agent-executor':
-        specifier: workspace:*
-        version: link:../agent-executor
       '@robota-sdk/agent-interface-transport':
         specifier: workspace:*
         version: link:../agent-interface-transport
@@ -1853,19 +1853,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
-      openai:
-        specifier: ^4.104.0
-        version: 4.104.0(zod@3.25.76)
-      zod:
-        specifier: ^3.24.4
-        version: 3.25.76
-    devDependencies:
       '@robota-sdk/dag-adapters-local':
         specifier: workspace:*
         version: link:../dag-adapters-local
-      '@robota-sdk/dag-api':
-        specifier: workspace:*
-        version: link:../dag-api
       '@robota-sdk/dag-builder':
         specifier: workspace:*
         version: link:../dag-builder
@@ -1917,6 +1907,16 @@ importers:
       '@robota-sdk/dag-orchestration-client':
         specifier: workspace:*
         version: link:../dag-orchestration-client
+      openai:
+        specifier: ^4.104.0
+        version: 4.104.0(zod@3.25.76)
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@robota-sdk/dag-api':
+        specifier: workspace:*
+        version: link:../dag-api
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)

--- a/scripts/harness/__tests__/check-dep-kind.test.mjs
+++ b/scripts/harness/__tests__/check-dep-kind.test.mjs
@@ -1,0 +1,123 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { findDevDepOnlyRuntimeImports } from '../check-dep-kind.mjs';
+
+async function createFixture(packages) {
+  const root = await mkdtemp(path.join(tmpdir(), 'robota-dep-kind-'));
+  for (const pkg of packages) {
+    const pkgDir = path.join(root, 'packages', pkg.dir);
+    mkdirSync(path.join(pkgDir, 'src'), { recursive: true });
+    writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify(pkg.manifest, null, 2));
+    for (const [relative, content] of Object.entries(pkg.files ?? {})) {
+      const target = path.join(pkgDir, relative);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, content);
+    }
+  }
+  return root;
+}
+
+describe('findDevDepOnlyRuntimeImports (INFRA-024)', () => {
+  it('flags a runtime value import declared only in devDependencies', async () => {
+    const root = await createFixture([
+      {
+        dir: 'consumer',
+        manifest: {
+          name: '@robota-sdk/consumer',
+          devDependencies: { '@robota-sdk/agent-executor': 'workspace:*' },
+        },
+        files: {
+          'src/main.ts': "import { createRunners } from '@robota-sdk/agent-executor';\n",
+        },
+      },
+    ]);
+
+    const { findings } = await findDevDepOnlyRuntimeImports(root);
+    expect(findings).toEqual([
+      {
+        package: '@robota-sdk/consumer',
+        module: '@robota-sdk/agent-executor',
+        file: path.join('packages', 'consumer', 'src', 'main.ts'),
+      },
+    ]);
+  });
+
+  it('allows type-only imports and peerDependencies value imports', async () => {
+    const root = await createFixture([
+      {
+        dir: 'typed',
+        manifest: {
+          name: '@robota-sdk/typed',
+          devDependencies: { '@robota-sdk/agent-executor': 'workspace:*' },
+        },
+        files: {
+          'src/types.ts': "import type { IRunner } from '@robota-sdk/agent-executor';\n",
+        },
+      },
+      {
+        dir: 'peered',
+        manifest: {
+          name: '@robota-sdk/peered',
+          peerDependencies: { '@robota-sdk/agent-core': 'workspace:*' },
+          devDependencies: { '@robota-sdk/agent-core': 'workspace:*' },
+        },
+        files: {
+          'src/tool.ts': "import { AbstractTool } from '@robota-sdk/agent-core';\n",
+        },
+      },
+    ]);
+
+    const { findings } = await findDevDepOnlyRuntimeImports(root);
+    expect(findings).toEqual([]);
+  });
+
+  it('ignores JSDoc examples, generated-code strings, and test surfaces', async () => {
+    const root = await createFixture([
+      {
+        dir: 'clean',
+        manifest: {
+          name: '@robota-sdk/clean',
+          devDependencies: { '@robota-sdk/agent-provider': 'workspace:*' },
+        },
+        files: {
+          'src/doc.ts': [
+            '/**',
+            " * import { OpenAIProvider } from '@robota-sdk/agent-provider';",
+            ' */',
+            'export const codegen = [',
+            "  `import { X } from '@robota-sdk/agent-provider';`,",
+            '];',
+            '',
+          ].join('\n'),
+          'src/__tests__/probe.test.ts':
+            "import { OpenAIProvider } from '@robota-sdk/agent-provider';\n",
+          'src/testing/harness.ts':
+            "import { OpenAIProvider } from '@robota-sdk/agent-provider';\n",
+        },
+      },
+    ]);
+
+    const { findings } = await findDevDepOnlyRuntimeImports(root);
+    expect(findings).toEqual([]);
+  });
+
+  it('leaves entirely-undeclared imports to the deps scan (no double reporting)', async () => {
+    const root = await createFixture([
+      {
+        dir: 'undeclared',
+        manifest: { name: '@robota-sdk/undeclared' },
+        files: {
+          'src/main.ts': "import { x } from '@robota-sdk/agent-tools';\n",
+        },
+      },
+    ]);
+
+    const { findings } = await findDevDepOnlyRuntimeImports(root);
+    expect(findings).toEqual([]);
+  });
+});

--- a/scripts/harness/check-dep-kind.mjs
+++ b/scripts/harness/check-dep-kind.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Dep-kind conformance scan (INFRA-024).
+ *
+ * A runtime VALUE import of a `@robota-sdk/*` module in a package's production source must
+ * resolve to `dependencies` or `peerDependencies` — never to a devDependencies-only
+ * declaration. A devDeps-only runtime import works locally by hoisting accident and breaks
+ * for published consumers under strictly-isolated installs (found: agent-cli value-importing
+ * agent-executor, 2026-07-04 architecture audit F1). Direction-only scans (`deps`,
+ * `dependency-direction`) cannot see this class.
+ *
+ * False-positive classes excluded by construction (audit-probe verified):
+ * - `import type` / inline type-only imports (erased at build) — allowed against devDeps;
+ * - JSDoc example lines (`* import ...` — not at line start);
+ * - generated-code string literals (line does not START with `import`);
+ * - test and testing-surface files (dev-time execution).
+ *
+ * Exit code 0 = conformant, 1 = violation found. Allowlist entries require a reason and are
+ * reported on every run — never silent.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { WORKSPACE_ROOT } from './shared.mjs';
+
+/** Allowlist: `${packageName}:${importedModule}` → reason. Empty today by design. */
+export const DEP_KIND_ALLOWLIST = new Map();
+
+const VALUE_IMPORT_RE = /^import\s+(?!type\b)[^;]*?from\s+['"](@robota-sdk\/[a-z0-9-]+)['"]/gm;
+const SIDE_EFFECT_IMPORT_RE = /^import\s+['"](@robota-sdk\/[a-z0-9-]+)['"]/gm;
+
+function isTestSurface(filePath) {
+  return (
+    filePath.includes('__tests__') ||
+    /\.(test|spec)\.[cm]?tsx?$/.test(filePath) ||
+    filePath.split(path.sep).includes('testing')
+  );
+}
+
+async function listSourceFiles(dir) {
+  const found = [];
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      found.push(...(await listSourceFiles(full)));
+    } else if (/\.[cm]?tsx?$/.test(entry.name)) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function collectValueImports(source) {
+  const modules = new Set();
+  for (const re of [VALUE_IMPORT_RE, SIDE_EFFECT_IMPORT_RE]) {
+    re.lastIndex = 0;
+    for (const match of source.matchAll(re)) {
+      modules.add(match[1]);
+    }
+  }
+  return modules;
+}
+
+/** Scan every workspace package; returns findings + applied allowlist exemptions. */
+export async function findDevDepOnlyRuntimeImports(root = WORKSPACE_ROOT) {
+  const findings = [];
+  const exemptions = [];
+  const packageDirs = [];
+  for (const tier of ['packages', 'apps']) {
+    let entries = [];
+    try {
+      entries = await fs.readdir(path.join(root, tier), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) packageDirs.push(path.join(root, tier, entry.name));
+    }
+  }
+
+  for (const pkgDir of packageDirs) {
+    let manifest;
+    try {
+      manifest = JSON.parse(await fs.readFile(path.join(pkgDir, 'package.json'), 'utf8'));
+    } catch {
+      continue;
+    }
+    const runtimeDeclared = new Set([
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
+    ]);
+    const devDeclared = new Set(Object.keys(manifest.devDependencies ?? {}));
+
+    for (const filePath of await listSourceFiles(path.join(pkgDir, 'src'))) {
+      if (isTestSurface(filePath)) continue;
+      const source = await fs.readFile(filePath, 'utf8');
+      for (const module of collectValueImports(source)) {
+        if (module === manifest.name || runtimeDeclared.has(module)) continue;
+        if (!devDeclared.has(module)) continue; // undeclared entirely → owned by the deps scan
+        const key = `${manifest.name}:${module}`;
+        if (DEP_KIND_ALLOWLIST.has(key)) {
+          exemptions.push({ key, reason: DEP_KIND_ALLOWLIST.get(key) });
+          continue;
+        }
+        findings.push({
+          package: manifest.name,
+          module,
+          file: path.relative(root, filePath),
+        });
+      }
+    }
+  }
+  const seen = new Set();
+  return {
+    findings: findings.filter((f) => {
+      const key = `${f.package}:${f.module}:${f.file}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    }),
+    exemptions,
+  };
+}
+
+export async function main() {
+  const { findings, exemptions } = await findDevDepOnlyRuntimeImports();
+  for (const exemption of exemptions) {
+    process.stdout.write(`  allowlisted: ${exemption.key} — ${exemption.reason}\n`);
+  }
+  if (findings.length > 0) {
+    process.stdout.write(
+      'dep-kind scan failed — runtime value imports declared only in devDependencies:\n',
+    );
+    for (const finding of findings) {
+      process.stdout.write(`  - ${finding.package} imports ${finding.module} (${finding.file})\n`);
+    }
+    process.stdout.write(
+      'Move the module to dependencies (or peerDependencies) of the importing package.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write('dep-kind scan passed.\n');
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -89,6 +89,7 @@ const SCAN_COMMANDS = [
   },
   { name: 'orphan-exports', command: ['node', 'scripts/harness/check-orphan-exports.mjs'] },
   { name: 'deps', command: ['node', 'scripts/harness/check-dependency-direction.mjs'] },
+  { name: 'dep-kind', command: ['node', 'scripts/harness/check-dep-kind.mjs'] },
   {
     name: 'interface-imports',
     command: ['node', 'scripts/harness/check-interface-imports.mjs'],


### PR DESCRIPTION
## Accepted recommendation

Executes the INFRA-024 backlog (filed from the user-approved architecture audit, merged in #941).

- **New `dep-kind` scan** (`check-dep-kind.mjs`, 45 scans total): a runtime VALUE import of a `@robota-sdk/*` module in production source must resolve to `dependencies`/`peerDependencies`. The audit's three false-positive classes (JSDoc examples, generated-code string literals, type-only imports) plus test surfaces are excluded by construction. Allowlist requires reason strings, reported never silent (empty today).
- **Prove (red → green)**: pre-fix run failed naming the audit finding — and **swept the class**: `dag-cli` declared ALL 19 runtime `dag-*` imports as devDependencies (`private: false`, ships the `robota-dag` bin — same latent break at publish). Post-move run passes.
- **Fixes**: `agent-cli` agent-executor devDeps→dependencies; `dag-cli` 18 flagged modules devDeps→dependencies (dag-api stays dev — type-only). Lockfile refreshed (workspace-field moves only).

## Verification

- Harness suite 235 green (4 new fixture tests); 45 scans green; typecheck 0; lint 0 errors.
- Both CLI binaries build and execute post-move (`robota 3.0.0-beta.76`; `robota-dag` loads — all runtime imports resolve). agent-cli 150 / dag-cli 992 tests green.
- User execution test scenario: **not applicable** — packaging/harness change; the defect only manifests at isolated install time (unreachable pre-publish). Engineering evidence: the red/green prove run, recorded in the backlog (moved to completed/ in this PR).

## Residual risks

- The scan's line-start heuristic intentionally skips imports inside multi-line template literals spanning line starts — none exist today; a future exotic case lands in the allowlist with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj