### PR TITLE
feat(dag-nodes): seedance-video node (WORKFLOW-005 P1 #3)

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -176,4 +176,32 @@ catalog: true`; the node is reached, resolves config, and returns the graceful v
     `config.model` is set (mirrored behavior).
   - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement + agent-server-boundary
     scans pass.
-  - Branch: `feat/workflow-005-p1-text-to-image`.
+  - Branch: `feat/workflow-005-p1-text-to-image`. Merged via PR #966 → develop.
+
+- **node #3 — seedance-video node — DONE (2026-07-05).** Filled the existing empty stub
+  `packages/dag-nodes/seedance-video` → `@robota-sdk/dag-node-seedance-video` (`private: true`). NodeType
+  `seedance-video` (matches pre-authored `.dag-storage` fixtures and the planned node in
+  `packages/dag-nodes/docs/SPEC.md`). `SeedanceVideoNodeDefinition` (category `AI`): single `text` input,
+  single binary `video` output (`VIDEO_MP4`); config `{ model, baseCredits(=0.5), durationSeconds?,
+aspectRatio?, pollIntervalMs(=5000), maxWaitMs(=300000) }`. Backend: `@robota-sdk/agent-provider/bytedance`
+  `BytedanceProvider` (implements `IVideoGenerationProvider`). Video generation is an **async job** —
+  `SeedanceVideoRuntime.generateVideo` calls `createVideo` then **polls `getVideoJob`** every
+  `pollIntervalMs` until `succeeded`/`failed`/`cancelled` or `maxWaitMs` (best-effort `cancelVideoJob` on
+  timeout). Creds `SEEDANCE_API_KEY` + `SEEDANCE_BASE_URL` (both required); default model
+  `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL`; allowlist `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS`. `seed` intentionally
+  not exposed (provider rejects it). New `video-output-normalizer` (lenient: missing mime → `video/mp4`).
+  Registered in the async/optional loader list. SPEC at `packages/dag-nodes/seedance-video/docs/SPEC.md`.
+  - Tests: 13 node tests (mock runtime) + 11 runtime tests (mock `BytedanceProvider`; incl. poll-until-
+    succeeded, running→succeeded, failed/cancelled, poll-failure, timeout+cancel, output-missing, seed-omitted,
+    mime-default) with an injected instant `sleep` + registry assertion. Full suites green: seedance-video 24,
+    dag-framework 113. typecheck + lint + mock scan clean.
+  - Live UE (no `SEEDANCE_API_KEY`/`SEEDANCE_BASE_URL`): `input → seedance-video` workflow run through
+    `LocalDagRuntimeProvider.execute` (async registry). Evidence: `seedance-video in runtime catalog: true`;
+    node reached, resolves config, returns graceful
+    `SEEDANCE_API_KEY and SEEDANCE_BASE_URL must both be configured` validation error. The poll/success paths
+    are covered deterministically by the mocked-provider runtime tests.
+  - Boundary: CLI-077 holds; capability-placement + agent-server-boundary + test-module-mocks scans pass.
+  - Branch: `feat/workflow-005-p1-video`.
+
+**P1 status: node-kind completion — tool ✅, text-to-image ✅, seedance-video ✅; skill node remaining
+(deferred as an LLM-backed agent node — see the skill-node research entry above).**

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -57,6 +57,7 @@
     "@robota-sdk/dag-node-input": "workspace:*",
     "@robota-sdk/dag-node-multi-input": "workspace:*",
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
+    "@robota-sdk/dag-node-seedance-video": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
     "@robota-sdk/dag-node-text-to-image": "workspace:*",

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -40,6 +40,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.map((n) => n.nodeType)).toContain('text-to-image');
   });
 
+  it('loads the seedance-video node (optional, ByteDance-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('seedance-video');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -110,6 +110,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
       modulePath: '@robota-sdk/dag-node-text-to-image',
       factories: [(mod) => new (mod.TextToImageNodeDefinition as new () => IDagNodeDefinition)()],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-seedance-video',
+      factories: [(mod) => new (mod.SeedanceVideoNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-nodes/seedance-video/.eslintrc.json
+++ b/packages/dag-nodes/seedance-video/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/seedance-video/docs/README.md
+++ b/packages/dag-nodes/seedance-video/docs/README.md
@@ -1,0 +1,3 @@
+# Seedance Video Node Docs Index
+
+- `SPEC.md`: Node scope, provider dependencies, async job model, and package boundaries.

--- a/packages/dag-nodes/seedance-video/docs/SPEC.md
+++ b/packages/dag-nodes/seedance-video/docs/SPEC.md
@@ -1,0 +1,52 @@
+# Seedance Video Node Specification
+
+## Scope
+
+- Owns the `seedance-video` DAG node definition.
+- Generates a video from a text prompt via the ByteDance/ModelArk (Seedance) video API, emitting a binary video output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Delegates to `@robota-sdk/agent-provider/bytedance` `BytedanceProvider`, which implements `IVideoGenerationProvider` (`createVideo` → `getVideoJob` → `cancelVideoJob`). Video generation is an **asynchronous job**: submit, then poll until a terminal status.
+- Distinct from the image nodes: image generation is a single synchronous provider call; this node runs a **poll loop** inside `executeWithConfig` until the job reaches `succeeded`/`failed`/`cancelled` or a max-wait timeout.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the **async/optional** node-registry list (the ByteDance provider is optional; the node self-skips if it cannot construct).
+- Matches the existing `nodeType: "seedance-video"` used by pre-authored `.dag-storage` fixtures and the planned node in `packages/dag-nodes/docs/SPEC.md`.
+
+## Architecture Overview
+
+- `SeedanceVideoNodeDefinition` — node with a single `text` input port (string, required) and a single binary `video` output port (`VIDEO_MP4` preset). `defaultInputPort='text'`, `defaultOutputPort='video'`.
+- `SeedanceVideoRuntime.generateVideo(request)` — isolates provider/credential/model resolution and the submit→poll job loop:
+  - default model: `config.model` if non-empty, else `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL` (required, else validation error).
+  - allowed models: `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS` (CSV); when non-empty the resolved model must be a member.
+  - provider: constructed only when both `SEEDANCE_API_KEY` and `SEEDANCE_BASE_URL` are present; otherwise a validation error.
+  - `createVideo({ prompt, model, durationSeconds?, aspectRatio? })` → `jobId`; then poll `getVideoJob(jobId)` every `pollIntervalMs` until terminal or `maxWaitMs` elapsed.
+  - `succeeded` + `output` → `normalizeVideoOutput` → `IPortBinaryValue` (`kind:'video'`). `failed`/`cancelled` → task-execution error. Timeout → best-effort `cancelVideoJob` + task-execution error.
+  - `seed` is intentionally NOT exposed (the ModelArk Seedance provider rejects it).
+- A `sleep` function is injectable via runtime options for deterministic tests (defaults to a `setTimeout`-based delay).
+- Cost estimate: `config.baseCredits` (default 0.5).
+
+## Type Ownership
+
+| Type                           | Location                         | Purpose                                                                        |
+| ------------------------------ | -------------------------------- | ------------------------------------------------------------------------------ |
+| `SeedanceVideoNodeDefinition`  | `src/index.ts`                   | Node definition class                                                          |
+| `SeedanceVideoConfigSchema`    | `src/index.ts`                   | Zod config schema                                                              |
+| `SeedanceVideoRuntime`         | `src/runtime-core.ts`            | Provider/model resolution + poll loop                                          |
+| `ISeedanceVideoRequest`        | `src/runtime-core.ts`            | `{ prompt, model, durationSeconds?, aspectRatio?, pollIntervalMs, maxWaitMs }` |
+| `ISeedanceVideoRuntimeOptions` | `src/runtime-core.ts`            | `{ apiKey?, baseUrl?, defaultModel?, allowedModels?, sleep? }`                 |
+| `normalizeVideoOutput`         | `src/video-output-normalizer.ts` | `IMediaOutputRef` → `IPortBinaryValue` (video)                                 |
+
+## Public API Surface
+
+- `SeedanceVideoNodeDefinition` — class
+- `createSeedanceVideoNodeDefinition()` — factory function
+- `SeedanceVideoConfigSchema` — Zod schema
+- `TSeedanceVideoConfig` — inferred config type
+- `SeedanceVideoRuntime`, `ISeedanceVideoRequest`, `ISeedanceVideoRuntimeOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `model`, `baseCredits`, `durationSeconds`, `aspectRatio`, `pollIntervalMs` (default 5000), `maxWaitMs` (default 300000).
+- Env `SEEDANCE_API_KEY`, `SEEDANCE_BASE_URL`, `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL`, `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS`.
+- Error codes: `DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED`, `DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED`, `DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED`, `DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_*`.

--- a/packages/dag-nodes/seedance-video/package.json
+++ b/packages/dag-nodes/seedance-video/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-seedance-video",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG seedance-video node for Robota — generate a video from a text prompt via the ByteDance/Seedance video API",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/seedance-video/src/index.test.ts
+++ b/packages/dag-nodes/seedance-video/src/index.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IPortBinaryValue, INodeExecutionContext, TPortPayload } from '@robota-sdk/dag-core';
+
+// Mock runtime-core to isolate the node definition from provider/poll logic
+vi.mock('./runtime-core.js', () => {
+  const mockGenerateVideo = vi.fn();
+  return {
+    SeedanceVideoRuntime: vi.fn().mockImplementation(() => ({
+      generateVideo: mockGenerateVideo,
+    })),
+  };
+});
+
+import {
+  SeedanceVideoNodeDefinition,
+  SeedanceVideoConfigSchema,
+  createSeedanceVideoNodeDefinition,
+} from './index.js';
+import { SeedanceVideoRuntime } from './runtime-core.js';
+
+function getMockGenerateVideo(): ReturnType<typeof vi.fn> {
+  const runtimeInstance = vi.mocked(SeedanceVideoRuntime).mock.results[
+    vi.mocked(SeedanceVideoRuntime).mock.results.length - 1
+  ]?.value as { generateVideo: ReturnType<typeof vi.fn> };
+  return runtimeInstance.generateVideo;
+}
+
+function makeVideoBinary(overrides?: Partial<IPortBinaryValue>): IPortBinaryValue {
+  return {
+    kind: 'video',
+    mimeType: 'video/mp4',
+    uri: 'https://cdn.example.test/v.mp4',
+    referenceType: 'uri',
+    ...overrides,
+  };
+}
+
+function makeExecutionContext(nodeId = 'node-1'): INodeExecutionContext {
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId,
+      nodeType: 'seedance-video',
+      dependsOn: [],
+      config: {},
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'seedance-video',
+      displayName: 'Seedance Video',
+      category: 'AI',
+      inputs: [],
+      outputs: [],
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('SeedanceVideoNodeDefinition', () => {
+  let node: SeedanceVideoNodeDefinition;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    node = new SeedanceVideoNodeDefinition();
+  });
+
+  describe('static properties', () => {
+    it('has correct nodeType/displayName/category', () => {
+      expect(node.nodeType).toBe('seedance-video');
+      expect(node.displayName).toBe('Seedance Video');
+      expect(node.category).toBe('AI');
+    });
+
+    it('has a required text input port and video output port', () => {
+      const textInput = node.inputs.find((p) => p.key === 'text');
+      expect(textInput?.required).toBe(true);
+      expect(textInput?.type).toBe('string');
+      const videoOutput = node.outputs.find((p) => p.key === 'video');
+      expect(videoOutput).toBeDefined();
+      expect(node.defaultInputPort).toBe('text');
+      expect(node.defaultOutputPort).toBe('video');
+    });
+
+    it('factory returns an instance', () => {
+      expect(createSeedanceVideoNodeDefinition()).toBeInstanceOf(SeedanceVideoNodeDefinition);
+    });
+  });
+
+  describe('config schema', () => {
+    it('applies defaults', () => {
+      const parsed = SeedanceVideoConfigSchema.parse({});
+      expect(parsed.model).toBe('');
+      expect(parsed.baseCredits).toBe(0.5);
+      expect(parsed.pollIntervalMs).toBe(5000);
+      expect(parsed.maxWaitMs).toBe(300000);
+    });
+
+    it('rejects non-positive maxWaitMs', () => {
+      expect(SeedanceVideoConfigSchema.safeParse({ maxWaitMs: 0 }).success).toBe(false);
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('returns default cost estimate', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = {};
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.5);
+    });
+
+    it('returns custom cost from config', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = { baseCredits: 1.25 };
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(1.25);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns validation error when prompt is missing', async () => {
+      const result = await node.taskHandler.execute!({}, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED');
+    });
+
+    it('returns validation error when prompt is empty', async () => {
+      const input: TPortPayload = { text: '   ' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED');
+    });
+
+    it('returns success with video output when runtime succeeds', async () => {
+      getMockGenerateVideo().mockResolvedValue({ ok: true, value: makeVideoBinary() });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.video).toBeDefined();
+    });
+
+    it('propagates runtime error when generateVideo fails', async () => {
+      getMockGenerateVideo().mockResolvedValue({
+        ok: false,
+        error: {
+          code: 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED',
+          message: 'job failed',
+          layer: 'execution',
+          retryable: false,
+        },
+      });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED');
+    });
+
+    it('returns error when runtime returns non-video output', async () => {
+      getMockGenerateVideo().mockResolvedValue({
+        ok: true,
+        value: { kind: 'image', mimeType: 'image/png', uri: 'asset://x' },
+      });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_INVALID');
+    });
+  });
+
+  describe('construction with options', () => {
+    it('passes options to SeedanceVideoRuntime', () => {
+      const options = { apiKey: 'k', baseUrl: 'https://api.test', defaultModel: 'seedance-2.0' };
+      new SeedanceVideoNodeDefinition(options);
+      expect(SeedanceVideoRuntime).toHaveBeenCalledWith(options);
+    });
+  });
+});

--- a/packages/dag-nodes/seedance-video/src/index.ts
+++ b/packages/dag-nodes/seedance-video/src/index.ts
@@ -1,0 +1,135 @@
+import {
+  AbstractNodeDefinition,
+  BINARY_PORT_PRESETS,
+  NodeIoAccessor,
+  createBinaryPortDefinition,
+} from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { SeedanceVideoRuntime, type ISeedanceVideoRuntimeOptions } from './runtime-core.js';
+
+export type { ISeedanceVideoRequest, ISeedanceVideoRuntimeOptions } from './runtime-core.js';
+export { SeedanceVideoRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link SeedanceVideoNodeDefinition}. */
+export interface ISeedanceVideoNodeDefinitionOptions extends ISeedanceVideoRuntimeOptions {}
+
+const DEFAULT_SEEDANCE_VIDEO_COST_USD = 0.5;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_WAIT_MS = 300000;
+
+export const SeedanceVideoConfigSchema = z.object({
+  model: z.string().default(''),
+  baseCredits: z.number().default(DEFAULT_SEEDANCE_VIDEO_COST_USD),
+  durationSeconds: z.number().int().positive().optional(),
+  aspectRatio: z.string().optional(),
+  pollIntervalMs: z.number().int().positive().default(DEFAULT_POLL_INTERVAL_MS),
+  maxWaitMs: z.number().int().positive().default(DEFAULT_MAX_WAIT_MS),
+});
+
+export type TSeedanceVideoConfig = z.output<typeof SeedanceVideoConfigSchema>;
+
+/**
+ * DAG node that generates a video from a text prompt using the ByteDance/Seedance video API.
+ *
+ * Submits an async job and polls until it completes, then returns the generated video.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class SeedanceVideoNodeDefinition extends AbstractNodeDefinition<
+  typeof SeedanceVideoConfigSchema
+> {
+  public readonly nodeType = 'seedance-video';
+  public readonly displayName = 'Seedance Video';
+  public readonly category = 'AI';
+  public readonly inputs: IDagNodeDefinition['inputs'] = [
+    { key: 'text', label: 'Text', order: 0, type: 'string', required: true },
+  ];
+  public readonly outputs: IDagNodeDefinition['outputs'] = [
+    createBinaryPortDefinition({
+      key: 'video',
+      label: 'Video',
+      order: 0,
+      required: true,
+      preset: BINARY_PORT_PRESETS.VIDEO_MP4,
+    }),
+  ];
+  public override readonly defaultInputPort = 'text';
+  public override readonly defaultOutputPort = 'video';
+  public readonly configSchemaDefinition = SeedanceVideoConfigSchema;
+
+  private readonly runtime: SeedanceVideoRuntime;
+
+  public constructor(options?: ISeedanceVideoNodeDefinitionOptions) {
+    super();
+    this.runtime = new SeedanceVideoRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TSeedanceVideoConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TSeedanceVideoConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const textInputResult = io.requireInputString('text');
+    if (!textInputResult.ok || textInputResult.value.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED',
+          'Seedance video node requires non-empty text input',
+          { nodeId: context.nodeDefinition.nodeId },
+        ),
+      };
+    }
+
+    const generateResult = await this.runtime.generateVideo({
+      prompt: textInputResult.value.trim(),
+      model: config.model,
+      ...(config.durationSeconds !== undefined ? { durationSeconds: config.durationSeconds } : {}),
+      ...(config.aspectRatio !== undefined ? { aspectRatio: config.aspectRatio } : {}),
+      pollIntervalMs: config.pollIntervalMs,
+      maxWaitMs: config.maxWaitMs,
+    });
+    if (!generateResult.ok) {
+      return generateResult;
+    }
+    if (generateResult.value.kind !== 'video') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_INVALID',
+          'Seedance video node returned non-video output',
+          false,
+        ),
+      };
+    }
+    io.setOutput('video', generateResult.value);
+    io.setOutput(
+      '_agentSummary',
+      `Video generated from prompt with Seedance. Model: ${config.model}.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createSeedanceVideoNodeDefinition(): SeedanceVideoNodeDefinition {
+  return new SeedanceVideoNodeDefinition();
+}

--- a/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
+++ b/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type {
+  IVideoJobAccepted,
+  IVideoJobSnapshot,
+  TProviderMediaResult,
+} from '@robota-sdk/agent-core';
+import { SeedanceVideoRuntime, type ISeedanceVideoRequest } from './runtime-core.js';
+import { BytedanceProvider } from '@robota-sdk/agent-provider/bytedance';
+
+// Shared job mocks so every constructed BytedanceProvider uses the same fns. The factory lives in
+// vi.hoisted so the vi.mock() call stays a single line (keeps the allow-module-mock escape attached).
+const { createVideo, getVideoJob, cancelVideoJob, bytedanceMockFactory } = vi.hoisted(() => {
+  const createVideo = vi.fn();
+  const getVideoJob = vi.fn();
+  const cancelVideoJob = vi.fn();
+  const bytedanceMockFactory = (): { BytedanceProvider: unknown } => ({
+    BytedanceProvider: vi
+      .fn()
+      .mockImplementation(() => ({ createVideo, getVideoJob, cancelVideoJob })),
+  });
+  return { createVideo, getVideoJob, cancelVideoJob, bytedanceMockFactory };
+});
+
+// Full replacement avoids loading the ByteDance HTTP client; only the video job methods are exercised.
+vi.mock('@robota-sdk/agent-provider/bytedance', bytedanceMockFactory); // allow-module-mock: BytedanceProvider hits the real ModelArk API
+
+const MODEL = 'seedance-2.0';
+
+function accepted(): TProviderMediaResult<IVideoJobAccepted> {
+  return {
+    ok: true,
+    value: { jobId: 'job-1', status: 'queued', createdAt: '2026-07-05T00:00:00Z' },
+  };
+}
+
+function snapshot(overrides: Partial<IVideoJobSnapshot>): TProviderMediaResult<IVideoJobSnapshot> {
+  return {
+    ok: true,
+    value: { jobId: 'job-1', status: 'running', updatedAt: '2026-07-05T00:00:01Z', ...overrides },
+  };
+}
+
+function makeRuntime(): SeedanceVideoRuntime {
+  return new SeedanceVideoRuntime({
+    apiKey: 'k',
+    baseUrl: 'https://api.test',
+    defaultModel: MODEL,
+    sleep: async () => {},
+  });
+}
+
+function req(overrides?: Partial<ISeedanceVideoRequest>): ISeedanceVideoRequest {
+  return { prompt: 'a drone shot', model: '', pollIntervalMs: 1, maxWaitMs: 1000, ...overrides };
+}
+
+describe('SeedanceVideoRuntime', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = {
+      SEEDANCE_API_KEY: process.env.SEEDANCE_API_KEY,
+      SEEDANCE_BASE_URL: process.env.SEEDANCE_BASE_URL,
+      DAG_SEEDANCE_VIDEO_DEFAULT_MODEL: process.env.DAG_SEEDANCE_VIDEO_DEFAULT_MODEL,
+      DAG_SEEDANCE_VIDEO_ALLOWED_MODELS: process.env.DAG_SEEDANCE_VIDEO_ALLOWED_MODELS,
+    };
+    for (const key of Object.keys(savedEnv)) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('returns validation error when default model is missing', async () => {
+    const runtime = new SeedanceVideoRuntime({ apiKey: 'k', baseUrl: 'https://api.test' });
+    const result = await runtime.generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED');
+  });
+
+  it('returns validation error when credentials are missing', async () => {
+    const runtime = new SeedanceVideoRuntime({ defaultModel: MODEL });
+    const result = await runtime.generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED');
+    }
+  });
+
+  it('returns validation error when model is not allowed', async () => {
+    const runtime = new SeedanceVideoRuntime({
+      apiKey: 'k',
+      baseUrl: 'https://api.test',
+      defaultModel: MODEL,
+      allowedModels: ['only-this'],
+      sleep: async () => {},
+    });
+    const result = await runtime.generateVideo(req({ model: 'other-model' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED');
+  });
+
+  it('maps a createVideo failure to a task execution error', async () => {
+    createVideo.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_AUTH_ERROR', message: 'bad key' },
+    });
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED');
+  });
+
+  it('polls until succeeded and normalizes the video output', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValueOnce(snapshot({ status: 'running' })).mockResolvedValueOnce(
+      snapshot({
+        status: 'succeeded',
+        output: { kind: 'uri', uri: 'https://cdn.test/v.mp4', mimeType: 'video/mp4', bytes: 1024 },
+      }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(getVideoJob).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe('video');
+      expect(result.value.mimeType).toBe('video/mp4');
+      expect(result.value.uri).toBe('https://cdn.test/v.mp4');
+    }
+  });
+
+  it('defaults a missing mime type to video/mp4', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'succeeded', output: { kind: 'uri', uri: 'https://cdn.test/v.mp4' } }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.mimeType).toBe('video/mp4');
+  });
+
+  it('maps a failed job to a task execution error', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'failed', error: { code: 'PROVIDER_UPSTREAM_ERROR', message: 'boom' } }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED');
+  });
+
+  it('maps a getVideoJob failure to a poll error', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_JOB_NOT_FOUND', message: 'gone' },
+    });
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED');
+  });
+
+  it('errors when a succeeded job has no output', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(snapshot({ status: 'succeeded' }));
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MISSING');
+  });
+
+  it('times out and best-effort cancels when the job never completes', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(snapshot({ status: 'running' }));
+    cancelVideoJob.mockResolvedValue(snapshot({ status: 'cancelled' }));
+    const result = await makeRuntime().generateVideo(req({ maxWaitMs: 0 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT');
+    expect(cancelVideoJob).toHaveBeenCalledWith('job-1');
+  });
+
+  it('does not send the seed field and forwards duration/aspectRatio', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'succeeded', output: { kind: 'uri', uri: 'https://cdn.test/v.mp4' } }),
+    );
+    await makeRuntime().generateVideo(req({ durationSeconds: 5, aspectRatio: '16:9' }));
+    expect(createVideo).toHaveBeenCalledWith({
+      prompt: 'a drone shot',
+      model: MODEL,
+      durationSeconds: 5,
+      aspectRatio: '16:9',
+    });
+  });
+});

--- a/packages/dag-nodes/seedance-video/src/runtime-core.ts
+++ b/packages/dag-nodes/seedance-video/src/runtime-core.ts
@@ -1,0 +1,253 @@
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { BytedanceProvider } from '@robota-sdk/agent-provider/bytedance';
+import type {
+  IProviderMediaError,
+  IVideoGenerationProvider,
+  IVideoJobSnapshot,
+} from '@robota-sdk/agent-core';
+import { normalizeVideoOutput } from './video-output-normalizer.js';
+
+/** Request payload for generating a video from a text prompt. */
+export interface ISeedanceVideoRequest {
+  prompt: string;
+  model: string;
+  durationSeconds?: number;
+  aspectRatio?: string;
+  pollIntervalMs: number;
+  maxWaitMs: number;
+}
+
+/** Configuration options for the seedance-video runtime. */
+export interface ISeedanceVideoRuntimeOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+  allowedModels?: string[];
+  /** Injectable delay (defaults to a setTimeout-based sleep) — overridable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function resolveModel(
+  selectedModel: string,
+  defaultModel: string,
+  allowedModels: string[],
+): TResult<string, IDagError> {
+  const model = selectedModel.trim().length > 0 ? selectedModel.trim() : defaultModel;
+  if (allowedModels.length > 0 && !allowedModels.includes(model)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED',
+        'Selected seedance-video model is not allowed in DAG runtime',
+        { model },
+      ),
+    };
+  }
+  return { ok: true, value: model };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Runtime that delegates video generation to the ByteDance/Seedance provider.
+ *
+ * Video generation is asynchronous: `createVideo` submits a job, then `getVideoJob`
+ * is polled until the job reaches a terminal status or the max-wait timeout elapses.
+ */
+export class SeedanceVideoRuntime {
+  private readonly explicitApiKey?: string;
+  private readonly explicitBaseUrl?: string;
+  private readonly explicitDefaultModel?: string;
+  private readonly explicitAllowedModels?: string[];
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  public constructor(options?: ISeedanceVideoRuntimeOptions) {
+    this.explicitApiKey = options?.apiKey;
+    this.explicitBaseUrl = options?.baseUrl;
+    this.explicitDefaultModel = options?.defaultModel;
+    this.explicitAllowedModels = options?.allowedModels;
+    this.sleep = options?.sleep ?? defaultSleep;
+  }
+
+  private resolveDefaultModel(): TResult<string, IDagError> {
+    const defaultModelValue =
+      this.explicitDefaultModel ?? process.env.DAG_SEEDANCE_VIDEO_DEFAULT_MODEL;
+    if (typeof defaultModelValue !== 'string' || defaultModelValue.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED',
+          'DAG_SEEDANCE_VIDEO_DEFAULT_MODEL must be configured or model must be specified in node config',
+        ),
+      };
+    }
+    return { ok: true, value: defaultModelValue.trim() };
+  }
+
+  private resolveAllowedModels(): string[] {
+    return this.explicitAllowedModels ?? parseCsv(process.env.DAG_SEEDANCE_VIDEO_ALLOWED_MODELS);
+  }
+
+  private resolveProvider(): IVideoGenerationProvider | undefined {
+    const apiKey = this.explicitApiKey ?? process.env.SEEDANCE_API_KEY;
+    const baseUrl = this.explicitBaseUrl ?? process.env.SEEDANCE_BASE_URL;
+    if (
+      typeof apiKey === 'string' &&
+      apiKey.trim().length > 0 &&
+      typeof baseUrl === 'string' &&
+      baseUrl.trim().length > 0
+    ) {
+      return new BytedanceProvider({ apiKey: apiKey.trim(), baseUrl: baseUrl.trim() });
+    }
+    return undefined;
+  }
+
+  private mapProviderError(
+    code:
+      | 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED'
+      | 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED',
+    error: IProviderMediaError,
+    model: string,
+  ): TResult<never, IDagError> {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(code, error.message, false, { code: error.code, model }),
+    };
+  }
+
+  private async tryCancel(provider: IVideoGenerationProvider, jobId: string): Promise<void> {
+    try {
+      await provider.cancelVideoJob(jobId);
+    } catch {
+      // allow-fallback: cancel is best-effort on timeout
+    }
+  }
+
+  public async generateVideo(
+    request: ISeedanceVideoRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const defaultModelResult = this.resolveDefaultModel();
+    if (!defaultModelResult.ok) return defaultModelResult;
+    const allowedModels = this.resolveAllowedModels();
+    const provider = this.resolveProvider();
+    if (!provider) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED',
+          'SEEDANCE_API_KEY and SEEDANCE_BASE_URL must both be configured for seedance-video node runtime',
+        ),
+      };
+    }
+    const modelResult = resolveModel(request.model, defaultModelResult.value, allowedModels);
+    if (!modelResult.ok) return modelResult;
+
+    const created = await provider.createVideo({
+      prompt: request.prompt,
+      model: modelResult.value,
+      ...(request.durationSeconds !== undefined
+        ? { durationSeconds: request.durationSeconds }
+        : {}),
+      ...(request.aspectRatio !== undefined ? { aspectRatio: request.aspectRatio } : {}),
+    });
+    if (!created.ok) {
+      return this.mapProviderError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED',
+        created.error,
+        modelResult.value,
+      );
+    }
+
+    return this.pollJob(provider, created.value.jobId, modelResult.value, request);
+  }
+
+  /**
+   * Maps a terminal job snapshot to a result. Returns `undefined` for non-terminal
+   * (`queued`/`running`) states so the caller keeps polling.
+   */
+  private mapTerminalSnapshot(
+    job: IVideoJobSnapshot,
+    model: string,
+  ): TResult<IPortBinaryValue, IDagError> | undefined {
+    if (job.status === 'succeeded') {
+      if (!job.output) {
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MISSING',
+            'Seedance video job succeeded but returned no output',
+            false,
+            { jobId: job.jobId, model },
+          ),
+        };
+      }
+      return normalizeVideoOutput(job.output);
+    }
+    if (job.status === 'failed' || job.status === 'cancelled') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED',
+          `Seedance video job ${job.status}: ${job.error?.message ?? 'no error detail'}`,
+          false,
+          { jobId: job.jobId, status: job.status, providerCode: job.error?.code ?? 'unknown' },
+        ),
+      };
+    }
+    return undefined;
+  }
+
+  private async pollJob(
+    provider: IVideoGenerationProvider,
+    jobId: string,
+    model: string,
+    request: ISeedanceVideoRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const startMs = Date.now();
+    for (;;) {
+      const snapshot = await provider.getVideoJob(jobId);
+      if (!snapshot.ok) {
+        return this.mapProviderError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED',
+          snapshot.error,
+          model,
+        );
+      }
+      const terminal = this.mapTerminalSnapshot(snapshot.value, model);
+      if (terminal) return terminal;
+      if (Date.now() - startMs >= request.maxWaitMs) {
+        await this.tryCancel(provider, jobId);
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT',
+            `Seedance video job did not complete within ${request.maxWaitMs}ms`,
+            true,
+            { jobId, maxWaitMs: request.maxWaitMs },
+          ),
+        };
+      }
+      await this.sleep(request.pollIntervalMs);
+    }
+  }
+}

