### PR TITLE
feat(harness): capability-reachability floor (HARNESS-030)

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -180,6 +180,15 @@ capability "done," and the capability's epic is not COMPLETE until the agent-run
 closes the loophole where a library seam no surface enables silently marks the user-execution gate N/A —
 the exact gap that let SELFHOST-008 memory ship OFF in the real agent, unverified end-to-end.)
 
+**Mechanical floor (HARNESS-030).** A capability spec DECLARES itself with two frontmatter keys —
+`capability: true` and `user_execution: agent-run | manual | none`. `scan-capability-reachability.mjs` (in
+`run-all-scans`) then enforces, over `.agents/spec-docs/done/`: a `capability: true` spec MUST NOT record
+`user_execution: none`/omit it (no N/A dodge), and a `capability: true` + `user_execution: agent-run` spec MUST
+have a matching agent-run scenario file under `.agents/evals/scenarios/` (name containing the spec's base ID).
+The floor is opt-in — the scan never GUESSES which spec is a capability (that semantic call, and "is the seam
+truly reachable," stay with the GATE-COMPLETE reviewer); it fences the recurrence once the capability is
+declared. Set both keys on every user-facing capability spec.
+
 ### Agent Executability Requirement — MANDATORY
 
 **Before writing a scenario, the agent must ask: "Can I execute this via Bash right now?"**

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -180,14 +180,17 @@ capability "done," and the capability's epic is not COMPLETE until the agent-run
 closes the loophole where a library seam no surface enables silently marks the user-execution gate N/A —
 the exact gap that let SELFHOST-008 memory ship OFF in the real agent, unverified end-to-end.)
 
-**Mechanical floor (HARNESS-030).** A capability spec DECLARES itself with two frontmatter keys —
-`capability: true` and `user_execution: agent-run | manual | none`. `scan-capability-reachability.mjs` (in
+**Mechanical floor (HARNESS-030).** A capability spec DECLARES itself with three frontmatter keys —
+`capability: true`, `user_execution: agent-run | manual | none`, and (for `agent-run`)
+`user_execution_scenario: <path>` naming the evidence file EXPLICITLY. `scan-capability-reachability.mjs` (in
 `run-all-scans`) then enforces, over `.agents/spec-docs/done/`: a `capability: true` spec MUST NOT record
 `user_execution: none`/omit it (no N/A dodge), and a `capability: true` + `user_execution: agent-run` spec MUST
-have a matching agent-run scenario file under `.agents/evals/scenarios/` (name containing the spec's base ID).
+name a `user_execution_scenario:` path that EXISTS. The reference is an explicit path, NOT a name/base-ID
+guess — a spec's evidence may live under a differently-named scenario (e.g. SEC-001's evidence is the GUI-007
+scenario file). `check-spec-doc-frontmatter.mjs` documents all three keys as recognized optional frontmatter.
 The floor is opt-in — the scan never GUESSES which spec is a capability (that semantic call, and "is the seam
 truly reachable," stay with the GATE-COMPLETE reviewer); it fences the recurrence once the capability is
-declared. Set both keys on every user-facing capability spec.
+declared. Set these keys on every user-facing capability spec (add `user_execution_scenario:` for agent-run).
 
 ### Agent Executability Requirement — MANDATORY
 

--- a/.agents/spec-docs/active/HARNESS-030-capability-reachability-floor.md
+++ b/.agents/spec-docs/active/HARNESS-030-capability-reachability-floor.md
@@ -1,0 +1,129 @@
+---
+status: in-progress
+type: INFRA
+tags: [harness, scan, capability, agent-run, reachability, done-gate, floor]
+---
+
+# HARNESS-030: mechanical floor for the capability-reachability / agent-run done-gate
+
+## Problem
+
+[backlog-execution.md](../rules/backlog-execution.md) → "Capability Reachability — no library-seam N/A dodge"
+forbids marking the user-execution gate "N/A" for a user-facing capability that ships as a library seam no
+surface enables, and requires an AGENT-RUN e2e verification. Today this is **prose + GATE-COMPLETE reviewer
+judgment only** — no mechanical check — so the exact defect (SELFHOST-008 P2/P3/P4 shipping OFF in the real
+agent, unverified) could recur silently.
+
+## Prior Art Research
+
+Waived: internal-consistency mechanical floor over the repo's OWN capability/agent-run convention — no external
+product prior-art applies (this fences a Robota-specific done-gate rule, not a user-facing behavior). The design
+mirrors the sibling mechanical floors already in the repo — `scan-*-neutrality.mjs`, `scan-no-fallback.mjs`,
+`scan-hook-catalog.mjs` (opt-in/declared-then-enforced, pure `findX` + live walk + red/green fixtures) — which
+are the established precedent for a harness floor here.
+
+## Why not fully mechanized (the semantic core stays with the reviewer)
+
+"Is this spec a user-facing capability?" and "does some surface actually enable the seam?" are SEMANTIC
+judgments a scan cannot make reliably (intent + cross-package call-graph reasoning). A naive keyword scan is
+high-FP/FN. So the reviewer (GATE-COMPLETE guardian) still owns "is this a capability" and "is it truly
+reachable." This floor makes the OTHER half mechanical: once a spec DECLARES itself a capability, it MUST carry
+an agent-run verification — no silent N/A.
+
+## Architecture Review
+
+### Decision (opt-in declaration → mechanical enforcement)
+
+Add three OPTIONAL frontmatter keys (registered in RULE-011 `check-spec-doc-frontmatter.mjs` +
+backlog-execution.md):
+
+- `capability: true` — the author declares this spec ships a user-facing capability (the semantic call the
+  reviewer confirms at GATE-COMPLETE).
+- `user_execution: agent-run | manual | none` — how the user-execution gate was met.
+- `user_execution_scenario: <path>` — the agent-run evidence file, **an EXPLICIT reference** (a spec's evidence
+  may live under a differently-named scenario — e.g. SEC-001's agent-run evidence is the GUI-007 scenario).
+
+`scan-capability-reachability.mjs` (registered in `run-all-scans.mjs`) then enforces, over
+`.agents/spec-docs/done/`:
+
+1. A spec with `capability: true` MUST NOT record `user_execution: none`/`N/A` (or omit it) — a shipped
+   user-facing capability cannot dodge the user-execution gate.
+2. A `capability: true` spec with `user_execution: agent-run` MUST name a `user_execution_scenario:` path that
+   EXISTS. FAIL if the key is absent or the file is missing.
+
+**Honest scope:** this mechanizes the DECLARED half only. The scan never GUESSES which spec is a capability
+(the FP hazard the backlog flags) — "is this a user-facing capability?" and "is the seam truly reachable?"
+stay with the GATE-COMPLETE reviewer. So an _undeclared_ dodge (a capability shipped with no flag) is NOT
+caught here; the floor fences only the _declared-then-dodge_ case. A **warn-only capability-candidate
+surfacer** (heuristic over type/tags, nudging the reviewer to set `capability: true`) is the FP-safe way to
+also pressure the undeclared gap — DEFERRED as a follow-up (avoids landing a noisy heuristic in v1).
+
+### Alternatives Considered
+
+- **Auto-detect capabilities by keyword/type (hard-fail)** — REJECTED: high FP/FN (the backlog's stated
+  reason); the "is this a capability" call stays with the reviewer.
+- **Filename-substring scenario matcher** (name contains the spec base ID) — REJECTED: the SEC-001 case proves
+  it wrong (its reviewed agent-run scenario is a differently-named file). Replaced by the EXPLICIT
+  `user_execution_scenario:` reference, which also removes case-sensitivity + shared-base-ID coarseness.
+
+## Solution
+
+- `scripts/harness/scan-capability-reachability.mjs`: pure `evaluateSpec(frontmatter, filename, scenarioExists)`
+  - live `findCapabilityReachabilityFindings()` walking `done/`; mirrors the sibling scan conventions.
+- Backfill the recently-DONE capabilities that have agent-run scenarios — **SELFHOST-008/009/011/012/013/014,
+  GUI-007, and SEC-001 (→ the GUI-007 scenario, an explicit cross-reference)** — each with `capability: true` +
+  `user_execution: agent-run` + `user_execution_scenario: <path>`. (CLI-076 is NOT backfilled — it has no
+  `spec-docs/done/` spec-doc, only a legacy `backlog/completed/` item; out of scan scope.)
+- Document the keys in RULE-011 (`check-spec-doc-frontmatter.mjs`) + backlog-execution.md.
+
+## Affected Files
+
+- `scripts/harness/scan-capability-reachability.mjs` (+ test), `scripts/harness/run-all-scans.mjs`
+- The backfilled `done/` spec-docs (frontmatter only)
+- `.agents/rules/backlog-execution.md` + the spec-writing-standard skill (document the keys)
+
+## Completion Criteria
+
+- TC-01 — a `done/` spec with `capability: true` + `user_execution: none` FAILs; `agent-run` + a matching
+  scenario PASSes (unit).
+- TC-02 — a `capability: true` + `user_execution: agent-run` spec that names NO `user_execution_scenario` FAILs.
+- TC-02b — a `capability: true` + `user_execution: agent-run` spec naming a MISSING/misnamed scenario file FAILs
+  (the SEC-001-shaped case); a CROSS-REFERENCED existing file (SEC-001 → GUI-007 scenario) PASSes (unit).
+- TC-03 — a spec WITHOUT `capability: true` is not checked (opt-in; no false positive) (unit).
+- TC-04 — the live `done/` tree is GREEN after backfilling the capability specs.
+- TC-05 — registered in `run-all-scans.mjs`; the keys documented in RULE-011 + backlog-execution.md.
+
+## Test Plan
+
+Red/green fixtures for the pure predicate (declared-but-none, declared-agent-run-with/without-scenario,
+undeclared) + a live-tree green assertion.
+
+## Tasks
+
+- [x] scan + test + run-all-scans registration DONE
+- [x] backfill (8 specs incl SEC-001 cross-ref) + RULE-011/backlog-execution docs DONE
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-07-20
+
+- Prior Art Research: Waived (internal-consistency floor; sibling-floor precedent) → scan-spec-research green.
+- Frontmatter (status/type INFRA/tags): green.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-07-20
+
+Independent `proposal-reviewer`: **REVISE → resolved**. Reviewer ENDORSED the opt-in `capability` design + the
+`done/`-only scope (verified: unknown frontmatter keys are inert to RULE-011; the SELFHOST-008 defect was in
+`done/`). REVISE for 5 items, ALL applied:
+
+1. **Backfill corrected** — dropped CLI-076 (no `spec-docs/done/` entry); SEC-001 kept (its evidence is the
+   GUI-007 scenario) — enabled by #2.
+2. **Explicit-scenario matcher** — replaced the fragile filename-substring guess with an explicit
+   `user_execution_scenario: <path>` reference the scan verifies exists. Resolves the SEC-001→GUI-007
+   cross-reference + removes case-sensitivity/shared-base-ID fragility.
+3. **Honest scope** — Decision now states the floor mechanizes the DECLARED half only; undeclared-capability
+   recognition stays reviewer-owned; a warn-only candidate surfacer is a deferred follow-up.
+4. **RULE-011 registration** — the three keys documented in `check-spec-doc-frontmatter.mjs` (frontmatter SSOT).
+5. **TC-02b added** — missing/misnamed named scenario FAILs; cross-referenced existing file PASSes.
+
+Owner directive ("모두 끝까지") = standing GATE-APPROVAL sign-off. 8/8 unit tests, live scan + 63/63 scans green.

--- a/.agents/spec-docs/done/GUI-007-web-surface-placement.md
+++ b/.agents/spec-docs/done/GUI-007-web-surface-placement.md
@@ -1,6 +1,9 @@
 ---
 status: done
 type: INFRA
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/gui-007-cli-served-monitor-agent-run.md
 tags:
   [architecture, placement, web, gui, surface-taxonomy, agent-web, agent-web-monitor, cli, sec-001]
 ---

--- a/.agents/spec-docs/done/SEC-001-default-loopback-ws-auth.md
+++ b/.agents/spec-docs/done/SEC-001-default-loopback-ws-auth.md
@@ -1,6 +1,9 @@
 ---
 status: done
 type: SECURITY
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/gui-007-cli-served-monitor-agent-run.md
 tags: [security, transport, websocket, loopback, auth, token, dns-rebinding, gui-002]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-008-P1R-memory-port-remediation.md
+++ b/.agents/spec-docs/done/SELFHOST-008-P1R-memory-port-remediation.md
@@ -1,6 +1,9 @@
 ---
 status: done
 type: DATA
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-008-memory-agent-run.md
 tags: [memory, dip-port, async, remediation, selfhost]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-009-hook-catalog.md
+++ b/.agents/spec-docs/done/SELFHOST-009-hook-catalog.md
@@ -2,6 +2,9 @@
 status: done
 completed: 2026-07-19
 type: BEHAVIOR
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-009-pretooluse-gate-agent-run.md
 tags: [hooks, lifecycle, security-gate, agent-core, selfhost]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-011-P3-evals-helpers.md
+++ b/.agents/spec-docs/done/SELFHOST-011-P3-evals-helpers.md
@@ -2,6 +2,9 @@
 status: done
 completed: 2026-07-19
 type: BEHAVIOR
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-011-eval-gate-agent-run.md
 tags: [evals, sdk, agent-framework, neutral-helpers, selfhost]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-012-scheduled-tasks.md
+++ b/.agents/spec-docs/done/SELFHOST-012-scheduled-tasks.md
@@ -2,6 +2,9 @@
 status: done
 completed: 2026-07-19
 type: FLOW
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-012-schedule-lifecycle-agent-run.md
 tags: [scheduler, cron, tasks, dag-scheduler, agent-command, selfhost]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-013-multi-surface-deployment-gateway.md
+++ b/.agents/spec-docs/done/SELFHOST-013-multi-surface-deployment-gateway.md
@@ -2,6 +2,9 @@
 status: done
 completed: 2026-07-19
 type: INFRA
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-013-multi-surface-agent-run.md
 tags: [deployment, gateway, transport, multi-surface, agent-server, selfhost]
 ---
 

--- a/.agents/spec-docs/done/SELFHOST-014-shared-async-session-artifacts.md
+++ b/.agents/spec-docs/done/SELFHOST-014-shared-async-session-artifacts.md
@@ -2,6 +2,9 @@
 status: done
 completed: 2026-07-19
 type: DATA
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/selfhost-014-session-artifact-agent-run.md
 tags: [session-artifact, sharing, resume, persistence, agent-session, selfhost]
 ---
 

--- a/scripts/harness/__tests__/scan-capability-reachability.test.mjs
+++ b/scripts/harness/__tests__/scan-capability-reachability.test.mjs
@@ -104,6 +104,13 @@ describe('HARNESS-030 — helpers + live tree', () => {
     expect(fm.user_execution).toBe('agent-run');
   });
 
+  it('parseFrontmatter strips surrounding quotes from a value', () => {
+    const fm = parseFrontmatter(
+      '---\nuser_execution_scenario: ".agents/evals/scenarios/x.md"\n---\nbody',
+    );
+    expect(fm.user_execution_scenario).toBe('.agents/evals/scenarios/x.md');
+  });
+
   it('TC-04: the live done/ tree is clean (every declared capability names an existing scenario)', () => {
     expect(findCapabilityReachabilityFindings()).toEqual([]);
   });

--- a/scripts/harness/__tests__/scan-capability-reachability.test.mjs
+++ b/scripts/harness/__tests__/scan-capability-reachability.test.mjs
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateSpec,
+  findCapabilityReachabilityFindings,
+  parseFrontmatter,
+} from '../scan-capability-reachability.mjs';
+
+/**
+ * HARNESS-030 — the capability-reachability floor (opt-in, explicit-scenario-reference).
+ * TC-01: capability + user_execution none/omitted → FAIL; agent-run + existing named scenario → clean.
+ * TC-02: capability + agent-run but NO user_execution_scenario named → FAIL.
+ * TC-02b: capability + agent-run naming a MISSING/misnamed scenario file → FAIL (the SEC-001-shaped case).
+ * TC-03: no `capability: true` → not checked (opt-in, no FP).
+ * TC-04: the live done/ tree is GREEN.
+ */
+
+// scenarioExists: only these two evidence files "exist" in the fixtures.
+const exists = (p) =>
+  [
+    '.agents/evals/scenarios/selfhost-011-eval-gate-agent-run.md',
+    '.agents/evals/scenarios/gui-007-cli-served-monitor-agent-run.md',
+  ].includes(p);
+
+describe('HARNESS-030 TC-01/02 — declared capability must carry agent-run evidence', () => {
+  it('FAILs a capability spec that records no user-execution (none / missing / N/A)', () => {
+    expect(
+      evaluateSpec({ capability: 'true', user_execution: 'none' }, 'FOO-001.md', exists),
+    ).toMatch(/must NOT dodge/);
+    expect(evaluateSpec({ capability: 'true' }, 'FOO-001.md', exists)).toMatch(/must NOT dodge/);
+    expect(
+      evaluateSpec({ capability: 'true', user_execution: 'N/A' }, 'FOO-001.md', exists),
+    ).toMatch(/must NOT dodge/);
+  });
+
+  it('TC-02: FAILs a capability + agent-run spec that names no user_execution_scenario', () => {
+    expect(
+      evaluateSpec({ capability: 'true', user_execution: 'agent-run' }, 'NOPE-042.md', exists),
+    ).toMatch(/names no 'user_execution_scenario/);
+  });
+
+  it('TC-02b: FAILs a capability + agent-run spec whose named scenario file does not exist', () => {
+    expect(
+      evaluateSpec(
+        {
+          capability: 'true',
+          user_execution: 'agent-run',
+          user_execution_scenario: '.agents/evals/scenarios/does-not-exist.md',
+        },
+        'NOPE-043.md',
+        exists,
+      ),
+    ).toMatch(/does not exist/);
+  });
+
+  it('is CLEAN when the named scenario exists — including a CROSS-REFERENCED file (SEC-001 → GUI-007)', () => {
+    expect(
+      evaluateSpec(
+        {
+          capability: 'true',
+          user_execution: 'agent-run',
+          user_execution_scenario: '.agents/evals/scenarios/selfhost-011-eval-gate-agent-run.md',
+        },
+        'SELFHOST-011-P3.md',
+        exists,
+      ),
+    ).toBeNull();
+    // SEC-001's evidence lives under the GUI-007 scenario file — the explicit reference resolves it.
+    expect(
+      evaluateSpec(
+        {
+          capability: 'true',
+          user_execution: 'agent-run',
+          user_execution_scenario:
+            '.agents/evals/scenarios/gui-007-cli-served-monitor-agent-run.md',
+        },
+        'SEC-001-default-loopback-ws-auth.md',
+        exists,
+      ),
+    ).toBeNull();
+  });
+
+  it('accepts user_execution: manual without requiring a scenario', () => {
+    expect(
+      evaluateSpec({ capability: 'true', user_execution: 'manual' }, 'BAR-001.md', exists),
+    ).toBeNull();
+  });
+});
+
+describe('HARNESS-030 TC-03 — opt-in (undeclared specs are not checked)', () => {
+  it('does not flag a spec without `capability: true`', () => {
+    expect(evaluateSpec({ user_execution: 'none' }, 'FOO-001.md', exists)).toBeNull();
+    expect(evaluateSpec({ capability: 'false' }, 'FOO-001.md', exists)).toBeNull();
+    expect(evaluateSpec({}, 'FOO-001.md', exists)).toBeNull();
+  });
+});
+
+describe('HARNESS-030 — helpers + live tree', () => {
+  it('parseFrontmatter reads the --- block', () => {
+    const fm = parseFrontmatter(
+      '---\nstatus: done\ncapability: true\nuser_execution: agent-run\n---\nbody',
+    );
+    expect(fm.capability).toBe('true');
+    expect(fm.user_execution).toBe('agent-run');
+  });
+
+  it('TC-04: the live done/ tree is clean (every declared capability names an existing scenario)', () => {
+    expect(findCapabilityReachabilityFindings()).toEqual([]);
+  });
+});

--- a/scripts/harness/check-spec-doc-frontmatter.mjs
+++ b/scripts/harness/check-spec-doc-frontmatter.mjs
@@ -12,6 +12,12 @@
  *     - `tags`   present (a non-empty list)
  *   Warning: duplicate `<namespace>-<NNN>` IDs across the tree.
  *
+ * Recognized OPTIONAL keys (validity not enforced here; extra keys are inert to this gate):
+ *   - `completed: <date>` — set at GATE-COMPLETE.
+ *   - `capability: true` + `user_execution: agent-run|manual|none` + `user_execution_scenario: <path>` —
+ *     the capability-reachability convention (HARNESS-030); enforced by `scan-capability-reachability.mjs`,
+ *     which requires a `capability: true` spec in `done/` to name an existing agent-run scenario.
+ *
  * Usage: `node scripts/harness/check-spec-doc-frontmatter.mjs [path-to-dir-or-file]`
  * Exit code 0 = clean (warnings allowed), 1 = blocking findings.
  */

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -123,6 +123,10 @@ const SCAN_COMMANDS = [
     name: 'evals-neutrality',
     command: ['node', 'scripts/harness/scan-evals-neutrality.mjs'],
   },
+  {
+    name: 'capability-reachability',
+    command: ['node', 'scripts/harness/scan-capability-reachability.mjs'],
+  },
   { name: 'deprecated-markers', command: ['node', 'scripts/harness/scan-deprecated-markers.mjs'] },
   { name: 'done-evidence', command: ['node', 'scripts/harness/check-done-evidence.mjs'] },
   { name: 'task-archival', command: ['node', 'scripts/harness/check-task-archival.mjs'] },

--- a/scripts/harness/scan-capability-reachability.mjs
+++ b/scripts/harness/scan-capability-reachability.mjs
@@ -42,7 +42,9 @@ export function parseFrontmatter(source) {
   const fm = {};
   for (const line of m[1].split('\n')) {
     const kv = /^([A-Za-z_]+):\s*(.*)$/.exec(line);
-    if (kv) fm[kv[1]] = kv[2].trim();
+    // Strip a single layer of surrounding quotes so `key: "value"` resolves to `value` (a quoted
+    // path would otherwise fail existsSync and yield a confusing "does not exist" for a real file).
+    if (kv) fm[kv[1]] = kv[2].trim().replace(/^(['"])(.*)\1$/, '$2');
   }
   return fm;
 }

--- a/scripts/harness/scan-capability-reachability.mjs
+++ b/scripts/harness/scan-capability-reachability.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * HARNESS-030 — mechanical floor for the capability-reachability / agent-run done-gate.
+ *
+ * `backlog-execution.md` ("Capability Reachability — no library-seam N/A dodge") forbids marking the
+ * user-execution gate "N/A" for a user-facing capability that ships as a library seam no surface enables, and
+ * requires an AGENT-RUN e2e verification. "Is this a user-facing capability?" and "is the seam truly reachable?"
+ * are SEMANTIC calls a scan cannot make (the FP hazard) — those stay with the GATE-COMPLETE reviewer. This floor
+ * makes the OTHER half mechanical: once a spec DECLARES itself a capability, it MUST carry an agent-run
+ * verification — no silent N/A, no missing evidence.
+ *
+ * Opt-in by design: three optional spec-doc frontmatter keys —
+ *   `capability: true`            — the author (confirmed by the reviewer) declares a user-facing capability.
+ *   `user_execution: agent-run | manual | none`  — how the user-execution gate was met.
+ *   `user_execution_scenario: <path>`  — the agent-run evidence file (EXPLICIT reference, not a name guess —
+ *      a spec's evidence may live under a differently-named scenario, e.g. SEC-001's is the GUI-007 scenario).
+ *
+ * Over `.agents/spec-docs/done/`, a spec with `capability: true`:
+ *   1. MUST NOT record `user_execution: none` (or omit it) — a shipped capability cannot dodge the gate.
+ *   2. with `user_execution: agent-run` MUST name a `user_execution_scenario:` path that EXISTS.
+ * A spec WITHOUT `capability: true` is not checked (zero false positives).
+ *
+ * SCOPE (honest): this mechanizes ONLY the DECLARED half. "Is this a user-facing capability?" and "is the seam
+ * truly reachable?" stay with the GATE-COMPLETE reviewer — an author who never sets `capability: true` is not
+ * caught here (a warn-only capability-candidate surfacer over type/tags is a deferred follow-up; auto-detecting
+ * capabilities is the FP hazard the backlog flags). This floor fences the "declared-then-dodge" recurrence.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const DONE_DIR = '.agents/spec-docs/done';
+
+/** Read the `---` frontmatter block into a flat key→value map (string values). */
+export function parseFrontmatter(source) {
+  const m = /^---\n([\s\S]*?)\n---/.exec(source);
+  if (!m) return {};
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const kv = /^([A-Za-z_]+):\s*(.*)$/.exec(line);
+    if (kv) fm[kv[1]] = kv[2].trim();
+  }
+  return fm;
+}
+
+/**
+ * Pure evaluation of one spec's capability declaration. `scenarioExists(path)` reports whether the named
+ * evidence file exists (injected so the test can drive fixtures without disk). Returns a finding string, or
+ * null if clean / not a declared capability.
+ */
+export function evaluateSpec(frontmatter, filename, scenarioExists) {
+  if (String(frontmatter.capability).toLowerCase() !== 'true') return null; // opt-in: only declared capabilities
+  const ux = (frontmatter.user_execution ?? '').toLowerCase();
+  if (ux === '' || ux === 'none' || ux === 'n/a') {
+    return `capability spec '${filename}' records no user-execution (user_execution: ${frontmatter.user_execution ?? '<missing>'}) — a shipped user-facing capability must NOT dodge the user-execution gate (no library-seam N/A). Verify it AGENT-RUN and set 'user_execution: agent-run' + 'user_execution_scenario: <path>'.`;
+  }
+  if (ux === 'agent-run') {
+    const scenario = frontmatter.user_execution_scenario;
+    if (!scenario) {
+      return `capability spec '${filename}' declares 'user_execution: agent-run' but names no 'user_execution_scenario: <path>' evidence file.`;
+    }
+    if (!scenarioExists(scenario)) {
+      return `capability spec '${filename}' names 'user_execution_scenario: ${scenario}' which does not exist.`;
+    }
+  }
+  return null;
+}
+
+export function findCapabilityReachabilityFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  const doneDir = path.join(root, DONE_DIR);
+  if (!existsSync(doneDir)) return findings;
+  const scenarioExists = (rel) => existsSync(path.join(root, rel));
+  for (const entry of readdirSync(doneDir)) {
+    if (!entry.endsWith('.md')) continue;
+    const fm = parseFrontmatter(readFileSync(path.join(doneDir, entry), 'utf8'));
+    const finding = evaluateSpec(fm, entry, scenarioExists);
+    if (finding) findings.push(finding);
+  }
+  return findings;
+}
+
+function main() {
+  const findings = findCapabilityReachabilityFindings();
+  if (findings.length === 0) {
+    console.log('capability-reachability scan passed.');
+    process.exit(0);
+  }
+  console.error(
+    'capability-reachability scan FAILED — a declared capability lacks agent-run verification:',
+  );
+  for (const f of findings) console.error(`  - ${f}`);
+  console.error(
+    '\nbacklog-execution.md: a user-facing capability (capability: true) must be reachable via a surface AND\n' +
+      '  verified by an AGENT-RUN scenario — never marked N/A. Add the scenario under .agents/evals/scenarios/,\n' +
+      '  or (if it is genuinely not a user-facing capability) drop the `capability: true` flag.',
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Mechanizes the DECLARED half of the capability/agent-run done-gate (backlog-execution.md 'no library-seam N/A dodge'), previously reviewer-judgment-only.

## Design (opt-in, explicit-reference)
Three optional spec-doc frontmatter keys: `capability: true` + `user_execution: agent-run|manual|none` + `user_execution_scenario: <path>`. `scan-capability-reachability.mjs` (in run-all-scans) fails a `done/` `capability: true` spec that dodges the gate (`user_execution: none`/omitted) or names a missing agent-run scenario.

**Honest scope:** mechanizes the *declared* half only — 'is this a capability?' and 'is the seam reachable?' stay with the GATE-COMPLETE reviewer (auto-detection is the FP hazard the backlog flags). A warn-only candidate surfacer is a deferred follow-up.

## proposal-reviewer REVISE → resolved
- **Explicit `user_execution_scenario` reference** (not a filename-substring guess) — resolves SEC-001's evidence living under the GUI-007 scenario; removes case-sensitivity/shared-base-ID fragility.
- Backfill corrected (dropped CLI-076 — no done spec-doc; SEC-001 → GUI-007 cross-ref).
- Keys registered in RULE-011 (`check-spec-doc-frontmatter`) + backlog-execution.md.
- TC-02b (missing/misnamed named scenario fails; cross-ref passes).

## Verification
8 unit tests; 63/63 run-all-scans green; backfilled 8 done capability specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)