### PR TITLE
ci: scope heavy jobs to code changes (docs-only PRs skip the matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,36 @@ jobs:
               exit 1 ;;
           esac
 
+  # Proportional CI (DX): classify whether a PR touches CODE or is documentation-only, so a docs/harness-markdown
+  # PR skips the heavy build/test/e2e matrix. Those gated jobs are NOT required status checks (required =
+  # build/quality/scans/security-audit/commitlint, which always run), so skipping them is safe for branch
+  # protection — a skipped non-required job does not block the merge.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }} --depth=50
+      - id: filter
+        name: Classify changed paths (code vs docs-only)
+        run: |
+          files="$(git diff --name-only --diff-filter=ACMRD origin/${{ github.base_ref }}...HEAD)"
+          echo "changed files:"; printf '%s\n' "$files"
+          # 'code' = ANY changed file that is not pure documentation (markdown / docs site / versioned content).
+          # A .agents/**/*.md harness-content PR is docs-only; a scripts/**, packages/**, .github/** change is code.
+          if printf '%s\n' "$files" | grep -qvE '(\.mdx?$|^docs/|^content/)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "→ code changes present: full matrix runs."
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "→ docs-only PR: heavy build/test/e2e jobs are skipped."
+          fi
+
   build:
     name: build
     runs-on: ubuntu-latest
@@ -373,7 +403,8 @@ jobs:
   examples-typecheck:
     name: examples-typecheck
     runs-on: ubuntu-latest
-    if: github.base_ref != 'main'
+    needs: changes
+    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -408,7 +439,8 @@ jobs:
   windows-shell:
     name: windows-shell
     runs-on: windows-latest
-    if: github.base_ref != 'main'
+    needs: changes
+    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -446,7 +478,8 @@ jobs:
   tui-e2e:
     name: tui-e2e
     runs-on: ubuntu-latest
-    if: github.base_ref != 'main'
+    needs: changes
+    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -481,7 +514,8 @@ jobs:
   regression-red-proof:
     name: regression-red-proof (advisory)
     runs-on: ubuntu-latest
-    if: github.base_ref != 'main'
+    needs: changes
+    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,14 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # Proportional CI: skip SAST for documentation-only PRs (no analyzable JS/TS changed). CodeQL is advisory
+    # (not a required check), so not triggering it on a docs-only PR is safe for branch protection. The weekly
+    # schedule + push-to-branch runs still give full coverage.
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - 'content/**'
   schedule:
     # Weekly full scan (catches issues in code that a given PR didn't touch).
     - cron: '27 4 * * 1'


### PR DESCRIPTION
## Problem

Docs / harness-markdown-only PRs (e.g. the GATE-COMPLETE reconciliations #1270, #1271, #1273 — each touching only `.agents/**/*.md`) ran the **entire** CI matrix: `tui-e2e` (~3.5m), `examples-typecheck` (~3m), CodeQL `Analyze` (~3m), `windows-shell` (~1.7m), `regression-red-proof`. That's ~10 min of build/e2e/SAST runner time for a change that touches no code.

## Fix — proportional CI

- New **`changes`** job classifies a PR as **code** vs **docs-only** from its diff (`code = any changed file not matching `**/*.md` / `docs/` / `content/``).
- The expensive **non-required** jobs (`examples-typecheck`, `windows-shell`, `tui-e2e`, `regression-red-proof`) now gate on `needs.changes.outputs.code == 'true'`.
- Advisory **CodeQL** gets `paths-ignore` for docs-only PRs.

## Why it's safe for branch protection

Required checks are `build`, `quality`, `scans`, `security audit`, `commitlint` — these **always run**. Only **non-required** jobs are conditionally skipped, and a skipped non-required job does not block a merge (unlike a workflow-level `paths:` filter, which would leave a *required* check pending forever — that pitfall is avoided here). `build`/`quality` already self-scope internally via `harness:plan` affected-detection, so they stay always-on.

## Effect

| PR kind | Before | After |
| --- | --- | --- |
| docs / `.agents/**/*.md` only | full matrix (~10 min heavy jobs) | required fast checks only (~1–2 min) |
| code (`packages/**`, `scripts/**`, `.github/**`) | full matrix | full matrix (unchanged) |

This PR touches `.github/**` → classified as code → runs the full matrix on itself (validates the gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)