### PR TITLE
fix(cli-077): decouple agent-cli from unpublished workflow/DAG chain; privatize DAG subsystem

### DIFF
--- a/.agents/backlog/completed/CLI-077-optional-workflows-command.md
+++ b/.agents/backlog/completed/CLI-077-optional-workflows-command.md
@@ -1,0 +1,72 @@
+---
+title: 'CLI-077: decouple agent-cli from the unpublished workflow/DAG chain — optional /workflows'
+status: done
+created: 2026-07-05
+completed: 2026-07-05
+priority: high
+urgency: now
+area: packages/agent-cli, packages/agent-command-workflows, packages/dag-*
+depends_on: []
+---
+
+# Decouple agent-cli from the unpublished workflow/DAG chain (optional /workflows)
+
+Release-blocking for beta.77. `agent-cli` hard-imports `createWorkflowsCommandModule` from
+`@robota-sdk/agent-command-workflows` (a `dependencies` entry), which transitively requires
+`dag-builder`/`dag-core`/`dag-framework` and the wider DAG subsystem (21-package runtime closure).
+The DAG/workflow track is in-progress and must stay unpublished (`private: true`). Publishing
+`agent-cli@beta.77` with that hard dep would ship an uninstallable package (its `workspace:*` deps
+resolve to versions that are not on npm).
+
+## What
+
+1. Make the `/workflows` command an **optional** module: load `@robota-sdk/agent-command-workflows`
+   through a guarded `createRequire` in `command-setup.ts`; when the package is absent (default
+   published install) omit the command, when present (monorepo dev / a user who installed it) register
+   it. No hard static import.
+2. Move `@robota-sdk/agent-command-workflows` from `dependencies` → `devDependencies` in agent-cli so
+   the published package has no runtime edge into the DAG chain, while dev/tests still resolve it.
+3. Mark the entire unpublished DAG/workflow subsystem `private: true` (per owner instruction, kept
+   private until separately released): `agent-command-workflows`, `agent-testing` (never published,
+   devDep-only test util), all `dag-*` (15), all `dag-node-*` (22).
+4. SPEC: agent-cli — document `/workflows` as an optional, dynamically-loaded module.
+
+The completion of the `/workflows` track (making it a first-class published capability) is tracked
+separately — see the follow-on workflow-completion backlog.
+
+## Test Plan
+
+- `buildCommandSetup` registers `/workflows` when the module loads and omits it (no throw) when the
+  loader returns undefined; the rest of the command modules are unaffected either way.
+
+Also decoupled the sibling case found during the same audit: `agent-cli` hard-imported
+`createReplayProviderFromLogFile` from `@robota-sdk/agent-provider-replay` (a `private` INFRA-017
+test/replay util) for `--session-log`. Same treatment — `cli.ts` `loadReplayProvider` guarded load +
+devDependency. After both moves the published `agent-cli` runtime closure contains no `private`/
+unpublished package.
+
+Privatized (per owner instruction, kept private until separately released): `agent-command-workflows`,
+`agent-testing`, all `dag-*` (15) and `dag-nodes/*` (22) — 38 packages set `private: true`. Final
+publishable set = the 19 previously-published agent-line packages + `agent-process` = exactly 20.
+
+## Test Plan
+
+- `buildCommandSetup` builds a non-empty module set without throwing regardless of the optional
+  package; includes the workflows module iff its package resolves (never a partial/stub entry).
+- Regression: agent-cli suite 155 passed; typecheck + lint (0 errors).
+
+## User Execution Test Scenarios
+
+- agent-executable. Built CLI (PTY) boots and reaches the prompt; `/workflows` present in dev, absent
+  in the published shape.
+- Evidence (2026-07-05, built CLI `packages/agent-cli/bin/robota.cjs` in a real PTY; driver was a
+  disposable gitignored scratch script — superseded for regression by the git-tracked
+  `command-setup-optional-workflows.test.ts`):
+  - **Published-dependency proof (decisive):** `pnpm pack` of agent-cli → the published `package.json`
+    lists 11 `@robota-sdk` runtime deps, ALL in the 20-package publish set; **zero** `private`/`dag-*`/
+    `agent-command-workflows`/`agent-provider-replay` deps. `npm install @robota-sdk/agent-cli` resolves.
+  - UE-1 (dev): built CLI boots to the prompt; `/workflows` is recognized (optional package resolvable).
+  - UE-2 (published shape): with `agent-command-workflows/dist` hidden so `createRequire` fails, the
+    built CLI still **boots gracefully** to the prompt and `/workflows` is absent (no crash).
+  - Direct check: `createRequire(cli/dist).('@robota-sdk/agent-command-workflows').createWorkflowsCommandModule()`
+    loads (`systemCommands: workflows`) — confirming the guarded load path is exercised, not dead.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -56,6 +56,24 @@ A **thin CLI layer** built on top of agent-sdk, responsible only for the termina
 | `agent-provider`        | ✅ Provider definition assembly only | CLI composes injected `IProviderDefinition[]`; the provider package owns defaults and factories         |
 | `agent-preset`          | ✅ Preset id selection + resolution  | CLI selects the preset id and forwards CLI-flag overrides; `resolvePreset` owns the precedence merge    |
 
