### PR TITLE
feat(dag-nodes): skill node (WORKFLOW-005 P1 #4)

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -203,5 +203,32 @@ aspectRatio?, pollIntervalMs(=5000), maxWaitMs(=300000) }`. Backend: `@robota-sd
   - Boundary: CLI-077 holds; capability-placement + agent-server-boundary + test-module-mocks scans pass.
   - Branch: `feat/workflow-005-p1-video`.
 
-**P1 status: node-kind completion — tool ✅, text-to-image ✅, seedance-video ✅; skill node remaining
-(deferred as an LLM-backed agent node — see the skill-node research entry above).**
+- **node #4 — skill node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-skill`
+  (`packages/dag-nodes/skill`, `private: true`). Owner decision (2026-07-05): build it as a **prompt
+  resolver**, not an LLM executor — the resolver approach chosen over the self-contained fork-executor
+  (which would embed a whole subagent LLM loop). `SkillNodeDefinition` (nodeType `skill`, category
+  `Integration`): optional `args` input, `prompt` + `mode` outputs; config `{ skillName, args, cwd,
+sessionId, baseCredits(=0) }`. `SkillResolverRuntime` loads skills via `@robota-sdk/agent-framework`
+  `SkillCommandSource` and resolves the inject prompt via `executeSkill` (no `shellExec` → shell
+  interpolations are stripped, never executed; no LLM, no provider). Fork-context skills are rejected
+  (`DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`) — a pure resolver has no subagent runtime. Deps
+  (`loadCommands`/`executeSkillFn`) are **injected** so tests use fakes + the real `executeSkill` — no
+  module mocking. Emits the `<skill>` prompt for a downstream LLM node to execute (`skill → llm-text → …`).
+  Registered in the async/optional loader (lazy import of the agent-framework-backed node). SPEC at
+  `packages/dag-nodes/skill/docs/SPEC.md`.
+  - Tests: 7 runtime tests (inject fixtures + real `executeSkill`: resolve, not-found, fork-reject,
+    discovery-failure, executeSkill-failure, non-inject result, 0-based positional `$N`/`$ARGUMENTS`) +
+    7 node tests (metadata/ports, config, args-input-over-config precedence, not-found/fork propagation).
+    Full suites green: skill 14, dag-framework 114. typecheck + lint + mock scan clean.
+  - Live UE (**fully real — no credentials needed**): created a temp `.agents/skills/greet/SKILL.md` and
+    ran `input('World') → skill('greet')` through `LocalDagRuntimeProvider.execute`. Evidence: `run ok: true`;
+    `node-2.prompt = "<skill name=\"greet\">…Say hello to World in a friendly, upbeat tone.…</skill>\n\nExecute the \"greet\" skill: World"`, `node-2.mode = "inject"`.
+  - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement (incl. the new
+    dag-nodes → agent-framework edge) + agent-server-boundary + test-module-mocks scans pass.
+  - Branch: `feat/workflow-005-p1-skill`.
+
+**P1 status: node-kind completion COMPLETE — tool ✅, text-to-image ✅, seedance-video ✅, skill ✅
+(skill built as an inject-prompt resolver; a self-contained fork/LLM skill-executor node remains a
+possible future addition).** Next phases per the phasing plan: P2 (dynamic authoring — instant-node
+Phase C + unified persistence + composite reload fix), P3 (surface unification — expose create/save/build
+through `/workflows` + WORKFLOW-004 build).

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, skill, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -58,6 +58,7 @@
     "@robota-sdk/dag-node-multi-input": "workspace:*",
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-seedance-video": "workspace:*",
+    "@robota-sdk/dag-node-skill": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
     "@robota-sdk/dag-node-text-to-image": "workspace:*",

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -45,6 +45,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.map((n) => n.nodeType)).toContain('seedance-video');
   });
 
+  it('loads the skill node (optional, agent-framework-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('skill');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -114,6 +114,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
       modulePath: '@robota-sdk/dag-node-seedance-video',
       factories: [(mod) => new (mod.SeedanceVideoNodeDefinition as new () => IDagNodeDefinition)()],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-skill',
+      factories: [(mod) => new (mod.SkillNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-nodes/skill/.eslintrc.json
+++ b/packages/dag-nodes/skill/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/skill/docs/README.md
+++ b/packages/dag-nodes/skill/docs/README.md
@@ -1,0 +1,3 @@
+# Skill Node Docs Index
+
+- `SPEC.md`: Node scope, skill resolution (inject prompt) model, and package boundaries.

--- a/packages/dag-nodes/skill/docs/SPEC.md
+++ b/packages/dag-nodes/skill/docs/SPEC.md
@@ -1,0 +1,48 @@
+# Skill Node Specification
+
+## Scope
+
+- Owns the `skill` DAG node definition.
+- Resolves a Robota skill (by name) to its expanded **inject-mode prompt string**, emitted on an output port. It does NOT run the skill through an LLM — it produces the prompt a downstream LLM node consumes.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- A "skill" is a `SKILL.md` parsed into an `ICommand` (SSOT `@robota-sdk/agent-interface-transport`). This node uses `@robota-sdk/agent-framework` `SkillCommandSource` (discover/list skills) and `executeSkill` (inject mode) to resolve the prompt.
+- **Resolver, not executor.** `executeSkill` in inject mode returns a prompt string via pure substitution — no LLM, no provider, no session. Wire this node to an LLM node to actually execute the skill (`skill → llm-text → …`).
+- **Fork skills are out of scope.** A skill with `context: 'fork'` requires a subagent LLM loop (`runInFork`), which a pure resolver has no runtime for — the node returns a validation error for such skills.
+- **No shell execution.** `executeSkill` is called with no `shellExec`, so `` !`cmd` `` interpolations in a skill body are stripped to empty (never executed) — the resolver never runs arbitrary shell.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the async/optional node-registry list (lazy import of the agent-framework-backed node).
+
+## Architecture Overview
+
+- `SkillNodeDefinition` — node with an optional `args` input port (string) and `prompt` + `mode` output ports. `defaultInputPort='args'`, `defaultOutputPort='prompt'`.
+- `SkillResolverRuntime` — resolves the skill, isolated from the node for testability via **dependency injection**:
+  - `loadCommands(cwd, home): ICommand[]` — defaults to `new SkillCommandSource(cwd, home).getCommands()`.
+  - `executeSkillFn` — defaults to `executeSkill`.
+  - `resolvePrompt({ skillName, args })`: find the command by name (else `DAG_VALIDATION_SKILL_NOT_FOUND` with the available names as `options`); reject `context: 'fork'` skills (`DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`); call `executeSkillFn(skill, args, {}, { sessionId })` and return `{ prompt, mode }`.
+- Args precedence: the `args` input port (if a non-empty string) overrides `config.args`.
+- Cost estimate: `config.baseCredits` (default 0 — resolution runs no model).
+
+## Type Ownership
+
+| Type                    | Location              | Purpose                                    |
+| ----------------------- | --------------------- | ------------------------------------------ |
+| `SkillNodeDefinition`   | `src/index.ts`        | Node definition class                      |
+| `SkillNodeConfigSchema` | `src/index.ts`        | Zod config schema                          |
+| `SkillResolverRuntime`  | `src/runtime-core.ts` | Skill discovery + inject-prompt resolution |
+| `ISkillResolverOptions` | `src/runtime-core.ts` | Injected deps + `cwd`/`home`/`sessionId`   |
+
+## Public API Surface
+
+- `SkillNodeDefinition` — class
+- `createSkillNodeDefinition()` — factory function
+- `SkillNodeConfigSchema` — Zod schema
+- `TSkillNodeConfig` — inferred config type
+- `SkillResolverRuntime`, `ISkillResolverOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `skillName` (required), `args` (static default), `cwd`, `sessionId`, `baseCredits`.
+- Runtime options `loadCommands` / `executeSkillFn` for injection (tests / alternate skill sources).
+- Error codes: `DAG_VALIDATION_SKILL_NOT_FOUND`, `DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`, `DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED`.

--- a/packages/dag-nodes/skill/package.json
+++ b/packages/dag-nodes/skill/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-skill",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG skill node for Robota — resolve a Robota skill to its inject-mode prompt as a DAG step",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-framework": "workspace:*",
+    "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/skill/src/index.test.ts
+++ b/packages/dag-nodes/skill/src/index.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { INodeExecutionContext, INodeConfigObject, TPortPayload } from '@robota-sdk/dag-core';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import {
+  SkillNodeDefinition,
+  SkillNodeConfigSchema,
+  createSkillNodeDefinition,
+  type ISkillNodeDefinitionOptions,
+} from './index.js';
+
+const greet: ICommand = {
+  name: 'greet',
+  description: 'Greets the user',
+  source: 'skill',
+  skillContent: 'Say hello to $ARGUMENTS.',
+};
+
+const forkSkill: ICommand = {
+  name: 'deep',
+  description: 'deep',
+  source: 'skill',
+  context: 'fork',
+  skillContent: 'x',
+};
+
+function makeNode(options?: ISkillNodeDefinitionOptions): SkillNodeDefinition {
+  return new SkillNodeDefinition(options ?? { loadCommands: () => [greet, forkSkill] });
+}
+
+function makeContext(config: Record<string, unknown>): INodeExecutionContext {
+  const node = makeNode();
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId: 'skill-1',
+      nodeType: 'skill',
+      dependsOn: [],
+      config: config as INodeConfigObject,
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'skill',
+      displayName: 'Skill',
+      category: 'Integration',
+      inputs: node.inputs,
+      outputs: node.outputs,
+      defaultInputPort: node.defaultInputPort,
+      defaultOutputPort: node.defaultOutputPort,
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('SkillNodeDefinition metadata', () => {
+  it('has correct nodeType/displayName/category and ports', () => {
+    const node = makeNode();
+    expect(node.nodeType).toBe('skill');
+    expect(node.displayName).toBe('Skill');
+    expect(node.category).toBe('Integration');
+    expect(node.inputs.find((p) => p.key === 'args')?.required).toBe(false);
+    expect(node.outputs.find((p) => p.key === 'prompt')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'mode')).toBeDefined();
+    expect(node.defaultInputPort).toBe('args');
+    expect(node.defaultOutputPort).toBe('prompt');
+  });
+
+  it('factory returns an instance', () => {
+    expect(createSkillNodeDefinition()).toBeInstanceOf(SkillNodeDefinition);
+  });
+});
+
+describe('SkillNodeConfigSchema', () => {
+  it('applies defaults and requires skillName', () => {
+    const parsed = SkillNodeConfigSchema.parse({ skillName: 'greet' });
+    expect(parsed.args).toBe('');
+    expect(parsed.baseCredits).toBe(0);
+    expect(SkillNodeConfigSchema.safeParse({ skillName: '' }).success).toBe(false);
+  });
+});
+
+describe('SkillNodeDefinition execution', () => {
+  it('resolves a skill and emits the prompt (config args)', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute(
+      {},
+      makeContext({ skillName: 'greet', args: 'World' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.mode).toBe('inject');
+      expect(String(result.value.prompt)).toContain('Say hello to World.');
+    }
+  });
+
+  it('lets the args input port override config args', async () => {
+    const node = makeNode();
+    const input: TPortPayload = { args: 'FromInput' };
+    const result = await node.taskHandler.execute(
+      input,
+      makeContext({ skillName: 'greet', args: 'FromConfig' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(String(result.value.prompt)).toContain('Say hello to FromInput.');
+  });
+
+  it('propagates skill-not-found', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute({}, makeContext({ skillName: 'nope' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_NOT_FOUND');
+  });
+
+  it('propagates fork-unsupported', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute({}, makeContext({ skillName: 'deep' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_FORK_UNSUPPORTED');
+  });
+});

--- a/packages/dag-nodes/skill/src/index.ts
+++ b/packages/dag-nodes/skill/src/index.ts
@@ -1,0 +1,127 @@
+import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+import {
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type IPortDefinition,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { SkillResolverRuntime, type ISkillResolverOptions } from './runtime-core.js';
+
+export type {
+  ISkillResolverOptions,
+  ISkillResolveRequest,
+  ISkillResolveResult,
+  TLoadSkillCommands,
+} from './runtime-core.js';
+export { SkillResolverRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link SkillNodeDefinition}. */
+export interface ISkillNodeDefinitionOptions extends ISkillResolverOptions {}
+
+export const SkillNodeConfigSchema = z.object({
+  /** Name of the skill to resolve (as discovered by SkillCommandSource). */
+  skillName: z.string().min(1),
+  /** Static skill arguments; the `args` input port overrides this when non-empty. */
+  args: z.string().default(''),
+  /** Working directory to discover skills from. Defaults to the process cwd. */
+  cwd: z.string().optional(),
+  /** Session id substituted for `${CLAUDE_SESSION_ID}` in the skill body. */
+  sessionId: z.string().optional(),
+  /** Base credit cost (resolution runs no model — default 0). */
+  baseCredits: z.number().nonnegative().default(0),
+});
+
+export type TSkillNodeConfig = z.output<typeof SkillNodeConfigSchema>;
+
+const SKILL_INPUTS: IPortDefinition[] = [
+  { key: 'args', label: 'Args', order: 0, type: 'string', required: false },
+];
+
+const SKILL_OUTPUTS: IPortDefinition[] = [
+  { key: 'prompt', label: 'Prompt', order: 0, type: 'string', required: true },
+  { key: 'mode', label: 'Mode', order: 1, type: 'string', required: true },
+];
+
+/**
+ * DAG node that resolves a Robota skill to its inject-mode prompt string.
+ *
+ * Emits the expanded `<skill>` prompt for a downstream LLM node to execute;
+ * it does not run the skill itself.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class SkillNodeDefinition extends AbstractNodeDefinition<typeof SkillNodeConfigSchema> {
+  public readonly nodeType = 'skill';
+  public readonly displayName = 'Skill';
+  public readonly category = 'Integration';
+  public readonly inputs: IDagNodeDefinition['inputs'] = SKILL_INPUTS;
+  public readonly outputs: IDagNodeDefinition['outputs'] = SKILL_OUTPUTS;
+  public readonly configSchemaDefinition = SkillNodeConfigSchema;
+  public override readonly defaultInputPort = 'args';
+  public override readonly defaultOutputPort = 'prompt';
+
+  private readonly runtime: SkillResolverRuntime;
+
+  public constructor(options?: ISkillNodeDefinitionOptions) {
+    super();
+    this.runtime = new SkillResolverRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TSkillNodeConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TSkillNodeConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+
+    const argsInput = io.getInput('args');
+    const args =
+      typeof argsInput === 'string' && argsInput.trim().length > 0 ? argsInput : config.args;
+
+    const resolved = await this.runtime.resolvePrompt({
+      skillName: config.skillName,
+      args,
+      cwd: config.cwd ?? process.cwd(),
+      ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
+    });
+    if (!resolved.ok) {
+      return resolved;
+    }
+
+    if (resolved.value.prompt.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_EMPTY_PROMPT',
+          `Skill "${config.skillName}" resolved to an empty prompt`,
+          { skillName: config.skillName },
+        ),
+      };
+    }
+
+    io.setOutput('prompt', resolved.value.prompt);
+    io.setOutput('mode', resolved.value.mode);
+    io.setOutput(
+      '_agentSummary',
+      `Skill "${config.skillName}" resolved (${resolved.value.mode}): ${resolved.value.prompt.length} chars.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createSkillNodeDefinition(): SkillNodeDefinition {
+  return new SkillNodeDefinition();
+}

--- a/packages/dag-nodes/skill/src/runtime-core.test.ts
+++ b/packages/dag-nodes/skill/src/runtime-core.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import { SkillResolverRuntime, type ISkillResolveRequest } from './runtime-core.js';
+
+const greet: ICommand = {
+  name: 'greet',
+  description: 'Greets the user',
+  source: 'skill',
+  skillContent: 'Say hello to $ARGUMENTS.',
+};
+
+const forkSkill: ICommand = {
+  name: 'deep-research',
+  description: 'Runs deep research',
+  source: 'skill',
+  context: 'fork',
+  skillContent: 'Research $ARGUMENTS thoroughly.',
+};
+
+function req(overrides?: Partial<ISkillResolveRequest>): ISkillResolveRequest {
+  return { skillName: 'greet', args: 'World', cwd: '/tmp/x', ...overrides };
+}
+
+describe('SkillResolverRuntime', () => {
+  it('resolves an inject skill to its expanded prompt (real executeSkill)', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.mode).toBe('inject');
+      expect(result.value.prompt).toContain('skill name="greet"');
+      expect(result.value.prompt).toContain('Say hello to World.');
+    }
+  });
+
+  it('returns a not-found error listing available skills', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req({ skillName: 'missing' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_VALIDATION_SKILL_NOT_FOUND');
+      expect(result.error.fix?.options).toEqual(['greet', 'deep-research']);
+    }
+  });
+
+  it('rejects a fork-context skill', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req({ skillName: 'deep-research' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_FORK_UNSUPPORTED');
+  });
+
+  it('surfaces a skill-discovery failure as a task error', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => {
+        throw new Error('disk gone');
+      },
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+      expect(result.error.retryable).toBe(true);
+    }
+  });
+
+  it('surfaces an executeSkill failure as a task error', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [greet],
+      executeSkillFn: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+  });
+
+  it('errors when executeSkill returns no inject prompt', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [greet],
+      executeSkillFn: async () => ({ mode: 'fork', result: 'x' }),
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+  });
+
+  it('substitutes positional args (0-based) and $ARGUMENTS', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [
+        {
+          name: 'echo',
+          description: 'e',
+          source: 'skill',
+          skillContent: 'a=$0 b=$1 all=$ARGUMENTS',
+        },
+      ],
+    });
+    const result = await runtime.resolvePrompt(req({ skillName: 'echo', args: 'alpha beta' }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.prompt).toContain('a=alpha');
+      expect(result.value.prompt).toContain('b=beta');
+      expect(result.value.prompt).toContain('all=alpha beta');
+    }
+  });
+});

--- a/packages/dag-nodes/skill/src/runtime-core.ts
+++ b/packages/dag-nodes/skill/src/runtime-core.ts
@@ -1,0 +1,142 @@
+import { SkillCommandSource, executeSkill } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type TResult,
+} from '@robota-sdk/dag-core';
+
+/** Loads the available skill commands for a working directory. */
+export type TLoadSkillCommands = (cwd: string, home?: string) => ICommand[];
+
+/** Configuration options for the skill resolver runtime (dependency injection for tests). */
+export interface ISkillResolverOptions {
+  /** Skill discovery. Defaults to `new SkillCommandSource(cwd, home).getCommands()`. */
+  loadCommands?: TLoadSkillCommands;
+  /** Skill resolution. Defaults to the real `executeSkill`. */
+  executeSkillFn?: typeof executeSkill;
+}
+
+/** Request to resolve a skill to its inject-mode prompt. */
+export interface ISkillResolveRequest {
+  skillName: string;
+  args: string;
+  cwd: string;
+  home?: string;
+  sessionId?: string;
+}
+
+/** Result of resolving a skill. */
+export interface ISkillResolveResult {
+  prompt: string;
+  mode: string;
+}
+
+function defaultLoadCommands(cwd: string, home?: string): ICommand[] {
+  return new SkillCommandSource(cwd, home).getCommands();
+}
+
+/**
+ * Resolves a Robota skill (by name) to its inject-mode prompt string. No LLM, no
+ * provider, no shell: `executeSkill` is called with empty callbacks so shell
+ * interpolations are stripped rather than executed, and fork skills are rejected.
+ */
+export class SkillResolverRuntime {
+  private readonly loadCommands: TLoadSkillCommands;
+  private readonly executeSkillFn: typeof executeSkill;
+
+  public constructor(options?: ISkillResolverOptions) {
+    this.loadCommands = options?.loadCommands ?? defaultLoadCommands;
+    this.executeSkillFn = options?.executeSkillFn ?? executeSkill;
+  }
+
+  public async resolvePrompt(
+    request: ISkillResolveRequest,
+  ): Promise<TResult<ISkillResolveResult, IDagError>> {
+    let commands: ICommand[];
+    try {
+      commands = this.loadCommands(request.cwd, request.home);
+    } catch (err) {
+      // allow-fallback: skill discovery failure surfaced as a retryable task error
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+          `Failed to load skills: ${message}`,
+          true,
+          { cwd: request.cwd },
+        ),
+      };
+    }
+
+    const skill = commands.find((command) => command.name === request.skillName);
+    if (!skill) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_NOT_FOUND',
+          `Skill "${request.skillName}" was not found in ${request.cwd}`,
+          { skillName: request.skillName },
+          {
+            action: 'set_config',
+            suggestion: 'Set skillName to an available skill',
+            options: commands.map((command) => command.name),
+          },
+        ),
+      };
+    }
+
+    if (skill.context === 'fork') {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_FORK_UNSUPPORTED',
+          `Skill "${request.skillName}" uses fork context, which the resolver node does not support (no subagent runtime). Use an inject-context skill.`,
+          { skillName: request.skillName },
+        ),
+      };
+    }
+
+    return this.resolveInject(skill, request);
+  }
+
+  private async resolveInject(
+    skill: ICommand,
+    request: ISkillResolveRequest,
+  ): Promise<TResult<ISkillResolveResult, IDagError>> {
+    try {
+      const result = await this.executeSkillFn(
+        skill,
+        request.args,
+        {},
+        request.sessionId !== undefined ? { sessionId: request.sessionId } : undefined,
+      );
+      if (typeof result.prompt !== 'string') {
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+            `Skill "${request.skillName}" did not resolve to an inject prompt`,
+            false,
+            { skillName: request.skillName, mode: result.mode },
+          ),
+        };
+      }
+      return { ok: true, value: { prompt: result.prompt, mode: result.mode } };
+    } catch (err) {
+      // allow-fallback: unexpected executeSkill failure surfaced as a task error
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+          `Failed to resolve skill "${request.skillName}": ${message}`,
+          false,
+          { skillName: request.skillName },
+        ),
+      };
+    }
+  }
+}

