### PR TITLE
Merge develop → main: WORKFLOW-005 P1 nodes + streaming token usage fix

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -176,4 +176,32 @@ catalog: true`; the node is reached, resolves config, and returns the graceful v
     `config.model` is set (mirrored behavior).
   - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement + agent-server-boundary
     scans pass.
-  - Branch: `feat/workflow-005-p1-text-to-image`.
+  - Branch: `feat/workflow-005-p1-text-to-image`. Merged via PR #966 → develop.
+
+- **node #3 — seedance-video node — DONE (2026-07-05).** Filled the existing empty stub
+  `packages/dag-nodes/seedance-video` → `@robota-sdk/dag-node-seedance-video` (`private: true`). NodeType
+  `seedance-video` (matches pre-authored `.dag-storage` fixtures and the planned node in
+  `packages/dag-nodes/docs/SPEC.md`). `SeedanceVideoNodeDefinition` (category `AI`): single `text` input,
+  single binary `video` output (`VIDEO_MP4`); config `{ model, baseCredits(=0.5), durationSeconds?,
+aspectRatio?, pollIntervalMs(=5000), maxWaitMs(=300000) }`. Backend: `@robota-sdk/agent-provider/bytedance`
+  `BytedanceProvider` (implements `IVideoGenerationProvider`). Video generation is an **async job** —
+  `SeedanceVideoRuntime.generateVideo` calls `createVideo` then **polls `getVideoJob`** every
+  `pollIntervalMs` until `succeeded`/`failed`/`cancelled` or `maxWaitMs` (best-effort `cancelVideoJob` on
+  timeout). Creds `SEEDANCE_API_KEY` + `SEEDANCE_BASE_URL` (both required); default model
+  `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL`; allowlist `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS`. `seed` intentionally
+  not exposed (provider rejects it). New `video-output-normalizer` (lenient: missing mime → `video/mp4`).
+  Registered in the async/optional loader list. SPEC at `packages/dag-nodes/seedance-video/docs/SPEC.md`.
+  - Tests: 13 node tests (mock runtime) + 11 runtime tests (mock `BytedanceProvider`; incl. poll-until-
+    succeeded, running→succeeded, failed/cancelled, poll-failure, timeout+cancel, output-missing, seed-omitted,
+    mime-default) with an injected instant `sleep` + registry assertion. Full suites green: seedance-video 24,
+    dag-framework 113. typecheck + lint + mock scan clean.
+  - Live UE (no `SEEDANCE_API_KEY`/`SEEDANCE_BASE_URL`): `input → seedance-video` workflow run through
+    `LocalDagRuntimeProvider.execute` (async registry). Evidence: `seedance-video in runtime catalog: true`;
+    node reached, resolves config, returns graceful
+    `SEEDANCE_API_KEY and SEEDANCE_BASE_URL must both be configured` validation error. The poll/success paths
+    are covered deterministically by the mocked-provider runtime tests.
+  - Boundary: CLI-077 holds; capability-placement + agent-server-boundary + test-module-mocks scans pass.
+  - Branch: `feat/workflow-005-p1-video`.
+
+**P1 status: node-kind completion — tool ✅, text-to-image ✅, seedance-video ✅; skill node remaining
+(deferred as an LLM-backed agent node — see the skill-node research entry above).**

--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -1,0 +1,146 @@
+---
+title: 'WORKFLOW-005: complete the /workflows feature (dynamic node+workflow authoring; DAG stays private)'
+status: todo
+created: 2026-07-05
+approved: 2026-07-05
+start_phase: 'P1 — node-kind completion (owner-approved 2026-07-05)'
+priority: medium
+urgency: soon
+area: packages/agent-command-workflows, packages/dag-nodes, packages/dag-node, packages/dag-cli
+depends_on: ['CLI-077', 'WORKFLOW-004']
+---
+
+# Complete the /workflows feature (Option A — feature completion, DAG kept private)
+
+Owner decision (2026-07-05): complete the **feature** in the dev/private context; the DAG subsystem
+stays `private` (no publish, no IP exposure) until a separate instruction. So the published CLI keeps
+CLI-077's optional/absent `/workflows`; this item advances the capability itself.
+
+## Vision
+
+Dynamically create workflows AND workflow nodes on the fly. A node can be a **skill**, a **tool call**,
+an **LLM** call, **generative AI** (image/video), or an arbitrary **custom function** — all on one
+common node interface. Anything created is **reusable** and **savable** to disk for reload. (Similar in
+spirit to Claude Code workflows; this predates it and is now being solidified.)
+
+## Current state (research 2026-07-05)
+
+- **Common interface already exists** — `IDagNodeDefinition` + `INodeTaskHandler`
+  (`packages/dag-core/src/types/node-lifecycle.ts`); every node conforms. Authoring via
+  `AbstractNodeDefinition` / `defineDagNode` (`packages/dag-node/src/lifecycle/`). The "common
+  interface" requirement is structurally satisfied.
+- **Dynamic node creation exists, partially** — `instant-node` builds nodes from data at runtime:
+  `createPromptBackedNodeDefinition` (LLM-prompt node) and `createCompositeInstantNodeDefinition`
+  (wrap an inner DAG). Phase C (arbitrary code node via API) is explicitly out of scope today.
+- **Node catalog** — a static hand-maintained registry (`dag-framework/src/default-node-registry.ts`):
+  LLM text (anthropic/openai/gemini/deepseek/qwen/router), gemini image edit/compose, mcp-tool
+  (external MCP-over-HTTP), file/http/transform/text/utility nodes.
+- **Persistence exists but fragmented** — `.dag/workflows/*.dag.json` (workflows),
+  `.dag/nodes/*.instant-node.json` (prompt nodes), `*.dag.node.js` (code nodes). Three formats.
+- **Builder is pipeline-only** — `buildDagFromPipeline` (linear + parallel fan-out, auto-wired); no
+  free-form graph/branch builder.
+- **Two surfaces** — the thin `/workflows` slash command (`list`/`catalog`/`validate`/`run`) vs the
+  rich `dag-cli` **MCP** toolset (build, instant-node CRUD+save, export/import, templates). The
+  dynamic-creation power lives only in the MCP layer, not the agent slash command.
+
+## Gaps to close (the "완성" work)
+
+1. **Missing node kinds on the common interface** (each is an additive `IDagNodeDefinition`):
+   - **skill node** — wrap a Robota skill (MISSING).
+   - **in-process tool node** — wrap the agent `agent-tools` FunctionTool registry (only external
+     MCP-over-HTTP `mcp-tool` exists today).
+   - **custom-function / code node** — instant-node **Phase C**: define behavior via API at runtime,
+     persistable (today custom code requires hand-writing a `*.dag.node.js` file).
+   - **generative image (text-to-image)** and **generative video** — image is edit/compose only;
+     video MISSING (payload already supports `binaryKind: 'video'`).
+2. **Fix + unify persistence** — composite/instant nodes with `taskCode: null` are dropped on reload
+   (`dag-cli/.../instant-nodes.ts`); unify "save this node OR workflow, reload it" into one abstraction.
+3. **Expose dynamic creation through `/workflows`** — bring create-node / save / build to the agent
+   slash command (or a shared authoring API the slash command and MCP both use), so the agent can
+   create and reuse nodes+workflows on the fly, not only via MCP.
+4. **WORKFLOW-004 `build` subcommand** — LLM-assisted workflow authoring (its own spec-first sub-item).
+
+## Proposed phasing (to confirm)
+
+- **P1 — node-kind completion**: skill node + in-process tool node + text-to-image/video nodes
+  (additive, common interface). Highest vision value, lowest risk.
+- **P2 — dynamic authoring**: instant-node Phase C (code node via API) + unified persistence + fix
+  composite reload.
+- **P3 — surface unification**: expose create/save/build through `/workflows` (+ WORKFLOW-004 build).
+
+Deferred (separate instruction): making the DAG subsystem publishable so `/workflows` ships in the
+CLI (WORKFLOW-005 does NOT publish anything).
+
+## Test Plan
+
+- Per new node: a `defineDagNode`/lifecycle unit test + a functional run through
+  `LocalDagRuntimeProvider.execute` with a scripted provider; boundary `rg` stays 0.
+- Persistence: save→reload round-trip for prompt, composite, and code nodes (composite reload fixed).
+- No published-closure change (CLI-077 invariant holds; DAG stays private).
+
+## User Execution Test Scenarios
+
+- agent-executable (dev/monorepo, DAG present). Create a node of each kind on the fly, save it, reload,
+  compose a small workflow using it, and run it end-to-end via the dev `/workflows` path.
+- Evidence: _to fill at implementation._
+
+## P1 implementation notes — node #1: in-process tool node (grounded 2026-07-05)
+
+Design confirmed by research; ready to implement (SPEC-first → TDD → live UE).
+
+- **Package**: `@robota-sdk/dag-node-tool` at `packages/dag-nodes/tool`, `private: true` (DAG subsystem
+  stays private). Scaffold by mirroring `packages/dag-nodes/mcp-tool` (package.json, tsconfig,
+  tsdown.config, vitest.config, src/index.ts, docs/SPEC.md, README).
+- **Boundary**: distinct from the existing `mcp-tool` node (external MCP-over-HTTP/stdio). This node
+  wraps the agent's **in-process** `@robota-sdk/agent-tools` builtins as a DAG step.
+- **Pattern**: `class ToolNodeDefinition extends AbstractNodeDefinition<typeof ConfigSchema>` (from
+  `@robota-sdk/dag-node`), **no-arg constructor** (same as the LLM nodes — runtime params come from the
+  node `config`, not injection). Import `@robota-sdk/agent-tools` directly (dag-nodes may depend on
+  agent packages — instant-node already depends on agent-core).
+- **config (zod)**: `toolName: z.string().min(1)` selecting a builtin (`read`/`write`/`edit`/`glob`/
+  `grep`/`shell`/`bash`/`web-fetch`/`web-search`/…), optional `params` (static tool args merged under
+  the input), `baseCredits`. Map `toolName` → the agent-tools factory (e.g. `createReadTool`,
+  `createShellTool`, …) — a static switch, mirroring how the LLM node constructs its provider.
+- **ports**: input `params` (JSON string, optional) → merged with config params → tool parameters;
+  outputs `output` (string, from `IToolResult.output`) + `isError` (boolean). defaultInput=`params`,
+  defaultOutput=`output`.
+- **execute**: `NodeIoAccessor` to read input; construct the selected builtin tool; call
+  `tool.execute(mergedParams)`; on `result.success` emit `{ output, isError:false }`, else
+  `buildTaskExecutionError(...)` (or emit `{ output: error, isError:true }` per validate/output policy).
+  Unknown `toolName` → `buildValidationError` with the allowed list as `options`.
+- **registry**: add to the SYNC list in `packages/dag-framework/src/default-node-registry.ts`
+  (`createDefaultNodeRegistrySync`) — agent-tools loads without an optional provider SDK.
+- **New-package harness gotchas** (learned from agent-process/CORE-023): register in
+  `.agents/project-structure.md` package listing; add to `check-capability-placement.mjs` family rule;
+  create `docs/README.md` pointing to SPEC.md; mark any illustrative README code blocks
+  `<!-- doc-example-skip -->`; the package is `private:true` so the dist-freshness scan skips it
+  (fixed in the beta.77 release).
+- **Tests (TDD)**: node lifecycle unit test (config parse, port defs, unknown-tool validation) + a
+  functional run through `LocalDagRuntimeProvider.execute` on a 1-node workflow that invokes a safe
+  builtin (e.g. `grep`/`read` in a temp dir) and asserts the output port.
+- **Live UE**: dev `/workflows` — build/run a `.dag.json` with a `tool` node (e.g. read a temp file)
+  and confirm the output; boundary `rg` for forbidden imports stays 0.
+
+Then repeat the pattern for the remaining P1 nodes: **skill node** (wrap a Robota skill), **text-to-image**
+(extend the gemini-image pattern with a from-scratch generate), **video** (new generative node;
+`binaryKind: 'video'` payload already supported).
+
+## P1 progress log
+
+- **node #1 — in-process tool node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-tool`
+  (`packages/dag-nodes/tool`, `private: true`). `ToolNodeDefinition` (nodeType `tool`) wraps the
+  `@robota-sdk/agent-tools` builtins (`read`/`write`/`edit`/`shell`/`bash`/`glob`/`grep`/`web-fetch`/
+  `web-search`) as a DAG step via a static allowlist (`TOOL_NODE_ALLOWED_TOOLS`). Config `toolName` +
+  `params` (input port merged over config) + `cwd` + `baseCredits`; ports `output`/`isError`.
+  Registered in `createDefaultNodeRegistrySync` (sync tier — no optional provider SDK). SPEC at
+  `packages/dag-nodes/tool/docs/SPEC.md`.
+  - Tests: 12 unit tests (lifecycle/config/unknown-tool/invalid-params/read/merge/soft-error) +
+    1 functional integration test in dag-framework running a 1-node `tool` workflow through
+    `LocalDagRuntimeProvider.execute` (`tool-node-run.test.ts`) + registry test asserts `tool` present.
+    Full suites green: dag-node-tool 12, dag-framework 111.
+  - Live UE evidence: `read` builtin via the provider path returned
+    `{ ok: true, "node-1.output": "[File: …/note.txt (2 lines)]\n1\thello from the tool node\n2\tsecond line", "node-1.isError": false }`.
+  - Boundary: CLI-077 holds — `agent-cli` published closure still has 0 dag/workflow deps
+    (`dag-node-tool` and `dag-framework` are private and not in agent-cli's graph); capability-placement
+    and agent-server-boundary scans pass. `dag-nodes/*` family rule auto-covers the new package.
+  - Branch: `feat/workflow-005-p1-tool-node`.

--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -203,5 +203,32 @@ aspectRatio?, pollIntervalMs(=5000), maxWaitMs(=300000) }`. Backend: `@robota-sd
   - Boundary: CLI-077 holds; capability-placement + agent-server-boundary + test-module-mocks scans pass.
   - Branch: `feat/workflow-005-p1-video`.
 
-**P1 status: node-kind completion — tool ✅, text-to-image ✅, seedance-video ✅; skill node remaining
-(deferred as an LLM-backed agent node — see the skill-node research entry above).**
+- **node #4 — skill node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-skill`
+  (`packages/dag-nodes/skill`, `private: true`). Owner decision (2026-07-05): build it as a **prompt
+  resolver**, not an LLM executor — the resolver approach chosen over the self-contained fork-executor
+  (which would embed a whole subagent LLM loop). `SkillNodeDefinition` (nodeType `skill`, category
+  `Integration`): optional `args` input, `prompt` + `mode` outputs; config `{ skillName, args, cwd,
+sessionId, baseCredits(=0) }`. `SkillResolverRuntime` loads skills via `@robota-sdk/agent-framework`
+  `SkillCommandSource` and resolves the inject prompt via `executeSkill` (no `shellExec` → shell
+  interpolations are stripped, never executed; no LLM, no provider). Fork-context skills are rejected
+  (`DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`) — a pure resolver has no subagent runtime. Deps
+  (`loadCommands`/`executeSkillFn`) are **injected** so tests use fakes + the real `executeSkill` — no
+  module mocking. Emits the `<skill>` prompt for a downstream LLM node to execute (`skill → llm-text → …`).
+  Registered in the async/optional loader (lazy import of the agent-framework-backed node). SPEC at
+  `packages/dag-nodes/skill/docs/SPEC.md`.
+  - Tests: 7 runtime tests (inject fixtures + real `executeSkill`: resolve, not-found, fork-reject,
+    discovery-failure, executeSkill-failure, non-inject result, 0-based positional `$N`/`$ARGUMENTS`) +
+    7 node tests (metadata/ports, config, args-input-over-config precedence, not-found/fork propagation).
+    Full suites green: skill 14, dag-framework 114. typecheck + lint + mock scan clean.
+  - Live UE (**fully real — no credentials needed**): created a temp `.agents/skills/greet/SKILL.md` and
+    ran `input('World') → skill('greet')` through `LocalDagRuntimeProvider.execute`. Evidence: `run ok: true`;
+    `node-2.prompt = "<skill name=\"greet\">…Say hello to World in a friendly, upbeat tone.…</skill>\n\nExecute the \"greet\" skill: World"`, `node-2.mode = "inject"`.
+  - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement (incl. the new
+    dag-nodes → agent-framework edge) + agent-server-boundary + test-module-mocks scans pass.
+  - Branch: `feat/workflow-005-p1-skill`.
+
+**P1 status: node-kind completion COMPLETE — tool ✅, text-to-image ✅, seedance-video ✅, skill ✅
+(skill built as an inject-prompt resolver; a self-contained fork/LLM skill-executor node remains a
+possible future addition).** Next phases per the phasing plan: P2 (dynamic authoring — instant-node
+Phase C + unified persistence + composite reload fix), P3 (surface unification — expose create/save/build
+through `/workflows` + WORKFLOW-004 build).

--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -143,4 +143,37 @@ Then repeat the pattern for the remaining P1 nodes: **skill node** (wrap a Robot
   - Boundary: CLI-077 holds — `agent-cli` published closure still has 0 dag/workflow deps
     (`dag-node-tool` and `dag-framework` are private and not in agent-cli's graph); capability-placement
     and agent-server-boundary scans pass. `dag-nodes/*` family rule auto-covers the new package.
-  - Branch: `feat/workflow-005-p1-tool-node`.
+  - Branch: `feat/workflow-005-p1-tool-node`. Merged via PR #965 → develop.
+
+- **skill node — research done, DEFERRED (2026-07-05).** Investigation found a "Robota skill" is NOT a
+  pure in-process function like a tool: a skill is a `SKILL.md` parsed into an `ICommand`; there is no
+  `Skill` executor class. `executeSkill()` (in `@robota-sdk/agent-framework`) returns a **prompt string**
+  in `inject` mode (default) — only an agent LLM turn produces a result — and only `fork`-context skills
+  yield a standalone `result`, via `runSkillInFork` → `createSubagentSession` → `Session.run()` (a full
+  LLM loop needing a provider + agent runtime deps). So a skill node is an **LLM-backed agent node**, not
+  a tool-node clone. Owner (2026-07-05) chose to do text-to-image/video first and design the skill node
+  as an explicit LLM-backed node later. Do NOT model it as a cheap deterministic step.
+
+- **node #2 — text-to-image node — DONE (2026-07-05).** Package `@robota-sdk/dag-node-text-to-image`
+  (`packages/dag-nodes/text-to-image`, `private: true`), mirroring the `gemini-image-edit` skeleton but
+  pure generation (no input image). `TextToImageNodeDefinition` (nodeType `text-to-image`, category `AI`):
+  single `text` input port, single binary `image` output port (`IMAGE_COMMON`); config `{ model,
+baseCredits(=0.02) }`. `TextToImageRuntime.generateImage({prompt,model})` → `@robota-sdk/agent-provider/google`
+  `GoogleProvider.generateImage` (already a required provider method); creds `GEMINI_API_KEY`, default model
+  `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL`, allowlist `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS`; output normalized to an
+  `IPortBinaryValue`. Registered in the **async/optional** loader list in `default-node-registry.ts` (Gemini
+  SDK optional). SPEC at `packages/dag-nodes/text-to-image/docs/SPEC.md`.
+  - Tests: 12 node-definition tests (mock runtime) + 7 runtime tests (mock `GoogleProvider`, incl. success
+    normalization / missing-model / missing-key / model-not-allowed / provider-failure / empty-outputs /
+    config-model-override) + registry test asserts `text-to-image` in the async registry. Full suites green:
+    text-to-image 19, dag-framework 112. typecheck + lint clean (0 problems).
+  - Live UE (no `GEMINI_API_KEY` available; real generation needs credentials + network — same constraint as
+    gemini-image-edit, whose tests also mock the provider): built an `input → text-to-image` workflow and ran
+    it through `LocalDagRuntimeProvider.execute` with the async registry. Evidence: `text-to-image in runtime
+catalog: true`; the node is reached, resolves config, and returns the graceful validation error
+    `GEMINI_API_KEY must be configured for text-to-image node runtime` (deepest reachable point without creds).
+    Note: like `gemini-image-edit`, the runtime requires `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL` even when
+    `config.model` is set (mirrored behavior).
+  - Boundary: CLI-077 holds (agent-cli still 0 dag/workflow deps); capability-placement + agent-server-boundary
+    scans pass.
+  - Branch: `feat/workflow-005-p1-text-to-image`.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, skill, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -42,7 +42,7 @@ packages/
 ├── dag-scheduler/               # DAG scheduled-run triggering
 ├── dag-adapters-local/          # DAG in-memory persistence/queue/clock adapters
 ├── dag-adapters-sqlite/         # DAG SQLite persistence adapter
-└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, http, file r/w, mcp-tool, in-process tool, router, instant-node
+└── dag-nodes/*/                 # DAG node-family packages (`@robota-sdk/dag-node-*`): llm-text providers, image edit, text-to-image, seedance-video, http, file r/w, mcp-tool, in-process tool, router, instant-node
 apps/
 ├── action/                 # Official GitHub Action wrapper for the CLI (robota-sdk/action)
 ├── agent-web/              # Web application (Agent Playground)

--- a/.agents/spec-docs/done/BEHAVIOR-005-streaming-token-usage-exposure.md
+++ b/.agents/spec-docs/done/BEHAVIOR-005-streaming-token-usage-exposure.md
@@ -1,5 +1,5 @@
 ---
-status: verifying
+status: done
 type: BEHAVIOR
 tags: [streaming, async, typescript]
 ---
