### PR TITLE
chore(backlog): archive 8 verified-done items to completed/ (status reconciliation)

### DIFF
--- a/.agents/backlog/completed/HARNESS-030-capability-reachability-floor.md
+++ b/.agents/backlog/completed/HARNESS-030-capability-reachability-floor.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-030: mechanical floor for capability-reachability / agent-run-verification done-gate'
-status: todo
+status: done
+completed: 2026-07-20
 created: 2026-07-18
 priority: medium
 urgency: later

--- a/.agents/backlog/completed/REMOTE-001-webrtc-p2p-remote-control.md
+++ b/.agents/backlog/completed/REMOTE-001-webrtc-p2p-remote-control.md
@@ -1,6 +1,7 @@
 ---
 title: 'REMOTE-001: /remote-control — WebRTC P2P remote access to a running agent-cli session'
-status: in-progress
+status: done
+completed: 2026-07-13
 created: 2026-07-10
 priority: medium
 urgency: later

--- a/.agents/backlog/completed/RUNTIME-001-shared-headless-runtime-surface.md
+++ b/.agents/backlog/completed/RUNTIME-001-shared-headless-runtime-surface.md
@@ -1,6 +1,7 @@
 ---
 title: 'RUNTIME-001: extract a shared headless runtime/session surface — TUI and GUI as sibling presentations'
-status: todo
+status: done
+completed: 2026-07-13
 created: 2026-07-12
 priority: medium
 urgency: later

--- a/.agents/backlog/completed/SELFHOST-004-trace-cost-view.md
+++ b/.agents/backlog/completed/SELFHOST-004-trace-cost-view.md
@@ -1,6 +1,7 @@
 ---
 title: 'SELFHOST-004: first-class run tracing + token/cost budgeting surfaced in TUI/GUI'
-status: todo
+status: done
+completed: 2026-07-18
 created: 2026-07-16
 priority: high
 urgency: soon

--- a/.agents/backlog/completed/SELFHOST-011-evals-as-code.md
+++ b/.agents/backlog/completed/SELFHOST-011-evals-as-code.md
@@ -1,6 +1,7 @@
 ---
 title: 'SELFHOST-011: evals-as-code harness for SDK users (gate CI)'
-status: todo
+status: done
+completed: 2026-07-19
 created: 2026-07-16
 priority: medium
 urgency: later

--- a/.agents/backlog/completed/SELFHOST-012-scheduled-tasks.md
+++ b/.agents/backlog/completed/SELFHOST-012-scheduled-tasks.md
@@ -1,6 +1,7 @@
 ---
 title: 'SELFHOST-012: scheduled / cron tasks with pause/resume/edit'
-status: todo
+status: done
+completed: 2026-07-19
 created: 2026-07-16
 priority: low
 urgency: later

--- a/.agents/backlog/completed/SELFHOST-013-multi-surface-deployment-gateway.md
+++ b/.agents/backlog/completed/SELFHOST-013-multi-surface-deployment-gateway.md
@@ -1,6 +1,7 @@
 ---
 title: 'SELFHOST-013: multi-surface deployment + gateway (one agent → many channels/runtimes)'
-status: todo
+status: done
+completed: 2026-07-19
 created: 2026-07-16
 priority: low
 urgency: later

--- a/.agents/backlog/completed/SELFHOST-014-shared-async-session-artifacts.md
+++ b/.agents/backlog/completed/SELFHOST-014-shared-async-session-artifacts.md
@@ -1,6 +1,7 @@
 ---
 title: 'SELFHOST-014: shared / synced async session artifacts for collaboration'
-status: todo
+status: done
+completed: 2026-07-19
 created: 2026-07-16
 priority: low
 urgency: later


### PR DESCRIPTION
Fixes backlog↔spec-doc **archival drift**: 8 items whose implementation is confirmed-done still sat in the backlog root carrying `status: todo`/`in-progress`, violating the `backlog-execution.md` Status Invariant (no `status: done` in backlog root; terminal ⇔ `completed/`).

## Archived (→ `completed/`, `status: done` + `completed:` date, from git merge dates)
- `SELFHOST-011-evals-as-code`, `SELFHOST-012`, `SELFHOST-013`, `SELFHOST-014` — epics DONE (daily report 2026-07-19)
- `HARNESS-030-capability-reachability-floor` — #1255/#1256
- `REMOTE-001-webrtc-p2p-remote-control` — on main (#1155/#1156)
- `RUNTIME-001-shared-headless-runtime-surface`
- `SELFHOST-004-trace-cost-view` — #1205/#1210/#1211

## Deliberately NOT flipped (needs per-item verification)
`SELFHOST-001/002/003/005-010`, `CMD-004`, `SCREEN-004`, `SELFHOST-011-P3-P4`. Their spec-doc being in `done/` means the **design gate** passed — implementation may be partial or open (e.g. SELFHOST-008 shipped memory OFF; SELFHOST-003 P4 embedding backend still open). Flipping these mechanically would assert a false `done`. They belong to a PROC-001-style reconciliation pass with item-by-item verification.

## Verification
- Every archived item: 0 unchecked checklist boxes + a matching `spec-docs/done/` entry + memory/merge confirmation.
- `check-backlog-placement.mjs` green; `check-task-archival.mjs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)