### PR TITLE
docs(audit): neutrality & prompt-intervention audit — verdict + NEUT-001..006

### DIFF
--- a/.agents/backlog/NEUT-001-evict-selfhosting-verification-from-framework.md
+++ b/.agents/backlog/NEUT-001-evict-selfhosting-verification-from-framework.md
@@ -1,0 +1,32 @@
+---
+title: 'NEUT-001: evict Robota repo-process from agent-framework self-hosting-verification'
+status: todo
+created: 2026-07-25
+priority: high
+urgency: soon
+area: packages/agent-framework
+depends_on: []
+---
+
+# NEUT-001: self-hosting-verification domain leak
+
+## Problem
+
+`agent-framework/src/self-hosting/self-hosting-verification.ts` serializes THIS repository's process into
+the published library: `DEFAULT_BASE_REF='origin/develop'`, `pnpm --filter <scope> test/typecheck/build`,
+and `pnpm harness:verify -- --base-ref … --skip-record-check` ("Run Robota harness verification"), exported
+via `index.ts`. Any consumer importing `planSelfHostingVerification` gets plans meaningful only inside this
+repo — the exact "Robota-specific content in packages/" north-star violation. Worst finding of the
+2026-07-24 neutrality audit (.design/audits/2026-07-24-neutrality-prompt-audit.md).
+
+## What
+
+Move the Robota-specific plan content to the composition root or an unpublished repo-side module
+(`scripts/` tier). If a generic verify-before-swap planner is worth keeping in the library, it takes
+`{ baseRef, commandTemplates }` as injected config with NO defaults naming pnpm/harness/origin-develop.
+Update agent-framework SPEC + remove/replace the public export (breaking; beta line).
+
+## Test Plan
+
+Red-first: a test asserting the framework source contains no `harness:verify`/`origin/develop` literals
+(becomes part of the NEUT-006 floor); existing self-hosting tests migrate with the code.

--- a/.agents/backlog/NEUT-002-agent-tools-builtin-description-sweep.md
+++ b/.agents/backlog/NEUT-002-agent-tools-builtin-description-sweep.md
@@ -1,0 +1,34 @@
+---
+title: 'NEUT-002: agent-tools builtin tool descriptions — strip foreign product policy, add override seam'
+status: todo
+created: 2026-07-25
+priority: high
+urgency: soon
+area: packages/agent-tools
+depends_on: []
+---
+
+# NEUT-002: builtin tool-description policy sweep
+
+## Problem (audit .design/audits/2026-07-24-neutrality-prompt-audit.md, core-tier findings)
+
+Builtin descriptions are Claude-Code-era copy carrying product policy with NO override seam:
+
+- `write-tool.ts:59` "NEVER create documentation files (\*.md) or README files" — foreign workflow policy;
+  a docs-product consumer gets a tool arguing against its purpose.
+- `glob-tool.ts:109` "use the Agent tool instead" — no such tool exists in this tier.
+- `grep-tool.ts:254` "NEVER invoke grep or rg as a Bash command" — default tool name is `Shell`, not Bash.
+- `shell-tool.ts:52-56` hardcodes sibling-tool routing (Glob/Grep/Read/Edit) regardless of registration.
+- `edit-tool.ts:125` states an unenforced read-first contract.
+
+## What
+
+1. Strip foreign policy to mechanism-level text; fix/derive cross-tool references from the ACTUALLY
+   registered tool set (or accept `description`/`routingHints` options on the create\* factories).
+2. Add a description-override seam to all builtin factories (singletons → factory options).
+3. Declare tool descriptions as a model-facing contract section in agent-tools `docs/SPEC.md`.
+
+## Test Plan
+
+Red-first unit per fixed description (asserts absence of the policy phrases + presence of derived names);
+registry-subset test proves routing text matches registration.

