### PR TITLE
fix(release): disambiguate desktop app assets from agent-cli binaries

### DIFF
--- a/apps/agent-app/electron-builder.yml
+++ b/apps/agent-app/electron-builder.yml
@@ -6,8 +6,11 @@ appId: com.robota-sdk.desktop
 productName: Robota
 copyright: Robota
 # The package `name` is scoped (@robota-sdk/agent-app) — its slash breaks default artifact paths (esp. deb).
-# Derive artifact names from productName instead.
-artifactName: ${productName}-${version}-${arch}.${ext}
+# Release-asset filenames use a fixed lowercase `robota-desktop-` prefix (NOT ${productName}, which is the
+# capitalized OS display name "Robota"). This keeps desktop installers disambiguated from the agent-cli
+# single binaries (`robota-<os>-<arch>`), which are lowercase and version-less; the two product families
+# no longer collide on the GitHub release. The installed app is still displayed as "Robota" (productName).
+artifactName: robota-desktop-${version}-${arch}.${ext}
 # The app has NO native node modules (renderer + electron main + a bundled external runtime binary), and pnpm's
 # non-flat store confuses @electron/rebuild's dep walk — skip the native rebuild entirely.
 npmRebuild: false


### PR DESCRIPTION
## Problem
On the GitHub release, the two product families collided:
- **agent-cli** binaries: `robota-<os>-<arch>` (lowercase, version-less)
- **desktop app** installers: `Robota-<version>-<arch>.<ext>` (capitalized `${productName}`)

Same base name, inconsistent case, and both emit a windows `.exe` — indistinguishable.

## Fix
`apps/agent-app/electron-builder.yml` → `artifactName: robota-desktop-${version}-${arch}.${ext}` (fixed lowercase, disambiguated). `productName` stays `Robota` so the installed app's OS display name is unchanged. CLI binary names unchanged (canonical `robota` command; `install.sh` unaffected — verified no doc/script references the old names).

Result (both future releases AND the already-published v3.0.0-beta.79, whose desktop assets were renamed in place via the GitHub API):
- `robota-<os>-<arch>` — CLI
- `robota-desktop-<version>-<arch>.<ext>` — desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)