### PR TITLE
feat(remote): promote REMOTE-010 Stage E1 (user-supplied TURN fallback) to main

### DIFF
--- a/.agents/spec-docs/active/REMOTE-010-stage-e1-turn-fallback.md
+++ b/.agents/spec-docs/active/REMOTE-010-stage-e1-turn-fallback.md
@@ -1,0 +1,181 @@
+---
+status: in-progress
+type: INFRA
+tags: [remote-control, webrtc, turn, ice, hardening]
+parent: REMOTE-001
+---
+
+# REMOTE-010: Stage E1 — user-supplied TURN fallback
+
+Parent: [REMOTE-001](../todo/REMOTE-001-webrtc-p2p-remote-control-design.md) (ENDORSED). Prior stages DONE:
+REMOTE-002..009 — the full user story ships (host `/remote-control` → QR/link → browser pairs + co-drives over
+WebRTC). **Stage E (final hardening) is decomposed** (grounding 2026-07-11) into: **E1 = TURN fallback (this)**;
+E2 = signaling-server abuse hardening; E3 = TOFU trusted-device reconnect; E4 = reconnection/session-resume (on E3);
+E5 = co-drive concurrency + attribution. E1/E2 are the self-contained, protocol-free, hardening-first pieces.
+
+**E1 problem:** host-candidate-only P2P fails behind symmetric NAT / restrictive firewalls — the two peers can never
+form a direct connection, so remote control silently never connects. The fix is user-supplied TURN relay servers (the
+operator brings their own TURN; we do not host one) threaded to BOTH peers' `RTCPeerConnection`, plus the optional
+`forceTurn` privacy hardening (REMOTE-004) that restricts ICE to relay candidates only.
+
+## Problem (grounded)
+
+Both `RTCPeerConnection` sinks already accept ICE config; **nothing threads it from config**:
+
+1. **Host transport — accepts, unwired.** `IWebRtcTransportOptions` already has `iceServers?: readonly {urls:string}[]`
+   (`webrtc-transport.ts:18`) + `forceTurn?: boolean` (`:24`), consumed in `start()` (`:74-77`). But the composition
+   root `defaultCreateTransport` (`remote-control-controller.ts:171-182`) constructs `new WebRtcTransport({signaling,
+secret,onPaired,onPairingFailed})` — **no iceServers/forceTurn**. `IRemoteControlControllerDeps` (`:26-46`) +
+   `readWebrtcOption` (`index.ts:20-46`) read only `relayUrl`/`clientUrl`.
+2. **Browser client — accepts, unwired.** `IRtcSessionClientOptions.iceServers?: RTCIceServer[]`
+   (`rtc-session-client.ts:48`, comment literally "Stage E supplies TURN") is consumed at `:122`. But `useRtcSession`
+   (`useWsSession.ts:230`) calls `createRtcSessionClient({relayUrl,rendezvous,secret})` — no iceServers;
+   `parseRemoteClientLocation` (`parse-remote-location.ts`) parses no ICE; `RemoteClient` passes `location` straight through.
+3. **Config surface — untyped bag.** `transports.webrtc.options` is `Record<string, unknown>` (`agent-framework/src/config/config-types.ts`,
+   the `transports?: Record<string,{enabled?;options?:Record<string,unknown>}>` shape). `relayUrl`/`clientUrl` are read
+   from it by a **string-only** `readWebrtcOption` (`index.ts:21-31`). `iceServers` is a STRUCTURED value, so it needs a
+   NEW validating reader (the string reader cannot be reused).
+
+## Solution (sub-sequenced, each commit green)
+
+1. **Host config → transport (with a validating reader).** Add `readIceServers(): RTCIceServer[] | undefined` +
+   `readForceTurn(): boolean` to `IRemoteControlControllerDeps` + `createRemoteControlController`. `readIceServers` is a
+   **dedicated validator** that narrows the untyped `transports.webrtc.options.iceServers` (`unknown`) → a well-formed
+   `RTCIceServer[]` (each entry has a string/array `urls` with a sane `stun:`/`turn:`/`turns:` scheme; optional
+   string `username`/`credential`) — **no `any`, no unchecked cast** (strict-TS); a malformed value **fails closed** (a
+   clear error, not a silent partial config). Pass both through `defaultCreateTransport` → `new WebRtcTransport({...,
+iceServers, forceTurn})`. Validate: `forceTurn` requires ≥1 `turn:`/`turns:` url in `iceServers` (REMOTE-004
+   belt-and-braces — `forceTurn` with no TURN filters ICE to relay-only → zero candidates → a SILENT never-connect;
+   turning that into a config-time error is the no-fallback fix, not a privacy regression). Controller unit tests via
+   the existing `createTransport` seam. NOTE the read stays in `agent-cli` (the composition root that already depends on
+   `agent-transport-webrtc`) because `agent-framework`'s config layer is deliberately **domain-free** — teaching it the
+   webrtc option shape would push transport-domain knowledge up a layer (dependency-direction violation). (This is the
+   LAYERING reason, not "no schema change".)
+2. **Browser TURN threading (with a validating decoder).** Extend `IRemoteClientLocation` + `parseRemoteClientLocation`
+   to read an optional `ice` query param (a base64url-encoded JSON `RTCIceServer[]`) and a `forceTurn` flag, thread
+   through `RemoteClient` → `useRtcSession` → `createRtcSessionClient({..., iceServers, forceTurn})`. The `ice` param is
+   **attacker-influenceable input** (anyone who crafts a pairing link controls it), so the decoder MUST validate the
+   decoded value into a well-formed `RTCIceServer[]` (sane URL schemes) and **fail closed** on malformed input — no
+   loose cast into `RTCConfiguration`. The operator bakes their TURN into `clientUrl`'s query (like `relay`), which
+   `toPairingUrl` preserves. **Security honesty:** unlike the secret (which lives ONLY in the `#` fragment, hidden from
+   the page's HTTP host), the `ice` query param reaches the page's HTTP host (access logs / referrer) AND appears in the
+   QR, URL bar, and browser history — it is NOT secret material and never goes to the RELAY, but it is NOT
+   fragment-protected. Acceptable for user-supplied TURN shared with a trusted device; long-lived TURN credentials
+   should use short-lived TURN REST tokens. (A page-deployment-config home — meta tag / same-origin fetch — is the
+   cleaner place for STATIC long-lived credentials; deferred as a later-E nicety, out of E1 scope.) Absent ⇒
+   host-candidate-only (unchanged behavior). Parser + client unit tests, incl. a malformed-`ice` fail-closed case.
+3. **Docs + verify.** Document `transports.webrtc.options.iceServers`/`forceTurn` (host) and the `ice`/`forceTurn` query
+   params (browser page) in the webrtc + web-ui SPECs. harness:scan + full typecheck + changeset.
+
+## Affected Files
+
+- `agent-cli/src/remote-control/index.ts` (read iceServers/forceTurn) + `remote-control-controller.ts`
+  (`IRemoteControlControllerDeps` + `defaultCreateTransport` pass-through + forceTurn-needs-TURN validation) + tests
+- `agent-web-ui/src/client/parse-remote-location.ts` (`ice`/`forceTurn` query) + `rtc-session-client.ts` (thread
+  `forceTurn`) + `hooks/useWsSession.ts` (`useRtcSession` threads ice) + `components/RemoteClient.tsx` + tests
+- `agent-transport-webrtc/docs/SPEC.md` + `agent-web-ui/docs/SPEC.md`
+- changeset
+
+## Decisions (resolved at GATE-APPROVAL round 1)
+
+- **D1 — browser TURN via the pairing-URL `ice` query param** (consistent with the existing `relay=`; `toPairingUrl`
+  provably preserves the query). **Security honesty:** the `ice` param reaches the page's HTTP host (logs/referrer) +
+  the QR/URL/history — it is NOT fragment-protected like the secret, and NOT sent to the relay. OK for user-supplied
+  TURN shared with a trusted device; long-lived creds → short-lived TURN REST tokens. Static-credential page-config
+  (meta tag / same-origin fetch) is the cleaner home for long-lived creds — deferred (out of E1).
+- **D2 — read `iceServers`/`forceTurn` in `agent-cli` (the composition root)** with a NEW **validating reader** that
+  narrows the untyped `options.iceServers` (`unknown`) → a well-formed `RTCIceServer[]`, no `any`/cast, fail-closed on
+  malformed input. The string-only `readWebrtcOption` cannot be reused for a structured value. **Rationale = LAYERING**
+  (not "no schema change"): `agent-framework`'s config layer is deliberately domain-free; teaching it the webrtc option
+  shape would push transport-domain knowledge up a layer (dependency-direction violation). The composition root already
+  depends on `agent-transport-webrtc`, so it is the right owner.
+- **D3 — fail closed on `forceTurn` without a TURN url**, at BOTH the host root and the browser client. Correct on the
+  REMOTE-004 contract (`forceTurn` "requires a TURN server") AND the no-fallback rule: `forceTurn` + no relay candidate
+  → zero ICE candidates → a SILENT never-connect; a config-time error surfaces it. Not a privacy regression (werift does
+  not silently fall back to host candidates under `forceTurn`).
+- **D4 — E1 = TURN only** (protocol-free, session-free, cleanest self-contained unit). E2 (signaling abuse) is an
+  orthogonal sibling sub-spec. Stage-E decomposition E1(TURN)/E2(abuse)/E3(TOFU)/E4(reconnect, on E3)/E5(co-drive
+  attribution) is sound + correctly sequenced.
+
+**Threat model note (unchanged by E1):** the parent design already treats signaling AND TURN as fully untrusted,
+content-blind relays carrying only DTLS-encrypted traffic; REMOTE-005's DTLS-fingerprint channel binding still detects
+a MITM. An attacker who could inject a malicious `ice=` already controls the rendezvous+secret in the same link (they
+already own the pairing). The only genuinely new surface is parsing attacker-influenced JSON → covered by the D2/step-2
+fail-closed validators.
+
+## Test Plan
+
+RED→GREEN. **Host:** the controller passes configured `iceServers`/`forceTurn` into the transport (via the
+`createTransport` seam); `forceTurn` with no TURN url fails closed. **Host validator fail-closed (D2):**
+`readIceServers` rejects a malformed `transports.webrtc.options.iceServers` (wrong shape, or a bad/unsupported URL
+scheme) with a clear error — no silent partial config, no cast. **Browser:** `parseRemoteClientLocation` reads the
+`ice`/`forceTurn` query (round-trip a `toPairingUrl` link); `createRtcSessionClient`/`useRtcSession` thread `iceServers`
+into the peer (fake `createPeer` asserts the config); `forceTurn` with no TURN fails closed. **Browser decoder
+fail-closed (D1/step-2):** `parseRemoteClientLocation` fails closed on a malformed / bad-scheme decoded `ice` param —
+the exact attacker-influenced surface, never a loose cast into `RTCConfiguration`. Absent ICE ⇒ unchanged
+(host-candidate) behavior. harness:scan + full typecheck + changeset.
+
+## Evidence Log
+
+- 2026-07-11 GATE-DRAFT — authored from the Stage-E grounding Explore. Verified: both `RTCPeerConnection` sinks already
+  accept + consume `iceServers`/`forceTurn` (`webrtc-transport.ts:18,24,74-77`; `rtc-session-client.ts:48,122`); only
+  the config-read + threading layers are missing on both peers; `transports.webrtc.options` is an untyped bag read the
+  same way for `relayUrl`/`clientUrl` (no schema change needed); no TURN/iceServers tests exist yet; existing
+  injection-seam harnesses (`createTransport` controller seam, `createPeer` browser-client seam) are the natural test
+  homes. E1 is protocol-free + session-free — the cleanest first Stage-E piece. Pending proposal-reviewer ENDORSE.
+- 2026-07-11 GATE-APPROVAL round 1 — proposal-reviewer **REVISE** (direction correct + well-grounded; all 4
+  recommendations APPROVED as D1–D4; every premise TRUE against source). Two required refinements folded in: **D2** —
+  re-grounded the config-read placement on LAYERING (agent-framework config must stay domain-free), NOT "no schema
+  change" (a discounted diff-size argument), AND committed to a dedicated **validating reader** that narrows
+  `unknown`→`RTCIceServer[]` (no `any`/cast, fail-closed) since `iceServers` is structured and the string-only reader
+  cannot be reused; **D1/step-2** — sharpened the security honesty (the `ice` query reaches the page host/QR/logs,
+  unlike the fragment-protected secret) + required the browser `ice`-param decoder to validate attacker-influenced input
+  and fail closed. Confirmed threading TURN weakens no REMOTE-005 channel-binding / REMOTE-004 forceTurn property
+  (signaling+TURN already untrusted in the threat model). Re-review → round 2.
+- 2026-07-11 GATE-APPROVAL round 2 — proposal-reviewer **REVISE**. Confirmed both round-1 refinements landed in prose
+  (D2 LAYERING re-grounding + validating reader, no `any`/cast; D1/step-2 query-vs-fragment security honesty + validate
+  attacker-influenced `ice`; the "no schema change" diff-size framing is disowned in D2 + step 1). One remaining
+  Solution↔Test-Plan inconsistency: the new fail-closed VALIDATORS (host `readIceServers`, browser `ice`-decoder) — the
+  exact new attacker-facing surface — were promised in the Solution but not in the canonical Test Plan. Added both to
+  the Test Plan: host `readIceServers` rejects a malformed/bad-scheme value fail-closed; browser
+  `parseRemoteClientLocation` fails closed on a malformed/bad-scheme decoded `ice` param (+ browser
+  `forceTurn`-without-TURN fail-closed). Re-review → round 3.
+- 2026-07-11 GATE-APPROVAL round 3 — proposal-reviewer **ENDORSE**. Both round-2 Test-Plan additions verified present
+  (host `readIceServers` malformed/bad-scheme fail-closed; browser `parseRemoteClientLocation` malformed/bad-scheme
+  `ice` fail-closed) + both `forceTurn`-without-TURN cases; no symbol drift, uniform no-cast/fail-closed language across
+  D1/D2/Solution/Test-Plan, "no schema change" stays disowned, threat-model note now covers a tested surface.
+  **GATE-APPROVAL cleared** → status in-progress, spec to active, implement on an `origin/develop`-based branch, Step 1
+  (host validating reader → transport) first.
+
+## Tasks
+
+- [x] Step 1 — host: `readIceServers` (validating `unknown`→`RTCIceServer[]`, no cast, fail-closed) + `readForceTurn` in
+      `agent-cli/src/remote-control/index.ts` + `IRemoteControlControllerDeps`; `defaultCreateTransport` passes
+      `iceServers`/`forceTurn`; `forceTurn`-needs-TURN validation fails closed. Controller + reader unit tests
+      (incl. malformed-value + forceTurn-without-TURN fail-closed).
+- [x] Step 2 — browser: extend `IRemoteClientLocation` + `parseRemoteClientLocation` with a validating `ice` decoder
+      (base64url JSON → `RTCIceServer[]`, fail-closed) + `forceTurn`; thread through `RemoteClient` → `useRtcSession` →
+      `createRtcSessionClient`. Parser + client unit tests (incl. malformed-`ice` + forceTurn-without-TURN fail-closed).
+- [x] Step 3 — docs (webrtc + web-ui SPECs) + changeset + verify (harness:scan + full typecheck).
+- 2026-07-11 GATE-BUILD — implemented on `feat/remote-010-turn-fallback` (off origin/develop), all 3 steps. Step 1
+  (host): `parseIceServers` validator (unknown→IIceServer[], no cast, fail-closed on malformed/bad-scheme) + hasTurnServer
+  in agent-cli; readIceServers/readForceTurn deps + defaultCreateTransport pass-through + forceTurn⇒TURN fail-closed;
+  widened IWebRtcTransportOptions.iceServers (+werift loader) for TURN username/credential + array urls. Step 2
+  (browser): parse-ice-servers.ts browser decoder (base64url→JSON→validate, fail-closed) + parseRemoteClientLocation
+  reads ice/forceTurn query + createRtcSessionClient forceTurn→iceTransportPolicy:'relay' + useRtcSession threads them.
+  Step 3: SPECs + changeset. Verify: agent-web-ui 48, agent-cli 190, agent-transport-webrtc 23; harness:scan 49/49;
+  full-repo typecheck 0. Both fail-closed validators tested (host malformed + browser malformed/bad-scheme +
+  forceTurn-without-TURN on both peers). Ready for implementation review + merge-verifier.
+- 2026-07-11 GATE-REVIEW (implementation) — proposal-reviewer **REVISE→fixed** (browser side ENDORSED; 2 host
+  fail-OPEN defects at the werift boundary, both empirically confirmed + fixed). **Defect 1 (privacy):** werift's ICE
+  gatherer derives relay-only from `iceTransportPolicy === 'relay'` and IGNORES a top-level `forceTurn` — so the host
+  `forceTurn` was a silent no-op (host candidates still leak). Fixed: map `forceTurn` → `peerConfig.iceTransportPolicy =
+'relay'`; werift-loader config type corrected (`iceTransportPolicy?:'all'|'relay'`, dropped the ignored `forceTurn`).
+  **Defect 2 (silent drop):** werift's `parseIceServers` consumes only a single-string `turn:`/`stun:` url and silently
+  drops array `urls` + `turns:`/`stuns:` — the host validator accepted them → TURN configured-but-discarded → silent
+  never-connect. Fixed: narrowed `IIceServer.urls` to a single string and the host `parseIceServers` REJECTS (fail-closed)
+  array urls + `turns:`/`stuns:` (with a clear werift-limitation error); the browser decoder stays wider (native
+  RTCPeerConnection supports those). Added a werift-level regression test (fake-werift seam captures the config:
+  forceTurn→iceTransportPolicy:'relay', no top-level forceTurn emitted). Also fixed a non-blocking nit (browser base64url
+  decoder now proper UTF-8 for non-ASCII creds). Verify: webrtc 24, cli 192, web-ui 48; harness:scan 49/49; full
+  typecheck 0. Ready for re-review + merge.

--- a/.changeset/remote-010-turn-fallback.md
+++ b/.changeset/remote-010-turn-fallback.md
@@ -1,0 +1,14 @@
+---
+'@robota-sdk/agent-transport-webrtc': minor
+'@robota-sdk/agent-cli': minor
+'@robota-sdk/agent-web-ui': minor
+---
+
+Add user-supplied TURN fallback for remote control (REMOTE-010 / Stage E1) so P2P works behind symmetric
+NAT / restrictive firewalls. The host reads + validates `transports.webrtc.options.iceServers`/`forceTurn`
+at the agent-cli composition root (a fail-closed validator narrowing the untyped value → `IIceServer[]`;
+`IWebRtcTransportOptions.iceServers` widened to carry TURN `username`/`credential`), and the browser reads a
+validated `ice`/`forceTurn` pairing-URL query param (fail-closed decoder for the attacker-influenceable value;
+`forceTurn` → `iceTransportPolicy: 'relay'`) — both threaded into their `RTCPeerConnection`. `forceTurn` without
+a TURN server fails closed (else ICE gathers no candidates and silently never connects). Absent ICE config ⇒
+host-candidate-only, unchanged.

--- a/packages/agent-cli/src/remote-control/__tests__/ice-config.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/ice-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasTurnServer, parseIceServers } from '../ice-config.js';
+
+/**
+ * REMOTE-010 Step 1 — the host ICE validating reader. `transports.webrtc.options.iceServers` is an untyped bag
+ * value; a malformed value must FAIL CLOSED (throw), never a silent partial/cast config.
+ */
+
+describe('parseIceServers (REMOTE-010 host validator)', () => {
+  it('returns undefined for absent/empty', () => {
+    expect(parseIceServers(undefined)).toBeUndefined();
+    expect(parseIceServers(null)).toBeUndefined();
+    expect(parseIceServers([])).toBeUndefined();
+  });
+
+  it('accepts a STUN server (string urls)', () => {
+    expect(parseIceServers([{ urls: 'stun:stun.l.google.com:19302' }])).toEqual([
+      { urls: 'stun:stun.l.google.com:19302' },
+    ]);
+  });
+
+  it('accepts a single-string TURN server with credentials', () => {
+    const cfg = [{ urls: 'turn:turn.example:3478', username: 'u', credential: 'p' }];
+    expect(parseIceServers(cfg)).toEqual(cfg);
+  });
+
+  it('fail-closed: array urls — werift silently drops them, so reject (do not fail open)', () => {
+    expect(() => parseIceServers([{ urls: ['turn:a:3478', 'turn:b:3478'] }])).toThrow(
+      /single url string/,
+    );
+  });
+
+  it('fail-closed: turns:/stuns: scheme — werift drops them, so reject', () => {
+    expect(() => parseIceServers([{ urls: 'turns:turn.example:5349' }])).toThrow(/turns:\/stuns:/);
+    expect(() => parseIceServers([{ urls: 'stuns:x' }])).toThrow(/scheme/);
+  });
+
+  it('fail-closed: not an array', () => {
+    expect(() => parseIceServers({ urls: 'stun:x' })).toThrow(/must be an array/);
+  });
+
+  it('fail-closed: entry not an object', () => {
+    expect(() => parseIceServers(['stun:x'])).toThrow(/must be an object/);
+  });
+
+  it('fail-closed: bad/unsupported URL scheme (attacker-influenced)', () => {
+    expect(() => parseIceServers([{ urls: 'http://evil.example' }])).toThrow(/scheme/);
+    expect(() => parseIceServers([{ urls: 'javascript:alert(1)' }])).toThrow(/scheme/);
+  });
+
+  it('fail-closed: non-string username/credential', () => {
+    expect(() => parseIceServers([{ urls: 'turn:x', username: 42 }])).toThrow(/username/);
+    expect(() => parseIceServers([{ urls: 'turn:x', credential: {} }])).toThrow(/credential/);
+  });
+
+  it('fail-closed: empty/non-string url', () => {
+    expect(() => parseIceServers([{ urls: '' }])).toThrow(/url/);
+    expect(() => parseIceServers([{ urls: 123 }])).toThrow(/url/);
+  });
+});
+
+describe('hasTurnServer', () => {
+  it('detects a turn: url, ignores STUN-only', () => {
+    expect(hasTurnServer([{ urls: 'stun:x' }])).toBe(false);
+    expect(hasTurnServer([{ urls: 'turn:x' }])).toBe(true);
+    expect(hasTurnServer(undefined)).toBe(false);
+  });
+});

