### PR TITLE
docs(backlog): register REMOTE Stage E sub-items E2–E5 (REMOTE-011..014)

### DIFF
--- a/.agents/backlog/REMOTE-001-webrtc-p2p-remote-control.md
+++ b/.agents/backlog/REMOTE-001-webrtc-p2p-remote-control.md
@@ -14,6 +14,19 @@ depends_on: []
 > see [`.agents/spec-docs/todo/REMOTE-001-webrtc-p2p-remote-control-design.md`](../spec-docs/todo/REMOTE-001-webrtc-p2p-remote-control-design.md).
 > Implementation proceeds as per-stage gated specs (Stage A: extract `agent-transport-protocol` +
 > `agent-transport-webrtc` skeleton + minimal signaling server, loopback-only, no enable path).
+>
+> **Stage progress (2026-07-11):** Stages A–D DONE + on main (REMOTE-002…009) — the full user story
+> ships (host `/remote-control` → QR/link → browser pairs + co-drives over WebRTC). **Stage E (final
+> hardening)** is decomposed into child backlog items, sequenced:
+>
+> - E1 = user-supplied TURN fallback — REMOTE-010, **DONE** (`.agents/spec-docs/done/`).
+> - E2 = signaling-server abuse hardening — [REMOTE-011](REMOTE-011-stage-e2-signaling-abuse-hardening.md) (self-contained).
+> - E3 = TOFU trusted-device reconnect — [REMOTE-012](REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md).
+> - E4 = reconnection/session-resume — [REMOTE-013](REMOTE-013-stage-e4-reconnection-session-resume.md) (on E3).
+> - E5 = co-drive concurrency + attribution — [REMOTE-014](REMOTE-014-stage-e5-co-drive-concurrency-attribution.md).
+>
+> This item stays `in-progress` until Stage E completes and the User Execution Test Scenario evidence
+> below is filled.
 
 ## Problem / Goal
 

