### PR TITLE
feat(cmd-004): Phase 2 Stage D — remote surfaces (requester-routed ui_intent, GUI notices, headless parity, TC-09)

### DIFF
--- a/apps/agent-app/src/__tests__/session-surface.test.tsx
+++ b/apps/agent-app/src/__tests__/session-surface.test.tsx
@@ -63,4 +63,27 @@ describe('SessionSurface (GUI-002 TC-01/TC-02)', () => {
     fireEvent.click(screen.getByText('Allow'));
     expect(state.answerPermission).toHaveBeenCalledWith('p1', true);
   });
+
+  it('CMD-004 TC-05: a ui_intent notice renders VISIBLY and Dismiss removes it via the reducer', () => {
+    const state = stubState({
+      dismissUiIntentNotice: vi.fn(),
+      uiIntentNotices: [
+        {
+          id: 'n1',
+          intentType: 'show-settings',
+          notice:
+            'The settings screen is not available on this surface. Use the robota terminal on the host.',
+        },
+      ],
+    } as unknown as Partial<IWsSessionState>);
+    render(<SessionSurface state={state} />);
+    // The explicit unsupported signal (never a silent drop) is user-visible …
+    expect(screen.getByText(/settings screen is not available on this surface/i)).toBeTruthy();
+    // … and dismissible through the reducer's handle.
+    fireEvent.click(screen.getByLabelText('dismiss show-settings notice'));
+    expect(
+      (state as unknown as { dismissUiIntentNotice: ReturnType<typeof vi.fn> })
+        .dismissUiIntentNotice,
+    ).toHaveBeenCalledWith('n1');
+  });
 });

--- a/packages/agent-transport-gui/docs/SPEC.md
+++ b/packages/agent-transport-gui/docs/SPEC.md
@@ -21,6 +21,15 @@ Provides:
   localhost transport for the reducer.
 - **Prompt state** — `applyPromptEvent` / `permissionResponse` / `askResponse` (pure), the REMOTE-007
   permission/ask model folded by the reducer for BOTH transports.
+- **UI-intent state (CMD-004 Stage D)** — `applyUiIntentEvent` / `removeUiIntentNotice` /
+  `describeUiIntentForGui` (pure). A `ui_intent` server message (requester-routed to this surface by
+  the server) folds into an explicit, dismissible `IUiIntentNotice` rendered by `SessionSurface`; the
+  reducer exposes `uiIntentNotices` + `dismissUiIntentNotice`. The GUI has no full-screen equivalent
+  of the four intents yet (`show-settings` / `show-session-picker` / `show-plugin-manager` /
+  `show-agent-switcher`), so v1 folds EVERY intent — including unknown future kinds arriving on the
+  wire — into an explicit "not available on this surface" notice, never a silent no-op (TC-05, the
+  no-fallback rule). When a GUI screen for an intent lands, its arm in `describeUiIntentForGui`
+  switches from a notice to the mapped surface state.
 - **Components** — `ConversationView` (pure conversation render, markdown), `AgentActivityPanel` (background
   task rail), `PermissionPrompt` (permission/ask modal), `SessionSurface` (the full terminal-noir desktop
   layout over an `IWsSessionState`), and `CenteredChrome` (pre-session / fatal chrome).
@@ -50,6 +59,8 @@ not own session lifecycle, conversation history, or agent runtime state.
   (`disconnected | connecting | connected | error`).
 - OWNS: the permission/ask prompt state (`applyPromptEvent`, `permissionResponse`, `askResponse`,
   `TPendingPrompt`).
+- OWNS: the ui-intent notice state (`applyUiIntentEvent`, `removeUiIntentNotice`,
+  `describeUiIntentForGui`, `IUiIntentNotice`) — CMD-004 Stage D.
 - OWNS: the React presentation — `ConversationView`, `AgentActivityPanel`, `PermissionPrompt`,
   `SessionSurface`, `CenteredChrome`.
 - OWNS: the "terminal-noir" theme (`styles/theme.css`).
@@ -100,27 +111,30 @@ logic — it forwards user intent through the reducer's `send` / `answerPermissi
 
 Exported from the package root (node) and `./client` (browser):
 
-| Export                  | Kind      | Description                                                                          |
-| ----------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `useSessionClient`      | hook      | Transport-neutral session reducer, generic over the status type                      |
-| `useWsSession`          | hook      | `useSessionClient` bound to a localhost WS via `createWsSessionClient`               |
-| `createWsSessionClient` | function  | Browser WebSocket client (reconnecting) implementing `ISessionClientHandle`          |
-| `applyPromptEvent`      | function  | Fold a permission/ask/resolved event into the pending-prompt list                    |
-| `permissionResponse`    | function  | Build the `TClientMessage` answering a permission prompt                             |
-| `askResponse`           | function  | Build the `TClientMessage` answering an ask prompt                                   |
-| `ConversationView`      | component | Pure conversation renderer (markdown); messages/activeTools/streamingText/isThinking |
-| `AgentActivityPanel`    | component | Background-task rail; `tasks: readonly IExecutionWorkspaceEntry[]`                   |
-| `PermissionPrompt`      | component | Permission/ask modal; prompts + `onAnswerPermission`/`onAnswerAsk`                   |
-| `SessionSurface`        | component | Full terminal-noir desktop layout over an `IWsSessionState`; optional `surface`      |
-| `CenteredChrome`        | component | Pre-session / fatal chrome frame; `tone` + children                                  |
-| `SessionMonitor`        | component | Localhost-WS **web** session shell (composes the reducer + views); prop `wsUrl`      |
-| `IConversationMessage`  | type      | Reconstructed conversation message (id, role, content, author?)                      |
-| `IActiveTool`           | type      | Active tool-call display state                                                       |
-| `IWsSessionState`       | type      | Reducer return state (generic over the status type)                                  |
-| `ISessionClientHandle`  | type      | The `connect`/`disconnect`/`send` handle a transport client returns                  |
-| `TMakeSessionClient`    | type      | Factory the reducer calls to build its client from the callbacks                     |
-| `TConnectionStatus`     | type      | WS lifecycle status (`disconnected \| connecting \| connected \| error`)             |
-| `TPendingPrompt`        | type      | A pending permission/ask prompt awaiting the owner's answer                          |
+| Export                   | Kind      | Description                                                                          |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------ |
+| `useSessionClient`       | hook      | Transport-neutral session reducer, generic over the status type                      |
+| `useWsSession`           | hook      | `useSessionClient` bound to a localhost WS via `createWsSessionClient`               |
+| `createWsSessionClient`  | function  | Browser WebSocket client (reconnecting) implementing `ISessionClientHandle`          |
+| `applyPromptEvent`       | function  | Fold a permission/ask/resolved event into the pending-prompt list                    |
+| `permissionResponse`     | function  | Build the `TClientMessage` answering a permission prompt                             |
+| `askResponse`            | function  | Build the `TClientMessage` answering an ask prompt                                   |
+| `applyUiIntentEvent`     | function  | Fold a `ui_intent` server message into the explicit notice list (CMD-004 Stage D)    |
+| `removeUiIntentNotice`   | function  | Dismiss one ui-intent notice by id (idempotent)                                      |
+| `describeUiIntentForGui` | function  | Per-kind explicit "not available on this surface" text for an intent                 |
+| `ConversationView`       | component | Pure conversation renderer (markdown); messages/activeTools/streamingText/isThinking |
+| `AgentActivityPanel`     | component | Background-task rail; `tasks: readonly IExecutionWorkspaceEntry[]`                   |
+| `PermissionPrompt`       | component | Permission/ask modal; prompts + `onAnswerPermission`/`onAnswerAsk`                   |
+| `SessionSurface`         | component | Full terminal-noir desktop layout over an `IWsSessionState`; optional `surface`      |
+| `CenteredChrome`         | component | Pre-session / fatal chrome frame; `tone` + children                                  |
+| `SessionMonitor`         | component | Localhost-WS **web** session shell (composes the reducer + views); prop `wsUrl`      |
+| `IConversationMessage`   | type      | Reconstructed conversation message (id, role, content, author?)                      |
+| `IActiveTool`            | type      | Active tool-call display state                                                       |
+| `IWsSessionState`        | type      | Reducer return state (generic over the status type)                                  |
+| `ISessionClientHandle`   | type      | The `connect`/`disconnect`/`send` handle a transport client returns                  |
+| `TMakeSessionClient`     | type      | Factory the reducer calls to build its client from the callbacks                     |
+| `TConnectionStatus`      | type      | WS lifecycle status (`disconnected \| connecting \| connected \| error`)             |
+| `TPendingPrompt`         | type      | A pending permission/ask prompt awaiting the owner's answer                          |
 
 Style: `./styles/theme.css` (source; consumer-compiled). Consumers import these directly — this package is
 NOT re-exported through a sibling product (`agent-transport-webrtc-web` does not re-export it; the repo forbids
@@ -142,6 +156,8 @@ pass-through re-exports).
 
 - `ws-session-client.test.ts` — malformed-frame safety + connect/replay behavior of the WS client.
 - `prompt-state.test.ts` — the permission/ask reducer helpers.
