### PR TITLE
chore(release): merge develop into main — DATA-002 P1 unified persistence store

### DIFF
--- a/.agents/spec-docs/draft/DATA-002-unified-node-persistence.md
+++ b/.agents/spec-docs/draft/DATA-002-unified-node-persistence.md
@@ -1,0 +1,192 @@
+---
+status: in-progress
+type: DATA
+tags: [typescript, async]
+---
+
+# DATA-002: unified manifest-centered node persistence (WORKFLOW-005 P2 #2)
+
+## Problem
+
+DAG persistence is fragmented across three independent on-disk formats with three independent
+save/scan/load implementations and duplicated `.dag/` path + readdir-scan boilerplate (private DAG
+subsystem — no publish):
+
+1. **Workflows** — `.dag/workflows/*.dag.json` (`saveCommand` `commands/save.ts:280`; `scanCatalogDir`
+   `catalog/catalog-scanner.ts:46`). Data-only `IDagDefinition`/`IDagWorkflowFile`.
+2. **Instant nodes** — `.dag/nodes/*.instant-node.json` (`saveInstantNodeToDisk` /
+   `loadSavedInstantNodes` `mcp/handlers/instant-nodes.ts`; record `TPersistedInstantNode`,
+   `kind:'prompt'|'composite'`, per BEHAVIOR-006). Data → rebuilt class instance.
+3. **Code nodes** — `*.dag.node.js` scattered anywhere in the project, discovered by a whole-tree
+   scanner (`local-runner/local-node-loader.ts` `loadLocalNodeDefinitions`), loaded via dynamic
+   `import()`. No manifest, no save path; behavior is authored JS.
+
+There is **no shared abstraction**. Adding a new savable kind (e.g. Phase C data-code nodes) means a
+fourth silo. Code nodes are structurally orphaned from the node registry (no metadata record; loaded
+by a different mechanism than instant nodes).
+
+## Architecture Review
+
+### The unified model (greenfield — no legacy/back-compat)
+
+`/workflows` is not a released feature, so there is **no legacy and no migration**. The formats are
+redefined to the single correct model, and every call site is switched directly. Representation is
+chosen per kind — **not dogmatically paired** — for the naturally-right shape.
+
+**One store owns `.dag/` and all persistence.** Every node has a **`.node.json` manifest** — the
+ALWAYS-present base that holds all metadata (nodeType, kind, displayName, ports, …). The behavior code
+`.js` is **supplementary**, attached only to code-kind nodes; metadata always lives in the manifest,
+never in the `.js`:
+
+```
+.dag/nodes/
+  greet.node.json        manifest (ALWAYS) — kind 'prompt' : metadata + systemPromptTemplate + ports
+  merge.node.json        manifest (ALWAYS) — kind 'composite' : metadata + innerDag + exposed ports
+  upshout.node.json      manifest (ALWAYS) — kind 'code' : metadata + ports + codeFile pointer
+  upshout.dag.node.js    SUPPLEMENTARY — the execute() behavior for the 'code' node (behavior only)
+.dag/workflows/
+  <name>.dag.json        workflow (data-only), managed by the same store
+```
+
+- **`prompt` / `composite`** → the `.node.json` manifest is the whole node (behavior is data). Non-pair.
+- **`code`** → the `.node.json` manifest holds the metadata (nodeType, ports, `kind:'code'`, a
+  `codeFile` pointer); the paired `.dag.node.js` holds **only** the `execute()` behavior. On load: read
+  the manifest for metadata → `import()` the companion for behavior → `adaptSimpleNode`
+  (`local-node-loader.ts:36`) combines them. Metadata is read from the manifest, so nodes can be
+  listed/validated **without importing arbitrary code**.
+- **Workflows** → `.dag/workflows/*.dag.json`, managed by the same store (data-only, load = parse).
+
+**Manifest filename:** the record extension is generalized from BEHAVIOR-006's `.instant-node.json`
+to **`.node.json`** — it is now the universal node manifest (all kinds), not instant-specific.
+(No legacy → free to rename.) The data-node record shape (`TPersistedInstantNode`) is otherwise
+unchanged; `kind:'code'` is added.
+
+Code nodes live **uniformly in `.dag/nodes/`** (discovered by the store), replacing the ad-hoc
+whole-project scatter-scan. `--node-file <path>` remains an explicit escape hatch. No scatter-scan,
+`kind`-inference, or migration is carried (no legacy).
+
+This delivers "save a node OR a workflow, reload it" through **one store** with **one uniform metadata
+record** (`.node.json`) per node; behavior code is a supplementary attachment for code-kind nodes.
+
+### Affected Scope
+
+- `packages/dag-cli/src/local-runner/persistence/` (NEW) — the `PersistenceStore`: `saveNode(def)`,
+  `loadNodes(liveDefs)`, `saveWorkflow(name, def)`, `loadWorkflows()`, `scanNodeArtifacts()`. Owns all
+  `.dag/` path computation + readdir-skip boilerplate (removing the inline duplication in `save.ts`,
+  `catalog-scanner.ts`, `instant-nodes.ts`, `local-node-loader.ts`).
+- `packages/dag-cli/src/local-runner/local-node-loader.ts` + `node-registry.ts` — code-node discovery
+  moves to `.dag/nodes/` via the store; the whole-project scatter-scan is removed (no legacy).
+  `loadNodeFileExplicit` (`--node-file`) retained.
+- `packages/dag-cli/src/mcp/handlers/instant-nodes.ts` + `mcp/context.ts` — route through the store.
+- `packages/dag-cli/src/commands/{save,catalog,run,validate,node}.ts`, `studio/http-server.ts` — switch
+  to the store for save/scan/load (direct cut-over, no shims).
+- `packages/dag-nodes/instant-node/docs/SPEC.md` — reference the unified store location if the record
+  shape is affected (data-node records are unchanged from BEHAVIOR-006).
+- **No published-package change**; CLI-077 holds. No published on-disk contract exists to break.
+
+### Alternatives Considered
+
+1. **Manifest-always (`.node.json`) as the metadata SSOT; behavior `.js` supplementary for code nodes;
+   one store over `.dag/` (chosen — owner model).** Pro: one uniform metadata record per node
+   (list/validate without importing code); code behavior stays authored code; workflows join the same
+   store; direct cut-over (no legacy). Con: largest blast radius (all persistence call sites) —
+   mitigated by size-phasing (below), not compat-phasing.
+2. **Self-describing single file per code node (no manifest; `.dag.node.js` carries its own metadata).**
+   Pro: no manifest for code. Con: metadata only available by importing arbitrary code (can't list/
+   validate without executing an import); non-uniform record model. Rejected by the owner ("메타정보는
+   .json이 가진다").
+3. **Shared helpers only — centralize `.dag/` paths + scan boilerplate, leave three formats.** Pro:
+   minimal. Con: does not deliver one abstraction; code nodes stay orphaned. Rejected.
+
+### Decision
+
+Alternative 1 (owner model). One `PersistenceStore` over `.dag/`. Every node has a `.node.json`
+manifest (metadata SSOT, discriminated by `kind`); a `code` node additionally has a supplementary
+`.dag.node.js` holding only `execute()`. Data nodes (`prompt`/`composite`) are the manifest alone.
+Workflows in `.dag/workflows/`. All call sites cut over directly. **No back-compat, migration, or
+deprecation shim** (feature unreleased — no legacy); the `.instant-node.json` extension is renamed to
+the universal `.node.json`.
+
+**Size-phasing (implementation order only — each phase is the clean end-state for its slice, no
+shims):** (1) store + `.node.json` manifest for data nodes (prompt/composite) + workflows routed
+through it; (2) `kind:'code'` manifest + supplementary `.dag.node.js`, code-node discovery moved into
+`.dag/nodes/`, scatter-scan removed; (3) remaining command call sites (validate/node/studio) cut over.
+Every phase lands independently green.
+
+**Validation (wide blast radius — persistence + registry + run path):**
+
+- **Reachability** — every kind resolves into the same `IDagNodeDefinition[]` consumed by
+  `getAllDefinitions()` / `LocalDagRunner` (traced: `context.ts` merge, `runs.ts` registry); workflows
+  resolve to `IDagDefinition`. A `code` manifest's metadata + its `.js` behavior combine via
+  `adaptSimpleNode`. Verified against load→register→run.
+- **Capability preservation** — prompt/composite reload (BEHAVIOR-006) unchanged; code-node `execute`
+  adaptation preserved via the same `adaptSimpleNode`; `--node-file` explicit load preserved. The only
+  dropped capability is scatter-scanning code files from arbitrary project locations — a deliberate
+  removal (no legacy), replaced by the uniform `.dag/nodes/` location + `--node-file`.
+- **Adversarial pass** — (a) a `code` manifest whose supplementary `.dag.node.js` is missing/fails to
+  import → node skipped with a log, not a crash; (b) manifest `nodeType` ≠ the `.js` export's nodeType
+  → manifest wins (metadata SSOT), logged; (c) a `.dag.node.ts` companion (needs tsx) → skipped with a
+  clear message as today; (d) empty/missing `.dag/nodes/` → no-op.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — BEHAVIOR-006 instant-node persist/reload is the sibling; `.node.json` generalizes its record; workflows + code manifests join the same store
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료 (no legacy/migration; manifest-always metadata SSOT; size-phased only)
+
+## Solution
+
+1. `PersistenceStore` in `local-runner/persistence/` — `saveNode(def)` (writes `<nodeType>.node.json`;
+   for a code node also writes/points to `<nodeType>.dag.node.js`), `loadNodes(liveDefs)` (scan
+   `.dag/nodes/*.node.json`; per manifest `kind`: prompt/composite → `reconstructInstantNode`; code →
+   `import()` the `codeFile` + `adaptSimpleNode` using the manifest's metadata), `saveWorkflow` /
+   `loadWorkflows`; all `.dag/` path + readdir-skip boilerplate centralized.
+2. Generalize the record to `.node.json` and add `IPersistedCodeNode { kind:'code', nodeType,
+displayName, category?, inputs, outputs, defaultInputPort?, defaultOutputPort?, codeFile }`.
+3. `mcp/context.ts` + instant-node handlers + `save`/`catalog` commands call the store; code-node
+   discovery = `.dag/nodes/` manifests via the store; remove the whole-project scatter scan; keep
+   `--node-file`.
+
+## Affected Files
+
+- `packages/dag-cli/src/local-runner/persistence/*` (new), `local-node-loader.ts`, `node-registry.ts`
+- `packages/dag-cli/src/mcp/handlers/instant-nodes.ts`, `mcp/context.ts`
+- `packages/dag-nodes/instant-node/src/index.ts` (+ `docs/SPEC.md`) — `.node.json` rename note + `IPersistedCodeNode`
+- `packages/dag-cli/src/commands/{save,catalog,run,validate,node}.ts`, `studio/http-server.ts`
+- Tests: `packages/dag-cli/src/__tests__/*` (store round-trip: data node, code node manifest+companion, workflow)
+
+## Completion Criteria
+
+- [ ] TC-01: `PersistenceStore.loadNodes` over `.dag/nodes/` containing a `kind:'code'` `.node.json`
+      manifest + its supplementary `.dag.node.js` reconstructs a runnable `IDagNodeDefinition` (manifest
+      metadata + imported `execute` via `adaptSimpleNode`).
+- [ ] TC-02: prompt + composite `.node.json` round-trip through the store unchanged (BEHAVIOR-006 record
+      logic, `.node.json` extension).
+- [ ] TC-03: a workflow round-trips through the store (`saveWorkflow` → `loadWorkflows` → identical `IDagDefinition`).
+- [ ] TC-04: a `code` manifest whose `.dag.node.js` is missing/unimportable is skipped with a log (no
+      crash); a manifest-vs-export `nodeType` mismatch resolves to the manifest (logged).
+- [ ] TC-05: end-to-end — a code node (manifest + `.dag.node.js`) in `.dag/nodes/`, loaded via the store
+      into a fresh registry, runs through `LocalDagRunner` (real fs, no mocks).
+
+## Test Plan
+
+DATA + async → save→reload round-trip integration tests (fs-mocked units + a real round-trip), plus
+unit tests for the store path/scan helpers and the record discrimination.
+
+| TC-ID | Test Type          | Tool / Approach                                                              | Notes |
+| ----- | ------------------ | ---------------------------------------------------------------------------- | ----- |
+| TC-01 | Unit/Integration   | vitest — store code-node save+load, fs-mocked + adapt assertion              |       |
+| TC-02 | Unit (regression)  | vitest — prompt/composite via store (BEHAVIOR-006 parity)                    |       |
+| TC-03 | Unit               | vitest — workflow save/load identity through the store                       |       |
+| TC-04 | Unit               | vitest — missing companion skipped; standalone scanner still loads (Phase 1) |       |
+| TC-05 | Integration (real) | vitest — real fs + `LocalDagRunner`, code node reload→run                    |       |
+
+## Tasks
+
+- [ ] `.agents/tasks/DATA-002.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log
+
+- **GATE-WRITE — PASS (2026-07-05).** All sections present; TC-01…TC-05 command/observable; checklist all [x]; test-plan row per TC.
+- **GATE-APPROVAL — PASS (2026-07-05).** Design iterated with owner: no legacy/migration (feature unreleased); manifest-always `.node.json` as metadata SSOT; code behavior is a supplementary `.dag.node.js` (runtime-`import()`able, `.ts` needs a transform → excluded, types via `.d.ts`/JSDoc). Owner sign-offs, verbatim: model — "나 선택"; metadata-in-json — "메타정보는 .json 이 가지고 있는거지"; code format — ".js" ("좋아"); final — **"좋아"**. Implementation authorized (size-phased).

--- a/.agents/tasks/DATA-002.md
+++ b/.agents/tasks/DATA-002.md
@@ -1,0 +1,23 @@
+# DATA-002: unified manifest-centered node persistence (WORKFLOW-005 P2 #2)
+
+- **Status:** in-progress (Phase 1)
+- **Spec:** `.agents/spec-docs/draft/DATA-002-unified-node-persistence.md`
+- **Branch:** `feat/dag-unified-persistence`
+- **Approved:** 2026-07-05 (owner "좋아"; model 나, metadata-in-.node.json, code=.js)
+
+## Goal
+
+One `PersistenceStore` over `.dag/`. Every node = a `.node.json` manifest (metadata SSOT, `kind`
+prompt|composite|code); a code node additionally has a supplementary `.dag.node.js` (behavior only).
+Workflows in `.dag/workflows/` via the same store. No legacy/migration (feature unreleased).
+
+## Phases (size only — each independently green)
+
+- [x] Phase 1: PersistenceStore + `.node.json` for data nodes (prompt/composite) + workflow routing.
+- [ ] Phase 2: `kind:'code'` manifest + supplementary `.dag.node.js`; code discovery in `.dag/nodes/`; remove scatter-scan.
+- [ ] Phase 3: remaining command call sites (validate/node/studio) cut over.
+
+## Test Plan
+
+TC-01..05 in the spec-doc: code manifest+companion load/run; prompt/composite `.node.json` round-trip;
+workflow round-trip; missing-companion skip + nodeType precedence; real fs + LocalDagRunner e2e.

--- a/packages/dag-cli/src/__tests__/composite-reload-real.test.ts
+++ b/packages/dag-cli/src/__tests__/composite-reload-real.test.ts
@@ -72,7 +72,7 @@ describe('BEHAVIOR-006 composite reload — real fs + runner', () => {
   });
 
   it('creates → persists → reloads → runs a composite after a simulated restart', async () => {
-    // 1. Create + persist the composite (writes .dag/nodes/echo-composite.instant-node.json).
+    // 1. Create + persist the composite (writes .dag/nodes/echo-composite.node.json).
     const createCtx = makeRealContext(projectDir);
     const created = await handleDagInstantNodeCreateComposite(
       createCtx,

--- a/packages/dag-cli/src/__tests__/mcp-handlers.test.ts
+++ b/packages/dag-cli/src/__tests__/mcp-handlers.test.ts
@@ -1068,9 +1068,9 @@ describe('BEHAVIOR-006: composite instant node save → reload', () => {
     const { loadSavedInstantNodes } = await import('../mcp/handlers/instant-nodes.js');
     const fs = await import('node:fs/promises');
     const record = { kind: 'composite', ...VALID_COMPOSITE };
-    vi.mocked(fs.readdir).mockResolvedValueOnce([
-      'my-composite.instant-node.json',
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce(['my-composite.node.json'] as unknown as Awaited<
+      ReturnType<typeof fs.readdir>
+    >);
     vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(record));
 
     const liveDefs: ILocalMcpServerContext['instantNodeDefinitions'] = [];
@@ -1087,40 +1087,41 @@ describe('BEHAVIOR-006: composite instant node save → reload', () => {
     const written = await lastWrittenRecord();
 
     // Simulate restart: a fresh registry reloads from the exact written record.
-    vi.mocked(fs.readdir).mockResolvedValueOnce([
-      'my-composite.instant-node.json',
-    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
+    vi.mocked(fs.readdir).mockResolvedValueOnce(['my-composite.node.json'] as unknown as Awaited<
+      ReturnType<typeof fs.readdir>
+    >);
     vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(written));
     const reloaded: ILocalMcpServerContext['instantNodeDefinitions'] = [];
     await loadSavedInstantNodes('/proj', reloaded);
     expect(reloaded.some((n) => n.nodeType === written['nodeType'])).toBe(true);
   });
 
-  it('back-compat: legacy prompt reloads; a composite with no innerDag is skipped (TC-04)', async () => {
+  it('reloads a valid prompt manifest; an unrecoverable record is skipped (TC-04)', async () => {
     const { loadSavedInstantNodes } = await import('../mcp/handlers/instant-nodes.js');
     const fs = await import('node:fs/promises');
     vi.mocked(fs.readdir).mockResolvedValueOnce([
-      'legacy-prompt.instant-node.json',
-      'old-composite.instant-node.json',
+      'good-prompt.node.json',
+      'bad-composite.node.json',
     ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
     vi.mocked(fs.readFile)
       .mockResolvedValueOnce(
         JSON.stringify({
-          nodeType: 'legacy-prompt',
-          displayName: 'Legacy',
-          taskCode: 'Say hi to {{text}}',
-          inputs: [{ key: 'text' }],
-          outputs: [{ key: 'text' }],
+          kind: 'prompt',
+          nodeType: 'good-prompt',
+          displayName: 'Good',
+          systemPromptTemplate: 'Say hi to {{text}}',
+          inputPorts: [{ key: 'text' }],
+          outputPort: { key: 'text' },
         }),
       )
       .mockResolvedValueOnce(
-        JSON.stringify({ nodeType: 'old-composite', displayName: 'Old', taskCode: null }),
+        JSON.stringify({ kind: 'composite', nodeType: 'bad-composite', displayName: 'Bad' }),
       );
 
     const defs: ILocalMcpServerContext['instantNodeDefinitions'] = [];
     await loadSavedInstantNodes('/proj', defs);
-    expect(defs.map((n) => n.nodeType)).toContain('legacy-prompt');
-    expect(defs.map((n) => n.nodeType)).not.toContain('old-composite');
+    expect(defs.map((n) => n.nodeType)).toContain('good-prompt');
+    expect(defs.map((n) => n.nodeType)).not.toContain('bad-composite');
   });
 });
 
@@ -1138,24 +1139,22 @@ describe('handleInstantNodeListSaved', () => {
     const { handleInstantNodeListSaved } = await import('../mcp/handlers/instant-nodes.js');
     const ctx = makeContext();
     const result = await handleInstantNodeListSaved({}, ctx);
-    expect(getText(result.content, 0)).toContain('No saved instant nodes');
+    expect(getText(result.content, 0)).toContain('No saved nodes');
   });
 
-  it('returns empty message when dir exists but no instant-node files', async () => {
+  it('returns empty message when dir exists but no node manifest files', async () => {
     const fsModule = await import('node:fs/promises');
     vi.mocked(fsModule.readdir).mockResolvedValueOnce(['other-file.json'] as unknown as never);
 
     const { handleInstantNodeListSaved } = await import('../mcp/handlers/instant-nodes.js');
     const ctx = makeContext();
     const result = await handleInstantNodeListSaved({}, ctx);
-    expect(getText(result.content, 0)).toContain('No saved instant nodes');
+    expect(getText(result.content, 0)).toContain('No saved nodes');
   });
 
-  it('returns list of saved instant nodes', async () => {
+  it('returns list of saved nodes', async () => {
     const fsModule = await import('node:fs/promises');
-    vi.mocked(fsModule.readdir).mockResolvedValueOnce([
-      'my-node.instant-node.json',
-    ] as unknown as never);
+    vi.mocked(fsModule.readdir).mockResolvedValueOnce(['my-node.node.json'] as unknown as never);
     vi.mocked(fsModule.readFile).mockResolvedValueOnce(
       JSON.stringify({
         nodeType: 'my-node',

--- a/packages/dag-cli/src/__tests__/persistence-store.test.ts
+++ b/packages/dag-cli/src/__tests__/persistence-store.test.ts
@@ -1,0 +1,58 @@
+/**
+ * DATA-002 persistence store — real-fs round-trips (no mocks).
+ * Phase 1: workflows and data-node manifests are owned by the single store.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IDagDefinition } from '@robota-sdk/dag-core';
+import {
+  saveWorkflow,
+  loadWorkflows,
+  workflowsDir,
+  WORKFLOW_EXT,
+} from '../local-runner/persistence/store.js';
+
+const WORKFLOW: IDagDefinition = {
+  dagId: 'my-flow',
+  version: 1,
+  status: 'draft',
+  nodes: [{ nodeId: 'n1', nodeType: 'input', dependsOn: [], config: { text: 'hi' } }],
+  edges: [],
+} as unknown as IDagDefinition;
+
+describe('DATA-002 persistence store — workflows (TC-03)', () => {
+  let projectDir: string;
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'persist-store-'));
+  });
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a workflow: saveWorkflow → loadWorkflows → identical definition', async () => {
+    const written = await saveWorkflow('my-flow', WORKFLOW, projectDir);
+    expect(written).toBe(join(workflowsDir(projectDir), `my-flow${WORKFLOW_EXT}`));
+
+    const loaded = await loadWorkflows(projectDir);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].name).toBe('my-flow');
+    expect(loaded[0].definition).toEqual(WORKFLOW);
+  });
+
+  it('returns empty when .dag/workflows/ does not exist', async () => {
+    const loaded = await loadWorkflows(projectDir);
+    expect(loaded).toEqual([]);
+  });
+
+  it('skips non-.dag.json and malformed files', async () => {
+    await saveWorkflow('good', WORKFLOW, projectDir);
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(join(workflowsDir(projectDir), 'notes.txt'), 'ignore me', 'utf-8');
+    await fs.writeFile(join(workflowsDir(projectDir), 'broken.dag.json'), '{ not json', 'utf-8');
+
+    const loaded = await loadWorkflows(projectDir);
+    expect(loaded.map((w) => w.name)).toEqual(['good']);
+  });
+});

--- a/packages/dag-cli/src/__tests__/save-command.test.ts
+++ b/packages/dag-cli/src/__tests__/save-command.test.ts
@@ -108,7 +108,7 @@ describe('saveCommand', () => {
     expect(mockWriteFile).toHaveBeenCalledWith(
       expect.stringContaining('my-pipeline.dag.json'),
       expect.stringContaining('"dagId": "my-pipeline"'),
-      'utf8',
+      'utf-8',
     );
   });
 

--- a/packages/dag-cli/src/commands/save.ts
+++ b/packages/dag-cli/src/commands/save.ts
@@ -1,5 +1,3 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import type {
   IDagDefinition,
   IDagEdgeDefinition,
@@ -11,9 +9,8 @@ import type { IDagCliIo } from '../types.js';
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE, USAGE_ERROR_EXIT_CODE } from '../types.js';
 import { createCliNodeRegistry } from '../local-runner/index.js';
 import { parsePipelineSpec } from '../pipeline-parser.js';
-import { DEFAULT_CATALOG_DIR } from '../catalog/catalog-scanner.js';
+import { saveWorkflow } from '../local-runner/persistence/store.js';
 
-const JSON_INDENT_SPACES = 2;
 const NODE_X_SPACING = 300;
 
 const SAVE_HELP = `Usage: dag save --pipeline "<spec>" --name <name> [--node-config <nodeId.key=value>]
@@ -277,22 +274,11 @@ export async function saveCommand(
 
   const definition = applyNodeConfigs(buildResult.definition, nodeConfigs, io);
 
-  const workflowsDir = DEFAULT_CATALOG_DIR;
+  let outputPath: string;
   try {
-    await mkdir(workflowsDir, { recursive: true });
-  } catch (mkdirErr) {
-    // allow-fallback: directory creation failure reported as structured error
-    const msg = mkdirErr instanceof Error ? mkdirErr.message : String(mkdirErr);
-    io.write(`Error: Failed to create workflows directory: ${msg}\n`);
-    return FAILURE_EXIT_CODE;
-  }
-
-  const outputPath = join(workflowsDir, `${name}.dag.json`);
-  const dagJson = JSON.stringify(definition, null, JSON_INDENT_SPACES);
-  try {
-    await writeFile(outputPath, dagJson + '\n', 'utf8');
+    outputPath = await saveWorkflow(name, definition, process.cwd());
   } catch (writeErr) {
-    // allow-fallback: file write failure reported as structured error and non-zero exit
+    // allow-fallback: directory/file write failure reported as structured error and non-zero exit
     const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);
     io.write(`Error: Failed to write workflow file: ${msg}\n`);
     return FAILURE_EXIT_CODE;

--- a/packages/dag-cli/src/local-runner/persistence/store.ts
+++ b/packages/dag-cli/src/local-runner/persistence/store.ts
@@ -1,0 +1,261 @@
+/**
+ * Persistence store (DATA-002, WORKFLOW-005 P2).
+ *
+ * Single owner of `.dag/` save + load. Every node is a `.node.json` manifest (metadata SSOT,
+ * discriminated by `kind`). Data nodes (prompt/composite) are the manifest alone; a code node
+ * additionally has a supplementary `.dag.node.js` (added in Phase 2). Workflows live in
+ * `.dag/workflows/*.dag.json` (data-only) and are managed here too. Centralizes the `.dag/` path +
+ * readdir-skip boilerplate that was duplicated across handlers/context/commands.
+ */
+import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { IDagDefinition, IDagNodeDefinition, TPortPayload } from '@robota-sdk/dag-core';
+import {
+  createPromptBackedNodeDefinition,
+  createCompositeInstantNodeDefinition,
+  type ICreateCompositeNodeInput,
+  type ICompositeSubRunner,
+  type TInstantNodeProvider,
+  type IPersistableInstantNode,
+  type TPersistedInstantNode,
+} from '@robota-sdk/dag-node-instant-node';
+import { LocalDagRunner, createCliNodeRegistry } from '../index.js';
+import { safeParseJson } from '../../mcp/utils.js';
+
+/** Universal node manifest extension (DATA-002 — generalized from `.instant-node.json`). */
+export const NODE_MANIFEST_EXT = '.node.json';
+
+/** The `.dag/nodes/` directory for a project. */
+export function nodesDir(projectDir: string): string {
+  return join(projectDir, '.dag', 'nodes');
+}
+
+/** Narrow an arbitrary node definition to one that can serialize itself for reload. */
+function asPersistable(nodeDef: IDagNodeDefinition): IPersistableInstantNode | undefined {
+  return typeof (nodeDef as Partial<IPersistableInstantNode>).toPersisted === 'function'
+    ? (nodeDef as unknown as IPersistableInstantNode)
+    : undefined;
+}
+
+/**
+ * Persist a node from its own serializable manifest view. Prompt AND composite nodes; the composite
+ * `runner` is behavioral and is rebuilt on reload, never serialized.
+ */
+export async function saveNode(nodeDef: IDagNodeDefinition, projectDir: string): Promise<void> {
+  const persistable = asPersistable(nodeDef);
+  if (!persistable) return;
+  const dir = nodesDir(projectDir);
+  await mkdir(dir, { recursive: true });
+  const record = { ...persistable.toPersisted(), createdAt: new Date().toISOString() };
+  await writeFile(
+    join(dir, `${nodeDef.nodeType}${NODE_MANIFEST_EXT}`),
+    JSON.stringify(record, null, 2),
+    'utf-8',
+  );
+}
+
+/**
+ * Build a composite sub-runner that closes over the **live** definitions array so nested/other
+ * nodes registered before OR after are visible at run time. Shared by create-time and reload.
+ */
+export function buildCompositeRunner(liveDefs: IDagNodeDefinition[]): ICompositeSubRunner {
+  return {
+    async run(dag, input) {
+      const subRunner = new LocalDagRunner([...createCliNodeRegistry(), ...liveDefs]);
+      try {
+        // allow-fallback: inner DAG errors are returned as structured result
+        const subResult = await subRunner.run(dag, input);
+        const outputs: Record<string, TPortPayload> = {};
+        for (const tr of subResult.taskRuns) {
+          if (tr.outputSnapshot) {
+            const parsed = safeParseJson(tr.outputSnapshot);
+            if (typeof parsed === 'object' && parsed !== null) {
+              outputs[tr.nodeId] = parsed as TPortPayload;
+            }
+          }
+        }
+        return { ok: subResult.dagRun.status === 'success', outputs };
+      } catch (err) {
+        // allow-fallback: inner DAG errors are returned as structured result
+        return {
+          ok: false,
+          outputs: {},
+          error: err instanceof Error ? err.message : 'Inner DAG run failed',
+        };
+      }
+    },
+  };
+}
+
+function toRecordObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function parsePortKeys(value: unknown): Array<{ key: string; description?: string }> | null {
+  if (!Array.isArray(value)) return null;
+  const ports = value
+    .map((p) => toRecordObject(p))
+    .filter((p): p is Record<string, unknown> => p !== null && typeof p['key'] === 'string')
+    .map((p) => ({ key: p['key'] as string }));
+  return ports.length > 0 ? ports : null;
+}
+
+/** Parse an on-disk manifest into a discriminated persisted node record. */
+function parsePersistedRecord(raw: unknown): TPersistedInstantNode | null {
+  const r = toRecordObject(raw);
+  if (!r || typeof r['nodeType'] !== 'string') return null;
+  const nodeType = r['nodeType'];
+  const displayName = typeof r['displayName'] === 'string' ? r['displayName'] : nodeType;
+
+  if (r['kind'] === 'composite') {
+    const innerDag = toRecordObject(r['innerDag']);
+    const exposedInputPort = toRecordObject(r['exposedInputPort']);
+    if (
+      !innerDag ||
+      !exposedInputPort ||
+      typeof exposedInputPort['key'] !== 'string' ||
+      !Array.isArray(r['exposedOutputPorts']) ||
+      r['exposedOutputPorts'].length === 0
+    ) {
+      return null;
+    }
+    return {
+      kind: 'composite',
+      nodeType,
+      displayName,
+      innerDag: innerDag as unknown as import('@robota-sdk/dag-core').IDagDefinition,
+      exposedInputPort:
+        exposedInputPort as unknown as ICreateCompositeNodeInput['exposedInputPort'],
+      exposedOutputPorts: r[
+        'exposedOutputPorts'
+      ] as unknown as ICreateCompositeNodeInput['exposedOutputPorts'],
+      ...(typeof r['maxDepth'] === 'number' ? { maxDepth: r['maxDepth'] } : {}),
+    };
+  }
+
+  // prompt
+  const template = r['systemPromptTemplate'];
+  if (typeof template !== 'string') return null;
+  const inputPorts = parsePortKeys(r['inputPorts']) ?? [{ key: 'text' }];
+  const outputPorts = parsePortKeys(r['outputPort'] !== undefined ? [r['outputPort']] : undefined);
+  return {
+    kind: 'prompt',
+    nodeType,
+    displayName,
+    systemPromptTemplate: template,
+    inputPorts,
+    outputPort: outputPorts ? { key: outputPorts[0].key } : { key: 'text' },
+    ...(typeof r['provider'] === 'string'
+      ? { provider: r['provider'] as TInstantNodeProvider }
+      : {}),
+    ...(typeof r['model'] === 'string' ? { model: r['model'] } : {}),
+  };
+}
+
+function reconstructNode(
+  record: TPersistedInstantNode,
+  liveDefs: IDagNodeDefinition[],
+): IDagNodeDefinition {
+  if (record.kind === 'composite') {
+    return createCompositeInstantNodeDefinition({
+      nodeType: record.nodeType,
+      displayName: record.displayName,
+      innerDag: record.innerDag,
+      exposedInputPort: record.exposedInputPort,
+      exposedOutputPorts: record.exposedOutputPorts,
+      runner: buildCompositeRunner(liveDefs),
+      ...(record.maxDepth !== undefined ? { maxDepth: record.maxDepth } : {}),
+    });
+  }
+  return createPromptBackedNodeDefinition({
+    nodeType: record.nodeType,
+    displayName: record.displayName,
+    systemPromptTemplate: record.systemPromptTemplate,
+    inputPorts: record.inputPorts,
+    outputPort: record.outputPort,
+    ...(record.provider !== undefined ? { provider: record.provider } : {}),
+    ...(record.model !== undefined ? { model: record.model } : {}),
+  });
+}
+
+/**
+ * Load persisted node manifests from `.dag/nodes/*.node.json` into `liveDefs`, skipping
+ * already-registered/malformed records. Composite runners close over `liveDefs` so nested nodes
+ * resolve regardless of load order.
+ */
+export async function loadNodes(projectDir: string, liveDefs: IDagNodeDefinition[]): Promise<void> {
+  const dir = nodesDir(projectDir);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    // allow-fallback: .dag/nodes/ may not exist yet
+    return;
+  }
+  for (const file of files.filter((f) => f.endsWith(NODE_MANIFEST_EXT))) {
+    try {
+      const record = parsePersistedRecord(JSON.parse(await readFile(join(dir, file), 'utf-8')));
+      if (!record) continue;
+      if (liveDefs.some((n) => n.nodeType === record.nodeType)) continue;
+      liveDefs.push(reconstructNode(record, liveDefs));
+    } catch {
+      // allow-fallback: unreadable/unparseable/unconstructable record skipped
+      continue;
+    }
+  }
+}
+
+// --- Workflows (data-only `.dag.json` under `.dag/workflows/`) ---
+
+/** Workflow file extension. */
+export const WORKFLOW_EXT = '.dag.json';
+
+/** The `.dag/workflows/` directory for a project. */
+export function workflowsDir(projectDir: string): string {
+  return join(projectDir, '.dag', 'workflows');
+}
+
+/** Persist a workflow definition to `.dag/workflows/<name>.dag.json`. Returns the written path. */
+export async function saveWorkflow(
+  name: string,
+  definition: IDagDefinition,
+  projectDir: string,
+): Promise<string> {
+  const dir = workflowsDir(projectDir);
+  await mkdir(dir, { recursive: true });
+  const outputPath = join(dir, `${name}${WORKFLOW_EXT}`);
+  await writeFile(outputPath, `${JSON.stringify(definition, null, 2)}\n`, 'utf-8');
+  return outputPath;
+}
+
+/**
+ * Load workflow definitions from `.dag/workflows/*.dag.json` (data-only parse). Malformed/unreadable
+ * files are skipped. Returns `{ name, definition }` per valid file.
+ */
+export async function loadWorkflows(
+  projectDir: string,
+): Promise<Array<{ name: string; definition: IDagDefinition }>> {
+  const dir = workflowsDir(projectDir);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    // allow-fallback: .dag/workflows/ may not exist yet
+    return [];
+  }
+  const workflows: Array<{ name: string; definition: IDagDefinition }> = [];
+  for (const file of files.filter((f) => f.endsWith(WORKFLOW_EXT))) {
+    try {
+      const parsed = JSON.parse(await readFile(join(dir, file), 'utf-8')) as unknown;
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
+      workflows.push({
+        name: file.slice(0, -WORKFLOW_EXT.length),
+        definition: parsed as IDagDefinition,
+      });
+    } catch {
+      // allow-fallback: unreadable/unparseable workflow file skipped
+      continue;
+    }
+  }
+  return workflows;
+}

--- a/packages/dag-cli/src/mcp/handlers/instant-nodes.ts
+++ b/packages/dag-cli/src/mcp/handlers/instant-nodes.ts
@@ -1,6 +1,6 @@
 /** Handlers for instant-node MCP tools: dag_instant_node_create, dag_instant_node_create_composite, dag_instant_node_list */
 
-import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { IDagNodeDefinition } from '@robota-sdk/dag-core';
@@ -9,72 +9,23 @@ import {
   createCompositeInstantNodeDefinition,
   type ICreatePromptNodeInput,
   type ICreateCompositeNodeInput,
-  type ICompositeSubRunner,
   type TInstantNodeProvider,
-  type IPersistableInstantNode,
-  type TPersistedInstantNode,
 } from '@robota-sdk/dag-node-instant-node';
-import { LocalDagRunner, createCliNodeRegistry } from '../../local-runner/index.js';
+import {
+  saveNode,
+  loadNodes,
+  buildCompositeRunner,
+  nodesDir,
+  NODE_MANIFEST_EXT,
+} from '../../local-runner/persistence/store.js';
 import type { ILocalMcpServerContext } from '../context.js';
-import { makeTextResult, makeErrorResult, safeParseJson } from '../utils.js';
+import { makeTextResult, makeErrorResult } from '../utils.js';
 
-/** Narrow an arbitrary node definition to one that can serialize itself for reload. */
-function asPersistable(nodeDef: IDagNodeDefinition): IPersistableInstantNode | undefined {
-  return typeof (nodeDef as Partial<IPersistableInstantNode>).toPersisted === 'function'
-    ? (nodeDef as unknown as IPersistableInstantNode)
-    : undefined;
-}
+/** Re-exported for the server context startup loader. */
+export { loadNodes as loadSavedInstantNodes };
 
-/**
- * Persist an instant node from its own serializable view (BEHAVIOR-006). Works for prompt AND
- * composite nodes at every call site — the node owns its persisted data; the composite `runner`
- * is behavioral and is rebuilt on reload, never serialized.
- */
-async function saveInstantNodeToDisk(
-  nodeDef: IDagNodeDefinition,
-  ctx: ILocalMcpServerContext,
-): Promise<void> {
-  const persistable = asPersistable(nodeDef);
-  if (!persistable) return;
-  const nodesDir = join(ctx.options.projectDir ?? process.cwd(), '.dag', 'nodes');
-  await mkdir(nodesDir, { recursive: true });
-  const record = { ...persistable.toPersisted(), createdAt: new Date().toISOString() };
-  const filePath = join(nodesDir, `${nodeDef.nodeType}.instant-node.json`);
-  await writeFile(filePath, JSON.stringify(record, null, 2), 'utf-8');
-}
-
-/**
- * Build a composite sub-runner that closes over the **live** definitions array so nested/other
- * instant nodes registered before OR after are visible at run time (Finding C). Shared by
- * create-time and reload.
- */
-function buildCompositeRunner(liveDefs: IDagNodeDefinition[]): ICompositeSubRunner {
-  return {
-    async run(dag, input) {
-      const subRunner = new LocalDagRunner([...createCliNodeRegistry(), ...liveDefs]);
-      try {
-        // allow-fallback: inner DAG errors are returned as structured result
-        const subResult = await subRunner.run(dag, input);
-        const outputs: Record<string, import('@robota-sdk/dag-core').TPortPayload> = {};
-        for (const tr of subResult.taskRuns) {
-          if (tr.outputSnapshot) {
-            const parsed = safeParseJson(tr.outputSnapshot);
-            if (typeof parsed === 'object' && parsed !== null) {
-              outputs[tr.nodeId] = parsed as import('@robota-sdk/dag-core').TPortPayload;
-            }
-          }
-        }
-        return { ok: subResult.dagRun.status === 'success', outputs };
-      } catch (err) {
-        // allow-fallback: inner DAG errors are returned as structured result
-        return {
-          ok: false,
-          outputs: {},
-          error: err instanceof Error ? err.message : 'Inner DAG run failed',
-        };
-      }
-    },
-  };
+function projectDirOf(ctx: ILocalMcpServerContext): string {
+  return ctx.options.projectDir ?? process.cwd();
 }
 
 export async function handleDagInstantNodeCreate(
@@ -161,7 +112,7 @@ export async function handleDagInstantNodeCreate(
   const nodeDef = createPromptBackedNodeDefinition(spec);
   ctx.invalidateNodeCache();
   ctx.instantNodeDefinitions.push(nodeDef);
-  await saveInstantNodeToDisk(nodeDef, ctx);
+  await saveNode(nodeDef, projectDirOf(ctx));
 
   const manifests = ctx.getManifests();
   const manifest = manifests.find((m) => m.nodeType === spec.nodeType);
@@ -232,7 +183,7 @@ export async function handleDagInstantNodeCreateComposite(
   const nodeDef = createCompositeInstantNodeDefinition(spec);
   ctx.invalidateNodeCache();
   ctx.instantNodeDefinitions.push(nodeDef);
-  await saveInstantNodeToDisk(nodeDef, ctx);
+  await saveNode(nodeDef, projectDirOf(ctx));
 
   const manifests = ctx.getManifests();
   const manifest = manifests.find((m) => m.nodeType === spec.nodeType);
@@ -272,178 +223,44 @@ export async function handleInstantNodeSave(
       content: [{ type: 'text', text: `Error: instant node "${nodeType}" not found in memory.` }],
     };
   }
-  await saveInstantNodeToDisk(nodeDef, ctx);
+  await saveNode(nodeDef, projectDirOf(ctx));
   return {
     content: [
       {
         type: 'text',
-        text: `Saved instant node "${nodeType}" to .dag/nodes/${nodeType}.instant-node.json`,
+        text: `Saved node "${nodeType}" to .dag/nodes/${nodeType}${NODE_MANIFEST_EXT}`,
       },
     ],
   };
-}
-
-function toRecordObject(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
-}
-
-function parsePortKeys(value: unknown): Array<{ key: string; description?: string }> | null {
-  if (!Array.isArray(value)) return null;
-  const ports = value
-    .map((p) => toRecordObject(p))
-    .filter((p): p is Record<string, unknown> => p !== null && typeof p['key'] === 'string')
-    .map((p) => ({ key: p['key'] as string }));
-  return ports.length > 0 ? ports : null;
-}
-
-/**
- * Parse an on-disk record into a discriminated persisted node (BEHAVIOR-006), with back-compat for
- * pre-fix files (no `kind`): a string `taskCode` → prompt; `taskCode:null` + `innerDag` → composite;
- * a `taskCode:null` with no `innerDag` (old composite) is unrecoverable → null (skipped).
- */
-function parsePersistedRecord(raw: unknown): TPersistedInstantNode | null {
-  const r = toRecordObject(raw);
-  if (!r || typeof r['nodeType'] !== 'string') return null;
-  const nodeType = r['nodeType'];
-  const displayName = typeof r['displayName'] === 'string' ? r['displayName'] : nodeType;
-  const kind = r['kind'];
-
-  const isComposite =
-    kind === 'composite' ||
-    (kind === undefined && r['taskCode'] === null && toRecordObject(r['innerDag']) !== null);
-  if (isComposite) {
-    const innerDag = toRecordObject(r['innerDag']);
-    const exposedInputPort = toRecordObject(r['exposedInputPort']);
-    if (
-      !innerDag ||
-      !exposedInputPort ||
-      typeof exposedInputPort['key'] !== 'string' ||
-      !Array.isArray(r['exposedOutputPorts']) ||
-      r['exposedOutputPorts'].length === 0
-    ) {
-      return null;
-    }
-    return {
-      kind: 'composite',
-      nodeType,
-      displayName,
-      innerDag: innerDag as unknown as import('@robota-sdk/dag-core').IDagDefinition,
-      exposedInputPort:
-        exposedInputPort as unknown as ICreateCompositeNodeInput['exposedInputPort'],
-      exposedOutputPorts: r[
-        'exposedOutputPorts'
-      ] as unknown as ICreateCompositeNodeInput['exposedOutputPorts'],
-      ...(typeof r['maxDepth'] === 'number' ? { maxDepth: r['maxDepth'] } : {}),
-    };
-  }
-
-  // prompt — new (`kind:'prompt'` + `systemPromptTemplate`) or legacy (`taskCode` string).
-  const template = kind === 'prompt' ? r['systemPromptTemplate'] : r['taskCode'];
-  if (typeof template !== 'string') return null;
-  const inputPorts = parsePortKeys(r['inputPorts']) ??
-    parsePortKeys(r['inputs']) ?? [{ key: 'text' }];
-  const outputPorts =
-    parsePortKeys(r['outputPort'] !== undefined ? [r['outputPort']] : undefined) ??
-    parsePortKeys(r['outputs']);
-  return {
-    kind: 'prompt',
-    nodeType,
-    displayName,
-    systemPromptTemplate: template,
-    inputPorts,
-    outputPort: outputPorts ? { key: outputPorts[0].key } : { key: 'text' },
-    ...(typeof r['provider'] === 'string'
-      ? { provider: r['provider'] as TInstantNodeProvider }
-      : {}),
-    ...(typeof r['model'] === 'string' ? { model: r['model'] } : {}),
-  };
-}
-
-function reconstructInstantNode(
-  record: TPersistedInstantNode,
-  liveDefs: IDagNodeDefinition[],
-): IDagNodeDefinition {
-  if (record.kind === 'composite') {
-    return createCompositeInstantNodeDefinition({
-      nodeType: record.nodeType,
-      displayName: record.displayName,
-      innerDag: record.innerDag,
-      exposedInputPort: record.exposedInputPort,
-      exposedOutputPorts: record.exposedOutputPorts,
-      runner: buildCompositeRunner(liveDefs),
-      ...(record.maxDepth !== undefined ? { maxDepth: record.maxDepth } : {}),
-    });
-  }
-  return createPromptBackedNodeDefinition({
-    nodeType: record.nodeType,
-    displayName: record.displayName,
-    systemPromptTemplate: record.systemPromptTemplate,
-    inputPorts: record.inputPorts,
-    outputPort: record.outputPort,
-    ...(record.provider !== undefined ? { provider: record.provider } : {}),
-    ...(record.model !== undefined ? { model: record.model } : {}),
-  });
-}
-
-/**
- * Load saved instant nodes from `.dag/nodes/*.instant-node.json` and reconstruct them (prompt AND
- * composite — BEHAVIOR-006) into `liveDefs`, skipping already-registered/malformed records. Composite
- * runners close over `liveDefs` so nested instant nodes resolve regardless of load order.
- */
-export async function loadSavedInstantNodes(
-  projectDir: string,
-  liveDefs: IDagNodeDefinition[],
-): Promise<void> {
-  const nodesDir = join(projectDir, '.dag', 'nodes');
-  let files: string[];
-  try {
-    files = await readdir(nodesDir);
-  } catch {
-    // allow-fallback: .dag/nodes/ may not exist yet
-    return;
-  }
-  for (const file of files.filter((f) => f.endsWith('.instant-node.json'))) {
-    try {
-      const record = parsePersistedRecord(
-        JSON.parse(await readFile(join(nodesDir, file), 'utf-8')),
-      );
-      if (!record) continue;
-      if (liveDefs.some((n) => n.nodeType === record.nodeType)) continue;
-      liveDefs.push(reconstructInstantNode(record, liveDefs));
-    } catch {
-      // allow-fallback: unreadable/unparseable/unconstructable record skipped
-      continue;
-    }
-  }
 }
 
 export async function handleInstantNodeListSaved(
   _args: Record<string, unknown>,
   ctx: ILocalMcpServerContext,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
-  const nodesDir = join(ctx.options.projectDir ?? process.cwd(), '.dag', 'nodes');
+  const dir = nodesDir(projectDirOf(ctx));
   let files: string[];
   try {
-    files = await readdir(nodesDir);
+    files = await readdir(dir);
   } catch {
     // allow-fallback: .dag/nodes/ may not exist yet; treat as empty
     return {
       content: [
         {
           type: 'text',
-          text: 'No saved instant nodes found (.dag/nodes/ does not exist).',
+          text: 'No saved nodes found (.dag/nodes/ does not exist).',
         },
       ],
     };
   }
-  const jsonFiles = files.filter((f) => f.endsWith('.instant-node.json'));
+  const jsonFiles = files.filter((f) => f.endsWith(NODE_MANIFEST_EXT));
   if (jsonFiles.length === 0) {
-    return { content: [{ type: 'text', text: 'No saved instant nodes found.' }] };
+    return { content: [{ type: 'text', text: 'No saved nodes found.' }] };
   }
   const items: string[] = [];
   for (const file of jsonFiles) {
     try {
-      const content = await readFile(join(nodesDir, file), 'utf-8');
+      const content = await readFile(join(dir, file), 'utf-8');
       const record = JSON.parse(content) as {
         nodeType: string;
         displayName: string;
@@ -456,8 +273,6 @@ export async function handleInstantNodeListSaved(
     }
   }
   return {
-    content: [
-      { type: 'text', text: `Saved instant nodes (${jsonFiles.length}):\n${items.join('\n')}` },
-    ],
+    content: [{ type: 'text', text: `Saved nodes (${jsonFiles.length}):\n${items.join('\n')}` }],
   };
 }

--- a/packages/dag-cli/src/mcp/tool-definitions.ts
+++ b/packages/dag-cli/src/mcp/tool-definitions.ts
@@ -335,7 +335,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'dag_instant_node_save',
     description:
-      'Persist an in-memory instant node to disk as .dag/nodes/<nodeType>.instant-node.json so it is automatically restored on the next MCP server startup.',
+      'Persist an in-memory instant node to disk as .dag/nodes/<nodeType>.node.json so it is automatically restored on the next MCP server startup.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
Merge develop → main.

Contains: DATA-002 Phase 1 — unified persistence store (`.node.json` manifests + workflow routing) for the private DAG subsystem (#975). No published-package change; CLI-077 holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)