### PR TITLE
Merge develop → main: REMOTE-004 Stage B2 (production signaling + relay hardening)

### DIFF
--- a/.agents/spec-docs/active/REMOTE-004-stage-b2-signaling-client-relay-hardening.md
+++ b/.agents/spec-docs/active/REMOTE-004-stage-b2-signaling-client-relay-hardening.md
@@ -1,0 +1,196 @@
+---
+status: in-progress
+type: INFRA
+tags: [remote-control, webrtc, signaling, security]
+parent: REMOTE-001
+---
+
+# REMOTE-004: Stage B2 — production ws signaling client + relay abuse-hardening + CVE-2024-29415 discharge
+
+Parent design: [REMOTE-001](../todo/REMOTE-001-webrtc-p2p-remote-control-design.md) (ENDORSED). Prior sub-stages
+done: [REMOTE-002](../done/REMOTE-002-stage-a-transport-protocol-webrtc-skeleton.md) (Stage A),
+[REMOTE-003](../done/REMOTE-003-stage-b1-command-verb-gating.md) (Stage B1). Stage B is **hardening-first**; this is
+**B2** — make the P2P path real over an actual signaling server, harden that server against abuse, and discharge
+the werift-transitive `CVE-2024-29415` that was ignored in Stage A. **Still NO user-facing enable path** (that is
+B4); B2 ships production plumbing exercised only by tests.
+
+## Problem
+
+1. **No production signaling client.** Stage A shipped only `createInMemorySignalingPair()` (loopback/mock). The
+   `WebRtcTransport` takes an injected `ISignalingClient` (`packages/agent-transport-webrtc/src/signaling.ts:15-22`,
+   `send`/`onSignal`/`close`), but nothing connects it to the real relay (`apps/remote-signaling`). The full P2P
+   path (two NAT'd peers → real relay → direct `RTCDataChannel`) has never been exercised end-to-end.
+2. **The relay has no abuse protection.** `SignalingRelay` exposes a synchronous `onJoinAttempt(rendezvous,
+peerId)` seam (`apps/remote-signaling/src/relay.ts:39-41`) that is a documented no-op, and the ws binding
+   (`server.ts`) does not even capture the client address. An open relay is trivially floodable — rendezvous
+   exhaustion, join spam — before any pairing exists.
+3. **`CVE-2024-29415` is carried, not resolved.** Stage A added it to `pnpm.auditConfig.ignoreCves` because
+   werift was unwired; B2 makes real ICE gathering reachable, so REMOTE-002's Evidence Log mandates discharging it
+   here (mitigate / override / reviewed re-accept) before the enable path ships.
+
+## Solution (sub-sequenced, each commit green)
+
+1. **Production `WsSignalingClient`** (new, in `agent-transport-webrtc`; add `ws` as a dependency — a third-party
+   npm dep that stays external under INFRA-028, already used by `agent-transport-ws` + `remote-signaling`).
+   Implements `ISignalingClient` over a `ws` socket: connect to `{ url, rendezvous }`; on open send
+   `{ type: 'join', rendezvous }`; map inbound relay `{ type: 'signal', kind, data }` → `onSignal({ kind, data })`;
+   `send(ISignalMessage)` → `{ type: 'signal', kind, data }`; `close()` tears down the socket. Connection/relay
+   errors (`error` frames, socket errors, close-before-join) surface via an explicit error callback / thrown
+   rejection — **never a silent degrade** (no-fallback, mirroring `loadReplayProvider`). Buffer outbound signals
+   produced before the socket opens and flush on open (so an offer created before `open` is not dropped).
+2. **Relay abuse-hardening — enforced inside the relay, safe-by-default (Decision D2).** The rate limiter lives
+   **in `SignalingRelay`** (not stranded in the ws binding): it is an injected, **default-on**, content-blind
+   component (clock + params injected → deterministically testable by the existing fake-peer unit suite; never
+   inspects `data`). The ws binding's only new job is to capture the client remote address at connection
+   (`req.socket.remoteAddress`) and deliver it to the relay via the **widened join context** (see D1) or on
+   `ISignalingPeer`. Mechanisms:
+   - per-source (IP) **token-bucket** on join attempts (N per window) — a rejected join gets `join-rejected` and
+     the relay never forwards a signal for it;
+   - **single-use rendezvous — exact predicate (D3):** the relay tracks the **lifetime count of distinct peers
+     admitted** to a rendezvous id. A join is refused (`rendezvous-full`) when admitting it would make that
+     lifetime count exceed 2 — i.e. a _new distinct_ peer beyond the two that ever held it, **even after one
+     leaves** (no id reuse; a ws reconnect is a new `peer.id` → refused, which is the intended security behavior).
+     An **idempotent re-join by an already-admitted peer/connection** (`room.has(peer)`, `relay.ts:101,105-109`)
+     stays allowed — single-use must NOT break in-session re-joins.
+   - **short rendezvous TTL** — a rendezvous holding only one peer expires after ~60s (matches the design's
+     single-use + short-TTL pairing-secret model); the TTL timer runs only while exactly one peer is present and
+     is cleared when the second peer joins.
+   - **cap total concurrent rendezvous** (a hard ceiling).
+   - **Trusted-proxy caveat (forward note for B4/E):** `req.socket.remoteAddress` is the proxy/LB IP behind any
+     real deployment (collapsing all per-IP buckets), and `X-Forwarded-For` is spoofable. This is acceptable in B2
+     (loopback, no enable path), but **B4/E must add a configured trusted-proxy setting before the per-IP key is
+     meaningful** — otherwise the online-guess bound the parent design's pairing security leans on is undermined at
+     deploy time. Recorded as a B4/E prerequisite, not solved here.
+3. **Discharge `CVE-2024-29415` (evidence-based re-accept).** Reachability analysis (grep-verified): werift /
+   werift-ice **never call the vulnerable `ip.isPublic` / `ip.isPrivate`** (the CVE's SSRF functions). The only
+   `ip.*` usages are STUN codec helpers (`isV4Format` / `toBuffer` / `toString`) and `ip.isLoopback`, and
+   `isLoopback` is applied to **the host's own `os.networkInterfaces()` output** (trusted local NIC list, not
+   attacker-controlled remote data) when gathering host candidates. The SSRF vector (attacker-controlled input to
+   `isPublic`/`isPrivate`) is therefore **not reachable**. Decision: **keep the `ignoreCves` entry with this
+   documented reachability rationale** (a reviewed re-accept — permanent, not a deferral), and expose werift's
+   `forceTurn` / ICE-server config on `IWebRtcTransportOptions` as opt-in **defense-in-depth** (relay-only ICE
+   restricts host-candidate gathering entirely).
+   - **Explicit override of the parent design (D4).** REMOTE-001 Stage B (design lines 188–193) assumed the
+     `ip.isPublic`/`isPrivate` miscategorization "becomes security-relevant" once ICE is reachable and directed
+     that the `ignoreCves` entry be **removed** after an ICE-candidate-policy mitigation. Code verification shows
+     that underlying premise is **false for werift** — those functions are never called — so B2 **deliberately
+     overrides that remove-expectation** and instead re-accepts with the reachability evidence. This is a reviewed
+     correction of a wrong parent premise, not a silent contradiction: land paired updates to the REMOTE-002
+     Evidence Log **and** the REMOTE-001 design Stage B note recording the analysis + the override.
+4. **NO enable path.** Do not register the transport, `WsSignalingClient`, or the rate-limited relay into any
+   runnable/publish/deploy path; the relay still binds loopback/ephemeral in tests. B2 is exercised only by tests.
+
+## Affected Files
+
+- `packages/agent-transport-webrtc/src/ws-signaling-client.ts` (new: `WsSignalingClient implements ISignalingClient`) + `index.ts` export + `package.json` (`ws` dep) + `docs/SPEC.md`
+- `packages/agent-transport-webrtc/src/webrtc-transport.ts` (`IWebRtcTransportOptions` gains opt-in `forceTurn`/ICE config for defense-in-depth)
+- `apps/remote-signaling/src/relay.ts` (widened join-seam context incl. `remoteAddress`; **injected default-on rate limiter + single-use lifetime-peer-count + TTL enforced in the relay**), new `src/rate-limiter.ts` (token-bucket, injected clock), `src/server.ts` (capture `req.socket.remoteAddress` → relay only) + `docs/SPEC.md`
+- `packages/agent-transport-webrtc/src/__tests__/*` (ws-client ↔ real-relay integration round-trip), `apps/remote-signaling/src/__tests__/*` (rate-limit / TTL / single-use)
+- `package.json` root `pnpm.auditConfig.ignoreCves` (retain `CVE-2024-29415` with an inline-adjacent doc/comment reference to the resolved analysis)
+- REMOTE-002 done-spec Evidence + REMOTE-001 design Stage B note (record CVE resolved); changeset
+
+## Completion Criteria
+
+- [x] TC-01: `WsSignalingClient` implements `ISignalingClient`; a loopback integration test starts the real
+      `startSignalingServer()`, connects two `WsSignalingClient`s to one rendezvous, drives `WebRtcTransport`
+      (offerer) + an answerer, and round-trips a `TClientMessage`→session→`TServerMessage` over the resulting
+      **real `RTCDataChannel`** (no in-memory pair) — end-to-end through the actual relay.
+- [x] TC-02: signals produced before the socket opens are buffered + flushed (an offer created pre-open is
+      delivered), and relay/socket errors surface explicitly (no silent degrade) — asserted.
+- [x] TC-03: rate limiting — enforced **inside the relay** (fake-peer unit suite, no network): join attempts
+      beyond the per-source token-bucket are rejected (`join-rejected`); the relay never forwards a signal for a
+      rejected join.
+- [x] TC-04: single-use + TTL — a **new distinct** peer joining after the rendezvous's lifetime distinct-peer
+      count reached 2 is refused (`rendezvous-full`), including after one peer left; an **idempotent re-join by an
+      already-admitted peer** is still allowed; a half-open (1-peer) rendezvous expires after its TTL (injected
+      clock), and the TTL timer is cleared when the second peer joins.
+- [x] TC-05: `CVE-2024-29415` reachability analysis recorded; `ip.isPublic`/`isPrivate` are grep-verified as
+      never called by werift/werift-ice; the `ignoreCves` entry is retained with the documented rationale;
+      `pnpm audit --audit-level high` exits 0. Optional `forceTurn` defense-in-depth is exposed + unit-checked.
+- [x] TC-06: **NO enable path** — no `WsSignalingClient` / rate-limited relay wired into `cli.ts` / any
+      runnable/publish/deploy path (grep-asserted); relay binds loopback/ephemeral in tests.
+- [x] TC-07: `pnpm harness:scan` (+ deps/spec-public-surface for the new exports) + affected suites
+      (agent-transport-webrtc, remote-signaling) + full-repo `pnpm typecheck` 0; changeset present.
+
+## Test Plan
+
+RED→GREEN. The ws client is proven by a Node↔Node **real-relay** integration test (start the ws relay on
+`127.0.0.1:0`, two ws signaling clients, a full data-channel round-trip through the reused handler — a strict
+superset of Stage A's in-memory TC-03). The rate limiter + TTL + single-use are unit-tested with an injected clock
+against fake peers. The CVE analysis is captured as a repeatable grep assertion (isPublic/isPrivate absent) plus
+`pnpm audit --audit-level high` exit 0. harness `deps`/`spec-public-surface`/`entry-point-only` green; changeset.
+
+## Decisions (resolved at GATE-APPROVAL round 1)
+
+- **D1 — Join-seam widened + built-in limiter.** Extend the join seam to a context object
+  `{ rendezvous, peerId, remoteAddress? }` (so limiting can key on IP) AND add a **built-in, default-on** limiter —
+  the relay must be safe by default, not only when a host wires a hook. The hook remains for custom auth on top.
+- **D2 — Limiter enforced INSIDE the relay** (injected, default-on, injected clock), NOT in the ws binding — so it
+  is safe-by-default at the relay layer and covered by the network-free fake-peer unit suite. `server.ts` only
+  captures `remoteAddress` and passes it through.
+- **D3 — Single-use exact predicate:** track the **lifetime count of distinct peers admitted** per rendezvous;
+  refuse a join that would push it past 2 (a new distinct peer, even after one leaves; a ws reconnect = new
+  `peer.id` → refused). Idempotent re-join by an already-admitted `peer` (`room.has(peer)`) stays allowed.
+- **D4 — CVE-2024-29415 evidence-based re-accept, overriding the parent's remove-expectation.** Keep the
+  `ignoreCves` entry with the verified non-reachability rationale (no upstream fix exists → a fork override is a
+  worse supply-chain posture than a documented re-accept); expose `forceTurn` as opt-in defense-in-depth; land the
+  paired REMOTE-002 Evidence + REMOTE-001 Stage B updates recording the override.
+- **D5 — `ws` as an external dep of `agent-transport-webrtc`** (INFRA-028-safe; already used by sibling packages)
+  over a transport-injected socket factory. This `WsSignalingClient` is the Node host-side client only; the Stage D
+  browser client implements `ISignalingClient` on native `WebSocket`.
+- **D6 — Trusted-proxy is a B4/E prerequisite** (not solved here): behind a proxy, `req.socket.remoteAddress`
+  collapses per-IP buckets and `X-Forwarded-For` is spoofable — acceptable in B2 (loopback, no enable path), but a
+  configured trusted-proxy setting must land before the per-IP key is meaningful in deployment.
+
+## Open Questions (for GATE-APPROVAL)
+
+None — resolved at round 2. **Pinned defaults (all injected params, tunable):** token-bucket = burst 5 joins,
+refill 1 token / 12s (~5/min steady) per source; rendezvous TTL = 60s (half-open); max concurrent rendezvous = 1024. A **max-concurrent-rendezvous-cap** assertion is added to the TC-04 unit suite (round-2 note).
+
+## Tasks
+
+- [x] Step 1 — `WsSignalingClient` (ws-backed `ISignalingClient`; pre-open buffering; explicit error surfacing) + export + `ws` dep.
+- [x] Step 2 — relay abuse-hardening IN THE RELAY: injected default-on token-bucket (fed `remoteAddress` via the widened join context), single-use lifetime-distinct-peer predicate (D3), TTL (injected clock), max-rendezvous cap; `server.ts` captures the address only.
+- [x] Step 3 — CVE-2024-29415 reachability analysis + retain `ignoreCves` with rationale; expose `forceTurn` defense-in-depth.
+- [x] Step 4 — real-relay integration round-trip test + rate-limit/TTL unit tests; SPEC updates + changeset.
+- [x] Step 5 — verify: no enable path (TC-06); harness:scan + audit exit 0 + typecheck + changeset.
+
+## Evidence Log
+
+- 2026-07-10 GATE-DRAFT — authored from the REMOTE-001 Stage B decomposition (B2). Grounding verified against
+  code: only `createInMemorySignalingPair` exists (no production client); the relay `onJoinAttempt` seam is a
+  no-op and `server.ts` does not capture the client address; **`CVE-2024-29415` reachability**: grep of
+  `werift@0.23.0` + `werift-ice@0.2.2` finds **no `ip.isPublic`/`ip.isPrivate` call sites** — the only `ip.*`
+  usages are `isV4Format`/`toBuffer`/`toString` (STUN codec) + `ip.isLoopback` on `os.networkInterfaces()` output
+  (trusted local NICs), so the CVE's SSRF vector is not reachable. Pending proposal-reviewer ENDORSE.
+- 2026-07-10 GATE-APPROVAL round 1 — proposal-reviewer **REVISE** (direction + all six core decisions endorsed;
+  the CVE non-reachability crux **independently verified sound** — zero `isPublic`/`isPrivate` call sites in
+  werift/werift-ice; only STUN codec helpers + `ip.isLoopback` on trusted local NICs; no upstream fix → re-accept
+  beats a fork). Four corrections folded in: (1) **D3** — stated the exact single-use predicate (lifetime distinct
+  peers > 2 refused; idempotent re-join by an already-admitted peer preserved, reconciled with `relay.ts:101-109`).
+  (2) **D2** — moved the rate limiter INTO the relay (injected, default-on, fake-peer-unit-testable), not stranded
+  in `server.ts`. (3) **D6** — added the `remoteAddress`/trusted-proxy caveat as a B4/E prerequisite. (4) **D4** —
+  explicitly recorded that B2 overrides the parent design's "remove `ignoreCves` after mitigation" expectation on
+  the strength of the verified non-reachability, with paired REMOTE-002/REMOTE-001 updates. Re-review → round 2.
+- 2026-07-10 GATE-APPROVAL round 2 — proposal-reviewer **ENDORSE**. All four round-1 corrections verified folded
+  in + code-accurate + internally consistent (D3 predicate reconciled with `relay.ts:101-109`; D2 limiter in the
+  relay with matching Affected Files/TC/Tasks; D6 caveat present; D4 override framed with paired updates). CVE
+  non-reachability re-confirmed incl. the indirect path (`ip.address()` → `isPrivate/isPublic` is never reached —
+  werift uses its own `nodeIpAddress` over `os.networkInterfaces()`). Two non-blocking impl notes adopted:
+  (i) add a **max-concurrent-rendezvous-cap** assertion to the TC-04 unit suite; (ii) pinned rate-limit defaults
+  (burst 5, refill 1/12s, TTL 60s, max 1024 rendezvous — all injected/tunable). Design APPROVED → implement.
+  Spec → active.
+- 2026-07-11 GATE-IMPLEMENT — B2 built per D1–D6. `WsSignalingClient` (ws-backed `ISignalingClient`; pre-open
+  buffering + flush; explicit `onError`; `onReady` on join) + `ws` dep + `forceTurn` on `IWebRtcTransportOptions`.
+  Relay hardened IN-LAYER: `TokenBucketLimiter` (injected clock), single-use lifetime-distinct-peer predicate,
+  half-open TTL + post-empty lifetime GC (injected scheduler), max-rendezvous cap; `server.ts` captures
+  `req.socket.remoteAddress` and force-terminates live sockets on close. CVE-2024-29415 kept as a reviewed
+  re-accept with a regression guard (`cve-2024-29415-reachability.test.ts`); paired REMOTE-002 Evidence + REMOTE-001
+  Stage B note updated to "RESOLVED (option c)".
+  - **Verification:** new/updated suites green — agent-transport-webrtc **11** (ws-client 5, CVE 1, +existing),
+    remote-signaling **17** (rate-limiter 3, hardening 7, real-relay E2E round-trip 1, +existing 6). The E2E
+    (TC-01) revealed and fixed a real bug: `server.close()` hung on lingering ws sockets → now force-terminates
+    clients. Full-repo `typecheck` 0; `harness:scan` **49/49** (spec-public-surface updated for `WsSignalingClient`
+    - the rate-limiter exports). `pnpm audit --audit-level high` exit 0. TC-06 grep: no enable path
+      (`WsSignalingClient`/`remote-signaling`/`WebRtcTransport` absent from `agent-cli`). Lint 0 errors (boundary
+      `unknown` warnings only, tolerated). Changeset added. → GATE-VERIFY.

--- a/.agents/spec-docs/done/REMOTE-002-stage-a-transport-protocol-webrtc-skeleton.md
+++ b/.agents/spec-docs/done/REMOTE-002-stage-a-transport-protocol-webrtc-skeleton.md
@@ -199,6 +199,12 @@ pairing + no-content. Harness `deps`/`entry-point-only`/`spec-public-surface` gr
     ICE candidate policy (restricted STUN/TURN + candidate-type allowlist) fully neutralizes the miscategorization,
     (b) override `ip` to a maintained fork, or (c) re-accept with a documented, reviewed rationale. This must NOT
     be silently inherited — recorded here + carried into the REMOTE-001 design's Stage B security section.
+  - **RESOLVED in REMOTE-004 Stage B2 (2026-07-11) → option (c), reviewed re-accept.** Code verification (and an
+    independent proposal-reviewer pass) established that werift/werift-ice **never call** the vulnerable
+    `ip.isPublic`/`isPrivate`/`address` — the only `ip.*` usage is STUN codec helpers + `ip.isLoopback` on the
+    host's own `os.networkInterfaces()` (trusted). The SSRF vector is **not reachable**, so the `ignoreCves` entry
+    is **retained** with the documented rationale (no upstream fix → fork override is a worse posture), guarded by
+    a regression test (`cve-2024-29415-reachability.test.ts`) + opt-in `forceTurn` defense-in-depth.
 - 2026-07-10 GATE-COMPLETE — after the `ignoreCves` fix, PR #1079 CI fully green (security audit pass) →
   merged to **develop** (`ad2006b38`), then promoted **develop→main** via PR #1080 (`402555dab`). Both hops
   independently confirmed by the merge-verifier (PASS/PASS): all REMOTE-002 Stage A paths present on

--- a/.agents/spec-docs/todo/REMOTE-001-webrtc-p2p-remote-control-design.md
+++ b/.agents/spec-docs/todo/REMOTE-001-webrtc-p2p-remote-control-design.md
@@ -185,13 +185,16 @@ user-facing enable path ships.
   protocol boundary). Add a **"waiting-for-operator-approval" server message** so a remote peer whose work
   stalls on a local TUI permission prompt sees a state, not a hang. This is where the user-facing enable path
   first ships — after the hardening, not before.
-  - **Inherited security debt from Stage A (MANDATORY, do not skip):** Stage A ignored **CVE-2024-29415**
-    (`ip` SSRF via werift's ICE stack) because it was unreachable with no enable path. Stage B makes ICE
-    candidate gathering reachable, so this becomes live. Before shipping the enable path, resolve it: (a) prove
-    our ICE candidate policy (restricted STUN/TURN + candidate-type allowlist) neutralizes the `isPublic`/
-    `isPrivate` miscategorization, (b) override `ip` to a maintained fork, or (c) re-accept with a reviewed,
-    documented rationale. Remove `CVE-2024-29415` from `pnpm.auditConfig.ignoreCves` if (a)/(b) resolves it. See
-    REMOTE-002 Evidence Log (2026-07-10 GATE-VERIFY).
+  - **Inherited security debt from Stage A — RESOLVED in Stage B2 (REMOTE-004, 2026-07-11).** This note's
+    original premise — that the `ip.isPublic`/`isPrivate` miscategorization "becomes live once ICE gathering is
+    reachable" — was **disproven by code verification**: werift / werift-ice **never call** the vulnerable
+    `ip.isPublic`/`isPrivate`/`address` functions (their only `ip.*` usage is STUN codec helpers +
+    `ip.isLoopback` over the host's own `os.networkInterfaces()` — trusted, not attacker-controlled). The SSRF
+    vector is **not reachable**, so B2 took option (c): a **reviewed re-accept**, keeping `CVE-2024-29415` in
+    `pnpm.auditConfig.ignoreCves` with the documented non-reachability rationale (no upstream fix exists → a fork
+    override is a worse supply-chain posture), guarded by a regression test that fails if a future werift version
+    reaches those functions, plus opt-in `forceTurn` defense-in-depth on the transport. The `ignoreCves` entry is
+    therefore **retained, not removed**. See REMOTE-004 (done) + REMOTE-002 Evidence Log.
 - **Stage D — Remote web client.** A generic fragment-injected static page (+ optional desktop shell) reusing
   the protocol + `IAgentDriver`, swapping WebSocket for `RTCDataChannel`; pairing UX (open link/scan → SPAKE2 →
   connected); `localStorage` TOFU key. (There is no Stage "C": a per-connection/enrollment manual-accept step is

--- a/.changeset/remote-004-stage-b2-signaling-relay.md
+++ b/.changeset/remote-004-stage-b2-signaling-relay.md
@@ -1,0 +1,18 @@
+---
+'@robota-sdk/agent-transport-webrtc': minor
+---
+
+REMOTE-004 Stage B2: production WebRTC signaling + relay abuse-hardening (still no user-facing enable path).
+
+- Add `WsSignalingClient` — a production `ISignalingClient` over a `ws` socket to the `@robota-sdk/remote-signaling`
+  relay (Node host-side): joins a rendezvous, buffers signals produced before the socket opens and flushes them,
+  and surfaces relay/socket errors through an explicit `onError` (no silent degrade). An `onReady` callback fires
+  once the rendezvous join is confirmed.
+- Expose opt-in `forceTurn` on `IWebRtcTransportOptions` (relay-only ICE) as defense-in-depth.
+- The private `@robota-sdk/remote-signaling` relay is hardened in-layer (safe by default): a per-source
+  token-bucket bounds join floods, rendezvous ids are single-use (a distinct third peer is refused for the id's
+  lifetime, even after one of the pair leaves), a half-open rendezvous expires after a TTL, and concurrent
+  rendezvous are capped — all with injected clock/scheduler for deterministic tests.
+- `CVE-2024-29415` (werift-transitive `ip` SSRF) is discharged as a reviewed re-accept: werift never calls the
+  vulnerable `ip.isPublic`/`isPrivate`/`address` (verified + guarded by a regression test), so the
+  `ignoreCves` entry is retained with a documented non-reachability rationale.

--- a/apps/remote-signaling/docs/SPEC.md
+++ b/apps/remote-signaling/docs/SPEC.md
@@ -46,11 +46,17 @@ default, and returns a handle exposing the resolved port + a `close()`.
 
 ## Public API Surface
 
-| Export                     | Kind     | Description                                           |
-| -------------------------- | -------- | ----------------------------------------------------- |
-| `SignalingRelay`           | class    | Content-blind rendezvous + SDP/ICE relay logic.       |
-| `startSignalingServer`     | function | Bind the relay over WebSocket; returns a stop handle. |
-| `MAX_PEERS_PER_RENDEZVOUS` | const    | Peer cap per rendezvous (2).                          |
+| Export                      | Kind     | Description                                                            |
+| --------------------------- | -------- | ---------------------------------------------------------------------- |
+| `SignalingRelay`            | class    | Content-blind rendezvous + SDP/ICE relay with built-in abuse controls. |
+| `startSignalingServer`      | function | Bind the relay over WebSocket; returns a stop handle.                  |
+| `MAX_PEERS_PER_RENDEZVOUS`  | const    | Peer cap per rendezvous (2).                                           |
+| `TokenBucketLimiter`        | class    | Per-source join token-bucket (REMOTE-004; injected clock).             |
+| `systemClock`               | const    | Default `Date.now`-based `IClock`.                                     |
+| `systemScheduler`           | const    | Default `setTimeout`-based `IScheduler`.                               |
+| `DEFAULT_TOKEN_BUCKET`      | const    | Default join bucket (burst 5, refill 1/12s).                           |
+| `DEFAULT_RENDEZVOUS_TTL_MS` | const    | Default half-open rendezvous TTL (60s).                                |
+| `DEFAULT_MAX_RENDEZVOUS`    | const    | Default concurrent-rendezvous cap (1024).                              |
 
 ## Extension Points
 

--- a/apps/remote-signaling/package.json
+++ b/apps/remote-signaling/package.json
@@ -37,12 +37,15 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/agent-transport-webrtc": "workspace:*",
     "@types/node": "^22.19.21",
     "@types/ws": "^8.18.1",
     "rimraf": "^5.0.10",
     "tsdown": "^0.22.2",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.6"
+    "vitest": "^3.2.6",
+    "werift": "^0.23.0"
   },
   "license": "AGPL-3.0-only OR LicenseRef-Commercial"
 }

--- a/apps/remote-signaling/src/__tests__/integration-webrtc-relay.test.ts
+++ b/apps/remote-signaling/src/__tests__/integration-webrtc-relay.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RTCPeerConnection } from 'werift';
+import { WebRtcTransport, WsSignalingClient } from '@robota-sdk/agent-transport-webrtc';
+
+import { startSignalingServer } from '../server.js';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * REMOTE-004 B2 TC-01 — full end-to-end over the REAL relay (no in-memory pair): a `WebRtcTransport` (offerer)
+ * and a werift answerer each reach the running `startSignalingServer()` via a production `WsSignalingClient`,
+ * establish a real `RTCDataChannel`, and round-trip a `TClientMessage`→session→`TServerMessage` through the
+ * reused `createWsHandler`. A strict superset of Stage A's in-memory TC-03.
+ */
+
+function createStubSession(): IInteractiveSession {
+  return {
+    getMessages: vi.fn().mockReturnValue([{ role: 'user', content: 'hi' }]),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as IInteractiveSession;
+}
+
+/**
+ * The answerer: reaches the relay via its own `WsSignalingClient`, mirrors the serialized signal-chain pattern.
+ * Resolves `ready` once it has joined the rendezvous (so the offerer only offers when a counterpart is present —
+ * the relay forwards only to peers currently in the room; offerer-first "wait for remote" orchestration is B4),
+ * and resolves `reply` with the first `TServerMessage` received over the data channel.
+ */
+function connectRemoteAnswerer(
+  url: string,
+  rendezvous: string,
+): { ready: Promise<void>; reply: Promise<Record<string, unknown>> } {
+  let markReady!: () => void;
+  const ready = new Promise<void>((r) => (markReady = r));
+  const reply = new Promise<Record<string, unknown>>((resolve, reject) => {
+    const peer = new RTCPeerConnection();
+    const signaling = new WsSignalingClient({
+      url,
+      rendezvous,
+      onError: reject,
+      onReady: markReady,
+    });
+
+    peer.onIceCandidate.subscribe((candidate) => {
+      if (candidate) signaling.send({ kind: 'ice', data: candidate.toJSON() });
+    });
+
+    let chain: Promise<void> = Promise.resolve();
+    signaling.onSignal((message) => {
+      chain = chain
+        .then(async () => {
+          if (message.kind === 'offer') {
+            await peer.setRemoteDescription(
+              message.data as Parameters<typeof peer.setRemoteDescription>[0],
+            );
+            const answer = await peer.createAnswer();
+            await peer.setLocalDescription(answer);
+            signaling.send({ kind: 'answer', data: peer.localDescription });
+          } else if (message.kind === 'ice') {
+            await peer.addIceCandidate(message.data as Parameters<typeof peer.addIceCandidate>[0]);
+          }
+        })
+        .catch(reject);
+    });
+
+    peer.onDataChannel.subscribe((channel) => {
+      channel.stateChanged.subscribe((state) => {
+        if (state === 'open') channel.send(JSON.stringify({ type: 'get-messages' }));
+      });
+      channel.onMessage.subscribe((data) => {
+        resolve(JSON.parse(typeof data === 'string' ? data : data.toString()));
+      });
+    });
+  });
+  return { ready, reply };
+}
+
+describe('WebRtc P2P over the real signaling relay (REMOTE-004 B2 — TC-01)', () => {
+  it('round-trips a session message over a real RTCDataChannel established through the relay', async () => {
+    const server = await startSignalingServer(); // 127.0.0.1 : ephemeral
+    const url = `ws://127.0.0.1:${server.port}`;
+    const rendezvous = 'e2e-rendezvous';
+
+    const session = createStubSession();
+    const hostSignaling = new WsSignalingClient({ url, rendezvous });
+    const host = new WebRtcTransport({ signaling: hostSignaling });
+    host.attach(session);
+
+    // Bring the answerer into the rendezvous FIRST, then let the host offer (counterpart must be present).
+    const remote = connectRemoteAnswerer(url, rendezvous);
+    await remote.ready;
+    await host.start();
+
+    const reply = await remote.reply;
+    expect(reply.type).toBe('messages');
+    expect(reply.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(session.getMessages).toHaveBeenCalled();
+
+    await host.stop();
+    hostSignaling.close();
+    await server.close();
+  }, 20000);
+});

--- a/apps/remote-signaling/src/__tests__/rate-limiter.test.ts
+++ b/apps/remote-signaling/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { TokenBucketLimiter, type IClock } from '../rate-limiter.js';
+
+function mutableClock(start = 0): IClock & { set(t: number): void } {
+  let t = start;
+  return { now: () => t, set: (v: number) => (t = v) };
+}
+
+describe('TokenBucketLimiter (REMOTE-004 B2)', () => {
+  it('allows up to the burst, then refuses until refill', () => {
+    const clock = mutableClock(0);
+    const limiter = new TokenBucketLimiter({ burst: 3, refillPerMs: 0.001 }, clock);
+    expect(limiter.tryConsume('ip')).toBe(true);
+    expect(limiter.tryConsume('ip')).toBe(true);
+    expect(limiter.tryConsume('ip')).toBe(true);
+    expect(limiter.tryConsume('ip')).toBe(false); // burst exhausted, no time passed
+  });
+
+  it('refills over time at the configured rate', () => {
+    const clock = mutableClock(0);
+    const limiter = new TokenBucketLimiter({ burst: 1, refillPerMs: 1 / 1000 }, clock); // 1 token/sec
+    expect(limiter.tryConsume('ip')).toBe(true);
+    expect(limiter.tryConsume('ip')).toBe(false);
+    clock.set(1000); // +1s → +1 token
+    expect(limiter.tryConsume('ip')).toBe(true);
+  });
+
+  it('keeps independent buckets per source key', () => {
+    const clock = mutableClock(0);
+    const limiter = new TokenBucketLimiter({ burst: 1, refillPerMs: 0 }, clock);
+    expect(limiter.tryConsume('a')).toBe(true);
+    expect(limiter.tryConsume('a')).toBe(false);
+    expect(limiter.tryConsume('b')).toBe(true); // separate bucket
+  });
+});

--- a/apps/remote-signaling/src/__tests__/relay-hardening.test.ts
+++ b/apps/remote-signaling/src/__tests__/relay-hardening.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SignalingRelay, type ISignalingPeer } from '../relay.js';
+import type { IClock, IScheduler } from '../rate-limiter.js';
+
+/**
+ * REMOTE-004 B2 — the relay's abuse controls (rate limit, single-use rendezvous, half-open TTL, concurrency cap)
+ * are enforced INSIDE the relay and exercised here with injected clock + scheduler and in-memory fake peers — no
+ * network, no real timers.
+ */
+
+let peerSeq = 0;
+function fakePeer(
+  remoteAddress?: string,
+): ISignalingPeer & { readonly sent: string[]; closed: boolean } {
+  const sent: string[] = [];
+  const peer = {
+    id: `peer_${(peerSeq += 1)}`,
+    ...(remoteAddress ? { remoteAddress } : {}),
+    sent,
+    closed: false,
+    send(raw: string): void {
+      sent.push(raw);
+    },
+    close(): void {
+      peer.closed = true;
+    },
+  };
+  return peer;
+}
+
+function lastFrame(peer: { readonly sent: string[] }): Record<string, unknown> {
+  return JSON.parse(peer.sent[peer.sent.length - 1]) as Record<string, unknown>;
+}
+
+function createFakeScheduler(): {
+  scheduler: IScheduler;
+  fireAll: () => void;
+  pending: () => number;
+} {
+  const tasks: { cb: () => void; cancelled: boolean }[] = [];
+  return {
+    scheduler: {
+      schedule(cb: () => void): () => void {
+        const task = { cb, cancelled: false };
+        tasks.push(task);
+        return () => {
+          task.cancelled = true;
+        };
+      },
+    },
+    fireAll(): void {
+      for (const task of tasks) if (!task.cancelled) task.cb();
+    },
+    pending: () => tasks.filter((t) => !t.cancelled).length,
+  };
+}
+
+const frozenClock: IClock = { now: () => 1_000 };
+
+function join(relay: SignalingRelay, peer: ISignalingPeer, rendezvous = 'r'): void {
+  relay.handleFrame(peer, JSON.stringify({ type: 'join', rendezvous }));
+}
+
+describe('SignalingRelay abuse-hardening (REMOTE-004 B2)', () => {
+  it('TC-03: rate-limits join floods per source and never relays a rejected join', () => {
+    const relay = new SignalingRelay({
+      rateLimit: { burst: 2, refillPerMs: 0 },
+      clock: frozenClock,
+    });
+    const p = fakePeer('9.9.9.9');
+    join(relay, p); // token 1 → joined
+    join(relay, p); // token 2 → joined (idempotent re-join)
+    join(relay, p); // token 3 → rate-limited
+    expect(lastFrame(p)).toEqual({ type: 'error', reason: 'rate-limited' });
+  });
+
+  it('TC-04: single-use — a new distinct peer is refused after the lifetime count reaches 2, even after a leave', () => {
+    const relay = new SignalingRelay({ scheduler: createFakeScheduler().scheduler });
+    const a = fakePeer();
+    const b = fakePeer();
+    join(relay, a);
+    join(relay, b);
+    relay.remove(a); // a leaves — room now holds only b
+    const c = fakePeer(); // a brand-new distinct peer
+    join(relay, c);
+    expect(lastFrame(c)).toEqual({ type: 'error', reason: 'rendezvous-full' });
+  });
+
+  it('TC-04: idempotent re-join by an already-admitted peer is allowed', () => {
+    const relay = new SignalingRelay({ scheduler: createFakeScheduler().scheduler });
+    const a = fakePeer();
+    join(relay, a);
+    join(relay, a); // same peer id → allowed
+    expect(lastFrame(a)).toEqual({ type: 'joined', rendezvous: 'r' });
+  });
+
+  it('TC-04: a half-open (one-peer) rendezvous expires after its TTL and the lone peer is closed', () => {
+    const fake = createFakeScheduler();
+    const relay = new SignalingRelay({ scheduler: fake.scheduler });
+    const a = fakePeer();
+    join(relay, a);
+    expect(fake.pending()).toBe(1); // TTL armed while half-open
+    fake.fireAll();
+    expect(a.closed).toBe(true);
+    expect(relay.rendezvousCount).toBe(0);
+  });
+
+  it('TC-04: the TTL timer is cancelled once the second peer joins', () => {
+    const fake = createFakeScheduler();
+    const relay = new SignalingRelay({ scheduler: fake.scheduler });
+    const a = fakePeer();
+    const b = fakePeer();
+    join(relay, a);
+    join(relay, b); // completes the pair → timer cancelled
+    expect(fake.pending()).toBe(0);
+    fake.fireAll(); // nothing to fire
+    expect(a.closed).toBe(false);
+    expect(b.closed).toBe(false);
+  });
+
+  it('TC-04: caps concurrent rendezvous (max-rendezvous)', () => {
+    const relay = new SignalingRelay({
+      maxRendezvous: 1,
+      scheduler: createFakeScheduler().scheduler,
+    });
+    const a = fakePeer();
+    const b = fakePeer();
+    join(relay, a, 'ra'); // creates the only allowed rendezvous
+    join(relay, b, 'rb'); // would be a 2nd concurrent rendezvous → refused
+    expect(lastFrame(b)).toEqual({ type: 'error', reason: 'too-many-rendezvous' });
+    expect(relay.rendezvousCount).toBe(1);
+  });
+
+  it('passes the widened join context (incl. remoteAddress) to a custom onJoinAttempt hook', () => {
+    const onJoinAttempt = vi.fn().mockReturnValue(true);
+    const relay = new SignalingRelay({
+      hooks: { onJoinAttempt },
+      scheduler: createFakeScheduler().scheduler,
+    });
+    const a = fakePeer('1.2.3.4');
+    join(relay, a);
+    expect(onJoinAttempt).toHaveBeenCalledWith({
+      rendezvous: 'r',
+      peerId: a.id,
+      remoteAddress: '1.2.3.4',
+    });
+  });
+});

--- a/apps/remote-signaling/src/index.ts
+++ b/apps/remote-signaling/src/index.ts
@@ -5,6 +5,22 @@
  * auth in Stage A. Not wired into any default runnable / publish / deploy path (TC-06).
  */
 export { SignalingRelay, MAX_PEERS_PER_RENDEZVOUS } from './relay.js';
-export type { ISignalingPeer, ISignalingRelayHooks, TInboundFrame, TSignalKind } from './relay.js';
+export type {
+  ISignalingPeer,
+  ISignalingRelayHooks,
+  ISignalingRelayOptions,
+  IJoinAttemptContext,
+  TInboundFrame,
+  TSignalKind,
+} from './relay.js';
+export {
+  TokenBucketLimiter,
+  systemClock,
+  systemScheduler,
+  DEFAULT_TOKEN_BUCKET,
+  DEFAULT_RENDEZVOUS_TTL_MS,
+  DEFAULT_MAX_RENDEZVOUS,
+} from './rate-limiter.js';
+export type { IClock, IScheduler, ITokenBucketConfig } from './rate-limiter.js';
 export { startSignalingServer } from './server.js';
 export type { ISignalingServerOptions, ISignalingServerHandle } from './server.js';

--- a/apps/remote-signaling/src/rate-limiter.ts
+++ b/apps/remote-signaling/src/rate-limiter.ts
@@ -1,0 +1,71 @@
+/**
+ * Abuse-hardening primitives for the signaling relay (REMOTE-004 Stage B2).
+ *
+ * A per-source token-bucket bounds join attempts; a scheduler drives rendezvous TTL expiry. Both take injected
+ * dependencies (an `IClock` for the bucket, an `IScheduler` for timers) so the relay's abuse controls are covered
+ * by the same network-free, deterministic fake-peer unit suite as its routing logic — no real timers, no wall
+ * clock, no sockets.
+ */
+
+/** Monotonic-enough time source (defaults to `Date.now`). */
+export interface IClock {
+  now(): number;
+}
+
+/** Deferred-callback scheduler (defaults to `setTimeout`/`clearTimeout`); tests inject a controllable fake. */
+export interface IScheduler {
+  /** Run `callback` after `delayMs`; returns a cancel function. */
+  schedule(callback: () => void, delayMs: number): () => void;
+}
+
+export interface ITokenBucketConfig {
+  /** Maximum tokens (burst) per source. */
+  readonly burst: number;
+  /** Tokens refilled per millisecond (steady-state rate). */
+  readonly refillPerMs: number;
+}
+
+/** Default: burst 5 joins, refill 1 token / 12s (~5/min steady) per source. */
+export const DEFAULT_TOKEN_BUCKET: ITokenBucketConfig = { burst: 5, refillPerMs: 1 / 12_000 };
+
+/** Default half-open rendezvous TTL (a rendezvous holding a single peer expires after this). */
+export const DEFAULT_RENDEZVOUS_TTL_MS = 60_000;
+
+/** Default ceiling on concurrent rendezvous. */
+export const DEFAULT_MAX_RENDEZVOUS = 1024;
+
+export const systemClock: IClock = { now: () => Date.now() };
+
+export const systemScheduler: IScheduler = {
+  schedule(callback: () => void, delayMs: number): () => void {
+    const timer = setTimeout(callback, delayMs);
+    return () => clearTimeout(timer);
+  },
+};
+
+/** Per-key token bucket. `tryConsume(key)` returns false when the key is over its rate. */
+export class TokenBucketLimiter {
+  private readonly buckets = new Map<string, { tokens: number; last: number }>();
+
+  public constructor(
+    private readonly config: ITokenBucketConfig = DEFAULT_TOKEN_BUCKET,
+    private readonly clock: IClock = systemClock,
+  ) {}
+
+  public tryConsume(key: string): boolean {
+    const now = this.clock.now();
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: this.config.burst, last: now };
+      this.buckets.set(key, bucket);
+    }
+    const elapsed = Math.max(0, now - bucket.last);
+    bucket.tokens = Math.min(this.config.burst, bucket.tokens + elapsed * this.config.refillPerMs);
+    bucket.last = now;
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+}

--- a/apps/remote-signaling/src/relay.ts
+++ b/apps/remote-signaling/src/relay.ts
@@ -1,16 +1,27 @@
 /**
- * Content-blind signaling relay (REMOTE-002 Stage A, Step 3).
+ * Content-blind signaling relay (REMOTE-002 Stage A; abuse-hardened in REMOTE-004 Stage B2).
  *
  * Two NAT'd WebRTC peers exchange SDP offers/answers + ICE candidates through this relay to establish a direct
  * P2P `RTCDataChannel`. The relay is a **dumb rendezvous**: it pairs at most two peers by an opaque rendezvous
  * id and forwards **only** `offer`/`answer`/`ice` frames verbatim between them. It NEVER inspects the `data`
- * payload, NEVER forwards a non-signaling frame, and holds **no session state** — only transient per-rendezvous
- * membership that is dropped when a peer disconnects. Auth/trust is deliberately absent in Stage A (added in
- * Stage B); this module carries a rate-limit seam (`onJoinAttempt`) that is a no-op until then.
+ * payload, NEVER forwards a non-signaling frame, and holds **no session content** — only transient membership.
  *
- * The relay logic is intentionally decoupled from `ws` (via {@link ISignalingPeer}) so it is unit-testable with
- * in-memory fake peers — no server, no network (TC-04).
+ * B2 makes the relay **safe by default** at its own layer (not only when a host wires a hook): a per-source
+ * token-bucket bounds join floods, rendezvous ids are **single-use** (a distinct third peer is refused for the
+ * lifetime of the id, even after one of the original two leaves), a **half-open** rendezvous (one peer, no
+ * counterpart) expires after a TTL, and the number of concurrent rendezvous is capped. All abuse controls take
+ * injected dependencies (clock + scheduler + params) so they are exercised by the network-free fake-peer suite.
  */
+import {
+  TokenBucketLimiter,
+  systemClock,
+  systemScheduler,
+  DEFAULT_RENDEZVOUS_TTL_MS,
+  DEFAULT_MAX_RENDEZVOUS,
+  type IClock,
+  type IScheduler,
+  type ITokenBucketConfig,
+} from './rate-limiter.js';
 
 /** The kinds of signaling frame the relay will forward. Anything else is rejected, never relayed. */
 export type TSignalKind = 'offer' | 'answer' | 'ice';
@@ -24,6 +35,8 @@ export const MAX_PEERS_PER_RENDEZVOUS = 2;
 export interface ISignalingPeer {
   /** Stable per-connection id (relay-assigned). */
   readonly id: string;
+  /** Client remote address (IP), when known — the rate-limit key. */
+  readonly remoteAddress?: string;
   /** Deliver a raw JSON frame to this peer. */
   send(raw: string): void;
   /** Force-close this peer's connection. */
@@ -35,9 +48,31 @@ export type TInboundFrame =
   | { readonly type: 'join'; readonly rendezvous: string }
   | { readonly type: 'signal'; readonly kind: TSignalKind; readonly data: unknown };
 
-/** Optional hooks. `onJoinAttempt` is the Stage-B rate-limit/auth seam — return false to reject a join. */
+/** Context passed to the join seam (REMOTE-004 — widened from the Stage-A `(rendezvous, peerId)` form). */
+export interface IJoinAttemptContext {
+  readonly rendezvous: string;
+  readonly peerId: string;
+  readonly remoteAddress?: string;
+}
+
+/** Optional hooks. `onJoinAttempt` is a custom-auth seam layered ON TOP of the built-in rate limiter. */
 export interface ISignalingRelayHooks {
-  onJoinAttempt?(rendezvous: string, peerId: string): boolean;
+  onJoinAttempt?(context: IJoinAttemptContext): boolean;
+}
+
+/** Relay construction options. Abuse controls default on with production-safe values. */
+export interface ISignalingRelayOptions {
+  readonly hooks?: ISignalingRelayHooks;
+  /** Per-source join token-bucket (default: burst 5, refill 1/12s). */
+  readonly rateLimit?: ITokenBucketConfig;
+  /** Half-open rendezvous TTL in ms (default 60s). */
+  readonly rendezvousTtlMs?: number;
+  /** Ceiling on concurrent (active) rendezvous (default 1024). */
+  readonly maxRendezvous?: number;
+  /** Injected time source (default `Date.now`). */
+  readonly clock?: IClock;
+  /** Injected timer scheduler (default `setTimeout`). */
+  readonly scheduler?: IScheduler;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -45,13 +80,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Routes signaling frames between the (≤2) peers sharing a rendezvous id. Pure in-memory; no persistence.
+ * Routes signaling frames between the (≤2) peers sharing a rendezvous id, with built-in abuse hardening.
  */
 export class SignalingRelay {
   private readonly rooms = new Map<string, Set<ISignalingPeer>>();
   private readonly peerRendezvous = new Map<string, string>();
+  /** Distinct peer ids EVER admitted to a rendezvous — enforces single-use (id not reusable by a new peer). */
+  private readonly lifetimePeers = new Map<string, Set<string>>();
+  /** One pending timer per rendezvous (half-open expiry or post-empty lifetime GC). */
+  private readonly timers = new Map<string, () => void>();
 
-  public constructor(private readonly hooks: ISignalingRelayHooks = {}) {}
+  private readonly hooks: ISignalingRelayHooks;
+  private readonly limiter: TokenBucketLimiter;
+  private readonly scheduler: IScheduler;
+  private readonly ttlMs: number;
+  private readonly maxRendezvous: number;
+
+  public constructor(options: ISignalingRelayOptions = {}) {
+    this.hooks = options.hooks ?? {};
+    this.scheduler = options.scheduler ?? systemScheduler;
+    this.ttlMs = options.rendezvousTtlMs ?? DEFAULT_RENDEZVOUS_TTL_MS;
+    this.maxRendezvous = options.maxRendezvous ?? DEFAULT_MAX_RENDEZVOUS;
+    this.limiter = new TokenBucketLimiter(options.rateLimit, options.clock ?? systemClock);
+  }
 
   /** Handle one raw inbound frame from `peer`. Only `signal` frames are ever forwarded, and only to the peer's counterpart. */
   public handleFrame(peer: ISignalingPeer, raw: string): void {
@@ -85,29 +136,59 @@ export class SignalingRelay {
   }
 
   private join(peer: ISignalingPeer, rendezvous: string): void {
+    // Rate-limit first (before any state is touched) — key by source IP, falling back to the peer id.
+    if (!this.limiter.tryConsume(peer.remoteAddress ?? peer.id)) {
+      this.reject(peer, 'rate-limited');
+      return;
+    }
     if (rendezvous.length === 0) {
       this.reject(peer, 'empty-rendezvous');
       return;
     }
-    if (this.hooks.onJoinAttempt && !this.hooks.onJoinAttempt(rendezvous, peer.id)) {
+    if (
+      this.hooks.onJoinAttempt &&
+      !this.hooks.onJoinAttempt({ rendezvous, peerId: peer.id, remoteAddress: peer.remoteAddress })
+    ) {
       this.reject(peer, 'join-rejected');
       return;
     }
+
+    const lifetime = this.lifetimePeers.get(rendezvous);
+    const alreadyAdmitted = lifetime?.has(peer.id) ?? false;
+    if (!alreadyAdmitted) {
+      // Single-use: a NEW distinct peer beyond the two that ever held this id is refused (even after a leave).
+      if (lifetime && lifetime.size >= MAX_PEERS_PER_RENDEZVOUS) {
+        this.reject(peer, 'rendezvous-full');
+        return;
+      }
+      // Concurrency cap: only when creating a brand-new rendezvous (unknown to both rooms + lifetime).
+      const isNew = !this.rooms.has(rendezvous) && !this.lifetimePeers.has(rendezvous);
+      if (isNew && this.rooms.size >= this.maxRendezvous) {
+        this.reject(peer, 'too-many-rendezvous');
+        return;
+      }
+    }
+
+    // Re-joining a different rendezvous moves the peer; drop it from any prior room first (no cross-room leak).
+    const prior = this.peerRendezvous.get(peer.id);
+    if (prior && prior !== rendezvous) this.leaveRoom(peer, prior);
+
     let room = this.rooms.get(rendezvous);
     if (!room) {
       room = new Set<ISignalingPeer>();
       this.rooms.set(rendezvous, room);
     }
-    if (!room.has(peer) && room.size >= MAX_PEERS_PER_RENDEZVOUS) {
-      this.reject(peer, 'rendezvous-full');
-      return;
+    let admitted = this.lifetimePeers.get(rendezvous);
+    if (!admitted) {
+      admitted = new Set<string>();
+      this.lifetimePeers.set(rendezvous, admitted);
     }
-    // Re-joining moves the peer; drop it from any prior rendezvous first (no cross-room leakage).
-    const prior = this.peerRendezvous.get(peer.id);
-    if (prior && prior !== rendezvous) this.leaveRoom(peer, prior);
     room.add(peer);
+    admitted.add(peer.id);
     this.peerRendezvous.set(peer.id, rendezvous);
     peer.send(JSON.stringify({ type: 'joined', rendezvous }));
+    this.armTimer(rendezvous);
+    if (prior && prior !== rendezvous) this.armTimer(prior);
   }
 
   private relay(peer: ISignalingPeer, kind: TSignalKind, data: unknown): void {
@@ -129,11 +210,14 @@ export class SignalingRelay {
     peer.send(JSON.stringify({ type: 'error', reason }));
   }
 
-  /** Drop a peer from its rendezvous (on disconnect). Empty rooms are deleted — no lingering session state. */
+  /** Drop a peer from its rendezvous (on disconnect). */
   public remove(peer: ISignalingPeer): void {
     const rendezvous = this.peerRendezvous.get(peer.id);
-    if (rendezvous) this.leaveRoom(peer, rendezvous);
     this.peerRendezvous.delete(peer.id);
+    if (rendezvous) {
+      this.leaveRoom(peer, rendezvous);
+      this.armTimer(rendezvous);
+    }
   }
 
   private leaveRoom(peer: ISignalingPeer, rendezvous: string): void {
@@ -143,7 +227,55 @@ export class SignalingRelay {
     if (room.size === 0) this.rooms.delete(rendezvous);
   }
 
-  /** Diagnostics only: current rendezvous count (holds no session content). */
+  /**
+   * (Re)arm the single pending timer for a rendezvous based on its current occupancy:
+   * - 1 peer  → half-open expiry after `ttlMs` (kick the lone peer, forget the id);
+   * - 0 peers → lifetime-GC after `ttlMs` (bound memory; the id may be reused only after the window);
+   * - 2 peers → no timer (cancel any pending).
+   */
+  private armTimer(rendezvous: string): void {
+    this.clearTimer(rendezvous);
+    const size = this.rooms.get(rendezvous)?.size ?? 0;
+    if (size === 1) {
+      this.timers.set(
+        rendezvous,
+        this.scheduler.schedule(() => this.expireHalfOpen(rendezvous), this.ttlMs),
+      );
+    } else if (size === 0 && this.lifetimePeers.has(rendezvous)) {
+      this.timers.set(
+        rendezvous,
+        this.scheduler.schedule(() => this.gcLifetime(rendezvous), this.ttlMs),
+      );
+    }
+  }
+
+  private expireHalfOpen(rendezvous: string): void {
+    this.timers.delete(rendezvous);
+    const room = this.rooms.get(rendezvous);
+    if (room && room.size === 1) {
+      for (const lone of room) {
+        this.peerRendezvous.delete(lone.id);
+        lone.close();
+      }
+      this.rooms.delete(rendezvous);
+    }
+    this.gcLifetime(rendezvous);
+  }
+
+  private gcLifetime(rendezvous: string): void {
+    this.lifetimePeers.delete(rendezvous);
+    this.clearTimer(rendezvous);
+  }
+
+  private clearTimer(rendezvous: string): void {
+    const cancel = this.timers.get(rendezvous);
+    if (cancel) {
+      cancel();
+      this.timers.delete(rendezvous);
+    }
+  }
+
+  /** Diagnostics only: current (active) rendezvous count (holds no session content). */
   public get rendezvousCount(): number {
     return this.rooms.size;
   }

--- a/apps/remote-signaling/src/server.ts
+++ b/apps/remote-signaling/src/server.ts
@@ -6,19 +6,19 @@
  * expose a network-reachable surface; a deployment would pass an explicit host/port. Stage A wires **no auth**
  * (Stage B adds pairing) and this server is NOT referenced by any publish/deploy path (TC-06).
  */
-import { createServer, type Server } from 'node:http';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
 
 import { WebSocketServer, type WebSocket } from 'ws';
 
-import { SignalingRelay, type ISignalingPeer, type ISignalingRelayHooks } from './relay.js';
+import { SignalingRelay, type ISignalingPeer, type ISignalingRelayOptions } from './relay.js';
 
 export interface ISignalingServerOptions {
   /** Port to bind. Default `0` (ephemeral) — the actual port is reported by {@link ISignalingServerHandle.port}. */
   readonly port?: number;
   /** Host to bind. Default `127.0.0.1` (loopback) so no network-reachable surface is exposed by default. */
   readonly host?: string;
-  /** Optional relay hooks (Stage-B rate-limit/auth seam). */
-  readonly hooks?: ISignalingRelayHooks;
+  /** Relay behavior — custom-auth hooks + abuse-control params (rate limit, TTL, caps). Defaults are safe. */
+  readonly relay?: ISignalingRelayOptions;
 }
 
 export interface ISignalingServerHandle {
@@ -32,10 +32,11 @@ export interface ISignalingServerHandle {
 
 let peerCounter = 0;
 
-function wrapSocket(socket: WebSocket): ISignalingPeer {
+function wrapSocket(socket: WebSocket, remoteAddress?: string): ISignalingPeer {
   const id = `peer_${(peerCounter += 1)}`;
   return {
     id,
+    ...(remoteAddress ? { remoteAddress } : {}),
     send(raw: string): void {
       if (socket.readyState === socket.OPEN) socket.send(raw);
     },
@@ -51,13 +52,13 @@ export function startSignalingServer(
 ): Promise<ISignalingServerHandle> {
   const host = options.host ?? '127.0.0.1';
   const port = options.port ?? 0;
-  const relay = new SignalingRelay(options.hooks);
+  const relay = new SignalingRelay(options.relay);
 
   const httpServer: Server = createServer();
   const wss = new WebSocketServer({ server: httpServer });
 
-  wss.on('connection', (socket: WebSocket) => {
-    const peer = wrapSocket(socket);
+  wss.on('connection', (socket: WebSocket, request: IncomingMessage) => {
+    const peer = wrapSocket(socket, request.socket.remoteAddress);
     socket.on('message', (data: Buffer) => relay.handleFrame(peer, data.toString()));
     socket.on('close', () => relay.remove(peer));
     socket.on('error', () => relay.remove(peer));
@@ -73,6 +74,9 @@ export function startSignalingServer(
         relay,
         close(): Promise<void> {
           return new Promise<void>((res) => {
+            // Force-terminate any live sockets first — otherwise `httpServer.close()` blocks waiting for open
+            // WebSocket connections to end on their own.
+            for (const client of wss.clients) client.terminate();
             wss.close(() => httpServer.close(() => res()));
           });
         },

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -48,15 +48,19 @@ throws). `stop()` tears down the handler, signal subscription, and peer.
 
 ## Public API Surface
 
-| Export                        | Kind     | Description                                                           |
-| ----------------------------- | -------- | --------------------------------------------------------------------- |
-| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`. |
-| `IWebRtcTransportOptions`     | type     | Construction options.                                                 |
-| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).             |
-| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                   |
-| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                              |
-| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).         |
-| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.           |
+| Export                        | Kind     | Description                                                                      |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.            |
+| `IWebRtcTransportOptions`     | type     | Construction options.                                                            |
+| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                        |
+| `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).      |
+| `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory). |
+| `IWebSocketLike`              | type     | Minimal socket surface `WsSignalingClient` needs (injectable in tests).          |
+| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                              |
+| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                                         |
+| `TSignalKind`                 | type     | `'offer' \| 'answer' \| 'ice'`.                                                  |
+| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).                    |
+| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.                      |
 
 ## Extension Points
 

--- a/packages/agent-transport-webrtc/package.json
+++ b/packages/agent-transport-webrtc/package.json
@@ -46,7 +46,8 @@
   },
   "dependencies": {
     "@robota-sdk/agent-interface-transport": "workspace:*",
-    "@robota-sdk/agent-transport-protocol": "workspace:*"
+    "@robota-sdk/agent-transport-protocol": "workspace:*",
+    "ws": "^8.21.0"
   },
   "peerDependencies": {
     "werift": "^0.23.0"
@@ -57,6 +58,7 @@
     }
   },
   "devDependencies": {
+    "@types/ws": "^8.18.1",
     "rimraf": "^5.0.10",
     "tsdown": "^0.22.2",
     "typescript": "^5.9.3",

--- a/packages/agent-transport-webrtc/src/__tests__/cve-2024-29415-reachability.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/cve-2024-29415-reachability.test.ts
@@ -1,0 +1,61 @@
+import { createRequire } from 'node:module';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * REMOTE-004 B2 TC-05 — regression guard for the CVE-2024-29415 evidence-based re-accept.
+ *
+ * The `ip` package's SSRF advisory (CVE-2024-29415) affects `ip.isPublic` / `ip.isPrivate` (and `ip.address()`,
+ * which calls them). werift/werift-ice reach `ip` only through STUN codec helpers (`isV4Format`/`toBuffer`/
+ * `toString`) and `ip.isLoopback` over the host's own `os.networkInterfaces()` — never the vulnerable functions,
+ * so the SSRF vector is unreachable and the root `pnpm.auditConfig.ignoreCves` entry is a reviewed re-accept.
+ * This test fails if a future werift version starts calling the vulnerable functions, forcing a re-evaluation.
+ */
+
+function resolveWeriftLibDirs(): string[] {
+  const require = createRequire(import.meta.url);
+  const dirs: string[] = [];
+  for (const pkg of ['werift', 'werift-ice']) {
+    try {
+      const pkgJson = require.resolve(`${pkg}/package.json`);
+      dirs.push(dirname(pkgJson));
+    } catch {
+      /* werift-ice may only be reachable transitively; werift resolves for sure (devDep) */
+    }
+  }
+  return dirs;
+}
+
+function collectJsFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (entry !== 'node_modules') collectJsFiles(full, acc);
+    } else if (/\.(js|mjs|cjs)$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('CVE-2024-29415 non-reachability in werift (REMOTE-004 B2 — TC-05)', () => {
+  it('werift never calls the vulnerable ip.isPublic / ip.isPrivate / ip.address', () => {
+    const dirs = resolveWeriftLibDirs();
+    expect(dirs.length).toBeGreaterThan(0); // werift is a devDep — must resolve
+
+    const offenders: string[] = [];
+    for (const dir of dirs) {
+      for (const file of collectJsFiles(dir)) {
+        const text = readFileSync(file, 'utf8');
+        // Match property access on the `ip` module: `.isPublic(`, `.isPrivate(`, `.address(`.
+        if (/\.isPublic\s*\(|\.isPrivate\s*\(|ip[_0-9]*\.(?:default\.)?address\s*\(/.test(text)) {
+          offenders.push(file);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/agent-transport-webrtc/src/__tests__/ws-signaling-client.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/ws-signaling-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { WsSignalingClient, type IWebSocketLike } from '../ws-signaling-client.js';
+import type { ISignalMessage } from '../signaling.js';
+
+/**
+ * REMOTE-004 B2 — `WsSignalingClient` unit tests with an injected fake socket (no network). Cover pre-open
+ * buffering + flush and explicit error surfacing (relay `error` frame, close-before-join).
+ */
+
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+
+function createFakeSocket(): IWebSocketLike & {
+  readonly sent: string[];
+  readyState: number;
+  emit(event: 'open' | 'message' | 'error' | 'close', arg?: unknown): void;
+} {
+  const sent: string[] = [];
+  const listeners: Record<string, ((arg: unknown) => void)[]> = {};
+  return {
+    sent,
+    readyState: WS_CONNECTING,
+    send(data: string): void {
+      sent.push(data);
+    },
+    close(): void {
+      /* no-op for the fake */
+    },
+    on(event, handler): void {
+      (listeners[event] ??= []).push(handler);
+    },
+    emit(event, arg): void {
+      for (const h of listeners[event] ?? []) h(arg);
+    },
+  };
+}
+
+function parse(raw: string): Record<string, unknown> {
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe('WsSignalingClient (REMOTE-004 B2)', () => {
+  it('TC-02: buffers signals produced before open and flushes them (after the join) on open', () => {
+    const socket = createFakeSocket();
+    const client = new WsSignalingClient({
+      url: 'ws://x',
+      rendezvous: 'r',
+      createSocket: () => socket,
+    });
+    // send an offer before the socket opens
+    const offer: ISignalMessage = { kind: 'offer', data: { sdp: 'v=0' } };
+    client.send(offer);
+    expect(socket.sent).toHaveLength(0); // buffered, nothing on the wire yet
+
+    socket.readyState = WS_OPEN;
+    socket.emit('open');
+
+    // first frame is the join, then the flushed offer
+    expect(parse(socket.sent[0]!)).toEqual({ type: 'join', rendezvous: 'r' });
+    expect(parse(socket.sent[1]!)).toEqual({ type: 'signal', kind: 'offer', data: { sdp: 'v=0' } });
+  });
+
+  it('delivers inbound relay signals to onSignal handlers', () => {
+    const socket = createFakeSocket();
+    const client = new WsSignalingClient({
+      url: 'ws://x',
+      rendezvous: 'r',
+      createSocket: () => socket,
+    });
+    const received: ISignalMessage[] = [];
+    client.onSignal((m) => received.push(m));
+    socket.emit('message', JSON.stringify({ type: 'signal', kind: 'answer', data: { sdp: 'a' } }));
+    expect(received).toEqual([{ kind: 'answer', data: { sdp: 'a' } }]);
+  });
+
+  it('TC-02: surfaces a relay error frame via onError (no silent degrade)', () => {
+    const socket = createFakeSocket();
+    const onError = vi.fn();
+    new WsSignalingClient({ url: 'ws://x', rendezvous: 'r', onError, createSocket: () => socket });
+    socket.emit('message', JSON.stringify({ type: 'error', reason: 'rate-limited' }));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]![0] as Error).message).toMatch(/rate-limited/);
+  });
+
+  it('TC-02: surfaces a close-before-join as an explicit error', () => {
+    const socket = createFakeSocket();
+    const onError = vi.fn();
+    new WsSignalingClient({ url: 'ws://x', rendezvous: 'r', onError, createSocket: () => socket });
+    socket.emit('close');
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]![0] as Error).message).toMatch(/closed before/);
+  });
+
+  it('does NOT treat an intentional close() as an error', () => {
+    const socket = createFakeSocket();
+    const onError = vi.fn();
+    const client = new WsSignalingClient({
+      url: 'ws://x',
+      rendezvous: 'r',
+      onError,
+      createSocket: () => socket,
+    });
+    client.close();
+    socket.emit('close');
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-transport-webrtc/src/index.ts
+++ b/packages/agent-transport-webrtc/src/index.ts
@@ -1,6 +1,8 @@
 export { WebRtcTransport } from './webrtc-transport.js';
 export type { IWebRtcTransportOptions } from './webrtc-transport.js';
 export { createInMemorySignalingPair } from './signaling.js';
-export type { ISignalingClient, ISignalMessage } from './signaling.js';
+export type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
+export { WsSignalingClient } from './ws-signaling-client.js';
+export type { IWsSignalingClientOptions, IWebSocketLike } from './ws-signaling-client.js';
 export { loadWerift } from './werift-loader.js';
 export type { IWeriftModule } from './werift-loader.js';

--- a/packages/agent-transport-webrtc/src/signaling.ts
+++ b/packages/agent-transport-webrtc/src/signaling.ts
@@ -4,9 +4,12 @@
  * candidates — never session content — so a signaling server (or the in-memory test pair) is content-blind.
  */
 
+/** The kinds of signal a peer exchanges through the relay. */
+export type TSignalKind = 'offer' | 'answer' | 'ice';
+
 /** An opaque signaling message relayed by rendezvous id. `data` is an SDP description or an ICE candidate. */
 export interface ISignalMessage {
-  readonly kind: 'offer' | 'answer' | 'ice';
+  readonly kind: TSignalKind;
   /** Opaque payload (serialized SDP or ICE candidate). The signaling layer never inspects it. */
   readonly data: unknown;
 }

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -14,6 +14,12 @@ export interface IWebRtcTransportOptions {
   readonly signaling: ISignalingClient;
   /** Optional ICE servers (STUN/TURN). Omitted → host-candidate/loopback only. */
   readonly iceServers?: readonly { urls: string }[];
+  /**
+   * REMOTE-004 defense-in-depth: when true, restrict ICE to **relay (TURN) candidates only** (werift `forceTurn`),
+   * so host/server-reflexive candidates — and the local-interface gathering that touches the (unreachable, but
+   * belt-and-braces) `ip` code path — are never used. Requires a TURN server in `iceServers`.
+   */
+  readonly forceTurn?: boolean;
 }
 
 /**
@@ -48,9 +54,10 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
     if (!session) throw new Error('WebRtcTransport: attach() must be called before start()');
 
     const { RTCPeerConnection } = loadWerift();
-    const peer = new RTCPeerConnection(
-      this.options.iceServers ? { iceServers: [...this.options.iceServers] } : undefined,
-    );
+    const peerConfig: { iceServers?: { urls: string }[]; forceTurn?: boolean } = {};
+    if (this.options.iceServers) peerConfig.iceServers = [...this.options.iceServers];
+    if (this.options.forceTurn) peerConfig.forceTurn = true;
+    const peer = new RTCPeerConnection(Object.keys(peerConfig).length > 0 ? peerConfig : undefined);
     this.peer = peer;
     const signaling = this.options.signaling;
 

--- a/packages/agent-transport-webrtc/src/werift-loader.ts
+++ b/packages/agent-transport-webrtc/src/werift-loader.ts
@@ -4,7 +4,10 @@ import type { RTCPeerConnection } from 'werift';
 
 /** The subset of the `werift` module surface this transport constructs. */
 export interface IWeriftModule {
-  RTCPeerConnection: new (configuration?: { iceServers?: { urls: string }[] }) => RTCPeerConnection;
+  RTCPeerConnection: new (configuration?: {
+    iceServers?: { urls: string }[];
+    forceTurn?: boolean;
+  }) => RTCPeerConnection;
 }
 
 /**

--- a/packages/agent-transport-webrtc/src/ws-signaling-client.ts
+++ b/packages/agent-transport-webrtc/src/ws-signaling-client.ts
@@ -1,0 +1,139 @@
+/**
+ * Production `ISignalingClient` over a WebSocket connection to the `@robota-sdk/remote-signaling` relay
+ * (REMOTE-004 Stage B2). This is the **Node host-side** client (the browser remote client, Stage D, implements
+ * `ISignalingClient` on the native `WebSocket`).
+ *
+ * On open it `join`s the rendezvous and flushes any signals produced before the socket opened (the offer is
+ * created in `WebRtcTransport.start()`, which can run before the socket connects — buffering avoids dropping it).
+ * Relay `error` frames, socket errors, and a close-before-join are surfaced through an explicit `onError`
+ * callback — **never a silent degrade** (no-fallback, mirroring `loadReplayProvider`/`loadWerift`). The relay is
+ * content-blind: this client only ever emits `join` + `signal` frames and only ever consumes `joined` / `signal`
+ * / `error` frames.
+ */
+import WebSocket from 'ws';
+
+import type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
+
+/** A minimal WebSocket-like surface — so tests can inject a fake without a real socket. */
+export interface IWebSocketLike {
+  send(data: string): void;
+  close(): void;
+  readyState: number;
+  on(event: 'open' | 'message' | 'error' | 'close', handler: (arg: unknown) => void): void;
+}
+
+export interface IWsSignalingClientOptions {
+  /** Relay URL, e.g. `ws://127.0.0.1:1234`. */
+  readonly url: string;
+  /** Rendezvous id to join. */
+  readonly rendezvous: string;
+  /**
+   * Explicit error sink. Called on a relay `error` frame, a socket error, or a close-before-join — the signaling
+   * channel cannot function and the caller must know (no silent degrade).
+   */
+  readonly onError?: (error: Error) => void;
+  /** Called once the relay confirms the rendezvous `join` (the `joined` frame). */
+  readonly onReady?: () => void;
+  /** Injectable socket factory (defaults to a real `ws` WebSocket) — for tests. */
+  readonly createSocket?: (url: string) => IWebSocketLike;
+}
+
+const SIGNAL_KINDS: ReadonlySet<string> = new Set<TSignalKind>(['offer', 'answer', 'ice']);
+const WS_OPEN = 1;
+
+function defaultCreateSocket(url: string): IWebSocketLike {
+  return new WebSocket(url) as unknown as IWebSocketLike;
+}
+
+export class WsSignalingClient implements ISignalingClient {
+  private readonly socket: IWebSocketLike;
+  private readonly handlers: ((message: ISignalMessage) => void)[] = [];
+  private readonly outbox: ISignalMessage[] = [];
+  private joined = false;
+  private closed = false;
+
+  public constructor(private readonly options: IWsSignalingClientOptions) {
+    const factory = options.createSocket ?? defaultCreateSocket;
+    this.socket = factory(options.url);
+    this.socket.on('open', () => this.handleOpen());
+    this.socket.on('message', (data) => this.handleMessage(data));
+    this.socket.on('error', (err) =>
+      this.fail(err instanceof Error ? err : new Error(String(err))),
+    );
+    this.socket.on('close', () => this.handleClose());
+  }
+
+  private handleOpen(): void {
+    this.socket.send(JSON.stringify({ type: 'join', rendezvous: this.options.rendezvous }));
+    // Flush any signals produced before the socket opened (e.g. the offer from WebRtcTransport.start()).
+    for (const message of this.outbox) this.writeSignal(message);
+    this.outbox.length = 0;
+  }
+
+  private handleMessage(data: unknown): void {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(typeof data === 'string' ? data : String(data));
+    } catch {
+      return; // a non-JSON frame from the relay is ignored (the relay only emits JSON)
+    }
+    if (typeof frame !== 'object' || frame === null) return;
+    const record = frame as Record<string, unknown>;
+    if (record.type === 'joined') {
+      this.joined = true;
+      this.options.onReady?.();
+      return;
+    }
+    if (record.type === 'error') {
+      this.fail(new Error(`signaling relay rejected the connection: ${String(record.reason)}`));
+      return;
+    }
+    if (
+      record.type === 'signal' &&
+      typeof record.kind === 'string' &&
+      SIGNAL_KINDS.has(record.kind)
+    ) {
+      const message: ISignalMessage = { kind: record.kind as TSignalKind, data: record.data };
+      for (const handler of this.handlers) handler(message);
+    }
+  }
+
+  private handleClose(): void {
+    if (this.closed) return; // an intentional close() is not an error
+    if (!this.joined) {
+      this.fail(new Error('signaling socket closed before the rendezvous was joined'));
+    }
+  }
+
+  private fail(error: Error): void {
+    this.options.onError?.(error);
+  }
+
+  private writeSignal(message: ISignalMessage): void {
+    this.socket.send(JSON.stringify({ type: 'signal', kind: message.kind, data: message.data }));
+  }
+
+  public send(message: ISignalMessage): void {
+    if (this.closed) return;
+    if (this.socket.readyState === WS_OPEN) {
+      this.writeSignal(message);
+    } else {
+      this.outbox.push(message); // buffer until open (see handleOpen)
+    }
+  }
+
+  public onSignal(handler: (message: ISignalMessage) => void): () => void {
+    this.handlers.push(handler);
+    return () => {
+      const index = this.handlers.indexOf(handler);
+      if (index >= 0) this.handlers.splice(index, 1);
+    };
+  }
+
+  public close(): void {
+    this.closed = true;
+    this.handlers.length = 0;
+    this.outbox.length = 0;
+    this.socket.close();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,12 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
     devDependencies:
+      '@robota-sdk/agent-interface-transport':
+        specifier: workspace:*
+        version: link:../../packages/agent-interface-transport
+      '@robota-sdk/agent-transport-webrtc':
+        specifier: workspace:*
+        version: link:../../packages/agent-transport-webrtc
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21
@@ -473,6 +479,9 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
+      werift:
+        specifier: ^0.23.0
+        version: 0.23.0
 
   apps/starter-nextjs:
     dependencies:
@@ -1968,7 +1977,13 @@ importers:
       '@robota-sdk/agent-transport-protocol':
         specifier: workspace:*
         version: link:../agent-transport-protocol
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       rimraf:
         specifier: ^5.0.10
         version: 5.0.10


### PR DESCRIPTION
Promotes `develop` to `main`. Primary content since the last promotion:

**REMOTE-004 Stage B2 (#1087)** — production WebRTC signaling client (`WsSignalingClient`) + relay abuse-hardening (per-source token-bucket, single-use rendezvous, half-open TTL, concurrency cap) + `CVE-2024-29415` discharged as a verified reviewed re-accept. Still no user-facing enable path (that is B4).

Real-relay end-to-end RTCDataChannel round-trip proven; full suites green, typecheck 0, harness:scan 49/49, `pnpm audit --audit-level high` exit 0. Release is manual (`workflow_dispatch`); this merge does not publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)