### PR TITLE
chore(agents): GATE-COMPLETE for FLOW-007, DATA-003, INFRA-029

### DIFF
--- a/.agents/spec-docs/done/DATA-003-instant-node-provider-ssot-and-round-trip.md
+++ b/.agents/spec-docs/done/DATA-003-instant-node-provider-ssot-and-round-trip.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: done
 type: DATA
 tags: [typescript, json-schema]
 ---
@@ -171,3 +171,13 @@ Zod/JSON round-trip tests for the persistence symmetry, plus a consumer-refactor
   scenarios (incl. a deterministic DATA-003 reload-round-trip that stubs authoring but runs the prompt
   node against the real LLM) green; 45/45 scans; 0 lint errors. SPECs updated. dag-cli's private
   reconstruction copy remains a documented follow-up.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-07
+
+Implemented + merged (#1005 → #1006) and released in `3.0.0-beta.79`. TC-01 (provider runtime SSOT;
+zero duplicated arrays), TC-02 (prompt round-trip), TC-03 (composite round-trip in owner / write-reject
+in consumer — no silent orphan), TC-04 (`isPersistableInstantNode` guard replaces the `as unknown as`
+double-cast), TC-05 (consumer unit + opt-in live suites green) all verified: 7 owner round-trip tests
+(no module mocks) + 3 consumer writer tests + 28 consumer unit + a deterministic real-LLM reload
+round-trip; 45/45 scans, 0 lint errors. dag-cli's private reconstruction copy remains a documented
+follow-up. Spec `draft/` → `done/`, `status: done`; task at `.agents/tasks/completed/DATA-003.md`.

--- a/.agents/spec-docs/done/FLOW-007-workflows-nl-authoring.md
+++ b/.agents/spec-docs/done/FLOW-007-workflows-nl-authoring.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: FLOW
 tags: [cli, agent]
 ---
@@ -179,3 +179,14 @@ with a stubbed/injected provider (deterministic response) for unit/integration; 
 - **Live LLM verification — DONE (2026-07-06).** Ran `/workflows create` against a real Anthropic provider (`claude-sonnet-4-6`) across 5 scenarios: uppercase, lowercase, **2-step trim→uppercase** (the LLM composed the multi-node pipeline itself), repeat, and a **Phase-3 bespoke prompt node** ("rewrite as a pirate") — the LLM authored a `pirate-rewriter` prompt node, saved it to `.workflows/nodes/`, and **ran it live** producing real pirate text (~1.8s node call). 5/5 passed. The live run caught two real bugs a stubbed test could not: (1) the authoring `chat` call omitted the model → `readProviderSettings(...).model` is now threaded into the chat options; (2) the provider wrapped its JSON in a ` ```json ` fence → `parseAuthoredSpec` now strips code fences. Both fixed + unit-tested (25 tests); fixes on branch `fix/workflows-create-live-llm`.
 - **Live tests automated — DONE (2026-07-06).** The per-phase live UEs are now a repeatable opt-in suite: `src/__tests__/create-command.live.test.ts`, run via `pnpm --filter @robota-sdk/agent-command-workflows test:live`. Gated on `RUN_LIVE_LLM=1` + a provider key, so normal `pnpm test`/CI skip it (no network/cost/key). 4 real-LLM scenarios pass (uppercase, model-composed trim→uppercase, Phase-3 prompt node persisted-with-provider + executed, re-run-from-disk); a guard test fails loudly if opted-in without a key. Also fixed: authored prompt nodes now inherit + persist the active provider (was defaulting to anthropic).
 - **Phase 1b — DONE (2026-07-06).** C3 shared reader `scanWorkspaceCatalog` in `dag-framework` (commit 714b9a272) now backs all three former read paths (persistence `loadWorkflows`, dag-cli `catalog-scanner`, `/workflows catalog`). C2 receiver: `LocalDagRuntimeProvider` accepts `workspace`. C1 injection: `/workflows` command module resolves+threads `workspace` (commit d225fef12); **dag-cli** resolves a leading `--workspace <dir>` global flag at the `runDagCli` composition root and threads the layout to run/save/catalog/node (commit 75062cc57). dag-cli 1007 tests + agent-command-workflows green, 45 scans, 0 lint errors. **Live UE:** a custom `--workspace .myws` round-trip — `save` → `catalog list` → `catalog run` (correct output) → `node scaffold` — all read/write `.myws/` while the default `.workflows/` stays untouched (isolation confirmed). Phase 1 complete.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-07
+
+All four phases shipped to `main` and released in `3.0.0-beta.79` (bundled into agent-cli). TC-01
+(`.workflows/` storage + injectable workspace) — Phase 1, live `--workspace .myws` round-trip. TC-02/03
+(author→save→run + self-contained re-run) — unit + real-LLM live (uppercase, model-composed
+trim→uppercase). TC-04 (no-provider → actionable error, no write) — unit. TC-05 (prompt node
+create/save/reuse) — unit + real-LLM pirate/sonnet node. TC-06 (model-invocable) — module test +
+`builtin-command` descriptor projection. Opt-in real-LLM suite (`test:live`) 4/4; 28 unit; 45/45 scans;
+clean-room `npx @robota-sdk/agent-cli@3.0.0-beta.79` install verified. Spec `draft/` → `done/`,
+`status: done`; task archived to `.agents/tasks/completed/FLOW-007.md`.

--- a/.agents/spec-docs/done/INFRA-029-publish-single-otp-flow.md
+++ b/.agents/spec-docs/done/INFRA-029-publish-single-otp-flow.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: done
 type: INFRA
 tags: [ci]
 ---
@@ -134,3 +134,13 @@ detection assertion + code-review of the ordering/parallelism cover the criteria
   `latest === beta === VERSION` verification is unchanged. `bash -n` clean; 45/45 harness scans. Full
   end-to-end is only provable at the next real release (per the Test Plan); the detection assertion +
   `--skip-build` trace + code review cover TC-01…TC-04 without publishing.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-07
+
+Implemented + merged (#1012 → #1013). TC-01/04 (version-scoped detection excludes off-version
+`agent-process`, targets exactly the 19 release packages), TC-02 (build-before-OTP preflight +
+`--skip-build`), TC-03 (parallel beta dist-tag sync; final `latest === beta === VERSION` verify intact)
+verified via the detection assertion, the `--skip-build` trace, `bash -n`, and the harness
+characterization test (78 tests, +3 new invariants), 45/45 scans. Full end-to-end is only provable at
+the next real release (per the Test Plan). Spec `draft/` → `done/`, `status: done`; task at
+`.agents/tasks/completed/INFRA-029.md`.

--- a/.agents/tasks/completed/DATA-003.md
+++ b/.agents/tasks/completed/DATA-003.md
@@ -1,0 +1,19 @@
+# DATA-003 — instant-node provider SSOT + symmetric persistence round-trip
+
+- **Status:** completed (merged #1005 → #1006; released in 3.0.0-beta.79)
+- **Spec:** `.agents/spec-docs/done/DATA-003-instant-node-provider-ssot-and-round-trip.md`
+
+## Outcome
+
+Owner `@robota-sdk/dag-node-instant-node` now owns both halves of its data model:
+`INSTANT_NODE_PROVIDERS` (runtime SSOT, `TInstantNodeProvider` derived) + `isInstantNodeProvider`, and
+`parsePersistedInstantNode` / `rehydrateInstantNode` (both kinds; composite needs an injected runner
+else throws) + `isPersistableInstantNode`. Consumer `@robota-sdk/agent-command-workflows` dropped both
+duplicated provider arrays and the `as unknown as` double-cast and delegates to the owner;
+`saveInstantNodeFile` refuses composites (no unreloadable orphan). 7 owner round-trip tests + 3 consumer
+writer tests + 28 consumer unit + a deterministic real-LLM reload round-trip; 45/45 scans; 0 lint errors.
+
+## Follow-up
+
+- `dag-cli`'s private duplicate reconstruction (`store.ts`) may later delegate to the owner
+  `rehydrateInstantNode` to unify the two copies (deferred; noted in the spec).

--- a/.agents/tasks/completed/FLOW-007.md
+++ b/.agents/tasks/completed/FLOW-007.md
@@ -1,7 +1,7 @@
 # FLOW-007: natural-language workflow authoring & run via `/workflows`
 
-- **Status:** in-progress (Phases 2–4 implemented; PR pending)
-- **Spec:** `.agents/spec-docs/draft/FLOW-007-workflows-nl-authoring.md`
+- **Status:** completed (all phases shipped to main + released in 3.0.0-beta.79)
+- **Spec:** `.agents/spec-docs/done/FLOW-007-workflows-nl-authoring.md`
 - **Branch:** `feat/workflows-storage-layout` (Phase 1, merged) → `feat/workflows-nl-authoring` (Phases 2–4)
 - **Approved:** 2026-07-06 (owner "승인함")
 

--- a/.agents/tasks/completed/INFRA-029.md
+++ b/.agents/tasks/completed/INFRA-029.md
@@ -1,0 +1,14 @@
+# INFRA-029 — publish-packages.sh version-scoped detection + single-OTP flow
+
+- **Status:** completed (merged #1012 → #1013)
+- **Spec:** `.agents/spec-docs/done/INFRA-029-publish-single-otp-flow.md`
+
+## Outcome
+
+`scripts/publish/publish-packages.sh`: (1) publishable detection filters `private:false` AND
+`version === VERSION` so off-version packages (agent-process at beta.77) no longer make the
+exposure-wait hang; (2) a build preflight runs before the OTP prompt (`--skip-build` opt-out) so
+entering the OTP runs the publish immediately; (3) the beta dist-tag sync is issued in parallel so
+publish + tag sync fit one OTP window. Verified via detection assertion, `--skip-build` trace, `bash
+-n`, harness characterization test (78 tests, +3 invariants), 45/45 scans. Surfaced by the 3.0.0-beta.79
+release (OTP requested 4×).


### PR DESCRIPTION
Closes the loop on the three specs shipped this cycle (all merged to main + released in 3.0.0-beta.79):

- **FLOW-007** (`/workflows create` NL authoring, Phases 1–4)
- **DATA-003** (instant-node provider SSOT + persistence round-trip)
- **INFRA-029** (publish single-OTP flow)

For each: appended a `### [GATE-COMPLETE] — ✅ PASS` evidence entry, flipped frontmatter to `status: done`, moved the spec `draft/` → `done/`, and archived the task to `.agents/tasks/completed/` (FLOW-007 moved; DATA-003 + INFRA-029 completed records created). 45/45 scans pass (task-archival, spec-doc-frontmatter, done-evidence all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)