### PR TITLE
fix(permissions): match star patterns for custom tools

### DIFF
--- a/packages/agent-core/src/permissions/__tests__/permission-gate.test.ts
+++ b/packages/agent-core/src/permissions/__tests__/permission-gate.test.ts
@@ -30,4 +30,20 @@ describe('evaluatePermission deny precedence', () => {
     });
     expect(decision).toBe('deny');
   });
+
+  it('ToolName(*) deny pattern matches custom tools without a primary argument', () => {
+    const decision = evaluatePermission('CustomTool', { value: 'x' }, 'bypassPermissions', {
+      deny: ['CustomTool(*)'],
+    });
+    expect(decision).toBe('deny');
+  });
+});
+
+describe('evaluatePermission allow-star fallback', () => {
+  it('ToolName(*) allow pattern matches custom tools without a primary argument', () => {
+    const decision = evaluatePermission('CustomTool', { value: 'x' }, 'default', {
+      allow: ['CustomTool(*)'],
+    });
+    expect(decision).toBe('auto');
+  });
 });

--- a/packages/agent-core/src/permissions/permission-gate.ts
+++ b/packages/agent-core/src/permissions/permission-gate.ts
@@ -108,7 +108,10 @@ function matchesPattern(toolName: string, args: TToolArgs, pattern: string): boo
 
   const primary = primaryArg(toolName, args);
   if (primary === undefined) {
-    return false;
+    // ToolName(*) is generated for explicit allowedTools/deniedTools entries.
+    // It must match custom tools even when the permission system does not know
+    // which argument should be treated as that tool's primary value.
+    return parsed.argPattern === '*';
   }
 
   return globToRegex(parsed.argPattern).test(primary);


### PR DESCRIPTION
## Summary
- make `ToolName(*)` permission patterns match custom tools that do not have a built-in primary argument mapping
- cover both explicit deny and allow behavior for custom tools

## Root cause
`allowedTools`, `deniedTools`, and project/session approval persistence use `ToolName(*)` as the broad tool pattern. The permission matcher only tested argument patterns against a known primary argument, so custom tools without a built-in primary argument fell through to the mode fallback instead of matching `(*)`.

## Validation
- `corepack pnpm@8.15.4 --filter @robota-sdk/agent-core test -- src/permissions/__tests__/permission-gate.test.ts`
- `corepack pnpm@8.15.4 --filter @robota-sdk/agent-core test`
- `corepack pnpm@8.15.4 --filter @robota-sdk/agent-core typecheck`
- `corepack pnpm@8.15.4 --filter @robota-sdk/agent-core lint` (passes with existing warnings)
- `git diff --check`