### PR TITLE
ci(security): migrate dependency-review deny-licenses → allow-licenses (INFRA-047)

### DIFF
--- a/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
+++ b/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-047: migrate dependency-review deny-licenses → allow-licenses before the v6 bump'
-status: todo
+status: in-progress
 created: 2026-07-25
 priority: low
 urgency: later
@@ -24,3 +24,10 @@ Gate: do NOT accept a Dependabot v6 bump before this lands.
 ## Test Plan
 
 A test PR introducing a GPL dev-dep is BLOCKED under the new input (then closed).
+
+Verify post-merge: the input swap itself landed via `ci/infra-047-allow-licenses` (allow-list =
+verified lockfile inventory closure of 2026-07-25 + purl exemptions for the @robota-sdk dual-licensed
+self-deps and the LGPL @img/sharp-libvips prebuilt family). The red-test above cannot run pre-merge —
+dependency-review executes the config of the PR's MERGE result against the target branch, so the new
+allow-list only gates PRs opened AFTER this lands. Run the GPL-fixture PR against develop after merge;
+only then may this item be closed.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 name: Dependency Review
 
 # Gate PR-introduced dependencies by vulnerability AND license policy (distinct from the lockfile-wide
-# osv-scanner in ci.yml): dependency-review diffs the PR's ADDED deps and enforces a license deny-list.
+# osv-scanner in ci.yml): dependency-review diffs the PR's ADDED deps and enforces a license allow-list.
 # License gating matters here — the project is dual-licensed (AGPL + Commercial, no CLA yet), so a runtime
 # dep under a strong-copyleft license would virally break the commercial-relicensing right.
 on:
@@ -32,11 +32,37 @@ jobs:
         with:
           # Block the PR on a newly-introduced HIGH+ vulnerability.
           fail-on-severity: high
-          # Strong-copyleft licenses that would compromise the commercial-relicensing right of the dual
-          # license. Permissive (MIT/Apache-2.0/BSD/ISC) deps are unaffected. LGPL is intentionally NOT denied
-          # (weaker, dynamic-link copyleft) — revisit if a static-bundling concern arises.
-          # NOTE: `deny-licenses` is deprecated for possible removal in dependency-review-action v6 —
-          # this list is load-bearing (dual-license AGPL+Commercial policy), so migrate to
-          # `allow-licenses` BEFORE accepting a v6 bump.
-          deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+          # License ALLOW-list (INFRA-047: replaces the v6-deprecated `deny-licenses`). The list is the
+          # verified closure of SPDX leaf licenses present in the full pnpm-lock.yaml graph (prod + dev,
+          # all platform variants) as of 2026-07-25 — every id is permissive/non-viral, preserving the
+          # commercial-relicensing right of the dual license. Anything NOT listed — GPL/AGPL/LGPL/SSPL
+          # and every other copyleft — now fails the check (strictly stronger than the old 6-id deny
+          # list). MPL-2.0 is included deliberately: its copyleft is file-scoped to the MPL-licensed
+          # files themselves and does not reach the containing work.
+          # To extend: confirm the new id is permissive/non-viral, then append it here. The action
+          # matches SPDX expressions per-leaf via spdx-satisfies: `A OR B` passes if EITHER id is
+          # listed, `A AND B` only if BOTH are.
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, ISC, MIT, MIT-0, MPL-2.0, Python-2.0, Unlicense, WTFPL
+          # Name-scoped (any-version) exemptions for packages ALREADY in the graph whose license
+          # expression contains a non-allowlisted leaf:
+          # - @robota-sdk/*: our own published packages under our own dual license
+          #   (`AGPL-3.0-only OR LicenseRef-Commercial`) — self-deps, not third-party ingress.
+          # - @img/sharp-libvips-* and @img/sharp-wasm32: sharp's bundled libvips prebuilds
+          #   (`LGPL-3.0-or-later`). LGPL stays OFF the general allow-list — a NEW LGPL dep now fails;
+          #   only this existing family is exempted. If sharp adds a platform variant, extend THIS
+          #   list (not allow-licenses).
+          allow-dependencies-licenses: >-
+            pkg:npm/%40robota-sdk/agent-core,
+            pkg:npm/%40robota-sdk/agent-provider,
+            pkg:npm/%40img/sharp-libvips-darwin-arm64,
+            pkg:npm/%40img/sharp-libvips-darwin-x64,
+            pkg:npm/%40img/sharp-libvips-linux-arm,
+            pkg:npm/%40img/sharp-libvips-linux-arm64,
+            pkg:npm/%40img/sharp-libvips-linux-ppc64,
+            pkg:npm/%40img/sharp-libvips-linux-riscv64,
+            pkg:npm/%40img/sharp-libvips-linux-s390x,
+            pkg:npm/%40img/sharp-libvips-linux-x64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-arm64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-x64,
+            pkg:npm/%40img/sharp-wasm32
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

