### PR TITLE
chore(agents): INFRA-028 GATE-COMPLETE (spec-doc → done, task archived)

### DIFF
--- a/.agents/spec-docs/done/INFRA-028-self-contained-agent-cli-bundle.md
+++ b/.agents/spec-docs/done/INFRA-028-self-contained-agent-cli-bundle.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags: [cli, ci]
 ---

--- a/.agents/tasks/completed/INFRA-028.md
+++ b/.agents/tasks/completed/INFRA-028.md
@@ -1,7 +1,8 @@
 # INFRA-028: self-contained `@robota-sdk/agent-cli` published bundle
 
-- **Status:** in-progress
-- **Spec:** `.agents/spec-docs/draft/INFRA-028-self-contained-agent-cli-bundle.md`
+- **Status:** completed
+- **Completed:** 2026-07-05 (#983 → develop → main #984)
+- **Spec:** `.agents/spec-docs/done/INFRA-028-self-contained-agent-cli-bundle.md`
 - **Branch:** `feat/agent-cli-self-contained-bundle`
 - **Approved:** 2026-07-05 (owner "@robota-sdk만 번들 (추천)")
 


### PR DESCRIPTION
INFRA-028 (self-contained agent-cli bundle) is complete — merged to main (#983 → develop → main #984).

Lands the backlog done gate: spec-doc `draft → done` (status: done) and task `→ completed/`. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)