### PR TITLE
chore(backlog): re-scope CLI-061 to watch upstream Ink for the CJK-IME fix

### DIFF
--- a/.agents/backlog/CLI-061-ime-last-character-drop.md
+++ b/.agents/backlog/CLI-061-ime-last-character-drop.md
@@ -1,45 +1,53 @@
 ---
-title: 'CLI-061: Korean IME last composed character dropped on Enter in TUI input'
+title: 'CLI-061: watch Ink upstream for a Korean-IME composition fix, then upgrade + verify'
 status: todo
 created: 2026-06-10
-priority: medium
-urgency: soon
-area: packages/agent-transport
+priority: low
+urgency: later
+area: packages/agent-cli, packages/agent-transport-tui
 depends_on: []
+blocked_on: 'upstream ink (raw-mode composition / IME handling)'
 ---
 
-# CLI-061: Korean IME last character drop on Enter
+# CLI-061: Korean IME last-character drop — track upstream Ink, do not patch locally
 
 ## Problem
 
-When typing Korean via IME in the TUI input and pressing Enter, the last in-composition
-character can be lost. Documented as a known limitation in
-`packages/agent-transport/src/tui/InputArea.tsx:42-45`: Ink raw mode exposes no
-compositionstart/compositionend events. For the product's primary Korean-speaking users this
-corrupts almost every submitted prompt ending in Hangul — a core input feature that exists but
-does not work correctly.
+When typing Korean via IME in the TUI input and pressing Enter, the last in-composition character can be
+lost. Root cause: **Ink runs stdin in raw mode, which exposes no `compositionstart`/`compositionend` events**
+(documented in `packages/agent-transport/src/tui/InputArea.tsx`). Byte-level jamo composition cannot be
+reliably distinguished from a completed keystroke at our layer, so a local mitigation (deferring submit,
+flushing pending bytes, timing heuristics) is fragile and risks double-submit / added latency on non-IME input.
 
-## Expected Behavior
+**Decision (owner, 2026-07-23): do NOT patch this locally.** A robust fix belongs upstream in Ink's raw-mode
+input handling. This item is re-scoped from "implement a fix" to **"watch Ink for a version that addresses it,
+then upgrade and verify."**
 
-Submitted prompt text includes the final composed character. Candidate mitigations to evaluate
-(spec/design first): deferring submit by one input tick when the last byte sequence is an
-incomplete/in-flight Hangul jamo composition; flushing pending composition bytes before
-treating Enter as submit; or upstream Ink/stdin handling improvements.
+## What (monitor → upgrade → verify)
+
+Current Ink: **`^7.0.5`** (`packages/agent-cli`, `packages/agent-transport-tui`).
+
+1. **Periodically check** for a newer Ink release (> the currently-pinned version) whose changelog / release
+   notes mention IME / composition / CJK / raw-mode input handling. Sources: the Ink GitHub releases +
+   CHANGELOG, and the open IME/CJK issues on the Ink repo.
+2. **When a candidate version ships**, bump Ink in both packages, rebuild, and run the CJK verification below.
+3. If verified fixed → close this item with evidence. If a candidate ships but does NOT fix it → record the
+   checked version + result and keep watching.
 
 ## Test Plan
 
-- Unit tests on the input flow reducer feeding byte sequences that simulate IME composition
-  followed by Enter (the cjk-text-input-flow is a pure module and testable).
-- Regression tests for non-IME input (no added latency or double-submit).
-- `pnpm --filter @robota-sdk/agent-transport test`
+- On an Ink bump: `pnpm --filter @robota-sdk/agent-transport-tui --filter @robota-sdk/agent-cli build && test`
+  (no TUI regression).
+- Verify the CJK scenario below on the built binary.
 
 ## User Execution Test Scenarios
 
-- Prerequisite: macOS/iTerm2 (and Terminal.app) with Korean IME; built CLI binary. Environment
-  already exists.
-- Steps: run `robota`, type `안녕하세요` and press Enter immediately while the last syllable is
-  still composing.
-- Expected observable result: the submitted user message in the transcript shows the full text
-  `안녕하세요` including the final syllable.
-- Cleanup: none.
-- Evidence: (fill after implementation — TUI capture showing complete submitted text)
+- Prerequisite: macOS/iTerm2 (or Terminal.app) with Korean IME; built CLI binary.
+- Steps: run `robota`, type `안녕하세요`, press Enter immediately while the last syllable is still composing.
+- Expected: the submitted user message shows the full `안녕하세요` including the final syllable.
+- Evidence: (fill after an Ink bump that claims a fix — TUI capture of the complete submitted text).
+
+## Notes
+
+- This is a **blocked, watch-only** item — no local code change is planned unless the owner reverses the
+  decision. It surfaces on each Ink dependency bump (Dependabot / manual) as the natural re-check trigger.


### PR DESCRIPTION
Per owner decision (2026-07-23): the Korean-IME last-character drop is an **Ink raw-mode limitation** (Ink exposes no `compositionstart`/`compositionend` events). A local mitigation is fragile (double-submit / added-latency risk on non-IME input), so **do not patch locally** — the robust fix belongs upstream in Ink.

Re-scopes CLI-061 from "implement a fix" to a **watch-only** item:
- Monitor Ink releases (current `^7.0.5`) for a version whose changelog/notes mention IME / CJK / composition / raw-mode input.
- When a candidate ships → bump Ink in both packages, rebuild, and run the CJK verification; close with evidence if fixed, else record the checked version and keep watching.
- Set `low`/`later`, `blocked_on: upstream ink`; the natural re-check trigger is an Ink dependency bump (Dependabot / manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)