--- a/.agents/backlog/NEUT-003-builtin-agents-and-subagent-prompt-seams.md
+++ b/.agents/backlog/NEUT-003-builtin-agents-and-subagent-prompt-seams.md
@@ -1,0 +1,35 @@
+---
+title: 'NEUT-003: built-in agents de-doctrine + injection seam; subagent suffix seam'
+status: todo
+created: 2026-07-25
+priority: high
+urgency: soon
+area: packages/agent-framework
+depends_on: []
+---
+
+# NEUT-003: built-in agent + subagent prompt seams
+
+## Problem (audit .design/audits/2026-07-24-neutrality-prompt-audit.md)
+
+- `built-in-agents.ts:11` embeds house doctrine ("strict types, no fallbacks, proper error handling") —
+  `.agents/rules` vocabulary shipped to every SDK consumer.
+- Built-ins are force-merged: shadowable by name but not removable/replaceable as a set.
+- `subagent-prompts.ts` mandates style (≤500 words, no emojis, absolute paths) with no caller seam
+  (`create-subagent-session.ts:167-172` appends unconditionally).
+- `agent-tool.ts:86` zod description hardcodes the three built-in names (drifts vs custom registries).
+
+## What
+
+1. Delete/generalize the doctrine sentence ("match the conventions stated in the project's instruction files").
+2. `builtInAgents?: IAgentDefinition[]` injection seam (default = current three; empty array allowed).
+3. `ISubagentOptions.suffix?: string | ((ctx)=>string)` with current text as default; consider relocating
+   default text to the defaults/preset layer.
+4. Derive the schema description from injected definitions; document the `general-purpose` fallback in SPEC.
+   Also fold: `SELF_VERIFICATION_CONTENT` becomes a string-valued seam (text liftable to preset);
+   `claudeMd` contract field → neutral name (breaking; beta).
+
+## Test Plan
+
+Red-first: doctrine-phrase absence; replace/remove built-in set round-trip; custom suffix honored;
+schema description reflects a custom registry.

--- a/.agents/backlog/NEUT-004-task-context-opt-in.md
+++ b/.agents/backlog/NEUT-004-task-context-opt-in.md
@@ -1,0 +1,29 @@
+---
+title: 'NEUT-004: make .agents/tasks context injection opt-in/configurable + reconcile read-only claim'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: soon
+area: packages/agent-framework
+depends_on: []
+---
+
+# NEUT-004: task-context injection discipline
+
+## Problem (audit .design/audits/2026-07-24-neutrality-prompt-audit.md, surface-tier F2)
+
+Every session on ANY repo unconditionally scans `.agents/tasks/*.md`, parses the Robota harness task
+schema (`task-context.ts:60-151`), injects it into the system prompt (priority 27) — no settings/CLI
+toggle exists. `updateTaskFileStatus` also WRITES into `.agents/`, contradicting `paths.ts:5`
+(".agents/ is read-only from CLI's perspective").
+
+## What
+
+Gate behind settings (`taskContext: { enabled, dir }` — default preserving today's behavior but documented
+and off-switchable), or demote to a composition-root opt-in. Reconcile or delete the write API vs the
+read-only claim. Low fold-ins: reword "Robota repository convention" comments to "supported convention";
+fix the `.robota/skills` project-level discovery asymmetry.
+
+## Test Plan
+
+Red-first: disabled ⇒ no section injected + no scan performed; default unchanged; write-path decision tested.

--- a/.agents/backlog/NEUT-005-core-session-prompt-hygiene.md
+++ b/.agents/backlog/NEUT-005-core-session-prompt-hygiene.md
@@ -1,0 +1,32 @@
+---
+title: 'NEUT-005: core/session prompt hygiene (dead templates, defaults, /compact leak, compaction & naming seams)'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: soon
+area: packages/agent-core, packages/agent-session, packages/agent-framework
+depends_on: []
+---
+
+# NEUT-005: core/session prompt hygiene batch
+
+## Problem (audit .design/audits/2026-07-24-neutrality-prompt-audit.md)
+
+1. `agent-core/src/templates/builtin-templates.json` — 7 full personas, ZERO importers (dead) — delete or
+   lift to a preset.
+2. `agent-factory-helpers.ts:77,128` — 'You are a helpful AI assistant.' default: `||` makes empty
+   inexpressible; undocumented in SPEC. Empty-by-default (+ `??`), document.
+3. `execution-round-context.ts:77` — zero-dep core emits "Run /compact and retry." (product slash-command
+   vocabulary). Neutral phrasing or injectable capacity notice; CLI adds the /compact hint at its tier.
+4. `agent-session/compaction-orchestrator.ts:128-139` — dev-domain-biased summarize prompt, base
+   irreplaceable (append-only seam), contradicts session SPEC ("does not own system prompt building").
+   Injectable base template; de-bias defaults; fix SPEC.
+5. `agent-framework/interactive/session-naming.ts` — hardcoded naming prompt + `sanitizeName` strips all
+   non-Latin chars (Korean first message ⇒ garbage/empty title). Prompt/sanitizer injection + Unicode-aware
+   sanitize.
+   Low fold-ins: `.robota/settings.local.json` comment rewording in two contracts; dag-cli scaffold provider
+   param; `DEFAULT_AGENT_NAME='robota-cli'` reconsideration.
+
+## Test Plan
+
+Red-first per item (incl. a Korean-title naming test that FAILS today); SPEC updates in the same PR.

