### PR TITLE
chore(harness): enforce branch-base-from-develop + block committing auto-lessons

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -77,7 +77,13 @@ distinguish them automatically.
 - `develop` is the integration branch. All feature work branches from `develop`. Direct commits to
   `develop` are also prohibited — branch first, then PR. (Both `main` and `develop` are protected;
   enforced by `.husky/pre-commit` and the `branch-guard` skill/hook.)
-- Feature branches must be created from `develop` and merged back into `develop`.
+- Feature branches must be created from `develop` and merged back into `develop`. **Create them from the
+  freshly-fetched `origin/develop` head, never from `main`.** After a `develop → main` promotion, `main` sits
+  AHEAD of `develop`; a branch cut from `main` (or that has merged one in) and PR'd to `develop` drags the
+  promotion's `Merge pull request … from develop` commits into the PR range, which then fail `commitlint`. A clean
+  feature/docs branch has **zero merge commits** in its `origin/develop..HEAD` range. **Enforced** by
+  `.claude/hooks/pre-push-check.sh` (blocks a push when `git log --merges origin/develop..HEAD` is non-empty on a
+  non-integration branch); recover with `git reset --hard origin/develop && git cherry-pick <your-commit(s)>`.
 - Merging `develop` into `main` requires explicit user approval and is a release-level action.
 - When merging a branch, always merge back to the branch it was forked from. Verify the fork point before proposing a merge target.
 - If the agent wants to suggest a different merge target than the fork origin, it must explicitly recommend and receive user approval before proceeding.
@@ -161,6 +167,10 @@ After a branch is merged, follow this exact cycle to start the next feature bran
    ```
    `pnpm harness:pre-push` already tolerates this specific churn (it does not block a push when the only
    dirty files are the auto-generated evals lessons), so no stash is needed for the push itself.
+   **Never commit these files.** They are regenerated in place; staging them (typically via a broad
+   `git add .agents`) sweeps machine-churn into a feature/spec commit. **Stage explicit paths, not a broad
+   directory add.** **Enforced** by `.husky/pre-commit`, which blocks a commit that stages
+   `.agents/evals/lessons/*` (override only for a sanctioned harness update: `ALLOW_LESSONS_COMMIT=1`).
 2. **Pull develop** so the new branch is based on the freshly-pulled integration head.
 3. **Create the feature branch** from the updated `develop`.
 4. **Verify the base.** Confirm the new branch forked from the freshly-pulled `develop`, not a previous

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -24,6 +24,28 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 
 echo "[pre-push-check] Running pre-push CI checks..." >&2
 
+# ── 0. Branch-base hygiene (git-branch.md: feature branches start from origin/develop) ──────────
+# After a develop→main promotion, `main` sits AHEAD of `develop`. A branch cut from `main` (or that
+# merged one in) and PR'd to develop carries the promotion's merge commits in its `origin/develop..HEAD`
+# range, which land in the PR range and fail commitlint. A clean feature/docs branch has ZERO merge
+# commits over origin/develop. Skip integration/detached branches and when origin/develop is absent.
+CUR_BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+case "$CUR_BRANCH" in
+  main | master | develop | "") : ;;
+  *)
+    if git -C "$PROJECT_DIR" rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then
+      FOREIGN_MERGES=$(git -C "$PROJECT_DIR" log --merges --oneline origin/develop..HEAD 2>/dev/null || true)
+      if [ -n "$FOREIGN_MERGES" ]; then
+        echo "[pre-push-check] Blocked: branch '$CUR_BRANCH' carries merge commits in its range over origin/develop:" >&2
+        echo "$FOREIGN_MERGES" | sed 's/^/[pre-push-check]   /' >&2
+        echo "[pre-push-check] It was likely based on 'main' (ahead of develop after a promotion), not origin/develop." >&2
+        echo "[pre-push-check] Re-base on develop: git reset --hard origin/develop && git cherry-pick <your-commit(s)>" >&2
+        exit 2
+      fi
+    fi
+    ;;
+esac
+
 # ── 1. Lockfile sync check ──────────────────────────────────────────────────
 
 if ! git -C "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,4 +22,20 @@ if [ "${ALLOW_PROTECTED_COMMIT:-0}" != "1" ] && [ ! -f "$(git rev-parse --git-di
   esac
 fi
 
+# Auto-generated learning-artifact guard (git-branch.md — lessons are regenerated churn, not
+# hand-authored content). Block a commit that STAGES `.agents/evals/lessons/*` — these files are
+# regenerated in place and must never be swept into a feature/spec commit via a broad `git add`.
+# A sanctioned harness process that intentionally updates them sets ALLOW_LESSONS_COMMIT=1.
+if [ "${ALLOW_LESSONS_COMMIT:-0}" != "1" ]; then
+  STAGED_LESSONS=$(git diff --cached --name-only | grep -E '^\.agents/evals/lessons/' || true)
+  if [ -n "$STAGED_LESSONS" ]; then
+    echo "[pre-commit] Blocked: auto-generated lessons are staged (do not commit them):" >&2
+    echo "$STAGED_LESSONS" | sed 's/^/[pre-commit]   /' >&2
+    echo "[pre-commit] Unstage them (regenerated churn): git restore --staged .agents/evals/lessons" >&2
+    echo "[pre-commit] Stage explicit paths, not a broad 'git add .agents'. (git-branch.md)" >&2
+    echo "[pre-commit] Sanctioned harness update only: ALLOW_LESSONS_COMMIT=1 git commit ..." >&2
+    exit 1
+  fi
+fi
+
 NODE_OPTIONS="--max-old-space-size=8192" pnpm exec lint-staged


### PR DESCRIPTION
Institutionalizes two repeated lessons from the session as **mechanized** harness guards (per `lesson-to-harness`). Both rules already existed in `git-branch.md` as prose but were **unenforced**, so they were violated — the fix is the enforcement mechanism, not more prose.

### C1 — feature branches base on `origin/develop`, not `main`
After a `develop → main` promotion, `main` is ahead of `develop`; a branch cut from `main` and PR'd to `develop` drags the promotion's `Merge pull request … from develop` commits into the PR range and fails `commitlint` (**hit twice**: #1081, #1083). **Mechanism:** `.claude/hooks/pre-push-check.sh` blocks a push when `git log --merges origin/develop..HEAD` is non-empty on a non-integration branch.

### C2 — never commit auto-generated lessons
`.agents/evals/lessons/*` are regenerated churn; a broad `git add .agents` swept them into a feature commit (merge-verifier flagged it). **Mechanism:** `.husky/pre-commit` blocks a commit that stages `.agents/evals/lessons/*` (override `ALLOW_LESSONS_COMMIT=1` for a sanctioned harness update).

### Proof (both mechanisms catch the incident)
- C1: a range containing promotion merges → `FOREIGN_MERGES` non-empty → **push BLOCKED**; a linear range → empty → **ALLOWED**.
- C2: staging `.agents/evals/lessons/auto-lessons.md` + code → guard matches → **commit BLOCKED** (verified **end-to-end** live: the pre-commit hook rejected the commit); no lessons staged → **ALLOWED**.

`git-branch.md` augmented to reference both mechanisms. This PR itself dogfoods C1 (branched from `origin/develop`, single commit, zero foreign merges) and C2 (no lessons staged). harness:scan 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)