### PR TITLE
fix(agents): forbid tree-mutating git in read-only agents (HARNESS-DIET-001)

### DIFF
--- a/.agents/backlog/completed/HARNESS-DIET-001-reviewer-agent-git-safety.md
+++ b/.agents/backlog/completed/HARNESS-DIET-001-reviewer-agent-git-safety.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-DIET-001: read-only reviewer/auditor agents must not run tree-mutating git'
-status: todo
+status: done
+completed: 2026-07-23
 created: 2026-07-23
 priority: high
 urgency: now
@@ -9,6 +10,10 @@ depends_on: []
 ---
 
 # HARNESS-DIET-001: reviewer-agent destructive-git safety
+
+## Outcome (DONE 2026-07-23)
+
+Added a `## Working-tree safety (read-only)` guardrail (the phrase "tree-mutating git" + the concrete ban on reset/checkout/clean/stash/rm/commit/push/apply) to all 8 read-only agents (architecture-auditor, architecture-conformance-auditor, capability-scout, doc-auditor, merge-verifier, pr-review-reviewer, prior-art-researcher, proposal-reviewer). Rewrote pr-review-reviewer's red-proof to an ISOLATED `git worktree add` only (deleted the live-tree checkout/revert wording). Mechanized via `check-agent-def-convention.mjs`: a read-only agent carrying `Bash` whose body lacks the guardrail now FAILS the scan (proven red-before-green; +2 unit tests, 12 pass).
 
 ## Problem
 

--- a/.claude/agents/architecture-auditor.md
+++ b/.claude/agents/architecture-auditor.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: ACTIONABLE FINDINGS
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Architecture Auditor
 
 You are an independent, **read-only** architecture and design-quality auditor. You produce findings; you never edit code, specs, or docs. Your value is an outside, skeptical pass that judges the design **on its own merits by universal engineering principles** — portable to any codebase.

--- a/.claude/agents/architecture-conformance-auditor.md
+++ b/.claude/agents/architecture-conformance-auditor.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: ACTIONABLE FINDINGS
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Architecture Conformance Auditor
 
 You are an independent, **read-only** auditor of the match between a system's **documented/intended

--- a/.claude/agents/capability-scout.md
+++ b/.claude/agents/capability-scout.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: DECOMPOSITION
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Capability Scout
 
 You are an independent, **read-only** scout for **role decomposition**. Given a described workflow, a

--- a/.claude/agents/doc-auditor.md
+++ b/.claude/agents/doc-auditor.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: ACTIONABLE FINDINGS
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Documentation Auditor
 
 You are an independent, **read-only** documentation auditor. You produce findings; you never edit docs or code. Your value is an outside pass that judges each document **against what the code actually does**, by universal documentation-quality criteria — portable to any codebase.

--- a/.claude/agents/merge-verifier.md
+++ b/.claude/agents/merge-verifier.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: MERGE VERIFIED
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Merge Verifier
 
 Your one job: **confirm a merge actually landed, correctly, on the remote target branch** — and say so

--- a/.claude/agents/pr-review-reviewer.md
+++ b/.claude/agents/pr-review-reviewer.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: ACTIONABLE FINDINGS
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # PR Review — Reviewer (guardian)
 
 You are an independent, **read-only** code reviewer. Your single job: judge a PR and report findings. You do
@@ -26,9 +33,10 @@ NOT edit code, do NOT post the review to GitHub, do NOT fix anything — those a
 4. **Regression-test red-proof (REQUIRED when the PR fixes a defect + adds/changes a test).** A test that claims
    to verify a bug/leak/race fix is worthless if it passes on the buggy code too ("accidental-green"). Do not
    take the test's green run as proof. Actively verify it would have caught the bug: run the new/changed test
