### PR TITLE
fix(hooks): make branch-guard + pre-push-check worktree-aware

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -34,19 +34,35 @@ if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAM
   BRANCH_GUARD_ALLOW_BADNAME=1
 fi
 
+# Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
+# a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
+# producing false blocks. Precedence: `git -C <path>` in the command > hook-input `cwd` > project dir.
+HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
+GIT_C_PATH=$(printf '%s' "$COMMAND" | sed -nE 's/^[[:space:]]*git[[:space:]]+-C[[:space:]]+"?([^"[:space:]]+)"?.*/\1/p')
+EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
+if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  EFFECTIVE_DIR="$HOOK_CWD"
+fi
+if [[ -n "$GIT_C_PATH" ]] && git -C "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  EFFECTIVE_DIR="$GIT_C_PATH"
+fi
+
 # Detect git action type
 IS_COMMIT=false
 IS_PUSH=false
 IS_MERGE=false
 IS_BRANCH_CREATE=false
 IS_GH_DELETE_BRANCH=false
-echo "$COMMAND" | grep -qE '^\s*git\s+commit\b' && IS_COMMIT=true
-echo "$COMMAND" | grep -qE '^\s*git\s+(push|push\s)' && IS_PUSH=true
-echo "$COMMAND" | grep -qE '^\s*git\s+merge\b' && IS_MERGE=true
+# GITPFX tolerates global git flags before the subcommand — `git -C <path> commit`, `git -c k=v push` —
+# which previously slipped past every action regex (worktree-blindness, parallel-wave lesson).
+GITPFX='^\s*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+echo "$COMMAND" | grep -qE "${GITPFX}commit\b" && IS_COMMIT=true
+echo "$COMMAND" | grep -qE "${GITPFX}push(\s|$)" && IS_PUSH=true
+echo "$COMMAND" | grep -qE "${GITPFX}merge\b" && IS_MERGE=true
 # Tolerate flags between the subcommand and -b/-c (e.g. `git checkout -q -b x`, which
 # previously slipped past the create-guard entirely).
-echo "$COMMAND" | grep -qE '^\s*git\s+checkout\s+(-\S+\s+)*-b\b' && IS_BRANCH_CREATE=true
-echo "$COMMAND" | grep -qE '^\s*git\s+switch\s+(-\S+\s+)*-c\b' && IS_BRANCH_CREATE=true
+echo "$COMMAND" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-b\b" && IS_BRANCH_CREATE=true
+echo "$COMMAND" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-c\b" && IS_BRANCH_CREATE=true
 # `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
 # develop integration branch. Match ONLY when --delete-branch is an actual argument
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag
@@ -108,8 +124,8 @@ if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" && "$IS_MERGE" == "false"
   exit 0
 fi
 
-# Get current branch
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+# Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
+PROJECT_DIR="$EFFECTIVE_DIR"
 CURRENT_BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
 
 if [[ -z "$CURRENT_BRANCH" ]]; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -19,10 +19,20 @@ fi
 
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
 
-# Only intercept git push commands
-echo "$COMMAND" | grep -qE '^\s*git\s+(push)(\s|$)' || exit 0
+# Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`)
+echo "$COMMAND" | grep -qE '^\s*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*push(\s|$)' || exit 0
 
+# Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
+# in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.
+HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
+GIT_C_PATH=$(printf '%s' "$COMMAND" | sed -nE 's/^[[:space:]]*git[[:space:]]+-C[[:space:]]+"?([^"[:space:]]+)"?.*/\1/p')
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  PROJECT_DIR="$HOOK_CWD"
+fi
+if [[ -n "$GIT_C_PATH" ]] && git -C "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  PROJECT_DIR="$GIT_C_PATH"
+fi
 
 echo "[pre-push-check] Running fast pre-push gates (branch hygiene, lockfile sync)..." >&2
 


### PR DESCRIPTION
## Problem (flagged independently by all 4 wave agents)

`branch-guard.sh` and `pre-push-check.sh` judged `CLAUDE_PROJECT_DIR` (the main clone, sitting on `develop`) instead of the repo the command actually runs in. Every worktree-parallel agent was falsely blocked on commit/push and had to route around the guards (`git -C` / `--no-verify`) — and conversely, `git -C <path> commit` forms slipped past the action regexes entirely (unguarded).

## Fix

- **Effective-context resolution** in both hooks: `git -C <path>` in the command > hook-input `cwd` (when it is a git work tree) > `CLAUDE_PROJECT_DIR`. Branch state is judged there.
- **`GITPFX` action regexes** now see through env prefixes (`FOO=1 git commit`) and global git flags (`git -C <path> commit`, `git -c k=v push`) — previously these forms were invisible to the guard.

## Verification (7 synthetic hook-input tests against a real throwaway worktree)

| Test | Expect | Got |
| --- | --- | --- |
| commit, `cwd`=worktree on develop (protected) | BLOCK 2 | 2 |
| commit, `cwd`=main clone on a feature branch | ALLOW 0 | 0 |
| `git -C <worktree-on-develop> commit` (no cwd) | BLOCK 2 | 2 |
| branch-create in worktree with inline `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1` | ALLOW 0 | 0 |
| `FOO=1 git commit` on protected worktree | BLOCK 2 | 2 |
| `git -C <path> push` triggers pre-push gates | 0 (gates pass) | 0 |
| non-push command untouched | 0 | 0 |

61/61 scans pass; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)