### PR TITLE
feat(cost): turn-granular costUsd foundation (SELFHOST-004 P1)

### DIFF
--- a/.agents/spec-docs/active/SELFHOST-004-trace-cost-view.md
+++ b/.agents/spec-docs/active/SELFHOST-004-trace-cost-view.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: in-progress
 type: OBSERVABILITY
 tags: [tracing, cost, budget, agent-plugin, agent-interface-transport, tui, gui, selfhost]
 ---
@@ -218,7 +218,9 @@ mirroring `SessionMonitor`, the timeline reaching the GUI over the new `TServerM
 
 ## Tasks
 
-`.agents/tasks/SELFHOST-004.md` — 미생성 (GATE-APPROVAL 통과 후 생성).
+[`.agents/tasks/SELFHOST-004.md`](../../tasks/SELFHOST-004.md) — created at GATE-IMPLEMENT. Split into named work
+units: P1 (turn-granular cost foundation, TC-06, this slice) / P2 (span timing, TC-07) / P3 (read-model, TC-01/03) /
+P4 (per-run budget cap, TC-02/04) / P5 (TServerMessage carrier + TUI/GUI view, TC-05/08).
 
 ## Evidence Log
 

--- a/.agents/spec-docs/active/SELFHOST-004-trace-cost-view.md
+++ b/.agents/spec-docs/active/SELFHOST-004-trace-cost-view.md
@@ -318,3 +318,14 @@ P4 (per-run budget cap, TC-02/04) / P5 (TServerMessage carrier + TUI/GUI view, T
   PASSED** — after 7 iterations (3 REVISE at the data-flow layer, 1 REJECT that forced the P2 redesign, 2 REVISE at
   the seam, final ENDORSE); the gate held the line on a genuine, repeatedly-relabeled illegal-dependency defect that
   would otherwise have surfaced only in a post-implementation architecture audit.
+- 2026-07-18 — **GATE-IMPLEMENT: P1 implemented (turn-granular cost foundation, TC-06)** (moved todo/ → active/,
+  status in-progress; task created split P1–P5). `agent-interface-transport`: OPTIONAL derived `costUsd?: number` on
+  `IUsageSnapshot` (present iff `costStatus !== 'unknown'`; backward-compatible). `agent-framework`: `extractTurnUsage`
+  now resolves the turn's model id (threaded from the caller's `ctx.getSession().getModelId()` through
+  `buildResult`/`buildInterruptedResult`) and computes `costUsd` via `calculateModelCost` (the `agent-core/model-pricing.ts`
+  SSOT — exact input/output split), flipping `costStatus` `'unknown'` → `'exact'`; stays `'unknown'`/absent for an
+  unpriced/absent model. No `agent-plugin` edge; this seam owns ONLY turn cost (span timing is P2). TC-06 proven:
+  `interactive-session-usage.test.ts` (gpt-4o → costUsd 0.00075 + `exact`; unpriced → absent + `unknown`). Verified:
+  build + typecheck + full agent-framework suite **1133/1133** (incl. updated Session mocks) + agent-interface-transport
+  10/10 + lint (0 errors) + `pnpm harness:scan` (54/54). **P2** (span timing, TC-07) / **P3** (read-model, TC-01/03) /
+  **P4** (budget cap, TC-02/04) / **P5** (carrier + view, TC-05/08) remain.

--- a/.agents/tasks/SELFHOST-004.md
+++ b/.agents/tasks/SELFHOST-004.md
@@ -15,15 +15,15 @@ cycle) is preserved slice by slice:
 
 ## P1 — turn-granular cost foundation (this slice, TC-06)
 
-- [ ] `agent-interface-transport`: add OPTIONAL derived `costUsd?: number` on `IUsageSnapshot` (present iff
+- [x] `agent-interface-transport`: add OPTIONAL derived `costUsd?: number` on `IUsageSnapshot` (present iff
       `costStatus !== 'unknown'`; turn-granular). Backward-compatible.
-- [ ] `agent-framework`: `extractTurnUsage` (`interactive-session-execution.ts`) resolves the turn's model id
+- [x] `agent-framework`: `extractTurnUsage` (`interactive-session-execution.ts`) resolves the turn's model id
       (threaded from the caller's `ctx.getSession().getModelId()`) and computes `costUsd` via `calculateModelCost`
       (the `agent-core/model-pricing.ts` SSOT — exact input/output split), flipping `costStatus` from `'unknown'` to
       `exact` (or leaving `unknown` when the model is unpriced). No `agent-plugin` edge; owns ONLY turn cost.
-- [ ] Tests (TC-06): `extractTurnUsage` populates `costUsd` + flips `costStatus` for a priced model; leaves it
+- [x] Tests (TC-06): `extractTurnUsage` populates `costUsd` + flips `costStatus` for a priced model; leaves it
       absent/`unknown` for an unpriced/absent model.
-- [ ] Verify: build + typecheck + tests + lint + `pnpm harness:scan`.
+- [x] Verify: build + typecheck + tests + lint + `pnpm harness:scan`.
 
 ## P2 — span timing (agent-core span-completion event + ISpanEntry + framework entry) — TC-07 — PENDING
 

--- a/.agents/tasks/SELFHOST-004.md
+++ b/.agents/tasks/SELFHOST-004.md
@@ -1,0 +1,41 @@
+<!-- archival-exempt: EPIC in progress — a large 7-package observability epic split into named work units; P1 (turn-granular cost foundation, TC-06) is the first slice. P2..P5 remain, so the spec stays in spec-docs/active/ until the slices land and GATE-VERIFY/GATE-COMPLETE run. -->
+
+# SELFHOST-004 — run tracing + per-run cost budgeting view (EPIC)
+
+Spec: [`.agents/spec-docs/active/SELFHOST-004-trace-cost-view.md`](../spec-docs/active/SELFHOST-004-trace-cost-view.md)
+GATE-APPROVAL: PASSED (iteration 8 ENDORSE, after a REJECT-forced redesign). GATE-IMPLEMENT in progress.
+
+## Recommendation (gate)
+
+A large multi-package epic (agent-core span-timing SOURCE, agent-interface-transport contracts, agent-framework
+record-entry + turn cost, agent-transport-protocol carrier, agent-session-analytics read-model, agent-plugin limits
+enforcement, transport-tui/gui view). Split into named work units so each is independently testable/mergeable and the
+subtle dependency-legality (no `agent-plugin` edge into core/framework/analytics/cli; no `agent-core → transport`
+cycle) is preserved slice by slice:
+
+## P1 — turn-granular cost foundation (this slice, TC-06)
+
+- [ ] `agent-interface-transport`: add OPTIONAL derived `costUsd?: number` on `IUsageSnapshot` (present iff
+      `costStatus !== 'unknown'`; turn-granular). Backward-compatible.
+- [ ] `agent-framework`: `extractTurnUsage` (`interactive-session-execution.ts`) resolves the turn's model id
+      (threaded from the caller's `ctx.getSession().getModelId()`) and computes `costUsd` via `calculateModelCost`
+      (the `agent-core/model-pricing.ts` SSOT — exact input/output split), flipping `costStatus` from `'unknown'` to
+      `exact` (or leaving `unknown` when the model is unpriced). No `agent-plugin` edge; owns ONLY turn cost.
+- [ ] Tests (TC-06): `extractTurnUsage` populates `costUsd` + flips `costStatus` for a priced model; leaves it
+      absent/`unknown` for an unpriced/absent model.
+- [ ] Verify: build + typecheck + tests + lint + `pnpm harness:scan`.
+
+## P2 — span timing (agent-core span-completion event + ISpanEntry + framework entry) — TC-07 — PENDING
+
+## P3 — trace/cost read-model (`summarizeUsageBySource` timeline + cost-by-source) — TC-01/03 — PENDING
+
+## P4 — per-run cumulative budget cap in LimitsPlugin (sessionId, never-reset, exact costUsd) — TC-02/04 — PENDING
+
+## P5 — new TServerMessage carrier + TUI/GUI trace/cost view — TC-05/08 — PENDING
+
+## Test Plan
+
+Maps the spec's Completion Criteria to the planned verification (this slice = TC-06; others in later slices):
+
+- **TC-06** (`extractTurnUsage` populates `costUsd`) → vitest unit in `agent-framework`.
+- TC-01/02/03/04/05/07/08 → P2–P5 (see the spec Test Plan).

--- a/packages/agent-framework/src/__tests__/history-cross-package.test.ts
+++ b/packages/agent-framework/src/__tests__/history-cross-package.test.ts
@@ -34,6 +34,7 @@ function createMockSession(options?: {
     clearHistory: vi.fn(),
     getPermissionMode: vi.fn().mockReturnValue('default'),
     setPermissionMode: vi.fn(),
+    getModelId: vi.fn().mockReturnValue('test-model'),
     getSessionId: vi.fn().mockReturnValue('test-session-id'),
     getMessageCount: vi.fn().mockReturnValue(0),
     getSessionAllowedTools: vi.fn().mockReturnValue([]),

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-behavior.test.ts
@@ -38,6 +38,7 @@ function createMockSession(options?: {
     clearHistory: vi.fn(),
     getPermissionMode: vi.fn().mockReturnValue('default'),
     setPermissionMode: vi.fn(),
+    getModelId: vi.fn().mockReturnValue('test-model'),
     getSessionId: vi.fn().mockReturnValue('sess-1'),
     getSystemMessage: vi.fn().mockReturnValue('system prompt with capabilities'),
     getToolSchemas: vi

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-usage.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-usage.test.ts
@@ -46,6 +46,55 @@ describe('interactive session usage summaries', () => {
     });
   });
 
+  // SELFHOST-004 TC-06: extractTurnUsage resolves the turn's model id and populates costUsd via the
+  // model-pricing SSOT (exact input/output split), flipping costStatus 'unknown' → 'exact'.
+  it('TC-06: populates costUsd + flips costStatus to exact for a priced model', () => {
+    const sessionHistory: TUniversalMessage[] = [
+      { id: 'u1', role: 'user', content: 'hi', state: 'complete', timestamp: new Date() },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'done',
+        state: 'complete',
+        timestamp: new Date(),
+        metadata: { inputTokens: 100, outputTokens: 50 },
+      },
+    ];
+
+    // gpt-4o = $2.5/M input, $10/M output → (100/1e6)*2.5 + (50/1e6)*10 = 0.00075.
+    const result = buildResult('done', sessionHistory, [], 0, CONTEXT_STATE, undefined, 'gpt-4o');
+
+    expect(result.usage?.costStatus).toBe('exact');
+    expect(result.usage?.costUsd).toBeCloseTo(0.00075, 10);
+  });
+
+  it('TC-06: leaves costUsd absent + costStatus unknown for an unpriced model', () => {
+    const sessionHistory: TUniversalMessage[] = [
+      { id: 'u1', role: 'user', content: 'hi', state: 'complete', timestamp: new Date() },
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: 'done',
+        state: 'complete',
+        timestamp: new Date(),
+        metadata: { inputTokens: 100, outputTokens: 50 },
+      },
+    ];
+
+    const result = buildResult(
+      'done',
+      sessionHistory,
+      [],
+      0,
+      CONTEXT_STATE,
+      undefined,
+      'no-such-model-xyz',
+    );
+
+    expect(result.usage?.costStatus).toBe('unknown');
+    expect(result.usage?.costUsd).toBeUndefined();
+  });
+
   it('creates persisted usage-summary history entries', () => {
     const usage = {
       kind: 'exact' as const,

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-usage.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-usage.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildResult, createUsageSummaryEntry } from '../interactive-session-execution.js';
+import {
+  buildResult,
+  createUsageSummaryEntry,
+  createSourceUsageSummaryEntry,
+} from '../interactive-session-execution.js';
 
 import type { IContextWindowState, TUniversalMessage } from '@robota-sdk/agent-core';
 
@@ -93,6 +97,17 @@ describe('interactive session usage summaries', () => {
 
     expect(result.usage?.costStatus).toBe('unknown');
     expect(result.usage?.costUsd).toBeUndefined();
+  });
+
+  // SELFHOST-004: the source-attribution entry derives no cost → costStatus 'unknown' + no costUsd,
+  // honoring the invariant "costUsd present iff costStatus !== 'unknown'".
+  it('TC-06: source-attributed usage carries costStatus unknown and no costUsd', () => {
+    const entry = createSourceUsageSummaryEntry(
+      { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+      { scope: 'subagent', id: 'agent_1' },
+    );
+    expect(entry.data?.costStatus).toBe('unknown');
+    expect(entry.data?.costUsd).toBeUndefined();
   });
 
   it('creates persisted usage-summary history entries', () => {

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session.test.ts
@@ -39,6 +39,7 @@ function createMockSession(options?: {
     syncContextFromHistory: vi.fn(),
 
     getSessionId: vi.fn().mockReturnValue(options?.sessionId ?? 'test-session-id'),
+    getModelId: vi.fn().mockReturnValue('test-model'),
     getSystemMessage: vi.fn().mockReturnValue('mock system prompt'),
     getToolSchemas: vi.fn().mockReturnValue([]),
   };

--- a/packages/agent-framework/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution.ts
@@ -130,6 +130,9 @@ export function createUsageSummaryEntry(usage: IUsageSnapshot): IHistoryEntry<IU
  * ANALYTICS-001 (Phase 2): build a usage-summary entry attributed to a non-main source (a subagent /
  * background task) so the parent session log can report token usage per source. Context fields are
  * not meaningful for a child run and are left at 0; the usage reducer only reads the token totals.
+ * Cost is NOT derived here (no model id is in scope for the child run), so `costStatus: 'unknown'`
+ * and `costUsd` is omitted — honoring the SELFHOST-004 invariant "costUsd present iff costStatus !==
+ * 'unknown'" (the `kind: 'exact'` still reflects exact TOKENS).
  */
 export function createSourceUsageSummaryEntry(
   totals: { promptTokens: number; completionTokens: number; totalTokens: number },
@@ -144,7 +147,7 @@ export function createSourceUsageSummaryEntry(
     contextUsedTokens: 0,
     contextMaxTokens: 0,
     contextUsedPercentage: 0,
-    costStatus: 'exact',
+    costStatus: 'unknown',
     source,
   });
 }

--- a/packages/agent-framework/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { collectAssistantUsageMetadata } from '@robota-sdk/agent-core';
+import { collectAssistantUsageMetadata, calculateModelCost } from '@robota-sdk/agent-core';
 
 import { listActiveContextReferences } from '../context/context-reference-inventory.js';
 import {
@@ -73,9 +73,10 @@ export function buildResult(
   historyBefore: number,
   contextState: IContextWindowState,
   promptFileReferences?: readonly IPromptFileReferenceRecord[],
+  modelId?: string,
 ): IExecutionResult {
   const toolSummaries = extractToolSummaries(sessionHistory, historyBefore);
-  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState);
+  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState, modelId);
   return {
     response,
     history: interactiveHistory,
@@ -97,6 +98,7 @@ export function buildInterruptedResult(
   interactiveHistory: IHistoryEntry[],
   historyBefore: number,
   contextState: IContextWindowState,
+  modelId?: string,
 ): IExecutionResult {
   const toolSummaries = extractToolSummaries(sessionHistory, historyBefore);
   const parts: string[] = [];
@@ -104,7 +106,7 @@ export function buildInterruptedResult(
     const msg = sessionHistory[i];
     if (msg?.role === 'assistant' && msg.content) parts.push(msg.content);
   }
-  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState);
+  const usage = extractTurnUsage(sessionHistory, historyBefore, contextState, modelId);
   return {
     response: parts.join('\n\n'),
     history: interactiveHistory,
@@ -202,6 +204,7 @@ function extractTurnUsage(
   sessionHistory: TUniversalMessage[],
   historyBefore: number,
   contextState: IContextWindowState,
+  modelId?: string,
 ): IUsageSnapshot | undefined {
   const turnMessages = sessionHistory.slice(historyBefore);
   let promptTokens = 0;
@@ -218,6 +221,11 @@ function extractTurnUsage(
   }
 
   if (!foundUsage) return undefined;
+
+  // SELFHOST-004: derive the turn's exact cost from the model-pricing SSOT (input/output split).
+  // `undefined` when no model id is in scope or the model is unpriced → costStatus stays 'unknown'.
+  const costUsd = modelId ? calculateModelCost(modelId, promptTokens, completionTokens) : undefined;
+
   return {
     kind: 'exact',
     scope: 'turn',
@@ -227,7 +235,8 @@ function extractTurnUsage(
     contextUsedTokens: contextState.usedTokens,
     contextMaxTokens: contextState.maxTokens,
     contextUsedPercentage: contextState.usedPercentage,
-    costStatus: 'unknown',
+    costStatus: costUsd !== undefined ? 'exact' : 'unknown',
+    ...(costUsd !== undefined ? { costUsd } : {}),
   };
 }
 

--- a/packages/agent-framework/src/interactive/interactive-session-prompt.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-prompt.ts
@@ -88,6 +88,7 @@ export async function executePromptTurn(
       historyBefore,
       ctx.getSession().getContextState(),
       preparedPrompt.promptFileReferenceRecords,
+      ctx.getSession().getModelId(),
     );
     history.push(messageToHistoryEntry(createAssistantMessage(result.response)));
     if (result.usage) history.push(createUsageSummaryEntry(result.usage));
@@ -101,6 +102,7 @@ export async function executePromptTurn(
         history,
         historyBefore,
         ctx.getSession().getContextState(),
+        ctx.getSession().getModelId(),
       );
       pushToolSummaryToHistory({ activeTools: ctx.getActiveTools(), history });
       ctx.clearStreaming();

--- a/packages/agent-interface-transport/src/session-contracts.ts
+++ b/packages/agent-interface-transport/src/session-contracts.ts
@@ -112,6 +112,12 @@ export interface IUsageSnapshot {
   contextMaxTokens: number;
   contextUsedPercentage: number;
   costStatus: 'unknown' | 'estimated' | 'exact';
+  /**
+   * SELFHOST-004: derived turn cost in USD, present iff `costStatus !== 'unknown'` (i.e. the turn's
+   * model was priced). Computed from the `agent-core/model-pricing.ts` SSOT (`calculateModelCost`,
+   * exact input/output split). Optional = backward-compatible; a turn on an unpriced model omits it.
+   */
+  costUsd?: number;
   /** ANALYTICS-001: which execution unit consumed these tokens. Defaults to the main thread. */
   source?: IUsageSource;
 }


### PR DESCRIPTION
## SELFHOST-004 P1 — turn-granular cost foundation (TC-06)

First slice of the run tracing + per-run cost epic. Populates the **turn cost** the whole feature renders/enforces, from the single pricing SSOT.

### agent-interface-transport
- OPTIONAL derived **`costUsd?: number`** on `IUsageSnapshot` — present iff `costStatus !== 'unknown'` (the turn's model was priced), turn-granular. Backward-compatible (all construction sites keep compiling).

### agent-framework
- `extractTurnUsage` resolves the turn's **model id** (threaded from the caller's `ctx.getSession().getModelId()` through `buildResult`/`buildInterruptedResult`) and computes `costUsd` via **`calculateModelCost`** (the `agent-core/model-pricing.ts` SSOT — exact input/output split), flipping `costStatus` `'unknown'` → `'exact'`. Stays `'unknown'`/absent for an unpriced/absent model. **No `agent-plugin` edge**; this seam owns ONLY turn cost — span timing is P2.

### TC-06
`interactive-session-usage.test.ts`: gpt-4o (100 in/50 out) → `costUsd` 0.00075 + `exact`; unpriced model → absent + `unknown`. (Also threaded `getModelId` into the incomplete Session mocks the new path exercises.)

### Verification
build + typecheck + full agent-framework suite **1133/1133** + agent-interface-transport 10/10 + lint (0 errors) + `pnpm harness:scan` (**54/54**).

**Scope:** P2 (span timing) / P3 (read-model) / P4 (budget cap) / P5 (carrier + view) remain — epic spec stays in `active/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)