--- a/.agents/backlog/NEUT-006-model-facing-prose-floor.md
+++ b/.agents/backlog/NEUT-006-model-facing-prose-floor.md
@@ -1,0 +1,33 @@
+---
+title: 'NEUT-006: mechanical floor for model-facing prose in packages/* (prompt-inventory ratchet)'
+status: todo
+created: 2026-07-25
+priority: high
+urgency: soon
+area: scripts/harness, .agents/harness.config.json
+depends_on: []
+---
+
+# NEUT-006: prompt-prose neutrality floor
+
+## Problem (audit .design/audits/2026-07-24-neutrality-prompt-audit.md, gap #6)
+
+The five neutrality scans guard dependencies/identifiers/corpus files — NOT model-facing prose. Plan-mode,
+guardrails, computer-use, built-in agents, and tool descriptions rest on convention alone; nothing stops
+the next "helpful default prompt" landing in a library layer unseen (this is exactly how the 2026-03 debt
+accumulated).
+
+## What
+
+`scan-prompt-prose.mjs`: detect model-facing instruction prose in `packages/*/src` (heuristics: multi-word
+imperative strings in known prompt sinks — `description:`, `systemPrompt`/`systemMessage` literals,
+template exports; refine against the audit's 17-file inventory) with a FROZEN BASELINE ratchet (file-size
+/ spec-surface precedent): current prompt-bearing files frozen at their prose fingerprint; NEW prose in a
+non-baselined library file FAILS; baseline shrinks as NEUT-001..005 land. Config data (sinks, baseline)
+in `harness.config.json`. Also add the role-vocabulary assertion from the delta audit (`planner|editor|
+reviewer` + model IDs appear only in `agent-provider-defaults`).
+
+## Test Plan
+
+Red-before-green fixtures (new prose in core ⇒ FAIL; baselined file unchanged ⇒ pass; shrink ⇒ tighten
+notice); register in run-all-scans.

