### PR TITLE
chore(harness): config-ize session-artifact/memory/evals neutrality data (HARNESS-DIET-002 finish)

### DIFF
--- a/.agents/backlog/completed/HARNESS-DIET-002-scans-neutrality-config.md
+++ b/.agents/backlog/completed/HARNESS-DIET-002-scans-neutrality-config.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-DIET-002: config-drive scan neutrality — kill Robota-specifics baked into general scans'
-status: todo
+status: done
+completed: 2026-07-24
 created: 2026-07-23
 priority: high
 urgency: soon
@@ -9,6 +10,37 @@ depends_on: []
 ---
 
 # HARNESS-DIET-002: scans — config-drive neutrality
+
+## Outcome (2026-07-24)
+
+All 5 scans of the library-neutrality family are now config-driven: Robota-specific POLICY DATA lives in
+`.agents/harness.config.json` (`neutrality.*`, loaded via `scripts/harness/harness-config.mjs`); each scan
+keeps its distinct ENGINE (per the 2026-07-23 re-scoping — no forced single engine).
+
+- `scan-agent-tools-neutrality` → `neutrality.agentToolsRuntimeAllowlist` (PR #1286).
+- `scan-orchestration-neutrality` → `neutrality.orchestrationScanDirs` / `orchestrationForbiddenTerms` (PR #1286).
+- `scan-session-artifact-neutrality` → `neutrality.sessionArtifactTarget` + the 19 forbidden-token regexes as
+  SOURCE strings in `sessionArtifactForbiddenTokens` (compiled case-insensitive in the engine;
+  comment-stripping stays engine).
+- `scan-memory-neutrality` → `neutrality.libraryPackagesDir`, `memoryCorpusIndexFilename`,
+  `memoryCorpusTopicsPathSegment`, `memorySubsystemDirName`, `memoryPromptIdentifierTerms` (the ReDoS-safe
+  > =40-char literal machinery + suppression/anti-rot mechanics stay engine).
+- `scan-evals-neutrality` → `neutrality.libraryPackagesDir`, `evalsSubsystemDirName`,
+  `evalsDatasetDataExtensions`, `evalsDatasetNameMarkers`, `evalsContentBindingTerms`,
+  `evalsContentTypeNames` (`IEvalDefinition`/`IMetric` — the Robota contract names — are now data; the
+  export-shape/factory-vs-value machinery stays engine).
+
+Behavior identical: all 3 unit tests pass with only config-plumbing additions (27 tests, no assertion
+weakened; red capability re-proven by injecting violating fixtures through the exported pure functions,
+including a new config-plumbing test asserting the 19 patterns load from config and still flag). Full scan
+suite green (62/62 with `--skip dist` on a no-build worktree; `dist` is a local pre-CI freshness check by
+charter). The optional shared forbidden-token helper was assessed and skipped: the three engines' shapes
+(single-file multi-regex vs. bespoke walkers with suppression windows) share too little to factor without
+weakening a floor.
+
+What-§2 (relocating the bespoke layering scans) and What-§3 (config-izing the `@robota-sdk/` scope prefix in
+the 6 general checks) are NOT covered by this closure — they proceed under the HARNESS-DIET-003+ items /
+follow-up scan-consolidation work.
 
 ## Progress + re-scoping (2026-07-23)
 

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -15,6 +15,38 @@
       "packages/agent-core/src/orchestration",
       "packages/agent-framework/src/orchestration"
     ],
-    "orchestrationForbiddenTerms": ["room", "persona", "topic"]
+    "orchestrationForbiddenTerms": ["room", "persona", "topic"],
+    "libraryPackagesDir": "packages",
+    "sessionArtifactTarget": "packages/agent-session/src/session-artifact.ts",
+    "sessionArtifactForbiddenTokens": [
+      "\\bhttps?://",
+      "\\bfetch\\s*\\(",
+      "\\bupload\\b",
+      "\\bdownload\\b",
+      "\\bcloud\\b",
+      "\\bpresign",
+      "\\bbucket\\b",
+      "\\bs3\\b",
+      "\\bshareLink\\b",
+      "\\bshareUrl\\b",
+      "\\bshare\\b",
+      "\\blink\\b",
+      "\\bsync\\b",
+      "\\baccessControl\\b",
+      "\\b(acl|rbac)\\b",
+      "\\bpermissions?\\b",
+      "\\bauthToken\\b",
+      "\\b(redaction|field)Policy\\b",
+      "\\ballowlist\\b"
+    ],
+    "memoryCorpusIndexFilename": "MEMORY.md",
+    "memoryCorpusTopicsPathSegment": "memory/topics",
+    "memorySubsystemDirName": "memory",
+    "memoryPromptIdentifierTerms": ["prompt", "persona", "instruction"],
+    "evalsSubsystemDirName": "evals",
+    "evalsDatasetDataExtensions": ["json", "jsonl", "csv", "yaml", "yml"],
+    "evalsDatasetNameMarkers": ["evalset", "cases", "dataset", "corpus"],
+    "evalsContentBindingTerms": ["cases", "dataset", "evalset", "corpus"],
+    "evalsContentTypeNames": ["IEvalDefinition", "IMetric"]
   }
 }

