### PR TITLE
fix(ci): share a concurrency group across the two v* release workflows

### DIFF
--- a/.github/workflows/release-bun-binaries.yml
+++ b/.github/workflows/release-bun-binaries.yml
@@ -18,6 +18,12 @@ on:
 permissions:
   contents: write
 
+# Shares the Release with release-desktop-app.yml (both fire on v*) — same group so they serialize on release
+# creation and never race on `gh release create`.
+concurrency:
+  group: release-assets-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   bun-binaries:
     name: Build + publish Bun binaries


### PR DESCRIPTION
Both `release-bun-binaries.yml` and `release-desktop-app.yml` fire on `push: tags: v*` and create-or-view the same Release. Add the shared `release-assets-${tag}` concurrency group to the bun workflow (desktop already has it) so they serialize on release creation — prevents a `gh release create` race. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)