### PR TITLE
fix(dag-node-tool): repoint FunctionTool type off removed agent-tools export (DATA-005 follow-up)

### DIFF
--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -44,6 +44,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -8,10 +8,18 @@ import {
   grepTool,
   webFetchTool,
   webSearchTool,
-  type FunctionTool,
   type ISandboxToolOptions,
 } from '@robota-sdk/agent-tools';
+import { type ITool } from '@robota-sdk/agent-core';
 import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+
+/**
+ * Structural tool contract these agent-tools builtins satisfy (`FunctionTool` is owned by
+ * `@robota-sdk/agent-core`, DATA-005 SSOT). Typed by the `ITool` interface rather than the concrete
+ * class so it unifies across agent-core's dual ESM/CJS `.d.ts` (the class's private `eventService`
+ * would otherwise read as a distinct nominal type). Only `.execute()` is used here.
+ */
+type FunctionTool = ITool;
 import {
   buildTaskExecutionError,
   buildValidationError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2953,6 +2953,9 @@ importers:
 
   packages/dag-nodes/tool:
     dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
       '@robota-sdk/agent-tools':
         specifier: workspace:*
         version: link:../../agent-tools


### PR DESCRIPTION
**merge-verifier caught this**: DATA-005 (#1034/#1035) merged with a red `quality` gate, leaving a broken typecheck on `main` — `packages/dag-nodes/tool/src/index.ts` still imported `type FunctionTool` from `@robota-sdk/agent-tools`, which DATA-005 removed from that barrel (TS2459).

Fix: type the builtins' return via the structural `ITool` interface from `@robota-sdk/agent-core` (added as a dep) instead of the `FunctionTool` class — avoids agent-core's dual ESM/CJS `.d.ts` nominal identity clash (private `eventService`); only `.execute()` is used. typecheck + build green; `harness:scan` 45/45.

**This PR must land only with a green `quality` check.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)