### PR TITLE
chore(engines): raise the Node floor to >=20.19.0, remove compat-node18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,40 +338,9 @@ jobs:
           chmod +x "$RUNNER_TEMP/osv-scanner"
           "$RUNNER_TEMP/osv-scanner" scan source --config osv-scanner.toml --lockfile pnpm-lock.yaml
 
-  # HARNESS-DIET-007: this job verifies the declared Node >=18 engines floor, so it
-  # must actually run on Node 18 (it previously ran on 22.x and tested nothing extra).
-  compat-node18:
-    name: compat-node18
-    runs-on: ubuntu-latest
-    if: github.base_ref == 'main'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 50
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8.15.4
-
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build packages
-        run: pnpm run build:deps
-
-      - name: Test with coverage (excludes packages requiring Node 20+)
-        # robota-web (apps/agent-web) is a jest-based Next.js app, not a published
-        # Node-18 consumer surface; jest cannot parse the vitest coverage flags.
-        run: pnpm --filter !@robota-sdk/agent-cli --filter !robota-web run test -- --coverage --coverage.thresholds.lines=80
-
+  # compat-node18 was removed: its first REAL Node 18 run (promotion #1306) proved the build chain
+  # (rolldown, engines ^20.19 || >=22.12) cannot run on Node 18 at all, and Node 18 has been EOL since
+  # 2025-04 — the engines floor is now >=20.19.0, making a separate compat job redundant with `build`.
   commitlint:
     name: commitlint
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The capability roadmap toward it is tracked in [`.agents/backlog/SELFHOST-*`](.a
 TypeScript/JavaScript monorepo for building AI agents with multi-provider support. Uses a pnpm workspace with strict TypeScript and ESLint.
 
 - Package manager: `pnpm` 8.15.4
-- Node.js: 22.14.0 (Volta), minimum 18.0.0
+- Node.js: 22.14.0 (Volta), minimum 20.19.0 (Node 18 is EOL; the rolldown build chain requires ^20.19 || >=22.12)
 - Module system: ES modules only (`"type": "module"`)
 - Repository: <https://github.com/woojubb/robota.git>
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "vitest": "^3.2.6"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.19.0",
     "pnpm": "8.15.4"
   },
   "packageManager": "pnpm@8.15.4",

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -74,7 +74,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",

--- a/packages/dag-api/package.json
+++ b/packages/dag-api/package.json
@@ -47,7 +47,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*"

--- a/packages/dag-builder/package.json
+++ b/packages/dag-builder/package.json
@@ -43,7 +43,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*"

--- a/packages/dag-cli/package.json
+++ b/packages/dag-cli/package.json
@@ -57,7 +57,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",

--- a/packages/dag-core/package.json
+++ b/packages/dag-core/package.json
@@ -60,7 +60,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "zod": "^3.24.4",

--- a/packages/dag-framework/package.json
+++ b/packages/dag-framework/package.json
@@ -43,7 +43,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",

--- a/packages/dag-mcp-server/package.json
+++ b/packages/dag-mcp-server/package.json
@@ -56,7 +56,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/dag-nodes-default/package.json
+++ b/packages/dag-nodes-default/package.json
@@ -41,7 +41,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",

--- a/packages/dag-orchestration-client/package.json
+++ b/packages/dag-orchestration-client/package.json
@@ -45,7 +45,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*",

--- a/packages/dag-projection/package.json
+++ b/packages/dag-projection/package.json
@@ -47,7 +47,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*"

--- a/packages/dag-runtime/package.json
+++ b/packages/dag-runtime/package.json
@@ -57,7 +57,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*"

--- a/packages/dag-scheduler/package.json
+++ b/packages/dag-scheduler/package.json
@@ -47,7 +47,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*",

--- a/packages/dag-worker/package.json
+++ b/packages/dag-worker/package.json
@@ -47,7 +47,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "dependencies": {
     "@robota-sdk/dag-core": "workspace:*"


### PR DESCRIPTION
## Recommendation (pre-approved rationale-based execution)

The promotion PR (#1306) ran `compat-node18`'s **first real Node 18 execution** (after #1295 made it honest) and it failed at "Build packages": **`rolldown` requires `^20.19.0 || >=22.12.0`** — this monorepo has never been buildable on Node 18, so the declared `>=18.0.0` floor was never validated. Node 18 is also **EOL since 2025-04**; advertising support for an EOL runtime is a false signal to consumers.

**Decision: make the floor honest — `>=20.19.0`** (the lowest Node the toolchain actually supports), rather than engineering a two-Node build-on-22/test-on-18 CI dance for a runtime nobody should run.

## What
- `engines.node` `>=18.0.0` → `>=20.19.0` in the root + 13 published package manifests (React `>=18` **peer** ranges untouched — unrelated).
- `compat-node18` job removed (with the floor honest, it's redundant with `build`); explanatory comment left in ci.yml.
- AGENTS.md environment line updated.

## Notes
- The engines change reaches npm only at the next manual OTP publish (beta line) — no release is triggered here.
- 59/59 scans pass; ci.yml YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)