+### Optional (dev-only) modules — must not enter the published dependency graph
+
+Some capabilities are backed by packages deliberately kept **unpublished / `private`** (an in-progress
+track, or an internal test utility). agent-cli must **not** declare a runtime `dependencies` edge to
+any such package — a `workspace:*` edge would resolve, at publish time, to a version that is not on npm
+and break `npm install @robota-sdk/agent-cli`. These packages are `devDependencies` and loaded through
+a guarded `createRequire`, so the command/feature is present in the monorepo (and for anyone who
+installs the optional package) and cleanly absent (never a crash) in the default published CLI:
+
+| Feature                | Optional package                      | Loader                          | Absent behavior                            |
+| ---------------------- | ------------------------------------- | ------------------------------- | ------------------------------------------ |
+| `/workflows` command   | `@robota-sdk/agent-command-workflows` | `command-setup.ts` guarded load | command omitted                            |
+| `--session-log` replay | `@robota-sdk/agent-provider-replay`   | `cli.ts` `loadReplayProvider`   | clear error only when `--session-log` used |
+
+Rule: a runtime `dependencies` entry of agent-cli must be a package that is published in the same
+release. The published dependency closure is verified to contain no `private`/unpublished package (see
+CLI-077).
+
 ## Architecture
 
 For an LLM-scannable source-verified composition map, dependency graph, execution-mode diagrams,

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -53,13 +53,11 @@
   },
   "dependencies": {
     "@robota-sdk/agent-command": "workspace:*",
-    "@robota-sdk/agent-command-workflows": "workspace:*",
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-executor": "workspace:*",
     "@robota-sdk/agent-framework": "workspace:*",
     "@robota-sdk/agent-preset": "workspace:*",
     "@robota-sdk/agent-provider": "workspace:*",
-    "@robota-sdk/agent-provider-replay": "workspace:*",
     "@robota-sdk/agent-session-analytics": "workspace:*",
     "@robota-sdk/agent-subagent-runner": "workspace:*",
     "@robota-sdk/agent-transport": "workspace:*",
@@ -75,7 +73,9 @@
   },
   "devDependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
+    "@robota-sdk/agent-command-workflows": "workspace:*",
     "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/agent-provider-replay": "workspace:*",
     "@types/marked": "^6.0.0",
     "@types/ws": "^8.18.1",
     "rimraf": "^5.0.10",