--- a/.agents/backlog/REMOTE-011-stage-e2-signaling-abuse-hardening.md
+++ b/.agents/backlog/REMOTE-011-stage-e2-signaling-abuse-hardening.md
@@ -1,0 +1,72 @@
+---
+title: 'REMOTE-011: Stage E2 — signaling-server abuse hardening'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: apps/remote-signaling
+depends_on: []
+---
+
+# REMOTE-011: Stage E2 — signaling-server abuse hardening
+
+Parent: [REMOTE-001](REMOTE-001-webrtc-p2p-remote-control.md). Stage E (final hardening) decomposition
+(grounding 2026-07-11): E1 = TURN fallback (REMOTE-010, DONE); **E2 = signaling-server abuse hardening
+(this)**; E3 = TOFU trusted-device reconnect (REMOTE-012); E4 = reconnection/session-resume (REMOTE-013,
+on E3); E5 = co-drive concurrency + attribution (REMOTE-014). E2 is **self-contained and protocol-free**
+— it hardens only `apps/remote-signaling` and needs no change to the pairing protocol or the session
+contract, so it can proceed independently of E3–E5.
+
+## Problem / Goal
+
+The signaling server (`apps/remote-signaling`) is the one owner-hosted, publicly reachable component. It
+relays SDP offers/answers + ICE candidates by rendezvous id and holds no session content — but a public
+rendezvous endpoint with no abuse controls is exploitable by an unauthenticated attacker:
+
+- **Rendezvous-slot hijack / squatting:** a peer that is not the paired client claims or races for a
+  rendezvous id, intercepting the host's offer or denying the real client its slot.
+- **Enumeration / flooding:** brute-forcing or spraying rendezvous ids to discover live sessions or to
+  exhaust server memory/connection slots (DoS).
+- **Oversized / malformed frames:** unbounded or malformed signaling messages consuming resources or
+  crashing the relay.
+- **Replay / stale-slot reuse:** reconnecting against an expired or already-consumed rendezvous id.
+
+Goal: add abuse hardening to the signaling server while keeping it strictly minimal and content-free —
+no session payload, no long-term state beyond what a rendezvous needs.
+
+## Scope / Approach (to be confirmed in the spec)
+
+- **Per-connection + per-IP rate limiting** on rendezvous registration and message relay; connection caps.
+- **Rendezvous-slot exclusivity:** a rendezvous id is claimed by exactly the two expected roles
+  (host + one client); additional claimants are refused. Short-lived, single-use slot with TTL/expiry.
+- **Message validation:** strict allowlist of signaling message kinds (offer/answer/ice), bounded size,
+  schema-validated shape; reject anything else fail-closed.
+- **High-entropy rendezvous ids** (already pairing-secret-bound; confirm enumeration resistance) and
+  slot expiry so stale ids cannot be reused.
+- No new dependency-direction violation; the server stays a minimal SSOT with no session content.
+
+## Test Plan
+
+- Unit/integration (server): slot-exclusivity (second claimant refused); rate-limit trips at threshold;
+  oversized/malformed frame rejected fail-closed; expired rendezvous rejected; valid two-party rendezvous
+  still succeeds end-to-end (regression).
+- Security: an attacker connection cannot hijack a rendezvous already claimed by the paired pair, cannot
+  enumerate live ids within the rate budget, and cannot exhaust slots below the cap.
+- Harness: `pnpm harness:scan` + typecheck + build green.
+
+## User Execution Test Scenario
+
+1. **Abuse controls hold under a hostile second peer.**
+   - Prerequisites: `apps/remote-signaling` running; a host `/remote-control on` with a rendezvous id;
+     a legitimate client paired.
+   - Steps: from a third (attacker) connection, attempt to (a) claim the same rendezvous id, (b) spray N
+     random ids past the rate threshold, (c) send an oversized/malformed frame.
+   - Expected: (a) refused (slot already claimed) — the legitimate pair stays connected; (b) throttled
+     after the threshold with no server memory blowup; (c) connection dropped fail-closed. The legitimate
+     host↔client P2P session is unaffected throughout.
+   - Evidence: _(fill after implementation)_
+
+## Notes
+
+Keep the signaling server content-free; all security- and content-sensitive logic stays on the P2P
+channel. This item is the orthogonal sibling of E1 (TURN) — both are hardening-first and protocol-free.

