### PR TITLE
docs(process): DX-001 close-out — reconcile PR Unit Rule + checklist nudge

### DIFF
--- a/.agents/backlog/completed/DX-001-pr-batching-policy.md
+++ b/.agents/backlog/completed/DX-001-pr-batching-policy.md
@@ -1,6 +1,7 @@
 ---
 title: 'DX-001: PR batching policy — bundle coherent work into appropriately-sized PRs (fewer CI waits)'
-status: in-progress
+status: done
+completed: 2026-07-23
 created: 2026-07-16
 priority: high
 urgency: now
@@ -9,6 +10,16 @@ depends_on: []
 ---
 
 # PR batching policy
+
+## Outcome (DONE 2026-07-23)
+
+Policy authored in `git-branch.md` (§ "PR Batching — appropriately-sized PRs (DX-001)", PR #1189):
+coherent-work-unit + soft size ceiling (~600 lines / ~15 files), one conventional commit per logical
+step, reconciled against the One-Branch-At-A-Time / PR Unit Rule (unrelated → separate PRs; related
+steps of one unit → one multi-commit PR). Test-Plan follow-ups closed here: `backlog-execution.md`'s
+PR Unit Rule now cross-references the batching policy (clarifying the "one backlog per PR default" is
+not an anti-batching rule), and `post-implementation-checklist` Step 4 carries the batching nudge. No
+mechanical scan (soft process guideline, as the Test Plan specified).
 
 ## Problem
 

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -110,6 +110,12 @@ startup. Any push with modified or staged uncommitted files is blocked with exit
 - If a backlog is too large, split it into explicitly named work units before implementation; each
   work unit must have its own recommendation gate.
 - Do not combine unrelated backlogs in one PR.
+- **This default is not an anti-batching rule.** A single coherent work-unit (one design-gate pass,
+  one authoring pass, a rule + its enforcement + its wiring) belongs in ONE multi-commit PR — do not
+  split it into many tiny PRs that each wait on a full CI run. Bundle by coherence + a soft size ceiling
+  (~600 changed lines / ~15 files); see the [PR Batching policy](git-branch.md) (DX-001) in `git-branch.md`
+  for the exact criteria. The line: **unrelated backlogs → separate PRs; related steps of one unit →
+  one PR.**
 - **Sequence by relatedness.** Decide the execution shape from whether items share files or contracts:
   items that touch the **same files/contracts are related — serialize them** (one ordered unit, or
   sequential PRs on the same seam) so reviews and merges do not interleave or conflict. Items that are

--- a/.agents/skills/post-implementation-checklist/SKILL.md
+++ b/.agents/skills/post-implementation-checklist/SKILL.md
@@ -87,6 +87,11 @@ For each modified package:
 
 - [ ] Commit all SPEC + README + code changes
 - [ ] Push to current branch
+- [ ] **PR batching (DX-001):** keep one coherent work-unit in ONE multi-commit PR (one conventional
+      commit per logical step) rather than opening many tiny PRs that each wait on a full CI run — split
+      only when the bundle exceeds the soft ceiling (~600 changed lines / ~15 files) or a part is
+      independently revertible. Unrelated backlogs still go in separate PRs. See the
+      [PR Batching policy](../../rules/git-branch.md).
 
 ### 5. npm Publish (if public packages changed)
 


### PR DESCRIPTION
## What

Closes out **DX-001** (PR batching policy, `priority: high`/`urgency: now`). The core policy landed in `git-branch.md` via #1189; this finishes the two remaining Test-Plan follow-ups and archives the item.

- **`backlog-execution.md` PR Unit Rule** now cross-references the batching policy — clarifying the "one backlog per PR by default" line is *not* an anti-batching rule (a coherent multi-commit work-unit belongs in one PR; only unrelated backlogs split).
- **`post-implementation-checklist` Step 4** carries the batching nudge (one coherent unit → one multi-commit PR; split at the ~600-line / ~15-file soft ceiling).
- **DX-001 → `backlog/completed/`** with an Outcome note; no mechanical scan (soft process guideline, as the Test Plan specified).

## Verification

- 63/63 harness scans pass.
- Docs/process-only; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)