--- a/packages/agent-cli/src/__tests__/command-setup-optional-workflows.test.ts
+++ b/packages/agent-cli/src/__tests__/command-setup-optional-workflows.test.ts
@@ -1,0 +1,30 @@
+/**
+ * CLI-077: the `/workflows` command module is loaded optionally. agent-cli must build its command
+ * set whether or not `@robota-sdk/agent-command-workflows` (a devDependency kept out of the published
+ * dependency graph) resolves — its absence just omits the command, never throws.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { buildCommandSetup } from '../startup/command-setup.js';
+
+import type { IParsedCliArgs } from '../utils/cli-args.js';
+
+const MINIMAL_ARGS = { noUpdateCheck: true } as unknown as IParsedCliArgs;
+
+describe('buildCommandSetup — optional /workflows (CLI-077)', () => {
+  it('builds a non-empty command-module set without throwing, regardless of the optional package', () => {
+    expect(() => buildCommandSetup('/tmp', MINIMAL_ARGS, {}, '0.0.0-test')).not.toThrow();
+    const setup = buildCommandSetup('/tmp', MINIMAL_ARGS, {}, '0.0.0-test');
+    expect(setup.commandModules.length).toBeGreaterThan(0);
+  });
+
+  it('includes the workflows module iff its optional package resolves — and never a partial/broken entry', () => {
+    const setup = buildCommandSetup('/tmp', MINIMAL_ARGS, {}, '0.0.0-test');
+    const workflows = setup.commandModules.filter((m) => m.name === 'agent-command-workflows');
+    // Zero (published-install shape) or exactly one fully-formed module (dev shape) — never a stub.
+    expect(workflows.length).toBeLessThanOrEqual(1);
+    for (const mod of workflows) {
+      expect(mod.systemCommands?.some((c) => c.name === 'workflows')).toBe(true);
+    }
+  });
+});

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -4,7 +4,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { createReplayProviderFromLogFile } from '@robota-sdk/agent-provider-replay';
+import { createRequire } from 'node:module';
+
 import { PrintTerminal, promptInput } from '@robota-sdk/agent-transport/headless';
 import {
   createProjectSessionStore,
@@ -23,6 +24,7 @@ import {
 } from '@robota-sdk/agent-framework';
 import { parseCliArgs, parseToolList, printHelp } from './utils/cli-args.js';
 import type { IParsedCliArgs } from './utils/cli-args.js';
+import type { IAIProvider } from '@robota-sdk/agent-core';
 import { resolveCliPreset, selectPresetId } from './startup/preset-selection.js';
 import { DEFAULT_AGENT_NAME, loadExternalPresets } from '@robota-sdk/agent-preset';
 import type { IResolvedPresetOptions } from '@robota-sdk/agent-preset';
@@ -61,6 +63,25 @@ export type { IStartCliOptions };
  * app-assembly decision, so the CLI (the composition root) wires `WsTransport` here rather than
  * the transport core depending on the ws package.
  */
