### PR TITLE
docs(backlog): file remaining loose threads as tracked items

### DIFF
--- a/.agents/backlog/DOCS-021-docs-inline-style-debt.md
+++ b/.agents/backlog/DOCS-021-docs-inline-style-debt.md
@@ -1,0 +1,26 @@
+---
+title: 'DOCS-021: finish Tailwind conversion of docs-site homepage/ToC inline styles'
+status: todo
+created: 2026-07-25
+priority: low
+urgency: later
+area: apps/docs
+depends_on: []
+---
+
+# DOCS-021: docs-site inline-style debt
+
+## Problem
+
+DOCS-002 (#1332) converted Header/Sidebar/DocsLayout/Search/ThemeToggle to Tailwind, but pre-existing
+inline `style` usage remains on the homepage and ToC components (flagged as follow-up in that PR) —
+violating the Tailwind-only frontend rule.
+
+## What
+
+Convert the remaining inline styles to Tailwind utilities; delete any dead custom CSS uncovered.
+
+## Test Plan
+
+`pnpm --filter robota-docs build` fully green (311-page prerender + pagefind); grep floor: zero `style={{`
+in `apps/docs/src` (excluding any documented dynamic-value exemptions).

--- a/.agents/backlog/HARNESS-042-scan-selftest-coverage.md
+++ b/.agents/backlog/HARNESS-042-scan-selftest-coverage.md
@@ -1,0 +1,27 @@
+---
+title: 'HARNESS-042: close the scan self-test gap (14 registered scans without direct tests)'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: soon
+area: scripts/harness/__tests__
+depends_on: []
+---
+
+# HARNESS-042: scan self-test coverage completion
+
+## Problem
+
+HARNESS-023's mechanically computed table (see its Outcome in `backlog/completed/`) found **14 of 58
+registered scans lack direct tests** — an untested guardian can rot silently (the vacuous-gate class the
+diet just purged). Priority-High per that table: `scan-dist-freshness`, `scan-conflict-markers`.
+
+## What
+
+Fixture-based red/green tests per untested scan, HARNESS-023's pattern (exported pure finding-collector +
+CLI exit tests). Batch by area; start with the two High items. Each test must include at least one RED
+fixture per rule class (no green-only suites — accidental-green rule).
+
+## Test Plan
+
+The tests ARE the deliverable; `pnpm harness:test` green; per-scan red fixtures demonstrated in the PR.

--- a/.agents/backlog/INFRA-046-promote-advisory-gates.md
+++ b/.agents/backlog/INFRA-046-promote-advisory-gates.md
@@ -1,0 +1,27 @@
+---
+title: 'INFRA-046: promote advisory CI gates (regression-red-proof, patch-coverage) to blocking'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: later
+area: .github/workflows/ci.yml, repo rulesets
+depends_on: []
+---
+
+# INFRA-046: advisory→required gate promotion
+
+## Problem
+
+Two quality floors run advisory-only by design (v1 rollout): `regression-red-proof` (HARNESS-041) and
+`patch-coverage` (INFRA-041). Advisory gates that stay advisory forever become noise.
+
+## What
+
+Define + apply the promotion criteria: after N=10 code-PRs each with zero false-positive verdicts
+(evaluated from the jobs' logged decisions), flip `REGRESSION_RED_PROOF_ENFORCE=1` /
+`PATCH_COVERAGE_ENFORCE=1` and add the job(s) to the develop ruleset's required checks (they are
+`changes`-gated, so docs-only PRs skip=pass, same as tui-e2e). Record the false-positive tally in the PR.
+
+## Test Plan
+
+A deliberately-failing fixture PR proves each gate BLOCKS post-promotion; docs-only PR proves skip=pass.