@@ -226,3 +226,9 @@ and request builder.
 123, outputTokens: 45 }`; `runStream()` committed metadata `{ inputTokens:123, outputTokens:45,
 usage:{ totalTokens:168, inputTokens:123, outputTokens:45 } }` and `readTokenUsageFromMessage =
 { inputTokens:123, outputTokens:45 }`.
+- **GATE-COMPLETE — PASS (2026-07-05).** Merged to `develop` via **PR #969** (squash `6f308d10`);
+  SPEC (`packages/agent-provider/docs/SPEC.md` Streaming Token Usage) + changeset
+  (`.changeset/fix-streaming-token-usage.md`, agent-core/agent-provider patch) landed. CI green
+  (the single `tui-e2e` failure was an unrelated pre-existing teardown flake — `rmSync` `ENOTEMPTY`
+  race; passed on a zero-change re-run; tracked separately as **INFRA-026**). Spec-doc promoted
+  `draft/ → done/`; task archived to `.agents/tasks/completed/`.

--- a/.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md
+++ b/.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md
@@ -1,0 +1,228 @@
+---
+status: verifying
+type: BEHAVIOR
+tags: [streaming, async, typescript]
+---
+
+# BEHAVIOR-005: expose token usage on the streaming execution path
+
+## Problem
+
+Token usage is silently lost on the streaming execution path, so after any
+`Robota.run()` / `Robota.runStream()` a consumer cannot read the turn's token usage —
+`readTokenUsageFromMessage(lastHistoryMessage)` returns `undefined`, and robota's own
+usage analytics (`collectAssistantUsageMetadata` → `execution-round.ts` →
+`assistant_message_committed` event → `sumHistoryUsage`, ANALYTICS-001) sum to 0 for
+streaming turns.
+
+Reproduction (local OpenAI-compatible HTTP stub, no key needed — full script in
+`.design/bug-report-streaming-usage-2026-07-05.md`): a stub that returns a final SSE
+chunk carrying `usage: { prompt_tokens, completion_tokens, total_tokens }` still yields
+`readTokenUsageFromMessage(last) === undefined`, and the assembled assistant message
+metadata contains only `executionId` — no usage.
+
+Root causes (source-confirmed):
+
+1. **`stream_options: { include_usage: true }` is never sent.**
+   `buildChatRequestParams` (`packages/agent-provider/src/openai/chat-completions-chat.ts:121`)
+   emits no `stream_options`; `grep -rn 'include_usage|stream_options' packages/*/src` = 0.
+   OpenAI-compatible endpoints do not emit a usage chunk on streams without it.
+2. **The stream assembler drops final-chunk usage.**
+   `assembleOpenAICompatibleStream` / `applyChunk` / `buildMessage`
+   (`packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts:27,48,158`)
+   never read `chunk.usage`. `applyChunk` also early-returns on the empty-`choices` final
+   chunk (L57–60) that actually carries usage. So even when the endpoint sends usage, it is
+   discarded during assembly.
+3. **Premise correction to the bug report — there is no `IRunOptions.stream` flag.**
+   The report's proposal #3 ("`stream: false` is ignored") targets a field that does not
+   exist: `IRunOptions` (`packages/agent-core/src/interfaces/agent.ts:190`) has no `stream`
+   boolean (the cited L114 is JSDoc prose). `run()` uses the round path
+   (`execution-round-provider.ts:callProviderWithCache` → `provider.chat` with a wrapped
+   `onTextDelta` → the streaming-assembly branch), so it always streams; there is nothing to
+   "respect". No new dispatch option is added.
+4. **`runStream()` uses a SEPARATE path that reconstructs the message and never collected usage.**
+   (Discovered during implementation — corrects the initial "agent-core needs no change" reading.)
+   `run()` (round path) collects usage at `execution-round.ts:193`
+   (`collectAssistantUsageMetadata(assistantResponse)`) → commits it into the assistant
+   message metadata, so once (1)+(2) make the assembled message carry `usage`, `run()` works.
+   But `runStream()` goes through `execution-stream.ts`, which iterates `provider.chatStream`
+   and commits the assistant message from the accumulated `fullResponse` **string** +
+   `toolCalls` (`execution-stream.ts:248` `addAssistantMessage(fullResponse, toolCalls,
+{ executionId })`) — the provider message object and its `usage` are discarded, and
+   `collectAssistantUsageMetadata` is never called. So `runStream()` needs a third change:
+   capture the usage-bearing final chunk in that loop and attach the usage metadata at commit,
+   mirroring the round path.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-provider` — the only package with behavior changes:
+  - `src/openai/chat-completions-chat.ts` — add `stream_options: { include_usage: true }` to
+    the two streaming request literals (L38–40, L79–82), gated by the opt-out option.
+  - `src/openai/types.ts` — add opt-out `IOpenAIProviderOptions.includeStreamUsage?: boolean`
+    (default `true`), read via `input.providerOptions` at the request-build site.
+  - `src/shared/openai-compatible/stream-assembler.ts` — capture `chunk.usage` (incl. the
+    empty-`choices` final chunk) into `IAssemblyState`; attach top-level
+    `usage: { promptTokens, completionTokens, totalTokens }` in `buildMessage`.
+  - `src/shared/openai-compatible/response-parser.ts` — `parseStreamingChunk` (L102) attaches
+    the same `usage` shape for the `chatStream` generator path (parity).
+  - `docs/SPEC.md` — SPEC update (behavior + new provider option).
+- `packages/agent-core` — the `runStream` path needs the usage collected into the committed
+  message (the round path already does this; readers are unchanged):
+  - `src/services/execution-stream.ts` — in the `chatStream` consumption loop, capture the
+    usage-bearing chunk via `collectAssistantUsageMetadata(chunk)` and spread it into the
+    `addAssistantMessage(fullResponse, toolCalls, { executionId, ...usageMetadata })` commit —
+    mirroring `execution-round.ts:193`/`209`.
+  - `src/core/robota.test.ts` — regression test: a `chatStream` ending in a usage chunk →
+    committed assistant message metadata carries `inputTokens`/`outputTokens`/`usage`.
+  - Readers `readTokenUsageFromMessage` / `collectAssistantUsageMetadata` are **unchanged** —
+    they already accept the top-level `usage: { promptTokens, completionTokens, totalTokens }`
+    shape the non-streaming `parseUsage` produces; the fix makes streaming emit that shape and
+    routes it into the committed metadata on both execution paths.
+
+### Alternatives Considered
+
+1. **Send `include_usage` + assemble the usage chunk (chosen).** Mirror the non-streaming
+   `parseUsage` shape as a top-level `usage` on the assembled message. Pro: zero changes to
+   agent-core readers/analytics; one coherent shape across streaming + non-streaming; fixes
+   `run()` and `runStream()` together. Con: `stream_options` is unsupported by a few
+   OpenAI-compatible servers → mitigated by the `includeStreamUsage` opt-out (default on).
+2. **Add a real `IRunOptions.stream: false` and route it to a non-streaming `provider.chat`.**
+   Pro: matches the bug report's literal proposal #3. Con: the option does not exist today
+   (scope creep — a new public API + a second dispatch path in the round service), and is
+   **unnecessary**: (1)+(2) already fix usage for the always-streaming `run()`. Rejected as
+   out-of-scope feature work; may be a separate future item.
+3. **Expose usage via a side channel (return metadata / callback) instead of on the message.**
+   Pro: avoids touching the assembler shape. Con: duplicates the usage contract, diverges from
+   the non-streaming path, and strands the existing `readTokenUsageFromMessage` /
+   `metadata.usage` readers. Rejected.
+
+### Decision
+
+Alternative 1. Send `stream_options: { include_usage: true }` on OpenAI-compatible streaming
+requests (opt-out via `includeStreamUsage`, default `true`), and make the shared stream
+assembler capture the final-chunk `usage` and attach top-level
+`usage: { promptTokens, completionTokens, totalTokens }` — byte-for-byte the shape
+`response-parser.ts:parseUsage` already emits on the non-streaming path.
+
+**Validation (wide blast radius — streaming is the default execution path):**
+
+- **Reachability** — every usage consumer reads the message/metadata, not a provider-specific
+  field: `readTokenUsageFromMessage` (top-level `usage` or `metadata.usage`),
+  `collectAssistantUsageMetadata` (execution-round.ts:193), `sumHistoryUsage`. Producing the
+  existing top-level `usage` shape reaches all of them with no reader edits (confirmed by
+  reading `context/token-usage.ts` + `services/execution-usage.ts`).
+- **Capability preservation** — the non-streaming path's usage capability (`parseChoice` +
+  `parseUsage`) is preserved and mirrored, not replaced; both paths converge on one shape.
+- **Adversarial pass** — (a) servers rejecting `stream_options` → opt-out flag, default on;
+  (b) final usage chunk has `choices: []` and would hit the assembler's early return → the fix
+  reads `chunk.usage` before that return; (c) providers that never send usage → `usage` stays
+  absent (readers already treat absence as "no usage", unchanged from today); (d) tool-call
+  streams → usage chunk is independent of choices, captured the same way.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — non-streaming path (`response-parser.ts` `parseChoice`/`parseUsage`) is the sibling; the fix mirrors its exact usage shape
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Solution
+
+1. `chat-completions-chat.ts`: when building a streaming request (both the `onTextDelta`
+   assembly branch and the `chatStream` generator branch), include
+   `stream_options: { include_usage: true }` unless `input.providerOptions.includeStreamUsage`
+   is `false`. Never send it on the non-streaming `create`.
+2. `types.ts`: add `includeStreamUsage?: boolean` to `IOpenAIProviderOptions` (documented
+   default `true`).
+3. `stream-assembler.ts`: add `usage?: { promptTokens; completionTokens; totalTokens }` to
+   `IAssemblyState`; in `applyChunk`, map `chunk.usage` (`prompt_tokens`/`completion_tokens`/
+   `total_tokens`) before the empty-choices early return; in `buildMessage`, attach it as a
+   top-level `usage` on the returned `TUniversalMessage`.
+4. `response-parser.ts`: `parseStreamingChunk` attaches the same `usage` shape when a chunk
+   carries `usage` — for the `chatStream` generator, the final usage chunk (empty `choices`)
+   becomes a usage-only assistant message instead of being dropped (chatStream parity, and the
+   channel `runStream` consumes).
+5. `execution-stream.ts` (agent-core): in the `chatStream` loop, capture the usage-bearing chunk
+   via `collectAssistantUsageMetadata(chunk)` and spread it into the `addAssistantMessage(...)`
+   commit metadata — so the `runStream` committed message exposes usage like the round path.
+
+## Affected Files
+
+- `packages/agent-provider/src/openai/chat-completions-chat.ts`
+- `packages/agent-provider/src/openai/types.ts`
+- `packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts`
+- `packages/agent-provider/src/shared/openai-compatible/response-parser.ts`
+- `packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts` (tests)
+- `packages/agent-provider/src/openai/provider.test.ts` (tests)
+- `packages/agent-provider/docs/SPEC.md` (SPEC update)
+- `packages/agent-core/src/services/execution-stream.ts` (runStream usage collection)
+- `packages/agent-core/src/core/robota.test.ts` (runStream usage regression test)
+
+## Completion Criteria
+
+- [x] TC-01: A streaming `provider.chat(messages, { onTextDelta })` call invokes the OpenAI
+      client `create` with `stream: true` AND `stream_options: { include_usage: true }`
+      (provider test `toHaveBeenCalledWith(expect.objectContaining({ stream_options: { include_usage: true } }))`).
+- [x] TC-02: With `new OpenAIProvider({ …, includeStreamUsage: false })`, the streaming
+      `create` call omits `stream_options` (provider test asserts absence).
+- [x] TC-03: `assembleOpenAICompatibleStream` over a stream ending in a `choices: []` chunk
+      with `usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }` returns
+      `result.usage` deep-equal to `{ promptTokens: 123, completionTokens: 45, totalTokens: 168 }`
+      (assembler unit test).
+- [x] TC-04: End-to-end reproduction (local OpenAI-compatible stub, no key): after
+      `for await (…) of agent.runStream('hi')`, `readTokenUsageFromMessage(getHistory().at(-1))`
+      returns `{ inputTokens: 123, outputTokens: 45, totalTokens: 168 }` (integration test /
+      scratch script exits 0 with usage populated).
+- [x] TC-05: The non-streaming `create` (no `onTextDelta`) is NOT called with `stream_options`
+      (regression: option only on streaming requests).
+- [x] TC-06: `runStream()` over a `provider.chatStream` ending in a usage chunk commits an
+      assistant message whose metadata carries `inputTokens: 123`, `outputTokens: 45`, and
+      `usage: { totalTokens: 168, inputTokens: 123, outputTokens: 45 }` (agent-core
+      `robota.test.ts` integration test).
+
+## Test Plan
+
+BEHAVIOR + streaming → stream output integration test; supporting unit tests for the assembler
+and request builder.
+
+| TC-ID | Test Type            | Tool / Approach                                                                                                                             | Notes |
+| ----- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| TC-01 | Unit (request build) | vitest — `provider.test.ts`, mock `client.chat.completions.create`, assert args                                                             |       |
+| TC-02 | Unit (request build) | vitest — provider constructed with `includeStreamUsage:false`, assert no `stream_options`                                                   |       |
+| TC-03 | Unit (assembler)     | vitest — `stream-assembler.test.ts`, feed empty-choices usage chunk, assert `result.usage`                                                  |       |
+| TC-04 | Integration (stream) | vitest — in-memory async-generator stream through `provider.chat`, assert assembled `usage`; the doc's HTTP-stub repro re-run as scratch UE |       |
+| TC-05 | Unit (request build) | vitest — non-streaming `create` args exclude `stream_options`                                                                               |       |
+| TC-06 | Integration (stream) | vitest — `robota.test.ts`, `runStream` over a fake `chatStream` with a usage chunk, assert committed metadata usage                         |       |
+
+## Tasks
+
+- [x] `.agents/tasks/BEHAVIOR-005.md` — created at GATE-APPROVAL.
+
+## Evidence Log
+
+- **GATE-WRITE — PASS (2026-07-05).** All required sections present; TC-01…TC-05 carry TC-N
+  prefixes with command/observable forms; Architecture Review checklist all `[x]`; Test Plan has
+  a row per TC; no `manual` rows. Premise correction (no `IRunOptions.stream`) documented in
+  Problem/Decision.
+- **GATE-APPROVAL — PASS (2026-07-05).** Design + scope presented (Paths 1+2; corrected report
+  Path 3; `include_usage` default-on with `includeStreamUsage` opt-out; assembler attaches the
+  non-streaming `parseUsage` shape). User sign-off, verbatim: **"좋아"**. Implementation authorized.
+- **SPEC CORRECTION during implement (2026-07-05).** The approved scope claimed "agent-core needs
+  no change". While verifying the live UE, the `runStream` E2E returned `undefined` — the `runStream`
+  path (`execution-stream.ts`, via `provider.chatStream`) commits from the accumulated string and
+  never called `collectAssistantUsageMetadata`. Corrected the spec (Problem cause #4, Affected Scope,
+  Solution #5, Affected Files, TC-06) and added the `execution-stream.ts` collection + parseStreaming
+  chunk usage-only-message handling. `run()` (round path) already worked with the provider-only fix.
+- **GATE-VERIFY — PASS (2026-07-05).**
+  - TC-01…TC-05 (agent-provider): full suite green — `stream-assembler.test.ts` (usage captured /
+    absent / null-ignored), `provider.test.ts` (stream_options sent / opt-out omits / non-streaming
+    omits / assembled usage). agent-provider **580 tests pass**, typecheck + lint (0 errors) clean.
+  - TC-06 (agent-core): `robota.test.ts` runStream usage regression green; agent-core **839 tests
+    pass** (840 with the new test), typecheck clean, 0 lint errors.
+  - TC-04 live UE (local OpenAI-compatible HTTP stub, no key, source build): endpoint received
+    `stream_options: { include_usage: true }`; `run()` → `readTokenUsageFromMessage = { inputTokens:
+123, outputTokens: 45 }`; `runStream()` committed metadata `{ inputTokens:123, outputTokens:45,
+usage:{ totalTokens:168, inputTokens:123, outputTokens:45 } }` and `readTokenUsageFromMessage =
+{ inputTokens:123, outputTokens:45 }`.

--- a/.agents/spec-docs/draft/INFRA-026-tui-pty-teardown-flake.md
+++ b/.agents/spec-docs/draft/INFRA-026-tui-pty-teardown-flake.md
@@ -1,0 +1,107 @@
+---
+status: draft
+type: INFRA
+tags: [cli, async]
+---
+
+# INFRA-026: TUI PTY e2e teardown race (ENOTEMPTY on rmSync)
+
+## Problem
+
+The TUI PTY e2e suite (`packages/agent-transport-tui`, `test:pty`) flakes at test
+**teardown**, not on any behavior assertion. Observed on PR #969 CI (job 85193039688):
+
+```
+FAIL src/__tests__/pty/flag-tui.ptytest.ts > ... --permission-mode acceptEdits ...
+Error: ENOTEMPTY: directory not empty, rmdir '/tmp/robota-flagtui-XUHcOB/.robota'
+  ❯ src/__tests__/pty/flag-tui.ptytest.ts:32:5   rmSync(projectDir, { recursive: true, force: true })
+```
+
+Root cause: the `afterEach` kills the PTY session and immediately removes the temp project dir:
+
+```ts
+afterEach(() => {
+  session?.kill(); // pty-driver kill() → session.dispose() (sync; does NOT await child exit)
+  rmSync(projectDir, { recursive: true, force: true }); // races the dying child still writing <projectDir>/.robota
+});
+```
+
+`kill()` (in `pty-driver.ts`, `kill: () => session.dispose()`) signals the PTY child but does
+not await its exit. The booted `robota` binary persists settings/session into
+`<projectDir>/.robota`; if a write lands between `rmSync`'s internal `readdir` and `rmdir`, the
+`rmdir` sees a non-empty `.robota` and throws `ENOTEMPTY`. `force: true` suppresses `ENOENT`, not
+`ENOTEMPTY`. The failure is non-deterministic (a race), confirmed flaky: the same commit passed on
+a zero-change CI re-run, and the suite passed on PRs #965–#968 with the same TUI code.
+
+This is a shared-teardown pattern — other `*.ptytest.ts` files use the same `kill()` + `rmSync`
+sequence, so the flake can surface in any PTY test, not just `flag-tui`.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-transport-tui/src/__tests__/pty/pty-driver.ts` — the shared PTY session driver
+  (`IPtySession.kill()` → `dispose()`); candidate for an awaitable exit / async dispose.
+- `packages/agent-transport-tui/src/__tests__/pty/*.ptytest.ts` — the `afterEach` teardown pattern
+  (`flag-tui`, and any sibling using `kill()` + `rmSync`).
+
+### Alternatives Considered
+
+1. **Await child exit before `rmSync` (preferred).** Add an awaitable exit to the driver (resolve on
+   the pty `onExit`) and `await session.disposeAsync()` (or `waitForExit()`) in `afterEach` before
+   removing the dir. Pro: removes the race at its source; benefits every PTY test via the shared
+   driver. Con: teardown becomes async (trivial — vitest `afterEach` supports async).
+2. **Retry `rmSync` on `ENOTEMPTY`.** Wrap removal in a short bounded retry loop. Pro: minimal,
+   localized. Con: treats the symptom, not the race; masks a real "child still alive after kill".
+3. **Do both — await exit + a defensive bounded `ENOTEMPTY` retry.** Pro: robust; the retry covers
+   any residual OS-level lag after exit. Con: slightly more code. Likely the safest combination.
+
+### Decision
+
+_Deferred._ Recommendation on record: Alternative 1 (await child exit in the shared driver before
+`rmSync`), optionally combined with Alternative 3's defensive retry. To be finalized at GATE-APPROVAL
+when this item is picked up.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — all `packages/agent-transport-tui/src/__tests__/pty/*.ptytest.ts` share the `kill()` + `rmSync` teardown; fix belongs in the shared `pty-driver.ts`
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료 (recommendation recorded; final decision deferred to pickup)
+
+## Solution
+
+Make the shared PTY driver expose an awaitable exit, and have each `*.ptytest.ts` teardown await the
+session's exit before `rmSync(projectDir, ...)`; optionally add a bounded `ENOTEMPTY` retry around the
+removal as defense-in-depth. No production code changes — test infrastructure only.
+
+## Affected Files
+
+- `packages/agent-transport-tui/src/__tests__/pty/pty-driver.ts`
+- `packages/agent-transport-tui/src/__tests__/pty/flag-tui.ptytest.ts` (and sibling `*.ptytest.ts` teardowns)
+
+## Completion Criteria
+
+- [ ] TC-01: The shared PTY driver exposes an awaitable exit (e.g. `waitForExit()` / async
+      `dispose()`) that resolves after the child process has exited.
+- [ ] TC-02: `*.ptytest.ts` teardowns await the session exit before `rmSync`; a stress run of the PTY
+      suite (repeat the previously-flaky `flag-tui` case N≥20 times locally) shows 0 `ENOTEMPTY`
+      failures.
+- [ ] TC-03: `pnpm --filter @robota-sdk/agent-transport-tui test:pty` exits 0 (CI `tui-e2e` green).
+
+## Test Plan
+
+INFRA (test-infra reliability) — the deliverable is a reliably-green PTY e2e suite; verified by a
+local repeat-run stress check plus the CI `tui-e2e` job.
+
+| TC-ID | Test Type         | Tool / Approach                                                                                | Notes |
+| ----- | ----------------- | ---------------------------------------------------------------------------------------------- | ----- |
+| TC-01 | Unit (driver)     | vitest — assert the driver's awaitable exit resolves after child exit                          |       |
+| TC-02 | Integration (PTY) | vitest — loop the `flag-tui` PTY test ≥20× (or a seeded stress harness), assert no `ENOTEMPTY` |       |
+| TC-03 | CI smoke          | `pnpm --filter @robota-sdk/agent-transport-tui test:pty` exits 0 (CI `tui-e2e`)                |       |
+
+## Tasks
+
+- [ ] `.agents/tasks/INFRA-026.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log

--- a/.agents/tasks/BEHAVIOR-005.md
+++ b/.agents/tasks/BEHAVIOR-005.md
@@ -1,0 +1,38 @@
+# BEHAVIOR-005: expose token usage on the streaming execution path
+
+- **Status:** in-progress
+- **Spec:** `.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md`
+- **Branch:** `fix/streaming-usage-exposure`
+- **Approved:** 2026-07-05 (user sign-off "좋아")
+
+## Goal
+
+Streaming requests send `stream_options: { include_usage: true }` (opt-out via
+`includeStreamUsage`, default true); the shared OpenAI-compatible stream assembler captures the
+final-chunk `usage` and attaches top-level `usage: { promptTokens, completionTokens, totalTokens }`
+— the same shape the non-streaming `parseUsage` path emits — so `readTokenUsageFromMessage` and
+the usage analytics work unchanged for `run()` and `runStream()`.
+
+## Progress
+
+- [x] Spec drafted + approved (GATE-WRITE, GATE-APPROVAL PASS).
+- [x] SPEC-first: updated `packages/agent-provider/docs/SPEC.md` (Streaming Token Usage).
+- [x] TDD: assembler + request-builder + runStream regression tests (red → green).
+- [x] Live UE: bug-report reproduction stub shows usage populated for run()/runStream().
+- [ ] PR → develop, CI green, merge.
+
+## Test Plan
+
+Full detail (TC-01…TC-06) lives in the spec-doc
+`.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md`. Summary:
+
+- **Unit (agent-provider):** `stream-assembler.test.ts` asserts the assembler captures the
+  final empty-choices `usage` chunk (and ignores `usage: null`); `provider.test.ts` asserts the
+  streaming request carries `stream_options: { include_usage: true }`, the `includeStreamUsage:
+false` opt-out omits it, the non-streaming request omits it, and the assembled message carries
+  `usage`.
+- **Integration (agent-core):** `robota.test.ts` drives `runStream` over a fake `chatStream`
+  ending in a usage chunk and asserts the committed assistant message metadata carries
+  `inputTokens`/`outputTokens`/`usage`.
+- **Live UE:** local OpenAI-compatible HTTP stub (no key) — `run()` and `runStream()` both yield
+  `readTokenUsageFromMessage = { inputTokens: 123, outputTokens: 45 }`.

--- a/.agents/tasks/completed/BEHAVIOR-005.md
+++ b/.agents/tasks/completed/BEHAVIOR-005.md
@@ -1,8 +1,8 @@
 # BEHAVIOR-005: expose token usage on the streaming execution path
 
-- **Status:** in-progress
-- **Spec:** `.agents/spec-docs/draft/BEHAVIOR-005-streaming-token-usage-exposure.md`
-- **Branch:** `fix/streaming-usage-exposure`
+- **Status:** done (merged via PR #969, `develop`)
+- **Spec:** `.agents/spec-docs/done/BEHAVIOR-005-streaming-token-usage-exposure.md`
+- **Branch:** `fix/streaming-usage-exposure` (merged, deleted)
 - **Approved:** 2026-07-05 (user sign-off "좋아")
 
 ## Goal
@@ -19,7 +19,7 @@ the usage analytics work unchanged for `run()` and `runStream()`.
 - [x] SPEC-first: updated `packages/agent-provider/docs/SPEC.md` (Streaming Token Usage).
 - [x] TDD: assembler + request-builder + runStream regression tests (red → green).
 - [x] Live UE: bug-report reproduction stub shows usage populated for run()/runStream().
-- [ ] PR → develop, CI green, merge.
+- [x] PR → develop, CI green, merge (PR #969, squash `6f308d10`).
 
 ## Test Plan
 

--- a/.changeset/fix-streaming-token-usage.md
+++ b/.changeset/fix-streaming-token-usage.md
@@ -1,0 +1,8 @@
+---
+'@robota-sdk/agent-core': patch
+'@robota-sdk/agent-provider': patch
+---
+
+fix(streaming): expose token usage on the streaming execution path (BEHAVIOR-005)
+
+Token usage was silently dropped on streaming turns, so `readTokenUsageFromMessage` and robota's usage analytics returned empty/0 for every `run()`/`runStream()` (which always stream). OpenAI-compatible streaming requests now send `stream_options: { include_usage: true }`, the stream assembler and the `runStream` commit path attach the same top-level `usage` shape the non-streaming path already emits, and both `run()` and `runStream()` now expose usage. New opt-out `IOpenAIProviderOptions.includeStreamUsage` (default `true`) for OpenAI-compatible servers that reject `stream_options`.

--- a/.design/bug-report-streaming-usage-2026-07-05.md
+++ b/.design/bug-report-streaming-usage-2026-07-05.md
@@ -1,0 +1,138 @@
+# [Bug/Feature] 스트리밍 실행 경로가 토큰 usage 를 노출하지 않음 (getHistory·message.usage 부재)
+
+- **보고일**: 2026-07-05
+- **버전**: `@robota-sdk/agent-core` / `agent-provider` **3.0.0-beta.76** (npm, 실측) — 소스 **beta.77** 에서도 동일 코드 경로 확인
+- **환경**: Node 24.15, Linux, `OpenAIProvider({ apiKey, baseURL })` — OpenAI-호환 엔드포인트(로컬 HTTP 스텁으로 재현, 키·게이트웨이 불필요)
+- **심각도 제안**: 높음 — 토큰 usage 는 비용 과금·컨텍스트 관리·관측의 기본 신호인데, **스트리밍 경로에서 조용히 사라진다**. 스트리밍이 대화형 UX 의 기본 실행 방식이라 영향 범위가 넓다.
+- **출처**: speech 프로젝트 정밀 과금 도입 중 실측(동반: `.design/bug-report-maxtokens-2026-07-03.md` 와 같은 "스트리밍 경로 2급 시민" 패턴)
+
+## 요약
+
+`Robota.run()` / `runStream()` 완료 후 소비자가 턴의 토큰 usage 를 얻을 공개 경로가 사실상 없다.
+usage 리더 3종(`readTokenUsageFromMessage`, `readTokenUsageFromMetadata`,
+`collectAssistantUsageMetadata`)은 모두 대화 히스토리 메시지의 `metadata.usage` / `message.usage`
+를 읽지만, **스트리밍 실행에서는 그 필드가 채워지지 않는다**. 그리고 `run()` 조차 내부적으로
+스트리밍을 쓰므로(아래 3번), 비스트리밍 파싱 경로(`parseChoice(choice, response.usage)`)에 도달하지
+못한다. 결과적으로 **모든 실행에서 usage 가 `undefined`** 다.
+
+> **이것은 "usage 미지원"이 아니라 robota 자신의 usage 서브시스템이 스트리밍에서 빈 데이터로
+> 먹여지는 자기모순적 결함이다.** `execution-round.ts` 는 매 라운드
+> `collectAssistantUsageMetadata(assistantResponse)` 로 usage 를 수집해 커밋 메시지 metadata 에
+> 부착하고(L193·L211), `assistant_message_committed` 실행 이벤트로 발행하며(L219),
+> `execution-usage.ts`(ANALYTICS-001)가 세션 총 usage 를 합산한다. 즉 usage 를 message·이벤트·
+> 분석까지 전파하도록 이미 배선돼 있는데, **스트리밍 `assistantResponse` 에 usage 가 실리지 않아
+> 이 파이프라인 전체가 0/undefined 로 귀결**된다. 소비자용 API 결함일 뿐 아니라 robota 내장
+> 분석 기능이 스트리밍 턴에서 조용히 틀린 값을 산출한다.
+
+## 사안 분류 (정확한 스코프)
+
+- **명백한 버그**: (3) `IRunOptions.stream: false` 가 조용히 무시됨 — 타입에 존재하고 문서화된
+  옵션이 no-op. (그리고 위 요약처럼 robota 내장 usage 분석이 스트리밍에서 0 을 산출.)
+- **호환성 판단이 걸린 개선**: (1) 스트리밍에 `include_usage` 를 기본 전송할지는 일부 OpenAI-호환
+  서버의 미지원 가능성 때문에 옵트인/폴백 설계가 필요 — 방향은 메인테이너 재량.
+
+## 근본 원인 (소스 확인)
+
+1. **`stream_options: { include_usage: true }` 미전송.** `chat-completions-chat.ts` 의 스트리밍
+   요청 파라미터(`stream: true`, L39/L81)에 `stream_options` 가 없다. OpenAI/OpenAI-호환 엔드포인트는
+   `include_usage` 없이는 스트리밍 응답에 usage 청크를 보내지 않는다. (`grep -rn 'include_usage\|stream_options' packages/*/src` → 0건.)
+2. **스트림 조립기가 final-청크 usage 를 부착하지 않음 (런타임 증명).** 본 보고의 스텁은 final SSE
+   청크에 usage 를 **실제로 실어 보냈는데도**, 조립된 assistant 메시지 `metadata` 에는 `executionId`
+   만 남았다(usage 없음) — 즉 `include_usage` 를 보내 엔드포인트가 usage 를 줘도 조립 단계에서
+   버려진다. (`openai/streaming/`·`chat-completions-chat.ts`·`adapter.ts` 소스 grep 도 usage 처리 0건.)
+3. **`IRunOptions.stream: false` 가 무시됨.** `run(input, { stream: false })` 도 엔드포인트에
+   `stream: true` 로 전송된다(실측 request body). 따라서 usage 를 붙이는 비스트리밍 경로
+   (`parseChoice(t, e.usage)`, `...usage && { usage: parseUsage(usage) }`)로 우회할 수도 없다.
+
+## 실측 (로컬 OpenAI-호환 스텁, 키 불필요)
+
+스텁이 `POST /v1/chat/completions` 에 대해 스트리밍 시 final SSE 청크에
+`usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }` 를 실어 응답:
+
+| 실행                            | 엔드포인트가 받은 요청            | `readTokenUsageFromMessage(last)` |
+| ------------------------------- | --------------------------------- | --------------------------------- |
+| `runStream(input)`              | `{ stream: true }` (no usage opt) | `undefined`                       |
+| `run(input)`                    | `{ stream: true }`                | `undefined`                       |
+| `run(input, { stream: false })` | `{ stream: true }` (무시됨)       | `undefined`                       |
+
+조립된 assistant 메시지: `{ role: 'assistant', content: '…', metadata: { executionId }, toolCalls: [] }`
+— usage 필드 없음.
+
+## 재현 스크립트
+
+```js
+// npm i @robota-sdk/agent-core@3.0.0-beta.76 @robota-sdk/agent-provider@3.0.0-beta.76
+import http from 'node:http';
+import { Robota, readTokenUsageFromMessage } from '@robota-sdk/agent-core';
+import { OpenAIProvider } from '@robota-sdk/agent-provider';
+
+const USAGE = { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 };
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    const p = JSON.parse(body || '{}');
+    console.log(
+      'endpoint received:',
+      JSON.stringify({ stream: p.stream, stream_options: p.stream_options }),
+    );
+    if (p.stream) {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      const base = { id: 'x', object: 'chat.completion.chunk', created: 0, model: 'm' };
+      res.write(
+        `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: { role: 'assistant', content: '안녕' }, finish_reason: null }] })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }], usage: USAGE })}\n\n`,
+      );
+      res.write('data: [DONE]\n\n');
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          id: 'x',
+          object: 'chat.completion',
+          created: 0,
+          model: 'm',
+          choices: [
+            { index: 0, message: { role: 'assistant', content: '안녕' }, finish_reason: 'stop' },
+          ],
+          usage: USAGE,
+        }),
+      );
+    }
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const baseURL = `http://127.0.0.1:${server.address().port}/v1`;
+const provider = new OpenAIProvider({ apiKey: 'k', baseURL });
+const agent = new Robota({
+  name: 't',
+  aiProviders: [provider],
+  defaultModel: { provider: 'openai', model: 'm' },
+  systemMessage: 's',
+});
+let out = '';
+for await (const d of agent.runStream('안녕')) out += d;
+const h = agent.getHistory();
+console.log('usage =>', readTokenUsageFromMessage(h[h.length - 1])); // undefined
+await agent.destroy().catch(() => {});
+server.close();
+```
+
+## 제안 (택1 또는 조합)
+
+1. **스트리밍 요청에 `stream_options: { include_usage: true }` 를 기본 포함**(OpenAI-호환 surface).
+   final 청크의 usage 를 `stream-assembler` 가 파싱해 조립된 assistant 메시지 `usage`/`metadata.usage`
+   에 채운다 → 기존 `readTokenUsageFromMessage` 가 그대로 동작.
+2. `IRunOptions.stream: false` 를 실제로 존중(무시하지 않기) — 비스트리밍 경로는 이미 usage 를
+   메시지에 붙이므로(`parseChoice(choice, response.usage)`) 이것만으로도 usage 획득 경로가 열린다.
+3. 또는 `run`/`runStream` 이 최종 usage 를 별도 채널(반환 메타/이벤트 콜백)로 노출.
+
+## 호환성 노트
+
+- OpenAI-호환 엔드포인트 중 `stream_options` 미지원 서버가 있을 수 있으니, (1)은 옵트아웃/그레이스풀
+  폴백을 두는 편이 안전하다.
+- 본 보고는 **중립적·보편적** 관점(임의의 OpenAI-호환 소비자)에서 작성됨. 특정 소비 앱에 종속된
+  요구가 아니다.

--- a/packages/agent-core/src/core/robota.test.ts
+++ b/packages/agent-core/src/core/robota.test.ts
@@ -79,6 +79,41 @@ class SecondProvider extends AbstractAIProvider {
   }
 }
 
+// A provider whose stream ends with a usage-bearing chunk (stream_options.include_usage parity)
+class UsageStreamProvider extends AbstractAIProvider {
+  readonly name = 'usage-stream-provider';
+  readonly version = '1.0.0';
+
+  async chat(messages: TUniversalMessage[]): Promise<TUniversalMessage> {
+    return {
+      id: 'x',
+      role: 'assistant',
+      content: `Response to: ${messages[messages.length - 1]?.content ?? ''}`,
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+  }
+
+  override async *chatStream(): AsyncIterable<TUniversalMessage> {
+    yield {
+      id: 'c1',
+      role: 'assistant',
+      content: 'Hi',
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+    // Final usage chunk: empty content, carries top-level provider usage.
+    yield {
+      id: 'c2',
+      role: 'assistant',
+      content: '',
+      state: 'complete' as const,
+      timestamp: new Date(),
+      usage: { promptTokens: 123, completionTokens: 45, totalTokens: 168 },
+    } as TUniversalMessage;
+  }
+}
+
 // Mock Tool with schema and execution tracking
 class TrackingTool extends AbstractTool {
   executionCount = 0;
@@ -1098,6 +1133,30 @@ describe('Robota Core', () => {
       }
 
       expect(chunks.length).toBeGreaterThan(0);
+    });
+
+    it('exposes token usage on the committed assistant message from the final usage chunk', async () => {
+      const robota = new Robota(
+        createConfig({
+          aiProviders: [new UsageStreamProvider()],
+          defaultModel: { provider: 'usage-stream-provider', model: 'm' },
+        }),
+      );
+
+      for await (const _chunk of robota.runStream('hi')) {
+        // drain the stream
+      }
+
+      const history = robota.getHistory();
+      const last = history[history.length - 1];
+      expect(last?.role).toBe('assistant');
+      expect(last?.metadata?.['inputTokens']).toBe(123);
+      expect(last?.metadata?.['outputTokens']).toBe(45);
+      expect(last?.metadata?.['usage']).toEqual({
+        totalTokens: 168,
+        inputTokens: 123,
+        outputTokens: 45,
+      });
     });
   });
 

--- a/packages/agent-core/src/services/execution-stream.ts
+++ b/packages/agent-core/src/services/execution-stream.ts
@@ -1,5 +1,6 @@
 import { assertToolChoiceValid, buildChatResponseFormat } from './execution-service-helpers';
 import { executeStreamToolCalls } from './execution-stream-tools';
+import { collectAssistantUsageMetadata } from './execution-usage';
 import { callPluginHook } from './plugin-hook-dispatcher';
 import { ConfigurationError } from '../utils/errors';
 
@@ -159,8 +160,15 @@ export async function* executeStream(
     let sawAssistantContent = false;
     const toolCalls: IToolCall[] = [];
     let currentToolCallIndex = -1;
+    let usageMetadata: ReturnType<typeof collectAssistantUsageMetadata>;
 
     for await (const chunk of stream) {
+      // The final usage chunk (stream_options.include_usage) carries token usage; collect it
+      // so the committed assistant message exposes usage like the non-streaming round path.
+      const chunkUsage = collectAssistantUsageMetadata(chunk);
+      if (chunkUsage) {
+        usageMetadata = chunkUsage;
+      }
       if (typeof chunk.content === 'string') {
         sawAssistantContent = true;
       }
@@ -247,6 +255,7 @@ export async function* executeStream(
     }
     conversationStore.addAssistantMessage(fullResponse, toolCalls, {
       executionId,
+      ...(usageMetadata ?? {}),
     });
 
     if (toolCalls.length > 0) {

--- a/packages/agent-provider/docs/SPEC.md
+++ b/packages/agent-provider/docs/SPEC.md
@@ -142,6 +142,28 @@ Responses):
 | Anthropic                                                    | `tool_choice`: `{ type: 'auto' }` / `{ type: 'none' }` / `{ type: 'any' }` (required) / `{ type: 'tool', name }`    |
 | Gemini (Google inherits)                                     | `toolConfig.functionCallingConfig`: mode `AUTO` / `NONE` / `ANY` (required); named = `ANY` + `allowedFunctionNames` |
 
+## Streaming Token Usage
+
+OpenAI-compatible surfaces (openai, openai-compatible, qwen, deepseek, gemma) request token
+usage on streaming turns and expose it on the assembled assistant message so that the
+streaming path carries the **same** usage contract as the non-streaming path.
+
+- **Request.** Streaming requests (both the `onTextDelta` assembly path and the `chatStream`
+  generator) include `stream_options: { include_usage: true }`. It is only sent on streaming
+  requests — never on the non-streaming `create`. Endpoints emit a final chunk (with
+  `choices: []`) carrying `usage` only when this is present.
+- **Assembly.** The shared stream assembler
+  (`shared/openai-compatible/stream-assembler.ts`) captures that final-chunk `usage` (including
+  the empty-`choices` chunk) and attaches a top-level
+  `usage: { promptTokens, completionTokens, totalTokens }` to the assembled `TUniversalMessage`
+  — byte-for-byte the shape the non-streaming `response-parser.ts` `parseUsage` produces. The
+  `chatStream` generator attaches the same shape via `parseStreamingChunk`. Consumers
+  (`readTokenUsageFromMessage`, `collectAssistantUsageMetadata` in agent-core) read it unchanged.
+  When a provider sends no usage, the field is simply absent (treated as "no usage", as before).
+- **Opt-out.** `IOpenAIProviderOptions.includeStreamUsage?: boolean` (default `true`) disables
+  sending `stream_options` for OpenAI-compatible endpoints that reject it; usage is then absent
+  on streaming turns for that provider.
+
 ## Dependencies
 
 | Package                  | Role                                                                  |

--- a/packages/agent-provider/src/openai/chat-completions-chat.ts
+++ b/packages/agent-provider/src/openai/chat-completions-chat.ts
@@ -37,6 +37,7 @@ export async function chatWithOpenAIChatCompletions(
       return await chatWithStreamingAssembly(client, input, {
         ...requestParams,
         stream: true,
+        ...buildStreamOptions(input),
       });
     }
 
@@ -79,6 +80,7 @@ export async function* chatStreamWithOpenAIChatCompletions(
     const requestParams: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
       ...buildChatRequestParams(input),
       stream: true,
+      ...buildStreamOptions(input),
     };
 
     await logPayload(input, requestParams, 'stream');
@@ -116,6 +118,19 @@ export async function* chatStreamWithOpenAIChatCompletions(
     const errorMessage = openaiError.message || 'OpenAI API request failed';
     throw new Error(`OpenAI stream failed: ${errorMessage}`);
   }
+}
+
+/**
+ * Streaming requests opt into token usage via `stream_options: { include_usage: true }`
+ * unless the provider sets `includeStreamUsage: false`. Only ever sent on streaming requests.
+ */
+function buildStreamOptions(
+  input: IOpenAIChatCompletionsOptions,
+): { stream_options: { include_usage: true } } | Record<string, never> {
+  if (input.providerOptions.includeStreamUsage === false) {
+    return {};
+  }
+  return { stream_options: { include_usage: true } };
 }
 
 function buildChatRequestParams(

--- a/packages/agent-provider/src/openai/provider.test.ts
+++ b/packages/agent-provider/src/openai/provider.test.ts
@@ -1112,6 +1112,103 @@ describe('OpenAIProvider', () => {
       );
     });
 
+    async function* createUsageStream() {
+      yield {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: { content: 'Hi' }, finish_reason: null, logprobs: null }],
+      };
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop', logprobs: null }],
+      };
+      yield {
+        id: 'chunk-usage',
+        object: 'chat.completion.chunk',
+        created: Date.now(),
+        model: 'gpt-4',
+        choices: [],
+        usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 },
+      };
+    }
+
+    function getCreateMock(provider: OpenAIProvider): ReturnType<typeof vi.fn> {
+      return (
+        provider as unknown as {
+          client: { chat: { completions: { create: ReturnType<typeof vi.fn> } } };
+        }
+      ).client.chat.completions.create;
+    }
+
+    it('sends stream_options include_usage on streaming requests', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue(createTextStream());
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4', onTextDelta: () => {} });
+
+      expect(getCreateMock(provider)).toHaveBeenCalledWith(
+        expect.objectContaining({ stream: true, stream_options: { include_usage: true } }),
+        undefined,
+      );
+    });
+
+    it('omits stream_options when includeStreamUsage is false', async () => {
+      const provider = new OpenAIProvider({
+        apiKey: 'sk-test',
+        apiSurface: 'chat-completions',
+        includeStreamUsage: false,
+      });
+      getCreateMock(provider).mockResolvedValue(createTextStream());
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4', onTextDelta: () => {} });
+
+      const params = getCreateMock(provider).mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(params['stream']).toBe(true);
+      expect(params['stream_options']).toBeUndefined();
+    });
+
+    it('does not send stream_options on non-streaming requests', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue({
+        id: 'r',
+        object: 'chat.completion',
+        created: 0,
+        model: 'gpt-4',
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      });
+
+      await provider.chat([createUserMessage('Hello')], { model: 'gpt-4' });
+
+      const params = getCreateMock(provider).mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(params['stream']).toBeUndefined();
+      expect(params['stream_options']).toBeUndefined();
+    });
+
+    it('attaches usage from the final usage chunk to the assembled message', async () => {
+      const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
+      getCreateMock(provider).mockResolvedValue(createUsageStream());
+
+      const result = await provider.chat([createUserMessage('Hello')], {
+        model: 'gpt-4',
+        onTextDelta: () => {},
+      });
+
+      const usage = (
+        result as {
+          usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+        }
+      ).usage;
+      expect(usage).toEqual({ promptTokens: 123, completionTokens: 45, totalTokens: 168 });
+    });
+
     it('emits ordered native Chat Completions stream chunks', async () => {
       const provider = new OpenAIProvider({ apiKey: 'sk-test', apiSurface: 'chat-completions' });
       const client = (

--- a/packages/agent-provider/src/openai/types.ts
+++ b/packages/agent-provider/src/openai/types.ts
@@ -66,6 +66,14 @@ export interface IOpenAIProviderOptions {
   timeout?: number;
 
   /**
+   * Whether to request token usage on streaming turns via
+   * `stream_options: { include_usage: true }` (default `true`). Set `false` for
+   * OpenAI-compatible endpoints that reject `stream_options`; usage is then absent
+   * on streaming turns for this provider.
+   */
+  includeStreamUsage?: boolean;
+
+  /**
    * API base URL (default: `'https://api.openai.com/v1'`).
    *
    * Point this at ANY OpenAI-compatible endpoint — this provider is a protocol

--- a/packages/agent-provider/src/shared/openai-compatible/response-parser.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/response-parser.ts
@@ -101,8 +101,21 @@ export class OpenAICompatibleResponseParser {
 
   parseStreamingChunk(chunk: OpenAI.Chat.ChatCompletionChunk): TUniversalMessage | null {
     try {
+      const usage = chunk.usage ? this.parseUsage(chunk.usage) : undefined;
       const choice = chunk.choices?.[0];
       if (!choice) {
+        // Final usage chunk (choices: []) when stream_options.include_usage is set.
+        if (usage) {
+          return {
+            id: randomUUID(),
+            state: 'complete',
+            role: 'assistant',
+            content: '',
+            timestamp: new Date(),
+            ...{ usage },
+            metadata: { isStreamChunk: true, isComplete: true },
+          };
+        }
         return null;
       }
 
@@ -124,6 +137,7 @@ export class OpenAICompatibleResponseParser {
           content: '',
           timestamp: new Date(),
           toolCalls,
+          ...(usage && { usage }),
           metadata: {
             isStreamChunk: true,
             isComplete: finishReason === 'stop' || finishReason === 'tool_calls',
@@ -137,6 +151,7 @@ export class OpenAICompatibleResponseParser {
         role: 'assistant',
         content: this.projectText(choice.delta.content || ''),
         timestamp: new Date(),
+        ...(usage && { usage }),
         metadata: {
           isStreamChunk: true,
           isComplete: finishReason === 'stop' || finishReason === 'tool_calls',

--- a/packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/stream-assembler.test.ts
@@ -71,6 +71,64 @@ describe('assembleOpenAICompatibleStream', () => {
     expect(onTextDelta).toHaveBeenNthCalledWith(2, 'world');
   });
 
+  function readUsage(
+    message: Awaited<ReturnType<typeof assembleOpenAICompatibleStream>>,
+  ): { promptTokens: number; completionTokens: number; totalTokens: number } | undefined {
+    return (
+      message as {
+        usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+      }
+    ).usage;
+  }
+
+  function createUsageChunk(usage: OpenAI.CompletionUsage): OpenAI.Chat.ChatCompletionChunk {
+    return {
+      id: 'chunk-usage',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'local-model',
+      choices: [],
+      usage,
+    };
+  }
+
+  it('captures usage from the final empty-choices usage chunk', async () => {
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([
+        createChunk('Hi'),
+        createChunk('', 'stop'),
+        createUsageChunk({ prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 }),
+      ]),
+    });
+
+    expect(result.content).toBe('Hi');
+    expect(readUsage(result)).toEqual({
+      promptTokens: 123,
+      completionTokens: 45,
+      totalTokens: 168,
+    });
+  });
+
+  it('leaves usage absent when no usage chunk arrives', async () => {
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([createChunk('Hi'), createChunk('', 'stop')]),
+    });
+
+    expect(readUsage(result)).toBeUndefined();
+  });
+
+  it('ignores null usage on non-final chunks', async () => {
+    const nullUsageChunk = {
+      ...createChunk('Hi'),
+      usage: null,
+    } as OpenAI.Chat.ChatCompletionChunk;
+    const result = await assembleOpenAICompatibleStream({
+      stream: asyncIterableFrom([nullUsageChunk, createChunk('', 'stop')]),
+    });
+
+    expect(readUsage(result)).toBeUndefined();
+  });
+
   it('assembles streamed tool call deltas by index', async () => {
     const stream = asyncIterableFrom<OpenAI.Chat.ChatCompletionChunk>([
       {

--- a/packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts
+++ b/packages/agent-provider/src/shared/openai-compatible/stream-assembler.ts
@@ -14,6 +14,12 @@ interface IToolCallPart {
   arguments: string;
 }
 
+interface IStreamUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
 interface IAssemblyState {
   textParts: string[];
   toolCallParts: Map<number, IToolCallPart>;
@@ -22,6 +28,7 @@ interface IAssemblyState {
   toolCallTextProjected: boolean;
   model: string;
   finishReason: string | null;
+  usage?: IStreamUsage;
 }
 
 export async function assembleOpenAICompatibleStream(
@@ -52,6 +59,16 @@ function applyChunk(
 ): void {
   if (chunk.model) {
     state.model = chunk.model;
+  }
+
+  // Usage arrives on the final chunk (choices: []) when stream_options.include_usage is set.
+  // Capture it before the empty-choices early return; non-final chunks carry usage: null.
+  if (chunk.usage) {
+    state.usage = {
+      promptTokens: chunk.usage.prompt_tokens,
+      completionTokens: chunk.usage.completion_tokens,
+      totalTokens: chunk.usage.total_tokens,
+    };
   }
 
   const choice = chunk.choices?.[0];
@@ -182,6 +199,7 @@ function buildMessage(
     state: 'complete',
     timestamp: new Date(),
     ...(toolCalls.length > 0 && { toolCalls }),
+    ...(state.usage && { usage: state.usage }),
     ...(Object.keys(resultMetadata).length > 0 && { metadata: resultMetadata }),
   };
 }

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -57,6 +57,7 @@
     "@robota-sdk/dag-node-input": "workspace:*",
     "@robota-sdk/dag-node-multi-input": "workspace:*",
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
+    "@robota-sdk/dag-node-seedance-video": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
     "@robota-sdk/dag-node-text-to-image": "workspace:*",

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -58,6 +58,7 @@
     "@robota-sdk/dag-node-multi-input": "workspace:*",
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-seedance-video": "workspace:*",
+    "@robota-sdk/dag-node-skill": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
     "@robota-sdk/dag-node-text-to-image": "workspace:*",

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -59,6 +59,7 @@
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
+    "@robota-sdk/dag-node-text-to-image": "workspace:*",
     "@robota-sdk/dag-node-tool": "workspace:*",
     "@robota-sdk/dag-node-transform": "workspace:*",
     "@robota-sdk/dag-node-utility-text": "workspace:3.0.0-beta.60",

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -59,6 +59,7 @@
     "@robota-sdk/dag-node-ok-emitter": "workspace:*",
     "@robota-sdk/dag-node-text-output": "workspace:*",
     "@robota-sdk/dag-node-text-template": "workspace:*",
+    "@robota-sdk/dag-node-tool": "workspace:*",
     "@robota-sdk/dag-node-transform": "workspace:*",
     "@robota-sdk/dag-node-utility-text": "workspace:3.0.0-beta.60",
     "@robota-sdk/dag-orchestration-client": "workspace:*",

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -35,6 +35,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.length).toBeGreaterThanOrEqual(syncNodes.length);
   });
 
+  it('loads the text-to-image node (optional, Gemini-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('text-to-image');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -40,6 +40,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.map((n) => n.nodeType)).toContain('text-to-image');
   });
 
+  it('loads the seedance-video node (optional, ByteDance-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('seedance-video');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -16,13 +16,15 @@ describe('createDefaultNodeRegistrySync', () => {
     expect(types).toContain('text-join');
     expect(types).toContain('json-extract');
     expect(types).toContain('conditional-text');
+    // in-process tool node (agent-tools builtins) is in the sync registry
+    expect(types).toContain('tool');
     // LLM nodes are NOT included in the sync registry
     expect(types).not.toContain('llm-text-anthropic');
   });
 
-  it('returns 22 or more nodes (base 8 + 14 utility-text)', () => {
+  it('returns 23 or more nodes (base 9 + 14 utility-text)', () => {
     const nodes = createDefaultNodeRegistrySync();
-    expect(nodes.length).toBeGreaterThanOrEqual(22);
+    expect(nodes.length).toBeGreaterThanOrEqual(23);
   });
 });
 

--- a/packages/dag-framework/src/__tests__/default-node-registry.test.ts
+++ b/packages/dag-framework/src/__tests__/default-node-registry.test.ts
@@ -45,6 +45,11 @@ describe('createDefaultNodeRegistry — optional loading', () => {
     expect(nodes.map((n) => n.nodeType)).toContain('seedance-video');
   });
 
+  it('loads the skill node (optional, agent-framework-backed)', async () => {
+    const nodes = await createDefaultNodeRegistry();
+    expect(nodes.map((n) => n.nodeType)).toContain('skill');
+  });
+
   it('handles import failure gracefully (tryImport catch)', async () => {
     // tryImport catches errors from import() — simulate a missing module scenario
     // by verifying that createDefaultNodeRegistry completes even when LLM modules

--- a/packages/dag-framework/src/__tests__/tool-node-run.test.ts
+++ b/packages/dag-framework/src/__tests__/tool-node-run.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildDagFromPipeline, toDagWorkflowFile } from '@robota-sdk/dag-builder';
+import type { INodeManifest } from '@robota-sdk/dag-core';
+import { LocalDagRuntimeProvider } from '../local-dag-runtime-provider.js';
+import { createDefaultNodeRegistrySync } from '../default-node-registry.js';
+
+function syncManifests(): INodeManifest[] {
+  return createDefaultNodeRegistrySync().map((d) => ({
+    nodeType: d.nodeType,
+    displayName: d.displayName,
+    category: d.category,
+    inputs: d.inputs,
+    outputs: d.outputs,
+    ...(d.defaultInputPort !== undefined ? { defaultInputPort: d.defaultInputPort } : {}),
+    ...(d.defaultOutputPort !== undefined ? { defaultOutputPort: d.defaultOutputPort } : {}),
+  }));
+}
+
+describe('tool node — functional run through LocalDagRuntimeProvider', () => {
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dag-tool-run-'));
+    file = join(dir, 'hello.txt');
+    writeFileSync(file, 'alpha\nbeta\ngamma\n', 'utf8');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('runs a 1-node `tool` workflow that reads a file end-to-end', async () => {
+    const provider = new LocalDagRuntimeProvider();
+
+    const build = buildDagFromPipeline(
+      {
+        dagId: 'tool-run',
+        pipeline: [
+          {
+            nodeType: 'tool',
+            id: 'read-1',
+            config: { toolName: 'read', params: { filePath: file } },
+          },
+        ],
+      },
+      syncManifests(),
+    );
+    expect(build.ok).toBe(true);
+    if (!build.ok) return;
+
+    const { workflowFile } = toDagWorkflowFile(build.definition);
+    const result = await provider.execute(workflowFile, {});
+
+    expect(result.ok).toBe(true);
+    const serialized = JSON.stringify(result.outputs);
+    expect(serialized).toContain('alpha');
+    expect(serialized).toContain('gamma');
+  });
+});

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -114,6 +114,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
       modulePath: '@robota-sdk/dag-node-seedance-video',
       factories: [(mod) => new (mod.SeedanceVideoNodeDefinition as new () => IDagNodeDefinition)()],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-skill',
+      factories: [(mod) => new (mod.SkillNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -7,6 +7,7 @@ import { TextOutputNodeDefinition } from '@robota-sdk/dag-node-text-output';
 import { ImageLoaderNodeDefinition } from '@robota-sdk/dag-node-image-loader';
 import { ImageSourceNodeDefinition } from '@robota-sdk/dag-node-image-source';
 import { OkEmitterNodeDefinition } from '@robota-sdk/dag-node-ok-emitter';
+import { ToolNodeDefinition } from '@robota-sdk/dag-node-tool';
 import {
   StringToNumberNodeDefinition,
   NumberToStringNodeDefinition,
@@ -39,6 +40,8 @@ export function createDefaultNodeRegistrySync(): IDagNodeDefinition[] {
     new ImageLoaderNodeDefinition(),
     new ImageSourceNodeDefinition(),
     new OkEmitterNodeDefinition(),
+    // in-process tool node (agent-tools builtins; no optional provider SDK)
+    new ToolNodeDefinition(),
     // utility text/data nodes (tier-1)
     new StringToNumberNodeDefinition(),
     new NumberToStringNodeDefinition(),

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -106,6 +106,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
         (mod) => new (mod.GeminiImageComposeNodeDefinition as new () => IDagNodeDefinition)(),
       ],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-text-to-image',
+      factories: [(mod) => new (mod.TextToImageNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-framework/src/default-node-registry.ts
+++ b/packages/dag-framework/src/default-node-registry.ts
@@ -110,6 +110,10 @@ export async function createDefaultNodeRegistry(): Promise<IDagNodeDefinition[]>
       modulePath: '@robota-sdk/dag-node-text-to-image',
       factories: [(mod) => new (mod.TextToImageNodeDefinition as new () => IDagNodeDefinition)()],
     },
+    {
+      modulePath: '@robota-sdk/dag-node-seedance-video',
+      factories: [(mod) => new (mod.SeedanceVideoNodeDefinition as new () => IDagNodeDefinition)()],
+    },
   ];
 
   const loadedGroups = await Promise.all(optionalLoaders.map(loadOptionalNodes));

--- a/packages/dag-nodes/seedance-video/.eslintrc.json
+++ b/packages/dag-nodes/seedance-video/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/seedance-video/docs/README.md
+++ b/packages/dag-nodes/seedance-video/docs/README.md
@@ -1,0 +1,3 @@
+# Seedance Video Node Docs Index
+
+- `SPEC.md`: Node scope, provider dependencies, async job model, and package boundaries.

--- a/packages/dag-nodes/seedance-video/docs/SPEC.md
+++ b/packages/dag-nodes/seedance-video/docs/SPEC.md
@@ -1,0 +1,52 @@
+# Seedance Video Node Specification
+
+## Scope
+
+- Owns the `seedance-video` DAG node definition.
+- Generates a video from a text prompt via the ByteDance/ModelArk (Seedance) video API, emitting a binary video output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Delegates to `@robota-sdk/agent-provider/bytedance` `BytedanceProvider`, which implements `IVideoGenerationProvider` (`createVideo` → `getVideoJob` → `cancelVideoJob`). Video generation is an **asynchronous job**: submit, then poll until a terminal status.
+- Distinct from the image nodes: image generation is a single synchronous provider call; this node runs a **poll loop** inside `executeWithConfig` until the job reaches `succeeded`/`failed`/`cancelled` or a max-wait timeout.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the **async/optional** node-registry list (the ByteDance provider is optional; the node self-skips if it cannot construct).
+- Matches the existing `nodeType: "seedance-video"` used by pre-authored `.dag-storage` fixtures and the planned node in `packages/dag-nodes/docs/SPEC.md`.
+
+## Architecture Overview
+
+- `SeedanceVideoNodeDefinition` — node with a single `text` input port (string, required) and a single binary `video` output port (`VIDEO_MP4` preset). `defaultInputPort='text'`, `defaultOutputPort='video'`.
+- `SeedanceVideoRuntime.generateVideo(request)` — isolates provider/credential/model resolution and the submit→poll job loop:
+  - default model: `config.model` if non-empty, else `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL` (required, else validation error).
+  - allowed models: `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS` (CSV); when non-empty the resolved model must be a member.
+  - provider: constructed only when both `SEEDANCE_API_KEY` and `SEEDANCE_BASE_URL` are present; otherwise a validation error.
+  - `createVideo({ prompt, model, durationSeconds?, aspectRatio? })` → `jobId`; then poll `getVideoJob(jobId)` every `pollIntervalMs` until terminal or `maxWaitMs` elapsed.
+  - `succeeded` + `output` → `normalizeVideoOutput` → `IPortBinaryValue` (`kind:'video'`). `failed`/`cancelled` → task-execution error. Timeout → best-effort `cancelVideoJob` + task-execution error.
+  - `seed` is intentionally NOT exposed (the ModelArk Seedance provider rejects it).
+- A `sleep` function is injectable via runtime options for deterministic tests (defaults to a `setTimeout`-based delay).
+- Cost estimate: `config.baseCredits` (default 0.5).
+
+## Type Ownership
+
+| Type                           | Location                         | Purpose                                                                        |
+| ------------------------------ | -------------------------------- | ------------------------------------------------------------------------------ |
+| `SeedanceVideoNodeDefinition`  | `src/index.ts`                   | Node definition class                                                          |
+| `SeedanceVideoConfigSchema`    | `src/index.ts`                   | Zod config schema                                                              |
+| `SeedanceVideoRuntime`         | `src/runtime-core.ts`            | Provider/model resolution + poll loop                                          |
+| `ISeedanceVideoRequest`        | `src/runtime-core.ts`            | `{ prompt, model, durationSeconds?, aspectRatio?, pollIntervalMs, maxWaitMs }` |
+| `ISeedanceVideoRuntimeOptions` | `src/runtime-core.ts`            | `{ apiKey?, baseUrl?, defaultModel?, allowedModels?, sleep? }`                 |
+| `normalizeVideoOutput`         | `src/video-output-normalizer.ts` | `IMediaOutputRef` → `IPortBinaryValue` (video)                                 |
+
+## Public API Surface
+
+- `SeedanceVideoNodeDefinition` — class
+- `createSeedanceVideoNodeDefinition()` — factory function
+- `SeedanceVideoConfigSchema` — Zod schema
+- `TSeedanceVideoConfig` — inferred config type
+- `SeedanceVideoRuntime`, `ISeedanceVideoRequest`, `ISeedanceVideoRuntimeOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `model`, `baseCredits`, `durationSeconds`, `aspectRatio`, `pollIntervalMs` (default 5000), `maxWaitMs` (default 300000).
+- Env `SEEDANCE_API_KEY`, `SEEDANCE_BASE_URL`, `DAG_SEEDANCE_VIDEO_DEFAULT_MODEL`, `DAG_SEEDANCE_VIDEO_ALLOWED_MODELS`.
+- Error codes: `DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED`, `DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED`, `DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED`, `DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT`, `DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_*`.

--- a/packages/dag-nodes/seedance-video/package.json
+++ b/packages/dag-nodes/seedance-video/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-seedance-video",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG seedance-video node for Robota — generate a video from a text prompt via the ByteDance/Seedance video API",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/seedance-video/src/index.test.ts
+++ b/packages/dag-nodes/seedance-video/src/index.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IPortBinaryValue, INodeExecutionContext, TPortPayload } from '@robota-sdk/dag-core';
+
+// Mock runtime-core to isolate the node definition from provider/poll logic
+vi.mock('./runtime-core.js', () => {
+  const mockGenerateVideo = vi.fn();
+  return {
+    SeedanceVideoRuntime: vi.fn().mockImplementation(() => ({
+      generateVideo: mockGenerateVideo,
+    })),
+  };
+});
+
+import {
+  SeedanceVideoNodeDefinition,
+  SeedanceVideoConfigSchema,
+  createSeedanceVideoNodeDefinition,
+} from './index.js';
+import { SeedanceVideoRuntime } from './runtime-core.js';
+
+function getMockGenerateVideo(): ReturnType<typeof vi.fn> {
+  const runtimeInstance = vi.mocked(SeedanceVideoRuntime).mock.results[
+    vi.mocked(SeedanceVideoRuntime).mock.results.length - 1
+  ]?.value as { generateVideo: ReturnType<typeof vi.fn> };
+  return runtimeInstance.generateVideo;
+}
+
+function makeVideoBinary(overrides?: Partial<IPortBinaryValue>): IPortBinaryValue {
+  return {
+    kind: 'video',
+    mimeType: 'video/mp4',
+    uri: 'https://cdn.example.test/v.mp4',
+    referenceType: 'uri',
+    ...overrides,
+  };
+}
+
+function makeExecutionContext(nodeId = 'node-1'): INodeExecutionContext {
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId,
+      nodeType: 'seedance-video',
+      dependsOn: [],
+      config: {},
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'seedance-video',
+      displayName: 'Seedance Video',
+      category: 'AI',
+      inputs: [],
+      outputs: [],
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('SeedanceVideoNodeDefinition', () => {
+  let node: SeedanceVideoNodeDefinition;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    node = new SeedanceVideoNodeDefinition();
+  });
+
+  describe('static properties', () => {
+    it('has correct nodeType/displayName/category', () => {
+      expect(node.nodeType).toBe('seedance-video');
+      expect(node.displayName).toBe('Seedance Video');
+      expect(node.category).toBe('AI');
+    });
+
+    it('has a required text input port and video output port', () => {
+      const textInput = node.inputs.find((p) => p.key === 'text');
+      expect(textInput?.required).toBe(true);
+      expect(textInput?.type).toBe('string');
+      const videoOutput = node.outputs.find((p) => p.key === 'video');
+      expect(videoOutput).toBeDefined();
+      expect(node.defaultInputPort).toBe('text');
+      expect(node.defaultOutputPort).toBe('video');
+    });
+
+    it('factory returns an instance', () => {
+      expect(createSeedanceVideoNodeDefinition()).toBeInstanceOf(SeedanceVideoNodeDefinition);
+    });
+  });
+
+  describe('config schema', () => {
+    it('applies defaults', () => {
+      const parsed = SeedanceVideoConfigSchema.parse({});
+      expect(parsed.model).toBe('');
+      expect(parsed.baseCredits).toBe(0.5);
+      expect(parsed.pollIntervalMs).toBe(5000);
+      expect(parsed.maxWaitMs).toBe(300000);
+    });
+
+    it('rejects non-positive maxWaitMs', () => {
+      expect(SeedanceVideoConfigSchema.safeParse({ maxWaitMs: 0 }).success).toBe(false);
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('returns default cost estimate', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = {};
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.5);
+    });
+
+    it('returns custom cost from config', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = { baseCredits: 1.25 };
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(1.25);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns validation error when prompt is missing', async () => {
+      const result = await node.taskHandler.execute!({}, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED');
+    });
+
+    it('returns validation error when prompt is empty', async () => {
+      const input: TPortPayload = { text: '   ' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED');
+    });
+
+    it('returns success with video output when runtime succeeds', async () => {
+      getMockGenerateVideo().mockResolvedValue({ ok: true, value: makeVideoBinary() });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.video).toBeDefined();
+    });
+
+    it('propagates runtime error when generateVideo fails', async () => {
+      getMockGenerateVideo().mockResolvedValue({
+        ok: false,
+        error: {
+          code: 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED',
+          message: 'job failed',
+          layer: 'execution',
+          retryable: false,
+        },
+      });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED');
+    });
+
+    it('returns error when runtime returns non-video output', async () => {
+      getMockGenerateVideo().mockResolvedValue({
+        ok: true,
+        value: { kind: 'image', mimeType: 'image/png', uri: 'asset://x' },
+      });
+      const input: TPortPayload = { text: 'a drone shot over mountains' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_INVALID');
+    });
+  });
+
+  describe('construction with options', () => {
+    it('passes options to SeedanceVideoRuntime', () => {
+      const options = { apiKey: 'k', baseUrl: 'https://api.test', defaultModel: 'seedance-2.0' };
+      new SeedanceVideoNodeDefinition(options);
+      expect(SeedanceVideoRuntime).toHaveBeenCalledWith(options);
+    });
+  });
+});

