### PR TITLE
feat(harness): harden hook-catalog drift-guard (HARNESS-031)

### DIFF
--- a/.agents/backlog/completed/HARNESS-031-hook-catalog-scan-hardening.md
+++ b/.agents/backlog/completed/HARNESS-031-hook-catalog-scan-hardening.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-031: harden the hook-catalog drift-guard (firing-leg + guide-table coverage)'
-status: todo
+status: done
 created: 2026-07-19
 priority: low
 urgency: later
@@ -31,6 +31,22 @@ PR #1228 review flagged two best-effort gaps (both CONSIDER, non-blocking — fi
 - Guide coverage: either extend `scan-hook-catalog.mjs` to also assert the guide table's event set matches the union,
   OR reduce the guide table to a link-only pointer to the `HOOK-CATALOG.md` SSOT (single catalog surface). The
   link-only option removes the second rot-prone surface entirely and is likely simpler.
+
+## Resolution (2026-07-19)
+
+Hardened `scan-hook-catalog.mjs` on both flagged legs (PR #1228 CONSIDERs):
+
+- **Firing leg scoped (Leg 1):** the `return '<Event>'` firing pattern (c) now counts ONLY within the
+  `getSubagentHookEvent` mapping function body (`extractFunctionBody` brace-match). A stray `return '<Event>'`
+  in an unrelated file can no longer satisfy the firing check and mask a deleted `runHooks`/`fire*Hook` call.
+- **Guide table covered (Leg 2):** added `parseGuideEventTable` (reads only the `| Event | Timing | …` table,
+  excluding the sibling permission-MODE table) + a guide↔union parity leg in `computeCatalogDrift`
+  (`guideEvents` optional; null ⇒ skip, back-compat). The exact drift SELFHOST-009 fixed (phantom
+  `Notification` + omissions) now FAILs the scan on either doc surface, not just `HOOK-CATALOG.md`.
+
+Tests: `scan-hook-catalog.test.mjs` extended to 19 (firing-scope stray-return negative, `extractFunctionBody`,
+`parseGuideEventTable` mode-table exclusion, guide-parity GREEN/RED-missing/RED-phantom/null-skip). Live scan +
+run-all-scans green.
 
 ## Notes
 

--- a/.agents/memory/selfhost-roadmap-progress.md
+++ b/.agents/memory/selfhost-roadmap-progress.md
@@ -151,4 +151,16 @@ NEXT: SELFHOST-011 P2 (CLI gate + agent-run verification), then 012-014.
 
 ## ROADMAP COMPLETE — all 14 SELFHOST specs DONE (001–014)
 
-Every spec design-gated → implemented (commit-cadence) → HARNESS-018 async review → agent-run capability verification → GATE-VERIFY/COMPLETE → merged. Governance floors added: HARNESS-028/029/032, deployment-matrix + session-artifact-neutrality scans. Deferred backlog (surface-side follow-ups, NOT roadmap gaps): 003-P4, 008-P5, 010-P2/P3/P4, 011-P3/P4, 013 robota-deploy veneer; HARNESS-027/030/031/033/034. NEXT: owner direction.
+Every spec design-gated → implemented (commit-cadence) → HARNESS-018 async review → agent-run capability verification → GATE-VERIFY/COMPLETE → merged. Governance floors added: HARNESS-028/029/032, deployment-matrix + session-artifact-neutrality scans. Deferred backlog (surface-side follow-ups, NOT roadmap gaps): 003-P4, 008-P5, 010-P2/P3/P4, 011-P4, 013 robota-deploy veneer.
+
+## Post-roadmap backlog run (owner: "모든 남은 백로그들 중 너가 스스로 수행 가능한 것부터 우선순위대로 모두 끝까지 진행해" = standing GATE-APPROVAL sign-off for self-performable items)
+
+Priority-ordered, each via full gate + HARNESS-018 review + agent-run where applicable:
+
+- **HARNESS-027 DONE** (#1243): mechanical agent-tools dep-allowlist neutrality floor (`scan-agent-tools-neutrality.mjs`; union of dependencies/peer/optional; allowlist fast-glob/p-limit/zod). Closes SELFHOST-010-P4.
+- **SELFHOST-011-P3 DONE** (#1244): neutral metric helpers (`metric-helpers.ts`) + `IMetric.score(result, evalCase?)` per-case extension + `dataset.ts` parser + `format.ts` shared formatter. 2 CONSIDER applied (stateless regexMatch; parseEvalCases throws on non-string expected). P4 still todo.
+- **CLI-076 DONE** (#1245): headless `--model` was silently substituted (No-Fallback violation) — print/TUI/serve channels never forwarded the resolved model into `buildRuntimeSession`. Fix threads `modelId` (header SSOT) into the session across all 3 channels; invalid model now surfaces the provider 404 (exit 1); header==actual. AGENT-RUN verified (live API). No client-side allowlist.
+- **HARNESS-034 DONE** (#1246): mechanical evals-neutrality floor (`scan-evals-neutrality.mjs`) — Class 1 dataset/corpus data files + Class 2 concrete metric/definition VALUE exports; neutral type/factory surface not matched. Closes SELFHOST-011 P2 TC-05. 2 CONSIDER applied (corpus marker; disk-walk positive test).
+- **HARNESS-031 DONE** (#pending): hardened the SELFHOST-009 hook-catalog drift-guard — firing leg (`return '<Event>'`) scoped to the `getSubagentHookEvent` body (stray literal can't mask drift) + user-guide Event/Timing table added to the union-parity check (2nd rot-prone surface guarded).
+
+Harness-floor PRs touching `run-all-scans.mjs` MUST serialize; scan-file-only edits (HARNESS-031) don't conflict. NEXT self-performable in priority order: HARNESS-033 (fake-in-src sweep), SEC-001 (default loopback WS auth), HARNESS-030 (capability-reachability floor). NOT self-performable: PM-_/REL-_, GUI/RUNTIME/WORKFLOW owner-decision items.

--- a/scripts/harness/__tests__/scan-hook-catalog.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-catalog.test.mjs
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   computeCatalogDrift,
+  extractFunctionBody,
   findFiringEvents,
   findHookCatalogFindings,
   parseDocEvents,
+  parseGuideEventTable,
   parseUnionEvents,
 } from '../scan-hook-catalog.mjs';
 
@@ -43,9 +45,44 @@ describe('scan-hook-catalog — parsers', () => {
   });
 
   it('findFiringEvents resolves a variable-dispatched event via the getSubagentHookEvent mapping', () => {
-    const src = `function m(e) { return 'SubagentStart'; }
+    const src = `function getSubagentHookEvent(e) { return 'SubagentStart'; }
     runHooks(hooks, hookEventName, { hook_event_name: hookEventName }, exec);`;
     expect(findFiringEvents(src)).toContain('SubagentStart');
+  });
+
+  it('HARNESS-031: a `return "Event"` OUTSIDE getSubagentHookEvent is NOT a firing site', () => {
+    // A stray literal return in an unrelated function must not satisfy the firing check (else deleting the
+    // real runHooks call could go undetected). Only the getSubagentHookEvent mapping body counts for (c).
+    const stray = `function unrelated() { return 'Stop'; }`;
+    expect(findFiringEvents(stray)).not.toContain('Stop');
+    // …but the same literal inside the real mapping function DOES count.
+    const mapping = `function getSubagentHookEvent(e) { return 'Stop'; }`;
+    expect(findFiringEvents(mapping)).toContain('Stop');
+  });
+
+  it('extractFunctionBody returns the brace-matched body, or "" when absent', () => {
+    expect(extractFunctionBody(`function f(x) { return { a: 1 }; }`, 'f')).toBe(
+      '{ return { a: 1 }; }',
+    );
+    expect(extractFunctionBody(`const y = 1;`, 'f')).toBe('');
+  });
+
+  it('parseGuideEventTable reads the Event/Timing table, not the permission-mode table', () => {
+    const guide = `## Modes
+
+| Mode | Read | Write |
+| ---- | ---- | ----- |
+| \`plan\` | deny | deny |
+| \`default\` | prompt | prompt |
+
+## Hooks
+
+| Event | Timing | Blocking |
+| ----- | ------ | -------- |
+| \`PreToolUse\` | before | BLOCKING |
+| \`Stop\` | after | Informational |`;
+    // Only the hook events — the mode rows (plan/default) must be excluded.
+    expect(parseGuideEventTable(guide).sort()).toEqual(['PreToolUse', 'Stop']);
   });
 
   it('findFiringEvents resolves a variable-dispatched event via a fire*Hook helper call-site', () => {
@@ -112,6 +149,47 @@ describe('scan-hook-catalog — TC-01 drift detection (red → green)', () => {
       firingEvents: firingAll,
     });
     expect(findings.some((f) => f.includes('Notification') && f.includes('phantom'))).toBe(true);
+  });
+
+  it('HARNESS-031 GREEN: guideEvents matching the union adds no findings', () => {
+    expect(
+      computeCatalogDrift({
+        unionEvents: ALL_EVENTS,
+        docEvents: ALL_EVENTS,
+        firingEvents: firingAll,
+        guideEvents: ALL_EVENTS,
+      }),
+    ).toEqual([]);
+  });
+
+  it('HARNESS-031 RED: an event missing from the guide table FAILs', () => {
+    const findings = computeCatalogDrift({
+      unionEvents: ALL_EVENTS,
+      docEvents: ALL_EVENTS,
+      firingEvents: firingAll,
+      guideEvents: ALL_EVENTS.filter((e) => e !== 'Stop'),
+    });
+    expect(findings.some((f) => f.includes('Stop') && f.includes('user guide'))).toBe(true);
+  });
+
+  it('HARNESS-031 RED: a phantom event in the guide table FAILs', () => {
+    const findings = computeCatalogDrift({
+      unionEvents: ALL_EVENTS,
+      docEvents: ALL_EVENTS,
+      firingEvents: firingAll,
+      guideEvents: [...ALL_EVENTS, 'Notification'],
+    });
+    expect(findings.some((f) => f.includes('Notification') && f.includes('guide'))).toBe(true);
+  });
+
+  it('HARNESS-031: guideEvents omitted (null) skips the guide legs — back-compat', () => {
+    expect(
+      computeCatalogDrift({
+        unionEvents: ALL_EVENTS,
+        docEvents: ALL_EVENTS,
+        firingEvents: firingAll,
+      }),
+    ).toEqual([]);
   });
 });
 

--- a/scripts/harness/scan-hook-catalog.mjs
+++ b/scripts/harness/scan-hook-catalog.mjs
@@ -89,7 +89,7 @@ export function parseDocEvents(source) {
 /**
  * Extract the `{ ... }` body of a named `function <fnName>` via brace matching, or '' if absent.
  * Brace-counting is imprecise around braces inside strings/comments, but the target (getSubagentHookEvent)
- * is a plain switch/return mapping table, so this is exact for the firing-scope use here (HARNESS-031).
+ * is a plain if/return mapping table, so this is exact for the firing-scope use here (HARNESS-031).
  */
 export function extractFunctionBody(source, fnName) {
   const decl = source.search(new RegExp(`function\\s+${fnName}\\b`));

--- a/scripts/harness/scan-hook-catalog.mjs
+++ b/scripts/harness/scan-hook-catalog.mjs
@@ -10,11 +10,12 @@
  *
  *   1. the THookEvent union     (packages/agent-core/src/hooks/types.ts)
  *   2. the documented catalog   (packages/agent-core/docs/HOOK-CATALOG.md — the Events table)
- *   3. the resolved firing call-sites across the workspace src trees
+ *   3. the user guide table     (content/guide/permissions-and-hooks.md — the Event/Timing table)
+ *   4. the resolved firing call-sites across the workspace src trees
  *
  * FAIL conditions:
- *   - a THookEvent union member missing from the catalog doc;
- *   - a documented event that is NOT a union member (phantom);
+ *   - a THookEvent union member missing from the catalog doc, or from the user guide table;
+ *   - a documented (catalog or guide) event that is NOT a union member (phantom);
  *   - a documented event with NO resolved firing call-site.
  *
  * Firing-site resolution handles VARIABLE dispatch, not only string literals at runHooks(. Some
@@ -24,13 +25,18 @@
  * firing event name is resolved from ANY of:
  *   (a) a string literal passed as the 2nd argument to runHooks(;
  *   (b) a hook_event_name: '<Event>' object-literal field (present at every firing site);
- *   (c) a string literal returned from the getSubagentHookEvent mapping (return '<Event>');
+ *   (c) a string literal returned from WITHIN the getSubagentHookEvent mapping function body
+ *       (return '<Event>') — HARNESS-031: scoped to that function so a stray `return '<Event>'` in an
+ *       unrelated file cannot satisfy the firing check and mask real firing-site drift;
  *   (d) a string literal passed as the 2nd argument to a fire*Hook helper
  *       (fireWorktreeHook / fireModelCallHook).
  *
  * These four cover all 16 events including the six variable-dispatched ones. Equality comparisons
  * such as input.hook_event_name === '<Event>' (agent-core hook-runner) are NOT matched — they have no
  * colon after hook_event_name — so a comparison site cannot mask real firing-site drift.
+ *
+ * HARNESS-031 also extended coverage to the user guide's Event/Timing table (a second rot-prone surface
+ * that had drifted before SELFHOST-009): its event set must match the union, exactly as the catalog does.
  *
  * Exit 0 = clean, 1 = drift.
  */
@@ -42,6 +48,7 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 const UNION_FILE = 'packages/agent-core/src/hooks/types.ts';
 const CATALOG_DOC = 'packages/agent-core/docs/HOOK-CATALOG.md';
+const GUIDE_DOC = 'content/guide/permissions-and-hooks.md';
 
 /** Directories whose src trees are scanned for firing call-sites. */
 const FIRING_SCAN_DIRS = ['packages'];
@@ -80,6 +87,28 @@ export function parseDocEvents(source) {
 }
 
 /**
+ * Extract the `{ ... }` body of a named `function <fnName>` via brace matching, or '' if absent.
+ * Brace-counting is imprecise around braces inside strings/comments, but the target (getSubagentHookEvent)
+ * is a plain switch/return mapping table, so this is exact for the firing-scope use here (HARNESS-031).
+ */
+export function extractFunctionBody(source, fnName) {
+  const decl = source.search(new RegExp(`function\\s+${fnName}\\b`));
+  if (decl === -1) return '';
+  const open = source.indexOf('{', decl);
+  if (open === -1) return '';
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  return source.slice(open);
+}
+
+/**
  * Resolve the firing event names present in a single source string, covering literal AND variable
  * dispatch (see the header). Returns the raw captures; the caller intersects with the union to decide
  * which events have a firing site.
@@ -91,8 +120,6 @@ export function findFiringEvents(source) {
     /runHooks\(\s*[^,()]+,\s*'([A-Za-z]+)'/g,
     // (b) hook_event_name: 'Event' — object-literal field at a firing site (NOT `=== 'Event'`).
     /hook_event_name:\s*'([A-Za-z]+)'/g,
-    // (c) return 'Event' — the getSubagentHookEvent mapping table.
-    /return\s+'([A-Za-z]+)'/g,
     // (d) fireWorktreeHook(x, 'Event', ...) / fireModelCallHook(x, 'Event', ...) — fire*Hook helper
     //     call-sites whose 2nd argument is the event-name literal.
     /\bfire[A-Za-z]*\(\s*[^,()]+,\s*'([A-Za-z]+)'/g,
@@ -103,14 +130,51 @@ export function findFiringEvents(source) {
       found.add(match[1]);
     }
   }
+  // (c) HARNESS-031: `return 'Event'` counts ONLY inside the getSubagentHookEvent mapping function body,
+  //     so a stray `return '<Event>'` elsewhere cannot masquerade as a firing site and hide real drift.
+  const mappingBody = extractFunctionBody(source, 'getSubagentHookEvent');
+  if (mappingBody) {
+    const re = /return\s+'([A-Za-z]+)'/g;
+    let match;
+    while ((match = re.exec(mappingBody)) !== null) {
+      found.add(match[1]);
+    }
+  }
   return [...found];
 }
 
 /**
- * Pure drift computation over the three resolved sets. Exposed so the harness test can drive
- * red→green fixtures (literal- AND variable-dispatched) without touching disk.
+ * Extract the event names from the user guide's Event/Timing table (HARNESS-031). The guide holds a
+ * SECOND back-ticked-first-column table (the permission-MODE table: `plan`/`default`/…), so match ONLY
+ * the hook-events table — identified by its `| Event | Timing | …` header — and collect its data rows
+ * until the table ends. This keeps the permission-mode rows out of the event set (no false phantoms).
  */
-export function computeCatalogDrift({ unionEvents, docEvents, firingEvents }) {
+export function parseGuideEventTable(source) {
+  const lines = source.split('\n');
+  const events = [];
+  let inTable = false;
+  for (const line of lines) {
+    if (!inTable) {
+      if (/^\|\s*Event\s*\|/.test(line) && /Timing/.test(line)) inTable = true;
+      continue;
+    }
+    if (/^\|\s*-+/.test(line)) continue; // the header separator row
+    const m = /^\|\s*`([A-Za-z]+)`\s*\|/.exec(line);
+    if (m) {
+      events.push(m[1]);
+      continue;
+    }
+    inTable = false; // first non-separator, non-event-row line ends the table
+  }
+  return events;
+}
+
+/**
+ * Pure drift computation over the resolved sets. `guideEvents` is OPTIONAL (HARNESS-031): when a
+ * `null`/`undefined` is passed, the guide-parity legs are skipped (keeps the disk-free unit fixtures
+ * focused on the union/catalog/firing legs). Exposed so the harness test can drive red→green fixtures.
+ */
+export function computeCatalogDrift({ unionEvents, docEvents, firingEvents, guideEvents = null }) {
   const union = new Set(unionEvents);
   const doc = new Set(docEvents);
   const firing = new Set(firingEvents);
@@ -133,6 +197,23 @@ export function computeCatalogDrift({ unionEvents, docEvents, firingEvents }) {
       findings.push(
         `documented event \`${event}\` has NO resolved firing call-site — wire it (or remove it if it no longer fires).`,
       );
+    }
+  }
+  if (guideEvents !== null && guideEvents !== undefined) {
+    const guide = new Set(guideEvents);
+    for (const event of union) {
+      if (!guide.has(event)) {
+        findings.push(
+          `union member \`${event}\` is missing from the user guide table (${GUIDE_DOC}).`,
+        );
+      }
+    }
+    for (const event of guide) {
+      if (!union.has(event)) {
+        findings.push(
+          `guide event \`${event}\` is NOT a THookEvent member (phantom) — remove it from ${GUIDE_DOC} or add it to the union.`,
+        );
+      }
     }
   }
   return findings;
@@ -181,7 +262,12 @@ export function findHookCatalogFindings(root = WORKSPACE_ROOT) {
   const unionEvents = parseUnionEvents(readFileSync(path.join(root, UNION_FILE), 'utf8'));
   const docEvents = parseDocEvents(readFileSync(path.join(root, CATALOG_DOC), 'utf8'));
   const firingEvents = collectFiringEvents(root);
-  return computeCatalogDrift({ unionEvents, docEvents, firingEvents });
+  // HARNESS-031: the user guide is a second doc surface (missing ⇒ skip its parity legs, not a hard error).
+  const guidePath = path.join(root, GUIDE_DOC);
+  const guideEvents = existsSync(guidePath)
+    ? parseGuideEventTable(readFileSync(guidePath, 'utf8'))
+    : null;
+  return computeCatalogDrift({ unionEvents, docEvents, firingEvents, guideEvents });
 }
 
 function main() {
@@ -191,13 +277,13 @@ function main() {
     process.exit(0);
   }
   console.error(
-    'hook-catalog scan FAILED — the documented catalog, the THookEvent union, and the firing call-sites disagree:',
+    'hook-catalog scan FAILED — the THookEvent union, the catalog doc, the user guide table, and the firing call-sites disagree:',
   );
   for (const f of findings) {
     console.error(`  - ${f}`);
   }
   console.error(
-    `\nKeep ${CATALOG_DOC} (the SSOT), the THookEvent union, and the runHooks firing sites in sync.`,
+    `\nKeep ${CATALOG_DOC} (the SSOT), the ${GUIDE_DOC} table, the THookEvent union, and the runHooks firing sites in sync.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## What

Hardens the SELFHOST-009 hook-catalog drift-guard on the two best-effort gaps the PR #1228 review flagged (both CONSIDER, non-blocking, filed as HARNESS-031).

## Changes to `scan-hook-catalog.mjs`

1. **Firing leg scoped (Leg 1).** The `return '<Event>'` firing pattern (c) previously matched anywhere in `packages/`, so a stray `return 'Stop'` could satisfy the "has a firing site" check even if the real `runHooks`/`fire*Hook` call was deleted. It now counts **only within the `getSubagentHookEvent` mapping function body** (`extractFunctionBody` brace-match). Patterns (a) runHooks, (b) hook_event_name, (d) fire*Hook are unchanged.
2. **Guide table covered (Leg 2).** `content/guide/permissions-and-hooks.md` reproduces the full event table — a second rot-prone surface the scan didn't guard (the exact drift SELFHOST-009 fixed could silently recur there). Added `parseGuideEventTable` (reads only the `| Event | Timing | …` table, excluding the sibling permission-MODE table) + a guide↔union parity leg in `computeCatalogDrift` (`guideEvents` optional; `null` ⇒ skip, back-compat).

## Verification

- `scan-hook-catalog.test.mjs` extended to **19 tests**: firing-scope stray-return negative + in-mapping positive, `extractFunctionBody`, `parseGuideEventTable` mode-table exclusion, guide-parity GREEN / RED-missing / RED-phantom / null-skip.
- Live scan + full `run-all-scans` green (the guide's 16-row table matches the union; all 16 events still resolve a firing site under the tighter (c)).

Non-blocking hardening; the doc↔union parity + current guide/catalog content are correct as merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)