### PR TITLE
docs(oss): standard OSS health files + CodeQL + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot — automated dependency + GitHub Actions update PRs.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # npm/pnpm dependencies (one entry covers the whole workspace via the root lockfile).
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    # Keep the noise down: batch non-major updates into grouped PRs; majors stay individual for review.
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Security updates are always opened regardless of the schedule.
+
+  # GitHub Actions used in .github/workflows (keeps action versions current + patches supply-chain CVEs).
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for the PR! Keep the title in Conventional Commits form (e.g. `feat: ...`, `fix: ...`) — commitlint
+checks it. Fill in the sections below and delete this comment.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Docs / chore / refactor (no runtime behavior change)
+
+## How was this tested?
+
+<!-- Commands run and what you verified. For a bug/regression fix, confirm the new test FAILS without the fix
+     (prove it red against the pre-fix state) — a test that passes on the buggy code guards nothing. -->
+
+## Checklist
+
+- [ ] `pnpm build` / `pnpm typecheck` / `pnpm lint` / `pnpm test` pass for the affected packages
+- [ ] `pnpm harness:scan` passes (repo gates)
+- [ ] Tests added/updated for the change (and a bug fix's regression test is proven red-before-green)
+- [ ] Docs updated where relevant (package `docs/SPEC.md`, README, `content/`)
+- [ ] Commits follow Conventional Commits
+- [ ] Targets `develop` (feature → develop → main; only `develop`/`release/*`/`hotfix/*` may target `main`)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+# Static analysis (SAST) for JavaScript/TypeScript — GitHub's standard code-scanning gate. Advisory: results
+# appear in the Security → Code scanning tab and as PR annotations, not as a required merge check unless added
+# to branch protection.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Weekly full scan (catches issues in code that a given PR didn't touch).
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # `security-and-quality` adds maintainability queries on top of the default security set.
+          queries: security-and-quality
+      # JS/TS needs no compilation; autobuild is a no-op but keeps the standard 3-step shape.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,108 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free
+experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy
+community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will
+take appropriate and fair corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki
+edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate
+reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially
+representing the community in public spaces. Examples of representing our community include using an official
+email address, posting via an official social media account, or acting as an appointed representative at an
+online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
+responsible for enforcement by opening a private report through
+[GitHub's private reporting](https://github.com/woojubb/robota/security/advisories/new) or by contacting the
+maintainers. <!-- maintainers: set a dedicated conduct contact email here if you prefer one. -->
+
+All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to
+respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action
+they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the
+violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time.
+Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a
+specified period of time. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained
+inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of
+individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+Robota is under active development toward a stable release. Security fixes are applied to the **latest
+published release** on the `main` line. Older pre-release versions are not maintained — please upgrade to the
+latest release before reporting.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Report a vulnerability privately through GitHub's private vulnerability reporting:
+
+- Go to the repository's **Security** tab → **Report a vulnerability**
+  (<https://github.com/woojubb/robota/security/advisories/new>).
+
+<!-- maintainers: to enable the "Report a vulnerability" button, turn on
+     Settings → Code security and analysis → Private vulnerability reporting. -->
+
+Please include, as much as you can:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) / version(s) and, if known, the affected code path.
+- Steps to reproduce (a minimal proof of concept is ideal).
+- Any suggested remediation.
+
+## What to Expect
+
+- **Acknowledgement**: we aim to acknowledge a report within a few business days.
+- **Assessment**: we will investigate, determine severity, and keep you informed of progress.
+- **Fix & disclosure**: we will work on a fix and coordinate a disclosure timeline with you. We ask that you
+  give us a reasonable window to release a fix before any public disclosure.
+- **Credit**: with your permission, we are happy to credit you in the release notes / advisory.
+
+## Scope
+
+This policy covers the code in this repository (the `@robota-sdk/*` packages, the CLI, and the apps under
+`apps/`). Vulnerabilities in third-party dependencies should be reported upstream; if a dependency issue
+affects Robota, we still want to hear about it so we can pin or patch.
+
+Thank you for helping keep Robota and its users safe.


### PR DESCRIPTION
Completes the standard open-source project apparatus (GitHub **Community Standards** + common automation). Existing files (LICENSE, README, CONTRIBUTING, CHANGELOG, CODEOWNERS, ISSUE_TEMPLATE, Discussions, topics) are untouched — this fills the gaps, written neutrally (no contribution-policy framing).

## Added
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1.
- **SECURITY.md** — private vulnerability reporting + supported versions + response expectations.
- **.github/pull_request_template.md** — standard checklist aligned to the repo gates (Conventional Commits, build/typecheck/lint/test/scans, docs/SPEC, feature→develop→main; includes the red-before-green regression-test reminder).
- **.github/dependabot.yml** — weekly npm + github-actions update PRs (grouped minor/patch; security updates always). Also the natural Ink-bump trigger for the re-scoped CLI-061 upstream watch.
- **.github/workflows/codeql.yml** — standard JS/TS SAST (advisory; push/PR + weekly schedule).

## Two dashboard toggles for the owner (not code)
1. **Enable Private Vulnerability Reporting** — Settings → Code security and analysis → *Private vulnerability reporting* (lights up the "Report a vulnerability" button SECURITY.md links to).
2. (Optional) add CodeQL / Cloudflare Pages to **required checks** only if you want them to hard-block merges — they're advisory by default.

Note: the CoC + SECURITY.md reference GitHub private reporting; if you prefer a dedicated contact email, set it where the `<!-- maintainers: ... -->` comments are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)