### PR TITLE
feat(harness): allow git worktrees for parallel subagents, with guardrails

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -3,26 +3,32 @@
 Mandatory rules for git operations and branch policy.
 Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 
-### Git Worktree — ABSOLUTELY PROHIBITED
+### Git Worktree — allowed for parallel agents, with guardrails
 
-**`git worktree` is banned. Zero exceptions.**
+**`git worktree` is ALLOWED.** Its purpose here is to run **multiple subagents in parallel** for speed: each
+agent works in its own isolated worktree, so their file edits never collide and the One-Branch-At-A-Time
+serialization does not throttle independent work. Prefer the Claude Code `Agent` tool's `isolation: "worktree"`
+parameter — it creates the worktree in an isolated path and auto-removes it when unchanged.
 
-- Never create, use, or reference a git worktree for any task.
-- Never propose worktrees as a solution to any problem.
-- Do all work directly on a normal feature branch in the main clone.
-- If the Claude Code `Agent` tool or any subagent requests a worktree, refuse. This includes
-  the `isolation: "worktree"` parameter on the `Agent` tool — never pass it.
-- If a leftover worktree is found (`git worktree list` shows more than the main clone), remove it
-  immediately: `git worktree remove -f -f <path>`.
+**Guardrails (these prevent the folder-confusion failures that originally motivated a ban):**
 
-**Automated enforcement:** `scripts/harness/pre-push.mjs` calls `assertNoActiveWorktrees()` at
-startup. Any push with an active non-main worktree is blocked with exit code 1.
+- **One working tree per session.** Never edit or commit the MAIN clone's working tree from inside a worktree
+  session, and never touch a worktree from the main-clone session. Operate in exactly one working tree at a time
+  (this is the #1 rule — the historical breakage was edits leaking between trees).
+- **Isolated location only.** Create worktrees in the `Agent` tool's managed path or a directory OUTSIDE the
+  repo — never nest one inside the repo's own tracked `packages/`/`apps/` tree.
+- **Each worktree gets its own branch** cut from a freshly-fetched `origin/develop`; all the branch rules in this
+  file still apply within it.
+- **Clean up when done:** `git worktree remove <path>` then `git worktree prune`. `Agent`-tool worktrees
+  auto-clean; manual ones are your responsibility.
 
-**Why:** Worktrees share the same `packages/` paths but have separate working trees. This has
-caused: (1) edits leaking from the worktree onto `develop`'s working tree, breaking typecheck;
-(2) pre-push hooks running in the wrong directory context; (3) symlink issues requiring manual
-workaround every session; (4) locked worktrees left behind after Claude Code agent sessions.
-The isolation they provide is not worth these failure modes.
+**Automated safeguard (non-blocking):** `scripts/harness/pre-push.mjs` runs `pruneAndWarnStaleWorktrees()` — it
+prunes administrative junk and WARNS about locked/stale leftover worktrees, but no longer blocks the push.
+
+**History:** worktrees were previously banned after (1) edits leaked between working trees, (2) a pre-push hook
+ran in the wrong directory, (3) symlink issues, and (4) locked worktrees were left behind. The guardrails above
+(one-working-tree-at-a-time, isolated location, cleanup + the prune-and-warn hook) address those modes; the
+parallel-agent speedup is worth it.
 
 ### Clean Working Tree Before Every Commit and Push
 

--- a/.agents/skills/lesson-to-harness/SKILL.md
+++ b/.agents/skills/lesson-to-harness/SKILL.md
@@ -66,7 +66,7 @@ A one-off single instruction ("just do X this once") is NOT a lesson — do not 
    reproduces the incident) and confirm it FAILS, then against the fixed state and confirm it PASSES.
    The new check carries its own coverage (a fixture / unit case) and stays scoped to the class — it must
    not broaden beyond the owned scope without a documented reason. Record the before/after result.
-10. **Ship** — follow the repo gates ([git-branch.md](../../rules/git-branch.md)): branch (no `git worktree`)
+10. **Ship** — follow the repo gates ([git-branch.md](../../rules/git-branch.md)): branch
     → conventional commit → PR → the **Pre-Merge Code-Review Gate** (`/code-review`, resolve all findings)
     → `gh pr merge`. Run `pnpm harness:scan` green before the PR.
 11. **Report** — list the repo files wired, the **swept instance count** (step 5), the **terminal state**

