### PR TITLE
fix(tools): block symlink path escapes

### DIFF
--- a/packages/agent-tools/src/__tests__/path-guard.test.ts
+++ b/packages/agent-tools/src/__tests__/path-guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -49,5 +50,45 @@ describe('checkPathWithinCwd', () => {
     expect(result).not.toBeUndefined();
     const parsed = JSON.parse(result!);
     expect(parsed.success).toBe(false);
+  });
+
+  it('blocks symlinked files that resolve outside cwd', () => {
+    const root = mkdtempSync(join(tmpdir(), 'robota-path-guard-root-'));
+    const outside = mkdtempSync(join(tmpdir(), 'robota-path-guard-outside-'));
+
+    try {
+      const secretPath = join(outside, 'secret.txt');
+      const linkPath = join(root, 'secret-link.txt');
+      writeFileSync(secretPath, 'secret\n', 'utf8');
+      symlinkSync(secretPath, linkPath);
+
+      const result = checkPathWithinCwd(linkPath, root);
+      expect(result).not.toBeUndefined();
+      const parsed = JSON.parse(result!);
+      expect(parsed.success).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks paths below symlinked directories that resolve outside cwd', () => {
+    const root = mkdtempSync(join(tmpdir(), 'robota-path-guard-root-'));
+    const outside = mkdtempSync(join(tmpdir(), 'robota-path-guard-outside-'));
+
+    try {
+      const outsideDir = join(outside, 'target');
+      const linkDir = join(root, 'linked-dir');
+      mkdirSync(outsideDir, { recursive: true });
+      symlinkSync(outsideDir, linkDir, 'dir');
+
+      const result = checkPathWithinCwd(join(linkDir, 'generated.txt'), root);
+      expect(result).not.toBeUndefined();
+      const parsed = JSON.parse(result!);
+      expect(parsed.success).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent-tools/src/builtins/path-guard.ts
+++ b/packages/agent-tools/src/builtins/path-guard.ts
@@ -1,6 +1,31 @@
-import { resolve, sep } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
 
 import type { IToolInvocationResult } from '../types/tool-result.js';
+
+function isWithinPath(path: string, root: string): boolean {
+  return path === root || path.startsWith(root + sep);
+}
+
+function tryRealpath(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function findExistingAncestor(path: string): string | undefined {
+  let current = path;
+
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+
+  return current;
+}
 
 /**
  * Returns a JSON-serialized IToolInvocationResult error when filePath is outside cwd.
@@ -12,7 +37,22 @@ export function checkPathWithinCwd(filePath: string, cwd: string | undefined): s
   const resolved = resolve(filePath);
   const cwdResolved = resolve(cwd);
 
-  if (resolved !== cwdResolved && !resolved.startsWith(cwdResolved + sep)) {
+  if (!isWithinPath(resolved, cwdResolved)) {
+    const result: IToolInvocationResult = {
+      success: false,
+      output: '',
+      error: `Access denied: "${filePath}" is outside the working directory`,
+    };
+    return JSON.stringify(result);
+  }
+
+  const cwdRealPath = tryRealpath(cwdResolved);
+  if (cwdRealPath === undefined) return undefined;
+
+  const realpathTarget = existsSync(resolved) ? resolved : findExistingAncestor(resolved);
+  const resolvedRealPath = realpathTarget !== undefined ? tryRealpath(realpathTarget) : undefined;
+
+  if (resolvedRealPath !== undefined && !isWithinPath(resolvedRealPath, cwdRealPath)) {
     const result: IToolInvocationResult = {
       success: false,
       output: '',


### PR DESCRIPTION
## Summary
- Harden `checkPathWithinCwd` with realpath validation for existing targets and the nearest existing ancestor.
- Block cwd-contained symlinked files and symlinked directories when they resolve outside the working directory.
- Preserve the existing lexical fallback for non-existent fake cwd paths used by unit tests.

## Why
The previous guard only compared `path.resolve()` strings. A path under `cwd` could still point outside the working directory through a symlink, which lets Read/Edit follow symlinked files or Write target files under symlinked directories outside the intended workspace boundary.

## Validation
- `corepack pnpm --filter @robota-sdk/agent-tools exec vitest run src/__tests__/path-guard.test.ts` — 10 passed
- `corepack pnpm --filter @robota-sdk/agent-framework exec vitest run src/__tests__/read-tool.test.ts src/__tests__/write-tool.test.ts src/__tests__/edit-tool.test.ts` — 39 passed
- `corepack pnpm --filter @robota-sdk/agent-tools exec eslint src/builtins/path-guard.ts src/__tests__/path-guard.test.ts` — passed
- `git diff --check` — passed

Note: `corepack pnpm --filter @robota-sdk/agent-tools test` is currently blocked locally by existing `FunctionTool` / `ToolRegistry` runtime export failures outside this diff; the targeted `path-guard` test in that same package passes.