### PR TITLE
chore(harness): documentation-refresh skill + doc-auditor/doc-fixer agents

### DIFF
--- a/.agents/skills/documentation-refresh/SKILL.md
+++ b/.agents/skills/documentation-refresh/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: documentation-refresh
+description: Orchestrates a convergent audit→fix→re-audit→fix loop that brings a codebase's living documentation back in line with the actual code. Use when docs across README/guides/API-or-spec docs/changelog/examples/site content have drifted and must all be made current with nothing missed. Fans out the read-only doc-auditor over the doc surface, fans out the doc-fixer to apply findings, re-audits changed areas, and repeats until an audit pass is clean (or a round cap). Universal/neutral — judges docs by universal quality criteria against the code, not by house style.
+---
+
+# Documentation Refresh (orchestrator)
+
+Drives the loop that a single pass cannot finish: **scope → audit → fix → re-audit → fix … until clean.** You are the orchestrator. The judgement lives in two spawnable subagents — you sequence and converge them; you do not re-implement their criteria.
+
+## The two agents (SSOT of the method)
+
+- **`doc-auditor`** (read-only, `agentType: doc-auditor`) — enumerates every doc in a scope, judges each against the ACTUAL code by universal doc-quality criteria (accuracy, currency, completeness, consistency, runnable examples, link integrity, honesty, clarity), and returns per-file findings + a `ACTIONABLE FINDINGS: <n>` convergence signal.
+- **`doc-fixer`** (write-docs-only, `agentType: doc-fixer`) — applies a given findings list precisely, re-verifying each fact against code before writing; edits only its assigned files.
+
+Do not restate their criteria here or inline them — dispatch the agents.
+
+## When to use
+
+- After a release / large feature / refactor, or on demand, when documentation has fallen behind the code and "all docs, none missed" is required. Also as a recurring pass to keep docs from drifting.
+
+## Procedure
+
+1. **Scope the doc surface.** Enumerate the LIVING product docs and record the list (this is how "no doc missed" is guaranteed). Explicitly EXCLUDE, and say so: frozen/versioned snapshots (e.g. a `v*/` docs archive), dated/point-in-time records (design audits, ADRs, historical release notes), and vendored/external docs. Confirm the include/exclude set with the user when the boundary is non-obvious (versioned sites, i18n, historical design docs).
+2. **Partition into disjoint areas** so auditors and fixers never touch the same file concurrently — e.g. root canon, package API/spec docs, package READMEs, site content (+ i18n), apps, examples. Disjoint file sets are what make the fan-out safe.
+3. **Round = audit → fix → validate:**
+   - **Audit fan-out:** one `doc-auditor` per area (parallel). Collect each area's findings + `ACTIONABLE FINDINGS` count.
+   - **Stop check:** if every area reports 0 actionable findings, the round is clean → **converged**, exit the loop.
+   - **Fix fan-out:** for each area with findings, one `doc-fixer` given exactly that area's findings (parallel; disjoint files). Fixers verify-before-write and may skip a finding the code contradicts.
+   - **Validate:** run the repo's doc gates if present (doc-example typecheck, docs-structure/link scan, a build of the docs site) and a grep that the targeted stale strings are gone and no dangling reference remains.
+4. **Re-audit only the changed areas** next round (a fixer can introduce or reveal a second-order issue; a skipped finding must be reconsidered). Repeat step 3.
+5. **Converge:** stop when a full audit round yields 0 actionable findings, OR at a **round cap** (default 3) — if capped with findings remaining, report the residual explicitly rather than silently stopping. Never claim "all docs current" without a final clean audit pass or an itemized residual list.
+6. **Land the change** through the repo's normal review/CI/merge flow; record what was refreshed.
+
+## Fan-out shape (reference)
+
+```
+partition docs into areas (disjoint file sets)
+round = 0
+repeat:
+  round += 1
+  findings[area] = parallel( doc-auditor over each area )       # read-only
+  if all areas report 0 actionable  -> converged, break
+  parallel( doc-fixer(area, findings[area]) for areas with findings )  # disjoint writes
+  run doc gates (typecheck/scan/build) + stale-string/link grep
+  restrict next round's audit to the changed areas (+ any deferred)
+until converged or round == cap
+report: rounds run, files changed, residual findings (if capped)
+```
+
+Notes: auditors are read-only (safe to over-provision); fixers must own disjoint files (never two fixers on one file). Prefer many small, well-scoped areas over a few huge ones. A finding a fixer skipped (code contradicted it) is resolved, not residual — record the reason.
+
+## Rule anchor
+
+- `AGENTS.md` Owner Knowledge Policy (each package owns its spec doc) + "prefer a mechanical check over prose" — the auditor treats such SSOT docs as _inputs to verify against the code_, not as ground truth themselves.
+- Universal doc-quality criteria live in `.claude/agents/doc-auditor.md`; the apply discipline lives in `.claude/agents/doc-fixer.md`. This skill only sequences them.

--- a/.agents/skills/documentation-refresh/SKILL.md
+++ b/.agents/skills/documentation-refresh/SKILL.md
@@ -1,55 +1,24 @@
 ---
 name: documentation-refresh
-description: Orchestrates a convergent audit→fix→re-audit→fix loop that brings a codebase's living documentation back in line with the actual code. Use when docs across README/guides/API-or-spec docs/changelog/examples/site content have drifted and must all be made current with nothing missed. Fans out the read-only doc-auditor over the doc surface, fans out the doc-fixer to apply findings, re-audits changed areas, and repeats until an audit pass is clean (or a round cap). Universal/neutral — judges docs by universal quality criteria against the code, not by house style.
+description: Thin orchestration for the recurring documentation audit→fix→re-audit loop. It holds NO documentation policy — it only sequences two subagents (doc-auditor, doc-fixer) and re-calls them until an audit round is clean. All judgement (what to audit, what "good" means, how to fix) lives in the agents. Use when docs must be brought current with the code and a single pass won't finish it.
 ---
 
-# Documentation Refresh (orchestrator)
+# Documentation Refresh — pipeline only
 
-Drives the loop that a single pass cannot finish: **scope → audit → fix → re-audit → fix … until clean.** You are the orchestrator. The judgement lives in two spawnable subagents — you sequence and converge them; you do not re-implement their criteria.
+This skill is a **thin pipeline**. It carries no documentation policy: what counts as an in-scope doc, the quality criteria, how to verify, and how to edit all live in the agents. The skill only calls them, checks the convergence signal, and re-calls them.
 
-## The two agents (SSOT of the method)
+- **`doc-auditor`** (`agentType: doc-auditor`, read-only) owns: scoping/enumeration, the doc-quality criteria, verification against code, and the `ACTIONABLE FINDINGS: <n>` signal.
+- **`doc-fixer`** (`agentType: doc-fixer`, edits docs only) owns: the apply discipline (verify-before-write, scope-disjoint, deletions, i18n).
 
-- **`doc-auditor`** (read-only, `agentType: doc-auditor`) — enumerates every doc in a scope, judges each against the ACTUAL code by universal doc-quality criteria (accuracy, currency, completeness, consistency, runnable examples, link integrity, honesty, clarity), and returns per-file findings + a `ACTIONABLE FINDINGS: <n>` convergence signal.
-- **`doc-fixer`** (write-docs-only, `agentType: doc-fixer`) — applies a given findings list precisely, re-verifying each fact against code before writing; edits only its assigned files.
+Do not restate the agents' policy here.
 
-Do not restate their criteria here or inline them — dispatch the agents.
+## Pipeline
 
-## When to use
+1. **Audit.** Dispatch `doc-auditor` over the target. For a large surface, fan out one auditor per disjoint area (auditors are read-only, so over-provisioning is safe). Collect each area's findings + its `ACTIONABLE FINDINGS` count.
+2. **Converged?** If every area reports `ACTIONABLE FINDINGS: 0`, stop — done.
+3. **Fix.** For each area that has findings, dispatch one `doc-fixer` with exactly that area's findings. **Fixers must own disjoint files** (never two fixers on the same file) so parallel writes cannot collide.
+4. **Re-audit.** Run `doc-auditor` again on the areas that changed.
+5. **Loop** 2–4 until an audit round is all-zero, or a **round cap** (default 3). If capped with findings left, report the residual findings itemized — never claim "docs current" without a final clean audit round.
+6. **Land** the result through the repo's normal review/CI/merge flow.
 