--- a/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
+++ b/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
@@ -1,0 +1,26 @@
+---
+title: 'INFRA-047: migrate dependency-review deny-licenses → allow-licenses before the v6 bump'
+status: todo
+created: 2026-07-25
+priority: low
+urgency: later
+area: .github/workflows/dependency-review.yml
+depends_on: []
+---
+
+# INFRA-047: license-gate input migration
+
+## Problem
+
+`dependency-review-action` deprecates `deny-licenses` for possible removal in v6 (noted in-file when v5
+landed, #1313). The deny list is LOAD-BEARING for the dual-license policy (blocks GPL/AGPL ingress).
+
+## What
+
+Build the equivalent `allow-licenses` list (inventory current dependency licenses; allow-list is stricter —
+verify no currently-green license falls outside), switch inputs, delete the in-file deprecation note.
+Gate: do NOT accept a Dependabot v6 bump before this lands.
+
+## Test Plan
+
+A test PR introducing a GPL dev-dep is BLOCKED under the new input (then closed).

--- a/.agents/backlog/NEUT-007-memory-extractor-policy-injection.md
+++ b/.agents/backlog/NEUT-007-memory-extractor-policy-injection.md
@@ -1,0 +1,28 @@
+---
+title: 'NEUT-007: memory candidate-extractor locale/domain heuristics → injectable policy'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: soon
+area: packages/agent-framework
+depends_on: []
+---
+
+# NEUT-007: memory-extractor heuristic policy in the library
+
+## Problem
+
+`agent-framework/src/memory/memory-candidate-extractor.ts:10-19` hardcodes Korean-language trigger regexes
+(기억해/앞으로/항상) and a dev-domain `PROJECT_TERMS` list (`repo|build|test|monorepo`) — locale + domain
+POLICY inside the neutral library, invisible to `scan-memory-neutrality` (it checks corpus files/long
+literals, not regex policy). Load-bearing under SELFHOST-008. (2026-07-24 neutrality audit, delta gap #6.)
+
+## What
+
+Extract the trigger patterns + project-term vocabulary into an injectable extractor policy (constructor
+option with the current bilingual/dev set as the DOCUMENTED default supplied by the composition root, or
+a defaults-layer export). NEUT-006's prose floor should cover the regex-policy class once this moves.
+
+## Test Plan
+
+Red-first: custom policy injected ⇒ custom triggers honored, defaults absent; default path unchanged.

--- a/.agents/backlog/NEUT-008-web-search-provider-port.md
+++ b/.agents/backlog/NEUT-008-web-search-provider-port.md
@@ -1,0 +1,27 @@
+---
+title: 'NEUT-008: web-search vendor coupling → provider port (Brave endpoint out of library defaults)'
+status: todo
+created: 2026-07-25
+priority: low
+urgency: later
+area: packages/agent-tools
+depends_on: []
+---
+
+# NEUT-008: web-search provider port
+
+## Problem
+
+`agent-tools/src/builtins/web-search-tool.ts:49,65` hardcodes the Brave Search endpoint and surfaces the
+Brave signup URL in model-visible errors — vendor coupling (not prompt policy) in a neutral builtin.
+(2026-07-24 neutrality audit, core-tier low note.)
+
+## What
+
+Duck-typed search-provider port (query→results) with Brave as the default adapter wired at the composition
+root (mirrors the retrieval/computer-use port pattern); error text loses the vendor URL at the library tier.
+
+## Test Plan
+
+Red-first: custom provider injected ⇒ used; library source contains no vendor endpoint literal
+(NEUT-006-class assertion).

--- a/.agents/backlog/REL-023-changeset-reconciliation.md
+++ b/.agents/backlog/REL-023-changeset-reconciliation.md
@@ -1,0 +1,28 @@
+---
+title: 'REL-023: reconcile 74 dormant .changeset files before the next npm publish'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: before-next-publish
+area: .changeset/
+depends_on: []
+---
+
+# REL-023: dormant changeset reconciliation
+
+## Problem
+
+74 unconsumed `.changeset/*.md` files have accumulated (REL-022 audit). The next `pnpm changeset version`
+will consume ALL of them at once, producing a chaotic wall of per-package CHANGELOG entries spanning months
+and potentially wrong bump levels for the beta line.
+
+## What
+
+Before the next npm publish: triage the 74 files — collapse superseded/duplicate entries, verify bump levels
+against what actually shipped (the generated root CHANGELOG.md from REL-022 is the cross-check), then run
+`changeset version` in a dedicated PR so the owner reviews the per-package changelog output in isolation.
+Document the go-forward rule in publish.md: changesets are consumed at every publish, never stockpiled.
+
+## Test Plan
+
+The version PR's generated changelogs are reviewed against the REL-022 CHANGELOG; publish dry-run green.


### PR DESCRIPTION
Files backlog items for every remaining loose thread surfaced this cycle — NEUT-007/008 (neutrality-audit lows), HARNESS-042 (scan self-test gap), INFRA-046/047 (gate promotion + license-input migration), REL-023 (changeset reconciliation), DOCS-021 (docs inline-style debt) — so the queue is complete before execution. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)