### PR TITLE
Promote language-policy clarification develop→main

### DIFF
--- a/.agents/rules/agent-conduct.md
+++ b/.agents/rules/agent-conduct.md
@@ -15,6 +15,14 @@ structure) are not in conflict and remain in force — see the Structured-artifa
 
 ## Communication & Formatting
 
+- **Language (non-negotiable).** Respond to the user in the language the user is writing in. This is
+  universal — follow whichever language the current user uses, not a fixed one — and it is a hard
+  compliance rule, not a preference: every message directed to the user, and in particular any that
+  **reports results, asks a question, or requests a decision**, MUST be in that user's language. Do not
+  mix in another language for the user-facing narrative. (Code, identifiers, and machine-parsed
+  artifacts follow their own policy in [naming-style.md](naming-style.md); this governs only the prose
+  addressed to the person.) SSOT: naming-style Language Policy; elevated here because it takes RCP
+  communication precedence and had been under-enforced.
 - **Tone.** Use a warm tone and treat the person as a capable adult, without negative assumptions
   about their judgement or ability. Push back when warranted, but constructively and honestly.
   Illustrate with examples, thought experiments, or metaphors where they aid clarity. Never curse

--- a/.agents/rules/naming-style.md
+++ b/.agents/rules/naming-style.md
@@ -5,15 +5,18 @@ Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 
 ### Language Policy
 
-- Code and comments: English only.
-- Conversations with the user: Korean only.
-- Documents in `.design/`: Korean only.
-- Documents in all other folders: English only.
-- Commit messages: English only and conventional commits format.
+- **User-facing responses: match the user's CURRENT message language, dynamically.** Reply in whichever
+  language the user writes in for that message — if they write English, reply in English; if Korean, reply in
+  Korean; this is matched per-message, never pinned to one language. This is the ONLY thing keyed to the user's
+  language, and it applies to every message addressed to the user (especially reports, questions, and
+  decision-requests). Do not mix another language into that user-facing narrative.
+- **Everything else defaults to English**, unless the user explicitly requests otherwise: code and comments,
+  ALL repository documents (including `.design/`), commit messages (conventional-commits format), and any other
+  written artifact.
 
-### Korean Writing Style (Blog / .design/)
+### Korean Writing Style (only when Korean output is explicitly requested)
 
-When writing Korean content (blog posts, presentations, design documents):
+When the user explicitly requests Korean content (e.g., a Korean blog post) — Korean is never the default:
 
 - No `적` suffix — restructure the sentence instead (e.g., "현실적인" → rephrase without "적")
 - No `의` possessive — restructure to avoid it

--- a/.agents/skills/repo-writing/SKILL.md
+++ b/.agents/skills/repo-writing/SKILL.md
@@ -31,18 +31,20 @@ description: Applies Robota's repository writing rules for `.design/`, general d
    - general repository document
    - generated documentation
    - commit message
-2. Apply the language rule:
-   - `.design/` in Korean
-   - repository documents outside `.design/` in English
-   - commit messages in English
+2. Apply the language rule (SSOT: [naming-style Language Policy](../../rules/naming-style.md)):
+   - ALL repository documents — including `.design/` — in English by default; another language only when the
+     user explicitly requests it
+   - commit messages in English (conventional-commits format)
+   - (only user-facing conversational responses match the user's current message language — that is not a
+     document-writing concern)
 3. If the target is generated docs, update the source or generator instead of editing generated output directly.
 4. If the target is a commit message, keep it in conventional commit format and focus on what changed for users or maintainers.
 5. Keep examples and surrounding prose aligned with the target language of the document.
 
 ## Stop Conditions
 
-- A `.design/` document is written in English.
-- A non-`.design/` repository document is written in Korean.
+- Any repository document (including `.design/`) is written in a non-English language without an explicit user
+  request for that language.
 - Generated docs are edited directly.
 - A commit message is not in English or not in conventional format.
 
@@ -63,7 +65,7 @@ docs(design): document harness migration phases
 ```
 
 ```text
-.design/tmp/ -> Korean
+.design/tmp/ -> English (default)
 packages/*/docs/ -> English
 README.md -> English
 ```


### PR DESCRIPTION
Promotes #1145: user-facing responses match the user's current message language (dynamic); everything else defaults to English. Docs/harness only. harness:scan 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)