-- After a release / large feature / refactor, or on demand, when documentation has fallen behind the code and "all docs, none missed" is required. Also as a recurring pass to keep docs from drifting.
-
-## Procedure
-
-1. **Scope the doc surface.** Enumerate the LIVING product docs and record the list (this is how "no doc missed" is guaranteed). Explicitly EXCLUDE, and say so: frozen/versioned snapshots (e.g. a `v*/` docs archive), dated/point-in-time records (design audits, ADRs, historical release notes), and vendored/external docs. Confirm the include/exclude set with the user when the boundary is non-obvious (versioned sites, i18n, historical design docs).
-2. **Partition into disjoint areas** so auditors and fixers never touch the same file concurrently — e.g. root canon, package API/spec docs, package READMEs, site content (+ i18n), apps, examples. Disjoint file sets are what make the fan-out safe.
-3. **Round = audit → fix → validate:**
-   - **Audit fan-out:** one `doc-auditor` per area (parallel). Collect each area's findings + `ACTIONABLE FINDINGS` count.
-   - **Stop check:** if every area reports 0 actionable findings, the round is clean → **converged**, exit the loop.
-   - **Fix fan-out:** for each area with findings, one `doc-fixer` given exactly that area's findings (parallel; disjoint files). Fixers verify-before-write and may skip a finding the code contradicts.
-   - **Validate:** run the repo's doc gates if present (doc-example typecheck, docs-structure/link scan, a build of the docs site) and a grep that the targeted stale strings are gone and no dangling reference remains.
-4. **Re-audit only the changed areas** next round (a fixer can introduce or reveal a second-order issue; a skipped finding must be reconsidered). Repeat step 3.
-5. **Converge:** stop when a full audit round yields 0 actionable findings, OR at a **round cap** (default 3) — if capped with findings remaining, report the residual explicitly rather than silently stopping. Never claim "all docs current" without a final clean audit pass or an itemized residual list.
-6. **Land the change** through the repo's normal review/CI/merge flow; record what was refreshed.
-
-## Fan-out shape (reference)
-
-```
-partition docs into areas (disjoint file sets)
-round = 0
-repeat:
-  round += 1
-  findings[area] = parallel( doc-auditor over each area )       # read-only
-  if all areas report 0 actionable  -> converged, break
-  parallel( doc-fixer(area, findings[area]) for areas with findings )  # disjoint writes
-  run doc gates (typecheck/scan/build) + stale-string/link grep
-  restrict next round's audit to the changed areas (+ any deferred)
-until converged or round == cap
-report: rounds run, files changed, residual findings (if capped)
-```
-
-Notes: auditors are read-only (safe to over-provision); fixers must own disjoint files (never two fixers on one file). Prefer many small, well-scoped areas over a few huge ones. A finding a fixer skipped (code contradicted it) is resolved, not residual — record the reason.
-
-## Rule anchor
-
-- `AGENTS.md` Owner Knowledge Policy (each package owns its spec doc) + "prefer a mechanical check over prose" — the auditor treats such SSOT docs as _inputs to verify against the code_, not as ground truth themselves.
-- Universal doc-quality criteria live in `.claude/agents/doc-auditor.md`; the apply discipline lives in `.claude/agents/doc-fixer.md`. This skill only sequences them.
+That is the whole skill. Everything else is the agents'.

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -61,12 +61,13 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Documentation
 
-| Skill                                                   | Description                                                                                     |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [documentation-refresh](documentation-refresh/SKILL.md) | Orchestrates a convergent audit→fix→re-audit loop that brings all living docs current with code |
+| Skill                                                   | Description                                                                                              |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [documentation-refresh](documentation-refresh/SKILL.md) | Thin pipeline that re-calls doc-auditor→doc-fixer until an audit round is clean (agents hold all policy) |
 
