### PR TITLE
feat(concurrency): CORE-026 floating-promise/race repair + no-floating-promises lint

### DIFF
--- a/.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md
+++ b/.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md
@@ -1,0 +1,49 @@
+# CORE-026 — floating-promise / race repair + no-floating-promises lint (agent-run)
+
+**Spec:** CORE-026 (RUNTIME-12/26/36 + `no-floating-promises` enablement on the touched packages).
+**Type:** agent-executable (the agent builds + tests + lints the touched packages; no owner action).
+
+## Scenario
+
+```bash
+pnpm --filter @robota-sdk/agent-framework --filter @robota-sdk/agent-transport --filter @robota-sdk/agent-core build
+
+# RUNTIME-12 — a concurrent submit while a turn is in flight coalesces (no double-start).
+npx vitest run packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
+
+# RUNTIME-36 — a headless slash-command that THROWS exits non-zero instead of hanging.
+npx vitest run packages/agent-transport/src/headless/__tests__/headless-runner.test.ts
+
+# no-floating-promises now ENABLED (type-aware) on the 3 touched packages — 0 errors.
+(cd packages/agent-core && npx eslint 'src/**/*.ts')
+(cd packages/agent-framework && npx eslint 'src/**/*.ts')
+(cd packages/agent-transport && npx eslint 'src/**/*.ts')
+```
+
+**Expected:** builds green; the concurrent submit coalesces (pending == 1, still one turn); the throwing
+slash-command resolves exit 1 (no hang); `no-floating-promises` reports 0 errors on all three packages.
+
+## Observed (2026-07-21)
+
+- **RUNTIME-12** — `✓ a second concurrent submit coalesces to pending instead of starting a second turn`. The
+  first turn is held in flight (blocked on a model-issued AskUserQuestion with a manually-released answer); a
+  concurrent `submit` lands in the pending queue (`getPendingCount() === 1`) and no second turn starts. The fix
+  claims `executing` SYNCHRONOUSLY at `executePrompt` entry (was set only after the awaited
+  `checkAndRefreshContextIfStale`, leaving a two-await double-start window; `checkAndRefreshContextIfStale` now
+  runs inside the try so the `finally` still releases the flag on a refresh throw).
+- **RUNTIME-26** — `interactive-session.requestWakeup` (`void this.submit(...)` wake) and `resumeGoalIfActive`
+  (`void this.ensureInitialized().then(...)` init) now `.catch → reportBackgroundError('agent-wakeup' /
+'goal-resume')` instead of dropping a detached rejection. The full interactive suite (248 tests) runs with
+  ZERO unhandled rejections — previously the wake's floating submit surfaced `Unhandled Rejection: Interactive
+session is shutting down`.
+- **RUNTIME-36** — `✓ a slash-command that THROWS exits non-zero instead of hanging` (exit 1). All three
+  headless format runners' `executeSlashCommandIfPresent(...).then(...)` chains gained a `.catch → onError`
+  (fail-closed exit code), and `agent-cli print-mode` wraps `run`/`runGoal` + `process.exit(getExitCode())` in
+  a `try/catch` so a throw can no longer bypass the exit-code contract.
+- **RUNTIME-21 / RUNTIME-24** — DROPPED after code review (no real defect): `runStream` already finalizes on
+  generator `return`; `Session.run` wires the AbortController synchronously with no lost-abort window.
+- **Lint** — `@typescript-eslint/no-floating-promises: error` enabled (with `parserOptions.project`) on
+  `agent-core`, `agent-framework`, `agent-transport`: **0 errors** on each. The monorepo-wide rollout is the
+  deferred INFRA follow-up.
+
+Full regression: agent-framework + agent-transport suites — **1868 tests pass**.

--- a/.agents/spec-docs/active/CORE-026-floating-promise-races.md
+++ b/.agents/spec-docs/active/CORE-026-floating-promise-races.md
@@ -1,0 +1,116 @@
+---
+status: in-progress
+type: BEHAVIOR
+tags: [concurrency, floating-promises, races, lint, runtime, background-tasks, capability]
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/core-026-floating-promise-races-agent-run.md
+---
+
+# CORE-026: residual floating-promise / race repair + no-floating-promises lint enablement
+
+## Problem
+
+Re-audit P2-17 (RUNTIME-12/21/24/26/36; the "T4" concurrency class). Several runtime paths start async work
+without awaiting or routing its rejection, and a few turn/stream transitions have check-then-act races. The
+`@typescript-eslint/no-floating-promises` rule — the industry-standard guard for exactly this hazard — is NOT
+enabled (the root `.eslintrc.json` has no `parserOptions.project`, so type-aware rules cannot run today).
+
+Confirmed sites (locations CORRECTED at GATE-APPROVAL — proposal-reviewer traced each against the code):
+
+- **RUNTIME-12 (REAL)** — turn double-start race. The busy flag is `executing` in `agent-framework`
+  `SessionExecutionController` (`interactive-session-execution-controller.ts:102`), gated at the `submit`
+  entry (`interactive-session.ts:489`). The race: `submit()` awaits `ensureInitialized()` (`:480`) BEFORE the
+  `if (execCtrl.executing)` check, and `executePrompt` awaits `checkAndRefreshContextIfStale`
+  (`...execution-controller.ts:268`) BEFORE setting `executing = true` (`:276`). Two concurrent entries
+  (realistic: REMOTE-014 co-drive, FLOW-002 `requestWakeup` `:542`, GOAL-001 `scheduleGoalTurn` `:913`) can
+  both observe idle and both start a turn. (NOT in `agent-session`; `session-contracts.ts:370` is the
+  interface declaration, not the flag.)
+- **RUNTIME-26 (REAL, RELOCATED)** — lost-rejection floating promises in the FRAMEWORK layer that CAN reach
+  `reportBackgroundError` (`interactive-session.ts:780`): `interactive-session.ts:542` `void this.submit(...)`
+  (wake, no catch) and `:933` `void this.ensureInitialized().then(...)` (init, no rejection handler). NOT the
+  executor manager — `background-task-manager.ts:94` `void deferred.promise.catch(()=>undefined)` is a correct
+  intentional guard, and `agent-executor` cannot call `reportBackgroundError` (one-way dep `agent-framework →
+agent-executor`; the reverse would be a cycle). The runner-result promise already routes to `onFailed`.
+- **RUNTIME-36 (REAL)** — headless slash-command paths in `agent-transport/src/headless/` (NOT
+  `agent-cli/print-mode`): `executeSlashCommandIfPresent` (`headless-stream-json.ts:32`) awaits
+  `session.executeCommand` with no catch and a failing command returns `{ success: false }` (`:41`) without a
+  non-zero exit; and `print-mode.ts:117` does `process.exit(channel.getExitCode())` AFTER `await channel.run`
+  — a throw in `run` bypasses the exit-code line.
+
+**Dropped after code review** (premises not substantiated):
+
+- **RUNTIME-21** — DROPPED: `runStream` (`robota-execution.ts`) already has `try/catch/finally` (`:161`); a
+  `for await` consumer that `break`s triggers the generator `.return()` → the `finally` runs, so a dropped
+  consumer IS finalized. No concrete parked-producer/queue-wedge site exists.
+- **RUNTIME-24 — DROPPED**: `session.ts` `run()` (185-193) creates the `AbortController`, destructures
+  `signal`, and hands off to `executeRun` all SYNCHRONOUSLY (no `await` between) — no lost-abort window.
+  `AbortSignal` is level-triggered and `session-run.ts` re-checks `abortSignal.aborted` (`:230`), so an early
+  abort is still observed. Fixing it would be churn with no design improvement.
+
+## Prior Art Research
+
+Waived: this is INTERNAL concurrency-correctness repair against the repo's OWN CORE-018 cancellation contract
+plus enabling a STANDARD lint rule. The authoritative external reference IS the rule itself —
+[`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/) (and its
+companion `no-misused-promises`) — whose documentation states the rationale (unhandled rejections, out-of-order
+execution, and lost errors) this spec applies. No comparable-product survey adds signal to "await or route
+every promise; set the busy flag synchronously." Enforced-waiver recorded per research.md.
+
+## Decision
+
+Scope corrected at GATE-APPROVAL to the THREE substantiated fixes (RUNTIME-12/26/36); RUNTIME-21/24 dropped
+(no real defect). Do NOT touch the already-blessed `allow-fallback` best-effort blocks (`session.ts:234`,
+`execution-controller.ts:297/359`, `background-task-manager.ts:94`).
+
+1. **RUNTIME-12** — set `SessionExecutionController.executing` SYNCHRONOUSLY at the `submit` entry
+   (`agent-framework`), before `ensureInitialized()` / `checkAndRefreshContextIfStale`, and reject/coalesce a
+   re-entry deterministically per the session contract. Closes the two-concurrent-entries window. Anchors on
+   the same single-threaded invariant CORE-025/ARCH-004 rely on.
+2. **RUNTIME-26** — route the FRAMEWORK lost-rejection floating promises to `reportBackgroundError`:
+   `interactive-session.ts:542` (`void this.submit(...)` wake) and `:933` (`void this.ensureInitialized().then`
+   init). Leave the executor manager's deferred guard + runner-result routing untouched (dependency-direction:
+   the executor cannot reach `reportBackgroundError`).
+3. **RUNTIME-36** — add `.catch` to the `agent-transport/src/headless/` slash-command site(s)
+   (`headless-stream-json.ts:32` + siblings) and close the `print-mode.ts:117` exit-on-throw bypass, so a
+   failing command surfaces the documented non-zero exit code.
+4. **Lint enablement (split, with a required floor).** `no-floating-promises` is type-aware and needs
+   `parserOptions.project`, absent from the monorepo config today — monorepo-wide rollout is a genuine INFRA
+   change (per-package `project` wiring + the resulting finding-flood + lint-perf cost) and is SPLIT into a
+   dedicated INFRA item. **Required floor (not optional):** enable `no-floating-promises` on the packages this
+   change touches — `agent-framework`, `agent-transport`, `agent-core` — by adding `project` for those and
+   clearing their findings, so the fixed surfaces are actually guarded against recurrence. Only the long-tail
+   monorepo rollout is deferred. State honestly which packages got the rule.
+
+## Test Plan
+
+- RUNTIME-12: two truly-concurrent `submit`s → exactly one turn starts (the other rejects/coalesces).
+- RUNTIME-26: an init/wake rejection reaches `reportBackgroundError` (spy).
+- RUNTIME-36: a failing headless slash-command exits non-zero (documented code); a throw in `channel.run` still
+  sets the exit code.
+- Lint: `no-floating-promises` reports 0 in `agent-framework`, `agent-transport`, `agent-core` (rule enabled).
+
+## User Execution Test Scenarios
+
+- **agent-executable.** Live headless run of a failing command → the documented non-zero exit code (measured);
+  two back-to-back `submit`s → no double turn (measured).
+- Evidence: `.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md` (record after execution).
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-07-21
+
+- Prior Art Research: WAIVED (internal concurrency-correctness + standard lint; rule docs are the reference);
+  scan-spec-research green.
+- Frontmatter (status/type BEHAVIOR/tags + capability keys): present.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-07-21
+
+Independent `proposal-reviewer`: **REVISE → resolved**. Reviewer traced every premise against the code:
+RUNTIME-12 REAL (mislocated → corrected to `agent-framework` SessionExecutionController), RUNTIME-36 REAL
+(re-pointed to `agent-transport/src/headless/`), RUNTIME-26 REAL but MISLOCATED + a dependency-direction
+violation as written (→ relocated to the framework sites that own `reportBackgroundError`; executor guard left
+alone), RUNTIME-21 UNPROVEN (runStream already finalizes on generator return) and RUNTIME-24 FALSE (no
+lost-abort window) → both DROPPED. Lint split ENDORSED with a tightened floor: enable the rule on the 3 touched
+packages (not zero). Research waiver VALID. All applied. Owner directive ("arch-004 core-026 진행") =
+GATE-APPROVAL sign-off; REVISE resolved.