--- a/.agents/backlog/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
+++ b/.agents/backlog/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
@@ -1,0 +1,69 @@
+---
+title: 'REMOTE-012: Stage E3 — TOFU trusted-device reconnect'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: packages/agent-remote-pairing, packages/agent-cli, packages/agent-web-ui
+depends_on: []
+---
+
+# REMOTE-012: Stage E3 — TOFU trusted-device reconnect
+
+Parent: [REMOTE-001](REMOTE-001-webrtc-p2p-remote-control.md). Stage E decomposition (2026-07-11):
+E1 = TURN (REMOTE-010, DONE); E2 = signaling abuse (REMOTE-011); **E3 = TOFU trusted-device reconnect
+(this)**; E4 = reconnection/session-resume (REMOTE-013, on E3); E5 = co-drive attribution (REMOTE-014).
+
+## Problem / Goal
+
+Today every connection requires a fresh out-of-band pairing: the host shows a QR/link carrying a
+one-time pairing secret and the client pairs with an explicit host-side accept. That is correct for a
+first contact, but it makes a **returning, already-trusted device** re-pair from scratch every time —
+poor UX and it trains the user to approve pairing prompts reflexively (which weakens the security of the
+prompt itself).
+
+Goal: a **Trust On First Use (TOFU)** model — after a successful first pairing + explicit host accept, the
+host may **remember that device** (an identity derived from the established channel) so a later reconnect
+from the same device can be recognized and (per host policy) resume without a full re-pair, while an
+unknown device still goes through the full first-use pairing + accept.
+
+## Scope / Approach (to be confirmed in the spec)
+
+- **Device identity:** derive a stable, non-secret device identifier from the established pairing —
+  building on `deriveSessionKey` (`packages/agent-remote-pairing/src/pairing.ts:155`) / the directional-HMAC
+  channel-binding (REMOTE-005). The stored value must NOT be the pairing secret itself and must not enable
+  impersonation if the host's trust store leaks (store a commitment/derived id, not a replayable secret).
+- **Host trust store:** persist accepted device ids locally (host side), with user-visible list +
+  revoke. Fail-closed: an unrecognized or revoked device falls back to full pairing.
+- **Reconnect recognition:** on a new connection, prove possession of the trusted device identity
+  (challenge/response over the channel binding) before the host treats it as trusted — never trust a
+  client-asserted id alone.
+- Client stores its side of the trust material in a fragment-scoped / device-local store (never in a
+  relayed or query-visible location — same discipline as the pairing secret).
+
+## Test Plan
+
+- Unit (pairing): device-id derivation is stable across reconnects and NOT equal to the pairing secret;
+  a leaked trust-store entry cannot be replayed to impersonate without the device-held material.
+- Integration: first pairing → host accept → store; reconnect from the same device is recognized
+  (challenge/response passes) without a new accept prompt; an unknown device still requires full pairing;
+  a revoked device is refused fail-closed.
+- Security: forged/copied device id without the device-held secret fails the challenge; trust-store leak
+  does not grant reconnect.
+- Harness: `pnpm harness:scan` + typecheck + build green.
+
+## User Execution Test Scenario
+
+1. **Trusted device reconnects without re-pairing; unknown/revoked device does not.**
+   - Prerequisites: host `agent-cli` with `/remote-control`; a browser client.
+   - Steps: pair the client once and accept on the host; disconnect; reconnect from the same browser;
+     then revoke the device on the host and reconnect again; then connect from a different browser.
+   - Expected: the first reconnect is recognized and resumes per host policy with no fresh accept prompt;
+     after revoke, the same browser must re-pair; the different browser always goes through full
+     first-use pairing + accept.
+   - Evidence: _(fill after implementation)_
+
+## Notes
+
+E3 introduces persistent host-side trust state — treat it as security-sensitive (SECURITY-typed spec).
+It is a prerequisite for E4 (session-resume needs a recognized device to resume against).

--- a/.agents/backlog/REMOTE-013-stage-e4-reconnection-session-resume.md
+++ b/.agents/backlog/REMOTE-013-stage-e4-reconnection-session-resume.md
@@ -1,0 +1,66 @@
+---
+title: 'REMOTE-013: Stage E4 — reconnection / session-resume'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: packages/agent-transport-webrtc, packages/agent-transport-protocol, packages/agent-cli, packages/agent-web-ui
+depends_on: ['REMOTE-012']
+---
+
+# REMOTE-013: Stage E4 — reconnection / session-resume
+
+Parent: [REMOTE-001](REMOTE-001-webrtc-p2p-remote-control.md). Stage E decomposition (2026-07-11):
+E1 = TURN (REMOTE-010, DONE); E2 = signaling abuse (REMOTE-011); E3 = TOFU trusted-device reconnect
+(REMOTE-012); **E4 = reconnection/session-resume (this, on E3)**; E5 = co-drive attribution (REMOTE-014).
+
+## Problem / Goal
+
+A WebRTC data channel drops on any network blip (Wi-Fi handoff, sleep/wake, NAT rebind, TURN hiccup).
+Today a drop ends the remote session: the peer connection is torn down and the client must start over —
+re-pair (unless E3 lands) and lose its view of the in-flight exchange. For a "drive my agent from my
+phone" use case this is fragile: a transient drop should self-heal, not end the session.
+
+Goal: **automatic reconnection with session-resume** — when the transport drops, the client re-establishes
+the P2P channel (recognized via E3 TOFU, no fresh accept) and resumes the SAME logical agent session,
+including any output streamed while disconnected, without duplicating or losing frames.
+
+## Scope / Approach (to be confirmed in the spec)
+
+- **Reconnect loop (client):** detect data-channel/ICE disconnect, re-run signaling + ICE (perfect-
+  negotiation / ICE restart) with bounded backoff; re-open the channel to the same host session.
+- **Session-resume contract:** a resume token / last-acked sequence in the transport-protocol framing so
+  the host can replay or fast-forward the stream from the client's last acknowledged point — exactly-once
+  delivery semantics across the reconnect (no dropped or duplicated `TServerMessage`).
+- **Host-side buffering:** bounded buffer of un-acked output so a brief disconnect can be replayed; the
+  host session itself keeps running while the peer is gone (already the case — confirm no teardown on
+  peer drop).
+- **Identity on reconnect:** the reconnecting peer is authenticated via E3 (trusted device), not a new
+  pairing — hence the `depends_on: REMOTE-012`.
+
+## Test Plan
+
+- Unit: resume-token / sequence bookkeeping (last-acked advance, replay window bounds, exactly-once).
+- Integration: two in-process peers establish a channel, force a disconnect mid-stream, and confirm the
+  client reconnects and resumes with no lost/duplicated frames; backoff bounds honored; host session
+  survives the peer drop.
+- Security: a reconnect still passes the E3 trusted-device challenge; a non-trusted peer cannot resume
+  another device's session (resume token is bound to the device identity, not guessable).
+- Harness: `pnpm harness:scan` + typecheck + build green.
+
+## User Execution Test Scenario
+
+1. **Transient drop self-heals without losing the exchange.**
+   - Prerequisites: host `agent-cli` `/remote-control`; a trusted (E3) browser client mid-conversation.
+   - Steps: send a prompt that streams a long response; mid-stream, drop the client's network briefly
+     (toggle Wi-Fi / sleep), then restore it.
+   - Expected: the client reconnects automatically (no re-pair, no fresh accept), the streamed response
+     continues from where it left off with no missing or duplicated output, and `/remote-control status`
+     shows the same peer resumed (not a new one).
+   - Evidence: _(fill after implementation)_
+
+## Notes
+
+Depends on E3 (REMOTE-012): resume must re-authenticate the reconnecting peer as a trusted device, not
+open a fresh pairing. This is the first Stage-E item that changes the transport-protocol framing (resume
+token / sequence), so it is a contract-boundary change — validate reachability across host + browser peers.

