### PR TITLE
docs(spec): GUI-007 + SEC-001 GATE-COMPLETE (merged #1249)

### DIFF
--- a/.agents/backlog/completed/SEC-001-default-loopback-ws-auth.md
+++ b/.agents/backlog/completed/SEC-001-default-loopback-ws-auth.md
@@ -1,6 +1,6 @@
 ---
 title: 'SEC-001: authenticate the default (defaultEnabled) loopback WebSocket path'
-status: in-progress
+status: done
 created: 2026-07-12
 priority: high
 urgency: soon

--- a/.agents/memory/web-surface-and-sec001.md
+++ b/.agents/memory/web-surface-and-sec001.md
@@ -1,5 +1,9 @@
 # Web-surface reorg (GUI-007) + loopback WS auth (SEC-001)
 
+## STATUS: DONE — merged #1249 (2026-07-20)
+
+GUI-007 (dissolve agent-web-monitor: monitor→packages/agent-cli-web CLI-served over localhost `--serve --open`; remote→apps/agent-web `/remote`; agent-transport-gui keeps transport name) + SEC-001 (auto-mint loopback token + Host/Origin 403-at-upgrade + fail-closed; token delivered via the served monitor `ws-url` `?token=`) BOTH implemented + gated (WRITE/APPROVAL/VERIFY/COMPLETE) + AGENT-RUN verified + merged. Review 1 SHOULD (malformed-URL DoS in serve-monitor-ui → try/catch 400) + CONSIDER (monitor Host guard) fixed. DEFERRED tracked: SEC-001 0600 connection file (no consumer — injection+env cover today), interactive-mode `--open`. Superseded branch `feat/sec-001-loopback-ws-auth` to delete. Distribution direction (single engine + layered CLI/GUI bundles, GUI .app ships `robota` shim) = separate future DIST spec, unwritten.
+
 In-repo mirror (memory-mirroring rule) of the 2026-07-19 owner-steered web/GUI-surface + loopback-security
 workstream. Host mirror: session memory `web-surface-and-sec001.md`.
 

--- a/.agents/spec-docs/done/GUI-007-web-surface-placement.md
+++ b/.agents/spec-docs/done/GUI-007-web-surface-placement.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: INFRA
 tags:
   [architecture, placement, web, gui, surface-taxonomy, agent-web, agent-web-monitor, cli, sec-001]
@@ -214,3 +214,7 @@ applied → **approved**.
 - 62/62 run-all-scans; agent-cli 232 tests; serve-monitor-ui 5; ws-transport-auth 15.
 
 **GATE-COMPLETE pending** the PR review (HARNESS-018) + merge-verify.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-20
+
+All TC-01..07 met (agent-web-monitor dissolved; agent-cli-web CLI-served monitor; agent-web /remote; 0 dangling refs; AGENT-RUN verified). Merged #1249. pr-review-reviewer 1 SHOULD (malformed-URL DoS) + CONSIDER (monitor Host guard) + 2 NIT all applied (`36f2cc6d6`); merge-verified on develop. Spec → `done/`.

--- a/.agents/spec-docs/done/SEC-001-default-loopback-ws-auth.md
+++ b/.agents/spec-docs/done/SEC-001-default-loopback-ws-auth.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: SECURITY
 tags: [security, transport, websocket, loopback, auth, token, dns-rebinding, gui-002]
 ---
@@ -280,3 +280,7 @@ integration):
 
 **GATE-COMPLETE pending** the PR review + merge-verify. Note the two DEFERRED items (0600 file, interactive-mode
 `--open`) are tracked follow-ups, not gaps.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-07-20
+
+Server core + Host/Origin + fail-closed + token delivery (via the CLI-served monitor ws-url injection) done + AGENT-RUN verified. TC-04 (0600 file) + interactive --open DEFERRED as tracked follow-ups (no consumer today). Merged #1249. pr-review-reviewer 1 SHOULD (malformed-URL DoS) + CONSIDER (monitor Host guard) + 2 NIT all applied (`36f2cc6d6`); merge-verified on develop. Spec → `done/`.


### PR DESCRIPTION
Gate-complete bookkeeping for the two specs delivered in #1249 (already merged to develop). Docs/spec-doc moves only:
- Both spec-docs `active/` → `done/` (status: done, GATE-COMPLETE recorded).
- SEC-001 backlog item → `completed/`.
- Memory mirror updated (DONE/merged).

Deferred follow-ups tracked in the specs (SEC-001 0600 connection file — no consumer today; interactive-mode `--open`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)