--- a/packages/dag-nodes/skill/tsconfig.eslint.json
+++ b/packages/dag-nodes/skill/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/skill/tsconfig.json
+++ b/packages/dag-nodes/skill/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/skill/tsdown.config.ts
+++ b/packages/dag-nodes/skill/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2042,6 +2042,9 @@ importers:
       '@robota-sdk/dag-node-seedance-video':
         specifier: workspace:*
         version: link:../dag-nodes/seedance-video
+      '@robota-sdk/dag-node-skill':
+        specifier: workspace:*
+        version: link:../dag-nodes/skill
       '@robota-sdk/dag-node-text-output':
         specifier: workspace:*
         version: link:../dag-nodes/text-output
@@ -2729,6 +2732,43 @@ importers:
       '@robota-sdk/agent-provider':
         specifier: workspace:*
         version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/skill:
+    dependencies:
+      '@robota-sdk/agent-framework':
+        specifier: workspace:*
+        version: link:../../agent-framework
+      '@robota-sdk/agent-interface-transport':
+        specifier: workspace:*
+        version: link:../../agent-interface-transport
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core


### PR DESCRIPTION
## Summary

WORKFLOW-005 Phase 3 (Option A — DAG stays private), **P1 node #4: skill** — the final P1 node-kind.

Adds `@robota-sdk/dag-node-skill` (`private: true`) — a DAG node that **resolves** a Robota skill to its inject-mode prompt string, emitted for a downstream LLM node to execute (`skill → llm-text → …`).

