### PR TITLE
chore(agents): BEHAVIOR-006 GATE-COMPLETE

### DIFF
--- a/.agents/spec-docs/done/BEHAVIOR-006-composite-instant-node-reload.md
+++ b/.agents/spec-docs/done/BEHAVIOR-006-composite-instant-node-reload.md
@@ -1,5 +1,5 @@
 ---
-status: verifying
+status: done
 type: BEHAVIOR
 tags: [async, typescript]
 ---
@@ -219,3 +219,6 @@ BEHAVIOR + async → save→reload round-trip integration test (fs-mocked) + uni
     `result === 'from-inner-dag'`. Before the fix the composite was dropped on reload (unknown-node-type).
   - dag-cli **997 tests** green; typecheck clean; 0 lint errors; test-module-mocks + capability-placement
     scans pass; CLI-077 holds (agent-cli published closure unchanged).
+- **GATE-COMPLETE — PASS (2026-07-05).** Merged to `develop` via **PR #972** (squash `76d5e88b`;
+  one follow-up commit unexported `buildCompositeRunner` for the orphan-exports scan). Private DAG
+  only — no publish/changeset; CLI-077 held. Spec-doc promoted `draft/ → done/`; task archived.

--- a/.agents/tasks/completed/BEHAVIOR-006.md
+++ b/.agents/tasks/completed/BEHAVIOR-006.md
@@ -1,6 +1,6 @@
 # BEHAVIOR-006: composite instant nodes survive save → reload (WORKFLOW-005 P2)
 
-- **Status:** in-progress
+- **Status:** done (merged via PR #972)
 - **Spec:** `.agents/spec-docs/draft/BEHAVIOR-006-composite-instant-node-reload.md`
 - **Branch:** `fix/dag-composite-instant-reload`
 - **Approved:** 2026-07-05 (user sign-off "승인함")


### PR DESCRIPTION
Docs bookkeeping only — promotes the merged composite-reload fix (#972) spec-doc `draft/ → done/` (status `done`, GATE-COMPLETE evidence) and archives the task to `tasks/completed/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)