### PR TITLE
chore: merge develop into main — DATA-005 dag-node-tool typecheck hotfix

### DIFF
--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -44,6 +44,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-tools": "workspace:*",
     "@robota-sdk/dag-core": "workspace:*",
     "@robota-sdk/dag-node": "workspace:*",

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -8,10 +8,18 @@ import {
   grepTool,
   webFetchTool,
   webSearchTool,
-  type FunctionTool,
   type ISandboxToolOptions,
 } from '@robota-sdk/agent-tools';
+import { type ITool } from '@robota-sdk/agent-core';
 import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
+
+/**
+ * Structural tool contract these agent-tools builtins satisfy (`FunctionTool` is owned by
+ * `@robota-sdk/agent-core`, DATA-005 SSOT). Typed by the `ITool` interface rather than the concrete
+ * class so it unifies across agent-core's dual ESM/CJS `.d.ts` (the class's private `eventService`
+ * would otherwise read as a distinct nominal type). Only `.execute()` is used here.
+ */
+type FunctionTool = ITool;
 import {
   buildTaskExecutionError,
   buildValidationError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2953,6 +2953,9 @@ importers:
 
   packages/dag-nodes/tool:
     dependencies:
+      '@robota-sdk/agent-core':
+        specifier: workspace:*
+        version: link:../../agent-core
       '@robota-sdk/agent-tools':
         specifier: workspace:*
         version: link:../../agent-tools


### PR DESCRIPTION
Repoints the dangling FunctionTool type import in dag-node-tool to agent-core's ITool interface, fixing the broken typecheck merge-verifier caught on main. quality green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)