### PR TITLE
feat(remote): signaling-server transport-layer DoS bounds (REMOTE-011 / Stage E2)

### DIFF
--- a/.agents/backlog/REMOTE-011-stage-e2-signaling-abuse-hardening.md
+++ b/.agents/backlog/REMOTE-011-stage-e2-signaling-abuse-hardening.md
@@ -20,50 +20,62 @@ contract, so it can proceed independently of E3–E5.
 ## Problem / Goal
 
 The signaling server (`apps/remote-signaling`) is the one owner-hosted, publicly reachable component. It
-relays SDP offers/answers + ICE candidates by rendezvous id and holds no session content — but a public
-rendezvous endpoint with no abuse controls is exploitable by an unauthenticated attacker:
+relays SDP offers/answers + ICE candidates by rendezvous id and holds no session content.
 
-- **Rendezvous-slot hijack / squatting:** a peer that is not the paired client claims or races for a
-  rendezvous id, intercepting the host's offer or denying the real client its slot.
-- **Enumeration / flooding:** brute-forcing or spraying rendezvous ids to discover live sessions or to
-  exhaust server memory/connection slots (DoS).
-- **Oversized / malformed frames:** unbounded or malformed signaling messages consuming resources or
-  crashing the relay.
-- **Replay / stale-slot reuse:** reconnecting against an expired or already-consumed rendezvous id.
+**Already hardened by REMOTE-004 (Stage B2), NOT in scope:** the _relay layer_ is safe-by-default —
+per-source token bucket on `join` floods, single-use rendezvous ids, half-open TTL expiry, concurrent-
+rendezvous cap, and a strict `offer`/`answer`/`ice` frame allowlist (everything else rejected
+fail-closed). Rendezvous-slot hijack, id enumeration/reuse, and malformed/unknown frames are covered
+there.
 
-Goal: add abuse hardening to the signaling server while keeping it strictly minimal and content-free —
-no session payload, no long-term state beyond what a rendezvous needs.
+**Residual gaps — the _WebSocket transport layer_ in `server.ts`** (this item):
+
+- **Unbounded frame size:** `WebSocketServer` sets no `maxPayload`, so `ws` buffers up to its 100 MiB
+  default per frame before the relay sees it — a memory-exhaustion vector (signaling frames are only a
+  few KB).
+- **No connection cap:** nothing bounds concurrent sockets, total or per-IP. The B2 bucket limits `join`
+  _attempts_, but a socket that connects and never joins is never bounded (FD/memory exhaustion).
+- **No per-connection message rate:** B2 buckets only `join`; an already-joined peer can flood `signal`
+  frames with no ceiling.
+
+Goal: bound these transport-layer resource-exhaustion vectors so the public endpoint is DoS-resistant
+by default, while keeping the server strictly minimal and content-free.
 
 ## Scope / Approach (to be confirmed in the spec)
 
-- **Per-connection + per-IP rate limiting** on rendezvous registration and message relay; connection caps.
-- **Rendezvous-slot exclusivity:** a rendezvous id is claimed by exactly the two expected roles
-  (host + one client); additional claimants are refused. Short-lived, single-use slot with TTL/expiry.
-- **Message validation:** strict allowlist of signaling message kinds (offer/answer/ice), bounded size,
-  schema-validated shape; reject anything else fail-closed.
-- **High-entropy rendezvous ids** (already pairing-secret-bound; confirm enumeration resistance) and
-  slot expiry so stale ids cannot be reused.
-- No new dependency-direction violation; the server stays a minimal SSOT with no session content.
+- **Frame size:** set `WebSocketServer` `maxPayload` to a small default (SDP/ICE are tiny) so oversized
+  frames are rejected before buffering.
+- **Connection caps:** total + per-IP concurrent-connection ceilings enforced at accept time
+  (refuse/close before the peer is registered).
+- **Per-connection message rate:** a token bucket on the `signal` relay path (distinct from the existing
+  per-source `join` bucket), reusing the B2 `TokenBucketLimiter` + injected clock.
+- Every bound defaults on with a production-safe value and is override-injectable (matches the B2
+  safe-by-default, dependency-injected, deterministically-tested pattern). No relayed-frame protocol
+  change; the server stays a minimal SSOT with no session content.
+
+See the spec: [`.agents/spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md`](../spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md).
 
 ## Test Plan
 
-- Unit/integration (server): slot-exclusivity (second claimant refused); rate-limit trips at threshold;
-  oversized/malformed frame rejected fail-closed; expired rendezvous rejected; valid two-party rendezvous
-  still succeeds end-to-end (regression).
-- Security: an attacker connection cannot hijack a rendezvous already claimed by the paired pair, cannot
-  enumerate live ids within the rate budget, and cannot exhaust slots below the cap.
+- Unit (fake-peer): a `signal` flood from a joined peer is throttled (per-connection message-rate bucket)
+  with no fan-out to the counterpart; the per-source join bucket is unaffected.
+- Integration (server): total + per-IP connection caps refuse the over-cap socket at accept time;
+  `maxPayload` closes an oversized frame before it reaches the relay; a normal small frame relays.
+- Regression: a legitimate two-peer pairing (join → offer/answer/ice at normal size + rate) still
+  round-trips end-to-end (B2 behavior unchanged).
 - Harness: `pnpm harness:scan` + typecheck + build green.
 
 ## User Execution Test Scenario
 
-1. **Abuse controls hold under a hostile second peer.**
-   - Prerequisites: `apps/remote-signaling` running; a host `/remote-control on` with a rendezvous id;
-     a legitimate client paired.
-   - Steps: from a third (attacker) connection, attempt to (a) claim the same rendezvous id, (b) spray N
-     random ids past the rate threshold, (c) send an oversized/malformed frame.
-   - Expected: (a) refused (slot already claimed) — the legitimate pair stays connected; (b) throttled
-     after the threshold with no server memory blowup; (c) connection dropped fail-closed. The legitimate
-     host↔client P2P session is unaffected throughout.
+1. **Transport-layer DoS bounds hold; well-behaved pairing is unaffected.**
+   - Prerequisites: `apps/remote-signaling` running with the default bounds; a host `/remote-control on`
+     with a legitimate client paired.
+   - Steps: from attacker connection(s), attempt to (a) open more sockets than the connection cap (total
+     and from one IP), (b) send a frame larger than `maxFrameBytes`, (c) after joining, flood `signal`
+     frames past the message-rate burst.
+   - Expected: (a) the over-cap sockets are closed at accept; (b) the oversized frame closes that socket
+     without reaching the relay; (c) the flood is throttled (`message-rate-limited`) with no counterpart
+     fan-out — and throughout, the legitimate host↔client P2P session stays connected and responsive.
    - Evidence: _(fill after implementation)_
 
 ## Notes

--- a/.agents/spec-docs/active/REMOTE-011-stage-e2-signaling-abuse-hardening.md
+++ b/.agents/spec-docs/active/REMOTE-011-stage-e2-signaling-abuse-hardening.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: in-progress
 type: SECURITY
 tags: [websocket, auth, async]
 ---
@@ -153,23 +153,23 @@ enabled via `trustProxy` (`X-Forwarded-For`) or disabled — never left to silen
 
 ## Completion Criteria
 
-- [ ] TC-01: A `signal` frame flood from one joined fake peer is throttled — after the burst, `relay()`
+- [x] TC-01: A `signal` frame flood from one joined fake peer is throttled — after the burst, `relay()`
       calls `reject(peer, 'message-rate-limited')` and does NOT forward to the counterpart; the join
       bucket for other sources is unaffected.
-- [ ] TC-02: With `maxConnections: N`, the (N+1)-th concurrent WebSocket connection is closed at accept
+- [x] TC-02: With `maxConnections: N`, the (N+1)-th concurrent WebSocket connection is closed at accept
       time (never registered as a peer); after one closes, a new connection is admitted again.
-- [ ] TC-03: With `maxConnectionsPerIp: K` and an injected address resolver mapping connections to two
+- [x] TC-03: With `maxConnectionsPerIp: K` and an injected address resolver mapping connections to two
       distinct source keys, the (K+1)-th connection sharing a source key is closed at accept
       (`close(1013,'over-capacity')`) while a connection with a different source key is still admitted;
       with `maxConnectionsPerIp: 0` the per-IP cap is off (no refusal on source-key collision).
-- [ ] TC-04: A frame larger than `maxFrameBytes` does not reach the relay handler (the `ws` connection is
+- [x] TC-04: A frame larger than `maxFrameBytes` does not reach the relay handler (the `ws` connection is
       closed with code `1009`); a normal small frame relays successfully (regression).
-- [ ] TC-05: A legitimate two-peer pairing (join → offer/answer/ice at normal size + rate) completes
+- [x] TC-05: A legitimate two-peer pairing (join → offer/answer/ice at normal size + rate) completes
       end-to-end unchanged — no new bound trips for well-behaved peers (regression against B2 behavior).
-- [ ] TC-06: `TokenBucketLimiter.evict(key)` removes a key's bucket; after a joined peer floods `signal`
+- [x] TC-06: `TokenBucketLimiter.evict(key)` removes a key's bucket; after a joined peer floods `signal`
       and then `remove()` runs, the message-bucket map no longer contains that peer id (memory bound), and
       the total/per-IP connection counters return to their pre-connection values after disconnect.
-- [ ] TC-07: New bounds are override-injectable and default to the documented safe constants
+- [x] TC-07: New bounds are override-injectable and default to the documented safe constants
       (`DEFAULT_MAX_FRAME_BYTES`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
       `DEFAULT_MESSAGE_RATE`); a resolved source address of `undefined` maps to the sentinel key (no crash,
       cap still applies); `pnpm harness:scan` + typecheck + build green.
@@ -188,6 +188,23 @@ enabled via `trustProxy` (`X-Forwarded-For`) or disabled — never left to silen
 
 ## Tasks
 
-- [ ] `.agents/tasks/REMOTE-011.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [x] `.agents/tasks/REMOTE-011.md` — created at GATE-APPROVAL.
 
 ## Evidence Log
+
+- **GATE-APPROVAL:** proposal-reviewer ENDORSE (2 rounds). Round 1 REVISE (G1 evict / G2 proxy stance /
+  G3 taxonomy split + tests); round 2 ENDORSE with all four resolved. Two non-blocking implementer notes
+  applied: XFF picks the trusted right-most hop (`forwardedForResolver`); option layering kept clean
+  (transport caps on `ISignalingServerOptions`, `messageRate` on `ISignalingRelayOptions`).
+- **Implementation:** `rate-limiter.ts` — `evict(key)` + `size` getter + `DEFAULT_MESSAGE_RATE`/
+  `DEFAULT_MAX_CONNECTIONS`/`DEFAULT_MAX_CONNECTIONS_PER_IP`/`DEFAULT_MAX_FRAME_BYTES`. `relay.ts` —
+  per-connection message-rate bucket keyed by peer id, `message-rate-limited` reject + no fan-out, evict
+  on `remove()`, `messageBucketCount` diagnostics. `server.ts` — `maxPayload`, total + per-IP caps at
+  accept (`close(1013,'over-capacity')`), injectable `addressResolver` (+ `trustProxy` XFF + `undefined`
+  sentinel), idempotent release decrement, `connectionCount` diagnostics. `index.ts` public exports;
+  `docs/SPEC.md` Boundaries + Error-Taxonomy split + Public API.
+- **Verification (2026-07-11):** `pnpm --filter @robota-sdk/remote-signaling test` → 26 passed (TC-01
+  message-rate throttle + per-connection isolation + no fan-out; TC-02 total cap; TC-03 per-IP cap via
+  resolver seam + `0` disables; TC-04 oversize→1009 + small relays; TC-05 webrtc-relay regression; TC-06
+  evict + counter/map shrink; TC-07 defaults + undefined sentinel). Full `pnpm typecheck` clean.
+  `pnpm harness:scan` → all 49 passed (incl. `spec-public-surface`).

--- a/.agents/spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md
+++ b/.agents/spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md
@@ -1,0 +1,152 @@
+---
+status: draft
+type: SECURITY
+tags: [websocket, auth, async]
+---
+
+# REMOTE-011: Stage E2 — signaling-server abuse hardening (transport-layer DoS bounds)
+
+## Problem
+
+`apps/remote-signaling` is the one owner-hosted, publicly reachable component of `/remote-control`. Its
+**relay layer** was already abuse-hardened in REMOTE-004 (Stage B2): a per-source token bucket bounds
+`join` floods (`relay.ts:140`), rendezvous ids are single-use (`relay.ts:159`), half-open rendezvous
+expire on a TTL (`relay.ts:252`), concurrent rendezvous are capped (`relay.ts:166`), and only
+`offer`/`answer`/`ice` frames are ever forwarded — everything else is rejected fail-closed
+(`relay.ts:135`). Those relay-layer vectors are **already covered** and are NOT in scope here.
+
+What remains unhardened is the **WebSocket transport layer** in `server.ts`, which is where an
+unauthenticated attacker can still mount denial-of-service against the public endpoint:
+
+1. **Unbounded frame size.** `new WebSocketServer({ server })` (`server.ts:58`) sets no `maxPayload`, so
+   `ws` accepts up to its 100 MiB default per frame. Signaling frames are tiny (an SDP offer is a few KB;
+   ICE candidates are smaller). A single peer can send a 100 MiB frame — `data.toString()`
+   (`server.ts:62`) buffers the whole thing before the relay ever sees it — repeatedly, to exhaust host
+   memory. Reproduction: connect and send one frame just under 100 MiB; server memory spikes with no bound.
+2. **No connection cap.** Nothing bounds the number of concurrent WebSocket connections, total or per
+   source IP. The B2 token bucket limits `join` _attempts_ per source, but a socket that connects and
+   never joins is never rate-limited (`join` is the only bucketed path). Reproduction: open thousands of
+   sockets without sending `join`; each consumes an FD + buffers with no ceiling.
+3. **No per-connection message rate.** B2 buckets only `join`. An already-joined peer can flood `signal`
+   frames (`relay()` at `relay.ts:194` has no rate limit), forcing unbounded relay work + fan-out to its
+   counterpart. Reproduction: join, then emit `signal` frames in a tight loop.
+
+All three are transport-layer resource-exhaustion vectors on a public endpoint. The relay stays
+content-blind and holds no session content; this stage only bounds resource consumption at the socket.
+
+## Architecture Review
+
+### Affected Scope
+
+- `apps/remote-signaling/src/server.ts` — set `WebSocketServer` `maxPayload`; enforce total + per-IP
+  connection caps at `wss.on('connection')`; thread new options.
+- `apps/remote-signaling/src/relay.ts` — add a per-connection **message-rate** limiter to the `signal`
+  relay path (distinct from the existing per-source **join** bucket); surface a new reject reason.
+- `apps/remote-signaling/src/rate-limiter.ts` — reuse `TokenBucketLimiter` for the message-rate bucket;
+  add typed defaults (`DEFAULT_MESSAGE_RATE`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
+  `DEFAULT_MAX_FRAME_BYTES`).
+- `apps/remote-signaling/src/index.ts` — export any new option/const on the public surface.
+- `apps/remote-signaling/docs/SPEC.md` — extend Boundaries / Error Taxonomy / Public API with the new
+  bounds and reject reasons.
+- Tests: `__tests__/relay-hardening.test.ts` (message-rate), a server-level test for caps + `maxPayload`.
+
+### Alternatives Considered
+
+1. **Bound only at the relay (application) layer — parse then measure size, count connections in the
+   relay.** Pro: single layer, fully covered by the network-free fake-peer suite. Con: the frame is
+   already fully buffered by `ws` before the relay sees it, so an application-layer size check does NOT
+   prevent the 100 MiB buffering — the DoS already happened. Connection counting in the relay also can't
+   refuse a socket that never sends a frame. Rejected: cannot close vectors #1/#2 at that layer.
+2. **Rely on an external reverse proxy (nginx/Cloudflare) for size + connection limits.** Pro: zero app
+   code; production-grade. Con: the server ships as a self-hostable minimal app (REMOTE-001 constraint —
+   "the one piece the owner hosts"); it must be safe **by default** without assuming a fronting proxy,
+   exactly as B2 made the relay safe by default rather than hook-dependent. Rejected as the sole control;
+   may complement in production but cannot be the default posture.
+3. **(Chosen) Bound at the transport layer in `server.ts` (maxPayload + connection caps) and add a
+   per-connection message-rate bucket at the relay.** Pro: `maxPayload` makes `ws` reject an oversized
+   frame before buffering it; connection caps refuse sockets at accept time regardless of join; message
+   rate reuses the proven `TokenBucketLimiter` with an injected clock so it stays in the deterministic
+   suite. Con: caps + maxPayload need a thin server-level test (a real `ws` connection) since they live
+   above the fake-peer relay seam. Accepted: each control sits at the only layer that can enforce it.
+
+### Decision
+
+Take alternative 3: enforce **frame size** and **connection caps** in `server.ts` (the transport layer,
+the only place that can refuse before buffering / before a frame is sent), and add a **per-connection
+message-rate** bucket to the relay's `signal` path (reusing `TokenBucketLimiter` + injected `IClock`).
+Every bound defaults on with a production-safe value and is override-injectable for tests — matching the
+B2 pattern (safe-by-default, dependency-injected, deterministically tested). This is a
+contract-boundary-safe change: it only adds refusal paths on an untrusted public surface (a legitimate
+host↔client pairing sends small, low-rate frames and is unaffected); it does not alter the relayed frame
+protocol, so both existing peers (werift host + browser client) remain fully reachable — validated
+against the relay's frame contract (`offer`/`answer`/`ice` unchanged) and the fake-peer regression suite.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: single app (`apps/remote-signaling`); no sibling signaling server exists (verified `apps/` listing — only this relay). The two enforcement layers (`server.ts` transport, `relay.ts` application) are both covered in scope.
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Solution
+
+- **Frame size (`server.ts`):** construct `new WebSocketServer({ server, maxPayload: MAX_FRAME_BYTES })`
+  with a small default (e.g. 64 KiB — comfortably above any SDP/ICE frame, far below 100 MiB). `ws`
+  rejects and closes a connection that exceeds it before delivering the frame to our handler.
+- **Connection caps (`server.ts`):** track live socket count total and per remote IP; in
+  `wss.on('connection')`, if either the total (`MAX_CONNECTIONS`) or the per-IP
+  (`MAX_CONNECTIONS_PER_IP`) ceiling is already met, `socket.close()` immediately (with a bounded close
+  code/reason) and do not register the peer. Decrement on `close`/`error`. Bound the per-IP tracking map
+  so it cannot itself grow unboundedly (evict zero-count entries).
+- **Message-rate (`relay.ts`):** add a second `TokenBucketLimiter` keyed by **peer id** (per connection),
+  consumed on each `signal` frame in `relay()`. On exhaustion, `reject(peer, 'message-rate-limited')` and
+  do not forward. The existing per-source **join** bucket is unchanged. Clean up a peer's message bucket
+  on `remove()` so the bucket map is bounded by live connections.
+- **Options:** thread `maxFrameBytes`, `maxConnections`, `maxConnectionsPerIp`, `messageRate` through
+  `ISignalingServerOptions` / `ISignalingRelayOptions`, each defaulting to the new safe constants.
+- **SPEC.md:** document the four bounds under Boundaries, add `message-rate-limited` (and any
+  connection-refused close reason) to the Error Taxonomy, and list new exports under Public API Surface.
+
+## Affected Files
+
+- `apps/remote-signaling/src/server.ts`
+- `apps/remote-signaling/src/relay.ts`
+- `apps/remote-signaling/src/rate-limiter.ts`
+- `apps/remote-signaling/src/index.ts`
+- `apps/remote-signaling/docs/SPEC.md`
+- `apps/remote-signaling/src/__tests__/relay-hardening.test.ts`
+- `apps/remote-signaling/src/__tests__/server-caps.test.ts` (new)
+
+## Completion Criteria
+
+- [ ] TC-01: A `signal` frame flood from one joined fake peer is throttled — after the burst, `relay()`
+      calls `reject(peer, 'message-rate-limited')` and does NOT forward to the counterpart; the join
+      bucket for other sources is unaffected.
+- [ ] TC-02: With `maxConnections: N`, the (N+1)-th concurrent WebSocket connection is closed at accept
+      time (never registered as a peer); after one closes, a new connection is admitted again.
+- [ ] TC-03: With `maxConnectionsPerIp: K`, the (K+1)-th connection from the SAME remote IP is closed at
+      accept time while a connection from a different IP is still admitted.
+- [ ] TC-04: A frame larger than `maxFrameBytes` does not reach the relay handler (the `ws` connection is
+      closed by `maxPayload`); a normal small frame relays successfully (regression).
+- [ ] TC-05: A legitimate two-peer pairing (join → offer/answer/ice at normal size + rate) completes
+      end-to-end unchanged — no new bound trips for well-behaved peers (regression against B2 behavior).
+- [ ] TC-06: New bounds are override-injectable and default to the documented safe constants
+      (`DEFAULT_MAX_FRAME_BYTES`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
+      `DEFAULT_MESSAGE_RATE`); `pnpm harness:scan` + typecheck + build green.
+
+## Test Plan
+
+| TC-ID | Test Type            | Tool / Approach                                                                                     | Notes                                                    |
+| ----- | -------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| TC-01 | Unit (fake-peer)     | vitest — fake peers + injected `IClock`; flood `signal`, assert `message-rate-limited` + no fan-out | Deterministic, network-free (reuses B2 harness)          |
+| TC-02 | Integration (server) | vitest — real `ws` client connections to `startSignalingServer({ relay:{ maxConnections } })`       | Server-layer cap; assert (N+1)-th socket closed          |
+| TC-03 | Integration (server) | vitest — two source addresses (loopback + stub `remoteAddress`) assert per-IP cap                   | Per-IP cap at accept                                     |
+| TC-04 | Integration (server) | vitest — send a frame > `maxFrameBytes`; assert handler not invoked / socket closed; small frame OK | Exercises `ws` `maxPayload`                              |
+| TC-05 | Integration (webrtc) | vitest — extend `integration-webrtc-relay.test.ts`: full pair still round-trips                     | Regression: well-behaved peers unaffected                |
+| TC-06 | CI smoke             | `pnpm --filter @robota-sdk/remote-signaling test` + `pnpm harness:scan` exit 0 + `pnpm typecheck`   | Defaults + injectability; scan/spec-public-surface green |
+
+## Tasks
+
+- [ ] `.agents/tasks/REMOTE-011.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log

--- a/.agents/spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md
+++ b/.agents/spec-docs/draft/REMOTE-011-stage-e2-signaling-abuse-hardening.md
@@ -39,16 +39,22 @@ content-blind and holds no session content; this stage only bounds resource cons
 ### Affected Scope
 
 - `apps/remote-signaling/src/server.ts` — set `WebSocketServer` `maxPayload`; enforce total + per-IP
-  connection caps at `wss.on('connection')`; thread new options.
+  connection caps at `wss.on('connection')`; add a per-IP-key **address resolver** seam (default
+  `request.socket.remoteAddress`, `trustProxy` variant reads a trusted `X-Forwarded-For`) that also gives
+  the server-level test a way to present distinct source addresses; thread new options.
 - `apps/remote-signaling/src/relay.ts` — add a per-connection **message-rate** limiter to the `signal`
-  relay path (distinct from the existing per-source **join** bucket); surface a new reject reason.
-- `apps/remote-signaling/src/rate-limiter.ts` — reuse `TokenBucketLimiter` for the message-rate bucket;
-  add typed defaults (`DEFAULT_MESSAGE_RATE`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
+  relay path (distinct from the existing per-source **join** bucket); evict a peer's bucket in `remove()`;
+  surface a new reject reason.
+- `apps/remote-signaling/src/rate-limiter.ts` — reuse `TokenBucketLimiter` for the message-rate bucket
+  **and add an `evict(key: string): void` method** (the class currently exposes only `tryConsume`, so a
+  per-connection bucket would otherwise grow by every peer id EVER admitted — an unbounded leak); add typed
+  defaults (`DEFAULT_MESSAGE_RATE`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
   `DEFAULT_MAX_FRAME_BYTES`).
-- `apps/remote-signaling/src/index.ts` — export any new option/const on the public surface.
+- `apps/remote-signaling/src/index.ts` — export any new option/const/method on the public surface.
 - `apps/remote-signaling/docs/SPEC.md` — extend Boundaries / Error Taxonomy / Public API with the new
-  bounds and reject reasons.
-- Tests: `__tests__/relay-hardening.test.ts` (message-rate), a server-level test for caps + `maxPayload`.
+  bounds, the relay reject reason, and the transport close codes.
+- Tests: `__tests__/relay-hardening.test.ts` (message-rate + bucket eviction), a server-level test for
+  caps + `maxPayload` + per-IP via the address-resolver seam.
 
 ### Alternatives Considered
 
@@ -61,7 +67,12 @@ content-blind and holds no session content; this stage only bounds resource cons
    code; production-grade. Con: the server ships as a self-hostable minimal app (REMOTE-001 constraint —
    "the one piece the owner hosts"); it must be safe **by default** without assuming a fronting proxy,
    exactly as B2 made the relay safe by default rather than hook-dependent. Rejected as the sole control;
-   may complement in production but cannot be the default posture.
+   may complement in production but cannot be the default posture. **Interaction hazard (must be resolved,
+   not ignored):** the per-IP cap keys on the TCP peer address — if a proxy IS fronting the server, every
+   connection presents the proxy's IP, so a naive per-IP cap collapses and rejects _legitimate_ clients.
+   The Decision therefore makes the per-IP cap assume **direct exposure by default** and adds an explicit
+   `trustProxy` opt-in (read a trusted `X-Forwarded-For`) plus the ability to disable the per-IP cap — so
+   the proxy deployment is correct rather than self-defeating.
 3. **(Chosen) Bound at the transport layer in `server.ts` (maxPayload + connection caps) and add a
    per-connection message-rate bucket at the relay.** Pro: `maxPayload` makes `ws` reject an oversized
    frame before buffering it; connection caps refuse sockets at accept time regardless of join; message
@@ -81,6 +92,14 @@ host↔client pairing sends small, low-rate frames and is unaffected); it does n
 protocol, so both existing peers (werift host + browser client) remain fully reachable — validated
 against the relay's frame contract (`offer`/`answer`/`ice` unchanged) and the fake-peer regression suite.
 
+Two correctness requirements ride with the decision (not optional): (a) the per-connection message-rate
+bucket is only truly "bounded by live connections" if `TokenBucketLimiter` can **evict** a key — so an
+`evict(key)` method is added and called from `relay.remove()`; without it the map grows by every peer id
+ever admitted, re-introducing the exact unbounded-growth class this stage closes. (The pre-existing B2
+`join` bucket keyed by `remoteAddress` has the same latent growth; that is out of scope here but noted so
+a future item can bound it.) (b) the per-IP cap assumes **direct exposure**; behind a trusted proxy it is
+enabled via `trustProxy` (`X-Forwarded-For`) or disabled — never left to silently reject all clients.
+
 ### Architecture Review Checklist
 
 - [x] 영향 패키지/레이어 목록 작성 완료
@@ -91,21 +110,36 @@ against the relay's frame contract (`offer`/`answer`/`ice` unchanged) and the fa
 ## Solution
 
 - **Frame size (`server.ts`):** construct `new WebSocketServer({ server, maxPayload: MAX_FRAME_BYTES })`
-  with a small default (e.g. 64 KiB — comfortably above any SDP/ICE frame, far below 100 MiB). `ws`
-  rejects and closes a connection that exceeds it before delivering the frame to our handler.
-- **Connection caps (`server.ts`):** track live socket count total and per remote IP; in
+  with a small default (e.g. 64 KiB — comfortably above any SDP/ICE frame, far below 100 MiB). `ws` reads
+  the frame's declared length from the header and closes with code **1009 (message too big)** BEFORE
+  buffering the body, so the oversized frame never reaches our `message` handler.
+- **Connection caps (`server.ts`):** track live socket count total and per resolved source key; in
   `wss.on('connection')`, if either the total (`MAX_CONNECTIONS`) or the per-IP
-  (`MAX_CONNECTIONS_PER_IP`) ceiling is already met, `socket.close()` immediately (with a bounded close
-  code/reason) and do not register the peer. Decrement on `close`/`error`. Bound the per-IP tracking map
-  so it cannot itself grow unboundedly (evict zero-count entries).
+  (`MAX_CONNECTIONS_PER_IP`) ceiling is already met, `socket.close(1013, 'over-capacity')` immediately and
+  do not register the peer. Decrement on `close`/`error`. Bound the per-IP tracking map so it cannot itself
+  grow unboundedly (delete a source key when its count returns to 0).
+- **Per-IP source resolution + proxy stance (`server.ts`):** the per-IP key comes from an injectable
+  **address resolver** `(request) => string`. Default resolver returns `request.socket.remoteAddress`,
+  falling back to a fixed sentinel (e.g. `'unknown'`) when it is `undefined` (so a missing address does not
+  crash or bypass the cap). A `trustProxy: true` option swaps in a resolver that reads the left-most
+  trusted `X-Forwarded-For` hop. The per-IP cap is **disable-able** (`maxConnectionsPerIp: 0`/undefined →
+  off) for proxy deployments that cannot supply a real client IP. The resolver seam doubles as the
+  server-level test's way to present distinct source addresses over loopback (TC-03).
 - **Message-rate (`relay.ts`):** add a second `TokenBucketLimiter` keyed by **peer id** (per connection),
   consumed on each `signal` frame in `relay()`. On exhaustion, `reject(peer, 'message-rate-limited')` and
-  do not forward. The existing per-source **join** bucket is unchanged. Clean up a peer's message bucket
-  on `remove()` so the bucket map is bounded by live connections.
-- **Options:** thread `maxFrameBytes`, `maxConnections`, `maxConnectionsPerIp`, `messageRate` through
-  `ISignalingServerOptions` / `ISignalingRelayOptions`, each defaulting to the new safe constants.
-- **SPEC.md:** document the four bounds under Boundaries, add `message-rate-limited` (and any
-  connection-refused close reason) to the Error Taxonomy, and list new exports under Public API Surface.
+  do not forward. The existing per-source **join** bucket is unchanged. In `remove()`, call the new
+  `limiter.evict(peerId)` on the message bucket so the map is bounded by LIVE connections, not lifetime.
+- **`TokenBucketLimiter.evict` (`rate-limiter.ts`):** add `evict(key: string): void { this.buckets.delete(key); }`
+  — the class currently exposes only `tryConsume`, so without eviction the "bounded by live connections"
+  guarantee is false. (Noted, out of scope: the B2 `join` bucket keyed by `remoteAddress` has the same
+  latent unbounded growth; a follow-up can evict it on a schedule.)
+- **Options:** thread `maxFrameBytes`, `maxConnections`, `maxConnectionsPerIp`, `trustProxy`,
+  `addressResolver`, `messageRate` through `ISignalingServerOptions` / `ISignalingRelayOptions`, each
+  defaulting to the new safe constants.
+- **SPEC.md:** document the bounds under Boundaries; split the failure surface into (i) **relay error
+  frames** — add `message-rate-limited` alongside the existing `{ type:'error', reason }` reasons — and
+  (ii) a new **transport close codes** subsection — `1009` (oversize, from `ws` `maxPayload`) and `1013`
+  (`over-capacity`, connection-cap refusal); list new exports under Public API Surface.
 
 ## Affected Files
 
@@ -124,26 +158,33 @@ against the relay's frame contract (`offer`/`answer`/`ice` unchanged) and the fa
       bucket for other sources is unaffected.
 - [ ] TC-02: With `maxConnections: N`, the (N+1)-th concurrent WebSocket connection is closed at accept
       time (never registered as a peer); after one closes, a new connection is admitted again.
-- [ ] TC-03: With `maxConnectionsPerIp: K`, the (K+1)-th connection from the SAME remote IP is closed at
-      accept time while a connection from a different IP is still admitted.
+- [ ] TC-03: With `maxConnectionsPerIp: K` and an injected address resolver mapping connections to two
+      distinct source keys, the (K+1)-th connection sharing a source key is closed at accept
+      (`close(1013,'over-capacity')`) while a connection with a different source key is still admitted;
+      with `maxConnectionsPerIp: 0` the per-IP cap is off (no refusal on source-key collision).
 - [ ] TC-04: A frame larger than `maxFrameBytes` does not reach the relay handler (the `ws` connection is
-      closed by `maxPayload`); a normal small frame relays successfully (regression).
+      closed with code `1009`); a normal small frame relays successfully (regression).
 - [ ] TC-05: A legitimate two-peer pairing (join → offer/answer/ice at normal size + rate) completes
       end-to-end unchanged — no new bound trips for well-behaved peers (regression against B2 behavior).
-- [ ] TC-06: New bounds are override-injectable and default to the documented safe constants
+- [ ] TC-06: `TokenBucketLimiter.evict(key)` removes a key's bucket; after a joined peer floods `signal`
+      and then `remove()` runs, the message-bucket map no longer contains that peer id (memory bound), and
+      the total/per-IP connection counters return to their pre-connection values after disconnect.
+- [ ] TC-07: New bounds are override-injectable and default to the documented safe constants
       (`DEFAULT_MAX_FRAME_BYTES`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`,
-      `DEFAULT_MESSAGE_RATE`); `pnpm harness:scan` + typecheck + build green.
+      `DEFAULT_MESSAGE_RATE`); a resolved source address of `undefined` maps to the sentinel key (no crash,
+      cap still applies); `pnpm harness:scan` + typecheck + build green.
 
 ## Test Plan
 
-| TC-ID | Test Type            | Tool / Approach                                                                                     | Notes                                                    |
-| ----- | -------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| TC-01 | Unit (fake-peer)     | vitest — fake peers + injected `IClock`; flood `signal`, assert `message-rate-limited` + no fan-out | Deterministic, network-free (reuses B2 harness)          |
-| TC-02 | Integration (server) | vitest — real `ws` client connections to `startSignalingServer({ relay:{ maxConnections } })`       | Server-layer cap; assert (N+1)-th socket closed          |
-| TC-03 | Integration (server) | vitest — two source addresses (loopback + stub `remoteAddress`) assert per-IP cap                   | Per-IP cap at accept                                     |
-| TC-04 | Integration (server) | vitest — send a frame > `maxFrameBytes`; assert handler not invoked / socket closed; small frame OK | Exercises `ws` `maxPayload`                              |
-| TC-05 | Integration (webrtc) | vitest — extend `integration-webrtc-relay.test.ts`: full pair still round-trips                     | Regression: well-behaved peers unaffected                |
-| TC-06 | CI smoke             | `pnpm --filter @robota-sdk/remote-signaling test` + `pnpm harness:scan` exit 0 + `pnpm typecheck`   | Defaults + injectability; scan/spec-public-surface green |
+| TC-ID | Test Type            | Tool / Approach                                                                                     | Notes                                                 |
+| ----- | -------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| TC-01 | Unit (fake-peer)     | vitest — fake peers + injected `IClock`; flood `signal`, assert `message-rate-limited` + no fan-out | Deterministic, network-free (reuses B2 harness)       |
+| TC-02 | Integration (server) | vitest — real `ws` client connections to `startSignalingServer({ relay:{ maxConnections } })`       | Server-layer cap; assert (N+1)-th socket closed       |
+| TC-03 | Integration (server) | vitest — injected `addressResolver` maps sockets to 2 source keys; assert per-IP cap + `0` disables | Resolver seam makes distinct source keys testable     |
+| TC-04 | Integration (server) | vitest — send a frame > `maxFrameBytes`; assert handler not invoked / socket closed 1009; small OK  | Exercises `ws` `maxPayload` → close 1009              |
+| TC-05 | Integration (webrtc) | vitest — extend `integration-webrtc-relay.test.ts`: full pair still round-trips                     | Regression: well-behaved peers unaffected             |
+| TC-06 | Unit + Integration   | vitest — `evict` unit test; flood-then-`remove()` asserts message-bucket map + conn counters shrink | Proves the memory bound (G1)                          |
+| TC-07 | CI smoke             | `pnpm --filter @robota-sdk/remote-signaling test` + `pnpm harness:scan` exit 0 + `pnpm typecheck`   | Defaults + injectability + undefined-address sentinel |
 
 ## Tasks
 

--- a/.agents/tasks/REMOTE-011.md
+++ b/.agents/tasks/REMOTE-011.md
@@ -1,0 +1,26 @@
+# REMOTE-011 — Stage E2: signaling-server abuse hardening (transport-layer DoS bounds)
+
+Spec: `.agents/spec-docs/active/REMOTE-011-stage-e2-signaling-abuse-hardening.md`
+
+Parent: REMOTE-001 (Stage E). GATE-APPROVAL: proposal-reviewer ENDORSE (2 rounds). Two non-blocking
+implementer notes: XFF picks the trusted-appended hop (not raw left-most); keep option layering clean
+(transport caps on `ISignalingServerOptions`, `messageRate` on `ISignalingRelayOptions`).
+
+## Tasks
+
+- [x] T1 (TC-06): `rate-limiter.ts` — add `TokenBucketLimiter.evict(key: string): void` (`this.buckets.delete(key)`); add typed defaults `DEFAULT_MESSAGE_RATE`, `DEFAULT_MAX_CONNECTIONS`, `DEFAULT_MAX_CONNECTIONS_PER_IP`, `DEFAULT_MAX_FRAME_BYTES`. Unit test: `evict` removes a key's bucket (absent-key no-op).
+- [x] T2 (TC-01/TC-06): `relay.ts` — add a per-connection message-rate `TokenBucketLimiter` keyed by peer id, consumed on each `signal` frame in `relay()`; on exhaustion `reject(peer, 'message-rate-limited')` and do NOT fan out; call `evict(peerId)` in `remove()`. Thread `messageRate` via `ISignalingRelayOptions`. Fake-peer tests: flood throttles + no fan-out; other sources unaffected; map shrinks after `remove()`.
+- [x] T3 (TC-02/03/07): `server.ts` — total + per-IP connection caps at `wss.on('connection')` (`close(1013,'over-capacity')`, never register); decrement on close/error; per-IP map deletes zero-count keys. Injectable `addressResolver` (default `request.socket.remoteAddress` → `'unknown'` sentinel; `trustProxy` reads trusted-appended `X-Forwarded-For` hop); `maxConnectionsPerIp: 0`/undefined disables per-IP. Thread `maxConnections`, `maxConnectionsPerIp`, `trustProxy`, `addressResolver` via `ISignalingServerOptions`.
+- [x] T4 (TC-04): `server.ts` — `new WebSocketServer({ server, maxPayload: maxFrameBytes })` (default `DEFAULT_MAX_FRAME_BYTES` ~64 KiB). Thread `maxFrameBytes` via `ISignalingServerOptions`.
+- [x] T5 (TC-02/03/04/06): new `__tests__/server-caps.test.ts` — real `ws` connections: total cap closes (N+1)-th; per-IP cap via injected resolver + `0` disables; oversized frame → close 1009, small frame relays; flood-then-disconnect shrinks counters.
+- [x] T6 (TC-05): extend `__tests__/integration-webrtc-relay.test.ts` — legitimate two-peer pairing still round-trips (regression).
+- [x] T7 (TC-01/06): extend `__tests__/relay-hardening.test.ts` — message-rate throttle + bucket eviction.
+- [x] T8: `index.ts` — export new options/consts/`evict` on the public surface (spec-public-surface scan).
+- [x] T9: `docs/SPEC.md` — Boundaries (four bounds), Error Taxonomy split (relay `message-rate-limited` frame vs transport close codes 1009/1013), Public API Surface.
+- [x] T10 (TC-07): `pnpm --filter @robota-sdk/remote-signaling test` + `pnpm typecheck` + `pnpm harness:scan` green.
+
+## Test Plan / 검증
+
+TDD: write each control's failing test first, then implement. Authoritative = the remote-signaling vitest
+suite (fake-peer message-rate + eviction; real-`ws` server caps + maxPayload 1009 + per-IP via resolver
+seam; webrtc-relay regression) + full typecheck + `harness:scan` (incl. spec-public-surface) green.

--- a/.agents/tasks/REMOTE-011.md
+++ b/.agents/tasks/REMOTE-011.md
@@ -18,6 +18,7 @@ implementer notes: XFF picks the trusted-appended hop (not raw left-most); keep 
 - [x] T8: `index.ts` — export new options/consts/`evict` on the public surface (spec-public-surface scan).
 - [x] T9: `docs/SPEC.md` — Boundaries (four bounds), Error Taxonomy split (relay `message-rate-limited` frame vs transport close codes 1009/1013), Public API Surface.
 - [x] T10 (TC-07): `pnpm --filter @robota-sdk/remote-signaling test` + `pnpm typecheck` + `pnpm harness:scan` green.
+- [ ] T11 (GATE-COMPLETE): after feature→develop merge (merge-verifier) and the batched Stage-E develop→main promotion, move the spec `active → done` (status `done`) and archive this task to `.agents/tasks/completed/`.
 
 ## Test Plan / 검증
 

--- a/apps/remote-signaling/docs/SPEC.md
+++ b/apps/remote-signaling/docs/SPEC.md
@@ -17,6 +17,14 @@ SDP/ICE relay logic and the WebSocket server entrypoint.
 - Carries **NO auth/trust in Stage A** (pairing lands in Stage B). It exposes an `onJoinAttempt` rate-limit/auth
   seam that is a no-op until then. It binds **loopback/ephemeral by default** and is not wired into any default
   runnable / publish / deploy path (REMOTE-002 TC-06).
+- **Bounds resource consumption at the transport layer, safe-by-default (REMOTE-011 E2):** a `maxPayload` frame
+  cap (`ws` closes an oversized frame with `1009` before buffering it), total + per-IP concurrent-connection
+  caps enforced at accept (`close(1013,'over-capacity')`, never registered), and a per-connection message-rate
+  bucket on the `signal` path (distinct from the per-source `join` bucket; evicted on disconnect). The per-IP
+  cap assumes **direct exposure** by default; behind a reverse proxy set `trustProxy` (reads the trusted,
+  right-most `X-Forwarded-For` hop) or disable it (`maxConnectionsPerIp: 0`) — otherwise every connection would
+  present the proxy IP and legitimate clients would be refused. None of these controls inspects `data`; the
+  relay stays content-blind.
 
 ## Architecture Overview
 
@@ -39,24 +47,30 @@ default, and returns a handle exposing the resolved port + a `close()`.
 
 ## Type Ownership
 
-| Type                                                                     | Location        | Purpose                        |
-| ------------------------------------------------------------------------ | --------------- | ------------------------------ |
-| `ISignalingPeer`, `ISignalingRelayHooks`, `TInboundFrame`, `TSignalKind` | `src/relay.ts`  | Relay contracts.               |
-| `ISignalingServerOptions`, `ISignalingServerHandle`                      | `src/server.ts` | Server start options + handle. |
+| Type                                                                     | Location        | Purpose                                      |
+| ------------------------------------------------------------------------ | --------------- | -------------------------------------------- |
+| `ISignalingPeer`, `ISignalingRelayHooks`, `TInboundFrame`, `TSignalKind` | `src/relay.ts`  | Relay contracts.                             |
+| `ISignalingServerOptions`, `ISignalingServerHandle`, `TAddressResolver`  | `src/server.ts` | Server start options + handle + IP-key seam. |
 
 ## Public API Surface
 
-| Export                      | Kind     | Description                                                            |
-| --------------------------- | -------- | ---------------------------------------------------------------------- |
-| `SignalingRelay`            | class    | Content-blind rendezvous + SDP/ICE relay with built-in abuse controls. |
-| `startSignalingServer`      | function | Bind the relay over WebSocket; returns a stop handle.                  |
-| `MAX_PEERS_PER_RENDEZVOUS`  | const    | Peer cap per rendezvous (2).                                           |
-| `TokenBucketLimiter`        | class    | Per-source join token-bucket (REMOTE-004; injected clock).             |
-| `systemClock`               | const    | Default `Date.now`-based `IClock`.                                     |
-| `systemScheduler`           | const    | Default `setTimeout`-based `IScheduler`.                               |
-| `DEFAULT_TOKEN_BUCKET`      | const    | Default join bucket (burst 5, refill 1/12s).                           |
-| `DEFAULT_RENDEZVOUS_TTL_MS` | const    | Default half-open rendezvous TTL (60s).                                |
-| `DEFAULT_MAX_RENDEZVOUS`    | const    | Default concurrent-rendezvous cap (1024).                              |
+| Export                           | Kind     | Description                                                                                               |
+| -------------------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `SignalingRelay`                 | class    | Content-blind rendezvous + SDP/ICE relay with built-in abuse controls.                                    |
+| `startSignalingServer`           | function | Bind the relay over WebSocket; returns a stop handle.                                                     |
+| `MAX_PEERS_PER_RENDEZVOUS`       | const    | Peer cap per rendezvous (2).                                                                              |
+| `TokenBucketLimiter`             | class    | Per-key token-bucket (REMOTE-004; injected clock); `evict(key)` drops a bucket (REMOTE-011 memory bound). |
+| `systemClock`                    | const    | Default `Date.now`-based `IClock`.                                                                        |
+| `systemScheduler`                | const    | Default `setTimeout`-based `IScheduler`.                                                                  |
+| `DEFAULT_TOKEN_BUCKET`           | const    | Default join bucket (burst 5, refill 1/12s).                                                              |
+| `DEFAULT_MESSAGE_RATE`           | const    | Default per-connection `signal` message-rate bucket (burst 60, ~10/s).                                    |
+| `DEFAULT_RENDEZVOUS_TTL_MS`      | const    | Default half-open rendezvous TTL (60s).                                                                   |
+| `DEFAULT_MAX_RENDEZVOUS`         | const    | Default concurrent-rendezvous cap (1024).                                                                 |
+| `DEFAULT_MAX_CONNECTIONS`        | const    | Default total concurrent-connection cap (2048).                                                           |
+| `DEFAULT_MAX_CONNECTIONS_PER_IP` | const    | Default per-source-key connection cap (64; `0` disables).                                                 |
+| `DEFAULT_MAX_FRAME_BYTES`        | const    | Default `maxPayload` per WebSocket frame (64 KiB).                                                        |
+| `OVER_CAPACITY_CLOSE_CODE`       | const    | WebSocket close code for a cap refusal (`1013`).                                                          |
+| `TAddressResolver`               | type     | Per-IP-key resolver seam (default TCP addr; `trustProxy` reads XFF).                                      |
 
 ## Extension Points
 
@@ -65,9 +79,16 @@ default, and returns a handle exposing the resolved port + a `close()`.
 
 ## Error Taxonomy
 
-Every rejection is a `{ type:'error', reason }` frame to the offending peer only: `invalid-json`,
-`malformed-frame`, `empty-rendezvous`, `join-rejected`, `rendezvous-full`, `unsupported-frame`, `not-joined`.
-No fallback behavior — a rejected frame is never partially relayed.
+Two distinct failure surfaces:
+
+**Relay error frames** — a `{ type:'error', reason }` frame to the offending peer only, no partial relay:
+`invalid-json`, `malformed-frame`, `empty-rendezvous`, `join-rejected`, `rendezvous-full`, `unsupported-frame`,
+`not-joined`, `rate-limited` (join flood), `message-rate-limited` (per-connection `signal` flood — the frame is
+dropped, the connection stays open).
+
+**Transport close codes** — a WebSocket close (the connection ends), not an application error frame:
+`1009` (message too big — a frame over `maxFrameBytes`, closed by `ws` before our handler runs) and `1013`
+(`over-capacity` — a connection refused at accept by the total or per-IP cap; the peer is never registered).
 
 ## Test Strategy
 
@@ -76,6 +97,14 @@ only, that a non-signaling payload (and an unknown signal kind) is never forward
 forwarding, the ≤2-peer cap, no-state-after-leave, and pre-join rejection; plus a loopback/ephemeral integration
 test that starts the real `ws` server on `127.0.0.1:0` and relays an offer between two live sockets (TC-06
 loopback binding).
+
+`src/__tests__/relay-hardening.test.ts` + `rate-limiter.test.ts` (REMOTE-004 B2 + REMOTE-011 E2): fake-peer +
+injected-clock coverage of the join bucket, single-use rendezvous, half-open TTL, concurrency cap, plus the
+per-connection message-rate throttle (per-connection isolation + no fan-out of the rejected frame) and
+`TokenBucketLimiter.evict` / `messageBucketCount` memory bound. `src/__tests__/server-caps.test.ts` (REMOTE-011
+E2): REAL `ws` connections assert the total + per-IP connection caps (via the injected `addressResolver` seam,
+and that `maxConnectionsPerIp: 0` disables it), `maxPayload` closing an oversized frame with `1009`, and the
+connection counter returning to 0 after disconnect.
 
 ## Class Contract Registry
 

--- a/apps/remote-signaling/src/__tests__/rate-limiter.test.ts
+++ b/apps/remote-signaling/src/__tests__/rate-limiter.test.ts
@@ -33,4 +33,18 @@ describe('TokenBucketLimiter (REMOTE-004 B2)', () => {
     expect(limiter.tryConsume('a')).toBe(false);
     expect(limiter.tryConsume('b')).toBe(true); // separate bucket
   });
+
+  it('TC-06: evict(key) drops a key bucket (memory bound); an absent key is a no-op', () => {
+    const clock = mutableClock(0);
+    const limiter = new TokenBucketLimiter({ burst: 1, refillPerMs: 0 }, clock);
+    limiter.tryConsume('a');
+    limiter.tryConsume('b');
+    expect(limiter.size).toBe(2);
+    limiter.evict('a');
+    expect(limiter.size).toBe(1);
+    limiter.evict('missing'); // no-op, no throw
+    expect(limiter.size).toBe(1);
+    // Evicting resets the key: a fresh consume gets a full burst again.
+    expect(limiter.tryConsume('a')).toBe(true);
+  });
 });

--- a/apps/remote-signaling/src/__tests__/relay-hardening.test.ts
+++ b/apps/remote-signaling/src/__tests__/relay-hardening.test.ts
@@ -62,6 +62,16 @@ function join(relay: SignalingRelay, peer: ISignalingPeer, rendezvous = 'r'): vo
   relay.handleFrame(peer, JSON.stringify({ type: 'join', rendezvous }));
 }
 
+function signal(relay: SignalingRelay, peer: ISignalingPeer, data: unknown = {}): void {
+  relay.handleFrame(peer, JSON.stringify({ type: 'signal', kind: 'ice', data }));
+}
+
+function signalFrames(peer: { readonly sent: string[] }): Record<string, unknown>[] {
+  return peer.sent
+    .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+    .filter((f) => f.type === 'signal');
+}
+
 describe('SignalingRelay abuse-hardening (REMOTE-004 B2)', () => {
   it('TC-03: rate-limits join floods per source and never relays a rejected join', () => {
     const relay = new SignalingRelay({
@@ -145,5 +155,65 @@ describe('SignalingRelay abuse-hardening (REMOTE-004 B2)', () => {
       peerId: a.id,
       remoteAddress: '1.2.3.4',
     });
+  });
+});
+
+describe('SignalingRelay per-connection message rate (REMOTE-011 E2)', () => {
+  it('TC-01: throttles a signal flood from one joined peer and does NOT fan out the rejected frame', () => {
+    const relay = new SignalingRelay({
+      messageRate: { burst: 2, refillPerMs: 0 }, // 2 signals, no refill
+      rateLimit: { burst: 5, refillPerMs: 0 },
+      clock: frozenClock,
+      scheduler: createFakeScheduler().scheduler,
+    });
+    const a = fakePeer('1.1.1.1');
+    const b = fakePeer('2.2.2.2');
+    join(relay, a);
+    join(relay, b);
+
+    signal(relay, a); // 1 → forwarded
+    signal(relay, a); // 2 → forwarded
+    signal(relay, a); // 3 → over burst → throttled
+
+    // Only the first two reached the counterpart; the third was dropped, not relayed.
+    expect(signalFrames(b)).toHaveLength(2);
+    expect(lastFrame(a)).toEqual({ type: 'error', reason: 'message-rate-limited' });
+  });
+
+  it('TC-01: the message bucket is per-connection — one peer flooding does not throttle the other', () => {
+    const relay = new SignalingRelay({
+      messageRate: { burst: 1, refillPerMs: 0 },
+      rateLimit: { burst: 5, refillPerMs: 0 },
+      clock: frozenClock,
+      scheduler: createFakeScheduler().scheduler,
+    });
+    const a = fakePeer('1.1.1.1');
+    const b = fakePeer('2.2.2.2');
+    join(relay, a);
+    join(relay, b);
+
+    signal(relay, a); // a: token 1 → forwarded to b
+    signal(relay, a); // a: throttled
+    signal(relay, b); // b has its own bucket → forwarded to a
+
+    expect(signalFrames(b)).toHaveLength(1); // b received a's single allowed signal
+    expect(signalFrames(a)).toHaveLength(1); // a received b's signal (b not throttled by a's flood)
+    expect(lastFrame(a)).toEqual({ type: 'signal', kind: 'ice', data: {} });
+  });
+
+  it('TC-06: a peer message bucket is evicted on remove() (bounded by live connections)', () => {
+    const relay = new SignalingRelay({
+      clock: frozenClock,
+      scheduler: createFakeScheduler().scheduler,
+    });
+    const a = fakePeer('1.1.1.1');
+    const b = fakePeer('2.2.2.2');
+    join(relay, a);
+    join(relay, b);
+    expect(relay.messageBucketCount).toBe(0); // no signal sent yet → no bucket
+    signal(relay, a); // creates a's message bucket
+    expect(relay.messageBucketCount).toBe(1);
+    relay.remove(a); // disconnect evicts the bucket
+    expect(relay.messageBucketCount).toBe(0);
   });
 });

--- a/apps/remote-signaling/src/__tests__/server-caps.test.ts
+++ b/apps/remote-signaling/src/__tests__/server-caps.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { startSignalingServer, type ISignalingServerHandle } from '../server.js';
+
+/**
+ * REMOTE-011 E2 — transport-layer DoS bounds enforced in `server.ts`, exercised with REAL `ws` client
+ * connections (these live ABOVE the fake-peer relay seam, so they need a real socket). Covers the total +
+ * per-IP connection caps, the injected address-resolver seam, `maxPayload` (close 1009), and the
+ * connection-counter memory bound.
+ */
+
+function connect(url: string, headers?: Record<string, string>): WebSocket {
+  return new WebSocket(url, headers ? { headers } : undefined);
+}
+
+function onceOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.on('open', () => resolve());
+    ws.on('error', reject);
+  });
+}
+
+function onceClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    ws.on('close', (code: number, reason: Buffer) => resolve({ code, reason: reason.toString() }));
+  });
+}
+
+function onceMessage(ws: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    ws.on('message', (data: Buffer) =>
+      resolve(JSON.parse(data.toString()) as Record<string, unknown>),
+    );
+  });
+}
+
+async function poll(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('poll timed out');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function withServer(
+  options: Parameters<typeof startSignalingServer>[0],
+  run: (server: ISignalingServerHandle, url: string) => Promise<void>,
+): Promise<void> {
+  const server = await startSignalingServer(options);
+  try {
+    await run(server, `ws://127.0.0.1:${server.port}`);
+  } finally {
+    await server.close();
+  }
+}
+
+describe('signaling server transport caps (REMOTE-011 E2)', () => {
+  it('TC-02: closes the (N+1)-th connection over the total cap; admits again after one closes', async () => {
+    await withServer({ maxConnections: 2 }, async (server, url) => {
+      const a = connect(url);
+      const b = connect(url);
+      await Promise.all([onceOpen(a), onceOpen(b)]);
+      await poll(() => server.connectionCount === 2);
+
+      const c = connect(url); // over the cap
+      const closed = await onceClose(c);
+      expect(closed.code).toBe(1013);
+      expect(server.connectionCount).toBe(2);
+
+      a.close();
+      await poll(() => server.connectionCount === 1);
+      const d = connect(url); // room again
+      await onceOpen(d);
+      await poll(() => server.connectionCount === 2);
+
+      b.close();
+      d.close();
+    });
+  }, 15000);
+
+  it('TC-03: per-IP cap refuses a second connection sharing a source key, admits a different key', async () => {
+    // Inject an address resolver keyed off a test header so distinct source keys are testable over loopback.
+    await withServer(
+      {
+        maxConnectionsPerIp: 1,
+        addressResolver: (req) => {
+          const h = req.headers['x-test-ip'];
+          return typeof h === 'string' ? h : undefined;
+        },
+      },
+      async (server, url) => {
+        const a1 = connect(url, { 'x-test-ip': 'A' });
+        await onceOpen(a1);
+        await poll(() => server.connectionCount === 1);
+
+        const a2 = connect(url, { 'x-test-ip': 'A' }); // same source key → refused
+        expect((await onceClose(a2)).code).toBe(1013);
+
+        const b1 = connect(url, { 'x-test-ip': 'B' }); // different key → admitted
+        await onceOpen(b1);
+        await poll(() => server.connectionCount === 2);
+
+        a1.close();
+        b1.close();
+      },
+    );
+  }, 15000);
+
+  it('TC-03: maxConnectionsPerIp:0 disables the per-IP cap', async () => {
+    await withServer(
+      {
+        maxConnectionsPerIp: 0,
+        addressResolver: () => 'same', // everything collapses to one key
+      },
+      async (server, url) => {
+        const a = connect(url, { 'x-test-ip': 'A' });
+        const b = connect(url, { 'x-test-ip': 'A' });
+        await Promise.all([onceOpen(a), onceOpen(b)]); // both admitted despite one key
+        await poll(() => server.connectionCount === 2);
+        a.close();
+        b.close();
+      },
+    );
+  }, 15000);
+
+  it('TC-04: a frame over maxFrameBytes closes with 1009; a small frame still relays (joined)', async () => {
+    await withServer({ maxFrameBytes: 1024 }, async (_server, url) => {
+      // Small frame: a normal join succeeds.
+      const ok = connect(url);
+      await onceOpen(ok);
+      const reply = onceMessage(ok);
+      ok.send(JSON.stringify({ type: 'join', rendezvous: 'r' }));
+      expect((await reply).type).toBe('joined');
+      ok.close();
+
+      // Oversized frame: ws closes the connection with 1009 before our handler sees it.
+      const big = connect(url);
+      await onceOpen(big);
+      const closed = onceClose(big);
+      big.send('x'.repeat(4096));
+      expect((await closed).code).toBe(1009);
+    });
+  }, 15000);
+
+  it('TC-06: the connection counter returns to 0 after all sockets disconnect (memory bound)', async () => {
+    await withServer({}, async (server, url) => {
+      const a = connect(url);
+      const b = connect(url);
+      await Promise.all([onceOpen(a), onceOpen(b)]);
+      await poll(() => server.connectionCount === 2);
+      a.close();
+      b.close();
+      await poll(() => server.connectionCount === 0);
+      expect(server.connectionCount).toBe(0);
+    });
+  }, 15000);
+});

