### PR TITLE
chore(release): merge develop into main — 3.0.0-beta.79 release run record

### DIFF
--- a/.agents/release-runs/3.0.0-beta.79.md
+++ b/.agents/release-runs/3.0.0-beta.79.md
@@ -1,0 +1,58 @@
+# Release Run: 3.0.0-beta.79
+
+## State
+
+- Version: 3.0.0-beta.79
+- Branch: main
+- SHA: c6f1eddab
+- PR: #1007 (version bump), #1008 (develop→main); features #991/#992 FLOW-007, #993/#994 + #995/#996 live-LLM fixes, #997/#998 live suite, #999/#1000 unit-test hardening, #1001/#1002 auditor, #1005/#1006 DATA-003
+- Target branch: main
+- Active gate: publish
+- Gate status: passed
+- Next action: Publish via pnpm publish:beta (OTP).
+- Stop condition: Stop if the active gate fails or stalls.
+
+## Publish Gate
+
+- Publish ready: yes
+- NPM auth verified: yes
+- Dry run passed: yes
+- OTP requested: yes
+
+## Long-Running Watchers
+
+- Active watchers: none
+- Cleanup status: clear
+
+## CI Triage Notes
+
+<!-- Append notes with pnpm harness:release:triage -- --version 3.0.0-beta.79 --pr <number> --check <name>. -->
+
+## Final Report
+
+- Merged PRs:
+  - #991/#992 — FLOW-007 `/workflows create` natural-language workflow authoring (Phases 2–4)
+  - #993/#994, #995/#996 — live-LLM fixes (model threading, code-fence tolerance, authored-node provider inheritance)
+  - #997/#998 — automated opt-in live-LLM suite (`test:live`)
+  - #999/#1000 — unit suite hardened to never make real key-using calls
+  - #1001/#1002 — spawnable universal/neutral `architecture-auditor` agent + lesson #76
+  - #1005/#1006 — DATA-003 instant-node provider SSOT + symmetric persistence round-trip
+  - #1007/#1008 — release: version packages to 3.0.0-beta.79
+- Published version: 3.0.0-beta.79
+- Packages: 19 published `@robota-sdk/agent-*` packages — target `latest` = `beta` = 3.0.0-beta.79.
+- Excluded (kept `private`): the DAG/workflow subsystem — `agent-command-workflows`, all `dag-*` and
+  `dag-nodes/*` — bundled into agent-cli, not published.
+- Validation gates: passed (build, typecheck, lint, tests green pre-merge; harness:scan 45/45;
+  release-grade verification green on every develop→main PR; npm dry-run = exactly the 19-package set,
+  zero private/dag leakage).
+- Publish notes: OTP-driven `pnpm publish:beta` spanned multiple OTP windows (publish + beta dist-tag
+  sync). All 19 target packages published to `latest`; the beta dist-tags were then synced to
+  3.0.0-beta.79 (verified `latest` = `beta` = 3.0.0-beta.79 for 19/19, mismatches: 0). Post-publish
+  clean-room `npx @robota-sdk/agent-cli@3.0.0-beta.79 --version` (isolated HOME) installed from npm and
+  ran (exit 0) — the bundled DAG/workflow subsystem holds with no dag/workflow runtime deps.
+- **Known script quirk (follow-up):** `scripts/publish/publish-packages.sh` counted
+  `@robota-sdk/agent-web-ui` as a pending publish target even though it is `private: true` (last public
+  release beta.67), so its exposure-wait loop failed after the 19 real packages were already published;
+  the beta dist-tag sync was completed manually. The publishable-package detection should exclude
+  `private: true` packages — filed as a follow-up.
+- Skipped checks: none.


### PR DESCRIPTION
Promotes `develop` → `main`.

## Contents
- **release-run record for 3.0.0-beta.79** (#1010): post-release documentation of the published set (19 agent-* packages, latest=beta=beta.79 verified, clean-room install confirmed), plus the noted `publish-packages.sh` private-package follow-up.

The 3.0.0-beta.79 packages are already published to npm; this only lands the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)