### PR TITLE
feat(dag-nodes): text-to-image node (WORKFLOW-005 P1 #2)

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -143,4 +143,37 @@ Then repeat the pattern for the remaining P1 nodes: **skill node** (wrap a Robot
   - Boundary: CLI-077 holds — `agent-cli` published closure still has 0 dag/workflow deps
     (`dag-node-tool` and `dag-framework` are private and not in agent-cli's graph); capability-placement
     and agent-server-boundary scans pass. `dag-nodes/*` family rule auto-covers the new package.
-  - Branch: `feat/workflow-005-p1-tool-node`.
+  - Branch: `feat/workflow-005-p1-tool-node`. Merged via PR #965 → develop.
+
+- **skill node — research done, DEFERRED (2026-07-05).** Investigation found a "Robota skill" is NOT a
+  pure in-process function like a tool: a skill is a `SKILL.md` parsed into an `ICommand`; there is no
+  `Skill` executor class. `executeSkill()` (in `@robota-sdk/agent-framework`) returns a **prompt string**
+  in `inject` mode (default) — only an agent LLM turn produces a result — and only `fork`-context skills
+  yield a standalone `result`, via `runSkillInFork` → `createSubagentSession` → `Session.run()` (a full
+  LLM loop needing a provider + agent runtime deps). So a skill node is an **LLM-backed agent node**, not
+  a tool-node clone. Owner (2026-07-05) chose to do text-to-image/video first and design the skill node
+  as an explicit LLM-backed node later. Do NOT model it as a cheap deterministic step.
+
+- **node #2 — text-to-image node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-text-to-image`
+  (`packages/dag-nodes/text-to-image`, `private: true`), mirroring the `gemini-image-edit` skeleton but
+  pure generation (no input image). `TextToImageNodeDefinition` (nodeType `text-to-image`, category `AI`):
+  single `text` input port, single binary `image` output port (`IMAGE_COMMON`); config `{ model,
+baseCredits(=0.02) }`. `TextToImageRuntime.generateImage({prompt,model})` → `@robota-sdk/agent-provider/google`
+  `GoogleProvider.generateImage` (already a required provider method); creds `GEMINI_API_KEY`, default model
+  `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL`, allowlist `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS`; output normalized to an
+  `IPortBinaryValue`. Registered in the **async/optional** loader list in `default-node-registry.ts` (Gemini
+  SDK optional). SPEC at `packages/dag-nodes/text-to-image/docs/SPEC.md`.
+  - Tests: 12 node-definition tests (mock runtime) + 7 runtime tests (mock `GoogleProvider`, incl. success
+    normalization / missing-model / missing-key / model-not-allowed / provider-failure / empty-outputs /
+    config-model-override) + registry test asserts `text-to-image` in the async registry. Full suites green:
+    text-to-image 19, dag-framework 112. typecheck + lint clean (0 problems).
+  - Live UE (no `GEMINI_API_KEY` available; real generation needs credentials + network — same constraint as
+    gemini-image-edit, whose tests also mock the provider): built an `input → text-to-image` workflow and ran
+    it through `LocalDagRuntimeProvider.execute` with the async registry. Evidence: `text-to-image in runtime
+catalog: true`; the node is reached, resolves config, and returns the graceful validation error
+    `GEMINI_API_KEY must be configured for text-to-image node runtime` (deepest reachable point without creds).
+    Note: like `gemini-image-edit`, the runtime requires `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL` even when
+    `config.model` is set (mirrored behavior).
+  - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement + agent-server-boundary
+    scans pass.
+  - Branch: `feat/workflow-005-p1-text-to-image`.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -59,6 +59,7 @@
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
+    "@robota-sdk/dag-node-text-to-image": "workspace:*",
     "@robota-sdk/dag-node-tool": "workspace:*",
     "@robota-sdk/dag-node-transform": "workspace:*",
     "@robota-sdk/dag-node-utility-text": "workspace:3.0.0-beta.60",

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -35,6 +35,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.length).toBeGreaterThanOrEqual(syncNodes.length);
   });
 
+  it('loads the text-to-image node (optional, Gemini-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('text-to-image');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -106,6 +106,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
         (mod) => new (mod.GeminiImageComposeNodeDefinition as new () => IDagNodeDefinition)(),
       ],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-text-to-image',
+      factories: [(mod) => new (mod.TextToImageNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-nodes/text-to-image/.eslintrc.json
+++ b/packages/dag-nodes/text-to-image/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/text-to-image/docs/README.md
+++ b/packages/dag-nodes/text-to-image/docs/README.md
@@ -1,0 +1,3 @@
+# Text to Image Node Docs Index
+
+- `SPEC.md`: Node scope, provider dependencies, and package boundaries.

--- a/packages/dag-nodes/text-to-image/docs/SPEC.md
+++ b/packages/dag-nodes/text-to-image/docs/SPEC.md
@@ -1,0 +1,49 @@
+# Text to Image Node Specification
+
+## Scope
+
+- Owns the `text-to-image` DAG node definition.
+- Generates a **new** image from a text prompt only (no input image) via the Gemini image API, emitting a binary image output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Distinct from `gemini-image-edit`/`gemini-image-compose`: those take one or more **input images** and edit/compose them. This node is pure generation — prompt in, image out, no binary input port.
+- Delegates to `@robota-sdk/agent-provider/google` `GoogleProvider.generateImage({ prompt, model })` (already a required method on `IImageGenerationProvider`). The Google SDK (`@google/genai`) is a transitive concern of `agent-provider`, not a direct dependency.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the **async/optional** node-registry list (the Gemini SDK is an optional peer — the node self-skips if the provider cannot construct).
+
+## Architecture Overview
+
+- `TextToImageNodeDefinition` — node with a single `text` input port (string, required) and a single binary `image` output port (`IMAGE_COMMON` preset). `defaultInputPort='text'`, `defaultOutputPort='image'`.
+- `TextToImageRuntime` — isolates provider/credential/model resolution and the API call from the node definition (mirrors `GeminiImageRuntime`, minus all input-image handling):
+  - default model: `config.model` if non-empty, else `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL` (required, else validation error).
+  - allowed models: `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS` (CSV); when non-empty the resolved model must be a member.
+  - provider: constructed only when `GEMINI_API_KEY` is present; otherwise a `set_config`-style validation error.
+  - calls `provider.generateImage({ prompt, model })`, takes the first output, and normalizes it to an `IPortBinaryValue` (`asset://` or `data:`/http image reference).
+- Cost estimate: `config.baseCredits` (default 0.02).
+
+## Type Ownership
+
+| Type                         | Location                         | Purpose                                      |
+| ---------------------------- | -------------------------------- | -------------------------------------------- |
+| `TextToImageNodeDefinition`  | `src/index.ts`                   | Node definition class                        |
+| `TextToImageConfigSchema`    | `src/index.ts`                   | Zod config schema                            |
+| `TextToImageRuntime`         | `src/runtime-core.ts`            | Provider/model resolution + API call         |
+| `ITextToImageRequest`        | `src/runtime-core.ts`            | `{ prompt, model }` runtime request          |
+| `ITextToImageRuntimeOptions` | `src/runtime-core.ts`            | `{ apiKey?, defaultModel?, allowedModels? }` |
+| `normalizeImageOutput`       | `src/image-output-normalizer.ts` | `IMediaOutputRef` → `IPortBinaryValue`       |
+
+## Public API Surface
+
+- `TextToImageNodeDefinition` — class
+- `createTextToImageNodeDefinition()` — factory function
+- `TextToImageConfigSchema` — Zod schema
+- `TTextToImageConfig` — inferred config type
+- `TextToImageRuntime`, `ITextToImageRequest`, `ITextToImageRuntimeOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `model`: overrides the default model for this node instance.
+- Config `baseCredits`: base cost per successful generation.
+- Env `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL`, `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS`, `GEMINI_API_KEY`.
+- Error codes: `DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED`, `DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED`, `DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED`, `DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_*`.

--- a/packages/dag-nodes/text-to-image/package.json
+++ b/packages/dag-nodes/text-to-image/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-text-to-image",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG text-to-image node for Robota — generate an image from a text prompt via the Gemini image API",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/text-to-image/src/image-output-normalizer.ts
+++ b/packages/dag-nodes/text-to-image/src/image-output-normalizer.ts
@@ -1,0 +1,140 @@
+import {
+  buildTaskExecutionError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import type { IMediaOutputRef } from '@robota-sdk/agent-core';
+
+/**
+ * Normalizes a provider media output reference into a standard binary port value.
+ *
+ * Handles both asset-based and URI-based outputs, including data URIs.
+ *
+ * @param output - The raw media output reference from the provider.
+ * @returns A result containing the normalized binary port value or an execution error.
+ */
+export function normalizeImageOutput(
+  output: IMediaOutputRef,
+): TResult<IPortBinaryValue, IDagError> {
+  if (output.kind === 'asset') {
+    return normalizeAssetOutput(output);
+  }
+  return normalizeUriOutput(output);
+}
+
+function normalizeAssetOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.assetId !== 'string' || output.assetId.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_ASSET_INVALID',
+        'Provider returned asset output without valid assetId',
+        false,
+      ),
+    };
+  }
+  const mimeType =
+    typeof output.mimeType === 'string' && output.mimeType.trim().length > 0 ? output.mimeType : '';
+  if (!mimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-image media type for text-to-image output',
+        false,
+        { mimeType },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType,
+      uri: `asset://${output.assetId}`,
+      referenceType: 'asset',
+      assetId: output.assetId,
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.uri !== 'string' || output.uri.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_URI_MISSING',
+        'Provider returned uri output without uri value',
+        false,
+      ),
+    };
+  }
+  const outputMimeType =
+    typeof output.mimeType === 'string' && output.mimeType.trim().length > 0 ? output.mimeType : '';
+  if (output.uri.startsWith('data:')) {
+    return normalizeDataUriOutput(output);
+  }
+  if (!outputMimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-image URI output for text-to-image runtime',
+        false,
+        { mimeType: outputMimeType },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType: outputMimeType,
+      uri: output.uri,
+      referenceType: 'uri',
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeDataUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  const parsedDataUri = parseDataUri(output.uri as string);
+  if (!parsedDataUri || !parsedDataUri.mimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_URI_UNSUPPORTED',
+        'Provider URI output must be image data URI',
+        false,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType: parsedDataUri.mimeType,
+      uri: output.uri as string,
+      referenceType: 'uri',
+    },
+  };
+}
+
+function parseDataUri(uri: string): { mimeType: string; data: string } | undefined {
+  const commaIndex = uri.indexOf(',');
+  if (commaIndex < 0) {
+    return undefined;
+  }
+  const header = uri.slice(0, commaIndex);
+  const payload = uri.slice(commaIndex + 1);
+  if (!header.startsWith('data:') || !header.endsWith(';base64')) {
+    return undefined;
+  }
+  const mimeType = header.replace('data:', '').replace(';base64', '').trim();
+  if (mimeType.length === 0 || payload.trim().length === 0) {
+    return undefined;
+  }
+  return { mimeType, data: payload };
+}

--- a/packages/dag-nodes/text-to-image/src/index.test.ts
+++ b/packages/dag-nodes/text-to-image/src/index.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IPortBinaryValue, INodeExecutionContext, TPortPayload } from '@robota-sdk/dag-core';
+
+// Mock runtime-core to isolate the node definition from provider logic
+vi.mock('./runtime-core.js', () => {
+  const mockGenerateImage = vi.fn();
+  return {
+    TextToImageRuntime: vi.fn().mockImplementation(() => ({
+      generateImage: mockGenerateImage,
+    })),
+  };
+});
+
+import {
+  TextToImageNodeDefinition,
+  TextToImageConfigSchema,
+  createTextToImageNodeDefinition,
+} from './index.js';
+import { TextToImageRuntime } from './runtime-core.js';
+
+function getMockGenerateImage(): ReturnType<typeof vi.fn> {
+  const runtimeInstance = vi.mocked(TextToImageRuntime).mock.results[
+    vi.mocked(TextToImageRuntime).mock.results.length - 1
+  ]?.value as { generateImage: ReturnType<typeof vi.fn> };
+  return runtimeInstance.generateImage;
+}
+
+function makeImageBinary(overrides?: Partial<IPortBinaryValue>): IPortBinaryValue {
+  return { kind: 'image', mimeType: 'image/png', uri: 'data:image/png;base64,iVBOR', ...overrides };
+}
+
+function makeExecutionContext(nodeId = 'node-1'): INodeExecutionContext {
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId,
+      nodeType: 'text-to-image',
+      dependsOn: [],
+      config: {},
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'text-to-image',
+      displayName: 'Text to Image',
+      category: 'AI',
+      inputs: [],
+      outputs: [],
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('TextToImageNodeDefinition', () => {
+  let node: TextToImageNodeDefinition;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    node = new TextToImageNodeDefinition();
+  });
+
+  describe('static properties', () => {
+    it('has correct nodeType/displayName/category', () => {
+      expect(node.nodeType).toBe('text-to-image');
+      expect(node.displayName).toBe('Text to Image');
+      expect(node.category).toBe('AI');
+    });
+
+    it('has a required text input port and image output port', () => {
+      const textInput = node.inputs.find((p) => p.key === 'text');
+      expect(textInput?.required).toBe(true);
+      expect(textInput?.type).toBe('string');
+      expect(node.inputs.find((p) => p.key === 'image')).toBeUndefined();
+      expect(node.outputs.find((p) => p.key === 'image')).toBeDefined();
+      expect(node.defaultInputPort).toBe('text');
+      expect(node.defaultOutputPort).toBe('image');
+    });
+
+    it('factory returns an instance', () => {
+      expect(createTextToImageNodeDefinition()).toBeInstanceOf(TextToImageNodeDefinition);
+    });
+  });
+
+  describe('config schema', () => {
+    it('applies defaults', () => {
+      const parsed = TextToImageConfigSchema.parse({});
+      expect(parsed.model).toBe('');
+      expect(parsed.baseCredits).toBe(0.02);
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('returns default cost estimate', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = {};
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.02);
+    });
+
+    it('returns custom cost from config', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = { baseCredits: 0.05 };
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.05);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns validation error when prompt is missing', async () => {
+      const result = await node.taskHandler.execute!({}, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED');
+    });
+
+    it('returns validation error when prompt is empty', async () => {
+      const input: TPortPayload = { text: '   ' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED');
+    });
+
+    it('returns success with image output when runtime succeeds', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: true,
+        value: makeImageBinary({ uri: 'data:image/png;base64,RESULT' }),
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.image).toBeDefined();
+    });
+
+    it('propagates runtime error when generateImage fails', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: false,
+        error: {
+          code: 'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED',
+          message: 'Generation failed',
+          layer: 'execution',
+          retryable: false,
+        },
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED');
+    });
+
+    it('returns error when runtime returns non-image output', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: true,
+        value: { kind: 'audio', mimeType: 'audio/mp3', uri: 'asset://x' },
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_INVALID');
+    });
+  });
+
+  describe('construction with options', () => {
+    it('passes options to TextToImageRuntime', () => {
+      const options = { apiKey: 'key-123', defaultModel: 'model-x' };
+      new TextToImageNodeDefinition(options);
+      expect(TextToImageRuntime).toHaveBeenCalledWith(options);
+    });
+  });
+});

