### PR TITLE
feat(remote): TOFU trusted-device reconnect (REMOTE-012 / Stage E3)

### DIFF
--- a/.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
+++ b/.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
@@ -204,31 +204,31 @@ explicit accept).
 
 ## Completion Criteria
 
-- [ ] TC-01: `signChallenge` + `verifyChallenge` round-trip: a signature over
+- [x] TC-01: `signChallenge` + `verifyChallenge` round-trip: a signature over
       `{nonceHost, nonceDevice, fpA, fpB}` verifies with the matching public key and FAILS for a different
       nonce (either), a different fingerprint pair, or a different keypair (isomorphic WebCrypto unit).
-- [ ] TC-02: `deriveIdentityId` is stable for a given public key and differs across keypairs;
+- [x] TC-02: `deriveIdentityId` is stable for a given public key and differs across keypairs;
       `exportPublicKey`→`importPublicKey` round-trips; a `SHA-256(SPKI)` id is second-preimage stable.
-- [ ] TC-03: `reconnect.ts` MUTUAL controller resolves accept on each side ONLY after it verifies the
+- [x] TC-03: `reconnect.ts` MUTUAL controller resolves accept on each side ONLY after it verifies the
       counterpart's signature against the pinned key; it rejects (fail-closed) on timeout, a wrong device
       signature, a wrong/absent HOST signature (rogue host), or an unknown deviceId.
-- [ ] TC-04: Host trusted-device store: `upsert` then `get`/`list` returns the record; `revoke` removes it;
+- [x] TC-04: Host trusted-device store: `upsert` then `get`/`list` returns the record; `revoke` removes it;
       a corrupt file **throws** (fail-fast); an absent id returns undefined; the persisted JSON contains
       **only public keys — no private key material** (negative assertion). Round-trips through a temp
       `~/.robota`. Host identity keypair: load-or-create persists a `0600` JWK and reloads the same key.
-- [ ] TC-05: Host gate/transport: on first-pair accept the device public key is enrolled (store `upsert`
+- [x] TC-05: Host gate/transport: on first-pair accept the device public key is enrolled (store `upsert`
       with a stable deviceId) AND the host advertises its identity public key; on a subsequent `rc-hello`
       for that deviceId the mutual reconnect admits WITHOUT a fresh pairing accept; on `rc-hello` for an
       unknown/revoked id the reconnect is refused fail-closed (no session exposed).
-- [ ] TC-06: Browser credential store: a generated device keypair + pinned host key persist (IndexedDB fake)
+- [x] TC-06: Browser credential store: a generated device keypair + pinned host key persist (IndexedDB fake)
       and reload so the client takes the reconnect path on the second connect and **verifies the host**; the
       private key is non-extractable (export rejects); no secret/key value is ever placed in
       `location.search`/history.
-- [ ] TC-07: End-to-end (Node responder oracle ↔ host gate): first pair enrolls both keys; reconnect with
+- [x] TC-07: End-to-end (Node responder oracle ↔ host gate): first pair enrolls both keys; reconnect with
       the pinned keypairs establishes a session with no re-accept; a **rogue host** (wrong host identity key)
       makes the DEVICE refuse fail-closed; a tampered fingerprint (simulated MITM) fails the channel-bound
       challenge → reconnect refused; a captured `rc-device` proof replayed against a fresh challenge → reject.
-- [ ] TC-08: `/remote-control devices` lists enrolled devices and `revoke <id>` removes one; a revoked
+- [x] TC-08: `/remote-control devices` lists enrolled devices and `revoke <id>` removes one; a revoked
       device must re-pair. `pnpm harness:scan` + `pnpm typecheck` + affected package tests green.
 
 ## Test Plan
@@ -246,6 +246,30 @@ explicit accept).
 
 ## Tasks
 
-- [ ] `.agents/tasks/REMOTE-012.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+- [x] `.agents/tasks/REMOTE-012.md` — created at GATE-APPROVAL.
 
 ## Evidence Log
+
+- **GATE-APPROVAL:** proposal-reviewer ENDORSE (2 rounds). Round 1 REVISE — the blocking gap was a one-way
+  reconnect (device→host only), dropping B3's mutual auth (rogue-host downgrade). Round 2 ENDORSE after
+  making reconnect MUTUAL (host identity keypair + host also signs a channel-bound challenge the device
+  verifies), deferring `sessionKey` to E4, excluding WebAuthn, and adding rogue-host / no-private-material /
+  replay tests. Optional hardening applied: the signed transcript binds `deviceId ‖ hostIdentityId`.
+- **Implementation (isomorphic, WebCrypto-only foundation):** `agent-remote-pairing` — `crypto-primitives.ts`
+  (SSOT extract), `device-identity.ts` (ECDSA-P256 keygen/SPKI/JWK/`deriveIdentityId`/`signChallenge`/
+  `verifyChallenge`), `reconnect.ts` (mutual `startDeviceReconnect`/`startHostReconnect`). Host —
+  `host-identity.ts` (0600 JWK, load/reload), `trusted-device-store.ts` (public keys only, fail-fast),
+  `remote-control-controller.ts` (reconnect config, enroll-on-accept, `listDevices`/`revokeDevice`),
+  `/remote-control devices`/`revoke <id>` verbs (case-preserving id) via a new `remoteControl` adapter surface.
+  Gate — `pairing-gate.ts` reactive E3 mode (first-pair-with-enrollment vs mutual reconnect; B4 path
+  unchanged), `webrtc-transport.ts` threads `IHostReconnectConfig` + `onPaired(result)`. Browser —
+  `device-credential-store.ts` (IndexedDB, injectable backend, non-extractable key), `rtc-responder-gate.ts`
+  (E3 enrollment + device reconnect), `rtc-session-client.ts`/`useRtcSession` wiring. **E3/E4 boundary:** E3
+  ships the identity/trust/auth layer + persistence + enrollment + the mutual reconnect protocol (both gates);
+  the transport-level reconnection LOOP (stable-rendezvous rediscovery + auto-reconnect + session resume) is E4.
+- **Verification (2026-07-12):** per-package vitest — agent-remote-pairing 28 (crypto round-trip+negatives,
+  mutual protocol fail-closed incl. rogue-host + proof-replay), agent-transport-webrtc 27 (gate enroll/
+  reconnect/deny), agent-cli 200 (host identity + store no-private-material/fail-fast + controller E3),
+  agent-web-ui 54 (credential store non-extractable + responder-gate E3 + session-client), agent-command 225
+  (`devices`/`revoke` incl. case-preserving id), agent-framework 1080. Full `pnpm typecheck` clean;
+  `pnpm harness:scan` all 49 passed (incl. `spec-public-surface`, `orphan-exports`).

--- a/.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
+++ b/.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: in-progress
 type: SECURITY
 tags: [auth, websocket, typescript]
 ---

--- a/.agents/spec-docs/draft/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
+++ b/.agents/spec-docs/draft/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
@@ -1,0 +1,195 @@
+---
+status: draft
+type: SECURITY
+tags: [auth, websocket, typescript]
+---
+
+# REMOTE-012: Stage E3 — TOFU trusted-device reconnect
+
+## Problem
+
+Every `/remote-control` connection today requires a fresh out-of-band pairing: the host mints a single-use
+256-bit secret (`generatePairingSecret`, `pairing.ts:85`), shows it as a QR/link, the client pairs, and the
+host operator explicitly accepts. That is correct for a **first** contact, but it forces a **returning,
+already-trusted device** (the operator's own phone/laptop) to re-pair from scratch every single time —
+scan a new QR and click accept on every reconnect. This is poor UX and it actively degrades security: an
+operator trained to approve a pairing prompt on every routine reconnect will approve reflexively, which is
+exactly when a real MITM/relay attempt slips through.
+
+The pairing layer already derives, on a successful accept, a domain-separated `sessionKey`
+(`deriveSessionKey`, `pairing.ts:155`; returned in `IPairingResult`, `handshake.ts:126`) — whose comment
+says its "USE (TOFU bootstrap / app-layer key) is Stage E". **Today that `sessionKey` is discarded** at both
+gate sites (`pairing-gate.ts:85`, `rtc-responder-gate.ts:62` — both `result.then(() => this.accept(), …)`
+drop the value). There is no persistent notion of a trusted device: no host store, no device credential,
+no reconnect-recognition path.
+
+Goal: **Trust On First Use** — after a first pairing + explicit host accept, the host may remember that
+device so a later reconnect from the same device is recognized and (per host policy) proceeds without a
+full re-pair + accept, while an **unknown** device still goes through full first-use pairing and a
+**revoked** device is refused fail-closed. A leak of the host's trust store must NOT let an attacker
+impersonate a trusted device.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-remote-pairing/` — new isomorphic (WebCrypto-only) `device-identity.ts`: device keypair
+  generation, public-key export/import, and a channel-bound reconnect challenge/response
+  (sign/verify over `challenge ‖ sortedPair(fingerprints)`). New `reconnect.ts` handshake analogous to
+  `handshake.ts` but authenticating a stored device instead of a fresh secret. New exports in `index.ts`.
+- `packages/agent-transport-webrtc/` — `PairingGate`/`WebRtcTransport`: (i) stop dropping `sessionKey`
+  (`pairing-gate.ts:85`) — thread it into `onAccept?(result)`; (ii) at first-pair accept receive the
+  device's public key over the authenticated channel and surface it to the host for storage; (iii) a
+  reconnect path that runs the reconnect challenge/response against a host-supplied trusted device.
+- `packages/agent-cli/src/remote-control/` — a host **trusted-device store** (JSON under `~/.robota`,
+  mirroring `edit-checkpoint-store.ts` / `settings-io.ts`); wire register-on-accept + lookup-on-reconnect
+  into `remote-control-controller.ts` (`onPaired`, `defaultCreateTransport`) via a new
+  `IRemoteControlControllerDeps.trustedDeviceStore` seam; a `/remote-control` surface to list + revoke.
+- `packages/agent-web-ui/src/client/` — a browser **device-credential store** (first browser-local storage
+  in the package): a non-extractable ECDSA `CryptoKey` in IndexedDB, honoring the fragment-only-secret
+  discipline (`parse-remote-location.ts:5-13`). `ResponderGate`/`rtc-session-client.ts` consume the accept
+  `sessionKey`, register the keypair on first pair, and take the reconnect path when a credential exists.
+- Tests across all four packages (unit + gate + e2e-oracle + controller + store).
+
+### Alternatives Considered
+
+1. **No TOFU — always re-pair (status quo).** Pro: zero new persistent state; simplest threat model. Con:
+   the stated UX + reflexive-approval security problem is unaddressed; `sessionKey` stays dead code.
+   Rejected: does not solve the problem.
+2. **Symmetric device key** — on first pair, both sides derive `deviceKey = HKDF(sessionKey, "device")`;
+   the device stores `deviceKey`, the host stores `deviceKey` (or its hash) keyed by device id; reconnect
+   re-runs the existing directional-HMAC handshake with `deviceKey` as the secret. Pro: reuses the proven
+   B3 handshake verbatim; small crypto surface. Con: the handshake is **symmetric** — to re-run it the host
+   must store a value from which the shared HMAC key is derivable, i.e. a **replayable secret**. A leak of
+   the host trust store then lets an attacker impersonate every trusted device (storing only a hash does
+   NOT help — the symmetric handshake needs the key itself, not a commitment). Rejected: violates the
+   "trust-store leak must not grant impersonation" requirement.
+3. **(Chosen) Asymmetric device keypair (TOFU public-key pinning).** On first pair, the device generates a
+   non-extractable ECDSA P-256 keypair (WebCrypto, isomorphic — same runtime story as `pairing.ts`), and
+   sends its **public** key to the host over the already-authenticated (B3-confirmed) channel. The host
+   stores `{ deviceId, publicKey, label, createdAt }` — **public keys only**. On reconnect the device sends
+   its `deviceId` in the clear, the host issues a fresh random challenge, and the device signs
+   `challenge ‖ sortedPair(localFingerprint, remoteFingerprint)` with its **private** key; the host verifies
+   with the stored public key. Pro: a host trust-store leak reveals only public keys — an attacker cannot
+   impersonate (no private key); the challenge is channel-bound (reuses B3's DTLS-fingerprint binding) so a
+   MITM relay is still detected; the private key is non-extractable in IndexedDB (never in query/history,
+   consistent with the fragment-only-secret discipline). Con: a new asymmetric crypto surface (keygen,
+   sign/verify) + a distinct reconnect protocol vs. reusing the symmetric handshake. Accepted: it is the
+   only option that satisfies the leak-resistance requirement, and WebCrypto ECDSA keeps it isomorphic.
+
+### Decision
+
+Take alternative 3 — **asymmetric device-keypair TOFU with public-key pinning**. First pairing stays exactly
+as today (single-use secret + directional-HMAC accept + explicit host accept); on that accept we (a) start
+consuming the derived `sessionKey` and (b) enroll the device by pinning its ECDSA public key in the host
+trusted-device store. Reconnect authenticates by a fresh, channel-bound challenge signed by the device's
+pinned private key — no re-pair, no fresh secret, still MITM-relay-resistant via the same
+DTLS-fingerprint binding. Unknown device → fall through to full first-use pairing; revoked/absent public
+key → refuse fail-closed. This is a **contract-boundary change** (a new reconnect wire protocol + a new
+persistent host store + new browser storage): the design is validated for reachability by both peers
+(werift host + browser client both speak WebCrypto ECDSA and the same fingerprint binding), capability
+preservation (first-pair path unchanged; reconnect is purely additive), and an adversarial pass (leak,
+replay across handshakes via the fresh challenge, cross-device forgery via public-key pinning, MITM via
+channel binding, revocation).
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — the two accept-drop sites are siblings (`pairing-gate.ts:85` host, `rtc-responder-gate.ts:62` browser); BOTH are updated to consume `sessionKey` symmetrically. No third gate exists (verified by the surface map).
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Solution
+
+- **`agent-remote-pairing/device-identity.ts` (isomorphic, WebCrypto only):**
+  - `generateDeviceKeyPair(): Promise<CryptoKeyPair>` — non-extractable ECDSA P-256 (browser stores it in
+    IndexedDB; Node host never generates one — it only verifies).
+  - `exportDevicePublicKey(key): Promise<string>` / `importDevicePublicKey(spki): Promise<CryptoKey>` —
+    base64url SPKI, the value pinned by the host.
+  - `deriveDeviceId(publicKeySpki): Promise<string>` — a stable id = base64url SHA-256 of the SPKI (a
+    non-secret commitment; also what the client sends in the clear on reconnect).
+  - `signReconnectChallenge(privateKey, { challenge, localFingerprint, remoteFingerprint }): Promise<string>`
+    and `verifyReconnectChallenge(publicKey, signature, { challenge, localFingerprint, remoteFingerprint })`
+    — sign/verify over `challenge ‖ sortedPair(fp,fp)` (reusing the B3 sorted-pair binding). `challenge` is a
+    fresh 128-bit host nonce per reconnect.
+- **`agent-remote-pairing/reconnect.ts`:** a small controller (mirroring `handshake.ts`) driving the
+  reconnect frames `{ t:'rc-hello', deviceId }` → `{ t:'rc-challenge', nonce }` → `{ t:'rc-proof', sig }`,
+  resolving accept only after `verifyReconnectChallenge` passes (host side) / after signing (device side),
+  fail-closed on timeout/mismatch/unknown device.
+- **Host gate + transport:** thread the resolved `IPairingResult`/`sessionKey` through `onAccept(result)`
+  (`pairing-gate.ts:85`) → `WebRtcTransport` `onPaired(enrollment)` where `enrollment` carries the device's
+  public key (received over the confirmed channel on first pair) or the reconnect outcome. Add a reconnect
+  branch that, when the client opens with `rc-hello`, looks up the pinned device via an injected resolver
+  and runs `reconnect.ts` instead of the fresh-secret handshake.
+- **Host trusted-device store (`agent-cli/src/remote-control/trusted-device-store.ts`):** JSON file under
+  `~/.robota` (via `getUserSettingsPath`/`userPaths` from `@robota-sdk/agent-framework`), keyed by
+  `deviceId`, holding `{ publicKey, label, createdAt, lastSeenAt }`. API: `list()`, `get(id)`,
+  `upsert(record)`, `revoke(id)`. Fail-closed: corrupt store throws (fail-fast, mirroring
+  `SettingsParseError`); an unknown/revoked id yields no record → reconnect refused → client re-pairs.
+  Wired via `IRemoteControlControllerDeps.trustedDeviceStore`; `/remote-control` gains `devices` (list) +
+  `revoke <id>` verbs. Host policy: **enroll requires explicit accept** (unchanged first-pair accept);
+  reconnect of a pinned device is auto-admitted unless policy requires re-accept (config flag, default
+  auto — the trust decision was already made at first pair).
+- **Browser device-credential store (`agent-web-ui/src/client/device-credential-store.ts`):** stores the
+  non-extractable `CryptoKeyPair` in IndexedDB keyed by relay origin + host identity; never serializes the
+  private key. On connect: if a credential exists for this host, take the reconnect path; else first-pair
+  and enroll (persist the new keypair). `sessionKey` is consumed at `rtc-session-client.ts:96` accept.
+
+## Affected Files
+
+- `packages/agent-remote-pairing/src/device-identity.ts` (new)
+- `packages/agent-remote-pairing/src/reconnect.ts` (new)
+- `packages/agent-remote-pairing/src/index.ts`
+- `packages/agent-remote-pairing/docs/SPEC.md`
+- `packages/agent-transport-webrtc/src/pairing-gate.ts`
+- `packages/agent-transport-webrtc/src/webrtc-transport.ts`
+- `packages/agent-transport-webrtc/docs/SPEC.md`
+- `packages/agent-cli/src/remote-control/trusted-device-store.ts` (new)
+- `packages/agent-cli/src/remote-control/remote-control-controller.ts`
+- `packages/agent-cli/src/remote-control/index.ts`
+- `packages/agent-web-ui/src/client/device-credential-store.ts` (new)
+- `packages/agent-web-ui/src/client/rtc-responder-gate.ts`
+- `packages/agent-web-ui/src/client/rtc-session-client.ts`
+- Tests in each package (see Test Plan).
+
+## Completion Criteria
+
+- [ ] TC-01: `signReconnectChallenge` + `verifyReconnectChallenge` round-trip: a signature over
+      `{challenge, fpA, fpB}` verifies with the matching public key and FAILS for a different challenge, a
+      different fingerprint pair, or a different keypair (isomorphic WebCrypto unit).
+- [ ] TC-02: `deriveDeviceId` is stable for a given public key and differs across keypairs; `exportDevicePublicKey`→`importDevicePublicKey` round-trips.
+- [ ] TC-03: `reconnect.ts` controller resolves accept only when the device signs a challenge verifiable by
+      the pinned public key; it rejects (fail-closed) on timeout, a wrong signature, or an unknown deviceId.
+- [ ] TC-04: Host trusted-device store: `upsert` then `get`/`list` returns the record; `revoke` removes it;
+      a corrupt file throws (fail-fast); an absent id returns undefined. Round-trips through a temp `~/.robota`.
+- [ ] TC-05: Host gate/transport: on first-pair accept the device public key is enrolled (store `upsert`
+      called with a stable deviceId); on a subsequent `rc-hello` for that deviceId the reconnect path admits
+      WITHOUT a fresh pairing accept; on `rc-hello` for an unknown/revoked id the reconnect is refused
+      fail-closed (no session exposed).
+- [ ] TC-06: Browser credential store: a generated keypair persists (IndexedDB fake) and is reloaded so the
+      client takes the reconnect path on the second connect; the private key is non-extractable (export
+      rejects); no secret/key value is ever placed in `location.search`/history.
+- [ ] TC-07: End-to-end (Node responder oracle ↔ host gate): first pair enrolls; reconnect with the pinned
+      keypair establishes a session with no re-accept; a tampered fingerprint (simulated MITM) fails the
+      channel-bound challenge → reconnect refused.
+- [ ] TC-08: `/remote-control devices` lists enrolled devices and `revoke <id>` removes one; a revoked
+      device must re-pair. `pnpm harness:scan` + `pnpm typecheck` + affected package tests green.
+
+## Test Plan
+
+| TC-ID | Test Type            | Tool / Approach                                                                                   | Notes                                         |
+| ----- | -------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| TC-01 | Unit (crypto)        | vitest — WebCrypto sign/verify round-trip + negative cases (challenge/fp/keypair mismatch)        | Isomorphic; runs under Node WebCrypto         |
+| TC-02 | Unit (crypto)        | vitest — deviceId stability + SPKI export/import round-trip                                       |                                               |
+| TC-03 | Unit (protocol)      | vitest — drive `reconnect.ts` frames with fakes; accept + fail-closed (timeout/bad-sig/unknown)   | Mirrors handshake.test.ts                     |
+| TC-04 | Unit (store)         | vitest — temp HOME; upsert/get/list/revoke + corrupt-file throw + absent-id undefined             | Mirrors settings-io.test.ts / edit-checkpoint |
+| TC-05 | Integration (gate)   | vitest — host gate with injected store: enroll-on-accept + reconnect-admit + unknown/revoked deny | Extends pairing-gate.test.ts                  |
+| TC-06 | Unit (browser store) | vitest — fake IndexedDB; persist+reload keypair, non-extractable assertion, no-secret-in-search   | First agent-web-ui browser-local store        |
+| TC-07 | E2E (oracle)         | vitest — Node responder as oracle vs host gate: first-pair→reconnect no-reaccept + MITM fp deny   | Extends pairing-e2e.test.ts                   |
+| TC-08 | Integration + smoke  | vitest controller `devices`/`revoke`; `pnpm harness:scan` exit 0 + `pnpm typecheck`               | spec-public-surface + controller behavior     |
+
+## Tasks
+
+- [ ] `.agents/tasks/REMOTE-012.md` — 미생성 (GATE-APPROVAL 통과 후 생성)
+
+## Evidence Log

--- a/.agents/spec-docs/draft/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
+++ b/.agents/spec-docs/draft/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md
@@ -16,39 +16,58 @@ scan a new QR and click accept on every reconnect. This is poor UX and it active
 operator trained to approve a pairing prompt on every routine reconnect will approve reflexively, which is
 exactly when a real MITM/relay attempt slips through.
 
-The pairing layer already derives, on a successful accept, a domain-separated `sessionKey`
-(`deriveSessionKey`, `pairing.ts:155`; returned in `IPairingResult`, `handshake.ts:126`) — whose comment
-says its "USE (TOFU bootstrap / app-layer key) is Stage E". **Today that `sessionKey` is discarded** at both
-gate sites (`pairing-gate.ts:85`, `rtc-responder-gate.ts:62` — both `result.then(() => this.accept(), …)`
-drop the value). There is no persistent notion of a trusted device: no host store, no device credential,
-no reconnect-recognition path.
+Note on `sessionKey`: the pairing layer derives a domain-separated `sessionKey` on accept
+(`deriveSessionKey`, `pairing.ts:155`; `IPairingResult`, `handshake.ts:126`), currently discarded at both
+gate sites (`pairing-gate.ts:85`, `rtc-responder-gate.ts:62`). Its comment reserves it for "Stage E". With
+the asymmetric design below, E3's credential is the **device keypair**, and first-pair enrollment is already
+protected by the B3-confirmed channel — so E3 does **not** need `sessionKey`. To avoid merely relocating dead
+code, **E3 leaves `sessionKey` unconsumed and explicitly reserves it for E4** (REMOTE-013 session-resume,
+which will key the resume stream). There is no persistent notion of a trusted device today: no host store,
+no device credential, no reconnect-recognition path.
 
-Goal: **Trust On First Use** — after a first pairing + explicit host accept, the host may remember that
-device so a later reconnect from the same device is recognized and (per host policy) proceeds without a
-full re-pair + accept, while an **unknown** device still goes through full first-use pairing and a
-**revoked** device is refused fail-closed. A leak of the host's trust store must NOT let an attacker
-impersonate a trusted device.
+Goal: **Trust On First Use** — after a first pairing + explicit host accept, the host remembers that device
+so a later reconnect from the same device is recognized and (per host policy) proceeds without a full re-pair
+
+- accept, while an **unknown** device still goes through full first-use pairing and a **revoked** device is
+  refused fail-closed. Two leak-resistance requirements: (a) a leak of the host's device-trust store must NOT
+  let an attacker impersonate a trusted device (host stores device **public** keys only); (b) reconnect must
+  stay **mutually** authenticated — the device must re-verify it is talking to the SAME host it first paired
+  with, not just prove itself — so an attacker who controls signaling cannot route a reconnect to a rogue host
+  and have the device auto-accept and co-drive it. (b) is what B3 first-pair already guarantees mutually;
+  reconnect must not silently downgrade it.
 
 ## Architecture Review
 
 ### Affected Scope
 
-- `packages/agent-remote-pairing/` — new isomorphic (WebCrypto-only) `device-identity.ts`: device keypair
-  generation, public-key export/import, and a channel-bound reconnect challenge/response
-  (sign/verify over `challenge ‖ sortedPair(fingerprints)`). New `reconnect.ts` handshake analogous to
-  `handshake.ts` but authenticating a stored device instead of a fresh secret. New exports in `index.ts`.
-- `packages/agent-transport-webrtc/` — `PairingGate`/`WebRtcTransport`: (i) stop dropping `sessionKey`
-  (`pairing-gate.ts:85`) — thread it into `onAccept?(result)`; (ii) at first-pair accept receive the
-  device's public key over the authenticated channel and surface it to the host for storage; (iii) a
-  reconnect path that runs the reconnect challenge/response against a host-supplied trusted device.
-- `packages/agent-cli/src/remote-control/` — a host **trusted-device store** (JSON under `~/.robota`,
-  mirroring `edit-checkpoint-store.ts` / `settings-io.ts`); wire register-on-accept + lookup-on-reconnect
-  into `remote-control-controller.ts` (`onPaired`, `defaultCreateTransport`) via a new
-  `IRemoteControlControllerDeps.trustedDeviceStore` seam; a `/remote-control` surface to list + revoke.
-- `packages/agent-web-ui/src/client/` — a browser **device-credential store** (first browser-local storage
-  in the package): a non-extractable ECDSA `CryptoKey` in IndexedDB, honoring the fragment-only-secret
-  discipline (`parse-remote-location.ts:5-13`). `ResponderGate`/`rtc-session-client.ts` consume the accept
-  `sessionKey`, register the keypair on first pair, and take the reconnect path when a credential exists.
+- `packages/agent-remote-pairing/` — new isomorphic (WebCrypto-only) `device-identity.ts`: ECDSA-P256
+  keypair generation (used for BOTH a device keypair and a host identity keypair), public-key export/import,
+  a stable id (`SHA-256(SPKI)`), and channel-bound challenge sign/verify over `nonceHost ‖ nonceDevice ‖
+sortedPair(fingerprints)`. New `reconnect.ts` **mutual** handshake analogous to `handshake.ts`: BOTH sides
+  sign a challenge bound to both nonces + the DTLS-fingerprint pair, and each verifies the other against a
+  pinned public key before accept — restoring B3's mutual property with pinned keys instead of a shared
+  secret. New exports in `index.ts`.
+- `packages/agent-transport-webrtc/` — `PairingGate`/`WebRtcTransport`: (i) thread the resolved
+  `IPairingResult` into `onAccept?(result)` (`pairing-gate.ts:85`) so the accept can carry enrollment data
+  (E3 does not consume `sessionKey`); (ii) at first-pair accept, **exchange identity public keys** over the
+  B3-confirmed channel — the device sends its device public key, the host sends its host-identity public
+  key — surfacing both to their stores; (iii) a reconnect path that runs the mutual `reconnect.ts` against
+  a host-supplied trusted device (host signs with its identity key; verifies the device against the pinned
+  device key).
+- `packages/agent-cli/src/remote-control/` — (a) a **host identity keypair** persisted once under
+  `~/.robota` (a `0600` JWK file — the host's own long-term key, like an SSH host key; the host needs the
+  private key to sign, so it is extractable-and-file-persisted, distinct from the device store); (b) a host
+  **trusted-device store** (JSON under `~/.robota`, fail-fast on corrupt — mirroring `settings-io.ts`,
+  NOT the soft-failing `edit-checkpoint-store.ts`) holding device **public** keys only. Wire
+  register-on-accept + lookup-on-reconnect into `remote-control-controller.ts` (`onPaired`,
+  `defaultCreateTransport`) via new `IRemoteControlControllerDeps.trustedDeviceStore` + `hostIdentity` seams;
+  a `/remote-control` surface to list + revoke devices.
+- `packages/agent-web-ui/src/client/` — a browser **credential store** (first browser-local storage in the
+  package): the device's non-extractable ECDSA `CryptoKey` **and the pinned host-identity public key**, in
+  IndexedDB keyed by `relayOrigin + hostIdentityId` (now well-defined = `SHA-256(host SPKI)`), honoring the
+  fragment-only-secret discipline (`parse-remote-location.ts:5-13`). `ResponderGate`/`rtc-session-client.ts`
+  enroll the device keypair + pin the host key on first pair, and on reconnect **verify the host** against
+  the pinned key before accepting.
 - Tests across all four packages (unit + gate + e2e-oracle + controller + store).
 
 ### Alternatives Considered
@@ -64,76 +83,106 @@ impersonate a trusted device.
    the host trust store then lets an attacker impersonate every trusted device (storing only a hash does
    NOT help — the symmetric handshake needs the key itself, not a commitment). Rejected: violates the
    "trust-store leak must not grant impersonation" requirement.
-3. **(Chosen) Asymmetric device keypair (TOFU public-key pinning).** On first pair, the device generates a
-   non-extractable ECDSA P-256 keypair (WebCrypto, isomorphic — same runtime story as `pairing.ts`), and
-   sends its **public** key to the host over the already-authenticated (B3-confirmed) channel. The host
-   stores `{ deviceId, publicKey, label, createdAt }` — **public keys only**. On reconnect the device sends
-   its `deviceId` in the clear, the host issues a fresh random challenge, and the device signs
-   `challenge ‖ sortedPair(localFingerprint, remoteFingerprint)` with its **private** key; the host verifies
-   with the stored public key. Pro: a host trust-store leak reveals only public keys — an attacker cannot
-   impersonate (no private key); the challenge is channel-bound (reuses B3's DTLS-fingerprint binding) so a
-   MITM relay is still detected; the private key is non-extractable in IndexedDB (never in query/history,
-   consistent with the fragment-only-secret discipline). Con: a new asymmetric crypto surface (keygen,
-   sign/verify) + a distinct reconnect protocol vs. reusing the symmetric handshake. Accepted: it is the
-   only option that satisfies the leak-resistance requirement, and WebCrypto ECDSA keeps it isomorphic.
+3. **WebAuthn / passkeys.** The natural "device-bound public key" primitive. Rejected: WebAuthn signs over
+   its own `clientDataJSON` (challenge + origin + type) and **cannot carry the DTLS-fingerprint channel
+   binding** that is this design's MITM-relay defense; it is browser-only (no Node host/oracle parity for
+   the mutual host-side signing); and it needs a stable RP-ID origin the fragment-only SPA does not have.
+   Raw WebCrypto ECDSA is preferable precisely because it signs arbitrary channel-binding bytes and is
+   isomorphic across the werift host, the Node oracle, and the browser.
+4. **(Chosen) Asymmetric keypairs on BOTH sides (mutual TOFU public-key pinning).** On first pair, over the
+   already-authenticated (B3-confirmed) channel, the device sends its ECDSA-P256 **public** key to the host
+   and the host sends its **host-identity public** key to the device; each pins the other. The host stores
+   `{ deviceId, publicKey, label, createdAt, lastSeenAt }` — device **public keys only**; the device stores
+   its own non-extractable keypair + the pinned host public key. On reconnect BOTH sides sign a fresh
+   challenge `nonceHost ‖ nonceDevice ‖ sortedPair(localFp, remoteFp)` and verify the other against the
+   pinned key before accept (mutual, exactly as B3 is mutual). Pro: a host device-store leak reveals only
+   public keys → no device impersonation; **mutual** auth means the device won't co-drive a rogue host
+   (closes the host→device downgrade); the challenge is channel-bound (reuses B3's fingerprint binding) so a
+   MITM relay is still detected; fresh per-side nonces prevent cross-handshake replay; the device private key
+   is non-extractable in IndexedDB (never in query/history — fragment-only-secret discipline preserved). Con:
+   an asymmetric crypto surface on both sides + a distinct mutual reconnect protocol; the host must persist
+   its own identity private key on disk (a `0600` JWK, like an SSH host key). Accepted: the only option that
+   satisfies BOTH the trust-store-leak requirement and the mutual-authentication requirement while staying
+   isomorphic.
 
 ### Decision
 
-Take alternative 3 — **asymmetric device-keypair TOFU with public-key pinning**. First pairing stays exactly
-as today (single-use secret + directional-HMAC accept + explicit host accept); on that accept we (a) start
-consuming the derived `sessionKey` and (b) enroll the device by pinning its ECDSA public key in the host
-trusted-device store. Reconnect authenticates by a fresh, channel-bound challenge signed by the device's
-pinned private key — no re-pair, no fresh secret, still MITM-relay-resistant via the same
-DTLS-fingerprint binding. Unknown device → fall through to full first-use pairing; revoked/absent public
-key → refuse fail-closed. This is a **contract-boundary change** (a new reconnect wire protocol + a new
-persistent host store + new browser storage): the design is validated for reachability by both peers
-(werift host + browser client both speak WebCrypto ECDSA and the same fingerprint binding), capability
-preservation (first-pair path unchanged; reconnect is purely additive), and an adversarial pass (leak,
-replay across handshakes via the fresh challenge, cross-device forgery via public-key pinning, MITM via
-channel binding, revocation).
+Take alternative 4 — **mutual asymmetric TOFU with public-key pinning on both sides**. First pairing stays
+exactly as today (single-use secret + directional-HMAC accept + explicit host accept); on that accept, over
+the B3-confirmed channel, the device and host exchange and pin each other's identity public keys (E3 does
+not consume the pairing `sessionKey` — reserved for E4). Reconnect authenticates **mutually** by fresh,
+channel-bound challenges — the host verifies the device against the pinned device key AND the device
+verifies the host against the pinned host key, each before exposing/accepting a session — no re-pair, no
+fresh secret, still MITM-relay-resistant via the same DTLS-fingerprint binding. Unknown device → fall
+through to full first-use pairing; revoked/absent key → refuse fail-closed. Device theft is the standard
+TOFU residual risk; the compensating control is **revocation** (`/remote-control revoke <id>`) plus an
+optional re-accept-on-reconnect policy flag. This is a **contract-boundary change** (a new mutual reconnect
+wire protocol + two persistent host artifacts + new browser storage): validated for reachability by both
+peers (werift host + browser client both speak WebCrypto ECDSA + the same fingerprint binding), capability
+preservation (first-pair path unchanged; reconnect is additive), and an adversarial pass (device-store leak
+→ public keys only; cross-handshake replay → fresh both-side nonces; cross-device forgery → per-device
+pinned key; MITM relay → fingerprint binding; **rogue host → device verifies pinned host key, fail-closed**;
+revocation; downgrade reconnect→first-pair grants nothing since first-pair still needs the QR secret +
+explicit accept).
 
 ### Architecture Review Checklist
 
 - [x] 영향 패키지/레이어 목록 작성 완료
-- [x] Sibling scan 완료 — the two accept-drop sites are siblings (`pairing-gate.ts:85` host, `rtc-responder-gate.ts:62` browser); BOTH are updated to consume `sessionKey` symmetrically. No third gate exists (verified by the surface map).
+- [x] Sibling scan 완료 — the two accept sites are siblings (`pairing-gate.ts:85` host, `rtc-responder-gate.ts:62` browser); BOTH are updated symmetrically to thread `IPairingResult` into `onAccept(result)` and to enroll/pin over the confirmed channel. No third gate exists (verified by the surface map).
 - [x] 대안 최소 2개 검토 완료
 - [x] 결정 근거 문서화 완료
 
 ## Solution
 
 - **`agent-remote-pairing/device-identity.ts` (isomorphic, WebCrypto only):**
-  - `generateDeviceKeyPair(): Promise<CryptoKeyPair>` — non-extractable ECDSA P-256 (browser stores it in
-    IndexedDB; Node host never generates one — it only verifies).
-  - `exportDevicePublicKey(key): Promise<string>` / `importDevicePublicKey(spki): Promise<CryptoKey>` —
-    base64url SPKI, the value pinned by the host.
-  - `deriveDeviceId(publicKeySpki): Promise<string>` — a stable id = base64url SHA-256 of the SPKI (a
-    non-secret commitment; also what the client sends in the clear on reconnect).
-  - `signReconnectChallenge(privateKey, { challenge, localFingerprint, remoteFingerprint }): Promise<string>`
-    and `verifyReconnectChallenge(publicKey, signature, { challenge, localFingerprint, remoteFingerprint })`
-    — sign/verify over `challenge ‖ sortedPair(fp,fp)` (reusing the B3 sorted-pair binding). `challenge` is a
-    fresh 128-bit host nonce per reconnect.
-- **`agent-remote-pairing/reconnect.ts`:** a small controller (mirroring `handshake.ts`) driving the
-  reconnect frames `{ t:'rc-hello', deviceId }` → `{ t:'rc-challenge', nonce }` → `{ t:'rc-proof', sig }`,
-  resolving accept only after `verifyReconnectChallenge` passes (host side) / after signing (device side),
-  fail-closed on timeout/mismatch/unknown device.
-- **Host gate + transport:** thread the resolved `IPairingResult`/`sessionKey` through `onAccept(result)`
-  (`pairing-gate.ts:85`) → `WebRtcTransport` `onPaired(enrollment)` where `enrollment` carries the device's
-  public key (received over the confirmed channel on first pair) or the reconnect outcome. Add a reconnect
-  branch that, when the client opens with `rc-hello`, looks up the pinned device via an injected resolver
-  and runs `reconnect.ts` instead of the fresh-secret handshake.
+  - `generateIdentityKeyPair(extractable): Promise<CryptoKeyPair>` — ECDSA P-256. The browser device calls it
+    with `extractable:false` (IndexedDB, never exportable); the Node host calls it with `extractable:true`
+    ONCE to persist its identity JWK to a `0600` file (a host must reload its own key across restarts, like
+    an SSH host key).
+  - `exportPublicKey(key): Promise<string>` / `importPublicKey(spki): Promise<CryptoKey>` — base64url SPKI,
+    the value each side pins for the other.
+  - `deriveIdentityId(publicKeySpki): Promise<string>` — stable id = base64url `SHA-256(SPKI)` (a non-secret
+    commitment; the `deviceId` a client sends in the clear on reconnect, and the `hostIdentityId` the browser
+    store keys on).
+  - `signChallenge(privateKey, { nonceHost, nonceDevice, localFingerprint, remoteFingerprint })` and
+    `verifyChallenge(publicKey, signature, { … })` — sign/verify over
+    `nonceHost ‖ nonceDevice ‖ sortedPair(localFingerprint, remoteFingerprint)` (reusing the B3 sorted-pair
+    binding). Both nonces are fresh 128-bit values, one issued by each side, so neither side's signature can
+    be replayed across handshakes.
+- **`agent-remote-pairing/reconnect.ts` — MUTUAL controller** (mirroring `handshake.ts`, fail-closed):
+  - Frames: device→host `{ t:'rc-hello', deviceId, nonceDevice }`; host→device
+    `{ t:'rc-host', nonceHost, sig }` (host's signature over the transcript, verifiable by the pinned host
+    key); device→host `{ t:'rc-device', sig }` (device's signature over the same transcript).
+  - Host resolves accept ONLY after `verifyChallenge(pinnedDeviceKey, deviceSig, …)` passes; the device
+    resolves accept ONLY after `verifyChallenge(pinnedHostKey, hostSig, …)` passes. Either side rejects
+    (fail-closed, channel closed) on timeout, signature mismatch, unknown deviceId, or an absent pinned host
+    key. This is the mutual dual of B3 — same guarantee, pinned keys instead of a shared secret.
+- **Host gate + transport:** thread the resolved `IPairingResult` through `onAccept(result)`
+  (`pairing-gate.ts:85`) → `WebRtcTransport` `onPaired(enrollment)`. First-pair: after B3 accept, exchange
+  identity public keys over the confirmed channel (device pubkey → host; host pubkey → device) and surface
+  both. Reconnect: when the client opens with `rc-hello`, look up the pinned device via an injected resolver
+  and run the mutual `reconnect.ts` (host signs with its identity key; verifies the device) instead of the
+  fresh-secret handshake — exposing the session only on mutual accept. (E3 does not read `sessionKey`.)
+- **Host identity keypair (`agent-cli/src/remote-control/host-identity.ts`):** load-or-create the host's
+  ECDSA identity keypair as a `0600` JWK under `~/.robota` (via `userPaths`); generated once, reused across
+  restarts; the host signs reconnect challenges with it and advertises its public key at first pair. Losing
+  it forces trusted devices to re-pair (acceptable; equivalent to rotating an SSH host key).
 - **Host trusted-device store (`agent-cli/src/remote-control/trusted-device-store.ts`):** JSON file under
-  `~/.robota` (via `getUserSettingsPath`/`userPaths` from `@robota-sdk/agent-framework`), keyed by
-  `deviceId`, holding `{ publicKey, label, createdAt, lastSeenAt }`. API: `list()`, `get(id)`,
-  `upsert(record)`, `revoke(id)`. Fail-closed: corrupt store throws (fail-fast, mirroring
-  `SettingsParseError`); an unknown/revoked id yields no record → reconnect refused → client re-pairs.
-  Wired via `IRemoteControlControllerDeps.trustedDeviceStore`; `/remote-control` gains `devices` (list) +
-  `revoke <id>` verbs. Host policy: **enroll requires explicit accept** (unchanged first-pair accept);
-  reconnect of a pinned device is auto-admitted unless policy requires re-accept (config flag, default
-  auto — the trust decision was already made at first pair).
-- **Browser device-credential store (`agent-web-ui/src/client/device-credential-store.ts`):** stores the
-  non-extractable `CryptoKeyPair` in IndexedDB keyed by relay origin + host identity; never serializes the
-  private key. On connect: if a credential exists for this host, take the reconnect path; else first-pair
-  and enroll (persist the new keypair). `sessionKey` is consumed at `rtc-session-client.ts:96` accept.
+  `~/.robota`, keyed by `deviceId`, holding `{ publicKey, label, createdAt, lastSeenAt }` — device **public
+  keys only, no private material**. API: `list()`, `get(id)`, `upsert(record)`, `revoke(id)`. Fail-closed:
+  corrupt store **throws** (fail-fast, mirroring `settings-io.ts` `SettingsParseError` — NOT the soft-failing
+  checkpoint store; a truncated trust store must surface, never silently read as an empty allow-list). An
+  unknown/revoked id yields no record → reconnect refused → client re-pairs. Wired via
+  `IRemoteControlControllerDeps.trustedDeviceStore` + `hostIdentity`; `/remote-control` gains `devices`
+  (list) + `revoke <id>` verbs. Policy: enroll requires the unchanged explicit first-pair accept; a pinned
+  device's reconnect is auto-admitted (the trust decision was made at first pair) unless a
+  `reacceptOnReconnect` policy flag is set.
+- **Browser credential store (`agent-web-ui/src/client/device-credential-store.ts`):** IndexedDB keyed by
+  `relayOrigin + hostIdentityId`, storing the device's non-extractable `CryptoKeyPair` **and the pinned host
+  public key**; never serializes the private key (structured-clone of the non-extractable `CryptoKey`). On
+  connect: if a credential exists for this host, take the mutual reconnect path and verify the host against
+  the pinned key before accepting; else first-pair, then enroll (persist the new device keypair + pin the
+  host key). Honors the fragment-only-secret discipline — no key value ever enters `location.search`/history.
 
 ## Affected Files
 
@@ -144,6 +193,7 @@ channel binding, revocation).
 - `packages/agent-transport-webrtc/src/pairing-gate.ts`
 - `packages/agent-transport-webrtc/src/webrtc-transport.ts`
 - `packages/agent-transport-webrtc/docs/SPEC.md`
+- `packages/agent-cli/src/remote-control/host-identity.ts` (new)
 - `packages/agent-cli/src/remote-control/trusted-device-store.ts` (new)
 - `packages/agent-cli/src/remote-control/remote-control-controller.ts`
 - `packages/agent-cli/src/remote-control/index.ts`
@@ -154,39 +204,45 @@ channel binding, revocation).
 
 ## Completion Criteria
 
-- [ ] TC-01: `signReconnectChallenge` + `verifyReconnectChallenge` round-trip: a signature over
-      `{challenge, fpA, fpB}` verifies with the matching public key and FAILS for a different challenge, a
-      different fingerprint pair, or a different keypair (isomorphic WebCrypto unit).
-- [ ] TC-02: `deriveDeviceId` is stable for a given public key and differs across keypairs; `exportDevicePublicKey`→`importDevicePublicKey` round-trips.
-- [ ] TC-03: `reconnect.ts` controller resolves accept only when the device signs a challenge verifiable by
-      the pinned public key; it rejects (fail-closed) on timeout, a wrong signature, or an unknown deviceId.
+- [ ] TC-01: `signChallenge` + `verifyChallenge` round-trip: a signature over
+      `{nonceHost, nonceDevice, fpA, fpB}` verifies with the matching public key and FAILS for a different
+      nonce (either), a different fingerprint pair, or a different keypair (isomorphic WebCrypto unit).
+- [ ] TC-02: `deriveIdentityId` is stable for a given public key and differs across keypairs;
+      `exportPublicKey`→`importPublicKey` round-trips; a `SHA-256(SPKI)` id is second-preimage stable.
+- [ ] TC-03: `reconnect.ts` MUTUAL controller resolves accept on each side ONLY after it verifies the
+      counterpart's signature against the pinned key; it rejects (fail-closed) on timeout, a wrong device
+      signature, a wrong/absent HOST signature (rogue host), or an unknown deviceId.
 - [ ] TC-04: Host trusted-device store: `upsert` then `get`/`list` returns the record; `revoke` removes it;
-      a corrupt file throws (fail-fast); an absent id returns undefined. Round-trips through a temp `~/.robota`.
+      a corrupt file **throws** (fail-fast); an absent id returns undefined; the persisted JSON contains
+      **only public keys — no private key material** (negative assertion). Round-trips through a temp
+      `~/.robota`. Host identity keypair: load-or-create persists a `0600` JWK and reloads the same key.
 - [ ] TC-05: Host gate/transport: on first-pair accept the device public key is enrolled (store `upsert`
-      called with a stable deviceId); on a subsequent `rc-hello` for that deviceId the reconnect path admits
-      WITHOUT a fresh pairing accept; on `rc-hello` for an unknown/revoked id the reconnect is refused
-      fail-closed (no session exposed).
-- [ ] TC-06: Browser credential store: a generated keypair persists (IndexedDB fake) and is reloaded so the
-      client takes the reconnect path on the second connect; the private key is non-extractable (export
-      rejects); no secret/key value is ever placed in `location.search`/history.
-- [ ] TC-07: End-to-end (Node responder oracle ↔ host gate): first pair enrolls; reconnect with the pinned
-      keypair establishes a session with no re-accept; a tampered fingerprint (simulated MITM) fails the
-      channel-bound challenge → reconnect refused.
+      with a stable deviceId) AND the host advertises its identity public key; on a subsequent `rc-hello`
+      for that deviceId the mutual reconnect admits WITHOUT a fresh pairing accept; on `rc-hello` for an
+      unknown/revoked id the reconnect is refused fail-closed (no session exposed).
+- [ ] TC-06: Browser credential store: a generated device keypair + pinned host key persist (IndexedDB fake)
+      and reload so the client takes the reconnect path on the second connect and **verifies the host**; the
+      private key is non-extractable (export rejects); no secret/key value is ever placed in
+      `location.search`/history.
+- [ ] TC-07: End-to-end (Node responder oracle ↔ host gate): first pair enrolls both keys; reconnect with
+      the pinned keypairs establishes a session with no re-accept; a **rogue host** (wrong host identity key)
+      makes the DEVICE refuse fail-closed; a tampered fingerprint (simulated MITM) fails the channel-bound
+      challenge → reconnect refused; a captured `rc-device` proof replayed against a fresh challenge → reject.
 - [ ] TC-08: `/remote-control devices` lists enrolled devices and `revoke <id>` removes one; a revoked
       device must re-pair. `pnpm harness:scan` + `pnpm typecheck` + affected package tests green.
 
 ## Test Plan
 