--- a/.design/audits/2026-07-24-neutrality-prompt-audit.md
+++ b/.design/audits/2026-07-24-neutrality-prompt-audit.md
@@ -1,0 +1,49 @@
+# Neutrality & Prompt-Intervention Audit — 2026-07-24
+
+Owner question: did the "Robota builds Robota" implementation (SELFHOST-001..014 wave + recent sessions)
+break the layered monorepo's neutrality/universality principle ("packages/\* = neutral mechanisms, prompt
+intervention avoided even in agent-cli")?
+
+Method: 4 parallel read-only auditors — core tier / framework tier / surface tier / historical delta —
+judging origin/develop `386af77e`, each with file:line evidence. Full per-file tables live in the four
+audit transcripts; this document is the synthesized verdict + remediation index.
+
+## Verdict
+
+**The principle was NOT broken by the SELFHOST wave — the wave measurably IMPROVED the posture.**
+
+- 12 of 13 package-touching capabilities landed as pure injected-policy mechanisms (plan-mode, guardrails,
+  role routing, memory port, branching, tracing, orchestration...). Total wave prompt delta into
+  `packages/*`: 2 tool descriptions (retrieval, computer-use), 1 threading glue line, 1 XML wrapper tag.
+- The wave CREATED the repo's first five mechanical neutrality floors (agent-tools deps, orchestration,
+  session-artifact, memory, evals — none existed before 2026-07-17).
+- Opinions were correctly quarantined: `agent-provider-defaults` (role→model table) and `agent-preset`
+  (personas) are chartered, opt-in, dependency-direction-clean opinion homes; the framework provably
+  depends on neither.
+- **agent-cli is still the thin neutral assembler** (its only prompt paths forward user-supplied flags);
+  all six transports are content-neutral pipes; all providers are clean transmitters (zero editorializing).
+- **Honest correction of the premise:** the pre-wave baseline was NOT prompt-free. The real debt entered
+  2026-03..05 (imported Claude-Code-style tool descriptions, built-in agent prompts, compaction/naming
+  prompts, memory heuristics) and simply never had a floor. The wave did not add to it; it also did not
+  clean it up.
+
+## Findings (consolidated, deduped; 4 audits: 2+6+8+8 raw → 6 remediation items)
+
+| #   | Finding                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Tier         | Class                                   | Severity                                                             |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------- | -------------------------------------------------------------------- |
+| 1   | `agent-framework/src/self-hosting/self-hosting-verification.ts` serializes THIS repo's process (`pnpm harness:verify`, `origin/develop`, pnpm-monorepo commands) into the published library (exported from index)                                                                                                                                                                                                                                                   | framework    | DOMAIN-LEAK                             | **high — worst single violation, and it IS a self-hosting artifact** |
+| 2   | `agent-tools` builtin tool descriptions carry another product's policy verbatim, non-overridable: write-tool "NEVER create documentation files"; glob-tool references a nonexistent `Agent` tool; grep-tool says "NEVER ... as a Bash command" while the default tool name is `Shell`; shell-tool hardcodes sibling-tool routing regardless of what is registered                                                                                                   | core (tools) | HARDCODED-POLICY (pre-wave, 2026-03-19) | high                                                                 |
+| 3   | `built-in-agents.ts` general-purpose prompt embeds house doctrine ("strict types, no fallbacks..."); built-in set is force-merged (shadowable by name, but not removable/replaceable); `subagent-prompts.ts` style mandates (≤500 words, no emojis) have no seam; agent-tool zod schema hardcodes the three built-in names                                                                                                                                          | framework    | HARDCODED-POLICY + one DOMAIN sentence  | high                                                                 |
+| 4   | `.agents/tasks` task-context: house schema parsed + injected into EVERY session's system prompt with no toggle; `updateTaskFileStatus` writes into `.agents/` contradicting `paths.ts` "read-only" claim                                                                                                                                                                                                                                                            | framework    | HARDCODED-POLICY                        | medium                                                               |
+| 5   | Core/session prompt hygiene: dead `builtin-templates.json` (7 personas, zero importers); `'You are a helpful AI assistant.'` default (seam exists but `\|\|` makes empty inexpressible; un-SPEC'd); `/compact` product vocabulary emitted by zero-dep core; compaction prompt dev-domain-biased + base irreplaceable + contradicts session SPEC; session-naming prompt seamless + sanitizer destroys non-Latin titles (Korean first message → garbage session name) | core/session | mixed (b)/(c)/(d)                       | medium                                                               |
+| 6   | No mechanical floor for model-facing PROSE in packages: the 5 existing scans guard deps/identifiers/corpus files, not prompt text — plan-mode/guardrails/computer-use/built-ins/tool descriptions rest on convention only                                                                                                                                                                                                                                           | harness      | GAP                                     | high (the systemic fix)                                              |
+
+Also noted (low, in transcripts): `SELF_VERIFICATION_CONTENT` boolean-only seam; `DEFAULT_AGENT_NAME='robota-cli'`
+in preset resolution; `claudeMd` field name in a public contract; `.robota/skills` project-level discovery
+asymmetry; dag-cli scaffold provider default; Brave endpoint in web-search errors; SPEC prompt-surface
+declarations missing in agent-core/agent-tools.
+
+## Remediation backlog
+
+NEUT-001..006 in `.agents/backlog/` map 1:1 to the table above. Recommended order: 006 (floor first, so
+cleanups ratchet), then 001/002/003, then 004/005.


### PR DESCRIPTION
Owner-requested audit of the 'Robota builds Robota' neutrality question. **Verdict: the SELFHOST wave did NOT break the principle — it improved the posture**; the real debt is pre-wave (2026-03..05) prompt imports. Full synthesis in `.design/audits/2026-07-24-neutrality-prompt-audit.md`; 6 remediation items filed as NEUT-001..006 (worst: the framework's self-hosting-verification module shipping this repo's harness commands in the published library). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)