### PR TITLE
chore(skills): consolidate conformance skill-tree + slim rule-restating skills (DIET-005)

### DIFF
--- a/.agents/backlog/completed/HARNESS-DIET-005-skills-diet.md
+++ b/.agents/backlog/completed/HARNESS-DIET-005-skills-diet.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-DIET-005: skills — remove dead/textbook/vendored, consolidate, slim rule-restating'
-status: in-progress
+status: done
 created: 2026-07-23
+completed: 2026-07-24
 priority: medium
 urgency: soon
 area: .agents/skills, .agents/skills/index.md
@@ -46,8 +47,34 @@ depends_on: []
   `git-branch.md`; the sole live referencers (`index.md`, `backlog-execution-orchestrator`) were updated
   in the same change. Remaining name-hits are test fixtures / doc examples using it as a sample skill
   name, not links to the skill file.
-- **REMAINING:** the INFRA-002 conformance-skill-tree CONSOLIDATE, and the SLIMs — each its own careful,
-  prose-editing PR.
+
+## Progress (2026-07-24) — CONSOLIDATE + SLIM batch (final)
+
+- **DONE — INFRA-002 conformance skill-tree CONSOLIDATED into the agent loop:** grep-verified the five
+  skills were referenced only by each other, `index.md`, archived spec-docs/tasks, and one rules pointer
+  (`spec-workflow.md` GATE-CONFORMANCE "Analytic layer" — rules file, flagged for the rules-owner pass).
+  `architecture-conformance-audit` → thin router (mechanical conformance scan + the `architecture-refresh`
+  pipeline with `architecture-conformance-auditor`/`architecture-auditor`); `doc-claim-verification`,
+  `conformance-finding-report`, `design-quality-audit` → pointer stubs at the agents that own the behavior
+  natively (files kept so inbound links resolve); `dependency-graph-extraction` kept as the mechanical-floor
+  leaf, repointed off the stubbed skill; `improvement-proposal-authoring` kept (remediation planning leaf).
+  None of the five is registered in `orchestration-map.md` — no map change. `index.md` rows updated.
+- **DONE — SLIMs (11 skills):** `post-implementation-checklist` (141→44, router: order+gates only; details
+  → spec-code-conformance / delegated-refactor-green-gate / version-management / git-branch.md),
+  `package-code-review` (150→86, kept MUST/SHOULD/CONSIDER/NIT + six perspectives + output format; dropped
+  restated code-quality rule bullets), `pre-refactor-test-harness` (141→54, kept Analyze→Test→Extract→Verify
+  - stop conditions; links shared loops), `architecture-patterns` (128→41, principle list + rule pointers;
+    code skeletons/checklist deleted), `effect-style-error-modeling` (77→31, kept Result-vs-throw decision
+    table + no-fallback pointer), `api-error-standard` (77→31, kept SSOT-ownership + urn namespace + usage
+    rules), `contract-testing` (76→24, short leaf), `architecture-decision-records` (91→55, template +
+    location only; guard `check-adr-completeness.mjs` noted), `lesson-to-harness` (123→66, kept full
+    procedure incl. sweep-class/mechanism/prove; preamble + anti-pattern table compressed),
+    `pnpm-monorepo-build` (66→41, kept lifecycle-hook + lockfile-surgery lessons; command listing dropped),
+    `branch-guard` (144→33, "hook + husky are the mechanical SSOT" pointer; policy → git-branch.md). Every
+    `AGENTS.md > "..."` asserted anchor line kept; scan suite green.
+- **DEFERRED (not this file's ownership):** `.agents/rules/spec-workflow.md` GATE-CONFORMANCE "Analytic
+  layer" bullet still narrates the retired 4-step prose chain — should be repointed at the
+  `architecture-conformance-audit` router / `architecture-refresh` loop in a rules-side change.
 
 ## Problem
 

--- a/.agents/skills/api-error-standard/SKILL.md
+++ b/.agents/skills/api-error-standard/SKILL.md
@@ -10,68 +10,22 @@ description: Defines the standard error response format for HTTP APIs based on R
 - `AGENTS.md` > "No Fallback Policy"
 - `AGENTS.md` > "Type System (Strict)"
 
-## Use This Skill When
+All HTTP API 4xx/5xx responses MUST use RFC 7807 Problem Details
+(`{ type, title, status, detail?, instance? }` — see the RFC for field semantics).
 
-- Implementing HTTP API error responses.
-- Reviewing API endpoint error handling.
-- Adding new error types to an API surface.
-
-## Standard Format (RFC 7807)
-
-All HTTP API error responses MUST use the Problem Details format:
-
-```ts
-interface IProblemDetails {
-  type: string; // URI reference identifying the error type
-  title: string; // Short human-readable summary
-  status: number; // HTTP status code
-  detail?: string; // Human-readable explanation specific to this occurrence
-  instance?: string; // URI reference identifying the specific occurrence
-}
-```
-
-## SSOT
+## SSOT Ownership
 
 The canonical `IProblemDetails` interface is owned by the API package or app that exposes the HTTP
 surface. Shared consumers must import from that owner instead of redeclaring the same shape.
 
 ## Usage Rules
 
-1. **Always return Problem Details** for 4xx and 5xx responses.
-2. **Use specific `type` URIs** — not generic strings. Format: `urn:robota:error:<domain>:<error-name>`.
-3. **Match `status` to HTTP status code** — do not return 200 with an error body.
-4. **Include `detail`** for errors that need context beyond the title.
-5. **Never expose internal details** (stack traces, database errors, internal paths) in production responses.
-
-## Error Type Registry Pattern
-
-Each API package should maintain a typed error union:
-
-```ts
-type TOrderError = 'ORDER_NOT_FOUND' | 'ORDER_ALREADY_COMPLETED' | 'INSUFFICIENT_INVENTORY';
-
-function toHttpStatus(error: TOrderError): number {
-  const statusMap: Record<TOrderError, number> = {
-    ORDER_NOT_FOUND: 404,
-    ORDER_ALREADY_COMPLETED: 409,
-    INSUFFICIENT_INVENTORY: 422,
-  };
-  return statusMap[error];
-}
-```
-
-## Anti-Patterns
-
-- Returning `{ error: true, message: "something went wrong" }` without structure.
-- Returning 200 status with an error body.
-- Exposing stack traces or internal error messages to clients.
-- Using inconsistent error shapes across endpoints in the same API.
-- Catching all errors and returning a generic 500 without classification.
-
-## Checklist
-
-- [ ] All error responses use `IProblemDetails` shape.
-- [ ] Error `type` field uses the `urn:robota:error:` namespace.
-- [ ] HTTP status code matches the error semantics.
-- [ ] No internal details exposed in production error responses.
-- [ ] Error types are documented in the package SPEC.md.
+1. `type` URIs are specific, namespaced identifiers: `urn:robota:error:<domain>:<error-name>` —
+   never generic strings.
+2. `status` matches the HTTP status code — never return 200 with an error body.
+3. Never expose internal details (stack traces, database errors, internal paths) in production
+   responses.
+4. Each API package maintains a typed error union with an explicit error→status mapping, and
+   documents its error types in the package SPEC.md.
+5. Error shapes are consistent across every endpoint of the same API — no catch-all generic 500s
+   without classification.

--- a/.agents/skills/architecture-conformance-audit/SKILL.md
+++ b/.agents/skills/architecture-conformance-audit/SKILL.md
@@ -1,59 +1,25 @@
 ---
 name: architecture-conformance-audit
-description: Orchestrates a repeatable doc-vs-code architecture conformance audit — sequences dependency-graph extraction, per-document claim verification, finding classification, and improvement-proposal authoring into the INFRA-002 report schema. Use before a release, after cross-package work, or when GATE-CONFORMANCE runs.
+description: Thin router for the doc-vs-code architecture conformance audit (GATE-CONFORMANCE). Routes to the mechanical conformance scan plus the architecture-refresh agent loop (architecture-conformance-auditor / architecture-auditor + fixers), which own the audit behavior natively. Use before a release, after cross-package work, or when GATE-CONFORMANCE runs.
 ---
 
-# Architecture Conformance Audit (orchestrator)
+# Architecture Conformance Audit (router)
 
-Repeatable orchestrator for a doc-vs-code architecture conformance audit. Codifies the INFRA-002
-methodology so it can run on demand instead of as a one-shot manual pass. This skill sequences the
-single-responsibility step skills; it does not itself extract graphs, judge claims, or write rules.
+The conformance audit is owned by the **agent loop**, not by a prose skill chain. This router only
+names the two layers; every judgement lives in the agents (see
+[enforcement-architecture.md](../../rules/enforcement-architecture.md) — no skill-tree tiers).
 
-## Rule Anchor
+1. **Mechanical floor.** Run the conformance scan — `pnpm harness:conformance` (see the
+   `harness:*` scripts in the root `package.json` for the current name) plus `pnpm harness:scan`.
+   Exit 0 = conformant; capture the JSON summary verbatim. For just the ground-truth dependency
+   edge set, use [dependency-graph-extraction](../dependency-graph-extraction/SKILL.md).
+2. **Agent loop.** Dispatch the [architecture-refresh](../architecture-refresh/SKILL.md) pipeline:
+   `architecture-conformance-auditor` (doc↔code claim verdicts — HOLDS/DRIFT/VIOLATION/PHANTOM/
+   UNDOCUMENTED — with findings + `ACTIONABLE FINDINGS: <n>`) and `architecture-auditor`
+   (design-quality judgement), routed to `architecture-fixer` / `architecture-implementer` until a
+   round is clean.
+3. **Remediation planning.** When findings need follow-up backlogs + guard recommendations, use
+   [improvement-proposal-authoring](../improvement-proposal-authoring/SKILL.md).
 
-- `AGENTS.md` > Document Discovery Policy + "prefer a mechanical check over adding more prose"
-- `.agents/rules/spec-workflow.md` > GATE-CONFORMANCE
-- `.agents/project-structure.md` > dependency-direction rules (the truth this audit checks docs against)
-
-## When to Use
-
-- Before a `develop → main` release, or after any cross-package change.
-- When `GATE-CONFORMANCE` is invoked (see `backlog-gate-guard`).
-- On demand to refresh `.design/architecture-audit/<date>/`.
-
-## Steps
-
-1. **Mechanical baseline.** Run `pnpm harness:conformance` (dependency-direction + workspace-package-name
-   guard) and `pnpm harness:scan`. Capture both verbatim. This is the deterministic floor — no human
-   judgement. See [dependency-graph-extraction](../dependency-graph-extraction/SKILL.md). **A green baseline
-   is a floor, not a ceiling:** several guards assert only that referenced _names/tokens_ exist, not that a
-   documented _edge/shape/direction_ is real (see [harness-governance](../harness-governance/SKILL.md)
-   "Assert the relation, not a proxy"). Treat guard **coverage gaps** — a boundary the audit can violate
-   that no guard catches — as first-class findings, and recommend the relation-asserting guard in step 4.
-2. **Per-document verification.** For each canonical architecture document (the set in
-   [doc-claim-verification](../doc-claim-verification/SKILL.md) > Canonical Document Set), assign every
-   checkable claim a verdict via [doc-claim-verification](../doc-claim-verification/SKILL.md).
-   **Enumerate the set mechanically — do not hand-list it.** The architecture-map has nested subtrees
-   (e.g. `agent-cli/`); enumerate with `find .agents/specs/architecture-map -name '*.md'` and
-   `ls packages/*/docs/SPEC.md`, then verify EVERY file. A risk-based pass may _prioritise_ recently
-   changed docs, but must still report which canonical docs were covered vs. deferred (no silent scoping).
-3. **Classify + report.** Turn verdicts into `AF-NN` findings with severity and a counts table via
-   [conformance-finding-report](../conformance-finding-report/SKILL.md), written to
-   `.design/architecture-audit/<date>/conformance-audit-report.md`.
-4. **Improvement proposal.** Map P0/P1 findings to remediation + follow-up backlogs + guard
-   recommendations via [improvement-proposal-authoring](../improvement-proposal-authoring/SKILL.md),
-   written to `.design/architecture-audit/<date>/improvement-proposal.md`.
-5. **Report the gate verdict.** Surface the `harness:conformance` exit code + JSON summary as the
-   machine-readable result; the prose findings are the analytic layer on top.
-
-## Output
-
-Two documents under `.design/architecture-audit/<date>/` (report + proposal) plus the captured
-`harness:conformance` / `harness:scan` baselines. Structure must match the INFRA-002 schema (see
-`conformance-finding-report`). Reference exemplar: `.design/architecture-audit/2026-06-13/`.
-
-## What This Skill Does NOT Do
-
-- Run gates or decide PASS/FAIL → that is `backlog-gate-guard` (GATE-CONFORMANCE).
-- Fix any finding → fixes are spun out as follow-up backlogs (spec-before-code).
-- Restate dependency-direction rules → those live in `.agents/project-structure.md`.
+PASS/FAIL is decided by GATE-CONFORMANCE (`.agents/rules/spec-workflow.md` > GATE-CONFORMANCE, run
+via `backlog-gate-guard`): the scan exits 0 and no unresolved P0 finding remains.

--- a/.agents/skills/architecture-decision-records/SKILL.md
+++ b/.agents/skills/architecture-decision-records/SKILL.md
@@ -10,22 +10,12 @@ description: Records architectural decisions with context, alternatives, and con
 - `AGENTS.md` > "Development Patterns"
 - `AGENTS.md` > "Build Requirements"
 
-## Use This Skill When
+Write one ADR per decision when a design choice affects multiple packages or modules, or has 2+ viable
+alternatives with real trade-offs. Accepted ADRs are immutable — supersede with a new ADR, never
+edit. Section presence + Status values are mechanically enforced by
+`scripts/harness/check-adr-completeness.mjs`; this skill owns the template.
 
-- A design choice affects multiple packages or modules.
-- There are two or more viable alternatives with meaningful trade-offs.
-- A Gate checkpoint is being passed.
-- A previous decision needs to be revisited or superseded.
-- Onboarding requires understanding "why was this done this way?"
-
-## Core Principles
-
-1. One ADR per decision (not per feature or per meeting).
-2. Immutable once accepted; superseded by a new ADR, never edited.
-3. Lightweight: short context, clear decision, concrete consequences.
-4. Stored in version control alongside code.
-
-## File Convention
+## Location & Naming
 
 - Location: `.design/decisions/`
 - Naming: `ADR-NNN-short-title.md` (e.g., `ADR-001-runtime-event-prefix-system.md`)
@@ -48,7 +38,6 @@ What is the problem or question? Why does it need a decision now?
 
 1. **Option A**: description — pros / cons
 2. **Option B**: description — pros / cons
-3. **Option C**: description — pros / cons
 
 ## Decision
 
@@ -64,28 +53,3 @@ Which option was chosen and why.
 
 - Related ADRs, specs, or rule anchors.
 ```
-
-## Workflow
-
-1. Identify that a decision is being made (not just an implementation detail).
-2. Write the ADR using the template above.
-3. Review: does the decision align with existing rules and principles?
-4. Merge the ADR file into the repository.
-5. When a decision is superseded, create a new ADR and mark the old one as `superseded by ADR-NNN`.
-
-## Checklist
-
-- [ ] Context clearly states the problem, not just the solution.
-- [ ] At least two alternatives are documented with trade-offs.
-- [ ] Decision states the chosen option and the primary reason.
-- [ ] Consequences include both positive and negative impacts.
-- [ ] ADR is stored in `.design/decisions/` with correct naming.
-- [ ] Related Gate checkpoints reference the ADR.
-
-## Anti-Patterns
-
-- Recording trivial implementation details as ADRs.
-- Editing accepted ADRs instead of superseding them.
-- Writing ADRs after the fact without reconstructing alternatives.
-- ADRs that describe "what" without "why".
-- No ADR for Gate-level decisions.

--- a/.agents/skills/architecture-patterns/SKILL.md
+++ b/.agents/skills/architecture-patterns/SKILL.md
@@ -1,128 +1,41 @@
 ---
 name: architecture-patterns
-description: Applies Robota's architecture patterns — functional core/imperative shell, ports-and-adapters, and DI-based composition. Use when designing module boundaries, separating domain from infrastructure, or improving testability.
+description: Applies the repo's architecture patterns — functional core/imperative shell, ports-and-adapters, and DI-based composition. Use when designing module boundaries, separating domain from infrastructure, or improving testability.
 ---
 
 # Architecture Patterns
 
 ## Rule Anchor
+
 - `AGENTS.md` > "Development Patterns"
 - `AGENTS.md` > "Type System (Strict)"
 - `AGENTS.md` > "Execution Safety"
 
-## Use This Skill When
-- Domain logic is mixed with API calls, storage, or logging.
-- Building or refactoring class-based services.
-- Reducing coupling between domain logic and infrastructure.
-- Replacing infrastructure should not rewrite core business logic.
-- Tests are slow because every case touches real side effects.
+The binding rules live in [code-quality.md](../../rules/code-quality.md) (development patterns) and
+[.agents/project-structure.md](../../project-structure.md) (dependency direction). This skill is a
+compact reminder of the three patterns to apply — not a textbook.
 
-## Core Principles
+## Principles
 
-### Functional Core, Imperative Shell
-1. **Pure core**: business rules as pure functions (same input, same output).
-2. **Thin shell**: perform I/O at the outer boundary only.
-3. **Explicit data flow**: pass dependencies and inputs explicitly.
-4. **Visible decisions**: keep side-effect decisions in the orchestration layer.
+**Functional core, imperative shell** — business rules as pure functions; I/O only at the outer
+boundary; dependencies and data flow explicit; side-effect decisions visible in the orchestration
+layer.
 
-### Ports and Adapters (Hexagonal)
-5. **Domain independence**: domain core depends on nothing external.
-6. **Port interfaces**: define required capabilities as interfaces owned by core/application.
-7. **Adapter implementations**: concrete technology lives in adapters only.
-8. **Composition root**: wire ports to adapters at a single entry point.
+**Ports and adapters** — the domain core depends on nothing external; required capabilities are
+interfaces (ports) owned by core/application; concrete technology lives in adapters only; wiring
+happens at a single composition root.
 
-### Dependency Injection and Composition
-9. **Composition over inheritance**: prefer object composition.
-10. **Constructor injection**: inject dependencies through constructors, not global imports.
-11. **Narrow responsibilities**: keep class responsibilities explicit and focused.
-12. **Strategy extension**: model extension points with interfaces and strategy objects.
+**DI-based composition** — composition over inheritance; constructor injection (not global
+imports); narrow, explicit class responsibilities; extension points modeled as interfaces/strategy
+objects.
 
-## Layer Map
-- **Domain**: entities, value objects, domain services, pure rules.
-- **Application**: use cases orchestrating domain operations.
-- **Ports**: interfaces for repositories, gateways, message buses.
-- **Adapters**: implementations (SQL, HTTP, queue, file, SDK).
-- **Shell**: thin orchestration — prepare data → call pure core → persist/output.
+## Applying them
 
-## Workflow
-1. Identify the use case entrypoint (controller, handler, command).
-2. Classify current responsibilities: domain logic vs I/O concerns.
-3. Extract pure transformation rules into separate functions.
-4. Define minimal interfaces for external collaborators (ports).
-5. Move API/DB/time/random/logger access into boundary adapters.
-6. Inject implementations via constructor defaults or factories.
-7. Keep application service thin and explicit.
-8. Wire dependencies only at composition root.
-9. Test core with table-driven tests; test shell with integration tests.
+Classify each responsibility as domain logic vs I/O, extract pure rules, define minimal ports for
+external collaborators, move API/DB/time/random/logger access into boundary adapters, inject via
+constructors, and wire only at the composition root. Test the core with table-driven unit tests
+(no mocks needed for pure logic) and the shell with integration tests.
 
-## Reference Skeletons
-
-### Functional Core + Imperative Shell
-```ts
-type TOrderDecision =
-  | { approved: true }
-  | { approved: false; reason: 'INVALID_TOTAL' | 'HIGH_RISK' };
-
-function evaluateOrder(input: IOrderInput): TOrderDecision {
-  if (input.total <= 0) return { approved: false, reason: 'INVALID_TOTAL' };
-  if (input.riskScore > 80) return { approved: false, reason: 'HIGH_RISK' };
-  return { approved: true };
-}
-
-async function processOrder(input: IOrderInput, deps: IProcessDeps): Promise<void> {
-  const decision = evaluateOrder(input);
-  await deps.repository.saveDecision(input.id, decision);
-  if (!decision.approved) await deps.notifier.sendRejection(input.id, decision.reason);
-}
-```
-
-### Constructor DI with Strategy
-```ts
-interface IUserRepository {
-  save(user: IUser): Promise<void>;
-}
-
-interface IPasswordHasher {
-  hash(password: string): Promise<string>;
-}
-
-class UserRegistrationService {
-  constructor(
-    private readonly repo: IUserRepository,
-    private readonly hasher: IPasswordHasher
-  ) {}
-
-  async register(input: IRegisterInput): Promise<IUser> {
-    const hashed = await this.hasher.hash(input.password);
-    const user = { ...input, password: hashed };
-    await this.repo.save(user);
-    return user;
-  }
-}
-```
-
-## Checklist
-- [ ] Business rules exist as pure functions.
-- [ ] Side effects are performed only in boundary layer.
-- [ ] Pure logic has no direct logger, DB, network, env access.
-- [ ] Domain layer imports no infrastructure package.
-- [ ] Ports are owned by core/application, not adapters.
-- [ ] Adapters implement ports without leaking transport details.
-- [ ] Composition root is the only place with concrete wiring.
-- [ ] Class has one clear responsibility.
-- [ ] External systems are abstracted behind interfaces.
-- [ ] Constructor receives all required collaborators.
-- [ ] Unit tests cover pure logic without mocks.
-- [ ] Integration tests validate boundary wiring.
-
-## Anti-Patterns
-- Hidden I/O inside utility functions labeled as "pure".
-- Passing framework objects deep into domain functions.
-- Mixing orchestration and validation logic in one large function.
-- "Hexagonal" folders with real logic still inside adapters.
-- Adapter-driven interfaces that leak vendor details.
-- Framework DTOs passed directly through domain models.
-- Fat service classes that orchestrate everything.
-- Inheritance chains for simple behavior reuse.
-- Static/global state used as implicit dependency injection.
-- Interface explosion without clear ownership or usage.
+Watch for: hidden I/O inside "pure" utilities, framework objects passed into domain functions,
+adapter-driven interfaces that leak vendor details, fat orchestrate-everything services, and
+static/global state as implicit DI.

--- a/.agents/skills/branch-guard/SKILL.md
+++ b/.agents/skills/branch-guard/SKILL.md
@@ -1,144 +1,33 @@
 ---
 name: branch-guard
-description: Guard against committing directly to protected branches (main, master, develop). Use before every git commit to ensure work happens on a feature branch.
+description: Pointer — protected-branch commit/merge policy is owned by the git-branch.md rule and enforced mechanically by the branch-guard hook + husky pre-commit. Consult before committing when on main/master/develop.
 ---
 
-# Branch Guard
+# Branch Guard (pointer)
+
+The policy (branch-first, protected branches, merge-target = fork origin, release merges,
+`--delete-branch` prohibition) is owned by [git-branch.md](../../rules/git-branch.md). Do not
+restate it — read it there.
 
 ## Rule Anchor
 
 - `AGENTS.md` > "Git Operations"
 
-## Use This Skill When
-
-- About to run `git commit` on any branch.
-- The current branch is `main`, `master`, or `develop`.
-
-## Preconditions
-
-- The agent has changes ready to commit.
-- The agent has confirmed user approval for the commit.
-
-## Execution Steps
-
-1. **Check current branch**:
-
-   ```bash
-   git branch --show-current
-   ```
-
-2. **If on a protected branch** (`main`, `master`, or `develop`):
-
-   **First commit in a task:**
-   - Do NOT commit directly.
-   - Ask the user whether to create a new branch before committing.
-   - Suggest a branch name based on the change type and scope:
-     - `feat/<scope>-<short-description>`
-     - `fix/<scope>-<short-description>`
-     - `refactor/<scope>-<short-description>`
-     - `docs/<scope>-<short-description>`
-     - `chore/<short-description>`
-   - Example: `docs/spec-expansion`, `feat/agents-caching`, `chore/harness-cleanup`
-   - Wait for user confirmation of the branch name before proceeding.
-   - Create and switch to the new branch:
-     ```bash
-     git checkout -b <approved-branch-name>
-     ```
-
-   **Subsequent commits within the same task:**
-   - If a feature branch was already created for the current task, continue committing on that branch without asking again.
-   - Mid-task commits (e.g., checkpointing progress in a multi-step plan) do not require a new branch — they are part of the same logical work.
-
-3. **If NOT on a protected branch**: proceed with the commit normally.
-
-## Protected Branches
-
-- `main`
-- `master`
-- `develop`
-
-## Defense Layers (why two)
-
-Protected-branch commits are blocked at **two** layers — both must stay in place:
+## Mechanical enforcement is the SSOT (two layers)
 
 1. **Claude PreToolUse hook** (`.claude/hooks/branch-guard.sh`) — blocks `git commit`/`push`/`merge`
-   Bash tool calls before they run. It parses the command string, so a commit whose message breaks
-   its regex extraction (multi-line, embedded quotes) can slip past. This is exactly how a
-   release-record commit landed directly on `main` and had to be reset → branched → re-PR'd
-   (2026-06-14).
-2. **Git-native `.husky/pre-commit`** — runs for EVERY commit regardless of how it is invoked, using
-   `git branch --show-current`. This is the robust backstop the parsing layer can miss.
+   Bash tool calls on `main`/`master`/`develop` before they run. It parses the command string, so a
+   commit whose message breaks its regex extraction (multi-line, embedded quotes) can slip past —
+   which is exactly how a release-record commit once landed directly on `main` (2026-06-14).
+2. **Git-native `.husky/pre-commit`** — runs for EVERY commit regardless of how it is invoked; the
+   robust backstop for what the parsing layer misses.
 
 Exceptions (both layers): a merge in progress (`.git/MERGE_HEAD`), or the explicit overrides
 `ALLOW_PROTECTED_COMMIT=1` (husky) / `BRANCH_GUARD_ALLOW_MAIN_MERGE=1` (Claude hook) for
-user-approved release automation. Branch-first is the rule even for one-line doc commits aimed at
-`main` — always branch → commit → PR.
+user-approved release automation. Branch-first applies even to one-line doc commits — always
+branch → commit → PR.
 
-4. **When merging a branch** (PR or local merge):
-
-   **Determine merge target:**
-   - Check the fork point of the current branch:
-     ```bash
-     git log --oneline --first-parent develop..HEAD
-     git log --oneline --first-parent main..HEAD
-     ```
-   - The merge target must be the branch it was forked from.
-   - If the branch was forked from `develop`, merge back into `develop`.
-   - If the branch was forked from `main`, merge back into `main` (rare, requires justification).
-
-   **Never assume `main` as the default target.** The default is always the fork origin.
-
-   **If the agent wants a different merge target:**
-   - Explicitly state the recommendation and reasoning.
-   - Wait for user approval before proceeding.
-
-   **Merging `develop` into `main`:**
-   - This is a release-level action. Always ask for explicit user approval.
-   - Never do this as part of a regular feature workflow.
-
-5. **When switching branch context for a separate task:**
-   - Commit and push all current work before switching.
-   - After the separate task is done, return to the original branch.
-   - If the current checkout cannot be used safely, stop and ask the user how to isolate the task before changing branches.
-   - Before merging or cleaning up remote branches, verify the PR and remote state:
-
-     ```bash
-     gh pr view <number> --json state,mergedAt,mergeCommit
-     git fetch origin develop --prune
-     ```
-
-   - If `gh pr merge` succeeds remotely but local synchronization fails, verify the PR state and do not retry the merge blindly.
-
-6. **When deploying docs or blog:**
-   - Cloudflare Pages deploys automatically when `main` is updated.
-   - Manual docs deployment uses `pnpm docs:deploy` after `pnpm docs:build` succeeds.
-   - Do not push generated documentation artifacts to source branches.
-   - Custom domain: `robota.io` is owned by the Cloudflare Pages project.
-
-## Stop Conditions
-
-- User declines branch creation — do not commit on the protected branch.
-- Branch name conflicts with an existing branch — ask for an alternative name.
-- Merge target differs from fork origin — ask user before proceeding.
-
-## Checklist
-
-- [ ] Current branch checked before every commit
-- [ ] Protected branch detected and user notified
-- [ ] Branch name suggested with conventional prefix
-- [ ] User approved the branch name
-- [ ] New branch created before committing
-- [ ] Merge target matches fork origin
-- [ ] Release merge (develop → main) explicitly approved by user
-
-## Anti-Patterns
-
-- Committing directly to `main`, `master`, or `develop` without asking.
-- Creating a branch without user approval of the name.
-- Using generic branch names like `temp` or `wip` without a descriptive suffix.
-- Creating a new branch for every intermediate commit within a single task.
-- Merging into `main` when the branch was forked from `develop`.
-- Assuming `main` as the default merge/PR target.
-- Passing `--delete-branch` to `gh pr merge` (zero exceptions — it once deleted the `develop`
-  integration branch). Merge without it; delete only on explicit user request via `git branch -D`
-  (local) or `gh api -X DELETE .../git/refs/heads/<name>` (remote). Enforced by `branch-guard.sh`.
+If the hook fires (or you notice you are on a protected branch): stop, propose a conventional
+branch name (`feat|fix|refactor|docs|chore/<scope>-<desc>`), get user approval, then
+`git checkout -b` and continue — subsequent commits in the same task stay on that branch without
+re-asking.

--- a/.agents/skills/conformance-finding-report/SKILL.md
+++ b/.agents/skills/conformance-finding-report/SKILL.md
@@ -1,52 +1,16 @@
 ---
 name: conformance-finding-report
-description: Turns per-document verdicts into a structured conformance audit report — assigns AF-NN IDs, P0/P1/P2 severities, per-document verdict summary, and a counts-by-severity table, in the INFRA-002 report schema. Use as step 3 of architecture-conformance-audit.
+description: Pointer stub — conformance findings reporting is owned by the architecture-conformance-auditor agent, which returns classified findings plus a machine-readable ACTIONABLE FINDINGS count natively. Dispatch it via the architecture-refresh pipeline instead of assembling a report from prose steps here.
 ---
 
-# Conformance Finding Report
+# Conformance Finding Report (pointer)
 
-Single-responsibility step: assemble the verdicts from `doc-claim-verification` and the baselines from
-`dependency-graph-extraction` into the conformance audit report. Authoring + classification only; it
-proposes no fixes.
+This behavior is owned by the **`architecture-conformance-auditor` agent**: it returns
+severity-classified, evidence-backed findings (doc-side / code-side) plus the machine-readable
+`ACTIONABLE FINDINGS: <n>` signal the orchestrator routes on — no separate prose report-assembly
+step. Historical INFRA-002 report exemplar:
+`.design/architecture-audit/2026-06-13/conformance-audit-report.md`.
 
-## Rule Anchor
-
-- `AGENTS.md` > Document Discovery Policy
-- Reference schema: `.design/architecture-audit/2026-06-13/conformance-audit-report.md` (INFRA-002)
-
-## Severity
-
-| Severity | Definition                                                                                       |
-| -------- | ------------------------------------------------------------------------------------------------ |
-| **P0**   | Rule violation or authority-doc contradiction that actively misleads about boundaries/contracts. |
-| **P1**   | Real drift: phantom packages, broken links, undocumented contracts, broken diagrams.             |
-| **P2**   | Cosmetic / minor naming / incompleteness.                                                        |
-
-## Report Schema (must match)
-
-1. **Method** — verdict vocabulary + severity definitions.
-2. **Mechanical Conformance Baseline** — `harness:conformance` + `harness:scan` results; reconcile each
-   reported issue into a finding or mark out-of-scope with a reason.
-3. **Dependency Graph Ground Truth** — the verbatim edge set + violation count.
-4. **Per-Document Verdict Summary** — one row per canonical document (authority / architecture-map /
-   package SPEC), each with an overall verdict + finding IDs.
-5. **Findings** — every finding gets `AF-NN`, a class, a `file:line` (or import / dep) evidence, and a
-   one-line description. Group by severity.
-6. **Counts by Severity** — a table summing P0/P1/P2 (+ process/info).
-7. **Headline Conclusions.**
-
-## Rules
-
-- Every finding MUST carry `AF-NN` + severity + classification — no exceptions.
-- Every non-`HOLDS` verdict in the summary MUST trace to a finding.
-- The counts table MUST sum to the total finding count.
-
-## Output
-
-`.design/architecture-audit/<date>/conformance-audit-report.md`.
-
-## What This Skill Does NOT Do
-
-- Assign verdicts → that is `doc-claim-verification`.
-- Propose remediation or follow-up backlogs → `improvement-proposal-authoring`.
-- Decide the gate PASS/FAIL → `backlog-gate-guard`.
+Dispatch via [architecture-refresh](../architecture-refresh/SKILL.md). Entry point:
+[architecture-conformance-audit](../architecture-conformance-audit/SKILL.md); follow-up planning:
+[improvement-proposal-authoring](../improvement-proposal-authoring/SKILL.md).

--- a/.agents/skills/contract-testing/SKILL.md
+++ b/.agents/skills/contract-testing/SKILL.md
@@ -10,67 +10,15 @@ description: Applies consumer-driven contract testing to verify API compatibilit
 - `AGENTS.md` > "Build Requirements"
 - `AGENTS.md` > "Type System (Strict)"
 
-## Use This Skill When
+For an API boundary between independently developed modules (HTTP, WebSocket, or typed interface):
 
-- Two modules communicate via API (HTTP, WebSocket, or typed interface).
-- The consumer and provider are developed independently.
-- You need to catch breaking API changes before deployment.
-- E2E tests are too slow or flaky for API compatibility checks.
+1. The **consumer defines the contract** — a version-controlled file (JSON/TS) of the
+   request/response pairs it depends on — and tests against a mock derived from it.
+2. The **provider verifies the contract** — replays the consumer's expectations against its real
+   handlers in its own tests, without either side needing the other running.
+3. CI runs both sides; a contract violation blocks the merge. When the API changes, update the
+   contract first, then the implementation (breaking vs. additive goes through review).
 
-## Core Principles
-
-1. **Consumer defines the contract**: what requests it sends and what responses it expects.
-2. **Provider verifies the contract**: replays consumer expectations against its implementation.
-3. **Contracts live in version control**: JSON or TypeScript files checked into the repo.
-4. **Independent testing**: consumer and provider run contract tests without needing the other running.
-
-## Workflow
-
-1. Consumer writes a contract file describing expected request/response pairs.
-2. Consumer tests pass against a mock that satisfies the contract.
-3. Provider loads the contract and replays requests against its real handlers.
-4. Provider tests verify all consumer expectations are met.
-5. CI runs both sides; a contract violation blocks the merge.
-6. When the API changes, update the contract first, then the implementation.
-
-## Contract File Format (Lightweight)
-
-```ts
-// contracts/agent-server.contract.ts
-export const AGENT_SERVER_CONTRACT = {
-  name: 'agent-server',
-  interactions: [
-    {
-      description: 'start a playground session',
-      request: {
-        method: 'POST',
-        path: '/v1/sessions',
-        body: { provider: 'openai', model: 'gpt-4.1-mini' },
-      },
-      response: { status: 201, bodySchema: { sessionId: 'string', status: 'string' } },
-    },
-    {
-      description: 'get server capabilities',
-      request: { method: 'GET', path: '/v1/capabilities' },
-      response: { status: 200, bodySchema: { scheduler: 'boolean', projection: 'boolean' } },
-    },
-  ],
-} as const;
-```
-
-## Checklist
-
-- [ ] Contract file exists for each API boundary.
-- [ ] Consumer tests use a mock derived from the contract.
-- [ ] Provider tests replay contract interactions.
-- [ ] Contract violations fail CI before merge.
-- [ ] Contract changes go through review (breaking vs. additive).
-- [ ] Contracts are versioned alongside API version (v1, v2).
-
-## Anti-Patterns
-
-- Consumer tests use hand-written mocks that drift from the real API.
-- Provider changes API without updating the contract.
-- Contracts are too detailed (testing internal implementation, not contract shape).
-- Relying solely on E2E tests for API compatibility.
-- Contracts stored outside version control.
+Anti-patterns: hand-written consumer mocks that drift from the real API; provider changes without
+a contract update; contracts that test internal implementation instead of the boundary shape;
+relying solely on E2E tests for compatibility.

--- a/.agents/skills/dependency-graph-extraction/SKILL.md
+++ b/.agents/skills/dependency-graph-extraction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-graph-extraction
-description: Extracts the actual workspace-internal dependency graph from package.json + imports and runs the mechanical conformance checks, emitting the ground-truth edge set + violations the rest of the audit verifies documents against. Use as step 1 of architecture-conformance-audit.
+description: Extracts the actual workspace-internal dependency graph from package.json + imports and runs the mechanical conformance checks, emitting the ground-truth edge set + violations the rest of the audit verifies documents against. Use as the mechanical-floor step of architecture-conformance-audit, or standalone.
 ---
 
 # Dependency Graph Extraction
@@ -39,11 +39,10 @@ when you only need the current dependency edge set.
 - The `harness:conformance` JSON summary + exit code.
 - The `harness:scan` output.
 
-These are consumed by [doc-claim-verification](../doc-claim-verification/SKILL.md) (to diff documented
-edges against reality) and recorded in the report's "Mechanical Conformance Baseline" + "Dependency
-Graph Ground Truth" sections.
+These are consumed by the `architecture-conformance-auditor` agent (dispatched via
+[architecture-refresh](../architecture-refresh/SKILL.md)) to diff documented edges against reality.
 
 ## What This Skill Does NOT Do
 
-- Judge whether documents match the graph → that is `doc-claim-verification`.
+- Judge whether documents match the graph → that is the `architecture-conformance-auditor` agent.
 - Modify `package.json` or fix violations → extraction only.

--- a/.agents/skills/design-quality-audit/SKILL.md
+++ b/.agents/skills/design-quality-audit/SKILL.md
@@ -1,90 +1,15 @@
 ---
 name: design-quality-audit
-description: Repeatable deep design-quality audit — judges whether the design is *right* (layer boundaries, coupling/cohesion, responsibility placement, type SSOT, extension seams, anti-patterns) by reading the code directly, not by checking docs against code. Use on demand, after large feature/refactor work, or before a release when you want a quality pass beyond conformance.
+description: Pointer stub — the deep "is this design right?" audit (layer boundaries, coupling/cohesion, responsibility placement, type SSOT, extension seams, anti-patterns) is owned by the architecture-auditor agent, which judges by universal design principles natively. Dispatch it via the architecture-refresh pipeline instead of following prose steps here.
 ---
 
-# Design-Quality Audit
+# Design-Quality Audit (pointer)
 
-Repeatable orchestrator for a **design-quality** audit: it reads the code and asks "is this the
-right design?" — not "does the doc match the code?". It produces severity-classified findings and
-maps them to remediation backlogs. Codifies the methodology used in the 2026-06-14 design-quality
-audit (DQ-01~DQ-17 → DQ-AUDIT-001~007) so it can run on demand instead of as a one-shot pass.
+This behavior is owned by the **`architecture-auditor` agent**: an independent, read-only
+design-quality judgement (is the design _right_? — vs. doc↔code conformance, which is
+`architecture-conformance-auditor`'s axis). It audits layer boundaries, coupling/cohesion,
+responsibility placement, type SSOT, extension seams, and anti-patterns natively.
 
-## Rule Anchor
-
-- `AGENTS.md` > Document Discovery Policy + "prefer a mechanical check over adding more prose"
-- `.agents/rules/code-quality.md` > type SSOT, no `any`, no fallback, "Proper architecture over cheap fixes"
-- `.agents/project-structure.md` > dependency-direction + one-way deps (the structural truth)
-
-## This Skill vs. architecture-conformance-audit
-
-Two different axes — run both, do not conflate:
-
-| Axis            | [architecture-conformance-audit](../architecture-conformance-audit/SKILL.md) | design-quality-audit (this)                                          |
-| --------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Question        | Does the **doc match the code**? (drift)                                     | Is the **design right**? (quality)                                   |
-| Source of truth | Architecture docs / SPEC.md claims                                           | Engineering judgement against rules + structure                      |
-| Typical finding | "doc says X, code does Y" (STALE/DRIFT/VIOLATION)                            | "this type has two owners" / "this package is a kitchen-sink barrel" |
-| Output          | INFRA-002 conformance report                                                 | DQ findings report + remediation backlogs                            |
-
-`design-quality-audit` does **not** verify doc claims, run conformance gates, or restate
-dependency rules — those are the conformance skill's job.
-
-## When to Use
-
-- After large feature or refactor work, or before a `develop → main` release.
-- On demand when you suspect coupling/responsibility drift the conformance audit won't catch.
-
-## Audit Axes (checklist)
-
-Read the code directly and judge each axis. Capture every issue as a finding.
-
-1. **Layer boundaries** — upward/reverse dependencies, layer-skipping, leaked concrete I/O across a port.
-2. **Coupling & cohesion** — kitchen-sink barrels, packages mixing unrelated concerns, god classes/files.
-3. **Responsibility placement** — logic in a thin shell that belongs in a domain package (and vice versa).
-4. **Type SSOT** — the same data modeled by two independent types; duplicated record/config shapes;
-   extension by copy instead of `extends`/`Pick`.
-5. **Extension seams** — hardcoded behavior where a plugin/event/strategy seam belongs; missing
-   composition root wiring.
-6. **Anti-patterns** — `fallback`/silent defaults, vendor/product-name literals, raw `throw new Error`
-   where a typed error exists, swallowed errors (`.catch(() => {})`), stub metrics (`return 0 // TODO`),
-   dead/deprecated code, double APIs on one interface.
-
-## Steps
-
-1. **Mechanical baseline.** Run `pnpm harness:scan`. The existing guards (orphan-exports,
-   interface-imports, capability-placement, dependency-direction, stub-markers, harness-config-paths)
-   are the deterministic floor — start from a clean scan.
-2. **Per-axis read.** Sweep the codebase against each Audit Axis above. Enumerate packages
-   mechanically (`ls packages/*/`); do not hand-pick. Record which packages were covered.
-3. **Classify.** Assign each finding a severity (P0 blocker / P1 / P2 / NIT) and a short id (`DQ-NN`).
-4. **Map to backlogs.** Group findings by theme into remediation backlogs (spec-before-code; the
-   architecturally-correct fix, not the cheapest — see code-quality "Proper architecture over cheap
-   fixes"). Direct rule violations may be fixed immediately; larger relocations get their own backlog.
-5. **Report.** Write findings + counts to `.design/architecture-audit/<date>/design-quality-audit.md`.
-
-## Relocation Sweep (when remediation moves code)
-
-When a finding's fix **relocates** code (split a package, move a responsibility), the move is not
-done until every downstream reference is swept — code moves silently leave ghosts:
-
-- backlog `## Affected Files` and Evidence Log path references,
-- `packages/*/docs/SPEC.md` source-path references,
-- **hardcoded paths inside harness scan scripts** (`scripts/harness/*.mjs`),
-- `interface-imports` / capability-placement patterns that named the old location.
-
-Re-run `pnpm harness:scan` after the move; `check-harness-config-paths`, `check-spec-paths`, and
-`check-done-evidence` catch the ghost-path classes. Incident: DQ-AUDIT-004/005 relocations left
-stale tui paths + ghost SPEC paths that failed several scans (2026-06-14).
-
-## Output
-
-One report under `.design/architecture-audit/<date>/design-quality-audit.md` (findings + severity
-counts) plus remediation backlogs in `.agents/backlog/`. Reference exemplar:
+Dispatch it via [architecture-refresh](../architecture-refresh/SKILL.md) (or standalone by
+`agentType: architecture-auditor`). Historical exemplar:
 `.design/architecture-audit/2026-06-14/design-quality-audit.md` → DQ-AUDIT-001~007.
-
-## What This Skill Does NOT Do
-
-- Verify doc-vs-code claims → that is `architecture-conformance-audit`.
-- Run gates or decide PASS/FAIL → that is `backlog-gate-guard`.
-- Fix findings inline → fixes are spun out as backlogs (spec-before-code).

--- a/.agents/skills/doc-claim-verification/SKILL.md
+++ b/.agents/skills/doc-claim-verification/SKILL.md
@@ -1,57 +1,14 @@
 ---
 name: doc-claim-verification
-description: Verifies one architecture document's concrete structural claims against code reality, assigning each claim a HOLDS/DRIFT/VIOLATION/CONTRADICTION/STALE verdict with file:line evidence. Use as step 2 of architecture-conformance-audit, once per canonical document.
+description: Pointer stub — per-document doc-vs-code claim verification is owned by the architecture-conformance-auditor agent, which emits HOLDS/DRIFT/VIOLATION/PHANTOM/UNDOCUMENTED verdicts with evidence natively. Dispatch it via the architecture-refresh pipeline instead of following prose steps here.
 ---
 
-# Doc Claim Verification
+# Doc Claim Verification (pointer)
 
-Single-responsibility step: take one architecture document and the extracted ground truth, and assign
-each checkable claim a verdict. Judgement only — it does not assign finding IDs, severities, or write
-the report (that is `conformance-finding-report`).
+This behavior is owned by the **`architecture-conformance-auditor` agent**: it verifies architecture
+documents' claims against code in both directions and classifies each claim
+(HOLDS / DRIFT / VIOLATION / PHANTOM / UNDOCUMENTED) with `file:line` evidence, natively.
 
-## Rule Anchor
-
-- `.agents/project-structure.md` + `packages/*/docs/SPEC.md` (the contracts being verified)
-- `AGENTS.md` > Owner Knowledge Policy (each package owns its SPEC truth)
-
-## Canonical Document Set
-
-Verify every document in this set (one invocation per document, or batched across documents):
-
-- `ARCHITECTURE.md`, `.agents/project-structure.md`, `.agents/specs/ARCHITECTURE-MAP.md`
-- `.agents/specs/architecture-map/**/*.md` — **all subdocuments, recursively** (this includes nested
-  subtrees such as `.agents/specs/architecture-map/agent-cli/*.md`; a non-recursive `*.md` glob misses
-  them). Enumerate with `find .agents/specs/architecture-map -name '*.md'`, not a shell `*.md` glob.
-- `packages/*/docs/SPEC.md` — **every package** (enumerate with `ls packages/*/docs/SPEC.md`; do not
-  scope to only recently-changed packages).
-
-## Verdict Vocabulary
-
-| Verdict           | Meaning                                                   |
-| ----------------- | --------------------------------------------------------- |
-| **HOLDS**         | Claim matches implementation (cite confirming evidence).  |
-| **DRIFT**         | Directionally right but stale/incomplete.                 |
-| **VIOLATION**     | Code / filesystem contradicts the claim.                  |
-| **CONTRADICTION** | Two documents — or a doc and its own diagram — conflict.  |
-| **STALE**         | References something that no longer / does not yet exist. |
-
-## Steps
-
-1. Extract the document's concrete, checkable structural claims (package counts, dependency edges,
-   layer ownership, planned packages, zero-dep assertions, interface-types-only, cited paths, diagram
-   nodes/edges). Ignore non-checkable prose.
-2. For each claim, check against the extracted edge set (from `dependency-graph-extraction`) and the
-   source tree (grep cited symbols/paths; confirm they resolve).
-3. Assign a verdict and cite evidence as a `file:line`, an `import` statement, or a `package.json`
-   dependency. Never assert a verdict without evidence.
-
-## Output
-
-A table per document: `| Claim | Verdict | Evidence (file:line) | Note |`. Hand these to
-[conformance-finding-report](../conformance-finding-report/SKILL.md).
-
-## What This Skill Does NOT Do
-
-- Assign `AF-NN` IDs or severities → `conformance-finding-report`.
-- Propose remediation → `improvement-proposal-authoring`.
-- Edit the audited documents → verification is read-only.
+Dispatch it via [architecture-refresh](../architecture-refresh/SKILL.md) (or standalone by
+`agentType: architecture-conformance-auditor`). Entry point:
+[architecture-conformance-audit](../architecture-conformance-audit/SKILL.md).

--- a/.agents/skills/effect-style-error-modeling/SKILL.md
+++ b/.agents/skills/effect-style-error-modeling/SKILL.md
@@ -6,72 +6,26 @@ description: Models success and failure explicitly in TypeScript using Result or
 # Effect-Style Error Modeling
 
 ## Rule Anchor
+
 - `AGENTS.md` > "No Fallback Policy" (Result type mandatory for failable public functions)
 - `AGENTS.md` > "Development Patterns"
 
-## Use This Skill When
-- Error handling is inconsistent (`throw`, `null`, `undefined`, magic strings).
-- Async logic has nested try/catch with unclear propagation.
-- You need explicit, typed failure paths.
-
-## Core Principles
-1. Model errors as data, not hidden control flow.
-2. Return a typed result from domain operations.
-3. Convert external exceptions into domain error variants at boundaries.
-4. Keep one canonical error path per use case.
-5. Preserve terminal failure integrity: do not convert terminal failure into active processing unless a separately gated policy explicitly allows it.
-
-## Minimal Result Shape
-```ts
-type Result<T, E> =
-  | { ok: true; value: T }
-  | { ok: false; error: E };
-```
-
-## Workflow
-1. Define domain-specific error unions.
-2. Make domain/application methods return `Result<T, E>`.
-3. Wrap external calls in boundary adapters and map exceptions.
-4. Compose operations by checking `ok` and returning early on failure.
-5. Convert final `Result` to transport response (HTTP/event/log) once.
-6. If a reprocess path is required, model it as a separately authorized policy path (disabled by default), not as implicit fallback.
-
-## Reference Skeleton
-```ts
-type CreateUserError = "EMAIL_TAKEN" | "INVALID_INPUT" | "INFRA_FAILURE";
-
-async function createUser(input: Input, deps: Deps): Promise<Result<User, CreateUserError>> {
-  if (!input.email) return { ok: false, error: "INVALID_INPUT" };
-  const exists = await deps.users.exists(input.email);
-  if (exists) return { ok: false, error: "EMAIL_TAKEN" };
-  const saved = await deps.users.save(input);
-  return saved ? { ok: true, value: saved } : { ok: false, error: "INFRA_FAILURE" };
-}
-```
-
-## Checklist
-- [ ] Error union types are explicit and domain-meaningful.
-- [ ] No mixed error channels in same layer.
-- [ ] Boundary adapters map third-party errors once.
-- [ ] Callers handle `ok: false` explicitly.
-- [ ] Logs and responses derive from typed error values.
-- [ ] Terminal failure is not converted to queued/running without explicit policy gate.
+The No-Fallback rule (owned by [code-quality.md](../../rules/code-quality.md)) is the constraint;
+this skill owns only the Result-vs-throw decision method. Model errors as data
+(`type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }`), define domain-specific
+error unions, map external exceptions to typed variants once at the boundary adapter, and keep one
+canonical error path per use case. Never convert terminal failure into active processing without a
+separately gated, explicitly authorized policy path.
 
 ## When to Use Result vs Throw
 
-| Scenario | Use | Rationale |
-|----------|-----|-----------|
-| Domain operation that can fail (validation, not found, conflict) | `Result<T, E>` | Caller must handle failure explicitly |
-| Truly unexpected programmer error (assertion, invariant violation) | `throw` | Should crash, not be silently handled |
-| External SDK/API call boundary | `Result<T, E>` via boundary adapter | Convert exception to typed error at boundary |
-| Internal helper called only by functions that already return Result | Either | Match the caller's convention |
+| Scenario                                                           | Use                                 | Rationale                                    |
+| ------------------------------------------------------------------ | ----------------------------------- | -------------------------------------------- |
+| Domain operation that can fail (validation, not found, conflict)   | `Result<T, E>`                      | Caller must handle failure explicitly        |
+| Truly unexpected programmer error (assertion, invariant violation) | `throw`                             | Should crash, not be silently handled        |
+| External SDK/API call boundary                                     | `Result<T, E>` via boundary adapter | Convert exception to typed error at boundary |
+| Internal helper called only by Result-returning functions          | Either                              | Match the caller's convention                |
 
-**Decision rule:** If the caller should reasonably handle the failure, return `Result`. If the failure means a bug in the code, throw.
-
-## Anti-Patterns
-- Catching everything and returning generic fallback success.
-- Throwing raw strings or unknown objects from domain logic.
-- Mixing `throw` and `Result` randomly in one flow.
-- Re-queuing failed work silently because "operations need convenience".
-- Using `throw` for expected failures (not found, validation error, conflict).
-- Returning `Result` for programmer errors that should crash.
+**Decision rule:** if the caller should reasonably handle the failure, return `Result`. If the
+failure means a bug in the code, throw. Do not mix `throw` and `Result` randomly in one flow, and
+never catch-everything into a generic fallback success.

--- a/.agents/skills/improvement-proposal-authoring/SKILL.md
+++ b/.agents/skills/improvement-proposal-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improvement-proposal-authoring
-description: Turns classified conformance findings into a prioritized improvement proposal — maps each P0/P1 finding to a remediation, a proposed follow-up backlog ID + type prefix, and a mechanical-guard recommendation. Use as step 4 of architecture-conformance-audit.
+description: Turns classified conformance findings into a prioritized improvement proposal — maps each P0/P1 finding to a remediation, a proposed follow-up backlog ID + type prefix, and a mechanical-guard recommendation. Use as the remediation-planning step after an architecture-conformance-audit run.
 ---
 
 # Improvement Proposal Authoring

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -19,7 +19,7 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 | [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                                                                                    |
 | [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                                                                               |
 | [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Route-only backlog PR pipeline — sequences the gates owned by `backlog-execution.md` and routes to owner skills                |
-| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Mandatory checklist after completing implementation work                                                                       |
+| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Router: mandatory post-implementation order + gates (SPEC sync → build/test → README → PR → publish → docs)                    |
 | [delegated-refactor-green-gate](delegated-refactor-green-gate/SKILL.md)   | Delegate a large mechanical refactor to a subagent under a hard green-or-report completion gate                                |
 | [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize                                                                      |
 | [pr-review-orchestration](pr-review-orchestration/SKILL.md)               | Route-only PR-review loop: reviewer→writer→fixer until `ACTIONABLE FINDINGS: 0` (bounded), then gated merge path (HARNESS-018) |
@@ -43,11 +43,11 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [architecture-refresh](architecture-refresh/SKILL.md)                     | Thin pipeline that re-calls architecture-auditor→architecture-fixer until an audit round is materially clean (agents hold all policy)                                                        |
 | [capability-extraction](capability-extraction/SKILL.md)                   | Thin pipeline that sequences capability-scout→proposal-reviewer→agent-skill-author, gating authoring on ENDORSE and convergence on the `agent-def-convention` guard (agents hold all policy) |
-| [architecture-conformance-audit](architecture-conformance-audit/SKILL.md) | Orchestrates a repeatable doc-vs-code architecture conformance audit (GATE-CONFORMANCE)                                                                                                      |
-| [design-quality-audit](design-quality-audit/SKILL.md)                     | Repeatable deep design-quality audit — judges whether the design is right (vs doc conformance)                                                                                               |
+| [architecture-conformance-audit](architecture-conformance-audit/SKILL.md) | Thin router: conformance audit = mechanical conformance scan + the architecture-refresh agent loop (GATE-CONFORMANCE)                                                                        |
+| [design-quality-audit](design-quality-audit/SKILL.md)                     | Pointer stub → the `architecture-auditor` agent owns the design-quality judgement natively                                                                                                   |
 | [dependency-graph-extraction](dependency-graph-extraction/SKILL.md)       | Extracts the actual workspace-internal dependency edge set + runs the mechanical conformance guards                                                                                          |
-| [doc-claim-verification](doc-claim-verification/SKILL.md)                 | Verifies one architecture document's claims vs code: HOLDS/DRIFT/VIOLATION/CONTRADICTION/STALE                                                                                               |
-| [conformance-finding-report](conformance-finding-report/SKILL.md)         | Assembles verdicts into the AF-NN findings report with severities + counts (INFRA-002 schema)                                                                                                |
+| [doc-claim-verification](doc-claim-verification/SKILL.md)                 | Pointer stub → the `architecture-conformance-auditor` agent emits per-claim doc↔code verdicts natively                                                                                       |
+| [conformance-finding-report](conformance-finding-report/SKILL.md)         | Pointer stub → the `architecture-conformance-auditor` agent returns classified findings + ACTIONABLE FINDINGS natively                                                                       |
 | [improvement-proposal-authoring](improvement-proposal-authoring/SKILL.md) | Maps findings to remediation + follow-up backlogs + mechanical-guard recommendations                                                                                                         |
 
 ### Spawnable Agents
@@ -98,10 +98,10 @@ The **agent-definition convention** they follow is a document-type contract in
 
 | Skill                                               | Description                                                                                     |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [pnpm-monorepo-build](pnpm-monorepo-build/SKILL.md) | pnpm workspace build commands and order                                                         |
+| [pnpm-monorepo-build](pnpm-monorepo-build/SKILL.md) | pnpm build gotchas: lifecycle pre/post silence + surgical workspace-dep lockfile edits          |
 | [harness-governance](harness-governance/SKILL.md)   | Rule-skill consistency, undefined terminology, mechanical checks                                |
 | [lesson-to-harness](lesson-to-harness/SKILL.md)     | Mine repeated user corrections → approve → institutionalize as neutral repo rules + enforcement |
-| [branch-guard](branch-guard/SKILL.md)               | Guard against direct commits to protected branches                                              |
+| [branch-guard](branch-guard/SKILL.md)               | Pointer: protected-branch policy lives in git-branch.md; hook + husky are the mechanical SSOT   |
 | [daily-report](daily-report/SKILL.md)               | Generate the committed daily work report (OBSERVABILITY-001) — one summary per UTC work day     |
 
 ## Package-Specific

--- a/.agents/skills/lesson-to-harness/SKILL.md
+++ b/.agents/skills/lesson-to-harness/SKILL.md
@@ -5,119 +5,62 @@ description: Invoke when the user says "turn this session's repeated requests in
 
 # Lesson → Harness
 
-Mine **repeated user requests/corrections** from the session and, after approval, institutionalize them
-as **rules enforced by the repo harness** — so the user never has to re-explain "make this a universal,
-neutral rule." This is the procedure that operationalizes [learning-loop.md](../../rules/learning-loop.md)
-(the lesson-capture philosophy); this skill is the step-by-step "how."
-
-## When to invoke
-
-Either trigger (propose first):
-
-- The user says "reflect this session's repeated requests as lessons", "교훈 처리해줘", "규칙/스킬로 박아줘", or similar.
-- The agent detects a **repeated correction/preference** in-session (same kind of point 2x+, or an explicit "from now on do / don't ...").
-
-A one-off single instruction ("just do X this once") is NOT a lesson — do not invoke.
+The step-by-step "how" for [learning-loop.md](../../rules/learning-loop.md): mine repeated user
+corrections, and after approval institutionalize them as rules **enforced by the repo harness**.
+The `.claude/hooks/correction-detect.sh` UserPromptSubmit hook nudges this skill on strong
+preference/principle signals — on that nudge (or self-detection), run the procedure. A one-off
+"just do X this once" is NOT a lesson.
 
 ## Procedure
 
-1. **Mine the session** — scan the whole session for items the user **repeated or explicitly corrected /
-   turned into a principle**. Attach **evidence** to each candidate (where/how many times it appeared).
-   Exclude one-off, task-specific instructions.
-2. **Propose + approve** — present the candidate list and get the user's approval for **which to
-   institutionalize** (AskUserQuestion or prose). Only approved candidates proceed. Never institutionalize
-   without approval.
-3. **Normalize** — turn each approved lesson into ONE _neutral, universal_ principle. Remove incident /
-   blame / one-off phrasing; generalize across surfaces and cases. Form: `Principle / Why / How to apply`.
-   (Matches learning-loop.md "Pattern Generalization".)
-4. **Choose the enforcement tier**
-   - **A (always-on hard gate)**: a non-negotiable rule → a row in the **AGENTS.md Mandatory Rules** table
-     - `.agents/rules/<slug>.md` + a matching `pnpm harness:scan` FAIL condition or `.claude/hooks/` check.
-   - **B (process guidance)**: → `.agents/rules/<slug>.md` + a checklist line in the relevant skill +
-     a `.agents/skills/index.md` / `.agents/rules/index.md` entry.
-   - **C (augment)**: update an existing rule/skill only.
-5. **Generalize to the class, then sweep** — a lesson from a concrete defect is never about the one
-   instance that triggered it. Name the **class** (the invariant that, if violated anywhere, reproduces
-   the symptom), then **enumerate every current instance** of that class in the repo and fix them all in
-   this change — not just the triggering one. If you fixed file A, the same defect in sibling files B/C
-   is still latent and will resurface. (Example shape: "a `packages/*` glob in build/CI tooling that
-   omits a nested package group" — fix the one that failed _and_ every other `packages/*` glob.) The
-   count of swept instances is part of the report.
-6. **Find every touchpoint** (consistency, no partial wiring) — candidates: `.agents/rules/index.md`,
-   the AGENTS.md Mandatory Rules table, related skills (`backlog-gate-guard` GATE-_,
-   `post-implementation-checklist`, `spec-writing-standard`, `harness-governance`, …), and — when the
-   invariant is mechanically checkable — `.claude/hooks/_`and`scripts/harness/\*`.
-7. **Write** — create/update the canonical `.agents/rules/<slug>.md` (neutral, domain-free) and wire a
-   reference into **all** the touchpoints above. One owner document per fact; no duplication.
-8. **Build the mechanism (mandatory — the lesson is not closed without it)** — a rule in prose is the
-   weakest possible outcome and, alone, does **not** institutionalize a lesson. Produce a **means that
-   makes recurrence fail loudly**, and reach one of exactly two terminal states:
-   - **Mechanized** — a `pnpm harness:scan` FAIL condition, a `.claude/hooks/` check, or a test that
-     trips on the violation. This is the default; mechanize unless you can show it is infeasible.
-   - **Infeasible-now** — a written, specific reason mechanization is not yet practical **plus** a tracked
-     backlog/task item to add the check. "Hard to check," "low value," or silence are not acceptable
-     reasons; only a concrete obstacle is.
+1. **Mine the session** — collect items the user repeated or explicitly turned into a principle,
+   each with evidence (where / how many times). Exclude one-off task-specific instructions.
+2. **Propose + approve** — present candidates; only user-approved ones proceed. Never
+   institutionalize without approval.
+3. **Normalize** — one neutral, universal principle per lesson (`Principle / Why / How to apply`);
+   remove incident/blame/one-off phrasing.
+4. **Choose the enforcement tier** — **A**: hard gate → AGENTS.md Mandatory Rules row +
+   `.agents/rules/<slug>.md` + a `harness:scan` FAIL condition or `.claude/hooks/` check;
+   **B**: process guidance → rule doc + skill checklist line + index entries; **C**: augment an
+   existing rule/skill.
+5. **Generalize to the class, then sweep** — a lesson is never about the one triggering instance.
+   Name the **class** (the invariant that reproduces the symptom anywhere it's violated), then
+   enumerate and fix **every current instance** in the repo in this change. The swept-instance
+   count is part of the report.
+6. **Find every touchpoint** — `.agents/rules/index.md`, the AGENTS.md Mandatory Rules table,
+   related skills, and (when mechanically checkable) `.claude/hooks/` + `scripts/harness/*`. No
+   partial wiring.
+7. **Write** — the canonical `.agents/rules/<slug>.md` (neutral, domain-free) + references at all
+   touchpoints. One owner document per fact.
+8. **Build the mechanism (mandatory — the lesson is not closed without it)** — prose alone never
+   closes a lesson. Reach one of exactly two terminal states:
+   - **Mechanized** — a `harness:scan` FAIL condition, hook check, or test that trips on the
+     violation (the default).
+   - **Infeasible-now** — a written, concrete obstacle **plus** a tracked backlog item to add the
+     check. "Hard to check" / "low value" / silence are not acceptable reasons.
+9. **Prove the mechanism catches the incident** — run the new check against the **pre-fix state**
+   (or a reproducing fixture) and confirm it FAILS, then against the fixed state and confirm it
+   PASSES. The check carries its own coverage and stays scoped to the class. Record the
+   before/after result.
+10. **Ship** per [git-branch.md](../../rules/git-branch.md) (branch → conventional commit → PR →
+    Pre-Merge Code-Review Gate → merge), `pnpm harness:scan` green before the PR.
+11. **Report** — files wired, swept-instance count (step 5), mechanism terminal state (step 8),
+    prove result (step 9). No named terminal state = the lesson is not closed.
 
-   "Documented in a rule, will-be-careful, when-practical, follow-up-later (untracked)" are **not**
-   terminal states — they are the formal/weak handling this step exists to prevent.
+## New recurring role → dispatch capability-extraction
 
-9. **Prove the mechanism catches the incident** — a check that would not have caught the original event
-   is not enforcement. Demonstrate it: run the new check against the **pre-fix state** (or a fixture that
-   reproduces the incident) and confirm it FAILS, then against the fixed state and confirm it PASSES.
-   The new check carries its own coverage (a fixture / unit case) and stays scoped to the class — it must
-   not broaden beyond the owned scope without a documented reason. Record the before/after result.
-10. **Ship** — follow the repo gates ([git-branch.md](../../rules/git-branch.md)): branch
-    → conventional commit → PR → the **Pre-Merge Code-Review Gate** (`/code-review`, resolve all findings)
-    → `gh pr merge`. Run `pnpm harness:scan` green before the PR.
-11. **Report** — list the repo files wired, the **swept instance count** (step 5), the **terminal state**
-    of the mechanism (mechanized vs infeasible-now+backlog, step 8), and the **prove result** (step 9).
-    A report that cannot name a mechanism terminal state means the lesson is not yet closed.
+When an approved lesson is "a new recurring role" (the session kept hand-building the same focused
+subagent + thin orchestration skill), dispatch the thin
+[capability-extraction](../capability-extraction/SKILL.md) pipeline (`capability-scout` →
+`proposal-reviewer` → `agent-skill-author` → the `agent-def-convention` guard) instead of
+hand-rolling this loop — the guard is the step-8 mechanism terminal state for a role lesson.
 
-## New recurring role → dispatch capability-extraction (don't duplicate this loop)
+## Single source = the repo
 
-When an approved lesson is **"a new recurring role"** (the session kept hand-building the same kind of
-focused, universal/neutral subagent + a thin orchestration skill that only sequences it), the
-institutionalization is a **specialization of this loop**, not a parallel one: dispatch
-capability-extraction — `capability-scout` proposes the role decomposition → `proposal-reviewer` signs
-it off → `agent-skill-author` writes the role(s) to the **agent-definition convention** (document type in
-[`document-standards/index.md`](../../specs/document-standards/index.md)) → the
-`check-agent-def-convention.mjs` guard (`harness:scan` → `agent-def-convention`) gates it. Reuse this
-skill's approve→institutionalize→**enforce** discipline; the guard is the mechanism terminal state
-(step 8) for a role lesson. This exact sequence is the thin
-[`capability-extraction`](../capability-extraction/SKILL.md) skill (scout → proposal-reviewer →
-`agent-skill-author` → `agent-def-convention` re-audit) — dispatch it; do not hand-roll the loop.
-
-## Single source = the repo (default sink)
-
-The canonical home is the **repo** (`.agents/`, `AGENTS.md`/`CLAUDE.md`) — `AGENTS.md` and `.agents/` load
-as session context, so a rule applies without memory. **Do not record a persistent lesson in
-session/agent memory only.** Memory may hold a copy, but a persistent lesson must also be written to the
-repo (canonical = repo). New persistent lessons are institutionalized here, not parked in memory.
-
-## Trigger (avoid missed invocation)
-
-`.agents/skills/` are agent-invoked, not auto-firing. The `UserPromptSubmit` hook
-`.claude/hooks/correction-detect.sh` detects strong preference/principle signals (from now on, don't,
-avoid, rule, lesson, always, never, …) and nudges (stdout) to use this skill. On that nudge — or on
-self-detecting a repeated correction / explicit principle — **run this procedure.**
-
-## Anti-patterns
-
-| Anti-pattern                                             | Correct behavior                                                                    |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| Mistaking a one-off instruction for a lesson             | Only 2x+ repeats or an explicit correction/principle                                |
-| Institutionalizing a candidate without approval          | Present candidates → institutionalize only approved                                 |
-| Recording in session/agent memory only                   | Repo (`.agents/`, AGENTS.md) is the single source                                   |
-| Incident-specific / blame phrasing                       | Normalize to a neutral, universal principle                                         |
-| **Stopping at a rule doc / "will be careful"**           | **Prose alone never closes a lesson — reach a mechanism terminal state (step 8)**   |
-| **"Mechanize when practical" used as an opt-out**        | **Mechanize by default; only a concrete, written obstacle + a backlog item defers** |
-| **Fixing the one instance, not the class**               | **Name the class, sweep every current instance, make the check catch all (step 5)** |
-| **Adding a check you never proved**                      | **Prove it FAILS on the pre-fix incident and PASSES after (step 9)**                |
-| **Leaving high-frequency auto-lesson candidates parked** | **A recurring signal with no mechanism is an open lesson, not a closed one**        |
-| Editing one file only (partial wiring)                   | Wire every touchpoint consistently                                                  |
+The canonical home is the repo (`.agents/`, `AGENTS.md`) — never record a persistent lesson in
+session/agent memory only. Memory may hold a copy; the repo copy is canonical.
 
 ## See also
 
-- [learning-loop.md](../../rules/learning-loop.md) — the lesson-capture philosophy this skill executes.
+- [learning-loop.md](../../rules/learning-loop.md) — the lesson-capture philosophy.
 - [harness-governance](../harness-governance/SKILL.md) — rule/skill consistency + mechanical checks.
-- [git-branch.md](../../rules/git-branch.md) — shipping gates + the Pre-Merge Code-Review Gate.

--- a/.agents/skills/package-code-review/SKILL.md
+++ b/.agents/skills/package-code-review/SKILL.md
@@ -5,17 +5,16 @@ description: Systematic per-package code review using six specialist perspective
 
 # Package Code Review
 
+This skill owns the review **taxonomy and method** (severity vocabulary, six perspectives, output
+format). The underlying code rules are NOT restated here — they are owned by
+[code-quality.md](../../rules/code-quality.md), [.agents/project-structure.md](../../project-structure.md)
+(dependency direction), and the other rule documents; review against those rules directly.
+
 ## Rule Anchor
 
 - `AGENTS.md` > "Type System (Strict)"
 - `AGENTS.md` > "No Fallback Policy"
 - `AGENTS.md` > "Development Patterns"
-
-## Use This Skill When
-
-- Reviewing an entire package for quality and compliance.
-- Reviewing a set of changed files before merge.
-- Running periodic codebase health checks.
 
 ## Severity Labels
 
@@ -26,84 +25,32 @@ description: Systematic per-package code review using six specialist perspective
 | **CONSIDER** | Refactoring opportunity, alternative approach       | Author decides                   |
 | **NIT**      | Minor style or naming preference                    | Ignorable                        |
 
-Classification rules:
+Classification rules: any Mandatory Rules violation → **MUST**; SPEC.md quality gate gap or
+untested public API surface → **SHOULD**; everything else → **CONSIDER** or **NIT**.
 
-- Any AGENTS.md Mandatory Rules violation → **MUST**
-- SPEC.md quality gate gap → **SHOULD**
-- Untested public API surface → **SHOULD**
-- Everything else → **CONSIDER** or **NIT**
+## Review Perspectives (apply all six, in order)
 
-## Review Perspectives
-
-Each package is reviewed through six specialist perspectives, in order:
-
-### 1. Correctness
-
-- Logic bugs and unreachable code paths
-- Edge cases: null, undefined, empty arrays, boundary values
-- Error handling completeness (catch boundaries narrowed, no silent swallowing)
-- Invariant violations (terminal states re-entered, duplicate prevention anti-patterns)
-- Promise handling (unhandled rejections, missing await)
-
-### 2. Architecture
-
-- Dependency direction (imports flow toward owner packages, no circular imports)
-- Boundary violations (package imports from internals of another package)
-- SSOT compliance (no re-declared types, no 1:1 trivial aliases)
-- Module cohesion (single responsibility, no god files)
-- Import standards (static by default, dynamic only for optional modules)
-- No fallback patterns
-
-### 3. Type Safety
-
-- No `any`, `{}`, `as any`, `as unknown as T` in production code
-- `unknown` narrowed before domain use
-- Naming convention: `I*` for interfaces, `T*` for type aliases
-- No trivial 1:1 type aliases
-- Explicit return types on exported functions
-- Type guards used at trust boundaries
-
-### 4. Security
-
-- No hardcoded secrets, API keys, or credentials
-- Input validation at system boundaries (user input, external APIs)
-- No command injection, XSS, SQL injection vectors
-- No `eval()`, `new Function()`, or unsafe dynamic code execution
-- Sensitive data not logged or exposed in error messages
-
-### 5. Performance
-
-- No unnecessary allocations in hot paths or loops
-- No N+1 query patterns
-- No synchronous blocking in async contexts
-- Appropriate use of caching (check before compute, save after success)
-- No unbounded growth (arrays, maps, event listeners without cleanup)
-
-### 6. Maintainability
-
-- Test coverage for public API surface
-- Naming clarity (functions describe actions, variables describe content)
-- File size: production files > 300 lines → **MUST** fix (split into focused modules)
-- Function size: functions > 50 lines → **MUST** fix (extract sub-operations)
-- Cyclomatic complexity: functions with > 15 branches → **SHOULD** simplify
-- Documentation accuracy (SPEC.md reflects current implementation)
-- Dead code (unused exports, unreachable branches)
-- Magic numbers/strings without named constants → **SHOULD** fix
-- Mutable function parameters → **MUST** fix (clone or create new objects)
+1. **Correctness** — logic bugs, edge cases, error-handling completeness, invariant violations,
+   promise handling.
+2. **Architecture** — dependency direction, boundary violations, SSOT compliance, cohesion,
+   import standards, no fallback (rules: project-structure + code-quality).
+3. **Type Safety** — the strict-TS rules in [code-quality.md](../../rules/code-quality.md)
+   (no `any`, narrowing at trust boundaries, naming, explicit return types).
+4. **Security** — no hardcoded secrets, boundary input validation, no injection vectors, no unsafe
+   dynamic code execution, no sensitive data in logs/errors.
+5. **Performance** — hot-path allocations, N+1 patterns, sync blocking in async contexts, caching,
+   unbounded growth.
+6. **Maintainability** — public-API test coverage, naming clarity, file/function size and
+   complexity limits (per code-quality), SPEC accuracy, dead code, magic values.
 
 ## Execution Steps
 
-1. **Scope**: Identify the target package(s) and file set.
-2. **Context**: Read SPEC.md, package.json, and index.ts to understand the package boundary and public surface.
-3. **Scan**: Read each production source file (exclude tests, examples, generated files).
-4. **Review**: Apply all six perspectives to each file. Record findings with severity, perspective, file:line, and description.
-5. **Cross-check**: Run harness commands to validate mechanical checks:
-   ```bash
-   pnpm --filter <pkg> build
-   pnpm --filter <pkg> test
-   pnpm harness:scan
-   ```
-6. **Report**: Output the review summary in the format below.
+1. **Scope** the target package(s)/file set; read SPEC.md, package.json, index.ts for the boundary.
+2. **Review** each production source file through all six perspectives; record findings with
+   severity, perspective, `file:line`, description.
+3. **Cross-check** mechanically: `pnpm --filter <pkg> build && pnpm --filter <pkg> test` +
+   `pnpm harness:scan`.
+4. **Report** in the format below.
 
 ## Output Format
 
@@ -119,18 +66,9 @@ Each package is reviewed through six specialist perspectives, in order:
 | NIT      | N     |
 
 ### Findings
-
 #### MUST
 1. (Perspective) `file:line` — Description
-
-#### SHOULD
-1. (Perspective) `file:line` — Description
-
-#### CONSIDER
-1. (Perspective) `file:line` — Description
-
-#### NIT
-1. (Perspective) `file:line` — Description
+(repeat per severity)
 
 ### Positive Observations
 - Things done well that should be preserved.
@@ -139,12 +77,10 @@ Each package is reviewed through six specialist perspectives, in order:
 ## Stop Conditions
 
 - Do not review test files, example files, or generated output (`.d.ts`, `dist/`).
-- Do not flag patterns explicitly allowed by AGENTS.md (e.g., `unknown` at catch boundaries).
-- Do not suggest changes beyond the review — create task files for large-scale work.
+- Do not flag patterns the rules explicitly allow (e.g., `unknown` at catch boundaries).
+- Do not make changes beyond the review — create task files for large-scale work.
 
 ## Relationship to Other Skills
 
-- Findings that require code changes → follow `repo-change-loop` skill.
-- Findings about SPEC.md gaps → follow `spec-writing-standard` skill.
-- Findings about type ownership → follow `type-boundary-and-ssot` skill.
-- Findings about test gaps → reference `vitest-testing-strategy` skill.
+Code changes → `repo-change-loop`; SPEC gaps → `spec-writing-standard`; type ownership →
+`type-boundary-and-ssot`; test gaps → `vitest-testing-strategy`.

--- a/.agents/skills/pnpm-monorepo-build/SKILL.md
+++ b/.agents/skills/pnpm-monorepo-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pnpm-monorepo-build
-description: Provide pnpm monorepo build commands and workflow guidance. Use when running package builds, filtered builds, or discussing build order.
+description: pnpm workspace build gotchas — lifecycle-script (pre/post) silence and surgical lockfile edits for workspace dependencies. Use when a build step silently does not run or when adding/removing a workspace dependency.
 ---
 
 # pnpm Monorepo Build
@@ -10,57 +10,32 @@ description: Provide pnpm monorepo build commands and workflow guidance. Use whe
 - `AGENTS.md` > "Project Structure"
 - `AGENTS.md` > "Build Requirements"
 
-## Scope
-
-Use this skill to choose the correct pnpm build commands for the workspace.
-
-## Common Commands
-
-```bash
-pnpm --filter @robota-sdk/* build
-pnpm --filter @robota-sdk/agent-core build
-pnpm --filter @robota-sdk/agent-provider-openai build
-pnpm --filter @robota-sdk/agent-team build
-pnpm build
-```
-
-## Build Order Notes
-
-- Build core packages first (agents), then dependents.
-- Use `--filter` to limit scope when possible.
+Build/filter commands are listed in the root `package.json` scripts (`pnpm run` to enumerate;
+`pnpm --filter <pkg> build` to scope). This skill owns only the two learned gotchas below.
 
 ## Lifecycle Scripts (`pre`/`post`)
 
 pnpm does **not** run npm-style `pre<script>`/`post<script>` hooks by default
-(`enable-pre-post-scripts` is off). A `postbuild` will silently never run from
-`pnpm build`, so any index/asset step defined that way is missing from the output.
+(`enable-pre-post-scripts` is off). A `postbuild` will silently never run from `pnpm build`.
 
 - Chain the step explicitly in the script instead: `"build": "next build && <step>"`.
-- Make the step's tool a real `devDependency` (not an ambient/`npx`-fetched binary),
-  so it resolves in CI.
-- Verify the produced artifact exists (e.g. the generated file in `out/`), not just a
-  zero exit code — a missing pre/post step does not fail the build.
+- Make the step's tool a real `devDependency` (not an ambient/`npx`-fetched binary).
+- Verify the produced artifact exists, not just a zero exit code — a missing pre/post step does
+  not fail the build.
 
-## Adding a Workspace Dependency
+## Adding a Workspace Dependency (surgical lockfile edit)
 
-When adding (or removing) a `workspace:*` dependency between packages, edit the lockfile **surgically** —
-never regenerate it with a full `pnpm install` in a network-restricted/sandbox environment.
+When adding (or removing) a `workspace:*` dependency between packages, edit the lockfile
+**surgically** — never regenerate it with a full `pnpm install` in a network-restricted/sandbox
+environment.
 
-1. Edit the consumer `package.json`: add the dep under `dependencies`/`devDependencies` as
-   `"@robota-sdk/<pkg>": "workspace:*"`.
-2. Apply a **surgical** `pnpm-lock.yaml` edit — add the entry to that package's `dependencies:` block:
-   - `specifier: workspace:*`
-   - `version: link:../<pkg>` for a sibling package, or `link:../../packages/<pkg>` for an app
-     consuming a package.
-3. Verify with `pnpm install --frozen-lockfile` — it must succeed without rewriting the lockfile.
+1. Consumer `package.json`: add `"<scope>/<pkg>": "workspace:*"`.
+2. Surgical `pnpm-lock.yaml` edit — add to that package's `dependencies:` block:
+   `specifier: workspace:*` + `version: link:../<pkg>` (sibling package) or
+   `link:../../packages/<pkg>` (app consuming a package).
+3. Verify with `pnpm install --frozen-lockfile` — must succeed without rewriting the lockfile, and
+   the lockfile diff must be limited to the intended block.
 
-**NEVER** commit a `pnpm-lock.yaml` that a full `pnpm install` regenerated in a network-restricted/sandbox
-env: it prunes the lockfile by thousands of lines (offline resolution drops unreachable registry entries),
-which is a corrupting change, not a real dependency update. If `--frozen-lockfile` fails, fix the surgical
-edit — never resolve it by regenerating the whole lockfile.
-
-## Verification
-
-- Check exit codes and logs for build success.
-- For dependency changes, confirm `pnpm install --frozen-lockfile` passes and the lockfile diff is limited
-  to the intended `dependencies:` block.
+**NEVER** commit a lockfile a full `pnpm install` regenerated in a network-restricted env: offline
+resolution prunes thousands of lines — a corrupting change, not a dependency update. If
+`--frozen-lockfile` fails, fix the surgical edit; never regenerate the whole lockfile.

--- a/.agents/skills/post-implementation-checklist/SKILL.md
+++ b/.agents/skills/post-implementation-checklist/SKILL.md
@@ -1,141 +1,44 @@
 ---
 name: post-implementation-checklist
-description: Mandatory checklist after completing implementation work — SPEC verification, README update, npm publish, content/ docs update, docs site deploy
+description: Router for the mandatory post-implementation sequence — SPEC sync, build/test, README, commit/PR, publish, content/ docs, docs deploy. Each step's detail lives in its owning skill/rule; this file only fixes the order and the gates. Execute automatically after implementation work; do not wait for the user to request it.
 ---
 
-# Post-Implementation Checklist
+# Post-Implementation Checklist (router)
 
-Every implementation task that modifies package code MUST complete this checklist before being marked as done. No exceptions. The agent MUST execute this checklist automatically after implementation — do NOT wait for the user to request it.
+Every implementation task that modifies package code MUST run this sequence before being marked
+done. This file owns only the **order and the gates** — each step's how-to lives in the owning
+skill/rule linked below.
 
-## When to Use
+## Sequence (execute in order)
 
-- After completing a feature, refactoring, or bug fix that changes package code
-- After creating a new package
-- After renaming, moving, or deleting a package
-
-## Checklist (execute in order)
-
-### 0. SPEC Update (MANDATORY before verification)
-
-**This step MUST be completed before any verification begins.** Code changes without SPEC updates make verification meaningless.
-
-- [ ] For each modified package, update `docs/SPEC.md` to reflect the new code behavior
-- [ ] SPEC describes the intended final state — write it as fact, not aspiration
-- [ ] If new types, methods, or behaviors were added, they MUST appear in the SPEC
-- [ ] If existing behavior changed, the SPEC MUST be updated to match
-- [ ] Commit SPEC updates separately before starting verification
-
-**GATE: Do NOT proceed to Step 1 until all SPECs are updated and committed.**
-
-### 1. Bidirectional SPEC-Code Verification Loop
-
-This is a **repeating cycle** that runs until zero issues are found.
-
-**Direction 1 — Is the SPEC correct?**
-
-- [ ] Read each modified package's `docs/SPEC.md`
-- [ ] Check for internal contradictions or inconsistencies
-- [ ] Verify type signatures are exact (not looser/tighter than code)
-- [ ] Verify descriptions match actual behavior (not aspirational)
-- [ ] Verify terminology is consistent across all SPECs
-- [ ] Fix any SPEC inaccuracies
-
-**Direction 2 — Does code match the SPEC?**
-
-- [ ] Verify every SPEC claim has matching code (file:line)
-- [ ] Verify `src/index.ts` exports match SPEC's Public API Surface
-- [ ] A public `src/index.ts` change MUST sync the `docs/SPEC.md` Public API table (every runtime export listed) — the reverse-edge `check-spec-public-surface` guard enforces this; this is the backstop reminder
-- [ ] Verify `package.json` dependencies match SPEC's Dependencies
-- [ ] Verify architecture diagrams are current
-- [ ] Fix any code that doesn't match SPEC
-
-**Cross-SPEC consistency:**
-
-- [ ] Verify related claims across packages are aligned (e.g., SDK SPEC ↔ Sessions SPEC)
-
-**Cycle rule:** After fixing issues, re-run the full check. Repeat until a clean cycle with zero issues.
-
-### 2. Build and Test
-
-- [ ] Run `pnpm build` for modified packages — must succeed
-- [ ] Run `pnpm test` for modified packages — must pass
-- [ ] Verify no stale references (deleted files, renamed types, removed exports)
-
-#### 2a. Independently re-verify any delegated "green" claim
-
-If any part of this code change was delegated to a subagent, the orchestrator MUST NOT trust the
-subagent's "all green" report at face value. Before marking the work done, the orchestrator
-independently re-runs the key gates in its own context:
-
-- [ ] `pnpm typecheck` — must pass
-- [ ] The relevant scan/guard for the change (e.g. `pnpm harness:scan`, dependency-direction, conformance)
-- [ ] `pnpm install --frozen-lockfile` whenever a dependency or lockfile was touched (catches a pruned or
-      regenerated lockfile a subagent may have produced)
-
-A subagent's claim is treated as a hypothesis until the orchestrator reproduces the green result. See
-[`delegated-refactor-green-gate`](../delegated-refactor-green-gate/SKILL.md) for the delegation contract.
-
-### 3. README Update
-
-For each modified package:
-
-- [ ] Read current `README.md`
-- [ ] Update to match SPEC changes (API surface, usage examples, architecture)
-- [ ] Create `README.md` if missing (new packages)
-
-### 4. Commit
-
-- [ ] Commit all SPEC + README + code changes
-- [ ] Push to current branch
-- [ ] **PR batching (DX-001):** keep one coherent work-unit in ONE multi-commit PR (one conventional
-      commit per logical step) rather than opening many tiny PRs that each wait on a full CI run — split
-      only when the bundle exceeds the soft ceiling (~600 changed lines / ~15 files) or a part is
-      independently revertible. Unrelated backlogs still go in separate PRs. See the
-      [PR Batching policy](../../rules/git-branch.md).
-
-### 5. npm Publish (if public packages changed)
-
-- [ ] Create changeset (`pnpm changeset`)
-- [ ] Enter prerelease mode if needed (`pnpm changeset pre enter beta`)
-- [ ] Apply version bump (`pnpm changeset version`)
-- [ ] Commit version bump
-- [ ] Run `pnpm publish:beta` (single command — dry-run → OTP → publish all → dist-tag sync)
-- [ ] NEVER use `pnpm publish --filter`, `npm publish`, or `pnpm changeset publish`
-
-### 6. content/ Documentation Update
-
-- [ ] Update `content/guide/architecture.md` if architecture changed
-- [ ] Update `content/guide/sdk.md` if SDK API changed
-- [ ] Update `content/guide/cli.md` if CLI behavior changed
-- [ ] Update other `content/guide/*.md` as needed
-- [ ] Do NOT touch `content/v2.0.0/` (legacy, frozen)
-
-### 7. Documentation Site Deploy
-
-**GATE: Steps 3 and 6 (README + content/) must be verified complete before deploying.** If any SPEC was changed in this cycle, the corresponding README.md and content/guide/\*.md MUST already be updated. If not, go back and update them first. Do NOT deploy stale documentation.
-
-- [ ] Verify: every modified SPEC.md has a matching README.md update
-- [ ] Verify: every user-facing behavior change has a matching content/guide/\*.md update
-- [ ] `pnpm docs:build` — must succeed
-- [ ] Deploy by merging to `main` for Cloudflare Pages automatic production deployment
-- [ ] Use `pnpm docs:deploy` only for explicit manual Cloudflare Pages direct upload
-
-## Abbreviated Form
-
-For small changes (1-2 packages, no new features):
-
-1. SPEC check → 2. Build + test → 3. README → 4. Commit → 5. Publish → 6. content/ → 7. docs deploy
+1. **SPEC sync (GATE — before any verification).** Update each modified package's `docs/SPEC.md`
+   to the new behavior and run the bidirectional SPEC↔code verification loop until a clean cycle →
+   [spec-code-conformance](../spec-code-conformance/SKILL.md). Do not proceed until SPECs are
+   updated and committed.
+2. **Build and test.** `pnpm build` + `pnpm test` for modified packages must pass; check for stale
+   references (deleted files, renamed types, removed exports). If any part was delegated to a
+   subagent, independently re-verify the "green" claim (typecheck, relevant scans,
+   `pnpm install --frozen-lockfile` when the lockfile was touched) →
+   [delegated-refactor-green-gate](../delegated-refactor-green-gate/SKILL.md).
+3. **README.** Update each modified package's `README.md` to match the SPEC changes (create it for
+   new packages).
+4. **Commit + PR.** Commit SPEC + README + code; keep one coherent work-unit in ONE multi-commit PR
+   per the PR Batching policy and ship per [git-branch.md](../../rules/git-branch.md).
+5. **npm publish (if public packages changed)** → [version-management](../version-management/SKILL.md)
+   (changesets, prerelease mode, `pnpm publish:beta` only — never `pnpm publish --filter` /
+   `npm publish` / `pnpm changeset publish`).
+6. **content/ docs.** Update the affected `content/guide/*.md` for any user-facing behavior change.
+   `content/v2.0.0/` is frozen — never modify.
+7. **Docs deploy (GATE — 3 and 6 must be complete first).** Verify every modified SPEC has a
+   matching README update and every user-facing change a matching `content/guide/*.md` update, then
+   `pnpm docs:build`; production deploys from `main` (Cloudflare Pages). `pnpm docs:deploy` is
+   manual-upload only, on explicit intent.
 
 ## Rules
 
-- NEVER skip SPEC verification — it catches drift before it accumulates
-- NEVER skip README update — every SPEC change must be reflected in README.md
-- NEVER skip content/ update — every user-facing behavior change must be reflected in content/guide/\*.md
-- The three documentation layers (SPEC.md → README.md → content/) must always be in sync after every change
-- NEVER publish without build + test passing
-- NEVER deploy docs without building first
-- content/v2.0.0/ is frozen — never modify
-- Cloudflare Pages production docs deploy from `main`; manual direct upload requires explicit intent
-- After a merge, the work is not "done" until the merge is **independently verified as landed** on the
-  target's remote head with the required CI gates green and no drift — see the "Merge Landing Verification"
-  rule in [git-branch.md](../../rules/git-branch.md) (dispatch the `merge-verifier` agent; verify each hop)
+- The three documentation layers (SPEC.md → README.md → content/) must be in sync after every
+  change — never skip a layer.
+- NEVER publish without build + test passing; never deploy docs without building first.
+- After a merge, the work is not done until the merge is **independently verified as landed** —
+  see "Merge Landing Verification" in [git-branch.md](../../rules/git-branch.md) (dispatch the
+  `merge-verifier` agent; verify each hop).

--- a/.agents/skills/pre-refactor-test-harness/SKILL.md
+++ b/.agents/skills/pre-refactor-test-harness/SKILL.md
@@ -11,131 +11,44 @@ description: Before modularizing or refactoring a package, analyze the code for 
 - `AGENTS.md` > "Build Requirements"
 - `AGENTS.md` > "No Fallback Policy"
 
-## Use This Skill When
+**Never refactor without tests. Never modularize without first proving the current behavior is
+captured.** The sequence is always: **Analyze → Test → Extract → Verify**.
 
-- A package has monolithic files (>300 lines) with mixed responsibilities.
-- User requests modularization, refactoring, or "clean up" of a package.
-- About to restructure code that lacks adequate test coverage.
-- **Trigger phrase patterns**: "modularize", "break up", "split into modules", "refactor [package]", "clean up [file]", "too much in one file".
+## Phases
 
-## Core Principle
+### 1. Analyze (no code changes)
 
-**Never refactor without tests. Never modularize without first proving the current behavior is captured.**
+Catalog each responsibility block in the target file(s) and classify it: pure logic (immediately
+extractable, highest test value — P1), I/O behind an interface (P2), framework-coupled (P3 — may
+need architectural discussion). Present the proposed module structure and get user approval before
+proceeding.
 
-The sequence is always: **Analyze → Test → Extract → Verify**.
+### 2. Characterization tests (before any refactoring)
 
-## Execution Steps
+Write tests capturing the **current** behavior of each P1 target (input→output contracts, edge
+cases, error paths; RED tests against the extracted signature if the code is inline-untestable).
+Run them, then **commit the tests separately** before any extraction — this preserves the rollback
+point (`test(<pkg>): add characterization tests for <target> before refactor`).
 
-### Phase 1: Analysis (no code changes)
+### 3. Extract (one module per commit)
 
-1. **Read the target files** and catalog each responsibility block:
-   - Pure logic (no I/O, no framework deps) → immediately extractable
-   - I/O operations (fs, network, process) → extract behind interface
-   - Framework-coupled (React hooks, state) → extract logic, leave glue
-   - UI rendering → test only if behavior-critical
+Extract one target at a time — pure move only, no behavior change ("while I'm here" fixes are the
+classic failure). Run the package tests + build after each extraction and commit each individually
+(`refactor(<pkg>): extract <module> from <source>`). P1 first; P2 needs its interface defined
+before the move.
 
-2. **Classify each block** into a table:
+### 4. Verify
 
-   | Block | Lines | Dependencies | Extractable | Test Priority |
-   |-------|-------|-------------|-------------|---------------|
-   | (name) | ~N | pure/IO/React | yes/partial/no | P1/P2/P3 |
-
-3. **Identify extraction targets** — functions or logic that can become:
-   - A pure function in a new module (highest value)
-   - A class/module behind an interface
-   - A custom hook with testable logic separated
-
-4. **Present the analysis to the user** with a proposed module structure and ask for approval before proceeding.
-
-### Phase 2: Characterization Tests (before any refactoring)
-
-5. **Write tests for current behavior** of each P1 extraction target:
-   - Test the function/logic as-is, even if inline
-   - If inline and untestable, write the test for the extracted signature first (RED)
-   - Focus on: input → output contracts, edge cases, error paths
-
-6. **Run tests** — all must pass (or fail predictably for RED tests):
-   ```bash
-   pnpm --filter @robota-sdk/<pkg> test
-   ```
-
-7. **Commit tests separately** before any extraction:
-   - Commit message: `test(<pkg>): add characterization tests for <target> before refactor`
-   - This preserves a rollback point
-
-### Phase 3: Extract (one module at a time)
-
-8. **Extract one module** — move the logic to its new file:
-   - Pure function extraction: move function, update imports
-   - Interface extraction: define interface, implement, inject
-   - Keep the original call site as a thin wrapper initially
-
-9. **Run tests after each extraction**:
-   ```bash
-   pnpm --filter @robota-sdk/<pkg> test
-   pnpm --filter @robota-sdk/<pkg> build
-   ```
-
-10. **Commit each extraction individually**:
-    - Commit message: `refactor(<pkg>): extract <module> from <source>`
-
-11. **Repeat steps 8-10** for each extraction target.
-
-### Phase 4: Verify
-
-12. **Run full verification**:
-    ```bash
-    pnpm build
-    pnpm test
-    pnpm typecheck
-    ```
-
-13. **Update SPEC.md** — add new files to File Structure, update module descriptions.
-
-14. **Summarize** what was extracted, what tests were added, and what remains.
+Full `pnpm build && pnpm test && pnpm typecheck`, then update SPEC.md file structure →
+[spec-code-conformance](../spec-code-conformance/SKILL.md).
 
 ## Stop Conditions
 
-- Do NOT extract code without existing or new tests covering it.
-- Do NOT extract multiple modules in one commit.
-- Do NOT change behavior during extraction — pure move only.
-- Do NOT skip the analysis phase — present the plan first.
-- Do NOT proceed without user approval of the extraction plan.
-
-## Extraction Priority Rules
-
-| Priority | Criteria | Example |
-|----------|----------|---------|
-| **P1** | Pure function, no deps, high reuse | `extractToolCalls()`, `formatTokenCount()` |
-| **P2** | I/O behind interface, moderate complexity | `SettingsIO.read()`, `PrintTerminal` |
-| **P3** | Framework-coupled, needs hook/state refactor | `usePermissionQueue`, `useSessionRunner` |
-
-- Always extract P1 first — highest test value, lowest risk.
-- P2 requires interface definition before extraction.
-- P3 may require architectural decisions — discuss with user.
-
-## Anti-Patterns
-
-- **Big bang refactor**: extracting everything at once without incremental tests.
-- **Test-after-extract**: moving code first, writing tests second (breaks rollback safety).
-- **Behavior change during extraction**: "while I'm here, let me also fix..."
-- **Skipping analysis**: jumping to extraction without understanding dependencies.
-- **Over-extraction**: creating a module for 5 lines of code that's used once.
-
-## Checklist
-
-- [ ] Target file(s) read and responsibilities cataloged
-- [ ] Extraction targets classified with priority (P1/P2/P3)
-- [ ] Analysis presented to user and approved
-- [ ] Characterization tests written for P1 targets
-- [ ] Tests committed before any extraction
-- [ ] Each extraction is one commit with passing tests
-- [ ] SPEC.md updated with new file structure
-- [ ] Full build + test + typecheck passes
+- No extraction without tests covering it; no multi-module commits; no behavior change during
+  extraction; no skipping the analysis phase or user approval of the plan.
 
 ## Related Skills
 
-- `tdd-red-green-refactor` — TDD cycle for new behavior after extraction
-- `repo-change-loop` — build/test/verify workflow
-- `spec-code-conformance` — SPEC update after structural changes
-- `vitest-testing-strategy` — testing patterns and conventions
+- [tdd-red-green-refactor](../tdd-red-green-refactor/SKILL.md) — TDD cycle for NEW behavior after extraction.
+- [repo-change-loop](../repo-change-loop/SKILL.md) — the shared build/test/verify loop.
+- [vitest-testing-strategy](../vitest-testing-strategy/SKILL.md) — testing patterns and conventions.


### PR DESCRIPTION
## Summary

Final HARNESS-DIET-005 batch (skills diet): consolidates the INFRA-002 conformance prose skill-tree into the `architecture-refresh` agent loop, and slims 11 heavy rule-restating skills to their genuinely unique content + pointers to the owning rule/skill. Marks HARNESS-DIET-005 done and archives it to `.agents/backlog/completed/`.

### 1. INFRA-002 conformance skill-tree → agent loop

Grep-verified inbound references: the five skills were referenced only by each other, `index.md`, archived spec-docs/tasks, and one rules-file pointer (see Deferred). None is registered in `orchestration-map.md` (only the `architecture-refresh` pipeline + auditor agents are) — no map change needed.

| Skill | Before | After | Change |
| --- | ---: | ---: | --- |
| architecture-conformance-audit | 59 | 25 | Thin router → mechanical conformance scan (`harness:conformance`, see root package.json harness scripts) + `architecture-refresh` agent loop + `improvement-proposal-authoring` |
| doc-claim-verification | 57 | 14 | Pointer stub → `architecture-conformance-auditor` agent (per-claim verdicts native) |
| conformance-finding-report | 52 | 16 | Pointer stub → `architecture-conformance-auditor` findings + `ACTIONABLE FINDINGS` signal |
| design-quality-audit | 90 | 15 | Pointer stub → `architecture-auditor` agent (design-quality judgement native) |
| dependency-graph-extraction | 49 | 48 | Kept as mechanical-floor leaf; repointed off the stubbed skill to the auditor agent |

Files kept (not deleted) so all inbound links keep resolving. `improvement-proposal-authoring` kept as the remediation-planning leaf (description tail updated).

### 2. Heavy-skill SLIMs (unique bit + pointer; rules untouched)

| Skill | Before | After | Kept |
| --- | ---: | ---: | --- |
| post-implementation-checklist | 141 | 44 | Router: step order + gates; details → spec-code-conformance / delegated-refactor-green-gate / version-management / git-branch.md (merge-verifier) |
| package-code-review | 150 | 86 | MUST/SHOULD/CONSIDER/NIT taxonomy + 6 perspectives + output format (pr-review-reviewer contract preserved) |
| pre-refactor-test-harness | 141 | 54 | Analyze→Test→Extract→Verify + stop conditions; links shared loops |
| architecture-patterns | 128 | 41 | Principle list + rule pointers; code skeletons/checklist deleted |
| effect-style-error-modeling | 77 | 31 | Result-vs-throw decision table + no-fallback pointer |
| api-error-standard | 77 | 31 | SSOT ownership + `urn:robota:error:` namespace + usage rules |
| contract-testing | 76 | 24 | Short leaf (consumer-defines / provider-verifies / CI-blocks) |
| architecture-decision-records | 91 | 55 | Template + location/naming only (aligned with check-adr-completeness.mjs MUST sections) |
| lesson-to-harness | 123 | 66 | Full procedure incl. sweep-class / mechanism-terminal-state / prove steps; preamble + anti-pattern table compressed |
| pnpm-monorepo-build | 66 | 41 | Lifecycle pre/post-hook silence + surgical lockfile-edit lessons; command listing dropped |
| branch-guard | 144 | 33 | "hook + husky are the mechanical SSOT" pointer; policy → git-branch.md |

Total across the 16 touched skills: 1,521 → 624 lines. `index.md` descriptions updated for the router/stub/re-scoped skills.

### Verification

- `node scripts/harness/run-all-scans.mjs`: **all 61 scans passed** (incl. `consistency`, `orchestration-map`, `docs-structure`, `agent-def-convention`).
- Every asserted `AGENTS.md > "..."` anchor line kept in the slimmed skills (scan-consistency verified).
- Inbound references grep-checked per skill; no deep heading links (`SKILL.md#...`) exist anywhere in the repo.

### Deferred (not this PR's file ownership)

- `.agents/rules/spec-workflow.md` GATE-CONFORMANCE "Analytic layer" bullet (lines ~237-239) still narrates the retired 4-step prose chain (`dependency-graph-extraction → doc-claim-verification → conformance-finding-report → improvement-proposal-authoring`) — should be repointed at the `architecture-conformance-audit` router / `architecture-refresh` loop in a rules-side change (sibling rules-diet scope). Links still resolve meanwhile.
- The `harness:conformance` script name is referenced softly in the router ("see the harness scripts in root package.json") in case a sibling renames the scan entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC