### PR TITLE
chore(ci): apply reviewed GH Actions major bumps + retarget Dependabot to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   # npm/pnpm dependencies (one entry covers the whole workspace via the root lockfile).
   - package-ecosystem: npm
     directory: '/'
+    # PRs must target develop — a PR to main from a non-promotion branch is hard-blocked by the
+    # main-pr-source-guard CI job (feature→develop→main flow).
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -25,6 +28,7 @@ updates:
   # GitHub Actions used in .github/workflows (keeps action versions current + patches supply-chain CVEs).
   - package-ecosystem: github-actions
     directory: '/'
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
       - name: Fetch base branch
@@ -66,7 +66,7 @@ jobs:
         if: github.base_ref == 'main'
         run: echo "build is covered by release-grade verification"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: github.base_ref != 'main'
         with:
           fetch-depth: 50
@@ -157,7 +157,7 @@ jobs:
         if: github.base_ref == 'main'
         run: echo "quality is covered by release-grade verification"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: github.base_ref != 'main'
         with:
           fetch-depth: 50
@@ -185,7 +185,7 @@ jobs:
 
       - name: Download package build output
         if: github.base_ref != 'main' && needs.build.outputs.package_dist_required == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-dist
           path: .artifacts/package-dist
@@ -228,7 +228,7 @@ jobs:
         if: github.base_ref == 'main'
         run: echo "scans are covered by release-grade verification"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: github.base_ref != 'main'
         with:
           fetch-depth: 50
@@ -273,7 +273,7 @@ jobs:
         if: github.base_ref == 'main'
         run: echo "security audit is covered by release-grade verification"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: github.base_ref != 'main'
         with:
           fetch-depth: 50
@@ -310,7 +310,7 @@ jobs:
     if: github.base_ref == 'main'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
 
@@ -347,7 +347,7 @@ jobs:
     if: github.base_ref != 'main'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -378,7 +378,7 @@ jobs:
     if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
 
@@ -414,7 +414,7 @@ jobs:
     if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
 
@@ -453,7 +453,7 @@ jobs:
     if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
 
@@ -489,7 +489,7 @@ jobs:
     if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     # Fork PRs have no access to secrets — skip so the run doesn't fail auth-less.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,17 +33,17 @@ jobs:
     name: Analyze (javascript-typescript)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           # `security-and-quality` adds maintainability queries on top of the default security set.
           queries: security-and-quality
       # JS/TS needs no compilation; autobuild is a no-op but keeps the standard 3-step shape.
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,15 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     # Fork PRs cannot post the summary comment; the check still runs read-only.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@v5
         with:
           # Block the PR on a newly-introduced HIGH+ vulnerability.
           fail-on-severity: high
           # Strong-copyleft licenses that would compromise the commercial-relicensing right of the dual
           # license. Permissive (MIT/Apache-2.0/BSD/ISC) deps are unaffected. LGPL is intentionally NOT denied
           # (weaker, dynamic-link copyleft) — revisit if a static-bundling concern arises.
+          # NOTE: `deny-licenses` is deprecated for possible removal in dependency-review-action v6 —
+          # this list is load-bearing (dual-license AGPL+Commercial policy), so migrate to
+          # `allow-licenses` BEFORE accepting a v6 bump.
           deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
           comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -58,13 +58,9 @@ jobs:
 
       - name: Run tests
         run: pnpm --filter @robota-sdk/agent-web run test:ci
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
-        with:
-          file: apps/agent-web/coverage/lcov.info
-          flags: web
-          fail_ci_if_error: false
+      # The codecov upload step was removed (Dependabot #1309 triage): no CODECOV_TOKEN secret, no
+      # codecov.yml, silent-fail config — the upload never worked. Re-add deliberately with a token
+      # if coverage reporting is ever wanted.
 
   build:
     name: Build and Deploy
@@ -77,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -96,7 +92,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download package build output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-dist
           path: .artifacts/package-dist

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 50
       - name: Fetch base branch

--- a/.github/workflows/release-bun-binaries.yml
+++ b/.github/workflows/release-bun-binaries.yml
@@ -33,7 +33,7 @@ jobs:
         id: tag
         run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -24,7 +24,7 @@ jobs:
     name: Push v<version> tag when agent-cli is bumped
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2 # need HEAD^ to detect a version change
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }} # push over SSH so the tag fires the v* workflows

--- a/.github/workflows/security-scheduled.yml
+++ b/.github/workflows/security-scheduled.yml
@@ -20,7 +20,7 @@ jobs:
     name: osv-scanner (scheduled, full lockfile)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: develop
 

--- a/scripts/harness/__tests__/harness-scripts.test.mjs
+++ b/scripts/harness/__tests__/harness-scripts.test.mjs
@@ -191,7 +191,8 @@ describe('deploy workflow', () => {
   it('points deploy artifacts and Vercel working directories at apps/agent-web', () => {
     const content = readFileSync('.github/workflows/deploy.yml', 'utf8');
 
-    expect(content).toContain('apps/agent-web/coverage/lcov.info');
+    // (The former lcov.info assertion lived in the codecov upload step, removed in the Dependabot
+    // #1309 triage — the path-correctness intent is carried by the remaining assertions.)
     expect(content).toContain('working-directory: apps/agent-web');
     expect(content).not.toContain('apps/web');
   });


### PR DESCRIPTION
## Recommendation (pre-approved rationale-based execution; supersedes Dependabot #1307–#1311)

A read-only subagent reviewed all five Dependabot GH-Actions major bumps against release notes AND our exact usage sites. Verdicts:

| Bump | Our usage | Relevant breaking changes | Verdict |
| --- | --- | --- | --- |
| checkout 4→7 | ~20 sites, `fetch-depth`/`ref`/`ssh-key` | v6 credential-file move (we never read `.git/config` token), v7 fork-PR block on `pull_request_target` (we use neither trigger) | ✅ applied — proven in vivo on the bot PR's own CI |
| download-artifact 4→8 | 2 sites, by-`name` + `path`, paired with upload@v4 | v4↔v8 artifact-API compatible; path-nesting change only affects by-ID | ✅ applied |
| dependency-review 4→5 | 1 site, `fail-on-severity`/`deny-licenses`/`comment-summary` | node24 runtime only; **`deny-licenses` deprecated for v6** — noted in-file (load-bearing for the AGPL+Commercial dual-license) | ✅ applied |
| codeql-action 3→4 | 3 refs (init/autobuild/analyze) | node24 only; v3 is deprecated 2026-12 | ✅ applied — proven in vivo |
| codecov 3→7 | 1 step in the **manual** deploy workflow | v4+ requires a token — **we have no `CODECOV_TOKEN`, no codecov.yml, `fail_ci_if_error:false`: the upload never worked** | ❌ step **removed** instead of bumped |

**Structural fix:** `dependabot.yml` now sets `target-branch: develop` for both ecosystems — Dependabot was opening PRs against `main`, which the `main-pr-source-guard` hard-blocks by design; that's why all five bot PRs were unmergeable.

The five bot PRs will be closed as superseded once this merges.

## Verification
- All workflow YAML valid; 59/59 scans; no `@v4`/`@v3` leftovers of the bumped actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)