--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
@@ -25,6 +25,7 @@ function makeDeps(over: Partial<IRemoteControlControllerDeps> = {}): {
   };
   signaling: { close: ReturnType<typeof vi.fn> };
   hooks: { onPaired?: () => void; onPairingFailed?: () => void };
+  captured: { ice?: { iceServers?: unknown; forceTurn?: boolean } };
 } {
   const registered: IConfigurableTransport<IInteractiveSession>[] = [];
   const registry = {
@@ -42,6 +43,8 @@ function makeDeps(over: Partial<IRemoteControlControllerDeps> = {}): {
   // Capture the pairing lifecycle hooks the controller passes into the transport, so a test can simulate
   // the gate accepting / rejecting.
   const hooks: { onPaired?: () => void; onPairingFailed?: () => void } = {};
+  // Capture the ICE config the controller passes into the transport (REMOTE-010).
+  const captured: { ice?: { iceServers?: unknown; forceTurn?: boolean } } = {};
   const deps: IRemoteControlControllerDeps = {
     registry,
     readRelayUrl: () => 'ws://127.0.0.1:9999',
@@ -49,14 +52,15 @@ function makeDeps(over: Partial<IRemoteControlControllerDeps> = {}): {
     getSession: () => ({}) as IInteractiveSession,
     renderQr: () => Promise.resolve('[QR]'),
     createSignaling: () => signaling as unknown as ISignalingClient,
-    createTransport: (_s, _secret, h) => {
+    createTransport: (_s, _secret, h, ice) => {
       hooks.onPaired = h.onPaired;
       hooks.onPairingFailed = h.onPairingFailed;
+      captured.ice = ice;
       return transport as unknown as IConfigurableTransport<IInteractiveSession>;
     },
     ...over,
   };
-  return { deps, registered, transport, signaling, hooks };
+  return { deps, registered, transport, signaling, hooks, captured };
 }
 
 describe('RemoteControlController (REMOTE-008)', () => {
@@ -100,6 +104,43 @@ describe('RemoteControlController (REMOTE-008)', () => {
     expect(createTransport).not.toHaveBeenCalled();
     expect(registered).toHaveLength(0);
     expect(controller.getStatus()).toEqual({ state: 'off' }); // untouched (no new enum variant)
+  });
+
+  it('REMOTE-010: passes configured iceServers + forceTurn into the transport', async () => {
+    const iceServers = [{ urls: 'turn:turn.example:3478', username: 'u', credential: 'p' }];
+    const { deps, captured } = makeDeps({
+      readIceServers: () => iceServers,
+      readForceTurn: () => true,
+    });
+    await new RemoteControlController(deps).enable();
+    expect(captured.ice).toEqual({ iceServers, forceTurn: true });
+  });
+
+  it('REMOTE-010: forceTurn without a TURN server fails closed — constructs nothing', async () => {
+    const createTransport = vi.fn();
+    const { deps } = makeDeps({
+      readIceServers: () => [{ urls: 'stun:stun.example:19302' }], // STUN only, no TURN
+      readForceTurn: () => true,
+      createTransport,
+    });
+    const msg = await new RemoteControlController(deps).enable();
+    expect(msg).toMatch(/forceTurn.*requires.*TURN/i);
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
+  it('REMOTE-010: a malformed iceServers config fails closed (throwing reader surfaced, nothing constructed)', async () => {
+    const createTransport = vi.fn();
+    const { deps } = makeDeps({
+      readIceServers: () => {
+        throw new Error(
+          'Invalid ICE config: iceServers[0].urls "http://x" must use a stun:/turn: scheme.',
+        );
+      },
+      createTransport,
+    });
+    const msg = await new RemoteControlController(deps).enable();
+    expect(msg).toMatch(/Invalid ICE config/);
+    expect(createTransport).not.toHaveBeenCalled();
   });
 
   it('enable with no session yet → reports and constructs nothing', async () => {

--- a/packages/agent-cli/src/remote-control/ice-config.ts
+++ b/packages/agent-cli/src/remote-control/ice-config.ts
@@ -1,0 +1,78 @@
+import type { IIceServer } from '@robota-sdk/agent-transport-webrtc';
+
+/**
+ * Validating reader for the HOST WebRTC ICE config (REMOTE-010 E1). `transports.webrtc.options.iceServers` is an
+ * UNTYPED bag value (`unknown`), so it must be narrowed with real validation — no `any`, no unchecked cast — and a
+ * malformed value must **fail closed** (a clear error), never a silent partial config.
+ *
+ * CRUCIALLY, this is constrained to what the HOST sink (werift) actually consumes: werift's ICE gatherer
+ * (`parseIceServers`) reads only a SINGLE-string `urls` with a `turn:`/`stun:` scheme and **silently drops** array
+ * `urls`, `turns:`/`stuns:` schemes, etc. So we REJECT (fail-closed) the shapes werift would drop — accepting them
+ * would advertise TURN as configured while werift discards it (a silent never-connect). (The browser peer uses the
+ * native `RTCPeerConnection`, which DOES support array urls / `turns:` — its decoder is deliberately wider.)
+ */
+
+const ICE_URL_SCHEME = /^(stun|turn):/i;
+
+function validateUrl(url: unknown, where: string): string {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error(`Invalid ICE config: ${where} must be a non-empty url string.`);
+  }
+  if (!ICE_URL_SCHEME.test(url)) {
+    throw new Error(
+      `Invalid ICE config: ${where} "${url}" must use a stun:/turn: scheme — the host (werift) transport does ` +
+        'not support turns:/stuns: (silently dropped). Use turn:/stun:.',
+    );
+  }
+  return url;
+}
+
+function validateServer(entry: unknown, index: number): IIceServer {
+  if (typeof entry !== 'object' || entry === null) {
+    throw new Error(`Invalid ICE config: iceServers[${index}] must be an object.`);
+  }
+  const record = entry as Record<string, unknown>;
+  const rawUrls = record.urls;
+  if (Array.isArray(rawUrls)) {
+    throw new Error(
+      `Invalid ICE config: iceServers[${index}].urls must be a single url string — the host (werift) transport ` +
+        'silently drops array urls. List each server as a separate { urls } entry.',
+    );
+  }
+  const urls = validateUrl(rawUrls, `iceServers[${index}].urls`);
+  const server: { urls: string; username?: string; credential?: string } = { urls };
+  if (record.username !== undefined) {
+    if (typeof record.username !== 'string') {
+      throw new Error(`Invalid ICE config: iceServers[${index}].username must be a string.`);
+    }
+    server.username = record.username;
+  }
+  if (record.credential !== undefined) {
+    if (typeof record.credential !== 'string') {
+      throw new Error(`Invalid ICE config: iceServers[${index}].credential must be a string.`);
+    }
+    server.credential = record.credential;
+  }
+  return server;
+}
+
+/**
+ * Narrow an untyped `iceServers` value → a validated `IIceServer[]`. Returns undefined when absent/empty;
+ * THROWS on a malformed value (fail-closed — never a silent partial config).
+ */
+export function parseIceServers(value: unknown): IIceServer[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(
+      'Invalid ICE config: `iceServers` must be an array of { urls, username?, credential? }.',
+    );
+  }
+  if (value.length === 0) return undefined;
+  return value.map((entry, index) => validateServer(entry, index));
+}
+
+/** True when any configured ICE server is a TURN (`turn:`) server (host validator rejects `turns:`). */
+export function hasTurnServer(iceServers: readonly IIceServer[] | undefined): boolean {
+  if (!iceServers) return false;
+  return iceServers.some((s) => /^turn:/i.test(s.urls));
+}

--- a/packages/agent-cli/src/remote-control/index.ts
+++ b/packages/agent-cli/src/remote-control/index.ts
@@ -1,6 +1,7 @@
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import { getUserSettingsPath, readSettings } from '@robota-sdk/agent-framework';
 
+import { parseIceServers } from './ice-config.js';
 import { renderQrToTerminal } from './render-qr.js';
 import { RemoteControlController } from './remote-control-controller.js';
 
@@ -30,6 +31,18 @@ function readWebrtcOption(key: string): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+/** Read a raw (untyped) value under `transports.webrtc.options.<key>` — for structured values (REMOTE-010). */
+function readWebrtcRawOption(key: string): unknown {
+  const settings = readSettings(getUserSettingsPath());
+  const transports = settings.transports;
+  if (typeof transports !== 'object' || transports === null) return undefined;
+  const webrtc = (transports as Record<string, unknown>).webrtc;
+  if (typeof webrtc !== 'object' || webrtc === null) return undefined;
+  const options = (webrtc as Record<string, unknown>).options;
+  if (typeof options !== 'object' || options === null) return undefined;
+  return (options as Record<string, unknown>)[key];
+}
+
 /**
  * Build the `/remote-control` controller at the composition root. The returned `setChannel` is called from
  * `onChannelReady` (each live channel, incl. session-switch re-creations) so the enable path attaches the
@@ -44,6 +57,8 @@ export function createRemoteControlController(registry: TransportRegistry): {
     registry,
     readRelayUrl: () => readWebrtcOption('relayUrl'),
     readClientUrl: () => readWebrtcOption('clientUrl'),
+    readIceServers: () => parseIceServers(readWebrtcRawOption('iceServers')),
+    readForceTurn: () => readWebrtcRawOption('forceTurn') === true,
     getSession: () => channel?.getSession(),
     renderQr: renderQrToTerminal,
     reportError: (message) =>

--- a/packages/agent-cli/src/remote-control/remote-control-controller.ts
+++ b/packages/agent-cli/src/remote-control/remote-control-controller.ts
@@ -1,7 +1,9 @@
 import { generatePairingSecret, toPairingUrl } from '@robota-sdk/agent-remote-pairing';
 import { WsSignalingClient, WebRtcTransport } from '@robota-sdk/agent-transport-webrtc';
 
-import type { ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
+import { hasTurnServer } from './ice-config.js';
+
+import type { IIceServer, ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
 import type { TransportRegistry } from '@robota-sdk/agent-transport';
 import type { TRemoteControlStatus } from '@robota-sdk/agent-framework';
 import type {
@@ -30,6 +32,11 @@ export interface IRemoteControlControllerDeps {
   readRelayUrl: () => string | undefined;
   /** Client base URL for the pairing link (`transports.webrtc.options.clientUrl`); unset ⇒ enable fails closed (REMOTE-009 D5). */
   readClientUrl: () => string | undefined;
+  /** REMOTE-010: validated user-supplied ICE (STUN/TURN) servers (`transports.webrtc.options.iceServers`), or
+   *  undefined when absent. THROWS on a malformed config (fail-closed) — surfaced as an enable error. */
+  readIceServers?: () => readonly IIceServer[] | undefined;
+  /** REMOTE-010: `transports.webrtc.options.forceTurn` — restrict ICE to relay candidates (requires a TURN server). */
+  readForceTurn?: () => boolean;
   /** The live interactive session to expose on pairing accept, or undefined before one is ready. */
   getSession: () => IInteractiveSession | undefined;
   /** Render a scannable QR for the given text (async). */
@@ -42,6 +49,7 @@ export interface IRemoteControlControllerDeps {
     signaling: ISignalingClient,
     secret: string,
     hooks: { onPaired: () => void; onPairingFailed: () => void },
+    ice: { iceServers?: readonly IIceServer[]; forceTurn?: boolean },
   ) => IConfigurableTransport<IInteractiveSession>;
 }
 
@@ -83,6 +91,23 @@ export class RemoteControlController {
       );
     }
 
+    // REMOTE-010: user-supplied TURN/STUN. `readIceServers` throws on a malformed config → fail closed with the
+    // error (don't construct/start). `forceTurn` requires a TURN server, else ICE yields zero candidates (silent
+    // never-connect) — surface that as a config error too.
+    let iceServers: readonly IIceServer[] | undefined;
+    try {
+      iceServers = this.deps.readIceServers?.();
+    } catch (error) {
+      return `Remote control: ${error instanceof Error ? error.message : String(error)}`;
+    }
+    const forceTurn = this.deps.readForceTurn?.() ?? false;
+    if (forceTurn && !hasTurnServer(iceServers)) {
+      return (
+        'Remote control: `transports.webrtc.options.forceTurn` requires at least one TURN server in ' +
+        '`iceServers` (a turn:/turns: url) — otherwise ICE gathers no candidates and never connects.'
+      );
+    }
+
     const pairing = generatePairingSecret();
     const signaling = (this.deps.createSignaling ?? defaultCreateSignaling)(
       relayUrl,
@@ -102,6 +127,7 @@ export class RemoteControlController {
           if (this.transport === transport) void this.teardown('off');
         },
       },
+      { ...(iceServers ? { iceServers } : {}), forceTurn },
     );
 
     this.deps.registry.register(transport);
@@ -172,11 +198,14 @@ function defaultCreateTransport(
   signaling: ISignalingClient,
   secret: string,
   hooks: { onPaired: () => void; onPairingFailed: () => void },
+  ice: { iceServers?: readonly IIceServer[]; forceTurn?: boolean },
 ): IConfigurableTransport<IInteractiveSession> {
   return new WebRtcTransport({
     signaling,
     secret,
     onPaired: hooks.onPaired,
     onPairingFailed: hooks.onPairingFailed,
+    ...(ice.iceServers ? { iceServers: ice.iceServers } : {}),
+    ...(ice.forceTurn ? { forceTurn: ice.forceTurn } : {}),
   });
 }

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -70,6 +70,7 @@ lifecycle (REMOTE-008: status `paired`, and teardown of the peer/signaling on fa
 | ----------------------------- | -------- | -------------------------------------------------------------------------------- |
 | `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.            |
 | `IWebRtcTransportOptions`     | type     | Construction options.                                                            |
+| `IIceServer`                  | type     | A STUN/TURN server (`urls` + optional `username`/`credential`; REMOTE-010).      |
 | `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                        |
 | `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).      |
 | `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory). |
@@ -84,6 +85,9 @@ lifecycle (REMOTE-008: status `paired`, and teardown of the peer/signaling on fa
 
 - **Signaling** is swappable via `ISignalingClient` — the in-memory pair, a WebSocket client to
   `apps/remote-signaling`, or any other rendezvous can be injected without touching the transport.
+- **REMOTE-010 TURN:** `IWebRtcTransportOptions.iceServers` is `readonly IIceServer[]` — TURN servers carry
+  `username`/`credential` (+ `urls` may be a string or array). The host reads + validates them from
+  `transports.webrtc.options.iceServers` at the `agent-cli` composition root; `forceTurn` requires a TURN server.
 - **ICE servers** (STUN/TURN) are supplied via `IWebRtcTransportOptions.iceServers`; omitted → host-candidate /
   loopback only.
 - **WebRTC implementation** is isolated behind `loadWerift`/`IWeriftModule`; switching to a native impl

--- a/packages/agent-transport-webrtc/src/__tests__/webrtc-transport.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/webrtc-transport.test.ts
@@ -66,6 +66,42 @@ describe('WebRtcTransport (REMOTE-002 Stage A — loopback)', () => {
     await expect(t.start()).rejects.toThrow(/attach\(\) must be called/);
   });
 
+  it('REMOTE-010: forceTurn → iceTransportPolicy:relay (NOT top-level forceTurn, which werift ignores) + turn: passes through', async () => {
+    // Inject a fake werift to capture the config the transport builds (a real relay-only peer + dead TURN would
+    // block ICE gathering). The mapping is proven against real werift empirically; this guards the regression:
+    // forceTurn MUST become iceTransportPolicy:'relay', never a top-level forceTurn werift silently drops.
+    let captured: Record<string, unknown> | undefined;
+    const fakeWerift = {
+      RTCPeerConnection: function (config?: Record<string, unknown>) {
+        captured = config;
+        return {
+          onIceCandidate: { subscribe: () => {} },
+          createDataChannel: () => ({ onMessage: { subscribe: () => {} }, send: () => {} }),
+          createOffer: async () => ({ type: 'offer', sdp: 'a=fingerprint:sha-256 AA' }),
+          setLocalDescription: async () => {},
+          localDescription: { sdp: 'a=fingerprint:sha-256 AA' },
+          close: async () => {},
+        };
+      },
+    } as unknown as import('../werift-loader.js').IWeriftModule;
+
+    const [sig] = createInMemorySignalingPair();
+    const t = new WebRtcTransport({
+      signaling: sig,
+      iceServers: [{ urls: 'turn:relay.example:3478', username: 'u', credential: 'c' }],
+      forceTurn: true,
+      loadWerift: () => fakeWerift,
+    });
+    t.attach(createStubSession());
+    await t.start();
+    expect(captured).toEqual({
+      iceServers: [{ urls: 'turn:relay.example:3478', username: 'u', credential: 'c' }],
+      iceTransportPolicy: 'relay',
+    });
+    expect(captured).not.toHaveProperty('forceTurn'); // werift ignores it → must not be emitted
+    await t.stop();
+  });
+
   it('TC-03: establishes an RTCDataChannel between two peers and round-trips TClient→session→TServer through the shared handler', async () => {
     const [hostSig, remoteSig] = createInMemorySignalingPair();
     const session = createStubSession();

--- a/packages/agent-transport-webrtc/src/index.ts
+++ b/packages/agent-transport-webrtc/src/index.ts
@@ -1,5 +1,5 @@
 export { WebRtcTransport } from './webrtc-transport.js';
-export type { IWebRtcTransportOptions } from './webrtc-transport.js';
+export type { IWebRtcTransportOptions, IIceServer } from './webrtc-transport.js';
 export { createInMemorySignalingPair } from './signaling.js';
 export type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
 export { WsSignalingClient } from './ws-signaling-client.js';

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -9,17 +9,32 @@ import type { RTCDataChannel, RTCPeerConnection } from 'werift';
 import { loadWerift } from './werift-loader.js';
 import { PairingGate } from './pairing-gate.js';
 import type { ISignalingClient } from './signaling.js';
+import type { IWeriftModule } from './werift-loader.js';
+
+/**
+ * A single ICE (STUN/TURN) server for the HOST (werift) transport (REMOTE-010). `urls` is a SINGLE string with a
+ * `turn:`/`turns:`/`stun:`/`stuns:` scheme — werift's ICE gatherer (`parseIceServers`) consumes only a single-string
+ * url and silently drops array `urls`, so the host reader (`agent-cli` `parseIceServers`) must narrow to this shape
+ * and reject what werift would drop (fail-closed). (The browser peer uses the native DOM `RTCIceServer`, which does
+ * support array urls / `turns:` — a separate, wider validator.) Kept a plain interface (no DOM dependency here).
+ */
+export interface IIceServer {
+  readonly urls: string;
+  readonly username?: string;
+  readonly credential?: string;
+}
 
 /** Construction options for {@link WebRtcTransport}. The signaling client is injected (Stage A: no settings). */
 export interface IWebRtcTransportOptions {
   /** Signaling port used to exchange SDP/ICE with the remote peer by rendezvous id. */
   readonly signaling: ISignalingClient;
   /** Optional ICE servers (STUN/TURN). Omitted → host-candidate/loopback only. */
-  readonly iceServers?: readonly { urls: string }[];
+  readonly iceServers?: readonly IIceServer[];
   /**
-   * REMOTE-004 defense-in-depth: when true, restrict ICE to **relay (TURN) candidates only** (werift `forceTurn`),
-   * so host/server-reflexive candidates — and the local-interface gathering that touches the (unreachable, but
-   * belt-and-braces) `ip` code path — are never used. Requires a TURN server in `iceServers`.
+   * REMOTE-004 defense-in-depth: when true, restrict ICE to **relay (TURN) candidates only**, so
+   * host/server-reflexive candidates — and the local-interface gathering that touches the (unreachable, but
+   * belt-and-braces) `ip` code path — are never used. Requires a TURN server in `iceServers`. Mapped to werift's
+   * `iceTransportPolicy: 'relay'` (REMOTE-010) — werift IGNORES a top-level `forceTurn`, so it must NOT be passed.
    */
   readonly forceTurn?: boolean;
   /**
@@ -33,6 +48,8 @@ export interface IWebRtcTransportOptions {
   readonly onPaired?: () => void;
   /** REMOTE-008: fired when pairing rejects/times out (host lifecycle → teardown; the channel is already closed). */
   readonly onPairingFailed?: () => void;
+  /** Test seam: inject the werift module (defaults to the real lazy loader). */
+  readonly loadWerift?: () => IWeriftModule;
 }
 
 /**
@@ -70,10 +87,17 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
     const session = this.session;
     if (!session) throw new Error('WebRtcTransport: attach() must be called before start()');
 
-    const { RTCPeerConnection } = loadWerift();
-    const peerConfig: { iceServers?: { urls: string }[]; forceTurn?: boolean } = {};
-    if (this.options.iceServers) peerConfig.iceServers = [...this.options.iceServers];
-    if (this.options.forceTurn) peerConfig.forceTurn = true;
+    const { RTCPeerConnection } = (this.options.loadWerift ?? loadWerift)();
+    const peerConfig: {
+      iceServers?: { urls: string; username?: string; credential?: string }[];
+      iceTransportPolicy?: 'all' | 'relay';
+    } = {};
+    if (this.options.iceServers)
+      peerConfig.iceServers = this.options.iceServers.map((s) => ({ ...s }));
+    // REMOTE-010: werift's ICE gatherer derives relay-only from `iceTransportPolicy === 'relay'` — it IGNORES a
+    // top-level `forceTurn`. Map `forceTurn` → `iceTransportPolicy:'relay'`, else the privacy control is a silent
+    // no-op and host/server-reflexive candidates still leak.
+    if (this.options.forceTurn) peerConfig.iceTransportPolicy = 'relay';
     const peer = new RTCPeerConnection(Object.keys(peerConfig).length > 0 ? peerConfig : undefined);
     this.peer = peer;
     const signaling = this.options.signaling;

--- a/packages/agent-transport-webrtc/src/werift-loader.ts
+++ b/packages/agent-transport-webrtc/src/werift-loader.ts
@@ -5,8 +5,11 @@ import type { RTCPeerConnection } from 'werift';
 /** The subset of the `werift` module surface this transport constructs. */
 export interface IWeriftModule {
   RTCPeerConnection: new (configuration?: {
-    iceServers?: { urls: string }[];
-    forceTurn?: boolean;
+    // REMOTE-010: werift's ICE gatherer consumes only a SINGLE-string `urls` (array urls / `turns:` are silently
+    // dropped by its `parseIceServers`); TURN servers carry username/credential. Relay-only comes from
+    // `iceTransportPolicy:'relay'` — werift IGNORES a top-level `forceTurn`, so this type must NOT declare it.
+    iceServers?: { urls: string; username?: string; credential?: string }[];
+    iceTransportPolicy?: 'all' | 'relay';
   }) => RTCPeerConnection;
 }
 

--- a/packages/agent-web-ui/docs/SPEC.md
+++ b/packages/agent-web-ui/docs/SPEC.md
@@ -22,6 +22,13 @@ the isomorphic zero-dep `@robota-sdk/agent-remote-pairing` leaf and takes **no**
 `permission_request`/`ask_request`/`prompt_resolved`, `PermissionPrompt` component) serves BOTH the WS and
 RTC clients — the paired owner answers its OWN prompts (local == remote).
 
+**REMOTE-010 TURN fallback.** `parseRemoteClientLocation` also reads an optional `ice` query param (a base64url
+JSON `RTCIceServer[]`, decoded + validated by a browser-local fail-closed decoder — the param is
+attacker-influenceable) and a `forceTurn` flag, threaded through `RemoteClient` → `useRtcSession` →
+`createRtcSessionClient` (`forceTurn` → `iceTransportPolicy: 'relay'`; requires a TURN server, else fail-closed).
+Like `relay=`, the `ice` config rides the query (reaches the page host / QR / history — NOT the fragment-protected
+secret, NOT the relay).
+
 This package sits in the **Product shells** layer. It is a pure browser UI library — it does not
 own session lifecycle, conversation history, or agent runtime state.
 

--- a/packages/agent-web-ui/src/client/__tests__/parse-ice-servers.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/parse-ice-servers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { iceHasTurn, parseIceServersParam } from '../parse-ice-servers.js';
+
+/**
+ * REMOTE-010 Step 2 — the browser `ice`-param decoder. The param is attacker-influenceable, so a malformed
+ * value must FAIL CLOSED (throw), never a loose cast into RTCConfiguration.
+ */
+
+/** Encode an RTCIceServer[] the way the operator's clientUrl would (base64url JSON). */
+function encode(servers: unknown): string {
+  return btoa(JSON.stringify(servers)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+describe('parseIceServersParam (REMOTE-010 browser decoder)', () => {
+  it('decodes + validates a STUN server', () => {
+    expect(parseIceServersParam(encode([{ urls: 'stun:stun.l.google.com:19302' }]))).toEqual([
+      { urls: 'stun:stun.l.google.com:19302' },
+    ]);
+  });
+
+  it('decodes a TURN server with credentials + array urls', () => {
+    const servers = [
+      {
+        urls: ['turn:turn.example:3478', 'turns:turn.example:5349'],
+        username: 'u',
+        credential: 'p',
+      },
+    ];
+    expect(parseIceServersParam(encode(servers))).toEqual(servers);
+  });
+
+  it('fail-closed: not base64url', () => {
+    expect(() => parseIceServersParam('@@@not-base64@@@')).toThrow();
+  });
+
+  it('fail-closed: decodes to non-JSON / non-array', () => {
+    expect(() => parseIceServersParam(btoa('not json'))).toThrow(/JSON/);
+    expect(() => parseIceServersParam(encode({ urls: 'stun:x' }))).toThrow(/array/);
+  });
+
+  it('fail-closed: bad/unsupported URL scheme (attacker-influenced)', () => {
+    expect(() => parseIceServersParam(encode([{ urls: 'http://evil.example' }]))).toThrow(/scheme/);
+    expect(() => parseIceServersParam(encode([{ urls: 'javascript:alert(1)' }]))).toThrow(/scheme/);
+  });
+
+  it('fail-closed: non-string credential', () => {
+    expect(() => parseIceServersParam(encode([{ urls: 'turn:x', credential: 9 }]))).toThrow(
+      /credential/,
+    );
+  });
+});
+
+describe('iceHasTurn', () => {
+  it('detects TURN vs STUN-only', () => {
+    expect(iceHasTurn([{ urls: 'stun:x' }])).toBe(false);
+    expect(iceHasTurn([{ urls: 'turns:y' }])).toBe(true);
+    expect(iceHasTurn(undefined)).toBe(false);
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/parse-remote-location.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/parse-remote-location.test.ts
@@ -39,4 +39,40 @@ describe('parseRemoteClientLocation (REMOTE-009)', () => {
   it('throws when the pairing fragment is missing', () => {
     expect(() => parseRemoteClientLocation('https://remote.example/?relay=wss://r')).toThrow();
   });
+
+  // ── REMOTE-010: ICE/TURN query params ──
+  const iceEnc = (s: unknown): string =>
+    btoa(JSON.stringify(s)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  it('REMOTE-010: reads a validated `ice` param + forceTurn from the query, r+s still from the fragment', () => {
+    const servers = [{ urls: 'turn:turn.example:3478', username: 'u', credential: 'p' }];
+    const base = `https://remote.example/?relay=wss://r&ice=${iceEnc(servers)}&forceTurn=1`;
+    const link = toPairingUrl(base, { rendezvous: 'rv', secret: 'sec' });
+    const loc = parseRemoteClientLocation(link);
+    expect(loc.iceServers).toEqual(servers);
+    expect(loc.forceTurn).toBe(true);
+    expect(loc.secret).toBe('sec');
+  });
+
+  it('REMOTE-010: absent ice ⇒ no iceServers/forceTurn (unchanged behavior)', () => {
+    const loc = parseRemoteClientLocation('https://remote.example/?relay=wss://r#r=rv&s=sec');
+    expect(loc.iceServers).toBeUndefined();
+    expect(loc.forceTurn).toBeUndefined();
+  });
+
+  it('REMOTE-010: fail-closed on a malformed/bad-scheme `ice` param (attacker-influenced)', () => {
+    const bad = iceEnc([{ urls: 'http://evil.example' }]);
+    expect(() =>
+      parseRemoteClientLocation(`https://remote.example/?relay=wss://r&ice=${bad}#r=rv&s=sec`),
+    ).toThrow(/scheme/);
+  });
+
+  it('REMOTE-010: forceTurn without a TURN server fails closed', () => {
+    const stunOnly = iceEnc([{ urls: 'stun:stun.example:19302' }]);
+    expect(() =>
+      parseRemoteClientLocation(
+        `https://remote.example/?relay=wss://r&ice=${stunOnly}&forceTurn=1#r=rv&s=sec`,
+      ),
+    ).toThrow(/forceTurn.*requires.*TURN/i);
+  });
 });

--- a/packages/agent-web-ui/src/client/__tests__/rtc-session-client.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/rtc-session-client.test.ts
@@ -115,6 +115,27 @@ describe('createRtcSessionClient (REMOTE-009 Step 2)', () => {
     expect(statuses.at(-1)).toBe('disconnected');
   });
 
+  it('REMOTE-010: threads iceServers + forceTurn (iceTransportPolicy: relay) into the peer config', () => {
+    const iceServers = [{ urls: 'turn:turn.example:3478', username: 'u', credential: 'p' }];
+    let peerConfig: RTCConfiguration | undefined;
+    createRtcSessionClient(
+      {
+        relayUrl: 'wss://r',
+        rendezvous: 'rv',
+        secret: 's',
+        iceServers,
+        forceTurn: true,
+        createSignaling: () => ({ send: vi.fn(), onSignal: () => () => {}, close: vi.fn() }),
+        createPeer: (config) => {
+          peerConfig = config;
+          return makeFakePeer().peer as unknown as RTCPeerConnection;
+        },
+      },
+      { onMessage: vi.fn(), onStatusChange: vi.fn() },
+    ).connect();
+    expect(peerConfig).toEqual({ iceServers, iceTransportPolicy: 'relay' });
+  });
+
   it('a signaling error fails the client closed', () => {
     const statuses: TRtcConnectionStatus[] = [];
     let capturedOnError: (() => void) | undefined;

--- a/packages/agent-web-ui/src/client/parse-ice-servers.ts
+++ b/packages/agent-web-ui/src/client/parse-ice-servers.ts
@@ -1,0 +1,86 @@
+/**
+ * Browser ICE-config decoder + validator (REMOTE-010). The `ice` pairing-URL query param is a base64url-encoded
+ * JSON `RTCIceServer[]`. It is **attacker-influenceable** (anyone who crafts a pairing link controls it), so the
+ * decoded value MUST be validated into a well-formed `RTCIceServer[]` (sane URL schemes) and **fail closed** on
+ * malformed input — never a loose cast into `RTCConfiguration`. Browser-local (agent-web-ui takes no dependency on
+ * the node validators in agent-cli / agent-transport-webrtc).
+ */
+
+const ICE_URL_SCHEME = /^(stuns?|turns?):/i;
+
+/** Decode a base64url string to a proper UTF-8 string (so non-ASCII TURN creds survive). Throws on malformed base64. */
+function base64UrlToUtf8(b64url: string): string {
+  const b64 = b64url
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(b64url.length / 4) * 4, '=');
+  const binary = atob(b64); // latin1 bytes
+  const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function validateUrl(url: unknown, where: string): string {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error(`Invalid ice param: ${where} must be a non-empty url string.`);
+  }
+  if (!ICE_URL_SCHEME.test(url)) {
+    throw new Error(
+      `Invalid ice param: ${where} "${url}" must use a stun:/stuns:/turn:/turns: scheme.`,
+    );
+  }
+  return url;
+}
+
+function validateServer(entry: unknown, index: number): RTCIceServer {
+  if (typeof entry !== 'object' || entry === null) {
+    throw new Error(`Invalid ice param: iceServers[${index}] must be an object.`);
+  }
+  const record = entry as Record<string, unknown>;
+  const rawUrls = record.urls;
+  const urls = Array.isArray(rawUrls)
+    ? rawUrls.map((u, i) => validateUrl(u, `iceServers[${index}].urls[${i}]`))
+    : validateUrl(rawUrls, `iceServers[${index}].urls`);
+  const server: RTCIceServer = { urls };
+  if (record.username !== undefined) {
+    if (typeof record.username !== 'string') {
+      throw new Error(`Invalid ice param: iceServers[${index}].username must be a string.`);
+    }
+    server.username = record.username;
+  }
+  if (record.credential !== undefined) {
+    if (typeof record.credential !== 'string') {
+      throw new Error(`Invalid ice param: iceServers[${index}].credential must be a string.`);
+    }
+    server.credential = record.credential;
+  }
+  return server;
+}
+
+/** Decode + validate the `ice` query param → `RTCIceServer[]`. Throws (fail-closed) on any malformed input. */
+export function parseIceServersParam(encoded: string): RTCIceServer[] {
+  let decoded: string;
+  try {
+    decoded = base64UrlToUtf8(encoded);
+  } catch {
+    throw new Error('Invalid ice param: not valid base64url.');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    throw new Error('Invalid ice param: not valid JSON.');
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('Invalid ice param: must be a JSON array of RTCIceServer.');
+  }
+  return parsed.map((entry, index) => validateServer(entry, index));
+}
+
+/** True when any server is a TURN (`turn:`/`turns:`) server. */
+export function iceHasTurn(iceServers: readonly RTCIceServer[] | undefined): boolean {
+  if (!iceServers) return false;
+  return iceServers.some((s) => {
+    const urls = Array.isArray(s.urls) ? s.urls : [s.urls];
+    return urls.some((u) => /^turns?:/i.test(u));
+  });
+}

--- a/packages/agent-web-ui/src/client/parse-remote-location.ts
+++ b/packages/agent-web-ui/src/client/parse-remote-location.ts
@@ -1,12 +1,16 @@
 import { parsePairingUrl } from '@robota-sdk/agent-remote-pairing';
 
+import { iceHasTurn, parseIceServersParam } from './parse-ice-servers.js';
+
 /**
- * Parse the Stage-D page's own URL into its connection inputs (REMOTE-009).
+ * Parse the Stage-D page's own URL into its connection inputs (REMOTE-009 + REMOTE-010).
  *
- * The pairing link is `clientUrl#r=<rendezvous>&s=<secret>` — the SECRET lives only in the **fragment**
- * (never sent to the page's host). The relay URL is NOT secret and is NOT in the fragment; the host operator
- * configures it into `clientUrl` as a `relay` query param (e.g. `https://page/?relay=wss://myrelay`), which
- * `toPairingUrl` preserves. So: relay ← `location.search`, rendezvous + secret ← `location.hash`.
+ * The pairing link is `clientUrl?relay=…&ice=…&forceTurn=1#r=<rendezvous>&s=<secret>`. The SECRET lives ONLY in
+ * the **fragment** (never sent to the page's host). The relay URL, the optional TURN/ICE config (`ice`, a
+ * base64url JSON `RTCIceServer[]`), and the `forceTurn` flag are NOT secret and ride the QUERY — the operator
+ * bakes them into `clientUrl` and `toPairingUrl` preserves the query. (Query values reach the page's HTTP host +
+ * QR/history — unlike the fragment-protected secret — acceptable for user-supplied TURN shared with a trusted
+ * device.) So: relay/ice/forceTurn ← `location.search`, rendezvous + secret ← `location.hash`.
  *
  * Pure + isomorphic (works on any href string) so it is unit-testable without a browser.
  */
@@ -14,16 +18,39 @@ export interface IRemoteClientLocation {
   readonly relayUrl: string;
   readonly rendezvous: string;
   readonly secret: string;
+  /** REMOTE-010: validated user-supplied ICE (STUN/TURN) servers, when the `ice` query param is present. */
+  readonly iceServers?: RTCIceServer[];
+  /** REMOTE-010: restrict ICE to relay candidates (`iceTransportPolicy: 'relay'`); requires a TURN server. */
+  readonly forceTurn?: boolean;
 }
 
-/** Parse `href`; throws a clear error when the relay query param or the pairing fragment is missing. */
+/** Parse `href`; throws a clear error when the relay query param or the pairing fragment is missing, or the
+ *  `ice`/`forceTurn` config is malformed (fail-closed — attacker-influenced input). */
 export function parseRemoteClientLocation(href: string): IRemoteClientLocation {
-  const relayUrl = new URL(href).searchParams.get('relay');
+  const query = new URL(href).searchParams;
+  const relayUrl = query.get('relay');
   if (!relayUrl) {
     throw new Error(
       'Missing `relay` query parameter — the pairing link must include the signaling relay URL.',
     );
   }
   const { rendezvous, secret } = parsePairingUrl(href); // throws if the fragment lacks r/s
-  return { relayUrl, rendezvous, secret };
+
+  const iceParam = query.get('ice');
+  const iceServers = iceParam ? parseIceServersParam(iceParam) : undefined; // throws (fail-closed) on malformed
+  const forceTurn = query.get('forceTurn') === '1' || query.get('forceTurn') === 'true';
+  if (forceTurn && !iceHasTurn(iceServers)) {
+    throw new Error(
+      '`forceTurn` requires at least one TURN server in the `ice` param (a turn:/turns: url) — ' +
+        'otherwise ICE gathers no candidates and never connects.',
+    );
+  }
+
+  return {
+    relayUrl,
+    rendezvous,
+    secret,
+    ...(iceServers ? { iceServers } : {}),
+    ...(forceTurn ? { forceTurn } : {}),
+  };
 }

--- a/packages/agent-web-ui/src/client/rtc-session-client.ts
+++ b/packages/agent-web-ui/src/client/rtc-session-client.ts
@@ -45,8 +45,10 @@ export interface IRtcSessionClientOptions {
   /** Rendezvous id + high-entropy secret from the pairing URL fragment. */
   readonly rendezvous: string;
   readonly secret: string;
-  /** Optional ICE servers (STUN/TURN) — Stage E supplies TURN; omitted → host candidates only. */
+  /** Optional ICE servers (STUN/TURN) — REMOTE-010 supplies TURN; omitted → host candidates only. */
   readonly iceServers?: RTCIceServer[];
+  /** REMOTE-010: restrict ICE to relay candidates (`iceTransportPolicy: 'relay'`); requires a TURN server. */
+  readonly forceTurn?: boolean;
   /** Injection seams (default to the real implementations) — for tests. */
   readonly createSignaling?: typeof createRtcSignalingClient;
   readonly createPeer?: (config?: RTCConfiguration) => RTCPeerConnection;
@@ -119,7 +121,10 @@ export function createRtcSessionClient(
       if (peer) return; // already connecting
       setStatus('connecting');
       const createPeer = options.createPeer ?? ((c) => new RTCPeerConnection(c));
-      peer = createPeer(options.iceServers ? { iceServers: options.iceServers } : undefined);
+      const peerConfig: RTCConfiguration = {};
+      if (options.iceServers) peerConfig.iceServers = options.iceServers;
+      if (options.forceTurn) peerConfig.iceTransportPolicy = 'relay'; // browser equivalent of werift forceTurn
+      peer = createPeer(Object.keys(peerConfig).length > 0 ? peerConfig : undefined);
       peer.onicecandidate = (event): void => {
         if (event.candidate) signaling?.send({ kind: 'ice', data: event.candidate.toJSON() });
       };

--- a/packages/agent-web-ui/src/hooks/useWsSession.ts
+++ b/packages/agent-web-ui/src/hooks/useWsSession.ts
@@ -223,12 +223,25 @@ export function useWsSession(url: string): IWsSessionState {
 
 /** Connect to a paired host over WebRTC (REMOTE-009 Stage D). Memoized on the primitive connection fields. */
 export function useRtcSession(
-  options: Pick<IRtcSessionClientOptions, 'relayUrl' | 'rendezvous' | 'secret'>,
+  options: Pick<
+    IRtcSessionClientOptions,
+    'relayUrl' | 'rendezvous' | 'secret' | 'iceServers' | 'forceTurn'
+  >,
 ): IWsSessionState {
-  const { relayUrl, rendezvous, secret } = options;
+  const { relayUrl, rendezvous, secret, iceServers, forceTurn } = options;
   const makeClient = useCallback<TMakeSessionClient>(
-    (cb) => createRtcSessionClient({ relayUrl, rendezvous, secret }, cb),
-    [relayUrl, rendezvous, secret],
+    (cb) =>
+      createRtcSessionClient(
+        {
+          relayUrl,
+          rendezvous,
+          secret,
+          ...(iceServers ? { iceServers } : {}),
+          ...(forceTurn ? { forceTurn } : {}),
+        },
+        cb,
+      ),
+    [relayUrl, rendezvous, secret, iceServers, forceTurn],
   );
   return useSessionClient(makeClient);
 }


### PR DESCRIPTION
## Promotion: develop → main

Promotes **REMOTE-010 (Stage E1 — user-supplied TURN fallback)** to `main`, already merged to `develop` via #1115 (merge-verified PASS).

### What ships
The first sub-stage of REMOTE-001's final Stage E: operators can supply their own STUN/TURN ICE servers (and an optional relay-only `forceTurn`) so remote pairing works across NATs where host/server-reflexive candidates fail.

- **Host (werift) transport** — `iceServers`/`forceTurn` threaded through the controller to `WebRtcTransport`. `forceTurn` maps to werift's `iceTransportPolicy:'relay'` (werift ignores a top-level `forceTurn`); `IIceServer.urls` narrowed to a single string (what werift actually consumes).
- **Host validator** (`ice-config.ts`) — fail-closed: rejects array `urls` and `turns:`/`stuns:` schemes, both of which werift silently drops (would advertise TURN while never connecting). `forceTurn` requires a TURN server.
- **Browser** (`parse-ice-servers.ts` / `parse-remote-location.ts`) — base64url→JSON `RTCIceServer[]` decoder, fail-closed on malformed input; deliberately wider than the host (native `RTCPeerConnection` supports array urls / `turns:`).
- **Regression test** — asserts `forceTurn → iceTransportPolicy:'relay'` and that no top-level `forceTurn` is emitted.

### Verification
- Full CI green on #1115 (build, quality, scans, security audit, tui-e2e, examples-typecheck, windows-shell, commitlint).
- proposal-reviewer ENDORSE (spec, 3 rounds); implementation re-review ENDORSE (host fail-open defects verified fixed against real werift 0.23.0).
- merge-verifier PASS on the feature→develop hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)