### PR TITLE
docs(process): DX-001 PR batching policy (fewer CI waits)

### DIFF
--- a/.agents/backlog/DX-001-pr-batching-policy.md
+++ b/.agents/backlog/DX-001-pr-batching-policy.md
@@ -1,0 +1,44 @@
+---
+title: 'DX-001: PR batching policy — bundle coherent work into appropriately-sized PRs (fewer CI waits)'
+status: in-progress
+created: 2026-07-16
+priority: high
+urgency: now
+area: .agents/rules/git-branch.md, .agents/rules/backlog-execution.md
+depends_on: []
+---
+
+# PR batching policy
+
+## Problem
+
+Splitting work into many tiny PRs (one per small doc/spec change) makes the agent wait for a full CI run on
+each — the wait repeats far more than the work warrants. Small, closely-related changes that will merge together
+anyway do not need a PR each. The existing **One-Backlog-per-PR / PR Unit Rule** (`git-branch.md`,
+`backlog-execution.md`) targets **not mixing UNRELATED backlogs** — it does NOT require splitting a single
+coherent work-unit into many PRs. That distinction was being over-applied.
+
+## What (the policy)
+
+Bundle multiple commits into one PR by BOTH criteria:
+
+1. **Coherent work-unit** — the commits belong to the same feature/epic/batch/theme (e.g. all spec revisions in
+   one design-gate pass; all backlog items in one roadmap authoring pass; a rule + its enforcement + its wiring).
+   Do NOT bundle genuinely unrelated backlogs (that still violates the PR Unit Rule).
+2. **Soft size ceiling** — split when a bundle would exceed roughly **~600 changed lines or ~15 files**, or when a
+   part is independently revertible and valuable. Otherwise keep it in one PR.
+
+Within a PR, use **one commit per logical step** (conventional-commit each), so history stays readable while CI
+runs once for the bundle. Prefer a small number of medium PRs over many tiny ones.
+
+**Reconcile with the PR Unit Rule:** unrelated backlogs → separate PRs (unchanged). Related steps of one
+work-unit → one multi-commit PR (this policy). Implementation PRs that change runtime behavior still carry their
+User Execution Test Scenarios; bundling does not waive any gate.
+
+## Test Plan
+
+- Update `git-branch.md` (and cross-ref `backlog-execution.md`) with the batching policy + the coherent-unit /
+  size-ceiling criteria, reconciled against the PR Unit Rule.
+- No mechanical scan required (a soft process guideline); a checklist line in `post-implementation-checklist` /
+  the relevant skill suffices. If a mechanical nudge is wanted later, a PR-size advisory could be added, but it
+  must not hard-block (some coherent units legitimately exceed the ceiling).

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -130,6 +130,23 @@ This rule applies even when:
 
 **The only exception:** The user explicitly says "create a new branch anyway" or "abandon the old branch."
 
+### PR Batching — appropriately-sized PRs (DX-001)
+
+Do NOT split a single coherent work-unit into many tiny PRs — each one waits on a full CI run, and that overhead
+repeats far more than the work warrants. Bundle multiple commits into one PR by BOTH criteria:
+
+1. **Coherent work-unit** — the commits belong to the same feature/epic/batch/theme (e.g. all spec revisions in
+   one design-gate pass; all backlog items in one authoring pass; a rule + its enforcement + its wiring).
+2. **Soft size ceiling** — split when a bundle would exceed roughly **~600 changed lines or ~15 files**, or when a
+   part is independently revertible and valuable. Otherwise keep it in one PR.
+
+Use **one conventional commit per logical step** within the PR, so history stays readable while CI runs once for
+the bundle. Prefer a few medium PRs over many tiny ones.
+
+This does NOT relax the **One-Branch-At-A-Time / PR Unit Rule** above: genuinely UNRELATED backlogs still go in
+separate PRs. Related steps of ONE work-unit go in one multi-commit PR. Bundling never waives a gate (an
+implementation PR still carries its User Execution Test Scenarios).
+
 ### Delete Merged Branches (mandatory)
 
 After a PR merges, delete its now-merged feature branch so only `develop` and `main` remain as standing


### PR DESCRIPTION
Bundle coherent work into appropriately-sized PRs instead of many tiny ones (each waits a full CI run). Policy (backlog DX-001 + git-branch.md section): one PR = a coherent work-unit under a soft ~600-line/~15-file ceiling, one conventional commit per logical step. Unrelated backlogs still split (PR Unit Rule unchanged); bundling never waives a gate. Adopted immediately for the ongoing SELFHOST design-gate work.

Generated with Claude Code.