--- a/packages/dag-nodes/seedance-video/src/index.ts
+++ b/packages/dag-nodes/seedance-video/src/index.ts
@@ -1,0 +1,135 @@
+import {
+  AbstractNodeDefinition,
+  BINARY_PORT_PRESETS,
+  NodeIoAccessor,
+  createBinaryPortDefinition,
+} from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { SeedanceVideoRuntime, type ISeedanceVideoRuntimeOptions } from './runtime-core.js';
+
+export type { ISeedanceVideoRequest, ISeedanceVideoRuntimeOptions } from './runtime-core.js';
+export { SeedanceVideoRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link SeedanceVideoNodeDefinition}. */
+export interface ISeedanceVideoNodeDefinitionOptions extends ISeedanceVideoRuntimeOptions {}
+
+const DEFAULT_SEEDANCE_VIDEO_COST_USD = 0.5;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_WAIT_MS = 300000;
+
+export const SeedanceVideoConfigSchema = z.object({
+  model: z.string().default(''),
+  baseCredits: z.number().default(DEFAULT_SEEDANCE_VIDEO_COST_USD),
+  durationSeconds: z.number().int().positive().optional(),
+  aspectRatio: z.string().optional(),
+  pollIntervalMs: z.number().int().positive().default(DEFAULT_POLL_INTERVAL_MS),
+  maxWaitMs: z.number().int().positive().default(DEFAULT_MAX_WAIT_MS),
+});
+
+export type TSeedanceVideoConfig = z.output<typeof SeedanceVideoConfigSchema>;
+
+/**
+ * DAG node that generates a video from a text prompt using the ByteDance/Seedance video API.
+ *
+ * Submits an async job and polls until it completes, then returns the generated video.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class SeedanceVideoNodeDefinition extends AbstractNodeDefinition<
+  typeof SeedanceVideoConfigSchema
+> {
+  public readonly nodeType = 'seedance-video';
+  public readonly displayName = 'Seedance Video';
+  public readonly category = 'AI';
+  public readonly inputs: IDagNodeDefinition['inputs'] = [
+    { key: 'text', label: 'Text', order: 0, type: 'string', required: true },
+  ];
+  public readonly outputs: IDagNodeDefinition['outputs'] = [
+    createBinaryPortDefinition({
+      key: 'video',
+      label: 'Video',
+      order: 0,
+      required: true,
+      preset: BINARY_PORT_PRESETS.VIDEO_MP4,
+    }),
+  ];
+  public override readonly defaultInputPort = 'text';
+  public override readonly defaultOutputPort = 'video';
+  public readonly configSchemaDefinition = SeedanceVideoConfigSchema;
+
+  private readonly runtime: SeedanceVideoRuntime;
+
+  public constructor(options?: ISeedanceVideoNodeDefinitionOptions) {
+    super();
+    this.runtime = new SeedanceVideoRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TSeedanceVideoConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TSeedanceVideoConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const textInputResult = io.requireInputString('text');
+    if (!textInputResult.ok || textInputResult.value.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_PROMPT_REQUIRED',
+          'Seedance video node requires non-empty text input',
+          { nodeId: context.nodeDefinition.nodeId },
+        ),
+      };
+    }
+
+    const generateResult = await this.runtime.generateVideo({
+      prompt: textInputResult.value.trim(),
+      model: config.model,
+      ...(config.durationSeconds !== undefined ? { durationSeconds: config.durationSeconds } : {}),
+      ...(config.aspectRatio !== undefined ? { aspectRatio: config.aspectRatio } : {}),
+      pollIntervalMs: config.pollIntervalMs,
+      maxWaitMs: config.maxWaitMs,
+    });
+    if (!generateResult.ok) {
+      return generateResult;
+    }
+    if (generateResult.value.kind !== 'video') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_INVALID',
+          'Seedance video node returned non-video output',
+          false,
+        ),
+      };
+    }
+    io.setOutput('video', generateResult.value);
+    io.setOutput(
+      '_agentSummary',
+      `Video generated from prompt with Seedance. Model: ${config.model}.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createSeedanceVideoNodeDefinition(): SeedanceVideoNodeDefinition {
+  return new SeedanceVideoNodeDefinition();
+}

--- a/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
+++ b/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type {
+  IVideoJobAccepted,
+  IVideoJobSnapshot,
+  TProviderMediaResult,
+} from '@robota-sdk/agent-core';
+import { SeedanceVideoRuntime, type ISeedanceVideoRequest } from './runtime-core.js';
+import { BytedanceProvider } from '@robota-sdk/agent-provider/bytedance';
+
+// Shared job mocks so every constructed BytedanceProvider uses the same fns. The factory lives in
+// vi.hoisted so the vi.mock() call stays a single line (keeps the allow-module-mock escape attached).
+const { createVideo, getVideoJob, cancelVideoJob, bytedanceMockFactory } = vi.hoisted(() => {
+  const createVideo = vi.fn();
+  const getVideoJob = vi.fn();
+  const cancelVideoJob = vi.fn();
+  const bytedanceMockFactory = (): { BytedanceProvider: unknown } => ({
+    BytedanceProvider: vi
+      .fn()
+      .mockImplementation(() => ({ createVideo, getVideoJob, cancelVideoJob })),
+  });
+  return { createVideo, getVideoJob, cancelVideoJob, bytedanceMockFactory };
+});
+
+// Full replacement avoids loading the ByteDance HTTP client; only the video job methods are exercised.
+vi.mock('@robota-sdk/agent-provider/bytedance', bytedanceMockFactory); // allow-module-mock: BytedanceProvider hits the real ModelArk API
+
+const MODEL = 'seedance-2.0';
+
+function accepted(): TProviderMediaResult<IVideoJobAccepted> {
+  return {
+    ok: true,
+    value: { jobId: 'job-1', status: 'queued', createdAt: '2026-07-05T00:00:00Z' },
+  };
+}
+
+function snapshot(overrides: Partial<IVideoJobSnapshot>): TProviderMediaResult<IVideoJobSnapshot> {
+  return {
+    ok: true,
+    value: { jobId: 'job-1', status: 'running', updatedAt: '2026-07-05T00:00:01Z', ...overrides },
+  };
+}
+
+function makeRuntime(): SeedanceVideoRuntime {
+  return new SeedanceVideoRuntime({
+    apiKey: 'k',
+    baseUrl: 'https://api.test',
+    defaultModel: MODEL,
+    sleep: async () => {},
+  });
+}
+
+function req(overrides?: Partial<ISeedanceVideoRequest>): ISeedanceVideoRequest {
+  return { prompt: 'a drone shot', model: '', pollIntervalMs: 1, maxWaitMs: 1000, ...overrides };
+}
+
+describe('SeedanceVideoRuntime', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = {
+      SEEDANCE_API_KEY: process.env.SEEDANCE_API_KEY,
+      SEEDANCE_BASE_URL: process.env.SEEDANCE_BASE_URL,
+      DAG_SEEDANCE_VIDEO_DEFAULT_MODEL: process.env.DAG_SEEDANCE_VIDEO_DEFAULT_MODEL,
+      DAG_SEEDANCE_VIDEO_ALLOWED_MODELS: process.env.DAG_SEEDANCE_VIDEO_ALLOWED_MODELS,
+    };
+    for (const key of Object.keys(savedEnv)) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('returns validation error when default model is missing', async () => {
+    const runtime = new SeedanceVideoRuntime({ apiKey: 'k', baseUrl: 'https://api.test' });
+    const result = await runtime.generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED');
+  });
+
+  it('returns validation error when credentials are missing', async () => {
+    const runtime = new SeedanceVideoRuntime({ defaultModel: MODEL });
+    const result = await runtime.generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED');
+    }
+  });
+
+  it('returns validation error when model is not allowed', async () => {
+    const runtime = new SeedanceVideoRuntime({
+      apiKey: 'k',
+      baseUrl: 'https://api.test',
+      defaultModel: MODEL,
+      allowedModels: ['only-this'],
+      sleep: async () => {},
+    });
+    const result = await runtime.generateVideo(req({ model: 'other-model' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED');
+  });
+
+  it('maps a createVideo failure to a task execution error', async () => {
+    createVideo.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_AUTH_ERROR', message: 'bad key' },
+    });
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED');
+  });
+
+  it('polls until succeeded and normalizes the video output', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValueOnce(snapshot({ status: 'running' })).mockResolvedValueOnce(
+      snapshot({
+        status: 'succeeded',
+        output: { kind: 'uri', uri: 'https://cdn.test/v.mp4', mimeType: 'video/mp4', bytes: 1024 },
+      }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(getVideoJob).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe('video');
+      expect(result.value.mimeType).toBe('video/mp4');
+      expect(result.value.uri).toBe('https://cdn.test/v.mp4');
+    }
+  });
+
+  it('defaults a missing mime type to video/mp4', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'succeeded', output: { kind: 'uri', uri: 'https://cdn.test/v.mp4' } }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.mimeType).toBe('video/mp4');
+  });
+
+  it('maps a failed job to a task execution error', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'failed', error: { code: 'PROVIDER_UPSTREAM_ERROR', message: 'boom' } }),
+    );
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED');
+  });
+
+  it('maps a getVideoJob failure to a poll error', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_JOB_NOT_FOUND', message: 'gone' },
+    });
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED');
+  });
+
+  it('errors when a succeeded job has no output', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(snapshot({ status: 'succeeded' }));
+    const result = await makeRuntime().generateVideo(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MISSING');
+  });
+
+  it('times out and best-effort cancels when the job never completes', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(snapshot({ status: 'running' }));
+    cancelVideoJob.mockResolvedValue(snapshot({ status: 'cancelled' }));
+    const result = await makeRuntime().generateVideo(req({ maxWaitMs: 0 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT');
+    expect(cancelVideoJob).toHaveBeenCalledWith('job-1');
+  });
+
+  it('does not send the seed field and forwards duration/aspectRatio', async () => {
+    createVideo.mockResolvedValue(accepted());
+    getVideoJob.mockResolvedValue(
+      snapshot({ status: 'succeeded', output: { kind: 'uri', uri: 'https://cdn.test/v.mp4' } }),
+    );
+    await makeRuntime().generateVideo(req({ durationSeconds: 5, aspectRatio: '16:9' }));
+    expect(createVideo).toHaveBeenCalledWith({
+      prompt: 'a drone shot',
+      model: MODEL,
+      durationSeconds: 5,
+      aspectRatio: '16:9',
+    });
+  });
+});

--- a/packages/dag-nodes/seedance-video/src/runtime-core.ts
+++ b/packages/dag-nodes/seedance-video/src/runtime-core.ts
@@ -1,0 +1,253 @@
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { BytedanceProvider } from '@robota-sdk/agent-provider/bytedance';
+import type {
+  IProviderMediaError,
+  IVideoGenerationProvider,
+  IVideoJobSnapshot,
+} from '@robota-sdk/agent-core';
+import { normalizeVideoOutput } from './video-output-normalizer.js';
+
+/** Request payload for generating a video from a text prompt. */
+export interface ISeedanceVideoRequest {
+  prompt: string;
+  model: string;
+  durationSeconds?: number;
+  aspectRatio?: string;
+  pollIntervalMs: number;
+  maxWaitMs: number;
+}
+
+/** Configuration options for the seedance-video runtime. */
+export interface ISeedanceVideoRuntimeOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  defaultModel?: string;
+  allowedModels?: string[];
+  /** Injectable delay (defaults to a setTimeout-based sleep) — overridable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function resolveModel(
+  selectedModel: string,
+  defaultModel: string,
+  allowedModels: string[],
+): TResult<string, IDagError> {
+  const model = selectedModel.trim().length > 0 ? selectedModel.trim() : defaultModel;
+  if (allowedModels.length > 0 && !allowedModels.includes(model)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_NOT_ALLOWED',
+        'Selected seedance-video model is not allowed in DAG runtime',
+        { model },
+      ),
+    };
+  }
+  return { ok: true, value: model };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Runtime that delegates video generation to the ByteDance/Seedance provider.
+ *
+ * Video generation is asynchronous: `createVideo` submits a job, then `getVideoJob`
+ * is polled until the job reaches a terminal status or the max-wait timeout elapses.
+ */
+export class SeedanceVideoRuntime {
+  private readonly explicitApiKey?: string;
+  private readonly explicitBaseUrl?: string;
+  private readonly explicitDefaultModel?: string;
+  private readonly explicitAllowedModels?: string[];
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  public constructor(options?: ISeedanceVideoRuntimeOptions) {
+    this.explicitApiKey = options?.apiKey;
+    this.explicitBaseUrl = options?.baseUrl;
+    this.explicitDefaultModel = options?.defaultModel;
+    this.explicitAllowedModels = options?.allowedModels;
+    this.sleep = options?.sleep ?? defaultSleep;
+  }
+
+  private resolveDefaultModel(): TResult<string, IDagError> {
+    const defaultModelValue =
+      this.explicitDefaultModel ?? process.env.DAG_SEEDANCE_VIDEO_DEFAULT_MODEL;
+    if (typeof defaultModelValue !== 'string' || defaultModelValue.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_MODEL_REQUIRED',
+          'DAG_SEEDANCE_VIDEO_DEFAULT_MODEL must be configured or model must be specified in node config',
+        ),
+      };
+    }
+    return { ok: true, value: defaultModelValue.trim() };
+  }
+
+  private resolveAllowedModels(): string[] {
+    return this.explicitAllowedModels ?? parseCsv(process.env.DAG_SEEDANCE_VIDEO_ALLOWED_MODELS);
+  }
+
+  private resolveProvider(): IVideoGenerationProvider | undefined {
+    const apiKey = this.explicitApiKey ?? process.env.SEEDANCE_API_KEY;
+    const baseUrl = this.explicitBaseUrl ?? process.env.SEEDANCE_BASE_URL;
+    if (
+      typeof apiKey === 'string' &&
+      apiKey.trim().length > 0 &&
+      typeof baseUrl === 'string' &&
+      baseUrl.trim().length > 0
+    ) {
+      return new BytedanceProvider({ apiKey: apiKey.trim(), baseUrl: baseUrl.trim() });
+    }
+    return undefined;
+  }
+
+  private mapProviderError(
+    code:
+      | 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED'
+      | 'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED',
+    error: IProviderMediaError,
+    model: string,
+  ): TResult<never, IDagError> {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(code, error.message, false, { code: error.code, model }),
+    };
+  }
+
+  private async tryCancel(provider: IVideoGenerationProvider, jobId: string): Promise<void> {
+    try {
+      await provider.cancelVideoJob(jobId);
+    } catch {
+      // allow-fallback: cancel is best-effort on timeout
+    }
+  }
+
+  public async generateVideo(
+    request: ISeedanceVideoRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const defaultModelResult = this.resolveDefaultModel();
+    if (!defaultModelResult.ok) return defaultModelResult;
+    const allowedModels = this.resolveAllowedModels();
+    const provider = this.resolveProvider();
+    if (!provider) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SEEDANCE_VIDEO_CREDENTIALS_REQUIRED',
+          'SEEDANCE_API_KEY and SEEDANCE_BASE_URL must both be configured for seedance-video node runtime',
+        ),
+      };
+    }
+    const modelResult = resolveModel(request.model, defaultModelResult.value, allowedModels);
+    if (!modelResult.ok) return modelResult;
+
+    const created = await provider.createVideo({
+      prompt: request.prompt,
+      model: modelResult.value,
+      ...(request.durationSeconds !== undefined
+        ? { durationSeconds: request.durationSeconds }
+        : {}),
+      ...(request.aspectRatio !== undefined ? { aspectRatio: request.aspectRatio } : {}),
+    });
+    if (!created.ok) {
+      return this.mapProviderError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_CREATE_FAILED',
+        created.error,
+        modelResult.value,
+      );
+    }
+
+    return this.pollJob(provider, created.value.jobId, modelResult.value, request);
+  }
+
+  /**
+   * Maps a terminal job snapshot to a result. Returns `undefined` for non-terminal
+   * (`queued`/`running`) states so the caller keeps polling.
+   */
+  private mapTerminalSnapshot(
+    job: IVideoJobSnapshot,
+    model: string,
+  ): TResult<IPortBinaryValue, IDagError> | undefined {
+    if (job.status === 'succeeded') {
+      if (!job.output) {
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MISSING',
+            'Seedance video job succeeded but returned no output',
+            false,
+            { jobId: job.jobId, model },
+          ),
+        };
+      }
+      return normalizeVideoOutput(job.output);
+    }
+    if (job.status === 'failed' || job.status === 'cancelled') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_JOB_FAILED',
+          `Seedance video job ${job.status}: ${job.error?.message ?? 'no error detail'}`,
+          false,
+          { jobId: job.jobId, status: job.status, providerCode: job.error?.code ?? 'unknown' },
+        ),
+      };
+    }
+    return undefined;
+  }
+
+  private async pollJob(
+    provider: IVideoGenerationProvider,
+    jobId: string,
+    model: string,
+    request: ISeedanceVideoRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const startMs = Date.now();
+    for (;;) {
+      const snapshot = await provider.getVideoJob(jobId);
+      if (!snapshot.ok) {
+        return this.mapProviderError(
+          'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_POLL_FAILED',
+          snapshot.error,
+          model,
+        );
+      }
+      const terminal = this.mapTerminalSnapshot(snapshot.value, model);
+      if (terminal) return terminal;
+      if (Date.now() - startMs >= request.maxWaitMs) {
+        await this.tryCancel(provider, jobId);
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_TIMEOUT',
+            `Seedance video job did not complete within ${request.maxWaitMs}ms`,
+            true,
+            { jobId, maxWaitMs: request.maxWaitMs },
+          ),
+        };
+      }
+      await this.sleep(request.pollIntervalMs);
+    }
+  }
+}

--- a/packages/dag-nodes/seedance-video/src/video-output-normalizer.ts
+++ b/packages/dag-nodes/seedance-video/src/video-output-normalizer.ts
@@ -1,0 +1,106 @@
+import {
+  buildTaskExecutionError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import type { IMediaOutputRef } from '@robota-sdk/agent-core';
+
+const DEFAULT_VIDEO_MIME_TYPE = 'video/mp4';
+
+/**
+ * Normalizes a provider media output reference into a video binary port value.
+ *
+ * Unlike the image normalizer, this is lenient about the mime type: the ByteDance
+ * provider often returns a plain URL with no mime type, so a missing/blank mime type
+ * defaults to `video/mp4`. A present-but-non-video mime type is still rejected.
+ */
+export function normalizeVideoOutput(
+  output: IMediaOutputRef,
+): TResult<IPortBinaryValue, IDagError> {
+  if (output.kind === 'asset') {
+    return normalizeAssetOutput(output);
+  }
+  return normalizeUriOutput(output);
+}
+
+function resolveVideoMimeType(rawMimeType: string | undefined): string | undefined {
+  if (typeof rawMimeType !== 'string' || rawMimeType.trim().length === 0) {
+    return DEFAULT_VIDEO_MIME_TYPE;
+  }
+  if (!rawMimeType.startsWith('video/')) {
+    return undefined;
+  }
+  return rawMimeType;
+}
+
+function normalizeAssetOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.assetId !== 'string' || output.assetId.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_ASSET_INVALID',
+        'Provider returned asset output without valid assetId',
+        false,
+      ),
+    };
+  }
+  const mimeType = resolveVideoMimeType(output.mimeType);
+  if (mimeType === undefined) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-video media type for seedance-video output',
+        false,
+        { mimeType: output.mimeType ?? 'missing' },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'video',
+      mimeType,
+      uri: `asset://${output.assetId}`,
+      referenceType: 'asset',
+      assetId: output.assetId,
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.uri !== 'string' || output.uri.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_URI_MISSING',
+        'Provider returned uri output without uri value',
+        false,
+      ),
+    };
+  }
+  const mimeType = resolveVideoMimeType(output.mimeType);
+  if (mimeType === undefined) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_SEEDANCE_VIDEO_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-video media type for seedance-video output',
+        false,
+        { mimeType: output.mimeType ?? 'missing' },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'video',
+      mimeType,
+      uri: output.uri,
+      referenceType: 'uri',
+      sizeBytes: output.bytes,
+    },
+  };
+}

--- a/packages/dag-nodes/seedance-video/tsconfig.eslint.json
+++ b/packages/dag-nodes/seedance-video/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/seedance-video/tsconfig.json
+++ b/packages/dag-nodes/seedance-video/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/seedance-video/tsdown.config.ts
+++ b/packages/dag-nodes/seedance-video/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/packages/dag-nodes/skill/.eslintrc.json
+++ b/packages/dag-nodes/skill/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/skill/docs/README.md
+++ b/packages/dag-nodes/skill/docs/README.md
@@ -1,0 +1,3 @@
+# Skill Node Docs Index
+
+- `SPEC.md`: Node scope, skill resolution (inject prompt) model, and package boundaries.

--- a/packages/dag-nodes/skill/docs/SPEC.md
+++ b/packages/dag-nodes/skill/docs/SPEC.md
@@ -1,0 +1,48 @@
+# Skill Node Specification
+
+## Scope
+
+- Owns the `skill` DAG node definition.
+- Resolves a Robota skill (by name) to its expanded **inject-mode prompt string**, emitted on an output port. It does NOT run the skill through an LLM — it produces the prompt a downstream LLM node consumes.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- A "skill" is a `SKILL.md` parsed into an `ICommand` (SSOT `@robota-sdk/agent-interface-transport`). This node uses `@robota-sdk/agent-framework` `SkillCommandSource` (discover/list skills) and `executeSkill` (inject mode) to resolve the prompt.
+- **Resolver, not executor.** `executeSkill` in inject mode returns a prompt string via pure substitution — no LLM, no provider, no session. Wire this node to an LLM node to actually execute the skill (`skill → llm-text → …`).
+- **Fork skills are out of scope.** A skill with `context: 'fork'` requires a subagent LLM loop (`runInFork`), which a pure resolver has no runtime for — the node returns a validation error for such skills.
+- **No shell execution.** `executeSkill` is called with no `shellExec`, so `` !`cmd` `` interpolations in a skill body are stripped to empty (never executed) — the resolver never runs arbitrary shell.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the async/optional node-registry list (lazy import of the agent-framework-backed node).
+
+## Architecture Overview
+
+- `SkillNodeDefinition` — node with an optional `args` input port (string) and `prompt` + `mode` output ports. `defaultInputPort='args'`, `defaultOutputPort='prompt'`.
+- `SkillResolverRuntime` — resolves the skill, isolated from the node for testability via **dependency injection**:
+  - `loadCommands(cwd, home): ICommand[]` — defaults to `new SkillCommandSource(cwd, home).getCommands()`.
+  - `executeSkillFn` — defaults to `executeSkill`.
+  - `resolvePrompt({ skillName, args })`: find the command by name (else `DAG_VALIDATION_SKILL_NOT_FOUND` with the available names as `options`); reject `context: 'fork'` skills (`DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`); call `executeSkillFn(skill, args, {}, { sessionId })` and return `{ prompt, mode }`.
+- Args precedence: the `args` input port (if a non-empty string) overrides `config.args`.
+- Cost estimate: `config.baseCredits` (default 0 — resolution runs no model).
+
+## Type Ownership
+
+| Type                    | Location              | Purpose                                    |
+| ----------------------- | --------------------- | ------------------------------------------ |
+| `SkillNodeDefinition`   | `src/index.ts`        | Node definition class                      |
+| `SkillNodeConfigSchema` | `src/index.ts`        | Zod config schema                          |
+| `SkillResolverRuntime`  | `src/runtime-core.ts` | Skill discovery + inject-prompt resolution |
+| `ISkillResolverOptions` | `src/runtime-core.ts` | Injected deps + `cwd`/`home`/`sessionId`   |
+
+## Public API Surface
+
+- `SkillNodeDefinition` — class
+- `createSkillNodeDefinition()` — factory function
+- `SkillNodeConfigSchema` — Zod schema
+- `TSkillNodeConfig` — inferred config type
+- `SkillResolverRuntime`, `ISkillResolverOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `skillName` (required), `args` (static default), `cwd`, `sessionId`, `baseCredits`.
+- Runtime options `loadCommands` / `executeSkillFn` for injection (tests / alternate skill sources).
+- Error codes: `DAG_VALIDATION_SKILL_NOT_FOUND`, `DAG_VALIDATION_SKILL_FORK_UNSUPPORTED`, `DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED`.

--- a/packages/dag-nodes/skill/package.json
+++ b/packages/dag-nodes/skill/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-skill",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG skill node for Robota — resolve a Robota skill to its inject-mode prompt as a DAG step",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-framework": "workspace:*",
+    "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/skill/src/index.test.ts
+++ b/packages/dag-nodes/skill/src/index.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { INodeExecutionContext, INodeConfigObject, TPortPayload } from '@robota-sdk/dag-core';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import {
+  SkillNodeDefinition,
+  SkillNodeConfigSchema,
+  createSkillNodeDefinition,
+  type ISkillNodeDefinitionOptions,
+} from './index.js';
+
+const greet: ICommand = {
+  name: 'greet',
+  description: 'Greets the user',
+  source: 'skill',
+  skillContent: 'Say hello to $ARGUMENTS.',
+};
+
+const forkSkill: ICommand = {
+  name: 'deep',
+  description: 'deep',
+  source: 'skill',
+  context: 'fork',
+  skillContent: 'x',
+};
+
+function makeNode(options?: ISkillNodeDefinitionOptions): SkillNodeDefinition {
+  return new SkillNodeDefinition(options ?? { loadCommands: () => [greet, forkSkill] });
+}
+
+function makeContext(config: Record<string, unknown>): INodeExecutionContext {
+  const node = makeNode();
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId: 'skill-1',
+      nodeType: 'skill',
+      dependsOn: [],
+      config: config as INodeConfigObject,
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'skill',
+      displayName: 'Skill',
+      category: 'Integration',
+      inputs: node.inputs,
+      outputs: node.outputs,
+      defaultInputPort: node.defaultInputPort,
+      defaultOutputPort: node.defaultOutputPort,
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('SkillNodeDefinition metadata', () => {
+  it('has correct nodeType/displayName/category and ports', () => {
+    const node = makeNode();
+    expect(node.nodeType).toBe('skill');
+    expect(node.displayName).toBe('Skill');
+    expect(node.category).toBe('Integration');
+    expect(node.inputs.find((p) => p.key === 'args')?.required).toBe(false);
+    expect(node.outputs.find((p) => p.key === 'prompt')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'mode')).toBeDefined();
+    expect(node.defaultInputPort).toBe('args');
+    expect(node.defaultOutputPort).toBe('prompt');
+  });
+
+  it('factory returns an instance', () => {
+    expect(createSkillNodeDefinition()).toBeInstanceOf(SkillNodeDefinition);
+  });
+});
+
+describe('SkillNodeConfigSchema', () => {
+  it('applies defaults and requires skillName', () => {
+    const parsed = SkillNodeConfigSchema.parse({ skillName: 'greet' });
+    expect(parsed.args).toBe('');
+    expect(parsed.baseCredits).toBe(0);
+    expect(SkillNodeConfigSchema.safeParse({ skillName: '' }).success).toBe(false);
+  });
+});
+
+describe('SkillNodeDefinition execution', () => {
+  it('resolves a skill and emits the prompt (config args)', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute(
+      {},
+      makeContext({ skillName: 'greet', args: 'World' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.mode).toBe('inject');
+      expect(String(result.value.prompt)).toContain('Say hello to World.');
+    }
+  });
+
+  it('lets the args input port override config args', async () => {
+    const node = makeNode();
+    const input: TPortPayload = { args: 'FromInput' };
+    const result = await node.taskHandler.execute(
+      input,
+      makeContext({ skillName: 'greet', args: 'FromConfig' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(String(result.value.prompt)).toContain('Say hello to FromInput.');
+  });
+
+  it('propagates skill-not-found', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute({}, makeContext({ skillName: 'nope' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_NOT_FOUND');
+  });
+
+  it('propagates fork-unsupported', async () => {
+    const node = makeNode();
+    const result = await node.taskHandler.execute({}, makeContext({ skillName: 'deep' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_FORK_UNSUPPORTED');
+  });
+});

--- a/packages/dag-nodes/skill/src/index.ts
+++ b/packages/dag-nodes/skill/src/index.ts
@@ -1,0 +1,127 @@
+import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+import {
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type IPortDefinition,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { SkillResolverRuntime, type ISkillResolverOptions } from './runtime-core.js';
+
+export type {
+  ISkillResolverOptions,
+  ISkillResolveRequest,
+  ISkillResolveResult,
+  TLoadSkillCommands,
+} from './runtime-core.js';
+export { SkillResolverRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link SkillNodeDefinition}. */
+export interface ISkillNodeDefinitionOptions extends ISkillResolverOptions {}
+
+export const SkillNodeConfigSchema = z.object({
+  /** Name of the skill to resolve (as discovered by SkillCommandSource). */
+  skillName: z.string().min(1),
+  /** Static skill arguments; the `args` input port overrides this when non-empty. */
+  args: z.string().default(''),
+  /** Working directory to discover skills from. Defaults to the process cwd. */
+  cwd: z.string().optional(),
+  /** Session id substituted for `${CLAUDE_SESSION_ID}` in the skill body. */
+  sessionId: z.string().optional(),
+  /** Base credit cost (resolution runs no model — default 0). */
+  baseCredits: z.number().nonnegative().default(0),
+});
+
+export type TSkillNodeConfig = z.output<typeof SkillNodeConfigSchema>;
+
+const SKILL_INPUTS: IPortDefinition[] = [
+  { key: 'args', label: 'Args', order: 0, type: 'string', required: false },
+];
+
+const SKILL_OUTPUTS: IPortDefinition[] = [
+  { key: 'prompt', label: 'Prompt', order: 0, type: 'string', required: true },
+  { key: 'mode', label: 'Mode', order: 1, type: 'string', required: true },
+];
+
+/**
+ * DAG node that resolves a Robota skill to its inject-mode prompt string.
+ *
+ * Emits the expanded `<skill>` prompt for a downstream LLM node to execute;
+ * it does not run the skill itself.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class SkillNodeDefinition extends AbstractNodeDefinition<typeof SkillNodeConfigSchema> {
+  public readonly nodeType = 'skill';
+  public readonly displayName = 'Skill';
+  public readonly category = 'Integration';
+  public readonly inputs: IDagNodeDefinition['inputs'] = SKILL_INPUTS;
+  public readonly outputs: IDagNodeDefinition['outputs'] = SKILL_OUTPUTS;
+  public readonly configSchemaDefinition = SkillNodeConfigSchema;
+  public override readonly defaultInputPort = 'args';
+  public override readonly defaultOutputPort = 'prompt';
+
+  private readonly runtime: SkillResolverRuntime;
+
+  public constructor(options?: ISkillNodeDefinitionOptions) {
+    super();
+    this.runtime = new SkillResolverRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TSkillNodeConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TSkillNodeConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+
+    const argsInput = io.getInput('args');
+    const args =
+      typeof argsInput === 'string' && argsInput.trim().length > 0 ? argsInput : config.args;
+
+    const resolved = await this.runtime.resolvePrompt({
+      skillName: config.skillName,
+      args,
+      cwd: config.cwd ?? process.cwd(),
+      ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
+    });
+    if (!resolved.ok) {
+      return resolved;
+    }
+
+    if (resolved.value.prompt.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_EMPTY_PROMPT',
+          `Skill "${config.skillName}" resolved to an empty prompt`,
+          { skillName: config.skillName },
+        ),
+      };
+    }
+
+    io.setOutput('prompt', resolved.value.prompt);
+    io.setOutput('mode', resolved.value.mode);
+    io.setOutput(
+      '_agentSummary',
+      `Skill "${config.skillName}" resolved (${resolved.value.mode}): ${resolved.value.prompt.length} chars.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createSkillNodeDefinition(): SkillNodeDefinition {
+  return new SkillNodeDefinition();
+}

--- a/packages/dag-nodes/skill/src/runtime-core.test.ts
+++ b/packages/dag-nodes/skill/src/runtime-core.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import { SkillResolverRuntime, type ISkillResolveRequest } from './runtime-core.js';
+
+const greet: ICommand = {
+  name: 'greet',
+  description: 'Greets the user',
+  source: 'skill',
+  skillContent: 'Say hello to $ARGUMENTS.',
+};
+
+const forkSkill: ICommand = {
+  name: 'deep-research',
+  description: 'Runs deep research',
+  source: 'skill',
+  context: 'fork',
+  skillContent: 'Research $ARGUMENTS thoroughly.',
+};
+
+function req(overrides?: Partial<ISkillResolveRequest>): ISkillResolveRequest {
+  return { skillName: 'greet', args: 'World', cwd: '/tmp/x', ...overrides };
+}
+
+describe('SkillResolverRuntime', () => {
+  it('resolves an inject skill to its expanded prompt (real executeSkill)', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.mode).toBe('inject');
+      expect(result.value.prompt).toContain('skill name="greet"');
+      expect(result.value.prompt).toContain('Say hello to World.');
+    }
+  });
+
+  it('returns a not-found error listing available skills', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req({ skillName: 'missing' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_VALIDATION_SKILL_NOT_FOUND');
+      expect(result.error.fix?.options).toEqual(['greet', 'deep-research']);
+    }
+  });
+
+  it('rejects a fork-context skill', async () => {
+    const runtime = new SkillResolverRuntime({ loadCommands: () => [greet, forkSkill] });
+    const result = await runtime.resolvePrompt(req({ skillName: 'deep-research' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_SKILL_FORK_UNSUPPORTED');
+  });
+
+  it('surfaces a skill-discovery failure as a task error', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => {
+        throw new Error('disk gone');
+      },
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+      expect(result.error.retryable).toBe(true);
+    }
+  });
+
+  it('surfaces an executeSkill failure as a task error', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [greet],
+      executeSkillFn: async () => {
+        throw new Error('boom');
+      },
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+  });
+
+  it('errors when executeSkill returns no inject prompt', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [greet],
+      executeSkillFn: async () => ({ mode: 'fork', result: 'x' }),
+    });
+    const result = await runtime.resolvePrompt(req());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED');
+  });
+
+  it('substitutes positional args (0-based) and $ARGUMENTS', async () => {
+    const runtime = new SkillResolverRuntime({
+      loadCommands: () => [
+        {
+          name: 'echo',
+          description: 'e',
+          source: 'skill',
+          skillContent: 'a=$0 b=$1 all=$ARGUMENTS',
+        },
+      ],
+    });
+    const result = await runtime.resolvePrompt(req({ skillName: 'echo', args: 'alpha beta' }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.prompt).toContain('a=alpha');
+      expect(result.value.prompt).toContain('b=beta');
+      expect(result.value.prompt).toContain('all=alpha beta');
+    }
+  });
+});

--- a/packages/dag-nodes/skill/src/runtime-core.ts
+++ b/packages/dag-nodes/skill/src/runtime-core.ts
@@ -1,0 +1,142 @@
+import { SkillCommandSource, executeSkill } from '@robota-sdk/agent-framework';
+import type { ICommand } from '@robota-sdk/agent-interface-transport';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type TResult,
+} from '@robota-sdk/dag-core';
+
+/** Loads the available skill commands for a working directory. */
+export type TLoadSkillCommands = (cwd: string, home?: string) => ICommand[];
+
+/** Configuration options for the skill resolver runtime (dependency injection for tests). */
+export interface ISkillResolverOptions {
+  /** Skill discovery. Defaults to `new SkillCommandSource(cwd, home).getCommands()`. */
+  loadCommands?: TLoadSkillCommands;
+  /** Skill resolution. Defaults to the real `executeSkill`. */
+  executeSkillFn?: typeof executeSkill;
+}
+
+/** Request to resolve a skill to its inject-mode prompt. */
+export interface ISkillResolveRequest {
+  skillName: string;
+  args: string;
+  cwd: string;
+  home?: string;
+  sessionId?: string;
+}
+
+/** Result of resolving a skill. */
+export interface ISkillResolveResult {
+  prompt: string;
+  mode: string;
+}
+
+function defaultLoadCommands(cwd: string, home?: string): ICommand[] {
+  return new SkillCommandSource(cwd, home).getCommands();
+}
+
+/**
+ * Resolves a Robota skill (by name) to its inject-mode prompt string. No LLM, no
+ * provider, no shell: `executeSkill` is called with empty callbacks so shell
+ * interpolations are stripped rather than executed, and fork skills are rejected.
+ */
+export class SkillResolverRuntime {
+  private readonly loadCommands: TLoadSkillCommands;
+  private readonly executeSkillFn: typeof executeSkill;
+
+  public constructor(options?: ISkillResolverOptions) {
+    this.loadCommands = options?.loadCommands ?? defaultLoadCommands;
+    this.executeSkillFn = options?.executeSkillFn ?? executeSkill;
+  }
+
+  public async resolvePrompt(
+    request: ISkillResolveRequest,
+  ): Promise<TResult<ISkillResolveResult, IDagError>> {
+    let commands: ICommand[];
+    try {
+      commands = this.loadCommands(request.cwd, request.home);
+    } catch (err) {
+      // allow-fallback: skill discovery failure surfaced as a retryable task error
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+          `Failed to load skills: ${message}`,
+          true,
+          { cwd: request.cwd },
+        ),
+      };
+    }
+
+    const skill = commands.find((command) => command.name === request.skillName);
+    if (!skill) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_NOT_FOUND',
+          `Skill "${request.skillName}" was not found in ${request.cwd}`,
+          { skillName: request.skillName },
+          {
+            action: 'set_config',
+            suggestion: 'Set skillName to an available skill',
+            options: commands.map((command) => command.name),
+          },
+        ),
+      };
+    }
+
+    if (skill.context === 'fork') {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_SKILL_FORK_UNSUPPORTED',
+          `Skill "${request.skillName}" uses fork context, which the resolver node does not support (no subagent runtime). Use an inject-context skill.`,
+          { skillName: request.skillName },
+        ),
+      };
+    }
+
+    return this.resolveInject(skill, request);
+  }
+
+  private async resolveInject(
+    skill: ICommand,
+    request: ISkillResolveRequest,
+  ): Promise<TResult<ISkillResolveResult, IDagError>> {
+    try {
+      const result = await this.executeSkillFn(
+        skill,
+        request.args,
+        {},
+        request.sessionId !== undefined ? { sessionId: request.sessionId } : undefined,
+      );
+      if (typeof result.prompt !== 'string') {
+        return {
+          ok: false,
+          error: buildTaskExecutionError(
+            'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+            `Skill "${request.skillName}" did not resolve to an inject prompt`,
+            false,
+            { skillName: request.skillName, mode: result.mode },
+          ),
+        };
+      }
+      return { ok: true, value: { prompt: result.prompt, mode: result.mode } };
+    } catch (err) {
+      // allow-fallback: unexpected executeSkill failure surfaced as a task error
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_SKILL_RESOLVE_FAILED',
+          `Failed to resolve skill "${request.skillName}": ${message}`,
+          false,
+          { skillName: request.skillName },
+        ),
+      };
+    }
+  }
+}

--- a/packages/dag-nodes/skill/tsconfig.eslint.json
+++ b/packages/dag-nodes/skill/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/skill/tsconfig.json
+++ b/packages/dag-nodes/skill/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/skill/tsdown.config.ts
+++ b/packages/dag-nodes/skill/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/packages/dag-nodes/text-to-image/.eslintrc.json
+++ b/packages/dag-nodes/text-to-image/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.eslintrc.json"
+}

--- a/packages/dag-nodes/text-to-image/docs/README.md
+++ b/packages/dag-nodes/text-to-image/docs/README.md
@@ -1,0 +1,3 @@
+# Text to Image Node Docs Index
+
+- `SPEC.md`: Node scope, provider dependencies, and package boundaries.

--- a/packages/dag-nodes/text-to-image/docs/SPEC.md
+++ b/packages/dag-nodes/text-to-image/docs/SPEC.md
@@ -1,0 +1,49 @@
+# Text to Image Node Specification
+
+## Scope
+
+- Owns the `text-to-image` DAG node definition.
+- Generates a **new** image from a text prompt only (no input image) via the Gemini image API, emitting a binary image output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Distinct from `gemini-image-edit`/`gemini-image-compose`: those take one or more **input images** and edit/compose them. This node is pure generation — prompt in, image out, no binary input port.
+- Delegates to `@robota-sdk/agent-provider/google` `GoogleProvider.generateImage({ prompt, model })` (already a required method on `IImageGenerationProvider`). The Google SDK (`@google/genai`) is a transitive concern of `agent-provider`, not a direct dependency.
+- The DAG subsystem stays private; this package is `private: true`. Registered in the **async/optional** node-registry list (the Gemini SDK is an optional peer — the node self-skips if the provider cannot construct).
+
+## Architecture Overview
+
+- `TextToImageNodeDefinition` — node with a single `text` input port (string, required) and a single binary `image` output port (`IMAGE_COMMON` preset). `defaultInputPort='text'`, `defaultOutputPort='image'`.
+- `TextToImageRuntime` — isolates provider/credential/model resolution and the API call from the node definition (mirrors `GeminiImageRuntime`, minus all input-image handling):
+  - default model: `config.model` if non-empty, else `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL` (required, else validation error).
+  - allowed models: `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS` (CSV); when non-empty the resolved model must be a member.
+  - provider: constructed only when `GEMINI_API_KEY` is present; otherwise a `set_config`-style validation error.
+  - calls `provider.generateImage({ prompt, model })`, takes the first output, and normalizes it to an `IPortBinaryValue` (`asset://` or `data:`/http image reference).
+- Cost estimate: `config.baseCredits` (default 0.02).
+
+## Type Ownership
+
+| Type                         | Location                         | Purpose                                      |
+| ---------------------------- | -------------------------------- | -------------------------------------------- |
+| `TextToImageNodeDefinition`  | `src/index.ts`                   | Node definition class                        |
+| `TextToImageConfigSchema`    | `src/index.ts`                   | Zod config schema                            |
+| `TextToImageRuntime`         | `src/runtime-core.ts`            | Provider/model resolution + API call         |
+| `ITextToImageRequest`        | `src/runtime-core.ts`            | `{ prompt, model }` runtime request          |
+| `ITextToImageRuntimeOptions` | `src/runtime-core.ts`            | `{ apiKey?, defaultModel?, allowedModels? }` |
+| `normalizeImageOutput`       | `src/image-output-normalizer.ts` | `IMediaOutputRef` → `IPortBinaryValue`       |
+
+## Public API Surface
+
+- `TextToImageNodeDefinition` — class
+- `createTextToImageNodeDefinition()` — factory function
+- `TextToImageConfigSchema` — Zod schema
+- `TTextToImageConfig` — inferred config type
+- `TextToImageRuntime`, `ITextToImageRequest`, `ITextToImageRuntimeOptions` — re-exported from the node module
+
+## Extension Points
+
+- Config `model`: overrides the default model for this node instance.
+- Config `baseCredits`: base cost per successful generation.
+- Env `DAG_TEXT_TO_IMAGE_DEFAULT_MODEL`, `DAG_TEXT_TO_IMAGE_ALLOWED_MODELS`, `GEMINI_API_KEY`.
+- Error codes: `DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED`, `DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED`, `DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED`, `DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE`, `DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_*`.

