### PR TITLE
chore(release): merge develop into main — FLOW-007 Phase 1 (.workflows/ layout)

### DIFF
--- a/.agents/spec-docs/draft/FLOW-007-workflows-nl-authoring.md
+++ b/.agents/spec-docs/draft/FLOW-007-workflows-nl-authoring.md
@@ -1,0 +1,177 @@
+---
+status: in-progress
+type: FLOW
+tags: [cli, agent]
+---
+
+# FLOW-007: natural-language workflow authoring & immediate run via `/workflows`
+
+## Problem
+
+`/workflows` today (WORKFLOW-003) only **lists / catalogs / validates / runs** existing workflow
+files — there is no path from a natural-language description to a runnable workflow. A user (or the
+agent itself, in chat) must hand-write DAG JSON. Reproduction: `/workflows` exposes
+`<list|catalog|validate|run>` only; there is no `create`/authoring subcommand, and the command is
+`modelInvocable: false`, so the agent cannot author a workflow from a chat request either.
+
+Goal: **describe a workflow in natural language → the system authors it, saves it as a reusable
+artifact, and runs it immediately** — composing existing nodes and, when a fitting node does not
+exist, creating a prompt-backed node on the fly. The agent can invoke this from normal chat.
+
+Secondary: the persisted layout `.dag/workflows/` repeats the same concept twice (`.dag` ≈
+`workflows`), and the workspace directory name is hardcoded across two products (dag-cli and the
+agent-cli `/workflows` bridge). Make the workspace layout a **configurable option** (single shared
+machinery, per-product folder name) with a de-jargoned default.
+
+## Architecture Review
+
+### Affected Scope
+
+- **Workspace layout parameterization (DATA-002 refactor).** The workspace root dir + workflow-file
+  extension become **configurable options** (shared machinery, per-product folder name), not hardcoded
+  `.dag`/`.dag.json` constants. New defaults: root **`.workflows/`**, workflow ext **`.json`**, workflow
+  definitions **flat** at `<root>/<name>.json`, nodes at `<root>/nodes/` (`<type>.node.json` manifest +
+  `<type>.dag.node.js` companion). Path helpers (`paths.ts`) take an optional `root`; `store.ts`,
+  `catalog/catalog-scanner.ts`, `commands/{save,run,node}.ts` (the `.dag/` walk-up + dir constants), and
+  `agent-command-workflows` (`catalog-command.ts` `DEFAULT_CATALOG_DIR`) thread/consume it. Each product
+  sets its own root (both default `.workflows/`); dag-cli MAY keep `.dag/` via the option. Behavior-
+  preserving; feature is unreleased so **no migration**.
+- **NL authoring (new).** `packages/agent-command-workflows/src/` gains a `create` subcommand + an
+  authoring module (build node-catalog context → prompt the active provider → validate the emitted
+  spec → assemble `IDagDefinition` → save → run). The reusable **spec→DAG assembly** is relocated into
+  `@robota-sdk/dag-framework` (or `dag-builder`) — **NOT** `dag-cli` (private). No new `@robota-sdk`
+  runtime edge for agent-cli beyond what is already bundled (INFRA-028).
+- **Provider access.** The authoring LLM call uses agent-cli's **active provider** (resolved via the
+  command host context / session), never a hardcoded provider.
+- **Instant nodes.** Reuse `createPromptBackedNodeDefinition` + the persistence store to define, save
+  (`.workflows/nodes/`), and register new prompt nodes for reuse.
+- **Model-invocable.** The create action is exposed `modelInvocable: true` so the agent authors + runs
+  a workflow from a natural chat request.
+
+### Alternatives Considered
+
+1. **Port `dag describe` as-is.** Pro: exists, proven. Con: lives in private `dag-cli`; hardcodes
+   `llm-text-anthropic` + `ANTHROPIC_API_KEY`; existing-nodes-only; the owner explicitly does not want
+   it as the template. Rejected.
+2. **Fresh authoring: LLM emits a schema-validated workflow spec, assembled deterministically and run
+   in-process; new prompt nodes created on demand; uses the active provider (chosen).** Pro: clean
+   separation (LLM _authors_, runtime _executes_ deterministically); respects the user's configured
+   provider; produces a legible, reusable saved artifact; not coupled to `dag-cli`. Con: provider-access
+   integration + relocating the shared spec→DAG assembly.
+3. **Agent-only (no explicit command; the chat agent builds workflows purely via tools).** Pro: most
+   "natural". Con: the owner wants an explicit `create` command that the agent then _uses_; harder to
+   test/verify deterministically. Rejected as the sole approach (kept as the Phase-4 model-invocable
+   layer on top of the command).
+
+### Decision
+
+Alternative 2. A fresh NL→workflow authoring path in `agent-command-workflows`: build the node-catalog
+context → prompt the **active provider** → the LLM returns a **schema-validated workflow spec** → the
+runtime **deterministically assembles** an `IDagDefinition` (plus any new prompt-node manifests) → save
+to `.workflows/` → run in-process on `LocalDagRuntimeProvider` → surface outputs. Storage de-jargoned
+to `.workflows/` (flat `.json` workflows + `nodes/`).
+
+Design principles adopted (concept only, from prior-art review): keep the orchestration in a **legible
+saved artifact** rather than model context; **structured/validated** authoring output (not free text);
+**deterministic execution** of the authored artifact; **save / reuse / re-run**; progress + result
+visibility.
+
+**Validated (wide blast radius — new agent-facing capability + storage rename):**
+
+- **Reachability** — both surfaces reach the same authoring path: the explicit `/workflows create`
+  subcommand and (Phase 4) the model-invocable tool. Authored workflows run on the same
+  `LocalDagRuntimeProvider` the existing `run` uses; saved artifacts are re-runnable via `run`/`catalog`.
+- **Capability preservation** — existing `list/catalog/validate/run` behavior unchanged; the storage
+  rename is behavior-preserving (unreleased layout, no on-disk contract to break); INFRA-028 bundle +
+  CLI-077 boundary hold (no new `@robota-sdk` runtime dep).
+- **Adversarial pass** — (a) LLM emits invalid/unassemblable spec → validation error surfaced, no
+  broken run; (b) no active provider / missing key → clear actionable error, never a silent guess; (c)
+  a generated prompt-node `nodeType` collides with an existing node → deterministic resolution
+  (reject or suffix, logged); (d) authored workflow fails at run → run error surfaced with the saved
+  artifact path so the user can inspect/re-run.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — the sibling is the existing `/workflows` subcommand family (list/catalog/validate/run); the new `create` joins it and the storage rename is shared by all
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료 (fresh authoring; active provider; deterministic assembly; `.workflows/` layout; no dag-cli dependency)
+
+## Solution
+
+Phased; each phase independently green.
+
+- **Phase 1a — workspace layout parameterization (DONE).** Layout as a configurable option (default
+  `.workflows/` flat `.json` + `.workflows/nodes/`); persistence/catalog/walk-up consume it. Verified.
+- **Phase 1b — injection wiring + catalog unification (architecture-reviewed; scope "b").** Given
+  dag-cli's **functional, decentralized** composition (thin `runDagCli` dispatcher; pure-function
+  commands that build their own runtime and read `process.cwd()`), the canonical injection is
+  options-threading with a **single resolution point per product** — not a DI container:
+  (C1) `runDagCli` resolves the layout once (a `--workspace <dir>` global flag / default) and threads
+  `{ io, workspace }` into every command; `createWorkflowsCommandModule({ workspace })` receives it and
+  agent-cli's `command-setup.ts` provides it. (C2) production callers pass the resolved layout to the
+  persistence/catalog functions (which keep the optional default for standalone use); `LocalDagRuntime
+Provider` options gain `workspace?` + local-node discovery. (C3) **unify the three workflow-read paths**
+  (DATA-002 `loadWorkflows`, dag-cli `catalog-scanner`, `/workflows` inline scan) behind **one shared
+  workspace-catalog reader in `dag-framework`**, layout-injected, consumed by all.
+- **Phase 2 — NL authoring (existing nodes).** `/workflows create "<description>"`: gather node-catalog
+  context → call the active provider → parse + **validate** the emitted workflow spec → assemble
+  `IDagDefinition` → save `.workflows/<name>.json` → run in-process → print outputs.
+- **Phase 3 — instant prompt-node creation.** The authoring output may define new prompt-backed nodes
+  when no existing node fits; each is saved to `.workflows/nodes/` (reusing DATA-002 persistence),
+  registered, and used in the workflow (and reusable later).
+- **Phase 4 — model-invocable.** Expose the create action `modelInvocable: true`; the agent authors +
+  runs a workflow from a natural chat request, surfacing the saved artifact + result.
+
+## Affected Files
+
+- `packages/agent-command-workflows/src/*` (new `create` subcommand + authoring module; module wiring)
+- `packages/dag-framework/src/*` (relocated shared spec→DAG assembly + node-catalog context helper)
+- `packages/dag-cli/src/local-runner/persistence/paths.ts`, `store.ts`, `catalog/catalog-scanner.ts`,
+  `commands/{save,run,node}.ts` (storage rename)
+- `packages/agent-command-workflows/docs/SPEC.md`, `packages/dag-cli/docs/SPEC.md`
+- Tests across the above.
+
+## Completion Criteria
+
+- [ ] TC-01: after Phase 1, with the default workspace root, `dag save`/`run`/scaffold + `/workflows
+catalog|run` operate on `.workflows/` (flat `.json` workflows, `.workflows/nodes/`); passing a custom
+      root option redirects all reads/writes to that dir (unit test asserts both default and override);
+      `pnpm --filter @robota-sdk/dag-cli test` green.
+- [ ] TC-02: `/workflows create "uppercase the input text"` (active provider configured) →
+      authors + saves `.workflows/<name>.json` and runs it → output is the input uppercased; exit success.
+- [ ] TC-03: the authored artifact is re-runnable — `/workflows run .workflows/<name>.json` (or
+      `catalog run <name>`) reproduces the result without re-authoring.
+- [ ] TC-04: with no active provider / missing key, `/workflows create "..."` returns a clear
+      actionable error (names the missing provider/key), does not crash, writes nothing.
+- [ ] TC-05: Phase 3 — a description needing a bespoke step (e.g. "rewrite the text as a pirate")
+      causes a prompt-backed node to be created, saved under `.workflows/nodes/`, used in the run, and
+      reusable on a second `create`.
+- [ ] TC-06: Phase 4 — a chat request to the agent ("make a workflow that summarizes my input and run
+      it") invokes the create action and surfaces the saved artifact path + run output.
+
+## Test Plan
+
+FLOW + cli/agent → command process-integration + agent-simulation. LLM-dependent authoring is tested
+with a stubbed/injected provider (deterministic response) for unit/integration; one live UE per phase.
+
+| TC-ID | Test Type              | Tool / Approach                                                           | Notes |
+| ----- | ---------------------- | ------------------------------------------------------------------------- | ----- |
+| TC-01 | Integration (fs+spawn) | vitest — storage-rename round-trip (save→catalog→run) on `.workflows/`    |       |
+| TC-02 | Integration            | vitest — `create` with an injected provider stub → assert saved + run out |       |
+| TC-03 | Integration            | vitest — re-run the saved artifact, assert identical result               |       |
+| TC-04 | Unit                   | vitest — no-provider path returns actionable error, no write              |       |
+| TC-05 | Integration            | vitest — prompt-node creation path (injected provider emits a new node)   |       |
+| TC-06 | Agent simulation       | vitest — model-invocable create via a scripted agent turn                 |       |
+
+## Tasks
+
+- [ ] `.agents/tasks/FLOW-007.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log
+
+- **GATE-WRITE — PASS (2026-07-06).** All sections present; Problem has concrete symptom (only `list/catalog/validate/run`, `modelInvocable:false`) + reproduction; Architecture Review has 3 alternatives + validated Decision; checklist all [x]; TC-01…TC-06 command/observable; one Test Plan row per TC (no `manual`). No third-party product named (prior-art reviewed conceptually only).
+- **GATE-APPROVAL — PASS (2026-07-06).** Design iterated with owner across the session: NL create-and-run in one step (re-run optional), existing nodes + on-the-fly prompt nodes, model-invocable, active provider; fresh design (dag-cli `describe` is a reference not a template); prior-art concepts adopted without naming the product; storage de-jargoned to `.workflows/` (flat `.json` + `nodes/`). Owner sign-off, verbatim: **"승인함"**. Implementation authorized (phased).
+- **Phase 1a — SHIPPED (2026-07-06, commit 3e4ae929b).** Workspace layout parameterized (default `.workflows/`); persistence/catalog/walk-up consume it. dag-cli 1007 + agent-command-workflows 9 tests, 45 scans, live UE (`save`→`catalog run`, `scaffold`→`run` incl. subdir walk-up) all consistent on `.workflows/`.
+- **ARCHITECTURE REVIEW — PASS (2026-07-06).** Audited existing dag-\* (clean layering; functional/decentralized composition — thin `runDagCli` dispatcher, pure-function commands; **fragmentation: 3 workflow-read paths**) and the Phase-1a impl (parameterized/injectable but not yet threaded from composition roots; default repeated per-function). Re-proposed the canonical injection (options-threading + single per-product resolution root + shared reader). Owner chose scope **"b"** — C1 injection wiring + C2 receivers + C3 unify the 3 readers into one `dag-framework` workspace-catalog. Verbatim: **"b"**. Phase 1b authorized.
+- **Phase 1b — DONE (2026-07-06).** C3 shared reader `scanWorkspaceCatalog` in `dag-framework` (commit 714b9a272) now backs all three former read paths (persistence `loadWorkflows`, dag-cli `catalog-scanner`, `/workflows catalog`). C2 receiver: `LocalDagRuntimeProvider` accepts `workspace`. C1 injection: `/workflows` command module resolves+threads `workspace` (commit d225fef12); **dag-cli** resolves a leading `--workspace <dir>` global flag at the `runDagCli` composition root and threads the layout to run/save/catalog/node (commit 75062cc57). dag-cli 1007 tests + agent-command-workflows green, 45 scans, 0 lint errors. **Live UE:** a custom `--workspace .myws` round-trip — `save` → `catalog list` → `catalog run` (correct output) → `node scaffold` — all read/write `.myws/` while the default `.workflows/` stays untouched (isolation confirmed). Phase 1 complete.

--- a/.agents/tasks/FLOW-007.md
+++ b/.agents/tasks/FLOW-007.md
@@ -1,0 +1,31 @@
+# FLOW-007: natural-language workflow authoring & run via `/workflows`
+
+- **Status:** in-progress (Phase 1)
+- **Spec:** `.agents/spec-docs/draft/FLOW-007-workflows-nl-authoring.md`
+- **Branch:** `feat/workflows-storage-layout` (Phase 1)
+- **Approved:** 2026-07-06 (owner "승인함")
+
+## Goal
+
+Natural-language → authored + immediately-run workflow via `/workflows`, composing existing nodes and
+creating prompt-backed nodes on the fly; model-invocable; active provider. Storage de-jargoned to
+`.workflows/` (flat `.json` workflows + `nodes/`).
+
+## Phases (each independently green)
+
+- [x] Phase 1: storage layout `.dag/` → `.workflows/` (flat `.json` workflows, `nodes/`). No migration. - 1a: layout parameterization (`IWorkspaceLayout`, default `.workflows/`). SHIPPED. - 1b: injection wiring — C1 `--workspace`/`workspace` option through dag-cli + `/workflows`
+      composition roots, C2 receivers (`LocalDagRuntimeProvider`), C3 unify 3 readers via
+      `scanWorkspaceCatalog`. DONE (live UE: custom `.myws` workspace round-trip).
+- [ ] Phase 2: `/workflows create "<desc>"` — active-provider LLM → validated spec → assemble → save → run.
+- [ ] Phase 3: on-the-fly prompt-node creation (saved to `.workflows/nodes/`, reusable).
+- [ ] Phase 4: model-invocable (agent authors + runs from chat).
+
+## Test Plan
+
+TC-01..06 in the spec. Phase 1 (workspace layout parameterization) is verified by: `persistence-store`
+unit tests (default `.workflows/` + a custom injected layout override); the full dag-cli suite (1007)
+and agent-command-workflows suite green after propagating the layout to catalog-scanner, the `run`
+walk-up, and the `/workflows catalog` command; and a **live end-to-end run** — `dag save` → `catalog
+list` → `catalog run`, plus `node scaffold` → `dag run` (incl. from a subdirectory via walk-up) — all
+operating consistently on `.workflows/` (flat `.json` workflows, `.workflows/nodes/`). Each later phase
+adds command/agent-simulation tests plus a live UE, per the spec's TC table.

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ apps/api-server/.dag-storage/
 
 # dag-cli runtime working directory (catalog/nodes/runs.db/run-history) — never commit local run state
 .dag/
+# FLOW-007 workspace layout: local workflow catalog + code nodes (test/dev working dir) — never commit
+.workflows/
 
 # Lock files from other package managers
 bun.lock

--- a/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
@@ -103,19 +103,19 @@ describe('workflows validate', () => {
 });
 
 describe('workflows catalog', () => {
-  it('reports an empty state when no catalog directory exists', async () => {
+  it('reports an empty state when no workflows exist', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'wf-catalog-'));
     const result = await executeWorkflowsCatalog(dir);
     expect(result.success).toBe(true);
-    expect(result.message).toContain('No workflow catalog');
+    expect(result.message).toContain('No workflow files');
   });
 
-  it('lists workflow files present in .dag/workflows', async () => {
+  it('lists workflow files flat under the workspace root (.workflows/)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'wf-catalog-'));
-    const catalogDir = join(dir, '.dag', 'workflows');
-    await mkdir(catalogDir, { recursive: true });
+    const catalogDir = join(dir, '.workflows');
+    await mkdir(join(catalogDir, 'nodes'), { recursive: true });
     await writeFile(
-      join(catalogDir, 'sample.dag.json'),
+      join(catalogDir, 'sample.json'),
       JSON.stringify({
         last_node_id: 1,
         last_link_id: 0,
@@ -124,9 +124,12 @@ describe('workflows catalog', () => {
         version: 0.4,
       }),
     );
+    // a node manifest sharing the root must NOT be listed as a workflow.
+    await writeFile(join(catalogDir, 'nodes', 'greet.node.json'), JSON.stringify({ kind: 'code' }));
     const result = await executeWorkflowsCatalog(dir);
     expect(result.success).toBe(true);
-    expect(result.message).toContain('sample.dag.json');
+    expect(result.message).toContain('sample.json');
     expect(result.message).toContain('1 node(s)');
+    expect(result.message).not.toContain('greet');
   });
 });

--- a/packages/agent-command-workflows/src/catalog-command.ts
+++ b/packages/agent-command-workflows/src/catalog-command.ts
@@ -1,46 +1,36 @@
-import { readdir, readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
-import type { IDagWorkflowFile } from '@robota-sdk/dag-core';
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
+import { scanWorkspaceCatalog } from '@robota-sdk/dag-framework';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-/** Default local catalog directory for workflow files (relative to the working directory). */
-const DEFAULT_CATALOG_DIR = '.dag/workflows';
-
 /**
- * `/workflows catalog` — list the workflow files in the local catalog directory
- * (`.dag/workflows`). A pure filesystem scan over `*.dag.json` files; no dependency on the
- * `dag-cli` product.
+ * `/workflows catalog` — list the workflow definitions flat under the injected workspace root (default
+ * `.workflows/`, `<name>.json`) via the shared `scanWorkspaceCatalog` reader (FLOW-007 C3 — one reader
+ * across dag-cli's `catalog` and this command). Node manifests + non-DAG JSON are skipped.
  */
 export async function executeWorkflowsCatalog(
   cwd: string,
-  dir: string = DEFAULT_CATALOG_DIR,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<ICommandResult> {
-  const catalogDir = resolve(cwd, dir);
-  // A missing catalog directory is a normal empty state, not an error.
-  const entries = await readdir(catalogDir).catch(() => null);
-  if (entries === null) {
-    return {
-      success: true,
-      message: `No workflow catalog at ${dir} (build or save a workflow to populate it).`,
+  const dir = layout.root;
+  const ext = layout.workflowExt;
+  const entries = await scanWorkspaceCatalog(resolve(cwd, dir), layout);
+  if (entries.length === 0) {
+    return { success: true, message: `No workflow files (*${ext}) in ${dir}.` };
+  }
+  const lines = entries.map((e) => {
+    const raw = e.definition as unknown as {
+      nodes?: unknown[];
+      edges?: unknown[];
+      links?: unknown[];
     };
-  }
-
-  const files = entries.filter((name) => name.endsWith('.dag.json')).sort();
-  if (files.length === 0) {
-    return { success: true, message: `No workflow files (*.dag.json) in ${dir}.` };
-  }
-
-  const lines: string[] = [];
-  for (const file of files) {
-    const summary = await readFile(join(catalogDir, file), 'utf-8')
-      .then((raw) => JSON.parse(raw) as IDagWorkflowFile)
-      .then((wf) => `${wf.nodes?.length ?? 0} node(s), ${wf.links?.length ?? 0} link(s)`)
-      .catch(() => 'unreadable');
-    lines.push(`  ${file} — ${summary}`);
-  }
+    const nodeCount = raw.nodes?.length ?? 0;
+    const linkCount = raw.edges?.length ?? raw.links?.length ?? 0;
+    return `  ${e.id}${ext} — ${nodeCount} node(s), ${linkCount} link(s)`;
+  });
   return {
     success: true,
-    message: `Workflows in ${dir} (${files.length}):\n${lines.join('\n')}`,
+    message: `Workflows in ${dir} (${entries.length}):\n${lines.join('\n')}`,
   };
 }

--- a/packages/agent-command-workflows/src/run-command.ts
+++ b/packages/agent-command-workflows/src/run-command.ts
@@ -3,7 +3,11 @@ import { resolve } from 'node:path';
 
 import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
 
-import type { IDagWorkflowFile } from '@robota-sdk/dag-core';
+import {
+  DEFAULT_WORKSPACE_LAYOUT,
+  type IDagWorkflowFile,
+  type IWorkspaceLayout,
+} from '@robota-sdk/dag-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 async function readDagFile(absPath: string): Promise<IDagWorkflowFile> {
@@ -15,9 +19,13 @@ async function readDagFile(absPath: string): Promise<IDagWorkflowFile> {
  * `/workflows run <file.dag.json>` — execute a workflow file on the in-process DAG runtime.
  * Composes `dag-framework`'s local provider; no dependency on the `dag-cli` product.
  */
-export async function executeWorkflowsRun(filePath: string, cwd: string): Promise<ICommandResult> {
+export async function executeWorkflowsRun(
+  filePath: string,
+  cwd: string,
+  workspace: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<ICommandResult> {
   if (!filePath) {
-    return { success: false, message: 'Usage: /workflows run <file.dag.json>' };
+    return { success: false, message: 'Usage: /workflows run <file.json>' };
   }
 
   // The read/parse error is surfaced as a failed command result, not silently swallowed.
@@ -29,7 +37,7 @@ export async function executeWorkflowsRun(filePath: string, cwd: string): Promis
     return { success: false, message: dag.message };
   }
 
-  const provider = new LocalDagRuntimeProvider();
+  const provider = new LocalDagRuntimeProvider({ workspace, projectDir: cwd });
   const result = await provider.execute(dag, {});
   if (!result.ok) {
     return {

--- a/packages/agent-command-workflows/src/workflows-command-module.ts
+++ b/packages/agent-command-workflows/src/workflows-command-module.ts
@@ -3,6 +3,7 @@ import { executeWorkflowsList } from './list-command.js';
 import { executeWorkflowsRun } from './run-command.js';
 import { executeWorkflowsValidate } from './validate-command.js';
 
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
 import type {
   ICommandModule,
   ICommandHostContext,
@@ -66,6 +67,7 @@ function splitSubcommand(args: string): { sub: string; rest: string } {
 async function executeWorkflowsCommand(
   _context: ICommandHostContext,
   args: string,
+  workspace: IWorkspaceLayout,
 ): Promise<ICommandResult> {
   const { sub, rest } = splitSubcommand(args);
   switch (sub) {
@@ -74,11 +76,11 @@ async function executeWorkflowsCommand(
     case 'list':
       return executeWorkflowsList();
     case 'catalog':
-      return executeWorkflowsCatalog(process.cwd());
+      return executeWorkflowsCatalog(process.cwd(), workspace);
     case 'validate':
       return executeWorkflowsValidate(rest, process.cwd());
     case 'run':
-      return executeWorkflowsRun(rest, process.cwd());
+      return executeWorkflowsRun(rest, process.cwd(), workspace);
     default:
       return { success: false, message: `Unknown subcommand "${sub}".\n${USAGE}` };
   }
@@ -96,7 +98,7 @@ export function createWorkflowsCommandEntry(): ICommand {
   };
 }
 
-function createWorkflowsSystemCommand(): ISystemCommand {
+function createWorkflowsSystemCommand(workspace: IWorkspaceLayout): ISystemCommand {
   const entry = createWorkflowsCommandEntry();
   return {
     name: entry.name,
@@ -108,7 +110,7 @@ function createWorkflowsSystemCommand(): ISystemCommand {
     argumentHint: entry.argumentHint,
     subcommands: entry.subcommands,
     lifecycle: 'inline',
-    execute: executeWorkflowsCommand,
+    execute: (context, args) => executeWorkflowsCommand(context, args, workspace),
   };
 }
 
@@ -120,10 +122,19 @@ export class WorkflowsCommandSource implements ICommandSource {
   }
 }
 
-export function createWorkflowsCommandModule(): ICommandModule {
+/** Dependencies injected by the composition root (agent-cli's `command-setup`). FLOW-007 C1. */
+export interface IWorkflowsCommandModuleDeps {
+  /** Workspace layout for on-disk workflow/node paths. Defaults to `.workflows/`. */
+  readonly workspace?: IWorkspaceLayout;
+}
+
+export function createWorkflowsCommandModule(
+  deps: IWorkflowsCommandModuleDeps = {},
+): ICommandModule {
+  const workspace = deps.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
   return {
     name: 'agent-command-workflows',
     commandSources: [new WorkflowsCommandSource()],
-    systemCommands: [createWorkflowsSystemCommand()],
+    systemCommands: [createWorkflowsSystemCommand(workspace)],
   };
 }

--- a/packages/dag-cli/src/__tests__/catalog-command.test.ts
+++ b/packages/dag-cli/src/__tests__/catalog-command.test.ts
@@ -87,8 +87,8 @@ describe('catalogCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupCatalog({
-      '.dag/workflows/hello.dag.json': HELLO_DAG,
-      '.dag/workflows/summarize.dag.json': SUMMARIZE_DAG,
+      '.workflows/hello.json': HELLO_DAG,
+      '.workflows/summarize.json': SUMMARIZE_DAG,
     });
   });
 
@@ -105,7 +105,7 @@ describe('catalogCommand', () => {
   describe('list', () => {
     it('lists workflows from catalog dir', async () => {
       const { io, lines } = makeIo();
-      const code = await catalogCommand(['list', '--catalog', '.dag/workflows'], { io });
+      const code = await catalogCommand(['list', '--catalog', '.workflows'], { io });
       expect(code).toBe(0);
       const out = lines.join('');
       expect(out).toContain('hello');
@@ -140,7 +140,7 @@ describe('catalogCommand', () => {
   describe('info', () => {
     it('shows info for a known workflow', async () => {
       const { io, lines } = makeIo();
-      const code = await catalogCommand(['info', 'hello', '--catalog', '.dag/workflows'], { io });
+      const code = await catalogCommand(['info', 'hello', '--catalog', '.workflows'], { io });
       expect(code).toBe(0);
       const out = lines.join('');
       expect(out).toContain('hello');
@@ -150,14 +150,14 @@ describe('catalogCommand', () => {
     it('returns 1 for unknown id', async () => {
       const { io } = makeIo();
       expect(
-        await catalogCommand(['info', 'does-not-exist', '--catalog', '.dag/workflows'], { io }),
+        await catalogCommand(['info', 'does-not-exist', '--catalog', '.workflows'], { io }),
       ).toBe(1);
     });
 
     it('returns json format when --output json', async () => {
       const { io, lines } = makeIo();
       const code = await catalogCommand(
-        ['info', 'hello', '--catalog', '.dag/workflows', '--output', 'json'],
+        ['info', 'hello', '--catalog', '.workflows', '--output', 'json'],
         { io },
       );
       expect(code).toBe(0);
@@ -169,7 +169,7 @@ describe('catalogCommand', () => {
   describe('search', () => {
     it('returns matching workflows by id', async () => {
       const { io, lines } = makeIo();
-      const code = await catalogCommand(['search', 'summarize', '--catalog', '.dag/workflows'], {
+      const code = await catalogCommand(['search', 'summarize', '--catalog', '.workflows'], {
         io,
       });
       expect(code).toBe(0);
@@ -178,14 +178,14 @@ describe('catalogCommand', () => {
 
     it('returns matching by tag', async () => {
       const { io, lines } = makeIo();
-      const code = await catalogCommand(['search', 'demo', '--catalog', '.dag/workflows'], { io });
+      const code = await catalogCommand(['search', 'demo', '--catalog', '.workflows'], { io });
       expect(code).toBe(0);
       expect(lines.join('')).toContain('hello');
     });
 
     it('returns 0 with no matches', async () => {
       const { io, lines } = makeIo();
-      const code = await catalogCommand(['search', 'zzz-no-match', '--catalog', '.dag/workflows'], {
+      const code = await catalogCommand(['search', 'zzz-no-match', '--catalog', '.workflows'], {
         io,
       });
       expect(code).toBe(0);
@@ -194,7 +194,7 @@ describe('catalogCommand', () => {
 
     it('returns 2 for missing query', async () => {
       const { io } = makeIo();
-      expect(await catalogCommand(['search', '--catalog', '.dag/workflows'], { io })).toBe(2);
+      expect(await catalogCommand(['search', '--catalog', '.workflows'], { io })).toBe(2);
     });
   });
 
@@ -206,8 +206,8 @@ describe('catalogCommand', () => {
           return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
         }
         const content = {
-          '.dag/workflows/hello.dag.json': HELLO_DAG,
-          '.dag/workflows/summarize.dag.json': SUMMARIZE_DAG,
+          '.workflows/hello.json': HELLO_DAG,
+          '.workflows/summarize.json': SUMMARIZE_DAG,
         }[filePath as string];
         if (content !== undefined) return Promise.resolve(content);
         return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
@@ -221,12 +221,12 @@ describe('catalogCommand', () => {
     it('lists run history entries when history file exists', async () => {
       const history = JSON.stringify([
         {
-          file: '.dag/workflows/hello.dag.json',
+          file: '.workflows/hello.json',
           date: '2026-05-20T10:00:00.000Z',
           status: 'success',
         },
         {
-          file: '.dag/workflows/summarize.dag.json',
+          file: '.workflows/summarize.json',
           date: '2026-05-21T08:30:00.000Z',
           status: 'failed',
         },
@@ -236,8 +236,8 @@ describe('catalogCommand', () => {
           return Promise.resolve(history);
         }
         const content = {
-          '.dag/workflows/hello.dag.json': HELLO_DAG,
-          '.dag/workflows/summarize.dag.json': SUMMARIZE_DAG,
+          '.workflows/hello.json': HELLO_DAG,
+          '.workflows/summarize.json': SUMMARIZE_DAG,
         }[filePath as string];
         if (content !== undefined) return Promise.resolve(content);
         return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
@@ -246,7 +246,7 @@ describe('catalogCommand', () => {
       const code = await catalogCommand(['history'], { io });
       expect(code).toBe(0);
       const out = lines.join('');
-      expect(out).toContain('hello.dag.json');
+      expect(out).toContain('hello.json');
     });
   });
 
@@ -262,7 +262,7 @@ describe('catalogCommand', () => {
         run: mockRun,
       };
       const code = await catalogCommand(
-        ['run', 'hello', '--catalog', '.dag/workflows', '--output', 'json'],
+        ['run', 'hello', '--catalog', '.workflows', '--output', 'json'],
         { io, createRunner: () => mockRunner as never },
       );
       expect(code).toBe(0);
@@ -272,13 +272,13 @@ describe('catalogCommand', () => {
     it('returns 1 for unknown id', async () => {
       const { io } = makeIo();
       expect(
-        await catalogCommand(['run', 'does-not-exist', '--catalog', '.dag/workflows'], { io }),
+        await catalogCommand(['run', 'does-not-exist', '--catalog', '.workflows'], { io }),
       ).toBe(1);
     });
 
     it('returns 2 for missing id', async () => {
       const { io } = makeIo();
-      expect(await catalogCommand(['run', '--catalog', '.dag/workflows'], { io })).toBe(2);
+      expect(await catalogCommand(['run', '--catalog', '.workflows'], { io })).toBe(2);
     });
   });
 });

--- a/packages/dag-cli/src/__tests__/code-node-persistence.test.ts
+++ b/packages/dag-cli/src/__tests__/code-node-persistence.test.ts
@@ -47,7 +47,7 @@ function writeCodeNode(
   manifest: Record<string, unknown>,
   companion: string | null,
 ): void {
-  const dir = join(projectDir, '.dag', 'nodes');
+  const dir = join(projectDir, '.workflows', 'nodes');
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     join(dir, `${nodeType}.node.json`),
@@ -140,11 +140,11 @@ describe('DATA-002 P2 — code node persistence', () => {
     expect(JSON.parse(shout!.outputSnapshot!)).toMatchObject({ text: 'HELLO' });
   });
 
-  it('P3: a workflow under .dag/workflows/ resolves a .dag/nodes/ code node (projectDir walk-up)', async () => {
+  it('P3: a workflow under .workflows/ resolves a .workflows/nodes/ code node (projectDir walk-up)', async () => {
     writeCodeNode(projectDir, 'upshout', {}, UPPER);
-    const wfDir = join(projectDir, '.dag', 'workflows');
+    const wfDir = join(projectDir, '.workflows');
     mkdirSync(wfDir, { recursive: true });
-    const dagFile = join(wfDir, 'shoutflow.dag.json');
+    const dagFile = join(wfDir, 'shoutflow.json');
     writeFileSync(
       dagFile,
       JSON.stringify({

--- a/packages/dag-cli/src/__tests__/localnode-e2e.test.ts
+++ b/packages/dag-cli/src/__tests__/localnode-e2e.test.ts
@@ -43,11 +43,11 @@ afterEach(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// LOCALNODE-005 / DATA-002 P3: dag node scaffold writes .dag/nodes/ manifest + companion
+// LOCALNODE-005 / DATA-002 P3: dag node scaffold writes .workflows/nodes/ manifest + companion
 // ---------------------------------------------------------------------------
 
 function nodesPath(dir: string, file: string): string {
-  return join(dir, '.dag', 'nodes', file);
+  return join(dir, '.workflows', 'nodes', file);
 }
 
 describe('LOCALNODE-005 / DATA-002 P3: dag node scaffold', () => {
@@ -93,7 +93,7 @@ describe('LOCALNODE-005 / DATA-002 P3: dag node scaffold', () => {
   });
 
   it('rejects if a target file already exists', async () => {
-    await mkdir(join(tmpDir, '.dag', 'nodes'), { recursive: true });
+    await mkdir(join(tmpDir, '.workflows', 'nodes'), { recursive: true });
     await writeFile(nodesPath(tmpDir, 'existing.node.json'), '{}', 'utf8');
 
     const { options, written } = makeIo();
@@ -132,7 +132,7 @@ describe('LOCALNODE-005 / DATA-002 P3: dag node scaffold', () => {
 });
 
 // ---------------------------------------------------------------------------
-// LOCALNODE-002 / DATA-002 P2: loadLocalNodeDefinitions discovers `.dag/nodes/` code manifests
+// LOCALNODE-002 / DATA-002 P2: loadLocalNodeDefinitions discovers `.workflows/nodes/` code manifests
 // ---------------------------------------------------------------------------
 
 async function writeCodeNode(
@@ -141,7 +141,7 @@ async function writeCodeNode(
   manifestExtra: Record<string, unknown>,
   companion: string | null,
 ): Promise<void> {
-  const nodesDir = join(dir, '.dag', 'nodes');
+  const nodesDir = join(dir, '.workflows', 'nodes');
   await mkdir(nodesDir, { recursive: true });
   await writeFile(
     join(nodesDir, `${nodeType}.node.json`),
@@ -161,13 +161,13 @@ async function writeCodeNode(
   }
 }
 
-describe('LOCALNODE-002 / DATA-002 P2: loadLocalNodeDefinitions from .dag/nodes/', () => {
-  it('returns empty array when .dag/nodes/ is absent', async () => {
+describe('LOCALNODE-002 / DATA-002 P2: loadLocalNodeDefinitions from .workflows/nodes/', () => {
+  it('returns empty array when .workflows/nodes/ is absent', async () => {
     const nodes = await loadLocalNodeDefinitions({ projectDir: tmpDir });
     expect(nodes).toHaveLength(0);
   });
 
-  it('discovers a code node (manifest + companion) in .dag/nodes/', async () => {
+  it('discovers a code node (manifest + companion) in .workflows/nodes/', async () => {
     await writeCodeNode(
       tmpDir,
       'upshout',

--- a/packages/dag-cli/src/__tests__/persistence-store.test.ts
+++ b/packages/dag-cli/src/__tests__/persistence-store.test.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { IDagDefinition } from '@robota-sdk/dag-core';
+import type { IDagDefinition, IWorkspaceLayout } from '@robota-sdk/dag-core';
 import { saveWorkflow, loadWorkflows } from '../local-runner/persistence/store.js';
 import { workflowsDir, WORKFLOW_EXT } from '../local-runner/persistence/paths.js';
 
@@ -37,18 +37,37 @@ describe('DATA-002 persistence store — workflows (TC-03)', () => {
     expect(loaded[0].definition).toEqual(WORKFLOW);
   });
 
-  it('returns empty when .dag/workflows/ does not exist', async () => {
+  it('workflows live flat in the default .workflows/ root as <name>.json', async () => {
+    const written = await saveWorkflow('my-flow', WORKFLOW, projectDir);
+    expect(written).toBe(join(projectDir, '.workflows', 'my-flow.json'));
+  });
+
+  it('returns empty when the workspace root does not exist', async () => {
     const loaded = await loadWorkflows(projectDir);
     expect(loaded).toEqual([]);
   });
 
-  it('skips non-.dag.json and malformed files', async () => {
+  it('skips non-workflow, malformed, and non-DAG JSON sharing the root', async () => {
     await saveWorkflow('good', WORKFLOW, projectDir);
     const fs = await import('node:fs/promises');
     await fs.writeFile(join(workflowsDir(projectDir), 'notes.txt'), 'ignore me', 'utf-8');
-    await fs.writeFile(join(workflowsDir(projectDir), 'broken.dag.json'), '{ not json', 'utf-8');
+    await fs.writeFile(join(workflowsDir(projectDir), 'broken.json'), '{ not json', 'utf-8');
+    // aux JSON that shares the root (e.g. aliases) parses fine but is not a DAG → skipped.
+    await fs.writeFile(join(workflowsDir(projectDir), 'aliases.json'), '{"a":1}', 'utf-8');
 
     const loaded = await loadWorkflows(projectDir);
     expect(loaded.map((w) => w.name)).toEqual(['good']);
+  });
+
+  it('TC-01: a custom injected layout redirects reads/writes to that root + extension', async () => {
+    const layout: IWorkspaceLayout = { root: '.custom-ws', workflowExt: '.flow.json' };
+    const written = await saveWorkflow('my-flow', WORKFLOW, projectDir, layout);
+    expect(written).toBe(join(projectDir, '.custom-ws', 'my-flow.flow.json'));
+
+    // default layout does NOT see it; the injected layout does.
+    expect(await loadWorkflows(projectDir)).toEqual([]);
+    const loaded = await loadWorkflows(projectDir, layout);
+    expect(loaded.map((w) => w.name)).toEqual(['my-flow']);
+    expect(loaded[0].definition).toEqual(WORKFLOW);
   });
 });

--- a/packages/dag-cli/src/__tests__/save-command.test.ts
+++ b/packages/dag-cli/src/__tests__/save-command.test.ts
@@ -82,7 +82,7 @@ describe('saveCommand', () => {
     expect(exitCode).toBe(2);
   });
 
-  it('saves pipeline to .dag/workflows/<name>.dag.json', async () => {
+  it('saves pipeline to .workflows/<name>.json', async () => {
     const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
     const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
     mockMkdir.mockClear();
@@ -98,7 +98,7 @@ describe('saveCommand', () => {
     expect(exitCode).toBe(0);
     const output = getOutput(options);
     expect(output).toContain('Saved:');
-    expect(output).toContain('my-pipeline.dag.json');
+    expect(output).toContain('my-pipeline.json');
     expect(output).toContain('dag catalog run my-pipeline');
 
     expect(mockMkdir).toHaveBeenCalledWith(
@@ -106,7 +106,7 @@ describe('saveCommand', () => {
       expect.objectContaining({ recursive: true }),
     );
     expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('my-pipeline.dag.json'),
+      expect.stringContaining('my-pipeline.json'),
       expect.stringContaining('"dagId": "my-pipeline"'),
       'utf-8',
     );

--- a/packages/dag-cli/src/catalog/catalog-scanner.ts
+++ b/packages/dag-cli/src/catalog/catalog-scanner.ts
@@ -1,7 +1,12 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { IDagDefinition } from '@robota-sdk/dag-core';
+import {
+  DEFAULT_WORKSPACE_LAYOUT,
+  type IDagDefinition,
+  type IWorkspaceLayout,
+} from '@robota-sdk/dag-core';
+import { scanWorkspaceCatalog } from '@robota-sdk/dag-framework';
 import { parseDagMd, DAG_MD_SUFFIX } from '../dag-md-parser/parse-dag-md.js';
 
 export interface ICatalogMeta {
@@ -17,47 +22,36 @@ export interface ICatalogEntry {
   readonly meta: ICatalogMeta;
 }
 
-const DAG_FILE_SUFFIX = '.dag.json';
-
-export const DEFAULT_CATALOG_DIR = '.dag/workflows';
-export const GLOBAL_CATALOG_DIR = join(homedir(), '.dag', 'workflows');
+// FLOW-007: JSON workflow definitions are read by the shared `scanWorkspaceCatalog`; only the
+// `.dag.md` id-stripping remains here for the markdown format.
+export const DEFAULT_CATALOG_DIR = DEFAULT_WORKSPACE_LAYOUT.root; // '.workflows'
+export const GLOBAL_CATALOG_DIR = join(homedir(), DEFAULT_WORKSPACE_LAYOUT.root);
 
 function extractId(fileName: string): string {
-  if (fileName.endsWith(DAG_MD_SUFFIX)) return fileName.slice(0, -DAG_MD_SUFFIX.length);
-  return fileName.endsWith(DAG_FILE_SUFFIX) ? fileName.slice(0, -DAG_FILE_SUFFIX.length) : fileName;
+  return fileName.endsWith(DAG_MD_SUFFIX) ? fileName.slice(0, -DAG_MD_SUFFIX.length) : fileName;
 }
 
-function extractMeta(raw: Record<string, unknown>): ICatalogMeta {
-  const meta = raw['meta'];
-  if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
-    return {};
-  }
-  const m = meta as Record<string, unknown>;
-  return {
-    description: typeof m['description'] === 'string' ? m['description'] : undefined,
-    displayName: typeof m['displayName'] === 'string' ? m['displayName'] : undefined,
-    tags: Array.isArray(m['tags'])
-      ? (m['tags'] as unknown[]).filter((t): t is string => typeof t === 'string')
-      : undefined,
-  };
-}
+/** Scan a directory for workflow definitions (shared JSON reader + `.dag.md`). */
+export async function scanCatalogDir(
+  dir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<ICatalogEntry[]> {
+  // FLOW-007 C3: JSON workflow definitions come from the shared workspace-catalog reader (one reader
+  // for all consumers). dag-cli additionally supports the `.dag.md` markdown workflow format, layered
+  // on top here.
+  const jsonEntries: ICatalogEntry[] = await scanWorkspaceCatalog(dir, layout);
 
-/** Scan a directory for `.dag.json` files and return parsed catalog entries. */
-export async function scanCatalogDir(dir: string): Promise<ICatalogEntry[]> {
   let fileNames: string[];
   try {
     fileNames = await readdir(dir);
   } catch {
-    // allow-fallback: missing or unreadable dir is treated as empty catalog
-    return [];
+    // allow-fallback: missing or unreadable dir → only whatever the shared reader found (empty)
+    return jsonEntries;
   }
 
-  const entries: ICatalogEntry[] = [];
+  const mdEntries: ICatalogEntry[] = [];
   for (const fileName of fileNames) {
-    const isDagJson = fileName.endsWith(DAG_FILE_SUFFIX);
-    const isDagMd = fileName.endsWith(DAG_MD_SUFFIX);
-    if (!isDagJson && !isDagMd) continue;
-
+    if (!fileName.endsWith(DAG_MD_SUFFIX)) continue;
     const filePath = join(dir, fileName);
     let text: string;
     try {
@@ -66,39 +60,17 @@ export async function scanCatalogDir(dir: string): Promise<ICatalogEntry[]> {
       // allow-fallback: unreadable file is silently skipped
       continue;
     }
-
-    if (isDagMd) {
-      const parseResult = parseDagMd(text);
-      if (!parseResult.ok) continue;
-      entries.push({
-        id: extractId(fileName),
-        filePath,
-        definition: parseResult.definition,
-        meta: parseResult.meta,
-      });
-      continue;
-    }
-
-    let raw: Record<string, unknown>;
-    try {
-      const parsed = JSON.parse(text) as unknown;
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
-      raw = parsed as Record<string, unknown>;
-    } catch {
-      // allow-fallback: malformed JSON file is silently skipped
-      continue;
-    }
-
-    entries.push({
+    const parseResult = parseDagMd(text);
+    if (!parseResult.ok) continue;
+    mdEntries.push({
       id: extractId(fileName),
       filePath,
-      definition: raw as unknown as IDagDefinition,
-      meta: extractMeta(raw),
+      definition: parseResult.definition,
+      meta: parseResult.meta,
     });
   }
 
-  entries.sort((a, b) => a.id.localeCompare(b.id));
-  return entries;
+  return [...jsonEntries, ...mdEntries].sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /** Resolve which catalog directories to scan based on flags. */

--- a/packages/dag-cli/src/commands/catalog.ts
+++ b/packages/dag-cli/src/commands/catalog.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import type { IWorkspaceLayout } from '@robota-sdk/dag-core';
 import type { IDagCliIo } from '../types.js';
 import { FAILURE_EXIT_CODE, USAGE_ERROR_EXIT_CODE, SUCCESS_EXIT_CODE } from '../types.js';
 import {
@@ -17,6 +19,8 @@ const JSON_INDENT_SPACES = 2;
 export interface ICatalogCommandOptions {
   readonly io: IDagCliIo;
   readonly createRunner?: () => LocalDagRunner;
+  /** FLOW-007: injected workspace layout (default `.workflows/`). */
+  readonly workspace?: IWorkspaceLayout;
 }
 
 type TCatalogSubcommand = 'list' | 'run' | 'info' | 'search' | 'history';
@@ -67,10 +71,13 @@ function parseCatalogArgv(args: readonly string[]): TParseResult {
   return { ok: true, subcommand, rest: args.slice(1) };
 }
 
-async function loadEntries(dirs: string[]): Promise<ICatalogEntry[]> {
+async function loadEntries(
+  dirs: string[],
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<ICatalogEntry[]> {
   const allEntries: ICatalogEntry[] = [];
   for (const dir of dirs) {
-    const entries = await scanCatalogDir(dir);
+    const entries = await scanCatalogDir(dir, layout);
     for (const entry of entries) {
       if (!allEntries.some((e) => e.id === entry.id)) {
         allEntries.push(entry);
@@ -93,16 +100,17 @@ async function handleListCommand(
     return USAGE_ERROR_EXIT_CODE;
   }
 
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
   const globalFlag = catalogResult.remaining.includes('--global');
   const allFlag = catalogResult.remaining.includes('--all');
 
   const dirs = resolveCatalogDirs({
-    catalogDir: catalogResult.value,
+    catalogDir: catalogResult.value ?? layout.root,
     global: globalFlag,
     all: allFlag,
   });
 
-  const entries = await loadEntries(dirs);
+  const entries = await loadEntries(dirs, layout);
   const dirLabel = dirs[0] ?? DEFAULT_CATALOG_DIR;
 
   if (entries.length === 0) {
@@ -133,7 +141,8 @@ async function handleRunCommand(
     return USAGE_ERROR_EXIT_CODE;
   }
 
-  const dirs = resolveCatalogDirs({ catalogDir: catalogResult.value });
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
+  const dirs = resolveCatalogDirs({ catalogDir: catalogResult.value ?? layout.root });
 
   // The positional id must be first in remaining; everything after is forwarded to runCommand.
   const argsWithoutCatalog = catalogResult.remaining;
@@ -151,7 +160,7 @@ async function handleRunCommand(
     ...argsWithoutCatalog.slice(firstNonFlag + 1),
   ];
 
-  const entries = await loadEntries(dirs);
+  const entries = await loadEntries(dirs, layout);
   const entry = entries.find((e) => e.id === id);
   if (!entry) {
     io.write(`Error: No workflow found with id "${id}".\n`);
@@ -163,7 +172,11 @@ async function handleRunCommand(
   }
 
   // Delegate to runCommand with the resolved file path
-  return runCommand([entry.filePath, ...forwardArgs], { io, createRunner: options.createRunner });
+  return runCommand([entry.filePath, ...forwardArgs], {
+    io,
+    createRunner: options.createRunner,
+    workspace: layout,
+  });
 }
 
 async function handleInfoCommand(
@@ -178,7 +191,8 @@ async function handleInfoCommand(
     return USAGE_ERROR_EXIT_CODE;
   }
 
-  const dirs = resolveCatalogDirs({ catalogDir: catalogResult.value });
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
+  const dirs = resolveCatalogDirs({ catalogDir: catalogResult.value ?? layout.root });
   const positional = catalogResult.remaining.filter((a) => !a.startsWith('--'));
 
   const id = positional[0];
@@ -190,7 +204,7 @@ async function handleInfoCommand(
   const outputResult = takeSingleOption(catalogResult.remaining, '--output');
   const outputFormat = outputResult.value ?? 'pretty';
 
-  const entries = await loadEntries(dirs);
+  const entries = await loadEntries(dirs, layout);
   const entry = entries.find((e) => e.id === id);
   if (!entry) {
     io.write(`Error: No workflow found with id "${id}".\n`);
@@ -241,10 +255,11 @@ async function handleSearchCommand(
     return USAGE_ERROR_EXIT_CODE;
   }
 
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
   const globalFlag = catalogResult.remaining.includes('--global');
   const allFlag = catalogResult.remaining.includes('--all');
   const dirs = resolveCatalogDirs({
-    catalogDir: catalogResult.value,
+    catalogDir: catalogResult.value ?? layout.root,
     global: globalFlag,
     all: allFlag,
   });
@@ -256,7 +271,7 @@ async function handleSearchCommand(
     return USAGE_ERROR_EXIT_CODE;
   }
 
-  const entries = await loadEntries(dirs);
+  const entries = await loadEntries(dirs, layout);
   const matches = entries.filter((e) => matchesCatalogQuery(e, query));
 
   if (matches.length === 0) {

--- a/packages/dag-cli/src/commands/node.ts
+++ b/packages/dag-cli/src/commands/node.ts
@@ -2,7 +2,8 @@ import { writeFile, unlink, mkdir, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import type { INodeManifest, IExternalNodePackage } from '@robota-sdk/dag-core';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import type { INodeManifest, IExternalNodePackage, IWorkspaceLayout } from '@robota-sdk/dag-core';
 import { buildNodeDefinitionAssembly } from '@robota-sdk/dag-node';
 import { discoverExternalNodePackages } from '../marketplace/external-node-scanner.js';
 import type { IDagCliIo } from '../types.js';
@@ -22,6 +23,7 @@ const JSON_INDENT_SPACES = 2;
 
 export interface INodeCommandOptions {
   readonly io: IDagCliIo;
+  readonly workspace?: IWorkspaceLayout;
 }
 
 type TNodeSubcommand = 'list' | 'info' | 'schema' | 'example' | 'scaffold' | 'validate';
@@ -918,6 +920,7 @@ export async function nodeCommand(
   options: INodeCommandOptions,
 ): Promise<number> {
   const { io } = options;
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
 
   const parseResult = parseNodeArgv(args);
   if (!parseResult.ok) {
@@ -946,7 +949,9 @@ export async function nodeCommand(
   const noLocal = parseResult.noLocal === true;
   const localDefs =
     !noLocal && (subcommand === 'list' || subcommand === 'info')
-      ? await loadLocalNodeDefinitions({ projectDir: process.cwd() }).catch(() => [])
+      ? await loadLocalNodeDefinitions({ projectDir: process.cwd(), workspace: layout }).catch(
+          () => [],
+        )
       : [];
   const nodeDefinitions = [...createCliNodeRegistry(), ...localDefs];
 
@@ -1035,6 +1040,7 @@ export async function nodeCommand(
         parseResult.localScaffold,
         io,
         parseResult.dryRun === true,
+        layout,
       );
     }
     return handleScaffoldCommand(scaffoldName, io, parseResult.jsFlag === true);
@@ -1418,13 +1424,14 @@ ${returnFields}
 `;
 }
 