--- a/scripts/harness/__tests__/scan-session-artifact-neutrality.test.mjs
+++ b/scripts/harness/__tests__/scan-session-artifact-neutrality.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { loadHarnessConfig } from '../harness-config.mjs';
 import { findForbiddenTokens } from '../scan-session-artifact-neutrality.mjs';
 
 /**
@@ -31,5 +32,17 @@ describe('findForbiddenTokens', () => {
       export const SESSION_ARTIFACT_SCHEMA_VERSION = 1;
     `;
     expect(findForbiddenTokens(withDoc)).toEqual([]);
+  });
+
+  it('sources its patterns from harness config (HARNESS-DIET-002) and keeps red capability', () => {
+    // The 19 forbidden-token patterns are policy data in `.agents/harness.config.json`; the engine compiles
+    // them. A violating fixture injected through the pure function must still be flagged (red capability).
+    const { neutrality } = loadHarnessConfig();
+    expect(neutrality.sessionArtifactForbiddenTokens).toHaveLength(19);
+    expect(neutrality.sessionArtifactTarget).toMatch(/\.ts$/);
+    expect(findForbiddenTokens('await upload(payload, bucket);')).toContain('upload');
+    expect(findForbiddenTokens('const fieldPolicy = pickRedactionFields();')).toContain(
+      'fieldPolicy',
+    );
   });
 });

--- a/scripts/harness/scan-evals-neutrality.mjs
+++ b/scripts/harness/scan-evals-neutrality.mjs
@@ -38,13 +38,30 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+import { loadHarnessConfig } from './harness-config.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
-/** Data-file extensions a case corpus / evalset would ship as. */
-const DATASET_DATA_EXT = /\.(json|jsonl|csv|ya?ml)$/i;
+// Robota-specific POLICY DATA lives in `.agents/harness.config.json` (`neutrality.*`, HARNESS-DIET-002):
+// the library root under scan, the evals-subsystem dir convention, the dataset data-file extensions and
+// corpus basename markers, and the Class-2 binding terms + concrete contract TYPE names
+// (`IEvalDefinition`/`IMetric`). The bespoke engine logic (export-shape regex construction, factory-vs-value
+// distinction, suppression/anti-rot mechanics) stays here.
+const NEUTRALITY = loadHarnessConfig().neutrality;
+const LIBRARY_PACKAGES_DIR = NEUTRALITY.libraryPackagesDir;
+const EVALS_SUBSYSTEM_DIRNAME = NEUTRALITY.evalsSubsystemDirName;
 
-/** Basename markers that name a file as an eval corpus regardless of directory. */
-const DATASET_NAME_MARKER = /\.(evalset|cases|dataset|corpus)\.[a-z0-9]+$/i;
+/** Data-file extensions a case corpus / evalset would ship as (config data, compiled here). */
+const DATASET_DATA_EXT = new RegExp(
+  `\\.(${NEUTRALITY.evalsDatasetDataExtensions.join('|')})$`,
+  'i',
+);
+
+/** Basename markers that name a file as an eval corpus regardless of directory (config data). */
+const DATASET_NAME_MARKER = new RegExp(
+  `\\.(${NEUTRALITY.evalsDatasetNameMarkers.join('|')})\\.[a-z0-9]+$`,
+  'i',
+);
 
 /**
  * Class 2 export shapes (concrete metric/dataset VALUE, not the neutral type/factory mechanism):
@@ -52,9 +69,13 @@ const DATASET_NAME_MARKER = /\.(evalset|cases|dataset|corpus)\.[a-z0-9]+$/i;
  *   export ... <name>: IEvalDefinition =                            → concrete eval definition value
  *   export ... <name>: IMetric =                                    → concrete named metric value
  * A neutral factory (`export function exactMatch(...): IMetric {`) has no `: IMetric =` and is not matched.
+ * Binding terms + contract type names are config data; the export-shape machinery is engine.
  */
-const LIBRARY_EVAL_CONTENT_DECL =
-  /export\s+(?:const|let|var|default)\s+\w*(?:cases|dataset|evalset|corpus)\w*\s*(?::[^=]+)?=\s*\[|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IEvalDefinition\s*=|export\s+(?:const|let|var|default)?\s*\w+\s*:\s*IMetric\s*=/i;
+const LIBRARY_EVAL_CONTENT_DECL = new RegExp(
+  `export\\s+(?:const|let|var|default)\\s+\\w*(?:${NEUTRALITY.evalsContentBindingTerms.join('|')})\\w*\\s*(?::[^=]+)?=\\s*\\[` +
+    `|export\\s+(?:const|let|var|default)?\\s*\\w+\\s*:\\s*(?:${NEUTRALITY.evalsContentTypeNames.join('|')})\\s*=`,
+  'i',
+);
 
 /** A well-formed escape hatch: the token followed by `:` and at least one non-space reason char. */
 const ANNOTATION_WITH_REASON = /allow-evals-content:\s*\S/;
@@ -69,9 +90,9 @@ function annotationInComment(line) {
   );
 }
 
-/** Is this path inside an `/evals/` DIRECTORY segment (the evals subsystem convention)? */
+/** Is this path inside the evals-subsystem DIRECTORY segment (the subsystem convention)? */
 export function inEvalsSubsystem(rel) {
-  return rel.replace(/\\/g, '/').includes('/evals/');
+  return rel.replace(/\\/g, '/').includes(`/${EVALS_SUBSYSTEM_DIRNAME}/`);
 }
 
 /**
@@ -122,11 +143,11 @@ export function findEvalsContentInSource(source, file = 'fixture.ts') {
 
 export function findEvalsNeutralityFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
+  const packagesDir = path.join(root, LIBRARY_PACKAGES_DIR);
   if (!existsSync(packagesDir)) return findings;
   for (const pkg of readdirSync(packagesDir, { withFileTypes: true })) {
     if (!pkg.isDirectory()) continue;
-    const pkgRel = path.join('packages', pkg.name);
+    const pkgRel = path.join(LIBRARY_PACKAGES_DIR, pkg.name);
     if (!statSync(path.join(root, pkgRel)).isDirectory()) continue;
     for (const rel of walkPackageFiles(pkgRel, root)) {
       // Class 1 — a dataset/corpus DATA file anywhere in the package.

--- a/scripts/harness/scan-memory-neutrality.mjs
+++ b/scripts/harness/scan-memory-neutrality.mjs
@@ -37,10 +37,24 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
+import { loadHarnessConfig } from './harness-config.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// Robota-specific POLICY DATA lives in `.agents/harness.config.json` (`neutrality.*`, HARNESS-DIET-002):
+// the library root under scan, the corpus artifact names (index filename + topics path segment — anchored to
+// `project-memory-store.ts`'s `INDEX_FILENAME`/`TOPICS_DIRNAME`), the memory-subsystem dir convention, and the
+// capture-prompt identifier terms. The bespoke engine logic (>=40-char literal heuristic, ReDoS-safe regex
+// construction, suppression/anti-rot mechanics) stays here.
+const NEUTRALITY = loadHarnessConfig().neutrality;
+const LIBRARY_PACKAGES_DIR = NEUTRALITY.libraryPackagesDir;
+const CORPUS_INDEX_FILENAME = NEUTRALITY.memoryCorpusIndexFilename;
+const CORPUS_TOPICS_SEGMENT = NEUTRALITY.memoryCorpusTopicsPathSegment;
+const MEMORY_SUBSYSTEM_DIRNAME = NEUTRALITY.memorySubsystemDirName;
 
 /**
  * A capture-prompt intent identifier assigned a string literal of >= 40 chars (a sentence, not a token).
+ * The identifier terms (`memoryPromptIdentifierTerms`) are config data; the literal machinery is engine.
  *
  * ReDoS-safe by construction: the inner alternation branches are DISJOINT — `\\.` consumes a backslash +
  * its escaped char, `(?!\1)[^\\]` consumes exactly one non-delimiter, non-backslash char. Because no input
@@ -49,8 +63,11 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
  * an opening quote + many backslashes and no closing delimiter — e.g. the first line of a multi-line prompt
  * template — backtracks exponentially and hangs the whole run-all-scans pass. Regression: TC-07.)
  */