**Design choice (owner-approved):** research showed a "skill" is not a pure function — `executeSkill` returns a prompt string in `inject` mode (default) and needs a subagent LLM loop only in `fork` mode. Rather than embed a whole agent in one node (a self-contained executor), this node is a **prompt resolver** — lightweight, composable, deterministic, and a natural fit for DAG composition.

## What's included

- **`SkillNodeDefinition`** (nodeType `skill`, category `Integration`): optional `args` input port; `prompt` + `mode` output ports; config `{ skillName, args, cwd, sessionId, baseCredits=0 }`. `defaultInputPort='args'`, `defaultOutputPort='prompt'`. Args input overrides config `args`.
- **`SkillResolverRuntime`** loads skills via `@robota-sdk/agent-framework` `SkillCommandSource` and resolves the inject prompt via `executeSkill` — called with **no `shellExec`** (so `` !`cmd` `` interpolations are stripped, never executed), no LLM, no provider. Fork-context skills are rejected with `DAG_VALIDATION_SKILL_FORK_UNSUPPORTED` (a resolver has no subagent runtime). `loadCommands`/`executeSkillFn` are **injected**, so tests use fakes plus the real `executeSkill` — **no module mocking**.
- Registered in the **async/optional** loader (lazy import of the agent-framework-backed node); framework dep added.
- **SPEC** at `packages/dag-nodes/skill/docs/SPEC.md`; README; project-structure listing updated.