-| TC-ID | Test Type            | Tool / Approach                                                                                   | Notes                                         |
-| ----- | -------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| TC-01 | Unit (crypto)        | vitest — WebCrypto sign/verify round-trip + negative cases (challenge/fp/keypair mismatch)        | Isomorphic; runs under Node WebCrypto         |
-| TC-02 | Unit (crypto)        | vitest — deviceId stability + SPKI export/import round-trip                                       |                                               |
-| TC-03 | Unit (protocol)      | vitest — drive `reconnect.ts` frames with fakes; accept + fail-closed (timeout/bad-sig/unknown)   | Mirrors handshake.test.ts                     |
-| TC-04 | Unit (store)         | vitest — temp HOME; upsert/get/list/revoke + corrupt-file throw + absent-id undefined             | Mirrors settings-io.test.ts / edit-checkpoint |
-| TC-05 | Integration (gate)   | vitest — host gate with injected store: enroll-on-accept + reconnect-admit + unknown/revoked deny | Extends pairing-gate.test.ts                  |
-| TC-06 | Unit (browser store) | vitest — fake IndexedDB; persist+reload keypair, non-extractable assertion, no-secret-in-search   | First agent-web-ui browser-local store        |
-| TC-07 | E2E (oracle)         | vitest — Node responder as oracle vs host gate: first-pair→reconnect no-reaccept + MITM fp deny   | Extends pairing-e2e.test.ts                   |
-| TC-08 | Integration + smoke  | vitest controller `devices`/`revoke`; `pnpm harness:scan` exit 0 + `pnpm typecheck`               | spec-public-surface + controller behavior     |
+| TC-ID | Test Type            | Tool / Approach                                                                                                                | Notes                                     |
+| ----- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| TC-01 | Unit (crypto)        | vitest — WebCrypto sign/verify round-trip + negatives (either-nonce / fp-pair / keypair mismatch)                              | Isomorphic; runs under Node WebCrypto     |
+| TC-02 | Unit (crypto)        | vitest — identityId stability + SPKI export/import round-trip                                                                  |                                           |
+| TC-03 | Unit (protocol)      | vitest — drive mutual `reconnect.ts` frames; both-side accept + fail-closed (timeout/bad device sig/rogue host sig/unknown)    | Mirrors handshake.test.ts                 |
+| TC-04 | Unit (store)         | vitest — temp HOME; upsert/get/list/revoke + corrupt-throw + absent-undefined + no-private-material; host-identity load/reload | Mirrors settings-io.test.ts               |
+| TC-05 | Integration (gate)   | vitest — host gate + injected store: enroll-on-accept (device+host keys) + reconnect-admit + unknown/revoked deny              | Extends pairing-gate.test.ts              |
+| TC-06 | Unit (browser store) | vitest — fake IndexedDB; persist+reload device keypair + pinned host key, non-extractable, no-secret-in-search                 | First agent-web-ui local store            |
+| TC-07 | E2E (oracle)         | vitest — Node oracle ↔ host gate: first-pair→reconnect no-reaccept; rogue-host deny; MITM-fp deny; proof-replay reject         | Extends pairing-e2e.test.ts               |
+| TC-08 | Integration + smoke  | vitest controller `devices`/`revoke`; `pnpm harness:scan` exit 0 + `pnpm typecheck`                                            | spec-public-surface + controller behavior |
 
 ## Tasks
 

--- a/.agents/tasks/REMOTE-012.md
+++ b/.agents/tasks/REMOTE-012.md
@@ -7,16 +7,16 @@ added in round 2). Optional hardening applied: embed `deviceId ‖ hostIdentityI
 
 ## Tasks
 
-- [ ] T1 (TC-01/02): `agent-remote-pairing/src/device-identity.ts` — `generateIdentityKeyPair(extractable)`, `exportPublicKey`/`importPublicKey` (SPKI base64url), `deriveIdentityId` (SHA-256(SPKI)), `signChallenge`/`verifyChallenge` over `deviceId ‖ hostIdentityId ‖ nonceHost ‖ nonceDevice ‖ sortedPair(fp)`. Isomorphic WebCrypto only. Unit tests: round-trip + negatives.
-- [ ] T2 (TC-03): `agent-remote-pairing/src/reconnect.ts` — mutual controller: frames rc-hello/rc-host/rc-device; each verifies the counterpart against its pinned key before accept; fail-closed on timeout/bad-sig/rogue-host/unknown. Unit test mirrors handshake.test.ts.
-- [ ] T3: `agent-remote-pairing/src/index.ts` exports + `docs/SPEC.md`.
-- [ ] T4 (TC-04): `agent-cli/src/remote-control/host-identity.ts` — load-or-create host ECDSA identity keypair as a 0600 JWK under ~/.robota; reload across restarts. Unit test.
-- [ ] T5 (TC-04): `agent-cli/src/remote-control/trusted-device-store.ts` — JSON store under ~/.robota keyed by deviceId ({publicKey,label,createdAt,lastSeenAt}); list/get/upsert/revoke; fail-fast on corrupt (SettingsParseError precedent); public keys only. Unit test incl. no-private-material assertion.
-- [ ] T6 (TC-05/08): wire into `remote-control-controller.ts` + `index.ts` — `IRemoteControlControllerDeps.trustedDeviceStore` + `hostIdentity` seams; enroll-on-accept; reconnect lookup; `/remote-control devices` + `revoke <id>` verbs.
-- [ ] T7 (TC-05/07): `agent-transport-webrtc` — `pairing-gate.ts` thread `IPairingResult` into `onAccept(result)`; first-pair identity-key exchange over confirmed channel; reconnect branch runs mutual `reconnect.ts`; `webrtc-transport.ts` `onPaired(enrollment)`. Extend pairing-gate + pairing-e2e tests (rogue-host, MITM-fp, proof-replay).
-- [ ] T8 (TC-06): `agent-web-ui/src/client/device-credential-store.ts` — IndexedDB keyed by relayOrigin+hostIdentityId; non-extractable device keypair + pinned host key; never serialize private key. `rtc-responder-gate.ts`/`rtc-session-client.ts` enroll+pin first pair, verify host on reconnect. Unit test (fake IndexedDB).
-- [ ] T9: `agent-transport-webrtc/docs/SPEC.md` + public-surface updates across packages (spec-public-surface scan).
-- [ ] T10 (TC-08): `pnpm typecheck` + affected package tests + `pnpm harness:scan` green.
+- [x] T1 (TC-01/02): `agent-remote-pairing/src/device-identity.ts` — `generateIdentityKeyPair(extractable)`, `exportPublicKey`/`importPublicKey` (SPKI base64url), `deriveIdentityId` (SHA-256(SPKI)), `signChallenge`/`verifyChallenge` over `deviceId ‖ hostIdentityId ‖ nonceHost ‖ nonceDevice ‖ sortedPair(fp)`. Isomorphic WebCrypto only. Unit tests: round-trip + negatives.
+- [x] T2 (TC-03): `agent-remote-pairing/src/reconnect.ts` — mutual controller: frames rc-hello/rc-host/rc-device; each verifies the counterpart against its pinned key before accept; fail-closed on timeout/bad-sig/rogue-host/unknown. Unit test mirrors handshake.test.ts.
+- [x] T3: `agent-remote-pairing/src/index.ts` exports + `docs/SPEC.md`.
+- [x] T4 (TC-04): `agent-cli/src/remote-control/host-identity.ts` — load-or-create host ECDSA identity keypair as a 0600 JWK under ~/.robota; reload across restarts. Unit test.
+- [x] T5 (TC-04): `agent-cli/src/remote-control/trusted-device-store.ts` — JSON store under ~/.robota keyed by deviceId ({publicKey,label,createdAt,lastSeenAt}); list/get/upsert/revoke; fail-fast on corrupt (SettingsParseError precedent); public keys only. Unit test incl. no-private-material assertion.
+- [x] T6 (TC-05/08): wire into `remote-control-controller.ts` + `index.ts` — `IRemoteControlControllerDeps.trustedDeviceStore` + `hostIdentity` seams; enroll-on-accept; reconnect lookup; `/remote-control devices` + `revoke <id>` verbs.
+- [x] T7 (TC-05/07): `agent-transport-webrtc` — `pairing-gate.ts` thread `IPairingResult` into `onAccept(result)`; first-pair identity-key exchange over confirmed channel; reconnect branch runs mutual `reconnect.ts`; `webrtc-transport.ts` `onPaired(enrollment)`. Extend pairing-gate + pairing-e2e tests (rogue-host, MITM-fp, proof-replay).
+- [x] T8 (TC-06): `agent-web-ui/src/client/device-credential-store.ts` — IndexedDB keyed by relayOrigin+hostIdentityId; non-extractable device keypair + pinned host key; never serialize private key. `rtc-responder-gate.ts`/`rtc-session-client.ts` enroll+pin first pair, verify host on reconnect. Unit test (fake IndexedDB).
+- [x] T9: `agent-transport-webrtc/docs/SPEC.md` + public-surface updates across packages (spec-public-surface scan).
+- [x] T10 (TC-08): `pnpm typecheck` + affected package tests + `pnpm harness:scan` green.
 - [ ] T11 (GATE-COMPLETE): after feature→develop merge (merge-verifier) + batched Stage-E develop→main promotion, move spec active→done and archive this task.
 
 ## Test Plan / 검증

--- a/.agents/tasks/REMOTE-012.md
+++ b/.agents/tasks/REMOTE-012.md
@@ -1,0 +1,27 @@
+# REMOTE-012 — Stage E3: TOFU trusted-device reconnect
+
+Spec: `.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md`
+
+Parent: REMOTE-001 (Stage E). GATE-APPROVAL: proposal-reviewer ENDORSE (2 rounds — mutual reconnect auth
+added in round 2). Optional hardening applied: embed `deviceId ‖ hostIdentityId` in the signed transcript.
+
+## Tasks
+
+- [ ] T1 (TC-01/02): `agent-remote-pairing/src/device-identity.ts` — `generateIdentityKeyPair(extractable)`, `exportPublicKey`/`importPublicKey` (SPKI base64url), `deriveIdentityId` (SHA-256(SPKI)), `signChallenge`/`verifyChallenge` over `deviceId ‖ hostIdentityId ‖ nonceHost ‖ nonceDevice ‖ sortedPair(fp)`. Isomorphic WebCrypto only. Unit tests: round-trip + negatives.
+- [ ] T2 (TC-03): `agent-remote-pairing/src/reconnect.ts` — mutual controller: frames rc-hello/rc-host/rc-device; each verifies the counterpart against its pinned key before accept; fail-closed on timeout/bad-sig/rogue-host/unknown. Unit test mirrors handshake.test.ts.
+- [ ] T3: `agent-remote-pairing/src/index.ts` exports + `docs/SPEC.md`.
+- [ ] T4 (TC-04): `agent-cli/src/remote-control/host-identity.ts` — load-or-create host ECDSA identity keypair as a 0600 JWK under ~/.robota; reload across restarts. Unit test.
+- [ ] T5 (TC-04): `agent-cli/src/remote-control/trusted-device-store.ts` — JSON store under ~/.robota keyed by deviceId ({publicKey,label,createdAt,lastSeenAt}); list/get/upsert/revoke; fail-fast on corrupt (SettingsParseError precedent); public keys only. Unit test incl. no-private-material assertion.
+- [ ] T6 (TC-05/08): wire into `remote-control-controller.ts` + `index.ts` — `IRemoteControlControllerDeps.trustedDeviceStore` + `hostIdentity` seams; enroll-on-accept; reconnect lookup; `/remote-control devices` + `revoke <id>` verbs.
+- [ ] T7 (TC-05/07): `agent-transport-webrtc` — `pairing-gate.ts` thread `IPairingResult` into `onAccept(result)`; first-pair identity-key exchange over confirmed channel; reconnect branch runs mutual `reconnect.ts`; `webrtc-transport.ts` `onPaired(enrollment)`. Extend pairing-gate + pairing-e2e tests (rogue-host, MITM-fp, proof-replay).
+- [ ] T8 (TC-06): `agent-web-ui/src/client/device-credential-store.ts` — IndexedDB keyed by relayOrigin+hostIdentityId; non-extractable device keypair + pinned host key; never serialize private key. `rtc-responder-gate.ts`/`rtc-session-client.ts` enroll+pin first pair, verify host on reconnect. Unit test (fake IndexedDB).
+- [ ] T9: `agent-transport-webrtc/docs/SPEC.md` + public-surface updates across packages (spec-public-surface scan).
+- [ ] T10 (TC-08): `pnpm typecheck` + affected package tests + `pnpm harness:scan` green.
+- [ ] T11 (GATE-COMPLETE): after feature→develop merge (merge-verifier) + batched Stage-E develop→main promotion, move spec active→done and archive this task.
+
+## Test Plan / 검증
+
+TDD, foundation-first: agent-remote-pairing crypto+protocol (isomorphic, WebCrypto) → host stores → gate
+wiring → browser store. Authoritative = per-package vitest (crypto round-trip+negatives; mutual protocol
+fail-closed incl. rogue-host; store round-trip+no-private-material+fail-fast; gate enroll/reconnect/deny;
+e2e oracle rogue-host+MITM+replay; browser IndexedDB persist+non-extractable) + full typecheck + harness:scan.

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -212,7 +212,17 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const transportRegistry = createDefaultTransportRegistry();
   const { controller: remoteControlController, setChannel: setRemoteControlChannel } =
     createRemoteControlController(transportRegistry);
-  commandHostAdapters.remoteControl = { getStatus: () => remoteControlController.getStatus() };
+  commandHostAdapters.remoteControl = {
+    getStatus: () => remoteControlController.getStatus(),
+    // REMOTE-012 E3: `/remote-control devices` + `revoke <id>` over the same controller (trusted-device store).
+    listDevices: () =>
+      remoteControlController.listDevices().map((d) => ({
+        deviceId: d.deviceId,
+        label: d.label,
+        lastSeenAt: d.lastSeenAt,
+      })),
+    revokeDevice: (deviceId: string) => remoteControlController.revokeDevice(deviceId),
+  };
 
   // INFRA-032: a preset command-module name that matched no module (a short form like "editor"
   // instead of agent-command-editor, or a typo) is surfaced as a non-fatal notice — never a silent

--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-e3.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-e3.test.ts
@@ -1,0 +1,146 @@
+import {
+  deriveIdentityId,
+  exportPublicKey,
+  generateIdentityKeyPair,
+} from '@robota-sdk/agent-remote-pairing';
+import type {
+  IConfigurableTransport,
+  IInteractiveSession,
+} from '@robota-sdk/agent-interface-transport';
+import type { IHostReconnectConfig, ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
+import type { TransportRegistry } from '@robota-sdk/agent-transport';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { IHostIdentity } from '../host-identity.js';
+import { RemoteControlController } from '../remote-control-controller.js';
+import type { ITrustedDeviceRecord, ITrustedDeviceStore } from '../trusted-device-store.js';
+
+/**
+ * REMOTE-012 E3 TC-05/08 — the controller wires a reconnect config from the host identity + trusted-device
+ * store, its `onEnroll` pins a device, `resolveDevicePublicKey` reads it back, and `listDevices`/`revokeDevice`
+ * delegate to the store.
+ */
+
+function memoryStore(): ITrustedDeviceStore {
+  const map = new Map<string, ITrustedDeviceRecord>();
+  return {
+    list: () => [...map.values()],
+    get: (id) => map.get(id),
+    upsert: (r) => void map.set(r.deviceId, r),
+    revoke: (id) => map.delete(id),
+  };
+}
+
+async function hostIdentity(): Promise<IHostIdentity> {
+  const keyPair = await generateIdentityKeyPair(true);
+  const publicKeySpki = await exportPublicKey(keyPair.publicKey);
+  return { keyPair, publicKeySpki, hostIdentityId: await deriveIdentityId(publicKeySpki) };
+}
+
+function build(
+  store: ITrustedDeviceStore,
+  identity: IHostIdentity,
+): {
+  controller: RemoteControlController;
+  captured: { reconnect?: IHostReconnectConfig };
+} {
+  const captured: { reconnect?: IHostReconnectConfig } = {};
+  const controller = new RemoteControlController({
+    registry: { register: () => {} } as unknown as TransportRegistry,
+    readRelayUrl: () => 'ws://127.0.0.1:9999',
+    readClientUrl: () => 'https://remote.example/',
+    getSession: () => ({}) as IInteractiveSession,
+    renderQr: () => Promise.resolve('[QR]'),
+    createSignaling: () =>
+      ({
+        send: vi.fn(),
+        onSignal: vi.fn(() => () => {}),
+        close: vi.fn(),
+      }) as unknown as ISignalingClient,
+    trustedDeviceStore: store,
+    loadHostIdentity: () => Promise.resolve(identity),
+    createTransport: (_s, _secret, _h, _ice, reconnect) => {
+      captured.reconnect = reconnect;
+      return {
+        name: 'webrtc',
+        defaultEnabled: false,
+        attach: vi.fn(),
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        validateOptions: () => true,
+      } as unknown as IConfigurableTransport<IInteractiveSession>;
+    },
+  });
+  return { controller, captured };
+}
+
+describe('RemoteControlController E3 wiring (REMOTE-012)', () => {
+  it('passes a reconnect config carrying the host identity; onEnroll pins + resolve reads back', async () => {
+    const store = memoryStore();
+    const identity = await hostIdentity();
+    const { controller, captured } = build(store, identity);
+
+    await controller.enable();
+    const rc = captured.reconnect;
+    expect(rc).toBeDefined();
+    expect(rc?.hostIdentityId).toBe(identity.hostIdentityId);
+    expect(rc?.hostPublicSpki).toBe(identity.publicKeySpki);
+
+    // A brand-new device is unknown until enrolled.
+    const device = await generateIdentityKeyPair(false);
+    const deviceSpki = await exportPublicKey(device.publicKey);
+    const deviceId = await deriveIdentityId(deviceSpki);
+    expect(await rc?.resolveDevicePublicKey(deviceId)).toBeUndefined();
+
+    rc?.onEnroll(deviceId, deviceSpki);
+    expect(store.get(deviceId)?.publicKey).toBe(deviceSpki);
+    expect(await rc?.resolveDevicePublicKey(deviceId)).toBeTruthy(); // now resolvable
+  });
+
+  it('listDevices / revokeDevice delegate to the store', async () => {
+    const store = memoryStore();
+    store.upsert({
+      deviceId: 'dev-1',
+      publicKey: 'spki',
+      label: 'phone',
+      createdAt: 't',
+      lastSeenAt: 't',
+    });
+    const { controller } = build(store, await hostIdentity());
+    expect(controller.listDevices()).toHaveLength(1);
+    expect(controller.revokeDevice('dev-1')).toBe(true);
+    expect(controller.listDevices()).toHaveLength(0);
+    expect(controller.revokeDevice('missing')).toBe(false);
+  });
+
+  it('with no store configured, listDevices is empty and reconnect config is absent', async () => {
+    const captured: { reconnect?: IHostReconnectConfig } = {};
+    const controller = new RemoteControlController({
+      registry: { register: () => {} } as unknown as TransportRegistry,
+      readRelayUrl: () => 'ws://127.0.0.1:9999',
+      readClientUrl: () => 'https://remote.example/',
+      getSession: () => ({}) as IInteractiveSession,
+      renderQr: () => Promise.resolve('[QR]'),
+      createSignaling: () =>
+        ({
+          send: vi.fn(),
+          onSignal: vi.fn(() => () => {}),
+          close: vi.fn(),
+        }) as unknown as ISignalingClient,
+      createTransport: (_s, _secret, _h, _ice, reconnect) => {
+        captured.reconnect = reconnect;
+        return {
+          name: 'webrtc',
+          defaultEnabled: false,
+          attach: vi.fn(),
+          start: vi.fn().mockResolvedValue(undefined),
+          stop: vi.fn().mockResolvedValue(undefined),
+          validateOptions: () => true,
+        } as unknown as IConfigurableTransport<IInteractiveSession>;
+      },
+    });
+    await controller.enable();
+    expect(captured.reconnect).toBeUndefined();
+    expect(controller.listDevices()).toEqual([]);
+  });
+});

--- a/packages/agent-cli/src/remote-control/__tests__/trusted-device-store.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/trusted-device-store.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadOrCreateHostIdentity } from '../host-identity.js';
+import { createTrustedDeviceStore, type ITrustedDeviceRecord } from '../trusted-device-store.js';
+
+/**
+ * REMOTE-012 E3 TC-04 — the host-side persistence: the trusted-device store (public keys only, fail-fast on
+ * corrupt) and the host identity keypair (load-or-create, reload across "restarts").
+ */
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'remote-e3-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function record(over: Partial<ITrustedDeviceRecord> = {}): ITrustedDeviceRecord {
+  return {
+    deviceId: 'dev-1',
+    publicKey: 'cHVibGljLXNwa2k',
+    label: 'phone',
+    createdAt: '2026-07-11T00:00:00.000Z',
+    lastSeenAt: '2026-07-11T00:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('trusted-device store (REMOTE-012 TC-04)', () => {
+  it('upsert → get/list; revoke removes; absent id is undefined', () => {
+    const file = join(dir, 'devices.json');
+    const store = createTrustedDeviceStore(file);
+    expect(store.list()).toEqual([]);
+    expect(store.get('dev-1')).toBeUndefined();
+
+    store.upsert(record());
+    store.upsert(record({ deviceId: 'dev-2', label: 'laptop' }));
+    expect(store.list()).toHaveLength(2);
+    expect(store.get('dev-1')?.label).toBe('phone');
+
+    expect(store.revoke('dev-1')).toBe(true);
+    expect(store.get('dev-1')).toBeUndefined();
+    expect(store.revoke('dev-1')).toBe(false); // already gone
+    expect(store.list()).toHaveLength(1);
+  });
+
+  it('persists ONLY public material — no private key ever written', () => {
+    const file = join(dir, 'devices.json');
+    createTrustedDeviceStore(file).upsert(record());
+    const raw = readFileSync(file, 'utf8');
+    expect(raw).toContain('publicKey');
+    expect(raw.toLowerCase()).not.toContain('private');
+    expect(raw).not.toContain('"d"'); // a JWK private scalar field
+  });
+
+  it('fail-closed: a corrupt store throws (never silently an empty allow-list)', () => {
+    const file = join(dir, 'devices.json');
+    writeFileSync(file, '{ not valid json');
+    expect(() => createTrustedDeviceStore(file).list()).toThrow(/corrupt/i);
+  });
+});
+
+describe('host identity keypair (REMOTE-012 TC-04)', () => {
+  it('creates a 0600 identity on first run and reloads the SAME key across restarts', async () => {
+    const file = join(dir, 'host-identity.json');
+    expect(existsSync(file)).toBe(false);
+
+    const first = await loadOrCreateHostIdentity(file);
+    expect(existsSync(file)).toBe(true);
+    expect(first.hostIdentityId).toBeTruthy();
+
+    const reloaded = await loadOrCreateHostIdentity(file);
+    // Same persisted key → identical public SPKI + id across "restarts".
+    expect(reloaded.publicKeySpki).toBe(first.publicKeySpki);
+    expect(reloaded.hostIdentityId).toBe(first.hostIdentityId);
+  });
+
+  it('fail-closed: a corrupt identity file throws (does not silently mint a new identity)', async () => {
+    const file = join(dir, 'host-identity.json');
+    writeFileSync(file, 'not json at all');
+    await expect(loadOrCreateHostIdentity(file)).rejects.toThrow(/corrupt/i);
+  });
+});

--- a/packages/agent-cli/src/remote-control/host-identity.ts
+++ b/packages/agent-cli/src/remote-control/host-identity.ts
@@ -37,7 +37,7 @@ interface IHostIdentityFile {
 }
 
 /** Default on-disk location for the host identity JWK. */
-export function defaultHostIdentityPath(): string {
+function defaultHostIdentityPath(): string {
   return join(homedir(), '.robota', 'remote-host-identity.json');
 }
 

--- a/packages/agent-cli/src/remote-control/host-identity.ts
+++ b/packages/agent-cli/src/remote-control/host-identity.ts
@@ -1,0 +1,75 @@
+/**
+ * Host identity keypair for TOFU trusted-device reconnect (REMOTE-012 Stage E3).
+ *
+ * The host is the stationary trust anchor: it must reload and sign reconnect challenges across process
+ * restarts, so — unlike the browser device key (non-extractable in IndexedDB) — its ECDSA identity keypair is
+ * generated **extractable** and persisted as a `0600` JWK file under `~/.robota` (exactly like an SSH host
+ * key). Confidentiality of that file buys an attacker nothing they don't already have: read access to
+ * `~/.robota` means control of the host process, which IS the agent. The device pins this host's PUBLIC key
+ * at first pair and verifies it on every reconnect (rogue-host defense).
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import {
+  deriveIdentityId,
+  exportKeyPairJwk,
+  exportPublicKey,
+  generateIdentityKeyPair,
+  importKeyPairJwk,
+  type IIdentityKeyPairJwk,
+} from '@robota-sdk/agent-remote-pairing';
+
+/** The loaded host identity: the keypair plus its pinned-value derivatives. */
+export interface IHostIdentity {
+  /** The host's ECDSA identity keypair (private key signs reconnect challenges). */
+  readonly keyPair: CryptoKeyPair;
+  /** base64url SPKI public key — advertised to a device at first pair for pinning. */
+  readonly publicKeySpki: string;
+  /** Stable `SHA-256(SPKI)` id — the value the browser credential store keys on. */
+  readonly hostIdentityId: string;
+}
+
+interface IHostIdentityFile {
+  readonly version: 1;
+  readonly keyPair: IIdentityKeyPairJwk;
+}
+
+/** Default on-disk location for the host identity JWK. */
+export function defaultHostIdentityPath(): string {
+  return join(homedir(), '.robota', 'remote-host-identity.json');
+}
+
+async function derive(keyPair: CryptoKeyPair): Promise<IHostIdentity> {
+  const publicKeySpki = await exportPublicKey(keyPair.publicKey);
+  return { keyPair, publicKeySpki, hostIdentityId: await deriveIdentityId(publicKeySpki) };
+}
+
+/**
+ * Load the host identity from `filePath`, or generate + persist a fresh one on first run. The file is written
+ * `0600`. A malformed file **throws** (fail-fast) rather than silently minting a new identity — a new
+ * identity would force every trusted device to re-pair, so surfacing corruption is the safer failure.
+ */
+export async function loadOrCreateHostIdentity(
+  filePath: string = defaultHostIdentityPath(),
+): Promise<IHostIdentity> {
+  if (existsSync(filePath)) {
+    let parsed: IHostIdentityFile;
+    try {
+      parsed = JSON.parse(readFileSync(filePath, 'utf8')) as IHostIdentityFile;
+    } catch (cause) {
+      throw new Error(`remote host identity file is corrupt: ${filePath}`, { cause });
+    }
+    if (parsed.version !== 1 || !parsed.keyPair?.privateJwk || !parsed.keyPair?.publicJwk) {
+      throw new Error(`remote host identity file has an unexpected shape: ${filePath}`);
+    }
+    return derive(await importKeyPairJwk(parsed.keyPair));
+  }
+
+  const keyPair = await generateIdentityKeyPair(true);
+  const file: IHostIdentityFile = { version: 1, keyPair: await exportKeyPairJwk(keyPair) };
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(file, null, 2), { mode: 0o600 });
+  return derive(keyPair);
+}

--- a/packages/agent-cli/src/remote-control/index.ts
+++ b/packages/agent-cli/src/remote-control/index.ts
@@ -1,9 +1,11 @@
 import { createSystemMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 import { getUserSettingsPath, readSettings } from '@robota-sdk/agent-framework';
 
+import { loadOrCreateHostIdentity } from './host-identity.js';
 import { parseIceServers } from './ice-config.js';
 import { renderQrToTerminal } from './render-qr.js';
 import { RemoteControlController } from './remote-control-controller.js';
+import { createTrustedDeviceStore } from './trusted-device-store.js';
 
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { TransportRegistry } from '@robota-sdk/agent-transport';
@@ -63,6 +65,11 @@ export function createRemoteControlController(registry: TransportRegistry): {
     renderQr: renderQrToTerminal,
     reportError: (message) =>
       channel?.stateManager.addEntry(messageToHistoryEntry(createSystemMessage(message))),
+    // REMOTE-012 E3: TOFU trusted-device reconnect is on by default — the host identity + device store live
+    // under ~/.robota (like an SSH host key + known_hosts). A returning device reconnects without re-pairing;
+    // a new device enrolls on first pair after the explicit accept.
+    trustedDeviceStore: createTrustedDeviceStore(),
+    loadHostIdentity: () => loadOrCreateHostIdentity(),
   });
   return {
     controller,

--- a/packages/agent-cli/src/remote-control/remote-control-controller.ts
+++ b/packages/agent-cli/src/remote-control/remote-control-controller.ts
@@ -1,9 +1,19 @@
-import { generatePairingSecret, toPairingUrl } from '@robota-sdk/agent-remote-pairing';
+import {
+  generatePairingSecret,
+  importPublicKey,
+  toPairingUrl,
+} from '@robota-sdk/agent-remote-pairing';
 import { WsSignalingClient, WebRtcTransport } from '@robota-sdk/agent-transport-webrtc';
 
 import { hasTurnServer } from './ice-config.js';
 
-import type { IIceServer, ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
+import type { IHostIdentity } from './host-identity.js';
+import type { ITrustedDeviceRecord, ITrustedDeviceStore } from './trusted-device-store.js';
+import type {
+  IHostReconnectConfig,
+  IIceServer,
+  ISignalingClient,
+} from '@robota-sdk/agent-transport-webrtc';
 import type { TransportRegistry } from '@robota-sdk/agent-transport';
 import type { TRemoteControlStatus } from '@robota-sdk/agent-framework';
 import type {
@@ -43,6 +53,10 @@ export interface IRemoteControlControllerDeps {
   renderQr: (text: string) => Promise<string>;
   /** Surface an async failure (e.g. a `werift`-absent `start()` failure) to the operator. */
   reportError?: (message: string) => void;
+  /** REMOTE-012 E3: the host trusted-device store (device public keys). Absent → first-pair only, no TOFU reconnect. */
+  trustedDeviceStore?: ITrustedDeviceStore;
+  /** REMOTE-012 E3: load-or-create the host identity keypair (async). Absent → first-pair only, no TOFU reconnect. */
+  loadHostIdentity?: () => Promise<IHostIdentity>;
   /** Construction seams (default to the real implementations; overridden in unit tests). */
   createSignaling?: (url: string, rendezvous: string) => ISignalingClient;
   createTransport?: (
@@ -50,6 +64,7 @@ export interface IRemoteControlControllerDeps {
     secret: string,
     hooks: { onPaired: () => void; onPairingFailed: () => void },
     ice: { iceServers?: readonly IIceServer[]; forceTurn?: boolean },
+    reconnect?: IHostReconnectConfig,
   ) => IConfigurableTransport<IInteractiveSession>;
 }
 
@@ -108,6 +123,21 @@ export class RemoteControlController {
       );
     }
 
+    // REMOTE-012 E3: when a trusted-device store + host identity are configured, build the reconnect config so
+    // the gate admits a pinned device without re-pairing (and enrolls new devices on first pair). A malformed
+    // host-identity file throws → fail closed with the error (don't start with a broken trust anchor).
+    let reconnect: IHostReconnectConfig | undefined;
+    if (this.deps.trustedDeviceStore && this.deps.loadHostIdentity) {
+      try {
+        reconnect = await this.buildReconnectConfig(
+          this.deps.trustedDeviceStore,
+          this.deps.loadHostIdentity,
+        );
+      } catch (error) {
+        return `Remote control: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    }
+
     const pairing = generatePairingSecret();
     const signaling = (this.deps.createSignaling ?? defaultCreateSignaling)(
       relayUrl,
@@ -128,6 +158,7 @@ export class RemoteControlController {
         },
       },
       { ...(iceServers ? { iceServers } : {}), forceTurn },
+      reconnect,
     );
 
     this.deps.registry.register(transport);
@@ -146,6 +177,48 @@ export class RemoteControlController {
     const pairingUrl = toPairingUrl(clientUrl, pairing);
     this.status = { state: 'awaiting-pairing', pairingUrl };
     return this.renderPairingMessage(pairingUrl);
+  }
+
+  /**
+   * REMOTE-012 E3: build the gate's reconnect/enrollment config from the host identity + trusted-device store.
+   * `resolveDevicePublicKey` imports a pinned SPKI (unknown/revoked → undefined → fail closed); `onEnroll`
+   * pins a device's public key on first pair (preserving `createdAt`/`label` on a re-enroll, bumping `lastSeenAt`).
+   */
+  private async buildReconnectConfig(
+    store: ITrustedDeviceStore,
+    loadHostIdentity: () => Promise<IHostIdentity>,
+  ): Promise<IHostReconnectConfig> {
+    const identity = await loadHostIdentity();
+    return {
+      hostIdentityId: identity.hostIdentityId,
+      hostPublicSpki: identity.publicKeySpki,
+      hostPrivateKey: identity.keyPair.privateKey,
+      resolveDevicePublicKey: async (deviceId) => {
+        const record = store.get(deviceId);
+        return record ? importPublicKey(record.publicKey) : undefined;
+      },
+      onEnroll: (deviceId, deviceSpki) => {
+        const now = new Date().toISOString();
+        const existing = store.get(deviceId);
+        store.upsert({
+          deviceId,
+          publicKey: deviceSpki,
+          label: existing?.label ?? 'remote device',
+          createdAt: existing?.createdAt ?? now,
+          lastSeenAt: now,
+        });
+      },
+    };
+  }
+
+  /** REMOTE-012 E3: list enrolled trusted devices (public data only). Empty when no store is configured. */
+  listDevices(): ITrustedDeviceRecord[] {
+    return this.deps.trustedDeviceStore?.list() ?? [];
+  }
+
+  /** REMOTE-012 E3: revoke a trusted device by id; it must re-pair. Returns false when unknown / no store. */
+  revokeDevice(deviceId: string): boolean {
+    return this.deps.trustedDeviceStore?.revoke(deviceId) ?? false;
   }
 
   /** Stop remote control and tear down the transport + signaling. */
@@ -199,6 +272,7 @@ function defaultCreateTransport(
   secret: string,
   hooks: { onPaired: () => void; onPairingFailed: () => void },
   ice: { iceServers?: readonly IIceServer[]; forceTurn?: boolean },
+  reconnect?: IHostReconnectConfig,
 ): IConfigurableTransport<IInteractiveSession> {
   return new WebRtcTransport({
     signaling,
@@ -207,5 +281,6 @@ function defaultCreateTransport(
     onPairingFailed: hooks.onPairingFailed,
     ...(ice.iceServers ? { iceServers: ice.iceServers } : {}),
     ...(ice.forceTurn ? { forceTurn: ice.forceTurn } : {}),
+    ...(reconnect ? { reconnect } : {}),
   });
 }

--- a/packages/agent-cli/src/remote-control/trusted-device-store.ts
+++ b/packages/agent-cli/src/remote-control/trusted-device-store.ts
@@ -38,7 +38,7 @@ interface ITrustedDeviceFile {
 }
 
 /** Default on-disk location for the trusted-device store. */
-export function defaultTrustedDeviceStorePath(): string {
+function defaultTrustedDeviceStorePath(): string {
   return join(homedir(), '.robota', 'remote-trusted-devices.json');
 }
 

--- a/packages/agent-cli/src/remote-control/trusted-device-store.ts
+++ b/packages/agent-cli/src/remote-control/trusted-device-store.ts
@@ -1,0 +1,94 @@
+/**
+ * Host trusted-device store for TOFU reconnect (REMOTE-012 Stage E3).
+ *
+ * A JSON file under `~/.robota` keyed by `deviceId`, holding each enrolled device's **public** key only — no
+ * private material, so a leak of this file cannot impersonate a device. Enrollment happens at first pair
+ * (after the explicit host accept); reconnect looks a device up by id and authenticates it against its pinned
+ * public key. Corruption **throws** (fail-fast, mirroring `settings-io`'s `SettingsParseError`) — a truncated
+ * trust store must surface, never be silently read as an empty allow-list that would force every device to
+ * re-pair or, worse, mask tampering.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** One enrolled device. `publicKey` is a base64url SPKI; timestamps are ISO-8601 strings supplied by the caller. */
+export interface ITrustedDeviceRecord {
+  readonly deviceId: string;
+  readonly publicKey: string;
+  readonly label: string;
+  readonly createdAt: string;
+  readonly lastSeenAt: string;
+}
+
+export interface ITrustedDeviceStore {
+  /** All enrolled devices (public data only). */
+  list(): ITrustedDeviceRecord[];
+  /** The record for `deviceId`, or undefined when unknown/revoked. */
+  get(deviceId: string): ITrustedDeviceRecord | undefined;
+  /** Insert or replace a device record (enroll on first pair / bump `lastSeenAt` on reconnect). */
+  upsert(record: ITrustedDeviceRecord): void;
+  /** Remove a device; returns true if one was removed. A revoked device must re-pair. */
+  revoke(deviceId: string): boolean;
+}
+
+interface ITrustedDeviceFile {
+  readonly version: 1;
+  readonly devices: Record<string, ITrustedDeviceRecord>;
+}
+
+/** Default on-disk location for the trusted-device store. */
+export function defaultTrustedDeviceStorePath(): string {
+  return join(homedir(), '.robota', 'remote-trusted-devices.json');
+}
+
+function readFile(filePath: string): ITrustedDeviceFile {
+  if (!existsSync(filePath)) return { version: 1, devices: {} };
+  let parsed: ITrustedDeviceFile;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8')) as ITrustedDeviceFile;
+  } catch (cause) {
+    throw new Error(`remote trusted-device store is corrupt: ${filePath}`, { cause });
+  }
+  if (parsed.version !== 1 || typeof parsed.devices !== 'object' || parsed.devices === null) {
+    throw new Error(`remote trusted-device store has an unexpected shape: ${filePath}`);
+  }
+  return parsed;
+}
+
+function writeFile(filePath: string, file: ITrustedDeviceFile): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(file, null, 2), { mode: 0o600 });
+}
+
+/**
+ * Create a file-backed trusted-device store. Reads are fresh from disk per call (small store; consistent with
+ * `settings-io`), so an external edit or `revoke` is seen immediately.
+ */
+export function createTrustedDeviceStore(
+  filePath: string = defaultTrustedDeviceStorePath(),
+): ITrustedDeviceStore {
+  return {
+    list(): ITrustedDeviceRecord[] {
+      return Object.values(readFile(filePath).devices);
+    },
+    get(deviceId: string): ITrustedDeviceRecord | undefined {
+      return readFile(filePath).devices[deviceId];
+    },
+    upsert(record: ITrustedDeviceRecord): void {
+      const file = readFile(filePath);
+      writeFile(filePath, {
+        version: 1,
+        devices: { ...file.devices, [record.deviceId]: record },
+      });
+    },
+    revoke(deviceId: string): boolean {
+      const file = readFile(filePath);
+      if (!(deviceId in file.devices)) return false;
+      const devices = { ...file.devices };
+      delete devices[deviceId];
+      writeFile(filePath, { version: 1, devices });
+      return true;
+    },
+  };
+}

--- a/packages/agent-command/src/remote-control/__tests__/remote-control-command.test.ts
+++ b/packages/agent-command/src/remote-control/__tests__/remote-control-command.test.ts
@@ -72,4 +72,62 @@ describe('executeRemoteControlCommand (REMOTE-008)', () => {
     expect(result.success).toBe(false);
     expect(result.effects).toBeUndefined();
   });
+
+  // REMOTE-012 E3 — trusted-device management verbs.
+  function e3ctx(over: Partial<ICommandRemoteControlAdapter>): ICommandHostContext {
+    const adapter: ICommandRemoteControlAdapter = { getStatus: () => ({ state: 'off' }), ...over };
+    return {
+      getCommandHostAdapters: () => ({ remoteControl: adapter }),
+    } as unknown as ICommandHostContext;
+  }
+
+  it('`devices` lists enrolled trusted devices', () => {
+    const result = executeRemoteControlCommand(
+      e3ctx({
+        listDevices: () => [
+          { deviceId: 'AbC-123', label: 'phone', lastSeenAt: '2026-07-11T00:00:00Z' },
+        ],
+      }),
+      'devices',
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('AbC-123');
+    expect(result.message).toContain('phone');
+  });
+
+  it('`devices` with none enrolled says so', () => {
+    const result = executeRemoteControlCommand(e3ctx({ listDevices: () => [] }), 'devices');
+    expect(result.message).toMatch(/no trusted devices/i);
+  });
+
+  it('`revoke <id>` removes a device (case-preserving id) and reports it', () => {
+    let revoked: string | undefined;
+    const result = executeRemoteControlCommand(
+      e3ctx({
+        revokeDevice: (id) => {
+          revoked = id;
+          return true;
+        },
+      }),
+      'revoke AbC-123',
+    );
+    expect(revoked).toBe('AbC-123'); // NOT lowercased
+    expect(result.success).toBe(true);
+    expect(result.message).toMatch(/revoked/i);
+  });
+
+  it('`revoke` of an unknown id is a failure notice', () => {
+    const result = executeRemoteControlCommand(
+      e3ctx({ revokeDevice: () => false }),
+      'revoke ghost',
+    );
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/no trusted device/i);
+  });
+
+  it('`revoke` with no id is a usage error', () => {
+    const result = executeRemoteControlCommand(e3ctx({ revokeDevice: () => true }), 'revoke');
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/usage/i);
+  });
 });

--- a/packages/agent-command/src/remote-control/remote-control-command.ts
+++ b/packages/agent-command/src/remote-control/remote-control-command.ts
@@ -43,13 +43,50 @@ export function executeRemoteControlCommand(
   context: ICommandHostContext,
   args: string,
 ): ICommandResult {
-  const sub = args.trim().toLowerCase();
+  const trimmed = args.trim();
+  // Split into a lowercased verb + the original-case remainder (a deviceId is case-sensitive base64url).
+  const spaceAt = trimmed.indexOf(' ');
+  const verb = (spaceAt === -1 ? trimmed : trimmed.slice(0, spaceAt)).toLowerCase();
+  const rest = spaceAt === -1 ? '' : trimmed.slice(spaceAt + 1).trim();
 
-  if (sub === 'status') {
+  if (verb === 'status') {
     return formatStatus(context.getCommandHostAdapters?.().remoteControl?.getStatus());
   }
 
-  if (sub === 'stop' || sub === 'off') {
+  if (verb === 'devices') {
+    const adapter = context.getCommandHostAdapters?.().remoteControl;
+    const devices = adapter?.listDevices?.();
+    if (!devices) {
+      return {
+        message: 'Trusted-device reconnect is not available in this environment.',
+        success: true,
+      };
+    }
+    if (devices.length === 0) {
+      return { message: 'No trusted devices are enrolled yet.', success: true };
+    }
+    const lines = devices.map((d) => `  ${d.deviceId}  ${d.label}  (last seen ${d.lastSeenAt})`);
+    return { message: `Trusted devices:\n${lines.join('\n')}`, success: true };
+  }
+
+  if (verb === 'revoke') {
+    if (!rest) {
+      return { message: 'Usage: /remote-control revoke <deviceId>', success: false };
+    }
+    const adapter = context.getCommandHostAdapters?.().remoteControl;
+    if (!adapter?.revokeDevice) {
+      return {
+        message: 'Trusted-device reconnect is not available in this environment.',
+        success: true,
+      };
+    }
+    const removed = adapter.revokeDevice(rest);
+    return removed
+      ? { message: `Revoked trusted device ${rest}. It must re-pair to reconnect.`, success: true }
+      : { message: `No trusted device with id ${rest}.`, success: false };
+  }
+
+  if (verb === 'stop' || verb === 'off') {
     return {
       message: 'Stopping remote control...',
       success: true,
@@ -58,7 +95,7 @@ export function executeRemoteControlCommand(
   }
 
   // Default (empty / `enable` / `on`): request enable. The host reports the pairing QR/link.
-  if (sub === '' || sub === 'enable' || sub === 'on') {
+  if (verb === '' || verb === 'enable' || verb === 'on') {
     return {
       message: 'Enabling remote control...',
       success: true,
@@ -67,7 +104,7 @@ export function executeRemoteControlCommand(
   }
 
   return {
-    message: `Unknown argument "${sub}". Usage: /remote-control [enable|stop|status]`,
+    message: `Unknown argument "${verb}". Usage: /remote-control [enable|stop|status|devices|revoke <id>]`,
     success: false,
   };
 }

--- a/packages/agent-framework/src/command-api/host-adapters.ts
+++ b/packages/agent-framework/src/command-api/host-adapters.ts
@@ -38,8 +38,19 @@ export type TRemoteControlStatus =
   | { readonly state: 'awaiting-pairing'; readonly pairingUrl: string }
   | { readonly state: 'paired' };
 
+/** A trusted device summary for `/remote-control devices` (public data only; REMOTE-012 E3). */
+export interface IRemoteTrustedDeviceSummary {
+  readonly deviceId: string;
+  readonly label: string;
+  readonly lastSeenAt: string;
+}
+
 export interface ICommandRemoteControlAdapter {
   getStatus(): TRemoteControlStatus;
+  /** REMOTE-012 E3: enrolled trusted devices (for `/remote-control devices`). Absent → TOFU not available. */
+  listDevices?(): IRemoteTrustedDeviceSummary[];
+  /** REMOTE-012 E3: revoke a trusted device by id (for `/remote-control revoke <id>`); returns true if removed. */
+  revokeDevice?(deviceId: string): boolean;
 }
 
 export interface ICommandHostAdapters {

--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -33,24 +33,32 @@ detection is a **directional, nonce-bound HMAC key-confirmation** bound to both 
 
 ## Public API Surface
 
-| Export                   | Kind     | Description                                                                                          |
-| ------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
-| `generatePairingSecret`  | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                               |
-| `generateNonce`          | function | Fresh per-handshake nonce.                                                                           |
-| `toPairingUrl`           | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                             |
-| `parsePairingUrl`        | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                           |
-| `extractDtlsFingerprint` | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                      |
-| `deriveSessionKey`       | function | HKDF a domain-separated session key (Stage-E use).                                                   |
-| `computeConfirmations`   | function | This peer's outgoing + expected-peer directional confirmations.                                      |
-| `verifyPeerConfirmation` | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                  |
-| `startPairingHandshake`  | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout. |
+| Export                                        | Kind     | Description                                                                                           |
+| --------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `generatePairingSecret`                       | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                                |
+| `generateNonce`                               | function | Fresh per-handshake nonce.                                                                            |
+| `toPairingUrl`                                | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                              |
+| `parsePairingUrl`                             | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                            |
+| `extractDtlsFingerprint`                      | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                       |
+| `deriveSessionKey`                            | function | HKDF a domain-separated session key (Stage-E use).                                                    |
+| `computeConfirmations`                        | function | This peer's outgoing + expected-peer directional confirmations.                                       |
+| `verifyPeerConfirmation`                      | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                   |
+| `startPairingHandshake`                       | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout.  |
+| `generateIdentityKeyPair`                     | function | ECDSA-P256 identity keypair (REMOTE-012 E3); `extractable:false` for the device, `true` for the host. |
+| `exportPublicKey` / `importPublicKey`         | function | Base64url SPKI export/import — the value each side pins for the other.                                |
+| `exportKeyPairJwk` / `importKeyPairJwk`       | function | Host-only JWK export/import for persisting its extractable identity key.                              |
+| `deriveIdentityId`                            | function | Stable non-secret id = base64url `SHA-256(SPKI)` (deviceId / hostIdentityId).                         |
+| `signChallenge` / `verifyChallenge`           | function | Sign/verify the channel-bound reconnect transcript (E3).                                              |
+| `startDeviceReconnect` / `startHostReconnect` | function | Mutual reconnect controllers; each verifies the counterpart's pinned key before accept.               |
 
 ## Type Ownership
 
-| Type                                                          | Location           | Purpose                       |
-| ------------------------------------------------------------- | ------------------ | ----------------------------- |
-| `IPairingSecret`, `IConfirmationInput`, `TPairingRole`        | `src/pairing.ts`   | Pairing crypto contracts.     |
-| `IPairingHandshakeOptions`, `IPairingResult`, `TPairingFrame` | `src/handshake.ts` | Handshake protocol contracts. |
+| Type                                                                                                              | Location                 | Purpose                              |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------ |
+| `IPairingSecret`, `IConfirmationInput`, `TPairingRole`                                                            | `src/pairing.ts`         | Pairing crypto contracts.            |
+| `IPairingHandshakeOptions`, `IPairingResult`, `TPairingFrame`                                                     | `src/handshake.ts`       | Handshake protocol contracts.        |
+| `IIdentityKeyPairJwk`, `IReconnectChallenge`                                                                      | `src/device-identity.ts` | E3 identity + challenge contracts.   |
+| `IReconnectController`, `IReconnectResult`, `IDeviceReconnectOptions`, `IHostReconnectOptions`, `TReconnectFrame` | `src/reconnect.ts`       | Mutual reconnect protocol contracts. |
 
 ## Extension Points
 

--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -33,23 +33,27 @@ detection is a **directional, nonce-bound HMAC key-confirmation** bound to both 
 
 ## Public API Surface
 
-| Export                                        | Kind     | Description                                                                                           |
-| --------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| `generatePairingSecret`                       | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                                |
-| `generateNonce`                               | function | Fresh per-handshake nonce.                                                                            |
-| `toPairingUrl`                                | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                              |
-| `parsePairingUrl`                             | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                            |
-| `extractDtlsFingerprint`                      | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                       |
-| `deriveSessionKey`                            | function | HKDF a domain-separated session key (Stage-E use).                                                    |
-| `computeConfirmations`                        | function | This peer's outgoing + expected-peer directional confirmations.                                       |
-| `verifyPeerConfirmation`                      | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                   |
-| `startPairingHandshake`                       | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout.  |
-| `generateIdentityKeyPair`                     | function | ECDSA-P256 identity keypair (REMOTE-012 E3); `extractable:false` for the device, `true` for the host. |
-| `exportPublicKey` / `importPublicKey`         | function | Base64url SPKI export/import — the value each side pins for the other.                                |
-| `exportKeyPairJwk` / `importKeyPairJwk`       | function | Host-only JWK export/import for persisting its extractable identity key.                              |
-| `deriveIdentityId`                            | function | Stable non-secret id = base64url `SHA-256(SPKI)` (deviceId / hostIdentityId).                         |
-| `signChallenge` / `verifyChallenge`           | function | Sign/verify the channel-bound reconnect transcript (E3).                                              |
-| `startDeviceReconnect` / `startHostReconnect` | function | Mutual reconnect controllers; each verifies the counterpart's pinned key before accept.               |
+| Export                    | Kind     | Description                                                                                           |
+| ------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `generatePairingSecret`   | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                                |
+| `generateNonce`           | function | Fresh per-handshake nonce.                                                                            |
+| `toPairingUrl`            | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                              |
+| `parsePairingUrl`         | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                            |
+| `extractDtlsFingerprint`  | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                       |
+| `deriveSessionKey`        | function | HKDF a domain-separated session key (Stage-E use).                                                    |
+| `computeConfirmations`    | function | This peer's outgoing + expected-peer directional confirmations.                                       |
+| `verifyPeerConfirmation`  | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                   |
+| `startPairingHandshake`   | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout.  |
+| `generateIdentityKeyPair` | function | ECDSA-P256 identity keypair (REMOTE-012 E3); `extractable:false` for the device, `true` for the host. |
+| `exportPublicKey`         | function | Export a public key as base64url SPKI — the value the counterpart pins.                               |
+| `importPublicKey`         | function | Import a base64url SPKI public key for verify.                                                        |
+| `exportKeyPairJwk`        | function | Host-only: export an extractable keypair to JWKs (0600 on-disk file).                                 |
+| `importKeyPairJwk`        | function | Host-only: reload a keypair from persisted JWKs.                                                      |
+| `deriveIdentityId`        | function | Stable non-secret id = base64url `SHA-256(SPKI)` (deviceId / hostIdentityId).                         |
+| `signChallenge`           | function | Sign the channel-bound reconnect transcript (E3).                                                     |
+| `verifyChallenge`         | function | Verify a counterpart's reconnect signature against its pinned public key (fail-closed).               |
+| `startDeviceReconnect`    | function | Device-side mutual reconnect controller; verifies the host before accept.                             |
+| `startHostReconnect`      | function | Host-side mutual reconnect controller; verifies the device before accept.                             |
 
 ## Type Ownership
 

--- a/packages/agent-remote-pairing/src/__tests__/device-identity.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/device-identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveIdentityId,
+  exportKeyPairJwk,
+  exportPublicKey,
+  generateIdentityKeyPair,
+  importKeyPairJwk,
+  importPublicKey,
+  signChallenge,
+  verifyChallenge,
+  type IReconnectChallenge,
+} from '../device-identity.js';
+
+/**
+ * REMOTE-012 E3 TC-01/02 — the isomorphic ECDSA device/host identity primitives, under Node WebCrypto (the
+ * same code path the browser runs). Proves the channel-bound reconnect signature round-trips and fails closed
+ * on any tampered field, and that identity ids + SPKI export/import are stable.
+ */
+
+function challenge(over: Partial<IReconnectChallenge> = {}): IReconnectChallenge {
+  return {
+    deviceId: 'device-id',
+    hostIdentityId: 'host-id',
+    nonceHost: 'aG9zdG5vbmNl',
+    nonceDevice: 'ZGV2bm9uY2U',
+    localFingerprint: 'AA:BB:CC',
+    remoteFingerprint: 'DD:EE:FF',
+    ...over,
+  };
+}
+
+describe('device-identity signChallenge/verifyChallenge (REMOTE-012 TC-01)', () => {
+  it('a signature verifies with the matching public key over the same transcript', async () => {
+    const pair = await generateIdentityKeyPair(false);
+    const spki = await exportPublicKey(pair.publicKey);
+    const pub = await importPublicKey(spki);
+    const c = challenge();
+    const sig = await signChallenge(pair.privateKey, c);
+    expect(await verifyChallenge(pub, sig, c)).toBe(true);
+  });
+
+  it('fails closed for a different nonce (host or device), a different fingerprint pair, or a different key', async () => {
+    const pair = await generateIdentityKeyPair(false);
+    const pub = await importPublicKey(await exportPublicKey(pair.publicKey));
+    const c = challenge();
+    const sig = await signChallenge(pair.privateKey, c);
+
+    expect(await verifyChallenge(pub, sig, challenge({ nonceHost: 'b3RoZXI' }))).toBe(false);
+    expect(await verifyChallenge(pub, sig, challenge({ nonceDevice: 'b3RoZXI' }))).toBe(false);
+    expect(await verifyChallenge(pub, sig, challenge({ remoteFingerprint: '99:99:99' }))).toBe(
+      false,
+    );
+    expect(await verifyChallenge(pub, sig, challenge({ deviceId: 'other-device' }))).toBe(false);
+
+    const other = await generateIdentityKeyPair(false);
+    const otherPub = await importPublicKey(await exportPublicKey(other.publicKey));
+    expect(await verifyChallenge(otherPub, sig, c)).toBe(false);
+  });
+
+  it('is order-independent in the fingerprint pair (sortedPair binding)', async () => {
+    const pair = await generateIdentityKeyPair(false);
+    const pub = await importPublicKey(await exportPublicKey(pair.publicKey));
+    const sig = await signChallenge(
+      pair.privateKey,
+      challenge({ localFingerprint: 'AA', remoteFingerprint: 'BB' }),
+    );
+    // The counterpart observes the same two fingerprints with local/remote swapped.
+    expect(
+      await verifyChallenge(
+        pub,
+        sig,
+        challenge({ localFingerprint: 'BB', remoteFingerprint: 'AA' }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('device-identity ids + key export/import (REMOTE-012 TC-02)', () => {
+  it('deriveIdentityId is stable for a key and differs across keys', async () => {
+    const a = await exportPublicKey((await generateIdentityKeyPair(false)).publicKey);
+    const b = await exportPublicKey((await generateIdentityKeyPair(false)).publicKey);
+    expect(await deriveIdentityId(a)).toBe(await deriveIdentityId(a));
+    expect(await deriveIdentityId(a)).not.toBe(await deriveIdentityId(b));
+  });
+
+  it('a host keypair round-trips through JWK export/import and still signs verifiably', async () => {
+    const pair = await generateIdentityKeyPair(true);
+    const jwk = await exportKeyPairJwk(pair);
+    const reloaded = await importKeyPairJwk(jwk);
+    const spki = await exportPublicKey(reloaded.publicKey);
+    const pub = await importPublicKey(spki);
+    const c = challenge();
+    expect(await verifyChallenge(pub, await signChallenge(reloaded.privateKey, c), c)).toBe(true);
+  });
+
+  it('a non-extractable device private key cannot be exported', async () => {
+    const pair = await generateIdentityKeyPair(false);
+    await expect(webcrypto_subtle_export(pair.privateKey)).rejects.toBeTruthy();
+  });
+});
+
+function webcrypto_subtle_export(key: CryptoKey): Promise<JsonWebKey> {
+  return globalThis.crypto.subtle.exportKey('jwk', key);
+}

--- a/packages/agent-remote-pairing/src/__tests__/reconnect.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/reconnect.test.ts
@@ -110,6 +110,53 @@ describe('mutual reconnect (REMOTE-012 TC-03)', () => {
     await expect(host.result).rejects.toThrow(/device authentication failed/i);
   });
 
+  it('fail-closed: a captured rc-device proof replayed against a fresh challenge is rejected', async () => {
+    const h = await setup();
+    // Capture a valid rc-device proof from a completed handshake.
+    const captured: TReconnectFrame[] = [];
+    let host1!: ReturnType<typeof startHostReconnect>;
+    let device1!: ReturnType<typeof startDeviceReconnect>;
+    host1 = startHostReconnect({
+      hostIdentityId: h.hostIdentityId,
+      ...HOST_FP,
+      hostPrivateKey: h.hostKeyPair.privateKey,
+      resolveDevicePublicKey: async () => h.devicePublicKey,
+      send: (f) => device1.onFrame(f),
+      timeoutMs: 1000,
+    });
+    device1 = startDeviceReconnect({
+      deviceId: h.deviceId,
+      hostIdentityId: h.hostIdentityId,
+      ...DEVICE_FP,
+      devicePrivateKey: h.deviceKeyPair.privateKey,
+      pinnedHostPublicKey: h.pinnedHostPublicKey,
+      send: (f) => {
+        if (f.t === 'rc-device') captured.push(f);
+        host1.onFrame(f);
+      },
+      timeoutMs: 1000,
+    });
+    await Promise.all([host1.result, device1.result]);
+    const staleProof = captured[0];
+    expect(staleProof?.t).toBe('rc-device');
+
+    // A fresh host handshake issues a new nonce; replaying the stale proof must fail its verify.
+    const host2 = startHostReconnect({
+      hostIdentityId: h.hostIdentityId,
+      ...HOST_FP,
+      hostPrivateKey: h.hostKeyPair.privateKey,
+      resolveDevicePublicKey: async () => h.devicePublicKey,
+      send: () => {}, // swallow rc-host; we inject the stale proof directly
+      timeoutMs: 200,
+    });
+    host2.onFrame({ t: 'rc-hello', deviceId: h.deviceId, nonceDevice: 'ZnJlc2g' });
+    // Let the host process rc-hello (resolve key + sign + set pending) before the stale proof arrives.
+    await new Promise((r) => setTimeout(r, 10));
+    host2.onFrame(staleProof);
+    // Any fail-closed rejection is acceptable — the stale proof must never authenticate.
+    await expect(host2.result).rejects.toThrow();
+  });
+
   it('fail-closed: times out if the counterpart never answers', async () => {
     const h = await setup();
     const device = startDeviceReconnect({

--- a/packages/agent-remote-pairing/src/__tests__/reconnect.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/reconnect.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveIdentityId,
+  exportPublicKey,
+  generateIdentityKeyPair,
+  importPublicKey,
+} from '../device-identity.js';
+import { startDeviceReconnect, startHostReconnect, type TReconnectFrame } from '../reconnect.js';
+
+/**
+ * REMOTE-012 E3 TC-03 — the MUTUAL reconnect controller: both sides authenticate before accept. Wires a
+ * device controller and a host controller in-memory and asserts mutual accept + fail-closed on a rogue host,
+ * an unknown device, and a tampered device proof.
+ */
+
+interface IHarness {
+  hostKeyPair: CryptoKeyPair;
+  deviceKeyPair: CryptoKeyPair;
+  hostIdentityId: string;
+  deviceId: string;
+  pinnedHostPublicKey: CryptoKey;
+  devicePublicKey: CryptoKey;
+}
+
+async function setup(): Promise<IHarness> {
+  const hostKeyPair = await generateIdentityKeyPair(false);
+  const deviceKeyPair = await generateIdentityKeyPair(false);
+  const hostSpki = await exportPublicKey(hostKeyPair.publicKey);
+  const deviceSpki = await exportPublicKey(deviceKeyPair.publicKey);
+  return {
+    hostKeyPair,
+    deviceKeyPair,
+    hostIdentityId: await deriveIdentityId(hostSpki),
+    deviceId: await deriveIdentityId(deviceSpki),
+    pinnedHostPublicKey: await importPublicKey(hostSpki),
+    devicePublicKey: await importPublicKey(deviceSpki),
+  };
+}
+
+/** Fingerprints as each side observes them (local/remote swapped) — sortedPair collapses them to one binding. */
+const HOST_FP = { localFingerprint: 'HOST:FP', remoteFingerprint: 'DEVICE:FP' };
+const DEVICE_FP = { localFingerprint: 'DEVICE:FP', remoteFingerprint: 'HOST:FP' };
+
+function connect(
+  h: IHarness,
+  opts: {
+    resolveDevice?: (id: string) => Promise<CryptoKey | undefined>;
+    pinnedHostPublicKey?: CryptoKey;
+  } = {},
+): {
+  host: ReturnType<typeof startHostReconnect>;
+  device: ReturnType<typeof startDeviceReconnect>;
+} {
+  let host!: ReturnType<typeof startHostReconnect>;
+  let device!: ReturnType<typeof startDeviceReconnect>;
+  const toHost = (f: TReconnectFrame): void => host.onFrame(f);
+  const toDevice = (f: TReconnectFrame): void => device.onFrame(f);
+
+  host = startHostReconnect({
+    hostIdentityId: h.hostIdentityId,
+    ...HOST_FP,
+    hostPrivateKey: h.hostKeyPair.privateKey,
+    resolveDevicePublicKey:
+      opts.resolveDevice ?? (async (id) => (id === h.deviceId ? h.devicePublicKey : undefined)),
+    send: toDevice,
+    timeoutMs: 1000,
+  });
+  device = startDeviceReconnect({
+    deviceId: h.deviceId,
+    hostIdentityId: h.hostIdentityId,
+    ...DEVICE_FP,
+    devicePrivateKey: h.deviceKeyPair.privateKey,
+    pinnedHostPublicKey: opts.pinnedHostPublicKey ?? h.pinnedHostPublicKey,
+    send: toHost,
+    timeoutMs: 1000,
+  });
+  return { host, device };
+}
+
+describe('mutual reconnect (REMOTE-012 TC-03)', () => {
+  it('both sides accept when the device is pinned and the host key matches', async () => {
+    const h = await setup();
+    const { host, device } = connect(h);
+    const [hr, dr] = await Promise.all([host.result, device.result]);
+    expect(hr.deviceId).toBe(h.deviceId);
+    expect(dr.deviceId).toBe(h.deviceId);
+  });
+
+  it('fail-closed: a rogue host (device pinned a different host key) → device rejects', async () => {
+    const h = await setup();
+    const wrongHost = await generateIdentityKeyPair(false);
+    const wrongPinned = await importPublicKey(await exportPublicKey(wrongHost.publicKey));
+    const { device } = connect(h, { pinnedHostPublicKey: wrongPinned });
+    await expect(device.result).rejects.toThrow(/host authentication failed|rogue host/i);
+  });
+
+  it('fail-closed: an unknown/revoked device (resolver returns undefined) → host rejects', async () => {
+    const h = await setup();
+    const { host } = connect(h, { resolveDevice: async () => undefined });
+    await expect(host.result).rejects.toThrow(/unknown or revoked/i);
+  });
+
+  it('fail-closed: a tampered device proof → host rejects', async () => {
+    const h = await setup();
+    // Host resolves a DIFFERENT device public key than the one actually signing → device proof fails verify.
+    const other = await generateIdentityKeyPair(false);
+    const otherPub = await importPublicKey(await exportPublicKey(other.publicKey));
+    const { host } = connect(h, { resolveDevice: async () => otherPub });
+    await expect(host.result).rejects.toThrow(/device authentication failed/i);
+  });
+
+  it('fail-closed: times out if the counterpart never answers', async () => {
+    const h = await setup();
+    const device = startDeviceReconnect({
+      deviceId: h.deviceId,
+      hostIdentityId: h.hostIdentityId,
+      ...DEVICE_FP,
+      devicePrivateKey: h.deviceKeyPair.privateKey,
+      pinnedHostPublicKey: h.pinnedHostPublicKey,
+      send: () => {}, // black hole — no host
+      timeoutMs: 50,
+    });
+    await expect(device.result).rejects.toThrow(/timed out/i);
+  });
+});

--- a/packages/agent-remote-pairing/src/crypto-primitives.ts
+++ b/packages/agent-remote-pairing/src/crypto-primitives.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared low-level crypto primitives for the remote-pairing package (extracted for SSOT between the B3
+ * pairing handshake and the E3 device-identity / reconnect layer). **Isomorphic**: WebCrypto + standard web
+ * APIs only (`globalThis.crypto`, `btoa`/`atob`, `TextEncoder`) — no `node:` imports, no workspace deps — so
+ * the same code runs on the Node host (agent-cli, Node 22) and the browser remote client.
+ */
+
+export const webcrypto: Crypto = globalThis.crypto;
+export const encoder = new TextEncoder();
+
+// ── base64url (isomorphic via btoa/atob, present in Node 22 + browsers) ──────────────────────────
+
+export function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function fromBase64Url(value: string): Uint8Array {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  webcrypto.getRandomValues(bytes);
+  return bytes;
+}
+
+export function concat(parts: readonly Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/** Normalize a byte view to a standalone `ArrayBuffer` (a `BufferSource` WebCrypto accepts across TS lib versions). */
+export function ab(view: Uint8Array): ArrayBuffer {
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+}
+
+/** Deterministic, order-independent join of two fingerprints — the channel-binding value both peers compute. */
+export function sortedPair(a: string, b: string): string {
+  return a <= b ? `${a}|${b}` : `${b}|${a}`;
+}

--- a/packages/agent-remote-pairing/src/device-identity.ts
+++ b/packages/agent-remote-pairing/src/device-identity.ts
@@ -1,0 +1,134 @@
+/**
+ * Device + host identity keys and the channel-bound reconnect challenge (REMOTE-012 Stage E3).
+ *
+ * **Isomorphic** (WebCrypto only — no `node:`, no deps): the same module runs on the Node host and the
+ * browser client. TOFU model: at first pairing (already authenticated by the B3 directional-HMAC handshake)
+ * the device and host exchange and pin each other's ECDSA-P256 **public** keys. On reconnect, BOTH sides
+ * sign a fresh, channel-bound challenge and verify the counterpart against the pinned key — the mutual dual
+ * of B3, using pinned public keys instead of a shared secret. Directionality is intrinsic: each side signs
+ * with its OWN private key and verifies with the OTHER's pinned public key, so a signature can never satisfy
+ * the counterpart-verification (no reflection). A host trust-store leak reveals only public keys ⇒ no
+ * impersonation; a rogue host cannot produce a valid host signature ⇒ the device fails closed.
+ */
+import {
+  ab,
+  encoder,
+  fromBase64Url,
+  sortedPair,
+  toBase64Url,
+  webcrypto,
+} from './crypto-primitives.js';
+
+const ECDSA_PARAMS: EcKeyImportParams & EcKeyGenParams = { name: 'ECDSA', namedCurve: 'P-256' };
+const ECDSA_SIGN: EcdsaParams = { name: 'ECDSA', hash: 'SHA-256' };
+
+/** Serialized ECDSA keypair (JWK) — used ONLY by the host to persist its own extractable identity key. */
+export interface IIdentityKeyPairJwk {
+  readonly privateJwk: JsonWebKey;
+  readonly publicJwk: JsonWebKey;
+}
+
+/**
+ * Generate an ECDSA-P256 identity keypair. The browser device passes `extractable: false` (the private key
+ * never leaves IndexedDB); the Node host passes `extractable: true` ONCE to persist its identity as a JWK.
+ */
+export function generateIdentityKeyPair(extractable: boolean): Promise<CryptoKeyPair> {
+  return webcrypto.subtle.generateKey(ECDSA_PARAMS, extractable, [
+    'sign',
+    'verify',
+  ]) as Promise<CryptoKeyPair>;
+}
+
+/** Export a public key as base64url SPKI — the value the counterpart pins. */
+export async function exportPublicKey(key: CryptoKey): Promise<string> {
+  const spki = await webcrypto.subtle.exportKey('spki', key);
+  return toBase64Url(new Uint8Array(spki));
+}
+
+/** Import a base64url SPKI public key for `verify`. */
+export function importPublicKey(spkiBase64Url: string): Promise<CryptoKey> {
+  return webcrypto.subtle.importKey('spki', ab(fromBase64Url(spkiBase64Url)), ECDSA_PARAMS, true, [
+    'verify',
+  ]);
+}
+
+/** Export the host's extractable keypair to JWKs (for a `0600` on-disk file). */
+export async function exportKeyPairJwk(pair: CryptoKeyPair): Promise<IIdentityKeyPairJwk> {
+  const [privateJwk, publicJwk] = await Promise.all([
+    webcrypto.subtle.exportKey('jwk', pair.privateKey),
+    webcrypto.subtle.exportKey('jwk', pair.publicKey),
+  ]);
+  return { privateJwk, publicJwk };
+}
+
+/** Reload a host keypair from persisted JWKs (private key extractable so it can be re-exported/re-persisted). */
+export async function importKeyPairJwk(jwk: IIdentityKeyPairJwk): Promise<CryptoKeyPair> {
+  const [privateKey, publicKey] = await Promise.all([
+    webcrypto.subtle.importKey('jwk', jwk.privateJwk, ECDSA_PARAMS, true, ['sign']),
+    webcrypto.subtle.importKey('jwk', jwk.publicJwk, ECDSA_PARAMS, true, ['verify']),
+  ]);
+  return { privateKey, publicKey };
+}
+
+/**
+ * Stable, non-secret identity id = base64url `SHA-256(SPKI)`. Used as the `deviceId` a client sends in the
+ * clear on reconnect, and the `hostIdentityId` the browser credential store keys on.
+ */
+export async function deriveIdentityId(spkiBase64Url: string): Promise<string> {
+  const digest = await webcrypto.subtle.digest('SHA-256', ab(fromBase64Url(spkiBase64Url)));
+  return toBase64Url(new Uint8Array(digest));
+}
+
+/** The fields bound into a reconnect signature. Both sides construct the identical canonical transcript. */
+export interface IReconnectChallenge {
+  readonly deviceId: string;
+  readonly hostIdentityId: string;
+  readonly nonceHost: string;
+  readonly nonceDevice: string;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+}
+
+/**
+ * Canonical, unambiguous transcript. Every field is base64url or hex (no `\n`), so newline-delimiting is a
+ * lossless separator. Binds the identity ids (defense-in-depth), both fresh nonces (replay resistance), and
+ * the sorted DTLS-fingerprint pair (MITM-relay resistance — the same binding B3 uses).
+ */
+function transcriptBytes(c: IReconnectChallenge): ArrayBuffer {
+  const canonical = [
+    'robota-reconnect/v1',
+    c.deviceId,
+    c.hostIdentityId,
+    c.nonceHost,
+    c.nonceDevice,
+    sortedPair(c.localFingerprint, c.remoteFingerprint),
+  ].join('\n');
+  return ab(encoder.encode(canonical));
+}
+
+/** Sign the reconnect transcript with this side's private key → base64url signature. */
+export async function signChallenge(
+  privateKey: CryptoKey,
+  challenge: IReconnectChallenge,
+): Promise<string> {
+  const signature = await webcrypto.subtle.sign(ECDSA_SIGN, privateKey, transcriptBytes(challenge));
+  return toBase64Url(new Uint8Array(signature));
+}
+
+/** Verify a counterpart's reconnect signature against its pinned public key. Fail-closed on any error. */
+export async function verifyChallenge(
+  publicKey: CryptoKey,
+  signature: string,
+  challenge: IReconnectChallenge,
+): Promise<boolean> {
+  try {
+    return await webcrypto.subtle.verify(
+      ECDSA_SIGN,
+      publicKey,
+      ab(fromBase64Url(signature)),
+      transcriptBytes(challenge),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent-remote-pairing/src/index.ts
+++ b/packages/agent-remote-pairing/src/index.ts
@@ -16,3 +16,22 @@ export {
 export type { IPairingSecret, IConfirmationInput, TPairingRole } from './pairing.js';
 export { startPairingHandshake } from './handshake.js';
 export type { IPairingHandshakeOptions, IPairingResult, TPairingFrame } from './handshake.js';
+export {
+  generateIdentityKeyPair,
+  exportPublicKey,
+  importPublicKey,
+  exportKeyPairJwk,
+  importKeyPairJwk,
+  deriveIdentityId,
+  signChallenge,
+  verifyChallenge,
+} from './device-identity.js';
+export type { IIdentityKeyPairJwk, IReconnectChallenge } from './device-identity.js';
+export { startDeviceReconnect, startHostReconnect } from './reconnect.js';
+export type {
+  IReconnectController,
+  IReconnectResult,
+  IDeviceReconnectOptions,
+  IHostReconnectOptions,
+  TReconnectFrame,
+} from './reconnect.js';

--- a/packages/agent-remote-pairing/src/pairing.ts
+++ b/packages/agent-remote-pairing/src/pairing.ts
@@ -15,8 +15,16 @@
  * a peer's own confirmation back to it, nor replay one across handshakes.
  */
 
-const webcrypto: Crypto = globalThis.crypto;
-const encoder = new TextEncoder();
+import {
+  ab,
+  concat,
+  encoder,
+  fromBase64Url,
+  randomBytes,
+  sortedPair,
+  toBase64Url,
+  webcrypto,
+} from './crypto-primitives.js';
 
 /** Fixed, non-secret HKDF salt (v1). Host and browser MUST use the identical salt/info to derive matching keys. */
 const HKDF_SALT = encoder.encode('robota-remote-pairing/v1');
@@ -39,44 +47,6 @@ export interface IPairingSecret {
   readonly rendezvous: string;
   /** High-entropy pairing secret — carried in the URL fragment, NEVER sent to any server. */
   readonly secret: string;
-}
-
-// ── base64url (isomorphic via btoa/atob, present in Node 22 + browsers) ──────────────────────────
-
-function toBase64Url(bytes: Uint8Array): string {
-  let binary = '';
-  for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function fromBase64Url(value: string): Uint8Array {
-  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
-
-function randomBytes(length: number): Uint8Array {
-  const bytes = new Uint8Array(length);
-  webcrypto.getRandomValues(bytes);
-  return bytes;
-}
-
-function concat(parts: readonly Uint8Array[]): Uint8Array {
-  const total = parts.reduce((sum, p) => sum + p.length, 0);
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const p of parts) {
-    out.set(p, offset);
-    offset += p.length;
-  }
-  return out;
-}
-
-/** Normalize a byte view to a standalone `ArrayBuffer` (a `BufferSource` WebCrypto accepts across TS lib versions). */
-function ab(view: Uint8Array): ArrayBuffer {
-  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
 }
 
 // ── secret + rendezvous + nonce ─────────────────────────────────────────────────────────────────
@@ -157,10 +127,6 @@ export async function deriveSessionKey(secret: string): Promise<string> {
 }
 
 // ── directional, nonce-bound channel confirmation ───────────────────────────────────────────────
-
-function sortedPair(a: string, b: string): string {
-  return a <= b ? `${a}|${b}` : `${b}|${a}`;
-}
 
 async function confirmationFor(
   key: CryptoKey,

--- a/packages/agent-remote-pairing/src/reconnect.ts
+++ b/packages/agent-remote-pairing/src/reconnect.ts
@@ -1,0 +1,205 @@
+/**
+ * Mutual trusted-device reconnect handshake (REMOTE-012 Stage E3) — the dual of the B3 first-pair handshake,
+ * but authenticating a previously-pinned device/host pair by asymmetric signatures instead of a shared
+ * secret. Transport-agnostic: the caller supplies `send` and feeds inbound frames via `onFrame`; the returned
+ * promise is the ONLY accept signal, and the caller MUST close the channel if it rejects (fail closed).
+ *
+ * Both sides sign the same channel-bound transcript (`signChallenge`) and each verifies the OTHER against a
+ * pinned public key BEFORE accepting — so the device will not co-drive a rogue host, and the host will not
+ * expose a session to an unpinned device. Directionality is intrinsic to the distinct keypairs.
+ *
+ * Frames: device→host `rc-hello{deviceId,nonceDevice}` → host→device `rc-host{nonceHost,sig}` →
+ * device→host `rc-device{sig}`.
+ */
+import { signChallenge, verifyChallenge, type IReconnectChallenge } from './device-identity.js';
+import { generateNonce } from './pairing.js';
+
+export type TReconnectFrame =
+  | { readonly t: 'rc-hello'; readonly deviceId: string; readonly nonceDevice: string }
+  | { readonly t: 'rc-host'; readonly nonceHost: string; readonly sig: string }
+  | { readonly t: 'rc-device'; readonly sig: string };
+
+export interface IReconnectResult {
+  /** The device that authenticated (the host learns which pinned device connected). */
+  readonly deviceId: string;
+}
+
+export interface IReconnectController {
+  /** Resolves accept (after verifying the counterpart) or rejects (caller must close the channel). */
+  readonly result: Promise<IReconnectResult>;
+  /** Feed one inbound frame from the data channel. */
+  onFrame(frame: TReconnectFrame): void;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface ISettle {
+  fail(message: string): void;
+  succeed(result: IReconnectResult): void;
+  settled(): boolean;
+}
+
+function makeSettle(
+  resolve: (r: IReconnectResult) => void,
+  reject: (e: Error) => void,
+  timeoutMs: number,
+): ISettle {
+  let done = false;
+  const timer = setTimeout(() => {
+    if (!done) {
+      done = true;
+      reject(new Error('reconnect handshake timed out'));
+    }
+  }, timeoutMs);
+  return {
+    fail(message: string): void {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      reject(new Error(message));
+    },
+    succeed(result: IReconnectResult): void {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(result);
+    },
+    settled: () => done,
+  };
+}
+
+export interface IDeviceReconnectOptions {
+  readonly deviceId: string;
+  readonly hostIdentityId: string;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+  /** This device's non-extractable private key. */
+  readonly devicePrivateKey: CryptoKey;
+  /** The host public key this device pinned at first pair. */
+  readonly pinnedHostPublicKey: CryptoKey;
+  readonly send: (frame: TReconnectFrame) => void;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Device side. Emits `rc-hello`, then on `rc-host` verifies the host against the pinned host key (fail-closed
+ * on a rogue/absent host signature), signs its own proof, sends `rc-device`, and accepts.
+ */
+export function startDeviceReconnect(options: IDeviceReconnectOptions): IReconnectController {
+  const nonceDevice = generateNonce();
+  let resolve!: (r: IReconnectResult) => void;
+  let reject!: (e: Error) => void;
+  const result = new Promise<IReconnectResult>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const settle = makeSettle(resolve, reject, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  options.send({ t: 'rc-hello', deviceId: options.deviceId, nonceDevice });
+
+  return {
+    result,
+    onFrame(frame: TReconnectFrame): void {
+      if (settle.settled() || frame.t !== 'rc-host') return;
+      void (async (): Promise<void> => {
+        const challenge: IReconnectChallenge = {
+          deviceId: options.deviceId,
+          hostIdentityId: options.hostIdentityId,
+          nonceHost: frame.nonceHost,
+          nonceDevice,
+          localFingerprint: options.localFingerprint,
+          remoteFingerprint: options.remoteFingerprint,
+        };
+        const hostOk = await verifyChallenge(options.pinnedHostPublicKey, frame.sig, challenge);
+        if (settle.settled()) return;
+        if (!hostOk) {
+          settle.fail('reconnect rejected: host authentication failed (possible rogue host)');
+          return;
+        }
+        const sig = await signChallenge(options.devicePrivateKey, challenge);
+        if (settle.settled()) return;
+        options.send({ t: 'rc-device', sig });
+        settle.succeed({ deviceId: options.deviceId });
+      })();
+    },
+  };
+}
+
+export interface IHostReconnectOptions {
+  readonly hostIdentityId: string;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+  /** The host's identity private key (signs the challenge). */
+  readonly hostPrivateKey: CryptoKey;
+  /** Resolve the pinned device public key for a `deviceId`, or undefined if unknown/revoked (→ fail closed). */
+  readonly resolveDevicePublicKey: (deviceId: string) => Promise<CryptoKey | undefined>;
+  readonly send: (frame: TReconnectFrame) => void;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Host side. On `rc-hello` it looks up the pinned device key (unknown → fail closed), signs and sends
+ * `rc-host`, then on `rc-device` verifies the device proof and accepts.
+ */
+export function startHostReconnect(options: IHostReconnectOptions): IReconnectController {
+  let resolve!: (r: IReconnectResult) => void;
+  let reject!: (e: Error) => void;
+  const result = new Promise<IReconnectResult>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const settle = makeSettle(resolve, reject, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  let pending:
+    | { deviceId: string; devicePublicKey: CryptoKey; challenge: IReconnectChallenge }
+    | undefined;
+
+  return {
+    result,
+    onFrame(frame: TReconnectFrame): void {
+      if (settle.settled()) return;
+      if (frame.t === 'rc-hello') {
+        void (async (): Promise<void> => {
+          const devicePublicKey = await options.resolveDevicePublicKey(frame.deviceId);
+          if (settle.settled()) return;
+          if (!devicePublicKey) {
+            settle.fail('reconnect rejected: unknown or revoked device');
+            return;
+          }
+          const nonceHost = generateNonce();
+          const challenge: IReconnectChallenge = {
+            deviceId: frame.deviceId,
+            hostIdentityId: options.hostIdentityId,
+            nonceHost,
+            nonceDevice: frame.nonceDevice,
+            localFingerprint: options.localFingerprint,
+            remoteFingerprint: options.remoteFingerprint,
+          };
+          const sig = await signChallenge(options.hostPrivateKey, challenge);
+          if (settle.settled()) return;
+          pending = { deviceId: frame.deviceId, devicePublicKey, challenge };
+          options.send({ t: 'rc-host', nonceHost, sig });
+        })();
+      } else if (frame.t === 'rc-device') {
+        const current = pending;
+        if (!current) {
+          settle.fail('reconnect rejected: rc-device before rc-hello');
+          return;
+        }
+        void (async (): Promise<void> => {
+          const deviceOk = await verifyChallenge(
+            current.devicePublicKey,
+            frame.sig,
+            current.challenge,
+          );
+          if (settle.settled()) return;
+          if (!deviceOk) {
+            settle.fail('reconnect rejected: device authentication failed');
+            return;
+          }
+          settle.succeed({ deviceId: current.deviceId });
+        })();
+      }
+    },
+  };
+}

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -50,7 +50,12 @@ constructed (the channel cannot open until DTLS, i.e. post-answer, so no frame p
 gate routes pairing frames to `startPairingHandshake` and DROPS everything else; on `result` accept it builds
 `createWsHandler` and switches routing to the session; on reject/timeout it closes the channel and exposes nothing.
 The transport's optional `onPaired`/`onPairingFailed` callbacks fire on gate accept/reject so the host can drive its
-lifecycle (REMOTE-008: status `paired`, and teardown of the peer/signaling on failure so nothing leaks).
+lifecycle (REMOTE-008: status `paired`, and teardown of the peer/signaling on failure so nothing leaks). **REMOTE-012
+E3:** when `IWebRtcTransportOptions.reconnect` (an `IHostReconnectConfig`) is set, the gate becomes reactive — the
+client's first frame selects **first-pair** (B3 handshake, then a mutual identity-key enrollment exchange that pins
+the device key before the session is exposed) or **reconnect** (the mutual `startHostReconnect` against the pinned
+device + host identity keys, no re-pair). `onPaired` carries the first-pair `IPairingResult` (its `sessionKey` is
+reserved for E4). Without `reconnect`, the gate is exactly the B4 first-pair-only gate.
 
 ## Type Ownership
 
@@ -66,20 +71,21 @@ lifecycle (REMOTE-008: status `paired`, and teardown of the peer/signaling on fa
 
 ## Public API Surface
 
-| Export                        | Kind     | Description                                                                      |
-| ----------------------------- | -------- | -------------------------------------------------------------------------------- |
-| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.            |
-| `IWebRtcTransportOptions`     | type     | Construction options.                                                            |
-| `IIceServer`                  | type     | A STUN/TURN server (`urls` + optional `username`/`credential`; REMOTE-010).      |
-| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                        |
-| `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).      |
-| `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory). |
-| `IWebSocketLike`              | type     | Minimal socket surface `WsSignalingClient` needs (injectable in tests).          |
-| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                              |
-| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                                         |
-| `TSignalKind`                 | type     | `'offer' \| 'answer' \| 'ice'`.                                                  |
-| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).                    |
-| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.                      |
+| Export                        | Kind     | Description                                                                                              |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.                                    |
+| `IWebRtcTransportOptions`     | type     | Construction options.                                                                                    |
+| `IIceServer`                  | type     | A STUN/TURN server (`urls` + optional `username`/`credential`; REMOTE-010).                              |
+| `IHostReconnectConfig`        | type     | E3 host reconnect/enrollment config for the gate (host identity + device resolver + enroll; REMOTE-012). |
+| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                                                |
+| `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).                              |
+| `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory).                         |
+| `IWebSocketLike`              | type     | Minimal socket surface `WsSignalingClient` needs (injectable in tests).                                  |
+| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                                                      |
+| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                                                                 |
+| `TSignalKind`                 | type     | `'offer' \| 'answer' \| 'ice'`.                                                                          |
+| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).                                            |
+| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.                                              |
 
 ## Extension Points
 

--- a/packages/agent-transport-webrtc/src/__tests__/pairing-gate-e3.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/pairing-gate-e3.test.ts
@@ -1,0 +1,187 @@
+import {
+  deriveIdentityId,
+  exportPublicKey,
+  generateIdentityKeyPair,
+  importPublicKey,
+  startDeviceReconnect,
+  type TReconnectFrame,
+} from '@robota-sdk/agent-remote-pairing';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PairingGate, type IHostReconnectConfig } from '../pairing-gate.js';
+
+/**
+ * REMOTE-012 E3 TC-05 — the host gate's E3 admission paths, in isolation with a stub channel: first-pair
+ * ENROLLMENT (pin the device key, expose the session) and mutual RECONNECT (admit a pinned device, deny an
+ * unknown/revoked one) — all fail-closed.
+ */
+
+function stubSession(): IInteractiveSession {
+  return {
+    getMessages: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as IInteractiveSession;
+}
+
+/** A channel that captures sends and can route parsed frames to a sink (the counterpart controller). */
+function stubChannel(sink?: (frame: unknown) => void): {
+  channel: { send: (d: string) => void; close: () => void };
+  sent: unknown[];
+  closed: () => boolean;
+} {
+  const sent: unknown[] = [];
+  let closed = false;
+  return {
+    channel: {
+      send(d: string): void {
+        const parsed = JSON.parse(d);
+        sent.push(parsed);
+        sink?.(parsed);
+      },
+      close(): void {
+        closed = true;
+      },
+    },
+    sent,
+    closed: () => closed,
+  };
+}
+
+const FP = { localFingerprint: 'HOST:FP', remoteFingerprint: 'DEV:FP' };
+
+async function hostConfig(over: Partial<IHostReconnectConfig> = {}): Promise<{
+  cfg: IHostReconnectConfig;
+  hostKeyPair: CryptoKeyPair;
+}> {
+  const hostKeyPair = await generateIdentityKeyPair(true);
+  const hostPublicSpki = await exportPublicKey(hostKeyPair.publicKey);
+  return {
+    hostKeyPair,
+    cfg: {
+      hostIdentityId: await deriveIdentityId(hostPublicSpki),
+      hostPublicSpki,
+      hostPrivateKey: hostKeyPair.privateKey,
+      resolveDevicePublicKey: async () => undefined,
+      onEnroll: vi.fn(),
+      ...over,
+    },
+  };
+}
+
+describe('PairingGate E3 first-pair enrollment (REMOTE-012 TC-05)', () => {
+  it('after B3 accept, advertises the host key, pins the device key, and exposes the session', async () => {
+    const { cfg } = await hostConfig();
+    const onAccept = vi.fn();
+    // Fake handshake that accepts immediately (isolates the enrollment path from real B3 crypto).
+    const fakeHandshake = (() => ({
+      result: Promise.resolve({ sessionKey: 'k' }),
+      onFrame: () => {},
+    })) as never;
+
+    const { channel, sent } = stubChannel();
+    const gate = new PairingGate({
+      channel,
+      session: stubSession(),
+      secret: 's',
+      role: 'initiator',
+      ...FP,
+      reconnect: cfg,
+      onAccept,
+      startHandshake: fakeHandshake,
+    });
+
+    // Client opens first-pair mode.
+    gate.onInbound(JSON.stringify({ t: 'pair-nonce', nonce: 'n' }));
+    await Promise.resolve();
+    await Promise.resolve();
+    // Host advertised its identity key.
+    expect(sent.some((f) => (f as { t?: string }).t === 'enroll-key')).toBe(true);
+
+    // Device replies with its public key → host pins it and exposes the session.
+    const deviceKey = await generateIdentityKeyPair(false);
+    const deviceSpki = await exportPublicKey(deviceKey.publicKey);
+    gate.onInbound(JSON.stringify({ t: 'enroll-key', spki: deviceSpki }));
+    await vi.waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+    expect(cfg.onEnroll).toHaveBeenCalledWith(await deriveIdentityId(deviceSpki), deviceSpki);
+  });
+});
+
+describe('PairingGate E3 reconnect (REMOTE-012 TC-05)', () => {
+  async function pinnedDevice(): Promise<{
+    keyPair: CryptoKeyPair;
+    deviceId: string;
+    publicKey: CryptoKey;
+  }> {
+    const keyPair = await generateIdentityKeyPair(false);
+    const spki = await exportPublicKey(keyPair.publicKey);
+    return {
+      keyPair,
+      deviceId: await deriveIdentityId(spki),
+      publicKey: await importPublicKey(spki),
+    };
+  }
+
+  it('admits a pinned device via mutual reconnect and exposes the session (no re-enroll)', async () => {
+    const device = await pinnedDevice();
+    const { cfg, hostKeyPair } = await hostConfig({
+      resolveDevicePublicKey: async (id) => (id === device.deviceId ? device.publicKey : undefined),
+    });
+    const hostPublicKey = await importPublicKey(cfg.hostPublicSpki);
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+
+    let gate!: PairingGate;
+    let deviceCtrl!: ReturnType<typeof startDeviceReconnect>;
+    // Route host→device frames into the device controller.
+    const { channel } = stubChannel((frame) => deviceCtrl.onFrame(frame as TReconnectFrame));
+    gate = new PairingGate({
+      channel,
+      session: stubSession(),
+      secret: 's',
+      role: 'initiator',
+      ...FP,
+      reconnect: cfg,
+      onAccept,
+      onReject,
+    });
+    // Device drives the reconnect; its frames go into the gate.
+    deviceCtrl = startDeviceReconnect({
+      deviceId: device.deviceId,
+      hostIdentityId: cfg.hostIdentityId,
+      localFingerprint: FP.remoteFingerprint,
+      remoteFingerprint: FP.localFingerprint,
+      devicePrivateKey: device.keyPair.privateKey,
+      pinnedHostPublicKey: hostPublicKey,
+      send: (frame) => gate.onInbound(JSON.stringify(frame)),
+      timeoutMs: 1000,
+    });
+
+    await deviceCtrl.result;
+    await vi.waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+    expect(onReject).not.toHaveBeenCalled();
+    expect(cfg.onEnroll).not.toHaveBeenCalled();
+  });
+
+  it('fail-closed: an unknown/revoked device is denied (channel closed, no session)', async () => {
+    const { cfg } = await hostConfig({ resolveDevicePublicKey: async () => undefined });
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+    const { channel, closed } = stubChannel();
+    const gate = new PairingGate({
+      channel,
+      session: stubSession(),
+      secret: 's',
+      role: 'initiator',
+      ...FP,
+      reconnect: cfg,
+      onAccept,
+      onReject,
+    });
+    gate.onInbound(JSON.stringify({ t: 'rc-hello', deviceId: 'ghost', nonceDevice: 'ZGV2' }));
+    await vi.waitFor(() => expect(onReject).toHaveBeenCalledTimes(1));
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(closed()).toBe(true);
+  });
+});

--- a/packages/agent-transport-webrtc/src/index.ts
+++ b/packages/agent-transport-webrtc/src/index.ts
@@ -1,5 +1,6 @@
 export { WebRtcTransport } from './webrtc-transport.js';
 export type { IWebRtcTransportOptions, IIceServer } from './webrtc-transport.js';
+export type { IHostReconnectConfig } from './pairing-gate.js';
 export { createInMemorySignalingPair } from './signaling.js';
 export type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
 export { WsSignalingClient } from './ws-signaling-client.js';

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -1,32 +1,37 @@
 /**
- * Pairing gate for the WebRTC data channel (REMOTE-008 Stage B4-2b, Step 1 — the SECURITY milestone).
+ * Pairing gate for the WebRTC data channel (REMOTE-008 Stage B4-2b; extended for REMOTE-012 Stage E3 TOFU
+ * reconnect).
  *
- * The data channel is **phase-separated**: pre-accept it carries ONLY pairing frames, post-accept ONLY
- * session messages. A single eager `onMessage` subscription (werift drops inbound frames received before a
- * subscription exists) feeds {@link PairingGate.onInbound}, which SWITCHES routing on accept — it never
- * defers the subscription. Until the pairing handshake accepts, the session bridge (`createWsHandler`) is
- * not even built, so nothing a peer sends can reach the live session.
+ * The data channel is **phase-separated**: pre-accept it carries ONLY pairing/reconnect frames, post-accept
+ * ONLY session messages. A single eager `onMessage` subscription (werift drops inbound frames received before
+ * a subscription exists) feeds {@link PairingGate.onInbound}, which SWITCHES routing on accept — it never
+ * defers the subscription. Until accept, the session bridge (`createWsHandler`) is not even built, so nothing
+ * a peer sends can reach the live session.
  *
- * Fail-closed invariants:
- * - a NON-pairing frame arriving pre-accept is DROPPED (never parsed as a session message);
- * - the handshake's `result` promise is the ONLY accept signal — on reject/timeout the channel is closed and
- *   no session bridge is ever created;
- * - a frame arriving after close is ignored.
+ * Two admission modes (E3), decided by the client's FIRST frame:
+ * - **first-pair** (`pair-nonce`): the B3 directional-HMAC handshake, then — when E3 `reconnect` config is
+ *   present — a mutual identity-key **enrollment** exchange (each side sends its ECDSA public key over the
+ *   just-confirmed channel; the host pins the device key) before the session is exposed;
+ * - **reconnect** (`rc-hello`): the mutual {@link startHostReconnect} handshake against the pinned device +
+ *   host identity keys — no re-pair, exposes the session only on mutual accept.
  *
- * Channel binding (REMOTE-005): the gate is constructed with the local + remote DTLS fingerprints (from the
- * offer/answer SDP); werift independently verifies the advertised remote fingerprint against the negotiated
- * cert, so an honest peer and a relay observe different sorted-fingerprint pairs and the directional-HMAC
- * confirmation fails closed on a MITM relay.
+ * Fail-closed: a non-admission frame pre-accept is DROPPED; the handshake `result` is the ONLY accept signal;
+ * on reject/timeout the channel is closed and no session bridge is ever created; a post-close frame is ignored.
  *
- * Kept as a standalone unit (not inlined in the transport) so the routing/fail-closed logic is unit-testable
- * with a stub channel + injected handshake, without a real peer connection.
+ * When no E3 `reconnect` config is supplied the gate is **exactly** the B4 first-pair-only gate (eager host
+ * `pair-nonce`, no enrollment, no reconnect) — preserving existing behavior.
  */
 
 import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
 import {
+  deriveIdentityId,
+  importPublicKey,
+  startHostReconnect,
   startPairingHandshake,
+  type IPairingResult,
   type TPairingFrame,
   type TPairingRole,
+  type TReconnectFrame,
 } from '@robota-sdk/agent-remote-pairing';
 
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
@@ -35,6 +40,25 @@ import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport'
 export interface IPairingChannel {
   send(data: string): void;
   close(): void;
+}
+
+/** E3 host reconnect/enrollment config. When present, the gate runs reactive (first-frame) mode detection. */
+export interface IHostReconnectConfig {
+  readonly hostIdentityId: string;
+  /** base64url SPKI advertised to a device at first-pair enrollment. */
+  readonly hostPublicSpki: string;
+  /** The host identity private key (signs reconnect challenges). */
+  readonly hostPrivateKey: CryptoKey;
+  /** Resolve a pinned device public key by id (undefined → unknown/revoked → fail closed). */
+  readonly resolveDevicePublicKey: (deviceId: string) => Promise<CryptoKey | undefined>;
+  /** Pin a device's public key on first-pair enrollment (deviceId, base64url SPKI). */
+  readonly onEnroll: (deviceId: string, deviceSpki: string) => void;
+}
+
+/** A gate-level identity-exchange frame (first-pair enrollment, post-B3-accept). */
+interface IEnrollFrame {
+  readonly t: 'enroll-key';
+  readonly spki: string;
 }
 
 export interface IPairingGateOptions {
@@ -46,53 +70,72 @@ export interface IPairingGateOptions {
   readonly remoteFingerprint: string;
   /** Handshake timeout (ms); fail closed on expiry. */
   readonly timeoutMs?: number;
-  /** REMOTE-008: fired once the handshake accepts + the session is exposed (host lifecycle → status 'paired'). */
-  readonly onAccept?: () => void;
-  /** REMOTE-008: fired once the handshake rejects/times out + the channel closes (host lifecycle → teardown). */
+  /** REMOTE-008: fired once admission accepts + the session is exposed. Carries the first-pair result (E4). */
+  readonly onAccept?: (result?: IPairingResult) => void;
+  /** REMOTE-008: fired once admission rejects/times out + the channel closes (host lifecycle → teardown). */
   readonly onReject?: () => void;
+  /** REMOTE-012 E3: host reconnect/enrollment config. Absent → B4 first-pair-only behavior (unchanged). */
+  readonly reconnect?: IHostReconnectConfig;
   /** Injection seams (default to the real implementations). */
   readonly startHandshake?: typeof startPairingHandshake;
   readonly createHandler?: typeof createWsHandler;
 }
 
-/** True when a parsed value is a pairing frame (`{ t: 'pair-nonce' | 'pair-confirm', … }`). */
+/** True when a parsed value is a B3 pairing frame (`{ t: 'pair-nonce' | 'pair-confirm', … }`). */
 function isPairingFrame(value: unknown): value is TPairingFrame {
   if (typeof value !== 'object' || value === null) return false;
   const t = (value as { t?: unknown }).t;
   return t === 'pair-nonce' || t === 'pair-confirm';
 }
 
-type TGateState = 'pairing' | 'accepted' | 'closed';
+/** True when a parsed value is a reconnect frame the host consumes (`rc-hello` / `rc-device`). */
+function isReconnectFrame(value: unknown): value is TReconnectFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = (value as { t?: unknown }).t;
+  return t === 'rc-hello' || t === 'rc-device';
+}
+
+function isEnrollFrame(value: unknown): value is IEnrollFrame {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { t?: unknown }).t === 'enroll-key' &&
+    typeof (value as { spki?: unknown }).spki === 'string'
+  );
+}
+
+type TGateState =
+  | 'awaiting-mode'
+  | 'pairing'
+  | 'enrolling'
+  | 'reconnecting'
+  | 'accepted'
+  | 'closed';
 
 export class PairingGate {
-  private state: TGateState = 'pairing';
+  private state: TGateState;
   /** Session message router — built ONLY on accept (nothing reaches the session before). */
   private onSessionMessage?: (data: string) => void;
   private handlerCleanup?: () => void;
+  private pairingController?: ReturnType<typeof startPairingHandshake>;
+  private reconnectController?: ReturnType<typeof startHostReconnect>;
+  /** The first-pair result, held so it can be surfaced on accept (E4 uses its sessionKey). */
+  private pendingResult?: IPairingResult;
 
   constructor(private readonly options: IPairingGateOptions) {
-    const start = options.startHandshake ?? startPairingHandshake;
-    const controller = start({
-      secret: options.secret,
-      role: options.role,
-      localFingerprint: options.localFingerprint,
-      remoteFingerprint: options.remoteFingerprint,
-      // Serialize each handshake frame over the same channel the session will later use.
-      send: (frame) => this.safeSend(JSON.stringify(frame)),
-      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-    });
-    this.pairingController = controller;
-    controller.result.then(
-      () => this.accept(),
-      () => this.rejectAndClose(),
-    );
+    if (options.reconnect) {
+      // E3 mode: stay reactive — the client's first frame selects first-pair vs reconnect.
+      this.state = 'awaiting-mode';
+    } else {
+      // Legacy B4 mode: eagerly start the first-pair handshake (host sends pair-nonce immediately).
+      this.state = 'pairing';
+      this.startFirstPair();
+    }
   }
 
-  private readonly pairingController: ReturnType<typeof startPairingHandshake>;
-
   /**
-   * Route one inbound channel frame. Pre-accept: pairing frames → the handshake, everything else DROPPED.
-   * Post-accept: session messages → the session bridge. Post-close: ignored.
+   * Route one inbound channel frame. Pre-accept: admission frames → the active controller, everything else
+   * DROPPED. Post-accept: session messages → the session bridge. Post-close: ignored.
    */
   onInbound(data: string): void {
     if (this.state === 'closed') return;
@@ -100,15 +143,44 @@ export class PairingGate {
       this.onSessionMessage?.(data);
       return;
     }
-    // state === 'pairing' — only pairing frames are allowed through; anything else is dropped (fail-closed).
+
     let parsed: unknown;
     try {
       parsed = JSON.parse(data);
     } catch {
       return; // undecodable pre-accept frame → drop
     }
-    if (isPairingFrame(parsed)) this.pairingController.onFrame(parsed);
-    // A well-formed but non-pairing frame pre-accept is a protocol violation → drop, never expose the session.
+
+    if (this.state === 'awaiting-mode') {
+      // First frame selects the mode (E3).
+      if (isReconnectFrame(parsed) && parsed.t === 'rc-hello') {
+        this.state = 'reconnecting';
+        this.startReconnect();
+        this.reconnectController?.onFrame(parsed);
+      } else if (isPairingFrame(parsed) && parsed.t === 'pair-nonce') {
+        this.state = 'pairing';
+        this.startFirstPair();
+        this.pairingController?.onFrame(parsed);
+      }
+      // anything else pre-mode → drop
+      return;
+    }
+
+    if (this.state === 'pairing') {
+      if (isPairingFrame(parsed)) this.pairingController?.onFrame(parsed);
+      return;
+    }
+
+    if (this.state === 'reconnecting') {
+      if (isReconnectFrame(parsed)) this.reconnectController?.onFrame(parsed);
+      return;
+    }
+
+    if (this.state === 'enrolling') {
+      // Awaiting the peer's identity public key to pin, then expose the session.
+      if (isEnrollFrame(parsed)) this.completeEnrollment(parsed.spki);
+      return;
+    }
   }
 
   /** Tear down: cleanup the session bridge (if built) and mark closed. Idempotent. */
@@ -119,8 +191,84 @@ export class PairingGate {
     this.onSessionMessage = undefined;
   }
 
-  private accept(): void {
-    if (this.state !== 'pairing') return; // closed/settled in the meantime
+  private startFirstPair(): void {
+    const start = this.options.startHandshake ?? startPairingHandshake;
+    const controller = start({
+      secret: this.options.secret,
+      role: this.options.role,
+      localFingerprint: this.options.localFingerprint,
+      remoteFingerprint: this.options.remoteFingerprint,
+      send: (frame) => this.safeSend(JSON.stringify(frame)),
+      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
+    });
+    this.pairingController = controller;
+    controller.result.then(
+      (result) => this.onFirstPairAccepted(result),
+      () => this.rejectAndClose(),
+    );
+  }
+
+  private startReconnect(): void {
+    const cfg = this.options.reconnect;
+    if (!cfg) {
+      this.rejectAndClose();
+      return;
+    }
+    const controller = startHostReconnect({
+      hostIdentityId: cfg.hostIdentityId,
+      localFingerprint: this.options.localFingerprint,
+      remoteFingerprint: this.options.remoteFingerprint,
+      hostPrivateKey: cfg.hostPrivateKey,
+      resolveDevicePublicKey: cfg.resolveDevicePublicKey,
+      send: (frame) => this.safeSend(JSON.stringify(frame)),
+      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
+    });
+    this.reconnectController = controller;
+    controller.result.then(
+      () => this.accept(),
+      () => this.rejectAndClose(),
+    );
+  }
+
+  /** B3 handshake accepted. Without E3: expose immediately. With E3: run first-pair enrollment first. */
+  private onFirstPairAccepted(result: IPairingResult): void {
+    if (this.state !== 'pairing') return;
+    this.pendingResult = result;
+    const cfg = this.options.reconnect;
+    if (!cfg) {
+      this.accept(result);
+      return;
+    }
+    // E3 enrollment: advertise the host public key; the peer's `enroll-key` completes it (then expose).
+    this.state = 'enrolling';
+    this.safeSend(
+      JSON.stringify({ t: 'enroll-key', spki: cfg.hostPublicSpki } satisfies IEnrollFrame),
+    );
+  }
+
+  private completeEnrollment(deviceSpki: string): void {
+    if (this.state !== 'enrolling') return;
+    const cfg = this.options.reconnect;
+    if (!cfg) {
+      this.rejectAndClose();
+      return;
+    }
+    void (async (): Promise<void> => {
+      try {
+        // Validate the SPKI parses as a public key before pinning (fail closed on garbage).
+        await importPublicKey(deviceSpki);
+        const deviceId = await deriveIdentityId(deviceSpki);
+        if (this.state !== 'enrolling') return;
+        cfg.onEnroll(deviceId, deviceSpki);
+        this.accept(this.pendingResult);
+      } catch {
+        this.rejectAndClose();
+      }
+    })();
+  }
+
+  private accept(result?: IPairingResult): void {
+    if (this.state === 'closed' || this.state === 'accepted') return;
     const create = this.options.createHandler ?? createWsHandler;
     const { onMessage, cleanup } = create({
       session: this.options.session,
@@ -129,13 +277,12 @@ export class PairingGate {
     this.onSessionMessage = onMessage;
     this.handlerCleanup = cleanup;
     this.state = 'accepted';
-    this.options.onAccept?.();
+    this.options.onAccept?.(result);
   }
 
   private rejectAndClose(): void {
     if (this.state === 'closed') return;
     this.state = 'closed';
-    // The handshake rejected (mismatch/timeout) — expose nothing and drop the channel.
     try {
       this.options.channel.close();
     } catch {

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -6,8 +6,10 @@ import type {
 } from '@robota-sdk/agent-interface-transport';
 import type { RTCDataChannel, RTCPeerConnection } from 'werift';
 
+import type { IPairingResult } from '@robota-sdk/agent-remote-pairing';
+
 import { loadWerift } from './werift-loader.js';
-import { PairingGate } from './pairing-gate.js';
+import { PairingGate, type IHostReconnectConfig } from './pairing-gate.js';
 import type { ISignalingClient } from './signaling.js';
 import type { IWeriftModule } from './werift-loader.js';
 
@@ -44,10 +46,12 @@ export interface IWebRtcTransportOptions {
    * exposed immediately with no pairing (unchanged behavior).
    */
   readonly secret?: string;
-  /** REMOTE-008: fired when pairing accepts + the session is exposed (host lifecycle → status 'paired'). */
-  readonly onPaired?: () => void;
+  /** REMOTE-008: fired when pairing accepts + the session is exposed (host lifecycle → status 'paired'). Carries the first-pair result (E4 uses its sessionKey). */
+  readonly onPaired?: (result?: IPairingResult) => void;
   /** REMOTE-008: fired when pairing rejects/times out (host lifecycle → teardown; the channel is already closed). */
   readonly onPairingFailed?: () => void;
+  /** REMOTE-012 E3: host reconnect/enrollment config. When set, the gate admits first-pair (with enrollment) OR a pinned-device reconnect. */
+  readonly reconnect?: IHostReconnectConfig;
   /** Test seam: inject the werift module (defaults to the real lazy loader). */
   readonly loadWerift?: () => IWeriftModule;
 }
@@ -159,6 +163,7 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
       remoteFingerprint: extractDtlsFingerprint(sdp),
       ...(this.options.onPaired ? { onAccept: this.options.onPaired } : {}),
       ...(this.options.onPairingFailed ? { onReject: this.options.onPairingFailed } : {}),
+      ...(this.options.reconnect ? { reconnect: this.options.reconnect } : {}),
     });
   }
 

--- a/packages/agent-web-ui/docs/SPEC.md
+++ b/packages/agent-web-ui/docs/SPEC.md
@@ -22,6 +22,15 @@ the isomorphic zero-dep `@robota-sdk/agent-remote-pairing` leaf and takes **no**
 `permission_request`/`ask_request`/`prompt_resolved`, `PermissionPrompt` component) serves BOTH the WS and
 RTC clients — the paired owner answers its OWN prompts (local == remote).
 
+**REMOTE-012 E3 TOFU reconnect.** `ResponderGate` gains E3 admission: on first pair (after B3 accept) it runs an
+identity-key **enrollment** exchange — it pins the host's advertised ECDSA public key and advertises the browser
+device's public key — before the session is exposed; it can also run a mutual `startDeviceReconnect` that verifies
+the host against the pinned key (rogue-host → fail closed). The browser-local `device-credential-store` (IndexedDB,
+keyed by `relayOrigin + hostIdentityId`) persists the device's **non-extractable** keypair + the pinned host key
+(never serialized, never in a URL). `createRtcSessionClient` takes an optional `deviceCredentials` store (wired from
+`useRtcSession`) so first-pair enrolls this device; reconnect INITIATION (reusing a stored credential) is E4. Without
+`deviceCredentials` the client is exactly the REMOTE-009 first-pair-only path.
+
 **REMOTE-010 TURN fallback.** `parseRemoteClientLocation` also reads an optional `ice` query param (a base64url
 JSON `RTCIceServer[]`, decoded + validated by a browser-local fail-closed decoder — the param is
 attacker-influenceable) and a `forceTurn` flag, threaded through `RemoteClient` → `useRtcSession` →

--- a/packages/agent-web-ui/src/client/__tests__/device-credential-store.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/device-credential-store.test.ts
@@ -1,0 +1,69 @@
+import { generateIdentityKeyPair } from '@robota-sdk/agent-remote-pairing';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createDeviceCredentialStore,
+  credentialKey,
+  type ICredentialBackend,
+  type IDeviceCredential,
+} from '../device-credential-store.js';
+
+/**
+ * REMOTE-012 E3 TC-06 — the browser device-credential store: persist + reload the (non-extractable) device
+ * keypair and the pinned host key, keyed by relay origin + host identity, with no secret ever serialized.
+ * Uses an in-memory backend (Node vitest has no IndexedDB; CryptoKeys are structured-cloneable, no serialize).
+ */
+
+function memoryBackend(): ICredentialBackend & { store: Map<string, IDeviceCredential> } {
+  const store = new Map<string, IDeviceCredential>();
+  return {
+    store,
+    get: (k) => Promise.resolve(store.get(k)),
+    set: (k, v) => {
+      store.set(k, v);
+      return Promise.resolve();
+    },
+    delete: (k) => {
+      store.delete(k);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe('device credential store (REMOTE-012 TC-06)', () => {
+  it('persists and reloads a device keypair + pinned host key, keyed by relayOrigin+hostIdentityId', async () => {
+    const backend = memoryBackend();
+    const store = createDeviceCredentialStore(backend);
+    const deviceKeyPair = await generateIdentityKeyPair(false);
+    const credential: IDeviceCredential = { deviceKeyPair, hostPublicSpki: 'host-spki' };
+
+    expect(await store.get('wss://relay', 'host-1')).toBeUndefined();
+    await store.save('wss://relay', 'host-1', credential);
+
+    const reloaded = await store.get('wss://relay', 'host-1');
+    expect(reloaded?.hostPublicSpki).toBe('host-spki');
+    expect(reloaded?.deviceKeyPair.privateKey).toBe(deviceKeyPair.privateKey);
+    // The reloaded private key is still non-extractable — it can never be serialized out.
+    await expect(
+      globalThis.crypto.subtle.exportKey('jwk', reloaded!.deviceKeyPair.privateKey),
+    ).rejects.toBeTruthy();
+  });
+
+  it('scopes credentials per host and removes on request', async () => {
+    const store = createDeviceCredentialStore(memoryBackend());
+    const a = { deviceKeyPair: await generateIdentityKeyPair(false), hostPublicSpki: 'a' };
+    const b = { deviceKeyPair: await generateIdentityKeyPair(false), hostPublicSpki: 'b' };
+    await store.save('wss://relay', 'host-a', a);
+    await store.save('wss://relay', 'host-b', b);
+    expect((await store.get('wss://relay', 'host-a'))?.hostPublicSpki).toBe('a');
+    expect((await store.get('wss://relay', 'host-b'))?.hostPublicSpki).toBe('b');
+
+    await store.remove('wss://relay', 'host-a');
+    expect(await store.get('wss://relay', 'host-a')).toBeUndefined();
+    expect(await store.get('wss://relay', 'host-b')).toBeTruthy(); // unaffected
+  });
+
+  it('credentialKey composes relay origin + host identity (no URL/secret material)', () => {
+    expect(credentialKey('wss://relay.example', 'host-xyz')).toBe('wss://relay.example|host-xyz');
+  });
+});

--- a/packages/agent-web-ui/src/client/__tests__/rtc-responder-gate-e3.test.ts
+++ b/packages/agent-web-ui/src/client/__tests__/rtc-responder-gate-e3.test.ts
@@ -1,0 +1,165 @@
+import {
+  deriveIdentityId,
+  exportPublicKey,
+  generateIdentityKeyPair,
+  importPublicKey,
+  startHostReconnect,
+  type TReconnectFrame,
+} from '@robota-sdk/agent-remote-pairing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ResponderGate, type IDeviceIdentityConfig } from '../rtc-responder-gate.js';
+
+/**
+ * REMOTE-012 E3 — the browser ResponderGate E3 paths: first-pair ENROLLMENT (pin the host key, advertise the
+ * device key, expose) and client-initiated RECONNECT (verify the host against the pinned key, fail-closed on
+ * a rogue host).
+ */
+
+const FP = { localFingerprint: 'DEV:FP', remoteFingerprint: 'HOST:FP' };
+
+function stubChannel(sink?: (f: unknown) => void): {
+  channel: { send: (d: string) => void; close: () => void };
+  sent: unknown[];
+  closed: () => boolean;
+} {
+  const sent: unknown[] = [];
+  let closed = false;
+  return {
+    channel: {
+      send(d: string): void {
+        const p = JSON.parse(d);
+        sent.push(p);
+        sink?.(p);
+      },
+      close(): void {
+        closed = true;
+      },
+    },
+    sent,
+    closed: () => closed,
+  };
+}
+
+async function deviceIdentity(
+  over: Partial<IDeviceIdentityConfig> = {},
+): Promise<IDeviceIdentityConfig> {
+  const deviceKeyPair = await generateIdentityKeyPair(false);
+  const devicePublicSpki = await exportPublicKey(deviceKeyPair.publicKey);
+  return {
+    deviceKeyPair,
+    deviceId: await deriveIdentityId(devicePublicSpki),
+    devicePublicSpki,
+    onEnrollHost: vi.fn(),
+    ...over,
+  };
+}
+
+describe('ResponderGate E3 first-pair enrollment (REMOTE-012)', () => {
+  it('after B3 accept, pins the host key, advertises the device key, and exposes the session', async () => {
+    const identity = await deviceIdentity();
+    const onAccept = vi.fn();
+    const fakeHandshake = (() => ({
+      result: Promise.resolve({ sessionKey: 'k' }),
+      onFrame: () => {},
+    })) as never;
+    const { channel, sent } = stubChannel();
+
+    const gate = new ResponderGate({
+      channel,
+      secret: 's',
+      ...FP,
+      onMessage: vi.fn(),
+      onAccept,
+      deviceIdentity: identity,
+      startHandshake: fakeHandshake,
+    });
+
+    // Drive B3 to accept (fake handshake already resolved) then the host advertises its key.
+    gate.onInbound(JSON.stringify({ t: 'pair-nonce', nonce: 'n' }));
+    await Promise.resolve();
+    const hostKey = await generateIdentityKeyPair(true);
+    const hostSpki = await exportPublicKey(hostKey.publicKey);
+    gate.onInbound(JSON.stringify({ t: 'enroll-key', spki: hostSpki }));
+
+    await vi.waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+    expect(identity.onEnrollHost).toHaveBeenCalledWith(hostSpki);
+    expect(sent.some((f) => (f as { t?: string }).t === 'enroll-key')).toBe(true);
+  });
+});
+
+describe('ResponderGate E3 reconnect (REMOTE-012)', () => {
+  it('verifies the host and exposes the session against a matching host reconnect controller', async () => {
+    const hostKey = await generateIdentityKeyPair(true);
+    const hostSpki = await exportPublicKey(hostKey.publicKey);
+    const hostIdentityId = await deriveIdentityId(hostSpki);
+    const identity = await deviceIdentity({
+      reconnect: { hostIdentityId, pinnedHostPublicKey: await importPublicKey(hostSpki) },
+    });
+    const devicePub = await importPublicKey(identity.devicePublicSpki);
+
+    // The device (gate) initiates reconnect in its constructor, so the host controller must exist FIRST.
+    let gate!: ResponderGate;
+    const hostCtrl = startHostReconnect({
+      hostIdentityId,
+      localFingerprint: FP.remoteFingerprint,
+      remoteFingerprint: FP.localFingerprint,
+      hostPrivateKey: hostKey.privateKey,
+      resolveDevicePublicKey: async (id) => (id === identity.deviceId ? devicePub : undefined),
+      send: (frame) => gate.onInbound(JSON.stringify(frame)),
+      timeoutMs: 1000,
+    });
+    const { channel } = stubChannel((frame) => hostCtrl.onFrame(frame as TReconnectFrame));
+    const onAccept = vi.fn();
+    gate = new ResponderGate({
+      channel,
+      secret: 's',
+      ...FP,
+      onMessage: vi.fn(),
+      onAccept,
+      deviceIdentity: identity,
+    });
+
+    await hostCtrl.result;
+    await vi.waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+  });
+
+  it('fail-closed: a rogue host (wrong pinned key) → the device rejects and closes', async () => {
+    const realHost = await generateIdentityKeyPair(true);
+    const rogue = await generateIdentityKeyPair(true);
+    const hostSpki = await exportPublicKey(realHost.publicKey);
+    const hostIdentityId = await deriveIdentityId(hostSpki);
+    // Device pinned the ROGUE key, but the real host signs — device verify fails.
+    const identity = await deviceIdentity({
+      reconnect: {
+        hostIdentityId,
+        pinnedHostPublicKey: await importPublicKey(await exportPublicKey(rogue.publicKey)),
+      },
+    });
+    const devicePub = await importPublicKey(identity.devicePublicSpki);
+
+    let gate!: ResponderGate;
+    const hostCtrl = startHostReconnect({
+      hostIdentityId,
+      localFingerprint: FP.remoteFingerprint,
+      remoteFingerprint: FP.localFingerprint,
+      hostPrivateKey: realHost.privateKey,
+      resolveDevicePublicKey: async () => devicePub,
+      send: (frame) => gate.onInbound(JSON.stringify(frame)),
+      timeoutMs: 1000,
+    });
+    const { channel, closed } = stubChannel((frame) => hostCtrl.onFrame(frame as TReconnectFrame));
+    const onReject = vi.fn();
+    gate = new ResponderGate({
+      channel,
+      secret: 's',
+      ...FP,
+      onMessage: vi.fn(),
+      onReject,
+      deviceIdentity: identity,
+    });
+
+    await vi.waitFor(() => expect(onReject).toHaveBeenCalledTimes(1));
+    expect(closed()).toBe(true);
+  });
+});

--- a/packages/agent-web-ui/src/client/device-credential-store.ts
+++ b/packages/agent-web-ui/src/client/device-credential-store.ts
@@ -1,0 +1,95 @@
+/**
+ * Browser device-credential store for TOFU trusted-device reconnect (REMOTE-012 Stage E3).
+ *
+ * Persists, per host, the browser device's **non-extractable** ECDSA keypair AND the pinned host-identity
+ * public key, so a returning device can re-authenticate to the SAME host (verifying the pinned host key)
+ * without re-pairing. Keyed by `relayOrigin | hostIdentityId` (the host identity is `SHA-256(host SPKI)`,
+ * learned at first-pair enrollment). The private key is a non-extractable `CryptoKey` held via IndexedDB's
+ * structured clone — it is NEVER serialized, and NO key/secret value ever touches `location.search`/history
+ * (the store takes plain arguments, not URLs), consistent with the fragment-only-secret discipline.
+ *
+ * The persistence backend is injectable: the default is IndexedDB (browser); tests inject an in-memory
+ * backend (Node vitest has no IndexedDB, and structured-cloneable CryptoKeys need no serialization anyway).
+ */
+
+/** One stored credential: the device keypair (non-extractable private key) + the pinned host public key (SPKI). */
+export interface IDeviceCredential {
+  readonly deviceKeyPair: CryptoKeyPair;
+  readonly hostPublicSpki: string;
+}
+
+/** Minimal async key/value backend the store needs. IndexedDB satisfies it; tests inject a Map-backed fake. */
+export interface ICredentialBackend {
+  get(key: string): Promise<IDeviceCredential | undefined>;
+  set(key: string, value: IDeviceCredential): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface IDeviceCredentialStore {
+  get(relayOrigin: string, hostIdentityId: string): Promise<IDeviceCredential | undefined>;
+  save(relayOrigin: string, hostIdentityId: string, credential: IDeviceCredential): Promise<void>;
+  remove(relayOrigin: string, hostIdentityId: string): Promise<void>;
+}
+
+/** Compose the per-host store key. `relayOrigin` + `hostIdentityId` uniquely identify a paired host. */
+export function credentialKey(relayOrigin: string, hostIdentityId: string): string {
+  return `${relayOrigin}|${hostIdentityId}`;
+}
+
+const DB_NAME = 'robota-remote';
+const STORE_NAME = 'device-credentials';
+
+/** Default IndexedDB backend (browser). Stores the `IDeviceCredential` via structured clone (no serialization). */
+function createIndexedDbBackend(indexed: IDBFactory = globalThis.indexedDB): ICredentialBackend {
+  function open(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = indexed.open(DB_NAME, 1);
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+          request.result.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error('indexedDB open failed'));
+    });
+  }
+
+  async function tx<T>(
+    mode: IDBTransactionMode,
+    run: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    const db = await open();
+    try {
+      return await new Promise<T>((resolve, reject) => {
+        const request = run(db.transaction(STORE_NAME, mode).objectStore(STORE_NAME));
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error('indexedDB request failed'));
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  return {
+    get: (key) => tx('readonly', (s) => s.get(key) as IDBRequest<IDeviceCredential | undefined>),
+    set: async (key, value) => {
+      await tx('readwrite', (s) => s.put(value, key) as IDBRequest<IDBValidKey>);
+    },
+    delete: async (key) => {
+      await tx('readwrite', (s) => s.delete(key) as IDBRequest<undefined>);
+    },
+  };
+}
+
+/** Create the device-credential store over a backend (default: IndexedDB). */
+export function createDeviceCredentialStore(
+  backend: ICredentialBackend = createIndexedDbBackend(),
+): IDeviceCredentialStore {
+  return {
+    get: (relayOrigin, hostIdentityId) => backend.get(credentialKey(relayOrigin, hostIdentityId)),
+    save: (relayOrigin, hostIdentityId, credential) =>
+      backend.set(credentialKey(relayOrigin, hostIdentityId), credential),
+    remove: (relayOrigin, hostIdentityId) =>
+      backend.delete(credentialKey(relayOrigin, hostIdentityId)),
+  };
+}

--- a/packages/agent-web-ui/src/client/rtc-responder-gate.ts
+++ b/packages/agent-web-ui/src/client/rtc-responder-gate.ts
@@ -1,17 +1,27 @@
 /**
- * Responder-side pairing gate for the browser remote client (REMOTE-009 Stage D) — the client dual of the
- * host `PairingGate`. The browser is the WebRTC ANSWERER ≡ pairing RESPONDER. It phase-separates the data
- * channel: pre-accept it carries ONLY pairing frames (routed to `startPairingHandshake({role:'responder'})`;
- * any non-pairing frame is DROPPED), and only after the handshake accepts does it deliver `TServerMessage`s to
- * the UI and allow `send(TClientMessage)`. Fail-closed: on reject/timeout it closes the channel and delivers
- * nothing.
+ * Responder-side pairing gate for the browser remote client (REMOTE-009 Stage D; extended for REMOTE-012
+ * Stage E3 TOFU reconnect) — the client dual of the host `PairingGate`. The browser is the WebRTC ANSWERER ≡
+ * pairing RESPONDER. It phase-separates the data channel: pre-accept it carries ONLY pairing/reconnect frames
+ * (non-admission frames are DROPPED); only after accept does it deliver `TServerMessage`s to the UI and allow
+ * `send(TClientMessage)`. Fail-closed: on reject/timeout it closes the channel and delivers nothing.
  *
- * Kept standalone (not inlined in `createRtcSessionClient`) so the routing/fail-closed logic is unit-testable
- * with a stub channel + real `agent-remote-pairing`, exactly like the host `PairingGate`. The Node responder in
- * `agent-transport-webrtc/src/__tests__/pairing-e2e.test.ts` is the algorithm oracle.
+ * Two admission modes (E3), decided by whether a credential exists for this host:
+ * - **first-pair** (default): the B3 handshake, then — when `deviceIdentity` is present — an identity-key
+ *   **enrollment** exchange (pin the host's advertised key; send the device's public key) before the session
+ *   is exposed;
+ * - **reconnect** (`deviceIdentity.reconnect` present): the client initiates {@link startDeviceReconnect},
+ *   verifies the host against the pinned host key (rogue-host → fail closed), and only then exposes the session.
+ *
+ * Without `deviceIdentity` the gate is exactly the REMOTE-009 first-pair-only gate.
  */
 
-import { startPairingHandshake, type TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import {
+  importPublicKey,
+  startDeviceReconnect,
+  startPairingHandshake,
+  type TPairingFrame,
+  type TReconnectFrame,
+} from '@robota-sdk/agent-remote-pairing';
 
 import type { TServerMessage, TClientMessage } from '@robota-sdk/agent-transport-protocol';
 
@@ -19,6 +29,22 @@ import type { TServerMessage, TClientMessage } from '@robota-sdk/agent-transport
 export interface IResponderChannel {
   send(data: string): void;
   close(): void;
+}
+
+/** E3 device identity config. When present, first-pair enrolls; when `reconnect` is set, the client reconnects. */
+export interface IDeviceIdentityConfig {
+  readonly deviceKeyPair: CryptoKeyPair;
+  /** `SHA-256(device SPKI)` — sent in the clear on reconnect / used to enroll. */
+  readonly deviceId: string;
+  /** base64url device public SPKI — advertised to the host at first-pair enrollment. */
+  readonly devicePublicSpki: string;
+  /** First-pair: pin the host's advertised public key (persist the credential). */
+  readonly onEnrollHost: (hostPublicSpki: string) => void;
+  /** Reconnect (client-initiated) config — present only when a credential for this host already exists. */
+  readonly reconnect?: {
+    readonly hostIdentityId: string;
+    readonly pinnedHostPublicKey: CryptoKey;
+  };
 }
 
 export interface IResponderGateOptions {
@@ -29,12 +55,15 @@ export interface IResponderGateOptions {
   readonly timeoutMs?: number;
   /** Deliver a session server message to the UI (only ever called post-accept). */
   readonly onMessage: (msg: TServerMessage) => void;
-  /** Pairing accepted — the session is now co-driveable. */
+  /** Pairing/reconnect accepted — the session is now co-driveable. */
   readonly onAccept?: () => void;
-  /** Pairing rejected/timed out — the channel is closed, nothing exposed. */
+  /** Pairing/reconnect rejected/timed out — the channel is closed, nothing exposed. */
   readonly onReject?: () => void;
-  /** Injection seam (defaults to the real handshake) — for tests. */
+  /** REMOTE-012 E3: device identity config. Absent → REMOTE-009 first-pair-only behavior (unchanged). */
+  readonly deviceIdentity?: IDeviceIdentityConfig;
+  /** Injection seams (default to the real handshakes) — for tests. */
   readonly startHandshake?: typeof startPairingHandshake;
+  readonly startReconnect?: typeof startDeviceReconnect;
 }
 
 function isPairingFrame(value: unknown): value is TPairingFrame {
@@ -43,52 +72,64 @@ function isPairingFrame(value: unknown): value is TPairingFrame {
   return t === 'pair-nonce' || t === 'pair-confirm';
 }
 
-type TGateState = 'pairing' | 'accepted' | 'closed';
+function isReconnectFrame(value: unknown): value is TReconnectFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  return (value as { t?: unknown }).t === 'rc-host';
+}
+
+function isEnrollFrame(value: unknown): value is { t: 'enroll-key'; spki: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { t?: unknown }).t === 'enroll-key' &&
+    typeof (value as { spki?: unknown }).spki === 'string'
+  );
+}
+
+type TGateState = 'pairing' | 'enrolling' | 'reconnecting' | 'accepted' | 'closed';
 
 export class ResponderGate {
   private state: TGateState = 'pairing';
-  private readonly controller: ReturnType<typeof startPairingHandshake>;
+  private pairingController?: ReturnType<typeof startPairingHandshake>;
+  private reconnectController?: ReturnType<typeof startDeviceReconnect>;
 
   constructor(private readonly options: IResponderGateOptions) {
-    const start = options.startHandshake ?? startPairingHandshake;
-    this.controller = start({
-      secret: options.secret,
-      role: 'responder',
-      localFingerprint: options.localFingerprint,
-      remoteFingerprint: options.remoteFingerprint,
-      send: (frame) => this.safeSend(JSON.stringify(frame)),
-      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-    });
-    this.controller.result.then(
-      () => this.accept(),
-      () => this.rejectAndClose(),
-    );
+    if (options.deviceIdentity?.reconnect) {
+      this.state = 'reconnecting';
+      this.startReconnect(options.deviceIdentity, options.deviceIdentity.reconnect);
+    } else {
+      this.startFirstPair();
+    }
   }
 
-  /** Route one inbound channel frame (pre-accept: pairing → handshake, else drop; post-accept: session). */
+  /** Route one inbound channel frame. Pre-accept: admission frames → controller; else drop. Post-accept: session. */
   onInbound(data: string): void {
     if (this.state === 'closed') return;
-    if (this.state === 'accepted') {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(data);
-      } catch {
-        return;
-      }
-      this.options.onMessage(parsed as TServerMessage);
-      return;
-    }
-    // pairing phase — only pairing frames pass; anything else is dropped (fail-closed).
     let parsed: unknown;
     try {
       parsed = JSON.parse(data);
     } catch {
       return;
     }
-    if (isPairingFrame(parsed)) this.controller.onFrame(parsed);
+    if (this.state === 'accepted') {
+      this.options.onMessage(parsed as TServerMessage);
+      return;
+    }
+    if (this.state === 'pairing') {
+      if (isPairingFrame(parsed)) this.pairingController?.onFrame(parsed);
+      return;
+    }
+    if (this.state === 'reconnecting') {
+      if (isReconnectFrame(parsed)) this.reconnectController?.onFrame(parsed);
+      return;
+    }
+    if (this.state === 'enrolling') {
+      if (isEnrollFrame(parsed)) this.completeEnrollment(parsed.spki);
+      return;
+    }
   }
 
-  /** Send a client message to the host — only after pairing accepts (no-op before/after). */
+  /** Send a client message to the host — only after accept (no-op before/after). */
   send(msg: TClientMessage): void {
     if (this.state !== 'accepted') return;
     this.safeSend(JSON.stringify(msg));
@@ -101,8 +142,78 @@ export class ResponderGate {
     this.safeClose();
   }
 
-  private accept(): void {
+  private startFirstPair(): void {
+    const start = this.options.startHandshake ?? startPairingHandshake;
+    this.state = 'pairing';
+    this.pairingController = start({
+      secret: this.options.secret,
+      role: 'responder',
+      localFingerprint: this.options.localFingerprint,
+      remoteFingerprint: this.options.remoteFingerprint,
+      send: (frame) => this.safeSend(JSON.stringify(frame)),
+      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
+    });
+    this.pairingController.result.then(
+      () => this.onFirstPairAccepted(),
+      () => this.rejectAndClose(),
+    );
+  }
+
+  private startReconnect(
+    identity: IDeviceIdentityConfig,
+    pinned: NonNullable<IDeviceIdentityConfig['reconnect']>,
+  ): void {
+    const start = this.options.startReconnect ?? startDeviceReconnect;
+    this.reconnectController = start({
+      deviceId: identity.deviceId,
+      hostIdentityId: pinned.hostIdentityId,
+      localFingerprint: this.options.localFingerprint,
+      remoteFingerprint: this.options.remoteFingerprint,
+      devicePrivateKey: identity.deviceKeyPair.privateKey,
+      pinnedHostPublicKey: pinned.pinnedHostPublicKey,
+      send: (frame) => this.safeSend(JSON.stringify(frame)),
+      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
+    });
+    this.reconnectController.result.then(
+      () => this.accept(),
+      () => this.rejectAndClose(),
+    );
+  }
+
+  /** B3 handshake accepted. Without E3: expose. With E3: wait for the host's enroll-key, pin it, reply, expose. */
+  private onFirstPairAccepted(): void {
     if (this.state !== 'pairing') return;
+    if (!this.options.deviceIdentity) {
+      this.accept();
+      return;
+    }
+    this.state = 'enrolling';
+    // The host advertises its identity key first (host sends enroll-key on its accept); we reply after pinning.
+  }
+
+  private completeEnrollment(hostSpki: string): void {
+    if (this.state !== 'enrolling') return;
+    const identity = this.options.deviceIdentity;
+    if (!identity) {
+      this.rejectAndClose();
+      return;
+    }
+    void (async (): Promise<void> => {
+      try {
+        // Validate the host SPKI parses as a public key before pinning (fail closed on garbage).
+        await importPublicKey(hostSpki);
+        if (this.state !== 'enrolling') return;
+        identity.onEnrollHost(hostSpki);
+        this.safeSend(JSON.stringify({ t: 'enroll-key', spki: identity.devicePublicSpki }));
+        this.accept();
+      } catch {
+        this.rejectAndClose();
+      }
+    })();
+  }
+
+  private accept(): void {
+    if (this.state === 'closed' || this.state === 'accepted') return;
     this.state = 'accepted';
     this.options.onAccept?.();
   }

--- a/packages/agent-web-ui/src/client/rtc-session-client.ts
+++ b/packages/agent-web-ui/src/client/rtc-session-client.ts
@@ -11,11 +11,17 @@
  * `agent-transport-webrtc/src/__tests__/pairing-e2e.test.ts`.
  */
 
-import { extractDtlsFingerprint } from '@robota-sdk/agent-remote-pairing';
+import {
+  deriveIdentityId,
+  exportPublicKey,
+  extractDtlsFingerprint,
+  generateIdentityKeyPair,
+} from '@robota-sdk/agent-remote-pairing';
 
-import { ResponderGate } from './rtc-responder-gate.js';
+import { ResponderGate, type IDeviceIdentityConfig } from './rtc-responder-gate.js';
 import { createRtcSignalingClient, type ISignalingClient } from './rtc-signaling.js';
 
+import type { IDeviceCredentialStore } from './device-credential-store.js';
 import type { startPairingHandshake } from '@robota-sdk/agent-remote-pairing';
 import type { TServerMessage, TClientMessage } from '@robota-sdk/agent-transport-protocol';
 
@@ -49,10 +55,23 @@ export interface IRtcSessionClientOptions {
   readonly iceServers?: RTCIceServer[];
   /** REMOTE-010: restrict ICE to relay candidates (`iceTransportPolicy: 'relay'`); requires a TURN server. */
   readonly forceTurn?: boolean;
+  /** REMOTE-012 E3: browser credential store. When set, first-pair ENROLLS this device (pins the host key +
+   *  advertises the device key) so a future reconnect (E4) can skip re-pairing. Absent → REMOTE-009 behavior. */
+  readonly deviceCredentials?: IDeviceCredentialStore;
   /** Injection seams (default to the real implementations) — for tests. */
   readonly createSignaling?: typeof createRtcSignalingClient;
   readonly createPeer?: (config?: RTCConfiguration) => RTCPeerConnection;
   readonly startHandshake?: typeof startPairingHandshake;
+  readonly generateDeviceKeyPair?: () => Promise<CryptoKeyPair>;
+}
+
+/** Stable origin for the credential-store key (falls back to the raw url if it does not parse). */
+function originOf(relayUrl: string): string {
+  try {
+    return new URL(relayUrl).origin;
+  } catch {
+    return relayUrl;
+  }
 }
 
 export function createRtcSessionClient(
@@ -75,6 +94,53 @@ export function createRtcSessionClient(
     if (status !== 'failed') setStatus('failed');
   };
 
+  /**
+   * REMOTE-012 E3: build the device-identity config for first-pair enrollment — a fresh device keypair whose
+   * public key is advertised to the host, and an `onEnrollHost` that pins the host's key + persists the
+   * credential (keyed by relay origin + host identity). Reconnect INITIATION (reusing a stored credential) is
+   * E4; E3 only enrolls. Returns undefined when no credential store is configured (REMOTE-009 behavior).
+   */
+  async function buildDeviceIdentity(): Promise<IDeviceIdentityConfig | undefined> {
+    const store = options.deviceCredentials;
+    if (!store) return undefined;
+    const deviceKeyPair = await (
+      options.generateDeviceKeyPair ?? (() => generateIdentityKeyPair(false))
+    )();
+    const devicePublicSpki = await exportPublicKey(deviceKeyPair.publicKey);
+    const relayOrigin = originOf(options.relayUrl);
+    return {
+      deviceKeyPair,
+      deviceId: await deriveIdentityId(devicePublicSpki),
+      devicePublicSpki,
+      onEnrollHost: (hostPublicSpki: string) => {
+        void (async (): Promise<void> => {
+          const hostIdentityId = await deriveIdentityId(hostPublicSpki);
+          await store.save(relayOrigin, hostIdentityId, { deviceKeyPair, hostPublicSpki });
+        })();
+      },
+    };
+  }
+
+  function makeGate(
+    channel: RTCDataChannel,
+    deviceIdentity?: IDeviceIdentityConfig,
+  ): ResponderGate {
+    return new ResponderGate({
+      channel: { send: (d) => channel.send(d), close: () => channel.close() },
+      secret: options.secret,
+      localFingerprint: localFingerprint as string,
+      remoteFingerprint: remoteFingerprint as string,
+      onMessage: callbacks.onMessage,
+      onAccept: () => {
+        setStatus('connected');
+        gate?.send({ type: 'get-messages' }); // request full history on connect (mirrors the WS client)
+      },
+      onReject: fail,
+      ...(deviceIdentity ? { deviceIdentity } : {}),
+      ...(options.startHandshake ? { startHandshake: options.startHandshake } : {}),
+    });
+  }
+
   function wireDataChannel(channel: RTCDataChannel): void {
     if (!remoteFingerprint || !localFingerprint) {
       // Fingerprints must be known before the channel opens (post-answer). If not, fail closed.
@@ -87,23 +153,30 @@ export function createRtcSessionClient(
       return;
     }
     setStatus('pairing');
-    gate = new ResponderGate({
-      channel: { send: (d) => channel.send(d), close: () => channel.close() },
-      secret: options.secret,
-      localFingerprint,
-      remoteFingerprint,
-      onMessage: callbacks.onMessage,
-      onAccept: () => {
-        setStatus('connected');
-        gate?.send({ type: 'get-messages' }); // request full history on connect (mirrors the WS client)
-      },
-      onReject: fail,
-      ...(options.startHandshake ? { startHandshake: options.startHandshake } : {}),
-    });
+
+    if (!options.deviceCredentials) {
+      // REMOTE-009 path — synchronous, unchanged.
+      gate = makeGate(channel);
+      channel.onmessage = (event: MessageEvent): void => {
+        const data = event.data;
+        gate?.onInbound(typeof data === 'string' ? data : String(data));
+      };
+      return;
+    }
+
+    // E3 path — the device keypair is async, so buffer inbound frames until the gate exists (werift/native do
+    // not buffer pre-subscription, and the enrollment build is a microtask or two).
+    const buffered: string[] = [];
     channel.onmessage = (event: MessageEvent): void => {
-      const data = event.data;
-      gate?.onInbound(typeof data === 'string' ? data : String(data));
+      const data = typeof event.data === 'string' ? event.data : String(event.data);
+      if (gate) gate.onInbound(data);
+      else buffered.push(data);
     };
+    void (async (): Promise<void> => {
+      const deviceIdentity = await buildDeviceIdentity();
+      gate = makeGate(channel, deviceIdentity);
+      for (const data of buffered) gate.onInbound(data);
+    })();
   }
 
   async function handleOffer(offer: RTCSessionDescriptionInit): Promise<void> {

--- a/packages/agent-web-ui/src/hooks/useWsSession.ts
+++ b/packages/agent-web-ui/src/hooks/useWsSession.ts
@@ -3,7 +3,7 @@
  * reconstructs conversation state from TServerMessage events.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 
 import {
   applyPromptEvent,
@@ -11,6 +11,7 @@ import {
   permissionResponse,
   type TPendingPrompt,
 } from './prompt-state.js';
+import { createDeviceCredentialStore } from '../client/device-credential-store.js';
 import {
   createRtcSessionClient,
   type IRtcSessionClientOptions,
@@ -229,6 +230,8 @@ export function useRtcSession(
   >,
 ): IWsSessionState {
   const { relayUrl, rendezvous, secret, iceServers, forceTurn } = options;
+  // REMOTE-012 E3: a stable per-session credential store (IndexedDB) so first-pair enrolls this device.
+  const deviceCredentials = useMemo(() => createDeviceCredentialStore(), []);
   const makeClient = useCallback<TMakeSessionClient>(
     (cb) =>
       createRtcSessionClient(
@@ -238,10 +241,11 @@ export function useRtcSession(
           secret,
           ...(iceServers ? { iceServers } : {}),
           ...(forceTurn ? { forceTurn } : {}),
+          deviceCredentials,
         },
         cb,
       ),
-    [relayUrl, rendezvous, secret, iceServers, forceTurn],
+    [relayUrl, rendezvous, secret, iceServers, forceTurn, deviceCredentials],
   );
   return useSessionClient(makeClient);
 }


### PR DESCRIPTION
Stage E3 of REMOTE-001 — **Trust On First Use trusted-device reconnect**: after a first pairing + explicit host accept, the host remembers the device (and the device pins the host) so a return visit re-authenticates **mutually** without re-pairing; unknown/revoked devices fail closed.

### Design (proposal-reviewer ENDORSE, 2 rounds)
**Mutual asymmetric public-key pinning.** First pair, over the B3-confirmed channel, the device and host exchange + pin each other's ECDSA-P256 **public** keys. On reconnect BOTH sides sign a fresh, DTLS-fingerprint-bound challenge (`deviceId ‖ hostIdentityId ‖ nonceHost ‖ nonceDevice ‖ sortedPair(fp)`) and verify the other against the pinned key before accepting.
- **Trust-store leak → no impersonation:** the host stores device public keys only.
- **Rogue host → device fails closed:** the device verifies the host's pinned key (round-2 fix: reconnect was one-way; now mutual, restoring B3's guarantee).
- **MITM relay → fingerprint binding; replay → fresh per-side nonces.**

### What ships
- **`agent-remote-pairing`** (isomorphic, WebCrypto-only): `device-identity.ts` (keygen/SPKI/JWK/`deriveIdentityId`/`signChallenge`/`verifyChallenge`), `reconnect.ts` (mutual `startDeviceReconnect`/`startHostReconnect`), `crypto-primitives.ts` (SSOT extract).
- **`agent-cli`**: `host-identity.ts` (0600 JWK, SSH-host-key model), `trusted-device-store.ts` (public keys only, fail-fast), controller enroll/reconnect wiring, `/remote-control devices` + `revoke <id>` verbs (revocation = the device-theft compensating control).
- **`agent-transport-webrtc`**: `pairing-gate.ts` reactive E3 mode (first-pair-with-enrollment vs mutual reconnect); B4 path byte-for-byte unchanged when no reconnect config.
- **`agent-web-ui`**: `device-credential-store.ts` (IndexedDB, non-extractable device key, no serialization), `ResponderGate` E3, session-client/hook wiring.

### E3/E4 boundary
E3 delivers the identity/trust/auth layer + persistence + enrollment + the mutual reconnect **protocol** (both gates). The transport-level reconnection **loop** (stable-rendezvous rediscovery + auto-reconnect + session resume) is **E4 (REMOTE-013)**. `sessionKey` is reserved for E4 (not consumed here).

### Verification
Per-package vitest: agent-remote-pairing 28, agent-transport-webrtc 27, agent-cli 200, agent-web-ui 54, agent-command 225, agent-framework 1080. Full `pnpm typecheck` clean; `pnpm harness:scan` **49/49**.

Spec: `.agents/spec-docs/active/REMOTE-012-stage-e3-tofu-trusted-device-reconnect.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)