### PR TITLE
docs(backlog): Bun single-binary distribution (DIST-001/002/003)

### DIFF
--- a/.agents/backlog/DIST-001-bun-compile-single-binary.md
+++ b/.agents/backlog/DIST-001-bun-compile-single-binary.md
@@ -1,0 +1,79 @@
+---
+title: 'DIST-001: Bun-compile single-binary distribution for agent-cli (Node path unchanged)'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: packages/agent-cli
+depends_on: []
+---
+
+# Bun-compile single-binary distribution for agent-cli
+
+Add a **Bun-based distribution path** that produces standalone single-file executables of the `robota` CLI,
+**without changing the existing Node.js execution**. Bun is used ONLY for build/packaging — never at runtime, and
+**no Bun-specific APIs** (`Bun.file`, `Bun.serve`, …) are introduced. The existing `robota` command and every
+current `package.json` script must keep working exactly as today.
+
+Owner requirement (2026-07-11). This is the foundation item; the release workflow (DIST-002) and the Node-less
+install scripts (DIST-003) depend on it.
+
+## What
+
+1. **Compatibility analysis + minimal fixes.** Determine whether `packages/agent-cli` (which INFRA-028 bundles the
+   entire `@robota-sdk` workspace into a single artifact; only third-party npm deps stay external) is
+   `bun build --compile`-compatible. Identify anything Bun's compiler cannot handle (dynamic `require`/`import`
+   patterns, native addons — e.g. any `better-sqlite3`/native transitive dep, `import.meta` usage, worker/child
+   spawning of `node`, asset/`__dirname` resolution). Apply the **minimum** changes needed for Bun compile;
+   do NOT restructure. Record every code change and its reason.
+2. **Cross-platform compile config.** Produce executables via `bun build --compile --target=…` for:
+   - macOS arm64 → `robota-darwin-arm64`
+   - macOS x64 → `robota-darwin-x64`
+   - Linux x64 → `robota-linux-x64`
+   - Linux arm64 → `robota-linux-arm64`
+   - Windows x64 → `robota-windows-x64.exe`
+3. **Additive `package.json` scripts only.** Add Bun build scripts (e.g. `build:bun`, `build:bun:all`, per-target
+   scripts) to `packages/agent-cli/package.json` (or root, whichever is cleaner). **Do NOT modify or remove any
+   existing script.** Node build/test/lint scripts remain byte-identical.
+4. **E2E smoke test for the compiled binary.** A test that runs the produced host-platform binary and asserts:
+   `robota --version` (prints the version), `robota --help` (prints usage), and one **basic command execution**
+   (a no-provider-call path — e.g. a help/subcommand or a print-mode invocation that does not require an API key).
+   The test must skip gracefully (not fail) when Bun is unavailable in the environment.
+
+**Constraints (hard):** existing Node.js run untouched; `robota` (Node) must not break; Bun for build/packaging
+only; no Bun-only runtime APIs. If a required fix would change Node behavior, STOP and surface it rather than
+proceeding.
+
+## Non-goals
+
+- Publishing binaries / GitHub Release upload (that is DIST-002).
+- The `install.sh` / `install.ps1` scripts + hosting (that is DIST-003).
+- Replacing the npm distribution or the Node entrypoint.
+
+## Test Plan
+
+- Compatibility spike: `bun build --compile` the host target; capture any compiler errors and the minimal fix set.
+- Verify existing Node path unchanged: `pnpm --filter @robota-sdk/agent-cli build` + `test` + `typecheck` green;
+  `robota --version`/`--help` via the Node entrypoint unchanged (diff the output vs pre-change).
+- New E2E: run the compiled host binary for `--version` / `--help` / a basic command; assert exit 0 + expected
+  output. Guard on Bun presence.
+- `pnpm harness:scan` green; changeset if any published-package surface changes (likely none — scripts + E2E only).
+
+## User Execution Test Scenarios
+
+**Scenario A — compiled binary basic use (host platform).**
+
+- Prerequisites: Bun installed locally; repo built.
+- Steps: `bun run build:bun` (host target) → run `./robota-<os>-<arch> --version`, then `--help`, then a basic
+  command (e.g. `./robota-<os>-<arch> --help <subcommand>` or a print-mode call with no API key needed).
+- Expected: version string prints; help/usage prints; the basic command runs and exits 0 — no Node.js installed
+  requirement for running the binary.
+- Evidence: _(fill after implementation: paste the three command outputs + `file ./robota-*` showing a native
+  executable.)_
+
+**Scenario B — existing Node path unaffected.**
+
+- Steps: with the change applied, run the current `robota` command via the Node entrypoint (`pnpm robota --version`
+  / `--help` / a basic command) exactly as before.
+- Expected: identical behavior/output to before this backlog; no regression.
+- Evidence: _(fill after implementation: outputs + confirmation the existing scripts are unchanged.)_

