### PR TITLE
feat(harness): mechanical evals-neutrality floor (HARNESS-034)

### DIFF
--- a/.agents/backlog/completed/HARNESS-034-evals-content-neutrality-floor.md
+++ b/.agents/backlog/completed/HARNESS-034-evals-content-neutrality-floor.md
@@ -1,12 +1,30 @@
 ---
 title: 'HARNESS-034: mechanical neutrality floor — no eval dataset/metric CONTENT in packages/'
-status: todo
+status: done
 created: 2026-07-19
 priority: medium
 urgency: later
 area: scripts
 depends_on: ['SELFHOST-011']
 ---
+
+## Resolution (2026-07-19)
+
+Added `scripts/harness/scan-evals-neutrality.mjs`, registered in `run-all-scans.mjs` as `evals-neutrality`,
+mirroring the `scan-memory-neutrality.mjs` convention (pure `findX(src, file)` + live `findX()` +
+`allow-evals-content: <reason>` suppression with reason-less anti-rot):
+
+- **Class 1 `evals-dataset-content`** (exact path/name, zero-FP): a `.json`/`.jsonl`/`.csv`/`.ya?ml` DATA file
+  that is eval-corpus-shaped — under an `/evals/` dir segment, or a corpus-marked basename
+  (`*.evalset.*`/`*.cases.*`/`*.dataset.*`).
+- **Class 2 `library-eval-content`** (source, evals-subsystem-scoped): an `export` of a concrete
+  metric/dataset VALUE — a `cases`/`dataset`/`evalset` array literal, a `: IEvalDefinition =` value, or a
+  `: IMetric =` value. The neutral mechanism (the `IMetric` TYPE, the runner contract, and the parameterized
+  FACTORIES declared `export function name(...): IMetric {`) is NOT matched.
+
+Test `scripts/harness/__tests__/scan-evals-neutrality.test.mjs` (8 tests: TC-01 data-file class, TC-02
+value class + neutral-surface negatives, TC-03 suppression + anti-rot, TC-04 live tree green). Live tree +
+`run-all-scans` both green. Closes SELFHOST-011 P2 TC-05 (the manual-grep neutrality check is now mechanized).
 
 # Mechanical neutrality floor for evals-as-code content (HARNESS-034)
 

--- a/scripts/harness/__tests__/scan-evals-neutrality.test.mjs
+++ b/scripts/harness/__tests__/scan-evals-neutrality.test.mjs
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
   findEvalsContentInSource,