--- a/packages/dag-nodes/text-to-image/package.json
+++ b/packages/dag-nodes/text-to-image/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@robota-sdk/dag-node-text-to-image",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "DAG text-to-image node for Robota — generate an image from a text prompt via the Gemini image API",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
+    "@robota-sdk/agent-provider": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/text-to-image/src/image-output-normalizer.ts
+++ b/packages/dag-nodes/text-to-image/src/image-output-normalizer.ts
@@ -1,0 +1,140 @@
+import {
+  buildTaskExecutionError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import type { IMediaOutputRef } from '@robota-sdk/agent-core';
+
+/**
+ * Normalizes a provider media output reference into a standard binary port value.
+ *
+ * Handles both asset-based and URI-based outputs, including data URIs.
+ *
+ * @param output - The raw media output reference from the provider.
+ * @returns A result containing the normalized binary port value or an execution error.
+ */
+export function normalizeImageOutput(
+  output: IMediaOutputRef,
+): TResult<IPortBinaryValue, IDagError> {
+  if (output.kind === 'asset') {
+    return normalizeAssetOutput(output);
+  }
+  return normalizeUriOutput(output);
+}
+
+function normalizeAssetOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.assetId !== 'string' || output.assetId.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_ASSET_INVALID',
+        'Provider returned asset output without valid assetId',
+        false,
+      ),
+    };
+  }
+  const mimeType =
+    typeof output.mimeType === 'string' && output.mimeType.trim().length > 0 ? output.mimeType : '';
+  if (!mimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-image media type for text-to-image output',
+        false,
+        { mimeType },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType,
+      uri: `asset://${output.assetId}`,
+      referenceType: 'asset',
+      assetId: output.assetId,
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  if (typeof output.uri !== 'string' || output.uri.trim().length === 0) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_URI_MISSING',
+        'Provider returned uri output without uri value',
+        false,
+      ),
+    };
+  }
+  const outputMimeType =
+    typeof output.mimeType === 'string' && output.mimeType.trim().length > 0 ? output.mimeType : '';
+  if (output.uri.startsWith('data:')) {
+    return normalizeDataUriOutput(output);
+  }
+  if (!outputMimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_MEDIA_TYPE_INVALID',
+        'Provider returned non-image URI output for text-to-image runtime',
+        false,
+        { mimeType: outputMimeType },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType: outputMimeType,
+      uri: output.uri,
+      referenceType: 'uri',
+      sizeBytes: output.bytes,
+    },
+  };
+}
+
+function normalizeDataUriOutput(output: IMediaOutputRef): TResult<IPortBinaryValue, IDagError> {
+  const parsedDataUri = parseDataUri(output.uri as string);
+  if (!parsedDataUri || !parsedDataUri.mimeType.startsWith('image/')) {
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_URI_UNSUPPORTED',
+        'Provider URI output must be image data URI',
+        false,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: 'image',
+      mimeType: parsedDataUri.mimeType,
+      uri: output.uri as string,
+      referenceType: 'uri',
+    },
+  };
+}
+
+function parseDataUri(uri: string): { mimeType: string; data: string } | undefined {
+  const commaIndex = uri.indexOf(',');
+  if (commaIndex < 0) {
+    return undefined;
+  }
+  const header = uri.slice(0, commaIndex);
+  const payload = uri.slice(commaIndex + 1);
+  if (!header.startsWith('data:') || !header.endsWith(';base64')) {
+    return undefined;
+  }
+  const mimeType = header.replace('data:', '').replace(';base64', '').trim();
+  if (mimeType.length === 0 || payload.trim().length === 0) {
+    return undefined;
+  }
+  return { mimeType, data: payload };
+}

--- a/packages/dag-nodes/text-to-image/src/index.test.ts
+++ b/packages/dag-nodes/text-to-image/src/index.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IPortBinaryValue, INodeExecutionContext, TPortPayload } from '@robota-sdk/dag-core';
+
+// Mock runtime-core to isolate the node definition from provider logic
+vi.mock('./runtime-core.js', () => {
+  const mockGenerateImage = vi.fn();
+  return {
+    TextToImageRuntime: vi.fn().mockImplementation(() => ({
+      generateImage: mockGenerateImage,
+    })),
+  };
+});
+
+import {
+  TextToImageNodeDefinition,
+  TextToImageConfigSchema,
+  createTextToImageNodeDefinition,
+} from './index.js';
+import { TextToImageRuntime } from './runtime-core.js';
+
+function getMockGenerateImage(): ReturnType<typeof vi.fn> {
+  const runtimeInstance = vi.mocked(TextToImageRuntime).mock.results[
+    vi.mocked(TextToImageRuntime).mock.results.length - 1
+  ]?.value as { generateImage: ReturnType<typeof vi.fn> };
+  return runtimeInstance.generateImage;
+}
+
+function makeImageBinary(overrides?: Partial<IPortBinaryValue>): IPortBinaryValue {
+  return { kind: 'image', mimeType: 'image/png', uri: 'data:image/png;base64,iVBOR', ...overrides };
+}
+
+function makeExecutionContext(nodeId = 'node-1'): INodeExecutionContext {
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId,
+      nodeType: 'text-to-image',
+      dependsOn: [],
+      config: {},
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'text-to-image',
+      displayName: 'Text to Image',
+      category: 'AI',
+      inputs: [],
+      outputs: [],
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('TextToImageNodeDefinition', () => {
+  let node: TextToImageNodeDefinition;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    node = new TextToImageNodeDefinition();
+  });
+
+  describe('static properties', () => {
+    it('has correct nodeType/displayName/category', () => {
+      expect(node.nodeType).toBe('text-to-image');
+      expect(node.displayName).toBe('Text to Image');
+      expect(node.category).toBe('AI');
+    });
+
+    it('has a required text input port and image output port', () => {
+      const textInput = node.inputs.find((p) => p.key === 'text');
+      expect(textInput?.required).toBe(true);
+      expect(textInput?.type).toBe('string');
+      expect(node.inputs.find((p) => p.key === 'image')).toBeUndefined();
+      expect(node.outputs.find((p) => p.key === 'image')).toBeDefined();
+      expect(node.defaultInputPort).toBe('text');
+      expect(node.defaultOutputPort).toBe('image');
+    });
+
+    it('factory returns an instance', () => {
+      expect(createTextToImageNodeDefinition()).toBeInstanceOf(TextToImageNodeDefinition);
+    });
+  });
+
+  describe('config schema', () => {
+    it('applies defaults', () => {
+      const parsed = TextToImageConfigSchema.parse({});
+      expect(parsed.model).toBe('');
+      expect(parsed.baseCredits).toBe(0.02);
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('returns default cost estimate', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = {};
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.02);
+    });
+
+    it('returns custom cost from config', async () => {
+      const context = makeExecutionContext();
+      context.nodeDefinition.config = { baseCredits: 0.05 };
+      const result = await node.taskHandler.estimateCost!({}, context);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.estimatedCredits).toBe(0.05);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns validation error when prompt is missing', async () => {
+      const result = await node.taskHandler.execute!({}, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED');
+    });
+
+    it('returns validation error when prompt is empty', async () => {
+      const input: TPortPayload = { text: '   ' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED');
+    });
+
+    it('returns success with image output when runtime succeeds', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: true,
+        value: makeImageBinary({ uri: 'data:image/png;base64,RESULT' }),
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.image).toBeDefined();
+    });
+
+    it('propagates runtime error when generateImage fails', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: false,
+        error: {
+          code: 'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED',
+          message: 'Generation failed',
+          layer: 'execution',
+          retryable: false,
+        },
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED');
+    });
+
+    it('returns error when runtime returns non-image output', async () => {
+      getMockGenerateImage().mockResolvedValue({
+        ok: true,
+        value: { kind: 'audio', mimeType: 'audio/mp3', uri: 'asset://x' },
+      });
+      const input: TPortPayload = { text: 'a red bicycle' };
+      const result = await node.taskHandler.execute!(input, makeExecutionContext());
+      expect(result.ok).toBe(false);
+      if (!result.ok)
+        expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_INVALID');
+    });
+  });
+
+  describe('construction with options', () => {
+    it('passes options to TextToImageRuntime', () => {
+      const options = { apiKey: 'key-123', defaultModel: 'model-x' };
+      new TextToImageNodeDefinition(options);
+      expect(TextToImageRuntime).toHaveBeenCalledWith(options);
+    });
+  });
+});

--- a/packages/dag-nodes/text-to-image/src/index.ts
+++ b/packages/dag-nodes/text-to-image/src/index.ts
@@ -1,0 +1,125 @@
+import {
+  AbstractNodeDefinition,
+  BINARY_PORT_PRESETS,
+  NodeIoAccessor,
+  createBinaryPortDefinition,
+} from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type TResult,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+import { TextToImageRuntime, type ITextToImageRuntimeOptions } from './runtime-core.js';
+
+export type { ITextToImageRequest, ITextToImageRuntimeOptions } from './runtime-core.js';
+export { TextToImageRuntime } from './runtime-core.js';
+
+/** Options for constructing a {@link TextToImageNodeDefinition}. */
+export interface ITextToImageNodeDefinitionOptions extends ITextToImageRuntimeOptions {}
+
+const DEFAULT_TEXT_TO_IMAGE_COST_USD = 0.02;
+
+export const TextToImageConfigSchema = z.object({
+  model: z.string().default(''),
+  baseCredits: z.number().default(DEFAULT_TEXT_TO_IMAGE_COST_USD),
+});
+
+export type TTextToImageConfig = z.output<typeof TextToImageConfigSchema>;
+
+/**
+ * DAG node that generates a new image from a text prompt using the Gemini image API.
+ *
+ * Takes only a text prompt (no input image) and returns the generated image.
+ *
+ * @extends AbstractNodeDefinition
+ */
+export class TextToImageNodeDefinition extends AbstractNodeDefinition<
+  typeof TextToImageConfigSchema
+> {
+  public readonly nodeType = 'text-to-image';
+  public readonly displayName = 'Text to Image';
+  public readonly category = 'AI';
+  public readonly inputs: IDagNodeDefinition['inputs'] = [
+    { key: 'text', label: 'Text', order: 0, type: 'string', required: true },
+  ];
+  public readonly outputs: IDagNodeDefinition['outputs'] = [
+    createBinaryPortDefinition({
+      key: 'image',
+      label: 'Image',
+      order: 0,
+      required: true,
+      preset: BINARY_PORT_PRESETS.IMAGE_COMMON,
+    }),
+  ];
+  public override readonly defaultInputPort = 'text';
+  public override readonly defaultOutputPort = 'image';
+  public readonly configSchemaDefinition = TextToImageConfigSchema;
+
+  private readonly runtime: TextToImageRuntime;
+
+  public constructor(options?: ITextToImageNodeDefinitionOptions) {
+    super();
+    this.runtime = new TextToImageRuntime(options);
+  }
+
+  public override async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TTextToImageConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TTextToImageConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const textInputResult = io.requireInputString('text');
+    if (!textInputResult.ok || textInputResult.value.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_PROMPT_REQUIRED',
+          'Text-to-image node requires non-empty text input',
+          { nodeId: context.nodeDefinition.nodeId },
+        ),
+      };
+    }
+
+    const generateResult = await this.runtime.generateImage({
+      prompt: textInputResult.value.trim(),
+      model: config.model,
+    });
+    if (!generateResult.ok) {
+      return generateResult;
+    }
+    if (generateResult.value.kind !== 'image') {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_OUTPUT_INVALID',
+          'Text-to-image node returned non-image output',
+          false,
+        ),
+      };
+    }
+    io.setOutput('image', generateResult.value);
+    io.setOutput(
+      '_agentSummary',
+      `Image generated from prompt with Gemini. Model: ${config.model}.`,
+    );
+    return { ok: true, value: io.toOutput() };
+  }
+}
+
+export function createTextToImageNodeDefinition(): TextToImageNodeDefinition {
+  return new TextToImageNodeDefinition();
+}

--- a/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IImageGenerationResult, TProviderMediaResult } from '@robota-sdk/agent-core';
+import { TextToImageRuntime } from './runtime-core.js';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
+
+// A shared generateImage mock so every constructed GoogleProvider instance uses the same fn —
+// lets us set the return value before the runtime constructs the provider. The factory lives in
+// vi.hoisted so the vi.mock() call stays a single line (keeps the allow-module-mock escape attached).
+const { sharedGenerateImage, googleMockFactory } = vi.hoisted(() => {
+  const sharedGenerateImage = vi.fn();
+  const googleMockFactory = (): { GoogleProvider: unknown } => ({
+    GoogleProvider: vi
+      .fn()
+      .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({
+        _apiKey: options.apiKey,
+        _imageCapableModels: options.imageCapableModels,
+        generateImage: sharedGenerateImage,
+      })),
+  });
+  return { sharedGenerateImage, googleMockFactory };
+});
+
+// Full replacement avoids loading the @google/genai SDK; only ctor + generateImage are exercised.
+vi.mock('@robota-sdk/agent-provider/google', googleMockFactory); // allow-module-mock: GoogleProvider hits the real Gemini API
+
+const TEST_MODEL = 'test-image-model';
+
+function makeSuccessResult(): TProviderMediaResult<IImageGenerationResult> {
+  return {
+    ok: true,
+    value: {
+      model: TEST_MODEL,
+      outputs: [
+        {
+          kind: 'uri',
+          uri: 'data:image/png;base64,RESULT_DATA',
+          mimeType: 'image/png',
+          bytes: 2048,
+        },
+      ],
+    },
+  };
+}
+
+describe('TextToImageRuntime', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = {
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+      DAG_TEXT_TO_IMAGE_DEFAULT_MODEL: process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL,
+      DAG_TEXT_TO_IMAGE_ALLOWED_MODELS: process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS,
+    };
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL;
+    delete process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('returns validation error when default model is missing', async () => {
+    const runtime = new TextToImageRuntime({ apiKey: 'k' });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED');
+  });
+
+  it('returns validation error when API key is missing', async () => {
+    const runtime = new TextToImageRuntime({ defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED');
+  });
+
+  it('returns validation error when model is not allowed', async () => {
+    const runtime = new TextToImageRuntime({
+      apiKey: 'k',
+      defaultModel: TEST_MODEL,
+      allowedModels: ['only-this-one'],
+    });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: 'some-other-model' });
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error.code).toBe('DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED');
+  });
+
+  it('maps a successful provider response to an image port value', async () => {
+    sharedGenerateImage.mockResolvedValue(makeSuccessResult());
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(GoogleProvider).toHaveBeenCalledWith({ apiKey: 'k', imageCapableModels: [] });
+    expect(sharedGenerateImage).toHaveBeenCalledWith({ prompt: 'a cat', model: TEST_MODEL });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe('image');
+      expect(result.value.mimeType).toBe('image/png');
+      expect(result.value.uri).toContain('data:image/png;base64,RESULT_DATA');
+    }
+  });
+
+  it('maps a provider failure to a task execution error', async () => {
+    sharedGenerateImage.mockResolvedValue({
+      ok: false,
+      error: { code: 'PROVIDER_ERROR', message: 'boom' },
+    });
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED');
+  });
+
+  it('errors when the provider returns no outputs', async () => {
+    sharedGenerateImage.mockResolvedValue({ ok: true, value: { model: TEST_MODEL, outputs: [] } });
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    const result = await runtime.generateImage({ prompt: 'a cat', model: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE');
+    }
+  });
+
+  it('resolves the model from config over the default', async () => {
+    sharedGenerateImage.mockResolvedValue(makeSuccessResult());
+    const runtime = new TextToImageRuntime({ apiKey: 'k', defaultModel: TEST_MODEL });
+    await runtime.generateImage({ prompt: 'a cat', model: 'chosen-model' });
+    expect(sharedGenerateImage).toHaveBeenCalledWith({ prompt: 'a cat', model: 'chosen-model' });
+  });
+});

--- a/packages/dag-nodes/text-to-image/src/runtime-core.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.ts
@@ -1,0 +1,178 @@
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type IDagError,
+  type IPortBinaryValue,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { GoogleProvider } from '@robota-sdk/agent-provider/google';
+import type { IImageGenerationProvider, IImageGenerationResult } from '@robota-sdk/agent-core';
+import { normalizeImageOutput } from './image-output-normalizer.js';
+
+/** Request payload for generating an image from a text prompt. */
+export interface ITextToImageRequest {
+  prompt: string;
+  model: string;
+}
+
+/** Configuration options for the text-to-image runtime, including API key and model restrictions. */
+export interface ITextToImageRuntimeOptions {
+  apiKey?: string;
+  defaultModel?: string;
+  allowedModels?: string[];
+}
+
+/**
+ * Parses a comma-separated string into a trimmed, non-empty array of values.
+ */
+function parseCsv(value: string | undefined): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Resolves and validates a model identifier against the allowed model list.
+ */
+function resolveModel(
+  selectedModel: string,
+  defaultModel: string,
+  allowedModels: string[],
+): TResult<string, IDagError> {
+  const model = selectedModel.trim().length > 0 ? selectedModel.trim() : defaultModel;
+  if (allowedModels.length > 0 && !allowedModels.includes(model)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_NOT_ALLOWED',
+        'Selected text-to-image model is not allowed in DAG runtime',
+        { model },
+      ),
+    };
+  }
+  return { ok: true, value: model };
+}
+
+/**
+ * Runtime that delegates text-to-image generation requests to the Google Gemini API
+ * via the GoogleProvider. Unlike the image-edit runtime, it takes no input image.
+ */
+export class TextToImageRuntime {
+  private readonly explicitApiKey?: string;
+  private readonly explicitDefaultModel?: string;
+  private readonly explicitAllowedModels?: string[];
+
+  public constructor(options?: ITextToImageRuntimeOptions) {
+    this.explicitApiKey = options?.apiKey;
+    this.explicitDefaultModel = options?.defaultModel;
+    this.explicitAllowedModels = options?.allowedModels;
+  }
+
+  private resolveDefaultModel(): TResult<string, IDagError> {
+    const defaultModelValue =
+      this.explicitDefaultModel ?? process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL;
+    if (typeof defaultModelValue !== 'string' || defaultModelValue.trim().length === 0) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_MODEL_REQUIRED',
+          'DAG_TEXT_TO_IMAGE_DEFAULT_MODEL must be configured or model must be specified in node config',
+        ),
+      };
+    }
+    return { ok: true, value: defaultModelValue.trim() };
+  }
+
+  private resolveAllowedModels(): string[] {
+    return this.explicitAllowedModels ?? parseCsv(process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS);
+  }
+
+  private resolveProvider(allowedModels: string[]): IImageGenerationProvider | undefined {
+    const apiKeyValue = this.explicitApiKey ?? process.env.GEMINI_API_KEY;
+    if (typeof apiKeyValue === 'string' && apiKeyValue.trim().length > 0) {
+      return new GoogleProvider({
+        apiKey: apiKeyValue.trim(),
+        imageCapableModels: allowedModels,
+      });
+    }
+    return undefined;
+  }
+
+  private getImageProviderCapability(
+    provider: IImageGenerationProvider | undefined,
+  ): TResult<IImageGenerationProvider, IDagError> {
+    if (!provider || typeof provider.generateImage !== 'function') {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TEXT_TO_IMAGE_API_KEY_REQUIRED',
+          'GEMINI_API_KEY must be configured for text-to-image node runtime',
+        ),
+      };
+    }
+    return { ok: true, value: provider };
+  }
+
+  private getFirstOutputOrError(
+    result: IImageGenerationResult,
+    model: string,
+  ): TResult<NonNullable<IImageGenerationResult['outputs'][number]>, IDagError> {
+    const firstOutput = result.outputs[0];
+    if (!firstOutput) {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_RESPONSE_MISSING_IMAGE',
+          'Text-to-image response did not include image data',
+          false,
+          { model },
+        ),
+      };
+    }
+    return { ok: true, value: firstOutput };
+  }
+
+  public async generateImage(
+    request: ITextToImageRequest,
+  ): Promise<TResult<IPortBinaryValue, IDagError>> {
+    const defaultModelResult = this.resolveDefaultModel();
+    if (!defaultModelResult.ok) return defaultModelResult;
+    const allowedModels = this.resolveAllowedModels();
+    const resolvedProvider = this.resolveProvider(allowedModels);
+    const providerCapabilityResult = this.getImageProviderCapability(resolvedProvider);
+    if (!providerCapabilityResult.ok) {
+      return providerCapabilityResult;
+    }
+    const provider = providerCapabilityResult.value;
+    const modelResult = resolveModel(request.model, defaultModelResult.value, allowedModels);
+    if (!modelResult.ok) {
+      return modelResult;
+    }
+
+    const result = await provider.generateImage({
+      prompt: request.prompt,
+      model: modelResult.value,
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: buildTaskExecutionError(
+          'DAG_TASK_EXECUTION_TEXT_TO_IMAGE_FAILED',
+          result.error.message,
+          false,
+          { code: result.error.code, model: modelResult.value },
+        ),
+      };
+    }
+
+    const outputResult = this.getFirstOutputOrError(result.value, modelResult.value);
+    if (!outputResult.ok) {
+      return outputResult;
+    }
+    return normalizeImageOutput(outputResult.value);
+  }
+}

--- a/packages/dag-nodes/text-to-image/tsconfig.eslint.json
+++ b/packages/dag-nodes/text-to-image/tsconfig.eslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.eslint.json"
+}

--- a/packages/dag-nodes/text-to-image/tsconfig.json
+++ b/packages/dag-nodes/text-to-image/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/text-to-image/tsdown.config.ts
+++ b/packages/dag-nodes/text-to-image/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/packages/dag-nodes/tool/docs/README.md
+++ b/packages/dag-nodes/tool/docs/README.md
@@ -1,0 +1,3 @@
+# dag-node-tool Docs Index
+
+- `SPEC.md`: Package specification for the `tool` DAG node definition (in-process agent-tools builtin invocation)