--- a/.agents/spec-docs/active/CORE-026-floating-promise-races.md
+++ b/.agents/spec-docs/active/CORE-026-floating-promise-races.md
@@ -114,3 +114,23 @@ alone), RUNTIME-21 UNPROVEN (runStream already finalizes on generator return) an
 lost-abort window) → both DROPPED. Lint split ENDORSED with a tightened floor: enable the rule on the 3 touched
 packages (not zero). Research waiver VALID. All applied. Owner directive ("arch-004 core-026 진행") =
 GATE-APPROVAL sign-off; REVISE resolved.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-07-21
+
+- **RUNTIME-12** (`interactive-session-execution-controller.ts`): `executing` claimed synchronously at
+  `executePrompt` entry (was set after the awaited `checkAndRefreshContextIfStale`); the refresh moved inside
+  the try so the `finally` still releases the flag on a refresh throw.
+- **RUNTIME-26** (`interactive-session.ts`): `requestWakeup` wake submit + `resumeGoalIfActive` init `.then`
+  now `.catch → reportBackgroundError` (framework layer; executor guard untouched — dependency direction).
+- **RUNTIME-36** (`agent-transport/src/headless/headless-runner.ts` ×3 + `agent-cli/print-mode.ts`): each
+  `executeSlashCommandIfPresent(...).then` gained a `.catch → onError` fail-closed exit; print-mode wraps
+  run/exit in try/catch so a throw surfaces exit 1.
+- **Lint**: `@typescript-eslint/no-floating-promises: error` + `parserOptions.project` enabled on `agent-core`,
+  `agent-framework`, `agent-transport`. RUNTIME-21/24 dropped (no defect).
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-21
+
+- RUNTIME-12 deterministic coalesce test + RUNTIME-36 throw→exit-1 test green; agent-framework + agent-transport
+  full suites **1868 tests pass**, no unhandled rejections (previously the wake floating submit surfaced one).
+- `no-floating-promises` reports **0 errors** on all three packages (type-aware).
+- Agent-run scenario executed — `.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md`.

--- a/.agents/spec-docs/active/CORE-026-floating-promise-races.md
+++ b/.agents/spec-docs/active/CORE-026-floating-promise-races.md
@@ -130,7 +130,9 @@ GATE-APPROVAL sign-off; REVISE resolved.
 
 ### [GATE-VERIFY] — ✅ PASS | 2026-07-21
 
-- RUNTIME-12 deterministic coalesce test + RUNTIME-36 throw→exit-1 test green; agent-framework + agent-transport
-  full suites **1868 tests pass**, no unhandled rejections (previously the wake floating submit surfaced one).
+- RUNTIME-12 race-window-isolated test (mocks `checkAndRefreshContextIfStale` to block, fires two truly
+  concurrent submits at the check→refresh→set window — FAILS on the pre-fix position, PASSES on the fix,
+  empirically verified both ways) + RUNTIME-36 throw→exit-1 test green; agent-framework + agent-transport full
+  suites **1868 tests pass**, no unhandled rejections (previously the wake floating submit surfaced one).
 - `no-floating-promises` reports **0 errors** on all three packages (type-aware).
 - Agent-run scenario executed — `.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md`.

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -106,13 +106,20 @@ export async function runPrintMode(
     ...memorySessionOptions,
   });
 
-  if (goalObjective) {
-    await channel.runGoal(
-      goalObjective,
-      args.goalMaxIterations ? { maxIterations: args.goalMaxIterations } : {},
-    );
-  } else {
-    await channel.run(prompt);
+  // RUNTIME-36: a throw from run/runGoal must NOT bypass the exit-code contract — surface a non-zero exit
+  // instead of leaving the process to an unhandled rejection.
+  try {
+    if (goalObjective) {
+      await channel.runGoal(
+        goalObjective,
+        args.goalMaxIterations ? { maxIterations: args.goalMaxIterations } : {},
+      );
+    } else {
+      await channel.run(prompt);
+    }
+    process.exit(channel.getExitCode());
+  } catch (error) {
+    process.stderr.write((error instanceof Error ? error.message : String(error)) + '\n');
+    process.exit(1);
   }
-  process.exit(channel.getExitCode());
 }

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -107,7 +107,8 @@ export async function runPrintMode(
   });
 
   // RUNTIME-36: a throw from run/runGoal must NOT bypass the exit-code contract — surface a non-zero exit