-// NODEDX-008 / DATA-002 P3: dryRun prints both files; otherwise writes the manifest + companion into
-// `.dag/nodes/` (the unified node location), replacing the former standalone `.dag.node.js` layout.
+// NODEDX-008 / DATA-002 P3 / FLOW-007: dryRun prints both files; otherwise writes the manifest +
+// companion into the workspace `<root>/nodes/` (default `.workflows/nodes/`).
 async function handleScaffoldLocalCommand(
   nodeType: string,
   opts: ILocalScaffoldOptions,
   io: IDagCliIo,
   dryRun = false,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<number> {
   const ports = computeScaffoldPorts(nodeType, opts);
   const manifestContent = buildCodeNodeManifest(nodeType, ports);
@@ -1437,7 +1444,7 @@ async function handleScaffoldLocalCommand(
     return SUCCESS_EXIT_CODE;
   }
 
-  const dir = nodesDir(opts.dir);
+  const dir = nodesDir(opts.dir, layout);
   const manifestPath = join(dir, manifestFile);
   const companionPath = join(dir, companionFile);
 
@@ -1472,7 +1479,7 @@ async function handleScaffoldLocalCommand(
   if (opts.configs.length > 0) {
     io.write(`  config:   ${opts.configs.join(', ')}\n`);
   }
-  io.write(`\nRun (auto-discovered from .dag/nodes/):\n`);
+  io.write(`\nRun (auto-discovered from ${join(layout.root, 'nodes')}/):\n`);
   io.write(`  dag run --pipeline "input | ${nodeType} | text-output" --input text="Hello"\n`);
 
   return SUCCESS_EXIT_CODE;

--- a/packages/dag-cli/src/commands/run.ts
+++ b/packages/dag-cli/src/commands/run.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
 import { watch } from 'node:fs';
 import { join, dirname, resolve, parse as parsePath } from 'node:path';
 import { homedir } from 'node:os';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
 import type {
   IDagDefinition,
   IDagEdgeDefinition,
@@ -10,6 +11,7 @@ import type {
   IDagRobotaCompanion,
   INodeConfigObject,
   INodeManifest,
+  IWorkspaceLayout,
   TPortPayload,
 } from '@robota-sdk/dag-core';
 import type { IDagCliIo } from '../types.js';
@@ -45,6 +47,8 @@ export interface IRunCommandOptions {
   readonly io: IDagCliIo;
   /** Optional factory override for testing. Defaults to LocalDagRunner with default registry. */
   readonly createRunner?: () => LocalDagRunner;
+  /** FLOW-007: injected workspace layout (default `.workflows/`). */
+  readonly workspace?: IWorkspaceLayout;
 }
 
 /** Parsed options from argv for the `run` subcommand. */
@@ -1876,18 +1880,22 @@ async function printAliases(io: IDagCliIo): Promise<void> {
 
 /**
 /**
- * DATA-002 P3: resolve the project root for local-node discovery. Walks up from `startDir` and
- * returns the nearest ancestor containing a `.dag/` directory (so a workflow inside
- * `<root>/.dag/workflows/` still finds code nodes in `<root>/.dag/nodes/`). Falls back to `startDir`.
+ * DATA-002 P3 / FLOW-007: resolve the project root for local-node discovery. Walks up from `startDir`
+ * and returns the nearest ancestor containing the workspace root directory (default `.workflows/`), so
+ * a workflow file still finds code nodes in `<root>/nodes/`. Falls back to `startDir`.
  */
-async function findDagProjectRoot(startDir: string): Promise<string> {
+async function findDagProjectRoot(
+  startDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<string> {
+  const workspaceRoot = layout.root;
   let dir = resolve(startDir);
   const { root } = parsePath(dir);
   for (;;) {
     try {
-      if ((await stat(join(dir, '.dag'))).isDirectory()) return dir;
+      if ((await stat(join(dir, workspaceRoot))).isDirectory()) return dir;
     } catch {
-      // allow-fallback: no `.dag/` here; keep walking up
+      // allow-fallback: no workspace root here; keep walking up
     }
     if (dir === root) return startDir;
     dir = dirname(dir);
@@ -1984,7 +1992,8 @@ export async function runCommand(
     typeof file === 'string' && !file.startsWith('http://') && !file.startsWith('https://')
       ? dirname(resolve(file))
       : process.cwd();
-  const projectDir = await findDagProjectRoot(fileBasedDir);
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
+  const projectDir = await findDagProjectRoot(fileBasedDir, layout);
 
   // Collect companion nodeFiles (relative to dag file) + explicit --node-file flags.
   const companionNodeFiles: string[] =
@@ -2022,7 +2031,9 @@ export async function runCommand(
   }
 
   // Auto-scan local nodes (unless --no-auto-nodes).
-  const autoNodes = noAutoNodes ? [] : await loadLocalNodeDefinitions({ projectDir });
+  const autoNodes = noAutoNodes
+    ? []
+    : await loadLocalNodeDefinitions({ projectDir, workspace: layout });
 
   // Merge: explicit > auto > built-in (later entries win on nodeType conflict).
   const builtIn = createCliNodeRegistry();

--- a/packages/dag-cli/src/commands/save.ts
+++ b/packages/dag-cli/src/commands/save.ts
@@ -1,8 +1,10 @@
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
 import type {
   IDagDefinition,
   IDagEdgeDefinition,
   IDagNode,
   INodeConfigObject,
+  IWorkspaceLayout,
 } from '@robota-sdk/dag-core';
 import { buildNodeDefinitionAssembly } from '@robota-sdk/dag-node';
 import type { IDagCliIo } from '../types.js';
@@ -30,6 +32,7 @@ Examples:
 
 export interface ISaveCommandOptions {
   readonly io: IDagCliIo;
+  readonly workspace?: IWorkspaceLayout;
 }
 
 interface IParsedSaveOptions {
@@ -244,6 +247,7 @@ export async function saveCommand(
   options: ISaveCommandOptions,
 ): Promise<number> {
   const { io } = options;
+  const layout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
 
   if (args.includes('--help') || args.includes('-h')) {
     io.write(SAVE_HELP);
@@ -258,8 +262,10 @@ export async function saveCommand(
 
   const { pipeline, name, nodeConfigs } = parseResult.value;
 
-  // DATA-002 P3: local-aware registry so pipelines can reference `.dag/nodes/` code nodes.
-  const nodeDefinitions = await createCliNodeRegistryWithLocalNodes(process.cwd());
+  // DATA-002 P3: local-aware registry so pipelines can reference local code nodes.
+  const nodeDefinitions = await createCliNodeRegistryWithLocalNodes(process.cwd(), {
+    workspace: layout,
+  });
   const assemblyResult = buildNodeDefinitionAssembly(nodeDefinitions);
   if (!assemblyResult.ok) {
     io.write(`Error: Failed to build node registry: ${assemblyResult.error.message}\n`);
@@ -277,7 +283,7 @@ export async function saveCommand(
 
   let outputPath: string;
   try {
-    outputPath = await saveWorkflow(name, definition, process.cwd());
+    outputPath = await saveWorkflow(name, definition, process.cwd(), layout);
   } catch (writeErr) {
     // allow-fallback: directory/file write failure reported as structured error and non-zero exit
     const msg = writeErr instanceof Error ? writeErr.message : String(writeErr);

--- a/packages/dag-cli/src/local-runner/local-node-loader.ts
+++ b/packages/dag-cli/src/local-runner/local-node-loader.ts
@@ -1,13 +1,16 @@
 import { stat } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { IDagNodeDefinition } from '@robota-sdk/dag-core';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import type { IDagNodeDefinition, IWorkspaceLayout } from '@robota-sdk/dag-core';
 import { adaptSimpleNode, isSimpleNodeExport, loadCodeNodesFromDir } from './code-node-adapter.js';
 import { nodesDir } from './persistence/paths.js';
 
 export interface LocalNodeLoaderOptions {
   projectDir: string;
   verbose?: boolean;
+  /** FLOW-007: injected workspace layout (default `.workflows/`). */
+  workspace?: IWorkspaceLayout;
 }
 
 /**
@@ -74,8 +77,8 @@ export async function loadNodeFileExplicit(filePath: string): Promise<IDagNodeDe
 export async function loadLocalNodeDefinitions(
   options: LocalNodeLoaderOptions,
 ): Promise<IDagNodeDefinition[]> {
-  const { projectDir, verbose = false } = options;
-  const dir = nodesDir(projectDir);
+  const { projectDir, verbose = false, workspace = DEFAULT_WORKSPACE_LAYOUT } = options;
+  const dir = nodesDir(projectDir, workspace);
   const results = await loadCodeNodesFromDir(dir);
   if (verbose) {
     process.stderr.write(`[local-node-loader] loaded ${results.length} code node(s) from ${dir}\n`);

--- a/packages/dag-cli/src/local-runner/node-registry.ts
+++ b/packages/dag-cli/src/local-runner/node-registry.ts
@@ -1,4 +1,4 @@
-import type { IDagNodeDefinition } from '@robota-sdk/dag-core';
+import type { IDagNodeDefinition, IWorkspaceLayout } from '@robota-sdk/dag-core';
 import { createDefaultNodeRegistrySync } from '@robota-sdk/dag-framework';
 import { LlmTextOpenAiNodeDefinition } from '@robota-sdk/dag-node-llm-text-openai';
 import { LlmTextAnthropicNodeDefinition } from '@robota-sdk/dag-node-llm-text-anthropic';
@@ -40,11 +40,15 @@ export function createCliNodeRegistry(): IDagNodeDefinition[] {
  */
 export async function createCliNodeRegistryWithLocalNodes(
   projectDir: string,
-  options?: { verbose?: boolean },
+  options?: { verbose?: boolean; workspace?: IWorkspaceLayout },
 ): Promise<IDagNodeDefinition[]> {
   const [builtIn, local] = await Promise.all([
     Promise.resolve(createCliNodeRegistry()),
-    loadLocalNodeDefinitions({ projectDir, verbose: options?.verbose }),
+    loadLocalNodeDefinitions({
+      projectDir,
+      verbose: options?.verbose,
+      ...(options?.workspace ? { workspace: options.workspace } : {}),
+    }),
   ]);
 
   if (local.length === 0) return builtIn;

--- a/packages/dag-cli/src/local-runner/persistence/paths.ts
+++ b/packages/dag-cli/src/local-runner/persistence/paths.ts
@@ -1,21 +1,32 @@
 /**
- * Persistence path + extension constants (DATA-002). Dependency-free leaf so the store, the code-node
- * adapter, the loader, and handlers can share `.dag/` path knowledge without an import cycle.
+ * Persistence path helpers (DATA-002, parameterized in FLOW-007). The workspace root + workflow
+ * extension are injected via an `IWorkspaceLayout` (owned by each product's composition root), not
+ * hardcoded. Defaults to `.workflows/` with flat `.json` workflow definitions.
  */
 import { join } from 'node:path';
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
 
 /** Universal node manifest extension (generalized from BEHAVIOR-006's `.instant-node.json`). */
 export const NODE_MANIFEST_EXT = '.node.json';
 
-/** Workflow file extension. */
-export const WORKFLOW_EXT = '.dag.json';
+/** Default workflow-definition extension (from the default layout). Prefer the injected layout. */
+export const WORKFLOW_EXT = DEFAULT_WORKSPACE_LAYOUT.workflowExt;
 
-/** The `.dag/nodes/` directory for a project. */
-export function nodesDir(projectDir: string): string {
-  return join(projectDir, '.dag', 'nodes');
+/** The nodes directory: `<root>/nodes/`. */
+export function nodesDir(
+  projectDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): string {
+  return join(projectDir, layout.root, 'nodes');
 }
 
-/** The `.dag/workflows/` directory for a project. */
-export function workflowsDir(projectDir: string): string {
-  return join(projectDir, '.dag', 'workflows');
+/**
+ * The directory holding workflow definitions — flat under the workspace **root** (FLOW-007 removed the
+ * redundant `.dag/workflows/` level; definitions now live as `<root>/<name><workflowExt>`).
+ */
+export function workflowsDir(
+  projectDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): string {
+  return join(projectDir, layout.root);
 }

--- a/packages/dag-cli/src/local-runner/persistence/store.ts
+++ b/packages/dag-cli/src/local-runner/persistence/store.ts
@@ -1,15 +1,21 @@
 /**
  * Persistence store (DATA-002, WORKFLOW-005 P2).
  *
- * Single owner of `.dag/` save + load. Every node is a `.node.json` manifest (metadata SSOT,
- * discriminated by `kind`). Data nodes (prompt/composite) are the manifest alone; a code node
- * additionally has a supplementary `.dag.node.js` (added in Phase 2). Workflows live in
- * `.dag/workflows/*.dag.json` (data-only) and are managed here too. Centralizes the `.dag/` path +
- * readdir-skip boilerplate that was duplicated across handlers/context/commands.
+ * Single owner of the workspace save + load. Every node is a `.node.json` manifest (metadata SSOT,
+ * discriminated by `kind`) under `<root>/nodes/`; a code node additionally has a supplementary
+ * `.dag.node.js` companion. Workflow definitions live flat under the workspace `<root>` (data-only).
+ * The workspace `<root>` + workflow extension are injected via an `IWorkspaceLayout` (FLOW-007),
+ * defaulting to `.workflows/` + `.json`. Centralizes the path + readdir-skip boilerplate.
  */
 import { mkdir, writeFile, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { IDagDefinition, IDagNodeDefinition, TPortPayload } from '@robota-sdk/dag-core';
+import {
+  DEFAULT_WORKSPACE_LAYOUT,
+  type IDagDefinition,
+  type IDagNodeDefinition,
+  type IWorkspaceLayout,
+  type TPortPayload,
+} from '@robota-sdk/dag-core';
 import {
   createPromptBackedNodeDefinition,
   createCompositeInstantNodeDefinition,
@@ -19,9 +25,10 @@ import {
   type IPersistableInstantNode,
   type TPersistedInstantNode,
 } from '@robota-sdk/dag-node-instant-node';
+import { scanWorkspaceCatalog } from '@robota-sdk/dag-framework';
 import { LocalDagRunner, createCliNodeRegistry } from '../index.js';
 import { parseCodeManifest, reconstructCodeNode } from '../code-node-adapter.js';
-import { NODE_MANIFEST_EXT, WORKFLOW_EXT, nodesDir, workflowsDir } from './paths.js';
+import { NODE_MANIFEST_EXT, nodesDir, workflowsDir } from './paths.js';
 import { safeParseJson } from '../../mcp/utils.js';
 
 /** Narrow an arbitrary node definition to one that can serialize itself for reload. */
@@ -35,10 +42,14 @@ function asPersistable(nodeDef: IDagNodeDefinition): IPersistableInstantNode | u
  * Persist a node from its own serializable manifest view. Prompt AND composite nodes; the composite
  * `runner` is behavioral and is rebuilt on reload, never serialized.
  */
-export async function saveNode(nodeDef: IDagNodeDefinition, projectDir: string): Promise<void> {
+export async function saveNode(
+  nodeDef: IDagNodeDefinition,
+  projectDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<void> {
   const persistable = asPersistable(nodeDef);
   if (!persistable) return;
-  const dir = nodesDir(projectDir);
+  const dir = nodesDir(projectDir, layout);
   await mkdir(dir, { recursive: true });
   const record = { ...persistable.toPersisted(), createdAt: new Date().toISOString() };
   await writeFile(
@@ -178,8 +189,12 @@ function reconstructNode(
  * manifest alone; `code` combines the manifest metadata with its companion `.dag.node.js` behavior.
  * Composite runners close over `liveDefs` so nested nodes resolve regardless of load order.
  */
-export async function loadNodes(projectDir: string, liveDefs: IDagNodeDefinition[]): Promise<void> {
-  const dir = nodesDir(projectDir);
+export async function loadNodes(
+  projectDir: string,
+  liveDefs: IDagNodeDefinition[],
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<void> {
+  const dir = nodesDir(projectDir, layout);
   let files: string[];
   try {
     files = await readdir(dir);
@@ -208,49 +223,30 @@ export async function loadNodes(projectDir: string, liveDefs: IDagNodeDefinition
   }
 }
 
-// --- Workflows (data-only `.dag.json` under `.dag/workflows/`) ---
+// --- Workflows (data-only definitions, flat under the workspace root) ---
 
-/** Persist a workflow definition to `.dag/workflows/<name>.dag.json`. Returns the written path. */
+/** Persist a workflow definition to `<root>/<name><workflowExt>`. Returns the written path. */
 export async function saveWorkflow(
   name: string,
   definition: IDagDefinition,
   projectDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<string> {
-  const dir = workflowsDir(projectDir);
+  const dir = workflowsDir(projectDir, layout);
   await mkdir(dir, { recursive: true });
-  const outputPath = join(dir, `${name}${WORKFLOW_EXT}`);
+  const outputPath = join(dir, `${name}${layout.workflowExt}`);
   await writeFile(outputPath, `${JSON.stringify(definition, null, 2)}\n`, 'utf-8');
   return outputPath;
 }
 
 /**
- * Load workflow definitions from `.dag/workflows/*.dag.json` (data-only parse). Malformed/unreadable
- * files are skipped. Returns `{ name, definition }` per valid file.
+ * Load workflow definitions from the workspace root via the shared `scanWorkspaceCatalog` reader
+ * (FLOW-007 C3 — one reader for all consumers). Returns `{ name, definition }` per valid file.
  */
 export async function loadWorkflows(
   projectDir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<Array<{ name: string; definition: IDagDefinition }>> {
-  const dir = workflowsDir(projectDir);
-  let files: string[];
-  try {
-    files = await readdir(dir);
-  } catch {
-    // allow-fallback: .dag/workflows/ may not exist yet
-    return [];
-  }
-  const workflows: Array<{ name: string; definition: IDagDefinition }> = [];
-  for (const file of files.filter((f) => f.endsWith(WORKFLOW_EXT))) {
-    try {
-      const parsed = JSON.parse(await readFile(join(dir, file), 'utf-8')) as unknown;
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
-      workflows.push({
-        name: file.slice(0, -WORKFLOW_EXT.length),
-        definition: parsed as IDagDefinition,
-      });
-    } catch {
-      // allow-fallback: unreadable/unparseable workflow file skipped
-      continue;
-    }
-  }
-  return workflows;
+  const entries = await scanWorkspaceCatalog(workflowsDir(projectDir, layout), layout);
+  return entries.map((e) => ({ name: e.id, definition: e.definition }));
 }

--- a/packages/dag-cli/src/runner.ts
+++ b/packages/dag-cli/src/runner.ts
@@ -3,7 +3,8 @@ import { readFile } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
-import type { IDagDefinition, TPortPayload } from '@robota-sdk/dag-core';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import type { IDagDefinition, IWorkspaceLayout, TPortPayload } from '@robota-sdk/dag-core';
 import { DagOrchestrationHttpClient } from '@robota-sdk/dag-orchestration-client';
 import { parseGlobalConfig } from './arguments.js';
 import { dispatchDagCliCommand } from './runner-dispatch.js';
@@ -194,11 +195,25 @@ Version: dag --version
 `;
 
 export async function runDagCli(
-  args: readonly string[],
+  rawArgs: readonly string[],
   options: IDagCliRunOptions = {},
 ): Promise<number> {
   const io = options.io ?? defaultIo;
   const fetchImpl = options.fetch ?? defaultFetch;
+
+  // FLOW-007: resolve the workspace layout from injected options or a leading `--workspace <dir>`
+  // global flag, then strip the flag so subcommand dispatch sees the same argv shape as before.
+  let workspace: IWorkspaceLayout = options.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
+  let args = rawArgs;
+  if (args[0] === '--workspace') {
+    const dir = args[1];
+    if (typeof dir !== 'string' || dir.startsWith('--')) {
+      io.write('Error: --workspace requires a directory value.\n');
+      return USAGE_ERROR_EXIT_CODE;
+    }
+    workspace = { root: dir, workflowExt: workspace.workflowExt };
+    args = args.slice(2);
+  }
 
   // Top-level help: no args, --help, or -h
   if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
@@ -217,7 +232,7 @@ export async function runDagCli(
 
   // Route `run` to local execution when no --server flag is present.
   if (args[0] === RUN_SUBCOMMAND && !args.includes(SERVER_FLAG)) {
-    return runCommand(args.slice(1), { io: wrappedIo });
+    return runCommand(args.slice(1), { io: wrappedIo, workspace });
   }
 
   // Route `validate` to local validation.
@@ -240,7 +255,7 @@ export async function runDagCli(
 
   // Route `node` subcommands to local node registry inspection.
   if (args[0] === NODE_SUBCOMMAND) {
-    return nodeCommand(args.slice(1), { io: wrappedIo });
+    return nodeCommand(args.slice(1), { io: wrappedIo, workspace });
   }
 
   // Route `init` to project scaffolding.
@@ -255,7 +270,7 @@ export async function runDagCli(
 
   // Route `catalog` to local file catalog commands.
   if (args[0] === CATALOG_SUBCOMMAND) {
-    return catalogCommand(args.slice(1), { io: wrappedIo });
+    return catalogCommand(args.slice(1), { io: wrappedIo, workspace });
   }
 
   // Route `template` to built-in topology templates.
@@ -362,7 +377,7 @@ export async function runDagCli(
 
   // Route `save` to pipeline → catalog file.
   if (args[0] === SAVE_SUBCOMMAND) {
-    return saveCommand(args.slice(1), { io: wrappedIo });
+    return saveCommand(args.slice(1), { io: wrappedIo, workspace });
   }
 
   // Route `alias` to alias management (add/list/remove).

--- a/packages/dag-cli/src/types.ts
+++ b/packages/dag-cli/src/types.ts
@@ -1,3 +1,4 @@
+import type { IWorkspaceLayout } from '@robota-sdk/dag-core';
 import type {
   IOrchestrationProblemDetails,
   TDagOrchestrationFetch,
@@ -33,6 +34,8 @@ export interface IDagCliRunOptions {
   readonly env?: IDagCliEnvironment;
   readonly io?: IDagCliIo;
   readonly fetch?: TDagCliFetch;
+  /** FLOW-007: workspace layout, resolved by the dispatch root (a `--workspace <dir>` flag / default). */
+  readonly workspace?: IWorkspaceLayout;
 }
 
 export interface IDagCliFailure {

--- a/packages/dag-core/src/index.ts
+++ b/packages/dag-core/src/index.ts
@@ -53,6 +53,7 @@ export type {
 export * from './types/run-result.js';
 export * from './types/marketplace.js';
 export * from './types/workflow-file.js';
+export * from './types/workspace-layout.js';
 export type {
   IDagNodeManifest,
   INodePortSpec,

--- a/packages/dag-core/src/types/workspace-layout.ts
+++ b/packages/dag-core/src/types/workspace-layout.ts
@@ -1,0 +1,23 @@
+/**
+ * Workspace layout (FLOW-007).
+ *
+ * A configurable, injectable description of where a dag/workflows product keeps its on-disk state.
+ * The workspace folder name and workflow-file extension are a **per-product option**, not a hardcoded
+ * constant — the composition root of each product (the dag-cli assembly, the `/workflows` command
+ * factory, …) injects an `IWorkspaceLayout`, and the shared persistence/runtime machinery consumes it.
+ *
+ * Pure data (no `fs`/`path` dependency); path computation belongs to the runtime layer that consumes
+ * this — dag-core stays platform-agnostic.
+ */
+export interface IWorkspaceLayout {
+  /** Workspace root directory, relative to the project dir (e.g. `.workflows`). */
+  readonly root: string;
+  /** Workflow-definition file extension (e.g. `.json`). Definitions live flat under `root`. */
+  readonly workflowExt: string;
+}
+
+/** Default layout: a `.workflows/` workspace with flat `.json` workflow definitions. */
+export const DEFAULT_WORKSPACE_LAYOUT: IWorkspaceLayout = {
+  root: '.workflows',
+  workflowExt: '.json',
+};

--- a/packages/dag-framework/src/__tests__/workspace-catalog.test.ts
+++ b/packages/dag-framework/src/__tests__/workspace-catalog.test.ts
@@ -1,0 +1,48 @@
+/**
+ * FLOW-007 C3 — shared workspace-catalog reader. Real fs, no mocks.
+ */
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IWorkspaceLayout } from '@robota-sdk/dag-core';
+import { scanWorkspaceCatalog } from '../workspace-catalog.js';
+
+const DAG = { dagId: 'x', version: 1, status: 'draft', nodes: [{ nodeId: 'a' }], edges: [] };
+
+describe('scanWorkspaceCatalog (FLOW-007 C3)', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ws-catalog-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] for a missing directory', async () => {
+    expect(await scanWorkspaceCatalog(join(dir, 'nope'))).toEqual([]);
+  });
+
+  it('lists flat .json workflows; skips node manifests, non-DAG JSON, and other files', async () => {
+    mkdirSync(join(dir, 'nodes'), { recursive: true });
+    writeFileSync(join(dir, 'greet.json'), JSON.stringify({ ...DAG, meta: { tags: ['hi'] } }));
+    writeFileSync(join(dir, 'summarize.json'), JSON.stringify(DAG));
+    writeFileSync(join(dir, 'aliases.json'), JSON.stringify({ a: 1 })); // aux, not a DAG
+    writeFileSync(join(dir, 'greet.node.json'), JSON.stringify({ kind: 'code' })); // node manifest
+    writeFileSync(join(dir, 'notes.txt'), 'x');
+    writeFileSync(join(dir, 'broken.json'), '{ not json');
+
+    const entries = await scanWorkspaceCatalog(dir);
+    expect(entries.map((e) => e.id)).toEqual(['greet', 'summarize']); // sorted, aux/manifest/etc. skipped
+    expect(entries[0].meta.tags).toEqual(['hi']);
+    expect(entries[0].filePath).toBe(join(dir, 'greet.json'));
+  });
+
+  it('honors a custom injected layout (root + workflow extension)', async () => {
+    const layout: IWorkspaceLayout = { root: '.custom', workflowExt: '.flow.json' };
+    writeFileSync(join(dir, 'a.flow.json'), JSON.stringify(DAG));
+    writeFileSync(join(dir, 'b.json'), JSON.stringify(DAG)); // wrong ext for this layout
+    const entries = await scanWorkspaceCatalog(dir, layout);
+    expect(entries.map((e) => e.id)).toEqual(['a']);
+  });
+});

--- a/packages/dag-framework/src/index.ts
+++ b/packages/dag-framework/src/index.ts
@@ -23,6 +23,8 @@ export type { IHttpDagRuntimeProviderOptions } from './http-dag-runtime-provider
 export { DagPromptBackend } from './adapters/prompt-backend.js';
 export { LocalFsAssetStore } from './adapters/local-fs-asset-store.js';
 export { createExecutionComposition } from './composition/create-execution-composition.js';
+export { scanWorkspaceCatalog } from './workspace-catalog.js';
+export type { IWorkspaceCatalogEntry, IWorkspaceCatalogMeta } from './workspace-catalog.js';
 export type { IWorkerLoopDriverLogger } from './runtime/worker-loop-driver.js';
 
 export const DAG_FRAMEWORK_PACKAGE_NAME = '@robota-sdk/dag-framework';

--- a/packages/dag-framework/src/local-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/local-dag-runtime-provider.ts
@@ -19,6 +19,7 @@ import type {
   TRunProgressEvent,
   IDagRun,
   ITaskRun,
+  IWorkspaceLayout,
 } from '@robota-sdk/dag-core';
 import { LifecycleTaskExecutorPort } from '@robota-sdk/dag-core';
 import {
@@ -69,6 +70,11 @@ export interface ILocalDagRuntimeProviderOptions {
   nodeRegistry?: IDagNodeDefinition[];
   /** DAG project directory — reserved for future local node-file scanning. */
   projectDir?: string;
+  /**
+   * FLOW-007: injected workspace layout (root dir + workflow ext). Reserved for local node discovery
+   * from `<root>/nodes/` when running authored workflows that reference local prompt/code nodes.
+   */
+  workspace?: IWorkspaceLayout;
   /** Instant nodes (typically injected from an MCP session context). */
   instantNodes?: IDagNodeDefinition[];
   /** Extra nodes appended at the end (test/special-purpose). */

--- a/packages/dag-framework/src/workspace-catalog.ts
+++ b/packages/dag-framework/src/workspace-catalog.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared workspace-catalog reader (FLOW-007 C3).
+ *
+ * The single owner of "list the workflow definitions in a workspace directory" — unifying the three
+ * previously-separate scanners (the persistence store's `loadWorkflows`, the dag-cli `catalog-scanner`,
+ * and the `/workflows catalog` inline scan). Workflow definitions live **flat** under the workspace
+ * root as `<name><workflowExt>`; node manifests (`.node.json`, which also end in `.json`) and non-DAG
+ * JSON that share the root are skipped. The workspace layout is injected (default `.workflows/`).
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  DEFAULT_WORKSPACE_LAYOUT,
+  type IDagDefinition,
+  type IWorkspaceLayout,
+} from '@robota-sdk/dag-core';
+
+/** Catalog metadata surfaced from a workflow definition's optional `meta` block. */
+export interface IWorkspaceCatalogMeta {
+  readonly description?: string;
+  readonly displayName?: string;
+  readonly tags?: readonly string[];
+}
+
+/** One workflow definition discovered in a workspace. */
+export interface IWorkspaceCatalogEntry {
+  /** File stem (the workflow id / name), e.g. `greet` for `greet.json`. */
+  readonly id: string;
+  /** Absolute path to the definition file. */
+  readonly filePath: string;
+  readonly definition: IDagDefinition;
+  readonly meta: IWorkspaceCatalogMeta;
+}
+
+const NODE_MANIFEST_SUFFIX = '.node.json';
+
+function extractMeta(raw: Record<string, unknown>): IWorkspaceCatalogMeta {
+  const meta = raw['meta'];
+  if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) return {};
+  const m = meta as Record<string, unknown>;
+  return {
+    description: typeof m['description'] === 'string' ? m['description'] : undefined,
+    displayName: typeof m['displayName'] === 'string' ? m['displayName'] : undefined,
+    tags: Array.isArray(m['tags'])
+      ? (m['tags'] as unknown[]).filter((t): t is string => typeof t === 'string')
+      : undefined,
+  };
+}
+
+/** True when a parsed object looks like a DAG workflow (has `nodes` or a `dagId`). */
+function isDagShaped(raw: Record<string, unknown>): boolean {
+  return Array.isArray(raw['nodes']) || typeof raw['dagId'] === 'string';
+}
+
+/**
+ * Scan a directory for flat workflow definitions (`<name><workflowExt>`). Missing/unreadable dirs and
+ * malformed / non-DAG / node-manifest files are skipped (never throws). Returns entries sorted by id.
+ */
+export async function scanWorkspaceCatalog(
+  dir: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<IWorkspaceCatalogEntry[]> {
+  let fileNames: string[];
+  try {
+    fileNames = await readdir(dir);
+  } catch {
+    // allow-fallback: a missing/unreadable workspace root is a normal empty catalog
+    return [];
+  }
+  const ext = layout.workflowExt;
+  const entries: IWorkspaceCatalogEntry[] = [];
+  for (const fileName of fileNames) {
+    if (fileName.endsWith(NODE_MANIFEST_SUFFIX) || !fileName.endsWith(ext)) continue;
+    const filePath = join(dir, fileName);
+    let raw: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(await readFile(filePath, 'utf8')) as unknown;
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
+      raw = parsed as Record<string, unknown>;
+    } catch {
+      // allow-fallback: unreadable/malformed file skipped
+      continue;
+    }
+    if (!isDagShaped(raw)) continue; // aux JSON (aliases/history/…) sharing the root
+    entries.push({
+      id: fileName.slice(0, -ext.length),
+      filePath,
+      definition: raw as unknown as IDagDefinition,
+      meta: extractMeta(raw),
+    });
+  }
+  return entries.sort((a, b) => a.id.localeCompare(b.id));
+}


### PR DESCRIPTION
Promotes `develop` → `main`.

## Contents
- **FLOW-007 Phase 1** (#989): de-jargons local workflow storage to a flat `.workflows/` container and makes the workspace layout a first-class injectable (`IWorkspaceLayout`) across all dag-* composition roots — persistence, the unified `scanWorkspaceCatalog` reader, `LocalDagRuntimeProvider`, the `/workflows` command module, and the dag-cli `--workspace <dir>` global flag.

Foundation for the natural-language `/workflows` authoring feature (Phases 2–4). DAG subsystem stays private.

Verified on the source PR: 1007 dag-cli tests + agent-command-workflows green, 45/45 harness scans, 0 lint errors, and a live `--workspace .myws` end-to-end round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)