### PR TITLE
chore(release): merge develop into main — unit test no longer makes real LLM calls

### DIFF
--- a/packages/agent-command-workflows/docs/SPEC.md
+++ b/packages/agent-command-workflows/docs/SPEC.md
@@ -86,7 +86,9 @@ swallowed; no fallback to a default workflow.
 stub** (deterministic): arg parsing; spec validation (incl. Markdown code-fence tolerance); TC-02
 author→save→run (uppercased output); `--input` precedence over `sampleInput`; TC-03 self-contained
 re-run reproduces the result; TC-04 no-provider → actionable error + no write; TC-05 prompt-node
-create/save/reuse.
+create/save/reuse — which **clears all provider keys** (`vi.stubEnv`) so the key-using node run is
+deterministic and free of any network call, and **explicitly asserts** the missing-key failure is
+detected/surfaced (never silently tolerated, never a real LLM call in the unit suite).
 
 `src/__tests__/create-command.live.test.ts` is an **opt-in live suite** hitting a REAL provider — it
 runs only when `RUN_LIVE_LLM=1` AND a provider key are both present, so normal `pnpm test` / CI skip

--- a/packages/agent-command-workflows/src/__tests__/create-command.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/create-command.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAssistantMessage } from '@robota-sdk/agent-core';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 import {
@@ -201,22 +201,42 @@ describe('executeWorkflowsCreate (TC-05: on-the-fly prompt node)', () => {
     sampleInput: { text: 'hello' },
   });
 
-  it('creates + saves the prompt node under .workflows/nodes/ and reuses it on a second create', async () => {
+  // This test executes a real key-using prompt node. To keep it deterministic and free of any
+  // network call, force the no-key path by clearing every provider key — regardless of what is in
+  // the ambient environment. The missing key MUST then surface as a detected error (asserted below),
+  // never a silent pass and never a real LLM call.
+  beforeEach(() => {
+    for (const key of [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GEMINI_API_KEY',
+      'DEEPSEEK_API_KEY',
+      'DASHSCOPE_API_KEY',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('saves the prompt node + workflow, surfaces the missing-key error, and reuses the node', async () => {
     const first = await executeWorkflowsCreate('"rewrite as a pirate"', dir, baseDeps(PIRATE_SPEC));
-    // The prompt node has no ANTHROPIC_API_KEY in the test env, so the RUN may fail — but the node
-    // and workflow must still be authored and saved (create saves before running).
+
+    // Author-before-run: the node + workflow are persisted even though the run cannot complete.
     const nodePath = join(dir, '.workflows', 'nodes', 'pirate-speak.node.json');
-    await expect(stat(nodePath)).resolves.toBeDefined();
     const nodeManifest = JSON.parse(await readFile(nodePath, 'utf-8')) as {
       kind: string;
       nodeType: string;
     };
     expect(nodeManifest.kind).toBe('prompt');
     expect(nodeManifest.nodeType).toBe('pirate-speak');
-
-    const wfPath = join(dir, '.workflows', 'pirate-rewrite.json');
-    await expect(stat(wfPath)).resolves.toBeDefined();
+    await expect(stat(join(dir, '.workflows', 'pirate-rewrite.json'))).resolves.toBeDefined();
     expect(first.message).toContain('pirate-speak.node.json');
+
+    // Key-using code ran without a key → the failure MUST be detected and surfaced, not swallowed.
+    expect(first.success).toBe(false);
+    expect(first.message).toMatch(/ANTHROPIC_API_KEY|api key|required|is not set/i);
 
     // Second create reuses the already-saved node (it is loaded and present in the catalog).
     const second = await executeWorkflowsCreate(


### PR DESCRIPTION
Promotes `develop` → `main`.

## Contents
- **TC-05 deterministic + asserts missing-key detection** (#999): the unit test executed real key-using code, so with a key in the environment it silently made a real Anthropic call inside `pnpm test`. It now clears provider keys (`vi.stubEnv`) for a deterministic, network-free run and explicitly asserts the missing-key failure is detected/surfaced. Full unit suite deterministic (25 pass, 5 skip); real-provider coverage stays in the opt-in `test:live` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)