### PR TITLE
chore(release): merge develop into main — DATA-004 dag-cli instant-node unify

### DIFF
--- a/.agents/spec-docs/done/DATA-004-dag-cli-instant-node-reload-unification.md
+++ b/.agents/spec-docs/done/DATA-004-dag-cli-instant-node-reload-unification.md
@@ -1,0 +1,117 @@
+---
+status: done
+type: DATA
+tags: [typescript, json-schema]
+---
+
+# DATA-004: unify dag-cli instant-node reload onto the owner round-trip
+
+## Problem
+
+DATA-003 gave `@robota-sdk/dag-node-instant-node` the read half of its persistence round-trip
+(`parsePersistedInstantNode` + `rehydrateInstantNode` + `isPersistableInstantNode`). But
+`packages/dag-cli/src/local-runner/persistence/store.ts` still carries its **own** hand-rolled copy of
+that logic — `parsePersistedRecord` (prompt + composite manifest parsing), `reconstructNode`
+(prompt→`createPromptBackedNodeDefinition`, composite→`createCompositeInstantNodeDefinition`), plus
+`toRecordObject`/`parsePortKeys` and a duck-typed `asPersistable`. This is the exact second copy
+DATA-003 flagged as a deferred follow-up: two independent deserializers for one owned data model, free
+to drift (e.g. dag-cli defaults missing prompt ports to `{key:'text'}` and drops port `description`;
+the owner validates strictly and preserves `description`). Reproduction: `parsePersistedRecord` and
+`reconstructNode` in `store.ts` duplicate `parsePersistedInstantNode`/`rehydrateInstantNode` in the
+owner package.
+
+Goal: `store.ts` delegates instant-node parse + reconstruct to the owner (single SSOT), keeping only
+what is genuinely dag-cli's — the `code` node kind (manifest + `.dag.node.js` companion) and the
+composite sub-runner (`buildCompositeRunner`, which closes over dag-cli's `LocalDagRunner`).
+
+## Architecture Review
+
+### Affected Scope
+
+- **`packages/dag-cli/src/local-runner/persistence/store.ts`** only. Delete `parsePersistedRecord`,
+  `reconstructNode`, `toRecordObject`, `parsePortKeys`, and the local `asPersistable`; import and call
+  `parsePersistedInstantNode`, `rehydrateInstantNode`, `isPersistableInstantNode` from the owner.
+  `loadNodes` passes `{ compositeRunner: buildCompositeRunner(liveDefs) }` to `rehydrateInstantNode`;
+  the `code` branch (`parseCodeManifest`/`reconstructCodeNode`) and `buildCompositeRunner` stay.
+- dag-cli is private (not published); no external contract. Behavior preserved for well-formed
+  manifests (all written by `saveNode`); the owner's stricter validation only affects hand-corrupted
+  manifests, which it skips rather than defaulting — an improvement, not a regression.
+
+### Alternatives Considered
+
+1. **Leave the duplicate.** Con: two deserializers for one owned model — the drift DATA-003 set out to
+   remove; the port-default divergence already exists. Rejected.
+2. **Delegate to the owner round-trip, keep code-node + composite-runner local (chosen).** Pro: one
+   SSOT for instant-node persistence; deletes ~70 lines; the owner's tests already cover the round-trip.
+   Con: a minor behavior tightening (strict port validation) — acceptable, manifests are owner-written.
+
+### Decision
+
+Alternative 2. `store.ts` uses the owner's parse + rehydrate; `code` nodes and `buildCompositeRunner`
+remain dag-cli's. Existing characterization tests (`composite-reload-real`, `code-node-persistence`,
+`mcp-handlers` prompt round-trip) are the safety net.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 (only `dag-cli` store.ts; owner unchanged)
+- [x] Sibling scan 완료 — the sibling is the owner round-trip added in DATA-003; this retires dag-cli's copy
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료 (single SSOT; keep code-node + composite-runner local)
+
+## Solution
+
+Replace `store.ts`'s instant-node parse/reconstruct/guard with the owner's, threading
+`buildCompositeRunner` as the composite runner; keep the `code`-kind branch and `buildCompositeRunner`.
+
+## Affected Files
+
+- `packages/dag-cli/src/local-runner/persistence/store.ts`
+- (tests) existing dag-cli persistence/composite tests must stay green; add one if a gap appears.
+
+## Completion Criteria
+
+- [x] TC-01: `store.ts` no longer defines `parsePersistedRecord`/`reconstructNode` (nor
+      `toRecordObject`/`parsePortKeys`); it imports `parsePersistedInstantNode`, `rehydrateInstantNode`,
+      `isPersistableInstantNode` from `@robota-sdk/dag-node-instant-node` — asserted by grep + typecheck.
+- [x] TC-02: a prompt node saved by `saveNode` reloads via `loadNodes` with the same nodeType/ports —
+      the existing prompt round-trip test stays green.
+- [x] TC-03: a composite node reloads and its sub-runner executes the inner DAG — the existing
+      `composite-reload-real` test stays green.
+- [x] TC-04: a `code` node still reconstructs from its manifest + companion — the existing
+      `code-node-persistence` test stays green.
+- [x] TC-05: full dag-cli suite + `pnpm harness:scan` green; 0 lint errors.
+
+## Test Plan
+
+DATA + typescript/json-schema → the change is covered by the existing dag-cli persistence
+characterization tests (prompt round-trip, composite real reload, code-node reload) plus a grep/type
+assertion that the duplication is gone.
+
+| TC-ID | Test Type          | Tool / Approach                                                         | Notes |
+| ----- | ------------------ | ----------------------------------------------------------------------- | ----- |
+| TC-01 | Unit (grep+type)   | `rg` shows no local parse/reconstruct; typecheck green after delegation |       |
+| TC-02 | Integration        | existing dag-cli prompt-node round-trip test stays green                |       |
+| TC-03 | Integration (real) | existing `composite-reload-real` test stays green                       |       |
+| TC-04 | Integration        | existing `code-node-persistence` test stays green                       |       |
+| TC-05 | CI smoke           | full dag-cli suite + harness:scan green                                 |       |
+
+## Tasks
+
+- [ ] `.agents/tasks/DATA-004.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log
+
+- **Origin + GATE-WRITE (2026-07-07).** The deferred DATA-003 Phase-3 follow-up: dag-cli's `store.ts`
+  duplicates the owner's DATA-003 round-trip. All sections present; concrete symptom + reproduction; 2
+  alternatives + decision; checklist [x]; TC-01…TC-05 observable; one Test Plan row per TC.
+- **GATE-APPROVAL (2026-07-07).** Owner directed resolving the outstanding follow-up. Verbatim:
+  **"미해결 그 문제 해결해"** (solve that unresolved problem).
+
+- **IMPLEMENTED + GATE-COMPLETE — ✅ PASS | 2026-07-07.** `store.ts` now imports
+  `parsePersistedInstantNode` / `rehydrateInstantNode` / `isPersistableInstantNode` from the owner and
+  deleted `parsePersistedRecord`/`reconstructNode`/`parsePortKeys`/`toRecordObject` + the local
+  `asPersistable` (~70 lines); `loadNodes` passes `{ compositeRunner: buildCompositeRunner(liveDefs) }`;
+  the `code` branch + `buildCompositeRunner` stay dag-cli's. TC-01 (grep: duplication gone; typecheck
+  green) · TC-02/03/04 (existing prompt round-trip, `composite-reload-real` real-fs+runner, and
+  `code-node-persistence` tests stay green) · TC-05 (full dag-cli 1007 tests, 45/45 scans, 0 lint
+  errors). Spec `draft/` → `done/`, `status: done`; task at `.agents/tasks/completed/DATA-004.md`.

--- a/.agents/tasks/completed/DATA-004.md
+++ b/.agents/tasks/completed/DATA-004.md
@@ -1,0 +1,14 @@
+# DATA-004 — unify dag-cli instant-node reload onto the owner round-trip
+
+- **Status:** completed
+- **Spec:** `.agents/spec-docs/done/DATA-004-dag-cli-instant-node-reload-unification.md`
+
+## Outcome
+
+Retired dag-cli's private duplicate of the instant-node deserializer (the DATA-003 Phase-3 follow-up):
+`packages/dag-cli/src/local-runner/persistence/store.ts` now delegates prompt/composite parse +
+reconstruct to the owner `@robota-sdk/dag-node-instant-node` (`parsePersistedInstantNode` /
+`rehydrateInstantNode` / `isPersistableInstantNode`), keeping only the dag-cli-specific `code`-node
+branch and `buildCompositeRunner`. ~70 lines removed. Behavior preserved (owner-written manifests);
+the owner's stricter port validation only tightens hand-corrupted manifests. Full dag-cli 1007 tests
+(incl. `composite-reload-real`, `code-node-persistence`, prompt round-trip) + 45/45 scans green.

--- a/packages/dag-cli/src/local-runner/persistence/store.ts
+++ b/packages/dag-cli/src/local-runner/persistence/store.ts
@@ -17,26 +17,16 @@ import {
   type TPortPayload,
 } from '@robota-sdk/dag-core';
 import {
-  createPromptBackedNodeDefinition,
-  createCompositeInstantNodeDefinition,
-  type ICreateCompositeNodeInput,
+  parsePersistedInstantNode,
+  rehydrateInstantNode,
+  isPersistableInstantNode,
   type ICompositeSubRunner,
-  type TInstantNodeProvider,
-  type IPersistableInstantNode,
-  type TPersistedInstantNode,
 } from '@robota-sdk/dag-node-instant-node';
 import { scanWorkspaceCatalog } from '@robota-sdk/dag-framework';
 import { LocalDagRunner, createCliNodeRegistry } from '../index.js';
 import { parseCodeManifest, reconstructCodeNode } from '../code-node-adapter.js';
 import { NODE_MANIFEST_EXT, nodesDir, workflowsDir } from './paths.js';
 import { safeParseJson } from '../../mcp/utils.js';
-
-/** Narrow an arbitrary node definition to one that can serialize itself for reload. */
-function asPersistable(nodeDef: IDagNodeDefinition): IPersistableInstantNode | undefined {
-  return typeof (nodeDef as Partial<IPersistableInstantNode>).toPersisted === 'function'
-    ? (nodeDef as unknown as IPersistableInstantNode)
-    : undefined;
-}
 
 /**
  * Persist a node from its own serializable manifest view. Prompt AND composite nodes; the composite
@@ -47,11 +37,10 @@ export async function saveNode(
   projectDir: string,
   layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<void> {
-  const persistable = asPersistable(nodeDef);
-  if (!persistable) return;
+  if (!isPersistableInstantNode(nodeDef)) return;
   const dir = nodesDir(projectDir, layout);
   await mkdir(dir, { recursive: true });
-  const record = { ...persistable.toPersisted(), createdAt: new Date().toISOString() };
+  const record = { ...nodeDef.toPersisted(), createdAt: new Date().toISOString() };
   await writeFile(
     join(dir, `${nodeDef.nodeType}${NODE_MANIFEST_EXT}`),
     JSON.stringify(record, null, 2),
@@ -92,97 +81,6 @@ export function buildCompositeRunner(liveDefs: IDagNodeDefinition[]): IComposite
   };
 }
 
-function toRecordObject(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
-}
-
-function parsePortKeys(value: unknown): Array<{ key: string; description?: string }> | null {
-  if (!Array.isArray(value)) return null;
-  const ports = value
-    .map((p) => toRecordObject(p))
-    .filter((p): p is Record<string, unknown> => p !== null && typeof p['key'] === 'string')
-    .map((p) => ({ key: p['key'] as string }));
-  return ports.length > 0 ? ports : null;
-}
-
-/** Parse an on-disk manifest into a discriminated persisted node record. */
-function parsePersistedRecord(raw: unknown): TPersistedInstantNode | null {
-  const r = toRecordObject(raw);
-  if (!r || typeof r['nodeType'] !== 'string') return null;
-  const nodeType = r['nodeType'];
-  const displayName = typeof r['displayName'] === 'string' ? r['displayName'] : nodeType;
-
-  if (r['kind'] === 'composite') {
-    const innerDag = toRecordObject(r['innerDag']);
-    const exposedInputPort = toRecordObject(r['exposedInputPort']);
-    if (
-      !innerDag ||
-      !exposedInputPort ||
-      typeof exposedInputPort['key'] !== 'string' ||
-      !Array.isArray(r['exposedOutputPorts']) ||
-      r['exposedOutputPorts'].length === 0
-    ) {
-      return null;
-    }
-    return {
-      kind: 'composite',
-      nodeType,
-      displayName,
-      innerDag: innerDag as unknown as import('@robota-sdk/dag-core').IDagDefinition,
-      exposedInputPort:
-        exposedInputPort as unknown as ICreateCompositeNodeInput['exposedInputPort'],
-      exposedOutputPorts: r[
-        'exposedOutputPorts'
-      ] as unknown as ICreateCompositeNodeInput['exposedOutputPorts'],
-      ...(typeof r['maxDepth'] === 'number' ? { maxDepth: r['maxDepth'] } : {}),
-    };
-  }
-
-  // prompt
-  const template = r['systemPromptTemplate'];
-  if (typeof template !== 'string') return null;
-  const inputPorts = parsePortKeys(r['inputPorts']) ?? [{ key: 'text' }];
-  const outputPorts = parsePortKeys(r['outputPort'] !== undefined ? [r['outputPort']] : undefined);
-  return {
-    kind: 'prompt',
-    nodeType,
-    displayName,
-    systemPromptTemplate: template,
-    inputPorts,
-    outputPort: outputPorts ? { key: outputPorts[0].key } : { key: 'text' },
-    ...(typeof r['provider'] === 'string'
-      ? { provider: r['provider'] as TInstantNodeProvider }
-      : {}),
-    ...(typeof r['model'] === 'string' ? { model: r['model'] } : {}),
-  };
-}
-
-function reconstructNode(
-  record: TPersistedInstantNode,
-  liveDefs: IDagNodeDefinition[],
-): IDagNodeDefinition {
-  if (record.kind === 'composite') {
-    return createCompositeInstantNodeDefinition({
-      nodeType: record.nodeType,
-      displayName: record.displayName,
-      innerDag: record.innerDag,
-      exposedInputPort: record.exposedInputPort,
-      exposedOutputPorts: record.exposedOutputPorts,
-      runner: buildCompositeRunner(liveDefs),
-      ...(record.maxDepth !== undefined ? { maxDepth: record.maxDepth } : {}),
-    });
-  }
-  return createPromptBackedNodeDefinition({
-    nodeType: record.nodeType,
-    displayName: record.displayName,
-    systemPromptTemplate: record.systemPromptTemplate,
-    inputPorts: record.inputPorts,
-    outputPort: record.outputPort,
-    ...(record.provider !== undefined ? { provider: record.provider } : {}),
-    ...(record.model !== undefined ? { model: record.model } : {}),
-  });
-}
-
 /**
  * Load persisted node manifests from `.dag/nodes/*.node.json` into `liveDefs`, skipping
  * already-registered/malformed records. Per manifest `kind`: prompt/composite reconstruct from the
@@ -212,10 +110,14 @@ export async function loadNodes(
         if (def) liveDefs.push(def);
         continue;
       }
-      const record = parsePersistedRecord(raw);
+      // Instant nodes (prompt/composite) parse + rehydrate through the owner round-trip (DATA-004);
+      // dag-cli supplies only the composite sub-runner, which closes over its LocalDagRunner.
+      const record = parsePersistedInstantNode(raw);
       if (!record) continue;
       if (liveDefs.some((n) => n.nodeType === record.nodeType)) continue;
-      liveDefs.push(reconstructNode(record, liveDefs));
+      liveDefs.push(
+        rehydrateInstantNode(record, { compositeRunner: buildCompositeRunner(liveDefs) }),
+      );
     } catch {
       // allow-fallback: unreadable/unparseable/unconstructable record skipped
       continue;


### PR DESCRIPTION
Promotes `develop` → `main`.

## Contents
- **DATA-004** (#1016): dag-cli's persistence store delegates instant-node parse/reconstruct to the owner round-trip (retires the DATA-003 Phase-3 duplicate; ~70 lines removed). Full dag-cli 1007 tests + 45/45 scans green. GATE-COMPLETE included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)