### PR TITLE
chore(release): finalize 3.0.0-beta.77 release run record

### DIFF
--- a/.agents/release-runs/3.0.0-beta.77.md
+++ b/.agents/release-runs/3.0.0-beta.77.md
@@ -3,21 +3,21 @@
 ## State
 
 - Version: 3.0.0-beta.77
-- Branch: release/bump-beta77
-- SHA: 2f808ccb7ba6
-- PR: none
-- Target branch: main
-- Active gate: initialized
-- Gate status: pending
-- Next action: Run release-grade verification.
+- Branch: develop
+- SHA: 33b4b2797
+- PR: #961 (version bump), #959 CLI-075, #960 CLI-077
+- Target branch: develop
+- Active gate: publish
+- Gate status: passed
+- Next action: Publish via pnpm publish:beta (OTP).
 - Stop condition: Stop if the active gate fails or stalls.
 
 ## Publish Gate
 
-- Publish ready: no
-- NPM auth verified: no
-- Dry run passed: no
-- OTP requested: no
+- Publish ready: yes
+- NPM auth verified: yes
+- Dry run passed: yes
+- OTP requested: yes
 
 ## Long-Running Watchers
 
@@ -30,7 +30,22 @@
 
 ## Final Report
 
-- Merged PRs: TBD
+- Merged PRs:
+  - #959 — CLI-075 TUI shutdown/channel hygiene
+  - #960 — CLI-077 decouple agent-cli from the unpublished DAG/workflow chain; privatize DAG subsystem
+  - #961 — release: version packages to 3.0.0-beta.77
 - Published version: 3.0.0-beta.77
-- Validation gates: TBD
-- Skipped checks: none
+- Packages: **20** published `@robota-sdk/*` packages — verified `latest` = `beta` = 3.0.0-beta.77
+  (20/20, mismatches: 0; an initial agent-preset mismatch was a registry-propagation false positive,
+  confirmed consistent on re-query). New this release: `@robota-sdk/agent-process` (first publish).
+- Excluded (kept `private`): the in-progress DAG/workflow subsystem — `agent-command-workflows`,
+  `agent-testing`, all `dag-*` (15) and `dag-nodes/*` (22) = 38 packages.
+- Validation gates: passed (build, typecheck, lint, test green pre-merge; harness:scan 45/45;
+  harness:release:check --publish passed; npm dry-run = exactly the 20-package set, zero private/dag
+  leakage).
+- Post-publish verification: clean-room `npx @robota-sdk/agent-cli@3.0.0-beta.77 -p …` (isolated HOME +
+  fresh npm cache) installed from npm with no dag/workflow deps and ran headless (exit 0) — the CLI-077
+  decoupling holds for a real end-user install.
+- Publish notes: OTP-driven `pnpm publish:beta` spanned multiple OTP windows (publish + beta dist-tag
+  sync); the script is idempotent (skips already-published packages, `dist-tag add` is idempotent).
+- Skipped checks: none.


### PR DESCRIPTION
Finalizes the beta.77 release-run record.

- **20** `@robota-sdk/*` packages published, `latest` = `beta` = 3.0.0-beta.77 (20/20 verified).
- New: `@robota-sdk/agent-process` (first publish).
- DAG/workflow subsystem (38 packages) kept `private` and excluded.
- Post-publish: clean-room `npx @robota-sdk/agent-cli@3.0.0-beta.77` installed from npm (no dag/workflow deps) and ran headless — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)