### PR TITLE
refactor(testing): INFRA-025 P3 — scripted harness sheds session-analytics

### DIFF
--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -58,11 +58,11 @@
     "@robota-sdk/agent-executor": "workspace:*",
     "@robota-sdk/agent-interface-transport": "workspace:*",
     "@robota-sdk/agent-session": "workspace:*",
-    "@robota-sdk/agent-session-analytics": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@robota-sdk/agent-session-analytics": "workspace:*",
     "rimraf": "^5.0.10",
     "tsdown": "^0.22.2",
     "typescript": "^5.9.3",

--- a/packages/agent-framework/src/testing/__tests__/usage-assertion-functional.test.ts
+++ b/packages/agent-framework/src/testing/__tests__/usage-assertion-functional.test.ts
@@ -5,6 +5,7 @@
  * the per-source usage breakdown and a budget — the mechanism that turns wrong/excessive token usage
  * into a failing test.
  */
+import { summarizeUsageBySource } from '@robota-sdk/agent-session-analytics';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { scriptedSession, type ScriptedSessionHarness } from '../index.js';
@@ -32,16 +33,16 @@ describe('Token-usage assertions (ANALYTICS-001) via the scripted-session harnes
       await harness.submit('one');
       await harness.submit('two');
 
-      const report = harness.usageReport();
+      const report = summarizeUsageBySource(harness.sessionLog());
       // 140 + 80, all attributed to the main thread (no sub-sources in this run).
       expect(report.totalTokens).toBe(220);
       expect(report.bySource).toHaveLength(1);
       expect(report.bySource[0]).toMatchObject({ label: 'main thread', percentage: 100 });
       expect(report.topConsumer?.label).toBe('main thread');
-      expect(harness.totalUsage()).toBe(220);
+      expect(summarizeUsageBySource(harness.sessionLog()).totalTokens).toBe(220);
 
       // The budget gate: an over-budget session would fail here.
-      expect(harness.totalUsage()).toBeLessThanOrEqual(500);
+      expect(summarizeUsageBySource(harness.sessionLog()).totalTokens).toBeLessThanOrEqual(500);
     },
     TEST_TIMEOUT,
   );
@@ -51,8 +52,8 @@ describe('Token-usage assertions (ANALYTICS-001) via the scripted-session harnes
     async () => {
       harness = scriptedSession({ turns: [{ text: 'no usage reported' }] });
       await harness.submit('hi');
-      expect(harness.totalUsage()).toBe(0);
-      expect(harness.usageReport().bySource).toEqual([]);
+      expect(summarizeUsageBySource(harness.sessionLog()).totalTokens).toBe(0);
+      expect(summarizeUsageBySource(harness.sessionLog()).bySource).toEqual([]);
     },
     TEST_TIMEOUT,
   );

--- a/packages/agent-framework/src/testing/scripted-session-harness.ts
+++ b/packages/agent-framework/src/testing/scripted-session-harness.ts
@@ -30,7 +30,6 @@ import {
   createReplayProvider,
   createRecordingProvider,
 } from '@robota-sdk/agent-core/testing';
-import { summarizeUsageBySource } from '@robota-sdk/agent-session-analytics';
 
 import { InteractiveSession } from '../interactive/index.js';
 import { createProjectSessionStore } from '../interactive/index.js';
@@ -54,7 +53,6 @@ import type {
   IToolSummary,
   TInteractiveEventName,
 } from '@robota-sdk/agent-interface-transport';
-import type { IUsageBySourceReport } from '@robota-sdk/agent-session-analytics';
 
 /** Options for {@link scriptedSession}. Provide exactly one of `turns`, `cassette`, or `record`. */
 export interface IScriptedSessionOptions {
@@ -347,20 +345,16 @@ export class ScriptedSessionHarness {
   }
 
   /**
-   * ANALYTICS-001: per-source token-usage breakdown for this session, computed from the recorded
-   * `usage-summary` history entries. Lets a test assert budgets — e.g. total usage ≤ N, or no single
-   * background task exceeds M — turning wrong/excessive token usage into a failing test.
+   * Neutral session-log accessor (INFRA-025): the id + full history in the shape analysis
+   * tooling consumes. Usage assertions compose it with `summarizeUsageBySource` from
+   * `@robota-sdk/agent-session-analytics` in the TEST — the harness itself carries no
+   * analytics dependency.
    */
-  usageReport(): IUsageBySourceReport {
-    return summarizeUsageBySource({
+  sessionLog(): { id: string; history: ReturnType<InteractiveSession['getFullHistory']> } {
+    return {
       id: this.session.getSession().getSessionId(),
       history: this.session.getFullHistory(),
-    });
-  }
-
-  /** Total tokens consumed across the whole session (ANALYTICS-001). */
-  totalUsage(): number {
-    return this.usageReport().totalTokens;
+    };
   }
 
   /** The real session-log directory the framework writes to (`{cwd}/.robota/logs`). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,9 +1071,6 @@ importers:
       '@robota-sdk/agent-session':
         specifier: workspace:*
         version: link:../agent-session
-      '@robota-sdk/agent-session-analytics':
-        specifier: workspace:*
-        version: link:../agent-session-analytics
       '@robota-sdk/agent-tools':
         specifier: workspace:*
         version: link:../agent-tools
@@ -1081,6 +1078,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@robota-sdk/agent-session-analytics':
+        specifier: workspace:*
+        version: link:../agent-session-analytics
       rimraf:
         specifier: ^5.0.10
         version: 5.0.10


### PR DESCRIPTION
## Child PR → initiative base

- `usageReport()`/`totalUsage()` deleted from the scripted-session-harness (breaking allowed); neutral `sessionLog()` accessor added — usage assertions compose `summarizeUsageBySource` in the test.
- `agent-framework`: session-analytics → devDependencies. Runtime dep tree: core/executor/interface-transport/session/tools.

Verification: typecheck 0, full build/test green, 45 scans, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQqJVbCccN9MUypu38mXj