### PR TITLE
feat(harness): HARNESS-041 accidental-green regression-test floor

### DIFF
--- a/.agents/backlog/INFRA-044-dependency-vuln-remediation-and-audit-scheduling.md
+++ b/.agents/backlog/INFRA-044-dependency-vuln-remediation-and-audit-scheduling.md
@@ -1,0 +1,54 @@
+---
+title: 'INFRA-044: triage 18 pre-existing dependency advisories + run security-audit on a schedule (not only on manifest PRs)'
+status: todo
+created: 2026-07-23
+priority: high
+urgency: soon
+area: .github/workflows/ci.yml, osv-scanner.toml, pnpm-lock.yaml
+depends_on: []
+---
+
+# INFRA-044: dependency-vulnerability remediation + audit-scheduling gap
+
+## Problem
+
+The `security-audit` CI job runs osv-scanner **only when a PR changes `package.json`/`pnpm-lock.yaml`**
+(`.github/workflows/ci.yml` "Detect dependency graph changes"). Advisories published against dependencies
+already in the lockfile therefore accumulate **invisibly** — no PR that leaves the manifest untouched ever runs
+the scan. Surfaced 2026-07-23 when HARNESS-041 added a single `package.json` script line and the audit tripped on
+**18 pre-existing advisories** (none introduced by that PR):
+
+| Package               | Version                | Advisory                                                      | CVSS            |
+| --------------------- | ---------------------- | ------------------------------------------------------------- | --------------- |
+| svgo                  | 4.0.1                  | GHSA-2p49-hgcm-8545                                           | 8.2             |
+| brace-expansion (dev) | 1.1.15 / 2.1.1 / 5.0.6 | GHSA-3jxr-9vmj-r5cp                                           | 7.7             |
+| fast-uri              | 3.1.2                  | GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx                      | 7.5             |
+| js-yaml               | 4.2.0                  | GHSA-52cp-r559-cp3m                                           | 7.5             |
+| sharp                 | 0.34.5                 | GHSA-f88m-g3jw-g9cj                                           | 7.0             |
+| hono                  | 4.12.25                | GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59, GHSA-xgm2-5f3f-mvvc | 6.5 / 6.1 / 4.8 |
+| protobufjs            | 8.6.3                  | GHSA-j3f2-48v5-ccww, GHSA-jfj6-75fj-8934                      | 5.3 / 4.8       |
+| @astrojs/rss          | 4.0.18                 | GHSA-8j5q-mfj2-5q9q                                           | 4.3             |
+| body-parser           | 1.20.5 / 2.2.2         | GHSA-v422-hmwv-36x6                                           | 3.7             |
+| dompurify             | 3.4.11                 | GHSA-c2j3-45gr-mqc4                                           | 2.1             |
+
+(The one already-accepted `ip@2.0.1` SSRF is correctly filtered via `osv-scanner.toml` — REMOTE-001.)
+
+## What
+
+1. **Triage each advisory**: bump to a fixed version where one exists (most of these have fixes), or add a
+   documented accepted-risk entry to `osv-scanner.toml` (the single SSOT) with a reachability rationale — matching
+   the existing `ip@2.0.1` precedent. Prioritise the high-CVSS transitive deps (svgo/brace-expansion/fast-uri/
+   js-yaml/sharp).
+2. **Close the scheduling gap**: run `security-audit` (osv-scanner) on a **schedule** (nightly/weekly `cron`) and/or
+   on every PR — not only when the manifest changes — so newly-published advisories are caught within a day
+   instead of at the next accidental `package.json` edit. Keep the manifest-change fast path; add a scheduled full
+   scan.
+
+## Test Plan
+
+- After triage, `osv-scanner scan source --config osv-scanner.toml --lockfile pnpm-lock.yaml` exits 0.
+- The scheduled workflow run appears green on `develop` and correctly fails on an injected known-vuln fixture.
+
+## User Execution Test Scenarios
+
+- Not applicable (CI/security infra). Evidence: a green osv-scanner run + the scheduled-workflow run URL.

--- a/.agents/spec-docs/active/HARNESS-041-accidental-green-regression-test-floor.md
+++ b/.agents/spec-docs/active/HARNESS-041-accidental-green-regression-test-floor.md
@@ -176,14 +176,26 @@ commitSubjects, reverseApply, runVitest, restore, isDirty, readText, fileExists 
 
 ### [GATE-VERIFY] — ✅ PASS | 2026-07-23
 
-- **25 unit tests** (`scripts/harness/__tests__/check-regression-red-proof.test.mjs`) cover the full fixture
-  matrix: genuinely-red, accidental-green, inconclusive-transform-error (C1), not-imported (C3), dirty-tree (C4),
-  opt-out, not-fix, no-pair, and restore-on-throw. `pnpm harness:test` → **429 pass** (48 files).
+- **29 unit tests** (`scripts/harness/__tests__/check-regression-red-proof.test.mjs`) cover the full fixture
+  matrix: genuinely-red, accidental-green, inconclusive-transform-error (C1), multi-file C1 (a run-error file is
+  not masked by a passing sibling), not-imported (C3), sibling-package boundary, dynamic-import/comment parsing,
+  dirty-tree (C4), opt-out, not-fix, no-pair, and restore-on-throw. `pnpm harness:test` → **433 pass**.
 - **Real end-to-end integration proof** on the CLI-061 fix commit `b9893455f`: real `git apply -R` of the source
   hunks (incl. deleting the new `defer-submit.ts`) + real `vitest` on the changed test files → C3 detected the
   import (`importsReversedFile: true`), outcome `assertion-fail` → **red-proof-ok**; tree clean after restore.
   This is the accidental-green check catching the inverse — it PASSES a genuinely-red regression test.
 - Self-run on `develop` → correct SKIP (no `fix:` range). YAML validates (job `regression-red-proof` present).
   63/63 scans pass.
+
+### [PR REVIEW] — ✅ resolved | 2026-07-23
+
+Independent `pr-review-reviewer` (HARNESS-018): **1 ACTIONABLE (SHOULD)** — fixed. `classifyVitestOutcome`
+masked a run-error as `all-pass` when a pair had MULTIPLE changed test files (one passing, one that failed to
+collect), producing a false `ACCIDENTAL_GREEN` — a direct C1 violation (empirically reproduced by the reviewer).
+Fixed: any wanted test file that did not run WITH assertions (missing OR zero-assertion) → `run-error`
+(INCONCLUSIVE); an assertion failure still wins. Also fixed 2 CONSIDER (sibling-package prefix match
+`pkgAbsRoot + path.sep`; dynamic `import()` + comment stripping in the graph regex) and the index-resolution NIT.
+Regression tests added for each. Reviewer confirmed a false-GREEN is structurally impossible (`RED_PROOF_OK`
+requires a real failed assertion), restore is `finally`-guaranteed, and the C4 dirty-guard precedes mutation.
 
 ### [GATE-COMPLETE] — pending merge + verification