@@ -26,6 +30,8 @@ describe('HARNESS-034 TC-01 — evals-dataset-content file-path class', () => {
     expect(isEvalsDatasetContent('packages/agent-framework/src/evals/dataset.jsonl')).toBe(true);
     expect(isEvalsDatasetContent('packages/foo/src/coding.evalset.json')).toBe(true);
     expect(isEvalsDatasetContent('packages/foo/src/x.cases.yaml')).toBe(true);
+    // 'corpus' — the term the subsystem's own prose uses most — is covered (PR #1246 review CONSIDER)
+    expect(isEvalsDatasetContent('packages/foo/src/coding.corpus.json')).toBe(true);
   });
 
   it('does NOT flag the neutral TS surface or unrelated data files', () => {
@@ -55,6 +61,10 @@ describe('HARNESS-034 TC-02 — library-eval-content value class', () => {
         `export const exactAnswer: IMetric = { name: 'exact', score: (r) => r.response === '42' };`,
       ),
     ).toContain('library-eval-content');
+    // 'corpus'-named array is covered (PR #1246 review CONSIDER)
+    expect(kinds(`export const codingCorpus = [{ input: 'x' }];`)).toContain(
+      'library-eval-content',
+    );
   });
 
   it('does NOT flag the neutral mechanism — the IMetric TYPE, factories, or the runner contract', () => {
@@ -95,5 +105,34 @@ describe('HARNESS-034 TC-04 — live packages/ tree is neutral', () => {
   it('inEvalsSubsystem detects the /evals/ directory segment', () => {
     expect(inEvalsSubsystem('packages/agent-framework/src/evals/runner.ts')).toBe(true);
     expect(inEvalsSubsystem('packages/agent-framework/src/runtime/agent-runtime.ts')).toBe(false);
+  });
+});
+
+describe('HARNESS-034 TC-04b — disk walk positive path (PR #1246 review CONSIDER)', () => {
+  let root;
+  beforeAll(() => {
+    // A throwaway workspace with planted content, to exercise the walk + per-file read + Class1→continue.
+    root = mkdtempSync(path.join(tmpdir(), 'evals-neutrality-'));
+    const evalsDir = path.join(root, 'packages', 'demo', 'src', 'evals');
+    mkdirSync(evalsDir, { recursive: true });
+    writeFileSync(path.join(evalsDir, 'cases.jsonl'), '{"input":"a","expected":"b"}\n');
+    writeFileSync(
+      path.join(evalsDir, 'suite.ts'),
+      `export const codingEval: IEvalDefinition = { cases, metrics };\n`,
+    );
+    // a neutral factory in the same dir must NOT be flagged
+    writeFileSync(
+      path.join(evalsDir, 'helpers.ts'),
+      `export function exactMatch(expected?: string): IMetric {\n  return { name: 'exact', score: () => true };\n}\n`,
+    );
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it('flags the planted dataset file (Class 1) and the concrete definition (Class 2), not the factory', () => {
+    const findings = findEvalsNeutralityFindings(root);
+    const kindsByFile = findings.map((f) => `${f.kind}:${path.basename(f.file)}`);
+    expect(kindsByFile).toContain('evals-dataset-content:cases.jsonl');
+    expect(kindsByFile).toContain('library-eval-content:suite.ts');
+    expect(kindsByFile.some((k) => k.endsWith('helpers.ts'))).toBe(false);
   });
 });

--- a/scripts/harness/__tests__/scan-evals-neutrality.test.mjs
+++ b/scripts/harness/__tests__/scan-evals-neutrality.test.mjs
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findEvalsContentInSource,
+  findEvalsNeutralityFindings,
+  isEvalsDatasetContent,
+  inEvalsSubsystem,
+} from '../scan-evals-neutrality.mjs';
+
+/**
+ * HARNESS-034 — the evals-neutrality mechanical floor (TC-05 guardian for SELFHOST-011).
+ *
+ * TC-01: dataset/corpus DATA file class (path/name predicate).
+ * TC-02: concrete metric/definition VALUE class; the neutral type/factory surface is NOT flagged.
+ * TC-03: suppression + anti-rot (v1 = reason-less-only).
+ * TC-04: the live packages/ tree is GREEN.
+ */
+
+function kinds(src) {
+  return findEvalsContentInSource(src).map((f) => f.kind);
+}
+
+describe('HARNESS-034 TC-01 — evals-dataset-content file-path class', () => {
+  it('flags a data-file corpus under an /evals/ dir or with a corpus-marked basename', () => {
+    expect(isEvalsDatasetContent('packages/agent-framework/src/evals/cases.json')).toBe(true);
+    expect(isEvalsDatasetContent('packages/agent-framework/src/evals/dataset.jsonl')).toBe(true);
+    expect(isEvalsDatasetContent('packages/foo/src/coding.evalset.json')).toBe(true);
+    expect(isEvalsDatasetContent('packages/foo/src/x.cases.yaml')).toBe(true);
+  });
+
+  it('does NOT flag the neutral TS surface or unrelated data files', () => {
+    expect(isEvalsDatasetContent('packages/agent-framework/src/evals/runner.ts')).toBe(false);
+    expect(isEvalsDatasetContent('packages/agent-framework/src/evals/metric-helpers.ts')).toBe(
+      false,
+    );
+    // a plain package.json / config json outside /evals/ and without a corpus marker is not content
+    expect(isEvalsDatasetContent('packages/agent-framework/package.json')).toBe(false);
+    expect(isEvalsDatasetContent('packages/agent-framework/src/config/settings.json')).toBe(false);
+  });
+});
+
+describe('HARNESS-034 TC-02 — library-eval-content value class', () => {
+  it('flags a checked-in case-corpus array, a concrete IEvalDefinition, and a concrete IMetric value', () => {
+    expect(kinds(`export const cases = [{ input: 'a', expected: 'b' }];`)).toContain(
+      'library-eval-content',
+    );
+    expect(kinds(`export const codingDataset = [\n  { input: 'x' },\n];`)).toContain(
+      'library-eval-content',
+    );
+    expect(
+      kinds(`export const codingEval: IEvalDefinition = { cases, metrics, threshold: 0.8 };`),
+    ).toContain('library-eval-content');
+    expect(
+      kinds(
+        `export const exactAnswer: IMetric = { name: 'exact', score: (r) => r.response === '42' };`,
+      ),
+    ).toContain('library-eval-content');
+  });
+
+  it('does NOT flag the neutral mechanism — the IMetric TYPE, factories, or the runner contract', () => {
+    // parameterized factory (declared as a function returning IMetric) — the neutral surface
+    expect(kinds(`export function exactMatch(expected?: string): IMetric {`)).not.toContain(
+      'library-eval-content',
+    );
+    // the type/interface itself
+    expect(
+      kinds(`export interface IMetric {\n  score(result: IExecutionResult): number | boolean;\n}`),
+    ).not.toContain('library-eval-content');
+    // runner takes IEvalDefinition as a PARAM, does not export a value of it
+    expect(
+      kinds(`export async function runEval(def: IEvalDefinition, runFn: TEvalRunFn) {`),
+    ).not.toContain('library-eval-content');
+  });
+});
+
+describe('HARNESS-034 TC-03 — suppression + anti-rot', () => {
+  it('suppresses a flagged value with an adjacent allow-evals-content: <reason>', () => {
+    const src = [
+      '// allow-evals-content: neutral reference definition used by the runner self-test',
+      `export const selfTestEval: IEvalDefinition = { cases, metrics };`,
+    ].join('\n');
+    expect(kinds(src)).not.toContain('library-eval-content');
+  });
+
+  it('fails a reason-less allow-evals-content annotation (anti-rot)', () => {
+    expect(kinds('// allow-evals-content\nconst x = 1;')).toContain('reasonless-annotation');
+  });
+});
+
+describe('HARNESS-034 TC-04 — live packages/ tree is neutral', () => {
+  it('produces no findings on the current tree', () => {
+    expect(findEvalsNeutralityFindings()).toEqual([]);
+  });
+
+  it('inEvalsSubsystem detects the /evals/ directory segment', () => {
+    expect(inEvalsSubsystem('packages/agent-framework/src/evals/runner.ts')).toBe(true);
+    expect(inEvalsSubsystem('packages/agent-framework/src/runtime/agent-runtime.ts')).toBe(false);
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -119,6 +119,10 @@ const SCAN_COMMANDS = [
     name: 'memory-neutrality',
     command: ['node', 'scripts/harness/scan-memory-neutrality.mjs'],
   },
+  {
+    name: 'evals-neutrality',
+    command: ['node', 'scripts/harness/scan-evals-neutrality.mjs'],
+  },
   { name: 'deprecated-markers', command: ['node', 'scripts/harness/scan-deprecated-markers.mjs'] },
   { name: 'done-evidence', command: ['node', 'scripts/harness/check-done-evidence.mjs'] },
   { name: 'task-archival', command: ['node', 'scripts/harness/check-task-archival.mjs'] },

--- a/scripts/harness/scan-evals-neutrality.mjs
+++ b/scripts/harness/scan-evals-neutrality.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * HARNESS-034 — mechanical neutrality floor for the SELFHOST-011 evals-as-code subsystem.
+ *
+ * Library-neutrality invariant (SELFHOST-011): `packages/**` ships only the NEUTRAL mechanism — the
+ * definition/runner contract (`IEvalDefinition`/`runEval`), the metric-as-function TYPE (`IMetric`), the
+ * dataset PARSER, and parameterized metric FACTORIES (`exactMatch(expected)`, `regexMatch(pattern)`, …).
+ * Concrete metrics and datasets are CONSUMER-supplied — the reference lives in
+ * `examples/capabilities/agent-eval/`, never in `packages/`. Until now this (TC-05) was enforced only by a
+ * manual grep; this scan is the always-on guardian, mirroring `scan-memory-neutrality.mjs` (its closest
+ * analog) + the `scan-no-fallback.mjs` suppression/anti-rot convention.
+ *
+ * It reports two classes of eval CONTENT smuggled into the library (`packages/<pkg>`):
+ *
+ *  1. `evals-dataset-content` — a dataset/case-corpus DATA file: a `.json`/`.jsonl`/`.csv`/`.yaml`/`.yml`
+ *     file whose path is eval-corpus-shaped — either it sits under an `/evals/` DIRECTORY segment, or its
+ *     basename carries a corpus marker (`*.evalset.*`, `*.cases.*`, `*.dataset.*`). Exact path/name check;
+ *     zero false positives on the neutral TS surface (which ships no data files).
+ *
+ *  2. `library-eval-content` — a concrete metric/dataset VALUE shipped as library code: within a `.ts`/`.tsx`
+ *     file under an `/evals/` directory segment (the subsystem convention — deliberately NOT "any file", to
+ *     bound false positives), an `export` of one of:
+ *       - a `cases`/`dataset`/`evalset`-named binding assigned an ARRAY literal (a checked-in case corpus), or
+ *       - a value annotated `: IEvalDefinition =` (a concrete eval definition), or
+ *       - a value annotated `: IMetric =` (a concrete named metric — as opposed to the neutral FACTORY, which
+ *         is declared `export function name(...): IMetric {`, not `export const name: IMetric =`).
+ *     This is an evadable FLOOR (a non-matching identifier/type slips through) that BACKS the manual TC-05
+ *     review; it does not replace it. Suppress a sanctioned occurrence with an adjacent
+ *     `// allow-evals-content: <reason>`.
+ *
+ *  Anti-rot (v1 = reason-less-only, mypy `ignore-without-code` analogue, mirroring HARNESS-028/029): a
+ *  reason-less `allow-evals-content` in a comment fails. Stale-detection is DEFERRED (narrow flagged set).
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Data-file extensions a case corpus / evalset would ship as. */
+const DATASET_DATA_EXT = /\.(json|jsonl|csv|ya?ml)$/i;
+
+/** Basename markers that name a file as an eval corpus regardless of directory. */
+const DATASET_NAME_MARKER = /\.(evalset|cases|dataset)\.[a-z0-9]+$/i;
+
+/**
+ * Class 2 export shapes (concrete metric/dataset VALUE, not the neutral type/factory mechanism):
+ *   export const|let|var|default <cases|dataset|evalset...> = [    → checked-in case corpus
+ *   export ... <name>: IEvalDefinition =                            → concrete eval definition value
+ *   export ... <name>: IMetric =                                    → concrete named metric value
+ * A neutral factory (`export function exactMatch(...): IMetric {`) has no `: IMetric =` and is not matched.
+ */
+const LIBRARY_EVAL_CONTENT_DECL =
+  /export\s+(?:const|let|var|default)\s+\w*(?:cases|dataset|evalset)\w*\s*(?::[^=]+)?=\s*\[|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IEvalDefinition\s*=|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IMetric\s*=/i;
+
+/** A well-formed escape hatch: the token followed by `:` and at least one non-space reason char. */
+const ANNOTATION_WITH_REASON = /allow-evals-content:\s*\S/;
+
+/** Whether `allow-evals-content` on this line sits in a COMMENT (line/JSDoc/block), not a string. */
+function annotationInComment(line) {
+  const trimmed = line.trim();
+  return (
+    /\/\/[^\n]*allow-evals-content/.test(line) ||
+    /\/\*[^\n]*allow-evals-content/.test(line) ||
+    (/^\*/.test(trimmed) && /allow-evals-content/.test(trimmed))
+  );
+}
+
+/** Is this path inside an `/evals/` DIRECTORY segment (the evals subsystem convention)? */
+export function inEvalsSubsystem(rel) {
+  return rel.replace(/\\/g, '/').includes('/evals/');
+}
+
+/**
+ * Class 1 (pure predicate, exposed for tests): a dataset/case-corpus DATA file checked into the library —
+ * a data-extension file that is eval-corpus-shaped (under an `/evals/` dir, or a corpus-marked basename).
+ * Separator-normalized so it is portable (POSIX + Windows) and unit-testable with `/`-separated paths.
+ */
+export function isEvalsDatasetContent(rel) {
+  const norm = rel.replace(/\\/g, '/');
+  if (!DATASET_DATA_EXT.test(norm)) return false;
+  const base = norm.split('/').pop() ?? '';
+  return norm.includes('/evals/') || DATASET_NAME_MARKER.test(base);
+}
+
+/**
+ * Class 2 (pure content check): a `library-eval-content` finding per source line exporting a concrete
+ * metric/dataset VALUE, unless suppressed by an adjacent `allow-evals-content: <reason>`. Exposed so the
+ * harness test can assert directly without disk.
+ */
+export function findEvalsContentInSource(source, file = 'fixture.ts') {
+  const findings = [];
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (LIBRARY_EVAL_CONTENT_DECL.test(line)) {
+      const windowText = `${lines[i - 1] ?? ''}\n${line}`;
+      if (!ANNOTATION_WITH_REASON.test(windowText)) {
+        findings.push({
+          file,
+          line: i + 1,
+          kind: 'library-eval-content',
+          text: line.trim().slice(0, 120),
+        });
+      }
+    }
+    // Anti-rot (v1 = reason-less-only): a comment-scoped `allow-evals-content` MUST carry a `: <reason>`.
+    if (annotationInComment(line) && !ANNOTATION_WITH_REASON.test(line)) {
+      findings.push({
+        file,
+        line: i + 1,
+        kind: 'reasonless-annotation',
+        text: line.trim().slice(0, 120),
+      });
+    }
+  }
+  return findings;
+}
+
+export function findEvalsNeutralityFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  const packagesDir = path.join(root, 'packages');
+  if (!existsSync(packagesDir)) return findings;
+  for (const pkg of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!pkg.isDirectory()) continue;
+    const pkgRel = path.join('packages', pkg.name);
+    if (!statSync(path.join(root, pkgRel)).isDirectory()) continue;
+    for (const rel of walkPackageFiles(pkgRel, root)) {
+      // Class 1 — a dataset/corpus DATA file anywhere in the package.
+      if (isEvalsDatasetContent(rel)) {
+        findings.push({
+          file: rel,
+          line: 1,
+          kind: 'evals-dataset-content',
+          text: path.basename(rel),
+        });
+        continue;
+      }
+      // Class 2 — a concrete metric/definition value, only within the evals subsystem source.
+      if (/\.tsx?$/.test(rel) && inEvalsSubsystem(rel)) {
+        findings.push(...findEvalsContentInSource(readFileSync(path.join(root, rel), 'utf8'), rel));
+      }
+    }
+  }
+  return findings;
+}
+
+/** Collect ALL non-test files (any extension) under a package, relative to `root`. */
+function walkPackageFiles(target, root = WORKSPACE_ROOT) {
+  const full = path.join(root, target);
+  if (!existsSync(full)) return [];
+  const out = [];
+  for (const entry of readdirSync(full, { withFileTypes: true })) {
+    if (
+      entry.name === '__tests__' ||
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === 'coverage' ||
+      entry.name === '.turbo'
+    ) {
+      continue;
+    }
+    const child = path.join(target, entry.name);
+    if (entry.isDirectory()) out.push(...walkPackageFiles(child, root));
+    else if (entry.isFile()) out.push(child);
+  }
+  return out;
+}
+
+function main() {
+  const findings = findEvalsNeutralityFindings();
+  if (findings.length === 0) {
+    console.log('evals-neutrality scan passed.');
+    process.exit(0);
+  }
+  console.error(
+    'evals-neutrality scan FAILED — eval dataset/metric content in the library (packages/):',
+  );
+  for (const f of findings) {
+    console.error(`  [${f.kind}] ${f.file}:${f.line}  ${f.text}`);
+  }
+  console.error(
+    '\nSELFHOST-011 neutrality: eval datasets + concrete metrics are CONSUMER-supplied (see\n' +
+      '  `examples/capabilities/agent-eval/`) — `packages/**` ships only the neutral definition/runner\n' +
+      '  contract, the IMetric TYPE, the dataset parser, and parameterized metric FACTORIES.\n' +
+      '  - evals-dataset-content: move the corpus/evalset file to the consumer workspace / examples.\n' +
+      '  - library-eval-content: move the concrete metric/definition to the consumer, OR (if genuinely\n' +
+      '    neutral mechanism) annotate with `// allow-evals-content: <reason>`.',
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/harness/scan-evals-neutrality.mjs
+++ b/scripts/harness/scan-evals-neutrality.mjs
@@ -15,7 +15,7 @@
  *
  *  1. `evals-dataset-content` — a dataset/case-corpus DATA file: a `.json`/`.jsonl`/`.csv`/`.yaml`/`.yml`
  *     file whose path is eval-corpus-shaped — either it sits under an `/evals/` DIRECTORY segment, or its
- *     basename carries a corpus marker (`*.evalset.*`, `*.cases.*`, `*.dataset.*`). Exact path/name check;
+ *     basename carries a corpus marker (`*.evalset.*`, `*.cases.*`, `*.dataset.*`, `*.corpus.*`). Exact path/name check;
  *     zero false positives on the neutral TS surface (which ships no data files).
  *
  *  2. `library-eval-content` — a concrete metric/dataset VALUE shipped as library code: within a `.ts`/`.tsx`
@@ -44,7 +44,7 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const DATASET_DATA_EXT = /\.(json|jsonl|csv|ya?ml)$/i;
 
 /** Basename markers that name a file as an eval corpus regardless of directory. */
-const DATASET_NAME_MARKER = /\.(evalset|cases|dataset)\.[a-z0-9]+$/i;
+const DATASET_NAME_MARKER = /\.(evalset|cases|dataset|corpus)\.[a-z0-9]+$/i;
 
 /**
  * Class 2 export shapes (concrete metric/dataset VALUE, not the neutral type/factory mechanism):
@@ -54,7 +54,7 @@ const DATASET_NAME_MARKER = /\.(evalset|cases|dataset)\.[a-z0-9]+$/i;
  * A neutral factory (`export function exactMatch(...): IMetric {`) has no `: IMetric =` and is not matched.
  */
 const LIBRARY_EVAL_CONTENT_DECL =
-  /export\s+(?:const|let|var|default)\s+\w*(?:cases|dataset|evalset)\w*\s*(?::[^=]+)?=\s*\[|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IEvalDefinition\s*=|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IMetric\s*=/i;
+  /export\s+(?:const|let|var|default)\s+\w*(?:cases|dataset|evalset|corpus)\w*\s*(?::[^=]+)?=\s*\[|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IEvalDefinition\s*=|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IMetric\s*=/i;
 
 /** A well-formed escape hatch: the token followed by `:` and at least one non-space reason char. */
 const ANNOTATION_WITH_REASON = /allow-evals-content:\s*\S/;


### PR DESCRIPTION
## What

Mechanizes the SELFHOST-011 evals-as-code neutrality check (TC-05), previously a manual grep. Per enforcement-architecture.md every guardian needs a mechanical floor.

## Scan

`scripts/harness/scan-evals-neutrality.mjs` (registered in `run-all-scans.mjs` as `evals-neutrality`), mirroring `scan-memory-neutrality.mjs` (pure `findX(src,file)` + live `findX()` + `allow-evals-content: <reason>` suppression + reason-less anti-rot):

- **Class 1 `evals-dataset-content`** (exact path/name, zero-FP): a `.json`/`.jsonl`/`.csv`/`.ya?ml` corpus DATA file that is eval-shaped — under an `/evals/` dir segment, or a corpus-marked basename (`*.evalset.*`/`*.cases.*`/`*.dataset.*`).
- **Class 2 `library-eval-content`** (evals-subsystem source): an `export` of a concrete metric/dataset VALUE — a `cases`/`dataset`/`evalset` array literal, a `: IEvalDefinition =` value, or a `: IMetric =` value. The neutral mechanism (the `IMetric` TYPE, the runner contract, and the parameterized FACTORIES declared `export function name(...): IMetric {`) is **not** matched.

## Verification

- `scripts/harness/__tests__/scan-evals-neutrality.test.mjs` — 8 tests: data-file class, value class + neutral-surface negatives, suppression + anti-rot, live-tree-green.
- Live scan + full `run-all-scans` both green on the current tree.

Closes SELFHOST-011 P2 TC-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)