--- a/apps/remote-signaling/src/index.ts
+++ b/apps/remote-signaling/src/index.ts
@@ -18,9 +18,17 @@ export {
   systemClock,
   systemScheduler,
   DEFAULT_TOKEN_BUCKET,
+  DEFAULT_MESSAGE_RATE,
   DEFAULT_RENDEZVOUS_TTL_MS,
   DEFAULT_MAX_RENDEZVOUS,
+  DEFAULT_MAX_CONNECTIONS,
+  DEFAULT_MAX_CONNECTIONS_PER_IP,
+  DEFAULT_MAX_FRAME_BYTES,
 } from './rate-limiter.js';
 export type { IClock, IScheduler, ITokenBucketConfig } from './rate-limiter.js';
-export { startSignalingServer } from './server.js';
-export type { ISignalingServerOptions, ISignalingServerHandle } from './server.js';
+export { startSignalingServer, OVER_CAPACITY_CLOSE_CODE } from './server.js';
+export type {
+  ISignalingServerOptions,
+  ISignalingServerHandle,
+  TAddressResolver,
+} from './server.js';

--- a/apps/remote-signaling/src/rate-limiter.ts
+++ b/apps/remote-signaling/src/rate-limiter.ts
@@ -28,11 +28,27 @@ export interface ITokenBucketConfig {
 /** Default: burst 5 joins, refill 1 token / 12s (~5/min steady) per source. */
 export const DEFAULT_TOKEN_BUCKET: ITokenBucketConfig = { burst: 5, refillPerMs: 1 / 12_000 };
 
+/**
+ * Default per-connection **message rate** for the relayed `signal` path (REMOTE-011 E2): burst 60, refill
+ * 1 token / 100ms (~10/s steady) — generous for a normal offer/answer + ICE-trickle negotiation, but bounds
+ * a `signal` flood from an already-joined peer. Distinct from the per-source `join` bucket above.
+ */
+export const DEFAULT_MESSAGE_RATE: ITokenBucketConfig = { burst: 60, refillPerMs: 1 / 100 };
+
 /** Default half-open rendezvous TTL (a rendezvous holding a single peer expires after this). */
 export const DEFAULT_RENDEZVOUS_TTL_MS = 60_000;
 
 /** Default ceiling on concurrent rendezvous. */
 export const DEFAULT_MAX_RENDEZVOUS = 1024;
+
+/** Default ceiling on total concurrent WebSocket connections (REMOTE-011 E2). ~2 peers × max rendezvous. */
+export const DEFAULT_MAX_CONNECTIONS = 2048;
+
+/** Default ceiling on concurrent connections per resolved source key (REMOTE-011 E2). `0` disables. */
+export const DEFAULT_MAX_CONNECTIONS_PER_IP = 64;
+
+/** Default max bytes per WebSocket frame (REMOTE-011 E2). Signaling frames are a few KB; far below ws's 100 MiB. */
+export const DEFAULT_MAX_FRAME_BYTES = 64 * 1024;
 
 export const systemClock: IClock = { now: () => Date.now() };
 
@@ -67,5 +83,19 @@ export class TokenBucketLimiter {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Drop a key's bucket (REMOTE-011 E2). Callers that key by a transient identity (e.g. a per-connection
+   * peer id) MUST evict on teardown, else the map grows by every key ever seen — an unbounded leak.
+   * Evicting an absent key is a harmless no-op.
+   */
+  public evict(key: string): void {
+    this.buckets.delete(key);
+  }
+
+  /** Diagnostics only: number of live buckets (used to assert the eviction/memory bound in tests). */
+  public get size(): number {
+    return this.buckets.size;
   }
 }

--- a/apps/remote-signaling/src/relay.ts
+++ b/apps/remote-signaling/src/relay.ts
@@ -16,6 +16,7 @@ import {
   TokenBucketLimiter,
   systemClock,
   systemScheduler,
+  DEFAULT_MESSAGE_RATE,
   DEFAULT_RENDEZVOUS_TTL_MS,
   DEFAULT_MAX_RENDEZVOUS,
   type IClock,
@@ -65,6 +66,12 @@ export interface ISignalingRelayOptions {
   readonly hooks?: ISignalingRelayHooks;
   /** Per-source join token-bucket (default: burst 5, refill 1/12s). */
   readonly rateLimit?: ITokenBucketConfig;
+  /**
+   * Per-connection **message rate** for the relayed `signal` path (REMOTE-011 E2; default
+   * {@link DEFAULT_MESSAGE_RATE}). Bounds a `signal` flood from an already-joined peer — distinct from the
+   * per-source `join` bucket (`rateLimit`). Keyed by peer id and evicted on `remove()`.
+   */
+  readonly messageRate?: ITokenBucketConfig;
   /** Half-open rendezvous TTL in ms (default 60s). */
   readonly rendezvousTtlMs?: number;
   /** Ceiling on concurrent (active) rendezvous (default 1024). */
@@ -92,6 +99,8 @@ export class SignalingRelay {
 
   private readonly hooks: ISignalingRelayHooks;
   private readonly limiter: TokenBucketLimiter;
+  /** Per-connection message-rate bucket for the `signal` path (keyed by peer id; evicted on remove). */
+  private readonly messageLimiter: TokenBucketLimiter;
   private readonly scheduler: IScheduler;
   private readonly ttlMs: number;
   private readonly maxRendezvous: number;
@@ -101,7 +110,12 @@ export class SignalingRelay {
     this.scheduler = options.scheduler ?? systemScheduler;
     this.ttlMs = options.rendezvousTtlMs ?? DEFAULT_RENDEZVOUS_TTL_MS;
     this.maxRendezvous = options.maxRendezvous ?? DEFAULT_MAX_RENDEZVOUS;
-    this.limiter = new TokenBucketLimiter(options.rateLimit, options.clock ?? systemClock);
+    const clock = options.clock ?? systemClock;
+    this.limiter = new TokenBucketLimiter(options.rateLimit, clock);
+    this.messageLimiter = new TokenBucketLimiter(
+      options.messageRate ?? DEFAULT_MESSAGE_RATE,
+      clock,
+    );
   }
 
   /** Handle one raw inbound frame from `peer`. Only `signal` frames are ever forwarded, and only to the peer's counterpart. */
@@ -197,6 +211,12 @@ export class SignalingRelay {
       this.reject(peer, 'not-joined');
       return;
     }
+    // Per-connection message-rate bound (REMOTE-011 E2): a joined peer flooding `signal` frames is
+    // throttled here — the frame is dropped (never forwarded) rather than closing the connection.
+    if (!this.messageLimiter.tryConsume(peer.id)) {
+      this.reject(peer, 'message-rate-limited');
+      return;
+    }
     const room = this.rooms.get(rendezvous);
     if (!room) return;
     // Forward the opaque signal verbatim to the counterpart(s) only — never echo back to the sender.
@@ -214,6 +234,9 @@ export class SignalingRelay {
   public remove(peer: ISignalingPeer): void {
     const rendezvous = this.peerRendezvous.get(peer.id);
     this.peerRendezvous.delete(peer.id);
+    // Evict the per-connection message bucket (REMOTE-011 E2) so the map is bounded by LIVE connections,
+    // not by every peer id ever admitted — the unbounded-growth class this stage exists to close.
+    this.messageLimiter.evict(peer.id);
     if (rendezvous) {
       this.leaveRoom(peer, rendezvous);
       this.armTimer(rendezvous);
@@ -278,5 +301,10 @@ export class SignalingRelay {
   /** Diagnostics only: current (active) rendezvous count (holds no session content). */
   public get rendezvousCount(): number {
     return this.rooms.size;
+  }
+
+  /** Diagnostics only (REMOTE-011 E2): live per-connection message-bucket count — asserts the memory bound. */
+  public get messageBucketCount(): number {
+    return this.messageLimiter.size;
   }
 }

--- a/apps/remote-signaling/src/server.ts
+++ b/apps/remote-signaling/src/server.ts
@@ -11,6 +11,25 @@ import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { WebSocketServer, type WebSocket } from 'ws';
 
 import { SignalingRelay, type ISignalingPeer, type ISignalingRelayOptions } from './relay.js';
+import {
+  DEFAULT_MAX_CONNECTIONS,
+  DEFAULT_MAX_CONNECTIONS_PER_IP,
+  DEFAULT_MAX_FRAME_BYTES,
+} from './rate-limiter.js';
+
+/**
+ * Resolve the per-IP cap key from a connection's request (REMOTE-011 E2). Default reads the TCP peer
+ * address; a `trustProxy` deployment reads a trusted `X-Forwarded-For` hop. Returning `undefined` maps to a
+ * fixed sentinel so a missing address neither crashes nor bypasses the cap. Injectable so the server-level
+ * test can present distinct source keys over loopback.
+ */
+export type TAddressResolver = (request: IncomingMessage) => string | undefined;
+
+/** WebSocket close code for a connection refused by the total/per-IP cap (RFC 6455 1013 — Try Again Later). */
+export const OVER_CAPACITY_CLOSE_CODE = 1013;
+
+/** Sentinel per-IP key when the resolver yields `undefined` (keeps the cap applied without a crash). */
+const UNKNOWN_SOURCE_KEY = 'unknown';
 
 export interface ISignalingServerOptions {
   /** Port to bind. Default `0` (ephemeral) — the actual port is reported by {@link ISignalingServerHandle.port}. */
@@ -19,6 +38,16 @@ export interface ISignalingServerOptions {
   readonly host?: string;
   /** Relay behavior — custom-auth hooks + abuse-control params (rate limit, TTL, caps). Defaults are safe. */
   readonly relay?: ISignalingRelayOptions;
+  /** Max bytes per WebSocket frame (REMOTE-011 E2; default {@link DEFAULT_MAX_FRAME_BYTES}). `ws` closes an oversized frame with 1009 before buffering it. */
+  readonly maxFrameBytes?: number;
+  /** Ceiling on total concurrent connections (REMOTE-011 E2; default {@link DEFAULT_MAX_CONNECTIONS}). */
+  readonly maxConnections?: number;
+  /** Ceiling on concurrent connections per resolved source key (REMOTE-011 E2; default {@link DEFAULT_MAX_CONNECTIONS_PER_IP}). `0` disables the per-IP cap (for proxy deployments that cannot supply a real client IP). */
+  readonly maxConnectionsPerIp?: number;
+  /** When true, resolve the per-IP key from a trusted `X-Forwarded-For` hop instead of the TCP address (REMOTE-011 E2). Assumes a single trusted proxy directly in front; ignored when a custom {@link ISignalingServerOptions.addressResolver} is supplied. */
+  readonly trustProxy?: boolean;
+  /** Custom per-IP key resolver (REMOTE-011 E2). Overrides `trustProxy`. Primarily a test seam for distinct source keys over loopback. */
+  readonly addressResolver?: TAddressResolver;
 }
 
 export interface ISignalingServerHandle {
@@ -26,11 +55,41 @@ export interface ISignalingServerHandle {
   readonly port: number;
   /** The relay instance (diagnostics/tests). */
   readonly relay: SignalingRelay;
+  /** Diagnostics only (REMOTE-011 E2): current live connection count — asserts the cap/counter memory bound. */
+  readonly connectionCount: number;
   /** Stop accepting connections and close the server. */
   close(): Promise<void>;
 }
 
 let peerCounter = 0;
+
+/** Default per-IP key: the TCP peer address (direct-exposure deployment). */
+function directAddressResolver(request: IncomingMessage): string | undefined {
+  return request.socket.remoteAddress;
+}
+
+/**
+ * `trustProxy` per-IP key: the **right-most** `X-Forwarded-For` entry — the hop the single trusted proxy
+ * directly in front appended (the left-most entry is client-forgeable, so it is never used). Falls back to
+ * the TCP address when the header is absent. Assumes exactly one trusted proxy in front.
+ */
+function forwardedForResolver(request: IncomingMessage): string | undefined {
+  const header = request.headers['x-forwarded-for'];
+  const raw = Array.isArray(header) ? header[header.length - 1] : header;
+  if (typeof raw === 'string') {
+    const hops = raw
+      .split(',')
+      .map((h) => h.trim())
+      .filter((h) => h.length > 0);
+    if (hops.length > 0) return hops[hops.length - 1];
+  }
+  return request.socket.remoteAddress;
+}
+
+function selectResolver(options: ISignalingServerOptions): TAddressResolver {
+  if (options.addressResolver) return options.addressResolver;
+  return options.trustProxy ? forwardedForResolver : directAddressResolver;
+}
 
 function wrapSocket(socket: WebSocket, remoteAddress?: string): ISignalingPeer {
   const id = `peer_${(peerCounter += 1)}`;
@@ -54,14 +113,54 @@ export function startSignalingServer(
   const port = options.port ?? 0;
   const relay = new SignalingRelay(options.relay);
 
+  const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
+  const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+  const maxConnectionsPerIp = options.maxConnectionsPerIp ?? DEFAULT_MAX_CONNECTIONS_PER_IP;
+  const resolveSourceKey = selectResolver(options);
+
+  // Connection-cap bookkeeping (REMOTE-011 E2): a total counter + a per-source-key counter map. A socket
+  // that connects and never `join`s is otherwise invisible to the relay's per-source join bucket, so caps
+  // are enforced here at accept time. The per-source map deletes a key when its count returns to 0 so it is
+  // itself bounded by live connections.
+  let totalConnections = 0;
+  const perSourceConnections = new Map<string, number>();
+
   const httpServer: Server = createServer();
-  const wss = new WebSocketServer({ server: httpServer });
+  // `maxPayload` makes `ws` reject an oversized frame with close code 1009 BEFORE buffering its body — an
+  // application-layer size check cannot, because the body is already buffered by the time the relay sees it.
+  const wss = new WebSocketServer({ server: httpServer, maxPayload: maxFrameBytes });
 
   wss.on('connection', (socket: WebSocket, request: IncomingMessage) => {
+    const sourceKey = resolveSourceKey(request) ?? UNKNOWN_SOURCE_KEY;
+    const perSource = perSourceConnections.get(sourceKey) ?? 0;
+    // Refuse at accept — do NOT register the peer — when either ceiling is already met. `maxConnectionsPerIp`
+    // of 0 disables the per-IP cap (proxy deployments that cannot supply a real client IP).
+    if (
+      totalConnections >= maxConnections ||
+      (maxConnectionsPerIp > 0 && perSource >= maxConnectionsPerIp)
+    ) {
+      socket.close(OVER_CAPACITY_CLOSE_CODE, 'over-capacity');
+      return;
+    }
+
+    totalConnections += 1;
+    perSourceConnections.set(sourceKey, perSource + 1);
+
     const peer = wrapSocket(socket, request.socket.remoteAddress);
+    let released = false;
+    const release = (): void => {
+      if (released) return; // close + error can both fire — decrement exactly once
+      released = true;
+      totalConnections -= 1;
+      const remaining = (perSourceConnections.get(sourceKey) ?? 1) - 1;
+      if (remaining <= 0) perSourceConnections.delete(sourceKey);
+      else perSourceConnections.set(sourceKey, remaining);
+      relay.remove(peer);
+    };
+
     socket.on('message', (data: Buffer) => relay.handleFrame(peer, data.toString()));
-    socket.on('close', () => relay.remove(peer));
-    socket.on('error', () => relay.remove(peer));
+    socket.on('close', release);
+    socket.on('error', release);
   });
 
   return new Promise<ISignalingServerHandle>((resolve, reject) => {
@@ -72,6 +171,9 @@ export function startSignalingServer(
       resolve({
         port: boundPort,
         relay,
+        get connectionCount(): number {
+          return totalConnections;
+        },
         close(): Promise<void> {
           return new Promise<void>((res) => {
             // Force-terminate any live sockets first — otherwise `httpServer.close()` blocks waiting for open


### PR DESCRIPTION
Stage E2 of REMOTE-001 — hardens `apps/remote-signaling` at the **WebSocket transport layer**, the residual DoS surface left by REMOTE-004/B2 (which already covers join-flood / single-use rendezvous / half-open TTL / concurrency cap / frame allowlist).

### What
- **Frame size:** `WebSocketServer` `maxPayload` (default 64 KiB) — `ws` closes an oversized frame with **1009** before buffering its body (an app-layer check can't; the body is already buffered by then).
- **Connection caps:** total + per-IP concurrent-connection ceilings enforced at accept (`close(1013,'over-capacity')`, peer never registered); counters decrement on close/error; per-IP map deletes zero-count keys.
- **Reverse-proxy safety:** injectable `addressResolver`; `trustProxy` reads the trusted right-most `X-Forwarded-For` hop; `undefined`-address sentinel; `maxConnectionsPerIp: 0` disables the per-IP cap so a fronting proxy doesn't collapse all clients to one key.
- **Message rate:** per-connection token bucket on the `signal` path (distinct from the per-source `join` bucket) — `message-rate-limited` reject with **no fan-out**; evicted on `remove()` so the map is bounded by live connections.
- **Primitive fix:** `TokenBucketLimiter.evict(key)` + `size` (without eviction a per-connection bucket leaks by every peer id ever seen). Diagnostics: server `connectionCount`, relay `messageBucketCount`.
- **SPEC.md:** Boundaries + Error-Taxonomy split (relay error frames vs transport close codes 1009/1013) + Public API.

### Gate + verification
- proposal-reviewer **ENDORSE** (2 rounds — round 1 REVISE fixed: evict/memory-bound, per-IP proxy stance, taxonomy split, tests).
- `pnpm --filter @robota-sdk/remote-signaling test` → **26 passed**; full `pnpm typecheck` clean; `pnpm harness:scan` → **49/49** (incl. `spec-public-surface`).

Spec: `.agents/spec-docs/active/REMOTE-011-stage-e2-signaling-abuse-hardening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)