### PR TITLE
ci(security): add gitleaks secret scan + dependency-review PR gates

### DIFF
--- a/.agents/backlog/INFRA-041-pr-patch-coverage-gate.md
+++ b/.agents/backlog/INFRA-041-pr-patch-coverage-gate.md
@@ -1,0 +1,55 @@
+---
+title: 'INFRA-041: PR patch (diff) coverage gate — new/changed lines must be tested'
+status: todo
+created: 2026-07-22
+priority: medium
+urgency: soon
+area: .github/workflows, vitest config
+depends_on: []
+---
+
+# PR patch (diff) coverage gate
+
+## Problem
+
+CI enforces a **global** 80% line-coverage threshold (the `compat-node18` job:
+`--coverage.thresholds.lines=80`), but that has a real hole: a PR can add untested lines and still pass as
+long as the whole repo stays above 80%. This is the same class as the accidental-green problem
+([tdd-and-planning.md](../rules/tdd-and-planning.md) "Prove the regression test RED") — a change whose new code
+is not actually exercised by tests. A **patch/diff coverage** gate closes it: the lines a PR adds/changes must
+themselves be covered.
+
+Not a "just add a workflow" — it changes the test/coverage contract and needs coverage plumbing (see below),
+so it goes through the gate rather than being rushed into CI.
+
+## What (design — pick one at IMPLEMENT)
+
+**Plumbing needed either way:** the root/per-package vitest coverage config currently reports
+`['text','json','html']` — **no lcov**. Add `lcov` to `coverage.reporter` so a machine-readable report exists.
+
+- **Option A — `diff-cover` (self-hosted, no external service; matches the osv-binary pattern).** A PR job:
+  run coverage across packages → emit per-package `coverage/lcov.info` → merge (`lcov-result-merger
+'packages/*/coverage/lcov.info' merged.info`) → `diff-cover merged.info --compare-branch=origin/<base>
+--fail-under=<X>`. Python3 + `pip install diff-cover` are available on `ubuntu-latest`.
+- **Option B — Codecov patch status (reuse the existing codecov setup).** `deploy.yml` already uploads to
+  codecov post-merge; add a PR coverage-upload job + `codecov.yml` with `coverage.status.patch.target: <X>%`.
+  Codecov computes the diff mapping and posts a `codecov/patch` status. Needs `CODECOV_TOKEN` (or tokenless
+  for this public repo).
+
+Recommendation: **Option A** (no external dependency, deterministic, self-hosted — consistent with the repo's
+osv-scanner-binary approach), unless the codecov PR integration is wanted for the UI.
+
+## Threshold
+
+Start at a pragmatic patch target (e.g. 80% of changed lines), advisory first (non-required status) for a few
+PRs to calibrate the false-positive rate, then promote to a required check.
+
+## Test Plan
+
+- A fixture PR that adds an untested function → the gate FAILS on the diff; adding a test for it → PASSES.
+- Docs/config-only PRs (no coverable lines) → the gate is a no-op, not a false failure.
+
+## User Execution Test Scenarios
+
+- Not applicable (CI gate; the fixture PR above is the maintained proof).
+- Evidence: the fixture red/green run.