-   against the **pre-fix state** — check out the merge-base (`git worktree add` or a temp checkout of
-   `origin/<base>`), copy in ONLY the new test (not the source fix), and run it; OR revert only the source fix
-   and run. It MUST **FAIL**. If it PASSES without the fix, that is a **SHOULD** ("accidental-green: the
+   against the **pre-fix state** in an ISOLATED `git worktree add <tmp> <merge-base>` ONLY (never a checkout or
+   revert in the live working tree — see Working-tree safety). In that throwaway worktree, apply ONLY the new
+   test (not the source fix) and run it — or equivalently, prefer the mechanical `check-regression-red-proof`
+   floor (HARNESS-041). It MUST **FAIL**. If it PASSES without the fix, that is a **SHOULD** ("accidental-green: the
    regression test does not fail on the pre-fix code, so it guards nothing"), with the fix direction being the
    smallest change that makes it exercise the actual bug window/branch. Watch especially for a test that asserts
    a **late invariant** both versions satisfy. Record the pre-fix run result in your review.

--- a/.claude/agents/prior-art-researcher.md
+++ b/.claude/agents/prior-art-researcher.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
 signal: PRIOR_ART_RESEARCH
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Prior Art Researcher
 
 You are an independent, **read-only** researcher. Your single job: given a spec topic or feature request,

--- a/.claude/agents/proposal-reviewer.md
+++ b/.claude/agents/proposal-reviewer.md
@@ -5,6 +5,13 @@ tools: Read, Grep, Glob, Bash
 signal: REVIEW VERDICT
 ---
 
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. There are uncommitted files in the repo; a stray
+`git reset --hard` / `git checkout` here destroys the user's work. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
 # Proposal Reviewer
 
 You review a **proposed change** — a spec, a design decision, or an RFC that states a problem, the

--- a/scripts/harness/__tests__/check-agent-def-convention.test.mjs
+++ b/scripts/harness/__tests__/check-agent-def-convention.test.mjs
@@ -18,6 +18,8 @@ const GOOD_READONLY_AGENT = [
   '',
   '# Fixture Auditor',
   '',
+  'You are read-only: never run tree-mutating git in the working tree.',
+  '',
   'End the report with the exact line `ACTIONABLE FINDINGS: <n>`.',
 ].join('\n');
 
@@ -63,6 +65,38 @@ describe('check-agent-def-convention (INFRA-030) — FAIL (standalone malformed 
     ].join('\n');
     const findings = analyzeAgent(agent, { referencedInIndex: true });
     expect(findings.some((f) => /does not instruct ending/.test(f))).toBe(true);
+  });
+
+  it('fails a read-only agent with Bash whose body lacks the tree-mutating-git guardrail (HARNESS-DIET-001)', () => {
+    const agent = [
+      '---',
+      'name: unguarded-auditor',
+      'description: Independent, read-only auditor.',
+      'tools: Read, Grep, Glob, Bash',
+      'signal: ACTIONABLE FINDINGS',
+      '---',
+      '',
+      '# Unguarded',
+      'End with `ACTIONABLE FINDINGS: <n>`.',
+    ].join('\n');
+    const findings = analyzeAgent(agent, { referencedInIndex: true });
+    expect(findings.some((f) => /tree-mutating git/.test(f))).toBe(true);
+  });
+
+  it('a read-only agent WITHOUT Bash needs no git guardrail', () => {
+    const agent = [
+      '---',
+      'name: no-bash-auditor',
+      'description: Independent, read-only auditor.',
+      'tools: Read, Grep, Glob',
+      'signal: ACTIONABLE FINDINGS',
+      '---',
+      '',
+      '# No Bash',
+      'End with `ACTIONABLE FINDINGS: <n>`.',
+    ].join('\n');
+    const findings = analyzeAgent(agent, { referencedInIndex: true });
+    expect(findings.some((f) => /tree-mutating git/.test(f))).toBe(false);
   });
 
   it('fails a read-only agent that carries Write', () => {

--- a/scripts/harness/check-agent-def-convention.mjs
+++ b/scripts/harness/check-agent-def-convention.mjs
@@ -76,6 +76,14 @@ export function analyzeAgent(text, { referencedInIndex = true } = {}) {
     if (carried.length > 0) {
       findings.push(`declares itself read-only but carries edit tool(s): ${carried.join(', ')}`);
     }
+    // HARNESS-DIET-001: `Bash` cannot be sub-scoped to read-only git subcommands, so a read-only agent that
+    // carries Bash CAN run `git reset --hard`/`checkout`/`clean` and destroy uncommitted work (this happened
+    // in-session). Require an explicit tree-mutating-git guardrail in the body as the mechanical floor.
+    if (tools.includes('Bash') && !/tree-mutating git/i.test(body)) {
+      findings.push(
+        'read-only agent carries Bash but its body does not forbid tree-mutating git — add the guardrail (the phrase "tree-mutating git"); see HARNESS-DIET-001',
+      );
+    }
   }
 
   if (Object.prototype.hasOwnProperty.call(frontmatter, 'signal')) {


### PR DESCRIPTION
## What (HARNESS-DIET-001)

All 8 read-only reviewer/auditor agents (`architecture-auditor`, `architecture-conformance-auditor`, `capability-scout`, `doc-auditor`, `merge-verifier`, `pr-review-reviewer`, `prior-art-researcher`, `proposal-reviewer`) carried `Bash` with **no guardrail against tree-mutating git** — so any of them could run `git reset --hard` / `checkout` / `clean` and destroy uncommitted work. This **actually happened this session**: a `proposal-reviewer` ran `git reset --hard` and deleted an untracked spec-doc.

- Added a `## Working-tree safety (read-only)` guardrail to each of the 8 agents (bans `reset`/`checkout`/`clean`/`stash`/`rm`/`commit`/`push`/`apply`; points to `git show`/`diff`/`log` or an isolated `git worktree add`).
- Rewrote `pr-review-reviewer`'s regression red-proof to use an **isolated `git worktree add` only** — deleted the "temp checkout of `origin/<base>`" / "revert only the source fix" wording that authorized mutating the live tree.
- **Mechanized (the floor):** `check-agent-def-convention.mjs` now FAILS any read-only agent that carries `Bash` but whose body lacks the guardrail. Proven **red-before-green** (the scan flagged all 8, then passed once guarded); +2 unit tests (12 pass).

## Verification

- `check-agent-def-convention` green; 63/63 scans; agent-def unit tests 12/12.

Archives HARNESS-DIET-001 → `completed/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)