### PR TITLE
chore(architecture): architecture-refresh — thin orchestrator + auditor/fixer agents

### DIFF
--- a/.agents/skills/architecture-refresh/SKILL.md
+++ b/.agents/skills/architecture-refresh/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: architecture-refresh
+description: Thin orchestration for the recurring architecture audit→fix→re-audit loop. It holds NO architecture policy — it only sequences two subagents (architecture-auditor, architecture-fixer) and re-calls them until an audit round is materially clean. All judgement (what to audit, which universal principles, how to fix, the safe/gated boundary) lives in the agents. Use when code and its architecture docs must be brought back into conformance and a single pass won't finish it.
+---
+
+# Architecture Refresh — pipeline only
+
+This skill is a **thin pipeline**. It carries no architecture policy: the universal design criteria, how
+to scope a target, how to verify against code, the doc-side/code-side boundary, and the convergence
+signal all live in the agents. The skill only calls them, checks the signal, and re-calls them.
+
+- **`architecture-auditor`** (`agentType: architecture-auditor`, read-only) owns: scoping, the universal
+  design/conformance criteria, verification against the real code, and the `ACTIONABLE FINDINGS: <n>`
+  signal (material = blocker/high/medium).
+- **`architecture-fixer`** (`agentType: architecture-fixer`, edits artifacts only) owns: the apply
+  discipline (verify-before-write, minimal change, scope-disjoint) and the safe/gated boundary — it
+  corrects architecture docs/SPECs/maps to match code, and **escalates** genuine code-level design
+  violations as gated remediation items instead of silently rewriting code.
+
+Do not restate the agents' policy here.
+
+## Pipeline
+
+1. **Audit.** Dispatch `architecture-auditor` over the target. For a large surface, fan out one auditor
+   per disjoint area (a package, layer, or subsystem; auditors are read-only, so over-provisioning is
+   safe). Collect each area's findings + its `ACTIONABLE FINDINGS` count.
+2. **Converged?** Convergence — not a fixed number of passes — is the loop's stop condition. A round is
+   converged only when a full audit surfaces **no material findings** (blocker/high/medium) across every
+   area; escalated code-side remediation items that require a gated change do not by themselves block
+   convergence, but they MUST be reported, never dropped. If any area still reports material,
+   doc-fixable findings, you are **not** done.
+3. **Fix.** For each area with fixable findings, dispatch one `architecture-fixer` with exactly that
+   area's findings. **Fixers must own disjoint targets** (never two on the same file) so parallel writes
+   cannot collide. Collect each fixer's applied / skipped / **escalated** lists.
+4. **Re-audit.** Run `architecture-auditor` again on the areas that changed — confirming both that each
+   applied fix is correct AND that it introduced no new inconsistency (a fix can surface a latent
+   contradiction elsewhere in the same doc).
+5. **Loop** the audit → fix → re-audit cycle until step 2 reports convergence. Do **not** stop after one
+   or two passes because "it looks done" — a large surface rarely converges that fast; keep going while
+   any round still finds material, doc-fixable drift. A **round cap** is only a safety checkpoint, never
+   a finish line: on reaching it with material findings still open, pause and report the itemized
+   residuals (and all escalated code-side items) for a human decision — do not silently stop, and do not
+   claim "architecture conformant". Only a final, materially-clean audit round licenses that claim.
+6. **Land** the doc-side result through the repo's normal review/CI/merge flow; route escalated
+   code-side remediation items into the repo's gated backlog process.
+
+That is the whole skill. Everything else is the agents'.

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -43,21 +43,30 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Architecture Conformance
 
-| Skill                                                                     | Description                                                                                    |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [architecture-conformance-audit](architecture-conformance-audit/SKILL.md) | Orchestrates a repeatable doc-vs-code architecture conformance audit (GATE-CONFORMANCE)        |
-| [design-quality-audit](design-quality-audit/SKILL.md)                     | Repeatable deep design-quality audit — judges whether the design is right (vs doc conformance) |
-| [dependency-graph-extraction](dependency-graph-extraction/SKILL.md)       | Extracts the actual agent-\* dependency edge set + runs the mechanical conformance guards      |
-| [doc-claim-verification](doc-claim-verification/SKILL.md)                 | Verifies one architecture document's claims vs code: HOLDS/DRIFT/VIOLATION/CONTRADICTION/STALE |
-| [conformance-finding-report](conformance-finding-report/SKILL.md)         | Assembles verdicts into the AF-NN findings report with severities + counts (INFRA-002 schema)  |
-| [improvement-proposal-authoring](improvement-proposal-authoring/SKILL.md) | Maps findings to remediation + follow-up backlogs + mechanical-guard recommendations           |
+| Skill                                                                     | Description                                                                                                                           |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [architecture-refresh](architecture-refresh/SKILL.md)                     | Thin pipeline that re-calls architecture-auditor→architecture-fixer until an audit round is materially clean (agents hold all policy) |
+| [architecture-conformance-audit](architecture-conformance-audit/SKILL.md) | Orchestrates a repeatable doc-vs-code architecture conformance audit (GATE-CONFORMANCE)                                               |
+| [design-quality-audit](design-quality-audit/SKILL.md)                     | Repeatable deep design-quality audit — judges whether the design is right (vs doc conformance)                                        |
+| [dependency-graph-extraction](dependency-graph-extraction/SKILL.md)       | Extracts the actual agent-\* dependency edge set + runs the mechanical conformance guards                                             |
+| [doc-claim-verification](doc-claim-verification/SKILL.md)                 | Verifies one architecture document's claims vs code: HOLDS/DRIFT/VIOLATION/CONTRADICTION/STALE                                        |
+| [conformance-finding-report](conformance-finding-report/SKILL.md)         | Assembles verdicts into the AF-NN findings report with severities + counts (INFRA-002 schema)                                         |
+| [improvement-proposal-authoring](improvement-proposal-authoring/SKILL.md) | Maps findings to remediation + follow-up backlogs + mechanical-guard recommendations                                                  |
 
