### PR TITLE
chore(agents): commit-cadence + feedback-promotion rules; daily-report backlog

### DIFF
--- a/.agents/backlog/OBSERVABILITY-001-daily-work-report-harness.md
+++ b/.agents/backlog/OBSERVABILITY-001-daily-work-report-harness.md
@@ -1,0 +1,51 @@
+---
+title: 'OBSERVABILITY-001: daily work-report harness (template-based, UTC-daily, background-triggered)'
+status: todo
+created: 2026-07-18
+priority: medium
+urgency: later
+area: .agents, scripts/harness, .claude
+depends_on: []
+---
+
+# Daily work-report harness
+
+## Problem
+
+There is no automatic summary of what was done each day. The owner wants a per-day `.md` report of that
+day's work, generated on a template, so the daily activity is captured without manual effort. This
+supports the self-improving-harness north-star (a durable, reviewable trace of what the harness did).
+
+## Owner requirements (verbatim intent, 2026-07-18)
+
+- **One report per work day, keyed to UTC.** The report summarizes the work done on that UTC day.
+- **Template-based.** There is a basic report template; each daily report is filled out to that template.
+- **Purpose:** summarize, day by day, what work was done.
+- **Delivered as a skill or a background agent** that triggers **naturally while the owner is working** —
+  when the time comes (a UTC hour boundary / 정각), it fires as a **background agent** and writes the report.
+- **No report on no-work days.** Days with no work produce no report.
+- **Catch-up, day by day.** When a report is needed again after the last one, generate reports for each
+  intervening **work** day **in order**, one per day (do not lump multiple days into one report).
+
+## Open design questions (resolve at spec/GATE-WRITE time)
+
+- **"Work day" detection signal.** Proposed default: a UTC day is a work day iff it has git commits (by the
+  configured author) and/or recorded session activity that day. Pick the authoritative signal.
+- **Report location + naming.** Proposed default: `.agents/reports/daily/YYYY-MM-DD.md` (UTC date). Confirm.
+- **Template contents.** Design the template (candidate sections: date/UTC-window, summary, PRs merged,
+  specs/tasks advanced, notable decisions, follow-ups filed, verification run). The template is the SSOT.
+- **Trigger mechanism.** How the background agent fires at a UTC hour boundary during active work —
+  a scheduled wakeup / cron entry, a session hook, or a `/`-invocable skill the owner (or a scheduler)
+  runs. Must degrade gracefully when no session is active.
+- **Idempotency + catch-up bookkeeping.** Track the last-reported UTC date so a re-run backfills each
+  missing **work** day exactly once, in chronological order, skipping no-work days. Re-running for an
+  already-reported day must not duplicate or clobber.
+- **Data source for the summary.** Git log for the UTC day + merged PRs + spec/task state changes; keep it
+  agent-generated from durable artifacts, not free-form recollection.
+
+## Scope
+
+Build the harness (template + work-day detection + report generation + background trigger + catch-up
+bookkeeping). **Create this backlog now; implement it only after the current in-flight work is done**
+(owner instruction 2026-07-18). Follow the spec-gate pipeline (GATE-WRITE → APPROVAL → IMPLEMENT → …) when
+implementation begins.

--- a/.agents/rules/agent-conduct.md
+++ b/.agents/rules/agent-conduct.md
@@ -72,6 +72,23 @@ structure) are not in conflict and remain in force — see the Structured-artifa
 - **Decision authority.** Where rule or architecture grounds are clear, decide and act directly
   without over-deferring; only product-direction or contract changes are confirmed with the user.
 
+## Feedback → Trial → Rule Promotion
+
+When the owner gives working-process feedback (how to work, not what to build), follow this routine so
+the harness compounds instead of forgetting:
+
+1. **Apply it immediately** in the current work — treat it as an active constraint, not a note for later.
+2. **Record it** as a session/in-repo `feedback` memory (per [memory-mirroring.md](memory-mirroring.md)) so
+   it survives the session even before it is a rule.
+3. **Trial it** across real work. If it proves out with no problems, **promote it to a permanent in-repo
+   rule** (`.agents/rules/…`, or a spec/skill when that is the right owner), citing the feedback and where
+   it was validated; leave the memory note pointing at the rule.
+4. If the trial surfaces problems, report them to the owner and adjust rather than silently promoting.
+
+Do not let process feedback live only in one session's context — either it is being trialed toward a rule
+or it is already a rule. This routine is itself a rule (added at owner request, 2026-07-17): the act of
+turning validated feedback into durable governance is not optional.
+
 ## Epistemic Discipline & Verification
 
 - **Verify, don't assume (external behavior).** Before asserting or coding against any

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -51,6 +51,17 @@ start from an inconsistent baseline.
 - Conventional commit format: `<type>(<scope>): <message>` (max 72 chars).
 - Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`.
 
+### Commit Cadence
+
+Commit at appropriate logical boundaries **as work progresses** — one commit per logical step (e.g.
+contract/types → adapter/mechanism → wiring/assembly → tests → docs/evidence), each left green
+(build/typecheck), then open one coherent PR (DX-001). **Never batch a whole slice into a single
+end-of-work commit, and never defer committing until the context is nearly exhausted** — committed
+progress is safe across a compaction, whereas a large uncommitted working tree is not, and deferring
+reads as stalling. Avoid the opposite failure too: do not fragment into many trivial commits. The
+context window filling is **not** a reason to stop implementing or to switch to planning-only; keep
+implementing and keep committing. (Owner feedback, 2026-07-17, validated on SELFHOST-003 P1.)
+
 ### `--delete-branch` is Prohibited in `gh pr merge`
 
 **Never pass `--delete-branch` to `gh pr merge`. Zero exceptions.**


### PR DESCRIPTION
Owner-requested process governance (in-session, 2026-07-17/18):

**Rules promoted/added:**
- **git-branch.md → `### Commit Cadence`** — commit at logical boundaries as work progresses (contract→adapter→wiring→tests→docs, each green), one coherent PR; never defer committing to the context limit; keep implementing under context pressure. Promoted after validating it on SELFHOST-003 P1's 7 incremental commits.
- **agent-conduct.md → `## Feedback → Trial → Rule Promotion`** — the routine itself, per owner request: apply owner process-feedback immediately, record it as memory, trial it in real work, and on success promote it to a durable in-repo rule. This is the meta-rule the owner asked for ("add the routine of trying feedback and promoting it to a rule").

**Backlog filed (implement later):**
- **OBSERVABILITY-001: daily work-report harness** — template-based per-UTC-day `.md` work report, background-triggered at a UTC hour boundary during active work, no report on no-work days, day-by-day catch-up for missed days. Created now; **implemented after other work** per owner instruction. Captures the requirements + open design questions for GATE-WRITE.

`pnpm harness:scan`: 54/54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)