### PR TITLE
ci(infra-041): advisory PR patch-coverage gate over changed lines

### DIFF
--- a/.agents/backlog/INFRA-041-pr-patch-coverage-gate.md
+++ b/.agents/backlog/INFRA-041-pr-patch-coverage-gate.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-041: PR patch (diff) coverage gate — new/changed lines must be tested'
-status: todo
+status: in-progress
 created: 2026-07-22
 priority: medium
 urgency: soon
@@ -53,3 +53,37 @@ PRs to calibrate the false-positive rate, then promote to a required check.
 
 - Not applicable (CI gate; the fixture PR above is the maintained proof).
 - Evidence: the fixture red/green run.
+
+## Outcome (v1 — advisory gate shipped)
+
+Implemented as a **variant of Option A** — self-hosted and deterministic like `diff-cover`, but with
+the lcov→diff mapping done in a Node checker (`scripts/harness/check-patch-coverage.mjs`) instead of
+`pip install diff-cover`, so there is no Python dependency and the decision logic is unit-tested
+in-repo (same seam pattern as `check-regression-red-proof.mjs`).
+
+- **CI job**: `patch-coverage (advisory)` in `.github/workflows/ci.yml` — path-scoped
+  (`needs: changes` + `code == 'true'`), plus a `--detect` pre-step that skips the build/test steps
+  entirely unless the PR changes coverable package/app `src` lines. Coverage runs execute ONLY the
+  affected packages' suites (bounded runtime).
+- **Advisory v1**: the checker always exits 0 unless `PATCH_COVERAGE_ENFORCE=1`, and even enforced
+  only `patch-coverage-below-target` fails (INCONCLUSIVE stays advisory — same contract as
+  HARNESS-041's `regression-red-proof`). Target: `PATCH_COVERAGE_TARGET` (default 80).
+- **Honesty**: a package whose coverage cannot be produced is NO-DATA (logged, verdict at best
+  INCONCLUSIVE); a changed src file absent from lcov is UNINSTRUMENTED (also INCONCLUSIVE) — never a
+  silent pass. Non-executable changed lines (types/comments) are excluded from the denominator, so
+  type-only diffs are a clean no-op, per the Test Plan.
+- **Plumbing**: root `vitest.config.ts` coverage reporter now includes `lcov`; per-package runs get
+  lcov via CLI flags (`--coverage.reporter=lcov`), so the 30+ per-package vitest configs needed no
+  edits. The hoisted root `@vitest/coverage-v8` resolves for per-package `pnpm --filter … exec vitest`
+  runs (verified empirically).
+- **Red/green proof (Test Plan executed)**: (1) maintained fixtures
+  `scripts/harness/__tests__/fixtures/patch-coverage/{red,green}` driven end-to-end through the real
+  CLI (`--fixture`) in `check-patch-coverage.test.mjs`, asserting the exit-code contract (red+enforce
+  → exit 1; red advisory → exit 0; green enforced → exit 0); (2) a documented injected run on a real
+  package: an untested function added to `packages/agent-process/src` → `0/6 (0.0%) →
+patch-coverage-below-target` (enforce exit 1); adding a covering test → `6/6 (100%) →
+patch-coverage-ok` (exit 0).
+
+**Remaining (why still open)**: calibrate on real PRs, then flip to enforced/required
+(`PATCH_COVERAGE_ENFORCE=1` + branch-protection required check). At flip time, decide whether
+INCONCLUSIVE should also block (v1 keeps it advisory to match the regression-red-proof precedent).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,3 +514,59 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/harness/check-regression-red-proof.mjs
+
+  # INFRA-041: PR patch (diff) coverage — the lines a PR adds/changes in package/app `src` must
+  # themselves be exercised by tests. The former global 80% average (compat-node18, removed) never
+  # guaranteed this: a PR could add untested lines while the repo average stayed green. ADVISORY in
+  # v1 (never blocks; the script exits 0 unless PATCH_COVERAGE_ENFORCE=1 — same rollout pattern as
+  # regression-red-proof). Honest by construction: when coverage data for an affected package cannot
+  # be produced, the verdict is INCONCLUSIVE with an explicit NO-DATA log — never a silent pass.
+  # Runtime is bounded: a --detect pre-step gates the build+test steps to PRs that actually change
+  # coverable src lines, and coverage runs execute ONLY the affected packages' suites.
+  patch-coverage:
+    name: patch-coverage (advisory)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 50
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch the base branch (for merge-base + changed-line diff)
+        run: git fetch origin ${{ github.base_ref }} --depth=50
+
+      - name: Detect packages with coverable changed lines
+        id: detect
+        env:
+          PATCH_COVERAGE_BASE_REF: origin/${{ github.base_ref }}
+        run: node scripts/harness/check-patch-coverage.mjs --detect
+
+      - name: Build workspace packages (affected suites import sibling dist)
+        if: steps.detect.outputs.affected == 'true'
+        run: pnpm build:deps
+
+      - name: Compute patch coverage over changed lines
+        if: steps.detect.outputs.affected == 'true'
+        env:
+          PATCH_COVERAGE_BASE_REF: origin/${{ github.base_ref }}
+        run: node scripts/harness/check-patch-coverage.mjs
+
+      - name: Skip (no coverable src changes)
+        if: steps.detect.outputs.affected != 'true'
+        run: echo "No package/app src lines changed — patch coverage is a no-op for this PR."

--- a/scripts/harness/__tests__/check-patch-coverage.test.mjs
+++ b/scripts/harness/__tests__/check-patch-coverage.test.mjs
@@ -1,0 +1,249 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  VERDICT,
+  computePatchCoverage,
+  decideVerdict,
+  groupCoverableChanges,
+  isCoverableSource,
+  isTestFile,
+  packageRootOf,
+  parseChangedNewLines,
+  parseLcov,
+  runPatchCoverage,
+} from '../check-patch-coverage.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const SCRIPT = path.join(WORKSPACE_ROOT, 'scripts/harness/check-patch-coverage.mjs');
+const FIXTURES = 'scripts/harness/__tests__/fixtures/patch-coverage';
+
+// Two-segment fixture roots: `packages/<x>` / `apps/<x>` have a package.json; deeper nested
+// fixture groups are modeled explicitly where a test needs them.
+const flatPkgJson = (dirRel) => dirRel.split('/').length === 2;
+
+describe('INFRA-041 file classification', () => {
+  it('packageRootOf finds the nearest package root, including nested workspace groups', () => {
+    expect(packageRootOf('packages/agent-core/src/a.ts', flatPkgJson)).toBe('packages/agent-core');
+    expect(packageRootOf('apps/agent-app/src/main.ts', flatPkgJson)).toBe('apps/agent-app');
+    // nested group (packages/dag-nodes/<pkg>): the DEEPEST dir with a package.json wins
+    const nested = (dirRel) => dirRel === 'packages/dag-nodes/tool';
+    expect(packageRootOf('packages/dag-nodes/tool/src/node.ts', nested)).toBe(
+      'packages/dag-nodes/tool',
+    );
+    expect(packageRootOf('scripts/harness/x.mjs', flatPkgJson)).toBeNull();
+    expect(packageRootOf('docs/guide.md', flatPkgJson)).toBeNull();
+  });
+
+  it('isCoverableSource takes non-test src TS/JS only', () => {
+    const pkg = 'packages/x';
+    expect(isCoverableSource('packages/x/src/a.ts', pkg)).toBe(true);
+    expect(isCoverableSource('packages/x/src/ui/b.tsx', pkg)).toBe(true);
+    expect(isCoverableSource('packages/x/src/a.test.ts', pkg)).toBe(false);
+    expect(isCoverableSource('packages/x/src/__tests__/a.ts', pkg)).toBe(false);
+    expect(isCoverableSource('packages/x/src/types.d.ts', pkg)).toBe(false);
+    expect(isCoverableSource('packages/x/docs/SPEC.md', pkg)).toBe(false);
+    expect(isCoverableSource('packages/x/tsdown.config.ts', pkg)).toBe(false);
+    expect(isTestFile('packages/x/tests/e2e.spec.ts')).toBe(true);
+  });
+
+  it('groupCoverableChanges groups by package and drops non-coverable files', () => {
+    const grouped = groupCoverableChanges(
+      [
+        'packages/a/src/one.ts',
+        'packages/a/src/two.ts',
+        'packages/a/src/two.test.ts',
+        'packages/b/src/x.ts',
+        'docs/readme.md',
+        '.github/workflows/ci.yml',
+      ],
+      flatPkgJson,
+    );
+    expect([...grouped.keys()].sort()).toEqual(['packages/a', 'packages/b']);
+    expect(grouped.get('packages/a')).toEqual(['packages/a/src/one.ts', 'packages/a/src/two.ts']);
+  });
+});
+
+describe('INFRA-041 diff parsing (-U0 new-side lines)', () => {
+  it('extracts new-side lines from hunk headers, with default and zero lengths', () => {
+    const diff = [
+      'diff --git a/packages/a/src/f.ts b/packages/a/src/f.ts',
+      '--- a/packages/a/src/f.ts',
+      '+++ b/packages/a/src/f.ts',
+      '@@ -10,2 +12,3 @@ ctx',
+      '+x',
+      '+y',
+      '+z',
+      '@@ -20 +30 @@',
+      '+single (length defaults to 1)',
+      '@@ -40,4 +50,0 @@',
+      'diff --git a/gone.ts b/gone.ts',
+      '--- a/gone.ts',
+      '+++ /dev/null',
+      '@@ -1,5 +0,0 @@',
+    ].join('\n');
+    const byFile = parseChangedNewLines(diff);
+    expect([...byFile.keys()]).toEqual(['packages/a/src/f.ts']);
+    expect([...byFile.get('packages/a/src/f.ts')].sort((a, b) => a - b)).toEqual([12, 13, 14, 30]);
+  });
+});
+
+describe('INFRA-041 lcov parsing', () => {
+  it('normalizes package-relative and absolute SF paths and merges duplicates by max hits', () => {
+    const absSf = path.join(WORKSPACE_ROOT, 'packages/a/src/f.ts');
+    const lcov = [
+      'TN:',
+      'SF:src/f.ts',
+      'DA:1,0',
+      'DA:2,1',
+      'end_of_record',
+      `SF:${absSf}`,
+      'DA:1,5',
+      'end_of_record',
+    ].join('\n');
+    const byFile = parseLcov(lcov, 'packages/a');
+    expect([...byFile.keys()]).toEqual(['packages/a/src/f.ts']);
+    expect(byFile.get('packages/a/src/f.ts').get(1)).toBe(5);
+    expect(byFile.get('packages/a/src/f.ts').get(2)).toBe(1);
+  });
+});
+
+describe('INFRA-041 patch-coverage computation + verdict', () => {
+  const lines = (...ns) => new Set(ns);
+
+  it('counts only executable changed lines; comments/types are excluded from the denominator', () => {
+    const changed = new Map([['packages/a/src/f.ts', lines(1, 2, 3, 4)]]);
+    const lcov = new Map([
+      [
+        'packages/a/src/f.ts',
+        new Map([
+          [2, 1],
+          [3, 0],
+          [99, 1],
+        ]),
+      ], // 1 & 4 non-executable
+    ]);
+    const r = computePatchCoverage(changed, lcov);
+    expect(r.measured).toBe(2);
+    expect(r.covered).toBe(1);
+    expect(r.perFile[0].missedLines).toEqual([3]);
+    expect(r.uninstrumented).toEqual([]);
+  });
+
+  it('flags a changed file entirely absent from lcov as UNINSTRUMENTED (never silently dropped)', () => {
+    const changed = new Map([['packages/a/src/ghost.ts', lines(1, 2)]]);
+    const r = computePatchCoverage(changed, new Map());
+    expect(r.uninstrumented).toEqual(['packages/a/src/ghost.ts']);
+    expect(r.measured).toBe(0);
+  });
+
+  it('verdict: BELOW_TARGET dominates, missing data is INCONCLUSIVE, full data at target is OK', () => {
+    const base = { coverableFileCount: 1, uninstrumented: [], noDataPackages: [], target: 80 };
+    expect(decideVerdict({ ...base, coverableFileCount: 0, measured: 0, covered: 0 })).toBe(
+      VERDICT.SKIPPED_NO_COVERABLE,
+    );
+    expect(decideVerdict({ ...base, measured: 10, covered: 7 })).toBe(VERDICT.BELOW_TARGET);
+    // a proven hole fails even when other data is missing
+    expect(
+      decideVerdict({ ...base, measured: 10, covered: 7, noDataPackages: ['packages/b'] }),
+    ).toBe(VERDICT.BELOW_TARGET);
+    expect(
+      decideVerdict({ ...base, measured: 10, covered: 9, noDataPackages: ['packages/b'] }),
+    ).toBe(VERDICT.INCONCLUSIVE);
+    expect(
+      decideVerdict({ ...base, measured: 0, covered: 0, uninstrumented: ['packages/a/src/g.ts'] }),
+    ).toBe(VERDICT.INCONCLUSIVE);
+    expect(decideVerdict({ ...base, measured: 10, covered: 8 })).toBe(VERDICT.OK);
+    // all changed lines non-executable, full data → OK (docs/type-only change is a clean no-op)
+    expect(decideVerdict({ ...base, measured: 0, covered: 0 })).toBe(VERDICT.OK);
+  });
+});
+
+describe('INFRA-041 orchestration (injected io)', () => {
+  const diffText = [
+    'diff --git a/packages/fixture-pkg/src/adder.ts b/packages/fixture-pkg/src/adder.ts',
+    '--- /dev/null',
+    '+++ b/packages/fixture-pkg/src/adder.ts',
+    '@@ -0,0 +1,8 @@',
+  ].join('\n');
+
+  it('returns BELOW_TARGET when the added lines are uncovered (red-capability)', async () => {
+    const { verdict, measured, covered } = await runPatchCoverage({
+      diffText,
+      hasPkgJson: flatPkgJson,
+      collectLcov: () => 'SF:src/adder.ts\nDA:2,0\nDA:3,0\nDA:6,0\nDA:7,0\nend_of_record\n',
+    });
+    expect(verdict).toBe(VERDICT.BELOW_TARGET);
+    expect(measured).toBe(4);
+    expect(covered).toBe(0);
+  });
+
+  it('returns OK when the added lines are covered', async () => {
+    const { verdict } = await runPatchCoverage({
+      diffText,
+      hasPkgJson: flatPkgJson,
+      collectLcov: () => 'SF:src/adder.ts\nDA:2,1\nDA:3,1\nDA:6,1\nDA:7,1\nend_of_record\n',
+    });
+    expect(verdict).toBe(VERDICT.OK);
+  });
+
+  it('returns INCONCLUSIVE (never a pass) when a package produces no coverage data', async () => {
+    const { verdict, noDataPackages } = await runPatchCoverage({
+      diffText,
+      hasPkgJson: flatPkgJson,
+      collectLcov: () => null,
+    });
+    expect(verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(noDataPackages).toEqual(['packages/fixture-pkg']);
+  });
+
+  it('SKIPs explicitly on a diff with no coverable src lines', async () => {
+    const { verdict } = await runPatchCoverage({
+      diffText: ['+++ b/docs/guide.md', '@@ -1,0 +1,3 @@'].join('\n'),
+      hasPkgJson: flatPkgJson,
+      collectLcov: () => {
+        throw new Error('must not be called');
+      },
+    });
+    expect(verdict).toBe(VERDICT.SKIPPED_NO_COVERABLE);
+  });
+});
+
+describe('INFRA-041 CLI red-proof (fixture end-to-end, exit-code contract)', () => {
+  const run = (fixture, env = {}) => {
+    try {
+      const stdout = execFileSync(
+        process.execPath,
+        [SCRIPT, '--fixture', `${FIXTURES}/${fixture}`],
+        {
+          cwd: WORKSPACE_ROOT,
+          encoding: 'utf8',
+          env: { ...process.env, PATCH_COVERAGE_ENFORCE: '', ...env },
+        },
+      );
+      return { code: 0, stdout };
+    } catch (err) {
+      return { code: err.status, stdout: String(err.stdout ?? '') };
+    }
+  };
+
+  it('RED fixture: detects the hole, exits 0 advisory, exits 1 under PATCH_COVERAGE_ENFORCE=1', () => {
+    const advisory = run('red');
+    expect(advisory.code).toBe(0);
+    expect(advisory.stdout).toContain(VERDICT.BELOW_TARGET);
+    expect(advisory.stdout).toContain('missed lines: 2, 3, 6, 7');
+
+    const enforced = run('red', { PATCH_COVERAGE_ENFORCE: '1' });
+    expect(enforced.code).toBe(1);
+    expect(enforced.stdout).toContain(VERDICT.BELOW_TARGET);
+  });
+
+  it('GREEN fixture: same diff with covering tests passes, even enforced', () => {
+    const enforced = run('green', { PATCH_COVERAGE_ENFORCE: '1' });
+    expect(enforced.code).toBe(0);
+    expect(enforced.stdout).toContain(VERDICT.OK);
+    expect(enforced.stdout).toContain('4/4');
+  });
+});

--- a/scripts/harness/__tests__/fixtures/patch-coverage/green/diff.patch
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/green/diff.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/fixture-pkg/src/adder.ts b/packages/fixture-pkg/src/adder.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/packages/fixture-pkg/src/adder.ts
+@@ -0,0 +1,8 @@
++/** INFRA-041 red fixture: an added function no test exercises. */
++export function add(a: number, b: number): number {
++  return a + b;
++}
++
++export function sub(a: number, b: number): number {
++  return a - b;
++}

--- a/scripts/harness/__tests__/fixtures/patch-coverage/green/lcov.info
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/green/lcov.info
@@ -1,0 +1,9 @@
+TN:
+SF:src/adder.ts
+DA:2,3
+DA:3,3
+DA:6,2
+DA:7,2
+LF:4
+LH:4
+end_of_record

--- a/scripts/harness/__tests__/fixtures/patch-coverage/red/diff.patch
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/red/diff.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/fixture-pkg/src/adder.ts b/packages/fixture-pkg/src/adder.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/packages/fixture-pkg/src/adder.ts
+@@ -0,0 +1,8 @@
++/** INFRA-041 red fixture: an added function no test exercises. */
++export function add(a: number, b: number): number {
++  return a + b;
++}
++
++export function sub(a: number, b: number): number {
++  return a - b;
++}

--- a/scripts/harness/__tests__/fixtures/patch-coverage/red/lcov.info
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/red/lcov.info
@@ -1,0 +1,9 @@
+TN:
+SF:src/adder.ts
+DA:2,0
+DA:3,0
+DA:6,0
+DA:7,0
+LF:4
+LH:0
+end_of_record

--- a/scripts/harness/check-patch-coverage.mjs
+++ b/scripts/harness/check-patch-coverage.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+/**
+ * INFRA-041 — PR patch (diff) coverage: the lines a PR adds/changes must themselves be tested.
+ *
+ * A global repo-average threshold never guaranteed this — a PR could add untested lines while the
+ * average stayed green (and the former global-threshold job, compat-node18, is now removed). This
+ * checker computes coverage over ONLY the PR's changed executable lines in package/app `src`.
+ *
+ * Approach (self-hosted, deterministic — no external service, no python):
+ *   changed lines  = `git diff -U0 <merge-base>..HEAD` new-side hunk lines
+ *   coverage       = per affected package: `vitest run --coverage --coverage.reporter=lcov`
+ *                    (the lcov reporter is injected via CLI flags, so per-package vitest configs
+ *                    need no edits; the hoisted root `@vitest/coverage-v8` resolves for packages)
+ *   patch coverage = covered changed executable lines / instrumented changed executable lines
+ *
+ * Honesty invariants:
+ *   - If coverage data for an affected package cannot be produced, that package is NO-DATA with an
+ *     explicit log and the overall verdict is at best INCONCLUSIVE — never a silent pass.
+ *   - A changed source file MISSING from its package's lcov (e.g. a config that set
+ *     `coverage.all: false`) is UNINSTRUMENTED and degrades the verdict to INCONCLUSIVE — a file no
+ *     test ever loads must not dodge the gate by being invisible to the reporter.
+ *   - Changed lines that are not executable (types, comments, blanks — absent from lcov DA records
+ *     of an instrumented file) are excluded from the denominator, so docs/type-only PRs are a
+ *     clean no-op, not a false failure.
+ *
+ * ADVISORY in v1 (HARNESS-041 rollout pattern): the CLI always exits 0 unless
+ * PATCH_COVERAGE_ENFORCE=1, and even then only BELOW-TARGET fails (INCONCLUSIVE stays advisory,
+ * matching check-regression-red-proof.mjs). Flip to a required check once calibrated on real PRs.
+ *
+ * Red-proof: `--fixture <dir>` runs the full pipeline on an on-disk (diff.patch + lcov.info)
+ * fixture — `scripts/harness/__tests__/fixtures/patch-coverage/{red,green}` prove the gate goes
+ * RED on an untested added function and GREEN once it is covered (see the unit test).
+ *
+ * The decision logic is pure and exported; git/vitest side effects live in the orchestrator and
+ * are injectable (same seam pattern as check-regression-red-proof.mjs).
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs, { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const DEFAULT_TARGET = 80;
+
+// ── Verdict vocabulary ────────────────────────────────────────────────────────────────────────────
+export const VERDICT = Object.freeze({
+  OK: 'patch-coverage-ok', // measured changed lines meet the target
+  BELOW_TARGET: 'patch-coverage-below-target', // the defect this gate exists to catch
+  INCONCLUSIVE: 'inconclusive-no-data', // coverage data missing/partial — never a silent pass
+  SKIPPED_NO_COVERABLE: 'skipped-no-coverable-changes', // no package/app src lines changed
+});
+
+// ── Pure: file classification ─────────────────────────────────────────────────────────────────────
+
+export function isTestFile(filePath) {
+  return /(\.(test|spec)\.[cm]?[jt]sx?$)|(^|\/)__tests__\/|(^|\/)tests?\//.test(filePath);
+}
+
+/**
+ * Nearest package/app root for a repo-relative path: the deepest ancestor directory under
+ * `packages/` or `apps/` that has a package.json. Handles nested workspace groups
+ * (e.g. `packages/dag-nodes/<pkg>`) without hardcoding them — depth is discovered, not assumed.
+ * `hasPkgJson(dirRel)` is injectable for tests/fixtures.
+ */
+export function packageRootOf(filePath, hasPkgJson) {
+  if (!/^(packages|apps)\//.test(filePath)) return null;
+  let dir = path.posix.dirname(filePath);
+  while (dir !== '.' && dir !== 'packages' && dir !== 'apps') {
+    if (hasPkgJson(dir)) return dir;
+    dir = path.posix.dirname(dir);
+  }
+  return null;
+}
+
+/** Coverable = a non-test TS/JS file under `<pkgRoot>/src/` (excluding `.d.ts`). */
+export function isCoverableSource(filePath, pkgRoot) {
+  if (!filePath.startsWith(`${pkgRoot}/src/`)) return false;
+  if (isTestFile(filePath)) return false;
+  if (filePath.endsWith('.d.ts')) return false;
+  return /\.[cm]?[jt]sx?$/.test(filePath);
+}
+
+/** Group the coverable subset of changed files by package root. Map pkgRoot → repo-relative files. */
+export function groupCoverableChanges(changedFiles, hasPkgJson) {
+  const byPkg = new Map();
+  for (const f of changedFiles) {
+    const pkgRoot = packageRootOf(f, hasPkgJson);
+    if (!pkgRoot || !isCoverableSource(f, pkgRoot)) continue;
+    if (!byPkg.has(pkgRoot)) byPkg.set(pkgRoot, []);
+    byPkg.get(pkgRoot).push(f);
+  }
+  return byPkg;
+}
+
+// ── Pure: unified-diff (-U0) new-side line extraction ────────────────────────────────────────────
+
+/**
+ * Parse `git diff -U0` text into Map(repo-relative new path → Set(new-side line numbers)).
+ * Hunk header: `@@ -a[,b] +c[,d] @@` — new lines are c..c+d-1 (d defaults to 1; d=0 = pure deletion).
+ * Deleted files (`+++ /dev/null`) contribute nothing.
+ */
+export function parseChangedNewLines(diffText) {
+  const byFile = new Map();
+  let current = null;
+  for (const line of diffText.split('\n')) {
+    const fileMatch = line.match(/^\+\+\+ (?:b\/(.*)|\/dev\/null)$/);
+    if (fileMatch) {
+      current = fileMatch[1] ?? null;
+      if (current && !byFile.has(current)) byFile.set(current, new Set());
+      continue;
+    }
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunk && current) {
+      const start = Number(hunk[1]);
+      const count = hunk[2] === undefined ? 1 : Number(hunk[2]);
+      for (let i = 0; i < count; i += 1) byFile.get(current).add(start + i);
+    }
+  }
+  for (const [file, lines] of byFile) if (lines.size === 0) byFile.delete(file);
+  return byFile;
+}
+
+// ── Pure: lcov parsing ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse lcov text into Map(repo-relative path → Map(line → hits)). `SF:` paths may be absolute or
+ * relative to the emitting package (`pkgRoot`, repo-relative) — both are normalized. Duplicate SF
+ * records merge by max hits (a line covered in any run is covered).
+ */
+export function parseLcov(lcovText, pkgRoot = '') {
+  const byFile = new Map();
+  let currentLines = null;
+  for (const raw of lcovText.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('SF:')) {
+      const sf = line.slice(3).trim();
+      const abs = path.isAbsolute(sf) ? sf : path.resolve(WORKSPACE_ROOT, pkgRoot, sf);
+      const rel = path.relative(WORKSPACE_ROOT, abs).split(path.sep).join('/');
+      if (!byFile.has(rel)) byFile.set(rel, new Map());
+      currentLines = byFile.get(rel);
+    } else if (line.startsWith('DA:') && currentLines) {
+      const [lineNo, hits] = line.slice(3).split(',').map(Number);
+      if (Number.isFinite(lineNo) && Number.isFinite(hits)) {
+        currentLines.set(lineNo, Math.max(currentLines.get(lineNo) ?? 0, hits));
+      }
+    } else if (line === 'end_of_record') {
+      currentLines = null;
+    }
+  }
+  return byFile;
+}
+
+// ── Pure: patch-coverage computation ──────────────────────────────────────────────────────────────
+
+/**
+ * Compute per-file and total patch coverage.
+ *   changedLinesByFile — Map(file → Set(lines)) restricted to coverable files
+ *   lcovByFile         — Map(file → Map(line → hits)) merged across packages
+ * A coverable changed file absent from lcov is UNINSTRUMENTED (tracked, not silently dropped).
+ * Changed lines absent from an instrumented file's DA records are non-executable and excluded.
+ */
+export function computePatchCoverage(changedLinesByFile, lcovByFile) {
+  const perFile = [];
+  let measured = 0;
+  let covered = 0;
+  const uninstrumented = [];
+  for (const [file, lines] of changedLinesByFile) {
+    const da = lcovByFile.get(file);
+    if (!da) {
+      uninstrumented.push(file);
+      perFile.push({ file, measured: 0, covered: 0, missedLines: [], uninstrumented: true });
+      continue;
+    }
+    const missedLines = [];
+    let fileMeasured = 0;
+    let fileCovered = 0;
+    for (const line of [...lines].sort((a, b) => a - b)) {
+      const hits = da.get(line);
+      if (hits === undefined) continue; // non-executable (comment/type/blank)
+      fileMeasured += 1;
+      if (hits > 0) fileCovered += 1;
+      else missedLines.push(line);
+    }
+    measured += fileMeasured;
+    covered += fileCovered;
+    perFile.push({
+      file,
+      measured: fileMeasured,
+      covered: fileCovered,
+      missedLines,
+      uninstrumented: false,
+    });
+  }
+  return { perFile, measured, covered, uninstrumented };
+}
+
+/**
+ * Final verdict. BELOW_TARGET dominates INCONCLUSIVE dominates OK:
+ *   - no coverable changed files → SKIPPED_NO_COVERABLE
+ *   - measured lines below target → BELOW_TARGET (even if other data is missing — a proven hole
+ *     is a proven hole)
+ *   - any NO-DATA package or UNINSTRUMENTED file → INCONCLUSIVE (missing data is never a pass)
+ *   - measured === 0 with full data → OK (the changed lines are all non-executable)
+ */
+export function decideVerdict({
+  coverableFileCount,
+  measured,
+  covered,
+  uninstrumented,
+  noDataPackages,
+  target,
+}) {
+  if (coverableFileCount === 0) return VERDICT.SKIPPED_NO_COVERABLE;
+  const pct = measured === 0 ? 100 : (covered / measured) * 100;
+  if (measured > 0 && pct < target) return VERDICT.BELOW_TARGET;
+  if (noDataPackages.length > 0 || uninstrumented.length > 0) return VERDICT.INCONCLUSIVE;
+  return VERDICT.OK;
+}
+
+// ── Impure orchestrator ─────────────────────────────────────────────────────────────────────────────
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { cwd: WORKSPACE_ROOT, encoding: 'utf8', ...opts }).trim();
+}
+
+function mergeBase() {
+  const ref = process.env.PATCH_COVERAGE_BASE_REF ?? 'origin/develop';
+  try {
+    return git(['merge-base', ref, 'HEAD']);
+  } catch {
+    return git(['merge-base', ref.replace(/^origin\//, ''), 'HEAD']);
+  }
+}
+
+function log(msg) {
+  process.stdout.write(`${msg}\n`);
+}
+
+function defaultHasPkgJson(dirRel) {
+  return existsSync(path.join(WORKSPACE_ROOT, dirRel, 'package.json'));
+}
+
+/**
+ * Run one package's suite with lcov coverage injected via CLI flags; return the lcov text or null
+ * (null = NO-DATA, the caller logs and degrades the verdict). The package's coverage dir is wiped
+ * first so stale data can never masquerade as fresh. A non-zero vitest exit is tolerated when
+ * lcov.info was still produced (e.g. a package-configured global threshold tripping is not this
+ * gate's concern), but a missing report is always NO-DATA — never a silent pass.
+ */
+function defaultCollectLcov(pkgRoot) {
+  const covDir = path.join(WORKSPACE_ROOT, pkgRoot, 'coverage');
+  fs.rmSync(covDir, { recursive: true, force: true });
+  try {
+    execFileSync(
+      'pnpm',
+      [
+        '--filter',
+        `./${pkgRoot}`,
+        'exec',
+        'vitest',
+        'run',
+        '--coverage',
+        '--coverage.reporter=lcov',
+        '--coverage.reportsDirectory=coverage',
+      ],
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'] },
+    );
+  } catch {
+    log(`⚠︎  ${pkgRoot}: vitest exited non-zero — using its lcov output only if present.`);
+  }
+  const lcovPath = path.join(covDir, 'lcov.info');
+  if (!existsSync(lcovPath)) return null;
+  return fs.readFileSync(lcovPath, 'utf8');
+}
+
+/**
+ * Full pipeline. Side effects (diff text, package-json probe, per-package lcov collection) are
+ * injected via `io` so the orchestration is unit-testable; defaults wire real git/vitest.
+ */
+export async function runPatchCoverage(io = {}) {
+  const target = Number(io.target ?? process.env.PATCH_COVERAGE_TARGET ?? DEFAULT_TARGET);
+  const base = io.diffText === undefined ? mergeBase() : null;
+  const diffText = io.diffText ?? git(['diff', '-U0', `${base}..HEAD`]);
+  const hasPkgJson = io.hasPkgJson ?? defaultHasPkgJson;
+  const collectLcov = io.collectLcov ?? defaultCollectLcov;
+
+  const changedNewLines = parseChangedNewLines(diffText);
+  const byPkg = groupCoverableChanges([...changedNewLines.keys()], hasPkgJson);
+
+  const coverableChangedLines = new Map();
+  for (const files of byPkg.values()) {
+    for (const f of files) coverableChangedLines.set(f, changedNewLines.get(f));
+  }
+  if (coverableChangedLines.size === 0) {
+    log('↩︎  SKIPPED: no coverable package/app src lines changed (docs/config/test-only diff).');
+    return { verdict: VERDICT.SKIPPED_NO_COVERABLE, measured: 0, covered: 0, perFile: [] };
+  }
+
+  const lcovByFile = new Map();
+  const noDataPackages = [];
+  for (const pkgRoot of byPkg.keys()) {
+    log(`▶  collecting coverage for ${pkgRoot} (${byPkg.get(pkgRoot).length} changed src file(s))`);
+    const lcovText = collectLcov(pkgRoot);
+    if (lcovText === null) {
+      log(
+        `⚠︎  ${pkgRoot}: NO-DATA — no lcov report produced; this package's changed lines are UNMEASURED.`,
+      );
+      noDataPackages.push(pkgRoot);
+      continue;
+    }
+    for (const [file, da] of parseLcov(lcovText, pkgRoot)) {
+      const merged = lcovByFile.get(file) ?? new Map();
+      for (const [line, hits] of da) merged.set(line, Math.max(merged.get(line) ?? 0, hits));
+      lcovByFile.set(file, merged);
+    }
+  }
+
+  const { perFile, measured, covered, uninstrumented } = computePatchCoverage(
+    coverableChangedLines,
+    lcovByFile,
+  );
+  const verdict = decideVerdict({
+    coverableFileCount: coverableChangedLines.size,
+    measured,
+    covered,
+    uninstrumented,
+    noDataPackages,
+    target,
+  });
+
+  log('\nPatch coverage over changed lines:');
+  for (const f of perFile) {
+    if (f.uninstrumented) {
+      log(
+        `  ⚠︎  ${f.file}: UNINSTRUMENTED (absent from lcov — no test loads it, or coverage excludes it)`,
+      );
+    } else if (f.measured === 0) {
+      log(`  –  ${f.file}: no executable changed lines`);
+    } else {
+      const pct = ((f.covered / f.measured) * 100).toFixed(1);
+      const miss = f.missedLines.length > 0 ? ` — missed lines: ${f.missedLines.join(', ')}` : '';
+      log(
+        `  ${f.covered === f.measured ? '✅' : '❌'} ${f.file}: ${f.covered}/${f.measured} (${pct}%)${miss}`,
+      );
+    }
+  }
+  const totalPct = measured === 0 ? 100 : (covered / measured) * 100;
+  log(
+    `\nTOTAL: ${covered}/${measured} changed executable lines covered (${totalPct.toFixed(1)}%), target ${target}%`,
+  );
+  if (noDataPackages.length > 0) log(`NO-DATA packages: ${noDataPackages.join(', ')}`);
+  log(`VERDICT: ${verdict}`);
+  return { verdict, measured, covered, perFile, uninstrumented, noDataPackages };
+}
+
+// ── CLI entry ───────────────────────────────────────────────────────────────────────────────────────
+
+function writeGithubOutput(lines) {
+  if (process.env.GITHUB_OUTPUT)
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+}
+
+/** `--detect`: list affected packages so the CI job can gate the (heavier) build+test steps. */
+function detectMode() {
+  const base = mergeBase();
+  const diffText = git(['diff', '-U0', `${base}..HEAD`]);
+  const byPkg = groupCoverableChanges(
+    [...parseChangedNewLines(diffText).keys()],
+    defaultHasPkgJson,
+  );
+  const pkgs = [...byPkg.keys()];
+  const affected = pkgs.length > 0;
+  log(affected ? `affected packages: ${pkgs.join(', ')}` : 'no coverable package/app src changes.');
+  writeGithubOutput([`affected=${affected}`, `packages=${pkgs.join(' ')}`]);
+}
+
+/** `--fixture <dir>`: run the pure pipeline over an on-disk diff.patch + lcov.info (red-proof). */
+function fixtureIo(dir) {
+  const abs = path.resolve(WORKSPACE_ROOT, dir);
+  return {
+    diffText: fs.readFileSync(path.join(abs, 'diff.patch'), 'utf8'),
+    // fixture package roots are the two-segment `packages/<x>` / `apps/<x>` shape
+    hasPkgJson: (dirRel) => dirRel.split('/').length === 2,
+    collectLcov: () => fs.readFileSync(path.join(abs, 'lcov.info'), 'utf8'),
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  if (args[0] === '--detect') {
+    try {
+      detectMode();
+    } catch (err) {
+      log(`patch-coverage detect error — ${err?.message ?? err}`);
+      writeGithubOutput(['affected=false', 'packages=']);
+    }
+    process.exit(0);
+  }
+  const io = args[0] === '--fixture' && args[1] ? fixtureIo(args[1]) : {};
+  runPatchCoverage(io)
+    .then(({ verdict }) => {
+      const enforce = process.env.PATCH_COVERAGE_ENFORCE === '1';
+      if (verdict === VERDICT.BELOW_TARGET) {
+        log(
+          '\n❌ patch coverage below target: this PR adds/changes lines no test exercises.\n' +
+            '   Add tests for the missed lines above (advisory in v1; enforced when PATCH_COVERAGE_ENFORCE=1).',
+        );
+        process.exit(enforce ? 1 : 0); // advisory rollout — flip to required once calibrated
+      }
+      if (verdict === VERDICT.INCONCLUSIVE) {
+        log(
+          '\n⚠︎  inconclusive — coverage data missing for part of the diff (see NO-DATA/UNINSTRUMENTED above). Advisory.',
+        );
+      }
+      process.exit(0);
+    })
+    .catch((err) => {
+      log(`patch-coverage: orchestration error — ${err?.message ?? err}`);
+      process.exit(0); // never block the pipeline on the checker's own failure (advisory)
+    });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,32 +1,34 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-    test: {
-        // New pattern: Place .test.ts or .spec.ts files next to source files
-        include: [
-            'packages/**/src/**/*.{test,spec}.{ts,tsx}',
-            // Continue to support existing test directories
-            'packages/**/tests/**/*.{test,spec}.{ts,tsx}',
-            // Harness script tests
-            'scripts/**/__tests__/**/*.test.{ts,mjs}',
-        ],
-        environment: 'node',
-        // Parallel execution
-        threads: true,
-        // Timeout settings
-        testTimeout: 10000,
-        // Coverage settings
-        coverage: {
-            provider: 'v8',
-            reporter: ['text', 'json', 'html'],
-            exclude: [
-                'node_modules/',
-                '**/dist/',
-                '**/test/',
-                '**/*.test.ts',
-                '**/*.spec.ts',
-                '**/*.d.ts',
-            ],
-        },
+  test: {
+    // New pattern: Place .test.ts or .spec.ts files next to source files
+    include: [
+      'packages/**/src/**/*.{test,spec}.{ts,tsx}',
+      // Continue to support existing test directories
+      'packages/**/tests/**/*.{test,spec}.{ts,tsx}',
+      // Harness script tests
+      'scripts/**/__tests__/**/*.test.{ts,mjs}',
+    ],
+    environment: 'node',
+    // Parallel execution
+    threads: true,
+    // Timeout settings
+    testTimeout: 10000,
+    // Coverage settings
+    coverage: {
+      provider: 'v8',
+      // 'lcov' (INFRA-041): machine-readable report for the PR patch-coverage gate
+      // (scripts/harness/check-patch-coverage.mjs); per-package runs get it via CLI flags.
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        '**/dist/',
+        '**/test/',
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/*.d.ts',
+      ],
     },
-}); 
+  },
+});


### PR DESCRIPTION
## Summary

Executes `.agents/backlog/INFRA-041-pr-patch-coverage-gate.md`: a PR-time **patch (diff) coverage** gate — the executable lines a PR adds/changes in package/app `src` must themselves be exercised by tests. The former global 80% average (`compat-node18`, since removed in #1312) never constrained NEW lines: a PR could add untested code while the repo average stayed green. This closes that hole, following the proven `regression-red-proof` advisory-rollout pattern (HARNESS-041).

## Design (Option A variant — self-hosted, no Python)

The backlog recommended Option A (`diff-cover`, self-hosted). This implements the same pipeline but does the lcov→diff mapping in a Node checker instead of `pip install diff-cover`, so there is no external tool dependency and the decision logic is unit-tested in-repo:

- **`scripts/harness/check-patch-coverage.mjs`** — changed lines from `git diff -U0 <merge-base>..HEAD`; per affected package, `vitest run --coverage --coverage.reporter=lcov` (reporter injected via CLI flags → the 30+ per-package vitest configs need **no edits**; the hoisted root `@vitest/coverage-v8` resolves for filtered runs — verified empirically). Patch coverage = covered changed executable lines / instrumented changed executable lines. Pure, exported decision functions (diff parsing, lcov parsing, computation, verdict) with injectable git/vitest seams — the exact seam pattern of `check-regression-red-proof.mjs`. Nested workspace groups (`packages/dag-nodes/*`) are handled by a nearest-`package.json` walk, never a one-level glob.
- **`patch-coverage (advisory)` job in ci.yml** — a NEW job only; no existing job touched. Path-scoped (`needs: changes` + `code == 'true'`), plus a `--detect` pre-step that skips build+test entirely unless the PR changes coverable src lines. Coverage runs execute ONLY the affected packages' suites (bounded runtime).
- **Advisory v1** — the script always exits 0 unless `PATCH_COVERAGE_ENFORCE=1`; even enforced, only `patch-coverage-below-target` fails (INCONCLUSIVE stays advisory, matching the regression-red-proof contract). Target via `PATCH_COVERAGE_TARGET` (default 80).
- **Honest, never a silent pass** — a package whose coverage can't be produced is **NO-DATA** (explicit log, verdict at best INCONCLUSIVE); a changed src file absent from lcov is **UNINSTRUMENTED** (also INCONCLUSIVE, so `coverage.all:false` configs can't hide an untested file). Non-executable changed lines (types/comments) are excluded from the denominator, so type-only diffs are a clean no-op per the backlog Test Plan.
- **Plumbing** — root `vitest.config.ts` coverage reporter gains `lcov` (backlog requirement).

## Red/green proof (HARNESS-041 discipline)

**1. Maintained fixtures, driven through the real CLI** (`scripts/harness/__tests__/fixtures/patch-coverage/{red,green}` + `check-patch-coverage.test.mjs`, 14 tests): the red fixture (added function, 0 hits) yields `patch-coverage-below-target` with exit 0 advisory / **exit 1 under `PATCH_COVERAGE_ENFORCE=1`**; the green fixture (same diff, covered) yields `patch-coverage-ok`, exit 0 even enforced.

**2. Documented injected run on a real package** (temporary commits on `packages/agent-process`, never pushed):
- Added an untested function → real vitest coverage run → `❌ 0/6 (0.0%) — missed lines: 2,3,4,5,6,7 → patch-coverage-below-target` (advisory exit 0, enforce exit **1**)
- Added a covering test → `✅ 6/6 (100.0%) → patch-coverage-ok` (enforce exit 0)
- `--detect` correctly reported `affected packages: packages/agent-process`, and the test-file addition itself was excluded from the denominator.

## Verification

- `pnpm harness:test`: 50 files / 479 tests green (includes the 14 new tests)
- `node scripts/harness/run-all-scans.mjs --skip dist --skip build-contracts` (the CI skip set): all 57 scans pass (`dist` is the local built-tree freshness check; this worktree run also passed it after `pnpm build`)
- `python3 -c "import yaml; yaml.safe_load(...)"`: ci.yml valid; action versions match the just-bumped set (checkout@v7 etc.)

## Follow-up (backlog stays in-progress)

Calibrate on real PRs, then flip to enforced/required (`PATCH_COVERAGE_ENFORCE=1` + required status check); decide at flip time whether INCONCLUSIVE should also block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC