### PR TITLE
docs(harness): institutionalize four session lessons (release)

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -110,6 +110,14 @@ startup. Any push with modified or staged uncommitted files is blocked with exit
 - If a backlog is too large, split it into explicitly named work units before implementation; each
   work unit must have its own recommendation gate.
 - Do not combine unrelated backlogs in one PR.
+- **Sequence by relatedness.** Decide the execution shape from whether items share files or contracts:
+  items that touch the **same files/contracts are related — serialize them** (one ordered unit, or
+  sequential PRs on the same seam) so reviews and merges do not interleave or conflict. Items that are
+  **genuinely disjoint are unrelated — deliver them as separate PR units** and let their read-only work
+  (audits, reviews, independent analyses) fan out in parallel. Parallelism applies to that read-only
+  fan-out and to independent PR _units_, **not** to concurrently-open feature branches — the
+  [One-Branch-At-A-Time rule](git-branch.md) still holds: branches are created and merged one at a time
+  to avoid divergence. So: related → serial; unrelated → separate units, still merged in sequence.
 - Every PR description must include the accepted recommendation, rationale, implementation summary,
   tests run, user execution test scenario gate result or not-applicable reason, and residual risks.
 

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -125,6 +125,27 @@ after confirming the branch is merged:
 keeps `develop`/`main` the only standing branches. The safe per-branch delete (never the merge-time
 `--delete-branch`) avoids the incident that deleted the `develop` integration branch.
 
+### Merge Landing Verification (mandatory)
+
+A merge is not "done" the moment `gh pr merge` returns. **Independently verify the merge actually landed
+before treating the work as complete** — the merge command can report success while the change is absent
+from the target's remote head, or while a required CI gate was still red (a red-`quality` PR has merged
+before). After every merge:
+
+1. Confirm the PR state is `MERGED` and its merge commit is on the **target branch's remote head**
+   (`origin/<target>`), not just locally.
+2. Confirm the changes the PR claimed are actually present on `origin/<target>` (spot-check the key
+   files/symbols), and that no unrelated drift was swept in.
+3. Confirm the required CI gates were green (explicitly check `quality`/build — do not treat "pending" or
+   "not-required-skipped" as pass).
+4. **Verify each hop of a multi-hop flow** (e.g. feature→develop→main): the landing check runs after every
+   hop, not only the last.
+
+The read-only `merge-verifier` agent (`.claude/agents/merge-verifier.md`, signal `MERGE VERIFIED`) is the
+mechanism for this check; dispatch it after a merge rather than eyeballing. **Why:** a PR merged despite a
+red quality gate and shipped a broken build to `main` (DATA-005); "the merge command succeeded" is not
+evidence the change landed correctly.
+
 ### Post-Merge Branch Cycle (mandatory)
 
 After a branch is merged, follow this exact cycle to start the next feature branch from a correct base:

--- a/.agents/skills/architecture-conformance-audit/SKILL.md
+++ b/.agents/skills/architecture-conformance-audit/SKILL.md
@@ -25,7 +25,11 @@ single-responsibility step skills; it does not itself extract graphs, judge clai
 
 1. **Mechanical baseline.** Run `pnpm harness:conformance` (dependency-direction + workspace-package-name
    guard) and `pnpm harness:scan`. Capture both verbatim. This is the deterministic floor — no human
-   judgement. See [dependency-graph-extraction](../dependency-graph-extraction/SKILL.md).
+   judgement. See [dependency-graph-extraction](../dependency-graph-extraction/SKILL.md). **A green baseline
+   is a floor, not a ceiling:** several guards assert only that referenced _names/tokens_ exist, not that a
+   documented _edge/shape/direction_ is real (see [harness-governance](../harness-governance/SKILL.md)
+   "Assert the relation, not a proxy"). Treat guard **coverage gaps** — a boundary the audit can violate
+   that no guard catches — as first-class findings, and recommend the relation-asserting guard in step 4.
 2. **Per-document verification.** For each canonical architecture document (the set in
    [doc-claim-verification](../doc-claim-verification/SKILL.md) > Canonical Document Set), assign every
    checkable claim a verdict via [doc-claim-verification](../doc-claim-verification/SKILL.md).

--- a/.agents/skills/harness-governance/SKILL.md
+++ b/.agents/skills/harness-governance/SKILL.md
@@ -53,6 +53,15 @@ When you add a mechanical guard (a scan/check that enforces an invariant):
    cover it, and do NOT drop the finding.
 3. Widening the guard's scope is itself a change that needs its own justification — handle it deliberately,
    not as a side effect of an unrelated run.
