### PR TITLE
chore(rules): HARNESS-DIET-004 — relocate baked project-data from rules to project-structure.md

### DIFF
--- a/.agents/backlog/HARNESS-DIET-004-rules-consolidation.md
+++ b/.agents/backlog/HARNESS-DIET-004-rules-consolidation.md
@@ -79,11 +79,28 @@ Completed in this pass (all stubs keep old links resolving — no file deleted o
 - `git-branch.md` (309 → 293 lines): multi-line incident narratives compressed to one-line
   rationales; Worktree section and One-Branch exceptions unchanged.
 
-Remaining (needs files outside the rules scope — frontend/documentation-sync/code-quality
-relocations touch `project-structure.md`, doc-map config, and architecture SPECs):
+## Progress (2026-07-24, chore/diet-004-neutralize-data — second pass)
 
-- Neutralize baked project-data: `frontend.md` App-Inventory table, `documentation-sync.md`
-  Documentation-Source-Map, `code-quality.md` Layered-Assembly section.
+Neutralize-baked-project-data bucket completed (all moved sections keep their headings as pointer
+stubs — no link target deleted):
+
+- `frontend.md`: App-Inventory + Interactive-Tools tables moved to `project-structure.md`
+  § "App Inventory and Approved Stack"; stale entries fixed while relocating
+  (`apps/agent-web-monitor` — dissolved in GUI-007, now `packages/agent-cli-web`; added the
+  missing real UI surfaces `apps/agent-app`, `apps/starter-nextjs`, `packages/agent-playground`).
+  The rule keeps the React/Next/Tailwind invariants; the app-specific Common-Mistakes row and the
+  Styling cross-reference were neutralized.
+- `documentation-sync.md`: Documentation-Source-Map moved to `project-structure.md`
+  § "Documentation Map"; stale generated-output paths fixed (`apps/docs/.temp/` +
+  `.vitepress/dist/` — VitePress was removed in SITE-005; now `apps/docs/out/` + `.next/`).
+  The rule keeps the same-PR doc gates + Document-Role sync gate, which now POINTS at
+  `spec-workflow.md` § "Document Authority and Content Placement" for class authority.
+- `code-quality.md`: Layered-Assembly section (stack diagram + command-layering rules) moved to
+  `project-structure.md` § "Layered Assembly Architecture" (merged with the dependency-direction
+  content there); the rule keeps the neutral type/pattern rules + a pointer stub (heading kept —
+  `common-mistakes.md` #16/#20 reference it).
+
+Remaining: none for this item's rule buckets.
 
 ## Test Plan
 

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -58,6 +58,76 @@ apps/
 └── agent-app/              # Electron desktop application (macOS/Linux/Windows); the desktop GUI surface. Runs STANDALONE — the user never launches agent-cli first. agent-cli (TUI) and agent-app (GUI) are SIBLING presentations over the same shared runtime; the GUI does NOT control the CLI. The app DRIVES a shared headless runtime — it spawns `robota --serve` (RUNTIME-001), the CLI's headless runtime-host entry that runs `startRuntimeHost` from `agent-framework` and serves the loopback-WS + required nonce auth, rendering NO ink; both the TUI and the GUI sit over the one runtime host (in the `agent-framework` assembly layer). The app renders the shared GUI presentation core agent-transport-gui. Depends on the agent RUNTIME, not the CLI's terminal UI; NO agent-framework/agent-core dep. Remote WebRTC (agent-transport-webrtc-web) is an optional in-app feature, not a requirement (GUI-002 foundation, GUI-005/006 taxonomy)
 ```
 
+## App Inventory and Approved Stack
+
+UI surfaces and their frameworks (SSOT; the framework RULES — React only, Next.js for SSR,
+Tailwind only — live in [rules/frontend.md](rules/frontend.md)):
+
+| App / Package                         | Framework               | Why                                                                                       |
+| ------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| `apps/agent-web`                      | Next.js 15              | Deployed web app — App Router + React 19; `/playground` host + `/remote` Stage-D page     |
+| `apps/docs`                           | Next.js 15              | Docs site — App Router + MDX + pagefind, static export (`output: 'export'`)               |
+| `apps/www`                            | Next.js 15              | Marketing site — static export                                                            |
+| `apps/starter-nextjs`                 | Next.js 15              | SDK starter template (PM-029)                                                             |
+| `apps/blog`                           | Astro                   | Content site — Astro components only                                                      |
+| `apps/agent-app`                      | Electron + React (Vite) | Desktop GUI shell rendering the shared GUI core `agent-transport-gui`                     |
+| `packages/agent-transport-gui`        | React                   | Shared GUI presentation core — `SessionMonitor` + session reducer                         |
+| `packages/agent-transport-webrtc-web` | React                   | Browser WebRTC peer over the GUI core                                                     |
+| `packages/agent-cli-web`              | React + Vite            | CLI-served browser monitor SPA (GUI-007; replaces the dissolved `apps/agent-web-monitor`) |
+| `packages/agent-playground`           | React                   | Playground UI package (`private` product shell)                                           |
+
+### Interactive Tools — Placement Decision
+
+If a new interactive tool or page needs:
+
+- Complex state, routing, or API calls → build it in `apps/agent-web` (Next.js).
+- Simple read-only display or calculator embeddable in docs → a React client component in `apps/docs`.
+
+## Layered Assembly Architecture
+
+The monorepo follows a strict bottom-up assembly model. Each layer builds on the layer below, never bypassing it.
+
+```
+agent-core        ← foundation: interfaces, abstractions, DI, events, plugins
+  ↑
+agent-executor    ← reusable runtime lifecycle/state/ports for background tasks and subagents
+  ↑
+agent-session     ← session lifecycle, wraps core with permissions/hooks
+agent-tools       ← tool implementations (FunctionTool, builtins)
+agent-provider    ← AI provider implementations
+agent-plugin      ← cross-cutting concerns (logging, usage, etc.)
+  ↑
+agent-framework   ← assembly layer: command contracts, common APIs, session/tool/provider composition
+  ↑
+agent-command     ← built-in/optional command modules that consume framework contracts like third-party modules
+  ↑
+agent-cli         ← product/UI layer: consumes agent-framework and selected command modules
+```
+
+**Rules:**
+
+- **No hardcoding of cross-cutting concerns.** Logging, persistence, analytics, and other side concerns MUST use the existing plugin/event architecture, not direct I/O (e.g., `fs.appendFileSync`, `console.log`). If no suitable plugin exists, create one or extend an existing one.
+- **No invented prompt/protocol directives.** Do not add arbitrary parser syntax, instruction strings, pseudo tool-call markers, model/provider heuristics, or magic command text in code or tests to force behavior. Protocol handling must come from an owned SPEC, a public external standard, or an injected adapter/strategy selected by composition.
+- **Prompt section labels are metadata, not behavior.** System-prompt composition may add neutral section titles such as "Built-in Commands", "Skills", or "Agents" and list owner-provided descriptors under them. The composer must not add behavioral instructions, imperative routing guidance, or ad hoc examples to make a model choose a path. Behavior text belongs to the owning command/tool/skill/agent descriptor or SPEC.
+- **Execution claims require runtime evidence.** Tool, command, agent, and background-task state may be reported only from structured runtime results or events. Assistant text, tag-like markup, or model-authored descriptions are never evidence that work started, completed, failed, or timed out.
+- **Provider domain neutrality.** Provider packages may translate provider-specific wire formats into universal messages and tool calls only through declared tool schemas, provider-owned protocol adapters, or injected projection strategies. A provider must not hardcode Robota domain tools, command names, slash commands, agent/subagent concepts, backlog concepts, CLI/TUI behavior, or product workflow semantics. If a model emits XML-like tool artifacts, the provider may parse generic XML and match only the request's declared tool names; it must not infer undeclared tool calls from tag names, role labels, or free-form command-like text.
+- **No user-session examples in model-facing guidance.** Do not promote ad hoc examples from user conversations into system prompts, tool descriptions, command descriptors, package specs, or tests. Model-facing examples must be generic, language-neutral, and owned by the relevant SPEC or command/tool contract.
+- **No layer skipping.** CLI must not directly use agent-core internals that should be wired through agent-session or agent-framework. Each layer consumes only its direct dependency's public API.
+- **Composition over integration.** Features should be assembled from existing building blocks (plugins, event service, tool registry) rather than baked into a single class. A 500-line Session class with hardcoded file I/O is a design smell.
+- **Interface-first extension.** When adding a capability (e.g., session logging), define the interface in agent-core, implement in a plugin or session package, and wire in agent-framework. Never implement directly in the consuming layer.
+- **Side concerns are injectable.** Any behavior that could vary by deployment (logging destination, storage path, analytics) must be injected, not imported directly.
+- **Factory context auto-forwarding.** When a factory function receives a config/context object, optional parameters derivable from that object must use it as the default value (`options.x ?? context.x`). Callers must not be required to manually extract and forward values that the factory already has access to. Explicit overrides take precedence.
+- **Composable material first.** Reusable capabilities must be shaped as small composable packages, ports, adapters, classes, and pure functions before they are wired into SDK or UI flows. The SDK should assemble reusable materials; CLI/TUI should render and inject runtime adapters. Do not let a feature become a CLI-only or SDK-only monolith when it has its own lifecycle, state model, adapters, or non-UI consumers.
+- **Package extraction trigger.** Before adding a substantial capability to an existing package, ask whether it is reusable outside that package's primary role. If the answer is yes, prefer a dedicated lower-level package or a clearly isolated module with public ports. A runtime capability with multiple adapters, transport projections, or independent tests is a strong candidate for package extraction.
+- **Orchestrator/adapter split.** Lifecycle orchestration, state transitions, and handoff metadata belong in reusable lower layers. Concrete I/O such as `child_process`, local files, Git commands, HTTP servers, and React/Ink rendering belongs in injected adapters or shell packages.
+- **Command module isolation.** Built-in and optional command packages (`agent-command`) consume framework command interfaces and are selected by composition roots. `agent-framework` must not import or special-case command packages. Product shells such as `agent-cli` may import selected command modules to assemble a default product experience.
+- **Slash-free command identity.** SDK command identifiers are canonical names such as `skills`, `agent`, or `memory`. `ICommand.name`, `ISystemCommand.name`, `ICapabilityDescriptor.name`, and projected model-command reverse mappings must not include a leading slash. Slash syntax such as `/skills` or `/agent` is a user input/display convention owned by UI/transport shells.
+- **Built-in means default composition, not SDK ownership.** A user-visible internal command must be implemented as an `ICommandModule` owner with metadata, execution, lifecycle policy, interactions, and effects in one place. "Built-in" means the product composes the module by default. It does not mean the command behavior belongs in `agent-cli`, TUI hooks, SDK orchestration classes, or provider packages.
+- **Framework command common API boundary.** `agent-framework` may own generic command contracts (`ICommandModule`, `ISystemCommand`, command effects/interactions, lifecycle metadata), registries/executors, and reusable common APIs or ports needed by commands. For example, provider settings/profile helpers may be SDK common APIs, while `/provider` command flow must consume those APIs as a command module would from a third-party package. When a command needs settings I/O, restart, picker, plugin UI, or provider creation, expose a typed port/adapter contract instead of importing concrete CLI/TUI code.
+- **CLI/TUI command thinness.** `agent-cli` may parse the leading slash, register composed command modules, render generic command prompts, apply typed host effects, and provide host adapters. It must not own command-specific state machines, setup flows, provider profile mutation, command metadata, command-specific switch branches, or duplicated command descriptors when an `ICommandModule` can own them.
+- **Legacy SDK-embedded commands are not precedent.** Existing SDK-embedded command behavior is migration debt unless it is only generic command infrastructure. New internal commands must be implemented as command modules first; expanding SDK command implementation files requires a SPEC-backed migration plan and a mechanical check exception.
+- **Per-product assembly ownership — no shared product factory.** Each deployable product (the CLI, a second CLI, an embedded host, an app) owns its own composition/wiring of provider, preset, and command modules. The reusable, product-agnostic capability lives in the framework/transport layers (e.g., the interaction runtime and the in-process/built-binary driver adapters over a shared interaction contract). Do NOT extract a shared cross-product assembly factory (e.g., a `createCliAgent`): a product shell is one assembler among many, not a shared utility. Reuse is achieved by sharing lower-layer materials, not by sharing the product's assembly. See `feedback_no_shared_cli_factory`.
+
 ## Library Neutrality Rule (packages/ vs apps/)
 
 Everything under `packages/` is a **library and must be universal and neutral** — usable by any
@@ -117,6 +187,27 @@ See [capability-placement.md](specs/architecture-map/capability-placement.md) fo
 | ------------------- | ----------------------------------------------------- |
 | `packages/auth/`    | Auth contracts, verifier ports, scope policy          |
 | `packages/credits/` | Credit account, reservation, and settlement contracts |
+
+## Documentation Map
+
+Source-to-site mapping for robota.io and package docs (SSOT; the documentation UPDATE gates —
+same-PR doc updates, document-role sync — live in
+[rules/documentation-sync.md](rules/documentation-sync.md)):
+
+- `content/README.md` is the robota.io home page source (`/`).
+- `content/getting-started/README.md` is `/getting-started/`.
+- `content/guide/README.md` is `/guide/`.
+- `content/guide/building-agents.md` is `/guide/building-agents.html`.
+- `content/guide/sdk.md` is `/guide/sdk.html`.
+- `content/guide/cli.md` is `/guide/cli.html`.
+- `content/guide/architecture.md` is `/guide/architecture.html`.
+- `content/guide/permissions-and-hooks.md` is `/guide/permissions-and-hooks.html`.
+- `content/guide/context-management.md` is `/guide/context-management.html`.
+- `content/examples/*.md` is `/examples/*`.
+- `packages/<pkg>/docs/README.md` is copied into robota.io as `/packages/<pkg>/`.
+- `packages/<pkg>/docs/SPEC.md` is package contract truth, not marketing docs.
+- `packages/<pkg>/README.md` is the npm/GitHub package README.
+- `apps/docs/out/` and `apps/docs/.next/` are generated build outputs (Next.js static export + pagefind). Do not edit them directly.
 
 ## Related Documents
 

--- a/.agents/rules/code-quality.md
+++ b/.agents/rules/code-quality.md
@@ -52,45 +52,7 @@ Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 
 ### Layered Assembly Architecture
 
-The monorepo follows a strict bottom-up assembly model. Each layer builds on the layer below, never bypassing it.
-
-```
-agent-core        ← foundation: interfaces, abstractions, DI, events, plugins
-  ↑
-agent-executor    ← reusable runtime lifecycle/state/ports for background tasks and subagents
-  ↑
-agent-session     ← session lifecycle, wraps core with permissions/hooks
-agent-tools       ← tool implementations (FunctionTool, builtins)
-agent-provider    ← AI provider implementations
-agent-plugin      ← cross-cutting concerns (logging, usage, etc.)
-  ↑
-agent-framework   ← assembly layer: command contracts, common APIs, session/tool/provider composition
-  ↑
-agent-command     ← built-in/optional command modules that consume framework contracts like third-party modules
-  ↑
-agent-cli         ← product/UI layer: consumes agent-framework and selected command modules
-```
-
-**Rules:**
-
-- **No hardcoding of cross-cutting concerns.** Logging, persistence, analytics, and other side concerns MUST use the existing plugin/event architecture, not direct I/O (e.g., `fs.appendFileSync`, `console.log`). If no suitable plugin exists, create one or extend an existing one.
-- **No invented prompt/protocol directives.** Do not add arbitrary parser syntax, instruction strings, pseudo tool-call markers, model/provider heuristics, or magic command text in code or tests to force behavior. Protocol handling must come from an owned SPEC, a public external standard, or an injected adapter/strategy selected by composition.
-- **Prompt section labels are metadata, not behavior.** System-prompt composition may add neutral section titles such as "Built-in Commands", "Skills", or "Agents" and list owner-provided descriptors under them. The composer must not add behavioral instructions, imperative routing guidance, or ad hoc examples to make a model choose a path. Behavior text belongs to the owning command/tool/skill/agent descriptor or SPEC.
-- **Execution claims require runtime evidence.** Tool, command, agent, and background-task state may be reported only from structured runtime results or events. Assistant text, tag-like markup, or model-authored descriptions are never evidence that work started, completed, failed, or timed out.
-- **Provider domain neutrality.** Provider packages may translate provider-specific wire formats into universal messages and tool calls only through declared tool schemas, provider-owned protocol adapters, or injected projection strategies. A provider must not hardcode Robota domain tools, command names, slash commands, agent/subagent concepts, backlog concepts, CLI/TUI behavior, or product workflow semantics. If a model emits XML-like tool artifacts, the provider may parse generic XML and match only the request's declared tool names; it must not infer undeclared tool calls from tag names, role labels, or free-form command-like text.
-- **No user-session examples in model-facing guidance.** Do not promote ad hoc examples from user conversations into system prompts, tool descriptions, command descriptors, package specs, or tests. Model-facing examples must be generic, language-neutral, and owned by the relevant SPEC or command/tool contract.
-- **No layer skipping.** CLI must not directly use agent-core internals that should be wired through agent-session or agent-framework. Each layer consumes only its direct dependency's public API.
-- **Composition over integration.** Features should be assembled from existing building blocks (plugins, event service, tool registry) rather than baked into a single class. A 500-line Session class with hardcoded file I/O is a design smell.
-- **Interface-first extension.** When adding a capability (e.g., session logging), define the interface in agent-core, implement in a plugin or session package, and wire in agent-framework. Never implement directly in the consuming layer.
-- **Side concerns are injectable.** Any behavior that could vary by deployment (logging destination, storage path, analytics) must be injected, not imported directly.
-- **Factory context auto-forwarding.** When a factory function receives a config/context object, optional parameters derivable from that object must use it as the default value (`options.x ?? context.x`). Callers must not be required to manually extract and forward values that the factory already has access to. Explicit overrides take precedence.
-- **Composable material first.** Reusable capabilities must be shaped as small composable packages, ports, adapters, classes, and pure functions before they are wired into SDK or UI flows. The SDK should assemble reusable materials; CLI/TUI should render and inject runtime adapters. Do not let a feature become a CLI-only or SDK-only monolith when it has its own lifecycle, state model, adapters, or non-UI consumers.
-- **Package extraction trigger.** Before adding a substantial capability to an existing package, ask whether it is reusable outside that package's primary role. If the answer is yes, prefer a dedicated lower-level package or a clearly isolated module with public ports. A runtime capability with multiple adapters, transport projections, or independent tests is a strong candidate for package extraction.
-- **Orchestrator/adapter split.** Lifecycle orchestration, state transitions, and handoff metadata belong in reusable lower layers. Concrete I/O such as `child_process`, local files, Git commands, HTTP servers, and React/Ink rendering belongs in injected adapters or shell packages.
-- **Command module isolation.** Built-in and optional command packages (`agent-command`) consume framework command interfaces and are selected by composition roots. `agent-framework` must not import or special-case command packages. Product shells such as `agent-cli` may import selected command modules to assemble a default product experience.
-- **Slash-free command identity.** SDK command identifiers are canonical names such as `skills`, `agent`, or `memory`. `ICommand.name`, `ISystemCommand.name`, `ICapabilityDescriptor.name`, and projected model-command reverse mappings must not include a leading slash. Slash syntax such as `/skills` or `/agent` is a user input/display convention owned by UI/transport shells.
-- **Built-in means default composition, not SDK ownership.** A user-visible internal command must be implemented as an `ICommandModule` owner with metadata, execution, lifecycle policy, interactions, and effects in one place. "Built-in" means the product composes the module by default. It does not mean the command behavior belongs in `agent-cli`, TUI hooks, SDK orchestration classes, or provider packages.
-- **Framework command common API boundary.** `agent-framework` may own generic command contracts (`ICommandModule`, `ISystemCommand`, command effects/interactions, lifecycle metadata), registries/executors, and reusable common APIs or ports needed by commands. For example, provider settings/profile helpers may be SDK common APIs, while `/provider` command flow must consume those APIs as a command module would from a third-party package. When a command needs settings I/O, restart, picker, plugin UI, or provider creation, expose a typed port/adapter contract instead of importing concrete CLI/TUI code.
-- **CLI/TUI command thinness.** `agent-cli` may parse the leading slash, register composed command modules, render generic command prompts, apply typed host effects, and provide host adapters. It must not own command-specific state machines, setup flows, provider profile mutation, command metadata, command-specific switch branches, or duplicated command descriptors when an `ICommandModule` can own them.
-- **Legacy SDK-embedded commands are not precedent.** Existing SDK-embedded command behavior is migration debt unless it is only generic command infrastructure. New internal commands must be implemented as command modules first; expanding SDK command implementation files requires a SPEC-backed migration plan and a mechanical check exception.
-- **Per-product assembly ownership — no shared product factory.** Each deployable product (the CLI, a second CLI, an embedded host, an app) owns its own composition/wiring of provider, preset, and command modules. The reusable, product-agnostic capability lives in the framework/transport layers (e.g., the interaction runtime and the in-process/built-binary driver adapters over a shared interaction contract). Do NOT extract a shared cross-product assembly factory (e.g., a `createCliAgent`): a product shell is one assembler among many, not a shared utility. Reuse is achieved by sharing lower-layer materials, not by sharing the product's assembly. See `feedback_no_shared_cli_factory`.
+Moved to [`.agents/project-structure.md`](../project-structure.md) § "Layered Assembly
+Architecture" (the SSOT for dependency-direction data) — the bottom-up package stack
+(agent-core → agent-cli) and the command-layering rules live there. This file owns only the
+neutral type/pattern rules above.

--- a/.agents/rules/documentation-sync.md
+++ b/.agents/rules/documentation-sync.md
@@ -5,20 +5,9 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 
 ### Documentation Source Map
 
-- `content/README.md` is the robota.io home page source (`/`).
-- `content/getting-started/README.md` is `/getting-started/`.
-- `content/guide/README.md` is `/guide/`.
-- `content/guide/building-agents.md` is `/guide/building-agents.html`.
-- `content/guide/sdk.md` is `/guide/sdk.html`.
-- `content/guide/cli.md` is `/guide/cli.html`.
-- `content/guide/architecture.md` is `/guide/architecture.html`.
-- `content/guide/permissions-and-hooks.md` is `/guide/permissions-and-hooks.html`.
-- `content/guide/context-management.md` is `/guide/context-management.html`.
-- `content/examples/*.md` is `/examples/*`.
-- `packages/<pkg>/docs/README.md` is copied into robota.io as `/packages/<pkg>/`.
-- `packages/<pkg>/docs/SPEC.md` is package contract truth, not marketing docs.
-- `packages/<pkg>/README.md` is the npm/GitHub package README.
-- `apps/docs/.temp/` and `apps/docs/.vitepress/dist/` are generated outputs. Do not edit them directly.
+Moved to [`.agents/project-structure.md`](../project-structure.md) § "Documentation Map" (the SSOT
+for repo path data) — the source-to-site mapping for robota.io `content/` pages and package docs
+lives there. This rule owns only the update gates below.
 
 ### Architecture Map Content Policy
 
@@ -49,6 +38,10 @@ This section owns the **content** policy (what belongs in these files). The **st
 - If an architecture map file requires more than one read to understand its structural relationships, it is too heavy. Strip it until each relationship is one line or one row.
 
 ### Document Role Sync Gate
+
+Document-class AUTHORITY (which document class owns which content) is owned by
+[spec-workflow.md](spec-workflow.md) § "Document Authority and Content Placement" — do not
+re-derive it here. This gate owns only WHEN each class must be updated:
 
 - Architecture maps own stable structural boundaries. Update them when ownership, layer direction,
   package topology, deployment topology, or product-shell responsibility changes.

--- a/.agents/rules/frontend.md
+++ b/.agents/rules/frontend.md
@@ -29,7 +29,8 @@ For statically-exported Next.js apps (e.g. `apps/www`):
 
 ## Styling
 
-Tailwind CSS utility classes only. This rule is shared with [naming-style.md](naming-style.md).
+Tailwind CSS utility classes only. This file owns the detailed styling constraints and their
+exceptions; [naming-style.md](naming-style.md) carries the one-line policy summary.
 
 - No `<style>` blocks (including `<style scoped>`)
 - No CSS modules
@@ -38,22 +39,10 @@ Tailwind CSS utility classes only. This rule is shared with [naming-style.md](na
 
 ## App Inventory and Approved Stack
 
-| App / Package                         | Framework    | Why                                                  |
-| ------------------------------------- | ------------ | ---------------------------------------------------- |
-| `apps/agent-web`                      | Next.js 15   | Primary web app — App Router + React 19              |
-| `apps/docs`                           | Next.js 15   | Docs site — App Router + MDX + pagefind              |
-| `apps/www`                            | Next.js 15   | Marketing site — static export                       |
-| `packages/agent-transport-gui`        | React        | Shared GUI core — `SessionMonitor` + session reducer |
-| `packages/agent-transport-webrtc-web` | React        | Browser WebRTC peer over the GUI core                |
-| `apps/agent-web-monitor`              | React + Vite | CLI-served browser monitor SPA                       |
-| `apps/blog`                           | Astro        | Content site — Astro components only                 |
-
-## Interactive Tools — Placement Decision
-
-If a new interactive tool or page needs:
-
-- Complex state, routing, or API calls → build it in `apps/agent-web` (Next.js).
-- Simple read-only display or calculator embeddable in docs → a React client component in `apps/docs`.
+Moved to [`.agents/project-structure.md`](../project-structure.md) § "App Inventory and Approved
+Stack" (the SSOT for the package/app listing) — the per-surface framework table and the
+Interactive-Tools placement decision live there. This rule owns only the portable stack
+invariants above (React only, Next.js for SSR, Tailwind only).
 
 ## Acceptable Exceptions to the Styling Rule
 
@@ -67,10 +56,10 @@ These are the only cases where non-Tailwind styling is permitted:
 
 ## Common Mistakes
 
-| Wrong                                              | Correct                                          |
-| -------------------------------------------------- | ------------------------------------------------ |
-| "I'll use Vue for a new component"                 | Vue is not approved. Use React.                  |
-| Building a full app as a Vue component             | Move complex UI to `apps/agent-web` (Next.js)    |
-| Adding `<style>` to a React component              | Use Tailwind utility classes only                |
-| Using `styled-components` or `emotion`             | Use Tailwind utility classes only                |
-| Defining custom CSS utility classes in globals.css | Use Tailwind utilities directly in JSX className |
+| Wrong                                              | Correct                                                                                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| "I'll use Vue for a new component"                 | Vue is not approved. Use React.                                                                                                |
+| Building a full app as a Vue component             | Move complex UI to the primary Next.js web app (see the placement decision in [project-structure.md](../project-structure.md)) |
+| Adding `<style>` to a React component              | Use Tailwind utility classes only                                                                                              |
+| Using `styled-components` or `emotion`             | Use Tailwind utility classes only                                                                                              |
+| Defining custom CSS utility classes in globals.css | Use Tailwind utilities directly in JSX className                                                                               |


### PR DESCRIPTION
## Summary

Agent H of the 3-agent parallel DIET-004 wave — the "Neutralize baked project-data" bucket. Rules now state only PORTABLE invariants; Robota-specific project DATA moved to `.agents/project-structure.md` (the declared SSOT for the package/app listing). Every moved section keeps its heading in the source rule as a pointer stub, so no inbound link target was deleted.

### What moved where

| From | Section | To |
| --- | --- | --- |
| `.agents/rules/frontend.md` | App-Inventory table + Interactive-Tools placement | `project-structure.md` § "App Inventory and Approved Stack" |
| `.agents/rules/documentation-sync.md` | Documentation Source Map | `project-structure.md` § "Documentation Map" |
| `.agents/rules/code-quality.md` | Layered Assembly Architecture (stack diagram + command-layering rules) | `project-structure.md` § "Layered Assembly Architecture" |

### Stale entries fixed while relocating (each verified against the real tree)

- `apps/agent-web-monitor` — dissolved in GUI-007; the CLI-served monitor SPA is `packages/agent-cli-web` (React + Vite). Table row corrected.
- Added missing real UI surfaces: `apps/agent-app` (Electron + React/Vite), `apps/starter-nextjs` (Next.js 15), `packages/agent-playground` (React product shell). Framework claims verified from each `package.json` (`apps/blog` is Astro 6; `apps/docs`/`www` are Next.js 15 `output: 'export'`).
- `apps/docs/.temp/` + `apps/docs/.vitepress/dist/` generated-output paths predate the SITE-005 VitePress→Next.js migration — corrected to `apps/docs/out/` + `apps/docs/.next/` (`next build && pagefind --site out`).
- All `content/` map paths verified to exist on disk.

### Rule-side hygiene in the same pass

- `frontend.md` Styling: ownership of the detailed constraints/exceptions clarified vs `naming-style.md`'s one-line summary (it said "shared with", which violated one-owner); app-specific Common-Mistakes row neutralized to point at the placement decision.
- `documentation-sync.md` Document-Role Sync Gate now POINTS at `spec-workflow.md` § "Document Authority and Content Placement" for class authority instead of re-deriving it (spec-workflow.md untouched).
- `code-quality.md` keeps the `### Layered Assembly Architecture` heading as a stub — `common-mistakes.md` #16/#20 reference it by that name (file outside this wave's ownership).
- `.agents/backlog/HARNESS-DIET-004-rules-consolidation.md` progress updated; the "Neutralize baked project-data" bucket is now complete.

## Verification

- `node scripts/harness/run-all-scans.mjs` — **all 61 scans pass** foreground (`consistency`, `document-authority`, `spec-paths`, `arch-map-paths`, `conformance`, `dist` included; `dist` required a full `pnpm build:deps`, which passed).
- No skill `AGENTS.md > "…"` anchor references any moved heading (checked the full anchor list against `scan-consistency`'s section extraction — `project-structure.md` is not in its section scan set, and the anchors used by skills all remain in place).
- Inbound-reference grep across `.agents`/`scripts`/`.claude`: no `#fragment` links target the moved headings; text references resolve via the kept stub headings.

## Deferred (outside this agent's file ownership — for a sibling/follow-up)

- `.agents/rules/index.md` Frontend row still says "VitePress exception" — stale since SITE-005 removed VitePress (rule file outside my ownership this wave).
- `.agents/rules/operational.md` line "Follow documentation-sync.md for the exact package README and robota.io source paths" still points at the rule; it resolves via the stub, but could point straight at `project-structure.md` § Documentation Map.
- `.agents/rules/naming-style.md` Styling section remains a 2-line duplicate summary; if the owner wants strict one-owner, it could become a pointer to `frontend.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC