### PR TITLE
release(gui): promote agent-gui Stage 1 + GUI-001 backlog to main (GUI-002)

### DIFF
--- a/.agents/backlog/GUI-001-agent-gui-desktop-thin-layer.md
+++ b/.agents/backlog/GUI-001-agent-gui-desktop-thin-layer.md
@@ -1,0 +1,74 @@
+---
+title: 'GUI-001: agent-gui — a thin GUI layer (mirroring the TUI) + desktop app'
+status: todo
+created: 2026-07-12
+priority: medium
+urgency: later
+area: packages/(new agent-transport-gui), apps/(new agent-gui desktop)
+depends_on: []
+---
+
+# GUI-001: agent-gui — a thin GUI presentation layer + desktop app
+
+> **This item is research-first.** It is NOT ready to implement directly — it goes through the spec gate
+> (`.agents/spec-docs/draft/<TYPE>-*.md` → GATE-WRITE → GATE-APPROVAL) before any code, exactly like
+> REMOTE-001. Requested 2026-07-12; sequenced AFTER Stage E of REMOTE-001 (REMOTE-011..014) completes.
+
+## Problem / Goal
+
+`agent-cli` drives a live `IInteractiveSession` through a **thin TUI presentation layer**
+(`@robota-sdk/agent-transport-tui` — `renderApp`, `createDefaultTuiCliAdapter`, `TuiInteractionChannel`),
+which is a display/interaction adapter over the transport-neutral session contract
+(`@robota-sdk/agent-interface-transport`). The session logic, command routing, permission/ask prompts, and
+co-drive attribution (REMOTE-014) all live BELOW the presentation layer; the TUI is "just another surface".
+
+Goal: build **`agent-gui`** — a graphical desktop application driven by the SAME session contract, with a
+**thin GUI presentation layer that mirrors the TUI layer's role and architecture** as closely as possible
+(same seams: an interaction channel over the session, a default adapter, command/permission/ask rendering,
+the OWNER PRINCIPLE local == remote). The end deliverable is a **desktop app** (the shell tech —
+Tauri/Electron/other — is a research decision, see below). Reuse, don't fork: the browser remote surface
+(`@robota-sdk/agent-web-ui`, React) already renders a session over the WS/RTC transport with
+permission/ask + attribution, so the GUI layer should share as much of that React surface + the transport
+contract as sensible, rather than re-implement session logic.
+
+## Execution Plan (research-first)
+
+1. **Research phase (read-only).**
+   - Study the TUI thin-layer seam: `agent-transport-tui` (`renderApp`, `createDefaultTuiCliAdapter`,
+     `TuiInteractionChannel`, plugin/command/permission handlers) and how `agent-cli` composes it
+     (`packages/agent-cli/src/cli.ts`). Extract the exact "presentation-layer contract" the GUI must satisfy.
+   - Study the existing React session surface (`agent-web-ui`: `SessionMonitor`, `useWsSession`/`useRtcSession`,
+     `PermissionPrompt`, message rendering) — the natural GUI rendering substrate, and what it already covers
+     (REMOTE-007 permission/ask, REMOTE-014 driver attribution).
+   - Desktop shell options: **Tauri** (Rust core, small binary, webview UI — aligns with the DIST-001 Bun/native
+     direction) vs **Electron** (Node runtime, larger) vs other. Evaluate against: the repo's ESM/pnpm/strict-TS
+     constraints, the INFRA-028 self-contained bundle + DIST-00x native/Bun distribution direction, node-side
+     deps the session needs, and packaging/signing per-OS. Deliverable: a findings doc + a recommended
+     architecture feeding the spec.
+2. **Spec phase (gate).** Author `.agents/spec-docs/draft/*` and take it through GATE-APPROVAL
+   (proposal-reviewer ENDORSE). Decide: the new package boundary (`agent-transport-gui` presentation layer vs
+   reusing `agent-web-ui`), the desktop shell, how the GUI hosts the session (in-process node vs a local
+   agent-server the GUI connects to), the command/permission/ask surface, and packaging.
+3. **Development phase (gated stages).** Build the thin GUI presentation layer + the `agent-gui` desktop app
+   as gated stages with tests, mirroring the TUI layer's seams.
+
+## Open Questions (resolve in the spec)
+
+- Package shape: a new `@robota-sdk/agent-transport-gui` presentation layer mirroring `agent-transport-tui`,
+  or does `agent-web-ui` already ARE the GUI layer (React) — is the desktop app just a shell hosting it?
+- Session hosting: does the GUI run the `IInteractiveSession` in-process (like `agent-cli` + TUI) or does it
+  connect to a local `agent-server`/`remote-signaling`-style transport (reusing the WS/RTC surface)?
+- Desktop shell: Tauri vs Electron vs other — bundle size, native-dep story, per-OS packaging/signing,
+  alignment with DIST-001/002/003 (Bun single-binary) and INFRA-028.
+- Dependency direction: the GUI layer must consume `agent-interface-transport` (contract) + reuse the session,
+  never invert it. Frontend rule: React only (VitePress is the sole Vue exception) — the GUI uses React.
+- Reuse vs fork of `agent-web-ui` components (SessionMonitor/PermissionPrompt/attribution render).
+
+## Notes
+
+- Mirror the TUI's "just another surface over the transport-neutral session" architecture — the OWNER
+  PRINCIPLE (local == remote; REMOTE-006) and the co-drive attribution (REMOTE-014) apply to the GUI as a
+  driver surface too.
+- Keep the presentation layer thin: no session/command/permission logic in the GUI — those live in
+  `agent-framework` / `agent-interface-transport` / the command layer, exactly as for the TUI.
+- Sequenced after REMOTE-001 Stage E; coordinate with the DIST-00x desktop/binary distribution backlog.

--- a/.agents/backlog/SEC-001-default-loopback-ws-auth.md
+++ b/.agents/backlog/SEC-001-default-loopback-ws-auth.md
@@ -1,0 +1,52 @@
+---
+title: 'SEC-001: authenticate the default (defaultEnabled) loopback WebSocket path'
+status: todo
+created: 2026-07-12
+priority: high
+urgency: soon
+area: packages/agent-transport-ws, packages/agent-web-ui, packages/agent-cli
+depends_on: []
+---
+
+# SEC-001: authenticate the default loopback WebSocket path
+
+> Filed by GUI-002 (companion SECURITY backlog). GUI-002 closed the unauthenticated-loopback hole **only
+> for its own Electron-spawned sidecar** (via a required per-launch token on `WsTransport`). The **default**
+> `defaultEnabled: true` localhost path — used by the plain TUI (`agent-cli`) and `apps/agent-web` — remains
+> unauthenticated and is tracked here rather than changed silently under GUI-002.
+
+## Problem / Goal
+
+`WsTransport` runs with `defaultEnabled: true` and, when no token is configured, binds
+`new WebSocketServer({ server })` on `127.0.0.1:7070` with **no auth**: every connection immediately
+receives full history + the execution-workspace snapshot and is wired to `createWsHandler`, which can
+`submit`, `executeCommand`, and **answer permission/ask prompts**. Because browser `WebSocket` connections
+are not gated by CORS, **any local process — or any web page open in any browser on the machine — can reach
+`ws://127.0.0.1:7070` and fully drive/authorize a running session.** Since permission-answering _is_ the
+authorization gate, this is a standing OWNER-PRINCIPLE exposure on the default path.
+
+GUI-002 added the mechanism to fix it (`IWsTransportConfig.token` → reject-before-emit, constant-time
+compare) but deliberately left the default path unchanged to avoid scope-creep and a behavior change to the
+existing TUI/web flows. This item decides and implements the default-path story.
+
+## Open Questions (resolve in the spec)
+
+- **Default posture:** should `WsTransport` mint a token automatically when none is supplied (secure by
+  default, print/expose it for the local client), or stay open-by-default and require opt-in? Weigh against
+  the existing TUI/`apps/agent-web` flows that connect with no token today.
+- **Local client token delivery:** how do `agent-cli`'s own consumers and `apps/agent-web` obtain the token
+  (a token file with `0600` perms in the user dir? a printed URL? an env handshake?) without breaking the
+  zero-config local dev experience.
+- **Origin/loopback hardening beyond the token:** should the server also check `Origin` / reject non-loopback
+  `Host` as defense-in-depth?
+- **Backwards compatibility:** a flag / settings toggle for the transition, and whether `defaultEnabled`
+  should remain `true`.
+
+## Notes
+
+- The reject-before-emit token mechanism already exists on `WsTransport` (GUI-002); this item is primarily a
+  policy + client-delivery decision for the DEFAULT path, plus wiring `apps/agent-web` / the TUI client to
+  present the token.
+- Coordinate with REMOTE-001 (the WebRTC/remote path already has its own pairing auth; this is only the
+  localhost WS path).
+- Research-first is NOT required (the mechanism is built); go straight to the spec gate for the policy call.

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -54,7 +54,8 @@ apps/
 ├── www/                    # Marketing site (robota.io)
 ├── agent-server/           # AI provider proxy + Playground WebSocket
 ├── dag-runtime-server/     # Native DAG runtime HTTP server (`/v1/dag/*` over Hono); serves dag-framework's IDagOrchestrationPort, native runtime surface, no external-runtime API (WORKFLOW-002)
-└── remote-signaling/       # Minimal content-blind WebRTC signaling relay (SDP/ICE rendezvous); dumb relay, no @robota-sdk deps, no session content (REMOTE-001/002 Stage A)
+├── remote-signaling/       # Minimal content-blind WebRTC signaling relay (SDP/ICE rendezvous); dumb relay, no @robota-sdk deps, no session content (REMOTE-001/002 Stage A)
+└── agent-gui/              # Electron desktop shell (macOS/Linux/Windows); thin presentation surface that spawns a robota loopback-WS sidecar (required nonce auth) and reuses agent-web-ui; NO agent-framework/agent-core dep (GUI-002)
 ```
 
 ## Library Neutrality Rule (packages/ vs apps/)

--- a/.agents/spec-docs/active/GUI-002-agent-gui-electron-sidecar-foundation.md
+++ b/.agents/spec-docs/active/GUI-002-agent-gui-electron-sidecar-foundation.md
@@ -1,0 +1,486 @@
+---
+status: in-progress
+type: INFRA
+tags: [desktop, electron, sidecar, gui, react, websocket]
+---
+
+# GUI-002: agent-gui — Electron + sidecar foundation (Stage 1 MVP)
+
+> Parent: [GUI-001](../../backlog/completed/) research-first backlog. This is the **foundational
+> architecture spec** for `agent-gui` and the **Stage 1 MVP** it authorizes. It records the two
+> owner-decided forks (Electron shell; spawn-the-CLI-sidecar hosting) so GATE-APPROVAL reviews the
+> decision, then authorizes a first buildable stage. Later stages (per-OS packaging/signing, richer
+> co-drive UI, in-process option if ever wanted) are separate specs.
+>
+> **Fork A revised (2026-07-12):** the shell was flipped **Tauri v2 → Electron** at the owner's direction
+> ("Node 생태계를 최대한 활용") after research showed every system-webview shell (Tauri/webview-nodejs/
+> electrobun) forces a non-Node toolchain (Rust/Bun) or a native addon — reintroducing exactly what
+> INFRA-028/DIST-001 avoid, and Rust does not even build in the current CI. Electron is the only option
+> satisfying all-Node + no-native-addon + builds-in-plain-Node-CI + mature signing. Sidecar model (Fork B),
+> the required nonce auth, and agent-web-ui reuse are unchanged. Re-endorsed by proposal-review (see
+> Evidence Log).
+
+## Problem
+
+`agent-cli` drives a live `IInteractiveSession` through a **thin TUI presentation layer**
+(`@robota-sdk/agent-transport-tui`) — a display/interaction surface over the transport-neutral session
+contract (`@robota-sdk/agent-interface-transport`). Session logic, command routing, permission/ask
+prompts (REMOTE-007), and co-drive attribution (REMOTE-014) all live BELOW the presentation layer; the
+TUI is "just another surface".
+
+**Concrete symptom / gap:** there is no graphical surface today — the only way to drive a session is the
+terminal TUI (`agent-cli`). A user who wants a windowed desktop app (`agent-gui` in the dock/Start menu,
+clickable permission prompts, no terminal) has nothing to run; `apps/` contains no desktop shell and no
+`robota`-driven GUI application.
+
+We want **`agent-gui`**: a graphical **desktop application** driven by the SAME session contract, whose
+GUI presentation layer mirrors the TUI layer's role and architecture (same seams, the OWNER PRINCIPLE
+local == remote). The hard question is not "how do we render a session" — a React surface that renders a
+live session over the wire **already exists** (`@robota-sdk/agent-web-ui`: conversation, tools, streaming,
+permission/ask, driver-attribution chips) — but **how a desktop app should host the session and which
+shell technology to use**, without duplicating session logic or forking the distribution direction.
+
+## Architecture Review
+
+### Affected Scope
+
+Research (GUI-001 phase 1, read-only) established the reusable substrate and the decision space:
+
+- **The TUI presentation-layer contract** (what a GUI surface must satisfy): construct or receive an
+  `IInteractiveSession`; subscribe to the 15 `IInteractiveSessionEvents`
+  (`user_message`, `text_delta`, `tool_start`/`tool_end`, `thinking`, `complete`, `interrupted`,
+  `error`, `context_update`, `compact`, `skill_activation`, `memory_event`,
+  `execution_workspace_event`, and the REMOTE-007 trio `permission_request`/`ask_request`/
+  `prompt_resolved`) and fold them into a view model; drive via `submit` / `executeCommand` / `abort` /
+  `cancelQueue` / `shutdown` / `getFullHistory` / `getContextState` /
+  `getExecutionWorkspaceSnapshot`; render + answer permission via `resolvePermission(id,result)` and ask
+  via `resolveAsk(id,response)`, dismissing on `prompt_resolved`.
+- **`agent-web-ui` already implements ~80–90% of this** as a browser-only React library. Its
+  `useSessionClient(makeClient)` reducer is **transport-agnostic** (a pluggable `TMakeSessionClient`
+  factory over `{onMessage(TServerMessage), onStatusChange}`); it ships a WS client
+  (`createWsSessionClient`, localhost sidecar) and a WebRTC client. `ConversationView`,
+  `PermissionPrompt`, `AgentActivityPanel`, `prompt-state` cover REMOTE-007 + REMOTE-014 today.
+  Dependencies are browser-clean (no `node:` imports; React + the three transport-contract packages).
+- **The session is Node-side** (providers, tools, `node:fs`, `child_process` for subagent worktrees,
+  `ws`, `werift`). A pure system-webview (Tauri) cannot host it in-process — but it need not: agent-cli
+  already exposes the session as a **loopback WebSocket server** (`WsTransport`, `127.0.0.1:7070`,
+  `defaultEnabled:true`), and `agent-web-ui` already targets exactly that (`apps/agent-web` monitor
+  connects to `ws://localhost:7070`). The runtime workspace closure was verified pure-JS by INFRA-028
+  (no native modules). DIST-001/002/003 _aim_ to produce a single-file Bun-compiled `robota` binary with
+  a Node-less install path, but **DIST-001 is a `todo` compatibility spike, not a shipped fact** — it
+  explicitly flags `bun --compile` unknowns including the `node` child-spawn the session uses for subagent
+  worktrees. So GUI-002 must NOT hard-depend on the Bun binary: it spawns _a_ `robota` executable, with the
+  ordinary **Node `robota` entrypoint as the Stage-1 dev-run sidecar**; adopting the Bun single-binary is a
+  later optimization gated on DIST-001, not a Stage-1 requirement.
+- **The loopback WS is UNAUTHENTICATED today.** `WsTransport` (`defaultEnabled:true`) runs
+  `new WebSocketServer({ server })` with no `verifyClient`, no origin check, no token — and on every
+  connection immediately emits full history + execution-workspace snapshot, then wires the socket to
+  `createWsHandler` (which can `submit`, `executeCommand`, and **answer permission/ask prompts**). Because
+  browser `WebSocket` connections are not gated by CORS, **any local process — or any web page open in any
+  browser on the machine — can currently reach `ws://127.0.0.1:7070` and fully drive/authorize a running
+  session.** That is a pre-existing OWNER-PRINCIPLE hole (permission-answering _is_ the authorization gate),
+  independent of the GUI. GUI-002 must therefore treat loopback auth as a REQUIRED gate, not an add-on.
+
+### Alternatives Considered (the two forks)
+
+**Fork A — desktop shell.** The candidates split into two classes: **bundled-Chromium** shells (Electron,
+NW.js — all-JS, prebuilt binary, no compiler) and **system-webview** shells (Tauri = Rust; `webview-nodejs`
+= C native addon, discontinued; `@webview/webview` = Rust native addon; electrobun = Bun + Zig). Research
+established a decisive structural fact: **binding a system webview inherently requires native code, so
+"small system-webview bundle" and "all-Node + no-native-addon + builds-in-plain-Node-CI" are mutually
+exclusive in this repo.** Every system-webview option reintroduces exactly the native-module / non-Node
+toolchain that INFRA-028 (pure-JS closure) and DIST-001 (Bun-compile hostile to native addons) avoid — and
+Rust/Bun are both **absent from the current CI** (Tauri literally does not build here). **Owner decision:
+Electron.** Rationale: it is the only candidate satisfying ALL hard constraints simultaneously — no new
+language/toolchain (prebuilt Chromium+Node; the app compiles nothing), **no native addon** (INFRA-028
+invariant preserved), **builds in the current plain Node/pnpm CI**, and mature per-OS packaging + signing
+(electron-builder: macOS notarization, Windows Authenticode) for the deferred GUI-003 stage. Between the
+two bundled-Chromium options, Electron dominates NW.js on community and signing tooling. Cost accepted:
+**~85–150 MB bundled-Chromium shell** (vs the ~5–15 MB a system webview would give) and **the shell itself
+is not Bun-compilable** — but because this is a **sidecar** architecture, that misalignment is confined to
+the window chrome: the DIST-001 Bun single-binary, if that spike succeeds, still becomes the **sidecar**
+Electron spawns, so the Bun/native direction is preserved for the part that carries the actual runtime.
+Flipping to Electron also **removes** two costs the Tauri path carried (Rust glue + Linux WebKitGTK QA;
+Electron ships uniform Chromium on all three OSes).
+
+**Fork B — session hosting.** Spawn the CLI as a **loopback-WS sidecar** vs host the session
+**in-process** in a Node runtime. **Owner decision: sidecar.** Rationale: reuses the entire existing
+WS surface (REMOTE-007 permission/ask, REMOTE-014 attribution, OWNER PRINCIPLE) with near-zero new
+transport code — it is literally what `apps/agent-web` already does. In-process hosting would couple
+`agent-gui` to `agent-framework`/`agent-core` (violating the no-framework-dep invariant), force the session
+runtime into the shell process, and directly contradict the Bun single-binary direction — whereas the
+sidecar keeps the runtime in a separate, independently-distributable `robota` process.
+
+**Package shape (consequence of A+B).** REUSE `agent-web-ui` as the presentation substrate rather than
+fork a new `agent-transport-gui`. A new `apps/agent-gui` owns ONLY the Electron shell + sidecar
+lifecycle + loopback wiring (its own product assembly, per the "no shared product factory" rule). Any
+GUI-only presentation seam that emerges is added _inside_ `agent-web-ui`, not a parallel package.
+
+### Decision
+
+Build `agent-gui` as a **thin Electron desktop shell** that (1) on launch **spawns a `robota` sidecar**
+(the Node entrypoint for Stage 1; the DIST-001 Bun single-binary later, gated on that spike) with the WS
+transport enabled on a loopback port and a **required launch-nonce loopback auth**; (2) loads the existing
+**`agent-web-ui` React SPA** into a `BrowserWindow` renderer, pointed at `ws://127.0.0.1:<port>`; (3) reuses
+`agent-web-ui`'s session reducer + rendering verbatim — **no session/command/permission logic in the GUI**.
+The Electron **main process is Node**, so `child_process.spawn('robota', …)` with the port+nonce is native
+and matches what `apps/agent-web` already does over loopback WS. The GUI is one more driver surface over the
+transport-neutral session; the OWNER PRINCIPLE (local == remote) and co-drive attribution (REMOTE-014)
+apply to it unchanged.
+
+**Cross-platform:** the app targets **macOS, Linux, and Windows** — Electron bundles uniform Chromium on all
+three (no per-OS webview divergence), and the Stage-1 dev-run works on each. Per-OS installers + code-signing
+(macOS notarization, Windows Authenticode; .dmg/.app, .AppImage/.deb/.rpm, .exe/.msi via electron-builder)
+are the deferred **GUI-003** stage; the `robota` sidecar likewise targets all three (DIST-001: macOS
+arm64/x64, Linux x64/arm64, Windows x64).
+
+**Stage 1 (this spec) delivers the MVP:** a desktop window that starts, spawns + supervises the sidecar,
+renders a live session (conversation, streaming, tools), and renders + answers permission/ask prompts —
+the core user story. It ships the app in dev/run form; **per-OS packaging + code-signing/notarization is
+a later spec (GUI-003)**.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — see **Affected Scope** + **Affected Files** (new `apps/agent-gui`;
+      reuse `agent-web-ui`; possible additive nonce option in a transport package; `project-structure.md`).
+- [x] Sibling scan 완료 — the "render a live session" surface already exists as a SIBLING (`agent-web-ui`,
+      the browser React surface, and `apps/agent-web` which mounts it over loopback WS); this spec REUSES that
+      sibling as the presentation substrate rather than forking a new `agent-transport-gui` — `apps/agent-gui`
+      adds ONLY the Electron shell + sidecar lifecycle. The TUI sibling (`agent-transport-tui`) is the
+      architectural mirror (thin surface over the transport-neutral session), not code to copy. N/A: no new
+      shared presentation package is introduced.
+- [x] 대안 최소 2개 검토 완료 — two forks each with ≥2 options: shell (bundled-Chromium: Electron/NW.js vs
+      system-webview: Tauri/webview-nodejs/electrobun) and hosting (sidecar vs in-process); see
+      **Alternatives Considered**.
+- [x] 결정 근거 문서화 완료 — see **Decision** (Electron+sidecar; rationale = only all-Node + no-native-addon +
+      builds-in-plain-CI + mature signing option; costs = ~100 MB bundled-Chromium shell + shell not
+      Bun-compilable, sidecar still can be).
+
+**Design invariants this spec must hold** (checked at implementation + review):
+
+- **Dependency direction:** `apps/agent-gui` → `agent-web-ui` (browser export) + the contract packages;
+  never inverts. The GUI does not depend on `agent-framework`/`agent-core` (the sidecar owns the runtime).
+- **Frontend rule:** React only (satisfied — reuses `agent-web-ui`). Tailwind-only styling (the shell
+  supplies the theme CSS variables the components consume).
+- **No shared product factory:** `apps/agent-gui` owns its own composition; reuse comes from the shared
+  lower layer (`agent-web-ui`), not a shared assembler.
+- **OWNER PRINCIPLE:** the GUI is a driver surface; attribution is display-only, never authorization.
+- **No native modules:** runtime closure is pure-JS (INFRA-028). Electron ships a prebuilt Chromium+Node
+  (no native addon in the app). The Stage-1 sidecar is the Node `robota` entrypoint; the Bun single-binary
+  is a later, DIST-001-gated substitution, not a Stage-1 dependency.
+- **All-Node toolchain:** the shell is JS/TS (Electron main + preload + renderer); no Rust/Bun/Go, builds in
+  the plain Node/pnpm CI. `contextIsolation` on + a minimal `preload` bridge (no `nodeIntegration` in the
+  renderer) so the `agent-web-ui` SPA stays a pure browser surface.
+- **Loopback auth is REQUIRED (not optional):** the GUI-spawned sidecar must reject any WS connection that
+  does not present the launch nonce, and the check must run **before** any session data is emitted.
+
+## Solution
+
+### Components (Stage 1)
+
+1. **`apps/agent-gui` — Electron project (all JS/TS).**
+   - `electron/main.ts` (Node main process): create the `BrowserWindow`; **mint** the loopback port + nonce
+     (`node:crypto`); **spawn** the `robota` sidecar via `child_process.spawn` with the port+nonce (env/CLI
+     flag); supervise the child (health, graceful `shutdown` on window-close, child-exit → UI fatal state);
+     `webPreferences` (`contextIsolation:true`, `nodeIntegration:false`, `sandbox:true`); load the built
+     `agent-web-ui` SPA via `loadFile` (local content, never a remote URL). **Renderer hardening (the
+     bundled Chromium renderer holds the nonce, so it is itself a "browser on the machine"):** a strict CSP
+     pinned to `default-src 'self'` + `connect-src ws://127.0.0.1:<port>` (renderer can only reach its own
+     loopback sidecar), plus **navigation lockdown** — `will-navigate` deny + `setWindowOpenHandler(() =>
+({action:'deny'}))` so a redirected/compromised renderer cannot carry the nonce/session to an external
+     origin. (Recorded in `docs/SPEC.md`.)
+   - `electron/preload.ts`: a minimal `contextBridge` exposing ONLY the port + nonce (and a fatal/ready
+     signal) to the renderer — no Node APIs leak into the SPA.
+   - `src/` (TS/React renderer): a thin entry that mounts `agent-web-ui`'s session view (composing
+     `ConversationView` + `AgentActivityPanel` + `PermissionPrompt` against `useWsSession(url)`, the way
+     `RemoteClient` composes for RTC — NOT the WS-hardwired `SessionMonitor`), reading the port+nonce from
+     the preload bridge, plus a Tailwind theme providing the CSS variables (`--background`, `--card`,
+     `--foreground`, `--primary`, …).
+2. **Sidecar contract + REQUIRED loopback auth.** The GUI spawns `robota` with the WS transport on a
+   chosen loopback port and a **mandatory launch nonce** (a high-entropy secret minted by the shell per
+   launch). The nonce is NOT optional and NOT merely "hostile-local-process" defense — as **Affected Scope**
+   documents, the loopback WS is unauthenticated today and reachable by any local process _or any browser
+   page_, so without the nonce a co-resident web page could answer permission prompts. Contract:
+   - **Mint:** the Electron main process generates the nonce (256-bit, `node:crypto`) and a free loopback
+     port at launch; passes both to the child (env var / CLI flag) and to the renderer via the `preload`
+     `contextBridge` (never a world-readable file).
+   - **Sidecar side:** the WS transport gains a **required-token option**; the server **rejects the
+     handshake (close, no data) BEFORE** the current unconditional `messages` / `execution_workspace_event`
+     send when the presented token is absent or wrong. This is a published-surface change to
+     `agent-transport-ws` (and possibly `agent-transport-protocol` / `agent-interface-transport` if the
+     token check belongs in the shared handler) — **SPEC-first** for the touched package.
+   - **Browser transport of the token:** the native `WebSocket` API **cannot set request headers**, so the
+     nonce travels via **query param or `Sec-WebSocket-Protocol` subprotocol**; `createWsSessionClient` /
+     `useWsSession(url)` are extended (additively) to carry it. The server validates it in the upgrade/first
+     frame before any emit.
+   - **Pre-existing exposure decision:** GUI-002 closes the hole **for its own sidecar** by requiring the
+     token (the GUI never spawns an unauthenticated WS). The **default `defaultEnabled:true` TUI/localhost
+     path stays as-is under this spec** and is handed to a **companion SECURITY backlog** (loopback WS auth
+     for the default path) rather than silently changed here — a stated decision, not omission.
+3. **Lifecycle.** Spawn on app ready → wait for WS readiness → connect the webview. On window close /
+   app quit → graceful sidecar shutdown (session `shutdown`), then process kill as a backstop. A sidecar
+   crash surfaces a reconnect/fatal state in the UI (reuse the existing `status` surface).
+
+### What Stage 1 explicitly defers
+
+- Per-OS bundling, code-signing, notarization, auto-update → **GUI-003**.
+- A `pendingCount` / prompt-queue affordance and richer co-drive UI → later (small; `agent-web-ui` gap).
+- Any in-process hosting path → out of scope (owner chose sidecar; would be a distinct spec).
+- Multi-session / tabs, settings UI beyond what the session already exposes.
+
+## Affected Files
+
+**New — `apps/agent-gui/`:**
+
+- `package.json` (private app; deps: `@robota-sdk/agent-web-ui`, React, Tailwind; devDeps: `electron`,
+  `electron-builder`, `vite`). NO `agent-framework`/`agent-core`.
+- `electron/main.ts` (spawn/supervise sidecar, port+nonce, CSP, BrowserWindow), `electron/preload.ts`
+  (contextBridge: port+nonce+ready/fatal), `electron/tsconfig.json`.
+- `src/main.tsx`, `src/App.tsx` (mount agent-web-ui session view), `src/theme.css` (Tailwind tokens),
+  `index.html`, `vite.config.ts` (renderer build), `tsconfig.json`.
+- `electron-builder.yml` (per-OS targets for GUI-003; present but packaging deferred), `docs/SPEC.md`
+  (new app spec; also list the sidecar/nonce contract).
+
+**Changed (small, additive):**
+
+- `agent-web-ui` — only if the composed session view needs a new exported seam (prefer reuse; if a
+  GUI-tailored root is needed, add it here, not a new package). Possibly export the compose-your-own
+  pieces already public.
+- `agent-web-ui` — `createWsSessionClient` / `useWsSession(url)` extended (additively) to carry the launch
+  nonce via query param or `Sec-WebSocket-Protocol` subprotocol (browser `WebSocket` can't set headers).
+- `agent-transport-ws` (and possibly `agent-transport-protocol` / `agent-interface-transport`) — a
+  **required-token option** on the WS transport/handler that rejects the handshake **before** any session
+  data is emitted. Published-surface contract change ⇒ **SPEC-first** for the touched package.
+- `.agents/project-structure.md` — register `apps/agent-gui` + its dependency edges.
+- Root build/release wiring — how `agent-gui` obtains the `robota` sidecar (Stage 1: the Node entrypoint;
+  Bun single-binary later, gated on DIST-001).
+
+**New backlog (companion, filed by this spec — not implemented here):**
+
+- A **SECURITY backlog** for authenticating the default `defaultEnabled:true` loopback WS path (the
+  pre-existing unauthenticated exposure the reviewer surfaced), so the TUI/`apps/agent-web` localhost path
+  is not left open after GUI-002 closes it only for its own sidecar.
+
+## Completion Criteria
+
+- [ ] **TC-01** — Observable: launching `apps/agent-gui` (dev run) opens a desktop window that spawns the
+      `robota` sidecar and connects the webview over loopback WS; submitting a user turn shows a streaming
+      assistant reply and tool cards in the GUI.
+- [ ] **TC-02** — Observable: a gated tool call renders a permission prompt in the GUI; clicking Allow/Deny
+      answers it via `resolvePermission`, and an ask prompt renders + answers via `resolveAsk`; a
+      `prompt_resolved` event dismisses an open prompt.
+- [ ] **TC-03** — Observable: a WS connection presenting a missing/wrong launch nonce is rejected by the
+      sidecar **before any session data (`messages` / `execution_workspace_event`) is emitted** (the reject
+      happens at the handshake/first-frame, not after the snapshot dump); a connection presenting the
+      correct nonce — carried via query param or `Sec-WebSocket-Protocol` subprotocol — is accepted.
+- [ ] **TC-04** — Observable: closing the window shuts the session down gracefully (session `shutdown`
+      called), and a killed/crashed sidecar surfaces a non-hanging fatal/reconnect state in the UI status.
+- [ ] **TC-05** — Observable: `apps/agent-gui` declares no dependency on `agent-framework`/`agent-core`;
+      the GUI adds no session/command/permission logic (dependency-direction check + review).
+- [ ] **TC-06** — Command: `pnpm --filter @robota-sdk/agent-gui typecheck` and the affected `pnpm test`
+      pass; `pnpm harness:scan` is green (incl. the new app SPEC doc/structure scans); `.agents/project-structure.md`
+      lists `apps/agent-gui` and its dependency edges.
+
+## Test Plan
+
+| TC-N  | Test type            | Tool / approach                                                                                                                                                                                                                                                      |
+| ----- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TC-01 | Manual smoke + unit  | Unit: compose-root mounts the session view against a stub `TMakeSessionClient` and renders folded events. Manual: dev-run launch on the dev OS drives a real session (recorded in the app SPEC User Execution scenario).                                             |
+| TC-02 | Unit                 | Prompt render + answer against a mock session surface: Allow/Deny → `resolvePermission`, ask option → `resolveAsk`, `prompt_resolved` → dismiss (reuses `agent-web-ui` prompt-state coverage; GUI compose-root wiring test).                                         |
+| TC-03 | Unit                 | Launch-nonce loopback auth: the WS client presents the token; the WS handler/transport accepts the correct nonce and rejects a missing/wrong one (test lives in the touched transport package if the option lands there).                                            |
+| TC-04 | Unit (TS)            | Electron main-process (TS): the sidecar spawn builds the right args (port + nonce); a child-exit maps to the UI fatal state; the window-close path invokes graceful `shutdown`; a simulated sidecar drop surfaces the fatal/reconnect status. (All JS/TS — no Rust.) |
+| TC-05 | Static / review      | Dependency-direction assertion (`apps/agent-gui` package.json has no `agent-framework`/`agent-core` dep) + harness `deps` scan + code review that no session/command/permission logic was added.                                                                     |
+| TC-06 | Command (CI/harness) | `pnpm --filter @robota-sdk/agent-gui typecheck`, affected `pnpm test`, `pnpm harness:scan` all green; `.agents/project-structure.md` updated and passing the structure scan.                                                                                         |
+
+## Tasks
+
+Task file: [`.agents/tasks/GUI-002.md`](../../tasks/GUI-002.md) (execution checklist T1–T10, one task per
+TC-N, with the mirrored Test Plan).
+
+- [ ] T1: GATE-APPROVAL — proposal-reviewer ENDORSE of this architecture (the two forks + Stage-1 scope).
+- [ ] T2: Scaffold `apps/agent-gui` (Electron + Vite + React, all JS/TS); register in `.agents/project-structure.md`.
+- [ ] T3: Electron main + preload (TS) — mint port+nonce (`node:crypto`); `child_process.spawn` the Node
+      `robota` sidecar + supervise; `contextIsolation`/`sandbox` + CSP; contextBridge port/nonce to renderer;
+      fatal-error surface.
+- [ ] T4: TS compose-root — mount `agent-web-ui` session view (ConversationView + AgentActivityPanel +
+      PermissionPrompt) against `useWsSession(loopbackUrl)`; Tailwind theme tokens.
+- [ ] T5: **Required** launch-nonce loopback auth — SPEC-first update to the touched transport package,
+      then: mint in shell → child + webview → WS client carries the token via query param /
+      `Sec-WebSocket-Protocol` subprotocol → handler **rejects before any session data is emitted**.
+      Extend `createWsSessionClient`/`useWsSession` additively (TC-03).
+- [ ] T6: File the **companion SECURITY backlog** (auth for the default `defaultEnabled:true` loopback WS
+      path) via backlog-writer — before/alongside implementation, so the pre-existing exposure is tracked.
+- [ ] T7: `apps/agent-gui/docs/SPEC.md` (+ sidecar/nonce contract + User Execution scenario); harness
+      doc/structure scans green.
+- [ ] T8: Tests (Test Plan) + `pnpm typecheck`/affected tests/`harness:scan` green; feature→develop→main
+      via merge-verifier at each hop.
+- [ ] T9: GATE-COMPLETE — spec active→done; open follow-up backlogs (GUI-003 packaging/signing;
+      pendingCount UI; Bun-binary sidecar swap gated on DIST-001).
+
+## Evidence Log
+
+### [GATE-WRITE] — ❌ FAIL | 2026-07-12
+
+**Status remains:** draft
+**Failed criteria:**
+
+- Frontmatter `type:`: found `ARCHITECTURE`; required exactly one of the 11-prefix list (SCREEN · API · FLOW · BEHAVIOR · DATA · RULE · AGREEMENT · INFRA · PERF · SECURITY · OBSERVABILITY). `ARCHITECTURE` is not a valid type value.
+  **Required action:** Change `type:` to a valid prefix value (e.g. `INFRA` for a foundation/shell spec).
+- Completion Criteria — TC-N prefixes: found 6 plain bullet items with no `TC-N` prefix; required every item prefixed `TC-01`, `TC-02`, … Items without a TC-N prefix = FAIL.
+  **Required action:** Rewrite each completion criterion as a `TC-N`-prefixed, command-form or observable-behavior item.
+- Test Plan — one row per TC-N: found a 4-item bullet list; required one row per `TC-N` in Completion Criteria with the count matching. No TC-N exist, so no rows can match.
+  **Required action:** Convert the Test Plan to a table with one row per TC-N (Test Type + Tool/Approach + Notes), matching the Completion Criteria count.
+- Evidence Log empty (first GATE-WRITE run): found a pre-existing 2026-07-12 research note; required empty on first run.
+  **Required action:** Move the research note into the Problem/Architecture Review narrative; keep Evidence Log for gate entries only.
+
+Additional observation (not the gating failure): the `## Problem` section frames a design question ("how a desktop app should host the session") rather than a concrete failing symptom + reproduction condition; consider stating the symptom form the GATE-WRITE Problem criteria expect. Frontmatter `status: draft` and `tags:` are present and valid; Tasks section is present with a placeholder; no `## Status`/`## Classification` body sections. The `type` / TC-N / Test-Plan failures block the draft → review-ready upgrade.
+
+### [GATE-WRITE] — ❌ FAIL | 2026-07-12
+
+**Status remains:** draft
+
+Prior-FAIL items now resolved (verified): `type:` is `INFRA` (valid 11-prefix value); Completion Criteria are `TC-01`..`TC-06`, each in Observable/Command form with no banned phrases; Test Plan is a table with exactly 6 rows (one per TC-N), each with a non-empty Test type + Tool/approach; the earlier research note is gone from the Evidence Log; the `## Problem` section now states a concrete symptom ("there is no graphical surface today … `apps/` contains no desktop shell") plus a reproduction condition ("a user who wants a windowed desktop app … has nothing to run"), no TBD/TODO. Frontmatter block present with `status: draft` and `tags:`; Tasks section present with placeholders; no `## Status`/`## Classification` body sections; Alternatives Considered has 2 entries (Tauri v2 vs Electron; sidecar vs in-process) each with pro/con; Decision references the driving trade-offs. The pre-existing FAIL entry is a legitimate historical record (this is a re-run, so a non-empty Evidence Log is expected).
+
+**Failed criteria:**
+
+- Architecture Review Checklist — "All 4 checklist items are `[x]`": found a `### Architecture Review Checklist` section containing 5 bold-labeled design-invariant bullets (Dependency direction, Frontend rule, No shared product factory, OWNER PRINCIPLE, No native modules), NONE of which are `[x]` checkbox items. Required: the canonical 4-item checklist all marked `[x]` (affected packages + layers listed; Sibling scan; ≥2 alternatives reviewed; decision rationale documented), per the passing-spec form.
+  **Required action:** Replace/augment the section with the 4 canonical `[x]` checklist items (all checked), keeping the current design-invariant bullets as supporting prose if desired.
+- Architecture Review Checklist — "Sibling scan item is `[x]` with completion evidence or explicit `N/A: <reason>`": no Sibling scan checklist item exists anywhere in the document. (Sibling context — the `agent-transport-tui` presentation layer and `apps/agent-web` loopback client — is discussed in the Affected Scope narrative, but not captured as the required `[x]` item.)
+  **Required action:** Add a `[x] Sibling scan …` checklist item with the completion evidence (the existing TUI/agent-web narrative can be cited) or an explicit `N/A: <reason>`.
+
+### [GATE-WRITE] — ✅ PASS | 2026-07-12
+
+**Status upgrade:** draft → review-ready
+
+- Frontmatter: `---` block present; `status: draft`; `type: INFRA` (valid 11-prefix value); `tags:` present (`[desktop, tauri, sidecar, gui, react, websocket]`). PASS.
+- Problem: concrete symptom ("there is no graphical surface today … `apps/` contains no desktop shell and no `robota`-driven GUI application") + reproduction condition ("A user who wants a windowed desktop app … has nothing to run"); no TBD/TODO/vague single-sentence. PASS.
+- Architecture Review Checklist: the prior FAIL is resolved — the section now carries the canonical 4 items ALL `[x]` (영향 패키지/레이어 목록; Sibling scan; 대안 최소 2개; 결정 근거). Sibling scan is `[x]` with completion evidence (`agent-web-ui` + `apps/agent-web` loopback client cited as the reused sibling) plus an explicit `N/A: no new shared presentation package is introduced`. The former design-invariant bullets are preserved below as a separate "Design invariants this spec must hold" note (not part of the checklist). PASS.
+- Alternatives Considered: 2 forks, each with ≥2 options and pro/con — shell (Tauri v2 vs Electron: bundle size / Node-in-webview / native-dep trade-offs) and hosting (sidecar vs in-process). Decision references the driving trade-offs (DIST-alignment + zero session-logic duplication + smallest bundle; costs = Rust glue + Linux WebKitGTK QA + loopback-nonce surface). PASS.
+- Completion Criteria: TC-01..TC-06, each Observable- or Command-form; no banned phrases ("works correctly"/"no errors"/"implemented"/"displays correctly"); ≥1 criterion per distinct feature. PASS.
+- Test Plan: `## Test Plan` table present with exactly 6 rows (TC-01..TC-06) — count matches the 6 Completion Criteria; each row has a non-empty Test type + Tool/approach; TC-01's manual portion carries an inline explanation (dev-run launch drives a real session, recorded in the app SPEC User Execution scenario). PASS.
+- Structure: Tasks section present with placeholders (T1–T8); Evidence Log present (two prior FAIL entries are legitimate historical records — non-empty is expected on a re-run); no `## Status`/`## Classification` body sections. PASS.
+- TC-N count check: Completion Criteria = 6 (TC-01..TC-06); Test Plan rows = 6 (TC-01..TC-06). Match confirmed.
+
+### [proposal-review] — 🔧 REVISE (round 1) → revisions applied | 2026-07-12
+
+Independent proposal-reviewer (read-only, premises tested against code) endorsed the DIRECTION (Tauri v2
+shell + spawn-CLI-loopback-WS-sidecar + reuse `agent-web-ui` verbatim; no superior fork) but returned
+REVISE on two load-bearing corrections. Both applied to the spec:
+
+1. **Loopback auth promoted from optional → REQUIRED, fully specified.** The reviewer verified the loopback
+   WS is UNAUTHENTICATED today (`WsTransport`, `defaultEnabled:true`, no `verifyClient`/origin/token; dumps
+   history + workspace on connect) and reachable by any local process OR any browser page — a pre-existing
+   OWNER-PRINCIPLE hole. Spec now: nonce is mandatory for the GUI sidecar; **reject before any session data
+   is emitted**; token carried via query param / `Sec-WebSocket-Protocol` subprotocol (native `WebSocket`
+   can't set headers); `createWsSessionClient`/`useWsSession` extended additively; SPEC-first on the touched
+   transport package; and an explicit decision to **file a companion SECURITY backlog** for the default
+   `defaultEnabled:true` path rather than change it silently. TC-03 strengthened to assert reject-before-emit.
+2. **DIST-001 Bun-binary premise corrected from settled fact → unproven dependency.** DIST-001 is a `todo`
+   compat spike (flags the `node` subagent child-spawn). Spec now spawns the **Node `robota` entrypoint** as
+   the Stage-1 sidecar; the Bun single-binary is a later DIST-001-gated swap; dropped "Node-less for free".
+
+Rule-alignment in the review: React-only ✓, dependency direction ✓ (no inversion; the additive nonce edge
+is a downward transport-contract change), no-shared-product-factory ✓, no native modules ✓.
+
+### [proposal-review] — 🔧 REVISE (round 2) → single leftover fixed | 2026-07-12
+
+Round-2 confirmed correction #1 (nonce) fully addressed and consistent across Decision/Solution/Affected
+Files/TC-03, and correction #2 applied in Affected Scope + Decision + invariants — but caught ONE mechanical
+leftover: the **Fork A rationale** still asserted "it ships the _exact_ DIST-001 Bun binary as its sidecar
+… the Node-less install story extends for free" (the phrase round 1 said to drop), contradicting the
+corrected Decision. Fixed (prose-only): the Fork A rationale now grounds Tauri on system-webview fit +
+smallest bundle + no native-dep handling, frames the Bun binary as a later DIST-001-gated _option_ ("if that
+spike succeeds"), and states Stage 1 spawns the Node entrypoint. The reviewer pre-authorized ENDORSE
+conditional on exactly this edit ("Fix lines 80-84 as above … and this is an ENDORSE"). Round-3 confirmation
+requested to record the clean verdict.
+
+### [proposal-review] — ✅ ENDORSE (round 3) | 2026-07-12
+
+Independent proposal-reviewer confirmed the sole round-2 blocker resolved: the Fork A rationale no longer
+asserts the Bun binary as fact or claims Node-less-for-free; it is grounded on system-webview fit + smallest
+bundle + no native-dep handling, with the Bun single-binary demoted to a DIST-001-gated future option; all
+four locations (Fork A / Decision / Affected Scope / invariants) tell the same story; no new inconsistency.
+Tauri v2 + sidecar + reuse-`agent-web-ui` endorsed on design-correctness grounds. **The design gate is
+satisfied; GATE-APPROVAL now requires the owner's explicit authorization to implement.**
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-07-12
+
+**Status upgrade:** review-ready → approved
+
+- Explicit owner approval directed at this spec, in the current conversation, via the GATE-APPROVAL
+  question "authorize implementation of the agent-gui Stage 1 MVP as specified (Tauri v2 shell + Node robota
+  sidecar + reuse agent-web-ui + required loopback-nonce auth + companion security backlog)?" — owner
+  answered verbatim: **"Approve — build Stage 1 MVP"**. Unambiguous confirmation of the design + authorization
+  to implement.
+- No Architecture Review or frontmatter `type`/`tags` modified after approval.
+- No implementation (file edits / commits) was started before this gate — the three prior review rounds and
+  all edits were to the spec document only.
+
+### [GATE-IMPLEMENT] — ❌ FAIL | 2026-07-12
+
+**Status remains:** approved
+
+Prior-gate precondition met: GATE-APPROVAL shows `✅ PASS | 2026-07-12` in this Evidence Log; frontmatter `status: approved` and the `todo/` folder match the expected input stage for GATE-IMPLEMENT.
+
+Criteria checked:
+
+- `.agents/tasks/GUI-002.md` created — PASS (file exists with T1–T10 + a `## Test Plan` section).
+- Tasks correspond to Completion Criteria (≥1 task per TC-N) — PASS. Task file maps every TC: T2→TC-01, T3→TC-01/TC-04, T4→TC-01/TC-02, T5→TC-03, T7→TC-06, T8→TC-01..TC-06, T9→TC-05. TC-01..TC-06 all covered.
+- Task file `## Test Plan` (≥50 chars) — PASS. `.agents/tasks/GUI-002.md` has a `## Test Plan` section (mirrors the spec's TC-01..TC-06, well over 50 chars). [AF-24]
+
+**Failed criteria:**
+
+- Tasks file path recorded in the `## Tasks` section of the spec: the spec's `## Tasks` section (T1–T9) lists tasks inline but contains no reference to the task file path `.agents/tasks/GUI-002.md`; required — the `## Tasks` section must record the tasks file path so the spec points to its execution tracker.
+  **Required action:** Add the task-file path (`.agents/tasks/GUI-002.md`) to the spec's `## Tasks` section (e.g. a `Tasks tracked in .agents/tasks/GUI-002.md` line), then re-run GATE-IMPLEMENT.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-07-12
+
+**Status upgrade:** approved → in-progress
+
+Prior-gate precondition met: GATE-APPROVAL shows `✅ PASS | 2026-07-12` in this Evidence Log; frontmatter `status: approved` and the `todo/` folder match the expected input stage for GATE-IMPLEMENT.
+
+- `.agents/tasks/GUI-002.md` created — PASS. File exists with tasks T1–T10 and a `## Test Plan` section.
+- Tasks file path recorded in the spec `## Tasks` section — PASS (prior FAIL resolved). The `## Tasks` section now opens with ``Task file: [`.agents/tasks/GUI-002.md`](../../tasks/GUI-002.md)`` (spec line 255), so the spec points to its execution tracker.
+- Tasks correspond to Completion Criteria (≥1 task per TC-N) — PASS. Task-file mapping covers all six: T2→TC-01, T3→TC-01/TC-04, T4→TC-01/TC-02, T5→TC-03, T7→TC-06, T9→TC-05, T8→TC-01..TC-06. TC-01..TC-06 all covered.
+- Task file `## Test Plan` (≥50 chars) — PASS. `.agents/tasks/GUI-002.md` has a `## Test Plan` section mirroring the spec's TC-01..TC-06, well over 50 chars. [AF-24]
+
+### [Fork A revision] — Tauri v2 → Electron + owner re-approval | 2026-07-12
+
+During implementation prep, the environment was found to have **no Rust toolchain** (`cargo`/`rustc` absent),
+so the GATE-APPROVED Tauri shell could not be compiled or run here. The owner challenged the shell choice on a
+sound principle — "우리는 node.js로 만든 환경이 다 갖춰져 있는데 … 생태계도 nodejs로 선택해야 하는거 아닌가?"
+(maximize the already-provisioned Node ecosystem). Follow-up research (read-only) established that **every
+system-webview shell forces a non-Node toolchain or a native addon** (Tauri = Rust; `webview-nodejs` = C
+addon, discontinued; `@webview/webview` = Rust addon; electrobun = Bun+Zig, Bun absent) — reintroducing
+exactly what INFRA-028 (pure-JS closure) and DIST-001 (Bun-compile hostile to native addons) avoid — so
+"small system-webview bundle" and "all-Node + no-native-addon + builds-in-plain-CI" are **mutually
+exclusive**. **Electron** is the only candidate satisfying all hard constraints (all-JS/TS, no native addon,
+builds in the current CI, mature per-OS signing, uniform Chromium on macOS/Linux/Windows).
+
+**Fork A revised Tauri v2 → Electron.** Fork B (sidecar), the required nonce auth, agent-web-ui reuse, the
+dependency direction, and every TC are UNCHANGED; the spec's `src-tauri/` Rust component became
+`electron/main.ts` + `preload.ts` (TS), and two costs (Rust glue + Linux WebKitGTK QA) were removed. Because
+this modifies the Architecture Review after the prior GATE-APPROVAL, the owner **re-approved the revised
+decision** via a Fork-A-reconsideration question — owner answered verbatim: **"Electron으로 확정 (권장)"** —
+and separately confirmed cross-platform support ("Mac, linux, windows 지원 가능하지?" → yes, all three).
+Re-endorsement by proposal-review recorded below.
+
+### [proposal-review] — ✅ ENDORSE (Electron revision) | 2026-07-12
+
+Independent proposal-reviewer re-reviewed the delta and ENDORSED. Confirmed: (1) the Electron choice is sound
+and internally consistent — every current-decision surface reads Electron; residual Tauri/Rust text is
+legitimately historical (Evidence Log) or the expected "why the system-webview/Rust class was rejected"
+rationale; (2) Electron satisfies every hard constraint — all-JS/TS (no new language), no native addon in the
+app closure (prebuilt Chromium+Node; INFRA-028's pure-JS-_runtime-closure_ concern is met since the runtime
+lives in the sidecar), builds in the current Node/pnpm CI, and PRESERVES the unchanged parts (sidecar,
+reject-before-emit nonce, agent-web-ui reuse, non-inverting dependency direction). The Node main process
+doing `child_process.spawn` of the sidecar is lifecycle/hosting, NOT session/command/permission logic, and
+does not tempt an `agent-framework`/`agent-core` import (TC-05 asserts the absence); (3) the sharpest
+Electron-specific risk — the bundled-Chromium renderer is itself "a browser on the machine" holding the nonce
+— is closed by the nonce + the webPreferences posture (`contextIsolation:true`, `nodeIntegration:false`,
+`sandbox:true`, `loadFile` of local content, preload bridge exposing only port+nonce). Two non-blocking
+hardening notes folded into the spec: Fork B's stale "(forcing Electron)" parenthetical reworded; and the
+"strict CSP" pinned to `default-src 'self'` + `connect-src ws://127.0.0.1:<port>` plus navigation lockdown
+(`will-navigate` deny + `setWindowOpenHandler` deny) recorded in Components (to be nailed down in the app
+`docs/SPEC.md` at T7). **Design gate satisfied for the Electron revision; implementation authorized (owner
+re-approved).**

--- a/.agents/tasks/GUI-002.md
+++ b/.agents/tasks/GUI-002.md
@@ -1,0 +1,58 @@
+# GUI-002 — agent-gui Electron + sidecar foundation (Stage 1 MVP)
+
+Spec: `.agents/spec-docs/active/GUI-002-agent-gui-electron-sidecar-foundation.md`. Owner-approved 2026-07-12
+("Approve — build Stage 1 MVP"). Design ENDORSED (3 review rounds); **Fork A revised Tauri→Electron**
+2026-07-12 at owner's direction (stay in the Node ecosystem — Rust doesn't build here; every system-webview
+shell needs a native addon / non-Node toolchain). Re-endorsed by proposal-review.
+
+Build a thin **Electron** desktop shell (all JS/TS) that spawns a **Node `robota` sidecar** over a loopback
+WS port with a **required launch-nonce auth**, and loads the existing **agent-web-ui** React SPA in its
+`BrowserWindow` — no session/command/permission logic in the GUI. Targets macOS, Linux, Windows.
+
+## Tasks
+
+- [x] T1: GATE-IMPLEMENT — this task file + spec → `active/`, status `in-progress`.
+- [x] T2 (TC-01): Scaffold `apps/agent-gui` (Electron + Vite + React, all JS/TS); `package.json` (deps:
+      agent-web-ui, React, Tailwind; devDeps: electron, electron-builder, vite; NO agent-framework/agent-core);
+      register in `.agents/project-structure.md`.
+- [x] T3 (TC-01/TC-04): Electron main + preload (TS) — mint free loopback port + nonce (`node:crypto`);
+      `child_process.spawn` the Node `robota` sidecar; supervise (health, graceful `shutdown` on window close,
+      child-exit → UI fatal state); `contextIsolation`/`sandbox` + strict CSP; contextBridge exposes only
+      port+nonce+ready/fatal to the renderer.
+- [x] T4 (TC-01/TC-02): TS compose-root — mount agent-web-ui session view (`ConversationView` +
+      `AgentActivityPanel` + `PermissionPrompt`) against `useWsSession(loopbackUrl)` (the `RemoteClient`
+      compose pattern, not the WS-hardwired `SessionMonitor`); Tailwind theme tokens.
+- [x] T5 (TC-03): **Required** launch-nonce loopback auth — SPEC-first update to the touched transport
+      package, then reject the handshake **before any session data is emitted** on missing/wrong token;
+      carry the token via query param / `Sec-WebSocket-Protocol` subprotocol; extend
+      `createWsSessionClient`/`useWsSession` additively.
+- [x] T6: File the **companion SECURITY backlog** (auth for the default `defaultEnabled:true` loopback WS
+      path) via backlog-writer, so the pre-existing exposure is tracked (not fixed here).
+- [x] T7 (TC-06): `apps/agent-gui/docs/SPEC.md` (+ sidecar/nonce contract + User Execution scenario);
+      harness doc/structure scans green.
+- [ ] T8 (TC-01..TC-06): Tests per Test Plan; `pnpm typecheck` + affected `pnpm test` + `pnpm harness:scan`
+      green; feature→develop→main via merge-verifier at each hop.
+- [x] T9 (TC-05): Dependency-direction check — `apps/agent-gui` has no `agent-framework`/`agent-core` dep;
+      no session/command/permission logic added (review + harness `deps` scan).
+- [ ] T10: GATE-COMPLETE — spec active→done; open follow-up backlogs (GUI-003 packaging/signing; pendingCount
+      UI; Bun-binary sidecar swap gated on DIST-001).
+
+## Test Plan
+
+Mirrors the spec's Test Plan (TC-01..TC-06):
+
+- **TC-01** (manual smoke + unit): compose-root mounts the session view against a stub `TMakeSessionClient`
+  and renders folded events; dev-run launch on the dev OS drives a real session (recorded in the app SPEC
+  User Execution scenario).
+- **TC-02** (unit): prompt render + answer against a mock session surface — Allow/Deny → `resolvePermission`,
+  ask option → `resolveAsk`, `prompt_resolved` → dismiss.
+- **TC-03** (unit): the WS client presents the nonce via query param / subprotocol; the handler/transport
+  accepts the correct nonce and rejects a missing/wrong one **before** any `messages`/`execution_workspace_event`
+  emit (test in the touched transport package).
+- **TC-04** (unit, TS): the Electron main-process (TS) sidecar spawn builds the right args (port + nonce) and
+  maps a child-exit to the UI fatal state; window-close invokes graceful `shutdown`; a simulated sidecar drop
+  surfaces the fatal/reconnect status. (All JS/TS — no Rust.)
+- **TC-05** (static/review): `apps/agent-gui` package.json has no `agent-framework`/`agent-core` dep; harness
+  `deps` scan + review confirm no session/command/permission logic added.
+- **TC-06** (command): `pnpm --filter @robota-sdk/agent-gui typecheck`, affected `pnpm test`,
+  `pnpm harness:scan` all green; `.agents/project-structure.md` updated + passing the structure scan.

--- a/apps/agent-gui/docs/README.md
+++ b/apps/agent-gui/docs/README.md
@@ -1,0 +1,31 @@
+# @robota-sdk/agent-gui
+
+An **Electron desktop app** (macOS / Linux / Windows) that drives a live `robota` session graphically —
+the graphical mirror of the terminal TUI (`agent-transport-tui`).
+
+`agent-gui` is a **thin presentation shell**: it spawns a `robota` **sidecar** process, connects to it over
+a loopback WebSocket, and renders the session by reusing `@robota-sdk/agent-web-ui`'s React view + reducer
+**verbatim**. All session, command, and permission logic lives in the sidecar (reached over the wire), so the
+GUI holds no agent runtime and depends on neither `agent-framework` nor `agent-core` (the OWNER PRINCIPLE:
+the GUI is "just another surface").
+
+The loopback connection is authenticated by a **per-launch nonce** (GUI-002): the shell mints a token + free
+port, passes them to the sidecar via env (`ROBOTA_WS_TOKEN` / `ROBOTA_WS_PORT`), and the `WsTransport` rejects
+any connection lacking the token **before** emitting session data — closing the otherwise-unauthenticated
+loopback port against a co-resident browser page.
+
+## Run (dev)
+
+```bash
+pnpm --filter @robota-sdk/agent-gui build     # renderer (Vite) + electron main/preload (tsc)
+pnpm --filter @robota-sdk/agent-gui start      # launch Electron (needs a display + a `robota` on PATH)
+```
+
+Set `ROBOTA_GUI_SIDECAR_CMD` to override the sidecar command (default `robota`).
+
+## Status (Stage 1 — GUI-002)
+
+Foundation MVP: window + sidecar spawn/supervise + live session render + permission/ask + required loopback
+auth. **Deferred:** per-OS packaging/code-signing (GUI-003), richer co-drive UI. See
+[`docs/SPEC.md`](./SPEC.md) for the architecture, the sidecar/nonce contract, and the User Execution Test
+Scenario.

--- a/apps/agent-gui/docs/SPEC.md
+++ b/apps/agent-gui/docs/SPEC.md
@@ -1,0 +1,100 @@
+# SPEC.md — @robota-sdk/agent-gui
+
+## Scope
+
+`agent-gui` is a thin **Electron** desktop application (macOS / Linux / Windows) that drives a live
+`robota` session graphically. It is a **presentation surface only** — the mirror of the TUI
+(`agent-transport-tui`): it owns the desktop shell (window, lifecycle) and the loopback wiring, and reuses
+`@robota-sdk/agent-web-ui`'s React session view + reducer verbatim. All session/command/permission logic
+lives **below the wire**, in a `robota` sidecar process reached over a loopback WebSocket (GUI-002).
+
+## Boundaries
+
+- **Does NOT own session logic.** No agent runtime, tools, providers, command routing, or permission
+  policy — those run in the spawned `robota` sidecar and are reached over WS (`agent-web-ui`'s reducer folds
+  the `TServerMessage` stream). The GUI never imports `@robota-sdk/agent-framework` or `agent-core`.
+- **Does NOT own the wire protocol or the session contract** — those belong to
+  `agent-transport-protocol` / `agent-interface-transport`, consumed transitively via `agent-web-ui`.
+- **Does NOT own packaging/signing** in Stage 1 — per-OS installers, code-signing, notarization, and
+  auto-update are deferred to **GUI-003** (`electron-builder`).
+
+## Architecture Overview
+
+Two processes, one wire:
+
+```
+Electron main (Node)                         robota sidecar (Node CLI)
+  ├─ mint free loopback port + 256-bit nonce   ├─ WsTransport binds 127.0.0.1:<port>
+  ├─ spawn `robota` with                        │    with token=<nonce> (GUI-002 T5)
+  │    env ROBOTA_WS_TOKEN / ROBOTA_WS_PORT ───▶ │    → rejects any connection lacking the
+  ├─ BrowserWindow (contextIsolation, sandbox)   │      nonce BEFORE emitting session data
+  │    preload contextBridge → { endpoint }       │
+  └─ supervise child (exit → fatal; close → SIGTERM→SIGKILL)
+        │
+        ▼ (renderer, Chromium)
+   agent-web-ui React SPA
+     useWsSession('ws://127.0.0.1:<port>?token=<nonce>')  ← token in query (browser WS can't set headers)
+     ConversationView + AgentActivityPanel + PermissionPrompt + composer
+```
+
+- **`electron/sidecar.ts`** — Electron-free logic (endpoint minting, spawn-arg building, `SidecarSupervisor`);
+  unit-tested without a display or the electron binary.
+- **`electron/main.ts`** — wires electron: free-port discovery, `child_process.spawn` of the sidecar, the
+  hardened `BrowserWindow`, CSP + navigation lockdown, IPC endpoint handoff, supervision.
+- **`electron/preload.ts`** — a minimal `contextBridge` exposing ONLY the endpoint + lifecycle signals.
+- **`src/App.tsx`** — `SessionSurface` (pure presentation over `IWsSessionState`, unit-tested) + `SessionView`
+  (the thin `useWsSession` binding) + `App` (endpoint resolution + fatal-state gate).
+
+## Sidecar + loopback-auth contract (GUI-002)
+
+- The shell mints a **per-launch 256-bit nonce** and a **free loopback port**, spawns `robota` with them in
+  the child environment (`ROBOTA_WS_TOKEN` / `ROBOTA_WS_PORT`) — never on argv (argv is world-readable).
+- `agent-cli` reads that env and constructs `WsTransport({ token, port })`; the transport **closes any
+  connection that does not present the token (query param or `Sec-WebSocket-Protocol` subprotocol) BEFORE
+  any `messages` / `execution_workspace_event` is emitted** (constant-time compare). This closes the
+  otherwise-unauthenticated loopback port against a co-resident browser page. (Contract owned by
+  `@robota-sdk/agent-transport-ws`; see its SPEC.)
+- **Renderer hardening:** `contextIsolation:true`, `nodeIntegration:false`, `sandbox:true`, `loadFile` of
+  local content only, a CSP pinned to `default-src 'self'` + `connect-src ws://127.0.0.1:<port>`, and
+  navigation lockdown (`will-navigate` deny + `setWindowOpenHandler` deny) so the nonce-holding renderer
+  cannot carry the session to an external origin.
+- **Default path unchanged:** the token is only enforced when set; the plain TUI/`apps/agent-web` localhost
+  path stays open and is tracked for hardening by **SEC-001**.
+
+## Public API Surface
+
+None — `agent-gui` is a private application (`"private": true`), not a library. It exports no package API.
+
+## Dependencies
+
+`@robota-sdk/agent-web-ui` (workspace) + `react`/`react-dom`. Dev: `electron`, `vite`,
+`@vitejs/plugin-react`, `vitest`, `@testing-library/react`, `jsdom`, `typescript`. **No
+`agent-framework`/`agent-core`** (the sidecar owns the runtime) — enforced by review + the harness `deps`
+scan.
+
+## Test Strategy
+
+- `electron/__tests__/sidecar.test.ts` — endpoint/token minting, spawn-arg building (token in env, not
+  argv), and `SidecarSupervisor` (crash → fatal, ready, shutdown SIGTERM→SIGKILL, idempotent).
+- `src/__tests__/session-surface.test.tsx` — the compose-root renders the session over a stub
+  `IWsSessionState` and answers permission prompts, proving no session logic lives in the GUI.
+- **Deferred (needs a desktop machine):** the manual dev-run smoke — launch the app, spawn a real sidecar,
+  drive a real session, answer a real permission prompt — is the **User Execution Test Scenario** below; it
+  cannot run in a headless CI without a display.
+
+## User Execution Test Scenario
+
+On a machine with a display + a built `robota` on `PATH` (or `ROBOTA_GUI_SIDECAR_CMD` set):
+
+1. `pnpm --filter @robota-sdk/agent-gui build && pnpm --filter @robota-sdk/agent-gui start`.
+2. The window opens, spawns the sidecar, and shows the conversation view (status `connected`).
+3. Send a message → a streaming assistant reply + tool cards appear.
+4. Trigger a gated tool → a permission prompt appears; **Allow** proceeds, **Deny** blocks.
+5. Close the window → the sidecar shuts down (no orphaned `robota` process).
+6. Kill the sidecar externally → the UI shows the non-hanging fatal state.
+
+## Constraints
+
+- Electron shell is JS/TS only (no Rust/Bun); the renderer is React (frontend rule) with a Tailwind theme.
+- Runs in Electron's bundled Chromium (recent) — the renderer build targets `esnext` (no legacy transpile).
+- `"private": true`; not published. Packaging/signing → GUI-003.

--- a/apps/agent-gui/electron/__tests__/sidecar.test.ts
+++ b/apps/agent-gui/electron/__tests__/sidecar.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  buildSidecarSpawn,
+  endpointUrl,
+  mintToken,
+  SidecarSupervisor,
+  type ISupervisedChild,
+  type TSidecarState,
+} from '../sidecar.js';
+
+/** GUI-002 TC-04 — the Electron-free sidecar logic (spawn args, endpoint, supervision). */
+
+const endpoint = { port: 51234, token: 'nonce-abc' };
+
+describe('endpoint + spawn args (GUI-002)', () => {
+  it('mints a 256-bit hex token', () => {
+    const t = mintToken();
+    expect(t).toMatch(/^[0-9a-f]{64}$/);
+    expect(mintToken()).not.toBe(t); // fresh each call
+  });
+
+  it('endpointUrl carries the token as a query param (browser WebSocket canʼt set headers)', () => {
+    expect(endpointUrl(endpoint)).toBe('ws://127.0.0.1:51234?token=nonce-abc');
+  });
+
+  it('puts the token+port in the child ENV, never on argv (argv is world-readable via ps)', () => {
+    const spawn = buildSidecarSpawn(endpoint, {
+      baseEnv: { PATH: '/usr/bin' },
+      extraArgs: ['--foo'],
+    });
+    expect(spawn.command).toBe('robota');
+    expect(spawn.env['ROBOTA_WS_TOKEN']).toBe('nonce-abc');
+    expect(spawn.env['ROBOTA_WS_PORT']).toBe('51234');
+    expect(spawn.env['PATH']).toBe('/usr/bin'); // base env preserved
+    expect(spawn.args).toEqual(['--foo']);
+    expect(spawn.args.join(' ')).not.toContain('nonce-abc'); // token NOT on argv
+  });
+
+  it('honors a command override (later: the bundled binary)', () => {
+    expect(buildSidecarSpawn(endpoint, { command: '/opt/robota' }).command).toBe('/opt/robota');
+  });
+});
+
+/** A controllable stub child for the supervisor. */
+function stubChild(): ISupervisedChild & {
+  fireExit: (code: number | null, signal: NodeJS.Signals | null) => void;
+  kills: string[];
+} {
+  let exitCb: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  const kills: string[] = [];
+  return {
+    on: (_e, cb) => {
+      exitCb = cb;
+    },
+    kill: (sig = 'SIGTERM') => {
+      kills.push(sig);
+      return true;
+    },
+    fireExit: (code, signal) => exitCb?.(code, signal),
+    kills,
+  };
+}
+
+describe('SidecarSupervisor (GUI-002 TC-04)', () => {
+  it('an unexpected child exit surfaces a non-hanging FATAL state', () => {
+    const states: TSidecarState[] = [];
+    const child = stubChild();
+    new SidecarSupervisor(child, (s) => states.push(s));
+    child.fireExit(1, null);
+    expect(states).toEqual(['fatal']);
+  });
+
+  it('markReady transitions to ready', () => {
+    const states: TSidecarState[] = [];
+    const sup = new SidecarSupervisor(stubChild(), (s) => states.push(s));
+    sup.markReady();
+    expect(states).toEqual(['ready']);
+    expect(sup.currentState).toBe('ready');
+  });
+
+  it('shutdown sends SIGTERM then a SIGKILL backstop, and a subsequent exit is NOT fatal', () => {
+    const states: TSidecarState[] = [];
+    const child = stubChild();
+    const timers: Array<() => void> = [];
+    const sup = new SidecarSupervisor(
+      child,
+      (s) => states.push(s),
+      3000,
+      (fn) => timers.push(fn),
+    );
+    sup.shutdown();
+    expect(child.kills).toEqual(['SIGTERM']);
+    timers.forEach((fn) => fn()); // fire the backstop timer
+    expect(child.kills).toEqual(['SIGTERM', 'SIGKILL']);
+    child.fireExit(0, 'SIGTERM'); // expected exit during shutdown
+    expect(states).not.toContain('fatal');
+  });
+
+  it('is idempotent on repeated shutdown', () => {
+    const child = stubChild();
+    const sup = new SidecarSupervisor(child, vi.fn(), 3000, vi.fn());
+    sup.shutdown();
+    sup.shutdown();
+    expect(child.kills).toEqual(['SIGTERM']); // second shutdown is a no-op
+  });
+});

--- a/apps/agent-gui/electron/main.ts
+++ b/apps/agent-gui/electron/main.ts
@@ -1,0 +1,119 @@
+/**
+ * GUI-002 — Electron main process (Node). Thin shell: mint a loopback endpoint, spawn the `robota` sidecar,
+ * load the agent-web-ui SPA in a hardened BrowserWindow, and supervise the child. NO session/command/
+ * permission logic lives here — all of that is in the sidecar, reached over the loopback WS (OWNER PRINCIPLE).
+ */
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { join } from 'node:path';
+
+import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
+
+import {
+  buildSidecarSpawn,
+  endpointUrl,
+  mintToken,
+  SidecarSupervisor,
+  type ISidecarEndpoint,
+  type TSidecarState,
+} from './sidecar.js';
+
+/** Ask the OS for a free loopback port (bind :0, read the assigned port, release). */
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('could not determine a free port')));
+      }
+    });
+  });
+}
+
+let endpoint: ISidecarEndpoint | null = null;
+let supervisor: SidecarSupervisor | null = null;
+
+/** Inject a strict CSP pinning the renderer's only reachable socket to its own loopback sidecar. */
+function installCsp(port: number): void {
+  session.defaultSession.webRequest.onHeadersReceived((details, cb) => {
+    cb({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          `default-src 'self'; connect-src ws://127.0.0.1:${port}; img-src 'self' data:; ` +
+            `style-src 'self' 'unsafe-inline'; script-src 'self'`,
+        ],
+      },
+    });
+  });
+}
+
+/** Deny all navigation + new-window: a redirected renderer must not carry the nonce/session to another origin. */
+function lockNavigation(win: BrowserWindow): void {
+  win.webContents.on('will-navigate', (e) => e.preventDefault());
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+}
+
+async function createWindow(): Promise<void> {
+  const port = await findFreePort();
+  endpoint = { port, token: mintToken() };
+
+  const sidecar = buildSidecarSpawn(endpoint, {
+    baseEnv: process.env,
+    ...(process.env['ROBOTA_GUI_SIDECAR_CMD']
+      ? { command: process.env['ROBOTA_GUI_SIDECAR_CMD'] }
+      : {}),
+  });
+  const child = spawn(sidecar.command, [...sidecar.args], { env: sidecar.env, stdio: 'inherit' });
+
+  const win = new BrowserWindow({
+    width: 1100,
+    height: 780,
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  installCsp(port);
+  lockNavigation(win);
+
+  supervisor = new SidecarSupervisor(child, (state: TSidecarState) => {
+    if (!win.isDestroyed()) win.webContents.send('agent-gui:state', state);
+  });
+
+  win.once('ready-to-show', () => win.show());
+  await win.loadFile(join(__dirname, '../renderer/index.html'));
+
+  win.on('close', () => supervisor?.shutdown());
+}
+
+// The renderer asks (via preload) for its loopback endpoint once, after the DOM is ready.
+ipcMain.handle('agent-gui:endpoint', () => (endpoint ? endpointUrl(endpoint) : null));
+ipcMain.on('agent-gui:ready', () => supervisor?.markReady());
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  supervisor?.shutdown();
+  if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('before-quit', () => supervisor?.shutdown());
+
+// Never open external URLs inside the app.
+app.on('web-contents-created', (_e, contents) => {
+  contents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+});

--- a/apps/agent-gui/electron/preload.ts
+++ b/apps/agent-gui/electron/preload.ts
@@ -1,0 +1,27 @@
+/**
+ * GUI-002 — Electron preload (runs in an isolated context). Exposes ONLY the loopback endpoint + lifecycle
+ * signals to the renderer via `contextBridge` — no Node APIs leak into the agent-web-ui SPA, and the endpoint
+ * (which carries the auth nonce) is never placed on `window` as a plain value that page script could read
+ * off a global before the bridge is set up.
+ */
+
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+
+import type { TSidecarState } from './sidecar.js';
+
+const api = {
+  /** Resolve the loopback WS URL (with the token) the renderer connects to. */
+  getEndpoint: (): Promise<string | null> => ipcRenderer.invoke('agent-gui:endpoint'),
+  /** Tell the main process the session is live (drives the supervisor's `ready`). */
+  signalReady: (): void => ipcRenderer.send('agent-gui:ready'),
+  /** Subscribe to sidecar lifecycle state (`starting`/`ready`/`fatal`). Returns an unsubscribe fn. */
+  onState: (cb: (state: TSidecarState) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, state: TSidecarState): void => cb(state);
+    ipcRenderer.on('agent-gui:state', listener);
+    return () => ipcRenderer.removeListener('agent-gui:state', listener);
+  },
+};
+
+export type TAgentGuiBridge = typeof api;
+
+contextBridge.exposeInMainWorld('agentGui', api);

--- a/apps/agent-gui/electron/sidecar.ts
+++ b/apps/agent-gui/electron/sidecar.ts
@@ -1,0 +1,123 @@
+/**
+ * GUI-002 — pure, Electron-free sidecar logic (unit-testable without a display or the electron binary).
+ *
+ * The Electron main process (`main.ts`) mints a per-launch loopback endpoint, spawns the `robota` CLI as a
+ * sidecar with the token+port in its environment, and supervises the child. All the logic that does NOT need
+ * the electron runtime lives here so it can be tested in a plain Node/vitest environment (TC-04).
+ */
+
+import { randomBytes } from 'node:crypto';
+
+/** Auth-token entropy: 256 bits (32 bytes), hex-encoded. */
+const TOKEN_BYTES = 32;
+
+/** A per-launch loopback endpoint: the free port the sidecar binds + the auth token it must enforce. */
+export interface ISidecarEndpoint {
+  readonly port: number;
+  readonly token: string;
+}
+
+/** The loopback WS URL the renderer connects to — the token rides as a query param (browsers can't set headers). */
+export function endpointUrl(endpoint: ISidecarEndpoint): string {
+  return `ws://127.0.0.1:${endpoint.port}?token=${encodeURIComponent(endpoint.token)}`;
+}
+
+/** Mint the auth token (256-bit, crypto-grade). The port is supplied by the caller (found free via `net`). */
+export function mintToken(): string {
+  return randomBytes(TOKEN_BYTES).toString('hex');
+}
+
+/** The concrete command/args/env used to spawn the `robota` sidecar for a given endpoint. */
+export interface ISidecarSpawn {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}
+
+export interface IBuildSidecarSpawnOptions {
+  /** Override the sidecar command (default `robota`, or `$ROBOTA_GUI_SIDECAR_CMD`). Later: the bundled binary. */
+  readonly command?: string;
+  /** Extra CLI args appended after the defaults. */
+  readonly extraArgs?: readonly string[];
+  /** Base environment to extend (defaults to an empty object in tests; `process.env` in main). */
+  readonly baseEnv?: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * Build the sidecar spawn descriptor: the `robota` CLI, carrying the endpoint as `ROBOTA_WS_TOKEN` +
+ * `ROBOTA_WS_PORT` env (which `agent-cli` reads to enforce the loopback auth — GUI-002 T5). The token is
+ * NEVER placed on the argv (argv is world-readable via `ps`); it travels in the child env only.
+ */
+export function buildSidecarSpawn(
+  endpoint: ISidecarEndpoint,
+  options: IBuildSidecarSpawnOptions = {},
+): ISidecarSpawn {
+  const command = options.command ?? 'robota';
+  const baseEnv = options.baseEnv ?? {};
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(baseEnv)) {
+    if (typeof v === 'string') env[k] = v;
+  }
+  env['ROBOTA_WS_TOKEN'] = endpoint.token;
+  env['ROBOTA_WS_PORT'] = String(endpoint.port);
+  return {
+    command,
+    args: [...(options.extraArgs ?? [])],
+    env,
+  };
+}
+
+/** The lifecycle state the renderer renders (reusing agent-web-ui's `status` surface for the fatal case). */
+export type TSidecarState = 'starting' | 'ready' | 'fatal';
+
+/** Minimal child handle the supervisor drives — satisfied by a `ChildProcess` and by a test stub. */
+export interface ISupervisedChild {
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+/**
+ * Supervise the sidecar child: report state transitions, map an unexpected child exit to `fatal`, and drive
+ * a graceful shutdown (SIGTERM → SIGKILL backstop) on window close. Electron-free; `main.ts` injects the real
+ * spawned child and a timer. Testable with a stub child + fake timers.
+ */
+export class SidecarSupervisor {
+  private state: TSidecarState = 'starting';
+  private stopping = false;
+
+  constructor(
+    private readonly child: ISupervisedChild,
+    private readonly onState: (state: TSidecarState) => void,
+    private readonly killGraceMs = 3000,
+    private readonly setTimer: (fn: () => void, ms: number) => void = setTimeout,
+  ) {
+    this.child.on('exit', (code, signal) => this.handleExit(code, signal));
+  }
+
+  /** Called once the renderer has connected + the session is live. */
+  markReady(): void {
+    if (this.stopping || this.state === 'fatal') return;
+    this.state = 'ready';
+    this.onState('ready');
+  }
+
+  /** Current lifecycle state (diagnostics/tests). */
+  get currentState(): TSidecarState {
+    return this.state;
+  }
+
+  /** Graceful shutdown on window-close/quit: SIGTERM (CLI shuts the session down), SIGKILL backstop. */
+  shutdown(): void {
+    if (this.stopping) return;
+    this.stopping = true;
+    this.child.kill('SIGTERM');
+    this.setTimer(() => this.child.kill('SIGKILL'), this.killGraceMs);
+  }
+
+  private handleExit(_code: number | null, _signal: NodeJS.Signals | null): void {
+    if (this.stopping) return; // expected exit during shutdown — not fatal
+    // An unexpected sidecar exit (crash) surfaces a non-hanging fatal state in the UI.
+    this.state = 'fatal';
+    this.onState('fatal');
+  }
+}

--- a/apps/agent-gui/electron/tsconfig.build.json
+++ b/apps/agent-gui/electron/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["main.ts", "preload.ts", "sidecar.ts"],
+  "exclude": ["../node_modules", "../dist", "__tests__"]
+}

--- a/apps/agent-gui/electron/tsconfig.json
+++ b/apps/agent-gui/electron/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "../dist/electron",
+    "rootDir": ".",
+    "types": ["node", "electron"],
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": false
+  },
+  "include": ["."],
+  "exclude": ["../node_modules", "../dist"]
+}

--- a/apps/agent-gui/index.html
+++ b/apps/agent-gui/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- GUI-002: strict CSP — the renderer may only connect to its own loopback sidecar. The exact port is
+         injected by the Electron main process at load via a CSP response header; this meta is the fallback
+         floor (no remote origins, no inline/eval script beyond the bundled app). -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src ws://127.0.0.1:*; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    />
+    <title>Robota agent-gui</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/agent-gui/package.json
+++ b/apps/agent-gui/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@robota-sdk/agent-gui",
+  "version": "3.0.0-beta.79",
+  "private": true,
+  "description": "agent-gui — a thin Electron desktop shell that drives a robota session over a loopback WS sidecar (GUI-002)",
+  "main": "dist/electron/main.js",
+  "scripts": {
+    "dev": "vite",
+    "build:renderer": "vite build",
+    "build:electron": "tsc -p electron/tsconfig.build.json",
+    "build": "pnpm build:renderer && pnpm build:electron",
+    "start": "electron dist/electron/main.cjs",
+    "typecheck": "tsc --noEmit && tsc -p electron/tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@robota-sdk/agent-web-ui": "workspace:*",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "electron": "^43.0.0",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7",
+    "vitest": "^3.2.6"
+  }
+}

--- a/apps/agent-gui/src/App.tsx
+++ b/apps/agent-gui/src/App.tsx
@@ -1,0 +1,108 @@
+import {
+  ConversationView,
+  AgentActivityPanel,
+  PermissionPrompt,
+  useWsSession,
+  type IWsSessionState,
+} from '@robota-sdk/agent-web-ui/client';
+import { useEffect, useState } from 'react';
+
+import type { TSidecarState } from '../electron/sidecar.js';
+
+/**
+ * GUI-002 renderer compose-root. Mirrors the TUI/`RemoteClient` pattern: it drives the transport-neutral
+ * session ONLY through `agent-web-ui`'s reducer + components — no session/command/permission logic here. The
+ * loopback endpoint (with the auth token) comes from the Electron preload bridge; the sidecar owns everything
+ * below the wire.
+ */
+
+/**
+ * Pure presentation over an `IWsSessionState` (no hooks, no transport) — unit-testable with a stub state
+ * (TC-01/TC-02). Renders the conversation, the background-activity panel, the permission/ask prompts, and a
+ * composer that submits a turn via the reducer's `send`.
+ */
+export function SessionSurface({ state }: { state: IWsSessionState }): React.ReactElement {
+  const [draft, setDraft] = useState('');
+  const submit = (): void => {
+    const prompt = draft.trim();
+    if (!prompt) return;
+    state.send({ type: 'submit', prompt });
+    setDraft('');
+  };
+
+  return (
+    <div className="agent-gui-root">
+      <header className="agent-gui-status" data-status={state.status}>
+        {state.status}
+      </header>
+
+      <ConversationView
+        messages={state.messages}
+        activeTools={state.activeTools}
+        streamingText={state.streamingText}
+        isThinking={state.isThinking}
+      />
+
+      {state.executionWorkspace ? (
+        <AgentActivityPanel tasks={state.executionWorkspace.entries} />
+      ) : null}
+
+      <PermissionPrompt
+        prompts={state.pendingPrompts}
+        onAnswerPermission={state.answerPermission}
+        onAnswerAsk={state.answerAsk}
+      />
+
+      <form
+        className="agent-gui-composer"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        <input
+          aria-label="message"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Message the agent…"
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+
+/** Thin wire binding: connect to the loopback sidecar over WS and render the surface. */
+function SessionView({ url }: { url: string }): React.ReactElement {
+  const state = useWsSession(url);
+  useEffect(() => {
+    if (state.status === 'connected') window.agentGui.signalReady();
+  }, [state.status]);
+  return <SessionSurface state={state} />;
+}
+
+/** Top-level: resolve the endpoint from the preload bridge, watch for a fatal sidecar state, then mount. */
+export function App(): React.ReactElement {
+  const [url, setUrl] = useState<string | null>(null);
+  const [fatal, setFatal] = useState<TSidecarState | null>(null);
+
+  useEffect(() => {
+    void window.agentGui.getEndpoint().then(setUrl);
+    const off = window.agentGui.onState((s) => {
+      if (s === 'fatal') setFatal('fatal');
+    });
+    return off;
+  }, []);
+
+  if (fatal) {
+    return (
+      <div className="agent-gui-fatal" role="alert">
+        The agent process stopped. Restart the app to reconnect.
+      </div>
+    );
+  }
+  if (!url) {
+    return <div className="agent-gui-loading">Starting the agent…</div>;
+  }
+  return <SessionView url={url} />;
+}

--- a/apps/agent-gui/src/__tests__/session-surface.test.tsx
+++ b/apps/agent-gui/src/__tests__/session-surface.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { SessionSurface } from '../App.js';
+
+import type { IWsSessionState } from '@robota-sdk/agent-web-ui/client';
+
+/**
+ * GUI-002 TC-01/TC-02 — the compose-root renders a session over agent-web-ui's reducer state and answers
+ * prompts, WITHOUT any session logic of its own (it only calls `send`/`answerPermission`/`answerAsk`).
+ */
+
+function stubState(over: Partial<IWsSessionState> = {}): IWsSessionState {
+  return {
+    status: 'connected',
+    messages: [{ id: 'm1', role: 'user', content: 'hello' }],
+    activeTools: [],
+    streamingText: '',
+    isThinking: false,
+    executionWorkspace: null,
+    pendingPrompts: [],
+    send: vi.fn(),
+    answerPermission: vi.fn(),
+    answerAsk: vi.fn(),
+    ...over,
+  } as unknown as IWsSessionState;
+}
+
+describe('SessionSurface (GUI-002 TC-01/TC-02)', () => {
+  it('TC-01: renders the conversation + status from the reducer state', () => {
+    render(<SessionSurface state={stubState()} />);
+    expect(screen.getByText('hello')).toBeTruthy();
+    expect(screen.getByText('connected')).toBeTruthy();
+  });
+
+  it('TC-01: submitting the composer calls send({type:submit}) and clears the draft', () => {
+    const state = stubState();
+    render(<SessionSurface state={state} />);
+    const input = screen.getByLabelText('message') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'do a thing' } });
+    fireEvent.click(screen.getByText('Send'));
+    expect(state.send).toHaveBeenCalledWith({ type: 'submit', prompt: 'do a thing' });
+    expect(input.value).toBe('');
+  });
+
+  it('TC-01: an empty/whitespace draft does not submit', () => {
+    const state = stubState();
+    render(<SessionSurface state={state} />);
+    fireEvent.change(screen.getByLabelText('message'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Send'));
+    expect(state.send).not.toHaveBeenCalled();
+  });
+
+  it('TC-02: a pending permission prompt renders and Allow answers it via answerPermission', () => {
+    const state = stubState({
+      pendingPrompts: [
+        { kind: 'permission', id: 'p1', toolName: 'write_file', toolArgs: { path: 'x' } },
+      ] as unknown as IWsSessionState['pendingPrompts'],
+    });
+    render(<SessionSurface state={state} />);
+    expect(screen.getByText(/permission request/i)).toBeTruthy();
+    fireEvent.click(screen.getByText('Allow'));
+    expect(state.answerPermission).toHaveBeenCalledWith('p1', true);
+  });
+});

--- a/apps/agent-gui/src/__tests__/setup.ts
+++ b/apps/agent-gui/src/__tests__/setup.ts
@@ -1,0 +1,7 @@
+/** jsdom lacks layout APIs the agent-web-ui components call (e.g. auto-scroll). Stub them for tests. */
+if (!('scrollIntoView' in Element.prototype)) {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    value: () => undefined,
+    writable: true,
+  });
+}

--- a/apps/agent-gui/src/agent-gui.d.ts
+++ b/apps/agent-gui/src/agent-gui.d.ts
@@ -1,0 +1,14 @@
+import type { TSidecarState } from '../electron/sidecar.js';
+
+/** The preload `contextBridge` surface (see electron/preload.ts). */
+export interface IAgentGuiBridge {
+  getEndpoint(): Promise<string | null>;
+  signalReady(): void;
+  onState(cb: (state: TSidecarState) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    readonly agentGui: IAgentGuiBridge;
+  }
+}

--- a/apps/agent-gui/src/main.tsx
+++ b/apps/agent-gui/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App.js';
+import './theme.css';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('agent-gui: #root not found');
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/agent-gui/src/theme.css
+++ b/apps/agent-gui/src/theme.css
@@ -1,0 +1,86 @@
+/*
+ * GUI-002 theme tokens. `agent-web-ui` components consume CSS custom properties (--background, --card,
+ * --foreground, --primary, …) but ship no CSS; the shell supplies them. Dark palette mirroring the web-ui
+ * demo. (Tailwind utilities used by the components are provided by the renderer's Tailwind build; this file
+ * defines only the design tokens + the shell's own layout classes.)
+ */
+
+:root {
+  --background: #0b0b0e;
+  --foreground: #e6e6ea;
+  --card: #14141a;
+  --card-foreground: #e6e6ea;
+  --muted: #1c1c24;
+  --muted-foreground: #9a9aa6;
+  --border: #26262f;
+  --primary: #7c8cff;
+  --primary-foreground: #0b0b0e;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.agent-gui-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.agent-gui-status {
+  padding: 6px 12px;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+  border-bottom: 1px solid var(--border);
+}
+
+.agent-gui-composer {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+}
+
+.agent-gui-composer input {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.agent-gui-composer button {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  cursor: pointer;
+}
+
+.agent-gui-loading,
+.agent-gui-fatal {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: var(--muted-foreground);
+}
+
+.agent-gui-fatal {
+  color: #f4a3a3;
+}

--- a/apps/agent-gui/tsconfig.json
+++ b/apps/agent-gui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "electron"]
+}

--- a/apps/agent-gui/vite.config.ts
+++ b/apps/agent-gui/vite.config.ts
@@ -1,0 +1,23 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+/**
+ * GUI-002 renderer build. Electron loads `dist/renderer/index.html` via `loadFile` (relative `base` so the
+ * `file://` load resolves assets), and the renderer connects to the sidecar over loopback WS. Vite owns the
+ * browser ESM bundle independently of the (CommonJS) Electron main/preload build.
+ */
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  build: {
+    outDir: 'dist/renderer',
+    emptyOutDir: true,
+    // The renderer runs only in Electron's bundled (recent) Chromium — no legacy-browser down-transpile.
+    target: 'esnext',
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+});

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -86,7 +86,19 @@ function loadReplayProvider(logFile: string): IAIProvider {
 
 function createDefaultTransportRegistry(): TransportRegistry {
   const registry = new TransportRegistry(getUserSettingsPath());
-  registry.register(new WsTransport());
+  // GUI-002: when a host (e.g. the agent-gui Electron shell) spawns this CLI as a loopback sidecar, it
+  // passes ROBOTA_WS_TOKEN (a per-launch nonce) + optional ROBOTA_WS_PORT via env. The token makes the WS
+  // transport reject any unauthenticated connection before emitting session data. Absent = unchanged
+  // default (open localhost path); the token is never persisted to settings (secret, runtime-only).
+  const wsToken = process.env['ROBOTA_WS_TOKEN'];
+  const wsPortRaw = process.env['ROBOTA_WS_PORT'];
+  const wsPort = wsPortRaw ? Number.parseInt(wsPortRaw, 10) : undefined;
+  registry.register(
+    new WsTransport({
+      ...(wsToken ? { token: wsToken } : {}),
+      ...(wsPort !== undefined && Number.isInteger(wsPort) ? { port: wsPort } : {}),
+    }),
+  );
   return registry;
 }
 

--- a/packages/agent-transport-ws/docs/SPEC.md
+++ b/packages/agent-transport-ws/docs/SPEC.md
@@ -41,6 +41,19 @@ imported from there. Consumers import execution-workspace contract types from
 | `WsTransport`       | class    | Settings-backed configurable WS transport |
 | `createWsTransport` | function | Functional WS transport factory           |
 
+### Loopback auth token (GUI-002)
+
+`IWsTransportConfig.token?: string` — an OPTIONAL per-connection auth token. **When set**, every incoming
+connection must present a matching token or the socket is **closed (code 1008) BEFORE any session data
+(`messages` / `execution_workspace_event`) is emitted**. The token is read from the upgrade request as the
+`?token=` query param (browser `WebSocket` cannot set headers) or, failing that, the first
+`Sec-WebSocket-Protocol` subprotocol; comparison is constant-time (`node:crypto` `timingSafeEqual`, length-guarded).
+**When unset** (the default, e.g. the local TUI path) the transport is unauthenticated exactly as before — a
+backward-compatible no-op. It is a runtime-injected secret (not part of `optionsSchema`, never persisted to
+settings). The `agent-cli` composition root passes it from `ROBOTA_WS_TOKEN` (+ optional `ROBOTA_WS_PORT`)
+when a host such as the `agent-gui` Electron shell spawns the CLI as a loopback sidecar. The pre-existing
+unauthenticated default path is tracked for hardening by a companion SECURITY backlog.
+
 ## Extension Points
 
 New message variants extend the protocol unions; new transport options extend the option interfaces.

--- a/packages/agent-transport-ws/src/__tests__/ws-transport-auth.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-transport-auth.test.ts
@@ -1,0 +1,107 @@
+import { AddressInfo } from 'node:net';
+
+import { WebSocket } from 'ws';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { WsTransport } from '../ws-transport-configurable.js';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * GUI-002 TC-03 — required loopback auth token. A configured token MUST be presented (query param or
+ * `Sec-WebSocket-Protocol` subprotocol) or the socket is closed BEFORE any session data (`messages` /
+ * `execution_workspace_event`) is emitted. No token configured = unchanged (open) behavior.
+ */
+
+function mockSession(): IInteractiveSession {
+  return {
+    getMessages: vi.fn().mockReturnValue([{ role: 'user', content: 'hi' }]),
+    getExecutionWorkspaceSnapshot: vi.fn().mockReturnValue({ entries: [] }),
+    on: vi.fn(),
+    off: vi.fn(),
+    submit: vi.fn(),
+    abort: vi.fn(),
+    cancelQueue: vi.fn(),
+    executeCommand: vi.fn(),
+    resolvePermission: vi.fn(),
+    resolveAsk: vi.fn(),
+  } as unknown as IInteractiveSession;
+}
+
+const started: WsTransport[] = [];
+
+async function startOn(config: { token?: string }): Promise<number> {
+  // Use a high, unlikely-occupied base port; retry covers rare collisions.
+  const port = 17000 + Math.floor((started.length + 1) * 7);
+  const t = new WsTransport({ port, maxRetries: 30, ...config });
+  t.attach(mockSession());
+  await t.start();
+  started.push(t);
+  return port;
+}
+
+afterEach(async () => {
+  while (started.length) await started.pop()!.stop();
+});
+
+/**
+ * Connect and resolve with the outcome: `'messages'` if a `messages` frame arrives first, or `'closed'`
+ * with the close code if the socket closes before any frame. 1.5s guard so a hang fails loudly.
+ */
+function probe(port: number, opts: { token?: string; subprotocol?: string } = {}): Promise<string> {
+  const url = `ws://127.0.0.1:${port}${opts.token ? `?token=${encodeURIComponent(opts.token)}` : ''}`;
+  const ws = opts.subprotocol ? new WebSocket(url, opts.subprotocol) : new WebSocket(url);
+  return new Promise<string>((resolve) => {
+    const done = (v: string): void => {
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+      resolve(v);
+    };
+    const timer = setTimeout(() => done('timeout'), 1500);
+    ws.on('message', (data) => {
+      const msg = JSON.parse(String(data)) as { type: string };
+      if (msg.type === 'messages') {
+        clearTimeout(timer);
+        done('messages');
+      }
+    });
+    ws.on('close', (code) => {
+      clearTimeout(timer);
+      done(`closed:${code}`);
+    });
+    ws.on('error', () => {
+      clearTimeout(timer);
+      done('closed:error');
+    });
+  });
+}
+
+describe('WsTransport loopback auth (GUI-002 TC-03)', () => {
+  it('accepts a connection presenting the correct token via query param', async () => {
+    const port = await startOn({ token: 'secret-nonce' });
+    expect(await probe(port, { token: 'secret-nonce' })).toBe('messages');
+  });
+
+  it('accepts the correct token via Sec-WebSocket-Protocol subprotocol', async () => {
+    const port = await startOn({ token: 'secret-nonce' });
+    expect(await probe(port, { subprotocol: 'secret-nonce' })).toBe('messages');
+  });
+
+  it('rejects a MISSING token before any session data is emitted', async () => {
+    const port = await startOn({ token: 'secret-nonce' });
+    expect(await probe(port)).toBe('closed:1008'); // never 'messages'
+  });
+
+  it('rejects a WRONG token before any session data is emitted', async () => {
+    const port = await startOn({ token: 'secret-nonce' });
+    expect(await probe(port, { token: 'not-the-nonce' })).toBe('closed:1008');
+  });
+
+  it('unchanged (open) behavior when NO token is configured — default TUI path', async () => {
+    const port = await startOn({}); // no token
+    expect(await probe(port)).toBe('messages'); // any connection is served
+  });
+});

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -3,7 +3,8 @@
  * Owns the WebSocket server lifecycle (ws package), started/stopped via the transport registry.
  */
 
-import { createServer, type Server } from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
 
 import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -21,6 +22,38 @@ const DEFAULT_MAX_RETRIES = 20;
 export interface IWsTransportConfig {
   port?: number;
   maxRetries?: number;
+  /**
+   * GUI-002: OPTIONAL loopback auth token. When set, every connection MUST present a matching token
+   * (query param `?token=` or the `Sec-WebSocket-Protocol` subprotocol) or the socket is closed
+   * BEFORE any session data is emitted. Unset (default, e.g. the local TUI path) = no auth, unchanged
+   * behavior. The GUI-spawned sidecar sets this so a co-resident browser page cannot drive the session.
+   */
+  token?: string;
+}
+
+/**
+ * Constant-time token comparison. Returns false on any length mismatch (never throws), so an
+ * absent/short/long presented token is a plain reject, not an error.
+ */
+function tokenMatches(expected: string, presented: string | null | undefined): boolean {
+  if (!presented) return false;
+  const a = Buffer.from(expected);
+  const b = Buffer.from(presented);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Read the presented token from the upgrade request: `?token=` query param, else the WS subprotocol. */
+function presentedToken(req: IncomingMessage): string | null {
+  try {
+    const url = new URL(req.url ?? '', 'ws://127.0.0.1');
+    const q = url.searchParams.get('token');
+    if (q) return q;
+  } catch {
+    // malformed URL → fall through to the subprotocol header
+  }
+  const proto = req.headers['sec-websocket-protocol'];
+  return typeof proto === 'string' ? proto.split(',')[0]?.trim() || null : null;
 }
 
 export class WsTransport implements IConfigurableTransport<IInteractiveSession> {
@@ -39,10 +72,12 @@ export class WsTransport implements IConfigurableTransport<IInteractiveSession> 
   private stopFn: (() => Promise<void>) | null = null;
   private readonly port: number;
   private readonly maxRetries: number;
+  private readonly token?: string;
 
   constructor(config: IWsTransportConfig = {}) {
     this.port = config.port ?? DEFAULT_PORT;
     this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    if (config.token) this.token = config.token;
   }
 
   attach(session: IInteractiveSession): void {
@@ -94,10 +129,19 @@ export class WsTransport implements IConfigurableTransport<IInteractiveSession> 
         reject(err);
       });
 
+      const expectedToken = this.token;
       httpServer.listen(port, '127.0.0.1', () => {
         const wss = new WebSocketServer({ server: httpServer });
 
-        wss.on('connection', (ws: WebSocket) => {
+        wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+          // GUI-002: REJECT BEFORE ANY SESSION DATA. When a token is configured, an unauthenticated
+          // connection is closed here — before the `messages` / `execution_workspace_event` sends below —
+          // so a co-resident browser page cannot read history or answer prompts on the open loopback port.
+          if (expectedToken !== undefined && !tokenMatches(expectedToken, presentedToken(req))) {
+            ws.close(1008, 'unauthorized');
+            return;
+          }
+
           const send = (message: TServerMessage): void => {
             if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(message));
           };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         version: 0.3.1
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   apps/action:
     dependencies:
@@ -132,6 +132,46 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
+
+  apps/agent-gui:
+    dependencies:
+      '@robota-sdk/agent-web-ui':
+        specifier: workspace:*
+        version: link:../../packages/agent-web-ui
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3)
+      electron:
+        specifier: ^43.0.0
+        version: 43.1.0
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.7
+        version: 6.4.3(@types/node@20.19.43)(tsx@4.22.4)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   apps/agent-server:
     dependencies:
@@ -1043,7 +1083,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-command:
     dependencies:
@@ -1163,7 +1203,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-executor:
     dependencies:
@@ -1194,7 +1234,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-framework:
     dependencies:
@@ -1231,7 +1271,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-interface-transport:
     dependencies:
@@ -1250,7 +1290,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-interface-tui:
     devDependencies:
@@ -1265,7 +1305,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-playground:
     dependencies:
@@ -1439,7 +1479,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-process:
     devDependencies:
@@ -1457,7 +1497,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-provider-anthropic:
     dependencies:
@@ -1641,7 +1681,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-remote-client:
     dependencies:
@@ -1663,7 +1703,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-remote-pairing:
     devDependencies:
@@ -1678,7 +1718,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-session:
     dependencies:
@@ -1703,7 +1743,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-session-analytics:
     dependencies:
@@ -1725,7 +1765,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-subagent-runner:
     dependencies:
@@ -1787,7 +1827,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-tool-mcp:
     devDependencies:
@@ -1805,7 +1845,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-tools:
     dependencies:
@@ -1836,7 +1876,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport:
     dependencies:
@@ -1867,7 +1907,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport-http:
     dependencies:
@@ -1889,7 +1929,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport-mcp:
     dependencies:
@@ -1911,7 +1951,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport-protocol:
     dependencies:
@@ -1930,7 +1970,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport-tui:
     dependencies:
@@ -2000,7 +2040,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-transport-webrtc:
     dependencies:
@@ -2031,7 +2071,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
       werift:
         specifier: ^0.23.0
         version: 0.23.0
@@ -2065,7 +2105,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/agent-web-ui:
     dependencies:
@@ -2120,7 +2160,7 @@ importers:
         version: 8.0.16(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-adapters-local:
     dependencies:
@@ -2142,7 +2182,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-adapters-sqlite:
     dependencies:
@@ -2167,7 +2207,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-api:
     dependencies:
@@ -2192,7 +2232,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-builder:
     dependencies:
@@ -2297,7 +2337,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-cost:
     dependencies:
@@ -2319,7 +2359,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-framework:
     dependencies:
@@ -2416,7 +2456,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes-default:
     dependencies:
@@ -2511,7 +2551,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/file-read:
     dependencies:
@@ -2542,7 +2582,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/file-write:
     dependencies:
@@ -2573,7 +2613,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/gemini-image-edit:
     dependencies:
@@ -2610,7 +2650,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/http-request:
     dependencies:
@@ -2641,7 +2681,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/image-loader:
     dependencies:
@@ -2669,7 +2709,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/image-source:
     dependencies:
@@ -2697,7 +2737,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/input:
     dependencies:
@@ -2725,7 +2765,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/instant-node:
     dependencies:
@@ -2771,7 +2811,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/llm-text:
     dependencies:
@@ -2805,7 +2845,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/mcp-tool:
     dependencies:
@@ -2839,7 +2879,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/multi-input:
     dependencies:
@@ -2867,7 +2907,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/ok-emitter:
     dependencies:
@@ -2895,7 +2935,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/seedance-video:
     dependencies:
@@ -2932,7 +2972,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/skill:
     dependencies:
@@ -2966,7 +3006,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/text-output:
     dependencies:
@@ -2994,7 +3034,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/text-template:
     dependencies:
@@ -3022,7 +3062,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/text-to-image:
     dependencies:
@@ -3059,7 +3099,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/tool:
     dependencies:
@@ -3096,7 +3136,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/transform:
     dependencies:
@@ -3124,7 +3164,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-nodes/utility-text:
     dependencies:
@@ -3152,7 +3192,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-orchestration-client:
     dependencies:
@@ -3180,7 +3220,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-projection:
     dependencies:
@@ -3205,7 +3245,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-runtime:
     dependencies:
@@ -3230,7 +3270,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-scheduler:
     dependencies:
@@ -3261,7 +3301,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   packages/dag-worker:
     dependencies:
@@ -3286,7 +3326,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4)
+        version: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
 
   scratch:
     dependencies:
@@ -4381,6 +4421,27 @@ packages:
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+    dev: true
+
+  /@electron-internal/extract-zip@1.0.4:
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    engines: {node: '>=22.12.0'}
+    dev: true
+
+  /@electron/get@5.0.0:
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
+    dependencies:
+      debug: 4.4.3
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
+      progress: 2.0.3
+      semver: 7.8.4
+      sumchecker: 3.0.1
+    optionalDependencies:
+      undici: 7.28.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@emnapi/core@1.10.0:
@@ -9010,7 +9071,6 @@ packages:
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
     dependencies:
       undici-types: 7.18.2
-    dev: false
 
   /@types/promise.allsettled@1.0.6:
     resolution: {integrity: sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg==}
@@ -9615,6 +9675,23 @@ packages:
       d3-transition: 3.0.1(d3-selection@3.0.0)
     dev: false
 
+  /@vitejs/plugin-react@4.7.0(vite@6.4.3):
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: '>=7.3.2'
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@20.19.43)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitejs/plugin-react@4.7.0(vite@8.0.16):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -9654,7 +9731,7 @@ packages:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/node@20.19.43)(tsx@4.22.4)
+      vitest: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11869,6 +11946,18 @@ packages:
   /electron-to-chromium@1.5.371:
     resolution: {integrity: sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==}
 
+  /electron@43.1.0:
+    resolution: {integrity: sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==}
+    engines: {node: '>= 22.12.0'}
+    hasBin: true
+    dependencies:
+      '@electron-internal/extract-zip': 1.0.4
+      '@electron/get': 5.0.0
+      '@types/node': 24.13.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
@@ -11945,6 +12034,11 @@ packages:
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+    dev: true
+
+  /env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /environment@1.1.0:
@@ -17597,6 +17691,11 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: true
 
+  /progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /promise.allsettled@1.0.7:
     resolution: {integrity: sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==}
     engines: {node: '>= 0.4'}
@@ -19268,6 +19367,15 @@ packages:
       ts-interface-checker: 0.1.13
     dev: true
 
+  /sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -19901,12 +20009,18 @@ packages:
 
   /undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-    dev: false
 
   /undici@6.24.1:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
     dev: false
+
+  /undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
@@ -20316,6 +20430,58 @@ packages:
       - yaml
     dev: true
 
+  /vite@6.4.3(@types/node@20.19.43)(tsx@4.22.4):
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 20.19.43
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.59.1
+      tinyglobby: 0.2.17
+      tsx: 4.22.4
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@8.0.16(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.22.4):
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -20503,7 +20669,7 @@ packages:
       - yaml
     dev: true
 
-  /vitest@3.2.6(@types/node@20.19.43)(tsx@4.22.4):
+  /vitest@3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.22.4):
     resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20543,6 +20709,7 @@ packages:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
+      jsdom: 25.0.1
       magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.4

--- a/scripts/harness/check-capability-placement.mjs
+++ b/scripts/harness/check-capability-placement.mjs
@@ -101,6 +101,7 @@ const DOCUMENTED_WORKSPACE_PATTERNS = [
   { pathPattern: /^packages\/dag-[^/]+$/, textPattern: /dag-core\// },
   { pathPattern: /^packages\/dag-nodes\/[^/]+$/, textPattern: /dag-nodes\/\*/ },
   { pathPattern: /^apps\/agent-web$/, textPattern: /agent-web/ },
+  { pathPattern: /^apps\/agent-gui$/, textPattern: /agent-gui/ },
   { pathPattern: /^apps\/agent-server$/, textPattern: /agent-server/ },
   { pathPattern: /^apps\/dag-runtime-server$/, textPattern: /dag-runtime-server/ },
   { pathPattern: /^apps\/remote-signaling$/, textPattern: /remote-signaling/ },


### PR DESCRIPTION
## Promotion — develop → main

Two commits, both agent-gui, already merge-verified on develop:

| Commit | What |
| --- | --- |
| #1129 | **GUI-002** — agent-gui Electron desktop shell Stage 1 MVP + the required loopback-auth token on `WsTransport` (reject-before-emit, closes the unauthenticated-loopback hole for the GUI sidecar). Fully gated (research → spec → 3 review rounds → GATE-APPROVAL → GATE-IMPLEMENT); Fork A Tauri→Electron per owner direction, re-endorsed. |
| #1124 | GUI-001 research-first backlog registration. |

### Verification
- PR #1129 merge-verified onto develop (PASS): all 27 files in scope, no lessons drift, reject-before-emit confirmed.
- develop CI green at `2fb9308bd`: build, quality, scans, security audit, tui-e2e, windows-shell, examples-typecheck, commitlint.
- No new code beyond those merged commits.

After merge: GATE-COMPLETE bookkeeping (GUI-002 spec active→done; GUI-002 task archived).

🤖 Generated with [Claude Code](https://claude.com/claude-code)