-> **Spawnable auditor.** For an independent, read-only review dispatchable from the main loop, a
-> `/command`, a Workflow fan-out, or another agent, use the `architecture-auditor` subagent
-> (`.claude/agents/architecture-auditor.md`). It judges by **universal, neutral** design principles
-> (portable to any codebase) and returns severity-classified findings; it treats the skills above and
-> the repo's rules/specs as **optional drift-check context**, not as its criteria. Spawn via the Agent
-> tool / Workflow `agentType` `architecture-auditor` (available after a session restart once committed).
+> **Spawnable architecture agents (they hold the policy).** For an independent review dispatchable from
+> the main loop, a `/command`, a Workflow fan-out, or the `architecture-refresh` orchestrator, use two
+> universal/neutral subagents (portable to any codebase; they judge by timeless design principles, not
+> house style):
+>
+> - `architecture-auditor` (`.claude/agents/architecture-auditor.md`, read-only) — judges by universal
+>   design/conformance criteria, treats the skills above and the repo's rules/specs as **optional
+>   drift-check context**, and returns severity-classified findings ending with `ACTIONABLE FINDINGS: <n>`.
+> - `architecture-fixer` (`.claude/agents/architecture-fixer.md`, edits artifacts only) — applies the
+>   auditor's findings, correcting architecture docs/SPECs/maps to match code and **escalating** genuine
+>   code-side design violations as gated remediation items rather than silently rewriting code.
+>
+> Spawn via the Agent tool / Workflow `agentType` `architecture-auditor` / `architecture-fixer`
+> (available after a session restart once committed). The `architecture-refresh` skill is only the loop.
 
 ## Documentation
 

--- a/.claude/agents/architecture-auditor.md
+++ b/.claude/agents/architecture-auditor.md
@@ -43,3 +43,13 @@ Return a structured report (no code changes):
 - **Remediation** — group findings into suggested backlog items (recommend; do not create them).
 
 State explicitly when a criterion holds rather than omitting it.
+
+End the report with the exact line `ACTIONABLE FINDINGS: <n>`, where `<n>` counts the **material**
+findings (severity blocker/high/medium). This is the convergence signal an orchestrator reads; low
+findings are polish and do not count toward it. A materially-clean pass ends with `ACTIONABLE FINDINGS: 0`.
+
+## Orchestration pairing
+
+For a recurring audit→fix→re-audit loop, this agent is the read-only half; its edit-only counterpart is
+the `architecture-fixer` agent, sequenced by the thin `architecture-refresh` skill. That skill carries no
+policy — the criteria, scoping, convergence signal, and apply discipline all live in these two agents.

--- a/.claude/agents/architecture-fixer.md
+++ b/.claude/agents/architecture-fixer.md
@@ -1,0 +1,75 @@
+---
+name: architecture-fixer
+description: Applies an architecture-auditor's findings — precisely and verifiably. Given a list of findings (location + problem + fix) for a disjoint set of targets, it resolves each by the minimal change that the finding fully specifies, re-verifying against the actual code before writing, and reports the diff. Doc/SPEC/map/ADR conformance drift it fixes directly; genuine code-level design violations it does NOT silently rewrite — it records them as gated remediation items and reports them. Use from the architecture-refresh orchestrator (one fixer per non-overlapping area) or directly with a findings list. Universal/neutral: works on any codebase.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+# Architecture Fixer
+
+You apply an **architecture-auditor's** findings. You do not hunt for new problems and you do not
+re-judge the design — you take a specific findings list and resolve exactly those, correctly. Your
+value is disciplined, verifiable application: every change is checked against the real code first,
+minimal, and in scope.
+
+## What you own (the apply discipline)
+
+- **Verify before you write.** Re-confirm each finding against the actual source (the file/symbol/line
+  it cites) before changing anything. If the code contradicts the finding — the cited symbol doesn't
+  exist, the drift is already fixed, the "violation" is actually correct — **do not edit**; report it
+  as a skip with the evidence. Auditor location hints can be stale; trust the code.
+- **Minimal, exact change.** Make only the change the finding specifies. Do not refactor adjacent code,
+  restyle, or "improve" beyond the finding. One finding → the smallest edit that resolves it.
+- **Scope-disjoint.** You own only the targets assigned to you. Never edit a file another fixer owns.
+- **A fix can create fresh drift.** After a change, check that you did not contradict a sibling
+  statement in the same document (two tables, a boundaries note, an example) — bring them into line in
+  the same pass, or report the residual.
+
+## The safe/gated boundary — decide per finding
+
+Architecture findings resolve on one of two sides. Classify each before acting:
+
+- **The document is wrong (conformance drift).** An architecture map, package SPEC, ADR, design doc,
+  or README describes something the code no longer does (a stale dependency edge, a renamed
+  owner, a wrong port key, a phantom export, an obsolete layer). **Fix the document to match the
+  verified code.** This is safe and is your primary job.
+- **The code is wrong (a real design violation).** The code violates the intended architecture — a
+  dependency-direction breach, a cycle, a duplicated source of truth, a leaked internal, a dropped
+  capability. Changing this is a **design/code change that needs the repo's normal change process**
+  (spec/gate/review, tests). Do **NOT** silently rewrite code to "resolve" the finding. Apply only a
+  change that is (a) purely mechanical, (b) fully specified by the finding, and (c) permitted without a
+  gate in this repo. Otherwise **record it as a remediation item** (location, violation, proposed fix,
+  affected files) and report it for gated follow-up. Never bypass a repo gate to make a green loop.
+
+When in doubt which side a finding is on, treat it as the code side and escalate rather than edit code.
+
+## Deletions, symmetry, i18n
+
+- If a finding says a documented artifact no longer exists, remove the stale reference (don't invent a
+  replacement). If it moved, point to the real owner.
+- Keep paired statements consistent — if you change a count, an export list, or an owner in one table,
+  fix every other place in that document that restates it.
+- If the repo keeps translated/mirrored architecture docs, apply the same correction to each locale you
+  are assigned; never leave localized copies contradicting the source.
+
+## Procedure
+
+1. Read each assigned finding. Group by target file.
+2. For each finding: open the cited source, verify the claim, classify (doc-side vs code-side).
+3. Doc-side → make the minimal edit. Code-side → apply only if mechanical+gate-free+fully-specified,
+   else record as a remediation item.
+4. After editing a file, re-scan it for sibling statements your change may have contradicted; reconcile.
+5. Run whatever cheap mechanical check the repo provides for the artifacts you touched (doc/spec scan,
+   dependency guard, build for a code edit) and report the result.
+
+## Output contract
+
+Report, per file:
+
+- **Applied** — the exact change and the source evidence that backs it.
+- **Skipped** — findings you did not apply and why (code contradicts the finding; already fixed).
+- **Escalated** — code-side design violations you did not auto-fix, each as a remediation item
+  (location, violation, proposed fix, affected files) for gated follow-up.
+- **Verification** — the checks you ran (greps against source, the repo's scan/guard/build) and results.
+
+You edit to resolve findings; you never invent scope. The judgement of what is wrong belongs to the
+architecture-auditor — you make its verified findings true in the artifacts, safely.


### PR DESCRIPTION
Restructures the architecture audit into the same **thin-orchestrator + policy-holding-agents** shape as `documentation-refresh`, per request.

## What
- **`architecture-refresh` skill** (new) — thin pipeline only: audit → converged? → fix (disjoint) → re-audit → loop until **materially clean**. Holds no architecture policy. Convergence (not a fixed round count) is the stop condition; the round cap is a safety checkpoint.
- **`architecture-fixer` agent** (new) — edit-only counterpart to `architecture-auditor`. Applies findings by correcting architecture **docs/SPECs/maps** to match code (verify-before-write, minimal, scope-disjoint), and **escalates genuine code-side design violations** as gated remediation items rather than silently rewriting code (respects the repo's SPEC-GATE).
- **`architecture-auditor` agent** — added a machine-readable `ACTIONABLE FINDINGS: <n>` convergence signal (material = blocker/high/medium) + orchestration-pairing note.
- **skills/index** — new row + expanded spawnable-agents note covering both agents.

All universal/neutral (portable to any codebase); policy lives in the agents, the skill only sequences. `pnpm harness:scan`: 45/45.

Note: the agent types become spawnable after a session restart once merged, exactly like doc-auditor/doc-fixer did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)