--- a/packages/dag-nodes/seedance-video/src/video-output-normalizer.ts
+++ b/packages/dag-nodes/seedance-video/src/video-output-normalizer.ts
@@ -1,0 +1,106 @@
+import {
+  buildTaskExecutionError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import type { IMediaOutputRef } from '@robota-sdk/agent-core';
+
+const DEFAULT_VIDEO_MIME_TYPE = 'video/mp4';
+
+/**
+ * Normalizes a provider media output reference into a video binary port value.
+ *
+ * Unlike the image normalizer, this is lenient about the mime type: the ByteDance
+ * provider often returns a plain URL with no mime type, so a missing/blank mime type
+ * defaults to `video/mp4`. A present-but-non-video mime type is still rejected.
+ */
+export function normalizeVideoOutput(
+  output: IMediaOutputRef,
+): TResult<IPortBinaryValue, IDagError> {
+  if (output.kind === 'asset') {
+    return normalizeAssetOutput(output);
+  }
+  return normalizeUriOutput(output);
+}
+
+function resolveVideoMimeType(rawMimeType: string | undefined): string | undefined {
+  if (typeof rawMimeType !== 'string' || rawMimeType.trim().length === 0) {
+    return DEFAULT_VIDEO_MIME_TYPE;
+  }
+  if (!rawMimeType.startsWith('video/')) {
+    return undefined;
+  }
+  return rawMimeType;
+}
+
+function normalizeAssetOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.assetId !== 'string' || output.assetId.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_ASSET_INVALID',
+        'Provider returned asset output without valid assetId',
+        false,
+      ),
+    };
+  }
+  const mimeType = resolveVideoMimeType(output.mimeType);
+  if (mimeType === undefined) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-video media type for seedance-video output',
+        false,
+        { mimeType: output.mimeType ?? 'missing' },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'video',
+      mimeType,
+      uri: `asset://${output.assetId}`,
+      referenceType: 'asset',
+      assetId: output.assetId,
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.uri !== 'string' || output.uri.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_URI_MISSING',
+        'Provider returned uri output without uri value',
+        false,
+      ),
+    };
+  }
+  const mimeType = resolveVideoMimeType(output.mimeType);
+  if (mimeType === undefined) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-video media type for seedance-video output',
+        false,
+        { mimeType: output.mimeType ?? 'missing' },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'video',
+      mimeType,
+      uri: output.uri,
+      referenceType: 'uri',
+      sizeBytes: output.bytes,
+    },
+  };
+}

--- a/packages/dag-nodes/seedance-video/tsconfig.eslint.json
+++ b/packages/dag-nodes/seedance-video/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/seedance-video/tsconfig.json
+++ b/packages/dag-nodes/seedance-video/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/seedance-video/tsdown.config.ts
+++ b/packages/dag-nodes/seedance-video/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2039,6 +2039,9 @@ importers:
       '@robota-sdk/dag-node-ok-emitter':
         specifier: workspace:*
         version: link:../dag-nodes/ok-emitter
+      '@robota-sdk/dag-node-seedance-video':
+        specifier: workspace:*
+        version: link:../dag-nodes/seedance-video
       '@robota-sdk/dag-node-text-output':
         specifier: workspace:*
         version: link:../dag-nodes/text-output
@@ -2702,6 +2705,43 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/seedance-video:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1


### PR DESCRIPTION
## Summary

WORKFLOW-005 Phase 3 (Option A — DAG stays private), **P1 node #3: seedance-video**.

Fills the previously-empty `packages/dag-nodes/seedance-video` stub with `@robota-sdk/dag-node-seedance-video` (`private: true`) — a DAG node that generates a video from a text prompt via the ByteDance/ModelArk (Seedance) video API. NodeType `seedance-video` matches the pre-authored `.dag-storage` fixtures and the planned node in `packages/dag-nodes/docs/SPEC.md`, so those DAGs become runnable.

## What's included

- **`SeedanceVideoNodeDefinition`** (nodeType `seedance-video`, category `AI`): single `text` input port, single binary `video` output port (`VIDEO_MP4`); config `{ model, baseCredits=0.5, durationSeconds?, aspectRatio?, pollIntervalMs=5000, maxWaitMs=300000 }`.
- **Async job model**: video generation is not a single call. `SeedanceVideoRuntime.generateVideo` submits via `BytedanceProvider.createVideo`, then **polls `getVideoJob`** every `pollIntervalMs` until `succeeded`/`failed`/`cancelled` or `maxWaitMs` elapses (best-effort `cancelVideoJob` on timeout). A `sleep` fn is injectable for deterministic tests.
- Backend `@robota-sdk/agent-provider/bytedance` `BytedanceProvider` (implements `IVideoGenerationProvider`). Creds `SEEDANCE_API_KEY` + `SEEDANCE_BASE_URL` (both required); default model `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL`; allowlist `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS`. `seed` intentionally omitted (the provider rejects it).
- New **lenient** `video-output-normalizer` — the provider often returns a plain URL with no mime type, so a missing mime defaults to `video/mp4` (a present non-video mime is still rejected).
- Registered in the **async/optional** loader list in `default-node-registry.ts`; framework dependency added.
- **SPEC** at `packages/dag-nodes/seedance-video/docs/SPEC.md`; README; project-structure listing updated.