+- `ui-intent-state.test.ts` — CMD-004 TC-05: every `ui_intent` kind (including unknown wire-level
+  kinds) folds to an explicit notice — never a silent no-op; dismissal is id-scoped + idempotent.
 - Component rendering (`SessionSurface`, prompts) is exercised by the consuming app's jsdom test
   (`apps/agent-app`) and its headless Electron e2e (real `WsTransport` sidecar).
 
@@ -156,6 +172,9 @@ pass-through re-exports).
 | `createWsSessionClient`              | factory  | Browser WS client (reconnecting) implementing `ISessionClientHandle`.   |
 | `applyPromptEvent`                   | function | Fold a permission/ask/resolved event into the pending-prompt list.      |
 | `permissionResponse` / `askResponse` | function | Build the `TClientMessage` answering a prompt.                          |
+| `applyUiIntentEvent`                 | function | Fold a `ui_intent` message into the explicit notice list (CMD-004).     |
+| `removeUiIntentNotice`               | function | Dismiss one ui-intent notice by id (idempotent).                        |
+| `describeUiIntentForGui`             | function | Explicit per-kind unavailable-on-this-surface text.                     |
 
 ### Components
 

--- a/packages/agent-transport-gui/src/components/SessionSurface.tsx
+++ b/packages/agent-transport-gui/src/components/SessionSurface.tsx
@@ -137,9 +137,37 @@ export function SessionSurface({
     !state.isThinking &&
     state.activeTools.length === 0;
 
+  // CMD-004 Stage D: `ui_intent` notices — a command issued from THIS surface requested a screen
+  // the GUI cannot render; the reducer folds it into an explicit dismissible notice (TC-05, never a
+  // silent drop). Tolerates a partial state stub (older embedders) via the nullish default.
+  const uiIntentNotices = state.uiIntentNotices ?? [];
+
   return (
     <div className="flex h-full flex-col bg-background text-foreground">
       <TitleBar status={state.status} surface={surface} />
+
+      {uiIntentNotices.length > 0 && (
+        <div className="flex flex-col gap-1 border-b border-border/50 bg-card/40 px-4 py-2">
+          {uiIntentNotices.map((n) => (
+            <div
+              key={n.id}
+              data-testid="ui-intent-notice"
+              data-intent={n.intentType}
+              className="flex items-center gap-3 font-mono text-[12px] text-amber-300/90"
+            >
+              <span className="flex-1">{n.notice}</span>
+              <button
+                type="button"
+                aria-label={`dismiss ${n.intentType} notice`}
+                className="rounded border border-border/60 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.16em] text-muted-foreground hover:text-foreground"
+                onClick={() => state.dismissUiIntentNotice?.(n.id)}
+              >
+                Dismiss
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
       <div className="flex flex-1 overflow-hidden">
         <div className="gui-rise flex min-w-0 flex-1 flex-col">

--- a/packages/agent-transport-gui/src/hooks/__tests__/ui-intent-state.test.ts
+++ b/packages/agent-transport-gui/src/hooks/__tests__/ui-intent-state.test.ts
@@ -1,0 +1,92 @@
+/**
+ * CMD-004 Stage D (TC-05) — folding a `ui_intent` server message into the GUI state produces either
+ * a mapped GUI surface state or an EXPLICIT unsupported-notice entry — NEVER a silent no-op.
+ *
+ * The GUI presentation core has no full-screen equivalent of the four intents today (no settings
+ * screen, session picker, plugin manager, or agent switcher exists in this package), so v1 maps
+ * every intent to an explicit user-visible "not available on this surface" notice — the
+ * spec-mandated unsupported signal (LSP `showDocument`-style), not a fallback.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyUiIntentEvent,
+  removeUiIntentNotice,
+  type TUiIntentNotice,
+} from '../ui-intent-state.js';
+
+import type { TCommandUiIntent } from '@robota-sdk/agent-interface-transport';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+function intentMessage(intent: TCommandUiIntent, requesterDriverId?: string): TServerMessage {
+  return {
+    type: 'ui_intent',
+    event: { intent, ...(requesterDriverId ? { requesterDriverId } : {}) },
+  };
+}
+
+const ALL_INTENTS: readonly TCommandUiIntent[] = [
+  { type: 'show-plugin-manager' },
+  { type: 'show-settings' },
+  { type: 'show-session-picker' },
+  { type: 'show-agent-switcher' },
+];
+
+describe('CMD-004 TC-05 — ui_intent fold (explicit notice, never silent)', () => {
+  it('EVERY intent kind folds to a visible entry — none is a silent no-op', () => {
+    let notices: readonly TUiIntentNotice[] = [];
+    for (const intent of ALL_INTENTS) {
+      notices = applyUiIntentEvent(notices, intentMessage(intent));
+    }
+    expect(notices).toHaveLength(ALL_INTENTS.length);
+    for (const [i, notice] of notices.entries()) {
+      expect(notice.intentType).toBe(ALL_INTENTS[i]!.type);
+      // The explicit unsupported signal the spec mandates (no GUI screen exists for these yet).
+      expect(notice.notice).toMatch(/not available on this surface/);
+      expect(notice.id.length).toBeGreaterThan(0);
+    }
+    // Distinct ids so a surface can dismiss one entry without touching the others.
+    expect(new Set(notices.map((n) => n.id)).size).toBe(notices.length);
+  });
+
+  it('each known intent names its screen in the notice (a user can tell WHAT was requested)', () => {
+    const fold = (intent: TCommandUiIntent): string =>
+      applyUiIntentEvent([], intentMessage(intent))[0]!.notice;
+    expect(fold({ type: 'show-settings' })).toMatch(/settings/i);
+    expect(fold({ type: 'show-session-picker' })).toMatch(/session picker/i);
+    expect(fold({ type: 'show-plugin-manager' })).toMatch(/plugin manager/i);
+    expect(fold({ type: 'show-agent-switcher' })).toMatch(/agent switcher/i);
+  });
+
+  it('keeps the requester attribution when stamped', () => {
+    const notices = applyUiIntentEvent([], intentMessage({ type: 'show-settings' }, 'device-42'));
+    expect(notices[0]!.requesterDriverId).toBe('device-42');
+  });
+
+  it('a non-ui_intent message returns the SAME list reference (no churn)', () => {
+    const before = applyUiIntentEvent([], intentMessage({ type: 'show-settings' }));
+    const after = applyUiIntentEvent(before, { type: 'thinking', isThinking: true });
+    expect(after).toBe(before);
+  });
+
+  it('an unknown future intent kind STILL yields an explicit notice (wire-level, never silent)', () => {
+    const notices = applyUiIntentEvent(
+      [],
+      intentMessage({ type: 'show-something-new' } as unknown as TCommandUiIntent),
+    );
+    expect(notices).toHaveLength(1);
+    expect(notices[0]!.notice).toMatch(/not available on this surface/);
+    expect(notices[0]!.notice).toContain('show-something-new');
+  });
+
+  it('removeUiIntentNotice dismisses exactly one entry by id', () => {
+    let notices = applyUiIntentEvent([], intentMessage({ type: 'show-settings' }));
+    notices = applyUiIntentEvent(notices, intentMessage({ type: 'show-session-picker' }));
+    const [first, second] = notices;
+    const remaining = removeUiIntentNotice(notices, first!.id);
+    expect(remaining).toEqual([second]);
+    // Unknown id → same reference (idempotent).
+    expect(removeUiIntentNotice(remaining, 'nope')).toBe(remaining);
+  });
+});

--- a/packages/agent-transport-gui/src/hooks/ui-intent-state.ts
+++ b/packages/agent-transport-gui/src/hooks/ui-intent-state.ts
@@ -1,0 +1,87 @@
+/**
+ * CMD-004 Stage D — pure `ui_intent` fold for the GUI surface (TC-05).
+ *
+ * The server requester-routes `ui_intent` (the WS handler forwards an intent only to the surface
+ * whose server-assigned driver id issued the command), so everything that arrives here is addressed
+ * to THIS surface and must be handled visibly. The GUI presentation core has no full-screen
+ * equivalent of the intents today (no settings screen / session picker / plugin manager / agent
+ * switcher exists in this package), so v1 folds EVERY intent into an explicit user-visible
+ * "not available on this surface" notice — the spec-mandated unsupported signal (LSP
+ * `showDocument`-style success/decline), never a silent drop. When a GUI screen for an intent
+ * lands, its arm in {@link describeUiIntentForGui} switches from a notice to the mapped surface
+ * state. Mirrors `prompt-state.ts` (pure list transition, shared by the WS and RTC clients).
+ */
+
+import type { TCommandUiIntent, TDriverId } from '@robota-sdk/agent-interface-transport';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+/** A visible, dismissible entry for a `ui_intent` this surface cannot render as a screen. */
+export interface IUiIntentNotice {
+  readonly id: string;
+  readonly intentType: string;
+  /** Explicit user-facing text — names the requested screen and that it is unavailable here. */
+  readonly notice: string;
+  /** The surface that issued the command (display-only attribution). */
+  readonly requesterDriverId?: TDriverId;
+}
+
+export type TUiIntentNotice = IUiIntentNotice;
+
+let noticeCounter = 0;
+function nextNoticeId(): string {
+  return `ui_intent_${++noticeCounter}_${Date.now()}`;
+}
+
+const UNAVAILABLE = 'is not available on this surface. Use the robota terminal on the host.';
+
+/**
+ * Describe one intent for this surface: the explicit unsupported notice (v1 — no GUI screen exists
+ * for any intent kind yet). An unknown wire-level kind (a newer host) still yields an explicit
+ * notice naming the raw kind — the "never a silent no-op" floor holds for future intents too.
+ */
+export function describeUiIntentForGui(intent: TCommandUiIntent): string {
+  switch (intent.type) {
+    case 'show-plugin-manager':
+      return `The plugin manager ${UNAVAILABLE}`;
+    case 'show-settings':
+      return `The settings screen ${UNAVAILABLE}`;
+    case 'show-session-picker':
+      return `The session picker ${UNAVAILABLE}`;
+    case 'show-agent-switcher':
+      return `The agent switcher ${UNAVAILABLE}`;
+    default:
+      // Spec-mandated unsupported signal for an intent kind this build does not know (not a
+      // fallback: the explicit notice IS the defined behavior for an unrenderable intent).
+      return `The screen requested by '${(intent as { type: string }).type}' ${UNAVAILABLE}`;
+  }
+}
+
+/**
+ * Fold a server message into the notice list: append an explicit entry on `ui_intent`; any other
+ * message returns the list unchanged (referential equality preserved).
+ */
+export function applyUiIntentEvent(
+  notices: readonly IUiIntentNotice[],
+  msg: TServerMessage,
+): readonly IUiIntentNotice[] {
+  if (msg.type !== 'ui_intent') return notices;
+  const { intent, requesterDriverId } = msg.event;
+  return [
+    ...notices,
+    {
+      id: nextNoticeId(),
+      intentType: intent.type,
+      notice: describeUiIntentForGui(intent),
+      ...(requesterDriverId ? { requesterDriverId } : {}),
+    },
+  ];
+}
+
+/** Dismiss one notice by id; an unknown id returns the SAME list reference (idempotent). */
+export function removeUiIntentNotice(
+  notices: readonly IUiIntentNotice[],
+  id: string,
+): readonly IUiIntentNotice[] {
+  const next = notices.filter((n) => n.id !== id);
+  return next.length === notices.length ? notices : next;
+}

--- a/packages/agent-transport-gui/src/hooks/useSessionClient.ts
+++ b/packages/agent-transport-gui/src/hooks/useSessionClient.ts
@@ -14,6 +14,11 @@ import {
   permissionResponse,
   type TPendingPrompt,
 } from './prompt-state.js';
+import {
+  applyUiIntentEvent,
+  removeUiIntentNotice,
+  type TUiIntentNotice,
+} from './ui-intent-state.js';
 import { createWsSessionClient } from '../client/ws-session-client.js';
 
 import type { TConnectionStatus, TClientMessage } from '../client/ws-session-client.js';
@@ -68,6 +73,13 @@ export interface IWsSessionState<TStatus extends string = TConnectionStatus> {
   answerPermission: (id: string, result: TPermissionResultValue) => void;
   /** Answer a pending ask prompt (sends `ask-response`). */
   answerAsk: (id: string, response: TActionResponse) => void;
+  /**
+   * CMD-004 Stage D: explicit notices for `ui_intent`s this surface cannot render as a screen
+   * (requester-routed to this surface by the server; never a silent drop — TC-05).
+   */
+  uiIntentNotices: readonly TUiIntentNotice[];
+  /** Dismiss one ui_intent notice by id. */
+  dismissUiIntentNotice: (id: string) => void;
 }
 
 let msgCounter = 0;
@@ -87,6 +99,7 @@ export function useSessionClient<TStatus extends string = TConnectionStatus>(
     null,
   );
   const [pendingPrompts, setPendingPrompts] = useState<readonly TPendingPrompt[]>([]);
+  const [uiIntentNotices, setUiIntentNotices] = useState<readonly TUiIntentNotice[]>([]);
 
   const clientRef = useRef<ISessionClientHandle | null>(null);
   const streamingIdRef = useRef<string | null>(null);
@@ -161,6 +174,12 @@ export function useSessionClient<TStatus extends string = TConnectionStatus>(
         setPendingPrompts((prev) => applyPromptEvent(prev, msg));
         break;
       }
+      case 'ui_intent': {
+        // CMD-004 Stage D: a command this surface issued requested a screen — fold it into an
+        // explicit visible notice (the GUI has no such screen yet; TC-05, never a silent no-op).
+        setUiIntentNotices((prev) => applyUiIntentEvent(prev, msg));
+        break;
+      }
       case 'complete':
       case 'interrupted': {
         const finalText = streamingTextRef.current;
@@ -195,6 +214,10 @@ export function useSessionClient<TStatus extends string = TConnectionStatus>(
     setPendingPrompts((prev) => prev.filter((p) => p.id !== id));
   }, []);
 
+  const dismissUiIntentNotice = useCallback((id: string): void => {
+    setUiIntentNotices((prev) => removeUiIntentNotice(prev, id));
+  }, []);
+
   useEffect(() => {
     const client = makeClient({ onMessage: handleMessage, onStatusChange: setStatus });
     clientRef.current = client;
@@ -216,6 +239,8 @@ export function useSessionClient<TStatus extends string = TConnectionStatus>(
     pendingPrompts,
     answerPermission,
     answerAsk,
+    uiIntentNotices,
+    dismissUiIntentNotice,
   };
 }
 

--- a/packages/agent-transport-gui/src/index.ts
+++ b/packages/agent-transport-gui/src/index.ts
@@ -21,6 +21,14 @@ export type { TConnectionStatus } from './client/ws-session-client.js';
 export { applyPromptEvent, permissionResponse, askResponse } from './hooks/prompt-state.js';
 export type { TPendingPrompt } from './hooks/prompt-state.js';
 
+// ── UI-intent (command screen-request) state — CMD-004 Stage D ──
+export {
+  applyUiIntentEvent,
+  removeUiIntentNotice,
+  describeUiIntentForGui,
+} from './hooks/ui-intent-state.js';
+export type { IUiIntentNotice, TUiIntentNotice } from './hooks/ui-intent-state.js';
+
 // ── Presentation components ─────────────────────────────────
 export { ConversationView } from './components/ConversationView.js';
 export { AgentActivityPanel } from './components/AgentActivityPanel.js';

--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -23,8 +23,14 @@ abort/...` from inbound `TClientMessage`s) + `cleanup()`. Framework-agnostic: wo
   `session.executeCommand(name, args, 'remote', driverId)` so the session executes host actions
   host-side BEFORE `command_result` is sent (the pre-CMD-004 handler dropped `result.effects` on the
   floor). The handler forwards the session's `ui_intent` events as `{ type: 'ui_intent', event }`
-  server messages (same pattern as `ask_request`); the event is requester-routed via
-  `event.requesterDriverId` and needs no answer (fire-and-forget).
+  server messages (same pattern as `ask_request`); the event needs no answer (fire-and-forget).
+  **Stage D — `ui_intent` is REQUESTER-ROUTED server-side:** `subscribeSessionEvents` delivers an
+  intent only when `event.requesterDriverId` matches THIS surface's server-assigned driver id (read
+  lazily via `ISubscribeSessionEventsOptions.getSurfaceDriverId` — lazy because the resume bridge
+  binds its id only at pairing). Other surfaces never see it. An UNATTRIBUTED intent (no requester
+  id — e.g. an idle model-invoked command) is unroutable and reaches every surface (never a silent
+  drop). In the `SessionResumeBridge`, routing happens BEFORE seq-stamping/buffering, so a foreign
+  surface's intent consumes no seq and cannot leak through a later `resume` replay.
 - **REMOTE-014 E5 co-drive attribution (SERVER-ASSIGNED, display-only).** `IWsHandlerOptions.driverId` binds a
   surface's server-assigned driver id (the E3 `deviceId`; the SessionResumeBridge sets it at pairing via
   `setDriverId`). The handler INJECTS it into every inbound `submit` / `permission-response` / `ask-response`

--- a/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
@@ -140,6 +140,47 @@ describe('SessionResumeBridge (REMOTE-013 TC-02)', () => {
     bridge.dispose();
   });
 
+  // CMD-004 Stage D — the bridge's single subscription requester-routes `ui_intent` with the
+  // LATE-BOUND driver id (`setDriverId` binds after pairing), so a skipped intent is never
+  // buffered and can never leak to this surface through a later `resume` replay.
+  it('requester-routes ui_intent by the late-bound driver id; foreign intents are never buffered', () => {
+    const { session, fire } = fakeSession();
+    const bridge = new SessionResumeBridge({ session });
+    const s = sink();
+    bridge.attach(s);
+
+    // Not paired yet (no driver id): an intent attributed to another surface is skipped.
+    fire('ui_intent', { intent: { type: 'show-settings' }, requesterDriverId: 'device-9' });
+    expect(s.calls).toHaveLength(0);
+
+    bridge.setDriverId('device-9');
+    fire('ui_intent', { intent: { type: 'show-settings' }, requesterDriverId: 'device-9' });
+    expect(frames(s)).toEqual([
+      {
+        type: 'ui_intent',
+        event: { intent: { type: 'show-settings' }, requesterDriverId: 'device-9' },
+        seq: 1, // the skipped foreign intent consumed NO seq — it was routed out BEFORE buffering
+      },
+    ]);
+
+    // Another surface's intent stays invisible even across a reconnect replay.
+    fire('ui_intent', { intent: { type: 'show-plugin-manager' }, requesterDriverId: 'device-2' });
+    const s2 = sink();
+    bridge.detach();
+    bridge.attach(s2);
+    bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+    expect(frames(s2).filter((f) => f.type === 'ui_intent')).toHaveLength(1); // only device-9's own
+
+    // Unattributed intents are unroutable → delivered (never silently dropped).
+    fire('ui_intent', { intent: { type: 'show-agent-switcher' } });
+    expect(frames(s2).at(-1)).toEqual({
+      type: 'ui_intent',
+      event: { intent: { type: 'show-agent-switcher' } },
+      seq: 2, // the device-2 intent consumed no seq either — routing precedes the buffer
+    });
+    bridge.dispose();
+  });
+
   it('regression: the WS createWsHandler path stamps NO seq', () => {
     const { session, fire } = fakeSession();
     const sent: unknown[] = [];

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
@@ -321,8 +321,14 @@ describe('WebSocket Transport Handler', () => {
     ).toHaveBeenCalledWith('settings', '', 'remote', 'device-7');
   });
 
-  it('forwards ui_intent session events to the client (CMD-004 Phase 2)', () => {
-    const { sent, session } = setup();
+  it('forwards ui_intent session events to the requesting client (CMD-004 Phase 2)', () => {
+    const session = createMockSession();
+    const sent: TServerMessage[] = [];
+    createWsHandler({
+      session: session as unknown as IInteractiveSession,
+      send: (msg) => sent.push(msg),
+      driverId: 'device-7',
+    });
     session._emit('ui_intent', {
       intent: { type: 'show-settings' },
       requesterDriverId: 'device-7',
@@ -333,6 +339,60 @@ describe('WebSocket Transport Handler', () => {
         event: { intent: { type: 'show-settings' }, requesterDriverId: 'device-7' },
       },
     ]);
+  });
+
+  // CMD-004 Stage D — `ui_intent` is REQUESTER-ROUTED (the spec's Key mechanics): the surface that
+  // issued the command renders the intent; other surfaces never see it. Only an UNATTRIBUTED intent
+  // (no requester id — e.g. an idle model-invoked command) reaches every surface, because it cannot
+  // be routed and a silent drop is banned.
+  describe('ui_intent requester routing (CMD-004 Stage D)', () => {
+    function twoSurfaces() {
+      const session = createMockSession();
+      const sentA: TServerMessage[] = [];
+      const sentB: TServerMessage[] = [];
+      createWsHandler({
+        session: session as unknown as IInteractiveSession,
+        send: (msg) => sentA.push(msg),
+        driverId: 'device-A',
+      });
+      createWsHandler({
+        session: session as unknown as IInteractiveSession,
+        send: (msg) => sentB.push(msg),
+        driverId: 'device-B',
+      });
+      return { session, sentA, sentB };
+    }
+
+    it('routes a requester-stamped intent ONLY to the invoking surface — not broadcast', () => {
+      const { session, sentA, sentB } = twoSurfaces();
+      session._emit('ui_intent', {
+        intent: { type: 'show-session-picker' },
+        requesterDriverId: 'device-A',
+      });
+      expect(sentA).toEqual([
+        {
+          type: 'ui_intent',
+          event: { intent: { type: 'show-session-picker' }, requesterDriverId: 'device-A' },
+        },
+      ]);
+      expect(sentB).toEqual([]);
+    });
+
+    it('an unattributed intent reaches every surface (unroutable — never silently dropped)', () => {
+      const { session, sentA, sentB } = twoSurfaces();
+      session._emit('ui_intent', { intent: { type: 'show-settings' } });
+      expect(sentA).toEqual([{ type: 'ui_intent', event: { intent: { type: 'show-settings' } } }]);
+      expect(sentB).toEqual(sentA);
+    });
+
+    it("a surface with NO server-assigned id never receives another surface's intent", () => {
+      const { sent, session } = setup(); // setup() builds a handler without a driverId
+      session._emit('ui_intent', {
+        intent: { type: 'show-agent-switcher' },
+        requesterDriverId: 'device-elsewhere',
+      });
+      expect(sent).toEqual([]);
+    });
   });
 
   it('invalid JSON sends protocol_error', () => {

--- a/packages/agent-transport-protocol/src/session-resume-bridge.ts
+++ b/packages/agent-transport-protocol/src/session-resume-bridge.ts
@@ -20,7 +20,8 @@
  */
 
 import { ResumeBuffer, type IResumeBufferOptions } from './resume-buffer.js';
-import { handleClientMessage, parseClientMessage, subscribeSessionEvents } from './ws-handler.js';
+import { handleClientMessage, parseClientMessage } from './ws-handler.js';
+import { subscribeSessionEvents } from './ws-session-events.js';
 
 import type { TSeqServerMessage, TServerMessage } from './ws-protocol.js';
 import type { IInteractiveSession, TDriverId } from '@robota-sdk/agent-interface-transport';
@@ -62,7 +63,12 @@ export class SessionResumeBridge {
     this.buffer = new ResumeBuffer(options.buffer);
     this.driverId = options.driverId;
     // ONE subscription for the whole session — outlives every channel. Every event → seq-stamped + buffered.
-    this.unsubscribe = subscribeSessionEvents(this.session, (message) => this.emit(message));
+    // CMD-004 Stage D: `ui_intent` is requester-routed against the LATE-BOUND driver id (bound by
+    // `setDriverId` after pairing) — routing happens BEFORE buffering, so a foreign surface's intent
+    // consumes no seq and can never leak through a later `resume` replay.
+    this.unsubscribe = subscribeSessionEvents(this.session, (message) => this.emit(message), {
+      getSurfaceDriverId: () => this.driverId,
+    });
   }
 
   /** Set the current channel sink (on connect / reconnect). Live messages reach the client; replay is `resume`-driven. */

--- a/packages/agent-transport-protocol/src/ws-handler.ts
+++ b/packages/agent-transport-protocol/src/ws-handler.ts
@@ -12,21 +12,15 @@ import {
   handleBackgroundControlMessage,
   handleBackgroundQueryMessage,
 } from './ws-background-messages.js';
+import { subscribeSessionEvents } from './ws-session-events.js';
 
 import type { TClientMessage, TServerMessage } from './ws-protocol.js';
-import type { TDriverId } from '@robota-sdk/agent-interface-transport';
-import type {
-  IAskRequestEvent,
-  IExecutionResult,
-  IExecutionWorkspaceEvent,
-  IInteractiveSession,
-  IPermissionRequestEvent,
-  IPromptResolvedEvent,
-  IToolState,
-  IUiIntentEvent,
-  TBackgroundJobGroupEvent,
-} from '@robota-sdk/agent-interface-transport';
-import type { TBackgroundTaskEvent } from '@robota-sdk/agent-interface-transport';
+import type { IInteractiveSession, TDriverId } from '@robota-sdk/agent-interface-transport';
+
+// Outbound session→TServerMessage fan-out (incl. CMD-004 requester-routed `ui_intent`) lives in
+// `ws-session-events.ts`; re-exported here for the bridge and existing importers.
+export { subscribeSessionEvents } from './ws-session-events.js';
+export type { ISubscribeSessionEventsOptions } from './ws-session-events.js';
 
 export interface IWsHandlerOptions {
   /** IInteractiveSession to expose. */
@@ -63,89 +57,12 @@ export function createWsHandler(options: IWsHandlerOptions): {
   onMessage: (data: string) => void;
   cleanup: () => void;
 } {
-  const cleanup = subscribeSessionEvents(options.session, options.send);
+  const cleanup = subscribeSessionEvents(options.session, options.send, {
+    getSurfaceDriverId: () => options.driverId,
+  });
   const onMessage = createWsMessageHandler(options.session, options.send, options.driverId);
 
   return { onMessage, cleanup };
-}
-
-/**
- * Subscribe the session's events and forward each as a `TServerMessage` via `send`; returns an unsubscribe.
- * Exported (REMOTE-013 E4) so the persistent {@link SessionResumeBridge} can own a SINGLE subscription that
- * outlives per-channel handlers.
- */
-export function subscribeSessionEvents(
-  session: IInteractiveSession,
-  send: (message: TServerMessage) => void,
-): () => void {
-  // REMOTE-014 E5: stamp the ACTIVE turn's driver id onto TURN-AUTHORED events (co-drive authorship,
-  // display-only), read at emit time. Only these events — background/goal/memory/execution-workspace events
-  // are NOT authored by a driver turn and carry no `driverId`. `undefined` when idle or unattributed.
-  const attr = (): { driverId?: TDriverId } => {
-    const d = session.getActiveDriverId?.() ?? undefined;
-    return d ? { driverId: d } : {};
-  };
-  const onUserMessage = (content: string): void =>
-    send({ type: 'user_message', content, ...attr() });
-  const onTextDelta = (delta: string): void => send({ type: 'text_delta', delta, ...attr() });
-  const onToolStart = (state: IToolState): void => send({ type: 'tool_start', state, ...attr() });
-  const onToolEnd = (state: IToolState): void => send({ type: 'tool_end', state, ...attr() });
-  const onThinking = (isThinking: boolean): void =>
-    send({ type: 'thinking', isThinking, ...attr() });
-  const onComplete = (result: IExecutionResult): void =>
-    send({ type: 'complete', result, ...attr() });
-  const onInterrupted = (result: IExecutionResult): void =>
-    send({ type: 'interrupted', result, ...attr() });
-  const onError = (error: Error): void =>
-    send({ type: 'error', message: error.message, ...attr() });
-  const onBackgroundTaskEvent = (event: TBackgroundTaskEvent): void =>
-    send({ type: 'background_task_event', event });
-  const onBackgroundJobGroupEvent = (event: TBackgroundJobGroupEvent): void =>
-    send({ type: 'background_job_group_event', event });
-  const onExecutionWorkspace = (event: IExecutionWorkspaceEvent): void =>
-    send({ type: 'execution_workspace_event', snapshot: event.snapshot });
-  // REMOTE-007: forward the transport-neutral prompt events so a remote surface can render + answer the
-  // SAME permission/ask prompt; `prompt_resolved` dismisses it when another surface answered first.
-  const onPermissionRequest = (event: IPermissionRequestEvent): void =>
-    send({ type: 'permission_request', event });
-  const onAskRequest = (event: IAskRequestEvent): void => send({ type: 'ask_request', event });
-  const onPromptResolved = (event: IPromptResolvedEvent): void =>
-    send({ type: 'prompt_resolved', event });
-  const onUiIntent = (event: IUiIntentEvent): void => send({ type: 'ui_intent', event }); // CMD-004
-
-  session.on('user_message', onUserMessage);
-  session.on('text_delta', onTextDelta);
-  session.on('tool_start', onToolStart);
-  session.on('tool_end', onToolEnd);
-  session.on('thinking', onThinking);
-  session.on('complete', onComplete);
-  session.on('interrupted', onInterrupted);
-  session.on('error', onError);
-  session.on('background_task_event', onBackgroundTaskEvent);
-  session.on('background_job_group_event', onBackgroundJobGroupEvent);
-  session.on('execution_workspace_event', onExecutionWorkspace);
-  session.on('permission_request', onPermissionRequest);
-  session.on('ask_request', onAskRequest);
-  session.on('prompt_resolved', onPromptResolved);
-  session.on('ui_intent', onUiIntent);
-
-  return (): void => {
-    session.off('user_message', onUserMessage);
-    session.off('text_delta', onTextDelta);
-    session.off('tool_start', onToolStart);
-    session.off('tool_end', onToolEnd);
-    session.off('thinking', onThinking);
-    session.off('complete', onComplete);
-    session.off('interrupted', onInterrupted);
-    session.off('error', onError);
-    session.off('background_task_event', onBackgroundTaskEvent);
-    session.off('background_job_group_event', onBackgroundJobGroupEvent);
-    session.off('execution_workspace_event', onExecutionWorkspace);
-    session.off('permission_request', onPermissionRequest);
-    session.off('ask_request', onAskRequest);
-    session.off('prompt_resolved', onPromptResolved);
-    session.off('ui_intent', onUiIntent);
-  };
 }
 
 function createWsMessageHandler(
@@ -222,11 +139,7 @@ function isSessionQueryMessage(msg: TClientMessage): msg is Extract<
   TClientMessage,
   {
     type:
-      | 'get-messages'
-      | 'get-context'
-      | 'get-executing'
-      | 'get-pending'
-      | 'get-execution-workspace';
+      'get-messages' | 'get-context' | 'get-executing' | 'get-pending' | 'get-execution-workspace';
   }
 > {
   return (

--- a/packages/agent-transport-protocol/src/ws-session-events.ts
+++ b/packages/agent-transport-protocol/src/ws-session-events.ts
@@ -1,0 +1,122 @@
+/**
+ * Outbound session-event subscription for the WS/WebRTC transports (split from `ws-handler.ts` —
+ * the inbound message routing stays there; this module owns the session→`TServerMessage` fan-out).
+ *
+ * Used by `createWsHandler` (one subscription per channel) and by the persistent
+ * `SessionResumeBridge` (REMOTE-013 E4 — a SINGLE subscription that outlives per-channel handlers).
+ */
+
+import type { TServerMessage } from './ws-protocol.js';
+import type { TDriverId } from '@robota-sdk/agent-interface-transport';
+import type {
+  IAskRequestEvent,
+  IExecutionResult,
+  IExecutionWorkspaceEvent,
+  IInteractiveSession,
+  IPermissionRequestEvent,
+  IPromptResolvedEvent,
+  IToolState,
+  IUiIntentEvent,
+  TBackgroundJobGroupEvent,
+  TBackgroundTaskEvent,
+} from '@robota-sdk/agent-interface-transport';
+
+/** Options for {@link subscribeSessionEvents}. */
+export interface ISubscribeSessionEventsOptions {
+  /**
+   * CMD-004 Stage D: lazily read the SERVER-ASSIGNED driver id of THIS surface — `ui_intent` is
+   * requester-routed against it (lazy because the resume bridge binds the id only after pairing).
+   */
+  getSurfaceDriverId?: () => TDriverId | undefined;
+}
+
+/**
+ * Subscribe the session's events and forward each as a `TServerMessage` via `send`; returns an unsubscribe.
+ * Exported (REMOTE-013 E4) so the persistent `SessionResumeBridge` can own a SINGLE subscription that
+ * outlives per-channel handlers.
+ */
+export function subscribeSessionEvents(
+  session: IInteractiveSession,
+  send: (message: TServerMessage) => void,
+  options?: ISubscribeSessionEventsOptions,
+): () => void {
+  // REMOTE-014 E5: stamp the ACTIVE turn's driver id onto TURN-AUTHORED events (co-drive authorship,
+  // display-only), read at emit time. Only these events — background/goal/memory/execution-workspace events
+  // are NOT authored by a driver turn and carry no `driverId`. `undefined` when idle or unattributed.
+  const attr = (): { driverId?: TDriverId } => {
+    const d = session.getActiveDriverId?.() ?? undefined;
+    return d ? { driverId: d } : {};
+  };
+  const onUserMessage = (content: string): void =>
+    send({ type: 'user_message', content, ...attr() });
+  const onTextDelta = (delta: string): void => send({ type: 'text_delta', delta, ...attr() });
+  const onToolStart = (state: IToolState): void => send({ type: 'tool_start', state, ...attr() });
+  const onToolEnd = (state: IToolState): void => send({ type: 'tool_end', state, ...attr() });
+  const onThinking = (isThinking: boolean): void =>
+    send({ type: 'thinking', isThinking, ...attr() });
+  const onComplete = (result: IExecutionResult): void =>
+    send({ type: 'complete', result, ...attr() });
+  const onInterrupted = (result: IExecutionResult): void =>
+    send({ type: 'interrupted', result, ...attr() });
+  const onError = (error: Error): void =>
+    send({ type: 'error', message: error.message, ...attr() });
+  const onBackgroundTaskEvent = (event: TBackgroundTaskEvent): void =>
+    send({ type: 'background_task_event', event });
+  const onBackgroundJobGroupEvent = (event: TBackgroundJobGroupEvent): void =>
+    send({ type: 'background_job_group_event', event });
+  const onExecutionWorkspace = (event: IExecutionWorkspaceEvent): void =>
+    send({ type: 'execution_workspace_event', snapshot: event.snapshot });
+  // REMOTE-007: forward the transport-neutral prompt events so a remote surface can render + answer the
+  // SAME permission/ask prompt; `prompt_resolved` dismisses it when another surface answered first.
+  const onPermissionRequest = (event: IPermissionRequestEvent): void =>
+    send({ type: 'permission_request', event });
+  const onAskRequest = (event: IAskRequestEvent): void => send({ type: 'ask_request', event });
+  const onPromptResolved = (event: IPromptResolvedEvent): void =>
+    send({ type: 'prompt_resolved', event });
+  // CMD-004 Stage D: `ui_intent` is REQUESTER-ROUTED — delivered only to the surface whose
+  // server-assigned driver id issued the command. An UNATTRIBUTED intent (no requester id, e.g. an
+  // idle model-invoked command) is unroutable and reaches every surface — never a silent drop.
+  const onUiIntent = (event: IUiIntentEvent): void => {
+    if (
+      event.requesterDriverId !== undefined &&
+      event.requesterDriverId !== options?.getSurfaceDriverId?.()
+    ) {
+      return; // another surface's intent — this surface never sees it (and never buffers it)
+    }
+    send({ type: 'ui_intent', event });
+  };
+
+  session.on('user_message', onUserMessage);
+  session.on('text_delta', onTextDelta);
+  session.on('tool_start', onToolStart);
+  session.on('tool_end', onToolEnd);
+  session.on('thinking', onThinking);
+  session.on('complete', onComplete);
+  session.on('interrupted', onInterrupted);
+  session.on('error', onError);
+  session.on('background_task_event', onBackgroundTaskEvent);
+  session.on('background_job_group_event', onBackgroundJobGroupEvent);
+  session.on('execution_workspace_event', onExecutionWorkspace);
+  session.on('permission_request', onPermissionRequest);
+  session.on('ask_request', onAskRequest);
+  session.on('prompt_resolved', onPromptResolved);
+  session.on('ui_intent', onUiIntent);
+
+  return (): void => {
+    session.off('user_message', onUserMessage);
+    session.off('text_delta', onTextDelta);
+    session.off('tool_start', onToolStart);
+    session.off('tool_end', onToolEnd);
+    session.off('thinking', onThinking);
+    session.off('complete', onComplete);
+    session.off('interrupted', onInterrupted);
+    session.off('error', onError);
+    session.off('background_task_event', onBackgroundTaskEvent);
+    session.off('background_job_group_event', onBackgroundJobGroupEvent);
+    session.off('execution_workspace_event', onExecutionWorkspace);
+    session.off('permission_request', onPermissionRequest);
+    session.off('ask_request', onAskRequest);
+    session.off('prompt_resolved', onPromptResolved);
+    session.off('ui_intent', onUiIntent);
+  };
+}

--- a/packages/agent-transport/docs/SPEC.md
+++ b/packages/agent-transport/docs/SPEC.md
@@ -55,6 +55,23 @@ one-way `InteractionEvent` stream into `events`, which the driver exposes as `as
 CMD-004 `askUser` a command may issue (an empty queue resolves `{ type: 'cancelled' }`, so a run never
 deadlocks). This is the in-process form of "drive the agent at will" (TEST-008).
 
+### Host-action parity (CMD-004 Stage D)
+
+A command's HOST ACTIONS (`language-change`, `settings-reset`, `session-exit`/`-restart`,
+`session-rename`, …) are executed by the SESSION via the injected `ICommandHostAdapters` — the LSP
+`workspace/executeCommand` model — so they work with **zero attached surfaces**: a headless or
+programmatic embedding gets the same command semantics as the TUI/GUI. An embedder that wires
+`commandHostAdapters` (settings/process/…) into its `InteractiveSession` gets full host execution;
+an embedding with no adapter for a requested action gets an EXPLICIT failure in the command result
+naming the missing capability (`Cannot apply '<action>': … not available in this environment.`) —
+never a silent skip (no-fallback). `createProgrammaticAgent` wires no adapters today, so host
+actions surface that explicit failure through the `command-result` event as data. UI intents
+(`ui_intent`) are fire-and-forget presentation requests: with zero listeners attached they are a
+defined no-op (there is no surface to render them; the host action half is unaffected). Proven by
+`src/__tests__/headless-host-action-parity.test.ts` and the multi-surface exit/restart policy e2e
+`src/__tests__/ws-multi-surface-exit-policy.test.ts` (TC-09: a remote `/exit` or restart acts on
+the SHARED host serving all surfaces — local == remote, REMOTE-006).
+
 ### Headless lifecycle
 
 `HeadlessInteractionChannel` constructs the `InteractiveSession`, runs a single prompt via

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -87,6 +87,7 @@
   },
   "devDependencies": {
     "@robota-sdk/agent-command": "workspace:*",
+    "@robota-sdk/agent-transport-protocol": "workspace:*",
     "rimraf": "^5.0.10",
     "tsdown": "^0.22.14",
     "tsx": "^4.23.1",

--- a/packages/agent-transport/src/__tests__/headless-host-action-parity.test.ts
+++ b/packages/agent-transport/src/__tests__/headless-host-action-parity.test.ts
@@ -1,0 +1,150 @@
+/**
+ * CMD-004 Stage D — headless/programmatic HOST-ACTION PARITY for the transport core.
+ *
+ * The LSP `workspace/executeCommand` model the spec adopts: a command's host actions are executed
+ * by the SESSION (the host) via the injected `ICommandHostAdapters` — with ZERO surfaces attached.
+ * A headless or programmatic embedder therefore gets the SAME command semantics as the TUI/GUI:
+ * `/language ko` writes settings and requests a restart with no renderer anywhere in the process.
+ * The no-fallback floor also holds headless: an action whose adapter is not wired yields an
+ * EXPLICIT failure in the command result — never a silent skip.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  createLanguageCommandModule,
+  createSettingsCommandModule,
+} from '@robota-sdk/agent-command';
+import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
+import { InteractiveSession } from '@robota-sdk/agent-framework';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createProgrammaticAgent } from '../programmatic/index.js';
+
+import type { ICommandHostAdapters, ICommandModule } from '@robota-sdk/agent-framework';
+import type { IAgentDriver, InteractionEvent } from '@robota-sdk/agent-interface-transport';
+
+/** The minimal runtime-session stub the InteractiveSession wraps (no provider turn is run here). */
+function createRuntimeSession(): Record<string, unknown> {
+  return {
+    run: vi.fn().mockResolvedValue('answer'),
+    abort: vi.fn(),
+    clearHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    injectMessage: vi.fn(),
+    getContextState: () => ({
+      maxTokens: 100,
+      usedTokens: 0,
+      usedPercentage: 0,
+      remainingPercentage: 100,
+    }),
+    getSessionId: () => 'session_headless_parity',
+    getMessageCount: () => 0,
+    getSystemMessage: vi.fn().mockReturnValue('system'),
+    getToolSchemas: vi.fn().mockReturnValue([]),
+    getEventService: () => ({ subscribe: () => {}, unsubscribe: () => {} }),
+  };
+}
+
+/** A zero-surface session: NOTHING subscribes to its events — the pure headless embedding. */
+function headlessSession(adapters: ICommandHostAdapters): InteractiveSession {
+  return new InteractiveSession({
+    session: createRuntimeSession() as never,
+    commandModules: [createLanguageCommandModule(), createSettingsCommandModule()],
+    commandHostAdapters: adapters,
+  });
+}
+
+describe('CMD-004 Stage D — host-action parity with ZERO attached surfaces (headless)', () => {
+  it('/language ko writes via the settings adapter and requests a restart — no surface anywhere', async () => {
+    const write = vi.fn();
+    const requestRestart = vi.fn();
+    const session = headlessSession({
+      settings: { read: () => ({}), write },
+      process: { requestExit: vi.fn(), requestRestart },
+    });
+
+    const result = await session.executeCommand('language', 'ko', 'user');
+
+    expect(result?.success).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ language: 'ko' }));
+    expect(requestRestart).toHaveBeenCalledTimes(1);
+    // Applied host actions are stripped — a surface that later replays the result cannot re-apply.
+    expect(result?.effects ?? []).toEqual([]);
+  });
+
+  it('an absent adapter is an EXPLICIT failure in the result — never a silent skip (no-fallback)', async () => {
+    // No process adapter wired: the language change cannot restart → explicit failure naming the gap.
+    const write = vi.fn();
+    const session = headlessSession({ settings: { read: () => ({}), write } });
+
+    const result = await session.executeCommand('language', 'ko', 'user');
+
+    expect(result?.success).toBe(false);
+    expect(result?.message).toContain("Cannot apply 'language-change'");
+    expect(result?.message).toContain('not available in this environment');
+  });
+});
+
+/** A command emitting a direct (Stage-E shape) host action — used through the programmatic driver. */
+const RELOAD_LANGUAGE_MODULE: ICommandModule = {
+  name: 'parity',
+  systemCommands: [
+    {
+      name: 'parity-language',
+      description: 'host-action parity probe',
+      userInvocable: true,
+      safety: 'read-only',
+      requiresPermission: false,
+      execute: () => ({
+        message: 'Language set to ko.',
+        success: true,
+        hostActions: [{ type: 'language-change', language: 'ko' }],
+      }),
+    },
+  ],
+};
+
+function commandOutputs(events: readonly InteractionEvent[]): string[] {
+  return events
+    .filter(
+      (e): e is Extract<InteractionEvent, { type: 'command-result' }> =>
+        e.type === 'command-result',
+    )
+    .map((e) => e.output);
+}
+
+describe('CMD-004 Stage D — programmatic driver surface (no adapters wired)', () => {
+  let cwd: string;
+  let driver: IAgentDriver | undefined;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'robota-parity-'));
+  });
+  afterEach(async () => {
+    await driver?.stop();
+    driver = undefined;
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('a host action reaching an adapter-less programmatic embedding fails EXPLICITLY, visibly in the command-result', async () => {
+    const scripted = createScriptedProvider([{ text: 'unused' }]);
+    driver = createProgrammaticAgent({
+      provider: scripted.provider,
+      cwd,
+      commandModules: [RELOAD_LANGUAGE_MODULE],
+    });
+    await driver.start();
+
+    await driver.send('/parity-language');
+
+    // The whole programmatic stack surfaces the no-fallback failure as DATA — not a silent no-op.
+    const outputs = commandOutputs(driver.events);
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]).toContain("Cannot apply 'language-change'");
+    expect(outputs[0]).toContain('not available in this environment');
+  });
+});

--- a/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
+++ b/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
@@ -1,0 +1,156 @@
+/**
+ * CMD-004 Stage D (TC-09) — WS e2e: the MULTI-SURFACE exit/restart policy.
+ *
+ * The spec's deliberate decision (local == remote, REMOTE-006): host-executed `session-exit` /
+ * `session-restart` invoked from a REMOTE surface terminate/restart the SHARED HOST serving ALL
+ * attached surfaces — exit/restart are session-scoped semantics, not surface-scoped ones. A surface
+ * that only wants to detach disconnects; `/exit` ends the session for everyone.
+ *
+ * Placement: this e2e needs a REAL `InteractiveSession` (agent-framework, a runtime dependency of
+ * this package) under real `createWsHandler` surfaces (agent-transport-protocol, a devDependency) —
+ * agent-transport is the Stage-D-owned package that legitimately sees both sides.
+ */
+
+import { createExitCommandModule, createLanguageCommandModule } from '@robota-sdk/agent-command';
+import { InteractiveSession } from '@robota-sdk/agent-framework';
+import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ICommandHostAdapters } from '@robota-sdk/agent-framework';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+function createRuntimeSession(): Record<string, unknown> {
+  return {
+    run: vi.fn().mockResolvedValue('answer'),
+    abort: vi.fn(),
+    clearHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    injectMessage: vi.fn(),
+    getContextState: () => ({
+      maxTokens: 100,
+      usedTokens: 0,
+      usedPercentage: 0,
+      remainingPercentage: 100,
+    }),
+    getSessionId: () => 'session_tc09',
+    getMessageCount: () => 0,
+    getSystemMessage: vi.fn().mockReturnValue('system'),
+    getToolSchemas: vi.fn().mockReturnValue([]),
+    getEventService: () => ({ subscribe: () => {}, unsubscribe: () => {} }),
+  };
+}
+
+interface ISurface {
+  sent: TServerMessage[];
+  onMessage: (data: string) => void;
+}
+
+/** ONE shared host session with TWO attached remote WS surfaces (device-A / device-B). */
+function setupSharedHost(adapters: ICommandHostAdapters): {
+  session: InteractiveSession;
+  surfaceA: ISurface;
+  surfaceB: ISurface;
+} {
+  const session = new InteractiveSession({
+    session: createRuntimeSession() as never,
+    commandModules: [createExitCommandModule(), createLanguageCommandModule()],
+    commandHostAdapters: adapters,
+  });
+  const attach = (driverId: string): ISurface => {
+    const sent: TServerMessage[] = [];
+    const { onMessage } = createWsHandler({
+      session: session as unknown as IInteractiveSession,
+      send: (msg) => sent.push(msg),
+      driverId,
+    });
+    return { sent, onMessage };
+  };
+  return { session, surfaceA: attach('device-A'), surfaceB: attach('device-B') };
+}
+
+async function waitFor<T extends TServerMessage['type']>(
+  sent: TServerMessage[],
+  type: T,
+): Promise<Extract<TServerMessage, { type: T }>> {
+  await vi.waitFor(() => {
+    if (!sent.some((m) => m.type === type)) throw new Error(`no ${type} yet`);
+  });
+  return sent.find((m) => m.type === type) as Extract<TServerMessage, { type: T }>;
+}
+
+describe('CMD-004 TC-09 — multi-surface exit/restart acts on the SHARED host (local == remote)', () => {
+  it("a remote /exit from surface A terminates the shared host serving BOTH surfaces — not just surface A's attachment", async () => {
+    const requestExit = vi.fn();
+    const requestRestart = vi.fn();
+    const { surfaceA, surfaceB } = setupSharedHost({
+      process: { requestExit, requestRestart },
+    });
+
+    surfaceA.onMessage(JSON.stringify({ type: 'command', name: 'exit', args: '' }));
+
+    // With interactive surfaces attached, /exit self-asks for confirmation over the transport-neutral
+    // ask seam; the parked ask BROADCASTS to both co-driving surfaces (REMOTE-007) …
+    const askA = await waitFor(surfaceA.sent, 'ask_request');
+    const askB = await waitFor(surfaceB.sent, 'ask_request');
+    expect(askB.event.id).toBe(askA.event.id);
+
+    // … and the REQUESTING surface confirms.
+    surfaceA.onMessage(
+      JSON.stringify({
+        type: 'ask-response',
+        id: askA.event.id,
+        response: { type: 'answer', values: ['yes'] },
+      }),
+    );
+
+    const result = await waitFor(surfaceA.sent, 'command_result');
+    expect(result.success).toBe(true);
+
+    // THE policy assertion: the ONE shared process adapter exits the host — session-scoped, for
+    // every surface — exactly once. No surface-scoped teardown happens instead of it.
+    expect(requestExit).toHaveBeenCalledTimes(1);
+    expect(requestExit).toHaveBeenCalledWith('prompt_input_exit');
+    expect(requestRestart).not.toHaveBeenCalled();
+
+    // The command result goes to the REQUESTER only; the host action is what the other surface shares.
+    expect(surfaceB.sent.some((m) => m.type === 'command_result')).toBe(false);
+  });
+
+  it('a remote /language (restart host action) from surface B restarts the SHARED host once', async () => {
+    const write = vi.fn();
+    const requestExit = vi.fn();
+    const requestRestart = vi.fn();
+    const { surfaceA, surfaceB } = setupSharedHost({
+      settings: { read: () => ({}), write },
+      process: { requestExit, requestRestart },
+    });
+
+    surfaceB.onMessage(JSON.stringify({ type: 'command', name: 'language', args: 'ko' }));
+    const result = await waitFor(surfaceB.sent, 'command_result');
+
+    expect(result.success).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    // One shared host, one restart — despite TWO attached surfaces (no per-surface duplication).
+    expect(requestRestart).toHaveBeenCalledTimes(1);
+    expect(requestRestart).toHaveBeenCalledWith('other', 'Language change restart');
+    expect(surfaceA.sent.some((m) => m.type === 'command_result')).toBe(false);
+  });
+
+  it('local == remote: a LOCAL /exit produces the IDENTICAL shared-host call as the remote one', async () => {
+    const requestExit = vi.fn();
+    // Zero attached surfaces → no interactive confirm (the headless embedding); the host action runs.
+    const session = new InteractiveSession({
+      session: createRuntimeSession() as never,
+      commandModules: [createExitCommandModule()],
+      commandHostAdapters: { process: { requestExit, requestRestart: vi.fn() } },
+    });
+
+    const result = await session.executeCommand('exit', '', 'user');
+
+    expect(result?.success).toBe(true);
+    // Same adapter call, same args as the remote-surface path above — the REMOTE-006 owner principle.
+    expect(requestExit).toHaveBeenCalledTimes(1);
+    expect(requestExit).toHaveBeenCalledWith('prompt_input_exit');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2007,6 +2007,9 @@ importers:
       '@robota-sdk/agent-command':
         specifier: workspace:*
         version: link:../agent-command
+      '@robota-sdk/agent-transport-protocol':
+        specifier: workspace:*
+        version: link:../agent-transport-protocol
       rimraf:
         specifier: ^5.0.10
         version: 5.0.10


### PR DESCRIPTION
## CMD-004 Phase 2 — Stage D (remote surfaces)

Per the approved spec `.agents/spec-docs/active/CMD-004-command-action-ui-separation.md` (Stage D). Builds on Stages A+B (#1338). Package-disjoint from Stage C (TUI) by design — touches `agent-transport-protocol`, `agent-transport-gui`, `agent-transport`, plus one jsdom test in `apps/agent-app` (the GUI component test home). The spec file itself is deliberately NOT edited here (Stage C's PR owns it this wave); Stage-D evidence is recorded below for folding into the Evidence Log after merge.

### 1. `agent-transport-protocol` — `ui_intent` is now REQUESTER-ROUTED server-side

Stage B forwarded `ui_intent` next to `ask_request` but to EVERY client (broadcast). The spec's Key mechanics require requester routing: the surface that issued the command renders the intent; other surfaces never see it.

- `subscribeSessionEvents` (split into `ws-session-events.ts` for the file-size ratchet — `ws-handler.ts` 393→286 lines, back under its frozen 370 baseline) delivers an intent only when `event.requesterDriverId` matches the surface's SERVER-ASSIGNED driver id, read lazily via `getSurfaceDriverId` so the `SessionResumeBridge`'s late-bound pairing id (`setDriverId`) routes correctly.
- An UNATTRIBUTED intent (no requester id — idle model-invoked command) is unroutable and reaches every surface: never a silent drop ("broadcast only where the spec says" — nothing else broadcasts).
- Bridge: routing happens BEFORE seq-stamping/buffering, so a foreign surface's intent consumes no seq and cannot leak through a later `resume` replay.

**RED → GREEN (requester-routing, red-first as required):**
- RED (recorded, pre-fix): `npx vitest run src/__tests__/ws-handler.test.ts src/__tests__/session-resume-bridge.test.ts` → **3 failed | 41 passed** — `routes a requester-stamped intent ONLY to the invoking surface` failed with device-B ALSO receiving device-A's intent (`expected [] to deeply equal [{ type: 'ui_intent', … }]` on the non-requesting surface), the no-id surface received a foreign intent, and the bridge forwarded a foreign intent pre-`setDriverId`.
- GREEN (post-fix): full protocol suite → **58 passed (5 files)**.

### 2. `agent-transport-gui` — explicit visible notices (TC-05, no silent drop)

The GUI presentation core has NO full-screen equivalent of any of the four intents today (no settings screen / session picker / plugin manager / agent switcher exists in the package — verified before implementing), so the spec's "render the equivalents it has, explicit notice for the rest" resolves to: every intent folds to an explicit, dismissible "not available on this surface" notice.

- New pure `ui-intent-state.ts` (mirrors `prompt-state.ts`; shared by WS and RTC clients): `applyUiIntentEvent` / `removeUiIntentNotice` / `describeUiIntentForGui`. Unknown future wire-level kinds ALSO produce an explicit notice naming the raw kind — the never-silent floor holds beyond the compiled union.
- Reducer (`useSessionClient`) exposes `uiIntentNotices` + `dismissUiIntentNotice`; `SessionSurface` renders the dismissible banner stack. When a GUI screen lands later, its arm in `describeUiIntentForGui` flips from notice to mapped surface state (single documented seam).
- TC-05 evidence: `ui-intent-state.test.ts` (6 tests — every kind folds visibly, per-kind screen naming, requester attribution kept, referential no-churn, unknown-kind explicit notice, id-scoped idempotent dismissal) was run RED first (module absent), then GREEN; GUI suite **16 passed**; app-level jsdom render+dismiss test in `apps/agent-app` → **17 passed**.

### 3. `agent-transport` — headless/programmatic host-action parity (docs + tests)

- `headless-host-action-parity.test.ts`: with ZERO attached surfaces (nothing subscribed), `/language ko` writes via the settings adapter + requests restart, applied actions stripped from the result; an absent adapter yields the EXPLICIT `Cannot apply 'language-change': … not available in this environment.` failure (no-fallback), including end-to-end through `createProgrammaticAgent` (surfaced as `command-result` data — the driver stack never swallows it).
- `docs/SPEC.md` gains a "Host-action parity (CMD-004 Stage D)" section (zero-surface execution, explicit adapter-absent failure, zero-listener `ui_intent` defined no-op).

### 4. TC-09 — multi-surface exit/restart WS e2e (local == remote, REMOTE-006)

`ws-multi-surface-exit-policy.test.ts`: TWO real `createWsHandler` surfaces (`device-A`/`device-B`) over ONE real `InteractiveSession` with the real `/exit` + `/language` command modules:

- A remote `/exit` from surface A (confirmed over the ask seam — the parked confirm BROADCASTS to both surfaces per REMOTE-007, same ask id on both) calls the ONE shared process adapter `requestExit('prompt_input_exit')` **exactly once** — session-scoped, terminating the shared host for every surface; no surface-scoped teardown substitutes for it. `command_result` reaches the requester only.
- A remote `/language ko` from surface B restarts the shared host **once** (`requestRestart('other', 'Language change restart')`) despite two attached surfaces.
- A LOCAL `/exit` produces the IDENTICAL shared-host adapter call as the remote one — the deliberate local == remote policy, asserted.

Placement: the e2e lives in `agent-transport` (runtime dep on `agent-framework`, new devDependency on `agent-transport-protocol` — no cycle: protocol depends on `agent-interface-transport` only). `agent-cli` (Stage-C territory) is untouched.

### Verification (all FOREGROUND)

- `pnpm --filter @robota-sdk/agent-transport-protocol --filter @robota-sdk/agent-transport-gui --filter @robota-sdk/agent-transport build` → green
- Suites: protocol **58 passed**, gui **16 passed**, transport **56 passed** (incl. the 6 new Stage-D tests), apps/agent-app **17 passed**
- `pnpm typecheck` (workspace) → exit 0
- `node scripts/harness/run-all-scans.mjs` → **all 59 scans passed** (spec-public-surface: new GUI exports documented in the SPEC Public API table; file-size: ws-handler.ts split back under baseline)
- ESLint on all touched sources → 0 errors

### Out of scope (later stages, per the spec)

Stage C (TUI pure renderer, TC-04/TC-10 deletion half) — sibling PR; Stage E (emitter migration + `TCommandEffect` deletion, TC-06/07 final floors). `plugin-registry-reload` final carrier remains a Stage-C/E decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC