### PR TITLE
feat(orchestration): SELFHOST-001 P1 — neutral contracts + sequential primitive

### DIFF
--- a/.agents/spec-docs/active/SELFHOST-001-multi-agent-orchestration-primitives.md
+++ b/.agents/spec-docs/active/SELFHOST-001-multi-agent-orchestration-primitives.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: in-progress
 type: BEHAVIOR
 tags: [orchestration, multi-agent, agent-core, agent-framework, selfhost]
 ---
@@ -188,3 +188,10 @@ SPEC amendment), P2 (parallel + handoff), P3 (hierarchical + group-chat).
   `InteractionEvent` analog; the false-green interface-runtime scan; the SPEC amendment target). Highest-stakes call
   (new-surface placement) correct on principle with a pinned, mechanical extraction trigger. Also cleaned the two
   stale "mirrors AbstractAIProvider" phrasings the reviewer flagged as document hygiene. **GATE-APPROVAL PASSED.**
+- 2026-07-17 — **GATE-IMPLEMENT: P1 implemented** (moved todo/ → active/, status in-progress). Shipped the neutral
+  contracts + event-type unions in `agent-core/src/orchestration/`, the `sequential` mechanism in
+  `agent-framework/src/orchestration/sequential.ts` composing over `agent-executor`'s `ISubagentManager`/
+  `ISubagentRunner` port, the standing `orchestration-neutrality` scan, and the agent-core/agent-framework SPEC
+  amendments. TC-01..TC-06 satisfied and verified locally: build + typecheck + 5/5 tests + lint (0 errors) +
+  `pnpm harness:scan` (all 54 scans pass). Tasks: [`.agents/tasks/SELFHOST-001.md`](../../tasks/SELFHOST-001.md).
+  P2 (`parallel`/`handoff`) and P3 (`hierarchical`/`group-chat`) remain.

--- a/.agents/tasks/SELFHOST-001.md
+++ b/.agents/tasks/SELFHOST-001.md
@@ -1,0 +1,48 @@
+<!-- archival-exempt: EPIC in progress — P1 shipped; P2 (parallel/handoff) + P3 (hierarchical/group-chat) remain, so the spec stays in spec-docs/active/ until the remaining slices land and GATE-VERIFY/GATE-COMPLETE run. -->
+
+# SELFHOST-001 — first-class multi-agent orchestration primitives (EPIC)
+
+Spec: [`.agents/spec-docs/active/SELFHOST-001-multi-agent-orchestration-primitives.md`](../spec-docs/active/SELFHOST-001-multi-agent-orchestration-primitives.md)
+GATE-APPROVAL: PASSED (iteration 4 ENDORSE). GATE-IMPLEMENT: P1 in progress.
+
+## P1 — `sequential` + neutral contracts + SPEC amendment (this slice) ✅ IMPLEMENTED
+
+- [x] agent-core: neutral orchestration contracts + event-type unions in `packages/agent-core/src/orchestration/`
+      (`orchestration-contracts.ts`, `orchestration-events.ts`, `index.ts`), exported from `src/index.ts`.
+      Pure types + const event names — zero new `@robota-sdk/agent-*` production deps (**TC-01** — deps scan green).
+- [x] agent-framework: the `sequential` mechanism in `packages/agent-framework/src/orchestration/sequential.ts`,
+      composing over `agent-executor`'s `ISubagentManager`/`ISubagentRunner` port; emits neutral lifecycle events
+      over the event-service (**TC-02**), runs end-to-end over the port (**TC-03**). Exported from `src/index.ts`.
+- [x] framework carries NO dep on `agent-subagent-runner` (**TC-04** — deps/one-way scan green; no-cycle).
+- [x] `orchestration-neutrality` standing scan (`scripts/harness/scan-orchestration-neutrality.mjs`), registered in
+      `run-all-scans.mjs`, failing-capable, guards P2/P3 `hierarchical`/`group-chat` (**TC-05**).
+- [x] SPEC amendments (**TC-06**): `agent-core/docs/SPEC.md` Boundaries reclassifies core as OWNER of the neutral
+      orchestration contracts + event unions (framework IMPLEMENTS them) + a dedicated Orchestration Public API
+      subsection; `agent-framework/docs/SPEC.md` documents `runSequential`.
+- [x] Tests: `packages/agent-framework/src/orchestration/__tests__/sequential.test.ts` (5 tests: events, output
+      threading, threadOutput:false, failed-rethrow, end-to-end over a SubagentManager backed by an ISubagentRunner).
+- [x] Verified locally: build (core+framework), typecheck, tests (5/5), lint (0 errors), `pnpm harness:scan`
+      (all 54 scans pass incl. `orchestration-neutrality`, `deps`, `spec-public-surface`).
+
+## Test Plan (P1)
+
+Maps the spec's Completion Criteria to the shipped verification (all green locally):
+
+- **TC-01** (agent-core contracts + event unions, zero new `@robota-sdk/agent-*` deps) — `deps` dependency-direction scan.
+- **TC-02** (`sequential` emits lifecycle events over the event-service) — `sequential.test.ts` "emits the neutral lifecycle events".
+- **TC-03** (framework composes `sequential` end-to-end over `ISubagentRunner`) — `sequential.test.ts` "composes end-to-end over a SubagentManager backed by an ISubagentRunner".
+- **TC-04** (no `agent-subagent-runner` dep / no-cycle) — `deps`/one-way scan.
+- **TC-05** (neutrality — no app-domain identity in the contracts) — standing `orchestration-neutrality` `pnpm harness:scan` floor (failing-capable; verified it FAILs on an injected `room` field and passes clean).
+- **TC-06** (SPEC amendments documented) — `spec-public-surface` + `docs-structure` scans; agent-core/agent-framework SPEC.md updated.
+
+Command evidence: `pnpm --filter @robota-sdk/agent-core --filter @robota-sdk/agent-framework build && … typecheck` (pass), `… test src/orchestration/__tests__/sequential.test.ts` (5/5), `… lint` (0 errors), `pnpm harness:scan` (all 54 scans pass).
+
+## P2 — `parallel` (bounded concurrency + aggregation) + `handoff` (control-transfer) — PENDING
+
+## P3 — `hierarchical` (manager-delegation) + `group-chat` (turn-taking) — PENDING
+
+## Extraction trigger (B3, deferred)
+
+When a second implementer family lands (a dag-\* adapter mapping sequential/parallel onto the graph engine), move
+BOTH the pure contracts AND the event-type unions into a new `agent-interface-orchestration` package
+(deps ⊆ {agent-core}), mirroring `agent-interface-transport`.

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -211,10 +211,17 @@ their own price tables. Prices are USD per 1,000,000 tokens.
 
 Neutral multi-agent orchestration runtime exports (the contracts/event-type unions are type-only; see `src/orchestration/`). agent-core OWNS these; the `agent-framework` layer IMPLEMENTS the mechanism.
 
-| Export                       | Kind  | Description                                                                                                  |
-| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ |
-| `ORCHESTRATION_EVENTS`       | const | Neutral orchestration lifecycle event names (`started`/`step_started`/`step_completed`/`completed`/`failed`) |
-| `ORCHESTRATION_EVENT_PREFIX` | const | Event-name prefix (`orchestration`) for the neutral orchestration lifecycle events                           |
+| Export                         | Kind  | Description                                                                                                  |
+| ------------------------------ | ----- | ------------------------------------------------------------------------------------------------------------ |
+| `ORCHESTRATION_EVENTS`         | const | Neutral orchestration lifecycle event names (`started`/`step_started`/`step_completed`/`completed`/`failed`) |
+| `ORCHESTRATION_EVENT_PREFIX`   | const | Event-name prefix (`orchestration`) for the neutral orchestration lifecycle events                           |
+| `TOrchestrationEvent`          | type  | Union of the orchestration lifecycle event names                                                             |
+| `TOrchestrationPrimitive`      | type  | Named neutral primitives: `sequential`/`parallel`/`hierarchical`/`handoff`/`group-chat`                      |
+| `IOrchestrationStep`           | type  | A neutral unit of work (id, label, agentType, prompt, optional model/tool scoping)                           |
+| `ISequentialOrchestrationSpec` | type  | Spec for a `sequential` run (ordered steps + `threadOutput`)                                                 |
+| `IOrchestrationStepResult`     | type  | One executed step's result (id, output, optional usage)                                                      |
+| `IOrchestrationRunResult`      | type  | A run's result (primitive, per-step results, aggregate output)                                               |
+| `IOrchestrationEventData`      | type  | Neutral event payload the primitives emit over `IEventService`                                               |
 
 ### Schema (CORE-015)
 

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -207,6 +207,15 @@ their own price tables. Prices are USD per 1,000,000 tokens.
 | `normalizeProviderConfig`               | function       | Resolve loose provider settings into a full `IProviderDefinitionConfig` (default model from `defaults.model`, `$ENV:` apiKey resolution)                                                                                                                |
 | `createProviderFromConfig`              | function       | Construct an `IAIProvider` from a resolved config against the injected registry, enforcing the credential requirement                                                                                                                                   |
 
+### Orchestration Public API (SELFHOST-001)
+
+Neutral multi-agent orchestration runtime exports (the contracts/event-type unions are type-only; see `src/orchestration/`). agent-core OWNS these; the `agent-framework` layer IMPLEMENTS the mechanism.
+
+| Export                       | Kind  | Description                                                                                                  |
+| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ |
+| `ORCHESTRATION_EVENTS`       | const | Neutral orchestration lifecycle event names (`started`/`step_started`/`step_completed`/`completed`/`failed`) |
+| `ORCHESTRATION_EVENT_PREFIX` | const | Event-name prefix (`orchestration`) for the neutral orchestration lifecycle events                           |
+
 ### Schema (CORE-015)
 
 | Export                                                                                                    | Kind     | Description                                                                                                               |
@@ -1118,4 +1127,14 @@ cassettePath, recordCwd? })` wraps a real provider and writes each interaction t
 - The session layer consumes `Robota`, `runHooks`, `evaluatePermission`, `TUniversalMessage`
 - The tools layer consumes `AbstractTool`, `IFunctionTool`, `IToolWithEventService`
 - External plugin packages extend `AbstractPlugin`
-- The multi-agent/orchestration layer consumes `Robota`, `IAgentConfig`, event services
+- **agent-core OWNS the neutral multi-agent orchestration contracts + event-type unions**
+  (`src/orchestration/` — `TOrchestrationPrimitive`, `IOrchestrationStep`,
+  `ISequentialOrchestrationSpec`, `IOrchestrationRunResult`, `IOrchestrationEventData`,
+  `ORCHESTRATION_EVENTS`); **the `agent-framework` layer IMPLEMENTS them** as the mechanism
+  over `agent-executor`'s `ISubagentRunner` port (SELFHOST-001). These are pure contracts (no
+  runtime, no class) and carry no app-domain identity (neutrality enforced by the standing
+  `orchestration-neutrality` harness scan). The multi-agent layer still consumes `Robota`,
+  `IAgentConfig`, and the event services for the single-agent runs the primitives compose.
+  Extraction trigger (B3): when a second implementer family lands (a dag-\* adapter), both these
+  contracts and the event unions move to a new `agent-interface-orchestration` package
+  (deps ⊆ {agent-core}).

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -241,6 +241,19 @@ export { EXECUTION_EVENTS, EXECUTION_EVENT_PREFIX } from './services/execution-s
 export { TOOL_EVENTS, TOOL_EVENT_PREFIX } from './services/tool-execution-service';
 export { AGENT_EVENTS, AGENT_EVENT_PREFIX } from './agents/constants';
 
+// Neutral multi-agent orchestration contracts + event-type unions (SELFHOST-001)
+export {
+  ORCHESTRATION_EVENTS,
+  ORCHESTRATION_EVENT_PREFIX,
+  type TOrchestrationEvent,
+  type TOrchestrationPrimitive,
+  type IOrchestrationStep,
+  type ISequentialOrchestrationSpec,
+  type IOrchestrationStepResult,
+  type IOrchestrationRunResult,
+  type IOrchestrationEventData,
+} from './orchestration';
+
 // Workflow converter interfaces
 export type {
   IWorkflowConverter,

--- a/packages/agent-core/src/orchestration/index.ts
+++ b/packages/agent-core/src/orchestration/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Neutral multi-agent orchestration contracts + event-type unions (SELFHOST-001).
+ *
+ * agent-core owns these; the framework layer implements the mechanism over
+ * `agent-executor`'s `ISubagentRunner` port. Pure types only — no runtime.
+ *
+ * Extraction trigger (B3): when a second implementer family lands (a dag-* adapter
+ * mapping sequential/parallel onto the graph engine), BOTH these contracts AND the
+ * event-type unions move to a new `agent-interface-orchestration` package
+ * (deps ⊆ {agent-core}), so that adapter need not depend on heavy agent-core for
+ * the event types.
+ */
+export type {
+  TOrchestrationPrimitive,
+  IOrchestrationStep,
+  ISequentialOrchestrationSpec,
+  IOrchestrationStepResult,
+  IOrchestrationRunResult,
+  IOrchestrationEventData,
+} from './orchestration-contracts';
+
+export {
+  ORCHESTRATION_EVENTS,
+  ORCHESTRATION_EVENT_PREFIX,
+  type TOrchestrationEvent,
+} from './orchestration-events';

--- a/packages/agent-core/src/orchestration/orchestration-contracts.ts
+++ b/packages/agent-core/src/orchestration/orchestration-contracts.ts
@@ -1,0 +1,93 @@
+import type { IBaseEventData } from '../event-service/interfaces';
+
+/**
+ * Neutral multi-agent orchestration contracts (SELFHOST-001).
+ *
+ * agent-core OWNS these neutral contracts + the event-type unions the primitives
+ * emit; the `agent-framework` layer IMPLEMENTS the mechanism over `agent-executor`'s
+ * `ISubagentRunner` port. These are pure interfaces/types — NO runtime, NO class,
+ * and NO app-domain identity fields, per the library-neutrality rule. The
+ * `orchestration-neutrality` harness scan is the standing floor.
+ */
+
+/**
+ * The named neutral orchestration primitives. Opaque mechanisms only.
+ * P1 implements `sequential`; `parallel`/`handoff` land in P2 and
+ * `hierarchical`/`group-chat` in P3 (the union is declared now so the
+ * event/result contracts are stable across slices).
+ */
+export type TOrchestrationPrimitive =
+  | 'sequential'
+  | 'parallel'
+  | 'hierarchical'
+  | 'handoff'
+  | 'group-chat';
+
+/**
+ * A single neutral unit of work in an orchestration run. Opaque — it carries no
+ * domain identity; `label` is a plain human-facing string, not an app-domain role.
+ */
+export interface IOrchestrationStep {
+  /** Stable id for the step within the run. */
+  id: string;
+  /** Neutral human-facing label. */
+  label: string;
+  /** The subagent type/definition key that executes this step. */
+  agentType: string;
+  /** The instruction for this step. */
+  prompt: string;
+  /** Optional model override for this step. */
+  model?: string;
+  /** Optional per-step tool restriction (reuses existing permission scoping). */
+  allowedTools?: string[];
+  /** Optional per-step tool denial (reuses existing permission scoping). */
+  disallowedTools?: string[];
+}
+
+/** The specification for a `sequential` orchestration run. */
+export interface ISequentialOrchestrationSpec {
+  /** The ordered steps to run one after another. */
+  steps: IOrchestrationStep[];
+  /**
+   * When true (default), each step's prompt is augmented with the previous
+   * step's output so a pipeline can thread results forward. When false, each
+   * step runs with only its own prompt.
+   */
+  threadOutput?: boolean;
+}
+
+/** The result of one executed step. */
+export interface IOrchestrationStepResult {
+  /** The step id this result corresponds to. */
+  id: string;
+  /** The step's output text. */
+  output: string;
+  /** Optional token usage of the step's subagent run (ANALYTICS-001 shape). */
+  usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
+}
+
+/** The result of an orchestration run. */
+export interface IOrchestrationRunResult {
+  /** Which primitive produced this result. */
+  primitive: TOrchestrationPrimitive;
+  /** Per-step results in execution order. */
+  steps: IOrchestrationStepResult[];
+  /** The aggregate output (for `sequential`, the last step's output). */
+  output: string;
+}
+
+/**
+ * Neutral event payload the orchestration primitives emit over the
+ * `IEventService`. Extends the base event shape; adds only neutral,
+ * mechanism-level fields.
+ */
+export interface IOrchestrationEventData extends IBaseEventData {
+  /** Which primitive emitted the event. */
+  primitive: TOrchestrationPrimitive;
+  /** The step id, present for step-scoped events. */
+  stepId?: string;
+  /** The step index, present for step-scoped events. */
+  stepIndex?: number;
+  /** A failure reason, present on the `failed` event. */
+  reason?: string;
+}

--- a/packages/agent-core/src/orchestration/orchestration-contracts.ts
+++ b/packages/agent-core/src/orchestration/orchestration-contracts.ts
@@ -62,7 +62,12 @@ export interface IOrchestrationStepResult {
   id: string;
   /** The step's output text. */
   output: string;
-  /** Optional token usage of the step's subagent run (ANALYTICS-001 shape). */
+  /**
+   * Optional token usage of the step's subagent run (ANALYTICS-001 shape). Present
+   * only when the underlying runner/manager surfaces usage through its result — the
+   * default `SubagentManager.wait` does not yet thread it, so this is `undefined`
+   * there until that port is extended.
+   */
   usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
 }
 

--- a/packages/agent-core/src/orchestration/orchestration-events.ts
+++ b/packages/agent-core/src/orchestration/orchestration-events.ts
@@ -1,0 +1,25 @@
+/**
+ * Neutral orchestration lifecycle event names (SELFHOST-001).
+ *
+ * Mirrors the existing `task-events` / `user-events` pattern: a const name set +
+ * a prefix + a union type. These are emitted by the framework orchestration
+ * mechanism over the existing `IEventService`. The names are pure mechanism —
+ * no app-domain identity fields anywhere (TRANS-001 neutrality; enforced by the
+ * `orchestration-neutrality` harness scan).
+ */
+export const ORCHESTRATION_EVENTS = {
+  /** An orchestration run began. */
+  STARTED: 'started',
+  /** A single step began executing. */
+  STEP_STARTED: 'step_started',
+  /** A single step finished executing. */
+  STEP_COMPLETED: 'step_completed',
+  /** The orchestration run finished successfully. */
+  COMPLETED: 'completed',
+  /** The orchestration run failed. */
+  FAILED: 'failed',
+} as const;
+
+export const ORCHESTRATION_EVENT_PREFIX = 'orchestration' as const;
+
+export type TOrchestrationEvent = (typeof ORCHESTRATION_EVENTS)[keyof typeof ORCHESTRATION_EVENTS];

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -26,6 +26,7 @@ This package does NOT own: provider implementations, generic session run loop, t
 - Self-hosting verification: `planSelfHostingVerification()`, `transitionSelfHostingLoop()`
 - Background job orchestration: `BackgroundJobOrchestrator`, execution workspace projections
 - Subagent assembly: `createSubagentSession()`, `createInProcessSubagentRunner()`, `createDefaultTools()`
+- Multi-agent orchestration mechanism (SELFHOST-001): `runSequential()` — IMPLEMENTS the neutral orchestration contracts agent-core OWNS (`src/orchestration/`), composing over `agent-executor`'s `ISubagentManager`/`ISubagentRunner` port. The framework never depends on `agent-subagent-runner` (would be a cycle); the concrete runner is injected at the `agent-cli` composition root. P1 ships `sequential`; `parallel`/`handoff` (P2) and `hierarchical`/`group-chat` (P3) follow.
 - Bundle plugin management: `BundlePluginLoader`, `BundlePluginInstaller`, `MarketplaceClient`, `PluginSettingsStore`
 - Agent tool: `createAgentTool()`, `storeAgentToolDeps()`, `retrieveAgentToolDeps()`
 - Hook executors: `PromptExecutor`, `AgentExecutor`
@@ -199,6 +200,7 @@ Core classes and functions exported from `@robota-sdk/agent-framework`:
 | `createLineDetailPage`                      | function | Build a cursor-based detail page for a task log                                                                                                                                |
 | `createMainThreadDetailPage`                | function | Build a detail page for the main thread transcript                                                                                                                             |
 | `createInProcessSubagentRunner`             | function | Default in-process subagent runner adapter                                                                                                                                     |
+| `runSequential`                             | function | SELFHOST-001 — run a `sequential` orchestration over `agent-executor`'s `ISubagentManager`/`ISubagentRunner` port; emits neutral lifecycle events over the event-service       |
 | `PromptExecutor`                            | class    | Hook executor: injects a prompt into session context                                                                                                                           |
 | `AgentExecutor`                             | class    | Hook executor: creates a nested agent session for hook input                                                                                                                   |
 | `promptForApproval`                         | function | Terminal permission approval prompt                                                                                                                                            |

--- a/packages/agent-framework/src/index.ts
+++ b/packages/agent-framework/src/index.ts
@@ -452,6 +452,10 @@ export type {
   TSubagentRunnerFactory,
 } from './subagents/index.js';
 
+// ── Multi-agent orchestration mechanism (SELFHOST-001) ──────
+export { runSequential } from './orchestration/index.js';
+export type { ISequentialOrchestratorDeps, ISequentialRunContext } from './orchestration/index.js';
+
 // ── Hook executors ──────────────────────────────────────────
 export { PromptExecutor, AgentExecutor } from './hooks/index.js';
 export type { TProviderFactory, IPromptProvider, IPromptExecutorOptions } from './hooks/index.js';

--- a/packages/agent-framework/src/orchestration/__tests__/sequential.test.ts
+++ b/packages/agent-framework/src/orchestration/__tests__/sequential.test.ts
@@ -42,15 +42,33 @@ function jobState(id: string): ISubagentJobState {
 /** A fake ISubagentManager that records spawn requests and returns canned outputs. */
 function fakeManager(outputs: string[]): {
   manager: ISubagentManager;
-  spawns: Array<{ prompt: string; type: string }>;
+  spawns: Array<{
+    prompt: string;
+    type: string;
+    model?: string;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+  }>;
 } {
-  const spawns: Array<{ prompt: string; type: string }> = [];
+  const spawns: Array<{
+    prompt: string;
+    type: string;
+    model?: string;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+  }> = [];
   let index = 0;
   const results = new Map<string, ISubagentJobResult>();
   const manager: ISubagentManager = {
     async spawn(request) {
       const id = `job-${index}`;
-      spawns.push({ prompt: request.prompt, type: request.type });
+      spawns.push({
+        prompt: request.prompt,
+        type: request.type,
+        model: request.model,
+        allowedTools: request.allowedTools,
+        disallowedTools: request.disallowedTools,
+      });
       results.set(id, { jobId: id, output: outputs[index] ?? '' });
       index += 1;
       return jobState(id);
@@ -119,6 +137,27 @@ describe('SELFHOST-001 P1 — sequential orchestration', () => {
     expect(result.primitive).toBe('sequential');
     expect(result.steps.map((s) => s.output)).toEqual(['PLAN', 'DONE']);
     expect(result.output).toBe('DONE'); // aggregate = last step output
+  });
+
+  it('threads per-step model + tool scoping into the spawn request', async () => {
+    const { manager, spawns } = fakeManager(['x']);
+    const spec: ISequentialOrchestrationSpec = {
+      steps: [
+        {
+          id: 's1',
+          label: 'scoped',
+          agentType: 'worker',
+          prompt: 'go',
+          model: 'claude-opus-4-8',
+          allowedTools: ['Read', 'Grep'],
+          disallowedTools: ['Shell'],
+        },
+      ],
+    };
+    await runSequential(spec, { manager, context: CONTEXT });
+    expect(spawns[0].model).toBe('claude-opus-4-8');
+    expect(spawns[0].allowedTools).toEqual(['Read', 'Grep']);
+    expect(spawns[0].disallowedTools).toEqual(['Shell']);
   });
 
   it('threadOutput:false runs each step with only its own prompt', async () => {

--- a/packages/agent-framework/src/orchestration/__tests__/sequential.test.ts
+++ b/packages/agent-framework/src/orchestration/__tests__/sequential.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ORCHESTRATION_EVENTS,
+  ORCHESTRATION_EVENT_PREFIX,
+  composeEventName,
+} from '@robota-sdk/agent-core';
+import type {
+  IEventService,
+  IBaseEventData,
+  IEventContext,
+  ISequentialOrchestrationSpec,
+} from '@robota-sdk/agent-core';
+import { SubagentManager } from '@robota-sdk/agent-executor';
+import type {
+  ISubagentManager,
+  ISubagentJobResult,
+  ISubagentRunner,
+  ISubagentJobStart,
+  ISubagentJobHandle,
+} from '@robota-sdk/agent-executor';
+import type { ISubagentJobState } from '@robota-sdk/agent-interface-transport';
+import { runSequential } from '../sequential';
+import { createInProcessSubagentRunner } from '../../subagents/index';
+
+const CONTEXT = { parentSessionId: 'sess-1', cwd: '/tmp/work', depth: 0 };
+
+function jobState(id: string): ISubagentJobState {
+  return {
+    id,
+    type: 'planner',
+    label: 'step',
+    parentSessionId: CONTEXT.parentSessionId,
+    status: 'completed',
+    mode: 'foreground',
+    depth: 0,
+    cwd: CONTEXT.cwd,
+    promptPreview: '',
+    updatedAt: '2026-07-17T00:00:00.000Z',
+  };
+}
+
+/** A fake ISubagentManager that records spawn requests and returns canned outputs. */
+function fakeManager(outputs: string[]): {
+  manager: ISubagentManager;
+  spawns: Array<{ prompt: string; type: string }>;
+} {
+  const spawns: Array<{ prompt: string; type: string }> = [];
+  let index = 0;
+  const results = new Map<string, ISubagentJobResult>();
+  const manager: ISubagentManager = {
+    async spawn(request) {
+      const id = `job-${index}`;
+      spawns.push({ prompt: request.prompt, type: request.type });
+      results.set(id, { jobId: id, output: outputs[index] ?? '' });
+      index += 1;
+      return jobState(id);
+    },
+    async wait(jobId) {
+      const result = results.get(jobId);
+      if (!result) throw new Error(`no result for ${jobId}`);
+      return result;
+    },
+    list: () => [],
+    get: () => undefined,
+    cancel: async () => {},
+    close: async () => {},
+    send: async () => {},
+    shutdown: async () => {},
+  };
+  return { manager, spawns };
+}
+
+/** A capturing event service. */
+function capturingEvents(): { events: IEventService; names: string[] } {
+  const names: string[] = [];
+  const events: IEventService = {
+    emit: (eventType: string, _data: IBaseEventData, _context?: IEventContext) => {
+      names.push(eventType);
+    },
+    subscribe: () => {},
+    unsubscribe: () => {},
+  };
+  return { events, names };
+}
+
+const twoStepSpec: ISequentialOrchestrationSpec = {
+  steps: [
+    { id: 's1', label: 'plan', agentType: 'planner', prompt: 'Make a plan.' },
+    { id: 's2', label: 'do', agentType: 'worker', prompt: 'Execute the plan.' },
+  ],
+};
+
+describe('SELFHOST-001 P1 — sequential orchestration', () => {
+  // TC-02: the sequential primitive emits its lifecycle events on the event-service.
+  it('TC-02: emits the neutral lifecycle events over the event-service', async () => {
+    const { manager } = fakeManager(['plan-out', 'do-out']);
+    const { events, names } = capturingEvents();
+
+    await runSequential(twoStepSpec, { manager, context: CONTEXT, events });
+
+    const p = (local: string) => composeEventName(ORCHESTRATION_EVENT_PREFIX, local);
+    expect(names).toEqual([
+      p(ORCHESTRATION_EVENTS.STARTED),
+      p(ORCHESTRATION_EVENTS.STEP_STARTED),
+      p(ORCHESTRATION_EVENTS.STEP_COMPLETED),
+      p(ORCHESTRATION_EVENTS.STEP_STARTED),
+      p(ORCHESTRATION_EVENTS.STEP_COMPLETED),
+      p(ORCHESTRATION_EVENTS.COMPLETED),
+    ]);
+  });
+
+  it('TC-02b: threads each step output into the next step prompt and returns the aggregate', async () => {
+    const { manager, spawns } = fakeManager(['PLAN', 'DONE']);
+    const result = await runSequential(twoStepSpec, { manager, context: CONTEXT });
+
+    expect(spawns[0].prompt).toBe('Make a plan.');
+    expect(spawns[1].prompt).toContain('Execute the plan.');
+    expect(spawns[1].prompt).toContain('PLAN'); // previous output threaded forward
+    expect(result.primitive).toBe('sequential');
+    expect(result.steps.map((s) => s.output)).toEqual(['PLAN', 'DONE']);
+    expect(result.output).toBe('DONE'); // aggregate = last step output
+  });
+
+  it('threadOutput:false runs each step with only its own prompt', async () => {
+    const { manager, spawns } = fakeManager(['A', 'B']);
+    await runSequential({ ...twoStepSpec, threadOutput: false }, { manager, context: CONTEXT });
+    expect(spawns[1].prompt).toBe('Execute the plan.');
+    expect(spawns[1].prompt).not.toContain('A');
+  });
+
+  it('emits failed and rethrows when a step throws', async () => {
+    const { events, names } = capturingEvents();
+    const manager: ISubagentManager = {
+      spawn: vi.fn().mockRejectedValue(new Error('boom')),
+      wait: vi.fn(),
+      list: () => [],
+      get: () => undefined,
+      cancel: async () => {},
+      close: async () => {},
+      send: async () => {},
+      shutdown: async () => {},
+    };
+    await expect(runSequential(twoStepSpec, { manager, context: CONTEXT, events })).rejects.toThrow(
+      'boom',
+    );
+    expect(names).toContain(
+      composeEventName(ORCHESTRATION_EVENT_PREFIX, ORCHESTRATION_EVENTS.FAILED),
+    );
+    expect(names).not.toContain(
+      composeEventName(ORCHESTRATION_EVENT_PREFIX, ORCHESTRATION_EVENTS.COMPLETED),
+    );
+  });
+
+  // TC-03: framework composes a sequential run end-to-end over agent-executor's
+  // ISubagentRunner (surfaced as ISubagentManager) — here through a real
+  // SubagentManager driving a fake ISubagentRunner. The production runner is
+  // createInProcessSubagentRunner (referenced below to prove availability + no
+  // agent-subagent-runner dependency); TC-04 mechanically enforces the no-cycle.
+  it('TC-03: composes end-to-end over a SubagentManager backed by an ISubagentRunner', async () => {
+    const started: string[] = [];
+    const runner: ISubagentRunner = {
+      start(job: ISubagentJobStart): ISubagentJobHandle {
+        started.push(job.request.type);
+        const output = `out:${job.request.type}`;
+        return {
+          jobId: job.jobId,
+          result: Promise.resolve<ISubagentJobResult>({ jobId: job.jobId, output }),
+          cancel: async () => {},
+        };
+      },
+    };
+    const manager = new SubagentManager({ runner });
+
+    const result = await runSequential(twoStepSpec, { manager, context: CONTEXT });
+
+    expect(started).toEqual(['planner', 'worker']); // the runner ran both steps in order
+    expect(result.steps).toHaveLength(2);
+    expect(result.output).toBe('out:worker');
+    // Production runner is available from agent-framework (no agent-subagent-runner dep):
+    expect(typeof createInProcessSubagentRunner).toBe('function');
+  });
+});

--- a/packages/agent-framework/src/orchestration/index.ts
+++ b/packages/agent-framework/src/orchestration/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Multi-agent orchestration mechanism (SELFHOST-001).
+ *
+ * agent-core owns the neutral contracts + event-type unions; this layer
+ * IMPLEMENTS the mechanism over `agent-executor`'s `ISubagentRunner` port
+ * (surfaced as `ISubagentManager`). P1 ships `sequential`; `parallel`/`handoff`
+ * (P2) and `hierarchical`/`group-chat` (P3) follow. The framework NEVER depends
+ * on `agent-subagent-runner` (that would be a cycle); the concrete runner is
+ * injected at the `agent-cli` composition root.
+ */
+export { runSequential } from './sequential';
+export type { ISequentialOrchestratorDeps, ISequentialRunContext } from './sequential';

--- a/packages/agent-framework/src/orchestration/sequential.ts
+++ b/packages/agent-framework/src/orchestration/sequential.ts
@@ -1,0 +1,144 @@
+import {
+  ORCHESTRATION_EVENTS,
+  ORCHESTRATION_EVENT_PREFIX,
+  composeEventName,
+} from '@robota-sdk/agent-core';
+
+import type {
+  ISequentialOrchestrationSpec,
+  IOrchestrationStep,
+  IOrchestrationRunResult,
+  IOrchestrationStepResult,
+  IOrchestrationEventData,
+  IEventService,
+  IEventContext,
+} from '@robota-sdk/agent-core';
+import type { ISubagentManager, ISubagentSpawnRequest } from '@robota-sdk/agent-executor';
+
+/**
+ * Neutral run context threaded into each spawned subagent request.
+ */
+export interface ISequentialRunContext {
+  /** The parent session id the run belongs to. */
+  parentSessionId: string;
+  /** The working directory for spawned subagents. */
+  cwd: string;
+  /** Depth of this orchestration in the hierarchy (0 = root). */
+  depth?: number;
+}
+
+/**
+ * Dependencies for the `sequential` orchestration mechanism.
+ *
+ * The `manager` is the `agent-executor` `ISubagentManager` — the port surface
+ * over `ISubagentRunner`. At the composition root it is built over the real
+ * runner (`createInProcessSubagentRunner` in-process, or the child-process
+ * runner from `agent-subagent-runner` injected at the `agent-cli` root). The
+ * framework NEVER depends on `agent-subagent-runner` (that would be a cycle);
+ * it composes only over the injected `ISubagentManager`.
+ */
+export interface ISequentialOrchestratorDeps {
+  /** The subagent manager (over `ISubagentRunner`) that runs each step. */
+  manager: ISubagentManager;
+  /** Run context threaded into each spawned subagent request. */
+  context: ISequentialRunContext;
+  /** Optional event service; when present, lifecycle events are emitted. */
+  events?: IEventService;
+}
+
+function emit(
+  events: IEventService | undefined,
+  local: string,
+  runId: string,
+  data: Omit<IOrchestrationEventData, 'timestamp' | 'primitive'>,
+): void {
+  if (!events) return;
+  const context: IEventContext = {
+    ownerType: ORCHESTRATION_EVENT_PREFIX,
+    ownerId: runId,
+    ownerPath: [{ type: ORCHESTRATION_EVENT_PREFIX, id: runId }],
+  };
+  const payload: IOrchestrationEventData = {
+    timestamp: new Date(),
+    primitive: 'sequential',
+    ...data,
+  };
+  events.emit(composeEventName(ORCHESTRATION_EVENT_PREFIX, local), payload, context);
+}
+
+/**
+ * Run a `sequential` orchestration: execute each step in order over the injected
+ * `ISubagentManager`, threading each step's output into the next (when
+ * `threadOutput` is not disabled), and emitting neutral lifecycle events over the
+ * event-service. Returns the per-step results plus the final aggregate output
+ * (the last step's output).
+ */
+function buildStepRequest(
+  step: IOrchestrationStep,
+  context: ISequentialRunContext,
+  prompt: string,
+): ISubagentSpawnRequest {
+  return {
+    type: step.agentType,
+    label: step.label,
+    parentSessionId: context.parentSessionId,
+    mode: 'foreground',
+    depth: context.depth ?? 0,
+    cwd: context.cwd,
+    prompt,
+    ...(step.model ? { model: step.model } : {}),
+    ...(step.allowedTools ? { allowedTools: step.allowedTools } : {}),
+    ...(step.disallowedTools ? { disallowedTools: step.disallowedTools } : {}),
+  };
+}
+
+async function runStep(
+  step: IOrchestrationStep,
+  index: number,
+  previousOutput: string,
+  spec: ISequentialOrchestrationSpec,
+  deps: ISequentialOrchestratorDeps,
+  runId: string,
+): Promise<IOrchestrationStepResult> {
+  const { manager, context, events } = deps;
+  emit(events, ORCHESTRATION_EVENTS.STEP_STARTED, runId, { stepId: step.id, stepIndex: index });
+
+  const threadOutput = spec.threadOutput !== false;
+  const prompt =
+    threadOutput && previousOutput
+      ? `${step.prompt}\n\n---\nPrevious step output:\n${previousOutput}`
+      : step.prompt;
+
+  const jobState = await manager.spawn(buildStepRequest(step, context, prompt));
+  const result = await manager.wait(jobState.id);
+
+  emit(events, ORCHESTRATION_EVENTS.STEP_COMPLETED, runId, { stepId: step.id, stepIndex: index });
+  return { id: step.id, output: result.output, ...(result.usage ? { usage: result.usage } : {}) };
+}
+
+export async function runSequential(
+  spec: ISequentialOrchestrationSpec,
+  deps: ISequentialOrchestratorDeps,
+): Promise<IOrchestrationRunResult> {
+  const runId = `${deps.context.parentSessionId}:seq`;
+  emit(deps.events, ORCHESTRATION_EVENTS.STARTED, runId, {});
+
+  const stepResults: IOrchestrationStepResult[] = [];
+  let previousOutput = '';
+
+  try {
+    for (let index = 0; index < spec.steps.length; index += 1) {
+      const stepResult = await runStep(spec.steps[index], index, previousOutput, spec, deps, runId);
+      stepResults.push(stepResult);
+      previousOutput = stepResult.output;
+    }
+  } catch (error) {
+    emit(deps.events, ORCHESTRATION_EVENTS.FAILED, runId, {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  emit(deps.events, ORCHESTRATION_EVENTS.COMPLETED, runId, {});
+  return { primitive: 'sequential', steps: stepResults, output: previousOutput };
+}

--- a/packages/agent-framework/src/orchestration/sequential.ts
+++ b/packages/agent-framework/src/orchestration/sequential.ts
@@ -116,11 +116,15 @@ async function runStep(
   return { id: step.id, output: result.output, ...(result.usage ? { usage: result.usage } : {}) };
 }
 
+/** Monotonic per-process counter so concurrent runs in one session get distinct run ids. */
+let sequentialRunCounter = 0;
+
 export async function runSequential(
   spec: ISequentialOrchestrationSpec,
   deps: ISequentialOrchestratorDeps,
 ): Promise<IOrchestrationRunResult> {
-  const runId = `${deps.context.parentSessionId}:seq`;
+  sequentialRunCounter += 1;
+  const runId = `${deps.context.parentSessionId}:seq:${sequentialRunCounter}`;
   emit(deps.events, ORCHESTRATION_EVENTS.STARTED, runId, {});
 
   const stepResults: IOrchestrationStepResult[] = [];

--- a/scripts/harness/__tests__/scan-orchestration-neutrality.test.mjs
+++ b/scripts/harness/__tests__/scan-orchestration-neutrality.test.mjs
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findNeutralityViolationsInSource,
+  findOrchestrationNeutralityFindings,
+} from '../scan-orchestration-neutrality.mjs';
+
+/** Convenience: does this source produce at least one neutrality violation? */
+function fails(src) {
+  return findNeutralityViolationsInSource(src, 'fixture.ts').length > 0;
+}
+
+describe('scan-orchestration-neutrality (SELFHOST-001 TC-05) — FAIL cases', () => {
+  it('flags the bare app-domain words', () => {
+    expect(fails('export interface X { room: string; }')).toBe(true);
+    expect(fails('export interface X { persona: string; }')).toBe(true);
+    expect(fails('export interface X { topic: string; }')).toBe(true);
+  });
+
+  // The realistic smuggling vector is a camelCase identifier, NOT the bare word —
+  // whole-word matching would let these pass. This is the guarantee P2/P3 rely on.
+  it('flags the camelCase identifier vector (roomId / chatRoom / personaName / topicTitle)', () => {
+    expect(fails('export interface X { roomId: string; }')).toBe(true);
+    expect(fails('export interface X { chatRoom: string; }')).toBe(true);
+    expect(fails('export interface X { personaName: string; }')).toBe(true);
+    expect(fails('export interface X { topicTitle: string; }')).toBe(true);
+    expect(fails('export interface X { conversationTopic: string; }')).toBe(true);
+  });
+
+  it('reports the line number of the violation', () => {
+    const findings = findNeutralityViolationsInSource('const a = 1;\nconst roomId = 2;\n');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBe(2);
+  });
+});
+
+describe('scan-orchestration-neutrality — PASS cases', () => {
+  it('does not flag the neutral orchestration vocabulary', () => {
+    expect(fails('export type TOrchestrationPrimitive = "sequential" | "parallel";')).toBe(false);
+    expect(
+      fails('export interface IOrchestrationStep { id: string; label: string; prompt: string; }'),
+    ).toBe(false);
+    expect(
+      fails('  primitive: TOrchestrationPrimitive; stepId?: string; stepIndex?: number;'),
+    ).toBe(false);
+  });
+
+  it('the live orchestration source is currently clean', () => {
+    expect(findOrchestrationNeutralityFindings()).toEqual([]);
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -34,6 +34,10 @@ const SCAN_COMMANDS = [
   { name: 'memory-mirror', command: ['node', 'scripts/harness/scan-memory-mirror.mjs'] },
   { name: 'spec-research', command: ['node', 'scripts/harness/scan-spec-research.mjs'] },
   { name: 'orchestration-map', command: ['node', 'scripts/harness/scan-orchestration-map.mjs'] },
+  {
+    name: 'orchestration-neutrality',
+    command: ['node', 'scripts/harness/scan-orchestration-neutrality.mjs'],
+  },
   { name: 'review-findings', command: ['node', 'scripts/harness/scan-review-findings.mjs'] },
   { name: 'document-authority', command: ['node', 'scripts/harness/check-document-authority.mjs'] },
   { name: 'commands', command: ['node', 'scripts/harness/check-command-layering.mjs'] },

--- a/scripts/harness/scan-orchestration-neutrality.mjs
+++ b/scripts/harness/scan-orchestration-neutrality.mjs
@@ -12,10 +12,12 @@
  * and NOT the `interface-runtime` scan (which neither covers `agent-core` nor
  * checks app-domain field names, so it would be false-green here).
  *
- * It flags the app-domain identifiers `room` / `persona` / `topic` (whole word,
- * case-insensitive) anywhere in the orchestration source (contracts + mechanism),
- * excluding test files. The scanner's own pattern definition is the only allowed
- * occurrence of those words under scan.
+ * It flags the app-domain identifiers `room` / `persona` / `topic` anywhere in the
+ * orchestration source (contracts + mechanism), excluding test files. The match is
+ * IDENTIFIER-CONTAINING (not whole-word), so the realistic smuggling vector — a
+ * camelCase field like `roomId`, `chatRoom`, `personaName`, `topicTitle`,
+ * `conversationTopic` — is caught, not just the bare word. The scanner's own pattern
+ * definition is the only allowed occurrence of those words under scan.
  *
  * Exit 0 = clean, 1 = findings.
  */
@@ -26,7 +28,10 @@ import path from 'node:path';
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 // App-domain identity terms forbidden in the neutral orchestration contracts.
-const FORBIDDEN = /\b(room|persona|topic)\b/i;
+// Matches any identifier-like token CONTAINING the term (case-insensitive), so
+// `roomId` / `chatRoom` / `personaName` / `topicTitle` / `conversationTopic` are all
+// flagged — not merely the standalone word.
+const FORBIDDEN = /\w*(room|persona|topic)\w*/i;
 
 // Directories whose orchestration source is the neutral surface under scan.
 const SCAN_DIRS = [
@@ -52,20 +57,28 @@ function walkSource(target) {
   return files;
 }
 
+/**
+ * Pure content check: return the neutrality violations in a source string.
+ * Exposed so the harness test can assert failing-capability directly (including the
+ * camelCase identifier vector) without touching disk.
+ */
+export function findNeutralityViolationsInSource(source, file = 'fixture.ts') {
+  const findings = [];
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    if (FORBIDDEN.test(lines[i])) {
+      findings.push({ file, line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return findings;
+}
+
 export function findOrchestrationNeutralityFindings(root = WORKSPACE_ROOT) {
   const findings = [];
   for (const dir of SCAN_DIRS) {
     for (const file of walkSource(dir)) {
-      const lines = readFileSync(file, 'utf8').split('\n');
-      for (let i = 0; i < lines.length; i += 1) {
-        if (FORBIDDEN.test(lines[i])) {
-          findings.push({
-            file: path.relative(root, file),
-            line: i + 1,
-            text: lines[i].trim(),
-          });
-        }
-      }
+      const rel = path.relative(root, file);
+      findings.push(...findNeutralityViolationsInSource(readFileSync(file, 'utf8'), rel));
     }
   }
   return findings;

--- a/scripts/harness/scan-orchestration-neutrality.mjs
+++ b/scripts/harness/scan-orchestration-neutrality.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * SELFHOST-001 TC-05 — standing neutrality floor for the multi-agent orchestration
+ * contracts.
+ *
+ * The neutral orchestration primitives (`sequential`/`parallel`/`hierarchical`/
+ * `handoff`/`group-chat`) must carry NO app-domain identity (chat-room / persona /
+ * conversation-topic style fields), per the Library Neutrality Rule (TRANS-001).
+ * This scan keeps FIRING on every run so P2/P3's `hierarchical`/`group-chat`
+ * additions cannot smuggle those concepts in later — it is NOT a one-time vitest,
+ * and NOT the `interface-runtime` scan (which neither covers `agent-core` nor
+ * checks app-domain field names, so it would be false-green here).
+ *
+ * It flags the app-domain identifiers `room` / `persona` / `topic` (whole word,
+ * case-insensitive) anywhere in the orchestration source (contracts + mechanism),
+ * excluding test files. The scanner's own pattern definition is the only allowed
+ * occurrence of those words under scan.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// App-domain identity terms forbidden in the neutral orchestration contracts.
+const FORBIDDEN = /\b(room|persona|topic)\b/i;
+
+// Directories whose orchestration source is the neutral surface under scan.
+const SCAN_DIRS = [
+  'packages/agent-core/src/orchestration',
+  'packages/agent-framework/src/orchestration',
+];
+
+function walkSource(target) {
+  const full = path.join(WORKSPACE_ROOT, target);
+  if (!existsSync(full)) return [];
+  if (statSync(full).isFile()) return full.endsWith('.ts') ? [full] : [];
+  const files = [];
+  for (const entry of readdirSync(full, { withFileTypes: true })) {
+    // Neutrality is a property of the CONTRACTS + mechanism, not test fixtures.
+    if (entry.name === '__tests__') continue;
+    const child = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkSource(child));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(path.join(WORKSPACE_ROOT, child));
+    }
+  }
+  return files;
+}
+
+export function findOrchestrationNeutralityFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  for (const dir of SCAN_DIRS) {
+    for (const file of walkSource(dir)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      for (let i = 0; i < lines.length; i += 1) {
+        if (FORBIDDEN.test(lines[i])) {
+          findings.push({
+            file: path.relative(root, file),
+            line: i + 1,
+            text: lines[i].trim(),
+          });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+function main() {
+  const findings = findOrchestrationNeutralityFindings();
+  if (findings.length === 0) {
+    console.log('orchestration-neutrality scan passed.');
+    process.exit(0);
+  }
+  console.error(
+    'orchestration-neutrality scan FAILED — app-domain identity (room/persona/topic) in the neutral orchestration contracts:',
+  );
+  for (const f of findings) {
+    console.error(`  ${f.file}:${f.line}  ${f.text}`);
+  }
+  console.error(
+    '\nThe orchestration primitives must stay neutral mechanisms (TRANS-001). Remove the app-domain field, or move the concept to a product/app layer.',
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

**First implementation slice (P1) of SELFHOST-001** — the multi-agent orchestration epic, the biggest capability gap toward [`VISION.md`](../blob/develop/VISION.md) "Robota builds Robota". Ships the neutral contracts + the `sequential` primitive end-to-end, exactly per the ENDORSE'd design (spec now `active/`, `status: in-progress`).

This is GATE-IMPLEMENT for P1 only; **P2** (`parallel`/`handoff`) and **P3** (`hierarchical`/`group-chat`) remain (the epic stays in `active/`).

## What ships

- **agent-core OWNS the neutral contracts + event-type unions** (`packages/agent-core/src/orchestration/`): `TOrchestrationPrimitive`, `IOrchestrationStep`, `ISequentialOrchestrationSpec`, `IOrchestrationRunResult`, `IOrchestrationStepResult`, `IOrchestrationEventData`, and `ORCHESTRATION_EVENTS`/`ORCHESTRATION_EVENT_PREFIX`. Pure types + const event names — **zero new `@robota-sdk/agent-*` production deps**.
- **agent-framework IMPLEMENTS the `sequential` mechanism** (`orchestration/sequential.ts` → `runSequential`) composing over `agent-executor`'s `ISubagentManager`/`ISubagentRunner` port; threads each step's output into the next; emits neutral lifecycle events over the existing event-service. The framework **never depends on `agent-subagent-runner`** (that would be a cycle — the concrete runner is injected at the `agent-cli` root).
- **Standing `orchestration-neutrality` harness scan** (`scripts/harness/scan-orchestration-neutrality.mjs`, registered in `run-all-scans.mjs`) — failing-capable, keeps firing so P2/P3's `hierarchical`/`group-chat` can't smuggle in app-domain identity (room/persona/topic).
- **SPEC amendments**: `agent-core/docs/SPEC.md` Boundaries reclassified (core OWNS the neutral orchestration contracts + event unions; framework IMPLEMENTS them) + an Orchestration Public API subsection; `agent-framework/docs/SPEC.md` documents `runSequential`.

## Completion Criteria (all green locally)

| TC | Verification |
| -- | ------------ |
| TC-01 / TC-04 | `deps` scan — zero new agent-* deps; no `agent-subagent-runner` edge (no cycle) |
| TC-02 | `sequential` emits lifecycle events over the event-service (unit test) |
| TC-03 | composes end-to-end over a `SubagentManager` backed by an `ISubagentRunner` (functional test) |
| TC-05 | standing `orchestration-neutrality` scan (verified: FAILs on an injected `room` field, passes clean) |
| TC-06 | SPEC amendments — `spec-public-surface` + `docs-structure` scans |

## Test plan / evidence

`packages/agent-framework/src/orchestration/__tests__/sequential.test.ts` — 5 tests (events, output threading, `threadOutput:false`, failed-rethrow, end-to-end over the runner port). Verified: build + typecheck (agent-core / agent-framework / agent-cli) + tests **5/5** + lint **0 errors** + `pnpm harness:scan` (**all 54 scans pass**, incl. `orchestration-neutrality`).

## Next

P2 (`parallel` bounded-concurrency + `handoff` control-transfer), then P3 (`hierarchical` manager-delegation + `group-chat` turn-taking). Extraction trigger B3 (move contracts + event unions to `agent-interface-orchestration`) fires when a second implementer family (a dag-\* adapter) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sz7bJyHGvL8WkqAt9Hwhnx
