### PR TITLE
feat(dag-nodes): in-process tool node (WORKFLOW-005 P1 #1)

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -1,0 +1,126 @@
+---
+title: 'WORKFLOW-005: complete the /workflows feature (dynamic node+workflow authoring; DAG stays private)'
+status: todo
+created: 2026-07-05
+approved: 2026-07-05
+start_phase: 'P1 — node-kind completion (owner-approved 2026-07-05)'
+priority: medium
+urgency: soon
+area: packages/agent-command-workflows, packages/dag-nodes, packages/dag-node, packages/dag-cli
+depends_on: ['CLI-077', 'WORKFLOW-004']
+---
+
+# Complete the /workflows feature (Option A — feature completion, DAG kept private)
+
+Owner decision (2026-07-05): complete the **feature** in the dev/private context; the DAG subsystem
+stays `private` (no publish, no IP exposure) until a separate instruction. So the published CLI keeps
+CLI-077's optional/absent `/workflows`; this item advances the capability itself.
+
+## Vision
+
+Dynamically create workflows AND workflow nodes on the fly. A node can be a **skill**, a **tool call**,
+an **LLM** call, **generative AI** (image/video), or an arbitrary **custom function** — all on one
+common node interface. Anything created is **reusable** and **savable** to disk for reload. (Similar in
+spirit to Claude Code workflows; this predates it and is now being solidified.)
+
+## Current state (research 2026-07-05)
+
+- **Common interface already exists** — `IDagNodeDefinition` + `INodeTaskHandler`
+  (`packages/dag-core/src/types/node-lifecycle.ts`); every node conforms. Authoring via
+  `AbstractNodeDefinition` / `defineDagNode` (`packages/dag-node/src/lifecycle/`). The "common
+  interface" requirement is structurally satisfied.
+- **Dynamic node creation exists, partially** — `instant-node` builds nodes from data at runtime:
+  `createPromptBackedNodeDefinition` (LLM-prompt node) and `createCompositeInstantNodeDefinition`
+  (wrap an inner DAG). Phase C (arbitrary code node via API) is explicitly out of scope today.
+- **Node catalog** — a static hand-maintained registry (`dag-framework/src/default-node-registry.ts`):
+  LLM text (anthropic/openai/gemini/deepseek/qwen/router), gemini image edit/compose, mcp-tool
+  (external MCP-over-HTTP), file/http/transform/text/utility nodes.
+- **Persistence exists but fragmented** — `.dag/workflows/*.dag.json` (workflows),
+  `.dag/nodes/*.instant-node.json` (prompt nodes), `*.dag.node.js` (code nodes). Three formats.
+- **Builder is pipeline-only** — `buildDagFromPipeline` (linear + parallel fan-out, auto-wired); no
+  free-form graph/branch builder.
+- **Two surfaces** — the thin `/workflows` slash command (`list`/`catalog`/`validate`/`run`) vs the
+  rich `dag-cli` **MCP** toolset (build, instant-node CRUD+save, export/import, templates). The
+  dynamic-creation power lives only in the MCP layer, not the agent slash command.
+
+## Gaps to close (the "완성" work)
+
+1. **Missing node kinds on the common interface** (each is an additive `IDagNodeDefinition`):
+   - **skill node** — wrap a Robota skill (MISSING).
+   - **in-process tool node** — wrap the agent `agent-tools` FunctionTool registry (only external
+     MCP-over-HTTP `mcp-tool` exists today).
+   - **custom-function / code node** — instant-node **Phase C**: define behavior via API at runtime,
+     persistable (today custom code requires hand-writing a `*.dag.node.js` file).
+   - **generative image (text-to-image)** and **generative video** — image is edit/compose only;
+     video MISSING (payload already supports `binaryKind: 'video'`).
+2. **Fix + unify persistence** — composite/instant nodes with `taskCode: null` are dropped on reload
+   (`dag-cli/.../instant-nodes.ts`); unify "save this node OR workflow, reload it" into one abstraction.
+3. **Expose dynamic creation through `/workflows`** — bring create-node / save / build to the agent
+   slash command (or a shared authoring API the slash command and MCP both use), so the agent can
+   create and reuse nodes+workflows on the fly, not only via MCP.
+4. **WORKFLOW-004 `build` subcommand** — LLM-assisted workflow authoring (its own spec-first sub-item).
+
+## Proposed phasing (to confirm)
+
+- **P1 — node-kind completion**: skill node + in-process tool node + text-to-image/video nodes
+  (additive, common interface). Highest vision value, lowest risk.
+- **P2 — dynamic authoring**: instant-node Phase C (code node via API) + unified persistence + fix
+  composite reload.
+- **P3 — surface unification**: expose create/save/build through `/workflows` (+ WORKFLOW-004 build).
+
+Deferred (separate instruction): making the DAG subsystem publishable so `/workflows` ships in the
+CLI (WORKFLOW-005 does NOT publish anything).
+
+## Test Plan
+
+- Per new node: a `defineDagNode`/lifecycle unit test + a functional run through
+  `LocalDagRuntimeProvider.execute` with a scripted provider; boundary `rg` stays 0.
+- Persistence: save→reload round-trip for prompt, composite, and code nodes (composite reload fixed).
+- No published-closure change (CLI-077 invariant holds; DAG stays private).
+
+## User Execution Test Scenarios
+
+- agent-executable (dev/monorepo, DAG present). Create a node of each kind on the fly, save it, reload,
+  compose a small workflow using it, and run it end-to-end via the dev `/workflows` path.
+- Evidence: _to fill at implementation._
+
+## P1 implementation notes — node #1: in-process tool node (grounded 2026-07-05)
+
+Design confirmed by research; ready to implement (SPEC-first → TDD → live UE).
+
+- **Package**: `@robota-sdk/dag-node-tool` at `packages/dag-nodes/tool`, `private: true` (DAG subsystem
+  stays private). Scaffold by mirroring `packages/dag-nodes/mcp-tool` (package.json, tsconfig,
+  tsdown.config, vitest.config, src/index.ts, docs/SPEC.md, README).
+- **Boundary**: distinct from the existing `mcp-tool` node (external MCP-over-HTTP/stdio). This node
+  wraps the agent's **in-process** `@robota-sdk/agent-tools` builtins as a DAG step.
+- **Pattern**: `class ToolNodeDefinition extends AbstractNodeDefinition<typeof ConfigSchema>` (from
+  `@robota-sdk/dag-node`), **no-arg constructor** (same as the LLM nodes — runtime params come from the
+  node `config`, not injection). Import `@robota-sdk/agent-tools` directly (dag-nodes may depend on
+  agent packages — instant-node already depends on agent-core).
+- **config (zod)**: `toolName: z.string().min(1)` selecting a builtin (`read`/`write`/`edit`/`glob`/
+  `grep`/`shell`/`bash`/`web-fetch`/`web-search`/…), optional `params` (static tool args merged under
+  the input), `baseCredits`. Map `toolName` → the agent-tools factory (e.g. `createReadTool`,
+  `createShellTool`, …) — a static switch, mirroring how the LLM node constructs its provider.
+- **ports**: input `params` (JSON string, optional) → merged with config params → tool parameters;
+  outputs `output` (string, from `IToolResult.output`) + `isError` (boolean). defaultInput=`params`,
+  defaultOutput=`output`.
+- **execute**: `NodeIoAccessor` to read input; construct the selected builtin tool; call
+  `tool.execute(mergedParams)`; on `result.success` emit `{ output, isError:false }`, else
+  `buildTaskExecutionError(...)` (or emit `{ output: error, isError:true }` per validate/output policy).
+  Unknown `toolName` → `buildValidationError` with the allowed list as `options`.
+- **registry**: add to the SYNC list in `packages/dag-framework/src/default-node-registry.ts`
+  (`createDefaultNodeRegistrySync`) — agent-tools loads without an optional provider SDK.
+- **New-package harness gotchas** (learned from agent-process/CORE-023): register in
+  `.agents/project-structure.md` package listing; add to `check-capability-placement.mjs` family rule;
+  create `docs/README.md` pointing to SPEC.md; mark any illustrative README code blocks
+  `<!-- doc-example-skip -->`; the package is `private:true` so the dist-freshness scan skips it
+  (fixed in the beta.77 release).
+- **Tests (TDD)**: node lifecycle unit test (config parse, port defs, unknown-tool validation) + a
+  functional run through `LocalDagRuntimeProvider.execute` on a 1-node workflow that invokes a safe
+  builtin (e.g. `grep`/`read` in a temp dir) and asserts the output port.
+- **Live UE**: dev `/workflows` — build/run a `.dag.json` with a `tool` node (e.g. read a temp file)
+  and confirm the output; boundary `rg` for forbidden imports stays 0.
+
+Then repeat the pattern for the remaining P1 nodes: **skill node** (wrap a Robota skill), **text-to-image**
+(extend the gemini-image pattern with a from-scratch generate), **video** (new generative node;
+`binaryKind: 'video'` payload already supported).

--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -124,3 +124,23 @@ Design confirmed by research; ready to implement (SPEC-first → TDD → live UE
 Then repeat the pattern for the remaining P1 nodes: **skill node** (wrap a Robota skill), **text-to-image**
 (extend the gemini-image pattern with a from-scratch generate), **video** (new generative node;
 `binaryKind: 'video'` payload already supported).
+
+## P1 progress log
+
+- **node #1 — in-process tool node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-tool`
+  (`packages/dag-nodes/tool`, `private: true`). `ToolNodeDefinition` (nodeType `tool`) wraps the
+  `@robota-sdk/agent-tools` builtins (`read`/`write`/`edit`/`shell`/`bash`/`glob`/`grep`/`web-fetch`/
+  `web-search`) as a DAG step via a static allowlist (`TOOL_NODE_ALLOWED_TOOLS`). Config `toolName` +
+  `params` (input port merged over config) + `cwd` + `baseCredits`; ports `output`/`isError`.
+  Registered in `createDefaultNodeRegistrySync` (sync tier — no optional provider SDK). SPEC at
+  `packages/dag-nodes/tool/docs/SPEC.md`.
+  - Tests: 12 unit tests (lifecycle/config/unknown-tool/invalid-params/read/merge/soft-error) +
+    1 functional integration test in dag-framework running a 1-node `tool` workflow through
+    `LocalDagRuntimeProvider.execute` (`tool-node-run.test.ts`) + registry test asserts `tool` present.
+    Full suites green: dag-node-tool 12, dag-framework 111.
+  - Live UE evidence: `read` builtin via the provider path returned
+    `{ ok: true, "node-1.output": "[File: …/note.txt (2 lines)]\n1\thello from the tool node\n2\tsecond line", "node-1.isError": false }`.
+  - Boundary: CLI-077 holds — `agent-cli` published closure still has 0 dag/workflow deps
+    (`dag-node-tool` and `dag-framework` are private and not in agent-cli's graph); capability-placement
+    and agent-server-boundary scans pass. `dag-nodes/*` family rule auto-covers the new package.
+  - Branch: `feat/workflow-005-p1-tool-node`.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -59,6 +59,7 @@
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
+    "@robota-sdk/dag-node-tool": "workspace:*",
     "@robota-sdk/dag-node-transform": "workspace:*",
     "@robota-sdk/dag-node-utility-text": "workspace:3.0.0-beta.60",
     "@robota-sdk/dag-orchestration-client": "workspace:*",

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -16,13 +16,15 @@ describe('createDefaultNodeRegistrySync', () => {
     expect(types).toContain('text-join');
     expect(types).toContain('json-extract');
     expect(types).toContain('conditional-text');
+    // in-process tool node (agent-tools builtins) is in the sync registry
+    expect(types).toContain('tool');
     // LLM nodes are NOT included in the sync registry
     expect(types).not.toContain('llm-text-anthropic');
   });
 
-  it('returns 22 or more nodes (base 8 + 14 utility-text)', () => {
+  it('returns 23 or more nodes (base 9 + 14 utility-text)', () => {
     const nodes = createDefaultNodeRegistrySync();
-    expect(nodes.length).toBeGreaterThanOrEqual(22);
+    expect(nodes.length).toBeGreaterThanOrEqual(23);
   });
 });
 

--- a/packages/dag-framework/src/__tests__/tool-node-run.test.ts
+++ b/packages/dag-framework/src/__tests__/tool-node-run.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildDagFromPipeline, toDagWorkflowFile } from '@robota-sdk/dag-builder';
+import type { INodeManifest } from '@robota-sdk/dag-core';
+import { LocalDagRuntimeProvider } from '../local-dag-runtime-provider.js';
+import { createDefaultNodeRegistrySync } from '../default-node-registry.js';
+
+function syncManifests(): INodeManifest[] {
+  return createDefaultNodeRegistrySync().map((d) => ({
+    nodeType: d.nodeType,
+    displayName: d.displayName,
+    category: d.category,
+    inputs: d.inputs,
+    outputs: d.outputs,
+    ...(d.defaultInputPort !== undefined ? { defaultInputPort: d.defaultInputPort } : {}),
+    ...(d.defaultOutputPort !== undefined ? { defaultOutputPort: d.defaultOutputPort } : {}),
+  }));
+}
+
+describe('tool node — functional run through LocalDagRuntimeProvider', () => {
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dag-tool-run-'));
+    file = join(dir, 'hello.txt');
+    writeFileSync(file, 'alpha\nbeta\ngamma\n', 'utf8');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('runs a 1-node `tool` workflow that reads a file end-to-end', async () => {
+    const provider = new LocalDagRuntimeProvider();
+
+    const build = buildDagFromPipeline(
+      {
+        dagId: 'tool-run',
+        pipeline: [
+          {
+            nodeType: 'tool',
+            id: 'read-1',
+            config: { toolName: 'read', params: { filePath: file } },
+          },
+        ],
+      },
+      syncManifests(),
+    );
+    expect(build.ok).toBe(true);
+    if (!build.ok) return;
+
+    const { workflowFile } = toDagWorkflowFile(build.definition);
+    const result = await provider.execute(workflowFile, {});
+
+    expect(result.ok).toBe(true);
+    const serialized = JSON.stringify(result.outputs);
+    expect(serialized).toContain('alpha');
+    expect(serialized).toContain('gamma');
+  });
+});

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -7,6 +7,7 @@ import { TextOutputNodeDefinition } from '@robota-sdk/dag-node-text-output';
 import { ImageLoaderNodeDefinition } from '@robota-sdk/dag-node-image-loader';
 import { ImageSourceNodeDefinition } from '@robota-sdk/dag-node-image-source';
 import { OkEmitterNodeDefinition } from '@robota-sdk/dag-node-ok-emitter';
+import { ToolNodeDefinition } from '@robota-sdk/dag-node-tool';
 import {
   StringToNumberNodeDefinition,
   NumberToStringNodeDefinition,
@@ -39,6 +40,8 @@ export function createDefaultNodeRegistrySync(): IDagNodeDefinition[] {
     new ImageLoaderNodeDefinition(),
     new ImageSourceNodeDefinition(),
     new OkEmitterNodeDefinition(),
+    // in-process tool node (agent-tools builtins; no optional provider SDK)
+    new ToolNodeDefinition(),
     // utility text/data nodes (tier-1)
     new StringToNumberNodeDefinition(),
     new NumberToStringNodeDefinition(),

--- a/packages/dag-nodes/tool/docs/README.md
+++ b/packages/dag-nodes/tool/docs/README.md
@@ -1,0 +1,3 @@
+# dag-node-tool Docs Index
+
+- `SPEC.md`: Package specification for the `tool` DAG node definition (in-process agent-tools builtin invocation)

--- a/packages/dag-nodes/tool/docs/SPEC.md
+++ b/packages/dag-nodes/tool/docs/SPEC.md
@@ -1,0 +1,49 @@
+# Tool Node Specification
+
+## Scope
+
+- Owns the `tool` DAG node definition.
+- Wraps a single **in-process** `@robota-sdk/agent-tools` builtin (Read, Write, Edit, Shell, Bash, Glob, Grep, WebFetch, WebSearch) as one DAG step, emitting its text output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Distinct from the `mcp-tool` node: `mcp-tool` calls an **external** MCP server over HTTP/stdio; this node runs an agent builtin **in the current process**. No network transport, no MCP client.
+- Depends on `@robota-sdk/agent-tools` directly (a published agent package). DAG-node packages are permitted to depend on agent packages — `instant-node` already depends on `agent-core`. The DAG subsystem itself stays `private`; this package is `private: true`.
+- Tool selection is a static allowlist (`toolName` → agent-tools factory). Only the enumerated builtins are constructible; an unknown `toolName` yields a `set_config` validation error listing the allowed names.
+
+## Architecture Overview
+
+- `ToolNodeDefinition` — node with an optional `params` input port (JSON string) and `output` + `isError` output ports.
+- `config.toolName` selects the builtin. `config.params` supplies static tool arguments; the `params` input port (parsed as JSON) is merged over them (input wins).
+- File/shell builtins (`read`/`write`/`edit`/`shell`/`bash`) receive `config.cwd` as a path restriction (`ISandboxToolOptions.cwd`); pure builtins (`glob`/`grep`/`web-fetch`/`web-search`) ignore it.
+- Result mapping:
+  - The builtin throws (`ValidationError` / `ToolExecutionError`) → node returns `ok: false` with `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
+  - The builtin returns a JSON-encoded `IToolInvocationResult` with `success: false` (a soft, tool-reported failure — e.g. binary file) → node returns `ok: true` with `output` = the error text and `isError: true`.
+  - Otherwise → `ok: true`, `output` = the tool's text, `isError: false`.
+- Cost estimate: `config.baseCredits` (default 0).
+
+## Type Ownership
+
+| Type                   | Location       | Purpose                         |
+| ---------------------- | -------------- | ------------------------------- |
+| `ToolNodeDefinition`   | `src/index.ts` | Node definition class           |
+| `ToolNodeConfigSchema` | `src/index.ts` | Zod config schema (exported)    |
+| `TToolNodeConfig`      | `src/index.ts` | Inferred config type (exported) |
+
+## Public API Surface
+
+- `ToolNodeDefinition` — class
+- `createToolNodeDefinition()` — factory function
+- `ToolNodeConfigSchema` — Zod schema (for external config validation)
+- `TToolNodeConfig` — TypeScript type
+- `TOOL_NODE_ALLOWED_TOOLS` — the allowlist of builtin names (readonly)
+
+## Extension Points
+
+- Config `toolName`: one of `read`, `write`, `edit`, `shell`, `bash`, `glob`, `grep`, `web-fetch`, `web-search`.
+- Config `params`: static arguments merged under the `params` input.
+- Config `cwd`: path restriction forwarded to file/shell builtins.
+- Config `baseCredits`: base cost per successful call.
+- Error codes: `DAG_VALIDATION_TOOL_UNKNOWN_TOOL`, `DAG_VALIDATION_TOOL_INVALID_PARAMS`, `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
+- Adding a builtin: extend `TOOL_NODE_ALLOWED_TOOLS` and the `TOOL_FACTORIES` map.

--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@robota-sdk/dag-node-tool",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "In-process tool node for Robota DAG — execute a single @robota-sdk/agent-tools builtin as a DAG step",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-tools": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
+++ b/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INodeExecutionContext, INodeConfigObject, TPortPayload } from '@robota-sdk/dag-core';
+import {
+  ToolNodeDefinition,
+  ToolNodeConfigSchema,
+  TOOL_NODE_ALLOWED_TOOLS,
+  createToolNodeDefinition,
+} from '../index.js';
+
+function makeContext(config: Record<string, unknown>): INodeExecutionContext {
+  const node = new ToolNodeDefinition();
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId: 'tool-1',
+      nodeType: 'tool',
+      dependsOn: [],
+      config: config as INodeConfigObject,
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'tool',
+      displayName: 'Tool',
+      category: 'Integration',
+      inputs: node.inputs,
+      outputs: node.outputs,
+      defaultInputPort: node.defaultInputPort,
+      defaultOutputPort: node.defaultOutputPort,
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('ToolNodeDefinition metadata', () => {
+  it('has correct nodeType and displayName', () => {
+    const node = new ToolNodeDefinition();
+    expect(node.nodeType).toBe('tool');
+    expect(node.displayName).toBe('Tool');
+    expect(node.category).toBe('Integration');
+  });
+
+  it('has correct port definitions', () => {
+    const node = new ToolNodeDefinition();
+    expect(node.inputs.find((p) => p.key === 'params')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'output')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'isError')).toBeDefined();
+    expect(node.defaultInputPort).toBe('params');
+    expect(node.defaultOutputPort).toBe('output');
+  });
+
+  it('factory returns an instance', () => {
+    expect(createToolNodeDefinition()).toBeInstanceOf(ToolNodeDefinition);
+  });
+
+  it('exposes the allowed-tools allowlist', () => {
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('read');
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('grep');
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('shell');
+  });
+});
+
+describe('ToolNodeConfigSchema', () => {
+  it('accepts minimal config and applies defaults', () => {
+    const result = ToolNodeConfigSchema.safeParse({ toolName: 'grep' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.params).toEqual({});
+    expect(result.data.baseCredits).toBe(0);
+  });
+
+  it('rejects empty toolName', () => {
+    expect(ToolNodeConfigSchema.safeParse({ toolName: '' }).success).toBe(false);
+  });
+
+  it('rejects negative baseCredits', () => {
+    expect(ToolNodeConfigSchema.safeParse({ toolName: 'read', baseCredits: -1 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('ToolNodeDefinition execution', () => {
+  const node = new ToolNodeDefinition();
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dag-tool-node-'));
+    file = join(dir, 'hello.txt');
+    writeFileSync(file, 'alpha\nbeta\ngamma\n', 'utf8');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function run(config: Record<string, unknown>, input: TPortPayload = {}) {
+    return node.taskHandler.execute(input, makeContext(config));
+  }
+
+  it('rejects an unknown toolName with a set_config validation error', async () => {
+    const result = await run({ toolName: 'does-not-exist' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('DAG_VALIDATION_TOOL_UNKNOWN_TOOL');
+    expect(result.error.fix?.action).toBe('set_config');
+    expect(Array.isArray(result.error.fix?.options)).toBe(true);
+  });
+
+  it('rejects invalid JSON in the params input port', async () => {
+    const result = await run({ toolName: 'read' }, { params: 'not json{' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('DAG_VALIDATION_TOOL_INVALID_PARAMS');
+  });
+
+  it('reads a file via the in-process read builtin (config params)', async () => {
+    const result = await run({ toolName: 'read', params: { filePath: file } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.output).toContain('alpha');
+    expect(result.value.output).toContain('gamma');
+    expect(result.value.isError).toBe(false);
+  });
+
+  it('merges the params input port over config params (input wins)', async () => {
+    const other = join(dir, 'other.txt');
+    writeFileSync(other, 'from-input-file\n', 'utf8');
+    const result = await run(
+      { toolName: 'read', params: { filePath: file } },
+      { params: JSON.stringify({ filePath: other }) },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.output).toContain('from-input-file');
+  });
+
+  it('surfaces a soft tool failure as isError=true (missing file)', async () => {
+    const result = await run({ toolName: 'read', params: { filePath: join(dir, 'nope.txt') } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.isError).toBe(true);
+  });
+});

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -1,0 +1,243 @@
+import {
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createShellTool,
+  createWriteTool,
+  globTool,
+  grepTool,
+  webFetchTool,
+  webSearchTool,
+  type FunctionTool,
+  type ISandboxToolOptions,
+} from '@robota-sdk/agent-tools';
+import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type IPortDefinition,
+  type TPortPayload,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+
+/**
+ * A builtin factory receives sandbox/cwd options; pure builtins (glob/grep/web-*)
+ * ignore them and return their shared singleton instance.
+ */
+type ToolFactory = (options: ISandboxToolOptions) => FunctionTool;
+
+/** Static allowlist mapping `toolName` → the agent-tools builtin factory. */
+const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
+  read: (o) => createReadTool(o),
+  write: (o) => createWriteTool(o),
+  edit: (o) => createEditTool(o),
+  shell: (o) => createShellTool(o),
+  bash: (o) => createBashTool(o),
+  glob: () => globTool,
+  grep: () => grepTool,
+  'web-fetch': () => webFetchTool,
+  'web-search': () => webSearchTool,
+};
+
+/** The builtin tool names this node can run in-process. */
+export const TOOL_NODE_ALLOWED_TOOLS: readonly string[] = Object.freeze(
+  Object.keys(TOOL_FACTORIES),
+);
+
+export const ToolNodeConfigSchema = z.object({
+  /** Which in-process agent-tools builtin to run (see TOOL_NODE_ALLOWED_TOOLS). */
+  toolName: z.string().min(1),
+  /** Static tool arguments; the `params` input port is merged over these (input wins). */
+  params: z.record(z.unknown()).default({}),
+  /** Path restriction forwarded to file/shell builtins (ISandboxToolOptions.cwd). */
+  cwd: z.string().optional(),
+  /** Base credit cost per successful call (for cost estimation). */
+  baseCredits: z.number().nonnegative().default(0),
+});
+
+export type TToolNodeConfig = z.infer<typeof ToolNodeConfigSchema>;
+
+const TOOL_INPUTS: IPortDefinition[] = [
+  {
+    key: 'params',
+    label: 'Tool Parameters (JSON string)',
+    order: 0,
+    type: 'string',
+    required: false,
+  },
+];
+
+const TOOL_OUTPUTS: IPortDefinition[] = [
+  { key: 'output', label: 'Output', order: 0, type: 'string', required: true },
+  { key: 'isError', label: 'Is Error', order: 1, type: 'boolean', required: true },
+];
+
+/**
+ * Coerce a builtin's raw return value into `{ output, isError }`.
+ *
+ * Builtins return either plain text (success) or a JSON-encoded
+ * `IToolInvocationResult` with `success: false` for soft, tool-reported
+ * failures (e.g. a missing/binary file). Both shapes are normalised here.
+ */
+function coerceToolResult(data: unknown): { output: string; isError: boolean } {
+  const text = typeof data === 'string' ? data : JSON.stringify(data ?? '');
+  try {
+    const parsed = JSON.parse(text) as { success?: unknown; output?: unknown; error?: unknown };
+    if (parsed !== null && typeof parsed === 'object' && typeof parsed.success === 'boolean') {
+      const value = parsed.success ? parsed.output : (parsed.error ?? parsed.output);
+      return {
+        output: typeof value === 'string' ? value : String(value ?? ''),
+        isError: !parsed.success,
+      };
+    }
+  } catch {
+    // allow-fallback: non-JSON output is plain success text
+  }
+  return { output: text, isError: false };
+}
+
+function invalidParamsError(toolName: string, message: string, suggestion: string): IDagError {
+  return buildValidationError(
+    'DAG_VALIDATION_TOOL_INVALID_PARAMS',
+    message,
+    { toolName },
+    { action: 'set_input', suggestion },
+  );
+}
+
+/**
+ * Resolve the optional `params` input port into a plain object, merged later
+ * over `config.params`. A JSON string is parsed; a non-object decode is rejected.
+ */
+function resolveInputParams(
+  rawParams: ReturnType<NodeIoAccessor['getInput']>,
+  toolName: string,
+): TResult<Record<string, unknown>, IDagError> {
+  if (typeof rawParams === 'string' && rawParams.trim() !== '') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawParams);
+    } catch {
+      return {
+        ok: false,
+        error: invalidParamsError(
+          toolName,
+          'The `params` input port must be a JSON object string.',
+          'Provide a valid JSON object as the params input',
+        ),
+      };
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {
+        ok: false,
+        error: invalidParamsError(
+          toolName,
+          'The `params` input port must decode to a JSON object.',
+          'Provide a JSON object (not an array or primitive)',
+        ),
+      };
+    }
+    return { ok: true, value: parsed as Record<string, unknown> };
+  }
+  if (rawParams !== null && typeof rawParams === 'object' && !Array.isArray(rawParams)) {
+    return { ok: true, value: rawParams as Record<string, unknown> };
+  }
+  return { ok: true, value: {} };
+}
+
+/** Execute the selected builtin and map its result onto the node's output ports. */
+async function runBuiltin(
+  tool: FunctionTool,
+  params: Record<string, unknown>,
+  toolName: string,
+  nodeId: string,
+): Promise<TResult<TPortPayload, IDagError>> {
+  try {
+    const result = await tool.execute(params as unknown as Parameters<FunctionTool['execute']>[0]);
+    const { output, isError } = coerceToolResult(result.data);
+
+    const out = new NodeIoAccessor({}, nodeId);
+    out.setOutput('output', output);
+    out.setOutput('isError', isError);
+    out.setOutput(
+      '_agentSummary',
+      `Tool "${toolName}" ran. ${isError ? 'Reported an error.' : `Output: ${output.length} chars.`}`,
+    );
+    return { ok: true, value: out.toOutput() };
+  } catch (err) {
+    // allow-fallback: a thrown ValidationError/ToolExecutionError is a hard node failure
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TOOL_CALL_FAILED',
+        `Tool "${toolName}" failed: ${message}`,
+        true,
+        { toolName },
+      ),
+    };
+  }
+}
+
+export class ToolNodeDefinition extends AbstractNodeDefinition<typeof ToolNodeConfigSchema> {
+  public readonly nodeType = 'tool';
+  public readonly displayName = 'Tool';
+  public readonly category = 'Integration';
+  public readonly inputs: IDagNodeDefinition['inputs'] = TOOL_INPUTS;
+  public readonly outputs: IDagNodeDefinition['outputs'] = TOOL_OUTPUTS;
+  public readonly configSchemaDefinition = ToolNodeConfigSchema;
+  public override readonly defaultInputPort = 'params';
+  public override readonly defaultOutputPort = 'output';
+
+  public constructor() {
+    super();
+  }
+
+  public async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TToolNodeConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TToolNodeConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const factory = TOOL_FACTORIES[config.toolName];
+    if (!factory) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TOOL_UNKNOWN_TOOL',
+          `Unknown toolName "${config.toolName}". Choose one of the supported in-process builtins.`,
+          { toolName: config.toolName },
+          {
+            action: 'set_config',
+            suggestion: 'Set toolName to a supported builtin',
+            options: [...TOOL_NODE_ALLOWED_TOOLS],
+          },
+        ),
+      };
+    }
+
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const paramsResult = resolveInputParams(io.getInput('params'), config.toolName);
+    if (!paramsResult.ok) return paramsResult;
+
+    const merged = { ...config.params, ...paramsResult.value };
+    const tool = factory(config.cwd !== undefined ? { cwd: config.cwd } : {});
+    return runBuiltin(tool, merged, config.toolName, context.nodeDefinition.nodeId);
+  }
+}
+
+export function createToolNodeDefinition(): ToolNodeDefinition {
+  return new ToolNodeDefinition();
+}

--- a/packages/dag-nodes/tool/tsconfig.json
+++ b/packages/dag-nodes/tool/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/tool/tsdown.config.ts
+++ b/packages/dag-nodes/tool/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2045,6 +2045,9 @@ importers:
       '@robota-sdk/dag-node-text-template':
         specifier: workspace:*
         version: link:../dag-nodes/text-template
+      '@robota-sdk/dag-node-tool':
+        specifier: workspace:*
+        version: link:../dag-nodes/tool
       '@robota-sdk/dag-node-transform':
         specifier: workspace:*
         version: link:../dag-nodes/transform
@@ -2752,6 +2755,40 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/tool:
+    dependencies:
+      '@robota-sdk/agent-tools':
+        specifier: workspace:*
+        version: link:../../agent-tools
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1


### PR DESCRIPTION
## Summary

WORKFLOW-005 Phase 3 (Option A — feature completion, DAG stays private), **P1 node #1: in-process tool node**.

Adds `@robota-sdk/dag-node-tool` (`packages/dag-nodes/tool`, `private: true`) — a DAG node that wraps the in-process `@robota-sdk/agent-tools` builtins (`read`/`write`/`edit`/`shell`/`bash`/`glob`/`grep`/`web-fetch`/`web-search`) as a single DAG step. Distinct from the existing `mcp-tool` node (external MCP over HTTP/stdio); this runs an agent builtin **in the current process**.

## What's included

- **`ToolNodeDefinition`** (nodeType `tool`): no-arg constructor, config-driven like the LLM nodes. Config: `toolName` + `params` (static args) + `cwd` (path restriction for file/shell builtins) + `baseCredits`. Ports: `output` (string) + `isError` (boolean). Static allowlist `TOOL_NODE_ALLOWED_TOOLS`; unknown `toolName` → `set_config` validation error listing allowed names. The `params` input port (JSON string) is merged over config params.
- **Result mapping**: a thrown error → `ok:false` (`DAG_TASK_EXECUTION_TOOL_CALL_FAILED`); a soft tool-reported failure (JSON `success:false`, e.g. missing/binary file) → `ok:true` with `isError:true`; otherwise `ok:true` with the tool text.
- **Registry**: added to `createDefaultNodeRegistrySync` (sync tier — no optional provider SDK).
- **SPEC** at `packages/dag-nodes/tool/docs/SPEC.md`; README index; project-structure listing updated.

## Tests (TDD red→green)

- 12 node unit tests (lifecycle, config parse/defaults, unknown-tool, invalid-params, read, input-over-config merge, soft-error).
- 1 **functional integration test** in dag-framework running a 1-node `tool` workflow end-to-end through `LocalDagRuntimeProvider.execute` (the `/workflows` runtime path).
- Registry test asserts `tool` is registered.
- Full suites green: **dag-node-tool 12**, **dag-framework 111**. 0 lint errors.

## Live UE evidence

`read` builtin via the provider path:
```
ok: true
outputs: {
  "node-1.output": "[File: …/note.txt (2 lines)]\n1\thello from the tool node\n2\tsecond line",
  "node-1.isError": false,
  "node-1._agentSummary": "Tool \"read\" ran. Output: 99 chars."
}
```

## Boundary / invariants

- **DAG stays private** — no publish, no IP exposure. New package is `private: true`.
- **CLI-077 holds** — `agent-cli` published closure still has **0** dag/workflow deps (`dag-node-tool` and `dag-framework` are private and not in agent-cli's graph). Capability-placement + agent-server-boundary scans pass; `dag-nodes/*` family rule auto-covers the new package.

Refs WORKFLOW-005 (P1 node #1). Next P1 nodes (skill, text-to-image, video) follow the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)