### PR TITLE
Merge develop → main: shared concurrency for the v* release workflows (#1163)

### DIFF
--- a/.github/workflows/release-bun-binaries.yml
+++ b/.github/workflows/release-bun-binaries.yml
@@ -18,6 +18,12 @@ on:
 permissions:
   contents: write
 
+# Shares the Release with release-desktop-app.yml (both fire on v*) — same group so they serialize on release
+# creation and never race on `gh release create`.
+concurrency:
+  group: release-assets-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   bun-binaries:
     name: Build + publish Bun binaries


### PR DESCRIPTION
Promotes #1163. Shared `release-assets-${tag}` concurrency group across release-bun-binaries + release-desktop-app so a v* tag push doesn't race on release creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)