### PR TITLE
ci(security): weekly scheduled osv-scanner over the full lockfile (INFRA-044 done)

### DIFF
--- a/.agents/backlog/completed/INFRA-044-dependency-vuln-remediation-and-audit-scheduling.md
+++ b/.agents/backlog/completed/INFRA-044-dependency-vuln-remediation-and-audit-scheduling.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-044: triage 18 pre-existing dependency advisories + run security-audit on a schedule (not only on manifest PRs)'
-status: todo
+status: done
+completed: 2026-07-24
 created: 2026-07-23
 priority: high
 urgency: soon
@@ -20,7 +21,10 @@ depends_on: []
   (GHSA-f88m, build-time-only on the sites' own trusted images; the 0.35.0 bump was reverted because it breaks
   the Cloudflare Pages docs build env). `osv-scanner` now exits 0; lockfile regenerated via `--lockfile-only` and
   verified frozen-installable.
-- **REMAINING:** the **audit-scheduling gap** — run `security-audit` (osv-scanner) on a nightly/weekly `cron`
+- **DONE (2026-07-24):** the audit-scheduling gap — `.github/workflows/security-scheduled.yml` runs the
+  same osv-scanner + `osv-scanner.toml` SSOT over the full lockfile weekly (Mon 04:47 UTC) + on
+  `workflow_dispatch`, so newly-published advisories surface within days instead of at the next manifest
+  edit. (Formerly REMAINING:) the **audit-scheduling gap** — run `security-audit` (osv-scanner) on a nightly/weekly `cron`
   (and/or every PR) so newly-published advisories are caught within a day instead of at the next manifest edit.
   (Small follow-up; the CodeQL workflow already has a weekly cron to model on.)
 

--- a/.github/workflows/security-scheduled.yml
+++ b/.github/workflows/security-scheduled.yml
@@ -1,0 +1,31 @@
+name: Scheduled security scan
+
+# INFRA-044 (part 2): the PR-time `security audit` job runs osv-scanner ONLY when a PR changes
+# package.json / pnpm-lock.yaml, so advisories published against dependencies ALREADY in the lockfile
+# accumulate invisibly (18 did exactly that before INFRA-044 part 1). This scheduled run scans the
+# lockfile weekly (and on demand) so new advisories surface within days, not at the next manifest edit.
+# Same scanner, same config SSOT (osv-scanner.toml) as ci.yml — one source of accepted-risk truth.
+
+on:
+  schedule:
+    # Mondays 04:47 UTC (offset from CodeQL's 04:27 cron to avoid runner contention).
+    - cron: '47 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  osv-scan:
+    name: osv-scanner (scheduled, full lockfile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Vulnerability scan (osv-scanner) over the full lockfile
+        run: |
+          curl -fsSL https://github.com/google/osv-scanner/releases/download/v2.0.2/osv-scanner_linux_amd64 -o "$RUNNER_TEMP/osv-scanner"
+          chmod +x "$RUNNER_TEMP/osv-scanner"
+          "$RUNNER_TEMP/osv-scanner" scan source --config osv-scanner.toml --lockfile pnpm-lock.yaml


### PR DESCRIPTION
## Recommendation (pre-approved rationale-based execution)

**Close INFRA-044's scheduling gap.** The PR-time `security audit` job runs osv-scanner only when a PR touches `package.json`/`pnpm-lock.yaml` — advisories published against dependencies *already in the lockfile* accumulate invisibly (that's exactly how 18 piled up before #1281). 

- New `.github/workflows/security-scheduled.yml`: **weekly** (Mon 04:47 UTC, offset from CodeQL's cron) + `workflow_dispatch`, scanning the full lockfile on `develop` with the **same scanner version and `osv-scanner.toml` SSOT** as ci.yml — one source of accepted-risk truth, no drift.
- Marks **INFRA-044 done** (part 1 remediation landed in #1281/#1284) and archives it.

## Verification
- YAML valid; 59/59 scans; the scan command is byte-identical to ci.yml's (proven green on the current lockfile locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)