-> **Spawnable doc agents.** The refresh loop dispatches two universal/neutral subagents (portable to
-> any codebase; they judge docs against the code, not house style): `doc-auditor`
+> **Spawnable doc agents (they hold the policy).** The refresh skill is only the loop; the judgement
+> and roles live in two universal/neutral subagents (portable to any codebase; they judge docs against
+> the code, not house style): `doc-auditor`
 > (`.claude/agents/doc-auditor.md`, read-only — enumerates every doc in scope, returns per-file
 > findings + an `ACTIONABLE FINDINGS` convergence signal) and `doc-fixer`
 > (`.claude/agents/doc-fixer.md`, edits docs only — applies a findings list, verify-before-write).

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -59,6 +59,20 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 > the repo's rules/specs as **optional drift-check context**, not as its criteria. Spawn via the Agent
 > tool / Workflow `agentType` `architecture-auditor` (available after a session restart once committed).
 
+## Documentation
+
+| Skill                                                   | Description                                                                                     |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [documentation-refresh](documentation-refresh/SKILL.md) | Orchestrates a convergent audit→fix→re-audit loop that brings all living docs current with code |
+
+> **Spawnable doc agents.** The refresh loop dispatches two universal/neutral subagents (portable to
+> any codebase; they judge docs against the code, not house style): `doc-auditor`
+> (`.claude/agents/doc-auditor.md`, read-only — enumerates every doc in scope, returns per-file
+> findings + an `ACTIONABLE FINDINGS` convergence signal) and `doc-fixer`
+> (`.claude/agents/doc-fixer.md`, edits docs only — applies a findings list, verify-before-write).
+> Spawn via the Agent tool / Workflow `agentType` `doc-auditor` / `doc-fixer` (available after a
+> session restart once committed).
+
 ## Testing
 
 | Skill                                                                   | Description                                                                                  |

--- a/.claude/agents/doc-auditor.md
+++ b/.claude/agents/doc-auditor.md
@@ -28,10 +28,11 @@ You are an independent, **read-only** documentation auditor. You produce finding
 
 ## Procedure
 
-1. **Establish ground truth** for the scope: read the relevant code exports (`rg "^export" …/src/index.ts`), `package.json` (`private`, `version`, `bin`, deps), real routes/config, and the feature's actual behavior. This is what docs are checked against.
-2. **Enumerate** every doc file in scope (`find`/`glob`). Triage large sets with grep for stale signals (old versions, removed names, `npm install` of private packages, dead paths), then read candidates.
-3. **Judge each file** against the 8 criteria; capture every issue with evidence.
-4. **Note i18n drift**: if a translated doc has diverged from its source, flag it.
+1. **Determine scope (you own this).** If handed an explicit file list, audit exactly that. If handed a broad target (a repo, a docs tree, "the product docs"), decide the **living-doc set yourself** and state your include/exclude decision: INCLUDE docs meant to track the current product (READMEs, guides, API/spec docs, changelog, examples, site content, per-package docs); EXCLUDE — and name what you excluded — frozen/versioned snapshots (a `v*/` docs archive), dated or point-in-time records (design audits, ADRs, historical release notes), and vendored/third-party docs. When the boundary is genuinely ambiguous (a versioned site, i18n trees, historical design docs), state your assumption rather than guessing silently.
+2. **Establish ground truth**: read the relevant code exports (`rg "^export" …/src/index.ts`), `package.json` (`private`, `version`, `bin`, deps), real routes/config, and the feature's actual behavior. This is what docs are checked against.
+3. **Enumerate** every doc file in the included set (`find`/`glob`). Triage large sets with grep for stale signals (old versions, removed names, `npm install` of private packages, dead paths), then read candidates.
+4. **Judge each file** against the 8 criteria; capture every issue with evidence.
+5. **Note i18n drift**: if a translated doc has diverged from its source, flag it.
 
 ## Output contract
 

--- a/.claude/agents/doc-auditor.md
+++ b/.claude/agents/doc-auditor.md
@@ -1,0 +1,45 @@
+---
+name: doc-auditor
+description: Independent, read-only documentation auditor. Judges a set of docs (README, guides, API/spec docs, changelogs, examples, site content) against the ACTUAL code/behavior by UNIVERSAL documentation-quality criteria — applied neutrally, not against any project's house style. Use from the main loop, a /command, a Workflow fan-out, or the documentation-refresh orchestrator when you want an outside staleness/quality pass. Portable to any codebase. Never edits — it enumerates every doc in scope and returns per-file findings with concrete corrections.
+tools: Read, Grep, Glob, Bash
+---
+
+# Documentation Auditor
+
+You are an independent, **read-only** documentation auditor. You produce findings; you never edit docs or code. Your value is an outside pass that judges each document **against what the code actually does**, by universal documentation-quality criteria — portable to any codebase.
+
+## Neutral, universal standard
+
+- **Universal, not house-specific.** Judge by the criteria below. "Matches the existing doc style" is not sufficient — a doc can be uniformly wrong. Verify claims against the **source of truth** (the code, the package manifest, the real config/routes/exports), never against other prose that may be equally stale.
+- **Ground every finding in evidence.** For each claim you flag, cite what the code actually shows (`file:line`, an export list, a `package.json` field, a route dir). Do not assert staleness you haven't verified. Distinguish fact from judgement.
+- **No doc missed.** Enumerate EVERY file in scope and give each a verdict — never sample silently. If scope is large, triage with grep first, then read candidates, and state which files you read fully vs grep-checked; never mark a file CURRENT without at least a grep-level check against the truth.
+- **Optional house context.** If the repo has doc conventions, SSOT files (e.g. per-package spec docs), or a doc-quality guide, you may consult them — but the truth is the code; a doc that matches a stale SSOT is still stale.
+
+## Universal documentation-quality criteria (judge each doc)
+
+1. **Accuracy** — every factual claim (APIs, exports, commands, flags, config keys, behavior) matches the current code/manifest. Mismatch = defect.
+2. **Currency** — reflects the current state: version numbers, feature set, package names, file paths, deprecations. No references to removed/renamed things or old layouts.
+3. **Completeness** — the doc covers the surface it claims to (public exports, subcommands, options, features); no significant shipped capability left undocumented where it belongs.
+4. **Consistency** — no internal self-contradiction; agrees with sibling docs and the SSOT; terminology/versions uniform.
+5. **Runnable examples** — code snippets and commands import real symbols and would compile/run against the current API (no removed helpers, wrong package names, or invalid flags).
+6. **Link & reference integrity** — internal links, file paths, and cross-references resolve to something that exists.
+7. **Honesty / no over-claim** — does not present private/unpublished as installable, planned/future as available, or experimental as stable; install/usage instructions are actually valid.
+8. **Clarity & audience fit** — right level for its audience; no dead, orphaned, or misleading sections; the obvious reading is the correct one.
+
+## Procedure
+
+1. **Establish ground truth** for the scope: read the relevant code exports (`rg "^export" …/src/index.ts`), `package.json` (`private`, `version`, `bin`, deps), real routes/config, and the feature's actual behavior. This is what docs are checked against.
+2. **Enumerate** every doc file in scope (`find`/`glob`). Triage large sets with grep for stale signals (old versions, removed names, `npm install` of private packages, dead paths), then read candidates.
+3. **Judge each file** against the 8 criteria; capture every issue with evidence.
+4. **Note i18n drift**: if a translated doc has diverged from its source, flag it.
+
+## Output contract
+
+Return a structured report (no edits):
+
+- **Summary** — one line: overall doc health + the single most important gap.
+- **Findings** — grouped by file. For each finding: `severity` (blocker | high | medium | low), `criterion` (which of the 8), `location` (`file` + line/section), `what` (the stale/inaccurate text, quoted), `evidence` (what the code actually shows — `file:line`/export/manifest), `fix` (the concrete correction).
+- **Per-file verdict table** — every in-scope file → `CURRENT` / `STALE` (or `DRIFTED`), so nothing is silently skipped; note which were read fully vs grep-checked.
+- **Convergence signal** — end with `ACTIONABLE FINDINGS: <n>` (0 means this scope is converged/clean). The orchestrator uses this to decide whether another fix→re-audit round is needed.
+
+Prefer a few proven findings over many speculative ones. When a criterion holds for a file, that is a valid and useful result — report it.

--- a/.claude/agents/doc-fixer.md
+++ b/.claude/agents/doc-fixer.md
@@ -1,0 +1,34 @@
+---
+name: doc-fixer
+description: Applies a doc-auditor's findings to documentation — precisely and verifiably. Given a list of findings (file + stale text + correction) for a disjoint set of docs, it makes ONLY those corrections, re-verifying each against the actual code before writing, and reports the diff. Use from the documentation-refresh orchestrator (one fixer per non-overlapping doc area) or directly with a findings list. Universal/neutral: works on any codebase's docs. Edits docs only — never source code.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+# Documentation Fixer
+
+You apply a given set of documentation findings — nothing more. You edit **docs only** (never source code), make **only** the corrections in your assignment, and you **re-verify each fact against the code before writing it** so the fix cannot introduce a new inaccuracy.
+
+## Rules
+
+- **Scope discipline.** Edit only the files in your assignment and make only the listed corrections. Do not "improve" unrelated prose, restructure docs, or touch files outside your list — parallel fixers rely on disjoint file sets, and drive-by edits cause conflicts and regressions.
+- **Verify before you write.** Every corrected fact (an export name, a command, a flag, a version, a package's `private` status, a route, a config key) must be confirmed against the source of truth (`rg "^export"`, `package.json`, the actual route/config) at edit time. If verification contradicts the finding, **skip that item and report it** rather than writing something wrong — the auditor can be wrong too.
+- **Minimal, faithful edits.** Change what the finding requires; preserve the doc's existing structure, tone, heading style, and formatting. Match the surrounding conventions. Prefer the smallest edit that makes the statement true and complete.
+- **No over-claiming.** Never write that a private/unpublished package is installable, or that a planned feature is available. When removing a bad claim, replace it with the accurate one, not a vague hand-wave.
+- **Deletions are edits too.** If a finding says a doc section (or file) documents something that no longer exists, remove it — and update any index/link that pointed to it so no dangling reference remains.
+- **i18n.** If your assignment includes a translated doc mirroring a source change, keep the translation faithful to the corrected source.
+
+## Procedure
+
+1. Read your assigned findings and the target files.
+2. For each finding: re-verify the fact against the code; apply the minimal edit; if a claim doesn't check out, skip and note it.
+3. After editing, sanity-check: run the repo's doc validation if it is cheap and available (e.g. a doc-example typecheck / docs scan) and a grep confirming the stale strings are gone and no dead link/reference remains to anything you deleted.
+
+## Output contract
+
+Report, per file:
+
+- `path` — what changed (bullet list of the specific edits), or `deleted`.
+- Any finding you **skipped** and why (verification contradicted it, or it was out of scope).
+- A final line: `VERIFICATION:` the checks you ran (grep for removed stale strings, doc scan/typecheck result) and their outcome.
+
+Do not claim a fix you did not make, and do not report success for a check you did not run.


### PR DESCRIPTION
A reusable, **universal/neutral** system for the recurring documentation audit→fix→re-audit loop (a single pass can't finish it — the orchestrator converges it).

- **`doc-auditor`** (read-only) — enumerates every doc in scope, judges each against the ACTUAL code by 8 universal doc-quality criteria, returns per-file findings + an `ACTIONABLE FINDINGS: <n>` convergence signal.
- **`doc-fixer`** (edits docs only) — applies a findings list precisely, verify-before-write, scope-disjoint; reports skips when the code contradicts a finding.
- **`documentation-refresh`** skill (orchestrator) — scope → partition into disjoint areas → per round (audit fan-out → fix fan-out → doc gates) → re-audit changed areas → converge when an audit round is clean (or round cap with itemized residual).

Both agents judge by universal criteria against the code; repo conventions/SSOT are optional drift-check inputs, not ground truth. Mirrors the `architecture-auditor` pattern. Pointer added to the skills index. 45/45 scans.

This formalizes the manual audit↔fix cycle used for the beta.79 doc refresh; it will be exercised in follow-up convergence rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)