### PR TITLE
docs(backlog): harness diet audit — epic + 7 backlog items

### DIFF
--- a/.agents/backlog/HARNESS-DIET-000-harness-diet-audit-roadmap.md
+++ b/.agents/backlog/HARNESS-DIET-000-harness-diet-audit-roadmap.md
@@ -1,0 +1,75 @@
+---
+title: 'HARNESS-DIET-000: harness diet — audit roadmap (rules / skills / hooks / scans / agents / routing)'
+status: todo
+created: 2026-07-23
+priority: high
+urgency: soon
+area: .agents/rules, .agents/skills, .claude/hooks, .claude/agents, scripts/harness, .github/workflows, AGENTS.md
+depends_on: []
+---
+
+# HARNESS-DIET-000: harness diet audit roadmap
+
+## Purpose
+
+Owner directive (2026-07-23): audit the repo's harness — **rules, skills, hooks, scans, agent definitions, and
+routing/workflows** — and slim it down. Remove what is **unnecessary, non-neutral, excessive, or ineffective**.
+This is the epic/index; the concrete work is in the `HARNESS-DIET-001..007` sub-items below. Execution is
+deliberately deferred to those items (this pass produced the audit + the backlog, per the directive to "create
+the backlogs, then end the refactoring").
+
+## Method
+
+Eight read-only auditor agents divided the surface (22 rules, 60 skills, 12 hooks, 85 harness scripts, 14 agent
+defs, top-level routing + 10 CI workflows). Each judged every item on four axes — **UNNECESSARY / NON-NEUTRAL /
+EXCESSIVE / INEFFECTIVE** — and returned a per-item verdict (KEEP / SLIM / MERGE / NEUTRALIZE / REMOVE) with
+grep-verified evidence. This file records the cross-cutting themes; each sub-item carries its scope's detailed
+findings.
+
+## Cross-cutting themes (why this matters)
+
+1. **Non-neutrality is the dominant defect (north-star violation).** Per [`VISION.md`] and
+   `.agents/memory/MEMORY.md`, robota is meant to be a **general, neutral** development-agent harness — building
+   Robota is only the validation benchmark. Yet Robota package names (`@robota-sdk/*`), specific file paths, app
+   inventories, and even required prose strings are hardcoded into machinery that presents as portable: ~10+
+   scans, several rules (`publish`, `release-operations`, `frontend`, `code-quality`, `documentation-sync`),
+   several skills (`robota-sdk-usage`, `contract-audit`, `backlog-execution-orchestrator`), and one agent
+   (`prior-art-researcher`). The fix pattern is uniform: move repo-specifics to config
+   (`harness-config`/`project-structure.md`/package SPECs); keep the machinery generic. → DIET-002, 004, 005.
+2. **Dead / vacuous machinery.** `bootstrap.mjs` targets deleted apps (`apps/web`, `apps/api-server`);
+   `scan-file-size` and `check-document-authority` are registered gates that **can never fail**;
+   `record-owner-scenario.mjs` is orphaned; ~11 skills are index-only textbook/vendored dead weight;
+   `operational.md`'s Idea-Capture + `{DOMAIN}-{BL|TK}-{NNN}` ID scheme are stale (the repo uses
+   `{DOMAIN}-{NNN}`); `compat-node18` runs Node 22, not 18. → DIET-003, 005, 007.
+3. **Redundancy / consolidation.** A triple routing layer (`AGENTS.md` ↔ `rules/index.md` ↔ `rules/process.md`);
+   a 5-scan "library-neutrality" family that should be one config-driven scan; the INFRA-002 conformance
+   skill-tree duplicating the `architecture-refresh` agent loop; `publish.md` + `release-operations.md`;
+   `backlog-execution.md` restating one rule ~5× (491 lines); four thin scans foldable into neighbours. →
+   DIET-002, 003, 004, 005, 007.
+4. **Excessive / heavy-preamble.** Skills that re-state rules a rule already owns; `common-mistakes.md` #1–55
+   restating other rules; `git-branch.md` war-stories; over-broad hook matchers (`spec-first-gate` fires on
+   `\bcode\b`/`\badd\b`/`\bwrite\b`); per-edit `eslint --fix` duplicating lint-staged. → DIET-004, 005, 006.
+5. **Safety (do first).** All 8 read-only reviewer/auditor agents carry `Bash` with **no guardrail against
+   tree-mutating git** — and this session a read-only reviewer ran `git reset --hard` and destroyed an untracked
+   spec-doc. `pr-review-reviewer` even _instructs_ a working-tree checkout/revert. → DIET-001 (security).
+
+## Sub-items
+
+| Item                                                                 | Scope                                    | Priority      |
+| -------------------------------------------------------------------- | ---------------------------------------- | ------------- |
+| [HARNESS-DIET-001](HARNESS-DIET-001-reviewer-agent-git-safety.md)    | reviewer-agent destructive-git safety    | high / now    |
+| [HARNESS-DIET-002](HARNESS-DIET-002-scans-neutrality-config.md)      | scans: config-drive neutrality           | high / soon   |
+| [HARNESS-DIET-003](HARNESS-DIET-003-scans-dead-and-consolidation.md) | scans: remove dead/vacuous + consolidate | high / soon   |
+| [HARNESS-DIET-004](HARNESS-DIET-004-rules-consolidation.md)          | rules: consolidate & neutralize          | medium / soon |
+| [HARNESS-DIET-005](HARNESS-DIET-005-skills-diet.md)                  | skills: remove dead + consolidate + slim | medium / soon |
+| [HARNESS-DIET-006](HARNESS-DIET-006-hooks-diet.md)                   | hooks: remove/slim/merge                 | medium / soon |
+| [HARNESS-DIET-007](HARNESS-DIET-007-routing-and-workflow-fixes.md)   | top-level routing & workflow fixes       | medium / soon |
+
+## Guardrails for execution
+
+- Each sub-item is a coherent PR unit (per the PR-batching policy, DX-001). Do NOT bundle unrelated sub-items.
+- A REMOVE must be grep-proven unreferenced first; a MERGE must preserve the merged check's coverage (add a
+  regression proof where a scan/hook changes behavior — see HARNESS-041 red-proof discipline).
+- Neutralization must not weaken enforcement: move the Robota-specific data to config, keep the mechanical gate.
+- Update `.agents/skills/index.md`, `.agents/rules/index.md`, `orchestration-map.md`, and `run-all-scans.mjs`
+  in the same PR as any add/remove they track (their scans will fail otherwise).

--- a/.agents/backlog/HARNESS-DIET-001-reviewer-agent-git-safety.md
+++ b/.agents/backlog/HARNESS-DIET-001-reviewer-agent-git-safety.md
@@ -1,0 +1,51 @@
+---
+title: 'HARNESS-DIET-001: read-only reviewer/auditor agents must not run tree-mutating git'
+status: todo
+created: 2026-07-23
+priority: high
+urgency: now
+area: .claude/agents, scripts/harness/check-agent-def-convention.mjs
+depends_on: []
+---
+
+# HARNESS-DIET-001: reviewer-agent destructive-git safety
+
+## Problem
+
+All 8 read-only reviewer/auditor/worker agents carry `Bash` in their `tools:` and **none forbids tree-mutating
+git**: `architecture-auditor`, `architecture-conformance-auditor`, `capability-scout`, `doc-auditor`,
+`merge-verifier`, `pr-review-reviewer`, `prior-art-researcher`, `proposal-reviewer`. Claude Code's `tools:`
+cannot sub-scope `Bash` to read-only git, so each can run `git reset --hard` / `checkout` / `clean` / `stash` and
+destroy uncommitted work. **This actually happened this session**: a `proposal-reviewer` ran `git reset --hard`
+mid-review and deleted an untracked spec-doc; separately a `pr-review-reviewer` was warned off the same.
+
+Two are worse than the rest:
+
+- **`pr-review-reviewer`** actively _instructs_ tree mutation in its body ("temp checkout of `origin/<base>`",
+  "revert only the source fix and run") — standing procedure that is destructive on a dirty tree.
+- **`merge-verifier`** forbids `merge/push/delete` but not `reset/checkout/clean` — a hole, and it routinely runs
+  git.
+
+## What
+
+1. Add a standard guardrail line to each of the 8 read-only agents' system prompts, e.g.:
+   > You are READ-ONLY. Never run tree-mutating git in the working tree — no `reset`, `checkout`, `clean`,
+   > `stash`, `rm`, `commit`, `push`, `apply`. To inspect other states use `git show`/`git diff`/`git log`
+   > against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+2. Rewrite `pr-review-reviewer`'s regression red-proof procedure to use an isolated `git worktree add <tmp>`
+   ONLY; delete the "temp checkout of origin/<base>" / "revert only the source fix in the working tree" phrasings.
+3. Extend `merge-verifier`'s "what is NOT your job" list to explicitly ban `reset/checkout/clean/stash`.
+4. **Mechanize** it: extend `scripts/harness/check-agent-def-convention.mjs` to FAIL any agent whose `tools:` is
+   read-only (no `Edit`/`Write`) and whose body lacks the tree-mutating-git ban. This is the guardian floor so
+   the guardrail cannot rot out.
+
+## Test Plan
+
+- `check-agent-def-convention` red-before-green: it must FAIL on the current agents (no ban present), then pass
+  after the ban lines are added. Register the updated scan in `run-all-scans` (already registered).
+- Spot-check: each of the 8 agents contains the ban; `pr-review-reviewer` no longer mentions a working-tree
+  checkout/revert.
+
+## User Execution Test Scenarios
+
+- Not applicable (harness/agent-definition change; the `check-agent-def-convention` scan is the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-002-scans-neutrality-config.md
+++ b/.agents/backlog/HARNESS-DIET-002-scans-neutrality-config.md
@@ -1,0 +1,55 @@
+---
+title: 'HARNESS-DIET-002: config-drive scan neutrality — kill Robota-specifics baked into general scans'
+status: todo
+created: 2026-07-23
+priority: high
+urgency: soon
+area: scripts/harness, .agents/harness-config
+depends_on: []
+---
+
+# HARNESS-DIET-002: scans — config-drive neutrality
+
+## Problem
+
+~10+ harness scans hardcode Robota specifics (`@robota-sdk/*` scope prefixes, exact package/file paths, even
+required SPEC prose) into machinery that presents as a general harness — the north-star's core "don't bake
+Robota into general machinery" violation. The repo already has `scripts/harness/harness-config.mjs` as the
+config-loader pattern; most of these scans predate it.
+
+## What
+
+### 1. Collapse the 5-scan "library-neutrality" family → one config-driven scan
+
+`scan-agent-tools-neutrality`, `scan-session-artifact-neutrality`, `scan-memory-neutrality`,
+`scan-evals-neutrality`, `scan-orchestration-neutrality` are the same guardian copy-pasted 5× (~670 lines total),
+each hardcoding one subsystem's `{path, forbiddenTokens, allowlist}`. Replace with a single
+`scan-library-neutrality.mjs` that reads those rows from `harness-config`. Preserve each subsystem's current
+token/allowlist as config rows (no coverage loss).
+
+### 2. Relocate the bespoke Robota-package layering scans out of the general suite
+
+`check-agent-server-boundary` (433 lines, hardcodes app graph + required-SPEC prose regexes),
+`check-command-layering` (CLI internals + literal slash-command name list), `check-sdk-public-surface`
+(agent-framework barrels + forbidden owner packages), `check-background-workspace-conformance` (executor/
+framework files + class names). Convert to config-driven repo-local layering rules (or one shared layering scan
+sourcing package/edge lists from config); drop the required-SPEC-_prose_ regexes entirely (a scan should check
+structure, not wording).
+
+### 3. Config-ize the hardcoded `@robota-sdk/` scope prefix
+
+In `check-test-module-mocks`, `check-workspace-refs`, `check-interface-imports`, `check-dep-kind`,
+`check-capability-placement` (40 hardcoded patterns), and the `checkDagNodesLeaf` rule in
+`check-dependency-direction` — source the scope prefix / package lists from `harness-config` so the otherwise
+general check ports to any repo. Keep legitimate burn-down allowlists (e.g. MOCK-001) as data.
+
+## Test Plan
+
+- Each converted scan keeps its current pass/fail behavior on the current tree (snapshot before/after: the
+  unified neutrality scan must flag exactly what the 5 separate scans flagged — add fixtures per subsystem).
+- `run-all-scans` registry updated (5 entries → 1); `harness:scan` stays green; no orphaned scan files.
+- `check-harness-config-paths` still passes (new config keys resolve).
+
+## User Execution Test Scenarios
+
+- Not applicable (harness scans; the scans' own fixtures + `harness:scan` are the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-003-scans-dead-and-consolidation.md
+++ b/.agents/backlog/HARNESS-DIET-003-scans-dead-and-consolidation.md
@@ -1,0 +1,63 @@
+---
+title: 'HARNESS-DIET-003: remove dead/vacuous scans + consolidate thin ones'
+status: todo
+created: 2026-07-23
+priority: high
+urgency: soon
+area: scripts/harness, scripts/harness/run-all-scans.mjs
+depends_on: []
+---
+
+# HARNESS-DIET-003: scans — remove dead/vacuous + consolidate
+
+## Problem
+
+Several harness scans are dead, vacuous (structurally cannot fail), orphaned, or thin single-rule checks that
+belong inside a neighbour. They add registry weight and false assurance without catching anything.
+
+## What
+
+### REMOVE (dead / orphaned)
+
+- `bootstrap.mjs` — `APP_DEFINITIONS` targets `apps/web` + `apps/api-server`, **neither exists** (renamed to
+  `agent-web`/`agent-server`); every run is a vacuous SKIP. Delete, or rewrite to derive apps dynamically.
+- `record-owner-scenario.mjs` — orphan; referenced only in `scripts/harness/README.md` (absent from
+  package.json, ci.yml, husky, skills). Its logic already lives in `scenario-records.mjs`. Delete.
+
+### FIX never-failing gates (enforce or drop — a scan that cannot fail is noise)
+
+- `scan-file-size` (`file-size`) — never sets `exitCode=1` (warn-only, per a stale "once CLI-BL-022 complete"
+  comment); 3 live >300-line files pass green. Flip to enforcing with a pinned baseline of the current 3, or drop
+  from `run-all-scans`.
+- `check-document-authority` (`document-authority`) — warn-only AND `getChangedFiles()` returns `[]` in the
+  base-ref-less `scans` job, so it can never fail. Make it blocking (and fetch the base) or drop from the
+  blocking suite.
+
+### SHRINK / SPLIT
+
+- `check-spec-public-surface` — its **641-line `@robota-sdk#symbol` reverse allowlist** has turned the
+  undocumented-export edge off for the whole surface ("do not grow casually" — it grew). Keep the cheap forward
+  phantom-export check; retire or radically shrink the reverse allowlist.
+- `scan-consistency` (394 lines) — a grab-bag mixing workspace-drift + required-script presence + skill anchors +
+  scenario-record validation + one-off Robota `PHRASE_CHECKS` literals. Split by responsibility; move phrase
+  blocklists to config or delete the stale one-offs.
+
+### MERGE thin/overlapping scans (trim the registry by ~4, no coverage loss)
+
+- `check-architecture-conformance` → fold its package-name-token check into `check-dependency-direction`
+  (`deps`); drop the spawn-wrapper (its docstring says "not wired into run-all-scans" but line 176 wires it).
+- `check-entry-point-only` → fold the single aggregator-import edge into `deps` / `capability-placement`.
+- `check-spec-publish-claims` → fold the single-incident private-pkg-claims-publish tripwire into
+  `check-publish-safety`.
+- `check-sdk-react-free` → fold the single-package React-free rule into a config-driven package-purity check.
+
+## Test Plan
+
+- Red-before-green for the enforce-now flips (`scan-file-size`, `check-document-authority`): prove they FAIL on
+  an injected violation, pass on the baseline.
+- Each MERGE: the absorbing scan must catch what the removed scan caught (add a fixture per merged rule).
+- `run-all-scans` registry updated; `harness:scan` green; no orphaned files; `check-harness-config-paths` green.
+
+## User Execution Test Scenarios
+
+- Not applicable (harness scans; fixtures + `harness:scan` are the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-004-rules-consolidation.md
+++ b/.agents/backlog/HARNESS-DIET-004-rules-consolidation.md
@@ -1,0 +1,67 @@
+---
+title: 'HARNESS-DIET-004: rules — consolidate, neutralize, de-duplicate, de-stale'
+status: todo
+created: 2026-07-23
+priority: medium
+urgency: soon
+area: .agents/rules
+depends_on: []
+---
+
+# HARNESS-DIET-004: rules consolidation & neutralization
+
+## Problem
+
+The 22 rule files are all referenced (no dead rules), but they carry heavy non-neutrality, internal repetition,
+a triple routing layer, and stale content. All enforcement claims were verified real (the named scans exist), so
+this is about slimming prose and relocating repo-data — NOT weakening gates.
+
+## What
+
+### Relocate release runbooks out of general `rules/`
+
+- `publish.md` + `release-operations.md` are ~100% `@robota-sdk`/`pnpm`/`npm`/OTP operational procedure and
+  overlap each other. Merge into one release runbook under a runbook/skill namespace (keep it enforced by
+  `check-publish-safety` / `check-release-governance`). Biggest neutrality win.
+
+### Collapse the routing layer
+
+- Fold `process.md` (a 20-line routing table already in `index.md`) into `index.md`; repoint `AGENTS.md`'s
+  Process link. (Pairs with DIET-007's AGENTS.md slim.)
+- Merge `api-boundary.md` (14 lines, no scan/hook enforces SIGTERM/OpenAPI) into `operational.md`.
+
+### De-duplicate internally
+
+- `backlog-execution.md` (491 lines) restates "never cite build/test/lint as User-Execution evidence" ~5×
+  (Done-Gate, Stop Conditions, Common-Mistakes table, Checklist). Collapse to one statement + the single enforced
+  gate.
+- `common-mistakes.md` — prune #1–#55 (generic restatements of code-quality/publish/spec rules); keep the dated
+  incident entries (#57+) with worked examples (the genuinely useful part).
+
+### Neutralize baked project-data
+
+- `frontend.md` App-Inventory table (hardcodes `apps/agent-web`, the dissolved `agent-web-monitor`, …) → move to
+  `project-structure.md`; keep the React/Next/Tailwind stack rules.
+- `documentation-sync.md` Documentation-Source-Map (robota.io `content/` path list) → move to a doc-map config;
+  keep the neutral "update docs in the same PR" gate; dedupe vs `spec-workflow` Document Authority.
+- `code-quality.md` Layered-Assembly section (full agent-core→agent-cli stack + command-layering) → move to the
+  architecture SPEC; keep the neutral type/pattern rules.
+
+### De-stale / de-scope
+
+- `operational.md` — refresh/remove Idea-Capture (points at empty `.agents/tasks/`; real flow is
+  `spec-docs/draft`) and the `{DOMAIN}-{BL|TK}-{NNN}` ID table (repo uses `{DOMAIN}-{NNN}`, e.g. `GUI-001`).
+- `naming-style.md` — the Korean 적/의/것/들 micro-style list has no enforcement and is owner-personal; move it
+  to a skill, keep Language/Identity/Styling SSOT.
+- `git-branch.md` (295 lines, well-enforced) — compress the multi-line incident narratives to one-line
+  rationales; the hooks already enforce.
+
+## Test Plan
+
+- No enforcement regression: every scan/hook that references a moved/renamed rule still resolves (`check-spec-paths`,
+  `check-harness-config-paths`, `scan-consistency` required-anchor checks) — update references in the same PR.
+- `harness:scan` green; AGENTS.md + `rules/index.md` links resolve.
+
+## User Execution Test Scenarios
+
+- Not applicable (rule/documentation change; the scan suite is the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-005-skills-diet.md
+++ b/.agents/backlog/HARNESS-DIET-005-skills-diet.md
@@ -1,0 +1,68 @@
+---
+title: 'HARNESS-DIET-005: skills — remove dead/textbook/vendored, consolidate, slim rule-restating'
+status: todo
+created: 2026-07-23
+priority: medium
+urgency: soon
+area: .agents/skills, .agents/skills/index.md
+depends_on: []
+---
+
+# HARNESS-DIET-005: skills diet
+
+## Problem
+
+Of 60 skills, a large fraction are index-only (never invoked by any orchestrator/hook/agent/sibling), generic
+textbook the model already knows, vendored copies of globally-available skills, or heavy-preamble skills that
+re-state a rule a rule already owns. The design ideal (memory `gstack-skillset-design-principle`,
+`harness-mechanical-not-skilltree`) is thin routing + single-responsibility leaf skills; reliability comes from
+mechanical hooks/scans, not deep skill-tree prose.
+
+## What
+
+### REMOVE — index-only dead weight (grep-verified: referenced only by `index.md`)
+
+`async-concurrency-patterns`, `cqrs-event-projection-basics`, `ddd-tactical-patterns`, `execution-caching`
+(generic textbook), `state-machine-design`, `logging-level-guide`, `tailwind-truncation` (trivial generic prose),
+`plugin-development` (non-neutral, content belongs in the package's PLUGINS.md), `deploy-to-vercel` (296-line
+vendored copy duplicating the global `deploy-to-vercel` plugin), `vercel-react-native-skills` (repo has **zero**
+React-Native/Expo usage), `web-design-guidelines` (vendored, WebFetches an external URL each run, duplicates the
+global gstack skill). Drop each `index.md` row too.
+
+### NEUTRALIZE — Robota-specifics baked into "general" skills
+
+- `robota-sdk-usage` → move to `packages/agent-core/docs`, delete from skills (the clearest north-star violation).
+- `scenario-verification-harness` → strip Robota tokens (`ownerPath`, `[STRICT-POLICY]`, `[EMITTER-CONTRACT]`) →
+  generic "verify against a recorded scenario", or fold into `repo-change-loop`.
+- `contract-audit`, `backlog-execution-orchestrator`, `dependency-graph-extraction` → genericize hardcoded
+  `@robota-sdk/*` package names / "Robota CLI/TUI/browser" product surfaces (source from `project-structure`).
+
+### CONSOLIDATE — the INFRA-002 conformance skill-tree into the agent loop
+
+`architecture-conformance-audit` + `dependency-graph-extraction` + `doc-claim-verification` +
+`conformance-finding-report` (+ `design-quality-audit`) re-implement, as sequenced prose skills, what the
+`architecture-refresh` + `architecture-conformance-auditor` / `architecture-auditor` **agents** now do natively.
+Keep the mechanical floor (`harness:conformance`, the completeness gates) and one thin agent loop; retire the
+parallel skill-tree.
+
+### MERGE
+
+- `semver-api-surface` → `version-management` (breaking-change table).
+- `repo-writing` → pointer into `naming-style` + `git-branch` rules (it already names them SSOT).
+
+### SLIM — heavy rule-restating / textbook skills (keep the unique bit + a pointer)
+
+`post-implementation-checklist`, `package-code-review`, `pre-refactor-test-harness`, `architecture-patterns`,
+`effect-style-error-modeling`, `api-error-standard`, `contract-testing`, `architecture-decision-records`,
+`lesson-to-harness`, `pnpm-monorepo-build`, `branch-guard`.
+
+## Test Plan
+
+- Every REMOVE grep-proven unreferenced outside `index.md` before deletion; update `index.md` in the same PR.
+- `scan-consistency` skill-anchor checks + any orchestrator that dispatches a consolidated skill still resolve
+  (update `orchestration-map.md` if an agent/skill wiring changes).
+- `harness:scan` green.
+
+## User Execution Test Scenarios
+
+- Not applicable (skill/documentation change; the scan suite is the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-006-hooks-diet.md
+++ b/.agents/backlog/HARNESS-DIET-006-hooks-diet.md
@@ -1,0 +1,54 @@
+---
+title: 'HARNESS-DIET-006: hooks — remove duplicate, slim heavy, merge duplicated, narrow over-broad'
+status: todo
+created: 2026-07-23
+priority: medium
+urgency: soon
+area: .claude/hooks, .claude/settings.json
+depends_on: []
+---
+
+# HARNESS-DIET-006: hook diet
+
+## Problem
+
+Of 12 hooks, none is wired-but-dead, but several duplicate CI scans / git-native husky hooks / ESLint, fire on
+nearly every turn with advisory-only output, or hardcode `@robota-sdk`/`.agents/tasks` paths. Mechanical hooks
+are the right enforcement layer (memory `harness-mechanical-not-skilltree`) — so the genuinely blocking, neutral
+ones stay; the redundant/advisory/over-broad ones get cut. Keep intact: `branch-guard`, `memory-mirror-reminder`,
+`eval-log-stop` + `revert-detect`.
+
+## What
+
+- **REMOVE `check-no-reexport.sh`** — hardcodes `@robota-sdk/`, exits 1 as a non-blocking PostToolUse warning
+  (not fed back as a block), and its `export *` pass-through case is already CI-gated by
+  `check-dependency-direction.mjs` (`checkPassthroughReexports`). If the named-`export {…} from` cross-package
+  case must be guarded, add it to that neutral, blocking scan instead.
+- **SLIM `pre-push-check.sh`** — it runs the full-repo `pnpm typecheck` + `lint` + **entire test suite** on every
+  push, duplicating `.husky/pre-push` (`harness:pre-push`) and CI. Keep only the cheap lockfile-sync +
+  foreign-merge branch-hygiene gates; drop the heavy re-runs.
+- **SLIM `post-tool-format.sh`** — drop the per-edit `npx eslint --fix` (node cold-start after _every_ Write/Edit);
+  `lint-staged` (`.husky/pre-commit`) already batches the identical `eslint --fix` + `prettier --write`. Keep
+  prettier-only for fast feedback, or remove entirely.
+- **SLIM / NEUTRALIZE `spec-first-gate.sh`** — its trigger list (`\bcode\b`, `\badd\b`, `\bchange\b`, `\bwrite\b`,
+  `\bfix\b`) fires on nearly every dev prompt, and the output is an advisory reminder (real enforcement is
+  `scan-spec-research` + GATE-WRITE). Narrow the trigger to strong "implement a new feature" intent, or retire the
+  reminder. Also de-hardcode the `.agents/spec-docs/draft`/`backlog-writer` paths.
+- **MERGE `task-tracking-start.sh` + `task-tracking-stop.sh`** — `classify_task()` is byte-for-byte duplicated in
+  both. Fold into one script invoked in `SessionStart`/`Stop` modes so the logic has a single owner.
+- **SLIM `check-forbidden-patterns.sh`** — `any` and `console.*` are already ESLint `error`s and the regex is
+  false-positive-prone (trips on an inline `// … any …` comment); the fallback case is covered by
+  `scan-no-fallback`. Keep at most the pre-write fallback block, or remove.
+- **TIGHTEN `correction-detect.sh`** — keep the `corrections.jsonl` metric; require an explicit "make this a rule"
+  phrasing for the `lesson-to-harness` nudge instead of firing on common words (`always`/`never`/`항상`/`반드시`).
+
+## Test Plan
+
+- After each change, the hook still fires on its intended case and no longer on the removed case (add a small
+  fixture/echo test where practical); `.claude/settings.json` wiring stays valid.
+- Confirm the removed/duplicated coverage is retained by its owner (CI scan / husky / ESLint) — cite the owner in
+  the PR.
+
+## User Execution Test Scenarios
+
+- Not applicable (hook/infra change; the retained CI scans + husky hooks are the maintained gate).

--- a/.agents/backlog/HARNESS-DIET-007-routing-and-workflow-fixes.md
+++ b/.agents/backlog/HARNESS-DIET-007-routing-and-workflow-fixes.md
@@ -1,0 +1,65 @@
+---
+title: 'HARNESS-DIET-007: top-level routing slim + CI/workflow correctness fixes'
+status: todo
+created: 2026-07-23
+priority: medium
+urgency: soon
+area: AGENTS.md, .agents/backlog/README.md, .agents/skills/index.md, .agents/specs/document-standards, .github/workflows
+depends_on: []
+---
+
+# HARNESS-DIET-007: top-level routing & workflow fixes
+
+## Problem
+
+The entry/routing docs carry the triple-routing duplication and a large stale ledger, and several CI workflows
+have concrete correctness bugs (a job that doesn't test what it claims, a mis-pointed template, a contradictory
+publish path).
+
+## What
+
+### Routing / doc slim
+
+- **`AGENTS.md`** → routing-only: drop the "Mandatory Rules" Key-rules column (owned by each rule doc) and the
+  inlined Project-Structure + Common-Commands blocks (owned by `project-structure.md` / `package.json`). Keep the
+  doc-tree table. Collapses the AGENTS.md ↔ `rules/index.md` ↔ `rules/process.md` triple layer (pairs with the
+  DIET-004 `process.md` fold).
+- **`.agents/backlog/README.md`** (766 lines) → delete the inline `## Items` ledger (~676 lines): it inlines
+  ✅-completed items despite the file's own "archived to `completed/`" policy (639 files already in `completed/`)
+  and holds the only dead reference (`.agents/reports/…`). Regenerate from frontmatter or link `completed/`;
+  reduce prose to Process + File-Format + a pointer to `backlog-execution.md`.
+- **`.agents/skills/index.md`** → trim the per-agent blockquotes (duplicate `orchestration-map.md` + the agent
+  files) to pointers; drop the `vercel-react-native-skills` row (see DIET-005).
+
+### CI / workflow correctness bugs
+
+- **`compat-node18` (ci.yml)** — sets `node-version: '22.x'`, so it does NOT test the declared `>=18` floor. Pin
+  Node 18 (or rename the job to what it actually tests). A required-looking job that catches nothing for its
+  stated purpose.
+- **`document-standards/index.md`** — the Package-`SPEC.md` taxonomy row has template `—` while `spec-template.md`
+  (which IS a package-SPEC template) is mis-routed as the _backlog spec-doc_ template. Point the Package-SPEC row
+  at `spec-template.md`; fix/replace the backlog-spec-doc pointer. The guard only checks the pointer resolves, so
+  the semantic mismatch is silent.
+- **`release.yml`** — `pnpm -r publish --access public --no-git-checks` with `NPM_TOKEN` and **no OTP**
+  contradicts the documented single-OTP manual publish flow (INFRA-029; memory: "npm stays OTP-manual"). Two
+  competing publish paths is a hazard — remove the token-based path or reconcile it to the OTP flow (owner
+  decision).
+- **`deploy.yml`** — environment URLs use `robota.dev`/`staging.robota.dev`; the real site is `robota.io`. Fix
+  the URL; drop the duplicate `security` job (osv-scanner already in ci.yml; Snyk needs a token + is
+  `continue-on-error`).
+
+### Optional
+
+- Factor the shared CI setup boilerplate (checkout + pnpm + node + install) copy-pasted across ~10 jobs into a
+  composite action.
+
+## Test Plan
+
+- `AGENTS.md` / `skills/index.md` / `document-standards` link integrity green (`check-document-standards-index`,
+  `scan-consistency`, `check-spec-paths`).
+- `compat-node18` actually runs on Node 18 (or is renamed); workflows still parse (YAML valid).
+- `release.yml`/`deploy.yml` change reviewed by owner (publish-path + deploy-URL are sensitive).
+
+## User Execution Test Scenarios
+
+- Not applicable (routing docs + CI config; link scans + YAML validity + a green CI run are the maintained gate).


### PR DESCRIPTION
## What

Owner directive (2026-07-23): audit the harness — **rules, skills, hooks, scans, agent definitions, routing/workflows** — and slim it, removing what is **unnecessary, non-neutral, excessive, or ineffective**. This PR delivers the **audit + the backlog** (execution is deferred to the sub-items, per the directive).

Eight read-only auditor agents divided the surface (**22 rules, 60 skills, 12 hooks, 85 harness scripts, 14 agent defs, top-level routing + 10 CI workflows**), each judging every item on four axes with grep-verified evidence.

## Deliverable — 8 backlog items

- **HARNESS-DIET-000** — epic/roadmap: method, cross-cutting themes, links.
- **001** — reviewer-agent destructive-git safety `[high/now]`: all 8 read-only agents carry `Bash` with no guardrail and can run `git reset --hard` — this **happened this session** (a reviewer destroyed an untracked spec-doc). Add the ban + mechanize via `check-agent-def-convention`.
- **002** — scans: config-drive neutrality `[high/soon]`: collapse the 5-scan "library-neutrality" family → one config-driven scan; move `@robota-sdk` scope + bespoke layering scans to config.
- **003** — scans: remove dead/vacuous + consolidate: `bootstrap.mjs` targets deleted apps; `scan-file-size` & `check-document-authority` **can never fail**; `check-spec-public-surface`'s 641-line allowlist; merge 4 thin scans.
- **004** — rules: consolidate & neutralize: `publish`/`release-operations` runbooks out of general `rules/`; collapse the triple routing layer; `backlog-execution.md` restates one rule 5×; stale `operational.md`.
- **005** — skills: remove ~11 dead/textbook/vendored skills; consolidate the INFRA-002 conformance skill-tree into the agent loop; slim rule-restating skills.
- **006** — hooks: remove/slim/merge 6 (duplicate CI/husky/ESLint, over-broad matchers).
- **007** — routing & workflow fixes: slim `AGENTS.md`; gut the 676-line backlog ledger; **`compat-node18` runs Node 22, not 18**; `release.yml` OTP contradiction; `deploy.yml` `robota.dev`→`robota.io`.

## Dominant finding

**Non-neutrality** — Robota package names/paths/prose baked into machinery that presents as a general, portable harness — is the single most pervasive defect, directly against the north-star (robota = a *general* agent; building Robota is only the validation benchmark). The fix pattern is uniform: move repo-specifics to config, keep the machinery generic.

Docs-only PR (all `.agents/**/*.md`) — exercises the new proportional-CI gating (#1274): the heavy build/e2e/SAST matrix is skipped. 63/63 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)