--- a/packages/dag-nodes/tool/docs/SPEC.md
+++ b/packages/dag-nodes/tool/docs/SPEC.md
@@ -1,0 +1,49 @@
+# Tool Node Specification
+
+## Scope
+
+- Owns the `tool` DAG node definition.
+- Wraps a single **in-process** `@robota-sdk/agent-tools` builtin (Read, Write, Edit, Shell, Bash, Glob, Grep, WebFetch, WebSearch) as one DAG step, emitting its text output.
+
+## Boundaries
+
+- Extends `AbstractNodeDefinition` from `@robota-sdk/dag-node`. Does not redefine core DAG contracts.
+- Distinct from the `mcp-tool` node: `mcp-tool` calls an **external** MCP server over HTTP/stdio; this node runs an agent builtin **in the current process**. No network transport, no MCP client.
+- Depends on `@robota-sdk/agent-tools` directly (a published agent package). DAG-node packages are permitted to depend on agent packages — `instant-node` already depends on `agent-core`. The DAG subsystem itself stays `private`; this package is `private: true`.
+- Tool selection is a static allowlist (`toolName` → agent-tools factory). Only the enumerated builtins are constructible; an unknown `toolName` yields a `set_config` validation error listing the allowed names.
+
+## Architecture Overview
+
+- `ToolNodeDefinition` — node with an optional `params` input port (JSON string) and `output` + `isError` output ports.
+- `config.toolName` selects the builtin. `config.params` supplies static tool arguments; the `params` input port (parsed as JSON) is merged over them (input wins).
+- File/shell builtins (`read`/`write`/`edit`/`shell`/`bash`) receive `config.cwd` as a path restriction (`ISandboxToolOptions.cwd`); pure builtins (`glob`/`grep`/`web-fetch`/`web-search`) ignore it.
+- Result mapping:
+  - The builtin throws (`ValidationError` / `ToolExecutionError`) → node returns `ok: false` with `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
+  - The builtin returns a JSON-encoded `IToolInvocationResult` with `success: false` (a soft, tool-reported failure — e.g. binary file) → node returns `ok: true` with `output` = the error text and `isError: true`.
+  - Otherwise → `ok: true`, `output` = the tool's text, `isError: false`.
+- Cost estimate: `config.baseCredits` (default 0).
+
+## Type Ownership
+
+| Type                   | Location       | Purpose                         |
+| ---------------------- | -------------- | ------------------------------- |
+| `ToolNodeDefinition`   | `src/index.ts` | Node definition class           |
+| `ToolNodeConfigSchema` | `src/index.ts` | Zod config schema (exported)    |
+| `TToolNodeConfig`      | `src/index.ts` | Inferred config type (exported) |
+
+## Public API Surface
+
+- `ToolNodeDefinition` — class
+- `createToolNodeDefinition()` — factory function
+- `ToolNodeConfigSchema` — Zod schema (for external config validation)
+- `TToolNodeConfig` — TypeScript type
+- `TOOL_NODE_ALLOWED_TOOLS` — the allowlist of builtin names (readonly)
+
+## Extension Points
+
+- Config `toolName`: one of `read`, `write`, `edit`, `shell`, `bash`, `glob`, `grep`, `web-fetch`, `web-search`.
+- Config `params`: static arguments merged under the `params` input.
+- Config `cwd`: path restriction forwarded to file/shell builtins.
+- Config `baseCredits`: base cost per successful call.
+- Error codes: `DAG_VALIDATION_TOOL_UNKNOWN_TOOL`, `DAG_VALIDATION_TOOL_INVALID_PARAMS`, `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
+- Adding a builtin: extend `TOOL_NODE_ALLOWED_TOOLS` and the `TOOL_FACTORIES` map.

--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@robota-sdk/dag-node-tool",
+  "version": "3.0.0-beta.61",
+  "private": true,
+  "description": "In-process tool node for Robota DAG — execute a single @robota-sdk/agent-tools builtin as a DAG step",
+  "type": "module",
+  "main": "dist/node/index.js",
+  "module": "dist/node/index.mjs",
+  "types": "dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "node": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      },
+      "browser": {
+        "import": "./dist/node/index.js"
+      },
+      "default": {
+        "import": "./dist/node/index.js",
+        "require": "./dist/node/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "build:js": "tsdown --no-dts",
+    "build:types": "tsdown --dts",
+    "dev": "tsdown --dts --watch",
+    "clean": "rimraf dist",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "bash ../../../scripts/check-pnpm-publish.sh"
+  },
+  "author": "Robota SDK Team",
+  "license": "AGPL-3.0-only OR LicenseRef-Commercial",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-tools": "workspace:*",
+    "@robota-sdk/dag-core": "workspace:*",
+    "@robota-sdk/dag-node": "workspace:*",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "eslint": "^8.56.0",
+    "rimraf": "^5.0.5",
+    "tsdown": "^0.22.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
+++ b/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { INodeExecutionContext, INodeConfigObject, TPortPayload } from '@robota-sdk/dag-core';
+import {
+  ToolNodeDefinition,
+  ToolNodeConfigSchema,
+  TOOL_NODE_ALLOWED_TOOLS,
+  createToolNodeDefinition,
+} from '../index.js';
+
+function makeContext(config: Record<string, unknown>): INodeExecutionContext {
+  const node = new ToolNodeDefinition();
+  return {
+    dagId: 'dag-1',
+    dagRunId: 'run-1',
+    taskRunId: 'task-1',
+    nodeDefinition: {
+      nodeId: 'tool-1',
+      nodeType: 'tool',
+      dependsOn: [],
+      config: config as INodeConfigObject,
+      inputs: [],
+      outputs: [],
+    },
+    nodeManifest: {
+      nodeType: 'tool',
+      displayName: 'Tool',
+      category: 'Integration',
+      inputs: node.inputs,
+      outputs: node.outputs,
+      defaultInputPort: node.defaultInputPort,
+      defaultOutputPort: node.defaultOutputPort,
+    },
+    attempt: 1,
+    executionPath: [],
+    currentTotalCredits: 0,
+  };
+}
+
+describe('ToolNodeDefinition metadata', () => {
+  it('has correct nodeType and displayName', () => {
+    const node = new ToolNodeDefinition();
+    expect(node.nodeType).toBe('tool');
+    expect(node.displayName).toBe('Tool');
+    expect(node.category).toBe('Integration');
+  });
+
+  it('has correct port definitions', () => {
+    const node = new ToolNodeDefinition();
+    expect(node.inputs.find((p) => p.key === 'params')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'output')).toBeDefined();
+    expect(node.outputs.find((p) => p.key === 'isError')).toBeDefined();
+    expect(node.defaultInputPort).toBe('params');
+    expect(node.defaultOutputPort).toBe('output');
+  });
+
+  it('factory returns an instance', () => {
+    expect(createToolNodeDefinition()).toBeInstanceOf(ToolNodeDefinition);
+  });
+
+  it('exposes the allowed-tools allowlist', () => {
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('read');
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('grep');
+    expect(TOOL_NODE_ALLOWED_TOOLS).toContain('shell');
+  });
+});
+
+describe('ToolNodeConfigSchema', () => {
+  it('accepts minimal config and applies defaults', () => {
+    const result = ToolNodeConfigSchema.safeParse({ toolName: 'grep' });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.params).toEqual({});
+    expect(result.data.baseCredits).toBe(0);
+  });
+
+  it('rejects empty toolName', () => {
+    expect(ToolNodeConfigSchema.safeParse({ toolName: '' }).success).toBe(false);
+  });
+
+  it('rejects negative baseCredits', () => {
+    expect(ToolNodeConfigSchema.safeParse({ toolName: 'read', baseCredits: -1 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('ToolNodeDefinition execution', () => {
+  const node = new ToolNodeDefinition();
+  let dir: string;
+  let file: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dag-tool-node-'));
+    file = join(dir, 'hello.txt');
+    writeFileSync(file, 'alpha\nbeta\ngamma\n', 'utf8');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function run(config: Record<string, unknown>, input: TPortPayload = {}) {
+    return node.taskHandler.execute(input, makeContext(config));
+  }
+
+  it('rejects an unknown toolName with a set_config validation error', async () => {
+    const result = await run({ toolName: 'does-not-exist' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('DAG_VALIDATION_TOOL_UNKNOWN_TOOL');
+    expect(result.error.fix?.action).toBe('set_config');
+    expect(Array.isArray(result.error.fix?.options)).toBe(true);
+  });
+
+  it('rejects invalid JSON in the params input port', async () => {
+    const result = await run({ toolName: 'read' }, { params: 'not json{' });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('DAG_VALIDATION_TOOL_INVALID_PARAMS');
+  });
+
+  it('reads a file via the in-process read builtin (config params)', async () => {
+    const result = await run({ toolName: 'read', params: { filePath: file } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.output).toContain('alpha');
+    expect(result.value.output).toContain('gamma');
+    expect(result.value.isError).toBe(false);
+  });
+
+  it('merges the params input port over config params (input wins)', async () => {
+    const other = join(dir, 'other.txt');
+    writeFileSync(other, 'from-input-file\n', 'utf8');
+    const result = await run(
+      { toolName: 'read', params: { filePath: file } },
+      { params: JSON.stringify({ filePath: other }) },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.output).toContain('from-input-file');
+  });
+
+  it('surfaces a soft tool failure as isError=true (missing file)', async () => {
+    const result = await run({ toolName: 'read', params: { filePath: join(dir, 'nope.txt') } });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.isError).toBe(true);
+  });
+});

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -1,0 +1,243 @@
+import {
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createShellTool,
+  createWriteTool,
+  globTool,
+  grepTool,
+  webFetchTool,
+  webSearchTool,
+  type FunctionTool,
+  type ISandboxToolOptions,
+} from '@robota-sdk/agent-tools';
+import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+import {
+  buildTaskExecutionError,
+  buildValidationError,
+  type ICostEstimate,
+  type IDagError,
+  type IDagNodeDefinition,
+  type INodeExecutionContext,
+  type IPortDefinition,
+  type TPortPayload,
+  type TResult,
+} from '@robota-sdk/dag-core';
+import { z } from 'zod';
+
+/**
+ * A builtin factory receives sandbox/cwd options; pure builtins (glob/grep/web-*)
+ * ignore them and return their shared singleton instance.
+ */
+type ToolFactory = (options: ISandboxToolOptions) => FunctionTool;
+
+/** Static allowlist mapping `toolName` → the agent-tools builtin factory. */
+const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
+  read: (o) => createReadTool(o),
+  write: (o) => createWriteTool(o),
+  edit: (o) => createEditTool(o),
+  shell: (o) => createShellTool(o),
+  bash: (o) => createBashTool(o),
+  glob: () => globTool,
+  grep: () => grepTool,
+  'web-fetch': () => webFetchTool,
+  'web-search': () => webSearchTool,
+};
+
+/** The builtin tool names this node can run in-process. */
+export const TOOL_NODE_ALLOWED_TOOLS: readonly string[] = Object.freeze(
+  Object.keys(TOOL_FACTORIES),
+);
+
+export const ToolNodeConfigSchema = z.object({
+  /** Which in-process agent-tools builtin to run (see TOOL_NODE_ALLOWED_TOOLS). */
+  toolName: z.string().min(1),
+  /** Static tool arguments; the `params` input port is merged over these (input wins). */
+  params: z.record(z.unknown()).default({}),
+  /** Path restriction forwarded to file/shell builtins (ISandboxToolOptions.cwd). */
+  cwd: z.string().optional(),
+  /** Base credit cost per successful call (for cost estimation). */
+  baseCredits: z.number().nonnegative().default(0),
+});
+
+export type TToolNodeConfig = z.infer<typeof ToolNodeConfigSchema>;
+
+const TOOL_INPUTS: IPortDefinition[] = [
+  {
+    key: 'params',
+    label: 'Tool Parameters (JSON string)',
+    order: 0,
+    type: 'string',
+    required: false,
+  },
+];
+
+const TOOL_OUTPUTS: IPortDefinition[] = [
+  { key: 'output', label: 'Output', order: 0, type: 'string', required: true },
+  { key: 'isError', label: 'Is Error', order: 1, type: 'boolean', required: true },
+];
+
+/**
+ * Coerce a builtin's raw return value into `{ output, isError }`.
+ *
+ * Builtins return either plain text (success) or a JSON-encoded
+ * `IToolInvocationResult` with `success: false` for soft, tool-reported
+ * failures (e.g. a missing/binary file). Both shapes are normalised here.
+ */
+function coerceToolResult(data: unknown): { output: string; isError: boolean } {
+  const text = typeof data === 'string' ? data : JSON.stringify(data ?? '');
+  try {
+    const parsed = JSON.parse(text) as { success?: unknown; output?: unknown; error?: unknown };
+    if (parsed !== null && typeof parsed === 'object' && typeof parsed.success === 'boolean') {
+      const value = parsed.success ? parsed.output : (parsed.error ?? parsed.output);
+      return {
+        output: typeof value === 'string' ? value : String(value ?? ''),
+        isError: !parsed.success,
+      };
+    }
+  } catch {
+    // allow-fallback: non-JSON output is plain success text
+  }
+  return { output: text, isError: false };
+}
+
+function invalidParamsError(toolName: string, message: string, suggestion: string): IDagError {
+  return buildValidationError(
+    'DAG_VALIDATION_TOOL_INVALID_PARAMS',
+    message,
+    { toolName },
+    { action: 'set_input', suggestion },
+  );
+}
+
+/**
+ * Resolve the optional `params` input port into a plain object, merged later
+ * over `config.params`. A JSON string is parsed; a non-object decode is rejected.
+ */
+function resolveInputParams(
+  rawParams: ReturnType<NodeIoAccessor['getInput']>,
+  toolName: string,
+): TResult<Record<string, unknown>, IDagError> {
+  if (typeof rawParams === 'string' && rawParams.trim() !== '') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawParams);
+    } catch {
+      return {
+        ok: false,
+        error: invalidParamsError(
+          toolName,
+          'The `params` input port must be a JSON object string.',
+          'Provide a valid JSON object as the params input',
+        ),
+      };
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {
+        ok: false,
+        error: invalidParamsError(
+          toolName,
+          'The `params` input port must decode to a JSON object.',
+          'Provide a JSON object (not an array or primitive)',
+        ),
+      };
+    }
+    return { ok: true, value: parsed as Record<string, unknown> };
+  }
+  if (rawParams !== null && typeof rawParams === 'object' && !Array.isArray(rawParams)) {
+    return { ok: true, value: rawParams as Record<string, unknown> };
+  }
+  return { ok: true, value: {} };
+}
+
+/** Execute the selected builtin and map its result onto the node's output ports. */
+async function runBuiltin(
+  tool: FunctionTool,
+  params: Record<string, unknown>,
+  toolName: string,
+  nodeId: string,
+): Promise<TResult<TPortPayload, IDagError>> {
+  try {
+    const result = await tool.execute(params as unknown as Parameters<FunctionTool['execute']>[0]);
+    const { output, isError } = coerceToolResult(result.data);
+
+    const out = new NodeIoAccessor({}, nodeId);
+    out.setOutput('output', output);
+    out.setOutput('isError', isError);
+    out.setOutput(
+      '_agentSummary',
+      `Tool "${toolName}" ran. ${isError ? 'Reported an error.' : `Output: ${output.length} chars.`}`,
+    );
+    return { ok: true, value: out.toOutput() };
+  } catch (err) {
+    // allow-fallback: a thrown ValidationError/ToolExecutionError is a hard node failure
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: buildTaskExecutionError(
+        'DAG_TASK_EXECUTION_TOOL_CALL_FAILED',
+        `Tool "${toolName}" failed: ${message}`,
+        true,
+        { toolName },
+      ),
+    };
+  }
+}
+
+export class ToolNodeDefinition extends AbstractNodeDefinition<typeof ToolNodeConfigSchema> {
+  public readonly nodeType = 'tool';
+  public readonly displayName = 'Tool';
+  public readonly category = 'Integration';
+  public readonly inputs: IDagNodeDefinition['inputs'] = TOOL_INPUTS;
+  public readonly outputs: IDagNodeDefinition['outputs'] = TOOL_OUTPUTS;
+  public readonly configSchemaDefinition = ToolNodeConfigSchema;
+  public override readonly defaultInputPort = 'params';
+  public override readonly defaultOutputPort = 'output';
+
+  public constructor() {
+    super();
+  }
+
+  public async estimateCostWithConfig(
+    _input: TPortPayload,
+    _context: INodeExecutionContext,
+    config: TToolNodeConfig,
+  ): Promise<TResult<ICostEstimate, IDagError>> {
+    return { ok: true, value: { estimatedCredits: config.baseCredits } };
+  }
+
+  protected override async executeWithConfig(
+    input: TPortPayload,
+    context: INodeExecutionContext,
+    config: TToolNodeConfig,
+  ): Promise<TResult<TPortPayload, IDagError>> {
+    const factory = TOOL_FACTORIES[config.toolName];
+    if (!factory) {
+      return {
+        ok: false,
+        error: buildValidationError(
+          'DAG_VALIDATION_TOOL_UNKNOWN_TOOL',
+          `Unknown toolName "${config.toolName}". Choose one of the supported in-process builtins.`,
+          { toolName: config.toolName },
+          {
+            action: 'set_config',
+            suggestion: 'Set toolName to a supported builtin',
+            options: [...TOOL_NODE_ALLOWED_TOOLS],
+          },
+        ),
+      };
+    }
+
+    const io = new NodeIoAccessor(input, context.nodeDefinition.nodeId);
+    const paramsResult = resolveInputParams(io.getInput('params'), config.toolName);
+    if (!paramsResult.ok) return paramsResult;
+
+    const merged = { ...config.params, ...paramsResult.value };
+    const tool = factory(config.cwd !== undefined ? { cwd: config.cwd } : {});
+    return runBuiltin(tool, merged, config.toolName, context.nodeDefinition.nodeId);
+  }
+}
+
+export function createToolNodeDefinition(): ToolNodeDefinition {
+  return new ToolNodeDefinition();
+}

--- a/packages/dag-nodes/tool/tsconfig.json
+++ b/packages/dag-nodes/tool/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/dag-nodes/tool/tsdown.config.ts
+++ b/packages/dag-nodes/tool/tsdown.config.ts
@@ -1,0 +1,10 @@
+export default {
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist/node',
+  clean: true,
+  outExtensions: (ctx) => ({
+    js: ctx.format === 'cjs' ? '.cjs' : '.js',
+    dts: ctx.format === 'cjs' ? '.d.cts' : '.d.ts',
+  }),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2045,6 +2045,9 @@ importers:
       '@robota-sdk/dag-node-text-template':
         specifier: workspace:*
         version: link:../dag-nodes/text-template
+      '@robota-sdk/dag-node-text-to-image':
+        specifier: workspace:*
+        version: link:../dag-nodes/text-to-image
       '@robota-sdk/dag-node-tool':
         specifier: workspace:*
         version: link:../dag-nodes/tool
@@ -2755,6 +2758,43 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/text-to-image:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2045,6 +2045,9 @@ importers:
       '@robota-sdk/dag-node-text-template':
         specifier: workspace:*
         version: link:../dag-nodes/text-template
+      '@robota-sdk/dag-node-tool':
+        specifier: workspace:*
+        version: link:../dag-nodes/tool
       '@robota-sdk/dag-node-transform':
         specifier: workspace:*
         version: link:../dag-nodes/transform
@@ -2752,6 +2755,40 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/tool:
+    dependencies:
+      '@robota-sdk/agent-tools':
+        specifier: workspace:*
+        version: link:../../agent-tools
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2042,6 +2042,9 @@ importers:
       '@robota-sdk/dag-node-seedance-video':
         specifier: workspace:*
         version: link:../dag-nodes/seedance-video
+      '@robota-sdk/dag-node-skill':
+        specifier: workspace:*
+        version: link:../dag-nodes/skill
       '@robota-sdk/dag-node-text-output':
         specifier: workspace:*
         version: link:../dag-nodes/text-output
@@ -2729,6 +2732,43 @@ importers:
       '@robota-sdk/agent-provider':
         specifier: workspace:*
         version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/skill:
+    dependencies:
+      '@robota-sdk/agent-framework':
+        specifier: workspace:*
+        version: link:../../agent-framework
+      '@robota-sdk/agent-interface-transport':
+        specifier: workspace:*
+        version: link:../../agent-interface-transport
       '@robota-sdk/dag-core':
         specifier: workspace:*
         version: link:../../dag-core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2039,6 +2039,9 @@ importers:
       '@robota-sdk/dag-node-ok-emitter':
         specifier: workspace:*
         version: link:../dag-nodes/ok-emitter
+      '@robota-sdk/dag-node-seedance-video':
+        specifier: workspace:*
+        version: link:../dag-nodes/seedance-video
       '@robota-sdk/dag-node-text-output':
         specifier: workspace:*
         version: link:../dag-nodes/text-output
@@ -2702,6 +2705,43 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+
+  packages/dag-nodes/seedance-video:
+    dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
+      '@robota-sdk/agent-provider':
+        specifier: workspace:*
+        version: link:../../agent-provider
+      '@robota-sdk/dag-core':
+        specifier: workspace:*
+        version: link:../../dag-core
+      '@robota-sdk/dag-node':
+        specifier: workspace:*
+        version: link:../../dag-node
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.43
       eslint:
         specifier: ^8.56.0
         version: 8.57.1


### PR DESCRIPTION
Promotes today's `develop` work to `main`.

## Included (#965–#970)

- **WORKFLOW-005 P1 node-kinds** (DAG stays private; CLI-077 held throughout):
  - `dag-node-tool` — in-process agent-tools builtin node (#965)
  - `dag-node-text-to-image` — Gemini generate-from-prompt node (#966)
  - `dag-node-seedance-video` — ByteDance async submit→poll video node (#967)
  - `dag-node-skill` — Robota skill → inject-prompt resolver node (#968)
- **fix: streaming token usage exposure** (BEHAVIOR-005) — OpenAI-compatible streaming now sends `stream_options.include_usage`; the assembler + `runStream` commit path attach usage; `run()`/`runStream()` expose token usage again. Changeset included (agent-core/agent-provider patch). (#969)
- **chore(agents):** BEHAVIOR-005 GATE-COMPLETE bookkeeping + INFRA-026 pty-teardown-flake backlog (#970)

Merge commit (not squash); `develop` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)