--- a/.agents/spec-docs/active/HARNESS-041-accidental-green-regression-test-floor.md
+++ b/.agents/spec-docs/active/HARNESS-041-accidental-green-regression-test-floor.md
@@ -1,0 +1,189 @@
+---
+status: in-progress
+type: INFRA
+tags: [harness, ci, testing, accidental-green, tdd]
+---
+
+# HARNESS-041: mechanical floor for accidental-green regression tests
+
+## Problem
+
+A regression test for a bug/leak/race fix is worthless if it also passes on the buggy pre-fix code
+("accidental-green") — it guards nothing and gives false assurance. The principle is already a rule
+([tdd-and-planning.md](../../rules/tdd-and-planning.md) "Prove the regression test RED") and a REQUIRED
+`pr-review-reviewer` guardian step. But per [enforcement-architecture.md](../../rules/enforcement-architecture.md),
+every guardian must be backed by a mechanical scan/hook floor — the reviewer is an agent judgement that can be
+skipped or can miss. This item builds that floor.
+
+It recurred **twice in one session** (ARCH-004 RUNTIME-14 disconnect test, CORE-026 RUNTIME-12 concurrency
+test), both caught only by the reviewer manually running the test against `origin/develop`. A mechanical check
+turns "the reviewer happened to check" into "the pipeline always checks".
+
+## Prior Art Research
+
+The general technique is **mutation testing** — mutate the source, re-run the tests, and require that some test
+now fails ("the mutant is killed"); a surviving mutant means the tests do not actually exercise that code.
+
+- **Stryker Mutator** (JS/TS) — https://stryker-mutator.io/docs/ — mutates source and reports survived vs killed
+  mutants; the canonical JS implementation of "a test that never fails on a changed source is not testing it".
+- **PIT / Pitest** (JVM) — https://pitest.org/ — same principle for Java; the reference for
+  mutation-driven test-effectiveness.
+- The general TDD red-green discipline (Beck) — a regression test must be observed FAILING before the fix, or it
+  proves nothing.
+
+Key constraint that shapes our design: full mutation testing is **too expensive per-PR** (mutates the whole tree,
+runs the suite N times). Our situation is narrower and cheaper: we already HAVE the intended mutation — it is the
+**inverse of the PR's own source diff**. Reversing the fix and requiring the changed test to fail is a single,
+targeted "mutant" (the exact code the PR changed), not a combinatorial sweep. So we adopt the mutation-testing
+_principle_ with a PR-diff-scoped, single-mutant implementation. INFRA-042 (nightly mutation testing) remains the
+place for broad, scheduled Stryker-style coverage; this item is the cheap per-PR floor.
+
+## Decision
+
+Ship a **PR-scoped "regression red-proof" CI check**, not a `run-all-scans` static scan (it executes tests, so it
+belongs in a dedicated CI job the way `tui-e2e` / `examples-typecheck` do — `.github/workflows/ci.yml`). The
+design resolves the three obstacles the backlog flagged (pairing, false positives, cost) and the four binding
+constraints from GATE-APPROVAL (C1–C4 below).
+
+### Mechanism (`scripts/harness/check-regression-red-proof.mjs`)
+
+1. **Compute the range** `merge-base(origin/develop, HEAD)..HEAD`. Split changed files into **source**
+   (`packages/*/src/**` and `apps/*/src/**`, excluding `*.test.*`, `*.spec.*`, `**/__tests__/**`) and **test**
+   (`*.test.*` / `*.spec.*` / `__tests__`).
+2. **Defect-fix scoping (C2).** Qualify the range only if it contains a `fix:` / `fix(` conventional commit — the
+   commit type whose regression tests must be red-proof. `feat:`/`docs:`/`chore:`/`refactor:`/`perf:` ranges are
+   NOT in scope (new-feature and refactor tests need not fail at base; **`perf:` is excluded because a perf fix
+   rarely has a boolean test that fails on the slow path without flaky timing** — perf PRs are expected opt-out
+   candidates if they ever mix in a `fix:`).
+3. **Same-package pairs only (the cost + pairing fix).** For each package that has BOTH a source change and a
+   test change, evaluate that package. A same-package test imports the changed source **relatively** (e.g.
+   `../CjkTextInput.js`), which vitest resolves to the TypeScript `src` directly — so reversing the source hunk
+   changes what the test sees **with no rebuild and no reinstall** (vitest transforms `src` on the fly; it never
+   reads `dist` for same-package resolution). Cross-package fix+test pairs resolve the dependency through built
+   `dist` and would need a rebuild — a v1 false-NEGATIVE (a miss), explicitly accepted; the two recurrences were
+   both same-package. Packages with only source OR only tests changed are skipped (nothing to prove).
+4. **Dirty-tree refusal (C4 — safety).** Before mutating, abort if any target source path has a pre-existing
+   uncommitted edit (`git status --porcelain <src paths>` non-empty). CI trees are clean; this prevents a local
+   self-run from silently discarding uncommitted work on restore. (This exact failure mode was demonstrated
+   during GATE-APPROVAL when a `git reset --hard` discarded working-tree files.)
+5. **Module-graph guard (C3).** Only mutate a source file that the changed test actually imports **relatively**
+   (resolve the test's relative-import graph and confirm the reversed file is in it). If a qualifying source file
+   is NOT reachably imported by any changed test in its package (e.g. the test imports it via package name/`dist`,
+   or they are unrelated same-package changes), do NOT emit accidental-green-fail — report **INCONCLUSIVE** for
+   that pair. This protects against the tool mis-firing as the relative-import convention drifts.
+6. **Reverse-apply the source hunks** for the pair via `git diff <base> -- <src paths> | git apply -R` onto the
+   current working tree. No worktree, no rebuild, no reinstall.
+7. **Run only the changed test files** for that package (`vitest run <changed test files>`), capturing the
+   machine-readable result (`--reporter=json`) so assertion failures are distinguished from run errors.
+8. **Verdict (C1 — correctness-critical).** Classify the outcome per changed test, never conflating the two:
+   - **≥1 changed test has a genuine assertion/test FAILURE** → **red-proof-ok** (PASS): the test exercises the
+     fixed behavior.
+   - **vitest could not evaluate** (transform/type error, collection error, module-not-found from a reversed
+     _added_ file — i.e. the suite never ran the assertion) → **INCONCLUSIVE** (advisory warn, surfaced), NEVER
+     counted as red-proof. A false green here would re-introduce exactly the accidental-green blindness this tool
+     exists to kill.
+   - **all changed tests PASS with the fix reversed** → **accidental-green-fail** (the tests do not exercise the
+     fix).
+9. **Always restore** the reversed hunks in a `finally` (`git checkout -- <src paths>`), so the tree is never
+   left mutated even on error (guarded by step 4's clean-tree precondition).
+
+### Opt-out (the false-positive escape hatch)
+
+A PR legitimately mixing a `fix:` with an **unrelated** new test in the same package, or a fixture/refactor test
+that correctly passes at base, opts out with **`allow-green-at-base: <reason>`** in the PR body or a range commit
+trailer. The check greps the range's commit messages + the PR body (when `GITHUB_*` env is present) for the
+marker and, if found with a non-empty reason, reports **SKIPPED** (logged, never silent — same anti-rot posture
+as `allow-fallback`).
+
+### Non-blocking rollout
+
+Wire it as a **dedicated CI job** on PRs to `develop`. To avoid a false positive (or an INCONCLUSIVE) wedging the
+pipeline before the heuristic is battle-tested, v1 is **advisory** (job runs, prints the verdict, is NOT added to
+the required-checks ruleset) — flip to required in a follow-up once it has proven stable across real PRs. Log
+every decision (evaluated / skipped-no-pair / skipped-not-fix / skipped-opt-out / red-proof-ok / inconclusive /
+accidental-green-fail).
+
+## Test Plan
+
+- **Red/green fixtures** under `scripts/harness/__tests__/regression-red-proof/`, driven through injected
+  "diff provider" + "test runner" seams (so fixtures need no real nested git repos); the checker's pure decision
+  logic (classify → scope → verdict) is unit-tested directly:
+  - `genuinely-red`: source fix + a same-package test asserting the fixed behavior → reversing source makes the
+    test **assertion-fail** → **red-proof-ok** (PASS).
+  - `accidental-green`: same source fix + a test asserting an invariant already true at base → reversing source
+    leaves it green → **accidental-green-fail**.
+  - `inconclusive-transform-error` (C1): reversing source yields a broken import / missing symbol so vitest
+    cannot run → **INCONCLUSIVE**, NOT red-proof-ok.
+  - `not-imported` (C3): a same-package source+test change where the test does not import the reversed file →
+    **INCONCLUSIVE**, not accidental-green-fail.
+  - `opt-out`: accidental-green fixture + `allow-green-at-base: <reason>` → **SKIPPED**.
+  - `no-pair` / `not-fix`: source-only, test-only, and non-`fix:` ranges → **SKIPPED** (out of scope).
+- `node scripts/harness/check-regression-red-proof.mjs` self-runs green (no qualifying pair) on this repo's
+  current PR shape.
+
+## User Execution Test Scenarios
+
+- Not applicable (harness/CI check). The scan's own red/green/inconclusive fixtures ARE the maintained gate,
+  exercised by the agent in CI and locally. Evidence: the fixture results recorded in the Evidence Log.
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-07-23
+
+- Prior-art (mutation testing: Stryker/PIT) substantiated; design resolves pairing (same-package scope), false
+  positives (`fix:`-only scoping + `allow-green-at-base` opt-out), and cost (reverse-source-patch, no rebuild).
+- Frontmatter: status/type INFRA/tags present; scan-spec-research + check-spec-doc-frontmatter green.
+- **Linchpin premise empirically validated** (2026-07-23): reversed the CLI-061 defer-submit hunk in
+  `CjkTextInput.tsx` (→ synchronous `onSubmit(effect.value)`) in the current working tree and ran
+  `cjk-defer-submit.test.tsx` with NO rebuild — the 2 same-package tests went from **2 passed → 2 failed**, then
+  restored identical to HEAD. Second premise: `git diff <base> -- <src paths> | git apply -R --check` on the
+  mixed source+test CLI-061 squash applies cleanly (source-only pathspec filter, test hunks excluded).
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-07-23
+
+Independent `proposal-reviewer`: **REVISE → conditional ENDORSE**. Verified all four premises against the real
+code (empirically proved P1: mutated `src` in place, no build, test went red; confirmed `dist/CjkTextInput.js`
+does not even exist so vitest reads `src` regardless of build state — the "already-built tree" language was
+dropped as misleading). Endorsed the direction, same-package scoping (the honest boundary of reverse-without-
+rebuild, not a diff-size dodge), the single-mutant cost trade (broad sweeps → INFRA-042), and advisory-first
+rollout. Four binding constraints folded into the Mechanism:
+
+1. **C1 (correctness-critical):** a vitest run-error (transform/collection/module-not-found) is **INCONCLUSIVE**,
+   NEVER red-proof-ok — only a genuine assertion failure counts. Conflating them would re-introduce accidental-
+   green blindness. Added the `inconclusive-transform-error` fixture.
+2. **C2:** qualify on `fix:`/`fix(` only; `perf:` excluded (no boolean fail-at-base without flaky timing).
+3. **C3:** only mutate a source file the changed test imports relatively (module-graph guard); else INCONCLUSIVE.
+4. **C4:** refuse to mutate a dirty tree (abort if target src paths have uncommitted edits) so restore cannot
+   discard local work.
+
+Rule alignment: ALIGNED with enforcement-architecture.md (prose/agent guardian → machine floor, reuses the
+CI-job floor pattern, no new orchestration tier) and tdd-and-planning.md "Prove the regression test RED".
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-07-23
+
+- `scripts/harness/check-regression-red-proof.mjs` — pure decision core (`classifyChanges`, `qualifyingPairs`,
+  `isDefectFixRange`, `parseOptOut`, `classifyVitestOutcome`, `decidePairVerdict`, `reachableRelativeGraph`)
+  separated from an injectable-seam orchestrator (`runRegressionRedProof({ mergeBase, changedFiles,
+commitSubjects, reverseApply, runVitest, restore, isDirty, readText, fileExists })`). All of C1–C4 implemented:
+  C1 run-error→INCONCLUSIVE (never a pass), C2 `fix:`-only, C3 relative module-graph guard, C4 dirty-tree refusal
+  with `finally` restore.
+- CI: advisory `regression-red-proof` job in `.github/workflows/ci.yml` (`if: base_ref != 'main'`, fetches base
+  for merge-base, exits 0 unless `REGRESSION_RED_PROOF_ENFORCE=1`). Invoked directly as
+  `node scripts/harness/check-regression-red-proof.mjs` — a `package.json` script alias is intentionally NOT
+  added, because touching `package.json` triggers the `security-audit` osv-scanner, which surfaced 18
+  pre-existing dependency advisories (filed as INFRA-044). This feature must not carry a dep-remediation; the
+  alias can be added once the audit is clean.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-07-23
+
+- **25 unit tests** (`scripts/harness/__tests__/check-regression-red-proof.test.mjs`) cover the full fixture
+  matrix: genuinely-red, accidental-green, inconclusive-transform-error (C1), not-imported (C3), dirty-tree (C4),
+  opt-out, not-fix, no-pair, and restore-on-throw. `pnpm harness:test` → **429 pass** (48 files).
+- **Real end-to-end integration proof** on the CLI-061 fix commit `b9893455f`: real `git apply -R` of the source
+  hunks (incl. deleting the new `defer-submit.ts`) + real `vitest` on the changed test files → C3 detected the
+  import (`importsReversedFile: true`), outcome `assertion-fail` → **red-proof-ok**; tree clean after restore.
+  This is the accidental-green check catching the inverse — it PASSES a genuinely-red regression test.
+- Self-run on `develop` → correct SKIP (no `fix:` range). YAML validates (job `regression-red-proof` present).
+  63/63 scans pass.
+
+### [GATE-COMPLETE] — pending merge + verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,3 +472,40 @@ jobs:
 
       - name: Run the TUI PTY E2E suite against the real binary
         run: pnpm --filter @robota-sdk/agent-transport-tui test:pty
+
+  # HARNESS-041: mechanical floor for accidental-green regression tests. For a `fix:` PR with a
+  # same-package (source+test) pair, it reverse-applies the source hunks and requires the changed test
+  # to FAIL — proving the regression test actually exercises the fix. ADVISORY in v1 (not a required
+  # check): the job runs and prints the verdict but never blocks the merge (the script exits 0 unless
+  # REGRESSION_RED_PROOF_ENFORCE=1). Flip to required once it has proven stable across real PRs.
+  regression-red-proof:
+    name: regression-red-proof (advisory)
+    runs-on: ubuntu-latest
+    if: github.base_ref != 'main'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch the base branch (for merge-base + reverse-diff)
+        run: git fetch origin ${{ github.base_ref }} --depth=50
+
+      - name: Prove regression tests are RED without the fix
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/harness/check-regression-red-proof.mjs

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -1,0 +1,272 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  VERDICT,
+  classifyChanges,
+  classifyVitestOutcome,
+  decidePairVerdict,
+  isDefectFixRange,
+  isSourceFile,
+  isTestFile,
+  parseOptOut,
+  pkgOf,
+  qualifyingPairs,
+  reachableRelativeGraph,
+  relativeSpecifiers,
+  resolveRelativeImport,
+  runRegressionRedProof,
+} from '../check-regression-red-proof.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const abs = (rel) => path.resolve(WORKSPACE_ROOT, rel);
+
+describe('HARNESS-041 file classification', () => {
+  it('pkgOf extracts the package/app root for src files only', () => {
+    expect(pkgOf('packages/agent-transport-tui/src/CjkTextInput.tsx')).toBe(
+      'packages/agent-transport-tui',
+    );
+    expect(pkgOf('apps/agent-app/src/main.ts')).toBe('apps/agent-app');
+    expect(pkgOf('packages/foo/docs/SPEC.md')).toBeNull();
+    expect(pkgOf('scripts/harness/x.mjs')).toBeNull();
+  });
+
+  it('isTestFile / isSourceFile split correctly', () => {
+    expect(isTestFile('packages/x/src/__tests__/a.test.tsx')).toBe(true);
+    expect(isTestFile('packages/x/src/a.spec.ts')).toBe(true);
+    expect(isTestFile('packages/x/src/a.tsx')).toBe(false);
+    expect(isSourceFile('packages/x/src/a.tsx')).toBe(true);
+    expect(isSourceFile('packages/x/src/a.test.ts')).toBe(false);
+    expect(isSourceFile('README.md')).toBe(false);
+  });
+
+  it('qualifyingPairs = packages with BOTH source and test changes', () => {
+    const byPkg = classifyChanges([
+      'packages/a/src/x.ts',
+      'packages/a/src/x.test.ts',
+      'packages/b/src/y.ts', // source only
+      'packages/c/src/z.test.ts', // test only
+    ]);
+    const pairs = qualifyingPairs(byPkg);
+    expect(pairs.map((p) => p.pkg)).toEqual(['packages/a']);
+  });
+});
+
+describe('HARNESS-041 scoping (C2) + opt-out', () => {
+  it('isDefectFixRange requires a fix: commit and excludes perf:', () => {
+    expect(isDefectFixRange(['fix: drop bug', 'chore: x'])).toBe(true);
+    expect(isDefectFixRange(['fix(tui): drop bug'])).toBe(true);
+    expect(isDefectFixRange(['feat: new', 'docs: y'])).toBe(false);
+    expect(isDefectFixRange(['perf: faster'])).toBe(false); // C2
+  });
+
+  it('parseOptOut reads allow-green-at-base: <reason>', () => {
+    expect(parseOptOut('body\nallow-green-at-base: unrelated fixture test\n')).toEqual({
+      optedOut: true,
+      reason: 'unrelated fixture test',
+    });
+    expect(parseOptOut('no marker here')).toEqual({ optedOut: false, reason: null });
+  });
+});
+
+describe('HARNESS-041 vitest outcome classification (C1 — assertion-fail vs run-error)', () => {
+  const testFile = 'packages/x/src/a.test.ts';
+  const nameAbs = abs(testFile);
+
+  it('a failed assertion → assertion-fail', () => {
+    const json = { testResults: [{ name: nameAbs, assertionResults: [{ status: 'failed' }] }] };
+    expect(classifyVitestOutcome(json, [testFile])).toBe('assertion-fail');
+  });
+
+  it('all assertions passed → all-pass', () => {
+    const json = { testResults: [{ name: nameAbs, assertionResults: [{ status: 'passed' }] }] };
+    expect(classifyVitestOutcome(json, [testFile])).toBe('all-pass');
+  });
+
+  it('present but zero assertions (failed to collect) → run-error', () => {
+    const json = { testResults: [{ name: nameAbs, assertionResults: [] }] };
+    expect(classifyVitestOutcome(json, [testFile])).toBe('run-error');
+  });
+
+  it('missing from results entirely (transform error) → run-error, NOT all-pass', () => {
+    expect(classifyVitestOutcome({ testResults: [] }, [testFile])).toBe('run-error');
+  });
+});
+
+describe('HARNESS-041 pair verdict (C1 + C3)', () => {
+  it('not imported (C3) → INCONCLUSIVE regardless of outcome', () => {
+    expect(decidePairVerdict({ importsReversedFile: false, outcome: 'all-pass' })).toBe(
+      VERDICT.INCONCLUSIVE,
+    );
+  });
+  it('assertion-fail → RED_PROOF_OK', () => {
+    expect(decidePairVerdict({ importsReversedFile: true, outcome: 'assertion-fail' })).toBe(
+      VERDICT.RED_PROOF_OK,
+    );
+  });
+  it('run-error → INCONCLUSIVE, never a pass (C1)', () => {
+    expect(decidePairVerdict({ importsReversedFile: true, outcome: 'run-error' })).toBe(
+      VERDICT.INCONCLUSIVE,
+    );
+  });
+  it('all-pass → ACCIDENTAL_GREEN', () => {
+    expect(decidePairVerdict({ importsReversedFile: true, outcome: 'all-pass' })).toBe(
+      VERDICT.ACCIDENTAL_GREEN,
+    );
+  });
+});
+
+describe('HARNESS-041 relative-import graph (C3)', () => {
+  it('relativeSpecifiers extracts relative imports only', () => {
+    const text = `
+      import CjkTextInput from '../CjkTextInput.js';
+      import { render } from 'ink-testing-library';
+      export { x } from './util.js';
+    `;
+    expect(relativeSpecifiers(text)).toEqual(['../CjkTextInput.js', './util.js']);
+  });
+
+  it('resolveRelativeImport maps a .js specifier to its .tsx source', () => {
+    const importer = abs('packages/x/src/__tests__/a.test.tsx');
+    const exists = (p) => p === abs('packages/x/src/CjkTextInput.tsx');
+    expect(resolveRelativeImport(importer, '../CjkTextInput.js', exists)).toBe(
+      abs('packages/x/src/CjkTextInput.tsx'),
+    );
+    expect(resolveRelativeImport(importer, 'ink', exists)).toBeNull(); // bare import
+  });
+
+  it('reachableRelativeGraph walks relative imports within the package', () => {
+    const pkgRoot = abs('packages/x');
+    const testAbs = abs('packages/x/src/a.test.ts');
+    const srcAbs = abs('packages/x/src/target.ts');
+    const files = {
+      [testAbs]: `import { t } from './target.js';`,
+      [srcAbs]: `export const t = 1;`,
+    };
+    const read = (p) => files[p] ?? '';
+    const exists = (p) => Object.prototype.hasOwnProperty.call(files, p);
+    const graph = reachableRelativeGraph([testAbs], pkgRoot, read, exists);
+    expect(graph.has(srcAbs)).toBe(true);
+    expect(graph.has(testAbs)).toBe(false); // the test file itself is removed
+  });
+});
+
+// ── Orchestrator through injected seams (the fixture matrix) ─────────────────────────────────────────
+
+function baseIo(overrides = {}) {
+  const testFile = 'packages/x/src/a.test.ts';
+  const srcFile = 'packages/x/src/target.ts';
+  const files = {
+    [abs(testFile)]: `import { t } from './target.js';`,
+    [abs(srcFile)]: `export const t = 1;`,
+  };
+  return {
+    mergeBase: 'BASE',
+    changedFiles: [srcFile, testFile],
+    commitSubjects: ['fix: something real'],
+    optOutText: '',
+    readText: (p) => files[p] ?? '',
+    fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+    isDirty: () => false,
+    reverseApply: () => {},
+    restore: () => {},
+    runVitest: () => ({ testResults: [] }),
+    ...overrides,
+  };
+}
+
+describe('HARNESS-041 orchestrator fixtures', () => {
+  it('genuinely-red: reversed source makes the test fail → RED_PROOF_OK', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({
+        runVitest: () => ({
+          testResults: [
+            { name: abs('packages/x/src/a.test.ts'), assertionResults: [{ status: 'failed' }] },
+          ],
+        }),
+      }),
+    );
+    expect(verdict).toBe(VERDICT.RED_PROOF_OK);
+  });
+
+  it('accidental-green: reversed source, test still passes → ACCIDENTAL_GREEN', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({
+        runVitest: () => ({
+          testResults: [
+            { name: abs('packages/x/src/a.test.ts'), assertionResults: [{ status: 'passed' }] },
+          ],
+        }),
+      }),
+    );
+    expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
+  });
+
+  it('inconclusive-transform-error (C1): vitest could not run → INCONCLUSIVE, not a pass', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({ runVitest: () => ({ testResults: [] }) }),
+    );
+    expect(verdict).toBe(VERDICT.INCONCLUSIVE);
+  });
+
+  it('not-imported (C3): test does not import the reversed file → INCONCLUSIVE (never mutates)', async () => {
+    let mutated = false;
+    const { verdict, decisions } = await runRegressionRedProof(
+      baseIo({
+        // test imports a different file than the changed source
+        readText: (p) =>
+          p === abs('packages/x/src/a.test.ts') ? `import { u } from './other.js';` : '',
+        reverseApply: () => {
+          mutated = true;
+        },
+      }),
+    );
+    expect(verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(mutated).toBe(false);
+    expect(decisions[0].importsReversedFile).toBe(false);
+  });
+
+  it('dirty-tree (C4): refuses to mutate, → INCONCLUSIVE', async () => {
+    let mutated = false;
+    const { verdict } = await runRegressionRedProof(
+      baseIo({ isDirty: () => true, reverseApply: () => (mutated = true) }),
+    );
+    expect(verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(mutated).toBe(false);
+  });
+
+  it('opt-out: allow-green-at-base marker → SKIPPED_OPT_OUT', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({ optOutText: 'allow-green-at-base: unrelated fixture' }),
+    );
+    expect(verdict).toBe(VERDICT.SKIPPED_OPT_OUT);
+  });
+
+  it('not a fix: range → SKIPPED_NOT_FIX', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({ commitSubjects: ['feat: new thing'] }),
+    );
+    expect(verdict).toBe(VERDICT.SKIPPED_NOT_FIX);
+  });
+
+  it('no same-package pair → SKIPPED_NO_PAIR', async () => {
+    const { verdict } = await runRegressionRedProof(
+      baseIo({ changedFiles: ['packages/x/src/target.ts'] }), // source only
+    );
+    expect(verdict).toBe(VERDICT.SKIPPED_NO_PAIR);
+  });
+
+  it('restores the tree even when vitest throws', async () => {
+    let restored = false;
+    await runRegressionRedProof(
+      baseIo({
+        runVitest: () => {
+          throw new Error('vitest blew up');
+        },
+        restore: () => (restored = true),
+      }),
+    ).catch(() => {});
+    expect(restored).toBe(true);
+  });
+});

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -92,6 +92,31 @@ describe('HARNESS-041 vitest outcome classification (C1 — assertion-fail vs ru
   it('missing from results entirely (transform error) → run-error, NOT all-pass', () => {
     expect(classifyVitestOutcome({ testResults: [] }, [testFile])).toBe('run-error');
   });
+
+  it('multi-file: a run-error file is NOT masked by a passing sibling → run-error (C1 regression)', () => {
+    const passing = 'packages/x/src/a.test.ts';
+    const brokeCollect = 'packages/x/src/b.test.ts';
+    const json = {
+      testResults: [
+        { name: abs(passing), assertionResults: [{ status: 'passed' }] },
+        { name: abs(brokeCollect), assertionResults: [] }, // failed to collect
+      ],
+    };
+    // Before the fix this returned 'all-pass' (→ false accidental-green). It must be run-error.
+    expect(classifyVitestOutcome(json, [passing, brokeCollect])).toBe('run-error');
+  });
+
+  it('multi-file: an assertion failure still wins over a sibling run-error → assertion-fail', () => {
+    const failing = 'packages/x/src/a.test.ts';
+    const brokeCollect = 'packages/x/src/b.test.ts';
+    const json = {
+      testResults: [
+        { name: abs(failing), assertionResults: [{ status: 'failed' }] },
+        { name: abs(brokeCollect), assertionResults: [] },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [failing, brokeCollect])).toBe('assertion-fail');
+  });
 });
 
 describe('HARNESS-041 pair verdict (C1 + C3)', () => {
@@ -125,6 +150,31 @@ describe('HARNESS-041 relative-import graph (C3)', () => {
       export { x } from './util.js';
     `;
     expect(relativeSpecifiers(text)).toEqual(['../CjkTextInput.js', './util.js']);
+  });
+
+  it('relativeSpecifiers captures dynamic import() and ignores commented-out imports', () => {
+    const text = `
+      const m = await import('./dynamic.js');
+      // import ghost from './commented.js';
+      /* import block from './block.js'; */
+      import real from './real.js';
+    `;
+    const specs = relativeSpecifiers(text);
+    expect(specs).toContain('./dynamic.js');
+    expect(specs).toContain('./real.js');
+    expect(specs).not.toContain('./commented.js');
+    expect(specs).not.toContain('./block.js');
+  });
+
+  it('reachableRelativeGraph does not cross into a sibling package sharing a name prefix', () => {
+    const pkgRoot = abs('packages/x');
+    const testAbs = abs('packages/x/src/a.test.ts');
+    const siblingSrc = abs('packages/x-utils/src/leak.ts');
+    const files = { [testAbs]: `import { u } from '../../x-utils/src/leak.js';`, [siblingSrc]: '' };
+    const read = (p) => files[p] ?? '';
+    const exists = (p) => Object.prototype.hasOwnProperty.call(files, p);
+    const graph = reachableRelativeGraph([testAbs], pkgRoot, read, exists);
+    expect(graph.has(siblingSrc)).toBe(false); // packages/x must not prefix-match packages/x-utils
   });
 
   it('resolveRelativeImport maps a .js specifier to its .tsx source', () => {

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * HARNESS-041 — mechanical floor for accidental-green regression tests.
+ *
+ * A regression test for a `fix:` is worthless if it also passes on the buggy pre-fix code
+ * ("accidental-green"). This is the mechanical backstop for the `pr-review-reviewer` guardian and the
+ * tdd-and-planning.md "Prove the regression test RED" rule.
+ *
+ * Approach (single-mutant, PR-diff-scoped — see .agents/spec-docs/active/HARNESS-041-*.md):
+ * the intended mutation IS the inverse of the PR's own source diff. For each SAME-PACKAGE (source+test)
+ * pair in a `fix:` range, reverse-apply the source hunks onto the working tree (vitest transforms `src`
+ * on the fly, so no rebuild is needed for a relative same-package import), run the changed test files,
+ * and require a genuine assertion FAILURE. All-pass ⇒ accidental-green. A vitest RUN error (transform /
+ * collection / missing module) is INCONCLUSIVE, never a pass (C1).
+ *
+ * The pure decision logic (classify → scope → verdict) is exported and unit-tested through injected
+ * "diff provider" + "test runner" seams; the git/vitest side effects live in the orchestrator.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs, { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// ── Verdict vocabulary ────────────────────────────────────────────────────────────────────────────
+export const VERDICT = Object.freeze({
+  RED_PROOF_OK: 'red-proof-ok', // ≥1 changed test genuinely fails with the fix reversed — good
+  ACCIDENTAL_GREEN: 'accidental-green-fail', // all changed tests still pass — the defect this tool exists to catch
+  INCONCLUSIVE: 'inconclusive', // vitest could not evaluate, or the test does not import the reversed file
+  SKIPPED_NOT_FIX: 'skipped-not-fix', // range has no fix: commit
+  SKIPPED_NO_PAIR: 'skipped-no-pair', // no same-package source+test pair
+  SKIPPED_OPT_OUT: 'skipped-opt-out', // allow-green-at-base: <reason>
+});
+
+// ── Pure: file classification ─────────────────────────────────────────────────────────────────────
+
+/** Package/app root key for a repo-relative path, or null if not under a package/app `src`. */
+export function pkgOf(filePath) {
+  const m = filePath.match(/^((?:packages|apps)\/[^/]+)\/src\//);
+  return m ? m[1] : null;
+}
+
+export function isTestFile(filePath) {
+  return /(\.(test|spec)\.[cm]?[jt]sx?$)|(^|\/)__tests__\//.test(filePath);
+}
+
+/** A source file is a package/app `src` file that is NOT a test file. */
+export function isSourceFile(filePath) {
+  return pkgOf(filePath) !== null && !isTestFile(filePath);
+}
+
+/**
+ * Split changed files into same-package (source, test) pairs.
+ * Returns a Map keyed by package root → { source: string[], test: string[] }.
+ */
+export function classifyChanges(changedFiles) {
+  const byPkg = new Map();
+  for (const f of changedFiles) {
+    const pkg = pkgOf(f);
+    if (!pkg) continue;
+    if (!byPkg.has(pkg)) byPkg.set(pkg, { source: [], test: [] });
+    if (isTestFile(f)) byPkg.get(pkg).test.push(f);
+    else byPkg.get(pkg).source.push(f);
+  }
+  return byPkg;
+}
+
+/** Packages that changed BOTH source and test — the only ones this v1 can red-prove. */
+export function qualifyingPairs(byPkg) {
+  const pairs = [];
+  for (const [pkg, { source, test }] of byPkg) {
+    if (source.length > 0 && test.length > 0) pairs.push({ pkg, source, test });
+  }
+  return pairs;
+}
+
+// ── Pure: range + opt-out scoping (C2, opt-out) ─────────────────────────────────────────────────────
+
+/** A defect-fix range has a `fix:` / `fix(scope): ` conventional commit. `perf:` is intentionally excluded. */
+export function isDefectFixRange(commitSubjects) {
+  return commitSubjects.some((s) => /^fix(\(|:)/.test(s.trim()));
+}
+
+/** Parse `allow-green-at-base: <reason>` (opt-out) from any text (PR body / commit trailers). */
+export function parseOptOut(text) {
+  const m = (text || '').match(/allow-green-at-base:\s*(\S.*)/i);
+  const reason = m ? m[1].trim() : null;
+  return { optedOut: Boolean(reason), reason };
+}
+
+// ── Pure: vitest outcome classification (C1 — the correctness-critical distinction) ──────────────────
+
+/**
+ * Given vitest `--reporter=json` output (parsed) and the changed test files, classify the outcome.
+ * NEVER conflate a genuine assertion failure with a run error.
+ *   'assertion-fail' — ≥1 changed test file has a failed assertion (the suite ran and the test failed)
+ *   'run-error'      — a changed test file could not be evaluated (transform/collection/missing module)
+ *   'all-pass'       — every changed test file ran and passed
+ */
+export function classifyVitestOutcome(vitestJson, changedTestFiles) {
+  const wanted = new Set(changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f)));
+  const results = Array.isArray(vitestJson?.testResults) ? vitestJson.testResults : [];
+  let sawAssertionFail = false;
+  let sawRan = false;
+  const seen = new Set();
+
+  for (const fileResult of results) {
+    const name = fileResult?.name ? path.resolve(fileResult.name) : null;
+    if (!name || !wanted.has(name)) continue;
+    seen.add(name);
+    const assertions = Array.isArray(fileResult.assertionResults)
+      ? fileResult.assertionResults
+      : [];
+    if (assertions.length === 0) {
+      // File is present but produced no assertions → it failed to collect/transform → run error.
+      continue;
+    }
+    sawRan = true;
+    if (assertions.some((a) => a.status === 'failed')) sawAssertionFail = true;
+  }
+
+  if (sawAssertionFail) return 'assertion-fail';
+  // A changed test file we expected but that never produced assertions (missing from results, or present
+  // with zero assertions) means vitest could not run it → inconclusive, not a pass.
+  const everyWantedRan = changedTestFiles.every((f) => {
+    const abs = path.resolve(WORKSPACE_ROOT, f);
+    return seen.has(abs);
+  });
+  if (!everyWantedRan || !sawRan) return 'run-error';
+  return 'all-pass';
+}
+
+// ── Pure: final verdict for one qualifying pair ─────────────────────────────────────────────────────
+
+/**
+ * Decide the verdict for a single same-package pair, given the observable inputs. Kept pure so it is
+ * unit-tested exhaustively without git or vitest.
+ *   importsReversedFile — did any changed test relatively import a reversed source file? (C3)
+ *   outcome             — classifyVitestOutcome result, or null if not run (guard tripped)
+ */
+export function decidePairVerdict({ importsReversedFile, outcome }) {
+  if (!importsReversedFile) return VERDICT.INCONCLUSIVE; // C3: not in the test's module graph
+  if (outcome === 'assertion-fail') return VERDICT.RED_PROOF_OK;
+  if (outcome === 'run-error') return VERDICT.INCONCLUSIVE; // C1: never a pass
+  if (outcome === 'all-pass') return VERDICT.ACCIDENTAL_GREEN;
+  return VERDICT.INCONCLUSIVE;
+}
+
+// ── Pure: relative-import module graph (C3) ─────────────────────────────────────────────────────────
+
+/** Resolve a relative import specifier from an importer file to an on-disk source path, or null. */
+export function resolveRelativeImport(importerAbsPath, specifier, fileExists = existsSync) {
+  if (!specifier.startsWith('.')) return null;
+  const baseDir = path.dirname(importerAbsPath);
+  const raw = path.resolve(baseDir, specifier);
+  // Map a `.js`/`.jsx` specifier to its TS source, plus bare + index resolutions.
+  const stripped = raw.replace(/\.[cm]?jsx?$/, '');
+  const candidates = [
+    raw,
+    `${stripped}.ts`,
+    `${stripped}.tsx`,
+    `${stripped}.mts`,
+    `${stripped}.js`,
+    `${stripped}.jsx`,
+    path.join(stripped, 'index.ts'),
+    path.join(stripped, 'index.tsx'),
+  ];
+  for (const c of candidates) if (fileExists(c)) return c;
+  return null;
+}
+
+const RELATIVE_IMPORT_RE =
+  /(?:import|export)[^'"]*from\s*['"](\.[^'"]+)['"]|import\s*['"](\.[^'"]+)['"]/g;
+
+/** Extract relative import specifiers from a file's text. */
+export function relativeSpecifiers(sourceText) {
+  const out = [];
+  let m;
+  RELATIVE_IMPORT_RE.lastIndex = 0;
+  while ((m = RELATIVE_IMPORT_RE.exec(sourceText)) !== null) out.push(m[1] || m[2]);
+  return out;
+}
+
+/**
+ * Transitive relative-import graph from the changed test files, staying within the package. Returns a Set
+ * of absolute source paths reachable via relative imports. Bounded by a visited set + within-package guard.
+ */
+export function reachableRelativeGraph(
+  testAbsPaths,
+  pkgAbsRoot,
+  readText,
+  fileExists = existsSync,
+) {
+  const visited = new Set();
+  const queue = [...testAbsPaths];
+  while (queue.length > 0) {
+    const cur = queue.shift();
+    if (visited.has(cur)) continue;
+    visited.add(cur);
+    let text;
+    try {
+      text = readText(cur);
+    } catch {
+      continue; // unreadable — skip (do not fail the graph walk)
+    }
+    for (const spec of relativeSpecifiers(text)) {
+      const resolved = resolveRelativeImport(cur, spec, fileExists);
+      if (resolved && resolved.startsWith(pkgAbsRoot) && !visited.has(resolved))
+        queue.push(resolved);
+    }
+  }
+  // Remove the test files themselves; callers care about imported sources.
+  for (const t of testAbsPaths) visited.delete(t);
+  return visited;
+}
+
+// ── Impure orchestrator ─────────────────────────────────────────────────────────────────────────────
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { cwd: WORKSPACE_ROOT, encoding: 'utf8', ...opts }).trim();
+}
+
+function mergeBase(ref = 'origin/develop') {
+  try {
+    return git(['merge-base', ref, 'HEAD']);
+  } catch {
+    return git(['merge-base', 'develop', 'HEAD']);
+  }
+}
+
+function log(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+/**
+ * Run the checker. Side-effecting parts (diff, commit subjects, opt-out text, vitest) are injected so the
+ * orchestration is testable; defaults wire the real git/vitest.
+ */
+export async function runRegressionRedProof(io = {}) {
+  const base = io.mergeBase ?? mergeBase();
+  const changedFiles =
+    io.changedFiles ??
+    git(['diff', '--name-only', `${base}..HEAD`])
+      .split('\n')
+      .filter(Boolean);
+  const commitSubjects =
+    io.commitSubjects ??
+    git(['log', '--format=%s', `${base}..HEAD`])
+      .split('\n')
+      .filter(Boolean);
+  const optOutText = io.optOutText ?? `${process.env.PR_BODY ?? ''}\n${commitSubjects.join('\n')}`;
+
+  const decisions = [];
+
+  const { optedOut, reason } = parseOptOut(optOutText);
+  if (optedOut) {
+    log(`↩︎  SKIPPED (opt-out): allow-green-at-base: ${reason}`);
+    return { verdict: VERDICT.SKIPPED_OPT_OUT, decisions };
+  }
+  if (!isDefectFixRange(commitSubjects)) {
+    log('↩︎  SKIPPED: range has no `fix:` commit (not a defect fix).');
+    return { verdict: VERDICT.SKIPPED_NOT_FIX, decisions };
+  }
+
+  const pairs = qualifyingPairs(classifyChanges(changedFiles));
+  if (pairs.length === 0) {
+    log('↩︎  SKIPPED: no same-package (source+test) pair to red-prove.');
+    return { verdict: VERDICT.SKIPPED_NO_PAIR, decisions };
+  }
+
+  const readText = io.readText ?? ((p) => fs.readFileSync(p, 'utf8'));
+  const fileExists = io.fileExists ?? existsSync;
+  const isDirty =
+    io.isDirty ?? ((paths) => git(['status', '--porcelain', '--', ...paths]).length > 0);
+  const reverseApply =
+    io.reverseApply ??
+    ((srcPaths) => {
+      const patch = git(['diff', `${base}..HEAD`, '--', ...srcPaths]);
+      execFileSync('git', ['apply', '-R'], { cwd: WORKSPACE_ROOT, input: patch });
+    });
+  const restore = io.restore ?? ((srcPaths) => git(['checkout', '--', ...srcPaths]));
+  const runVitest = io.runVitest ?? defaultRunVitest;
+
+  let worst = VERDICT.RED_PROOF_OK;
+  const rank = {
+    [VERDICT.ACCIDENTAL_GREEN]: 3,
+    [VERDICT.INCONCLUSIVE]: 2,
+    [VERDICT.RED_PROOF_OK]: 1,
+  };
+
+  for (const pair of pairs) {
+    // C4 — never mutate a dirty tree.
+    if (isDirty(pair.source)) {
+      log(
+        `⚠︎  ${pair.pkg}: source paths have uncommitted edits — refusing to mutate. INCONCLUSIVE.`,
+      );
+      decisions.push({ pkg: pair.pkg, verdict: VERDICT.INCONCLUSIVE, reason: 'dirty-tree' });
+      if (rank[VERDICT.INCONCLUSIVE] > rank[worst]) worst = VERDICT.INCONCLUSIVE;
+      continue;
+    }
+
+    // C3 — is any reversed source file in the changed test's relative-import graph?
+    const pkgAbsRoot = path.resolve(WORKSPACE_ROOT, pair.pkg);
+    const testAbs = pair.test.map((t) => path.resolve(WORKSPACE_ROOT, t));
+    const graph = reachableRelativeGraph(testAbs, pkgAbsRoot, readText, fileExists);
+    const srcAbs = pair.source.map((s) => path.resolve(WORKSPACE_ROOT, s));
+    const importsReversedFile = srcAbs.some((s) => graph.has(s));
+
+    let outcome = null;
+    if (importsReversedFile) {
+      reverseApply(pair.source);
+      try {
+        outcome = classifyVitestOutcome(await runVitest(pair.pkg, pair.test), pair.test);
+      } finally {
+        restore(pair.source);
+      }
+    }
+
+    const verdict = decidePairVerdict({ importsReversedFile, outcome });
+    decisions.push({ pkg: pair.pkg, verdict, outcome, importsReversedFile });
+    const icon =
+      verdict === VERDICT.RED_PROOF_OK ? '✅' : verdict === VERDICT.ACCIDENTAL_GREEN ? '❌' : '⚠︎';
+    log(`${icon}  ${pair.pkg}: ${verdict}${outcome ? ` (${outcome})` : ''}`);
+    if ((rank[verdict] ?? 0) > (rank[worst] ?? 0)) worst = verdict;
+  }
+
+  return { verdict: worst, decisions };
+}
+
+function defaultRunVitest(pkg, testFiles) {
+  const rel = testFiles.map((f) => path.relative(path.join(WORKSPACE_ROOT, pkg), f));
+  try {
+    const out = execFileSync(
+      'pnpm',
+      ['--filter', `./${pkg}`, 'exec', 'vitest', 'run', '--reporter=json', ...rel],
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    return JSON.parse(extractJson(out));
+  } catch (err) {
+    // vitest exits non-zero on failure; its JSON is still on stdout.
+    const stdout = String(err.stdout ?? '');
+    try {
+      return JSON.parse(extractJson(stdout));
+    } catch {
+      return { testResults: [] }; // unparseable → classified as run-error by the caller
+    }
+  }
+}
+
+/** vitest may print warnings before the JSON payload; grab the first `{`…matching object heuristically. */
+function extractJson(text) {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  return start >= 0 && end > start ? text.slice(start, end + 1) : text;
+}
+
+// ── CLI entry ───────────────────────────────────────────────────────────────────────────────────────
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runRegressionRedProof()
+    .then(({ verdict }) => {
+      const enforce = process.env.REGRESSION_RED_PROOF_ENFORCE === '1';
+      if (verdict === VERDICT.ACCIDENTAL_GREEN) {
+        log(
+          '\n❌ accidental-green: a regression test passes even with the fix reversed — it guards nothing.\n' +
+            '   Rewrite it to FAIL on the pre-fix code, or opt out with `allow-green-at-base: <reason>`.',
+        );
+        process.exit(enforce ? 1 : 0); // advisory in v1 (not a required check); flip via env once stable
+      }
+      if (verdict === VERDICT.INCONCLUSIVE) {
+        log('\n⚠︎  inconclusive — see decisions above (advisory).');
+      }
+      process.exit(0);
+    })
+    .catch((err) => {
+      log(`regression-red-proof: orchestration error — ${err?.message ?? err}`);
+      process.exit(0); // never block the pipeline on the checker's own failure (advisory)
+    });
+}

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -99,35 +99,29 @@ export function parseOptOut(text) {
  *   'all-pass'       — every changed test file ran and passed
  */
 export function classifyVitestOutcome(vitestJson, changedTestFiles) {
-  const wanted = new Set(changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f)));
+  const wanted = changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f));
   const results = Array.isArray(vitestJson?.testResults) ? vitestJson.testResults : [];
   let sawAssertionFail = false;
-  let sawRan = false;
-  const seen = new Set();
+  const ranWithAssertions = new Set();
 
   for (const fileResult of results) {
     const name = fileResult?.name ? path.resolve(fileResult.name) : null;
-    if (!name || !wanted.has(name)) continue;
-    seen.add(name);
+    if (!name || !wanted.includes(name)) continue;
     const assertions = Array.isArray(fileResult.assertionResults)
       ? fileResult.assertionResults
       : [];
-    if (assertions.length === 0) {
-      // File is present but produced no assertions → it failed to collect/transform → run error.
-      continue;
-    }
-    sawRan = true;
+    if (assertions.length === 0) continue; // present but no assertions → failed to collect/transform
+    ranWithAssertions.add(name);
     if (assertions.some((a) => a.status === 'failed')) sawAssertionFail = true;
   }
 
+  // C1 — a genuine assertion failure is the ONLY pass. ANY wanted test file that did not run with
+  // assertions (missing from results OR present-with-zero-assertions — a transform/collection error) is a
+  // run-error and yields INCONCLUSIVE, even if a SIBLING changed test file ran green. Never conflate a
+  // non-run with all-pass: that would be a false accidental-green alarm.
   if (sawAssertionFail) return 'assertion-fail';
-  // A changed test file we expected but that never produced assertions (missing from results, or present
-  // with zero assertions) means vitest could not run it → inconclusive, not a pass.
-  const everyWantedRan = changedTestFiles.every((f) => {
-    const abs = path.resolve(WORKSPACE_ROOT, f);
-    return seen.has(abs);
-  });
-  if (!everyWantedRan || !sawRan) return 'run-error';
+  const sawRunError = wanted.some((abs) => !ranWithAssertions.has(abs));
+  if (sawRunError) return 'run-error';
   return 'all-pass';
 }
 
@@ -154,31 +148,42 @@ export function resolveRelativeImport(importerAbsPath, specifier, fileExists = e
   if (!specifier.startsWith('.')) return null;
   const baseDir = path.dirname(importerAbsPath);
   const raw = path.resolve(baseDir, specifier);
-  // Map a `.js`/`.jsx` specifier to its TS source, plus bare + index resolutions.
+  // Map a `.js`/`.jsx`/`.cjs`/`.mjs` specifier to its TS source, plus bare + index resolutions.
   const stripped = raw.replace(/\.[cm]?jsx?$/, '');
   const candidates = [
     raw,
     `${stripped}.ts`,
     `${stripped}.tsx`,
     `${stripped}.mts`,
+    `${stripped}.cts`,
     `${stripped}.js`,
     `${stripped}.jsx`,
     path.join(stripped, 'index.ts'),
     path.join(stripped, 'index.tsx'),
+    path.join(stripped, 'index.mts'),
+    path.join(stripped, 'index.js'),
+    path.join(stripped, 'index.jsx'),
   ];
   for (const c of candidates) if (fileExists(c)) return c;
   return null;
 }
 
-const RELATIVE_IMPORT_RE =
-  /(?:import|export)[^'"]*from\s*['"](\.[^'"]+)['"]|import\s*['"](\.[^'"]+)['"]/g;
+// Strip line + block comments before scanning so commented-out imports do not pollute the graph.
+function stripComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
 
-/** Extract relative import specifiers from a file's text. */
+// Static `import … from './x'` / `export … from './x'` / side-effect `import './x'`, plus dynamic `import('./x')`.
+const RELATIVE_IMPORT_RE =
+  /(?:import|export)[^'"]*from\s*['"](\.[^'"]+)['"]|import\s*\(\s*['"](\.[^'"]+)['"]\s*\)|import\s*['"](\.[^'"]+)['"]/g;
+
+/** Extract relative import specifiers from a file's text (comments stripped). */
 export function relativeSpecifiers(sourceText) {
   const out = [];
   let m;
+  const text = stripComments(sourceText);
   RELATIVE_IMPORT_RE.lastIndex = 0;
-  while ((m = RELATIVE_IMPORT_RE.exec(sourceText)) !== null) out.push(m[1] || m[2]);
+  while ((m = RELATIVE_IMPORT_RE.exec(text)) !== null) out.push(m[1] || m[2] || m[3]);
   return out;
 }
 
@@ -206,7 +211,8 @@ export function reachableRelativeGraph(
     }
     for (const spec of relativeSpecifiers(text)) {
       const resolved = resolveRelativeImport(cur, spec, fileExists);
-      if (resolved && resolved.startsWith(pkgAbsRoot) && !visited.has(resolved))
+      // `+ path.sep` so `packages/x` does not prefix-match a sibling `packages/x-utils`.
+      if (resolved && resolved.startsWith(pkgAbsRoot + path.sep) && !visited.has(resolved))
         queue.push(resolved);
     }
   }


### PR DESCRIPTION
## What

Mechanical floor for **accidental-green** regression tests — a test that passes even on the buggy pre-fix code, guarding nothing. This is the machine backstop the `enforcement-architecture.md` rule requires behind the `pr-review-reviewer` guardian and the `tdd-and-planning.md` "Prove the regression test RED" rule. It **recurred twice in one session** (ARCH-004, CORE-026), each caught only because the reviewer manually re-ran the test against `origin/develop`.

## How

The intended mutation IS the inverse of the PR's own source diff. For a `fix:` PR with a **same-package** (source+test) pair, the check reverse-applies the source hunks and requires the changed test to **FAIL** — proving it exercises the fix. Same-package tests import source relatively, which vitest transforms from `src` on the fly, so **no rebuild** is needed (single targeted mutant, cheap — broad Stryker-style sweeps stay in INFRA-042).

Design gated by an independent `proposal-reviewer` (REVISE → ENDORSE); all four binding constraints folded in:
- **C1 (correctness-critical):** a vitest *run-error* (transform / collection / missing-module) is **INCONCLUSIVE**, never counted as red-proof — only a genuine assertion failure passes.
- **C2:** qualifies on `fix:` only (`perf:` excluded).
- **C3:** module-graph guard — mutate only a source file the changed test relatively imports; else INCONCLUSIVE.
- **C4:** refuses to mutate a dirty tree; restores in a `finally`.

## Verification

- **25 unit tests** over the full fixture matrix. `pnpm harness:test` → **429 pass**.
- **Real end-to-end proof** on the CLI-061 fix commit `b9893455f`: real `git apply -R` + real `vitest` → C3 detected the import, outcome `assertion-fail` → **red-proof-ok**, tree clean after restore.
- Self-run on `develop` correctly SKIPs; 63/63 scans pass; YAML validates.

## Rollout

Advisory CI job `regression-red-proof` — runs and prints the verdict but never blocks the merge (exits 0 unless `REGRESSION_RED_PROOF_ENFORCE=1`; not in the required-checks ruleset). Flip to required once stable.

## Note — no `package.json` alias (INFRA-044)

The checker is invoked directly as `node scripts/harness/check-regression-red-proof.mjs`; a `package.json` script alias is intentionally **omitted** because editing `package.json` trips the `security-audit` osv-scanner, which surfaced **18 pre-existing dependency advisories** (unrelated to this PR — they accumulate invisibly because the audit runs only on manifest-changing PRs). Filed as **INFRA-044** (triage + move the audit to a schedule). This feature carries no dependency remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)