### PR TITLE
feat(transport): ARCH-004 WS/HTTP lifecycle + abort hardening

### DIFF
--- a/.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md
+++ b/.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md
@@ -32,8 +32,10 @@ RUNTIME-13:
 
 RUNTIME-38 / RUNTIME-14:
 ✓ POST /submit returns 409 while a turn is already in flight (isExecuting)
-✓ POST /submit unsubscribes every listener it added once the stream ends (off count == on count, no leak)
-Tests  16 passed (16)   (14 prior + 2 new)
+✓ POST /submit unsubscribes every listener it added once the stream completes (off == on)
+✓ POST /submit tears down + aborts the run when the client DISCONNECTS mid-stream
+    (reader.cancel() → onAbort → session.abort() called + off == on — the load-bearing leak path)
+Tests  17 passed (17)   (14 prior + 3 new)
 ```
 
 ✅ PASS — RUNTIME-13: `stop()` sends a `close(1001)` frame to each client and terminates any survivor at a 5s

--- a/.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md
+++ b/.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md
@@ -1,0 +1,53 @@
+# ARCH-004 — transport lifecycle + abort hardening (agent-run)
+
+**Spec:** ARCH-004 (forward-provisioned transport surface hardening). Proves the WS/HTTP transports survive the
+lifecycle edges that previously hung or leaked: WS `stop()` with a live client (RUNTIME-13), HTTP `/submit` SSE
+listener teardown (RUNTIME-14), and concurrent-submit rejection (RUNTIME-38).
+**Type:** agent-executable (the agent builds the transport packages and drives the real server/routes; no owner
+action).
+
+## Scenario
+
+```bash
+pnpm --filter @robota-sdk/agent-transport-ws --filter @robota-sdk/agent-transport-http \
+  --filter @robota-sdk/agent-framework build
+
+# RUNTIME-13 — bind a real WS server, connect a live client, call stop(): must resolve (previously hung).
+npx vitest run packages/agent-transport-ws/src/__tests__/ws-transport-lifecycle.test.ts
+
+# RUNTIME-14 + RUNTIME-38 — /submit SSE teardown balance + 409-on-busy, via Hono's test client.
+npx vitest run packages/agent-transport-http/src/__tests__/routes.test.ts
+```
+
+**Expected:** builds green; `stop()` resolves with a client still connected; `/submit` removes every listener
+it added once the stream ends; a concurrent `/submit` on a busy session returns `409`.
+
+## Observed (2026-07-21)
+
+Build (3 packages) — green.
+
+```
+RUNTIME-13:
+✓ stop() resolves promptly with a client still connected (previously hung forever)   (elapsed ~15ms, ≪ 5s deadline)
+
+RUNTIME-38 / RUNTIME-14:
+✓ POST /submit returns 409 while a turn is already in flight (isExecuting)
+✓ POST /submit unsubscribes every listener it added once the stream ends (off count == on count, no leak)
+Tests  16 passed (16)   (14 prior + 2 new)
+```
+
+✅ PASS — RUNTIME-13: `stop()` sends a `close(1001)` frame to each client and terminates any survivor at a 5s
+deadline, so the all-clients-gone server-close callback can never hang (measured ~15ms with a live client).
+RUNTIME-14: the `/submit` handler wraps its body in `try/finally` and registers `stream.onAbort` →
+`session.abort()`, so the session `off` teardown ALWAYS runs — the on/off counts balance (zero leaked
+listeners) on the normal path, and a client disconnect cancels the run + tears down via the abort path.
+RUNTIME-38: a concurrent `/submit` while `session.isExecuting()` returns `409` instead of cross-subscribing.
+
+**RUNTIME-54 (doc-only):** subsumed by SEC-001 — the WS token is presented with the upgrade and validated
+synchronously on the `connection` event (socket closed `1008` before any session data), so there is no
+post-connect auth-message handshake and thus no parked-unauthenticated wait window. No 5s/4001 timeout needed.
+
+**STRUCT-07:** the `@robota-sdk/agent-core/testing` pass-through re-exports were removed from
+`agent-framework/src/testing/index.ts`; the importers (agent-command functional tests) use the local
+`scriptedSession`/`ScriptedSessionHarness` and stay green (5/5). The same-class load-bearing pass-through in
+`agent-transport/src/testing/index.ts` is logged as a separate follow-up.

--- a/.agents/spec-docs/active/ARCH-004-forward-surface-hardening.md
+++ b/.agents/spec-docs/active/ARCH-004-forward-surface-hardening.md
@@ -1,0 +1,182 @@
+---
+status: in-progress
+type: BEHAVIOR
+tags: [transport, http, websocket, sse, lifecycle, hardening, runtime, capability]
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md
+---
+
+# ARCH-004: forward-provisioned transport surface hardening (WS/HTTP lifecycle + abort)
+
+## Problem
+
+The `agent-transport-ws` / `agent-transport-http` surfaces are forward-provisioned (kept for external
+consumers, not dead code — per the Forward-Provisioned Surface Rule). Their **runtime defects are promoted to
+unconditional fixes**. Concrete, code-confirmed defects (re-audit P2-10):
+
+- **RUNTIME-13 — WS `stop()` hangs forever.** `ws-transport-configurable.ts:273-276` stops via
+  `wss.close(() => httpServer.close(res))`. The `ws` library's `WebSocketServer.close()` callback fires only
+  after **every** client connection has closed — a still-connected client makes `stop()` never resolve. No
+  client-close handshake, no forced-terminate deadline.
+- **RUNTIME-14 — HTTP `/submit` SSE leaks listeners on client disconnect.** `routes.ts:46-96` runs its
+  `cleanup` (session `off`) only at line 95, AFTER `await done`. `done` resolves solely on
+  complete/interrupted/error; a client that disconnects mid-stream never resolves it → the session listeners
+  leak permanently. There is no `stream.onAbort` teardown, no `try/finally`, and the non-terminal writes
+  (text_delta/tool_start/…) are fire-and-forget (unawaited/uncaught → a write to a closed stream throws
+  unhandled).
+- **RUNTIME-38 — concurrent `/submit` cross-talk.** `http-transport.ts:31` wires
+  `sessionFactory: () => session!` — a SINGLE shared session. Two concurrent `/submit` requests both subscribe
+  to the same session's events, so each stream receives the other's deltas.
+- **RUNTIME-54 — WS auth-wait has no timeout** (a connected-but-not-authenticated peer parks resources).
+- **STRUCT-07 — ownership violation.** `agent-framework/src/testing/index.ts:20-21` PASS-THROUGH re-exports
+  `createScriptedProvider` + `IScriptedProvider`/`TScriptedTurn` from `@robota-sdk/agent-core/testing`. A
+  package must not re-export another package's symbols (no pass-through re-exports rule).
+
+## Prior Art Research
+
+**Topic:** Graceful lifecycle + abort handling in a long-running agent transport server (WebSocket + HTTP/SSE).
+
+### References
+
+- **RFC 6455 §7 (WS closing handshake):** a Close frame is exchanged before TCP close (the TCP FIN is not
+  reliable through proxies). https://www.rfc-editor.org/rfc/rfc6455.html#section-7
+- **`ws` README:** `close()` sends a close frame and **waits for the close timer**; the documented remedy for a
+  peer that never replies is `terminate()` ("immediately destroys the connection"). https://github.com/websockets/ws/blob/master/README.md
+- **WebSocket.org heartbeat guide:** ping ~30s, `terminate()` on missed pong (dead-peer reaping). https://websocket.org/guides/heartbeat/
+- **WebSocket.org auth guide:** a **5s** unauthenticated-connection timeout, close code **4001** ("without it,
+  unauthenticated connections sit open indefinitely"). https://websocket.org/guides/authentication/
+- **Hono streaming helper:** `stream.writeSSE()` (awaitable), `stream.onAbort(cb)`, `stream.aborted`; **errors
+  thrown after streaming starts bypass Hono's `onError`** — the producer must guard its own writes. https://hono.dev/docs/helpers/streaming
+- **WHATWG SSE + MDN:** `EventSource` auto-reconnects; `id:` + `Last-Event-ID` resume; per-stream identity. https://html.spec.whatwg.org/multipage/server-sent-events.html
+- **Node `http` `'close'` / MDN `AbortSignal`:** client disconnect surfaced via req/res `'close'` or an
+  `AbortSignal`; teardown in `finally`. https://nodejs.org/api/http.html · https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+- **Kubernetes pod termination:** canonical **drain-then-force** with a default **30s** grace budget. https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+
+### Observed common behavior
+
+- **Graceful WS shutdown is ALWAYS bounded by a deadline** — "handshake, then force (`terminate`) after a
+  timer." No production doc describes an unbounded graceful close.
+- **Client disconnect on HTTP/SSE is an event you must subscribe to, and the write will not reliably throw** —
+  frameworks converge on onAbort/`'close'` + `finally` teardown + **awaited** writes in a `try/catch` (post-
+  headers errors bypass the framework error hook).
+- **Stream isolation is request-scoped** — per-request state in the handler closure, never shared/module state.
+- **Auth-wait windows are short + explicit** (~5s, app close code), treated as a resource-exhaustion surface.
+
+### Recommendation (adopted below)
+
+WS `stop()` = `close(1001)` each socket → **terminate at a 5s deadline** → server-close resolves (inside a
+30s-style overall budget). HTTP `/submit` = per-request `AbortController` + `onAbort`/`'close'` → cancel the
+run + `try/finally` teardown + **awaited/caught** writes. Concurrent streams: request-scoped isolation; since a
+Robota `Session` is single-threaded downstream (one turn at a time), **reject a concurrent submit (409)** is the
+justified v1. WS auth-wait: 5s / code 4001 — **but check SEC-001**: if the token is verified at `verifyClient`
+(upgrade), auth is resolved at handshake and no parked-unauth slot exists (RUNTIME-54 subsumed for the token path).
+
+PRIOR_ART_RESEARCH: FOUND
+
+## Decision (to be finalized against prior art)
+
+1. **RUNTIME-13 — graceful-then-forced WS stop.** On `stop()`: `ws.close(1001, ...)` each `wss.clients` socket,
+   start a **5s deadline**, `ws.terminate()` any still-open socket at the deadline; then `wss.close()` +
+   `httpServer.close()` resolve promptly. Matches RFC 6455 + `ws` + the Kubernetes drain-then-force convention —
+   removes the unbounded-hang failure mode. (Periodic heartbeat ping/pong reaping is a noted follow-up, not v1.)
+2. **RUNTIME-14 — guaranteed SSE teardown + run cancellation.** Wrap the stream body in `try/finally` so the
+   session `off` cleanup ALWAYS runs; register `stream.onAbort` (Hono `StreamingApi.onAbort`/`aborted`,
+   confirmed present in `hono@4.12.25`) to resolve + **cancel the underlying run** via `session.abort()`
+   (`session-contracts.ts:357` — not merely stop writing) on client disconnect; `await` writes and `.catch`
+   so a write to a closed stream cannot throw unhandled (post-headers errors bypass the framework hook — Hono
+   docs). **No-fallback posture:** the write `.catch` is a genuine nothing-to-do teardown on an aborted stream
+   and MUST carry a reason comment (HARNESS-028 swallow→default gate) so it reads as blessed teardown, not a
+   silent swallow.
+3. **RUNTIME-38 — reject concurrent submit (409), gated on the existing `session.isExecuting()`.** A Robota
+   `Session` is single-threaded downstream (one turn at a time) and the transport shares ONE session
+   (`sessionFactory: () => session!`), so two concurrent `/submit` cross-subscribe to the same global emitter.
+   Gate on the ALREADY-EXPOSED `session.isExecuting()` signal (`session-contracts.ts:370` — no new state):
+   while a turn is in flight, a second `/submit` returns `409` (busy). Per-turn `id:` correlation would only
+   demultiplex events — two turns still cannot run on one single-threaded session — so reject is the correct
+   v1 (real per-request concurrency needs `sessionFactory` returning distinct sessions, a larger change out of
+   scope). **Known limitation:** the check-then-submit gate has a small TOCTOU window (an `await c.req.json()`
+   sits between `isExecuting()` and `submit`); it is dramatically better than cross-talk and acceptable for v1.
+   **Interplay with RUNTIME-14:** because concurrency is rejected, the client owning an SSE stream is the SOLE
+   in-flight turn, so RUNTIME-14's `onAbort → session.abort()` aborts exactly THAT client's run and nothing
+   else — the shared-session abort is safe precisely because RUNTIME-38 rejects concurrency.
+4. **RUNTIME-54 — subsumed by SEC-001's synchronous connect-time auth (doc-only, no code).** The token is
+   presented WITH the upgrade request (query param / subprotocol) and validated **synchronously in
+   `wss.on('connection')`** (`ws-transport-configurable.ts:249`, socket closed `1008` before any session data
+   is sent) — NOT at `verifyClient` (which checks only Host/Origin, lines 229-242). Because auth is resolved
+   synchronously on connect with no post-connect auth-message handshake, there is no parked-unauthenticated
+   wait window, so no 5s / code-4001 timeout is needed. Record RUNTIME-54 as resolved-by-SEC-001.
+5. **STRUCT-07 — drop the pass-through.** Remove the `agent-core/testing` re-exports (lines 20-21) from
+   `agent-framework/src/testing/index.ts`; consumers import `createScriptedProvider` directly from
+   `@robota-sdk/agent-core/testing`. Verified safe: no importer resolves those symbols via
+   `@robota-sdk/agent-framework/testing` (the two agent-command functional tests use `scriptedSession`/
+   `ScriptedSessionHarness`; the harness itself imports from core/testing directly). **Same-class follow-up
+   (out of scope here, LOG only):** `agent-transport/src/testing/index.ts:9-10` has the identical pass-through
+   of `createScriptedProvider` and IS load-bearing (agent-transport-tui + agent-cli import it via
+   `@robota-sdk/agent-transport/testing`) — removing it is breaking, so it needs its own item to apply the rule
+   consistently rather than be silently exempted.
+6. **SPEC/README accuracy + missing tests** for both transports; document the consumption entry point (whether
+   the surface is wired into a shipped app stays a separate product decision, left open).
+
+## Test Plan
+
+- RUNTIME-13: a test that connects a client, calls `stop()`, and asserts it resolves within the deadline
+  (previously hung).
+- RUNTIME-14: subscribe count is 0 after a client aborts mid-stream (listener leak regression); writes after
+  abort do not throw.
+- RUNTIME-38: a concurrent `/submit` on a busy session returns 409; the first stream is uncontaminated.
+- STRUCT-07: `check-dependency-direction` / no-pass-through scan stays green; importers resolve.
+
+## User Execution Test Scenarios
+
+- **agent-executable.** Start `agent-transport-http` live → `/submit` stream round-trip; force-disconnect the
+  client mid-stream → server healthy, session listener count returns to 0 (measured). Start
+  `agent-transport-ws` live, connect a client, call `stop()` → resolves within the deadline with the client
+  still connected (measured, previously hung).
+- Evidence: `.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md` (record after execution).
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-07-21
+
+- Prior Art Research: substantiated (`prior-art-researcher`: RFC 6455 close→terminate-after-deadline, `ws`
+  close/terminate, Hono streamSSE onAbort, WHATWG SSE, Node `'close'`/AbortSignal, K8s drain-then-force,
+  WS 5s/4001 auth) → `PRIOR_ART_RESEARCH: FOUND`; scan-spec-research green.
+- Frontmatter (status/type BEHAVIOR/tags + capability keys): present.
+- Decision refined by prior art: WS 5s terminate deadline; SSE onAbort→cancel-run + try/finally + awaited
+  writes; RUNTIME-38 reject-409 (single-threaded session); RUNTIME-54 subsumed by SEC-001 connect-time auth.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-07-21
+
+Independent `proposal-reviewer`: **REVISE → resolved**. Verified all five decisions sound (RUNTIME-13 hang,
+RUNTIME-14 leak, RUNTIME-38 crosstalk + `isExecuting()` signal, RUNTIME-54 subsumed, STRUCT-07 removal safe).
+REVISE items applied:
+
+1. **RUNTIME-54 mechanism corrected** — the token is validated synchronously in `wss.on('connection')` (line
+   249, close `1008`), NOT at `verifyClient` (Host/Origin only). Conclusion (subsumed, no timeout) unchanged;
+   rationale now matches the code so no future refactor is built on the false "auth at verifyClient" claim.
+2. **RUNTIME-38↔14 interplay stated** + gate uses the existing `session.isExecuting()` (no new state) + the
+   check-then-submit TOCTOU window acknowledged.
+3. **No-fallback reason requirement** added for RUNTIME-14's caught writes (HARNESS-028 blessed-teardown).
+4. **Same-class follow-up logged** — `agent-transport/src/testing/index.ts:9-10` has the identical (but
+   load-bearing) pass-through; flagged for its own item so STRUCT-07's rule is applied consistently.
+
+Owner directive ("arch-004 core-026 진행") = GATE-APPROVAL sign-off; REVISE resolved.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-07-21
+
+- **RUNTIME-13** (`ws-transport-configurable.ts`): `stop()` now `close(1001)` each `wss.clients` socket, then
+  `terminate()` survivors at a 5s deadline (`WS_STOP_TERMINATE_DEADLINE_MS`), then `wss.close()`/`httpServer.close()`.
+- **RUNTIME-14** (`routes.ts`): `/submit` wrapped in `try/finally` (teardown always runs) + `stream.onAbort`
+  → `session.abort()` + resolve; a shared awaited/`.catch`'d `write` helper (blessed teardown, `allow-fallback:`).
+- **RUNTIME-38** (`routes.ts`): `/submit` returns `409` when `session.isExecuting()`.
+- **RUNTIME-54**: doc-only — subsumed by SEC-001 connect-time auth (no code).
+- **STRUCT-07** (`agent-framework/src/testing/index.ts`): the two `agent-core/testing` pass-through re-exports removed.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-21
+
+- 3-package build green. RUNTIME-13 lifecycle test (stop resolves ~15ms with a live client, previously hung) +
+  routes 16/16 (incl. new RUNTIME-38 `409`-on-busy and RUNTIME-14 listener-balance) + prior ws/http suites
+  (34→36) green; agent-command STRUCT-07 importers 5/5 green.
+- Scans: no-fallback, dependency-direction, entry-point-only green.
+- Agent-run scenario executed — `.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md`.

--- a/packages/agent-framework/src/testing/index.ts
+++ b/packages/agent-framework/src/testing/index.ts
@@ -5,8 +5,10 @@
  * deterministic scripted provider) and the lightweight stub session. Never import from runtime
  * code; exported via the `./testing` subpath so test fixtures stay out of the runtime bundle.
  *
- * The deterministic scripted provider itself lives in `@robota-sdk/agent-core/testing`; re-exported
- * here for convenience so a functional test imports turns + harness from one place.
+ * STRUCT-07: the deterministic scripted provider lives in `@robota-sdk/agent-core/testing` — import it FROM
+ * THERE directly. This package must not pass-through re-export another package's symbols (no pass-through
+ * re-exports rule); the previous `createScriptedProvider`/`IScriptedProvider`/`TScriptedTurn` re-exports were
+ * removed here.
  */
 
 export {
@@ -16,6 +18,3 @@ export {
 } from './scripted-session-harness.js';
 
 export { createTestInteractiveSession } from './create-test-interactive-session.js';
-
-export { createScriptedProvider } from '@robota-sdk/agent-core/testing';
-export type { IScriptedProvider, TScriptedTurn } from '@robota-sdk/agent-core/testing';

--- a/packages/agent-transport-http/src/__tests__/routes.test.ts
+++ b/packages/agent-transport-http/src/__tests__/routes.test.ts
@@ -230,4 +230,28 @@ describe('HTTP Transport Routes', () => {
     expect(body).toContain('event: error');
     expect(body).toContain('"message":"boom"');
   });
+
+  // ── ARCH-004 RUNTIME-38: reject concurrent /submit on a busy session ──
+
+  it('POST /submit returns 409 while a turn is already in flight (isExecuting)', async () => {
+    const { app } = createApp(createMockSession({ isExecuting: vi.fn().mockReturnValue(true) }));
+    const res = await app.request('/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi' }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  // ── ARCH-004 RUNTIME-14: SSE teardown always removes every listener (no leak) ──
+
+  it('POST /submit unsubscribes every listener it added once the stream ends', async () => {
+    const session = createEmitterSession('complete', { ok: true });
+    await requestSubmit(session);
+    // The try/finally teardown must `off` exactly what it `on`'d — a balanced count means zero leaked listeners.
+    const onCount = (session.on as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    const offCount = (session.off as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    expect(offCount).toBe(onCount);
+    expect(onCount).toBeGreaterThan(0);
+  });
 });

--- a/packages/agent-transport-http/src/__tests__/routes.test.ts
+++ b/packages/agent-transport-http/src/__tests__/routes.test.ts
@@ -245,13 +245,59 @@ describe('HTTP Transport Routes', () => {
 
   // ── ARCH-004 RUNTIME-14: SSE teardown always removes every listener (no leak) ──
 
-  it('POST /submit unsubscribes every listener it added once the stream ends', async () => {
+  it('POST /submit unsubscribes every listener it added once the stream completes', async () => {
     const session = createEmitterSession('complete', { ok: true });
     await requestSubmit(session);
     // The try/finally teardown must `off` exactly what it `on`'d — a balanced count means zero leaked listeners.
     const onCount = (session.on as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
     const offCount = (session.off as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
     expect(offCount).toBe(onCount);
+    expect(onCount).toBeGreaterThan(0);
+  });
+
+  /**
+   * The load-bearing RUNTIME-14 case: a client that disconnects MID-STREAM (before any terminal event). The
+   * pre-fix code ran cleanup only after `await done`, and `done` resolved solely on complete/interrupted/error
+   * — so a disconnect leaked every listener forever. The fix's `stream.onAbort` must cancel the run
+   * (`session.abort()`) and unblock `done` so the `finally` teardown runs.
+   */
+  it('POST /submit tears down + aborts the run when the client disconnects mid-stream', async () => {
+    const handlers = new Map<string, Set<(data: unknown) => void>>();
+    let settleSubmit: (() => void) | undefined;
+    const session = createMockSession({
+      isExecuting: vi.fn().mockReturnValue(false),
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        const set = handlers.get(event) ?? new Set();
+        set.add(handler);
+        handlers.set(event, set);
+      }),
+      off: vi.fn((event: string, handler: (data: unknown) => void) => {
+        handlers.get(event)?.delete(handler);
+      }),
+      // A run that never emits a terminal event on its own — it settles only when abort() is called.
+      submit: vi.fn(() => new Promise<void>((resolve) => (settleSubmit = resolve))),
+      abort: vi.fn(() => settleSubmit?.()),
+    });
+
+    const app = createAgentRoutes({ sessionFactory: () => session });
+    const res = await app.request('/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi' }),
+    });
+    expect(res.status).toBe(200);
+
+    // Let the handler subscribe + enter the in-flight `submit()`, then cancel the response stream — the
+    // Web-standard equivalent of a client disconnecting mid-stream (Hono fires `stream.onAbort`).
+    const reader = res.body!.getReader();
+    await new Promise((r) => setTimeout(r, 20));
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 20)); // let onAbort → session.abort() + the finally teardown run
+
+    expect(session.abort).toHaveBeenCalled(); // onAbort cancelled the run, not just stopped writing
+    const onCount = (session.on as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    const offCount = (session.off as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+    expect(offCount).toBe(onCount); // finally teardown removed every listener — no leak
     expect(onCount).toBeGreaterThan(0);
   });
 });

--- a/packages/agent-transport-http/src/routes.ts
+++ b/packages/agent-transport-http/src/routes.ts
@@ -45,8 +45,9 @@ export function createAgentRoutes(options: IAgentRoutesOptions): Hono {
 
     // RUNTIME-38: the session is single-threaded (one turn at a time) and shared across requests, so a
     // concurrent /submit would cross-subscribe to the same emitter and interleave two clients' events.
-    // Reject while a turn is in flight. (Known TOCTOU: the body parse above sits between this check and
-    // submit; the window is small and far better than silent cross-talk. Per-session isolation is a larger
+    // Reject while a turn is in flight. (Known TOCTOU: the synchronous streamSSE subscribe below runs before
+    // `await session.submit`, so two requests passing this check in the same tick could still both proceed;
+    // the window is small and far better than silent cross-talk. Per-session isolation is a larger
     // follow-up — see ARCH-004.)
     if (session.isExecuting()) {
       return c.json({ error: 'session busy — a turn is already in flight' }, 409);

--- a/packages/agent-transport-http/src/routes.ts
+++ b/packages/agent-transport-http/src/routes.ts
@@ -43,6 +43,15 @@ export function createAgentRoutes(options: IAgentRoutesOptions): Hono {
       return c.json({ error: 'prompt is required' }, 400);
     }
 
+    // RUNTIME-38: the session is single-threaded (one turn at a time) and shared across requests, so a
+    // concurrent /submit would cross-subscribe to the same emitter and interleave two clients' events.
+    // Reject while a turn is in flight. (Known TOCTOU: the body parse above sits between this check and
+    // submit; the window is small and far better than silent cross-talk. Per-session isolation is a larger
+    // follow-up — see ARCH-004.)
+    if (session.isExecuting()) {
+      return c.json({ error: 'session busy — a turn is already in flight' }, 409);
+    }
+
     return streamSSE(c, async (stream) => {
       const cleanup: Array<() => void> = [];
 
@@ -51,48 +60,51 @@ export function createAgentRoutes(options: IAgentRoutesOptions): Hono {
         cleanup.push(() => session.off(event as 'text_delta', handler as () => void));
       };
 
+      // RUNTIME-14: await + catch every SSE write so a write to a client-closed stream is a blessed no-op,
+      // not an unhandled rejection (post-headers errors bypass Hono's onError).
+      const write = (event: string, data: unknown): Promise<void> =>
+        stream.writeSSE({ event, data: JSON.stringify(data) }).catch(() => {
+          // allow-fallback: client closed the stream mid-write — nothing to deliver; the finally teardown
+          // (RUNTIME-14) removes the listeners, so this write has nothing left to do.
+        });
+
       const done = new Promise<void>((resolve) => {
-        subscribe('text_delta', (delta: string) => {
-          stream.writeSSE({ event: 'text_delta', data: JSON.stringify({ delta }) });
-        });
-
-        subscribe('tool_start', (state) => {
-          stream.writeSSE({ event: 'tool_start', data: JSON.stringify(state) });
-        });
-
-        subscribe('tool_end', (state) => {
-          stream.writeSSE({ event: 'tool_end', data: JSON.stringify(state) });
-        });
-
-        subscribe('thinking', (isThinking: boolean) => {
-          stream.writeSSE({ event: 'thinking', data: JSON.stringify({ isThinking }) });
-        });
+        subscribe('text_delta', (delta: string) => void write('text_delta', { delta }));
+        subscribe('tool_start', (state) => void write('tool_start', state));
+        subscribe('tool_end', (state) => void write('tool_end', state));
+        subscribe('thinking', (isThinking: boolean) => void write('thinking', { isThinking }));
 
         subscribe('complete', async (result) => {
           // Flush the terminal event before resolving, so the resolve → cleanup →
-          // stream-close continuation cannot race ahead of the fire-and-forget write.
-          await stream.writeSSE({ event: 'complete', data: JSON.stringify(result) });
+          // stream-close continuation cannot race ahead of the write.
+          await write('complete', result);
           resolve();
         });
-
         subscribe('interrupted', async (result) => {
-          await stream.writeSSE({ event: 'interrupted', data: JSON.stringify(result) });
+          await write('interrupted', result);
+          resolve();
+        });
+        subscribe('error', async (error: Error) => {
+          await write('error', { message: error.message });
           resolve();
         });
 
-        subscribe('error', async (error: Error) => {
-          await stream.writeSSE({
-            event: 'error',
-            data: JSON.stringify({ message: error.message }),
-          });
+        // RUNTIME-14: on client disconnect, CANCEL the underlying run (not merely stop writing) and unblock
+        // `done` so the finally teardown runs — otherwise `done` would never resolve and the listeners leak.
+        stream.onAbort(() => {
+          session.abort();
           resolve();
         });
       });
 
-      await session.submit(body.prompt);
-      await done;
-
-      for (const fn of cleanup) fn();
+      try {
+        await session.submit(body.prompt);
+        await done;
+      } finally {
+        // RUNTIME-14: teardown ALWAYS runs — on completion, error, OR client disconnect — so the session
+        // event listeners can never leak.
+        for (const fn of cleanup) fn();
+      }
     });
   });
 

--- a/packages/agent-transport-ws/src/__tests__/ws-transport-lifecycle.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-transport-lifecycle.test.ts
@@ -1,0 +1,60 @@
+import { WebSocket } from 'ws';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { WsTransport } from '../ws-transport-configurable.js';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * ARCH-004 RUNTIME-13 — `stop()` must resolve even with a client still connected.
+ *
+ * Before the fix, `stop()` did `wss.close(cb)`, whose callback fires only after every client socket is gone,
+ * so a live client made `stop()` hang forever. The fix sends a close frame to each client and terminates any
+ * survivor at a 5s deadline, so the server-close callback always resolves.
+ */
+
+function mockSession(): IInteractiveSession {
+  return {
+    getMessages: vi.fn().mockReturnValue([]),
+    getExecutionWorkspaceSnapshot: vi.fn().mockReturnValue({ entries: [] }),
+    on: vi.fn(),
+    off: vi.fn(),
+    submit: vi.fn(),
+    abort: vi.fn(),
+    cancelQueue: vi.fn(),
+  } as unknown as IInteractiveSession;
+}
+
+const started: WsTransport[] = [];
+afterEach(async () => {
+  while (started.length) await started.pop()!.stop();
+});
+
+describe('WsTransport lifecycle (ARCH-004 RUNTIME-13)', () => {
+  it('stop() resolves promptly with a client still connected (previously hung forever)', async () => {
+    const t = new WsTransport({ port: 17800, maxRetries: 40, open: true });
+    t.attach(mockSession());
+    await t.start();
+    started.push(t);
+    const port = t.boundPort;
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', () => resolve());
+      ws.on('error', reject);
+    });
+
+    const startedAt = Date.now();
+    await t.stop(); // must not hang — the whole test would time out if it did
+    const elapsed = Date.now() - startedAt;
+
+    // A well-behaved client closes on the 1001 frame, so stop() resolves well under the 5s terminate deadline.
+    expect(elapsed).toBeLessThan(4500);
+    started.pop(); // already stopped
+    try {
+      ws.terminate();
+    } catch {
+      /* already closed */
+    }
+  });
+});

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -60,6 +60,14 @@ function mintToken(): string {
  * moot, but accepting it is harmless. */
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 
+/**
+ * RUNTIME-13: forced-terminate deadline for `stop()`. `WebSocketServer.close()` fires its callback only after
+ * every client socket is gone, so a still-connected client would hang `stop()` forever. We send a close frame
+ * (1001 "going away") to each client, then `terminate()` any socket still open at this deadline — the RFC 6455
+ * + `ws` + drain-then-force convention (a WS close handshake completes in well under a second; 5s is generous).
+ */
+const WS_STOP_TERMINATE_DEADLINE_MS = 5000;
+
 /** Strip the `:port` suffix from a Host/authority (port-agnostic — `bindWithRetry` can walk the port). */
 function hostname(hostHeader: string | undefined): string | null {
   if (!hostHeader) return null;
@@ -272,7 +280,18 @@ export class WsTransport implements IConfigurableTransport<IInteractiveSession> 
           port,
           stop: () =>
             new Promise<void>((res) => {
-              wss.close(() => httpServer.close(() => res()));
+              // RUNTIME-13: graceful-then-forced shutdown. Send a close frame to each client so well-behaved
+              // peers close cleanly; terminate any socket still open at the deadline so `wss.close()`'s
+              // all-clients-gone callback can never hang. `verifyClient`/token gates are connection-time and
+              // untouched here (SEC-001 preserved).
+              for (const client of wss.clients) client.close(1001, 'server shutting down');
+              const deadline = setTimeout(() => {
+                for (const client of wss.clients) client.terminate();
+              }, WS_STOP_TERMINATE_DEADLINE_MS);
+              wss.close(() => {
+                clearTimeout(deadline);
+                httpServer.close(() => res());
+              });
             }),
         });
       });


### PR DESCRIPTION
Fixes confirmed runtime defects in the forward-provisioned `agent-transport-ws` / `agent-transport-http` surfaces (kept for external consumers; their runtime bugs are promoted to unconditional fixes).

## Fixes
- **RUNTIME-13 — WS `stop()` hang.** `wss.close()`'s callback fires only after every client socket is gone, so a live client hung `stop()` forever. Now: `close(1001)` each `wss.clients` socket → `terminate()` survivors at a **5s deadline** → close the server (RFC 6455 + `ws` + K8s drain-then-force). SEC-001 connection-time auth/verifyClient untouched.
- **RUNTIME-14 — SSE listener leak.** `/submit` ran its `session.off` cleanup only after `await done`, which never resolved on a mid-stream disconnect → leak. Now: `try/finally` (teardown always runs) + `stream.onAbort` → `session.abort()` (cancel the run, not just stop writing) + every SSE write awaited & `.catch`'d (blessed teardown; post-headers errors bypass Hono's `onError`).
- **RUNTIME-38 — concurrent `/submit` cross-talk.** The transport shares ONE single-threaded session; two concurrent submits cross-subscribed. Now returns **409** gated on the existing `session.isExecuting()` (no new state; small check-then-submit TOCTOU acknowledged).
- **RUNTIME-54 — doc-only.** Subsumed by SEC-001: the token is validated synchronously on the `connection` event (closed `1008` before session data), so there is no parked-unauthenticated window.
- **STRUCT-07 — pass-through removal.** Dropped the `@robota-sdk/agent-core/testing` re-exports from `agent-framework/testing` (no importer used them). The identical **load-bearing** pass-through in `agent-transport/testing` is logged as a separate follow-up.

## Verification
- RUNTIME-13 lifecycle test: `stop()` resolves ~15ms with a live client (previously hung). routes 16/16 (new `409`-on-busy + listener-balance). Prior ws/http suites + agent-command STRUCT-07 importers green. 62/62 harness scans.
- Prior-art-anchored; proposal-reviewer **REVISE resolved** (RUNTIME-54 mechanism corrected to synchronous connect-time auth).
- Spec (GATE-WRITE→VERIFY): `.agents/spec-docs/active/ARCH-004-forward-surface-hardening.md`; scenario `.agents/evals/scenarios/arch-004-transport-lifecycle-agent-run.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)