### PR TITLE
fix(workflows): authored prompt nodes inherit the active provider

### DIFF
--- a/packages/agent-command-workflows/src/create-command.ts
+++ b/packages/agent-command-workflows/src/create-command.ts
@@ -146,9 +146,17 @@ function toInstantProvider(value: string | undefined): TInstantNodeProvider | un
     : undefined;
 }
 
-/** Build a prompt-backed node definition from an authored `newNodes` entry. */
-function buildPromptNode(spec: IAuthoredPromptNode): IDagNodeDefinition {
-  const provider = toInstantProvider(spec.provider);
+/**
+ * Build a prompt-backed node definition from an authored `newNodes` entry. When the spec omits a
+ * provider (the common case — the LLM rarely sets one), inherit the ACTIVE provider used for
+ * authoring so the node doesn't silently hardcode-default to anthropic and fail for other providers.
+ * The chosen provider is persisted in the node manifest for a deterministic reload.
+ */
+function buildPromptNode(
+  spec: IAuthoredPromptNode,
+  fallbackProvider: TInstantNodeProvider | undefined,
+): IDagNodeDefinition {
+  const provider = toInstantProvider(spec.provider) ?? fallbackProvider;
   return createPromptBackedNodeDefinition({
     nodeType: spec.nodeType,
     displayName: spec.displayName ?? spec.nodeType,
@@ -213,12 +221,15 @@ export async function executeWorkflowsCreate(
   const providerDefinitions = deps.providerDefinitions ?? [];
   let provider: IAIProvider;
   let model = deps.model;
+  let activeProvider: TInstantNodeProvider | undefined;
   try {
     if (deps.resolveProvider) {
       provider = deps.resolveProvider(cwd);
     } else {
       provider = createProviderFromSettings(cwd, undefined, { providerDefinitions });
-      model = model ?? readProviderSettings(cwd, { providerDefinitions }).model;
+      const settings = readProviderSettings(cwd, { providerDefinitions });
+      model = model ?? settings.model;
+      activeProvider = toInstantProvider(settings.name);
     }
   } catch (err) {
     const detail =
@@ -262,7 +273,7 @@ export async function executeWorkflowsCreate(
   const existingTypes = new Set(baseNodeDefs.map((n) => n.nodeType));
   for (const nodeSpec of spec.newNodes ?? []) {
     if (existingTypes.has(nodeSpec.nodeType)) continue; // reuse existing; do not clobber
-    authoredNodes.push(buildPromptNode(nodeSpec));
+    authoredNodes.push(buildPromptNode(nodeSpec, activeProvider));
     existingTypes.add(nodeSpec.nodeType);
   }
 


### PR DESCRIPTION
**Found by auditing the generated artifacts.** The authored prompt-node manifest (`.workflows/nodes/*.node.json`) persisted **no `provider` field**, so on reload it hardcode-defaulted to anthropic regardless of the active provider — it would fail for a user whose active provider is e.g. openai (no `ANTHROPIC_API_KEY`).

Fix: when the LLM's spec omits a provider (the common case), inherit the **active provider** used for authoring (`readProviderSettings(cwd,{providerDefinitions}).name`) and persist it in the manifest for a deterministic reload.

### Live verification
- `/workflows create` of a Shakespearean-sonnet prompt node now writes `"provider": "anthropic"` into the manifest.
- **Re-running the saved artifact from disk** reloads that node and executes it against the real LLM — produced a full sonnet. Round-trip (create → persist w/ provider → re-run from disk → reload → execute) confirmed.

25 unit tests, 45/45 harness scans, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)