## Tests

- 13 node-definition tests (mock `runtime-core`): metadata/ports, config defaults, estimateCost, prompt-required, success, error propagation, non-video output, options passthrough.
- 11 runtime tests (mock `BytedanceProvider`, injected instant `sleep`): missing model / missing creds / model-not-allowed / createVideo-failure / **poll-until-succeeded** / running→succeeded / failed-job / poll-failure / **timeout+cancel** / output-missing / mime-default / seed-omitted+duration/aspectRatio forwarded.
- Registry test asserts `seedance-video` loads in the async registry.
- Full suites green: **seedance-video 24**, **dag-framework 113**. typecheck + lint + test-module-mocks scan clean.

## Live UE

No `SEEDANCE_API_KEY`/`SEEDANCE_BASE_URL` in this environment. An `input → seedance-video` workflow was built and run through `LocalDagRuntimeProvider.execute` (async registry):

```
seedance-video in runtime catalog: true
workflow built: nodes=2 edges=1
run ok: false
run error: node-2: SEEDANCE_API_KEY and SEEDANCE_BASE_URL must both be configured for seedance-video node runtime
```

Node registered, reachable, resolves config, fails gracefully. The submit→poll→success/timeout paths are covered deterministically by the mocked-provider runtime tests.

## Boundary / invariants

- **DAG stays private** — new package is `private: true`.
- **CLI-077 holds** — `agent-cli` published closure still has **0** dag/workflow deps. Capability-placement + agent-server-boundary scans pass.

Refs WORKFLOW-005 (P1 node #3). P1 node-kinds now: **tool ✅, text-to-image ✅, seedance-video ✅**; the **skill node** remains (deferred as an LLM-backed agent node — see the backlog research entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)