--- a/packages/dag-nodes/text-to-image/src/index.ts
+++ b/packages/dag-nodes/text-to-image/src/index.ts
@@ -1,0 +1,125 @@
+import {
+  AbstractNodeDefinition,
+  BINARY_PORT_PRESETS,
+  NodeIoAccessor,
+  createBinaryPortDefinition,
+} from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { TextToImageRuntime, type ITextToImageRuntimeOptions } from './runtime-core.js';
+
+export type { ITextToImageRequest, ITextToImageRuntimeOptions } from './runtime-core.js';
+export { TextToImageRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link TextToImageNodeDefinition}. */
+export interface ITextToImageNodeDefinitionOptions extends ITextToImageRuntimeOptions {}
+
+const DEFAULT_TEXT_TO_IMAGE_COST_USD = 0.02;
+
+export const TextToImageConfigSchema = z.object({
+  model: z.string().default(''),
+  baseCredits: z.number().default(DEFAULT_TEXT_TO_IMAGE_COST_USD),
+});
+
+export type TTextToImageConfig = z.output<typeof TextToImageConfigSchema>;
+
+/**
+ * DAG node that generates a new image from a text prompt using the Gemini image API.
+ *
+ * Takes only a text prompt (no input image) and returns the generated image.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class TextToImageNodeDefinition extends AbstractNodeDefinition<
+  typeof TextToImageConfigSchema
+> {
+  public readonly nodeType = 'text-to-image';
+  public readonly displayName = 'Text to Image';
+  public readonly category = 'AI';
+  public readonly inputs: IDagNodeDefinition['inputs'] = [
+    { key: 'text', label: 'Text', order: 0, type: 'string', required: true },
+  ];
+  public readonly outputs: IDagNodeDefinition['outputs'] = [
+    createBinaryPortDefinition({
+      key: 'image',
+      label: 'Image',
+      order: 0,
+      required: true,
+      preset: BINARY_PORT_PRESETS.IMAGE_COMMON,
+    }),
+  ];
+  public override readonly defaultInputPort = 'text';
+  public override readonly defaultOutputPort = 'image';
+  public readonly configSchemaDefinition = TextToImageConfigSchema;
+
+  private readonly runtime: TextToImageRuntime;
+
+  public constructor(options?: ITextToImageNodeDefinitionOptions) {
+    super();
+    this.runtime = new TextToImageRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TTextToImageConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TTextToImageConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const textInputResult = io.requireInputString('text');
+    if (!textInputResult.ok || textInputResult.value.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED',
+          'Text-to-image node requires non-empty text input',
+          { nodeId: context.nodeDefinition.nodeId },
+        ),
+      };
+    }
+
+    const generateResult = await this.runtime.generateImage({
+      prompt: textInputResult.value.trim(),
+      model: config.model,
+    });
+    if (!generateResult.ok) {
+      return generateResult;
+    }
+    if (generateResult.value.kind !== 'image') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_INVALID',
+          'Text-to-image node returned non-image output',
+          false,
+        ),
+      };
+    }
+    io.setOutput('image', generateResult.value);
+    io.setOutput(
+      '_agentSummary',
+      `Image generated from prompt with Gemini. Model: ${config.model}.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createTextToImageNodeDefinition(): TextToImageNodeDefinition {
+  return new TextToImageNodeDefinition();
+}

--- a/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
@@ -3,19 +3,25 @@ import type { IImageGenerationResult, TProviderMediaResult } from '@robota-sdk/a
 import { TextToImageRuntime } from './runtime-core.js';
 import { GoogleProvider } from '@robota-sdk/agent-provider/google';
 
-// A shared generateImage mock so every constructed GoogleProvider instance uses the
-// same fn — lets us set the return value before the runtime constructs the provider.
-const { sharedGenerateImage } = vi.hoisted(() => ({ sharedGenerateImage: vi.fn() }));
+// A shared generateImage mock so every constructed GoogleProvider instance uses the same fn —
+// lets us set the return value before the runtime constructs the provider. The factory lives in
+// vi.hoisted so the vi.mock() call stays a single line (keeps the allow-module-mock escape attached).
+const { sharedGenerateImage, googleMockFactory } = vi.hoisted(() => {
+  const sharedGenerateImage = vi.fn();
+  const googleMockFactory = (): { GoogleProvider: unknown } => ({
+    GoogleProvider: vi
+      .fn()
+      .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({
+        _apiKey: options.apiKey,
+        _imageCapableModels: options.imageCapableModels,
+        generateImage: sharedGenerateImage,
+      })),
+  });
+  return { sharedGenerateImage, googleMockFactory };
+});
 
-vi.mock('@robota-sdk/agent-provider/google', () => ({
-  GoogleProvider: vi
-    .fn()
-    .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({
-      _apiKey: options.apiKey,
-      _imageCapableModels: options.imageCapableModels,
-      generateImage: sharedGenerateImage,
-    })),
-}));
+// Full replacement avoids loading the @google/genai SDK; only ctor + generateImage are exercised.
+vi.mock('@robota-sdk/agent-provider/google', googleMockFactory); // allow-module-mock: GoogleProvider hits the real Gemini API
 
 const TEST_MODEL = 'test-image-model';
 

--- a/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IImageGenerationResult, TProviderMediaResult } from '@robota-sdk/agent-core';
+import { TextToImageRuntime } from './runtime-core.js';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
+
+// A shared generateImage mock so every constructed GoogleProvider instance uses the
+// same fn — lets us set the return value before the runtime constructs the provider.
+const { sharedGenerateImage } = vi.hoisted(() => ({ sharedGenerateImage: vi.fn() }));
+
+vi.mock('@robota-sdk/agent-provider/google', () => ({
+  GoogleProvider: vi
+    .fn()
+    .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({
+      _apiKey: options.apiKey,
+      _imageCapableModels: options.imageCapableModels,
+      generateImage: sharedGenerateImage,
+    })),
+}));
+
+const TEST_MODEL = 'test-image-model';
+
+function makeSuccessResult(): TProviderMediaResult<IImageGenerationResult> {
+  return {
+    ok: true,
+    value: {
+      model: TEST_MODEL,
+      outputs: [
+        {
+          kind: 'uri',
+          uri: 'data:image/png;base64,RESULT_DATA',
+          mimeType: 'image/png',
+          bytes: 2048,
+        },
+      ],
+    },
+  };
+}
+
+describe('TextToImageRuntime', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = {
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+      DAG_TEXT_TO_IMAGE_DEFAULT_MODEL: process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL,
+      DAG_TEXT_TO_IMAGE_ALLOWED_MODELS: process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS,
+    };
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL;
+    delete process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('returns validation error when default model is missing', async () => {
+    const runtime = new TextToImageRuntime({ apiKey: 'k' });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED');
+  });
+
+  it('returns validation error when API key is missing', async () => {
+    const runtime = new TextToImageRuntime({ defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED');
+  });
+
+  it('returns validation error when model is not allowed', async () => {
+    const runtime = new TextToImageRuntime({
+      apiKey: 'k',
+      defaultModel: TEST_MODEL,
+      allowedModels: ['only-this-one'],
+    });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: 'some-other-model' });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED');
+  });
+
+  it('maps a successful provider response to an image port value', async () => {
+    sharedGenerateImage.mockResolvedValue(makeSuccessResult());
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(GoogleProvider).toHaveBeenCalledWith({ apiKey: 'k', imageCapableModels: [] });
+    expect(sharedGenerateImage).toHaveBeenCalledWith({ prompt: 'a cat', model: TEST_MODEL });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe('image');
+      expect(result.value.mimeType).toBe('image/png');
+      expect(result.value.uri).toContain('data:image/png;base64,RESULT_DATA');
+    }
+  });
+
+  it('maps a provider failure to a task execution error', async () => {
+    sharedGenerateImage.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_ERROR', message: 'boom' },
+    });
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED');
+  });
+
+  it('errors when the provider returns no outputs', async () => {
+    sharedGenerateImage.mockResolvedValue({ ok: true, value: { model: TEST_MODEL, outputs: [] } });
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE');
+    }
+  });
+
+  it('resolves the model from config over the default', async () => {
+    sharedGenerateImage.mockResolvedValue(makeSuccessResult());
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    await runtime.generateImage({ prompt: 'a cat', model: 'chosen-model' });
+    expect(sharedGenerateImage).toHaveBeenCalledWith({ prompt: 'a cat', model: 'chosen-model' });
+  });
+});

--- a/packages/dag-nodes/text-to-image/src/runtime-core.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.ts
@@ -1,0 +1,178 @@
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
+import type { IImageGenerationProvider, IImageGenerationResult } from '@robota-sdk/agent-core';
+import { normalizeImageOutput } from './image-output-normalizer.js';
+
+/** Request payload for generating an image from a text prompt. */
+export interface ITextToImageRequest {
+  prompt: string;
+  model: string;
+}
+
+/** Configuration options for the text-to-image runtime, including API key and model restrictions. */
+export interface ITextToImageRuntimeOptions {
+  apiKey?: string;
+  defaultModel?: string;
+  allowedModels?: string[];
+}
+
+/**
+ * Parses a comma-separated string into a trimmed, non-empty array of values.
+ */
+function parseCsv(value: string | undefined): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Resolves and validates a model identifier against the allowed model list.
+ */
+function resolveModel(
+  selectedModel: string,
+  defaultModel: string,
+  allowedModels: string[],
+): TResult<string, IDagError> {
+  const model = selectedModel.trim().length > 0 ? selectedModel.trim() : defaultModel;
+  if (allowedModels.length > 0 && !allowedModels.includes(model)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED',
+        'Selected text-to-image model is not allowed in DAG runtime',
+        { model },
+      ),
+    };
+  }
+  return { ok: true, value: model };
+}
+
+/**
+ * Runtime that delegates text-to-image generation requests to the Google Gemini API
+ * via the GoogleProvider. Unlike the image-edit runtime, it takes no input image.
+ */
+export class TextToImageRuntime {
+  private readonly explicitApiKey?: string;
+  private readonly explicitDefaultModel?: string;
+  private readonly explicitAllowedModels?: string[];
+
+  public constructor(options?: ITextToImageRuntimeOptions) {
+    this.explicitApiKey = options?.apiKey;
+    this.explicitDefaultModel = options?.defaultModel;
+    this.explicitAllowedModels = options?.allowedModels;
+  }
+
+  private resolveDefaultModel(): TResult<string, IDagError> {
+    const defaultModelValue =
+      this.explicitDefaultModel ?? process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL;
+    if (typeof defaultModelValue !== 'string' || defaultModelValue.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED',
+          'DAG_TEXT_TO_IMAGE_DEFAULT_MODEL must be configured or model must be specified in node config',
+        ),
+      };
+    }
+    return { ok: true, value: defaultModelValue.trim() };
+  }
+
+  private resolveAllowedModels(): string[] {
+    return this.explicitAllowedModels ?? parseCsv(process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS);
+  }
+
+  private resolveProvider(allowedModels: string[]): IImageGenerationProvider | undefined {
+    const apiKeyValue = this.explicitApiKey ?? process.env.GEMINI_API_KEY;
+    if (typeof apiKeyValue === 'string' && apiKeyValue.trim().length > 0) {
+      return new GoogleProvider({
+        apiKey: apiKeyValue.trim(),
+        imageCapableModels: allowedModels,
+      });
+    }
+    return undefined;
+  }
+
+  private getImageProviderCapability(
+    provider: IImageGenerationProvider | undefined,
+  ): TResult<IImageGenerationProvider, IDagError> {
+    if (!provider || typeof provider.generateImage !== 'function') {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED',
+          'GEMINI_API_KEY must be configured for text-to-image node runtime',
+        ),
+      };
+    }
+    return { ok: true, value: provider };
+  }
+
+  private getFirstOutputOrError(
+    result: IImageGenerationResult,
+    model: string,
+  ): TResult<NonNullable<IImageGenerationResult['outputs'][number]>, IDagError> {
+    const firstOutput = result.outputs[0];
+    if (!firstOutput) {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE',
+          'Text-to-image response did not include image data',
+          false,
+          { model },
+        ),
+      };
+    }
+    return { ok: true, value: firstOutput };
+  }
+
+  public async generateImage(
+    request: ITextToImageRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const defaultModelResult = this.resolveDefaultModel();
+    if (!defaultModelResult.ok) return defaultModelResult;
+    const allowedModels = this.resolveAllowedModels();
+    const resolvedProvider = this.resolveProvider(allowedModels);
+    const providerCapabilityResult = this.getImageProviderCapability(resolvedProvider);
+    if (!providerCapabilityResult.ok) {
+      return providerCapabilityResult;
+    }
+    const provider = providerCapabilityResult.value;
+    const modelResult = resolveModel(request.model, defaultModelResult.value, allowedModels);
+    if (!modelResult.ok) {
+      return modelResult;
+    }
+
+    const result = await provider.generateImage({
+      prompt: request.prompt,
+      model: modelResult.value,
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED',
+          result.error.message,
+          false,
+          { code: result.error.code, model: modelResult.value },
+        ),
+      };
+    }
+
+    const outputResult = this.getFirstOutputOrError(result.value, modelResult.value);
+    if (!outputResult.ok) {
+      return outputResult;
+    }
+    return normalizeImageOutput(outputResult.value);
+  }
+}