## Tests

- 7 runtime tests (inject fixtures + the real `executeSkill`): resolve, not-found (lists available skills), fork-reject, discovery-failure, executeSkill-failure, non-inject result, 0-based `$N`/`$ARGUMENTS` substitution.
- 7 node tests: metadata/ports, config, **args-input-over-config precedence**, not-found/fork propagation.
- Registry test asserts `skill` loads in the async registry.
- Full suites green: **skill 14**, **dag-framework 114**. typecheck + lint + test-module-mocks scan clean.

## Live UE (fully real — no credentials)

Created a temp `.agents/skills/greet/SKILL.md` and ran `input('World') → skill('greet')` through `LocalDagRuntimeProvider.execute`:

```
skill in runtime catalog: true
run ok: true
node-2.prompt: "<skill name=\"greet\">\n---\nname: greet\ndescription: Greet someone warmly\n---\nSay hello to World in a friendly, upbeat tone.\n\n</skill>\n\nExecute the \"greet\" skill: World"
node-2.mode: "inject"
```

An actual `SKILL.md` was discovered, resolved, and its expanded prompt emitted end-to-end — a genuine full run (the media nodes could only reach graceful-failure without provider credentials).

## Boundary / invariants

- **DAG stays private** — new package is `private: true`.
- **CLI-077 holds** — `agent-cli` published closure still has **0** dag/workflow deps. Capability-placement (incl. the new `dag-nodes → agent-framework` edge) + agent-server-boundary + test-module-mocks scans pass.

Refs WORKFLOW-005 (P1 node #4). **This completes P1 node-kind completion: tool ✅, text-to-image ✅, seedance-video ✅, skill ✅.** A self-contained fork/LLM skill-executor node remains a possible future addition; next phases are P2 (dynamic authoring) and P3 (surface unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)