-  // instead of leaving the process to an unhandled rejection.
+  // instead of leaving the process to an unhandled rejection. `process.exit(getExitCode())` stays OUTSIDE the
+  // try so a NORMAL exit (including code 0) is not caught by the error branch.
   try {
     if (goalObjective) {
       await channel.runGoal(
@@ -117,9 +118,9 @@ export async function runPrintMode(
     } else {
       await channel.run(prompt);
     }
-    process.exit(channel.getExitCode());
   } catch (error) {
     process.stderr.write((error instanceof Error ? error.message : String(error)) + '\n');
     process.exit(1);
   }
+  process.exit(channel.getExitCode());
 }

--- a/packages/agent-core/.eslintrc.json
+++ b/packages/agent-core/.eslintrc.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../.eslintrc.json",
   "plugins": ["import"],
+  "parserOptions": { "project": "./tsconfig.eslint.json" },
   "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
     "import/order": [
       "warn",
       {

--- a/packages/agent-framework/.eslintrc.json
+++ b/packages/agent-framework/.eslintrc.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../.eslintrc.json",
   "plugins": ["import"],
+  "parserOptions": { "project": "./tsconfig.eslint.json" },
   "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
     "import/order": [
       "warn",
       {

--- a/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
@@ -1,80 +1,76 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   scriptedSession,
   type ScriptedSessionHarness,
 } from '../../testing/scripted-session-harness.js';
 
-import type { TActionResponse } from '@robota-sdk/agent-core';
-
 /**
  * CORE-026 RUNTIME-12 — turn double-start race.
  *
  * `submit()` gates on `execCtrl.executing`, but the flag used to be set only AFTER the awaited
- * `checkAndRefreshContextIfStale`, leaving a two-await window where two concurrent entries could both observe
- * "idle" and both start a turn. The fix claims `executing` SYNCHRONOUSLY at `executePrompt` entry, so a second
- * concurrent submit observes it and coalesces to the pending queue instead of double-starting.
+ * `checkAndRefreshContextIfStale` (which always awaits a context-file refresh), leaving a window where two
+ * concurrent entries both observed "idle" and both started a turn. The fix claims `executing` SYNCHRONOUSLY at
+ * `executePrompt` entry — before that await — so a second concurrent submit coalesces.
  *
- * The first turn is held in flight deterministically by blocking on a model-issued AskUserQuestion whose
- * `askHandler` answer we release manually — so the concurrent submit reliably arrives while a turn IS executing.
+ * To isolate exactly that window, this test MOCKS `checkAndRefreshContextIfStale` to block, fires two truly
+ * concurrent submits while the first is parked at that await, and asserts the second coalesced. On the pre-fix
+ * code the flag is not yet set at that point, so both submits pass the gate and double-start (pending stays 0).
  */
+const refreshCtl = vi.hoisted(() => {
+  return { blocking: false, release: undefined as (() => void) | undefined };
+});
+
+vi.mock('../interactive-session-context-refresh.js', () => ({
+  checkAndRefreshContextIfStale: (): Promise<void> =>
+    refreshCtl.blocking
+      ? new Promise<void>((resolve) => {
+          refreshCtl.release = resolve;
+        })
+      : Promise.resolve(),
+}));
+
 describe('CORE-026 RUNTIME-12 — no turn double-start', () => {
   let harness: ScriptedSessionHarness | undefined;
 
   afterEach(async () => {
+    refreshCtl.blocking = false;
+    refreshCtl.release?.();
     await harness?.dispose();
     harness = undefined;
   });
 
-  it('a second concurrent submit coalesces to pending instead of starting a second turn', async () => {
-    let releaseAsk: ((v: TActionResponse) => void) | undefined;
-    const blockedAnswer = new Promise<TActionResponse>((resolve) => {
-      releaseAsk = resolve;
-    });
-
-    harness = scriptedSession({
-      // The first turn asks; this handler BLOCKS until we release it, holding that turn in flight.
-      askHandler: () => blockedAnswer,
-      turns: [
-        {
-          toolCalls: [
-            {
-              name: 'AskUserQuestion',
-              args: { questions: [{ question: 'q?', options: [{ label: 'a' }] }] },
-            },
-          ],
-        },
-        { text: 'first turn done' },
-        { text: 'coalesced turn done' },
-      ],
-    });
+  it('a second concurrent submit coalesces instead of double-starting (race window isolated)', async () => {
+    harness = scriptedSession({ turns: [{ text: 'a' }, { text: 'b' }, { text: 'c' }] });
     const session = harness.session;
 
-    // Start the first turn but do NOT await — it blocks at the AskUserQuestion.
-    const first = session.submit('one');
+    // Warmup (refresh not yet blocking) so the session is initialized — ensureInitialized is then instant.
+    await session.submit('warmup');
 
-    // Wait until the first turn is executing (blocked at the ask).
-    for (let i = 0; i < 200 && !session.isExecuting(); i++) {
+    // Now hold the context refresh so a turn parks at the exact check→refresh→set window.
+    refreshCtl.blocking = true;
+
+    // First submit parks at the (blocked) checkAndRefreshContextIfStale.
+    const first = session.submit('one');
+    for (let i = 0; i < 200 && !refreshCtl.release; i++) {
       await new Promise((r) => setTimeout(r, 0));
     }
-    expect(session.isExecuting()).toBe(true);
+    expect(refreshCtl.release, 'first turn should be parked at the context refresh').toBeDefined();
 
-    // A concurrent submit while a turn is in flight MUST coalesce to the pending queue — not double-start.
-    // (submit() awaits ensureInitialized before reaching the gate, so poll until it lands in the queue; the
-    // first turn stays blocked at the ask the whole time, so a coalesce is the only correct outcome.)
+    // Second concurrent submit: on the FIXED code `executing` is already set (claimed synchronously at
+    // executePrompt entry, before the refresh await), so this coalesces → pending 1. On the pre-fix code the
+    // flag is not set until AFTER the refresh, so this would pass the gate and double-start → pending 0.
     void session.submit('two');
     for (let i = 0; i < 200 && session.getPendingCount() === 0; i++) {
       await new Promise((r) => setTimeout(r, 0));
     }
     expect(session.getPendingCount()).toBe(1);
-    expect(session.isExecuting()).toBe(true); // still the ONE original turn — no second turn started
 
-    // Clear the coalesced input before releasing, so the internal pending-drain re-submit cannot race the
-    // afterEach dispose (which would reject "session is shutting down"). abort() also aborts the blocked first
-    // turn, which we then let settle. This test asserts the COALESCE (no double-start), not the drain.
+    // Unblock and let everything drain before teardown.
+    refreshCtl.blocking = false;
+    refreshCtl.release?.();
     session.abort();
-    releaseAsk?.({ type: 'answer', values: ['a'] });
-    await first.catch(() => undefined); // the aborted turn settles (abort is not an error to this test)
+    await first.catch(() => undefined);
     for (let i = 0; i < 200 && (session.isExecuting() || session.getPendingCount() > 0); i++) {
       await new Promise((r) => setTimeout(r, 0));
     }

--- a/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  scriptedSession,
+  type ScriptedSessionHarness,
+} from '../../testing/scripted-session-harness.js';
+
+import type { TActionResponse } from '@robota-sdk/agent-core';
+
+/**
+ * CORE-026 RUNTIME-12 — turn double-start race.
+ *
+ * `submit()` gates on `execCtrl.executing`, but the flag used to be set only AFTER the awaited
+ * `checkAndRefreshContextIfStale`, leaving a two-await window where two concurrent entries could both observe
+ * "idle" and both start a turn. The fix claims `executing` SYNCHRONOUSLY at `executePrompt` entry, so a second
+ * concurrent submit observes it and coalesces to the pending queue instead of double-starting.
+ *
+ * The first turn is held in flight deterministically by blocking on a model-issued AskUserQuestion whose
+ * `askHandler` answer we release manually — so the concurrent submit reliably arrives while a turn IS executing.
+ */
+describe('CORE-026 RUNTIME-12 — no turn double-start', () => {
+  let harness: ScriptedSessionHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  it('a second concurrent submit coalesces to pending instead of starting a second turn', async () => {
+    let releaseAsk: ((v: TActionResponse) => void) | undefined;
+    const blockedAnswer = new Promise<TActionResponse>((resolve) => {
+      releaseAsk = resolve;
+    });
+
+    harness = scriptedSession({
+      // The first turn asks; this handler BLOCKS until we release it, holding that turn in flight.
+      askHandler: () => blockedAnswer,
+      turns: [
+        {
+          toolCalls: [
+            {
+              name: 'AskUserQuestion',
+              args: { questions: [{ question: 'q?', options: [{ label: 'a' }] }] },
+            },
+          ],
+        },
+        { text: 'first turn done' },
+        { text: 'coalesced turn done' },
+      ],
+    });
+    const session = harness.session;
+
+    // Start the first turn but do NOT await — it blocks at the AskUserQuestion.
+    const first = session.submit('one');
+
+    // Wait until the first turn is executing (blocked at the ask).
+    for (let i = 0; i < 200 && !session.isExecuting(); i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(session.isExecuting()).toBe(true);
+
+    // A concurrent submit while a turn is in flight MUST coalesce to the pending queue — not double-start.
+    // (submit() awaits ensureInitialized before reaching the gate, so poll until it lands in the queue; the
+    // first turn stays blocked at the ask the whole time, so a coalesce is the only correct outcome.)
+    void session.submit('two');
+    for (let i = 0; i < 200 && session.getPendingCount() === 0; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(session.getPendingCount()).toBe(1);
+    expect(session.isExecuting()).toBe(true); // still the ONE original turn — no second turn started
+
+    // Clear the coalesced input before releasing, so the internal pending-drain re-submit cannot race the
+    // afterEach dispose (which would reject "session is shutting down"). abort() also aborts the blocked first
+    // turn, which we then let settle. This test asserts the COALESCE (no double-start), not the drain.
+    session.abort();
+    releaseAsk?.({ type: 'answer', values: ['a'] });
+    await first.catch(() => undefined); // the aborted turn settles (abort is not an error to this test)
+    for (let i = 0; i < 200 && (session.isExecuting() || session.getPendingCount() > 0); i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+  });
+});

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -265,40 +265,46 @@ export class SessionExecutionController {
     submit: TSubmitFn,
     turnOptions: ITurnOptions = {},
   ): Promise<void> {
-    await checkAndRefreshContextIfStale(
-      agentsFileEntries,
-      claudeFileEntries,
-      rebuildSystemMessage,
-      setEntries,
-      () => this.callbacks.getSessionOrThrow(),
-      (event: string, payload: unknown) => this.callbacks.emit(event, payload),
-    );
+    // RUNTIME-12: claim the turn SYNCHRONOUSLY at entry. The caller's `if (execCtrl.executing)` gate
+    // (interactive-session.submit) and this assignment are synchronous, so a second concurrent submit
+    // observes `executing` and coalesces to the pending queue instead of BOTH starting a turn. (Previously
+    // set only AFTER the awaited checkAndRefreshContextIfStale below, leaving a two-await window where both
+    // entries saw idle.) The `finally` always releases it — including if the refresh throws, which is why
+    // checkAndRefreshContextIfStale now runs INSIDE the try.
     this.executing = true;
     // REMOTE-014 E5: capture the ACTIVE turn's driver so event/prompt emitters can attribute to it.
     this.activeDriverId = turnOptions.driverId ?? null;
-    this.clearStreaming();
-    // FLOW-002: surface the turn origin so consumers (hooks, TUI) can distinguish a human
-    // prompt from an agent-wakeup re-entry.
-    this.callbacks.emit('turn_source', turnOptions.turnSource ?? 'user');
-    this.callbacks.emit('user_message', displayInput ?? input);
-    this.callbacks.emit('thinking', true);
     // SELFHOST-008 P2: stash the completed turn's result so post-turn capture can run in the `finally`
     // BEFORE persistSession() (awaiting inside `onComplete` would not order there — it is not awaited).
     let completedResult: IExecutionResult | undefined;
-    // SELFHOST-008 P3: per-turn recall — compute the ephemeral `<recalled-memory>` block (query = input)
+    // SELFHOST-008 P3: per-turn recall — the ephemeral `<recalled-memory>` block (query = input) computed
     // BEFORE the turn's model call, guarded so a recall failure skips injection but never breaks the turn.
     let ephemeralSystemContext: string | undefined;
-    if (this.callbacks.recallMemory) {
-      try {
-        const recalled = await this.callbacks.recallMemory(input);
-        if (recalled && recalled.trim().length > 0) ephemeralSystemContext = recalled;
-      } catch {
-        // allow-fallback: per-turn recall is best-effort over the always-present startup memory; a recall
-        // error skips ephemeral injection and the turn proceeds normally (SELFHOST-008 P3 declared degradation).
-        ephemeralSystemContext = undefined;
-      }
-    }
     try {
+      await checkAndRefreshContextIfStale(
+        agentsFileEntries,
+        claudeFileEntries,
+        rebuildSystemMessage,
+        setEntries,
+        () => this.callbacks.getSessionOrThrow(),
+        (event: string, payload: unknown) => this.callbacks.emit(event, payload),
+      );
+      this.clearStreaming();
+      // FLOW-002: surface the turn origin so consumers (hooks, TUI) can distinguish a human
+      // prompt from an agent-wakeup re-entry.
+      this.callbacks.emit('turn_source', turnOptions.turnSource ?? 'user');
+      this.callbacks.emit('user_message', displayInput ?? input);
+      this.callbacks.emit('thinking', true);
+      if (this.callbacks.recallMemory) {
+        try {
+          const recalled = await this.callbacks.recallMemory(input);
+          if (recalled && recalled.trim().length > 0) ephemeralSystemContext = recalled;
+        } catch {
+          // allow-fallback: per-turn recall is best-effort over the always-present startup memory; a recall
+          // error skips ephemeral injection and the turn proceeds normally (SELFHOST-008 P3 declared degradation).
+          ephemeralSystemContext = undefined;
+        }
+      }
       await executePromptTurn(input, displayInput, rawInput, {
         ...(ephemeralSystemContext !== undefined ? { ephemeralSystemContext } : {}),
         getSession: () => this.callbacks.getSessionOrThrow(),

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -539,10 +539,17 @@ export class InteractiveSession
     if (this.execCtrl.shuttingDown) return false;
     if (this.execCtrl.wakeTaskIds.has(sourceTaskId)) return false;
     this.execCtrl.wakeTaskIds.add(sourceTaskId);
+    // RUNTIME-26: the wake turn runs detached — route its rejection to reportBackgroundError instead of
+    // letting it vanish (e.g. a turn error, or the "shutting down" throw when a wake races teardown).
     void this.submit(instruction, undefined, undefined, {
       turnSource: 'agent-wakeup',
       wakeTaskId: sourceTaskId,
-    });
+    }).catch((error) =>
+      this.reportBackgroundError(
+        error instanceof Error ? error : new Error(String(error)),
+        'agent-wakeup',
+      ),
+    );
     return true;
   }
 
@@ -933,10 +940,18 @@ export class InteractiveSession
   private resumeGoalIfActive(): void {
     const goal = this.goalController.getState();
     if (!goal || goal.status !== 'active') return;
-    void this.ensureInitialized().then(() => {
-      if (!this.goalController.isActive() || this.execCtrl.shuttingDown) return;
-      this.scheduleGoalTurn(buildGoalContinuationPrompt(goal), goal);
-    });
+    // RUNTIME-26: route a detached init/goal-resume rejection to reportBackgroundError rather than dropping it.
+    void this.ensureInitialized()
+      .then(() => {
+        if (!this.goalController.isActive() || this.execCtrl.shuttingDown) return;
+        this.scheduleGoalTurn(buildGoalContinuationPrompt(goal), goal);
+      })
+      .catch((error) =>
+        this.reportBackgroundError(
+          error instanceof Error ? error : new Error(String(error)),
+          'goal-resume',
+        ),
+      );
   }
 
   private async switchProvider(profileName: string): Promise<void> {

--- a/packages/agent-transport/.eslintrc.json
+++ b/packages/agent-transport/.eslintrc.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../.eslintrc.json",
   "plugins": ["import"],
+  "parserOptions": { "project": "./tsconfig.json" },
   "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
     "import/order": [
       "warn",
       {

--- a/packages/agent-transport/src/headless/__tests__/headless-runner.test.ts
+++ b/packages/agent-transport/src/headless/__tests__/headless-runner.test.ts
@@ -99,6 +99,20 @@ describe('createHeadlessRunner (text format)', () => {
     expect(stdoutWriteSpy).not.toHaveBeenCalled();
   });
 
+  it('CORE-026 RUNTIME-36: a slash-command that THROWS exits non-zero instead of hanging', async () => {
+    const session = createMockSession('complete');
+    // A thrown executeCommand previously left the exit-code promise unresolved (the `.then` had no `.catch`).
+    (session.executeCommand as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('command boom'),
+    );
+    const runner = createHeadlessRunner({ session, outputFormat: 'text' });
+
+    // Would hang (test timeout) without the RUNTIME-36 `.catch` → onError → resolve(1).
+    const exitCode = await runner.run('/failing-command');
+
+    expect(exitCode).toBe(1);
+  });
+
   it('TC-02 (CLI-064): text format writes the error message to stderr on error', async () => {
     const stderrWrites: string[] = [];
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {

--- a/packages/agent-transport/src/headless/headless-runner.ts
+++ b/packages/agent-transport/src/headless/headless-runner.ts
@@ -8,6 +8,11 @@ import type {
 
 export type TOutputFormat = 'text' | 'json' | 'stream-json';
 
+/** RUNTIME-36: normalize a caught unknown into an Error for the error/exit-code handlers. */
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 /** GOAL-001: options for an autonomous headless goal run. */
 export interface IHeadlessGoalOptions {
   maxIterations?: number;
@@ -154,15 +159,20 @@ function runTextFormat(session: IInteractiveSession, prompt: string): Promise<nu
     session.on('interrupted', onInterrupted);
     session.on('error', onError);
 
-    void executeSlashCommandIfPresent(session, prompt).then((cmd) => {
-      if (cmd.kind === 'command-result') {
-        cleanup();
-        process.stdout.write(cmd.result.message + '\n');
-        resolve(cmd.result.success ? 0 : 1);
-        return;
-      }
-      if (cmd.kind !== 'session-execution') void session.submit(prompt);
-    });
+    // RUNTIME-36: a thrown slash-command (or a failed submit) must surface a non-zero exit via onError, not
+    // vanish and hang the exit-code promise.
+    void executeSlashCommandIfPresent(session, prompt)
+      .then((cmd) => {
+        if (cmd.kind === 'command-result') {
+          cleanup();
+          process.stdout.write(cmd.result.message + '\n');
+          resolve(cmd.result.success ? 0 : 1);
+          return;
+        }
+        if (cmd.kind !== 'session-execution')
+          void session.submit(prompt).catch((error) => onError(toError(error)));
+      })
+      .catch((error) => onError(toError(error)));
   });
 }
 
@@ -193,19 +203,23 @@ function runJsonFormat(session: IInteractiveSession, prompt: string): Promise<nu
     session.on('interrupted', onInterrupted);
     session.on('error', onError);
 
-    void executeSlashCommandIfPresent(session, prompt).then((cmd) => {
-      if (cmd.kind === 'command-result') {
-        cleanup();
-        writeJsonResult(
-          getSessionId(session),
-          cmd.result.message,
-          cmd.result.success ? 'success' : 'error',
-        );
-        resolve(cmd.result.success ? 0 : 1);
-        return;
-      }
-      if (cmd.kind !== 'session-execution') void session.submit(prompt);
-    });
+    // RUNTIME-36: a thrown slash-command / failed submit surfaces a non-zero exit via onError, never vanishes.
+    void executeSlashCommandIfPresent(session, prompt)
+      .then((cmd) => {
+        if (cmd.kind === 'command-result') {
+          cleanup();
+          writeJsonResult(
+            getSessionId(session),
+            cmd.result.message,
+            cmd.result.success ? 'success' : 'error',
+          );
+          resolve(cmd.result.success ? 0 : 1);
+          return;
+        }
+        if (cmd.kind !== 'session-execution')
+          void session.submit(prompt).catch((error) => onError(toError(error)));
+      })
+      .catch((error) => onError(toError(error)));
   });
 }
 
@@ -213,18 +227,26 @@ function runStreamJsonFormat(session: IInteractiveSession, prompt: string): Prom
   return new Promise<number>((resolve) => {
     const cleanup = subscribeStreamJsonEvents(session, getSessionId, writeJsonResult, resolve);
 
-    void executeSlashCommandIfPresent(session, prompt).then((cmd) => {
-      if (cmd.kind === 'command-result') {
-        cleanup();
-        writeJsonResult(
-          getSessionId(session),
-          cmd.result.message,
-          cmd.result.success ? 'success' : 'error',
-        );
-        resolve(cmd.result.success ? 0 : 1);
-        return;
-      }
-      if (cmd.kind !== 'session-execution') void session.submit(prompt);
-    });
+    // RUNTIME-36: route a thrown slash-command / failed submit to a non-zero exit instead of hanging resolve.
+    const failClosed = (error: unknown): void => {
+      cleanup();
+      writeJsonResult(getSessionId(session), '', 'error', toError(error));
+      resolve(1);
+    };
+    void executeSlashCommandIfPresent(session, prompt)
+      .then((cmd) => {
+        if (cmd.kind === 'command-result') {
+          cleanup();
+          writeJsonResult(
+            getSessionId(session),
+            cmd.result.message,
+            cmd.result.success ? 'success' : 'error',
+          );
+          resolve(cmd.result.success ? 0 : 1);
+          return;
+        }
+        if (cmd.kind !== 'session-execution') void session.submit(prompt).catch(failClosed);
+      })
+      .catch(failClosed);
   });
 }


### PR DESCRIPTION
Three code-reviewer-substantiated fixes (RUNTIME-21/24 dropped as non-defects), plus enabling the standard type-aware guard on the touched packages.

## Fixes
- **RUNTIME-12 — turn double-start race.** `submit()` gated on `execCtrl.executing`, but the flag was set only AFTER the awaited `checkAndRefreshContextIfStale`, leaving a two-await window where two concurrent entries both saw idle and both started a turn. Now claimed **synchronously at `executePrompt` entry**; the refresh moved inside the `try` so the `finally` still releases the flag on a refresh throw.
- **RUNTIME-26 — dropped detached rejections.** `requestWakeup`'s `void this.submit(...)` and `resumeGoalIfActive`'s `void this.ensureInitialized().then(...)` now `.catch → reportBackgroundError` (framework layer — the executor manager's deferred guard is left alone because `agent-executor` cannot reach `reportBackgroundError` without inverting the one-way dep).
- **RUNTIME-36 — headless exit-code.** All three headless slash-command runners' `executeSlashCommandIfPresent(...).then` gained a `.catch → onError` (fail-closed non-zero exit instead of a hung promise), and `print-mode` wraps `run`/`runGoal` + `process.exit(getExitCode())` in `try/catch` so a throw can't bypass the exit-code contract.
- **RUNTIME-21 / RUNTIME-24 — dropped** after code review: `runStream` already finalizes on generator `return`; `Session.run` wires the AbortController synchronously (no lost-abort window).

## Lint
`@typescript-eslint/no-floating-promises: error` (with `parserOptions.project`) enabled on `agent-core`, `agent-framework`, `agent-transport` — **0 errors** each. The monorepo-wide rollout is the deferred INFRA follow-up (the reviewer-endorsed split with a 3-package floor).

## Verification
- Deterministic RUNTIME-12 coalesce test (first turn held in flight on a released AskUserQuestion) + RUNTIME-36 throw→exit-1 test. **1868** agent-framework/agent-transport tests pass, no unhandled rejections. 62/62 scans.
- Fully gated: `.agents/spec-docs/active/CORE-026-floating-promise-races.md` (proposal-reviewer REVISE resolved — premises corrected/dropped); scenario `.agents/evals/scenarios/core-026-floating-promise-races-agent-run.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)