### PR TITLE
fix(harness): strip hook-inherited GIT_* env from harness child processes

### DIFF
--- a/scripts/harness/check-done-evidence.mjs
+++ b/scripts/harness/check-done-evidence.mjs
@@ -20,6 +20,8 @@ import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { envWithoutGitVars } from './shared.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const COMPLETED_DIR = '.agents/backlog/completed';
 
@@ -53,6 +55,10 @@ function pathExists(root, relativePath) {
       const output = execFileSync('git', ['-C', root, 'ls-files'], {
         encoding: 'utf8',
         maxBuffer: 64 * 1024 * 1024,
+        // Strip hook-inherited GIT_DIR/GIT_INDEX_FILE etc. — under a git hook they redirect this call
+        // to the hook's repository regardless of `-C root`, listing the WRONG repo (see shared.mjs
+        // envWithoutGitVars).
+        env: envWithoutGitVars(),
       });
       trackedFilesCache = new Set(output.split('\n').filter(Boolean));
     } catch {

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -295,6 +295,17 @@ export function parseScopeArgs(argv) {
   return options;
 }
 
+/**
+ * `process.env` with hook-inherited `GIT_*` variables stripped. A git hook (husky pre-push) exports
+ * `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` etc., which redirect EVERY child `git` call to the hook's
+ * repository REGARDLESS of cwd — git-fixture tests inside a spawned suite then mutate the real checkout
+ * (observed 2026-07-24: rogue fixture commits + `core.bare=true` pollution during the parallel wave).
+ * Harness children always operate on their explicit cwd, so the redirect vars must never propagate.
+ */
+export function envWithoutGitVars(base = process.env) {
+  return Object.fromEntries(Object.entries(base).filter(([key]) => !key.startsWith('GIT_')));
+}
+
 export function runCommand(command, args, workdir, dryRun, envOverrides = {}) {
   const rendered = [command, ...args].join(' ');
   process.stdout.write(`> (${path.relative(WORKSPACE_ROOT, workdir) || '.'}) ${rendered}\n`);
@@ -308,7 +319,7 @@ export function runCommand(command, args, workdir, dryRun, envOverrides = {}) {
     stdio: 'inherit',
     encoding: 'utf8',
     env: {
-      ...process.env,
+      ...envWithoutGitVars(),
       ...envOverrides,
     },
   });


### PR DESCRIPTION
## Problem (incident from the parallel wave)

A git hook (husky pre-push) exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE`, which redirect **every child `git` call to the hook's repository regardless of cwd**. When the hook chain spawns the harness test suite, git-fixture tests (`git init`/`add`/`commit` in temp dirs) then mutate the REAL checkout. Observed during the 2026-07-24 parallel wave: rogue fixture commits on a live branch and `core.bare=true` written into the main clone's config (which then corrupted `git status` everywhere). Independently diagnosed by two wave agents.

## Fix

- **`shared.mjs`**: new `envWithoutGitVars()`; `runCommand` now spawns ALL harness children with `GIT_*` stripped — defense-in-depth for every suite/scan it runs.
- **`check-done-evidence.mjs`**: its `git ls-files` call is sanitized (under hook-exported `GIT_DIR` it listed the wrong repo's files — the deterministic test failure that forced two agents to push `--no-verify`).

## Red/green

- RED: `GIT_DIR=$(git rev-parse --absolute-git-dir) npx vitest run …/check-done-evidence.test.mjs` → **FAILED** (TC-01) before the fix.
- GREEN: same command → 5/5; the **full 449-test harness suite passes under the incident env** (`GIT_DIR`+`GIT_INDEX_FILE` exported).
- 61/61 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)