### PR TITLE
fix(harness): dist-freshness scan skips private packages

### DIFF
--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -50,6 +50,17 @@ for (const scope of buildable) {
   const distPath = join(ROOT, scope.relativeDir, 'dist');
   const pkg = await readJson(join(ROOT, scope.relativeDir, 'package.json'));
 
+  // Private packages are never published, so their dist freshness is a dev concern, not a
+  // release/publish gate. This is what "apps that don't publish" below intends — but a private
+  // package can still carry dist-based `exports`/`main` (e.g. a private server app), so key the
+  // skip on `private`, not just the absence of dist exports.
+  if (pkg.private === true) {
+    if (!isNonEmptyDir(distPath)) {
+      warn(`${scope.workspaceName}: no dist/ (private, not published — not blocking)`);
+    }
+    continue;
+  }
+
   // Skip packages with no exports pointing to dist (e.g. apps that don't publish)
   const hasDistExport =
     pkg.main?.includes('dist') || pkg.exports


### PR DESCRIPTION
The dist-freshness scan blocked **release-grade verification** on the develop→main sync (#963) via `@robota-sdk/dag-runtime-server` — a **private** server app (WORKFLOW-002) that carries dist-based `exports` but is never published and isn't built by `build:deps`.

The scan's intent is to skip "apps that don't publish", but its heuristic keyed on the *absence of dist exports*, so a private package *with* dist exports was wrongly gated. Fix: key the skip on `private: true`. Published packages (`private:false`) are unaffected.

Mechanical consequence of the CLI-077 DAG privatization; unblocks the 3.0.0-beta.77 develop→main sync.

- Local `pnpm harness:scan` → 45/45 (dist ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)