### PR TITLE
chore(release): merge develop into main — version packages to 3.0.0-beta.79

### DIFF
--- a/.changeset/batch-beta-79.md
+++ b/.changeset/batch-beta-79.md
@@ -1,0 +1,22 @@
+---
+'@robota-sdk/agent-cli': patch
+---
+
+Coordinated beta.79 release. Ships the natural-language workflow authoring feature and its
+follow-ups, all bundled into the published CLI:
+
+- **FLOW-007 `/workflows create "<description>"`** — author a workflow from natural language via the
+  active provider, save it as a reusable `.workflows/<name>.json` artifact, and run it immediately;
+  composes existing nodes and creates prompt-backed nodes on the fly; model-invocable so the agent can
+  author + run from chat. Storage de-jargoned to a flat `.workflows/` layout with an injectable
+  workspace.
+- Live-LLM hardening found by running against a real provider: the authoring call now threads the
+  resolved model; the spec parser tolerates a Markdown code fence; authored prompt nodes inherit +
+  persist the active provider; and the unit suite no longer makes real key-using calls (forces the
+  no-key path + asserts detection), with real coverage isolated in an opt-in `test:live`.
+- **DATA-003** — the instant-node package now owns a runtime provider SSOT (`INSTANT_NODE_PROVIDERS`)
+  and a symmetric persistence round-trip (`parsePersistedInstantNode` / `rehydrateInstantNode` +
+  guards), removing duplicated provider lists and a hand-rolled, prompt-only reload path.
+
+(The DAG/workflow subsystem stays private and is bundled into the CLI; no new runtime `@robota-sdk`
+edge is added.)

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -140,6 +140,7 @@
     "automatic-memory-capture-retrieval",
     "batch-beta-56",
     "batch-beta-77",
+    "batch-beta-79",
     "bright-status-activity",
     "cjk-ime-cursor-position",
     "cli-001-002-lint-layer-separation",

--- a/apps/agent-server/CHANGELOG.md
+++ b/apps/agent-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @robota-sdk/agent-server
 
+## 3.0.1-beta.35
+
+### Patch Changes
+
+- @robota-sdk/agent-command@3.0.0-beta.79
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+- @robota-sdk/agent-playground@3.0.0-beta.79
+
 ## 3.0.1-beta.34
 
 ### Patch Changes

--- a/apps/agent-server/package.json
+++ b/apps/agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-server",
-  "version": "3.0.1-beta.34",
+  "version": "3.0.1-beta.35",
   "description": "Agent Server - AI provider proxy and Playground WebSocket server",
   "private": true,
   "keywords": [

--- a/apps/dag-runtime-server/CHANGELOG.md
+++ b/apps/dag-runtime-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/dag-runtime-server
 
+## 3.0.0-beta.3
+
+### Patch Changes
+
+- @robota-sdk/dag-framework@0.1.0-beta.3
+
 ## 3.0.0-beta.2
 
 ### Patch Changes

--- a/apps/dag-runtime-server/package.json
+++ b/apps/dag-runtime-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-runtime-server",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "private": true,
   "description": "Native DAG runtime HTTP server (/v1/dag/*) over Hono — native runtime surface",
   "type": "module",

--- a/apps/starter-nextjs/CHANGELOG.md
+++ b/apps/starter-nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/starter-nextjs
 
+## 0.0.2-beta.11
+
+### Patch Changes
+
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 0.0.2-beta.10
 
 ### Patch Changes

--- a/apps/starter-nextjs/package.json
+++ b/apps/starter-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/starter-nextjs",
-  "version": "0.0.2-beta.10",
+  "version": "0.0.2-beta.11",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "private": true,
   "description": "Robota SDK — Next.js AI Chat starter template",

--- a/packages/agent-cli/CHANGELOG.md
+++ b/packages/agent-cli/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @robota-sdk/agent-cli
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- Coordinated beta.79 release. Ships the natural-language workflow authoring feature and its
+  follow-ups, all bundled into the published CLI:
+
+  - **FLOW-007 `/workflows create "<description>"`** — author a workflow from natural language via the
+    active provider, save it as a reusable `.workflows/<name>.json` artifact, and run it immediately;
+    composes existing nodes and creates prompt-backed nodes on the fly; model-invocable so the agent can
+    author + run from chat. Storage de-jargoned to a flat `.workflows/` layout with an injectable
+    workspace.
+  - Live-LLM hardening found by running against a real provider: the authoring call now threads the
+    resolved model; the spec parser tolerates a Markdown code fence; authored prompt nodes inherit +
+    persist the active provider; and the unit suite no longer makes real key-using calls (forces the
+    no-key path + asserts detection), with real coverage isolated in an opt-in `test:live`.
+  - **DATA-003** — the instant-node package now owns a runtime provider SSOT (`INSTANT_NODE_PROVIDERS`)
+    and a symmetric persistence round-trip (`parsePersistedInstantNode` / `rehydrateInstantNode` +
+    guards), removing duplicated provider lists and a hand-rolled, prompt-only reload path.
+
+  (The DAG/workflow subsystem stays private and is bundled into the CLI; no new runtime `@robota-sdk`
+  edge is added.)
+
 ## 3.0.0-beta.78
 
 ## 3.0.0-beta.77

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-cli",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "AI coding assistant CLI built on Robota SDK",
   "type": "module",
   "bin": {

--- a/packages/agent-command-workflows/CHANGELOG.md
+++ b/packages/agent-command-workflows/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-command-workflows
 
+## 3.0.0-beta.3
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/dag-node-instant-node@3.0.0-beta.63
+- @robota-sdk/dag-framework@0.1.0-beta.3
+
 ## 3.0.0-beta.2
 
 ### Patch Changes

--- a/packages/agent-command-workflows/package.json
+++ b/packages/agent-command-workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command-workflows",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "private": true,
   "description": "agent-cli /workflows command module — surfaces the DAG workflow engine by composing dag-framework",
   "type": "module",

--- a/packages/agent-command/CHANGELOG.md
+++ b/packages/agent-command/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-command
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-preset@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-command",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Consolidated command module implementations for Robota SDK CLI",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-core
 
+## 3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-core",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Complete AI agent implementation with unified core and tools functionality - conversation management, plugin system, and advanced agent features",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-executor/CHANGELOG.md
+++ b/packages/agent-executor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-executor
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-executor",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Composable runtime primitives for Robota background tasks and subagent orchestration",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-framework/CHANGELOG.md
+++ b/packages/agent-framework/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-framework
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-executor@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-session@3.0.0-beta.79
+- @robota-sdk/agent-tools@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-framework",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Programmatic SDK for building AI agents with Robota — provides InteractiveSession, createQuery(), command APIs, permissions, hooks, and context loading",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-transport/CHANGELOG.md
+++ b/packages/agent-interface-transport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-interface-transport
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-interface-transport/package.json
+++ b/packages/agent-interface-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-transport",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Transport contract interfaces for the Robota SDK (ITransportAdapter, IConfigurableTransport, ITransportConfig)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-interface-tui/CHANGELOG.md
+++ b/packages/agent-interface-tui/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @robota-sdk/agent-interface-tui
 
+## 3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ## 3.0.0-beta.77

--- a/packages/agent-interface-tui/package.json
+++ b/packages/agent-interface-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-interface-tui",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "TUI interaction contract interfaces for the Robota SDK (ITuiPickerItem, ITuiCommandInteraction, ITuiPickerInteraction, ITuiConfirmInteraction)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-playground/CHANGELOG.md
+++ b/packages/agent-playground/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-playground
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+- @robota-sdk/agent-tools@3.0.0-beta.79
+- @robota-sdk/agent-remote-client@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-playground/package.json
+++ b/packages/agent-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-playground",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "description": "Deployable Playground UI package (React implementation) for Robota SDK",
   "type": "module",

--- a/packages/agent-plugin/CHANGELOG.md
+++ b/packages/agent-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-plugin
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-plugin/package.json
+++ b/packages/agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-plugin",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Consolidated plugin implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-preset/CHANGELOG.md
+++ b/packages/agent-preset/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-preset
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-framework@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-preset/package.json
+++ b/packages/agent-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-preset",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Preset contract and resolver for the Robota SDK (IPreset, resolvePreset, listPresets, built-in presets)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider-replay/CHANGELOG.md
+++ b/packages/agent-provider-replay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-provider-replay
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-session@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-provider-replay/package.json
+++ b/packages/agent-provider-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider-replay",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Deterministic AI provider that replays a recorded Robota session log (offline, no model key)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-provider/CHANGELOG.md
+++ b/packages/agent-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-provider
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-provider/package.json
+++ b/packages/agent-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-provider",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "description": "Consolidated AI provider implementations for Robota SDK",
   "type": "module",

--- a/packages/agent-remote-client/CHANGELOG.md
+++ b/packages/agent-remote-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-remote-client
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-remote-client/package.json
+++ b/packages/agent-remote-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-remote-client",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Remote client for calling a Robota agent over HTTP",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session-analytics/CHANGELOG.md
+++ b/packages/agent-session-analytics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-session-analytics
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-session-analytics/package.json
+++ b/packages/agent-session-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session-analytics",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Session-log timing analysis and reporting for the Robota SDK (analyzeSession, aggregateReports, report formatters)",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-session/CHANGELOG.md
+++ b/packages/agent-session/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-session
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-session",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Session and chat management for Robota SDK - multi-session support with independent workspaces",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-subagent-runner/CHANGELOG.md
+++ b/packages/agent-subagent-runner/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/agent-subagent-runner
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-executor@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-subagent-runner/package.json
+++ b/packages/agent-subagent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-subagent-runner",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Child-process subagent runner for Robota SDK — optional package for running subagents in isolated child processes",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tool-mcp/CHANGELOG.md
+++ b/packages/agent-tool-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-tool-mcp
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-tool-mcp/package.json
+++ b/packages/agent-tool-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tool-mcp",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "MCP protocol tool implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-tools/CHANGELOG.md
+++ b/packages/agent-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-tools
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-tools/package.json
+++ b/packages/agent-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-tools",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Tool registry and implementations for Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-http/CHANGELOG.md
+++ b/packages/agent-transport-http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-transport-http
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-transport-http/package.json
+++ b/packages/agent-transport-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-http",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "HTTP (Hono) transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-mcp/CHANGELOG.md
+++ b/packages/agent-transport-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/agent-transport-mcp
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-transport-mcp/package.json
+++ b/packages/agent-transport-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-mcp",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Model Context Protocol (MCP) server transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-tui/CHANGELOG.md
+++ b/packages/agent-transport-tui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/agent-transport-tui
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-interface-tui@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-transport-tui/package.json
+++ b/packages/agent-transport-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-tui",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Terminal UI (React + Ink) transport for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport-ws/CHANGELOG.md
+++ b/packages/agent-transport-ws/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-transport-ws
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-transport-ws/package.json
+++ b/packages/agent-transport-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport-ws",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "WebSocket transport and protocol for the Robota SDK",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-transport/CHANGELOG.md
+++ b/packages/agent-transport/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @robota-sdk/agent-transport
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-transport",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Core transport package for Robota SDK — headless adapter, scripted-provider testing fixtures, and the transport registry",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/agent-web-ui/CHANGELOG.md
+++ b/packages/agent-web-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/agent-web
 
+## 3.0.0-beta.79
+
+### Patch Changes
+
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+- @robota-sdk/agent-transport-ws@3.0.0-beta.79
+
 ## 3.0.0-beta.78
 
 ### Patch Changes

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/agent-web-ui",
-  "version": "3.0.0-beta.78",
+  "version": "3.0.0-beta.79",
   "description": "Browser UI library for monitoring and controlling a running agent-cli session",
   "type": "module",
   "main": "dist/node/index.js",

--- a/packages/dag-cli/CHANGELOG.md
+++ b/packages/dag-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @robota-sdk/dag-cli
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/dag-node-gemini-image-edit@3.0.0-beta.63
+- @robota-sdk/dag-node-instant-node@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-anthropic@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-deepseek@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-gemini@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-openai@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-qwen@3.0.0-beta.63
+- @robota-sdk/dag-framework@0.1.0-beta.3
+- @robota-sdk/dag-node-llm-text-router@0.1.1-beta.2
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-cli/package.json
+++ b/packages/dag-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-cli",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG for AI agents — build and run AI pipelines via MCP or CLI",
   "type": "module",

--- a/packages/dag-framework/CHANGELOG.md
+++ b/packages/dag-framework/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @robota-sdk/dag-framework
 
+## 0.1.0-beta.3
+
+### Patch Changes
+
+- @robota-sdk/dag-node-seedance-video@3.0.0-beta.63
+- @robota-sdk/dag-node-text-to-image@3.0.0-beta.63
+- @robota-sdk/dag-node-skill@3.0.0-beta.63
+- @robota-sdk/dag-node-tool@3.0.0-beta.63
+
 ## 0.1.0-beta.2
 
 ### Patch Changes

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-framework",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "private": true,
   "description": "Embeddable in-process DAG runtime — runtime + worker + adapters + default nodes",
   "type": "module",

--- a/packages/dag-mcp-server/CHANGELOG.md
+++ b/packages/dag-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/dag-mcp-server
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/dag-framework@0.1.0-beta.3
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-mcp-server/package.json
+++ b/packages/dag-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-mcp-server",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "MCP server for robota-dag — AI agents build and run DAG workflows",
   "type": "module",

--- a/packages/dag-nodes/gemini-image-edit/CHANGELOG.md
+++ b/packages/dag-nodes/gemini-image-edit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-gemini-image-edit
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/gemini-image-edit/package.json
+++ b/packages/dag-nodes/gemini-image-edit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-gemini-image-edit",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG gemini-image-edit node for Robota",
   "type": "module",

--- a/packages/dag-nodes/instant-node/CHANGELOG.md
+++ b/packages/dag-nodes/instant-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-instant-node
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/instant-node/package.json
+++ b/packages/dag-nodes/instant-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-instant-node",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "Prompt-backed instant DAG node for Robota — create custom nodes at runtime from a system prompt template",
   "type": "module",

--- a/packages/dag-nodes/llm-text-anthropic/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-anthropic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-llm-text-anthropic
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-anthropic/package.json
+++ b/packages/dag-nodes/llm-text-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-anthropic",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG Anthropic llm-text node for Robota",
   "type": "module",

--- a/packages/dag-nodes/llm-text-deepseek/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-deepseek/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-llm-text-deepseek
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-deepseek/package.json
+++ b/packages/dag-nodes/llm-text-deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-deepseek",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG DeepSeek llm-text node for Robota",
   "type": "module",

--- a/packages/dag-nodes/llm-text-gemini/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-gemini/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-llm-text-gemini
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-gemini/package.json
+++ b/packages/dag-nodes/llm-text-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-gemini",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG Gemini llm-text node for Robota",
   "type": "module",

--- a/packages/dag-nodes/llm-text-openai/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-openai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-llm-text-openai
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-openai/package.json
+++ b/packages/dag-nodes/llm-text-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-openai",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG OpenAI llm-text node for Robota",
   "type": "module",

--- a/packages/dag-nodes/llm-text-qwen/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-qwen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-llm-text-qwen
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-qwen/package.json
+++ b/packages/dag-nodes/llm-text-qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-qwen",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG Qwen llm-text node for Robota",
   "type": "module",

--- a/packages/dag-nodes/llm-text-router/CHANGELOG.md
+++ b/packages/dag-nodes/llm-text-router/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @robota-sdk/dag-node-llm-text-router
 
+## 0.1.1-beta.2
+
+### Patch Changes
+
+- @robota-sdk/dag-node-llm-text-anthropic@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-deepseek@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-gemini@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-openai@3.0.0-beta.63
+- @robota-sdk/dag-node-llm-text-qwen@3.0.0-beta.63
+
 ## 0.1.1-beta.1
 
 ### Patch Changes

--- a/packages/dag-nodes/llm-text-router/package.json
+++ b/packages/dag-nodes/llm-text-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-llm-text-router",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta.2",
   "private": true,
   "description": "DAG LLM text router node — priority-fallback across multiple LLM providers",
   "type": "module",

--- a/packages/dag-nodes/seedance-video/CHANGELOG.md
+++ b/packages/dag-nodes/seedance-video/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-seedance-video
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/seedance-video/package.json
+++ b/packages/dag-nodes/seedance-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-seedance-video",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG seedance-video node for Robota — generate a video from a text prompt via the ByteDance/Seedance video API",
   "type": "module",

--- a/packages/dag-nodes/skill/CHANGELOG.md
+++ b/packages/dag-nodes/skill/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-skill
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-interface-transport@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/skill/package.json
+++ b/packages/dag-nodes/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-skill",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG skill node for Robota — resolve a Robota skill to its inject-mode prompt as a DAG step",
   "type": "module",

--- a/packages/dag-nodes/text-to-image/CHANGELOG.md
+++ b/packages/dag-nodes/text-to-image/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @robota-sdk/dag-node-text-to-image
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/text-to-image/package.json
+++ b/packages/dag-nodes/text-to-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-text-to-image",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "DAG text-to-image node for Robota — generate an image from a text prompt via the Gemini image API",
   "type": "module",

--- a/packages/dag-nodes/tool/CHANGELOG.md
+++ b/packages/dag-nodes/tool/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @robota-sdk/dag-node-tool
 
+## 3.0.0-beta.63
+
+### Patch Changes
+
+- @robota-sdk/agent-tools@3.0.0-beta.79
+
 ## 3.0.0-beta.62
 
 ### Patch Changes

--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robota-sdk/dag-node-tool",
-  "version": "3.0.0-beta.62",
+  "version": "3.0.0-beta.63",
   "private": true,
   "description": "In-process tool node for Robota DAG — execute a single @robota-sdk/agent-tools builtin as a DAG step",
   "type": "module",

--- a/scratch/CHANGELOG.md
+++ b/scratch/CHANGELOG.md
@@ -1,5 +1,15 @@
 # robota-scratch
 
+## 0.0.1-beta.2
+
+### Patch Changes
+
+- @robota-sdk/agent-core@3.0.0-beta.79
+- @robota-sdk/agent-framework@3.0.0-beta.79
+- @robota-sdk/agent-provider@3.0.0-beta.79
+- @robota-sdk/agent-session@3.0.0-beta.79
+- @robota-sdk/agent-tools@3.0.0-beta.79
+
 ## 0.0.1-beta.1
 
 ### Patch Changes

--- a/scratch/package.json
+++ b/scratch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robota-scratch",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "private": true,
   "description": "Disposable live-verification (User Execution) scripts. src/ contents are gitignored — nothing here is ever committed or published.",
   "type": "module",


### PR DESCRIPTION
Promotes `develop` → `main` for the **beta.79** release.

Ships FLOW-007 `/workflows create` (bundled into agent-cli), live-LLM fixes, and DATA-003 instant-node SSOT + round-trip. After merge, publish via `pnpm publish:beta` from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)