### PR TITLE
feat(retrieval): incremental re-index on file change (SELFHOST-003 P3)

### DIFF
--- a/.agents/spec-docs/active/SELFHOST-003-codebase-index-rag.md
+++ b/.agents/spec-docs/active/SELFHOST-003-codebase-index-rag.md
@@ -195,3 +195,11 @@ follow-up filed: [`.agents/backlog/HARNESS-027-agent-tools-neutrality-floor.md`]
   parse-once-not-per-retrieve). Verified: build + typecheck + retrieval tests **12/12** + lint (0 errors) +
   `pnpm harness:scan` (54/54, SPEC + spec-public-surface baseline updated for the 4 new runtime exports). **P3**
   (incremental re-index) / **P4** (vector backend, may revise port) remain.
+- 2026-07-18 — **GATE-IMPLEMENT: P3 implemented (incremental re-index).** `updateRepoMapIndex(index, changes, parser)`
+  - `IRepoMapIndexChanges` re-parse ONLY the changed (`upserted`) files and drop `removed` paths, reusing every
+    unchanged entry — no full-corpus re-parse on a file change. Returns a new index (input not mutated); ranking over
+    the result is identical to a full rebuild (order-independent). Neutral. Tests prove re-parse-only-changed
+    (call-count), full-rebuild parity, remove/add, immutability, and upsert-wins. Verified: build + typecheck +
+    retrieval tests **17/17** + lint (0 errors) + `pnpm harness:scan` (54/54, SPEC + baseline updated for
+    `updateRepoMapIndex`). **P4** (embedding-vector backend, may revise the port) is the only remaining slice —
+    consciously deferred; once done (or split to its own backlog), the epic reaches GATE-VERIFY/COMPLETE.

--- a/.agents/tasks/SELFHOST-003.md
+++ b/.agents/tasks/SELFHOST-003.md
@@ -42,7 +42,15 @@ surface** (no repo paths in `agent-tools`). `createRetrievalTool({ adapter })` m
       throw, corpus-vs-persisted ranking parity, parse-once-not-per-retrieve, construction-arg validation. 12/12.
 - [x] Verify: build + typecheck + tests + lint (0 errors) + `pnpm harness:scan` (54/54).
 
-## P3 — incremental re-index on file change — PENDING
+## P3 — incremental re-index on file change ✅ IMPLEMENTED
+
+- [x] `updateRepoMapIndex(index, changes, parser)` (`repo-map-index.ts`) + `IRepoMapIndexChanges` type: re-parse
+      ONLY the `upserted` files and drop `removed` paths, reusing every unchanged entry — no full-corpus re-parse on
+      a file change. Returns a new index (input not mutated); a path in both `removed`+`upserted` is upserted.
+      Exported; SPEC + spec-public-surface baseline updated.
+- [x] Tests (`repo-map-index.test.ts`): re-parses only changed files (call-count) + matches a full rebuild; drops
+      removed + adds new; input not mutated; upsert-wins. 17/17 retrieval tests.
+- [x] Verify: build + typecheck + tests + lint (0 errors) + `pnpm harness:scan` (54/54).
 
 ## P4 — embedding-vector backend (may revise the port) — PENDING
 

--- a/packages/agent-tools/docs/SPEC.md
+++ b/packages/agent-tools/docs/SPEC.md
@@ -124,6 +124,7 @@ Types owned by this package (SSOT):
 | `IRetrievalAdapter`                     | Type     | SELFHOST-003 — codebase-retrieval port (`retrieve(request) → ranked result within a token budget`)                                                         |
 | `IRetrievalSourceParser`                | Type     | SELFHOST-003 — duck-typed source-parser port injected into the ranking adapter                                                                             |
 | `buildRepoMapIndex`                     | Function | SELFHOST-003 P2 — parse the corpus once into a serializable `IRepoMapIndex` (build-once, rank-many)                                                        |
+| `updateRepoMapIndex`                    | Function | SELFHOST-003 P3 — incrementally re-index: re-parse only changed files (upsert/remove), reuse the rest                                                      |
 | `serializeRepoMapIndex`                 | Function | SELFHOST-003 P2 — serialize a built index to a neutral JSON string for surface persistence                                                                 |
 | `deserializeRepoMapIndex`               | Function | SELFHOST-003 P2 — restore a built index from JSON (throws on unsupported `version`)                                                                        |
 | `REPO_MAP_INDEX_VERSION`                | Const    | SELFHOST-003 P2 — persisted-schema version for `IRepoMapIndex`                                                                                             |

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -45,12 +45,14 @@ export type {
   IRepoMapRetrievalAdapterOptions,
   IRepoMapIndexEntry,
   IRepoMapIndex,
+  IRepoMapIndexChanges,
   IBuildRepoMapIndexOptions,
 } from './retrieval/index';
 export {
   RepoMapRetrievalAdapter,
   createRetrievalTool,
   buildRepoMapIndex,
+  updateRepoMapIndex,
   serializeRepoMapIndex,
   deserializeRepoMapIndex,
   REPO_MAP_INDEX_VERSION,

--- a/packages/agent-tools/src/retrieval/__tests__/repo-map-index.test.ts
+++ b/packages/agent-tools/src/retrieval/__tests__/repo-map-index.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { RepoMapRetrievalAdapter } from '../repo-map-adapter.js';
 import {
   buildRepoMapIndex,
+  updateRepoMapIndex,
   serializeRepoMapIndex,
   deserializeRepoMapIndex,
   REPO_MAP_INDEX_VERSION,
@@ -97,5 +98,65 @@ describe('SELFHOST-003 P2 — repo-map index build + persistence', () => {
 
   it('throws when constructed with neither an index nor a parser+corpus', () => {
     expect(() => new RepoMapRetrievalAdapter({})).toThrow(/requires either/);
+  });
+});
+
+describe('SELFHOST-003 P3 — incremental re-index (updateRepoMapIndex)', () => {
+  // b.ts modified: `bar` now also references `foo`.
+  const MODIFIED: Record<string, IRetrievalParsedFile> = {
+    ...PARSED,
+    'b.ts': {
+      definitions: [{ file: 'b.ts', name: 'bar', kind: 'function', line: 1 }],
+      references: ['foo'],
+    },
+  };
+
+  it('re-parses ONLY the changed files and matches a full rebuild', async () => {
+    const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
+    const parse = vi.fn(fakeParser(MODIFIED).parse);
+
+    const updated = updateRepoMapIndex(
+      initial,
+      { upserted: [{ path: 'b.ts', content: '' }] },
+      { parse },
+    );
+    expect(parse).toHaveBeenCalledTimes(1); // only b.ts, not the whole corpus
+
+    const rebuilt = buildRepoMapIndex({ parser: fakeParser(MODIFIED), corpus: CORPUS });
+    const req = { activeFiles: ['a.ts'], tokenBudget: 1000 };
+    expect(await new RepoMapRetrievalAdapter({ index: updated }).retrieve(req)).toEqual(
+      await new RepoMapRetrievalAdapter({ index: rebuilt }).retrieve(req),
+    );
+  });
+
+  it('drops removed paths and adds new files', () => {
+    const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
+    const parse = vi.fn(fakeParser({ 'd.ts': { definitions: [], references: [] } }).parse);
+
+    const updated = updateRepoMapIndex(
+      initial,
+      { removed: ['b.ts'], upserted: [{ path: 'd.ts', content: '' }] },
+      { parse },
+    );
+    const paths = updated.entries.map((e) => e.path).sort();
+    expect(paths).toEqual(['a.ts', 'c.ts', 'd.ts']); // b.ts dropped, d.ts added
+    expect(parse).toHaveBeenCalledTimes(1); // only the upserted d.ts
+  });
+
+  it('does not mutate the input index', () => {
+    const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
+    const before = JSON.stringify(initial);
+    updateRepoMapIndex(initial, { removed: ['b.ts'] }, fakeParser(PARSED));
+    expect(JSON.stringify(initial)).toBe(before);
+  });
+
+  it('upsert wins when a path is both removed and upserted', () => {
+    const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
+    const updated = updateRepoMapIndex(
+      initial,
+      { removed: ['b.ts'], upserted: [{ path: 'b.ts', content: '' }] },
+      fakeParser(MODIFIED),
+    );
+    expect(updated.entries.find((e) => e.path === 'b.ts')?.references).toEqual(['foo']);
   });
 });

--- a/packages/agent-tools/src/retrieval/__tests__/repo-map-index.test.ts
+++ b/packages/agent-tools/src/retrieval/__tests__/repo-map-index.test.ts
@@ -150,6 +150,21 @@ describe('SELFHOST-003 P3 — incremental re-index (updateRepoMapIndex)', () => 
     expect(JSON.stringify(initial)).toBe(before);
   });
 
+  it('de-duplicates a repeated upserted path (last-wins → one entry, matches a rebuild)', () => {
+    const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
+    const updated = updateRepoMapIndex(
+      initial,
+      {
+        upserted: [
+          { path: 'b.ts', content: 'stale' },
+          { path: 'b.ts', content: 'latest' },
+        ],
+      },
+      fakeParser(MODIFIED),
+    );
+    expect(updated.entries.filter((e) => e.path === 'b.ts')).toHaveLength(1);
+  });
+
   it('upsert wins when a path is both removed and upserted', () => {
     const initial = buildRepoMapIndex({ parser: fakeParser(PARSED), corpus: CORPUS });
     const updated = updateRepoMapIndex(

--- a/packages/agent-tools/src/retrieval/index.ts
+++ b/packages/agent-tools/src/retrieval/index.ts
@@ -12,10 +12,12 @@ export type {
   IRetrievalToolOptions,
   IRepoMapIndexEntry,
   IRepoMapIndex,
+  IRepoMapIndexChanges,
 } from './types.js';
 
 export {
   buildRepoMapIndex,
+  updateRepoMapIndex,
   serializeRepoMapIndex,
   deserializeRepoMapIndex,
   REPO_MAP_INDEX_VERSION,

--- a/packages/agent-tools/src/retrieval/repo-map-index.ts
+++ b/packages/agent-tools/src/retrieval/repo-map-index.ts
@@ -9,6 +9,7 @@
 
 import type {
   IRepoMapIndex,
+  IRepoMapIndexChanges,
   IRepoMapIndexEntry,
   IRetrievalCorpusFile,
   IRetrievalSourceParser,
@@ -24,13 +25,42 @@ export interface IBuildRepoMapIndexOptions {
   corpus: IRetrievalCorpusFile[];
 }
 
+/** Parse one corpus file into an index entry. */
+function parseEntry(
+  parser: IRetrievalSourceParser,
+  file: IRetrievalCorpusFile,
+): IRepoMapIndexEntry {
+  const parsed = parser.parse(file.path, file.content);
+  return { path: file.path, definitions: parsed.definitions, references: parsed.references };
+}
+
 /** Parse the whole corpus once into a serializable repo-map index. */
 export function buildRepoMapIndex(options: IBuildRepoMapIndexOptions): IRepoMapIndex {
-  const entries: IRepoMapIndexEntry[] = options.corpus.map((file) => {
-    const parsed = options.parser.parse(file.path, file.content);
-    return { path: file.path, definitions: parsed.definitions, references: parsed.references };
-  });
-  return { version: REPO_MAP_INDEX_VERSION, entries };
+  return {
+    version: REPO_MAP_INDEX_VERSION,
+    entries: options.corpus.map((file) => parseEntry(options.parser, file)),
+  };
+}
+
+/**
+ * Apply corpus changes to a built index INCREMENTALLY (SELFHOST-003 P3): re-parse only the `upserted`
+ * files and drop `removed` paths, reusing every unchanged entry. Returns a new index (the input is not
+ * mutated). A file present in both `removed` and `upserted` is upserted (re-parse wins). Ranking over
+ * the result is identical to a full rebuild of the changed corpus (entry order does not affect ranking).
+ */
+export function updateRepoMapIndex(
+  index: IRepoMapIndex,
+  changes: IRepoMapIndexChanges,
+  parser: IRetrievalSourceParser,
+): IRepoMapIndex {
+  const upsertedFiles = changes.upserted ?? [];
+  const touched = new Set<string>([
+    ...(changes.removed ?? []),
+    ...upsertedFiles.map((file) => file.path),
+  ]);
+  const kept = index.entries.filter((entry) => !touched.has(entry.path));
+  const upserted = upsertedFiles.map((file) => parseEntry(parser, file));
+  return { version: index.version, entries: [...kept, ...upserted] };
 }
 
 /** Serialize a built index to a neutral JSON string for persistence by the surface. */

--- a/packages/agent-tools/src/retrieval/repo-map-index.ts
+++ b/packages/agent-tools/src/retrieval/repo-map-index.ts
@@ -45,21 +45,21 @@ export function buildRepoMapIndex(options: IBuildRepoMapIndexOptions): IRepoMapI
 /**
  * Apply corpus changes to a built index INCREMENTALLY (SELFHOST-003 P3): re-parse only the `upserted`
  * files and drop `removed` paths, reusing every unchanged entry. Returns a new index (the input is not
- * mutated). A file present in both `removed` and `upserted` is upserted (re-parse wins). Ranking over
- * the result is identical to a full rebuild of the changed corpus (entry order does not affect ranking).
+ * mutated). A file present in both `removed` and `upserted` is upserted (re-parse wins); a path repeated
+ * within `upserted` is de-duplicated last-wins, so the result always has one entry per path — matching a
+ * full rebuild (entry order does not affect ranking). Unchanged entries are REUSED BY REFERENCE; index
+ * entries are treated as immutable, so callers must not mutate an entry in place.
  */
 export function updateRepoMapIndex(
   index: IRepoMapIndex,
   changes: IRepoMapIndexChanges,
   parser: IRetrievalSourceParser,
 ): IRepoMapIndex {
-  const upsertedFiles = changes.upserted ?? [];
-  const touched = new Set<string>([
-    ...(changes.removed ?? []),
-    ...upsertedFiles.map((file) => file.path),
-  ]);
+  // De-dup upserted by path (last-wins) so a repeated path yields a single, latest entry.
+  const upsertedByPath = new Map((changes.upserted ?? []).map((file) => [file.path, file]));
+  const touched = new Set<string>([...(changes.removed ?? []), ...upsertedByPath.keys()]);
   const kept = index.entries.filter((entry) => !touched.has(entry.path));
-  const upserted = upsertedFiles.map((file) => parseEntry(parser, file));
+  const upserted = [...upsertedByPath.values()].map((file) => parseEntry(parser, file));
   return { version: index.version, entries: [...kept, ...upserted] };
 }
 

--- a/packages/agent-tools/src/retrieval/types.ts
+++ b/packages/agent-tools/src/retrieval/types.ts
@@ -116,3 +116,14 @@ export interface IRepoMapIndex {
   /** One entry per corpus file, parsed. */
   entries: IRepoMapIndexEntry[];
 }
+
+/**
+ * A set of corpus changes to apply incrementally to a built index (SELFHOST-003 P3): only the changed
+ * files are re-parsed; the rest of the index is reused unchanged.
+ */
+export interface IRepoMapIndexChanges {
+  /** Files added or modified — re-parsed and upserted into the index. */
+  upserted?: IRetrievalCorpusFile[];
+  /** Repo-relative paths removed — their entries are dropped from the index. */
+  removed?: string[];
+}

--- a/scripts/harness/check-spec-public-surface.mjs
+++ b/scripts/harness/check-spec-public-surface.mjs
@@ -599,6 +599,7 @@ export const UNDOCUMENTED_EXPORT_ALLOWLIST = new Set([
   '@robota-sdk/agent-tools#RepoMapRetrievalAdapter',
   '@robota-sdk/agent-tools#REPO_MAP_INDEX_VERSION',
   '@robota-sdk/agent-tools#buildRepoMapIndex',
+  '@robota-sdk/agent-tools#updateRepoMapIndex',
   '@robota-sdk/agent-tools#serializeRepoMapIndex',
   '@robota-sdk/agent-tools#deserializeRepoMapIndex',
   '@robota-sdk/agent-tools#applyWorkspaceManifest',


### PR DESCRIPTION
## SELFHOST-003 P3 — incremental re-index

Third slice. P2 built the index once; P3 updates it **incrementally** when files change, without re-parsing the whole corpus.

### agent-tools
- **`updateRepoMapIndex(index, changes, parser)`** + **`IRepoMapIndexChanges`** (`{ upserted?, removed? }`) — re-parse ONLY the changed (`upserted`) files, drop `removed` paths, reuse every unchanged entry. Returns a **new** index (input not mutated); a path in both `removed`+`upserted` is upserted (re-parse wins). Ranking over the result is identical to a full rebuild (entry order does not affect ranking).

Neutral: parser injected, corpus from the surface; no repo paths, no heavy dep.

### Tests (17/17)
re-parses **only** changed files (call-count) + **matches a full rebuild** · drops removed + adds new · input not mutated · upsert-wins.

### Verification
build + typecheck + retrieval tests **17/17** + lint (0 errors) + `pnpm harness:scan` (**54/54**; SPEC + baseline updated for `updateRepoMapIndex`).

**Scope:** P4 (embedding-vector backend, may revise the port) is the only remaining slice — consciously deferred. Epic spec stays in `active/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)