--- a/packages/dag-nodes/text-to-image/tsconfig.eslint.json
+++ b/packages/dag-nodes/text-to-image/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/text-to-image/tsconfig.json
+++ b/packages/dag-nodes/text-to-image/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/text-to-image/tsdown.config.ts
+++ b/packages/dag-nodes/text-to-image/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2045,6 +2045,9 @@ importers:
       '@robota-sdk/dag-node-text-template':
         specifier: workspace:*
         version: link:../dag-nodes/text-template
+      '@robota-sdk/dag-node-text-to-image':
+        specifier: workspace:*
+        version: link:../dag-nodes/text-to-image
       '@robota-sdk/dag-node-tool':
         specifier: workspace:*
         version: link:../dag-nodes/tool
@@ -2755,6 +2758,43 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/text-to-image:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1


### PR DESCRIPTION
## Summary

WORKFLOW-005 Phase 3 (Option A — DAG stays private), **P1 node #2: text-to-image**.

Adds `@robota-sdk/dag-node-text-to-image` (`packages/dag-nodes/text-to-image`, `private: true`) — a DAG node that generates a **new** image from a text prompt via the Gemini image API. Mirrors the `gemini-image-edit` skeleton but is pure generation: no input image, prompt in → image out.

## What's included

- **`TextToImageNodeDefinition`** (nodeType `text-to-image`, category `AI`): single `text` input port (required), single binary `image` output port (`IMAGE_COMMON`); config `{ model, baseCredits=0.02 }`. `defaultInputPort='text'`, `defaultOutputPort='image'`.
- **`TextToImageRuntime.generateImage({ prompt, model })`** → `@robota-sdk/agent-provider/google` `GoogleProvider.generateImage` (already a required method on `IImageGenerationProvider`). Credentials `GEMINI_API_KEY`; default model `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL`; allowlist `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS`. Output normalized to an `IPortBinaryValue` (asset/data/http image reference).
- **Registration**: async/optional loader list in `default-node-registry.ts` (Gemini SDK is an optional peer — self-skips if the provider can't construct). Framework dependency added.
- **SPEC** at `packages/dag-nodes/text-to-image/docs/SPEC.md`; README; project-structure listing updated.

## Tests

- 12 node-definition tests (mock `runtime-core`): metadata/ports, config defaults, estimateCost, prompt-required, success, runtime-error propagation, non-image output, options passthrough.
- 7 runtime tests (mock `GoogleProvider` via `vi.hoisted` shared fn): success→normalized image, missing default model, missing API key, model-not-allowed, provider failure, empty outputs, config-model override.
- Registry test asserts `text-to-image` loads in the async registry.
- Full suites green: **text-to-image 19**, **dag-framework 112**. typecheck + lint clean (0 problems).

## Live UE

No `GEMINI_API_KEY` is available in this environment, so a real generation (network + credentials) isn't possible — the same constraint under which `gemini-image-edit` mocks the provider. Instead, an `input → text-to-image` workflow was built and run through `LocalDagRuntimeProvider.execute` (with the async registry, as the real `/workflows` path wires optional nodes):

```
text-to-image in runtime catalog: true
workflow built: nodes=2 edges=1
run ok: false
run error: node-2: GEMINI_API_KEY must be configured for text-to-image node runtime
```

The node is registered, reachable, resolves its config, and fails gracefully at the deepest reachable point without credentials. The success path is covered deterministically by the mocked-provider runtime tests.

_Note: like `gemini-image-edit`, the runtime requires `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL` even when `config.model` is set — mirrored behavior._

## Boundary / invariants

- **DAG stays private** — new package is `private: true`.
- **CLI-077 holds** — `agent-cli` published closure still has **0** dag/workflow deps. Capability-placement + agent-server-boundary scans pass.

Refs WORKFLOW-005 (P1 node #2). The **skill node** is deferred: research showed it's an LLM-backed agent node (not a tool-node clone) — see the backlog progress log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)