### PR TITLE
chore: promote REMOTE-010 GATE-COMPLETE + progress-report rule to main

### DIFF
--- a/.agents/backlog/HARNESS-026-progress-report-percentage-check.md
+++ b/.agents/backlog/HARNESS-026-progress-report-percentage-check.md
@@ -1,0 +1,35 @@
+---
+title: 'HARNESS-026: enforce quantified progress-report percentage when a channel to observe agent reports exists'
+status: todo
+created: 2026-07-11
+priority: low
+urgency: later
+area: scripts/harness, .claude/hooks
+depends_on: []
+---
+
+# Enforce the quantified-progress-report rule mechanically
+
+The **Quantified progress reporting** rule in
+[`.agents/rules/agent-conduct.md`](../rules/agent-conduct.md) (Communication & Formatting) requires
+that mid-work progress updates over a countable work set state a ratio **and** a percentage
+(completed ÷ total). It is currently a prose rule with **no mechanical enforcement**.
+
+## Why it is not mechanized yet (concrete obstacle)
+
+The harness (`pnpm harness:scan`, `.claude/hooks/*`, tests) has **no channel to observe or parse the
+agent's free-form conversational output**, which is where a progress report is emitted. A scan/hook
+inspects repo files and tool I/O, not the assistant's narrative message stream, so no current
+mechanism can assert "this progress report contained a percentage." This is an architectural gap,
+not a low-value or hard-to-write check.
+
+## What (when a channel exists)
+
+1. When the harness gains a way to inspect emitted progress/status reports (e.g. a report-lint hook
+   over assistant status messages, or a structured status-report artifact the harness reads),
+   add a check that FAILS when a mid-work status update over a known-countable set omits the
+   `count/total = %` form.
+2. Provide a fixture reproducing a bare "making progress" report and prove the check FAILS on it and
+   PASSES on the `3/7 = 43%` form (per lesson-to-harness step 9).
+
+Until then, the rule is enforced by agent conduct only, tracked here so the deferral is explicit.

--- a/.agents/rules/agent-conduct.md
+++ b/.agents/rules/agent-conduct.md
@@ -30,6 +30,14 @@ structure) are not in conflict and remain in force — see the Structured-artifa
   z"). For simple questions, answer in prose; short is fine. For reports, PR descriptions, commit
   bodies, status/handoff messages, and explanations, write prose without bullets, numbered lists,
   or excessive bolding unless a list or ranking is requested.
+- **Quantified progress reporting.** When reporting progress on work that decomposes into a
+  countable set (tasks, stages, files, findings, checks), state it as a ratio **and** a percentage —
+  completed out of total, e.g. "3/7 done = 43%" — not a vague "making progress." When the total is
+  not yet known, say so and report the running count with the total as unknown. _Why:_ a quantified
+  ratio lets the reader gauge how much remains at a glance and calibrate expectations, which vague
+  progress language hides. _How to apply:_ in any mid-work status update where a discrete work set
+  exists, compute completed ÷ total and report both the count and the percentage; keep single-step
+  or uncountable work in plain prose (this rule presupposes a countable set).
 - **Declining.** Never use bullet points when declining a task; prose softens the message.
 - **Structured-artifact boundary (precedence-preserving).** The formatting discipline governs
   free-form narrative output addressed to a person. It does not govern machine-parsed structured

--- a/.agents/spec-docs/done/REMOTE-010-stage-e1-turn-fallback.md
+++ b/.agents/spec-docs/done/REMOTE-010-stage-e1-turn-fallback.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags: [remote-control, webrtc, turn, ice, hardening]
 parent: REMOTE-001


### PR DESCRIPTION
## Promotion: develop → main

Promotes the two docs-only commits currently on `develop` but not `main`:

- **#1117** — `chore(agents): GATE-COMPLETE REMOTE-010` (spec active→done; the REMOTE-010 code already landed on main via #1116).
- **#1118** — `docs(rules): require quantified progress reports (count/total = %)` in `agent-conduct.md`, plus HARNESS-026 tracking the deferred mechanism.

No code changes — spec-status move + rule doc. `pnpm harness:scan` green (49/49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)