### PR TITLE
chore(harness): config-ize agent-tools + orchestration neutrality data (HARNESS-DIET-002)

### DIFF
--- a/.agents/backlog/HARNESS-DIET-002-scans-neutrality-config.md
+++ b/.agents/backlog/HARNESS-DIET-002-scans-neutrality-config.md
@@ -10,6 +10,22 @@ depends_on: []
 
 # HARNESS-DIET-002: scans — config-drive neutrality
 
+## Progress + re-scoping (2026-07-23)
+
+- **CORRECTION to the audit:** the 5 "library-neutrality" scans are NOT near-identical — they are **3 distinct
+  shapes**: `agent-tools` (a `package.json` runtime-dependency **allowlist** check), `session-artifact` (a
+  single-file **multi-regex forbidden-token** scan with comment-stripping), `orchestration` (a **dir-walk single
+  combined-regex** scan excluding `__tests__`), and `memory`/`evals` (197/198 lines, **bespoke** logic beyond a
+  token scan). A blind "5 → 1 config-driven scan" would need a flexible engine spanning all shapes and risks
+  subtly weakening real neutrality floors. The safe win is **externalizing each scan's Robota-specific DATA to
+  `harness.config.json`** while keeping its distinct engine.
+- **DONE:** config-ized 2 of the 5 — `scan-agent-tools-neutrality` (allowlist → `neutrality.agentToolsRuntimeAllowlist`)
+  and `scan-orchestration-neutrality` (dirs + forbidden terms → `neutrality.orchestrationScanDirs` /
+  `orchestrationForbiddenTerms`). Unit tests unchanged (9 pass); 63/63 scans green (incl. `harness-config-paths`).
+- **REMAINING:** externalize `session-artifact`'s 19 forbidden-token regexes and `memory`/`evals`' target paths +
+  token lists to config (leave their bespoke logic); only THEN, if worthwhile, factor a shared
+  forbidden-token-in-file helper. Do NOT force a single engine across the dep-check + token-scan shapes.
+
 ## Problem
 
 ~10+ harness scans hardcode Robota specifics (`@robota-sdk/*` scope prefixes, exact package/file paths, even

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -7,5 +7,14 @@
     "pluginLayerAllowed": ["@robota-sdk/agent-core"]
   },
   "productShellDirs": ["packages/agent-cli", "apps/agent-web", "apps/docs", "apps/blog"],
-  "lessonsDigestDisableEnv": "HARNESS_DISABLE_LESSONS_DIGEST"
+  "lessonsDigestDisableEnv": "HARNESS_DISABLE_LESSONS_DIGEST",
+  "neutrality": {
+    "$comment": "Per-subsystem library-neutrality policy DATA (HARNESS-DIET-002). The neutrality scan ENGINES live in scripts/harness/scan-*-neutrality.mjs; their Robota-specific target paths / allowlists / forbidden terms live here so the engines stay repo-agnostic.",
+    "agentToolsRuntimeAllowlist": ["fast-glob", "p-limit", "zod"],
+    "orchestrationScanDirs": [
+      "packages/agent-core/src/orchestration",
+      "packages/agent-framework/src/orchestration"
+    ],
+    "orchestrationForbiddenTerms": ["room", "persona", "topic"]
+  }
 }

--- a/scripts/harness/scan-agent-tools-neutrality.mjs
+++ b/scripts/harness/scan-agent-tools-neutrality.mjs
@@ -22,16 +22,19 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { loadHarnessConfig } from './harness-config.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const PKG = path.join(WORKSPACE_ROOT, 'packages/agent-tools/package.json');
 
 /**
- * The sanctioned third-party (non-`@robota-sdk/*`) runtime dependencies of `agent-tools`, verified against the
- * real package post-SELFHOST-003/010. Adding a dep here is a deliberate, reviewed act — the diff makes a heavy
+ * The sanctioned third-party (non-`@robota-sdk/*`) runtime dependencies of `agent-tools` — held as POLICY DATA in
+ * `.agents/harness.config.json` (`neutrality.agentToolsRuntimeAllowlist`, HARNESS-DIET-002), not hardcoded here,
+ * so this engine stays repo-agnostic. Adding a dep there is a deliberate, reviewed act — the diff makes a heavy
  * SDK visible. A heavy retrieval/parser/vector/browser SDK must be injected as a duck-typed port from the surface
  * instead of depending on it here.
  */
-const ALLOWLIST = new Set(['fast-glob', 'p-limit', 'zod']);
+const ALLOWLIST = new Set(loadHarnessConfig().neutrality.agentToolsRuntimeAllowlist);
 
 /** Runtime-reachable dep kinds (excludes `devDependencies`: not shipped for this non-bundled package). */
 const RUNTIME_DEP_KINDS = ['dependencies', 'peerDependencies', 'optionalDependencies'];

--- a/scripts/harness/scan-orchestration-neutrality.mjs
+++ b/scripts/harness/scan-orchestration-neutrality.mjs
@@ -25,19 +25,20 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+import { loadHarnessConfig } from './harness-config.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
-// App-domain identity terms forbidden in the neutral orchestration contracts.
-// Matches any identifier-like token CONTAINING the term (case-insensitive), so
-// `roomId` / `chatRoom` / `personaName` / `topicTitle` / `conversationTopic` are all
-// flagged — not merely the standalone word.
-const FORBIDDEN = /\w*(room|persona|topic)\w*/i;
+// App-domain identity terms forbidden in the neutral orchestration contracts, held as POLICY DATA in
+// `.agents/harness.config.json` (`neutrality.orchestrationForbiddenTerms` / `orchestrationScanDirs`,
+// HARNESS-DIET-002) so this engine stays repo-agnostic. The pattern matches any identifier-like token CONTAINING
+// a term (case-insensitive), so `roomId` / `chatRoom` / `personaName` / `topicTitle` / `conversationTopic` are
+// all flagged — not merely the standalone word.
+const NEUTRALITY = loadHarnessConfig().neutrality;
+const FORBIDDEN = new RegExp(`\\w*(${NEUTRALITY.orchestrationForbiddenTerms.join('|')})\\w*`, 'i');
 
 // Directories whose orchestration source is the neutral surface under scan.
-const SCAN_DIRS = [
-  'packages/agent-core/src/orchestration',
-  'packages/agent-framework/src/orchestration',
-];
+const SCAN_DIRS = NEUTRALITY.orchestrationScanDirs;
 
 function walkSource(target) {
   const full = path.join(WORKSPACE_ROOT, target);


### PR DESCRIPTION
## What (HARNESS-DIET-002, part 1)

Move the Robota-specific policy DATA out of two neutrality scan **engines** into `.agents/harness.config.json` (`neutrality.*`), so the engines stay repo-agnostic:
- `scan-agent-tools-neutrality`: runtime-dep allowlist → `neutrality.agentToolsRuntimeAllowlist`
- `scan-orchestration-neutrality`: scan dirs + forbidden terms → `neutrality.orchestrationScanDirs` / `orchestrationForbiddenTerms`

## Re-scoping note (audit correction)

The audit's "5 near-identical scans → 1" was **inaccurate** — the 5 are **3 distinct shapes**: `agent-tools` (package.json dep-allowlist), `session-artifact` (single-file multi-regex), `orchestration` (dir-walk single-regex), plus `memory`/`evals` (bespoke). A blind 5→1 merge would risk weakening real neutrality floors. The safe path is **config-izing each scan's data** while keeping its engine — done here for 2; the rest (session-artifact regexes, memory/evals data) tracked in the backlog.

## Verification

- Unit tests unchanged (9 pass); 63/63 scans green (incl. `harness-config-paths`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)