+/**
+ * Load the optional session-log replay provider (INFRA-017). `@robota-sdk/agent-provider-replay` is a
+ * dev/test-only package deliberately kept out of the published dependency graph, so `--session-log`
+ * replay is a development capability: resolvable in the monorepo (and for anyone who installs the
+ * package), and reported as unavailable — never a hard crash — in the default published CLI.
+ */
+function loadReplayProvider(logFile: string): IAIProvider {
+  let mod: { createReplayProviderFromLogFile: (file: string) => IAIProvider };
+  try {
+    const requireFrom = createRequire(import.meta.url);
+    mod = requireFrom('@robota-sdk/agent-provider-replay') as typeof mod;
+  } catch {
+    throw new Error(
+      '--session-log replay requires @robota-sdk/agent-provider-replay, a dev-only package that is not bundled in the published CLI.',
+    );
+  }
+  return mod.createReplayProviderFromLogFile(logFile);
+}
+
 function createDefaultTransportRegistry(): TransportRegistry {
   const registry = new TransportRegistry(getUserSettingsPath());
   registry.register(new WsTransport());
@@ -230,7 +251,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // model. Provider settings/model still come from the configured profile (no key is ever used —
   // the ReplayProvider answers every call from the recorded log).
   const provider = args.sessionLog
-    ? createReplayProviderFromLogFile(args.sessionLog)
+    ? loadReplayProvider(args.sessionLog)
     : createProviderFromSettings(cwd, resolvedPreset.model, providerOptions);
   const backgroundTaskRunners = createDefaultBackgroundTaskRunners();
   const paths = projectPaths(cwd);

--- a/packages/agent-cli/src/startup/command-setup.ts
+++ b/packages/agent-cli/src/startup/command-setup.ts
@@ -14,13 +14,35 @@ import type {
   ICommandModule,
   TProviderSettingsDocument,
 } from '@robota-sdk/agent-framework';
+import { createRequire } from 'node:module';
+
 import {
   createDefaultCommandModules,
   createDefaultPluginCommandAdapter,
 } from '@robota-sdk/agent-command';
-import { createWorkflowsCommandModule } from '@robota-sdk/agent-command-workflows';
 import { createDefaultProviderDefinitions } from '@robota-sdk/agent-provider';
 import type { IParsedCliArgs } from '../utils/cli-args.js';
+
+/**
+ * Load the optional `/workflows` command module (WORKFLOW-003). The DAG/workflow subsystem is an
+ * in-progress track kept out of the published dependency graph, so agent-cli must NOT hard-depend on
+ * it — otherwise the published package's `workspace:*` edge resolves to an unpublished version and
+ * `npm install @robota-sdk/agent-cli` breaks. `@robota-sdk/agent-command-workflows` is therefore a
+ * devDependency, loaded through a guarded `createRequire`: present in the monorepo (and for any user
+ * who installs it) → `/workflows` is registered; absent in the default published install → omitted.
+ */
+function loadOptionalWorkflowsCommandModule(): ICommandModule | undefined {
+  try {
+    const requireFrom = createRequire(import.meta.url);
+    const mod = requireFrom('@robota-sdk/agent-command-workflows') as {
+      createWorkflowsCommandModule: () => ICommandModule;
+    };
+    return mod.createWorkflowsCommandModule();
+  } catch {
+    // allow-fallback: the workflow subsystem is an optional, unpublished track — its absence just means no /workflows command
+    return undefined;
+  }
+}
 
 export interface IStartCliOptions {
   commandModules?: readonly ICommandModule[];
@@ -64,6 +86,9 @@ export function buildCommandSetup(
     writeTargetSettings: (settings: TProviderSettingsDocument) =>
       writeSettings(resolveProviderSettingsWriteTargetPath(cwd), settings),
   };
+  // DAG workflow engine surfaced as `/workflows` (WORKFLOW-003) — optional; omitted from the published
+  // CLI whose dependency graph must not include the unpublished DAG chain (see loader doc above).
+  const workflowsModule = loadOptionalWorkflowsCommandModule();
   const commandModules: readonly ICommandModule[] = [
     ...createDefaultCommandModules({
       cwd,
@@ -76,8 +101,7 @@ export function buildCommandSetup(
         ? { disabledCommandModules: moduleSelection.disabledCommandModules }
         : {}),
     }),
-    // DAG workflow engine surfaced as `/workflows` (WORKFLOW-003); composes dag-framework, not dag-cli.
-    createWorkflowsCommandModule(),
+    ...(workflowsModule ? [workflowsModule] : []),
     ...(options.commandModules ?? []),
   ];
   const startupUpdateNoticePromise = shouldRunStartupCliUpdateCheck(args)

--- a/packages/agent-command-workflows/package.json
+++ b/packages/agent-command-workflows/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/agent-command-workflows",
   "version": "3.0.0-beta.0",
+  "private": true,
   "description": "agent-cli /workflows command module — surfaces the DAG workflow engine by composing dag-framework",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/agent-testing",
   "version": "3.0.0-beta.76",
+  "private": true,
   "description": "Cross-cutting test harness for the Robota SDK — a real-PTY end-to-end driver (spawnPty/spawnPtyFixture)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/dag-adapters-local/package.json
+++ b/packages/dag-adapters-local/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-adapters-local",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Local adapter implementations for DAG ports (in-memory and file-based)",
   "type": "module",
   "main": "dist/node/index.js",
@@ -46,6 +47,5 @@
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-adapters-sqlite/package.json
+++ b/packages/dag-adapters-sqlite/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-adapters-sqlite",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "SQLite persistent storage adapter for DAG ports",
   "type": "module",
   "main": "dist/node/index.js",
@@ -46,6 +47,5 @@
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-api/package.json
+++ b/packages/dag-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-api",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "API and composition entry layer for Robota DAG",
   "type": "module",
   "main": "dist/node/index.js",
@@ -61,6 +62,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-builder/package.json
+++ b/packages/dag-builder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-builder",
   "version": "0.1.0-beta.0",
+  "private": true,
   "description": "Declarative pipeline-to-DAG-definition builder and validator",
   "type": "module",
   "main": "dist/node/index.js",
@@ -52,6 +53,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-cli/package.json
+++ b/packages/dag-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-cli",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG for AI agents — build and run AI pipelines via MCP or CLI",
   "type": "module",
   "bin": {
@@ -89,6 +90,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-core/package.json
+++ b/packages/dag-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-core",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Core types and interfaces for robota-dag AI workflow orchestration",
   "type": "module",
   "main": "dist/node/index.js",
@@ -74,6 +75,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-cost/package.json
+++ b/packages/dag-cost/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-cost",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Cost evaluation service for DAG orchestration using CEL formulas",
   "type": "module",
   "main": "dist/node/index.js",
@@ -46,6 +47,5 @@
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-framework",
   "version": "0.1.0-beta.0",
+  "private": true,
   "description": "Embeddable in-process DAG runtime — runtime + worker + adapters + default nodes",
   "type": "module",
   "main": "dist/node/index.js",
@@ -92,7 +93,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "private": false,
   "devDependencies": {
     "tsdown": "^0.22.2"
   }

--- a/packages/dag-mcp-server/package.json
+++ b/packages/dag-mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-mcp-server",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "MCP server for robota-dag — AI agents build and run DAG workflows",
   "type": "module",
   "bin": {
@@ -77,6 +78,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-node/package.json
+++ b/packages/dag-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "AbstractNodeDefinition base class for robota-dag AI workflow nodes",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "private": false,
   "license": "AGPL-3.0-only OR LicenseRef-Commercial"
 }

--- a/packages/dag-nodes/file-read/package.json
+++ b/packages/dag-nodes/file-read/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-file-read",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG node for reading files from the filesystem",
   "type": "module",
   "main": "dist/node/index.js",
@@ -57,6 +58,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/file-write/package.json
+++ b/packages/dag-nodes/file-write/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-file-write",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG node for writing files to the filesystem",
   "type": "module",
   "main": "dist/node/index.js",
@@ -57,6 +58,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/gemini-image-edit/package.json
+++ b/packages/dag-nodes/gemini-image-edit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-gemini-image-edit",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG gemini-image-edit node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/http-request/package.json
+++ b/packages/dag-nodes/http-request/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-http-request",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG node for making HTTP requests",
   "type": "module",
   "main": "dist/node/index.js",
@@ -57,6 +58,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/image-loader/package.json
+++ b/packages/dag-nodes/image-loader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-image-loader",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG image-loader node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/image-source/package.json
+++ b/packages/dag-nodes/image-source/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-image-source",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG image-source node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/input/package.json
+++ b/packages/dag-nodes/input/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-input",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG input node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/instant-node/package.json
+++ b/packages/dag-nodes/instant-node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-instant-node",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Prompt-backed instant DAG node for Robota — create custom nodes at runtime from a system prompt template",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-anthropic/package.json
+++ b/packages/dag-nodes/llm-text-anthropic/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-anthropic",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG Anthropic llm-text node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-deepseek/package.json
+++ b/packages/dag-nodes/llm-text-deepseek/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-deepseek",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG DeepSeek llm-text node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-gemini/package.json
+++ b/packages/dag-nodes/llm-text-gemini/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-gemini",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG Gemini llm-text node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-openai/package.json
+++ b/packages/dag-nodes/llm-text-openai/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-openai",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG OpenAI llm-text node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-qwen/package.json
+++ b/packages/dag-nodes/llm-text-qwen/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-qwen",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG Qwen llm-text node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -59,6 +60,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/llm-text-router/package.json
+++ b/packages/dag-nodes/llm-text-router/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-router",
   "version": "0.1.0",
+  "private": true,
   "description": "DAG LLM text router node — priority-fallback across multiple LLM providers",
   "type": "module",
   "main": "dist/node/index.js",
@@ -62,6 +63,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/mcp-tool/package.json
+++ b/packages/dag-nodes/mcp-tool/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-mcp-tool",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "MCP Tool node for Robota DAG — execute a single MCP server tool as a DAG step (Phase A: stateless)",
   "type": "module",
   "main": "dist/node/index.js",
@@ -58,6 +59,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/multi-input/package.json
+++ b/packages/dag-nodes/multi-input/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-multi-input",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG multi-input node for Robota — emits multiple named ports from runtime inputs",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/ok-emitter/package.json
+++ b/packages/dag-nodes/ok-emitter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-ok-emitter",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG ok-emitter node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/text-output/package.json
+++ b/packages/dag-nodes/text-output/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-text-output",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG text-output node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/text-template/package.json
+++ b/packages/dag-nodes/text-template/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-text-template",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG text-template node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/transform/package.json
+++ b/packages/dag-nodes/transform/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-transform",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG transform node for Robota",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-nodes/utility-text/package.json
+++ b/packages/dag-nodes/utility-text/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-node-utility-text",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Utility text/data nodes for Robota DAG",
   "type": "module",
   "main": "dist/node/index.js",
@@ -56,6 +57,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-orchestration-client/package.json
+++ b/packages/dag-orchestration-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-orchestration-client",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Thin client contracts for Robota DAG orchestration APIs",
   "type": "module",
   "main": "dist/node/index.js",
@@ -60,6 +61,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-projection/package.json
+++ b/packages/dag-projection/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-projection",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Projection and read-model layer for Robota DAG",
   "type": "module",
   "main": "dist/node/index.js",
@@ -61,6 +62,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-runtime/package.json
+++ b/packages/dag-runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-runtime",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "DAG execution engine for robota-dag AI workflow orchestration",
   "type": "module",
   "main": "dist/node/index.js",
@@ -71,6 +72,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-scheduler/package.json
+++ b/packages/dag-scheduler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-scheduler",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Scheduler layer for Robota DAG orchestration",
   "type": "module",
   "main": "dist/node/index.js",
@@ -63,6 +64,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/packages/dag-worker/package.json
+++ b/packages/dag-worker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@robota-sdk/dag-worker",
   "version": "3.0.0-beta.60",
+  "private": true,
   "description": "Worker execution layer for Robota DAG",
   "type": "module",
   "main": "dist/node/index.js",
@@ -61,6 +62,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "private": false
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,9 +838,6 @@ importers:
       '@robota-sdk/agent-command':
         specifier: workspace:*
         version: link:../agent-command
-      '@robota-sdk/agent-command-workflows':
-        specifier: workspace:*
-        version: link:../agent-command-workflows
       '@robota-sdk/agent-core':
         specifier: workspace:*
         version: link:../agent-core
@@ -856,9 +853,6 @@ importers:
       '@robota-sdk/agent-provider':
         specifier: workspace:*
         version: link:../agent-provider
-      '@robota-sdk/agent-provider-replay':
-        specifier: workspace:*
-        version: link:../agent-provider-replay
       '@robota-sdk/agent-session-analytics':
         specifier: workspace:*
         version: link:../agent-session-analytics
@@ -899,9 +893,15 @@ importers:
       '@homebridge/node-pty-prebuilt-multiarch':
         specifier: ^0.13.1
         version: 0.13.1
+      '@robota-sdk/agent-command-workflows':
+        specifier: workspace:*
+        version: link:../agent-command-workflows
       '@robota-sdk/agent-interface-transport':
         specifier: workspace:*
         version: link:../agent-interface-transport
+      '@robota-sdk/agent-provider-replay':
+        specifier: workspace:*
+        version: link:../agent-provider-replay
       '@types/marked':
         specifier: ^6.0.0
         version: 6.0.0


### PR DESCRIPTION
## CLI-077 — release-blocking publishability fix (prerequisite for beta.77)

`agent-cli` on develop had **hard runtime imports** of two packages deliberately kept out of the published dependency graph. Publishing would ship an **uninstallable** agent-cli (`workspace:*` edges resolving to versions not on npm):

- `createWorkflowsCommandModule` ← `@robota-sdk/agent-command-workflows` → transitively `dag-builder`/`dag-core`/`dag-framework` (a **21-package DAG closure**)
- `createReplayProviderFromLogFile` ← `@robota-sdk/agent-provider-replay` (a `private` INFRA-017 test/replay util, `--session-log`)

### Fix
- Both loaded via a guarded `createRequire` and moved to **devDependencies**. `/workflows` and `--session-log` replay are present in the monorepo (and for anyone who installs the optional package), and cleanly **absent — never a crash** — in the default published CLI.
- **Privatized** the in-progress DAG/workflow subsystem (owner instruction; kept private until separately released): `agent-command-workflows`, `agent-testing`, all `dag-*` (15) + `dag-nodes/*` (22) → `private: true`. **38 packages.**
- Final publishable set = the **19** previously-published agent-line packages **+ agent-process** = **exactly 20**.

### Verification
- **Decisive:** `pnpm pack` of agent-cli → published runtime closure has **zero** `private`/`dag`/workflow deps (all 11 `@robota-sdk` deps in the 20-package set). `npm install @robota-sdk/agent-cli` resolves.
- typecheck + lint (0 errors); agent-cli suite **155 passed** + new `command-setup-optional-workflows` test; **harness:scan 45/45**.
- **Live PTY UE:** dev boots with `/workflows` recognized; hiding the package's dist boots gracefully with `/workflows` absent (published shape).

Follow-on: completing the `/workflows` track as a first-class published capability is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)