--- a/.agents/backlog/REMOTE-014-stage-e5-co-drive-concurrency-attribution.md
+++ b/.agents/backlog/REMOTE-014-stage-e5-co-drive-concurrency-attribution.md
@@ -1,0 +1,72 @@
+---
+title: 'REMOTE-014: Stage E5 — co-drive concurrency + attribution'
+status: todo
+created: 2026-07-11
+priority: medium
+urgency: later
+area: packages/agent-transport-protocol, packages/agent-cli, packages/agent-web-ui
+depends_on: []
+---
+
+# REMOTE-014: Stage E5 — co-drive concurrency + attribution
+
+Parent: [REMOTE-001](REMOTE-001-webrtc-p2p-remote-control.md). Stage E decomposition (2026-07-11):
+E1 = TURN (REMOTE-010, DONE); E2 = signaling abuse (REMOTE-011); E3 = TOFU reconnect (REMOTE-012);
+E4 = reconnection/session-resume (REMOTE-013); **E5 = co-drive concurrency + attribution (this)** — the
+last Stage-E item, sequenced after the hardening + reconnect pieces because it changes the session/input
+model rather than merely hardening it.
+
+## Problem / Goal
+
+The local host and a remote peer share the SAME live session (mirror + co-drive) — both can send input.
+Today input arbitration and authorship are implicit: when two drivers (local TUI + remote client, or
+multiple remote peers if allowed) submit near-simultaneously, there is no defined ordering, no indication
+of **who** issued a given prompt/command, and no per-driver permission attribution. For a shared session
+this is both a correctness problem (interleaved input) and a trust problem (an action's origin is
+invisible, so the permission decision cannot be tied to the actor).
+
+Goal: a defined **co-drive concurrency model** with **per-message attribution** — every input frame
+carries a driver identity, the session serializes concurrent input deterministically, and both the local
+TUI and the remote client can see who did what (and permission prompts name the requesting driver).
+
+## Scope / Approach (to be confirmed in the spec)
+
+- **Driver identity in the protocol:** extend the transport-protocol framing so each client→session input
+  frame carries an authenticated driver id (bound to the pairing / E3 device identity, not client-asserted).
+- **Input arbitration:** define serialization for concurrent input (e.g. single-writer token, or ordered
+  queue with fairness) so two drivers cannot interleave a single logical turn; specify the policy
+  (turn-taking vs. last-writer, host-configurable).
+- **Attribution surfacing:** the session event stream tags each prompt/command/permission with its driver;
+  local TUI + remote client render authorship; permission/ask prompts (REMOTE-007) name the requesting
+  driver so the approver knows whose action they are authorizing.
+- **Permission attribution:** a remote driver remains subject to the same permission/command gating; the
+  gate decision is recorded against the actual driver, not the session generically.
+
+## Test Plan
+
+- Unit: framing carries + validates an authenticated driver id; arbitration serializes two concurrent
+  inputs deterministically per the chosen policy; attribution tag is attached to each session event.
+- Integration: local TUI + remote client both drive; concurrent submissions are serialized (no
+  interleaving) and each rendered with the correct author; a permission prompt names the requesting driver;
+  a remote driver cannot exceed the local permission policy.
+- Security: driver id cannot be spoofed by a client (bound to device identity); attribution cannot be
+  forged onto another driver.
+- Harness: `pnpm harness:scan` + typecheck + build green.
+
+## User Execution Test Scenario
+
+1. **Two drivers, deterministic ordering, visible authorship.**
+   - Prerequisites: host `agent-cli` `/remote-control` with a paired remote client; both local TUI and
+     remote client active on the same session.
+   - Steps: submit a prompt from the local TUI and one from the remote client at nearly the same time;
+     then trigger a tool that requires permission from the remote client.
+   - Expected: the two prompts are serialized in a defined, non-interleaved order; each turn shows who
+     authored it on BOTH surfaces; the permission prompt identifies the remote client as the requester and
+     enforces the same policy as a local action.
+   - Evidence: _(fill after implementation)_
+
+## Notes
+
+E5 changes the session/input contract (protocol + session), so it is the highest-blast-radius Stage-E
+item — sequence it last. It builds naturally on E3 device identity (attribution should bind to the same
+identity) but is specced independently; if E3 slips, E5 can fall back to pairing-scoped driver ids.


### PR DESCRIPTION
Registers the remaining REMOTE-001 **Stage E (final hardening)** sub-stages as tracked child backlog items and updates the parent with a stage-progress map.

### New backlog items
- **REMOTE-011** — E2: signaling-server abuse hardening (`apps/remote-signaling`; self-contained, protocol-free, `depends_on: []`).
- **REMOTE-012** — E3: TOFU trusted-device reconnect (builds on `deriveSessionKey` / directional-HMAC binding).
- **REMOTE-013** — E4: reconnection / session-resume (`depends_on: REMOTE-012`).
- **REMOTE-014** — E5: co-drive concurrency + attribution (session/protocol change; sequenced last).

### Parent update
- **REMOTE-001** — added a Stage-progress map (A–D done on main; E1/REMOTE-010 done; E2–E5 → the new children) and a note that it stays `in-progress` until Stage E completes and its User Execution Test Scenario evidence is filled.

Docs-only. `pnpm harness:scan` green (49/49, incl. `backlog-placement`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)