--- a/.agents/backlog/DIST-002-bun-binary-release-workflow.md
+++ b/.agents/backlog/DIST-002-bun-binary-release-workflow.md
@@ -1,0 +1,62 @@
+---
+title: 'DIST-002: GitHub Actions workflow to build + publish Bun binaries to Releases'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: .github/workflows, packages/agent-cli
+depends_on: ['DIST-001']
+---
+
+# GitHub Actions workflow: build + publish Bun binaries to GitHub Releases
+
+Add a CI workflow that builds the five Bun single-file executables (from DIST-001) for every target platform and
+uploads them as assets to a GitHub Release. Must NOT interfere with the existing release/publish flow (npm publish
+stays manual `workflow_dispatch`, per the current `release.yml`).
+
+Owner requirement (2026-07-11). Depends on DIST-001 (the compile config + binary names must exist first).
+
+## What
+
+1. **Build matrix** producing the five named binaries: `robota-darwin-arm64`, `robota-darwin-x64`,
+   `robota-linux-x64`, `robota-linux-arm64`, `robota-windows-x64.exe`. Prefer Bun's cross-compilation
+   (`--target=bun-<os>-<arch>`) so most/all targets can build from a single runner where feasible; otherwise use a
+   platform matrix (macos/ubuntu/windows runners). Document which approach is chosen and why.
+2. **Trigger.** Fire on a release tag (e.g. `v*`) and/or `workflow_dispatch`. Do NOT auto-run on every push. Keep
+   it independent of the existing `release.yml` (manual npm publish) — adding this must not change npm publishing.
+3. **Upload to GitHub Releases.** Attach all five binaries (+ optionally SHA-256 checksums) as release assets on
+   the matching release. Stable, predictable asset names (exactly the DIST-001 names) so the DIST-003 install
+   scripts can construct download URLs deterministically.
+4. **Provide the workflow as a concrete file** (`.github/workflows/bun-release.yml` or similar), reviewed against
+   the repo's existing workflow conventions (pinned action versions, least-privilege `permissions:` incl.
+   `contents: write` for release upload).
+
+## Non-goals
+
+- The Bun compile config itself (DIST-001).
+- The install scripts / hosting (DIST-003).
+- Changing npm publish or the `release.yml` manual flow.
+
+## Test Plan
+
+- `actionlint` (or the repo's workflow linter) clean on the new workflow.
+- Dry-run / `workflow_dispatch` on a test tag in a fork or a draft release; confirm all five assets appear with the
+  exact expected names + non-zero size, and checksums (if added) match.
+- Confirm the existing CI (`ci.yml`) and `release.yml` are unchanged and still green.
+
+## User Execution Test Scenarios
+
+**Scenario A — release produces all five binaries.**
+
+- Prerequisites: DIST-001 merged; a test tag / draft release.
+- Steps: trigger the workflow (tag push or `workflow_dispatch`) → open the resulting GitHub Release.
+- Expected: the release lists exactly `robota-darwin-arm64`, `robota-darwin-x64`, `robota-linux-x64`,
+  `robota-linux-arm64`, `robota-windows-x64.exe` (+ checksums if included), each downloadable and non-empty.
+- Evidence: _(fill after implementation: release URL + asset list screenshot/text; download one asset and run
+  `--version`.)_
+
+**Scenario B — a downloaded binary runs on its platform.**
+
+- Steps: download the asset matching the tester's OS/arch from the Release and run `--version` / `--help`.
+- Expected: runs with no Node.js installed; prints version/usage.
+- Evidence: _(fill after implementation.)_

--- a/.agents/backlog/DIST-003-nodeless-install-scripts.md
+++ b/.agents/backlog/DIST-003-nodeless-install-scripts.md
@@ -1,0 +1,71 @@
+---
+title: 'DIST-003: Node-less install scripts (install.sh / install.ps1) for Bun binaries'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: scripts, .github/workflows
+depends_on: ['DIST-002']
+---
+
+# Node-less install scripts for the Bun binaries
+
+Let users install `robota` **without Node.js** via a one-line command that detects OS + CPU, downloads the correct
+binary (from DIST-002 GitHub Releases), and installs it so `robota` runs from the shell.
+
+Owner requirement (2026-07-11). Depends on DIST-002 (the released assets + stable names).
+
+## What
+
+1. **`scripts/install.sh`** (macOS/Linux) — detect OS (`darwin`/`linux`) + CPU (`arm64`/`x64`) via `uname`,
+   construct the release asset name (`robota-<os>-<arch>`), download it, `chmod +x`, and place it on a PATH dir
+   (e.g. `~/.robota/bin` with a PATH hint, or `/usr/local/bin` when writable), then verify `robota --version`.
+2. **`scripts/install.ps1`** (Windows PowerShell) — detect arch, download `robota-windows-x64.exe`, install to a
+   per-user dir (e.g. `%LOCALAPPDATA%\robota\bin`), add it to the user PATH, verify `robota --version`.
+3. **Install URL as a single constant** in each script (the base download/host URL), clearly separated at the top
+   so it can be changed later without touching logic. Scripts must work when served from GitHub Pages, GitHub
+   Releases, or a separate static URL.
+4. **One-line install UX** documented + wired:
+   - macOS/Linux: `curl -fsSL https://<host>/install.sh | bash`
+   - Windows PowerShell: `irm https://<host>/install.ps1 | iex`
+     Decide + document how the scripts are hosted (e.g. published to GitHub Pages, or served from a pinned Release
+     asset / raw URL). Version selection: default to the latest release, with an optional pinned-version env/arg.
+5. **Robustness:** fail loudly on unsupported OS/arch, checksum-verify the download if DIST-002 publishes
+   checksums, and never require Node.js at any step.
+
+## Non-goals
+
+- The binaries themselves (DIST-001) or the release workflow (DIST-002).
+- A package-manager (brew/scoop) formula — could be a later follow-up.
+
+## Test Plan
+
+- `shellcheck` on `install.sh`; `PSScriptAnalyzer` on `install.ps1` (or the repo's chosen linters), both clean.
+- Dry-run each script against a real DIST-002 release: fresh environment WITHOUT Node.js → run the one-liner →
+  confirm `robota --version` works afterward on macOS, Linux, and Windows.
+- OS/arch detection unit-checks (table of `uname`/arch → expected asset name).
+- Confirm the install URL constant is the only place to change the host.
+
+## User Execution Test Scenarios
+
+**Scenario A — Node-less install on macOS/Linux.**
+
+- Prerequisites: a machine (or container) with NO Node.js installed; a published DIST-002 release.
+- Steps: `curl -fsSL https://<host>/install.sh | bash` → open a new shell → `robota --version` → `robota --help`
+  → a basic command.
+- Expected: install succeeds without Node; `robota` is on PATH and runs.
+- Evidence: _(fill after implementation: terminal transcript incl. `which robota` and the three commands, and
+  proof Node is absent — `command -v node` empty.)_
+
+**Scenario B — Node-less install on Windows.**
+
+- Steps: in PowerShell (no Node): `irm https://<host>/install.ps1 | iex` → new PowerShell session →
+  `robota --version` / `--help` / basic command.
+- Expected: installs to the user dir, adds to PATH, runs without Node.
+- Evidence: _(fill after implementation.)_
+
+**Scenario C — changing the install host is a one-line edit.**
+
+- Steps: change the URL constant at the top of each script; re-run.
+- Expected: downloads from the new host with no other edits.
+- Evidence: _(fill after implementation.)_


### PR DESCRIPTION
Records the owner's requirement (2026-07-11) to add a **Bun-based distribution path** for the `robota` CLI — producing standalone single-file executables — **without changing the existing Node.js execution**, as three linked, deferred backlog items:

- **DIST-001** — Bun-compile compatibility analysis + minimal fixes; cross-platform single-binary build (macOS arm64/x64, Linux x64/arm64, Windows x64 with the fixed `robota-<os>-<arch>` names); additive `package.json` scripts only; compiled-binary E2E smoke (`--version` / `--help` / basic command).
- **DIST-002** — GitHub Actions workflow to build the five binaries and upload them to GitHub Releases (independent of the manual npm publish). `depends_on: DIST-001`.
- **DIST-003** — Node-less `install.sh` / `install.ps1` (OS+CPU detection → download from Releases), one-line `curl … | bash` / `irm … | iex`, install URL as a single editable constant. `depends_on: DIST-002`.

Hard principles recorded in each item: Node path unchanged, `robota` must not break, Bun for build/packaging only, no Bun-only runtime APIs.

**Not started** — to be executed after the in-flight REMOTE-001 work completes. Docs-only; harness:scan 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)