`deny-licenses` is deprecated for removal in dependency-review-action v6 and the list is load-bearing for the dual-license (AGPL + Commercial) policy. This migrates the gate to `allow-licenses` built from the **actual license inventory of the dependency graph**, without weakening — in fact strictly strengthening — the copyleft-ingress block. The in-file deprecation NOTE is deleted; the backlog item stays open pending the post-merge red-test.

## Inventory → allowlist mapping

Inventory method: `pnpm install` at this commit, then `pnpm licenses list --json` (full graph: prod **and** dev, since the action gates every added dependency — the workflow sets no scope restriction). Packages not installed on linux (202 lockfile-only names, almost all platform variants of already-inventoried families) were cross-checked against the npm registry; every non-obvious one (`dmg-license`, `iconv-corefoundation`, `verror`, `@yuku-*` bindings, `fsevents`, …) is MIT.

| Inventory leaf (count: full graph) | Disposition |
|---|---|
| MIT (1492), ISC (111), Apache-2.0 (87), BSD-3-Clause (32), BSD-2-Clause (22), BlueOak-1.0.0 (12), Unlicense (3), CC0-1.0 (2), MIT-0 (1), Python-2.0 (1), CC-BY-4.0 (1), WTFPL (1 + OR-exprs), 0BSD (1) | **Allowed** — permissive |
| MPL-2.0 (6: axe-core, lightningcss×platforms, mediabunny, next-mdx-remote) | **Allowed, deliberate** — file-scoped weak copyleft; does not reach the containing work; was never denied before |
| LGPL-3.0-or-later (@img/sharp-libvips-* ×10 platforms, @img/sharp-wasm32) | **NOT allowed** — purl-exempted by name only (see below) |
| AGPL-3.0-only OR LicenseRef-Commercial (@robota-sdk/agent-core, agent-provider) | **NOT allowed** — purl-exempted: these are OUR OWN published dual-licensed packages (self-deps, not third-party ingress) |
| Unknown (4: @shinyoshiaki/jspack, khroma, rx.mini, spawndamnit — no license field; all MIT-licensed upstream) | No effect — the action classifies null licenses as *unlicensed*, which warns but does not fail |

**Final `allow-licenses` (14 ids):** `0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, ISC, MIT, MIT-0, MPL-2.0, Python-2.0, Unlicense, WTFPL`

**`allow-dependencies-licenses` (13 versionless purls):** 2× `@robota-sdk` self-deps + 11× `@img/sharp-libvips-*`/`sharp-wasm32` (sharp's bundled libvips prebuilds).

## ⚠ Copyleft found in the inventory — decision surfaced for review

The graph already contains **LGPL-3.0-or-later** (sharp's libvips prebuilds, dev-side via the docs/app image pipeline). The old config *explicitly* did not deny LGPL at all. Rather than putting LGPL on the general allowlist (weakening) or blocking the migration, this PR keeps **LGPL off the allowlist** and exempts only the existing sharp family by name — i.e. a **new** LGPL dep is now blocked where before it sailed through. If reviewers prefer the old blanket-LGPL-permitted stance, swap the 11 sharp purls for `LGPL-3.0-or-later` in `allow-licenses`.

## How SPDX-expression matching was verified

Read the action's v5 source (`src/licenses.ts`, `src/spdx.ts`, `src/purl.ts`):
- allow path = `spdx-satisfies(expr, allowList)`: `A OR B` passes if **either** leaf is allowed; `A AND B` only if **both** are; invalid expressions → *unresolved* → **fail**; null → *unlicensed* → warn only.
- purl exemptions match case-insensitive on name and **ignore version**, so versionless purls cover future bumps.

Then **replicated the action's exact logic locally** (same `spdx-satisfies` allow path + purl name-matching) over all **1,794** inventoried license rows: **0 forbidden, 0 unresolved**, 6 exempted, 4 unlicensed (warn-only). Negative controls `GPL-3.0-only`, `GPL-2.0-or-later`, `AGPL-3.0-only`, `LGPL-3.0-or-later`, `SSPL-1.0`, `MIT AND GPL-3.0-only` are all **blocked**; positive controls `(MIT OR GPL-3.0-only)`, `Apache-2.0 AND MIT`, `(MPL-2.0 OR Apache-2.0)` all pass. Workflow YAML parses cleanly.

## Policy-strength comparison

Old deny-list blocked exactly 6 ids (GPL-2.0/3.0, AGPL-3.0 variants) — GPL-1.0, SSPL, EUPL, CC-BY-SA, OSL, any future copyleft all passed. New allowlist blocks **everything** outside the 14 verified permissive ids. Net: strictly stronger.

## Test plan / remaining verification

- The true red-test (a fixture PR adding a GPL dev-dep gets blocked) **cannot run pre-merge**: dependency-review evaluates the config from the merge result against the *target branch*, so the new input only gates PRs opened after this lands. Per the INFRA-047 Test Plan, run the GPL-fixture PR against develop **after merge** (then close it).
- Accordingly the backlog item is left **open** (`status: in-progress`) with a verify-post-merge note — not archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC