### PR TITLE
chore(gui): GATE-COMPLETE GUI-005 + file GUI-006 web-unification backlog

### DIFF
--- a/.agents/backlog/GUI-006-web-gui-unification-agent-web-ui-absorption.md
+++ b/.agents/backlog/GUI-006-web-gui-unification-agent-web-ui-absorption.md
@@ -1,0 +1,56 @@
+---
+title: 'GUI-006: unify the web GUI surface over agent-transport-gui + absorb/retire agent-web-ui (GUI Phase-2)'
+status: todo
+created: 2026-07-12
+priority: medium
+urgency: later
+area: packages/agent-web-ui, packages/agent-transport-gui, apps/agent-web
+depends_on: [GUI-005]
+---
+
+# GUI-006: web GUI unification + agent-web-ui absorption (GUI Phase-2)
+
+> **Research-first.** Goes through the spec gate (`.agents/spec-docs/draft/<TYPE>-*.md` → GATE-WRITE →
+> GATE-APPROVAL) before any code. Requested by the owner during GUI-005: "결국은 차후에 agent-web-ui 는
+> 정리되어야겠다. 삭제하거나 다른거에 흡수되거나."
+
+## Problem / Goal
+
+GUI-005 established the taxonomy **presentation = TUI | GUI; GUI = app | web over a shared GUI core
+(`@robota-sdk/agent-transport-gui`)**. The desktop surface (`apps/agent-app`) now renders the shared core
+directly — the GUI analog of how `agent-cli` renders `agent-transport-tui`. The **web** surface is only
+partway there: `packages/agent-web-ui` still exists as a distinct product that (a) composes the shared core
+into a bespoke `SessionMonitor` page and (b) owns the browser-remote (WebRTC) peer surface (`RemoteClient`,
+`useRtcSession`, the RTC clients, `spa/remote.html`, REMOTE-009..013).
+
+The intent of Phase-2 is to make the web GUI a first-class sibling of the desktop GUI over the SAME shared
+core, and then **absorb or retire `agent-web-ui`** so there is no lingering standalone "browser product" that
+diverges from the taxonomy.
+
+## Scope to investigate (not yet decided — spec will choose)
+
+1. **Web GUI surface.** Should the web app render the shared `SessionSurface` (or a web-appropriate shell) from
+   `agent-transport-gui` directly, the way `apps/agent-app` does — replacing the bespoke `SessionMonitor`
+   layout? Decide whether `SessionMonitor` becomes a thin `apps/agent-web` composition or a shared-core export.
+2. **Browser-remote (WebRTC) home.** Where do the REMOTE-009..013 pieces live once `agent-web-ui` is absorbed?
+   Options: a dedicated `agent-transport-webrtc`-browser package, a `./remote` subpath of the shared core (only
+   if it does not drag pairing deps into the core's contract-pure boundary), or `apps/agent-web` app code.
+   Preserve the acyclic-deps + no-pass-through-re-export invariants and the fail-closed `ResponderGate`.
+3. **Retirement path for `agent-web-ui`.** A staged move (each owned symbol relocated to its correct home) with
+   `apps/agent-web` re-pointed, then the package deleted — no behavior change, verified by the existing web-ui
+   test suite migrating with the code.
+
+## Constraints / invariants (carry over from GUI-005)
+
+- The shared core `agent-transport-gui` stays contract-pure: deps = `agent-interface-transport` +
+  `agent-transport-protocol` only. No pairing/framework/core dep may leak in via the WebRTC relocation.
+- No dependency cycle; no pass-through re-exports.
+- Web verification is agent-owned (headless browser test env), mirroring the GUI-005 e2e approach.
+
+## Acceptance (high level — the spec will formalize)
+
+- The web GUI renders over the shared core on the same footing as `apps/agent-app`.
+- `agent-web-ui` is either deleted or reduced to nothing that duplicates the shared core; its remaining
+  responsibilities live in correctly-placed homes.
+- `apps/agent-web` builds/typechecks/e2e green; `harness:scan` green; `.agents/project-structure.md` + arch-map
+  updated.

--- a/.agents/spec-docs/done/GUI-005-gui-presentation-taxonomy.md
+++ b/.agents/spec-docs/done/GUI-005-gui-presentation-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags: [gui, architecture, presentation, electron, react, refactor]
 ---
@@ -263,3 +263,50 @@ apps/agent-app` rename, as an isolated commit per T4).
 - Test Plan present: task file has a `## Test Plan` section (TC-01..TC-05 rows, ≥50 chars) satisfying the `test-plans` harness scan requirement. [AF-24]
 - Note (non-blocking, not a gate criterion): the task file's TC-02 wording still references a "re-export shim", which the spec's post-proposal-review decision reversed (NO re-export shim). Content freshness of the task file is out of scope for this gate; flagged for the implementer to reconcile.
 - Spec moved `todo/ → active/`; frontmatter set to `status: in-progress`. Task file stays in place.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-12
+
+**Status upgrade:** in-progress → verify-passed
+
+Every Completion Criterion verified (agent-owned; GUI verification not deferred to the owner):
+
+- **TC-01** — `@robota-sdk/agent-transport-gui` builds (tsdown dual node/browser) + typechecks; exports the
+  session core (`useSessionClient`/`useWsSession`/`createWsSessionClient`, prompt-state, `ConversationView`/
+  `AgentActivityPanel`/`PermissionPrompt`/`SessionSurface`/`CenteredChrome`, `styles/theme.css`). Deps =
+  `agent-interface-transport` + `agent-transport-protocol` + react-markdown/remark-gfm + react peer only — NO
+  pairing, NO agent-web-ui. Unit tests 10/10.
+- **TC-02** — `agent-web-ui` refactored to the browser-remote surface; imports the core directly and does NOT
+  re-export it (proposal-review-corrected: exports only its owned RTC surface — no pass-through shim).
+  `apps/agent-web` (robota-web) typecheck green with no source edit. web-ui unit tests 45/45.
+- **TC-03** — `apps/agent-app` (renamed from `apps/agent-gui`) renders via `agent-transport-gui/client` (no
+  agent-web-ui import); Vite+Tailwind renderer + Electron build clean; jsdom unit tests 12/12; headless
+  Playwright `_electron`+xvfb e2e **5/5** over the real `WsTransport` sidecar; screenshots captured + shown to
+  the owner (terminal-noir shell: title/status bar, user/agent blocks, composer + key hints, permission modal).
+- **TC-04** — dependency-direction: `agent-transport-gui` → contract/protocol only; `agent-web-ui` +
+  `apps/agent-app` → `agent-transport-gui`; no cycle (generic status param keeps RTC states out of the core);
+  `apps/agent-app` has no agent-framework/agent-core dep. Registered in `.agents/project-structure.md` +
+  capability-placement allowlist (`apps/agent-app`).
+- **TC-05** — affected typecheck (agent-transport-gui, agent-web-ui, agent-app, robota-web) + tests (67 total) +
+  `pnpm harness:scan` **49/49** green. All packages `private:true` → no changeset. SPEC + README authored for
+  the new package + refactored for agent-web-ui + renamed app.
+
+Independent architecture-conformance audit (architecture-conformance-auditor): **materially conformant** — deps
+exact, no cycle, no pass-through re-export, correct peer-of-agent-transport-tui placement all HOLD. All five
+findings (four doc-side + one unused-dep) applied before merge.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-12
+
+**Status upgrade:** verify-passed → done
+
+- Shipped to `main`: implementation squash `55287530a` (#1137, feature→develop) promoted via #1138
+  (develop→main merge `6dcff493e`). Both hops merge-verified (merge-verifier → LANDED: PASS): the new
+  `packages/agent-transport-gui`, the renamed `apps/agent-app` (old `apps/agent-gui` gone), and `agent-web-ui`
+  import-not-re-export are present on the remote target; CI green (build/quality/scans/security/compat-node18/
+  release-grade verification); no unrelated drift.
+- GUI verification agent-owned end-to-end (headless Electron test env built + run by the agent; not deferred).
+- Follow-up filed: **GUI-006** backlog — unify the web GUI surface over `agent-transport-gui` and
+  absorb/retire `agent-web-ui` (GUI Phase-2), per the owner's "agent-web-ui는 정리되어야겠다" directive.
+- Parent GUI-001 backlog intent (a GUI layer mirroring the TUI) is now satisfied for the desktop surface; the
+  web surface unification remains as GUI-006.
+
+Spec moved `active/ → done/`; frontmatter `status: done`.

--- a/.agents/tasks/completed/GUI-005.md
+++ b/.agents/tasks/completed/GUI-005.md
@@ -11,27 +11,27 @@ cleanup/absorption.
 
 ## Tasks
 
-- [ ] T1: GATE-IMPLEMENT — task file + spec → active/, in-progress.
-- [ ] T2 (TC-01): Scaffold `packages/agent-transport-gui` (mirror agent-transport-tui package shape); MOVE the
+- [x] T1: GATE-IMPLEMENT — task file + spec → active/, in-progress.
+- [x] T2 (TC-01): Scaffold `packages/agent-transport-gui` (mirror agent-transport-tui package shape); MOVE the
       generic session UI (ConversationView, PermissionPrompt, AgentActivityPanel), `useSessionClient`/
       `useWsSession` reducer, `prompt-state`, `ws-session-client`, shared types from `agent-web-ui`; ADD the
       desktop shell (SessionSurface/TitleBar/Composer/empty·loading·fatal chrome) + Tailwind v4 entry +
       terminal-noir theme (from the GUI-004 WIP stash) + a `useLoopbackSession(url)` hook. Deps: contract +
       protocol + react-markdown/remark-gfm + react peer; NO agent-remote-pairing, NO agent-web-ui.
-- [ ] T3 (TC-02): Refactor `agent-web-ui` — add `agent-transport-gui` dep; RE-EXPORT the moved generics from
+- [x] T3 (TC-02): Refactor `agent-web-ui` — add `agent-transport-gui` dep; RE-EXPORT the moved generics from
       `src/index.ts` (public `./client` API byte-stable); re-point the browser-remote files (rtc-\*, RemoteClient,
       SessionMonitor, useRtcSession) to import generics from `agent-transport-gui`; delete the moved files.
       Verify `apps/agent-web` typecheck + build unchanged.
-- [ ] T4 (TC-03): `git mv apps/agent-gui apps/agent-app`; rename `@robota-sdk/agent-gui` → `@robota-sdk/agent-app`;
+- [x] T4 (TC-03): `git mv apps/agent-gui apps/agent-app`; rename `@robota-sdk/agent-gui` → `@robota-sdk/agent-app`;
       renderer imports `agent-transport-gui` (SessionSurface + useLoopbackSession + theme) instead of agent-web-ui;
       carry over electron shell/preload/sidecar/nonce/vite/e2e/docs; run the headless e2e (5/5) + capture.
-- [ ] T5 (TC-04): Dependency-direction — `agent-transport-gui` → contract/protocol only; app/web-ui →
+- [x] T5 (TC-04): Dependency-direction — `agent-transport-gui` → contract/protocol only; app/web-ui →
       agent-transport-gui; no cycle; app has no agent-framework/agent-core dep. Register in
       `.agents/project-structure.md` + capability-placement allowlist.
-- [ ] T6 (TC-05): affected typecheck + tests + `pnpm harness:scan` green; changeset if `agent-web-ui` published
+- [x] T6 (TC-05): affected typecheck + tests + `pnpm harness:scan` green; changeset if `agent-web-ui` published
       surface changed (expected none); SPEC + README for the new package + renamed app.
-- [ ] T7: feature→develop→main via merge-verifier; run the e2e myself (agent-owned).
-- [ ] T8: GATE-COMPLETE — spec active→done; file the Phase-2 backlog (agent-web-ui cleanup/absorption).
+- [x] T7: feature→develop→main via merge-verifier; run the e2e myself (agent-owned).
+- [x] T8: GATE-COMPLETE — spec active→done; file the Phase-2 backlog (agent-web-ui cleanup/absorption).
 
 ## Test Plan
 
@@ -44,3 +44,15 @@ cleanup/absorption.
 - **TC-04** (static/harness): dependency-direction + no cycle; `apps/agent-app` no framework/core dep;
   `pnpm harness:scan` (deps, capability-placement) green.
 - **TC-05** (harness): affected typecheck + tests + `pnpm harness:scan` all green; changeset check.
+
+## Completion (2026-07-12)
+
+DONE — shipped to `main` (impl #1137 `55287530a` → promotion #1138 `6dcff493e`), both hops merge-verified
+(LANDED: PASS). Independent architecture-conformance audit: materially conformant (findings applied).
+Verification agent-owned: builds + typecheck (agent-transport-gui / agent-web-ui / agent-app / robota-web),
+67 unit tests, 5/5 headless Electron e2e over the real WsTransport sidecar (screenshots shown to owner),
+harness:scan 49/49. Spec → `.agents/spec-docs/done/`. Phase-2 filed as **GUI-006** backlog.
+
+NOTE — T3's original "RE-EXPORT the moved generics" was reversed by proposal-review: agent-web-ui exports
+ONLY its owned RTC surface (no pass-through re-export); consumers import the core directly from
+`@robota-sdk/agent-transport-gui`. Implemented per the corrected decision.


### PR DESCRIPTION
Bookkeeping for the already-shipped GUI-005 (code merged to main via #1137→#1138, both merge-verified LANDED).

- GUI-005 spec `active/` → `done/` with `[GATE-VERIFY]` + `[GATE-COMPLETE]` records.
- Task file → `completed/` with a completion note (records the proposal-review-corrected no-re-export decision).
- **NEW `GUI-006` backlog** — unify the web GUI surface over `agent-transport-gui` and absorb/retire `agent-web-ui` (GUI Phase-2), per the owner's directive.

`pnpm harness:scan` 49/49 (done-evidence, task-archival, backlog-placement, spec-doc-frontmatter all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)