### PR TITLE
fix: expose token usage on the streaming execution path (BEHAVIOR-005)

### DIFF
--- a/.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md
+++ b/.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md
@@ -1,0 +1,228 @@
+---
+status: verifying
+type: BEHAVIOR
+tags: [streaming, async, typescript]
+---
+
+# BEHAVIOR-005: expose token usage on the streaming execution path
+
+## Problem
+
+Token usage is silently lost on the streaming execution path, so after any
+`Robota.run()` / `Robota.runStream()` a consumer cannot read the turn's token usage —
+`readTokenUsageFromMessage(lastHistoryMessage)` returns `undefined`, and robota's own
+usage analytics (`collectAssistantUsageMetadata` → `execution-round.ts` →
+`assistant_message_committed` event → `sumHistoryUsage`, ANALYTICS-001) sum to 0 for
+streaming turns.
+
+Reproduction (local OpenAI-compatible HTTP stub, no key needed — full script in
+`.design/bug-report-streaming-usage-2026-07-05.md`): a stub that returns a final SSE
+chunk carrying `usage: { prompt_tokens, completion_tokens, total_tokens }` still yields
+`readTokenUsageFromMessage(last) === undefined`, and the assembled assistant message
+metadata contains only `executionId` — no usage.
+
+Root causes (source-confirmed):
+
+1. **`stream_options: { include_usage: true }` is never sent.**
+   `buildChatRequestParams` (`packages/agent-provider/src/openai/chat-completions-chat.ts:121`)
+   emits no `stream_options`; `grep -rn 'include_usage|stream_options' packages/*/src` = 0.
+   OpenAI-compatible endpoints do not emit a usage chunk on streams without it.
+2. **The stream assembler drops final-chunk usage.**
+   `assembleOpenAICompatibleStream` / `applyChunk` / `buildMessage`
+   (`packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts:27,48,158`)
+   never read `chunk.usage`. `applyChunk` also early-returns on the empty-`choices` final
+   chunk (L57–60) that actually carries usage. So even when the endpoint sends usage, it is
+   discarded during assembly.
+3. **Premise correction to the bug report — there is no `IRunOptions.stream` flag.**
+   The report's proposal #3 ("`stream: false` is ignored") targets a field that does not
+   exist: `IRunOptions` (`packages/agent-core/src/interfaces/agent.ts:190`) has no `stream`
+   boolean (the cited L114 is JSDoc prose). `run()` uses the round path
+   (`execution-round-provider.ts:callProviderWithCache` → `provider.chat` with a wrapped
+   `onTextDelta` → the streaming-assembly branch), so it always streams; there is nothing to
+   "respect". No new dispatch option is added.
+4. **`runStream()` uses a SEPARATE path that reconstructs the message and never collected usage.**
+   (Discovered during implementation — corrects the initial "agent-core needs no change" reading.)
+   `run()` (round path) collects usage at `execution-round.ts:193`
+   (`collectAssistantUsageMetadata(assistantResponse)`) → commits it into the assistant
+   message metadata, so once (1)+(2) make the assembled message carry `usage`, `run()` works.
+   But `runStream()` goes through `execution-stream.ts`, which iterates `provider.chatStream`
+   and commits the assistant message from the accumulated `fullResponse` **string** +
+   `toolCalls` (`execution-stream.ts:248` `addAssistantMessage(fullResponse, toolCalls,
+{ executionId })`) — the provider message object and its `usage` are discarded, and
+   `collectAssistantUsageMetadata` is never called. So `runStream()` needs a third change:
+   capture the usage-bearing final chunk in that loop and attach the usage metadata at commit,
+   mirroring the round path.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-provider` — the only package with behavior changes:
+  - `src/openai/chat-completions-chat.ts` — add `stream_options: { include_usage: true }` to
+    the two streaming request literals (L38–40, L79–82), gated by the opt-out option.
+  - `src/openai/types.ts` — add opt-out `IOpenAIProviderOptions.includeStreamUsage?: boolean`
+    (default `true`), read via `input.providerOptions` at the request-build site.
+  - `src/shared/openai-compatible/stream-assembler.ts` — capture `chunk.usage` (incl. the
+    empty-`choices` final chunk) into `IAssemblyState`; attach top-level
+    `usage: { promptTokens, completionTokens, totalTokens }` in `buildMessage`.
+  - `src/shared/openai-compatible/response-parser.ts` — `parseStreamingChunk` (L102) attaches
+    the same `usage` shape for the `chatStream` generator path (parity).
+  - `docs/SPEC.md` — SPEC update (behavior + new provider option).
+- `packages/agent-core` — the `runStream` path needs the usage collected into the committed
+  message (the round path already does this; readers are unchanged):
+  - `src/services/execution-stream.ts` — in the `chatStream` consumption loop, capture the
+    usage-bearing chunk via `collectAssistantUsageMetadata(chunk)` and spread it into the
+    `addAssistantMessage(fullResponse, toolCalls, { executionId, ...usageMetadata })` commit —
+    mirroring `execution-round.ts:193`/`209`.
+  - `src/core/robota.test.ts` — regression test: a `chatStream` ending in a usage chunk →
+    committed assistant message metadata carries `inputTokens`/`outputTokens`/`usage`.
+  - Readers `readTokenUsageFromMessage` / `collectAssistantUsageMetadata` are **unchanged** —
+    they already accept the top-level `usage: { promptTokens, completionTokens, totalTokens }`
+    shape the non-streaming `parseUsage` produces; the fix makes streaming emit that shape and
+    routes it into the committed metadata on both execution paths.
+
+### Alternatives Considered
+
+1. **Send `include_usage` + assemble the usage chunk (chosen).** Mirror the non-streaming
+   `parseUsage` shape as a top-level `usage` on the assembled message. Pro: zero changes to
+   agent-core readers/analytics; one coherent shape across streaming + non-streaming; fixes
+   `run()` and `runStream()` together. Con: `stream_options` is unsupported by a few
+   OpenAI-compatible servers → mitigated by the `includeStreamUsage` opt-out (default on).
+2. **Add a real `IRunOptions.stream: false` and route it to a non-streaming `provider.chat`.**
+   Pro: matches the bug report's literal proposal #3. Con: the option does not exist today
+   (scope creep — a new public API + a second dispatch path in the round service), and is
+   **unnecessary**: (1)+(2) already fix usage for the always-streaming `run()`. Rejected as
+   out-of-scope feature work; may be a separate future item.
+3. **Expose usage via a side channel (return metadata / callback) instead of on the message.**
+   Pro: avoids touching the assembler shape. Con: duplicates the usage contract, diverges from
+   the non-streaming path, and strands the existing `readTokenUsageFromMessage` /
+   `metadata.usage` readers. Rejected.
+
+### Decision
+
+Alternative 1. Send `stream_options: { include_usage: true }` on OpenAI-compatible streaming
+requests (opt-out via `includeStreamUsage`, default `true`), and make the shared stream
+assembler capture the final-chunk `usage` and attach top-level
+`usage: { promptTokens, completionTokens, totalTokens }` — byte-for-byte the shape
+`response-parser.ts:parseUsage` already emits on the non-streaming path.
+
+**Validation (wide blast radius — streaming is the default execution path):**
+
+- **Reachability** — every usage consumer reads the message/metadata, not a provider-specific
+  field: `readTokenUsageFromMessage` (top-level `usage` or `metadata.usage`),
+  `collectAssistantUsageMetadata` (execution-round.ts:193), `sumHistoryUsage`. Producing the
+  existing top-level `usage` shape reaches all of them with no reader edits (confirmed by
+  reading `context/token-usage.ts` + `services/execution-usage.ts`).
+- **Capability preservation** — the non-streaming path's usage capability (`parseChoice` +
+  `parseUsage`) is preserved and mirrored, not replaced; both paths converge on one shape.
+- **Adversarial pass** — (a) servers rejecting `stream_options` → opt-out flag, default on;
+  (b) final usage chunk has `choices: []` and would hit the assembler's early return → the fix
+  reads `chunk.usage` before that return; (c) providers that never send usage → `usage` stays
+  absent (readers already treat absence as "no usage", unchanged from today); (d) tool-call
+  streams → usage chunk is independent of choices, captured the same way.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — non-streaming path (`response-parser.ts` `parseChoice`/`parseUsage`) is the sibling; the fix mirrors its exact usage shape
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Solution
+
+1. `chat-completions-chat.ts`: when building a streaming request (both the `onTextDelta`
+   assembly branch and the `chatStream` generator branch), include
+   `stream_options: { include_usage: true }` unless `input.providerOptions.includeStreamUsage`
+   is `false`. Never send it on the non-streaming `create`.
+2. `types.ts`: add `includeStreamUsage?: boolean` to `IOpenAIProviderOptions` (documented
+   default `true`).
+3. `stream-assembler.ts`: add `usage?: { promptTokens; completionTokens; totalTokens }` to
+   `IAssemblyState`; in `applyChunk`, map `chunk.usage` (`prompt_tokens`/`completion_tokens`/
+   `total_tokens`) before the empty-choices early return; in `buildMessage`, attach it as a
+   top-level `usage` on the returned `TUniversalMessage`.
+4. `response-parser.ts`: `parseStreamingChunk` attaches the same `usage` shape when a chunk
+   carries `usage` — for the `chatStream` generator, the final usage chunk (empty `choices`)
+   becomes a usage-only assistant message instead of being dropped (chatStream parity, and the
+   channel `runStream` consumes).
+5. `execution-stream.ts` (agent-core): in the `chatStream` loop, capture the usage-bearing chunk
+   via `collectAssistantUsageMetadata(chunk)` and spread it into the `addAssistantMessage(...)`
+   commit metadata — so the `runStream` committed message exposes usage like the round path.
+
+## Affected Files
+
+- `packages/agent-provider/src/openai/chat-completions-chat.ts`
+- `packages/agent-provider/src/openai/types.ts`
+- `packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts`
+- `packages/agent-provider/src/shared/openai-compatible/response-parser.ts`
+- `packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts` (tests)
+- `packages/agent-provider/src/openai/provider.test.ts` (tests)
+- `packages/agent-provider/docs/SPEC.md` (SPEC update)
+- `packages/agent-core/src/services/execution-stream.ts` (runStream usage collection)
+- `packages/agent-core/src/core/robota.test.ts` (runStream usage regression test)
+
+## Completion Criteria
+
+- [x] TC-01: A streaming `provider.chat(messages, { onTextDelta })` call invokes the OpenAI
+      client `create` with `stream: true` AND `stream_options: { include_usage: true }`
+      (provider test `toHaveBeenCalledWith(expect.objectContaining({ stream_options: { include_usage: true } }))`).
+- [x] TC-02: With `new OpenAIProvider({ …, includeStreamUsage: false })`, the streaming
+      `create` call omits `stream_options` (provider test asserts absence).
+- [x] TC-03: `assembleOpenAICompatibleStream` over a stream ending in a `choices: []` chunk
+      with `usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }` returns
+      `result.usage` deep-equal to `{ promptTokens: 123, completionTokens: 45, totalTokens: 168 }`
+      (assembler unit test).
+- [x] TC-04: End-to-end reproduction (local OpenAI-compatible stub, no key): after
+      `for await (…) of agent.runStream('hi')`, `readTokenUsageFromMessage(getHistory().at(-1))`
+      returns `{ inputTokens: 123, outputTokens: 45, totalTokens: 168 }` (integration test /
+      scratch script exits 0 with usage populated).
+- [x] TC-05: The non-streaming `create` (no `onTextDelta`) is NOT called with `stream_options`
+      (regression: option only on streaming requests).
+- [x] TC-06: `runStream()` over a `provider.chatStream` ending in a usage chunk commits an
+      assistant message whose metadata carries `inputTokens: 123`, `outputTokens: 45`, and
+      `usage: { totalTokens: 168, inputTokens: 123, outputTokens: 45 }` (agent-core
+      `robota.test.ts` integration test).
+
+## Test Plan
+
+BEHAVIOR + streaming → stream output integration test; supporting unit tests for the assembler
+and request builder.
+
+| TC-ID | Test Type            | Tool / Approach                                                                                                                             | Notes |
+| ----- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| TC-01 | Unit (request build) | vitest — `provider.test.ts`, mock `client.chat.completions.create`, assert args                                                             |       |
+| TC-02 | Unit (request build) | vitest — provider constructed with `includeStreamUsage:false`, assert no `stream_options`                                                   |       |
+| TC-03 | Unit (assembler)     | vitest — `stream-assembler.test.ts`, feed empty-choices usage chunk, assert `result.usage`                                                  |       |
+| TC-04 | Integration (stream) | vitest — in-memory async-generator stream through `provider.chat`, assert assembled `usage`; the doc's HTTP-stub repro re-run as scratch UE |       |
+| TC-05 | Unit (request build) | vitest — non-streaming `create` args exclude `stream_options`                                                                               |       |
+| TC-06 | Integration (stream) | vitest — `robota.test.ts`, `runStream` over a fake `chatStream` with a usage chunk, assert committed metadata usage                         |       |
+
+## Tasks
+
+- [x] `.agents/tasks/BEHAVIOR-005.md` — created at GATE-APPROVAL.
+
+## Evidence Log
+
+- **GATE-WRITE — PASS (2026-07-05).** All required sections present; TC-01…TC-05 carry TC-N
+  prefixes with command/observable forms; Architecture Review checklist all `[x]`; Test Plan has
+  a row per TC; no `manual` rows. Premise correction (no `IRunOptions.stream`) documented in
+  Problem/Decision.
+- **GATE-APPROVAL — PASS (2026-07-05).** Design + scope presented (Paths 1+2; corrected report
+  Path 3; `include_usage` default-on with `includeStreamUsage` opt-out; assembler attaches the
+  non-streaming `parseUsage` shape). User sign-off, verbatim: **"좋아"**. Implementation authorized.
+- **SPEC CORRECTION during implement (2026-07-05).** The approved scope claimed "agent-core needs
+  no change". While verifying the live UE, the `runStream` E2E returned `undefined` — the `runStream`
+  path (`execution-stream.ts`, via `provider.chatStream`) commits from the accumulated string and
+  never called `collectAssistantUsageMetadata`. Corrected the spec (Problem cause #4, Affected Scope,
+  Solution #5, Affected Files, TC-06) and added the `execution-stream.ts` collection + parseStreaming
+  chunk usage-only-message handling. `run()` (round path) already worked with the provider-only fix.
+- **GATE-VERIFY — PASS (2026-07-05).**
+  - TC-01…TC-05 (agent-provider): full suite green — `stream-assembler.test.ts` (usage captured /
+    absent / null-ignored), `provider.test.ts` (stream_options sent / opt-out omits / non-streaming
+    omits / assembled usage). agent-provider **580 tests pass**, typecheck + lint (0 errors) clean.
+  - TC-06 (agent-core): `robota.test.ts` runStream usage regression green; agent-core **839 tests
+    pass** (840 with the new test), typecheck clean, 0 lint errors.
+  - TC-04 live UE (local OpenAI-compatible HTTP stub, no key, source build): endpoint received
+    `stream_options: { include_usage: true }`; `run()` → `readTokenUsageFromMessage = { inputTokens:
+123, outputTokens: 45 }`; `runStream()` committed metadata `{ inputTokens:123, outputTokens:45,
+usage:{ totalTokens:168, inputTokens:123, outputTokens:45 } }` and `readTokenUsageFromMessage =
+{ inputTokens:123, outputTokens:45 }`.

--- a/.agents/tasks/BEHAVIOR-005.md
+++ b/.agents/tasks/BEHAVIOR-005.md
@@ -1,0 +1,38 @@
+# BEHAVIOR-005: expose token usage on the streaming execution path
+
+- **Status:** in-progress
+- **Spec:** `.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md`
+- **Branch:** `fix/streaming-usage-exposure`
+- **Approved:** 2026-07-05 (user sign-off "좋아")
+
+## Goal
+
+Streaming requests send `stream_options: { include_usage: true }` (opt-out via
+`includeStreamUsage`, default true); the shared OpenAI-compatible stream assembler captures the
+final-chunk `usage` and attaches top-level `usage: { promptTokens, completionTokens, totalTokens }`
+— the same shape the non-streaming `parseUsage` path emits — so `readTokenUsageFromMessage` and
+the usage analytics work unchanged for `run()` and `runStream()`.
+
+## Progress
+
+- [x] Spec drafted + approved (GATE-WRITE, GATE-APPROVAL PASS).
+- [x] SPEC-first: updated `packages/agent-provider/docs/SPEC.md` (Streaming Token Usage).
+- [x] TDD: assembler + request-builder + runStream regression tests (red → green).
+- [x] Live UE: bug-report reproduction stub shows usage populated for run()/runStream().
+- [ ] PR → develop, CI green, merge.
+
+## Test Plan
+
+Full detail (TC-01…TC-06) lives in the spec-doc
+`.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md`. Summary:
+
+- **Unit (agent-provider):** `stream-assembler.test.ts` asserts the assembler captures the
+  final empty-choices `usage` chunk (and ignores `usage: null`); `provider.test.ts` asserts the
+  streaming request carries `stream_options: { include_usage: true }`, the `includeStreamUsage:
+false` opt-out omits it, the non-streaming request omits it, and the assembled message carries
+  `usage`.
+- **Integration (agent-core):** `robota.test.ts` drives `runStream` over a fake `chatStream`
+  ending in a usage chunk and asserts the committed assistant message metadata carries
+  `inputTokens`/`outputTokens`/`usage`.
+- **Live UE:** local OpenAI-compatible HTTP stub (no key) — `run()` and `runStream()` both yield
+  `readTokenUsageFromMessage = { inputTokens: 123, outputTokens: 45 }`.

--- a/.changeset/fix-streaming-token-usage.md
+++ b/.changeset/fix-streaming-token-usage.md
@@ -1,0 +1,8 @@
+---
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-provider': patch
+---
+
+fix(streaming): expose token usage on the streaming execution path (BEHAVIOR-005)
+
+Token usage was silently dropped on streaming turns, so `readTokenUsageFromMessage` and robota's usage analytics returned empty/0 for every `run()`/`runStream()` (which always stream). OpenAI-compatible streaming requests now send `stream_options: { include_usage: true }`, the stream assembler and the `runStream` commit path attach the same top-level `usage` shape the non-streaming path already emits, and both `run()` and `runStream()` now expose usage. New opt-out `IOpenAIProviderOptions.includeStreamUsage` (default `true`) for OpenAI-compatible servers that reject `stream_options`.

--- a/.design/bug-report-streaming-usage-2026-07-05.md
+++ b/.design/bug-report-streaming-usage-2026-07-05.md
@@ -1,0 +1,138 @@
+# [Bug/Feature] 스트리밍 실행 경로가 토큰 usage 를 노출하지 않음 (getHistory·message.usage 부재)
+
+- **보고일**: 2026-07-05
+- **버전**: `@robota-sdk/agent-core` / `agent-provider` **3.0.0-beta.76** (npm, 실측) — 소스 **beta.77** 에서도 동일 코드 경로 확인
+- **환경**: Node 24.15, Linux, `OpenAIProvider({ apiKey, baseURL })` — OpenAI-호환 엔드포인트(로컬 HTTP 스텁으로 재현, 키·게이트웨이 불필요)
+- **심각도 제안**: 높음 — 토큰 usage 는 비용 과금·컨텍스트 관리·관측의 기본 신호인데, **스트리밍 경로에서 조용히 사라진다**. 스트리밍이 대화형 UX 의 기본 실행 방식이라 영향 범위가 넓다.
+- **출처**: speech 프로젝트 정밀 과금 도입 중 실측(동반: `.design/bug-report-maxtokens-2026-07-03.md` 와 같은 "스트리밍 경로 2급 시민" 패턴)
+
+## 요약
+
+`Robota.run()` / `runStream()` 완료 후 소비자가 턴의 토큰 usage 를 얻을 공개 경로가 사실상 없다.
+usage 리더 3종(`readTokenUsageFromMessage`, `readTokenUsageFromMetadata`,
+`collectAssistantUsageMetadata`)은 모두 대화 히스토리 메시지의 `metadata.usage` / `message.usage`
+를 읽지만, **스트리밍 실행에서는 그 필드가 채워지지 않는다**. 그리고 `run()` 조차 내부적으로
+스트리밍을 쓰므로(아래 3번), 비스트리밍 파싱 경로(`parseChoice(choice, response.usage)`)에 도달하지
+못한다. 결과적으로 **모든 실행에서 usage 가 `undefined`** 다.
+
+> **이것은 "usage 미지원"이 아니라 robota 자신의 usage 서브시스템이 스트리밍에서 빈 데이터로
+> 먹여지는 자기모순적 결함이다.** `execution-round.ts` 는 매 라운드
+> `collectAssistantUsageMetadata(assistantResponse)` 로 usage 를 수집해 커밋 메시지 metadata 에
+> 부착하고(L193·L211), `assistant_message_committed` 실행 이벤트로 발행하며(L219),
+> `execution-usage.ts`(ANALYTICS-001)가 세션 총 usage 를 합산한다. 즉 usage 를 message·이벤트·
+> 분석까지 전파하도록 이미 배선돼 있는데, **스트리밍 `assistantResponse` 에 usage 가 실리지 않아
+> 이 파이프라인 전체가 0/undefined 로 귀결**된다. 소비자용 API 결함일 뿐 아니라 robota 내장
+> 분석 기능이 스트리밍 턴에서 조용히 틀린 값을 산출한다.
+
+## 사안 분류 (정확한 스코프)
+
+- **명백한 버그**: (3) `IRunOptions.stream: false` 가 조용히 무시됨 — 타입에 존재하고 문서화된
+  옵션이 no-op. (그리고 위 요약처럼 robota 내장 usage 분석이 스트리밍에서 0 을 산출.)
+- **호환성 판단이 걸린 개선**: (1) 스트리밍에 `include_usage` 를 기본 전송할지는 일부 OpenAI-호환
+  서버의 미지원 가능성 때문에 옵트인/폴백 설계가 필요 — 방향은 메인테이너 재량.
+
+## 근본 원인 (소스 확인)
+
+1. **`stream_options: { include_usage: true }` 미전송.** `chat-completions-chat.ts` 의 스트리밍
+   요청 파라미터(`stream: true`, L39/L81)에 `stream_options` 가 없다. OpenAI/OpenAI-호환 엔드포인트는
+   `include_usage` 없이는 스트리밍 응답에 usage 청크를 보내지 않는다. (`grep -rn 'include_usage\|stream_options' packages/*/src` → 0건.)
+2. **스트림 조립기가 final-청크 usage 를 부착하지 않음 (런타임 증명).** 본 보고의 스텁은 final SSE
+   청크에 usage 를 **실제로 실어 보냈는데도**, 조립된 assistant 메시지 `metadata` 에는 `executionId`
+   만 남았다(usage 없음) — 즉 `include_usage` 를 보내 엔드포인트가 usage 를 줘도 조립 단계에서
+   버려진다. (`openai/streaming/`·`chat-completions-chat.ts`·`adapter.ts` 소스 grep 도 usage 처리 0건.)
+3. **`IRunOptions.stream: false` 가 무시됨.** `run(input, { stream: false })` 도 엔드포인트에
+   `stream: true` 로 전송된다(실측 request body). 따라서 usage 를 붙이는 비스트리밍 경로
+   (`parseChoice(t, e.usage)`, `...usage && { usage: parseUsage(usage) }`)로 우회할 수도 없다.
+
+## 실측 (로컬 OpenAI-호환 스텁, 키 불필요)
+
+스텁이 `POST /v1/chat/completions` 에 대해 스트리밍 시 final SSE 청크에
+`usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }` 를 실어 응답:
+
+| 실행                            | 엔드포인트가 받은 요청            | `readTokenUsageFromMessage(last)` |
+| ------------------------------- | --------------------------------- | --------------------------------- |
+| `runStream(input)`              | `{ stream: true }` (no usage opt) | `undefined`                       |
+| `run(input)`                    | `{ stream: true }`                | `undefined`                       |
+| `run(input, { stream: false })` | `{ stream: true }` (무시됨)       | `undefined`                       |
+
+조립된 assistant 메시지: `{ role: 'assistant', content: '…', metadata: { executionId }, toolCalls: [] }`
+— usage 필드 없음.
+
+## 재현 스크립트
+
+```js
+// npm i @robota-sdk/agent-core@3.0.0-beta.76 @robota-sdk/agent-provider@3.0.0-beta.76
+import http from 'node:http';
+import { Robota, readTokenUsageFromMessage } from '@robota-sdk/agent-core';
+import { OpenAIProvider } from '@robota-sdk/agent-provider';
+
+const USAGE = { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 };
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    const p = JSON.parse(body || '{}');
+    console.log(
+      'endpoint received:',
+      JSON.stringify({ stream: p.stream, stream_options: p.stream_options }),
+    );
+    if (p.stream) {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      const base = { id: 'x', object: 'chat.completion.chunk', created: 0, model: 'm' };
+      res.write(
+        `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: { role: 'assistant', content: '안녕' }, finish_reason: null }] })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }], usage: USAGE })}\n\n`,
+      );
+      res.write('data: [DONE]\n\n');
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          id: 'x',
+          object: 'chat.completion',
+          created: 0,
+          model: 'm',
+          choices: [
+            { index: 0, message: { role: 'assistant', content: '안녕' }, finish_reason: 'stop' },
+          ],
+          usage: USAGE,
+        }),
+      );
+    }
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const baseURL = `http://127.0.0.1:${server.address().port}/v1`;
+const provider = new OpenAIProvider({ apiKey: 'k', baseURL });
+const agent = new Robota({
+  name: 't',
+  aiProviders: [provider],
+  defaultModel: { provider: 'openai', model: 'm' },
+  systemMessage: 's',
+});
+let out = '';
+for await (const d of agent.runStream('안녕')) out += d;
+const h = agent.getHistory();
+console.log('usage =>', readTokenUsageFromMessage(h[h.length - 1])); // undefined
+await agent.destroy().catch(() => {});
+server.close();
+```
+
+## 제안 (택1 또는 조합)
+
+1. **스트리밍 요청에 `stream_options: { include_usage: true }` 를 기본 포함**(OpenAI-호환 surface).
+   final 청크의 usage 를 `stream-assembler` 가 파싱해 조립된 assistant 메시지 `usage`/`metadata.usage`
+   에 채운다 → 기존 `readTokenUsageFromMessage` 가 그대로 동작.
+2. `IRunOptions.stream: false` 를 실제로 존중(무시하지 않기) — 비스트리밍 경로는 이미 usage 를
+   메시지에 붙이므로(`parseChoice(choice, response.usage)`) 이것만으로도 usage 획득 경로가 열린다.
+3. 또는 `run`/`runStream` 이 최종 usage 를 별도 채널(반환 메타/이벤트 콜백)로 노출.
+
+## 호환성 노트
+
+- OpenAI-호환 엔드포인트 중 `stream_options` 미지원 서버가 있을 수 있으니, (1)은 옵트아웃/그레이스풀
+  폴백을 두는 편이 안전하다.
+- 본 보고는 **중립적·보편적** 관점(임의의 OpenAI-호환 소비자)에서 작성됨. 특정 소비 앱에 종속된
+  요구가 아니다.

--- a/packages/agent-core/src/core/robota.test.ts
+++ b/packages/agent-core/src/core/robota.test.ts
@@ -79,6 +79,41 @@ class SecondProvider extends AbstractAIProvider {
   }
 }
 
+// A provider whose stream ends with a usage-bearing chunk (stream_options.include_usage parity)
+class UsageStreamProvider extends AbstractAIProvider {
+  readonly name = 'usage-stream-provider';
+  readonly version = '1.0.0';
+
+  async chat(messages: TUniversalMessage[]): Promise<TUniversalMessage> {
+    return {
+      id: 'x',
+      role: 'assistant',
+      content: `Response to: ${messages[messages.length - 1]?.content ?? ''}`,
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+  }
+
+  override async *chatStream(): AsyncIterable<TUniversalMessage> {
+    yield {
+      id: 'c1',
+      role: 'assistant',
+      content: 'Hi',
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+    // Final usage chunk: empty content, carries top-level provider usage.
+    yield {
+      id: 'c2',
+      role: 'assistant',
+      content: '',
+      state: 'complete' as const,
+      timestamp: new Date(),
+      usage: { promptTokens: 123, completionTokens: 45, totalTokens: 168 },
+    } as TUniversalMessage;
+  }
+}
+
 // Mock Tool with schema and execution tracking
 class TrackingTool extends AbstractTool {
   executionCount = 0;
@@ -1098,6 +1133,30 @@ describe('Robota Core', () => {
       }
 
       expect(chunks.length).toBeGreaterThan(0);
+    });
+
+    it('exposes token usage on the committed assistant message from the final usage chunk', async () => {
+      const robota = new Robota(
+        createConfig({
+          aiProviders: [new UsageStreamProvider()],
+          defaultModel: { provider: 'usage-stream-provider', model: 'm' },
+        }),
+      );
+
+      for await (const _chunk of robota.runStream('hi')) {
+        // drain the stream
+      }
+
+      const history = robota.getHistory();
+      const last = history[history.length - 1];
+      expect(last?.role).toBe('assistant');
+      expect(last?.metadata?.['inputTokens']).toBe(123);
+      expect(last?.metadata?.['outputTokens']).toBe(45);
+      expect(last?.metadata?.['usage']).toEqual({
+        totalTokens: 168,
+        inputTokens: 123,
+        outputTokens: 45,
+      });
     });
   });
 

--- a/packages/agent-core/src/services/execution-stream.ts
+++ b/packages/agent-core/src/services/execution-stream.ts
@@ -1,5 +1,6 @@
 import { assertToolChoiceValid, buildChatResponseFormat } from './execution-service-helpers';
 import { executeStreamToolCalls } from './execution-stream-tools';
+import { collectAssistantUsageMetadata } from './execution-usage';
 import { callPluginHook } from './plugin-hook-dispatcher';
 import { ConfigurationError } from '../utils/errors';
 
@@ -159,8 +160,15 @@ export async function* executeStream(
     let sawAssistantContent = false;
     const toolCalls: IToolCall[] = [];
     let currentToolCallIndex = -1;
+    let usageMetadata: ReturnType<typeof collectAssistantUsageMetadata>;
 
     for await (const chunk of stream) {
+      // The final usage chunk (stream_options.include_usage) carries token usage; collect it
+      // so the committed assistant message exposes usage like the non-streaming round path.
+      const chunkUsage = collectAssistantUsageMetadata(chunk);
+      if (chunkUsage) {
+        usageMetadata = chunkUsage;
+      }
       if (typeof chunk.content === 'string') {
         sawAssistantContent = true;
       }
@@ -247,6 +255,7 @@ export async function* executeStream(
     }
     conversationStore.addAssistantMessage(fullResponse, toolCalls, {
       executionId,
+      ...(usageMetadata ?? {}),
     });
 
     if (toolCalls.length > 0) {

--- a/packages/agent-provider/docs/SPEC.md
+++ b/packages/agent-provider/docs/SPEC.md
@@ -142,6 +142,28 @@ Responses):
 | Anthropic                                                    | `tool_choice`: `{ type: 'auto' }` / `{ type: 'none' }` / `{ type: 'any' }` (required) / `{ type: 'tool', name }`    |
 | Gemini (Google inherits)                                     | `toolConfig.functionCallingConfig`: mode `AUTO` / `NONE` / `ANY` (required); named = `ANY` + `allowedFunctionNames` |
 
+## Streaming Token Usage
+
+OpenAI-compatible surfaces (openai, openai-compatible, qwen, deepseek, gemma) request token
+usage on streaming turns and expose it on the assembled assistant message so that the
+streaming path carries the **same** usage contract as the non-streaming path.
+
+- **Request.** Streaming requests (both the `onTextDelta` assembly path and the `chatStream`
+  generator) include `stream_options: { include_usage: true }`. It is only sent on streaming
+  requests — never on the non-streaming `create`. Endpoints emit a final chunk (with
+  `choices: []`) carrying `usage` only when this is present.
+- **Assembly.** The shared stream assembler
+  (`shared/openai-compatible/stream-assembler.ts`) captures that final-chunk `usage` (including
+  the empty-`choices` chunk) and attaches a top-level
+  `usage: { promptTokens, completionTokens, totalTokens }` to the assembled `TUniversalMessage`
+  — byte-for-byte the shape the non-streaming `response-parser.ts` `parseUsage` produces. The
+  `chatStream` generator attaches the same shape via `parseStreamingChunk`. Consumers
+  (`readTokenUsageFromMessage`, `collectAssistantUsageMetadata` in agent-core) read it unchanged.
+  When a provider sends no usage, the field is simply absent (treated as "no usage", as before).
+- **Opt-out.** `IOpenAIProviderOptions.includeStreamUsage?: boolean` (default `true`) disables
+  sending `stream_options` for OpenAI-compatible endpoints that reject it; usage is then absent
+  on streaming turns for that provider.
+
 ## Dependencies
 
 | Package                  | Role                                                                  |

--- a/packages/agent-provider/src/openai/chat-completions-chat.ts
+++ b/packages/agent-provider/src/openai/chat-completions-chat.ts
@@ -37,6 +37,7 @@ export async function chatWithOpenAIChatCompletions(
       return await chatWithStreamingAssembly(client, input, {
         ...requestParams,
         stream: true,
+        ...buildStreamOptions(input),
       });
     }
 
@@ -79,6 +80,7 @@ export async function* chatStreamWithOpenAIChatCompletions(
     const requestParams: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
       ...buildChatRequestParams(input),
       stream: true,
+      ...buildStreamOptions(input),
     };
 
     await logPayload(input, requestParams, 'stream');
@@ -116,6 +118,19 @@ export async function* chatStreamWithOpenAIChatCompletions(
     const errorMessage = openaiError.message || 'OpenAI API request failed';
     throw new Error(`OpenAI stream failed: ${errorMessage}`);
   }
+}
+
+/**
+ * Streaming requests opt into token usage via `stream_options: { include_usage: true }`
+ * unless the provider sets `includeStreamUsage: false`. Only ever sent on streaming requests.
+ */
+function buildStreamOptions(
+  input: IOpenAIChatCompletionsOptions,
+): { stream_options: { include_usage: true } } | Record<string, never> {
+  if (input.providerOptions.includeStreamUsage === false) {
+    return {};
+  }
+  return { stream_options: { include_usage: true } };
 }
 
 function buildChatRequestParams(

--- a/packages/agent-provider/src/openai/provider.test.ts
+++ b/packages/agent-provider/src/openai/provider.test.ts
@@ -1112,6 +1112,103 @@ describe('OpenAIProvider', () => {
       );
     });
 
+    async function* createUsageStream() {
+      yield {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: { content: 'Hi' }, finish_reason: null, logprobs: null }],
+      };
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop', logprobs: null }],
+      };
+      yield {
+        id: 'chunk-usage',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [],
+        usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 },
+      };
+    }
+
+    function getCreateMock(provider: OpenAIProvider): ReturnType<typeof vi.fn> {
+      return (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client.chat.completions.create;
+    }
+
+    it('sends stream_options include_usage on streaming requests', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue(createTextStream());
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4', onTextDelta: () => {} });
+
+      expect(getCreateMock(provider)).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true, stream_options: { include_usage: true } }),
+        undefined,
+      );
+    });
+
+    it('omits stream_options when includeStreamUsage is false', async () => {
+      const provider = new OpenAIProvider({
+        apiKey: 'sk-test',
+        apiSurface: 'chat-completions',
+        includeStreamUsage: false,
+      });
+      getCreateMock(provider).mockResolvedValue(createTextStream());
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4', onTextDelta: () => {} });
+
+      const params = getCreateMock(provider).mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(params['stream']).toBe(true);
+      expect(params['stream_options']).toBeUndefined();
+    });
+
+    it('does not send stream_options on non-streaming requests', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue({
+        id: 'r',
+        object: 'chat.completion',
+        created: 0,
+        model: 'gpt-4',
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      });
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4' });
+
+      const params = getCreateMock(provider).mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(params['stream']).toBeUndefined();
+      expect(params['stream_options']).toBeUndefined();
+    });
+
+    it('attaches usage from the final usage chunk to the assembled message', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue(createUsageStream());
+
+      const result = await provider.chat([createUserMessage('Hello')], {
+        model: 'gpt-4',
+        onTextDelta: () => {},
+      });
+
+      const usage = (
+        result as {
+          usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+        }
+      ).usage;
+      expect(usage).toEqual({ promptTokens: 123, completionTokens: 45, totalTokens: 168 });
+    });
+
     it('emits ordered native Chat Completions stream chunks', async () => {
       const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
       const client = (

--- a/packages/agent-provider/src/openai/types.ts
+++ b/packages/agent-provider/src/openai/types.ts
@@ -66,6 +66,14 @@ export interface IOpenAIProviderOptions {
   timeout?: number;
 
   /**
+   * Whether to request token usage on streaming turns via
+   * `stream_options: { include_usage: true }` (default `true`). Set `false` for
+   * OpenAI-compatible endpoints that reject `stream_options`; usage is then absent
+   * on streaming turns for this provider.
+   */
+  includeStreamUsage?: boolean;
+
+  /**
    * API base URL (default: `'https://api.openai.com/v1'`).
    *
    * Point this at ANY OpenAI-compatible endpoint — this provider is a protocol

--- a/packages/agent-provider/src/shared/openai-compatible/response-parser.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/response-parser.ts
@@ -101,8 +101,21 @@ export class OpenAICompatibleResponseParser {
 
   parseStreamingChunk(chunk: OpenAI.Chat.ChatCompletionChunk): TUniversalMessage | null {
     try {
+      const usage = chunk.usage ? this.parseUsage(chunk.usage) : undefined;
       const choice = chunk.choices?.[0];
       if (!choice) {
+        // Final usage chunk (choices: []) when stream_options.include_usage is set.
+        if (usage) {
+          return {
+            id: randomUUID(),
+            state: 'complete',
+            role: 'assistant',
+            content: '',
+            timestamp: new Date(),
+            ...{ usage },
+            metadata: { isStreamChunk: true, isComplete: true },
+          };
+        }
         return null;
       }
 
@@ -124,6 +137,7 @@ export class OpenAICompatibleResponseParser {
           content: '',
           timestamp: new Date(),
           toolCalls,
+          ...(usage && { usage }),
           metadata: {
             isStreamChunk: true,
             isComplete: finishReason === 'stop' || finishReason === 'tool_calls',
@@ -137,6 +151,7 @@ export class OpenAICompatibleResponseParser {
         role: 'assistant',
         content: this.projectText(choice.delta.content || ''),
         timestamp: new Date(),
+        ...(usage && { usage }),
         metadata: {
           isStreamChunk: true,
           isComplete: finishReason === 'stop' || finishReason === 'tool_calls',

--- a/packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts
@@ -71,6 +71,64 @@ describe('assembleOpenAICompatibleStream', () => {
     expect(onTextDelta).toHaveBeenNthCalledWith(2, 'world');
   });
 
+  function readUsage(
+    message: Awaited<ReturnType<typeof assembleOpenAICompatibleStream>>,
+  ): { promptTokens: number; completionTokens: number; totalTokens: number } | undefined {
+    return (
+      message as {
+        usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+      }
+    ).usage;
+  }
+
+  function createUsageChunk(usage: OpenAI.CompletionUsage): OpenAI.Chat.ChatCompletionChunk {
+    return {
+      id: 'chunk-usage',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'local-model',
+      choices: [],
+      usage,
+    };
+  }
+
+  it('captures usage from the final empty-choices usage chunk', async () => {
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([
+        createChunk('Hi'),
+        createChunk('', 'stop'),
+        createUsageChunk({ prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }),
+      ]),
+    });
+
+    expect(result.content).toBe('Hi');
+    expect(readUsage(result)).toEqual({
+      promptTokens: 123,
+      completionTokens: 45,
+      totalTokens: 168,
+    });
+  });
+
+  it('leaves usage absent when no usage chunk arrives', async () => {
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([createChunk('Hi'), createChunk('', 'stop')]),
+    });
+
+    expect(readUsage(result)).toBeUndefined();
+  });
+
+  it('ignores null usage on non-final chunks', async () => {
+    const nullUsageChunk = {
+      ...createChunk('Hi'),
+      usage: null,
+    } as OpenAI.Chat.ChatCompletionChunk;
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([nullUsageChunk, createChunk('', 'stop')]),
+    });
+
+    expect(readUsage(result)).toBeUndefined();
+  });
+
   it('assembles streamed tool call deltas by index', async () => {
     const stream = asyncIterableFrom<OpenAI.Chat.ChatCompletionChunk>([
       {

--- a/packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts
@@ -14,6 +14,12 @@ interface IToolCallPart {
   arguments: string;
 }
 
+interface IStreamUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
 interface IAssemblyState {
   textParts: string[];
   toolCallParts: Map<number, IToolCallPart>;
@@ -22,6 +28,7 @@ interface IAssemblyState {
   toolCallTextProjected: boolean;
   model: string;
   finishReason: string | null;
+  usage?: IStreamUsage;
 }
 
 export async function assembleOpenAICompatibleStream(
@@ -52,6 +59,16 @@ function applyChunk(
 ): void {
   if (chunk.model) {
     state.model = chunk.model;
+  }
+
+  // Usage arrives on the final chunk (choices: []) when stream_options.include_usage is set.
+  // Capture it before the empty-choices early return; non-final chunks carry usage: null.
+  if (chunk.usage) {
+    state.usage = {
+      promptTokens: chunk.usage.prompt_tokens,
+      completionTokens: chunk.usage.completion_tokens,
+      totalTokens: chunk.usage.total_tokens,
+    };
   }
 
   const choice = chunk.choices?.[0];
@@ -182,6 +199,7 @@ function buildMessage(
     state: 'complete',
     timestamp: new Date(),
     ...(toolCalls.length > 0 && { toolCalls }),
+    ...(state.usage && { usage: state.usage }),
     ...(Object.keys(resultMetadata).length > 0 && { metadata: resultMetadata }),
   };
 }


### PR DESCRIPTION
## Summary

Token usage was silently lost on the **streaming** execution path. After any `run()` / `runStream()`, `readTokenUsageFromMessage(lastHistoryMessage)` returned `undefined`, and robota's own usage analytics (`collectAssistantUsageMetadata` → `assistant_message_committed` → `sumHistoryUsage`) summed to **0** for streaming turns — which is every turn, since `run()` always streams via `onTextDelta`.

Source of the report: `.design/bug-report-streaming-usage-2026-07-05.md`. Design + gate record: `.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md` (GATE-APPROVAL sign-off: "좋아").

## Root causes fixed

1. **`stream_options` never sent.** Streaming requests now include `stream_options: { include_usage: true }` (both the `onTextDelta` assembly path and the `chatStream` generator). Opt-out: `IOpenAIProviderOptions.includeStreamUsage` (default `true`) for OpenAI-compatible servers that reject it. Never sent on the non-streaming `create`.
2. **Assembler dropped the final-chunk usage.** The shared OpenAI-compatible stream assembler now captures `chunk.usage` (including the empty-`choices` final chunk; `usage: null` on non-final chunks is ignored) and attaches a top-level `usage: { promptTokens, completionTokens, totalTokens }` — byte-for-byte the shape the non-streaming `parseUsage` already produces. `parseStreamingChunk` gains the same parity (the final usage chunk becomes a usage-only message instead of being dropped).
3. **`runStream()` reconstructed the message and never collected usage.** `execution-stream.ts` (which `runStream` uses via `provider.chatStream`) committed the assistant message from the accumulated string and never called `collectAssistantUsageMetadata`. It now captures the usage-bearing chunk and attaches the usage metadata at commit, **mirroring `execution-round.ts`** (the path `run()` uses, which already worked once the assembled message carried usage).

Readers (`readTokenUsageFromMessage`, `collectAssistantUsageMetadata`) are **unchanged** — the fix makes streaming emit the existing usage shape and routes it into the committed metadata on both execution paths.

### Bug-report premise correction

The report's proposal #3 ("`stream: false` is ignored") targets a field that **does not exist** — `IRunOptions` has no `stream` boolean (the cited line is JSDoc). `run()` always streams; fixing the above restores usage for both `run()` and `runStream()`. No new dispatch option was added (out of scope).

## Tests

- **agent-provider (580 green):** assembler usage-capture / absent / null-ignored; streaming request sends `stream_options`; `includeStreamUsage:false` omits it; non-streaming omits it; assembled message carries `usage`.
- **agent-core (840 green):** `robota.test.ts` `runStream` regression — a `chatStream` ending in a usage chunk commits an assistant message whose metadata carries `inputTokens`/`outputTokens`/`usage`.
- Both packages: build + typecheck + lint (0 errors) clean; test-module-mocks + architecture-conformance scans pass.

## Live UE (local OpenAI-compatible stub, no API key)

```
endpoint received: {"stream":true,"stream_options":{"include_usage":true}}
run()      readTokenUsage => { inputTokens: 123, outputTokens: 45 }
runStream() metadata      => { inputTokens: 123, outputTokens: 45, usage: { totalTokens: 168, inputTokens: 123, outputTokens: 45 } }
runStream() readTokenUsage => { inputTokens: 123, outputTokens: 45 }
```

## SPEC

`packages/agent-provider/docs/SPEC.md` — new **Streaming Token Usage** section (behavior + `includeStreamUsage` option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)