--- a/.agents/backlog/INFRA-042-nightly-mutation-testing.md
+++ b/.agents/backlog/INFRA-042-nightly-mutation-testing.md
@@ -1,0 +1,42 @@
+---
+title: 'INFRA-042: nightly mutation testing (Stryker) over core packages'
+status: todo
+created: 2026-07-22
+priority: low
+urgency: later
+area: .github/workflows, packages
+depends_on: ['INFRA-041']
+---
+
+# Nightly mutation testing (Stryker) over core packages
+
+## Problem
+
+The deepest defense against weak / accidental-green tests (the class that recurred twice — ARCH-004
+RUNTIME-14, CORE-026 RUNTIME-12; see [common-mistakes.md](../rules/common-mistakes.md) #82): mutation testing
+mutates the source (flip a `>` to `>=`, drop a statement, negate a condition) and re-runs the suite; a mutant
+that **survives** means no test noticed the change — i.e. a test that does not actually pin the behavior.
+Coverage says a line ran; mutation says a line's behavior is _asserted_.
+
+Deliberately deferred and SCOPED — mutation runs the suite once per mutant, so it is far too expensive for
+per-PR CI. Run it nightly/weekly over a bounded set.
+
+## What
+
+1. Add `@stryker-mutator/core` + the vitest runner (`@stryker-mutator/vitest-runner`).
+2. A `stryker.conf` scoped to the highest-value core packages first (e.g. `agent-core` permissions/gate,
+   `agent-session` permission-enforcer, `agent-executor` state-machine) — NOT the whole monorepo.
+3. A scheduled workflow (`on: schedule` nightly + manual `workflow_dispatch`), not `pull_request`. Publish the
+   mutation score + surviving-mutant report as an artifact / summary.
+4. Set a starting mutation-score threshold advisory-only; ratchet up over time. Surviving mutants become
+   test-hardening work items.
+
+## Test Plan
+
+- A known-weak test (asserts a late invariant) leaves a surviving mutant that Stryker reports; hardening the
+  test kills it. Validate on one package before widening scope.
+
+## User Execution Test Scenarios
+
+- Not applicable (scheduled CI quality job; the report is the maintained artifact).
+- Evidence: the first nightly run's mutation-score report over the scoped packages.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,39 @@
+name: Dependency Review
+
+# Gate PR-introduced dependencies by vulnerability AND license policy (distinct from the lockfile-wide
+# osv-scanner in ci.yml): dependency-review diffs the PR's ADDED deps and enforces a license deny-list.
+# License gating matters here — the project is dual-licensed (AGPL + Commercial, no CLA yet), so a runtime
+# dep under a strong-copyleft license would virally break the commercial-relicensing right.
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize]
+    # Dependency review is only meaningful when the dependency graph changes. This job is ADVISORY (not a
+    # required status check), so a paths-skip is safe — for a REQUIRED check, a paths-filtered skip reports
+    # "pending" forever and blocks merge, which is why ci.yml uses IN-JOB change detection instead.
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    # Fork PRs cannot post the summary comment; the check still runs read-only.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/dependency-review-action@v4
+        with:
+          # Block the PR on a newly-introduced HIGH+ vulnerability.
+          fail-on-severity: high
+          # Strong-copyleft licenses that would compromise the commercial-relicensing right of the dual
+          # license. Permissive (MIT/Apache-2.0/BSD/ISC) deps are unaffected. LGPL is intentionally NOT denied
+          # (weaker, dynamic-link copyleft) — revisit if a static-bundling concern arises.
+          deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,43 @@
+name: Secret Scan
+
+# Detect secrets/keys committed in a PR's diff. Runs the gitleaks binary directly (mirrors the osv-scanner
+# pattern in ci.yml) — no third-party action, no license key. A committed secret is an irreversible leak
+# (it stays in history and is indexed even if deleted), so this is a cheap gate against a severe, unrecoverable
+# failure. The repo routinely handles tokens (SEC-001 loopback tokens, provider API keys, deploy keys).
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: 8.21.2
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}" --depth=50
+      - name: Install gitleaks
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "$RUNNER_TEMP/gitleaks.tar.gz"
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
+          chmod +x "$RUNNER_TEMP/gitleaks"
+      - name: Scan PR commits for secrets
+        run: |
+          "$RUNNER_TEMP/gitleaks" detect \
+            --source . \
+            --config .gitleaks.toml \
+            --log-opts "origin/${{ github.base_ref }}..HEAD" \
+            --redact \
+            --no-banner \
+            --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# Gitleaks config (single SSOT, like osv-scanner.toml). Extends the default ruleset; the allowlist below
+# suppresses known-safe patterns so the secret scan is signal, not noise. Add a NARROW entry (with a reason)
+# when a real false positive appears — never broaden to whole product directories that could hide a real leak.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Robota repo allowlist — deterministic test fixtures and env-reference placeholders"
+
+# Test doubles / fixtures / e2e scripts commonly embed FAKE tokens to drive the scripted provider, permission,
+# and transport-auth paths; evals scenarios document example tokens (e.g. a 64-hex loopback WS token); build
+# artifacts (dist/, the Electron release bundle) contain third-party JWTs and are not source.
+paths = [
+  '''(^|/)__tests__/''',
+  '''(^|/)__fixtures__/''',
+  '''(^|/)e2e/''',
+  '''\.test\.(ts|tsx|js|mjs|cjs)$''',
+  '''\.bintest\.ts$''',
+  '''(^|/)\.agents/evals/''',
+  '''(^|/)pnpm-lock\.yaml$''',
+  # Build outputs (not source, and typically gitignored — belt-and-suspenders for local scans).
+  '''(^|/)dist/''',
+  '''(^|/)release/''',
+  '''\.asar$''',
+]
+
+# `$ENV:<NAME>` is the agent-core environment-reference format (a placeholder, never a literal secret), and
+# obvious example/placeholder keys used in docs/config samples.
+regexes = [
+  '''\$ENV:[A-Z0-9_]+''',
+  '''(?i)(example|placeholder|dummy|fake|test|your-?)[-_]?(api[-_]?key|token|secret)''',
+  '''sk-(ant-)?(example|test|placeholder|xxx)[A-Za-z0-9-]*''',
+]


### PR DESCRIPTION
Two cheap, high-value PR-time **security** gates (the owner-approved immediate set). They fill real gaps — `osv-scanner` already covers lockfile-wide dep vulns, and global coverage + commitlint already exist.

## Gates added
- **Secret scan (gitleaks)** — scans the PR diff (`origin/<base>..HEAD`) for committed secrets/keys. A committed secret is an **irreversible** leak (stays in history, indexed even if deleted); the repo routinely handles tokens (SEC-001 loopback tokens, provider keys, deploy keys). Runs the gitleaks binary directly (mirrors the osv-scanner pattern — no third-party action/license). `.gitleaks.toml` is the SSOT allowlist; **verified 0 findings** on the working tree after tuning (test fixtures / e2e / evals scenarios / `$ENV:` placeholders / build artifacts).
- **Dependency review** — gates PR-**introduced** deps by HIGH+ vulnerability **and** a license deny-list (GPL/AGPL family). The license gate protects the **dual (AGPL + Commercial, no-CLA) relicensing right** — a strong-copyleft runtime dep would virally break it. Path-filtered to manifest/lock changes; **advisory** (not a required check).

## Deferred to backlog (properly, via the gate)
- **INFRA-041** — PR patch/diff coverage gate (new/changed lines must be tested; closes the global-80%-threshold hole — same class as accidental-green). Needs an lcov reporter + coverage-merge plumbing, so it's specced not rushed.
- **INFRA-042** — nightly Stryker mutation testing over core packages (the deepest defense against weak/accidental-green tests).

Note on **path-conditional CI** (owner question): required checks use in-job change detection (ci.yml's `build_requirement`/`dependency_changes`) because a `paths`-skipped *required* check reports pending forever; advisory jobs like this one can safely use `on.paths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)