--- a/scripts/harness/pre-push.mjs
+++ b/scripts/harness/pre-push.mjs
@@ -43,21 +43,26 @@ function runGitQuiet(args) {
   );
 }
 
-function assertNoActiveWorktrees() {
+/**
+ * Worktrees are ALLOWED (they power parallel sub-agent work — see git-branch.md § Git Worktree). This is the
+ * non-blocking hygiene safeguard that replaces the old ban: prune administrative junk, then WARN about
+ * locked/stale extra worktrees so left-behind ones surface — it never blocks the push.
+ */
+function pruneAndWarnStaleWorktrees() {
+  spawnSync('git', ['worktree', 'prune'], { cwd: WORKSPACE_ROOT, encoding: 'utf8' });
   const result = spawnSync('git', ['worktree', 'list', '--porcelain'], {
     cwd: WORKSPACE_ROOT,
     encoding: 'utf8',
   });
   const entries = (result.stdout ?? '').trim().split('\n\n').filter(Boolean);
-  if (entries.length > 1) {
+  const extra = entries.slice(1); // entry[0] is the main clone
+  const locked = extra.filter((e) => /\nlocked/.test(`\n${e}`));
+  if (locked.length > 0) {
+    const paths = locked.map((e) => (e.match(/^worktree (.+)$/m) ?? [])[1] ?? '?').join('\n  ');
     process.stderr.write(
-      '\n[BANNED] Active git worktree(s) detected — push blocked.\n' +
-        'git worktree is absolutely prohibited in this repo.\n' +
-        'Remove all extra worktrees before pushing:\n' +
-        '  git worktree list\n' +
-        '  git worktree remove -f -f <path>\n\n',
+      `\n[worktree hygiene] ${locked.length} LOCKED worktree(s) present (not blocking):\n  ${paths}\n` +
+        'If these are stale agent leftovers, clean up: git worktree remove <path> && git worktree prune\n\n',
     );
-    process.exit(1);
   }
 }
 
@@ -176,7 +181,7 @@ function resolvePrePushMode(value) {
   return mode;
 }
 
-assertNoActiveWorktrees();
+pruneAndWarnStaleWorktrees();
 assertCleanWorkingTree();
 assertLockfileConsistency();
 


### PR DESCRIPTION
## Why

Reverse the git-worktree ban so **multiple subagents can run in parallel** (via the `Agent` tool's `isolation: "worktree"`) to increase work speed — each agent works in its own isolated worktree, so their edits never collide and the One-Branch-At-A-Time rule no longer serializes independent work.

## What

- **`git-branch.md`** — "Git Worktree — ABSOLUTELY PROHIBITED" → **"allowed for parallel agents, with guardrails"**. Guardrails that prevent the historical folder-confusion failures: one working tree per session (never cross-edit main clone ↔ worktree), isolated location only, each worktree on its own branch from `origin/develop`, clean up when done.
- **`pre-push.mjs`** — replace the blocking `assertNoActiveWorktrees()` (exit 1 on any worktree) with a **non-blocking** `pruneAndWarnStaleWorktrees()`: `git worktree prune` + a warning about locked/stale leftovers. It never blocks the push.
- **`lesson-to-harness` skill** — drop the "(no `git worktree`)" note.

## Safeguard vs the original failure modes

The ban existed because of (1) edits leaking between working trees, (2) pre-push running in the wrong dir, (3) symlink issues, (4) locked worktrees left behind. Addressed by: the **one-working-tree-at-a-time** guardrail (1,2), **isolated-location** rule (1,3), and **cleanup + prune-and-warn hook** (4).

## Verification

- 63/63 scans green; `pre-push.mjs` worktree path runs (prune+warn, no block).

Follow-up (optional): a thin skill documenting the parallel-subagent-via-worktree workflow (spawn N agents with `isolation: "worktree"`, each on its own branch, merge sequentially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)