+4. **Assert the relation, not a proxy for it.** A guard must verify the actual relation it claims to
+   enforce — a dependency _edge_, a contract _shape_, a direction, a round-trip — not merely that a
+   referenced _name/token exists_. Token-existence checks give false confidence: a doc can name real
+   packages while stating a dependency edge that does not exist, and two differently-named contracts can be
+   structurally identical while every name-level check passes. If the true relation is hard to check
+   mechanically, either check the closest verifiable proxy **and say so explicitly** (state what it does and
+   does not catch), or record the gap as a backlog item — never let a name-existence pass masquerade as
+   relation conformance. When a guard's stated intent and its actual scan target diverge (e.g. the docstring
+   names one package but the code scans another), that is itself a defect to fix.
 
 ## Stop Conditions
 

--- a/.agents/skills/post-implementation-checklist/SKILL.md
+++ b/.agents/skills/post-implementation-checklist/SKILL.md
@@ -131,3 +131,6 @@ For small changes (1-2 packages, no new features):
 - NEVER deploy docs without building first
 - content/v2.0.0/ is frozen — never modify
 - Cloudflare Pages production docs deploy from `main`; manual direct upload requires explicit intent
+- After a merge, the work is not "done" until the merge is **independently verified as landed** on the
+  target's remote head with the required CI gates green and no drift — see the "Merge Landing Verification"
+  rule in [git-branch.md](../../rules/git-branch.md) (dispatch the `merge-verifier` agent; verify each hop)

--- a/.agents/specs/document-standards/index.md
+++ b/.agents/specs/document-standards/index.md
@@ -92,6 +92,15 @@ gaps named), **gap** (type not yet defined).
   agents — classification is by `signal:`-field presence, never tool scope), plus skills-index
   registration, are all mechanized by the guard. The separate prose "agent-definition template" INFRA-030
   had listed as a follow-on is **retracted**: the guard supersedes it as the enforced form.
+  **Neutrality is a required authored property, not a nicety.** Every agent/skill MUST be universal and
+  neutral — it judges by timeless, portable principles and treats the host repo's rules/specs as _optional
+  drift-check context supplied at call time_, never as baked-in policy. Its policy body MUST NOT hardcode
+  project-specific package names, paths, or house conventions (a role that only works in this repo is
+  mis-scoped). `capability-scout` flags non-neutral roles at decomposition, `proposal-reviewer` checks
+  neutrality at the approval gate, and `agent-skill-author` must emit neutral definitions. This property is
+  **semantic**, so it is review-enforced rather than fully mechanizable; a lexical warning (e.g. flagging
+  `@robota-sdk/`/`packages/<name>` tokens inside an agent's policy sections) is a reasonable future
+  tripwire but cannot be the sole gate (legitimate call-time examples would false-positive).
 - **Thin orchestration skill → partial** (`INFRA-030`). **Identity/Altitude:** a harness-asset contract
   for a `SKILL.md` that is PURE PIPELINE — it only sequences agents and reacts to their terminal
   machine-signal, holding no domain judgement itself (that lives in the agents). NOT a design doc.

--- a/.claude/agents/agent-skill-author.md
+++ b/.claude/agents/agent-skill-author.md
@@ -38,6 +38,11 @@ Concretely, for each agent file you write:
 4. **Registration.** The agent's `name` is referenced in `.agents/skills/index.md` (registered, not
    orphaned). For a thin skill, register it in the same index and keep it pipeline-only (no policy — all
    judgement lives in the agents it sequences), mirroring `architecture-refresh`.
+5. **Neutrality.** Every definition you emit MUST be universal and neutral — it judges by timeless,
+   portable principles and takes the host repo's rules/specs as _optional call-time context_, never as
+   baked-in policy. Do NOT hardcode project-specific package names, paths, or house conventions in a role's
+   policy body (a role that only works in this repo is mis-scoped). If the endorsed decomposition would
+   require a non-neutral role, stop and report rather than emit it.
 
 After writing, **re-run the guard yourself** (`node scripts/harness/check-agent-def-convention.mjs`, or
 the aggregated `pnpm harness:scan`) and do not consider a file done until it is green. The guard PASS —


### PR DESCRIPTION
Promotes to `main` the harness-governance update landed on `develop` (#1050): four session lessons institutionalized as neutral principles via `lesson-to-harness` (C1 neutrality-required, C3 merge-landing-verification, C4 relatedness-sequencing, C5 guard-asserts-relation). Harness assets only — no package `src`, no changeset. All required CI gates were green on #1050 (quality/build/examples-typecheck/tui-e2e/windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)