-const CAPTURE_PROMPT_DECL =
-  /\b\w*(?:prompt|persona|instruction)\w*\s*[:=]\s*(['"`])((?:\\.|(?!\1)[^\\]){40,})\1/i;
+const CAPTURE_PROMPT_DECL = new RegExp(
+  `\\b\\w*(?:${NEUTRALITY.memoryPromptIdentifierTerms.join('|')})\\w*` +
+    `\\s*[:=]\\s*(['"\`])((?:\\\\.|(?!\\1)[^\\\\]){40,})\\1`,
+  'i',
+);
 
 /** A well-formed escape hatch: the token followed by `:` and at least one non-space reason char. */
 const ANNOTATION_WITH_REASON = /allow-memory-content:\s*\S/;
@@ -102,12 +119,15 @@ export function findMemoryNeutralityFindingsInSource(source, file = 'fixture.ts'
 
 /** Is this workspace-relative path inside a package's `src/` tree? */
 function isPackageSrc(rel) {
-  return rel.startsWith(`packages${path.sep}`) && rel.includes(`${path.sep}src${path.sep}`);
+  return (
+    rel.startsWith(`${LIBRARY_PACKAGES_DIR}${path.sep}`) &&
+    rel.includes(`${path.sep}src${path.sep}`)
+  );
 }
 
-/** Is this path inside a `/memory/` DIRECTORY segment (the durable-memory curation subsystem)? */
+/** Is this path inside the memory-subsystem DIRECTORY segment (the durable-memory curation subsystem)? */
 function inMemorySubsystem(rel) {
-  return rel.includes(`${path.sep}memory${path.sep}`);
+  return rel.includes(`${path.sep}${MEMORY_SUBSYSTEM_DIRNAME}${path.sep}`);
 }
 
 /**
@@ -117,17 +137,17 @@ function inMemorySubsystem(rel) {
  */
 export function isSeededMemoryContent(rel) {
   const norm = rel.replace(/\\/g, '/');
-  if (norm.split('/').pop() === 'MEMORY.md') return true;
-  return norm.includes('/memory/topics/') && norm.endsWith('.md');
+  if (norm.split('/').pop() === CORPUS_INDEX_FILENAME) return true;
+  return norm.includes(`/${CORPUS_TOPICS_SEGMENT}/`) && norm.endsWith('.md');
 }
 
 export function findMemoryNeutralityFindings(root = WORKSPACE_ROOT) {
   const findings = [];
-  const packagesDir = path.join(root, 'packages');
+  const packagesDir = path.join(root, LIBRARY_PACKAGES_DIR);
   if (!existsSync(packagesDir)) return findings;
   for (const pkg of readdirSync(packagesDir, { withFileTypes: true })) {
     if (!pkg.isDirectory()) continue;
-    const srcRel = path.join('packages', pkg.name, 'src');
+    const srcRel = path.join(LIBRARY_PACKAGES_DIR, pkg.name, 'src');
     if (!existsSync(path.join(root, srcRel)) || !statSync(path.join(root, srcRel)).isDirectory()) {
       continue;
     }

--- a/scripts/harness/scan-session-artifact-neutrality.mjs
+++ b/scripts/harness/scan-session-artifact-neutrality.mjs
@@ -16,31 +16,22 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
-const TARGET = path.join(WORKSPACE_ROOT, 'packages/agent-session/src/session-artifact.ts');
+import { loadHarnessConfig } from './harness-config.mjs';
 
-/** Sharing / cloud / access / field-policy tokens that must NOT appear in the neutral envelope's code. */
-const FORBIDDEN = [
-  /\bhttps?:\/\//i,
-  /\bfetch\s*\(/i,
-  /\bupload\b/i,
-  /\bdownload\b/i,
-  /\bcloud\b/i,
-  /\bpresign/i,
-  /\bbucket\b/i,
-  /\bs3\b/i,
-  /\bshareLink\b/i,
-  /\bshareUrl\b/i,
-  /\bshare\b/i,
-  /\blink\b/i,
-  /\bsync\b/i,
-  /\baccessControl\b/i,
-  /\b(acl|rbac)\b/i,
-  /\bpermissions?\b/i,
-  /\bauthToken\b/i,
-  /\b(redaction|field)Policy\b/i,
-  /\ballowlist\b/i,
-];
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// The envelope file under scan + its forbidden tokens are POLICY DATA in `.agents/harness.config.json`
+// (`neutrality.sessionArtifactTarget` / `sessionArtifactForbiddenTokens`, HARNESS-DIET-002), not hardcoded
+// here, so this engine stays repo-agnostic. The comment-stripping + match mechanics stay in the engine.
+const NEUTRALITY = loadHarnessConfig().neutrality;
+const TARGET_REL = NEUTRALITY.sessionArtifactTarget;
+const TARGET = path.join(WORKSPACE_ROOT, TARGET_REL);
+
+/**
+ * Sharing / cloud / access / field-policy tokens that must NOT appear in the neutral envelope's code.
+ * Stored as regex SOURCE strings in config; compiled here (all case-insensitive).
+ */
+const FORBIDDEN = NEUTRALITY.sessionArtifactForbiddenTokens.map((src) => new RegExp(src, 'i'));
 
 /** Strip block + line comments so the module's own neutrality doc (which names these words) is exempt. */
 function stripComments(source) {
@@ -51,9 +42,7 @@ function stripComments(source) {
 
 function main() {
   if (!existsSync(TARGET)) {
-    console.error(
-      'session-artifact-neutrality scan: packages/agent-session/src/session-artifact.ts is missing.',
-    );
+    console.error(`session-artifact-neutrality scan: ${TARGET_REL} is missing.`);
     process.exit(1);
   }
   const code = stripComments(readFileSync(TARGET, 'utf8'));


### PR DESCRIPTION
## What (HARNESS-DIET-002, part 2 — completes the item)

Config-izes the remaining 3 of 5 neutrality scans (produced by a worktree-parallel subagent; orchestrator-verified): the Robota-specific policy DATA moves to `.agents/harness.config.json` (`neutrality.*`), the scan ENGINES stay repo-agnostic:

- `scan-session-artifact-neutrality` — target file path + the 19 forbidden-token patterns → config (patterns stored as strings, RegExp built in the engine; comment-stripping stays in the engine).
- `scan-memory-neutrality` — target paths + forbidden-token lists → config (bespoke logic unchanged).
- `scan-evals-neutrality` — same.

With `scan-agent-tools-neutrality` + `scan-orchestration-neutrality` (#1286), all 5 neutrality scans are now config-driven → **HARNESS-DIET-002 marked done** and archived to `backlog/completed/`.

## Verification

- The 3 scans' unit tests: **27 pass** (behavior unchanged; +1 red-capability test).
- Full scan suite in the main clone: 63/63 (the worktree's `build-contracts`/`done-evidence` failures were environment artifacts — no `dist/` in a fresh worktree and a git-spawn flake; both pass in the main clone, and this diff touches neither).

🤖 Generated with [Claude Code](https://claude.com/claude-code)