### PR TITLE
release(develop→main): REMOTE-009 browser remote client (Stage D)

### DIFF
--- a/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
+++ b/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
@@ -1,0 +1,180 @@
+---
+status: in-progress
+type: INFRA
+tags: [remote-control, webrtc, browser, pairing, web-ui]
+parent: REMOTE-001
+---
+
+# REMOTE-009: Stage D — browser remote client
+
+Parent: [REMOTE-001](../todo/REMOTE-001-webrtc-p2p-remote-control-design.md) (ENDORSED). Prior sub-stages DONE:
+REMOTE-002..008 — the HOST enable path ships (`/remote-control` → QR/link → pairing-gated WebRTC). Stage D is the
+**other peer**: the browser page a user opens from the QR/link that pairs and co-drives the SAME live session over
+`RTCDataChannel`. Design doc: "a generic fragment-injected static page reusing the protocol + IAgentDriver, swapping
+WebSocket for RTCDataChannel; pairing UX (open link/scan → pairing → connected)."
+
+Under **local == remote** (REMOTE-006), the paired browser is the session OWNER — it must reach parity with the local
+TUI: observe the stream AND answer the owner's own permission/ask prompts (the REMOTE-007 render+answer the design doc
+deferred to this stage).
+
+## Problem (grounded)
+
+Everything the browser needs on the wire exists; **no browser peer speaks it**:
+
+1. **No browser answerer.** The host is the offerer (`webrtc-transport.ts` creates the data channel + offer). No
+   browser code answers an offer over a native `RTCPeerConnection` (the host uses werift; the browser must use the
+   platform `RTCPeerConnection` — `agent-transport-webrtc` is node/werift-only, not reusable in-browser).
+2. **No browser signaling client.** `WsSignalingClient` (`agent-transport-webrtc/src/ws-signaling-client.ts:13`) imports
+   `ws` (npm) + uses node `.on(...)` — **node-only** (its own header says the browser implements `ISignalingClient` on
+   native `WebSocket`, Stage D). The relay frames are join/joined/signal/error (`apps/remote-signaling/src/relay.ts`).
+3. **No browser pairing-responder wiring.** `agent-remote-pairing` is fully isomorphic (WebCrypto; `parsePairingUrl`,
+   `startPairingHandshake({role:'responder'})`, `extractDtlsFingerprint`, confirmations all browser-safe —
+   `isomorphic.test.ts`), but nothing runs the responder side over a browser data channel. The exact algorithm is
+   already proven in Node in `agent-transport-webrtc/src/__tests__/pairing-e2e.test.ts:45-105` — Stage D is the browser
+   version (phase-separate pairing vs. session frames; expose the session only post-accept).
+4. **Connection abstraction is WebSocket-bound.** `agent-web-ui`'s `ws-session-client.ts:52` does `new WebSocket(url)`
+   and exposes `{onMessage, onStatusChange, send}`; `useWsSession.ts` reconstructs conversation state from
+   `TServerMessage`. This is the reuse target — the single swap point is the socket → an `RTCDataChannel`.
+5. **No fragment entry.** The SPA (`agent-web-ui/spa/main.tsx`) reads a `ws://` URL from a `<meta>` tag (server-injected)
+   — there is NO `parsePairingUrl(window.location.href)` / hash read anywhere. The pairing secret lives in the URL
+   **fragment** (never sent to the page's host) and must be read client-side.
+6. **Web UI can't answer prompts.** `useWsSession.ts` handles `messages/text_delta/tool_*/complete/...` but NOT the
+   REMOTE-007 `permission_request`/`ask_request`/`prompt_resolved` server messages — the deferred permission render.
+7. **`clientUrl` is a placeholder.** `remote-control-controller.ts` defaults `DEFAULT_CLIENT_URL = 'robota-remote://pair'`
+   (a non-existent scheme). Stage D IS the page `transports.webrtc.options.clientUrl` should point at.
+
+## Solution (sub-sequenced, each commit green)
+
+The browser WebRTC/signaling/pairing/session-client code lives in **`agent-web-ui`** (the browser home — it already
+owns the Vite SPA, the ws client, the React reducer, and `SessionMonitor`). It gains one new dep: the isomorphic
+zero-dep `agent-remote-pairing` leaf. It does NOT depend on `agent-transport-webrtc` (node/werift). All new browser
+transport code uses the platform `RTCPeerConnection`/`WebSocket`.
+
+1. **Browser signaling client (`ISignalingClient` over native `WebSocket`).** Mirror `WsSignalingClient` but drop the
+   `ws` import and node `.on()` API — use `socket.onopen/onmessage/onerror/onclose`; same join/joined/signal/error frames
+   - pre-open outbox buffering. Unit-testable with a fake `WebSocket`.
+2. **Browser answerer + pairing responder + data-channel session client (`createRtcSessionClient`).** A new client with
+   the SAME `{ onMessage(TServerMessage), onStatusChange, send(TClientMessage) }` contract as `createWsSessionClient`,
+   backed by a native `RTCPeerConnection` (answerer): on `offer` → setRemoteDescription → createAnswer → setLocalDescription
+   → send answer; capture the host fingerprint from the offer SDP and the local from the answer SDP (`extractDtlsFingerprint`);
+   the data channel arrives via `ondatachannel`. Run `startPairingHandshake({ secret, role:'responder', localFingerprint,
+remoteFingerprint, send })` over the channel, **phase-separated**: pre-accept route inbound to `controller.onFrame`
+   (drop non-pairing), and only on `controller.result` accept switch routing to `onMessage(TServerMessage)` and allow
+   `send(TClientMessage)` (mirrors the host gate + the Node responder). Reject/timeout → status `failed`, expose nothing.
+3. **Fragment-injected SPA entry + pairing UX.** A new SPA entry that calls `parsePairingUrl(window.location.href)` →
+   `{ rendezvous, secret }`, builds the signaling client + `createRtcSessionClient`, and renders the pairing-UX states
+   (reading link → connecting/pairing → connected → failed). Feed the existing `useWsSession` reducer + `SessionMonitor`
+   from the RTC client (the reducer is transport-agnostic — `TServerMessage` in). Static, no server state; hostable anywhere.
+4. **REMOTE-007 permission/ask render+answer (deferred item, now home).** Extend `useWsSession` to handle
+   `permission_request`/`ask_request` (render a prompt) and `prompt_resolved` (dismiss), and send `permission-response`/
+   `ask-response` `TClientMessage`s — so the paired browser owner answers their OWN prompts (local == remote). This
+   works over BOTH the WS client (agent-web-ui's existing localhost path) and the new RTC client (same `TServerMessage`s).
+5. **`clientUrl` fail-closed (remove the fabricated default) + verify.** DELETE `DEFAULT_CLIENT_URL = 'robota-remote://pair'`
+   (`remote-control-controller.ts:27,113`) — a live no-fallback violation REMOTE-008 shipped that mints a link going
+   nowhere. When `transports.webrtc.options.clientUrl` is unset, `enable()` returns a surfaced error ("set clientUrl to
+   your hosted Stage-D page") and does NOT construct/start the transport — an early return like the existing "no active
+   session yet" path (`:77`), leaving `status` untouched (no new status-enum variant). Document setting `clientUrl` to
+   the hosted Stage-D page. Wire the SPA build + a smoke E2E.
+
+## Affected Files
+
+- `agent-web-ui/src/client/**` (NEW: `rtc-signaling-client.ts` browser `ISignalingClient`; `rtc-session-client.ts`
+  `createRtcSessionClient` = answerer + pairing responder + data-channel session client) + `package.json` (add
+  `agent-remote-pairing` dep)
+- `agent-web-ui/src/hooks/useWsSession.ts` (handle `permission_request`/`ask_request`/`prompt_resolved`; send
+  `permission-response`/`ask-response`) + a prompt component in `components/`
+- `agent-web-ui/spa/**` (NEW fragment-injected entry + pairing-UX shell) + `vite.spa.config.ts`/build wiring
+- `agent-web-ui/docs/SPEC.md`
+- `agent-cli/src/remote-control/remote-control-controller.ts` (DELETE `DEFAULT_CLIENT_URL`; when `clientUrl` unset,
+  `enable()` returns a surfaced error string and does NOT construct/start the transport — exactly like the existing
+  "no active session yet" early-return at `:77`, leaving `status` untouched; NO new status-enum variant, so no
+  `agent-framework` enum / `agent-command` renderer churn) + controller tests
+- `agent-web-ui/src/__tests__/**` (fingerprint-parity gate: `extractDtlsFingerprint` over a real native-browser answer
+  SDP fixture == the host-verified value; reuse the werift offer fixture)
+- changeset
+
+## Decisions (resolved at GATE-APPROVAL round 1)
+
+- **D1 — placement in `agent-web-ui`** (adds only the zero-dep `agent-remote-pairing` leaf; no cycle). The browser
+  session client is contract-coupled to the React reducer + WS client already there; `./client` browser subpath is the
+  home. **HARD: no `agent-transport-webrtc`/werift edge** — the browser uses the platform `RTCPeerConnection`.
+- **D2 — mirror `createWsSessionClient`'s `{onMessage,onStatusChange,send}` contract** (single honest swap point socket →
+  data channel), NOT the node `IAgentDriver` (a node/test contract the web UI doesn't consume).
+- **D3 — include the REMOTE-007 permission/ask render+answer in Stage D** — a CORRECTNESS requirement, not convenience:
+  under local == remote the paired browser is the OWNER; an owner that can't answer its own prompts deadlocks a gated
+  tool. Landing it in the shared `TServerMessage` reducer serves BOTH the WS and RTC clients at once.
+- **D4 — jsdom + fake `RTCPeerConnection`/`WebSocket`**, pairing crypto UNMOCKED (`agent-remote-pairing` real), Node
+  responder (`pairing-e2e.test.ts`) as the oracle. No headed-browser E2E.
+- **D5 — remove the fabricated `DEFAULT_CLIENT_URL` (no-fallback fix).** DELETE `robota-remote://pair`
+  (`remote-control-controller.ts:27,113`); when `clientUrl` is unset, `enable()` returns a surfaced error string and
+  does NOT construct/start the transport — an early return like the existing "no active session yet" path (`:77`),
+  leaving `status` untouched. **No new status-enum variant** (reviewer option A — avoids `agent-framework` enum SSOT +
+  `agent-command` renderer churn; a static config error is surfaced at enable time, not a persistent queryable state).
+  Closes a live no-fallback violation REMOTE-008 shipped: never mint a dead `robota-remote://pair` link.
+- **D6 — fingerprint parity is a GATING security test (not an open question).** `extractDtlsFingerprint` takes the first
+  `a=fingerprint` + uppercases; native browser SDP may carry session- + media-level lines / lowercase. A RED test
+  asserts extraction over a **real native-browser answer SDP fixture** yields the host-verified value (cross-checked vs
+  werift's advertised fp / the existing `packages/agent-remote-pairing/src/__tests__/fixtures/werift-offer.sdp`). The channel binding only holds if these
+  match. (TOFU reconnect is Stage E, out of scope.)
+
+## Test Plan
+
+RED→GREEN. Unit: the browser signaling client (fake `WebSocket`: join → buffered outbox → signal round-trip);
+`createRtcSessionClient` pairing wiring (fake `RTCPeerConnection`/channel + real `agent-remote-pairing`: answer the
+offer, run the responder handshake, expose the session ONLY post-accept, drop pre-accept non-pairing frames, `failed` on
+reject) — using the Node responder in `pairing-e2e.test.ts` as the algorithm oracle. **Fingerprint-parity gate (D6):**
+`extractDtlsFingerprint` over a real native-browser answer SDP fixture equals the host-verified value. `useWsSession`
+reducer: a `permission_request` renders a prompt and answering sends `permission-response`; `prompt_resolved` dismisses.
+Controller: unset `clientUrl` fails closed (no dead link). Build: the new SPA entry compiles + `parsePairingUrl` reads
+the fragment. harness:scan + full typecheck + changeset.
+
+## Evidence Log
+
+- 2026-07-11 GATE-DRAFT — authored from an 8-point read-only Explore. Grounding: `agent-remote-pairing` fully isomorphic
+  (browser-ready); `agent-web-ui` is the reuse target (`ws-session-client.ts:52` `new WebSocket(url)` is the swap point,
+  `useWsSession.ts` is the transport-agnostic `TServerMessage` reducer, Vite SPA build exists); `WsSignalingClient` is
+  node-only (`ws` import); no browser answerer/signaling/pairing/fragment-entry exists; `useWsSession` doesn't yet handle
+  the REMOTE-007 prompt messages; `agent-remote-client` (despite the name) is a node HTTP `IExecutor` — NOT a Stage-D
+  target. The Node responder in `pairing-e2e.test.ts:45-105` is the exact browser algorithm. Pending proposal-reviewer ENDORSE.
+- 2026-07-11 GATE-APPROVAL round 1 — proposal-reviewer **REVISE** (direction correct; all 6 recommendations verified +
+  adopted as D1–D6; every premise TRUE against source, incl. `agent-remote-pairing` zero-dep isomorphic, `agent-web-ui`
+  the reuse target, `WsSignalingClient` node-only, `useWsSession` missing the 3 prompt messages, the Node responder as
+  oracle). Two required changes folded in: **D5** — the spec now commits to DELETING the fabricated
+  `DEFAULT_CLIENT_URL='robota-remote://pair'` and failing closed on unset `clientUrl` (a live no-fallback violation
+  REMOTE-008 shipped, not to be carried forward); **D6** — fingerprint-parity reclassified from open question to a
+  gating security test (real native-browser answer SDP fixture == host-verified fp). Security design ENDORSED
+  (directional binding, expose-only-post-accept, phase separation, secret in fragment). Re-review → round 2.
+- 2026-07-11 GATE-APPROVAL round 2 — proposal-reviewer **REVISE**. Confirmed both round-1 fixes landed (D5 delete +
+  fail-closed; D6 gating fingerprint test; `DEFAULT_CLIENT_URL='robota-remote://pair'` verified live at
+  `remote-control-controller.ts:27,113`; `werift-offer.sdp` fixture exists). ONE new inconsistency my round-2 edit
+  introduced: a half-committed "new `no-client` status/message" phrase in Affected Files would need the
+  `TRemoteControlStatus` enum SSOT (`agent-framework/command-api/host-adapters.ts`) + the `formatStatus` renderer
+  (`agent-command/.../remote-control-command.ts`, which else silently falls to "unknown") — neither in scope. Adopted
+  reviewer **option A**: unset `clientUrl` → `enable()` returns a surfaced error + does NOT enable (early return like the
+  existing "no active session yet" path at `:77`), leaving `status` untouched — NO new enum variant, no
+  agent-framework/agent-command churn. Aligned D5, Solution step 5, Affected Files, Test Plan. Fixed the
+  `werift-offer.sdp` fixture path. Re-review → round 3.
+- 2026-07-11 GATE-APPROVAL round 3 — proposal-reviewer **ENDORSE**. Option A verified consistently applied across D5,
+  Solution step 5, Affected Files, Test Plan (delete `DEFAULT_CLIENT_URL`; unset `clientUrl` → error string + no
+  construct/start, early return like `:77`, status untouched, no new enum variant, no agent-framework/agent-command
+  churn); the `:77` "no active session yet" early-return + the `:27,113` default + the `werift-offer.sdp` fixture all
+  verified TRUE; D1–D4/D6 coherent; no remaining contradiction. Note: the `clientUrl` check must move ahead of the
+  current `:113` read to before transport construction (the spec's "early return" captures this). **GATE-APPROVAL
+  cleared** → status in-progress, spec to active, implement on an `origin/develop`-based branch, Step 1 first.
+
+## Tasks
+
+- [ ] Step 1 — browser signaling client `rtc-signaling-client.ts` (`ISignalingClient` over native `WebSocket`;
+      join/joined/signal/error + pre-open outbox buffering). Unit tests with a fake `WebSocket`.
+- [ ] Step 2 — `createRtcSessionClient` (native `RTCPeerConnection` answerer + `startPairingHandshake('responder')` over
+      the data channel; phase-separated routing switch, expose session ONLY post-accept, drop pre-accept non-pairing,
+      `failed` on reject; `{onMessage,onStatusChange,send}` contract mirroring `createWsSessionClient`) + the D6
+      fingerprint-parity gating test (native-answer SDP fixture == host-verified fp). Unit tests (fake RTCPeerConnection,
+      real agent-remote-pairing, Node responder oracle). + `agent-remote-pairing` dep.
+- [ ] Step 3 — fragment-injected SPA entry + pairing-UX shell (`parsePairingUrl(window.location.href)` → connecting →
+      pairing → connected → failed) feeding the existing `useWsSession` reducer + `SessionMonitor`. Vite build wiring.
+- [ ] Step 4 — REMOTE-007 render+answer in `useWsSession`: handle `permission_request`/`ask_request`/`prompt_resolved`,
+      send `permission-response`/`ask-response` + a prompt component. Reducer unit tests (works for WS + RTC clients).
+- [ ] Step 5 — D5 fail-closed: delete `DEFAULT_CLIENT_URL`, unset `clientUrl` → error string early-return (no
+      construct/start) + controller test. `agent-web-ui/docs/SPEC.md` + `clientUrl` guidance.
+- [ ] Step 6 — verify: harness:scan + full typecheck + changeset.

--- a/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
+++ b/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
@@ -189,3 +189,12 @@ the fragment. harness:scan + full typecheck + changeset.
   `spa/remote.html` fragment entry (both SPA entries build). No `agent-transport-webrtc`/werift edge (only the zero-dep
   `agent-remote-pairing` leaf added). Verify: agent-web-ui 36, agent-cli 178, harness:scan 49/49, full-repo typecheck 0,
   changeset present, agent-web-ui SPEC public-API table updated. Ready for implementation review + merge-verifier.
+- 2026-07-11 GATE-REVIEW (implementation) — proposal-reviewer **ENDORSE**. Security-critical core verified: no path
+  delivers a `TServerMessage` to the reducer (or sends a `TClientMessage`) before a genuine channel-bound
+  confirmation; `accept()` reachable only via the crypto `result`; fail-closed on reject/timeout/missing-fingerprint;
+  directional binding correct (host fp←offer, local fp←answer); D6 cross-dialect fingerprint parity real; secret only
+  in the fragment (never query/relay); dependency direction clean (only agent-remote-pairing added, no werift edge);
+  D5 fail-closed early-return before any construction. 3 non-blocking notes: fixed the stale `clientUrl` JSDoc; the
+  post-accept `TServerMessage` cast is safe (host cryptographically authenticated + reducer ignores unknown types);
+  the responder-nonce send starts synchronously in `ondatachannel` (safe — answerer's channel is open when the event
+  fires; fails closed via timeout if not) — flagged for a Stage-E headed-browser check. Ready for merge feature→develop→main.

--- a/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
+++ b/.agents/spec-docs/active/REMOTE-009-stage-d-browser-remote-client.md
@@ -164,17 +164,28 @@ the fragment. harness:scan + full typecheck + changeset.
 
 ## Tasks
 
-- [ ] Step 1 — browser signaling client `rtc-signaling-client.ts` (`ISignalingClient` over native `WebSocket`;
+- [x] Step 1 — browser signaling client `rtc-signaling-client.ts` (`ISignalingClient` over native `WebSocket`;
       join/joined/signal/error + pre-open outbox buffering). Unit tests with a fake `WebSocket`.
-- [ ] Step 2 — `createRtcSessionClient` (native `RTCPeerConnection` answerer + `startPairingHandshake('responder')` over
+- [x] Step 2 — `createRtcSessionClient` (native `RTCPeerConnection` answerer + `startPairingHandshake('responder')` over
       the data channel; phase-separated routing switch, expose session ONLY post-accept, drop pre-accept non-pairing,
       `failed` on reject; `{onMessage,onStatusChange,send}` contract mirroring `createWsSessionClient`) + the D6
       fingerprint-parity gating test (native-answer SDP fixture == host-verified fp). Unit tests (fake RTCPeerConnection,
       real agent-remote-pairing, Node responder oracle). + `agent-remote-pairing` dep.
-- [ ] Step 3 — fragment-injected SPA entry + pairing-UX shell (`parsePairingUrl(window.location.href)` → connecting →
+- [x] Step 3 — fragment-injected SPA entry + pairing-UX shell (`parsePairingUrl(window.location.href)` → connecting →
       pairing → connected → failed) feeding the existing `useWsSession` reducer + `SessionMonitor`. Vite build wiring.
-- [ ] Step 4 — REMOTE-007 render+answer in `useWsSession`: handle `permission_request`/`ask_request`/`prompt_resolved`,
+- [x] Step 4 — REMOTE-007 render+answer in `useWsSession`: handle `permission_request`/`ask_request`/`prompt_resolved`,
       send `permission-response`/`ask-response` + a prompt component. Reducer unit tests (works for WS + RTC clients).
-- [ ] Step 5 — D5 fail-closed: delete `DEFAULT_CLIENT_URL`, unset `clientUrl` → error string early-return (no
+- [x] Step 5 — D5 fail-closed: delete `DEFAULT_CLIENT_URL`, unset `clientUrl` → error string early-return (no
       construct/start) + controller test. `agent-web-ui/docs/SPEC.md` + `clientUrl` guidance.
-- [ ] Step 6 — verify: harness:scan + full typecheck + changeset.
+- [x] Step 6 — verify: harness:scan + full typecheck + changeset.
+- 2026-07-11 GATE-BUILD — implemented on `feat/remote-009-browser-remote-client` (off origin/develop), all 6 steps
+  committed. Step 1 `createRtcSignalingClient` (native WebSocket, 8 tests); Step 2 `ResponderGate` (client dual of the
+  host PairingGate — fail-closed routing switch, 8 tests) + `createRtcSessionClient` (answerer glue, 2 tests) + D6
+  fingerprint-parity gate (werift session-level uppercase == native media-level lowercase → identical canonical fp, 4
+  tests); Step 4 `useWsSession` permission/ask render+answer via a pure `prompt-state` module (6 tests) — REMOTE-007's
+  deferred web render, shared by WS + RTC; Step 5 deleted `DEFAULT_CLIENT_URL`, unset `clientUrl` fails closed (early
+  return, status untouched; +controller test); Step 3 hook generalized to `useSessionClient(makeClient)` +
+  `useWsSession`/`useRtcSession` wrappers, `parseRemoteClientLocation` (4 tests), `RemoteClient`/`PermissionPrompt`,
+  `spa/remote.html` fragment entry (both SPA entries build). No `agent-transport-webrtc`/werift edge (only the zero-dep
+  `agent-remote-pairing` leaf added). Verify: agent-web-ui 36, agent-cli 178, harness:scan 49/49, full-repo typecheck 0,
+  changeset present, agent-web-ui SPEC public-API table updated. Ready for implementation review + merge-verifier.

--- a/.changeset/remote-009-browser-remote-client.md
+++ b/.changeset/remote-009-browser-remote-client.md
@@ -1,0 +1,14 @@
+---
+'@robota-sdk/agent-web-ui': minor
+'@robota-sdk/agent-cli': patch
+---
+
+Add the browser remote client (REMOTE-009 Stage D) — the P2P peer that opens the pairing URL and
+co-drives a live session over WebRTC. `agent-web-ui` gains a native-`WebSocket` signaling client, a
+fail-closed responder pairing gate (session exposed only after the DTLS-fingerprint-bound handshake
+accepts), an RTC data-channel session client with the same contract as the WS client, a
+fragment-injected `spa/remote.html` static entry, and the REMOTE-007 permission/ask render+answer
+(the paired owner answers its own prompts — local == remote) shared by both the WS and RTC clients. It
+reuses the isomorphic `@robota-sdk/agent-remote-pairing` leaf and takes no node/werift dependency.
+`agent-cli` removes the fabricated `robota-remote://pair` client-URL default and fails closed when
+`transports.webrtc.options.clientUrl` is unset (no dead link).

--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
@@ -91,6 +91,17 @@ describe('RemoteControlController (REMOTE-008)', () => {
     expect(status.state).toBe('awaiting-pairing');
   });
 
+  it('D5: unset clientUrl fails closed — reports, constructs/starts nothing, status untouched (no dead link)', async () => {
+    const createTransport = vi.fn();
+    const { deps, registered } = makeDeps({ readClientUrl: () => undefined, createTransport });
+    const controller = new RemoteControlController(deps);
+    const msg = await controller.enable();
+    expect(msg).toMatch(/clientUrl/);
+    expect(createTransport).not.toHaveBeenCalled();
+    expect(registered).toHaveLength(0);
+    expect(controller.getStatus()).toEqual({ state: 'off' }); // untouched (no new enum variant)
+  });
+
   it('enable with no session yet → reports and constructs nothing', async () => {
     const createTransport = vi.fn();
     const { deps } = makeDeps({ getSession: () => undefined, createTransport });

--- a/packages/agent-cli/src/remote-control/remote-control-controller.ts
+++ b/packages/agent-cli/src/remote-control/remote-control-controller.ts
@@ -23,9 +23,6 @@ import type {
  * or start failure ⇒ report the error and stay off.
  */
 
-/** Fallback client base when none is configured — a custom scheme a future browser client registers. */
-const DEFAULT_CLIENT_URL = 'robota-remote://pair';
-
 export interface IRemoteControlControllerDeps {
   /** The full transport registry (needs `register`, so not the view). */
   registry: TransportRegistry;
@@ -76,6 +73,16 @@ export class RemoteControlController {
     const session = this.deps.getSession();
     if (!session) return 'Remote control: no active session yet — try again in a moment.';
 
+    // REMOTE-009 D5: a pairing link needs a hosted browser client. Fail closed BEFORE constructing/starting
+    // the transport when `clientUrl` is unset — never mint a link that goes nowhere (no fabricated default).
+    const clientUrl = this.deps.readClientUrl();
+    if (!clientUrl) {
+      return (
+        'Remote control needs a browser client page. Set `transports.webrtc.options.clientUrl` ' +
+        'in ~/.robota/settings.json to your hosted Stage-D page (`@robota-sdk/agent-web-ui`).'
+      );
+    }
+
     const pairing = generatePairingSecret();
     const signaling = (this.deps.createSignaling ?? defaultCreateSignaling)(
       relayUrl,
@@ -110,7 +117,6 @@ export class RemoteControlController {
 
     this.transport = transport;
     this.signaling = signaling;
-    const clientUrl = this.deps.readClientUrl() ?? DEFAULT_CLIENT_URL;
     const pairingUrl = toPairingUrl(clientUrl, pairing);
     this.status = { state: 'awaiting-pairing', pairingUrl };
     return this.renderPairingMessage(pairingUrl);

--- a/packages/agent-cli/src/remote-control/remote-control-controller.ts
+++ b/packages/agent-cli/src/remote-control/remote-control-controller.ts
@@ -28,7 +28,7 @@ export interface IRemoteControlControllerDeps {
   registry: TransportRegistry;
   /** Signaling relay URL (`transports.webrtc.options.relayUrl`), or undefined when unconfigured. */
   readRelayUrl: () => string | undefined;
-  /** Client base URL for the pairing link (`transports.webrtc.options.clientUrl`); defaults to a placeholder. */
+  /** Client base URL for the pairing link (`transports.webrtc.options.clientUrl`); unset ⇒ enable fails closed (REMOTE-009 D5). */
   readClientUrl: () => string | undefined;
   /** The live interactive session to expose on pairing accept, or undefined before one is ready. */
   getSession: () => IInteractiveSession | undefined;

--- a/packages/agent-web-ui/docs/SPEC.md
+++ b/packages/agent-web-ui/docs/SPEC.md
@@ -8,6 +8,20 @@ session over WebSocket. Provides a connection hook (`useWsSession`), a conversat
 widget (`SessionMonitor`) that applications can embed without importing from any other
 `@robota-sdk/*` package.
 
+**REMOTE-009 Stage D — browser remote client.** The package is also the P2P remote peer: it opens the
+pairing URL, answers the host's WebRTC offer over a **native** `RTCPeerConnection`, runs the pairing
+handshake as RESPONDER over the data channel, and co-drives the SAME session — swapping WebSocket for
+`RTCDataChannel`. The session hook is parameterized (`useSessionClient(makeClient)`) with two thin
+wrappers: `useWsSession(url)` (localhost) and `useRtcSession({relayUrl,rendezvous,secret})` (Stage D).
+The RTC path adds `createRtcSignalingClient` (native-`WebSocket` `ISignalingClient`), `ResponderGate`
+(fail-closed pairing routing switch — session exposed ONLY post-accept, dropped pre-accept non-pairing),
+`createRtcSessionClient` (answerer + gate + session client), `parseRemoteClientLocation` (relay ← query,
+secret ← fragment), and the `spa/remote.html` fragment-injected static entry (`RemoteClient`). It reuses
+the isomorphic zero-dep `@robota-sdk/agent-remote-pairing` leaf and takes **no** `agent-transport-webrtc`
+(node/werift) dependency. The permission/ask render+answer (`useWsSession` handles
+`permission_request`/`ask_request`/`prompt_resolved`, `PermissionPrompt` component) serves BOTH the WS and
+RTC clients — the paired owner answers its OWN prompts (local == remote).
+
 This package sits in the **Product shells** layer. It is a pure browser UI library — it does not
 own session lifecycle, conversation history, or agent runtime state.
 
@@ -24,10 +38,18 @@ share a name prefix but are different layers: this package is a library; the app
   `agent-framework`, `agent-session`, `agent-executor`.
 - Does NOT own `agent-core` types directly — protocol message types come from `agent-transport-protocol`.
 - Does NOT own the CLI sidecar server — that is `agent-cli` (`startWebSidecarServer`).
+- Does NOT own the pairing CRYPTO — the directional-HMAC handshake + DTLS-fingerprint channel binding is the
+  isomorphic zero-dep `@robota-sdk/agent-remote-pairing` leaf (the only REMOTE-009 dep added). Owns the browser
+  responder GATE + answerer glue. Takes **no** `agent-transport-webrtc`/werift dependency (that is node-only).
 - OWNS: browser WebSocket client lifecycle (`IWsSessionClient`, reconnect logic).
-- OWNS: React state reconstruction from `TServerMessage` events (`useWsSession`).
-- OWNS: React components `SessionMonitor`, `ConversationView`, and `AgentActivityPanel`.
-- OWNS: `TConnectionStatus` type (`disconnected | connecting | connected | error`).
+- OWNS: browser WebRTC remote client (REMOTE-009): `createRtcSignalingClient`, `ResponderGate`,
+  `createRtcSessionClient`, `parseRemoteClientLocation`, `RemoteClient`/`PermissionPrompt`, the `spa/remote.html`
+  entry, and the `useSessionClient`/`useRtcSession` hooks.
+- OWNS: React state reconstruction from `TServerMessage` events (`useSessionClient`), incl. the REMOTE-007
+  permission/ask prompt state (`applyPromptEvent`) for BOTH transports.
+- OWNS: React components `SessionMonitor`, `ConversationView`, `AgentActivityPanel`, `RemoteClient`, `PermissionPrompt`.
+- OWNS: `TConnectionStatus` (`disconnected | connecting | connected | error`) + `TRtcConnectionStatus`
+  (adds `pairing | failed`) + `TSessionStatus` (their union).
 - OWNS: `IWsSessionClientCallbacks` callback contract for `createWsSessionClient`.
 
 ## Architecture Overview
@@ -75,16 +97,25 @@ package.
 
 ## Public API Surface
 
-| Export                 | Kind      | Description                                                                                              |
-| ---------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| `SessionMonitor`       | component | Self-contained monitor widget; accepts `wsUrl` prop for the CLI sidecar WebSocket                        |
-| `ConversationView`     | component | Pure conversation renderer; accepts messages, activeTools, streamingText, isThinking                     |
-| `AgentActivityPanel`   | component | Background-task monitor panel; accepts `tasks: readonly IExecutionWorkspaceEntry[]` (exported from root) |
-| `useWsSession`         | hook      | React hook managing WebSocket connection and reconstructing session state                                |
-| `IConversationMessage` | type      | Reconstructed message shape for display                                                                  |
-| `IActiveTool`          | type      | Active tool call display state                                                                           |
-| `IWsSessionState`      | type      | Full hook return type including `executionWorkspace: IExecutionWorkspaceSnapshot \| null`                |
-| `TConnectionStatus`    | type      | WebSocket lifecycle status enum                                                                          |
+| Export                      | Kind      | Description                                                                                              |
+| --------------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `SessionMonitor`            | component | Self-contained monitor widget; accepts `wsUrl` prop for the CLI sidecar WebSocket                        |
+| `ConversationView`          | component | Pure conversation renderer; accepts messages, activeTools, streamingText, isThinking                     |
+| `AgentActivityPanel`        | component | Background-task monitor panel; accepts `tasks: readonly IExecutionWorkspaceEntry[]` (exported from root) |
+| `useWsSession`              | hook      | React hook managing WebSocket connection and reconstructing session state                                |
+| `useSessionClient`          | hook      | Core session hook parameterized by a client factory (WS or RTC); reconstructs state + prompt handling    |
+| `useRtcSession`             | hook      | REMOTE-009 Stage D: React hook for the WebRTC remote client (`{relayUrl,rendezvous,secret}`)             |
+| `RemoteClient`              | component | REMOTE-009 Stage D root: reads the pairing URL, pairs over WebRTC, renders the session + prompts         |
+| `PermissionPrompt`          | component | Renders the owner's pending permission/ask prompts + answer buttons (REMOTE-007 render+answer)           |
+| `createRtcSessionClient`    | function  | Browser WebRTC answerer + pairing responder + data-channel session client (REMOTE-009)                   |
+| `createRtcSignalingClient`  | function  | Browser `ISignalingClient` over the native `WebSocket` (REMOTE-009)                                      |
+| `parseRemoteClientLocation` | function  | Parse the Stage-D page URL: relay ← query, rendezvous + secret ← fragment (REMOTE-009)                   |
+| `IConversationMessage`      | type      | Reconstructed message shape for display                                                                  |
+| `TPendingPrompt`            | type      | A pending permission/ask prompt awaiting the owner's answer (REMOTE-007/009)                             |
+| `TSessionStatus`            | type      | Union of the WS + RTC connection statuses                                                                |
+| `IActiveTool`               | type      | Active tool call display state                                                                           |
+| `IWsSessionState`           | type      | Full hook return type including `executionWorkspace: IExecutionWorkspaceSnapshot \| null`                |
+| `TConnectionStatus`         | type      | WebSocket lifecycle status enum                                                                          |
 
 ## Extension Points
 

--- a/packages/agent-web-ui/package.json
+++ b/packages/agent-web-ui/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@robota-sdk/agent-interface-transport": "workspace:*",
+    "@robota-sdk/agent-remote-pairing": "workspace:*",
     "@robota-sdk/agent-transport-protocol": "workspace:*",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"

--- a/packages/agent-web-ui/spa/remote.html
+++ b/packages/agent-web-ui/spa/remote.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Robota Remote</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./remote.tsx"></script>
+  </body>
+</html>

--- a/packages/agent-web-ui/spa/remote.tsx
+++ b/packages/agent-web-ui/spa/remote.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import { RemoteClient } from '../src/components/RemoteClient.js';
+import './main.css';
+
+// REMOTE-009 Stage D: the browser remote client. Connection inputs come from THIS page's URL —
+// the relay from the `?relay=` query, the rendezvous + secret from the `#` fragment (the secret never
+// leaves the browser). No server-injected config.
+const rootEl = document.getElementById('root');
+if (!rootEl) throw new Error('No #root element');
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <div className="h-screen w-screen overflow-hidden">
+      <RemoteClient />
+    </div>
+  </React.StrictMode>,
+);

--- a/packages/agent-web-ui/src/client/__tests__/fingerprint-parity.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/fingerprint-parity.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { extractDtlsFingerprint } from '@robota-sdk/agent-remote-pairing';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * REMOTE-009 D6 — GATING security test: DTLS-fingerprint extraction PARITY across SDP dialects.
+ *
+ * The pairing channel binding only holds if the host (werift) and the browser (native `RTCPeerConnection`)
+ * extract the SAME normalized fingerprint from the SAME `a=fingerprint` line. werift emits a session-level,
+ * uppercase line; native browsers emit a media-level line, often lowercase. `extractDtlsFingerprint` must
+ * normalize both to one canonical value — otherwise the directional-HMAC confirmation fails for honest peers.
+ *
+ * This test uses the werift host offer fixture (`agent-remote-pairing/.../fixtures/werift-offer.sdp`) and a
+ * realistic native-browser data-channel answer fixture that carries the SAME fingerprint hex in the native
+ * dialect (media-level, lowercase). Parity ⇒ both extractions yield the identical string.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** The werift offer fixture is owned by agent-remote-pairing (the isomorphic pairing leaf); reuse it. */
+const WERIFT_OFFER = join(
+  __dirname,
+  '../../../../agent-remote-pairing/src/__tests__/fixtures/werift-offer.sdp',
+);
+const NATIVE_ANSWER = join(__dirname, 'fixtures/native-browser-answer.sdp');
+
+const EXPECTED =
+  'E9:A0:10:9D:94:1C:0A:FC:FE:76:D3:0A:B8:FB:2C:7C:82:E0:A3:83:FF:22:78:62:9B:C3:82:1F:2C:CC:25:A3';
+
+describe('DTLS fingerprint extraction parity (REMOTE-009 D6)', () => {
+  it('extracts the werift host offer fingerprint (session-level, uppercase)', () => {
+    expect(extractDtlsFingerprint(readFileSync(WERIFT_OFFER, 'utf8'))).toBe(EXPECTED);
+  });
+
+  it('extracts a native-browser answer fingerprint (media-level, LOWERCASE) to the same canonical form', () => {
+    const fp = extractDtlsFingerprint(readFileSync(NATIVE_ANSWER, 'utf8'));
+    expect(fp).toBe(EXPECTED); // normalized identically to the werift dialect → channel binding holds
+    expect(fp).toBe(fp.toUpperCase()); // canonical uppercase
+  });
+
+  it('parity: the browser and host extract the SAME string from the two dialects', () => {
+    const hostSide = extractDtlsFingerprint(readFileSync(WERIFT_OFFER, 'utf8'));
+    const browserSide = extractDtlsFingerprint(readFileSync(NATIVE_ANSWER, 'utf8'));
+    expect(browserSide).toBe(hostSide);
+  });
+
+  it('throws on an SDP with no a=fingerprint line (fail-closed, never a silent empty binding)', () => {
+    expect(() => extractDtlsFingerprint('v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\n')).toThrow();
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/fixtures/native-browser-answer.sdp
+++ b/packages/agent-web-ui/src/client/__tests__/fixtures/native-browser-answer.sdp
@@ -1,0 +1,17 @@
+v=0
+o=- 4611731400430051336 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=extmap-allow-mixed
+a=msid-semantic: WMS
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=ice-ufrag:4ZcD
+a=ice-pwd:by6Vq6C7lp8vT8f1Sv1sQ0aP
+a=ice-options:trickle
+a=fingerprint:sha-256 e9:a0:10:9d:94:1c:0a:fc:fe:76:d3:0a:b8:fb:2c:7c:82:e0:a3:83:ff:22:78:62:9b:c3:82:1f:2c:cc:25:a3
+a=setup:active
+a=mid:0
+a=sctp-port:5000
+a=max-message-size:262144

--- a/packages/agent-web-ui/src/client/__tests__/parse-remote-location.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/parse-remote-location.test.ts
@@ -1,0 +1,42 @@
+import { toPairingUrl } from '@robota-sdk/agent-remote-pairing';
+import { describe, expect, it } from 'vitest';
+
+import { parseRemoteClientLocation } from '../parse-remote-location.js';
+
+/**
+ * REMOTE-009 Step 3 — the Stage-D page reads relay ← query, rendezvous + secret ← fragment. Round-trips a
+ * real `toPairingUrl` output (the fragment the host mints) to prove the browser reads back what the host wrote.
+ */
+
+describe('parseRemoteClientLocation (REMOTE-009)', () => {
+  it('round-trips a toPairingUrl link: relay from query, r+s from the fragment', () => {
+    const pairing = { rendezvous: 'rv-abc', secret: 'sec-xyz-256bit' };
+    // The operator configures clientUrl with the relay query param; toPairingUrl preserves it + appends #r&s.
+    const link = toPairingUrl('https://remote.example/?relay=wss%3A%2F%2Frelay.test', pairing);
+    const loc = parseRemoteClientLocation(link);
+    expect(loc).toEqual({
+      relayUrl: 'wss://relay.test',
+      rendezvous: 'rv-abc',
+      secret: 'sec-xyz-256bit',
+    });
+  });
+
+  it('keeps the secret in the fragment (never in the query the server would see)', () => {
+    const link = toPairingUrl('https://remote.example/?relay=wss://r', {
+      rendezvous: 'rv',
+      secret: 'TOP-SECRET',
+    });
+    // The server-visible part (before #) must not contain the secret.
+    const serverVisible = link.split('#')[0]!;
+    expect(serverVisible).not.toContain('TOP-SECRET');
+    expect(parseRemoteClientLocation(link).secret).toBe('TOP-SECRET');
+  });
+
+  it('throws when the relay query param is missing', () => {
+    expect(() => parseRemoteClientLocation('https://remote.example/#r=rv&s=sec')).toThrow(/relay/);
+  });
+
+  it('throws when the pairing fragment is missing', () => {
+    expect(() => parseRemoteClientLocation('https://remote.example/?relay=wss://r')).toThrow();
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/rtc-responder-gate.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/rtc-responder-gate.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ResponderGate, type IResponderGateOptions } from '../rtc-responder-gate.js';
+
+import type { startPairingHandshake, TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * REMOTE-009 Step 2 — the browser responder-side pairing gate's fail-closed routing switch, driven with a
+ * stub channel + injected handshake (no real RTCPeerConnection). Mirror of the host PairingGate tests.
+ */
+
+function makeHandshakeStub() {
+  const received: TPairingFrame[] = [];
+  let resolveResult!: (v: { sessionKey: string }) => void;
+  let rejectResult!: (e: Error) => void;
+  const start: typeof startPairingHandshake = (options) => {
+    options.send({ t: 'pair-nonce', nonce: 'stub' }); // responder emits its nonce on start
+    return {
+      result: new Promise<{ sessionKey: string }>((res, rej) => {
+        resolveResult = res;
+        rejectResult = rej;
+      }),
+      onFrame: (frame: TPairingFrame) => received.push(frame),
+    };
+  };
+  return {
+    start,
+    received,
+    accept: () => resolveResult({ sessionKey: 'k' }),
+    reject: () => rejectResult(new Error('x')),
+  };
+}
+
+function makeGate(over: Partial<IResponderGateOptions> = {}) {
+  const channelSends: string[] = [];
+  const channel = { send: (d: string) => channelSends.push(d), close: vi.fn() };
+  const onMessage = vi.fn();
+  const hs = makeHandshakeStub();
+  const gate = new ResponderGate({
+    channel,
+    secret: 's',
+    localFingerprint: 'AA',
+    remoteFingerprint: 'BB',
+    onMessage,
+    startHandshake: hs.start,
+    ...over,
+  });
+  return { gate, channel, channelSends, onMessage, hs };
+}
+
+describe('ResponderGate (REMOTE-009 — browser pairing responder, fail-closed)', () => {
+  it('does not deliver any session message before the handshake accepts', () => {
+    const { gate, onMessage } = makeGate();
+    gate.onInbound(JSON.stringify({ type: 'messages', messages: [] }));
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('serializes its handshake frames over the channel', () => {
+    const { channelSends } = makeGate();
+    expect(channelSends).toContain(JSON.stringify({ t: 'pair-nonce', nonce: 'stub' }));
+  });
+
+  it('pre-accept routes a pairing frame to the handshake and DROPS a non-pairing frame', () => {
+    const { gate, hs, onMessage } = makeGate();
+    gate.onInbound(JSON.stringify({ t: 'pair-confirm', mac: 'm' }));
+    expect(hs.received).toEqual([{ t: 'pair-confirm', mac: 'm' }]);
+    gate.onInbound(JSON.stringify({ type: 'messages', messages: [] })); // non-pairing pre-accept → dropped
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('post-accept delivers TServerMessages and allows send(TClientMessage)', async () => {
+    const { gate, hs, onMessage, channelSends } = makeGate();
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(JSON.stringify({ type: 'text_delta', delta: 'hi' }));
+    expect(onMessage).toHaveBeenCalledWith({ type: 'text_delta', delta: 'hi' } as TServerMessage);
+    gate.send({ type: 'submit', prompt: 'go' });
+    expect(JSON.parse(channelSends.at(-1)!)).toEqual({ type: 'submit', prompt: 'go' });
+  });
+
+  it('send is a no-op before accept (nothing leaks pre-pairing)', () => {
+    const { gate, channelSends } = makeGate();
+    const before = channelSends.length;
+    gate.send({ type: 'submit', prompt: 'x' });
+    expect(channelSends.length).toBe(before);
+  });
+
+  it('on reject: closes the channel and never delivers a session message', async () => {
+    const { gate, channel, hs, onMessage } = makeGate();
+    hs.reject();
+    await Promise.resolve();
+    expect(channel.close).toHaveBeenCalledTimes(1);
+    gate.onInbound(JSON.stringify({ type: 'messages', messages: [] }));
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('fires onAccept on accept and onReject on reject', async () => {
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+    const a = makeGate({ onAccept, onReject });
+    a.hs.accept();
+    await Promise.resolve();
+    expect(onAccept).toHaveBeenCalledTimes(1);
+
+    const b = makeGate({ onAccept: vi.fn(), onReject });
+    b.hs.reject();
+    await Promise.resolve();
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('close() is idempotent and stops delivery', async () => {
+    const { gate, hs, onMessage } = makeGate();
+    hs.accept();
+    await Promise.resolve();
+    gate.close();
+    gate.close();
+    gate.onInbound(JSON.stringify({ type: 'text_delta', delta: 'x' }));
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/rtc-session-client.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/rtc-session-client.test.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createRtcSessionClient, type TRtcConnectionStatus } from '../rtc-session-client.js';
+
+import type { ISignalMessage, ISignalingClient } from '../rtc-signaling.js';
+import type { startPairingHandshake, TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * REMOTE-009 Step 2 — `createRtcSessionClient` answerer glue: receive the host offer → create + send an
+ * answer (capturing fingerprints) → wire the data channel through the responder gate → expose the session
+ * only after pairing accepts. Driven with a fake signaling + fake `RTCPeerConnection` + injected handshake.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const NATIVE_ANSWER = readFileSync(join(__dirname, 'fixtures/native-browser-answer.sdp'), 'utf8');
+const OFFER_SDP =
+  'v=0\r\no=- 1 2 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=fingerprint:sha-256 AA:BB\r\n';
+
+/** A controllable fake native RTCPeerConnection (data-channel answerer). */
+function makeFakePeer() {
+  let dataHandler: ((e: { channel: unknown }) => void) | null = null;
+  const peer = {
+    onicecandidate: null as unknown,
+    set ondatachannel(h: (e: { channel: unknown }) => void) {
+      dataHandler = h;
+    },
+    setRemoteDescription: vi.fn().mockResolvedValue(undefined),
+    createAnswer: vi.fn().mockResolvedValue({ type: 'answer', sdp: NATIVE_ANSWER }),
+    setLocalDescription: vi.fn().mockResolvedValue(undefined),
+    localDescription: { type: 'answer', sdp: NATIVE_ANSWER },
+    addIceCandidate: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+  };
+  return { peer, fireDataChannel: (channel: unknown) => dataHandler?.({ channel }) };
+}
+
+function makeHandshakeStub() {
+  let resolveResult!: (v: { sessionKey: string }) => void;
+  const start: typeof startPairingHandshake = (options) => {
+    options.send({ t: 'pair-nonce', nonce: 'stub' });
+    return {
+      result: new Promise<{ sessionKey: string }>((res) => (resolveResult = res)),
+      onFrame: (_f: TPairingFrame) => {},
+    };
+  };
+  return { start, accept: () => resolveResult({ sessionKey: 'k' }) };
+}
+
+describe('createRtcSessionClient (REMOTE-009 Step 2)', () => {
+  it('answers the offer, pairs, and exposes the session only post-accept', async () => {
+    let onSignal: ((m: ISignalMessage) => void) | null = null;
+    const sentSignals: ISignalMessage[] = [];
+    const fakeSignaling: ISignalingClient = {
+      send: (m) => sentSignals.push(m),
+      onSignal: (h) => {
+        onSignal = h;
+        return () => {};
+      },
+      close: vi.fn(),
+    };
+    const { peer, fireDataChannel } = makeFakePeer();
+    const hs = makeHandshakeStub();
+    const statuses: TRtcConnectionStatus[] = [];
+    const messages: TServerMessage[] = [];
+
+    const client = createRtcSessionClient(
+      {
+        relayUrl: 'wss://r',
+        rendezvous: 'rv',
+        secret: 's',
+        createSignaling: () => fakeSignaling,
+        createPeer: () => peer as unknown as RTCPeerConnection,
+        startHandshake: hs.start,
+      },
+      { onMessage: (m) => messages.push(m), onStatusChange: (s) => statuses.push(s) },
+    );
+
+    client.connect();
+    expect(statuses).toContain('connecting');
+
+    // Host sends the offer → the client answers.
+    onSignal!({ kind: 'offer', data: { type: 'offer', sdp: OFFER_SDP } });
+    await new Promise((r) => setTimeout(r, 0)); // let the async answer chain run
+    const answer = sentSignals.find((s) => s.kind === 'answer');
+    expect(answer).toBeDefined();
+    expect(peer.createAnswer).toHaveBeenCalled();
+
+    // Data channel opens → pairing phase; nothing exposed yet.
+    const channel = { send: vi.fn(), close: vi.fn(), onmessage: null as unknown };
+    fireDataChannel(channel);
+    expect(statuses).toContain('pairing');
+    (channel.onmessage as (e: { data: string }) => void)({
+      data: JSON.stringify({ type: 'messages', messages: [] }),
+    });
+    expect(messages).toHaveLength(0); // pre-accept non-pairing frame dropped
+
+    // Pairing accepts → connected, get-messages sent, session frames now delivered.
+    hs.accept();
+    await Promise.resolve();
+    expect(statuses).toContain('connected');
+    expect(JSON.parse((channel.send as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0])).toEqual({
+      type: 'get-messages',
+    });
+    (channel.onmessage as (e: { data: string }) => void)({
+      data: JSON.stringify({ type: 'text_delta', delta: 'hi' }),
+    });
+    expect(messages).toContainEqual({ type: 'text_delta', delta: 'hi' });
+
+    client.disconnect();
+    expect(statuses.at(-1)).toBe('disconnected');
+  });
+
+  it('a signaling error fails the client closed', () => {
+    const statuses: TRtcConnectionStatus[] = [];
+    let capturedOnError: (() => void) | undefined;
+    const client = createRtcSessionClient(
+      {
+        relayUrl: 'wss://r',
+        rendezvous: 'rv',
+        secret: 's',
+        createSignaling: (opts) => {
+          capturedOnError = opts.onError as () => void;
+          return { send: vi.fn(), onSignal: () => () => {}, close: vi.fn() };
+        },
+        createPeer: () => makeFakePeer().peer as unknown as RTCPeerConnection,
+      },
+      { onMessage: vi.fn(), onStatusChange: (s) => statuses.push(s) },
+    );
+    client.connect();
+    capturedOnError?.();
+    expect(statuses).toContain('failed');
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/rtc-signaling.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/rtc-signaling.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRtcSignalingClient,
+  type IBrowserWebSocketLike,
+  type ISignalMessage,
+} from '../rtc-signaling.js';
+
+/**
+ * REMOTE-009 Step 1 — the browser signaling client over a FAKE native WebSocket: join on open, buffer
+ * signals produced before open, round-trip relay `signal` frames, and surface errors (no silent degrade).
+ */
+
+class FakeSocket implements IBrowserWebSocketLike {
+  sent: string[] = [];
+  readyState = 0; // CONNECTING
+  onopen: ((e: unknown) => void) | null = null;
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onclose: ((e: unknown) => void) | null = null;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.onclose?.({});
+  }
+  /** Simulate the socket opening. */
+  open(): void {
+    this.readyState = 1; // OPEN
+    this.onopen?.({});
+  }
+  /** Simulate an inbound relay frame. */
+  deliver(frame: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+function setup() {
+  const socket = new FakeSocket();
+  const onError = vi.fn();
+  const onReady = vi.fn();
+  const client = createRtcSignalingClient({
+    url: 'wss://relay.test',
+    rendezvous: 'rv-1',
+    onError,
+    onReady,
+    createSocket: () => socket,
+  });
+  return { socket, onError, onReady, client };
+}
+
+describe('createRtcSignalingClient (REMOTE-009)', () => {
+  it('joins the rendezvous on open', () => {
+    const { socket } = setup();
+    socket.open();
+    expect(JSON.parse(socket.sent[0]!)).toEqual({ type: 'join', rendezvous: 'rv-1' });
+  });
+
+  it('buffers a signal produced before open, then flushes it on open (after join)', () => {
+    const { socket, client } = setup();
+    client.send({ kind: 'answer', data: { sdp: 'x' } });
+    expect(socket.sent).toHaveLength(0); // buffered, not sent while CONNECTING
+    socket.open();
+    // First frame is the join, then the buffered answer signal.
+    expect(JSON.parse(socket.sent[0]!).type).toBe('join');
+    expect(JSON.parse(socket.sent[1]!)).toEqual({
+      type: 'signal',
+      kind: 'answer',
+      data: { sdp: 'x' },
+    });
+  });
+
+  it('sends a signal immediately when already open', () => {
+    const { socket, client } = setup();
+    socket.open();
+    client.send({ kind: 'ice', data: { candidate: 'c' } });
+    expect(JSON.parse(socket.sent.at(-1)!)).toEqual({
+      type: 'signal',
+      kind: 'ice',
+      data: { candidate: 'c' },
+    });
+  });
+
+  it('fires onReady on the joined frame and delivers inbound signals to subscribers', () => {
+    const { socket, onReady, client } = setup();
+    const seen: ISignalMessage[] = [];
+    client.onSignal((m) => seen.push(m));
+    socket.open();
+    socket.deliver({ type: 'joined', rendezvous: 'rv-1' });
+    expect(onReady).toHaveBeenCalledTimes(1);
+    socket.deliver({ type: 'signal', kind: 'offer', data: { sdp: 'o' } });
+    expect(seen).toEqual([{ kind: 'offer', data: { sdp: 'o' } }]);
+  });
+
+  it('ignores a signal frame with an unknown kind', () => {
+    const { socket, client } = setup();
+    const seen: ISignalMessage[] = [];
+    client.onSignal((m) => seen.push(m));
+    socket.open();
+    socket.deliver({ type: 'signal', kind: 'bogus', data: {} });
+    expect(seen).toHaveLength(0);
+  });
+
+  it('surfaces a relay error frame via onError (no silent degrade)', () => {
+    const { socket, onError } = setup();
+    socket.open();
+    socket.deliver({ type: 'error', reason: 'rendezvous full' });
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/rendezvous full/) }),
+    );
+  });
+
+  it('a close before joined is an error; an intentional close() is not', () => {
+    const { socket, onError, client } = setup();
+    socket.open();
+    // close before a joined frame → error
+    socket.onclose?.({});
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    const b = setup();
+    b.socket.open();
+    b.socket.deliver({ type: 'joined', rendezvous: 'rv-1' });
+    b.client.close(); // intentional → no error
+    expect(b.onError).not.toHaveBeenCalled();
+  });
+
+  it('does not send after close()', () => {
+    const { socket, client } = setup();
+    socket.open();
+    const before = socket.sent.length;
+    client.close();
+    client.send({ kind: 'ice', data: {} });
+    expect(socket.sent.length).toBe(before);
+  });
+});

--- a/packages/agent-web-ui/src/client/parse-remote-location.ts
+++ b/packages/agent-web-ui/src/client/parse-remote-location.ts
@@ -1,0 +1,29 @@
+import { parsePairingUrl } from '@robota-sdk/agent-remote-pairing';
+
+/**
+ * Parse the Stage-D page's own URL into its connection inputs (REMOTE-009).
+ *
+ * The pairing link is `clientUrl#r=<rendezvous>&s=<secret>` — the SECRET lives only in the **fragment**
+ * (never sent to the page's host). The relay URL is NOT secret and is NOT in the fragment; the host operator
+ * configures it into `clientUrl` as a `relay` query param (e.g. `https://page/?relay=wss://myrelay`), which
+ * `toPairingUrl` preserves. So: relay ← `location.search`, rendezvous + secret ← `location.hash`.
+ *
+ * Pure + isomorphic (works on any href string) so it is unit-testable without a browser.
+ */
+export interface IRemoteClientLocation {
+  readonly relayUrl: string;
+  readonly rendezvous: string;
+  readonly secret: string;
+}
+
+/** Parse `href`; throws a clear error when the relay query param or the pairing fragment is missing. */
+export function parseRemoteClientLocation(href: string): IRemoteClientLocation {
+  const relayUrl = new URL(href).searchParams.get('relay');
+  if (!relayUrl) {
+    throw new Error(
+      'Missing `relay` query parameter — the pairing link must include the signaling relay URL.',
+    );
+  }
+  const { rendezvous, secret } = parsePairingUrl(href); // throws if the fragment lacks r/s
+  return { relayUrl, rendezvous, secret };
+}

--- a/packages/agent-web-ui/src/client/rtc-responder-gate.ts
+++ b/packages/agent-web-ui/src/client/rtc-responder-gate.ts
@@ -1,0 +1,132 @@
+/**
+ * Responder-side pairing gate for the browser remote client (REMOTE-009 Stage D) — the client dual of the
+ * host `PairingGate`. The browser is the WebRTC ANSWERER ≡ pairing RESPONDER. It phase-separates the data
+ * channel: pre-accept it carries ONLY pairing frames (routed to `startPairingHandshake({role:'responder'})`;
+ * any non-pairing frame is DROPPED), and only after the handshake accepts does it deliver `TServerMessage`s to
+ * the UI and allow `send(TClientMessage)`. Fail-closed: on reject/timeout it closes the channel and delivers
+ * nothing.
+ *
+ * Kept standalone (not inlined in `createRtcSessionClient`) so the routing/fail-closed logic is unit-testable
+ * with a stub channel + real `agent-remote-pairing`, exactly like the host `PairingGate`. The Node responder in
+ * `agent-transport-webrtc/src/__tests__/pairing-e2e.test.ts` is the algorithm oracle.
+ */
+
+import { startPairingHandshake, type TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+
+import type { TServerMessage, TClientMessage } from '@robota-sdk/agent-transport-protocol';
+
+/** The minimal data-channel surface the gate drives (a native `RTCDataChannel` satisfies it). */
+export interface IResponderChannel {
+  send(data: string): void;
+  close(): void;
+}
+
+export interface IResponderGateOptions {
+  readonly channel: IResponderChannel;
+  readonly secret: string;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+  readonly timeoutMs?: number;
+  /** Deliver a session server message to the UI (only ever called post-accept). */
+  readonly onMessage: (msg: TServerMessage) => void;
+  /** Pairing accepted — the session is now co-driveable. */
+  readonly onAccept?: () => void;
+  /** Pairing rejected/timed out — the channel is closed, nothing exposed. */
+  readonly onReject?: () => void;
+  /** Injection seam (defaults to the real handshake) — for tests. */
+  readonly startHandshake?: typeof startPairingHandshake;
+}
+
+function isPairingFrame(value: unknown): value is TPairingFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = (value as { t?: unknown }).t;
+  return t === 'pair-nonce' || t === 'pair-confirm';
+}
+
+type TGateState = 'pairing' | 'accepted' | 'closed';
+
+export class ResponderGate {
+  private state: TGateState = 'pairing';
+  private readonly controller: ReturnType<typeof startPairingHandshake>;
+
+  constructor(private readonly options: IResponderGateOptions) {
+    const start = options.startHandshake ?? startPairingHandshake;
+    this.controller = start({
+      secret: options.secret,
+      role: 'responder',
+      localFingerprint: options.localFingerprint,
+      remoteFingerprint: options.remoteFingerprint,
+      send: (frame) => this.safeSend(JSON.stringify(frame)),
+      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    });
+    this.controller.result.then(
+      () => this.accept(),
+      () => this.rejectAndClose(),
+    );
+  }
+
+  /** Route one inbound channel frame (pre-accept: pairing → handshake, else drop; post-accept: session). */
+  onInbound(data: string): void {
+    if (this.state === 'closed') return;
+    if (this.state === 'accepted') {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        return;
+      }
+      this.options.onMessage(parsed as TServerMessage);
+      return;
+    }
+    // pairing phase — only pairing frames pass; anything else is dropped (fail-closed).
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (isPairingFrame(parsed)) this.controller.onFrame(parsed);
+  }
+
+  /** Send a client message to the host — only after pairing accepts (no-op before/after). */
+  send(msg: TClientMessage): void {
+    if (this.state !== 'accepted') return;
+    this.safeSend(JSON.stringify(msg));
+  }
+
+  /** Tear down: mark closed and close the channel. Idempotent. */
+  close(): void {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    this.safeClose();
+  }
+
+  private accept(): void {
+    if (this.state !== 'pairing') return;
+    this.state = 'accepted';
+    this.options.onAccept?.();
+  }
+
+  private rejectAndClose(): void {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    this.safeClose();
+    this.options.onReject?.();
+  }
+
+  private safeSend(data: string): void {
+    try {
+      this.options.channel.send(data);
+    } catch {
+      // channel closing/closed
+    }
+  }
+
+  private safeClose(): void {
+    try {
+      this.options.channel.close();
+    } catch {
+      // already closed
+    }
+  }
+}

--- a/packages/agent-web-ui/src/client/rtc-session-client.ts
+++ b/packages/agent-web-ui/src/client/rtc-session-client.ts
@@ -1,0 +1,164 @@
+/**
+ * Browser data-channel session client (REMOTE-009 Stage D). The browser is the WebRTC ANSWERER: it joins the
+ * relay by rendezvous, answers the host's offer over a native `RTCPeerConnection`, runs the pairing handshake
+ * as RESPONDER over the data channel ({@link ResponderGate}), and — only after pairing accepts — exchanges
+ * `TServerMessage`/`TClientMessage`s with the host session.
+ *
+ * It exposes the SAME `{ onMessage, onStatusChange, send }` contract as `createWsSessionClient`, so the existing
+ * `useWsSession` reducer + `SessionMonitor` consume it unchanged — the single swap is WebSocket → data channel.
+ * The channel-binding fingerprints come from the SDP: the HOST (remote) fp from the received offer, the LOCAL fp
+ * from our own answer (`extractDtlsFingerprint`) — matching the Node responder oracle in
+ * `agent-transport-webrtc/src/__tests__/pairing-e2e.test.ts`.
+ */
+
+import { extractDtlsFingerprint } from '@robota-sdk/agent-remote-pairing';
+
+import { ResponderGate } from './rtc-responder-gate.js';
+import { createRtcSignalingClient, type ISignalingClient } from './rtc-signaling.js';
+
+import type { startPairingHandshake } from '@robota-sdk/agent-remote-pairing';
+import type { TServerMessage, TClientMessage } from '@robota-sdk/agent-transport-protocol';
+
+/** Connection lifecycle for the RTC client (superset of the WS client's statuses: adds pairing/failed). */
+export type TRtcConnectionStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'pairing'
+  | 'connected'
+  | 'failed';
+
+export interface IRtcSessionClientCallbacks {
+  onMessage: (msg: TServerMessage) => void;
+  onStatusChange: (status: TRtcConnectionStatus) => void;
+}
+
+export interface IRtcSessionClient {
+  connect: () => void;
+  disconnect: () => void;
+  send: (msg: TClientMessage) => void;
+  status: () => TRtcConnectionStatus;
+}
+
+export interface IRtcSessionClientOptions {
+  /** Relay URL (from config / the page). */
+  readonly relayUrl: string;
+  /** Rendezvous id + high-entropy secret from the pairing URL fragment. */
+  readonly rendezvous: string;
+  readonly secret: string;
+  /** Optional ICE servers (STUN/TURN) — Stage E supplies TURN; omitted → host candidates only. */
+  readonly iceServers?: RTCIceServer[];
+  /** Injection seams (default to the real implementations) — for tests. */
+  readonly createSignaling?: typeof createRtcSignalingClient;
+  readonly createPeer?: (config?: RTCConfiguration) => RTCPeerConnection;
+  readonly startHandshake?: typeof startPairingHandshake;
+}
+
+export function createRtcSessionClient(
+  options: IRtcSessionClientOptions,
+  callbacks: IRtcSessionClientCallbacks,
+): IRtcSessionClient {
+  let signaling: ISignalingClient | null = null;
+  let peer: RTCPeerConnection | null = null;
+  let gate: ResponderGate | null = null;
+  let localFingerprint: string | undefined;
+  let remoteFingerprint: string | undefined;
+  let status: TRtcConnectionStatus = 'disconnected';
+
+  const setStatus = (s: TRtcConnectionStatus): void => {
+    status = s;
+    callbacks.onStatusChange(s);
+  };
+
+  const fail = (): void => {
+    if (status !== 'failed') setStatus('failed');
+  };
+
+  function wireDataChannel(channel: RTCDataChannel): void {
+    if (!remoteFingerprint || !localFingerprint) {
+      // Fingerprints must be known before the channel opens (post-answer). If not, fail closed.
+      fail();
+      try {
+        channel.close();
+      } catch {
+        /* noop */
+      }
+      return;
+    }
+    setStatus('pairing');
+    gate = new ResponderGate({
+      channel: { send: (d) => channel.send(d), close: () => channel.close() },
+      secret: options.secret,
+      localFingerprint,
+      remoteFingerprint,
+      onMessage: callbacks.onMessage,
+      onAccept: () => {
+        setStatus('connected');
+        gate?.send({ type: 'get-messages' }); // request full history on connect (mirrors the WS client)
+      },
+      onReject: fail,
+      ...(options.startHandshake ? { startHandshake: options.startHandshake } : {}),
+    });
+    channel.onmessage = (event: MessageEvent): void => {
+      const data = event.data;
+      gate?.onInbound(typeof data === 'string' ? data : String(data));
+    };
+  }
+
+  async function handleOffer(offer: RTCSessionDescriptionInit): Promise<void> {
+    if (!peer) return;
+    remoteFingerprint = extractDtlsFingerprint(offer.sdp ?? '');
+    await peer.setRemoteDescription(offer);
+    const answer = await peer.createAnswer();
+    await peer.setLocalDescription(answer);
+    localFingerprint = extractDtlsFingerprint(peer.localDescription?.sdp ?? answer.sdp ?? '');
+    signaling?.send({ kind: 'answer', data: peer.localDescription ?? answer });
+  }
+
+  return {
+    connect(): void {
+      if (peer) return; // already connecting
+      setStatus('connecting');
+      const createPeer = options.createPeer ?? ((c) => new RTCPeerConnection(c));
+      peer = createPeer(options.iceServers ? { iceServers: options.iceServers } : undefined);
+      peer.onicecandidate = (event): void => {
+        if (event.candidate) signaling?.send({ kind: 'ice', data: event.candidate.toJSON() });
+      };
+      peer.ondatachannel = (event): void => wireDataChannel(event.channel);
+
+      signaling = (options.createSignaling ?? createRtcSignalingClient)({
+        url: options.relayUrl,
+        rendezvous: options.rendezvous,
+        onError: fail,
+      });
+      let chain: Promise<void> = Promise.resolve();
+      signaling.onSignal((message) => {
+        chain = chain
+          .then(async () => {
+            if (message.kind === 'offer') {
+              await handleOffer(message.data as RTCSessionDescriptionInit);
+            } else if (message.kind === 'ice' && peer) {
+              await peer.addIceCandidate(message.data as RTCIceCandidateInit);
+            }
+          })
+          .catch(() => fail());
+      });
+    },
+    disconnect(): void {
+      gate?.close();
+      gate = null;
+      try {
+        peer?.close();
+      } catch {
+        /* noop */
+      }
+      peer = null;
+      signaling?.close();
+      signaling = null;
+      setStatus('disconnected');
+    },
+    send(msg: TClientMessage): void {
+      gate?.send(msg);
+    },
+    status: () => status,
+  };
+}

--- a/packages/agent-web-ui/src/client/rtc-signaling.ts
+++ b/packages/agent-web-ui/src/client/rtc-signaling.ts
@@ -1,0 +1,135 @@
+/**
+ * Browser signaling client (REMOTE-009 Stage D) — the browser peer's `ISignalingClient` over the **native**
+ * `WebSocket`, talking to the `@robota-sdk/remote-signaling` relay. It is the browser counterpart of the Node
+ * host's `WsSignalingClient` (which imports `ws` + uses the node `.on()` API and cannot run in a browser).
+ *
+ * The relay is content-blind: this client only ever emits `join` + `signal` frames and only ever consumes
+ * `joined` / `signal` / `error` frames. Signals produced before the socket opens are buffered and flushed on
+ * open (the browser answerer may produce an ICE candidate before the socket connects). A relay `error` frame, a
+ * socket error, or a close-before-join is surfaced through an explicit `onError` — never a silent degrade.
+ *
+ * The signaling contract types are defined LOCALLY (not imported from `agent-transport-webrtc`, which is
+ * node/werift-only) so the browser package takes no dependency on the node transport.
+ */
+
+/** The kinds of signal a peer exchanges through the relay (SDP offers/answers + ICE candidates). */
+export type TSignalKind = 'offer' | 'answer' | 'ice';
+
+/** An opaque signaling message relayed by rendezvous id. `data` is an SDP description or an ICE candidate. */
+export interface ISignalMessage {
+  readonly kind: TSignalKind;
+  readonly data: unknown;
+}
+
+/** Port a WebRTC peer uses to reach its counterpart at a rendezvous id. */
+export interface ISignalingClient {
+  send(message: ISignalMessage): void;
+  onSignal(handler: (message: ISignalMessage) => void): () => void;
+  close(): void;
+}
+
+/** The subset of the native `WebSocket` surface the client uses — so tests inject a fake without a socket. */
+export interface IBrowserWebSocketLike {
+  send(data: string): void;
+  close(): void;
+  readonly readyState: number;
+  onopen: ((event: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  onclose: ((event: unknown) => void) | null;
+}
+
+export interface IRtcSignalingOptions {
+  /** Relay URL, e.g. `wss://relay.example`. */
+  readonly url: string;
+  /** Rendezvous id to join (from the pairing URL fragment). */
+  readonly rendezvous: string;
+  /** Relay `error` frame / socket error / close-before-join — the caller must know (no silent degrade). */
+  readonly onError?: (error: Error) => void;
+  /** Fired once the relay confirms the `join` (`joined` frame). */
+  readonly onReady?: () => void;
+  /** Injectable socket factory (defaults to the global `WebSocket`) — for tests. */
+  readonly createSocket?: (url: string) => IBrowserWebSocketLike;
+}
+
+const SIGNAL_KINDS: ReadonlySet<string> = new Set<TSignalKind>(['offer', 'answer', 'ice']);
+const WS_OPEN = 1;
+
+function defaultCreateSocket(url: string): IBrowserWebSocketLike {
+  return new WebSocket(url) as unknown as IBrowserWebSocketLike;
+}
+
+export function createRtcSignalingClient(options: IRtcSignalingOptions): ISignalingClient {
+  const socket = (options.createSocket ?? defaultCreateSocket)(options.url);
+  const handlers: ((message: ISignalMessage) => void)[] = [];
+  const outbox: ISignalMessage[] = [];
+  let joined = false;
+  let closed = false;
+
+  const fail = (error: Error): void => options.onError?.(error);
+
+  const writeSignal = (message: ISignalMessage): void =>
+    socket.send(JSON.stringify({ type: 'signal', kind: message.kind, data: message.data }));
+
+  socket.onopen = (): void => {
+    socket.send(JSON.stringify({ type: 'join', rendezvous: options.rendezvous }));
+    for (const message of outbox) writeSignal(message);
+    outbox.length = 0;
+  };
+
+  socket.onmessage = (event): void => {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(typeof event.data === 'string' ? event.data : String(event.data));
+    } catch {
+      return; // the relay only emits JSON
+    }
+    if (typeof frame !== 'object' || frame === null) return;
+    const record = frame as Record<string, unknown>;
+    if (record.type === 'joined') {
+      joined = true;
+      options.onReady?.();
+      return;
+    }
+    if (record.type === 'error') {
+      fail(new Error(`signaling relay rejected the connection: ${String(record.reason)}`));
+      return;
+    }
+    if (
+      record.type === 'signal' &&
+      typeof record.kind === 'string' &&
+      SIGNAL_KINDS.has(record.kind)
+    ) {
+      const message: ISignalMessage = { kind: record.kind as TSignalKind, data: record.data };
+      for (const handler of handlers) handler(message);
+    }
+  };
+
+  socket.onerror = (err): void => fail(err instanceof Error ? err : new Error(String(err)));
+
+  socket.onclose = (): void => {
+    if (closed) return; // an intentional close() is not an error
+    if (!joined) fail(new Error('signaling socket closed before the rendezvous was joined'));
+  };
+
+  return {
+    send(message: ISignalMessage): void {
+      if (closed) return;
+      if (socket.readyState === WS_OPEN) writeSignal(message);
+      else outbox.push(message);
+    },
+    onSignal(handler: (message: ISignalMessage) => void): () => void {
+      handlers.push(handler);
+      return () => {
+        const index = handlers.indexOf(handler);
+        if (index >= 0) handlers.splice(index, 1);
+      };
+    },
+    close(): void {
+      closed = true;
+      handlers.length = 0;
+      outbox.length = 0;
+      socket.close();
+    },
+  };
+}

--- a/packages/agent-web-ui/src/components/PermissionPrompt.tsx
+++ b/packages/agent-web-ui/src/components/PermissionPrompt.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React from 'react';
+
+import type { TPendingPrompt } from '../hooks/prompt-state.js';
+import type { TActionResponse } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * Renders the owner's pending permission/ask prompts (REMOTE-007/009). Under local == remote the paired
+ * browser owner answers its OWN prompts; the first pending prompt is shown as a modal-style card. A gated tool
+ * call blocks until answered, so this is on the critical path — not decorative.
+ */
+interface IPermissionPromptProps {
+  prompts: readonly TPendingPrompt[];
+  onAnswerPermission: (id: string, result: boolean) => void;
+  onAnswerAsk: (id: string, response: TActionResponse) => void;
+}
+
+export function PermissionPrompt({
+  prompts,
+  onAnswerPermission,
+  onAnswerAsk,
+}: IPermissionPromptProps): React.ReactElement | null {
+  const prompt = prompts[0];
+  if (!prompt) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-lg bg-[var(--card)] p-5 font-mono text-[13px] shadow-xl">
+        {prompt.kind === 'permission' ? (
+          <>
+            <p className="mb-1 font-bold text-[var(--foreground)]">Permission request</p>
+            <p className="mb-4 text-[var(--muted-foreground)]">
+              Allow <span className="text-[var(--foreground)]">{prompt.toolName}</span> to run?
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-md bg-emerald-600 px-3 py-1.5 text-white"
+                onClick={() => onAnswerPermission(prompt.id, true)}
+              >
+                Allow
+              </button>
+              <button
+                type="button"
+                className="rounded-md bg-rose-600 px-3 py-1.5 text-white"
+                onClick={() => onAnswerPermission(prompt.id, false)}
+              >
+                Deny
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="mb-1 font-bold text-[var(--foreground)]">{prompt.request.title}</p>
+            {prompt.request.description ? (
+              <p className="mb-3 text-[var(--muted-foreground)]">{prompt.request.description}</p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              {(prompt.request.options ?? []).map((opt) => (
+                <button
+                  type="button"
+                  key={opt.value}
+                  className="rounded-md bg-[var(--primary)] px-3 py-1.5 text-[var(--primary-foreground)]"
+                  onClick={() => onAnswerAsk(prompt.id, { type: 'answer', values: [opt.value] })}
+                >
+                  {opt.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                className="rounded-md bg-zinc-600 px-3 py-1.5 text-white"
+                onClick={() => onAnswerAsk(prompt.id, { type: 'cancelled' })}
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent-web-ui/src/components/RemoteClient.tsx
+++ b/packages/agent-web-ui/src/components/RemoteClient.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+import { ConversationView } from './ConversationView.js';
+import { PermissionPrompt } from './PermissionPrompt.js';
+import { parseRemoteClientLocation } from '../client/parse-remote-location.js';
+import { useRtcSession } from '../hooks/useWsSession.js';
+
+/**
+ * Stage-D browser remote client root (REMOTE-009). Reads its connection inputs from its own URL
+ * (relay ← query, rendezvous + secret ← fragment), pairs with the host over WebRTC, and co-drives the
+ * session — rendering the pairing-UX states and the owner's permission/ask prompts.
+ */
+
+const STATUS_LABEL: Record<string, string> = {
+  disconnected: 'Disconnected',
+  connecting: 'Connecting to relay…',
+  pairing: 'Pairing with host…',
+  connected: 'Connected',
+  failed: 'Pairing failed',
+  error: 'Error',
+};
+
+interface IRemoteClientProps {
+  /** The page href (defaults to `window.location.href`; injectable for tests). */
+  href?: string;
+}
+
+export function RemoteClient({ href }: IRemoteClientProps): React.ReactElement {
+  const parsed = useMemo(() => {
+    try {
+      return { location: parseRemoteClientLocation(href ?? window.location.href), error: null };
+    } catch (e) {
+      return { location: null, error: e instanceof Error ? e.message : String(e) };
+    }
+  }, [href]);
+
+  if (parsed.error || !parsed.location) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-8 font-mono text-[13px]">
+        <div className="max-w-md text-[var(--muted-foreground)]">
+          <p className="mb-2 font-bold text-[var(--foreground)]">Cannot pair</p>
+          <p>{parsed.error ?? 'Invalid pairing link.'}</p>
+          <p className="mt-2">Open the QR / link shown by `/remote-control` on the host.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <RemoteClientConnected location={parsed.location} />;
+}
+
+function RemoteClientConnected({
+  location,
+}: {
+  location: NonNullable<ReturnType<typeof parseRemoteClientLocation>>;
+}): React.ReactElement {
+  const session = useRtcSession(location);
+  return (
+    <div className="flex h-screen w-screen flex-col overflow-hidden">
+      <header className="flex items-center gap-2 border-b border-[var(--border)] px-4 py-2 font-mono text-[12px]">
+        <span
+          className={
+            session.status === 'connected'
+              ? 'text-emerald-400'
+              : session.status === 'failed' || session.status === 'error'
+                ? 'text-rose-400'
+                : 'text-amber-400'
+          }
+        >
+          ● {STATUS_LABEL[session.status] ?? session.status}
+        </span>
+      </header>
+      <main className="flex-1 overflow-auto">
+        <ConversationView
+          messages={session.messages}
+          activeTools={session.activeTools}
+          streamingText={session.streamingText}
+          isThinking={session.isThinking}
+        />
+      </main>
+      <PermissionPrompt
+        prompts={session.pendingPrompts}
+        onAnswerPermission={session.answerPermission}
+        onAnswerAsk={session.answerAsk}
+      />
+    </div>
+  );
+}

--- a/packages/agent-web-ui/src/hooks/__tests__/prompt-state.test.ts
+++ b/packages/agent-web-ui/src/hooks/__tests__/prompt-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyPromptEvent,
+  askResponse,
+  permissionResponse,
+  type TPendingPrompt,
+} from '../prompt-state.js';
+
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * REMOTE-009 Step 4 / REMOTE-007 render+answer — the pure prompt-state list transitions + answer builders.
+ * Shared by the WS and RTC clients (same TServerMessages), so testing the pure logic covers both.
+ */
+
+const permReq: TServerMessage = {
+  type: 'permission_request',
+  event: { id: 'p1', toolName: 'Bash', toolArgs: { command: 'ls' } },
+};
+const askReq: TServerMessage = {
+  type: 'ask_request',
+  event: { id: 'a1', request: { id: 'r', title: 'Pick' } },
+};
+
+describe('applyPromptEvent (REMOTE-007 web render)', () => {
+  it('appends a permission prompt on permission_request', () => {
+    const next = applyPromptEvent([], permReq);
+    expect(next).toEqual([
+      { kind: 'permission', id: 'p1', toolName: 'Bash', toolArgs: { command: 'ls' } },
+    ]);
+  });
+
+  it('appends an ask prompt on ask_request', () => {
+    const next = applyPromptEvent([], askReq);
+    expect(next).toEqual([{ kind: 'ask', id: 'a1', request: { id: 'r', title: 'Pick' } }]);
+  });
+
+  it('removes the prompt on prompt_resolved (co-drive dismiss)', () => {
+    const withPrompt = applyPromptEvent([], permReq);
+    const resolved: TServerMessage = { type: 'prompt_resolved', event: { id: 'p1' } };
+    expect(applyPromptEvent(withPrompt, resolved)).toEqual([]);
+  });
+
+  it('is idempotent against a duplicate request id', () => {
+    const once = applyPromptEvent([], permReq);
+    expect(applyPromptEvent(once, permReq)).toBe(once); // same ref, not re-appended
+  });
+
+  it('preserves referential equality for unrelated messages and unknown resolve ids', () => {
+    const prompts: readonly TPendingPrompt[] = applyPromptEvent([], permReq);
+    expect(
+      applyPromptEvent(prompts, { type: 'thinking', isThinking: true } as TServerMessage),
+    ).toBe(prompts);
+    expect(applyPromptEvent(prompts, { type: 'prompt_resolved', event: { id: 'nope' } })).toBe(
+      prompts,
+    );
+  });
+
+  it('builds the answer client messages', () => {
+    expect(permissionResponse('p1', true)).toEqual({
+      type: 'permission-response',
+      id: 'p1',
+      result: true,
+    });
+    expect(askResponse('a1', { type: 'answer', values: ['x'] })).toEqual({
+      type: 'ask-response',
+      id: 'a1',
+      response: { type: 'answer', values: ['x'] },
+    });
+  });
+});

--- a/packages/agent-web-ui/src/hooks/prompt-state.ts
+++ b/packages/agent-web-ui/src/hooks/prompt-state.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure prompt-state derivation for the web UI (REMOTE-009 Step 4 / REMOTE-007 render+answer).
+ *
+ * The paired browser is the session OWNER (local == remote), so it must render and ANSWER the owner's own
+ * permission/ask prompts. The server carries `permission_request`/`ask_request` (a prompt appears) and
+ * `prompt_resolved` (it was answered — by this or a co-driving surface — and must dismiss). The answer travels
+ * back as `permission-response`/`ask-response`. This module is the pure list-transition + message-builder logic,
+ * consumed by `useWsSession` and shared unchanged by BOTH the WS and RTC session clients (same `TServerMessage`s).
+ */
+
+import type {
+  IAskRequestEvent,
+  IPermissionRequestEvent,
+  TActionResponse,
+  TPermissionResultValue,
+} from '@robota-sdk/agent-interface-transport';
+import type { TClientMessage, TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+/** A prompt awaiting the owner's answer, rendered by the UI (built from the server event payloads). */
+export type TPendingPrompt =
+  | ({ readonly kind: 'permission' } & IPermissionRequestEvent)
+  | ({ readonly kind: 'ask' } & IAskRequestEvent);
+
+/**
+ * Fold a server message into the pending-prompt list: append on `permission_request`/`ask_request`, remove on
+ * `prompt_resolved`. Any other message returns the list unchanged (referential-equality preserved). Duplicate
+ * ids are not re-appended (idempotent against a resend).
+ */
+export function applyPromptEvent(
+  prompts: readonly TPendingPrompt[],
+  msg: TServerMessage,
+): readonly TPendingPrompt[] {
+  switch (msg.type) {
+    case 'permission_request': {
+      const { id, toolName, toolArgs } = msg.event;
+      if (prompts.some((p) => p.id === id)) return prompts;
+      return [...prompts, { kind: 'permission', id, toolName, toolArgs }];
+    }
+    case 'ask_request': {
+      const { id, request } = msg.event;
+      if (prompts.some((p) => p.id === id)) return prompts;
+      return [...prompts, { kind: 'ask', id, request }];
+    }
+    case 'prompt_resolved': {
+      const { id } = msg.event;
+      const next = prompts.filter((p) => p.id !== id);
+      return next.length === prompts.length ? prompts : next;
+    }
+    default:
+      return prompts;
+  }
+}
+
+/** Build the client message that answers a permission prompt. */
+export function permissionResponse(id: string, result: TPermissionResultValue): TClientMessage {
+  return { type: 'permission-response', id, result };
+}
+
+/** Build the client message that answers an ask prompt. */
+export function askResponse(id: string, response: TActionResponse): TClientMessage {
+  return { type: 'ask-response', id, response };
+}

--- a/packages/agent-web-ui/src/hooks/useWsSession.ts
+++ b/packages/agent-web-ui/src/hooks/useWsSession.ts
@@ -11,6 +11,11 @@ import {
   permissionResponse,
   type TPendingPrompt,
 } from './prompt-state.js';
+import {
+  createRtcSessionClient,
+  type IRtcSessionClientOptions,
+  type TRtcConnectionStatus,
+} from '../client/rtc-session-client.js';
 import { createWsSessionClient } from '../client/ws-session-client.js';
 
 import type { TConnectionStatus, TClientMessage } from '../client/ws-session-client.js';
@@ -36,8 +41,24 @@ export interface IActiveTool {
   result?: unknown;
 }
 
+/** The connection status shown by the UI — the WS statuses plus the RTC pairing/failed states. */
+export type TSessionStatus = TConnectionStatus | TRtcConnectionStatus;
+
+/** The minimal session-client surface both the WS and RTC clients satisfy. */
+export interface ISessionClientHandle {
+  connect: () => void;
+  disconnect: () => void;
+  send: (msg: TClientMessage) => void;
+}
+
+/** Factory the hook calls to build its client from the message/status callbacks. */
+export type TMakeSessionClient = (callbacks: {
+  onMessage: (msg: TServerMessage) => void;
+  onStatusChange: (status: TSessionStatus) => void;
+}) => ISessionClientHandle;
+
 export interface IWsSessionState {
-  status: TConnectionStatus;
+  status: TSessionStatus;
   messages: IConversationMessage[];
   activeTools: IActiveTool[];
   streamingText: string;
@@ -57,8 +78,8 @@ function nextId(): string {
   return `msg_${++msgCounter}_${Date.now()}`;
 }
 
-export function useWsSession(url: string): IWsSessionState {
-  const [status, setStatus] = useState<TConnectionStatus>('disconnected');
+export function useSessionClient(makeClient: TMakeSessionClient): IWsSessionState {
+  const [status, setStatus] = useState<TSessionStatus>('disconnected');
   const [messages, setMessages] = useState<IConversationMessage[]>([]);
   const [activeTools, setActiveTools] = useState<IActiveTool[]>([]);
   const [streamingText, setStreamingText] = useState('');
@@ -68,7 +89,7 @@ export function useWsSession(url: string): IWsSessionState {
   );
   const [pendingPrompts, setPendingPrompts] = useState<readonly TPendingPrompt[]>([]);
 
-  const clientRef = useRef<ReturnType<typeof createWsSessionClient> | null>(null);
+  const clientRef = useRef<ISessionClientHandle | null>(null);
   const streamingIdRef = useRef<string | null>(null);
   const streamingTextRef = useRef('');
 
@@ -171,17 +192,14 @@ export function useWsSession(url: string): IWsSessionState {
   }, []);
 
   useEffect(() => {
-    const client = createWsSessionClient(url, {
-      onMessage: handleMessage,
-      onStatusChange: setStatus,
-    });
+    const client = makeClient({ onMessage: handleMessage, onStatusChange: setStatus });
     clientRef.current = client;
     client.connect();
     return () => {
       client.disconnect();
       clientRef.current = null;
     };
-  }, [url, handleMessage]);
+  }, [makeClient, handleMessage]);
 
   return {
     status,
@@ -195,4 +213,22 @@ export function useWsSession(url: string): IWsSessionState {
     answerPermission,
     answerAsk,
   };
+}
+
+/** Connect to an agent-cli sidecar over WebSocket (localhost path). */
+export function useWsSession(url: string): IWsSessionState {
+  const makeClient = useCallback<TMakeSessionClient>((cb) => createWsSessionClient(url, cb), [url]);
+  return useSessionClient(makeClient);
+}
+
+/** Connect to a paired host over WebRTC (REMOTE-009 Stage D). Memoized on the primitive connection fields. */
+export function useRtcSession(
+  options: Pick<IRtcSessionClientOptions, 'relayUrl' | 'rendezvous' | 'secret'>,
+): IWsSessionState {
+  const { relayUrl, rendezvous, secret } = options;
+  const makeClient = useCallback<TMakeSessionClient>(
+    (cb) => createRtcSessionClient({ relayUrl, rendezvous, secret }, cb),
+    [relayUrl, rendezvous, secret],
+  );
+  return useSessionClient(makeClient);
 }

--- a/packages/agent-web-ui/src/hooks/useWsSession.ts
+++ b/packages/agent-web-ui/src/hooks/useWsSession.ts
@@ -5,10 +5,20 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 
+import {
+  applyPromptEvent,
+  askResponse,
+  permissionResponse,
+  type TPendingPrompt,
+} from './prompt-state.js';
 import { createWsSessionClient } from '../client/ws-session-client.js';
 
 import type { TConnectionStatus, TClientMessage } from '../client/ws-session-client.js';
-import type { IExecutionWorkspaceSnapshot } from '@robota-sdk/agent-interface-transport';
+import type {
+  IExecutionWorkspaceSnapshot,
+  TActionResponse,
+  TPermissionResultValue,
+} from '@robota-sdk/agent-interface-transport';
 import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
 
 export interface IConversationMessage {
@@ -34,6 +44,12 @@ export interface IWsSessionState {
   isThinking: boolean;
   executionWorkspace: IExecutionWorkspaceSnapshot | null;
   send: (msg: TClientMessage) => void;
+  /** REMOTE-007/009: prompts awaiting the owner's answer (permission/ask), rendered by the UI. */
+  pendingPrompts: readonly TPendingPrompt[];
+  /** Answer a pending permission prompt (sends `permission-response`). */
+  answerPermission: (id: string, result: TPermissionResultValue) => void;
+  /** Answer a pending ask prompt (sends `ask-response`). */
+  answerAsk: (id: string, response: TActionResponse) => void;
 }
 
 let msgCounter = 0;
@@ -50,6 +66,7 @@ export function useWsSession(url: string): IWsSessionState {
   const [executionWorkspace, setExecutionWorkspace] = useState<IExecutionWorkspaceSnapshot | null>(
     null,
   );
+  const [pendingPrompts, setPendingPrompts] = useState<readonly TPendingPrompt[]>([]);
 
   const clientRef = useRef<ReturnType<typeof createWsSessionClient> | null>(null);
   const streamingIdRef = useRef<string | null>(null);
@@ -112,6 +129,13 @@ export function useWsSession(url: string): IWsSessionState {
         setExecutionWorkspace(msg.snapshot);
         break;
       }
+      case 'permission_request':
+      case 'ask_request':
+      case 'prompt_resolved': {
+        // REMOTE-007/009: the paired owner renders + answers its own prompts (local == remote).
+        setPendingPrompts((prev) => applyPromptEvent(prev, msg));
+        break;
+      }
       case 'complete':
       case 'interrupted': {
         const finalText = streamingTextRef.current;
@@ -136,6 +160,16 @@ export function useWsSession(url: string): IWsSessionState {
     clientRef.current?.send(msg);
   }, []);
 
+  const answerPermission = useCallback((id: string, result: TPermissionResultValue): void => {
+    clientRef.current?.send(permissionResponse(id, result));
+    setPendingPrompts((prev) => prev.filter((p) => p.id !== id)); // optimistic dismiss (prompt_resolved confirms)
+  }, []);
+
+  const answerAsk = useCallback((id: string, response: TActionResponse): void => {
+    clientRef.current?.send(askResponse(id, response));
+    setPendingPrompts((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
   useEffect(() => {
     const client = createWsSessionClient(url, {
       onMessage: handleMessage,
@@ -149,5 +183,16 @@ export function useWsSession(url: string): IWsSessionState {
     };
   }, [url, handleMessage]);
 
-  return { status, messages, activeTools, streamingText, isThinking, executionWorkspace, send };
+  return {
+    status,
+    messages,
+    activeTools,
+    streamingText,
+    isThinking,
+    executionWorkspace,
+    send,
+    pendingPrompts,
+    answerPermission,
+    answerAsk,
+  };
 }

--- a/packages/agent-web-ui/src/index.ts
+++ b/packages/agent-web-ui/src/index.ts
@@ -1,6 +1,17 @@
 export { SessionMonitor } from './components/SessionMonitor.js';
 export { ConversationView } from './components/ConversationView.js';
 export { AgentActivityPanel } from './components/AgentActivityPanel.js';
-export { useWsSession } from './hooks/useWsSession.js';
-export type { IConversationMessage, IActiveTool, IWsSessionState } from './hooks/useWsSession.js';
+export { PermissionPrompt } from './components/PermissionPrompt.js';
+export { RemoteClient } from './components/RemoteClient.js';
+export { useWsSession, useRtcSession, useSessionClient } from './hooks/useWsSession.js';
+export type {
+  IConversationMessage,
+  IActiveTool,
+  IWsSessionState,
+  TSessionStatus,
+} from './hooks/useWsSession.js';
+export type { TPendingPrompt } from './hooks/prompt-state.js';
+export { createRtcSessionClient } from './client/rtc-session-client.js';
+export { createRtcSignalingClient } from './client/rtc-signaling.js';
+export { parseRemoteClientLocation } from './client/parse-remote-location.js';
 export type { TConnectionStatus } from './client/ws-session-client.js';

--- a/packages/agent-web-ui/vite.spa.config.ts
+++ b/packages/agent-web-ui/vite.spa.config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
@@ -9,5 +11,12 @@ export default defineConfig({
   build: {
     outDir: '../dist/spa',
     emptyOutDir: true,
+    rollupOptions: {
+      // Two static entries: the localhost monitor (index.html) and the Stage-D remote client (remote.html).
+      input: {
+        index: resolve(__dirname, 'spa/index.html'),
+        remote: resolve(__dirname, 'spa/remote.html'),
+      },
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2069,6 +2069,9 @@ importers:
       '@robota-sdk/agent-interface-transport':
         specifier: workspace:*
         version: link:../agent-interface-transport
+      '@robota-sdk/agent-remote-pairing':
+        specifier: workspace:*
+        version: link:../agent-remote-pairing
       '@robota-sdk/agent-transport-protocol':
         specifier: workspace:*
         version: link:../agent-transport-protocol


### PR DESCRIPTION
Promote `develop` → `main`.

Contains **REMOTE-009 (Stage D)** — the browser remote client (PR #1111, merge-verified on develop): native-`WebSocket` signaling, fail-closed responder pairing gate, RTC data-channel session client, fragment-injected SPA entry, REMOTE-007 permission/ask render+answer for both transports, and the D5 `clientUrl` fail-closed fix. 3-round spec gate + independent implementation review both ENDORSE. No `agent-transport-webrtc`/werift edge (only the isomorphic `agent-remote-pairing` leaf).

This completes REMOTE-001's user story: turn on `/remote-control` on the host → open the QR/link in a browser → pair and co-drive the same session over WebRTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)