### PR TITLE
docs(vision): SELFHOST-007..014 differentiator capability backlogs

### DIFF
--- a/.agents/backlog/SELFHOST-000-self-hosting-capability-roadmap.md
+++ b/.agents/backlog/SELFHOST-000-self-hosting-capability-roadmap.md
@@ -57,8 +57,10 @@ product opinion in `agent-cli`/`apps/agent-app`.
 | 13  | Multi-surface deployment + gateway (one agent → many channels/runtimes)                                 | D   | cli/app/web/remote exist, no documented "one agent → many channels" story | transports + surfaces (packaging/docs)                                     |
 | 14  | Shared/synced async session artifacts for collaboration                                                 | D   | REMOTE-001 live P2P, no async shareable session artifacts                 | agent-session persistence + sharing surface                                |
 
-**Close first (parity):** #1, #2, #3, #4, #5, #6 (spun out as SELFHOST-001..006).
-**Invest for edge (differentiators):** #7, #8, #9, #10, #11 (+ #12–14 opportunistic).
+**Close first (parity):** #1–#6 spun out as SELFHOST-001..006.
+**Invest for edge (differentiators):** #7–#14 spun out as SELFHOST-007..014 (SELFHOST-007 branching time-travel,
+-008 semantic memory, -009 hook catalog, -010 computer use, -011 evals-as-code, -012 scheduled tasks,
+-013 multi-surface deployment, -014 async shared sessions).
 
 ## Test Plan
 

--- a/.agents/backlog/SELFHOST-007-branching-time-travel.md
+++ b/.agents/backlog/SELFHOST-007-branching-time-travel.md
@@ -1,0 +1,32 @@
+---
+title: 'SELFHOST-007: branching time-travel checkpoints (rewind to any step, fork alternate branch)'
+status: todo
+created: 2026-07-16
+priority: medium
+urgency: later
+area: packages/agent-session, packages/agent-core
+depends_on: []
+---
+
+# Branching time-travel checkpoints
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has `/rewind`, but the advertised frontier is **branching**: rewind to any step and
+**fork** an alternate branch (what-if), like git for a session.
+
+## What
+
+A checkpoint **tree** (not just linear rewind) in `agent-session`: checkpoint events in `agent-core`, persist a
+branchable history, `/rewind` extended to fork/switch branches. Neutral persistence mechanism.
+
+## Prior Art
+
+LangGraph time-travel: rewind to any checkpoint, fork alternate branches, fault-tolerant resume
+(https://docs.langchain.com/oss/python/langgraph/persistence); aider `/undo` + branch a session
+(https://aider.chat/docs/); Claude Code checkpoints separate from git (https://code.claude.com/docs/).
+
+## Test Plan
+
+Unit tests for the checkpoint tree (branch, fork, switch); a functional test that forking preserves the parent
+and diverges; persistence round-trip. Architecture Review confirms the tree lives in agent-session with events
+in agent-core.

--- a/.agents/backlog/SELFHOST-008-durable-semantic-memory.md
+++ b/.agents/backlog/SELFHOST-008-durable-semantic-memory.md
@@ -1,0 +1,34 @@
+---
+title: 'SELFHOST-008: durable project + semantic long-term memory (auto-curated, cross-session)'
+status: todo
+created: 2026-07-16
+priority: medium
+urgency: later
+area: packages/agent-core, packages/agent-cli, apps/agent-app
+depends_on: []
+---
+
+# Durable + semantic long-term memory
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has a `/memory` command; the advertised edge is memory that **grows with you** —
+auto-curated project/workspace memory + optional semantic recall across sessions.
+
+## What
+
+A neutral **memory port** in `agent-core` (write/recall/curate) with a pluggable store adapter behind DIP
+(semantic/vector optional); auto-capture + curation **policy** and any memory _content_ live in
+`agent-cli`/`apps/agent-app` per library-neutrality (no memory content in `packages/`).
+
+## Prior Art
+
+Hermes agent-curated memory + cross-session FTS recall + user modeling
+(https://hermes-agent.nousresearch.com/docs/); Windsurf workspace-scoped auto-generated Memories persisted
+across sessions (https://docs.windsurf.com/windsurf/cascade/memories); Mastra working + semantic memory
+(https://mastra.ai/); OpenAI Agents SDK Sessions with pluggable backends
+(https://openai.github.io/openai-agents-python/).
+
+## Test Plan
+
+Unit tests for the memory port + a reference adapter; a functional test for cross-session recall; neutrality
+guard (no content in libs). Architecture Review sets the port/adapter boundary + where curation policy lives.

--- a/.agents/backlog/SELFHOST-009-hook-catalog.md
+++ b/.agents/backlog/SELFHOST-009-hook-catalog.md
@@ -1,0 +1,33 @@
+---
+title: 'SELFHOST-009: rich lifecycle hook catalog (named events + PreToolUse security gate)'
+status: todo
+created: 2026-07-16
+priority: medium
+urgency: later
+area: packages/agent-core
+depends_on: []
+---
+
+# Lifecycle hook catalog
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has hooks in `agent-core`; the gap vs the strongest exemplar is **breadth + a documented
+catalog** of named lifecycle events, including a PreToolUse security gate.
+
+## What
+
+Extend `agent-core`'s hooks with a documented **catalog** of named lifecycle events (session start/stop,
+pre/post tool use, pre/post model call, permission decision, error, subagent spawn, …) and a first-class
+**PreToolUse security gate**. Neutral mechanism; the events are the product surface for user-defined hooks.
+
+## Prior Art
+
+Claude Code 30 hook lifecycle events + PreToolUse security gate (https://code.claude.com/docs/); Microsoft
+Agent Framework middleware/filters (https://learn.microsoft.com/en-us/agent-framework/overview/); CrewAI
+callbacks (https://docs.crewai.com/).
+
+## Test Plan
+
+Unit tests that each catalogued event fires at the right point; a functional test that a PreToolUse hook can
+block a tool call; a doc/scan check that the catalog is documented. Architecture Review confirms this extends
+the existing hooks engine (no new tier).

--- a/.agents/backlog/SELFHOST-010-computer-use.md
+++ b/.agents/backlog/SELFHOST-010-computer-use.md
@@ -1,0 +1,33 @@
+---
+title: 'SELFHOST-010: computer/browser use tool (vision → click/type, approval-gated, takeover)'
+status: todo
+created: 2026-07-16
+priority: medium
+urgency: later
+area: packages/agent-tools, packages/agent-core
+depends_on: []
+---
+
+# Computer / browser use
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator, absent in Robota: a vision-driven GUI/browser control loop (screenshot → reason → click/type),
+gated by approvals, with a human **takeover** mode for credentials.
+
+## What
+
+A neutral **computer-use tool** in `agent-tools` (screenshot-perceive → action) with a screen/browser driver
+behind an adapter; every significant action **gated by the existing permissions**; a takeover mode that hands
+control to the human for credentials. Mechanism only; the target environment wiring lives in the surface.
+
+## Prior Art
+
+OpenAI Operator / Computer-Using-Agent (screenshot→reason→click/type, takeover, approve significant actions,
+https://developers.openai.com/api/docs/guides/tools-computer-use , https://openai.com/index/computer-using-agent/);
+Hermes full web control (search/browse/vision, https://hermes-agent.nousresearch.com/docs/).
+
+## Test Plan
+
+Unit tests for the action contract + a fake driver; a functional test that a significant action is blocked
+until approved and that takeover suspends the loop. Architecture Review sets the tool/driver-adapter boundary
+and confirms permission-gating reuse. Security: never auto-run against untrusted targets without approval.

--- a/.agents/backlog/SELFHOST-011-evals-as-code.md
+++ b/.agents/backlog/SELFHOST-011-evals-as-code.md
@@ -1,0 +1,33 @@
+---
+title: 'SELFHOST-011: evals-as-code harness for SDK users (gate CI)'
+status: todo
+created: 2026-07-16
+priority: medium
+urgency: later
+area: packages/agent-framework, packages/agent-cli
+depends_on: []
+---
+
+# Evals-as-code (product surface)
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has an internal `.agents/evals` harness, but no **product** eval surface for SDK users to
+define and run agent evals that gate their CI.
+
+## What
+
+An `agent-framework` SDK surface + a `robota` CLI command to define evals-as-code (metrics over agent runs)
+and run them, exit-coded to gate CI. Reuse the internal evals concepts; expose them as a neutral, consumer-facing
+API (no domain content in libs).
+
+## Prior Art
+
+Mastra evals-as-code in CI, gate deploys (faithfulness/relevance/toxicity, https://mastra.ai/); Google ADK
+build/evaluate/deploy toolkit (https://google.github.io/adk-docs/); OpenAI traces feeding eval tools
+(https://openai.github.io/openai-agents-python/).
+
+## Test Plan
+
+Unit tests for the eval-definition API + a runner; a functional test that a failing eval returns non-zero;
+example eval in `examples/`. Architecture Review confirms the SDK surface lives in agent-framework, CLI command
+in agent-cli.

--- a/.agents/backlog/SELFHOST-012-scheduled-tasks.md
+++ b/.agents/backlog/SELFHOST-012-scheduled-tasks.md
@@ -1,0 +1,30 @@
+---
+title: 'SELFHOST-012: scheduled / cron tasks with pause/resume/edit'
+status: todo
+created: 2026-07-16
+priority: low
+urgency: later
+area: packages/dag-scheduler, packages/agent-command, packages/agent-cli
+depends_on: []
+---
+
+# Scheduled / cron tasks
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has background tasks + `dag-scheduler`, but no **user-facing** scheduled-task surface
+(create/list/pause/resume/edit a cron task).
+
+## What
+
+A user-facing scheduled-task surface over `dag-scheduler`: create/list/pause/resume/edit recurring tasks, with a
+command in `agent-command`/`agent-cli`. Reuse the existing scheduler; add the surface + lifecycle controls.
+
+## Prior Art
+
+Hermes scheduled cron tasks with pause/resume/edit (https://hermes-agent.nousresearch.com/docs/).
+
+## Test Plan
+
+Unit tests for the schedule lifecycle (create/pause/resume/edit) over dag-scheduler; a functional test that a
+paused task does not fire and resumes; CLI behavior test. Architecture Review confirms reuse of dag-scheduler
+(no new scheduler).

--- a/.agents/backlog/SELFHOST-013-multi-surface-deployment-gateway.md
+++ b/.agents/backlog/SELFHOST-013-multi-surface-deployment-gateway.md
@@ -1,0 +1,32 @@
+---
+title: 'SELFHOST-013: multi-surface deployment + gateway (one agent → many channels/runtimes)'
+status: todo
+created: 2026-07-16
+priority: low
+urgency: later
+area: packages/agent-transport, apps/agent-server, docs
+depends_on: []
+---
+
+# Multi-surface deployment + gateway
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota already has cli/desktop/web/remote surfaces over a transport DIP; the gap is a documented,
+first-class **"one agent definition → many channels/runtimes"** deployment story.
+
+## What
+
+Largely a packaging + documentation effort over the existing transport DIP: a documented pattern (and any thin
+glue) for deploying one agent definition to multiple channels/runtimes (CLI, desktop, web, HTTP/WS server,
+remote), plus the deployment matrix. No new coupling; formalize what the transports already enable.
+
+## Prior Art
+
+Hermes 20+ chat-platform gateway + 6 terminal/deploy backends (Docker/SSH/Daytona/Modal, …,
+https://hermes-agent.nousresearch.com/docs/); Google ADK deployment-agnostic (Vertex/Agent Engine,
+https://google.github.io/adk-docs/).
+
+## Test Plan
+
+Doc/example coverage of the deploy matrix; a functional test that one agent definition serves over ≥2 transports
+unchanged. Architecture Review confirms this rides the transport DIP with no new sibling coupling.

--- a/.agents/backlog/SELFHOST-014-shared-async-session-artifacts.md
+++ b/.agents/backlog/SELFHOST-014-shared-async-session-artifacts.md
@@ -1,0 +1,31 @@
+---
+title: 'SELFHOST-014: shared / synced async session artifacts for collaboration'
+status: todo
+created: 2026-07-16
+priority: low
+urgency: later
+area: packages/agent-session, apps/agent-app, apps/agent-web
+depends_on: []
+---
+
+# Shared / synced async session artifacts
+
+Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md) / [VISION.md](../../VISION.md).
+Differentiator. Robota has REMOTE-001 live P2P collaboration; the gap is **asynchronous** shareable/resumable
+session artifacts (share a thread, resume it elsewhere/later) rather than only a live session.
+
+## What
+
+Persist a session as a **shareable artifact** in `agent-session` (export/import/resume a thread), surfaced for
+sharing in `apps/agent-app`/`apps/agent-web`. Complements REMOTE-001's live channel with an async, durable form.
+
+## Prior Art
+
+Amp persistent Threads synced to cloud, resume across devices/teammates (https://ampcode.com/manual); GitHub
+Copilot cloud agent draft PR + session logs (https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent);
+Devin PR descriptions + shared Wiki (https://www.deployhq.com/guides/devin).
+
+## Test Plan
+
+Unit tests for session export/import round-trip + resume; a functional test that a shared artifact resumes on a
+second surface. Architecture Review confirms persistence lives in agent-session, sharing UI in the app surfaces.


### PR DESCRIPTION
Completes the self-hosting roadmap (VISION.md / SELFHOST-000) — the eight differentiators as individual backlog items: branching time-travel (007), durable+semantic memory (008), lifecycle hook catalog (009), computer/browser use (010), evals-as-code (011), scheduled tasks (012), multi-surface deployment gateway (013), async shared session artifacts (014). Each with prior-art citations + correct-layer note + Test Plan stub. All 53 scans pass.

Generated with Claude Code.