### PR TITLE
feat(tui): CLI-062 — real terminal-cursor positioning for CJK IME composition

### DIFF
--- a/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
+++ b/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
@@ -18,6 +18,26 @@ depends_on: []
 > invariants I1–I5 and a pty regression plan). Implementation starts as soon as the CMD-004 Stage C
 > branch frees `agent-transport-tui`.
 
+> **2026-07-25 — IMPLEMENTED per the contract (PR: feat/cli-062-ime-cursor).** Shipped in
+> `packages/agent-transport-tui`: `src/flows/real-cursor-flow.ts` (pure `computeCursorCell` +
+> `shouldPositionRealCursor`), `src/hooks/useRealCursorPosition.ts` (yoga parent-chain origin +
+> `useCursor`, zero stream writes), `CjkTextInput` `<Box ref>` wiring with drawn-cursor
+> suppression only while active, `supportsImeCursorPositioning()` gate (Apple_Terminal off by
+> default, `ROBOTA_IME_CURSOR=1` opt-in / `=0` kill switch). Invariants I1–I5 each carry a code
+> comment + test; red-before-green proven — component + 24-row pty were RED pre-change
+> (`expected 0 to be greater than 0`); fallback pinned byte-identical
+> (`src/__tests__/cjk-fallback-render.test.tsx`). PTY regression:
+> `src/__tests__/pty/ime-cursor.ptytest.ts` (24-row: every post-boot `ESC[?25h` on the input row
+> at the composition column; 5-row: zero shows — I2). Housekeeping note: the design doc's
+> "lockfile resolves ink 7.0.5" observation is stale — develop's lockfile resolves the declared
+> `^7.1.1` (7.1.1) for both TUI packages; cursor internals verified byte-identical between
+> 7.0.5/7.1.1, so no dependency change was made.
+>
+> **REMAINING (do not archive):** the manual terminal matrix (iTerm2 + Terminal.app
+> ±`ROBOTA_IME_CURSOR`, kitty/WezTerm/Ghostty/Windows Terminal/tmux) on real hardware — I5 keeps
+> Apple_Terminal off by default until it passes — and the owner-observed user-execution evidence
+> (composition window at the input position, no Terminal.app crash).
+
 ## Problem
 
 Real terminal cursor positioning for the CJK text input is intentionally disabled:

--- a/.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md
+++ b/.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md
@@ -1,0 +1,66 @@
+# CLI-062 — real terminal-cursor positioning for CJK IME composition (agent-run)
+
+**Spec:** CLI-062 (IME composition window appears at the bottom of the screen because the hardware
+cursor is never positioned; the historical fix attempt SIGSEGV'd Terminal.app via a hardcoded `y: 0`).
+Proves the hardware cursor now rides ON the input row at the composition column — the exact evidence
+the OS IME acts on — under the five crash-avoidance invariants of the implementation contract
+(`.design/investigations/2026-07-25-cli-062-ime-cursor-design.md`).
+**Type:** agent-executable (a real pseudo-terminal drives the BUILT robota binary and a VT
+interpreter reads the raw ANSI stream the way a terminal emulator does; no owner terminal smoke —
+per the agent-run capability rule). The Terminal.app-on-real-hardware manual matrix remains open
+(I5 keeps Apple_Terminal off by default until it passes) — tracked in the CLI-062 backlog.
+
+## Scenario
+
+```bash
+pnpm --filter @robota-sdk/agent-transport-tui build && pnpm --filter @robota-sdk/agent-cli build
+
+# Unit: pure cell math (wrap-aware, wide-char straddle) + the SIGSEGV-invariant guard table.
+npx vitest run packages/agent-transport-tui/src/flows/__tests__/real-cursor-flow.test.ts
+# Component (interactive ink render on a fake TTY): positioned shows on the input row, CJK width
+# tracking, drawn-cursor suppression, blur/unmount withdrawal, zero process-stream writes.
+npx vitest run packages/agent-transport-tui/src/__tests__/real-cursor-positioning.test.tsx
+# Fallback pin: capability-off rendering byte-identical to pre-change output.
+npx vitest run packages/agent-transport-tui/src/__tests__/cjk-fallback-render.test.tsx
+# PTY regression against the built binary (24-row: every post-boot ESC[?25h on the input row at
+# the composition column; 5-row fullscreen geometry: zero shows — invariant I2).
+cd packages/agent-transport-tui && npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor.ptytest.ts
+```
+
+**Expected:** every post-boot cursor show in the 24-row pty lands on the input row, final column =
+prompt + `> ` (2) + `안녕` (4 display cols); zero shows in the 5-row pty; fallback frames byte-equal;
+no writes to the real process streams.
+
+## Observed (2026-07-25)
+
+```
+✓ src/flows/__tests__/real-cursor-flow.test.ts        (21 tests) — computeCursorCell table +
+    shouldPositionRealCursor guard table (every false row a SIGSEGV-invariant case)
+✓ src/__tests__/real-cursor-positioning.test.tsx      (3 tests)
+    ✓ shows the hardware cursor on the input row at the composition column and tracks CJK growth
+    ✓ I4: unfocused input never positions the cursor
+    ✓ I4: blur withdraws the position and unmount leaves the cursor visible
+✓ src/__tests__/cjk-fallback-render.test.tsx          (6 tests) — fallback byte-identical pin
+✓ src/__tests__/pty/ime-cursor.ptytest.ts             (2 tests)
+    ✓ 24-row pty: every post-boot cursor show lands on the input row at the composition column
+    ✓ 5-row pty (frame ≥ viewport, I2): zero cursor-show sequences during composition
+
+Full agent-transport-tui unit suite: 507 passed (65 files); full PTY suite: 17 passed (11 files).
+```
+
+**Red-before-green proof (anti-accidental-green, HARNESS-041):** run BEFORE the implementation
+(pre-change worktree at develop `288608655` + pre-change built binary):
+
+```
+FAIL src/__tests__/real-cursor-positioning.test.tsx
+  → AssertionError: expected 0 to be greater than 0   (no positioned show exists today)
+FAIL src/__tests__/pty/ime-cursor.ptytest.ts > 24-row pty
+  → AssertionError: expected 0 to be greater than 0   (compositionShows.length)
+FAIL src/flows/__tests__/real-cursor-flow.test.ts
+  → Failed to load url ../real-cursor-flow.js          (module did not exist)
+```
+
+✅ PASS — the hardware cursor is positioned via a yoga parent-chain absolute origin + ink
+`useCursor` inside the synchronized frame write, guarded by I1 (measured y only), I2 (never a
+frame ≥ viewport / y out of frame), I3 (no out-of-band writes), I4 (guard fail → today's drawn
+cursor, byte-identical), I5 (Apple_Terminal opt-in via `ROBOTA_IME_CURSOR=1`).

--- a/packages/agent-transport-tui/docs/SPEC.md
+++ b/packages/agent-transport-tui/docs/SPEC.md
@@ -139,6 +139,21 @@ out of this contract:
 - `ExecutionWorkspaceDetailPane.tsx` uses `▸` as a **group-summary disclosure glyph** (content, not a
   cursor); a future pass must not "fix" it into the selection convention.
 
+## IME Real-Cursor Contract (CLI-062)
+
+During focused text entry, `CjkTextInput` positions the REAL terminal cursor at the composition
+point so the OS IME window appears at the input position (contract:
+`.design/investigations/2026-07-25-cli-062-ime-cursor-design.md`). Mechanism: a `<Box ref>` yoga
+parent-chain walk yields the input's absolute frame-space origin
+(`src/hooks/useRealCursorPosition.ts`); the cell math and the crash-avoidance guard are pure
+(`src/flows/real-cursor-flow.ts`, reusing the input's own wrap-aware `displayOffset`); the cell
+rides ink's `useCursor` inside the synchronized frame write. Five invariants (I1 never a guessed
+row; I2 never into a frame ≥ viewport or a y outside it; I3 never out-of-band writes; I4 guard
+fail/blur/unmount → exactly today's drawn-cursor rendering; I5 Apple_Terminal off by default,
+`ROBOTA_IME_CURSOR=1` opt-in / `=0` kill switch via
+`supportsImeCursorPositioning()`) each exist as a code comment AND a test; the drawn inverse
+cursor is suppressed only while real positioning is active.
+
 ## Extension Points
 
 New TUI components/flows live under `src/`. The adapter seam (`ITuiCliAdapter`) lets the CLI inject

--- a/packages/agent-transport-tui/src/CjkTextInput.tsx
+++ b/packages/agent-transport-tui/src/CjkTextInput.tsx
@@ -12,7 +12,7 @@
  */
 
 import chalk from 'chalk';
-import { Text, useInput, usePaste } from 'ink';
+import { Box, Text, useInput, usePaste } from 'ink';
 import React, { useEffect, useRef, useState } from 'react';
 
 import {
@@ -28,6 +28,10 @@ import {
   scheduleDeferredSubmit,
   type IDeferSubmitState,
 } from './flows/defer-submit.js';
+import { useRealCursorPosition } from './hooks/useRealCursorPosition.js';
+import { supportsImeCursorPositioning } from './terminal-capabilities.js';
+
+import type { DOMElement } from 'ink';
 
 interface IProps {
   value: string;
@@ -92,20 +96,32 @@ export default function CjkTextInput({
     deferState: deferRef.current,
   });
 
-  // Real terminal cursor positioning is intentionally omitted.
-  // setCursorPosition(x, 0) crashes Terminal.app via Korean IME SIGSEGV.
-  // Correct fix requires the input row's y offset from the bottom of the render,
-  // which Ink does not expose. Tracked as a known limitation.
+  // CLI-062: real terminal cursor positioning so the OS IME composition window appears AT the
+  // input position. The historical Terminal.app SIGSEGV came from a hardcoded `y: 0` (logo area);
+  // the hook only positions with a y measured from the live yoga layout and refuses the ink
+  // fullscreen geometry (invariants I1–I5 — see flows/real-cursor-flow.ts and the hook itself).
+  const boxRef = useRef<DOMElement | null>(null);
+  const { realCursorActive } = useRealCursorPosition({
+    boxRef,
+    enabled: focus && showCursor && supportsImeCursorPositioning(),
+    value: stateRef.current.value,
+    cursor: stateRef.current.cursor,
+    ...(availableWidth !== undefined ? { availableWidth } : {}),
+  });
 
   return (
-    <Text>
-      {renderWithCursor(
-        stateRef.current.value,
-        stateRef.current.cursor,
-        placeholder,
-        showCursor && focus,
-      )}
-    </Text>
+    <Box ref={boxRef}>
+      <Text>
+        {renderWithCursor(
+          stateRef.current.value,
+          stateRef.current.cursor,
+          placeholder,
+          // I4: the drawn inverse cursor is suppressed ONLY while real positioning is active;
+          // any guard failure falls back to exactly today's rendering.
+          showCursor && focus && !realCursorActive,
+        )}
+      </Text>
+    </Box>
   );
 }
 

--- a/packages/agent-transport-tui/src/__tests__/cjk-fallback-render.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/cjk-fallback-render.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * CLI-062 — fallback-path pinning guard.
+ *
+ * When real-cursor positioning is NOT active (capability off — the default in this test process:
+ * stdout is not a TTY and ROBOTA_IME_CURSOR is unset), CjkTextInput's rendering must stay
+ * byte-identical to the pre-CLI-062 behavior (invariant I4: guard fail → today's visuals, drawn
+ * inverse cursor included). The expected strings below are literal captures of the component's
+ * output BEFORE the CLI-062 change (chalk.level forced to 3 so the inverse-cursor bytes are pinned,
+ * not stripped). If this test breaks, the `<Box ref>` wrapper or the drawn-cursor gating changed
+ * the fallback rendering — that is a regression, not a snapshot to refresh.
+ */
+
+import chalk from 'chalk';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import CjkTextInput from '../CjkTextInput.js';
+
+const noop = (): void => {};
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+
+const ORIGINAL_CHALK_LEVEL = chalk.level;
+
+describe('CLI-062 — fallback rendering is byte-identical to pre-change output', () => {
+  beforeAll(() => {
+    chalk.level = 3;
+  });
+  afterAll(() => {
+    chalk.level = ORIGINAL_CHALK_LEVEL;
+  });
+
+  it('sanity: capability is off in this test process (fallback path is the one being pinned)', () => {
+    expect(process.env['ROBOTA_IME_CURSOR']).toBeUndefined();
+    expect(Boolean(process.stdout.isTTY)).toBe(false);
+  });
+
+  it('ASCII value with drawn end-of-line cursor', async () => {
+    const { lastFrame, unmount } = render(<CjkTextInput value="hello" onChange={noop} />);
+    await tick();
+    expect(lastFrame()).toBe('hello\u001b[7m \u001b[27m');
+    unmount();
+  });
+
+  it('CJK value with drawn end-of-line cursor', async () => {
+    const { lastFrame, unmount } = render(<CjkTextInput value="안녕하세요" onChange={noop} />);
+    await tick();
+    expect(lastFrame()).toBe('안녕하세요\u001b[7m \u001b[27m');
+    unmount();
+  });
+
+  it('empty value renders placeholder with inverse first character', async () => {
+    const { lastFrame, unmount } = render(
+      <CjkTextInput value="" onChange={noop} placeholder="Type a message or /help" />,
+    );
+    await tick();
+    expect(lastFrame()).toBe('\u001b[7mT\u001b[27m\u001b[90mype a message or /help\u001b[39m');
+    unmount();
+  });
+
+  it('unfocused input renders plain text without a drawn cursor', async () => {
+    const { lastFrame, unmount } = render(
+      <CjkTextInput value="hello" onChange={noop} focus={false} />,
+    );
+    await tick();
+    expect(lastFrame()).toBe('hello');
+    unmount();
+  });
+
+  it('long value wraps identically (the <Box ref> wrapper must not change layout)', async () => {
+    const { lastFrame, unmount } = render(
+      <CjkTextInput value={'a'.repeat(150) + '안녕'} onChange={noop} availableWidth={58} />,
+    );
+    await tick();
+    expect(lastFrame()).toBe('a'.repeat(100) + '\n' + 'a'.repeat(50) + '안녕\u001b[7m \u001b[27m');
+    unmount();
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/helpers/vt-cursor-interpreter.ts
+++ b/packages/agent-transport-tui/src/__tests__/helpers/vt-cursor-interpreter.ts
@@ -1,0 +1,175 @@
+/**
+ * Minimal VT interpreter for cursor-positioning assertions (CLI-062).
+ *
+ * Tracks the hardware cursor row/col on a rows x cols screen while consuming a raw ANSI stream,
+ * recording every DECTCEM show (`ESC[?25h`) event with the cursor cell it lands on and its byte
+ * offset in the stream. This is the same evidence a terminal emulator (and the OS IME) acts on —
+ * ported from the CLI-062 investigation PoC (.design/investigations/2026-07-25-cli-062-ime-cursor-design.md).
+ *
+ * Screen bookkeeping treats every printable as width 1 (wide-char display-column math is exercised
+ * by the production x computation, which the recorded `cursorTo` columns reflect directly).
+ * Understands: CR, LF, CUU/CUD/CUF/CUB (A/B/C/D), CNL/CPL (E/F), CHA (G), CUP (H/f), EL (K),
+ * ED (J, state-only), DECSET/DECRST ?25 (show/hide), OSC strings, and skips other escapes.
+ */
+
+// eslint-disable-next-line no-control-regex -- a VT interpreter parses control bytes by definition
+const CSI_PATTERN = /^\u001b\[([0-9;?]*)([A-Za-z])/;
+// eslint-disable-next-line no-control-regex -- a VT interpreter parses control bytes by definition
+const OSC_PATTERN = /^\u001b\][^\u0007\u001b]*(\u0007|\u001b\\)/;
+
+export interface ICursorShowEvent {
+  /** Screen row (0-based) the cursor was on when it was shown. */
+  row: number;
+  /** Screen column (0-based) the cursor was on when it was shown. */
+  col: number;
+  /** Byte offset of the show sequence in the interpreted stream (for since-mark filtering). */
+  offset: number;
+}
+
+export interface IVtInterpretation {
+  /** Final cursor row. */
+  row: number;
+  /** Final cursor column. */
+  col: number;
+  /** Final DECTCEM visibility. */
+  visible: boolean;
+  /** Screen contents (width-1 bookkeeping per printable). */
+  screen: string[];
+  /** Every `ESC[?25h` with the cell it landed on. */
+  showEvents: ICursorShowEvent[];
+  /** Number of scroll-ups that occurred (content pushed past the bottom row). */
+  scrolls: number;
+}
+
+interface IVtState {
+  row: number;
+  col: number;
+  visible: boolean;
+  screen: string[][];
+  scrolls: number;
+  showEvents: ICursorShowEvent[];
+}
+
+export function interpretVtStream(stream: string, rows: number, cols: number): IVtInterpretation {
+  const state: IVtState = {
+    row: 0,
+    col: 0,
+    visible: true,
+    screen: Array.from({ length: rows }, () => Array<string>(cols).fill(' ')),
+    scrolls: 0,
+    showEvents: [],
+  };
+
+  let i = 0;
+  while (i < stream.length) {
+    const ch = stream[i]!;
+    if (ch === '\r') {
+      state.col = 0;
+      i++;
+    } else if (ch === '\n') {
+      lineFeed(state, rows, cols);
+      state.col = 0;
+      i++;
+    } else if (ch === '\u001b') {
+      i += consumeEscape(state, stream, i, rows, cols);
+    } else {
+      if (ch >= ' ') {
+        state.screen[state.row]![state.col] = ch;
+        state.col = Math.min(cols - 1, state.col + 1);
+      }
+      i++;
+    }
+  }
+
+  return {
+    row: state.row,
+    col: state.col,
+    visible: state.visible,
+    screen: state.screen.map((line) => line.join('')),
+    showEvents: state.showEvents,
+    scrolls: state.scrolls,
+  };
+}
+
+function lineFeed(state: IVtState, rows: number, cols: number): void {
+  if (state.row === rows - 1) {
+    state.screen.shift();
+    state.screen.push(Array<string>(cols).fill(' '));
+    state.scrolls++;
+  } else {
+    state.row++;
+  }
+}
+
+/** Consume one escape sequence at `start`; returns its length in the stream. */
+function consumeEscape(
+  state: IVtState,
+  stream: string,
+  start: number,
+  rows: number,
+  cols: number,
+): number {
+  const csi = CSI_PATTERN.exec(stream.slice(start));
+  if (csi) {
+    const [full, params = '', cmd = ''] = csi;
+    applyCsi(state, params, cmd, start, rows, cols);
+    return full.length;
+  }
+  const osc = OSC_PATTERN.exec(stream.slice(start));
+  if (osc) {
+    return osc[0].length;
+  }
+  return 2;
+}
+
+function applyCsi(
+  state: IVtState,
+  params: string,
+  cmd: string,
+  offset: number,
+  rows: number,
+  cols: number,
+): void {
+  if (applyCursorMove(state, params, cmd, rows, cols)) return;
+  if (cmd === 'K') {
+    const from = params === '1' ? 0 : state.col;
+    const to = params === '1' ? state.col + 1 : cols;
+    for (let c = from; c < to; c++) state.screen[state.row]![c] = ' ';
+  } else if (cmd === 'h' && params === '?25') {
+    state.visible = true;
+    state.showEvents.push({ row: state.row, col: state.col, offset });
+  } else if (cmd === 'l' && params === '?25') {
+    state.visible = false;
+  }
+}
+
+/** Cursor-movement CSI commands; returns true when the command was one of them. */
+function applyCursorMove(
+  state: IVtState,
+  params: string,
+  cmd: string,
+  rows: number,
+  cols: number,
+): boolean {
+  const n = Number.parseInt(params === '' ? '1' : params, 10) || 1;
+  if (cmd === 'A') state.row = Math.max(0, state.row - n);
+  else if (cmd === 'B') state.row = Math.min(rows - 1, state.row + n);
+  else if (cmd === 'C') state.col = Math.min(cols - 1, state.col + n);
+  else if (cmd === 'D') state.col = Math.max(0, state.col - n);
+  else if (cmd === 'E') {
+    for (let k = 0; k < n; k++) lineFeed(state, rows, cols);
+    state.col = 0;
+  } else if (cmd === 'F') {
+    state.row = Math.max(0, state.row - n);
+    state.col = 0;
+  } else if (cmd === 'G') {
+    state.col = Math.min(cols - 1, n - 1);
+  } else if (cmd === 'H' || cmd === 'f') {
+    const [r = '1', c = '1'] = params.split(';');
+    state.row = Math.min(rows - 1, (Number.parseInt(r, 10) || 1) - 1);
+    state.col = Math.min(cols - 1, (Number.parseInt(c, 10) || 1) - 1);
+  } else {
+    return false;
+  }
+  return true;
+}

--- a/packages/agent-transport-tui/src/__tests__/pty/ime-cursor.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/ime-cursor.ptytest.ts
@@ -1,0 +1,95 @@
+/**
+ * CLI-062 — PTY regression for real-terminal-cursor positioning (the OS-IME evidence).
+ *
+ * Runs the BUILT robota binary in a real pseudo-terminal and interprets the raw ANSI stream the
+ * way a terminal emulator (and the OS IME) does. Two geometries from the implementation contract
+ * (.design/investigations/2026-07-25-cli-062-ime-cursor-design.md):
+ *
+ *  - 24-row pty: while typing CJK, every `ESC[?25h` emitted after boot lands ON the input row at
+ *    the composition column — never the top region (the historical hardcoded-y:0 crash geometry).
+ *  - 5-row pty: the live frame fills the viewport (ink's fullscreen path, bottom-anchor
+ *    off-by-one) — invariant I2 must refuse to position: ZERO cursor-show sequences after boot.
+ *
+ * Assertions only cover the post-boot composition window: boot may legitimately show the cursor
+ * (spinners etc.), and teardown restores visibility — both are outside the invariant.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { spawnTui, writeTuiProviderSettings } from './pty-driver.js';
+import { interpretVtStream } from '../helpers/vt-cursor-interpreter.js';
+
+import type { IPtySession } from './pty-driver.js';
+
+const COLS = 80;
+const PROMPT_PLACEHOLDER = /Type a message or \/help/;
+/** Let ink's throttled (≤30fps) frame writes flush after the last keystroke. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 400));
+
+describe('CLI-062 — IME hardware-cursor positioning through a real PTY', () => {
+  let projectDir: string;
+  let session: IPtySession | undefined;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'robota-pty-ime-'));
+    writeTuiProviderSettings(projectDir);
+  });
+
+  afterEach(async () => {
+    await session?.disposeAsync();
+    session = undefined;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('24-row pty: every post-boot cursor show lands on the input row at the composition column', async () => {
+    const rows = 24;
+    session = spawnTui({ projectDir, homeDir: join(projectDir, 'home'), cols: COLS, rows });
+    await session.waitFor(PROMPT_PLACEHOLDER);
+    await flush();
+
+    const bootMark = session.raw().length;
+    await session.sendKeys('안녕');
+    await session.waitFor(/안녕/);
+    await flush();
+
+    const raw = session.raw();
+    const vt = interpretVtStream(raw, rows, COLS);
+    const compositionShows = vt.showEvents.filter((event) => event.offset >= bootMark);
+
+    // The feature must actually fire (this line is the pre-change RED):
+    expect(compositionShows.length).toBeGreaterThan(0);
+
+    // Locate the input row on the final screen ('> ' prompt followed by the typed value).
+    const inputRow = vt.screen.findIndex((line) => line.includes('> 안녕'));
+    expect(inputRow).toBeGreaterThanOrEqual(0);
+
+    for (const event of compositionShows) {
+      // Never the top region (the Terminal.app SIGSEGV geometry), always the input row.
+      expect(event.row).toBe(inputRow);
+    }
+
+    // Composition column: prompt col + '> ' (2) + 안녕 (4 display columns).
+    const promptCol = vt.screen[inputRow]!.indexOf('> ');
+    expect(compositionShows.at(-1)!.col).toBe(promptCol + 2 + 4);
+  }, 60_000);
+
+  it('5-row pty (frame ≥ viewport, I2): zero cursor-show sequences during composition', async () => {
+    const rows = 5;
+    session = spawnTui({ projectDir, homeDir: join(projectDir, 'home'), cols: COLS, rows });
+    await session.waitFor(PROMPT_PLACEHOLDER);
+    await flush();
+
+    const bootMark = session.raw().length;
+    await session.sendKeys('안녕');
+    await session.waitFor(/안녕/);
+    await flush();
+
+    const vt = interpretVtStream(session.raw(), rows, COLS);
+    const compositionShows = vt.showEvents.filter((event) => event.offset >= bootMark);
+    expect(compositionShows).toEqual([]);
+  }, 60_000);
+});

--- a/packages/agent-transport-tui/src/__tests__/pty/pty-driver.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/pty-driver.ts
@@ -55,6 +55,8 @@ export interface IPtySession {
   /** ANSI-stripped output that arrived after the `since` mark. */
   snapshotSince(since: number): string;
   snapshot(): string;
+  /** Raw (un-stripped) cumulative output — for cursor/escape-sequence assertions (CLI-062). */
+  raw(): string;
   expectExit(timeoutMs?: number): Promise<number>;
   kill(): void;
   /**
@@ -126,6 +128,7 @@ export function spawnTui(options: ISpawnTuiOptions): IPtySession {
       session.waitForSince(since, pattern, timeoutMs),
     snapshotSince: (since): string => session.snapshotSince(since),
     snapshot: (): string => session.snapshot(),
+    raw: (): string => session.raw(),
     expectExit: (timeoutMs): Promise<number> => session.expectExit(timeoutMs),
     kill: (): void => session.dispose(),
     disposeAsync: (timeoutMs): Promise<void> => killAndAwaitExit(session, timeoutMs),

--- a/packages/agent-transport-tui/src/__tests__/real-cursor-positioning.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/real-cursor-positioning.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * CLI-062 — real-terminal-cursor positioning through ink's actual interactive render path.
+ *
+ * Renders CjkTextInput inside a TransportTUI-shaped harness against a fake TTY stdout
+ * (`interactive: true`), then interprets the raw ANSI stream with the same VT logic a terminal
+ * emulator (and the OS IME) applies. This is the component-level half of the CLI-062 contract
+ * (.design/investigations/2026-07-25-cli-062-ime-cursor-design.md): the hardware cursor must be
+ * shown ON the input row at the composition column, track CJK width growth, disappear when the
+ * input is unfocused (I4), propagate `undefined` on unmount (I4), and the production code must
+ * write NOTHING to the real process streams (the PoC row-accounting lesson, I3).
+ *
+ * `ROBOTA_IME_CURSOR=1` opts the capability gate in explicitly — the vitest process has no TTY,
+ * so the default gate would (correctly) refuse; the opt-in is the supported override.
+ */
+
+import { EventEmitter } from 'node:events';
+
+import chalk from 'chalk';
+import { Box, Text, render } from 'ink';
+import React, { useState } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { interpretVtStream } from './helpers/vt-cursor-interpreter.js';
+import CjkTextInput from '../CjkTextInput.js';
+
+const COLS = 60;
+const ROWS = 24;
+const PROMPT = '> ';
+
+class FakeTtyStdout extends EventEmitter {
+  readonly isTTY = true;
+  readonly columns = COLS;
+  readonly rows = ROWS;
+  private chunks: string[] = [];
+  write = (chunk: string, callback?: () => void): boolean => {
+    this.chunks.push(String(chunk));
+    callback?.();
+    return true;
+  };
+  stream(): string {
+    return this.chunks.join('');
+  }
+}
+
+class FakeStdin extends EventEmitter {
+  readonly isTTY = true;
+  private pending: string | null = null;
+  setEncoding(): void {}
+  setRawMode(): void {}
+  resume(): void {}
+  pause(): void {}
+  ref(): void {}
+  unref(): void {}
+  read(): string | null {
+    const data = this.pending;
+    this.pending = null;
+    return data;
+  }
+  send(data: string): void {
+    this.pending = data;
+    this.emit('readable');
+    this.emit('data', data);
+  }
+}
+
+function Harness({ focus = true }: { focus?: boolean }): React.ReactElement {
+  const [value, setValue] = useState('');
+  return (
+    <Box flexDirection="column">
+      <Text>banner line</Text>
+      <Box>
+        <Text>{PROMPT}</Text>
+        <CjkTextInput value={value} onChange={setValue} availableWidth={COLS - 2} focus={focus} />
+      </Box>
+      <Text>status line</Text>
+    </Box>
+  );
+}
+
+interface IScenario {
+  stdout: FakeTtyStdout;
+  stdin: FakeStdin;
+  unmount: () => void;
+}
+
+function renderScenario(focus?: boolean): IScenario {
+  const stdout = new FakeTtyStdout();
+  const stdin = new FakeStdin();
+  const instance = render(<Harness {...(focus === undefined ? {} : { focus })} />, {
+    // Cast: ink wants real process streams; the fakes implement the parts its render loop uses.
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    interactive: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  return { stdout, stdin, unmount: instance.unmount };
+}
+
+/** Ink throttles frames (≤30fps) and React effects settle asynchronously — allow both to flush. */
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 120));
+
+const INPUT_ROW = 1; // banner is row 0, input row is row 1 in the harness frame
+
+describe('CLI-062 — real cursor positioning (interactive ink render)', () => {
+  const ORIGINAL_CHALK_LEVEL = chalk.level;
+
+  beforeAll(() => {
+    vi.stubEnv('ROBOTA_IME_CURSOR', '1');
+    chalk.level = 3; // make the drawn inverse cursor observable in bytes, so suppression is provable
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    chalk.level = ORIGINAL_CHALK_LEVEL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the hardware cursor on the input row at the composition column and tracks CJK growth', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write');
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+
+    const { stdout, stdin, unmount } = renderScenario();
+    await settle();
+
+    stdin.send('안녕');
+    await settle();
+
+    const afterTwo = interpretVtStream(stdout.stream(), ROWS, COLS);
+    const showsAfterTwo = afterTwo.showEvents;
+    expect(showsAfterTwo.length).toBeGreaterThan(0);
+    // Every show lands on the input row (never the banner/top region — the crash geometry).
+    for (const event of showsAfterTwo) {
+      expect(event.row).toBe(INPUT_ROW);
+    }
+    // Composition column: '> ' (2 cols) + 안녕 (2 wide chars = 4 cols).
+    expect(showsAfterTwo.at(-1)).toMatchObject({ row: INPUT_ROW, col: 6 });
+
+    stdin.send('하'); // one more wide char → +2 columns
+    await settle();
+
+    const afterThree = interpretVtStream(stdout.stream(), ROWS, COLS);
+    expect(afterThree.showEvents.at(-1)).toMatchObject({ row: INPUT_ROW, col: 8 });
+
+    // Drawn-cursor suppression: before the first measurement the fallback legitimately draws the
+    // inverse block (I1: no guessed rows), but from the first positioned show onward the hardware
+    // cursor and the inverse block must never coexist.
+    const firstShowOffset = afterThree.showEvents[0]!.offset;
+    expect(stdout.stream().slice(firstShowOffset)).not.toContain('\u001b[7m');
+
+    // I3/PoC lesson: the production path writes NOTHING to the real process streams.
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('I4: unfocused input never positions the cursor (and keeps the fallback drawn-cursor path off)', async () => {
+    const { stdout, stdin, unmount } = renderScenario(false);
+    await settle();
+    stdin.send('x'); // ignored — not focused
+    await settle();
+
+    const vt = interpretVtStream(stdout.stream(), ROWS, COLS);
+    expect(vt.showEvents).toEqual([]);
+    unmount();
+  });
+
+  it('I4: blur withdraws the position (no shows after focus loss) and unmount leaves the cursor visible', async () => {
+    const stdout = new FakeTtyStdout();
+    const stdin = new FakeStdin();
+    const instance = render(<Harness />, {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+    await settle();
+    stdin.send('안');
+    await settle();
+    expect(interpretVtStream(stdout.stream(), ROWS, COLS).showEvents.length).toBeGreaterThan(0);
+
+    // Blur: the guard fails → setCursorPosition(undefined) → ink hides the hardware cursor and
+    // emits NO further positioned shows (the I4 fallback path).
+    instance.rerender(<Harness focus={false} />);
+    await settle();
+    const afterBlurMark = stdout.stream().length;
+    stdin.send('x'); // ignored — not focused; also must not resurrect the cursor
+    await settle();
+    const blurShows = interpretVtStream(stdout.stream(), ROWS, COLS).showEvents.filter(
+      (event) => event.offset >= afterBlurMark,
+    );
+    expect(blurShows).toEqual([]);
+
+    // Unmount: useCursor's cleanup propagates `undefined`; ink's teardown restores a bare,
+    // visible cursor (never a freshly positioned one).
+    instance.unmount();
+    await settle();
+    expect(interpretVtStream(stdout.stream(), ROWS, COLS).visible).toBe(true);
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { isInteractiveColorTerminal } from '../terminal-capabilities.js';
+import {
+  isInteractiveColorTerminal,
+  supportsImeCursorPositioning,
+} from '../terminal-capabilities.js';
 
 const ORIG_NO_COLOR = process.env.NO_COLOR;
 const ORIG_FORCE_COLOR = process.env.FORCE_COLOR;
@@ -10,6 +13,11 @@ function setTty(value: boolean): void {
 }
 
 function restoreEnv(key: 'NO_COLOR' | 'FORCE_COLOR', value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function restoreEnvKey(key: string, value: string | undefined): void {
   if (value === undefined) delete process.env[key];
   else process.env[key] = value;
 }
@@ -46,5 +54,46 @@ describe('isInteractiveColorTerminal', () => {
     expect(isInteractiveColorTerminal()).toBe(true);
     setTty(false);
     expect(isInteractiveColorTerminal()).toBe(false);
+  });
+});
+
+describe('supportsImeCursorPositioning (CLI-062)', () => {
+  const ORIG_IME = process.env.ROBOTA_IME_CURSOR;
+  const ORIG_TERM_PROGRAM = process.env.TERM_PROGRAM;
+
+  afterEach(() => {
+    restoreEnvKey('ROBOTA_IME_CURSOR', ORIG_IME);
+    restoreEnvKey('TERM_PROGRAM', ORIG_TERM_PROGRAM);
+    Object.defineProperty(process.stdout, 'isTTY', { value: ORIG_TTY, configurable: true });
+  });
+
+  it('on for a plain interactive TTY, off for a non-TTY', () => {
+    delete process.env.ROBOTA_IME_CURSOR;
+    delete process.env.TERM_PROGRAM;
+    setTty(true);
+    expect(supportsImeCursorPositioning()).toBe(true);
+    setTty(false);
+    expect(supportsImeCursorPositioning()).toBe(false);
+  });
+
+  it('I5: Apple_Terminal is OFF by default (Korean-IME SIGSEGV is an Apple-side bug)', () => {
+    delete process.env.ROBOTA_IME_CURSOR;
+    setTty(true);
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    expect(supportsImeCursorPositioning()).toBe(false);
+  });
+
+  it('I5: ROBOTA_IME_CURSOR=1 opts Apple_Terminal in explicitly', () => {
+    setTty(true);
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    process.env.ROBOTA_IME_CURSOR = '1';
+    expect(supportsImeCursorPositioning()).toBe(true);
+  });
+
+  it('ROBOTA_IME_CURSOR=0 is a kill switch even on a capable terminal', () => {
+    setTty(true);
+    delete process.env.TERM_PROGRAM;
+    process.env.ROBOTA_IME_CURSOR = '0';
+    expect(supportsImeCursorPositioning()).toBe(false);
   });
 });

--- a/packages/agent-transport-tui/src/flows/__tests__/real-cursor-flow.test.ts
+++ b/packages/agent-transport-tui/src/flows/__tests__/real-cursor-flow.test.ts
@@ -1,0 +1,124 @@
+/**
+ * CLI-062 — unit tables for the real-cursor pure flow.
+ *
+ * `computeCursorCell` maps (absolute input origin, value, cursor index, wrap width) to the
+ * hardware-cursor cell, reusing the wrap-aware `displayOffset` math the input's vertical
+ * navigation already trusts. `shouldPositionRealCursor` is the crash-avoidance guard: every
+ * `false` row below is a SIGSEGV-invariant case (the historical Terminal.app crash geometry —
+ * see .design/investigations/2026-07-25-cli-062-ime-cursor-design.md, invariants I1/I2/I5).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { computeCursorCell, shouldPositionRealCursor } from '../real-cursor-flow.js';
+
+describe('computeCursorCell', () => {
+  const origin = { absX: 3, absY: 2 };
+
+  it('ASCII value, cursor at end, no wrap width', () => {
+    expect(computeCursorCell({ ...origin, value: 'hello', cursor: 5 })).toEqual({ x: 8, y: 2 });
+  });
+
+  it('ASCII value, cursor at start', () => {
+    expect(computeCursorCell({ ...origin, value: 'hello', cursor: 0 })).toEqual({ x: 3, y: 2 });
+  });
+
+  it('CJK wide chars count 2 columns each (안녕 → 4 columns)', () => {
+    expect(computeCursorCell({ ...origin, value: '안녕', cursor: 2, availableWidth: 20 })).toEqual({
+      x: 7,
+      y: 2,
+    });
+  });
+
+  it('mid-string cursor inside a CJK value', () => {
+    expect(
+      computeCursorCell({ ...origin, value: '안녕하세요', cursor: 2, availableWidth: 20 }),
+    ).toEqual({ x: 7, y: 2 });
+  });
+
+  it('no wrap width: CJK offset is the plain display-width sum', () => {
+    expect(computeCursorCell({ ...origin, value: '안녕하', cursor: 3 })).toEqual({ x: 9, y: 2 });
+  });
+
+  it('wraps to the next row when the offset passes the width', () => {
+    expect(
+      computeCursorCell({ ...origin, value: 'a'.repeat(12), cursor: 12, availableWidth: 10 }),
+    ).toEqual({ x: 5, y: 3 });
+  });
+
+  it('exact-width boundary lands on column 0 of the next row', () => {
+    expect(
+      computeCursorCell({ ...origin, value: 'a'.repeat(12), cursor: 10, availableWidth: 10 }),
+    ).toEqual({ x: 3, y: 3 });
+  });
+
+  it('wide char straddling the wrap boundary is pushed to the next row (display gap preserved)', () => {
+    // 9 ASCII cols + a wide char that cannot fit in the last column: displayOffset skips the
+    // dead column (9 → 10) then adds the wide char (→ 12) — cursor lands at row+1, col 2.
+    expect(
+      computeCursorCell({ ...origin, value: 'aaaaaaaaa안', cursor: 10, availableWidth: 10 }),
+    ).toEqual({ x: 5, y: 3 });
+  });
+
+  it('empty value (placeholder case) → the origin cell', () => {
+    expect(computeCursorCell({ ...origin, value: '', cursor: 0, availableWidth: 20 })).toEqual({
+      x: 3,
+      y: 2,
+    });
+  });
+
+  it('cursor index beyond the value length clamps to the end', () => {
+    expect(computeCursorCell({ ...origin, value: 'ab', cursor: 99 })).toEqual({ x: 5, y: 2 });
+  });
+
+  it('non-positive availableWidth behaves as unwrapped', () => {
+    expect(computeCursorCell({ ...origin, value: 'hello', cursor: 5, availableWidth: 0 })).toEqual({
+      x: 8,
+      y: 2,
+    });
+  });
+});
+
+describe('shouldPositionRealCursor (every false row is a SIGSEGV-invariant case)', () => {
+  const ok = { hasMeasured: true, y: 3, frameHeight: 8, viewportRows: 24, capability: true };
+
+  it('positions when measured, in-bounds, frame smaller than viewport, capability on', () => {
+    expect(shouldPositionRealCursor(ok)).toBe(true);
+  });
+
+  it('measured y === 0 is valid (only a GUESSED y:0 is the bug class, not a measured one)', () => {
+    expect(shouldPositionRealCursor({ ...ok, y: 0 })).toBe(true);
+  });
+
+  it('I5/gate: capability off → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, capability: false })).toBe(false);
+  });
+
+  it('I1: no measurement yet → never position (the historical hardcoded y:0 class)', () => {
+    expect(shouldPositionRealCursor({ ...ok, hasMeasured: false })).toBe(false);
+  });
+
+  it('I2: frame fills the viewport (ink fullscreen path, off-by-one) → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, frameHeight: 24 })).toBe(false);
+  });
+
+  it('I2: frame overflows the viewport (cursorUp clamps at screen top — crash geometry) → never', () => {
+    expect(shouldPositionRealCursor({ ...ok, frameHeight: 30 })).toBe(false);
+  });
+
+  it('I2: y below the frame → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, y: 8 })).toBe(false);
+  });
+
+  it('I2: negative y → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, y: -1 })).toBe(false);
+  });
+
+  it('degenerate viewport (0 rows) → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, viewportRows: 0 })).toBe(false);
+  });
+
+  it('degenerate frame (0 height) → never position', () => {
+    expect(shouldPositionRealCursor({ ...ok, frameHeight: 0 })).toBe(false);
+  });
+});

--- a/packages/agent-transport-tui/src/flows/real-cursor-flow.ts
+++ b/packages/agent-transport-tui/src/flows/real-cursor-flow.ts
@@ -1,0 +1,83 @@
+/**
+ * CLI-062 — pure flow for real-terminal-cursor positioning during CJK IME composition.
+ *
+ * Maps the input box's absolute frame-space origin plus the live (value, cursor) to the exact
+ * screen cell the hardware cursor must occupy, and guards WHEN positioning is allowed at all.
+ * Contract: .design/investigations/2026-07-25-cli-062-ime-cursor-design.md.
+ *
+ * The wrap math reuses `displayOffset` — the same wrap-aware column accounting the input's
+ * vertical navigation already trusts — so the computed cell always matches where ink actually
+ * rendered the character under the cursor.
+ */
+
+import { displayOffset } from './cjk-text-input-flow.js';
+
+export interface ICursorCellInput {
+  /** Absolute frame-space column of the input box's first cell. */
+  absX: number;
+  /** Absolute frame-space row of the input box's first line. */
+  absY: number;
+  /** Current input value. */
+  value: string;
+  /** Cursor as a character index into the value (clamped to the value length). */
+  cursor: number;
+  /** Wrap width in columns; unset/non-positive means the value renders unwrapped. */
+  availableWidth?: number;
+}
+
+export interface ICursorCell {
+  x: number;
+  y: number;
+}
+
+export interface IRealCursorGuardInput {
+  /** Whether the input box has been measured in the CURRENT yoga layout. */
+  hasMeasured: boolean;
+  /** Target cursor row (absolute frame space). */
+  y: number;
+  /** Height of the live frame (ink-root yoga height). */
+  frameHeight: number;
+  /** Terminal viewport rows. */
+  viewportRows: number;
+  /** Terminal capability + focus gate (supportsImeCursorPositioning() && focused && showCursor). */
+  capability: boolean;
+}
+
+/** Compute the hardware-cursor cell for the current composition point. */
+export function computeCursorCell(input: ICursorCellInput): ICursorCell {
+  const chars = [...input.value];
+  const cursor = Math.min(Math.max(input.cursor, 0), chars.length);
+  const width =
+    input.availableWidth !== undefined && input.availableWidth > 0
+      ? input.availableWidth
+      : undefined;
+  const offset = displayOffset(chars, cursor, width ?? Number.MAX_SAFE_INTEGER);
+  if (width === undefined) {
+    return { x: input.absX + offset, y: input.absY };
+  }
+  return { x: input.absX + (offset % width), y: input.absY + Math.floor(offset / width) };
+}
+
+/**
+ * Crash-avoidance guard — the SIGSEGV invariants from the CLI-062 contract:
+ *
+ * - I1: never a GUESSED row — position only with a y measured from the current yoga layout
+ *   (`hasMeasured`); the historical hardcoded `y: 0` pointed the cursor at the logo area, where
+ *   Terminal.app's Korean IME `attributedSubstringFromRange:` null-derefs (Apple-side bug).
+ * - I2: never into an overflowing frame — when `frameHeight >= viewportRows` ink's bottom-anchor
+ *   assumption breaks (upstream defect, present in ink 7.0.5 AND 7.1.1: the cursor lands one row
+ *   high in the fullscreen path, and an overflowing frame clamps `cursorUp` at the screen top —
+ *   the original crash geometry). Same for a y outside `[0, frameHeight)`.
+ * - I5 lives in `supportsImeCursorPositioning()` and arrives here folded into `capability`.
+ *
+ * I3 (all movement rides ink's synchronized frame writes) and I4 (guard fail → no call → today's
+ * rendering) are properties of the hook that consumes this guard (useRealCursorPosition).
+ */
+export function shouldPositionRealCursor(input: IRealCursorGuardInput): boolean {
+  if (!input.capability) return false;
+  if (!input.hasMeasured) return false; // I1
+  if (input.viewportRows <= 0 || input.frameHeight <= 0) return false;
+  if (input.frameHeight >= input.viewportRows) return false; // I2 (fullscreen / overflow)
+  if (input.y < 0 || input.y >= input.frameHeight) return false; // I2 (out of frame)
+  return true;
+}

--- a/packages/agent-transport-tui/src/hooks/useRealCursorPosition.ts
+++ b/packages/agent-transport-tui/src/hooks/useRealCursorPosition.ts
@@ -1,0 +1,125 @@
+/**
+ * CLI-062 — position the REAL terminal cursor at the CJK composition point.
+ *
+ * Mechanism (contract: .design/investigations/2026-07-25-cli-062-ime-cursor-design.md, POC-PASS):
+ * the input box's absolute frame-space origin comes from walking the yoga `parentNode` chain from
+ * a `<Box ref>` (the `5195e326b` approach, minus its debug logging); the cell is handed to ink's
+ * `useCursor().setCursorPosition`, which converts it into a relative `cursorUp` from the frame
+ * bottom INSIDE the same atomic synchronized frame write (invariant I3: never out-of-band — all
+ * cursor movement rides ink's ≤30fps frame writes; this hook itself writes NOTHING to any stream,
+ * the PoC row-accounting lesson).
+ *
+ * Measurement happens post-commit (layout is valid there) and is stored in state so the NEXT
+ * commit's insertion effect propagates a fresh position with its frame; `useBoxMetrics` provides
+ * the layout-change subscription so sibling-driven moves re-measure too. A stale origin self-heals
+ * within one frame (ink recomputes layout before onRender and notifies layout listeners).
+ */
+
+import { useBoxMetrics, useCursor, useWindowSize } from 'ink';
+import { useEffect, useState } from 'react';
+
+import { computeCursorCell, shouldPositionRealCursor } from '../flows/real-cursor-flow.js';
+
+import type { DOMElement } from 'ink';
+import type { RefObject } from 'react';
+
+export interface IUseRealCursorPositionOptions {
+  /** Ref attached to the `<Box>` wrapping the input's text. */
+  boxRef: RefObject<DOMElement | null>;
+  /** Capability + focus gate: supportsImeCursorPositioning() && focus && showCursor. */
+  enabled: boolean;
+  /** Live input value (from the input's state ref — fresh at render time). */
+  value: string;
+  /** Live cursor character index. */
+  cursor: number;
+  /** Wrap width in columns (matches the input's own wrap math). */
+  availableWidth?: number;
+}
+
+export interface IUseRealCursorPositionResult {
+  /** True while the hardware cursor is being positioned — the drawn cursor must be suppressed. */
+  realCursorActive: boolean;
+}
+
+interface IMeasuredOrigin {
+  x: number;
+  y: number;
+  frameHeight: number;
+}
+
+/** Walk the yoga `parentNode` chain to the absolute frame-space origin, plus the root frame height. */
+function measureAbsoluteOrigin(element: DOMElement): IMeasuredOrigin | undefined {
+  if (element.yogaNode === undefined) return undefined;
+  let x = 0;
+  let y = 0;
+  let current: DOMElement | undefined = element;
+  let root: DOMElement = element;
+  while (current !== undefined) {
+    const layout = current.yogaNode?.getComputedLayout();
+    x += layout?.left ?? 0;
+    y += layout?.top ?? 0;
+    root = current;
+    current = current.parentNode;
+  }
+  const frameHeight = root.yogaNode?.getComputedLayout().height ?? 0;
+  return { x, y, frameHeight };
+}
+
+function sameOrigin(a: IMeasuredOrigin | undefined, b: IMeasuredOrigin | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return a.x === b.x && a.y === b.y && a.frameHeight === b.frameHeight;
+}
+
+export function useRealCursorPosition(
+  options: IUseRealCursorPositionOptions,
+): IUseRealCursorPositionResult {
+  const { setCursorPosition } = useCursor();
+  // Layout-change subscription: useBoxMetrics re-renders this component whenever the tracked
+  // box's metrics change on a root layout commit, and exposes hasMeasured for invariant I1.
+  const metrics = useBoxMetrics(options.boxRef);
+  const { rows: viewportRows } = useWindowSize();
+  const [origin, setOrigin] = useState<IMeasuredOrigin | undefined>(undefined);
+
+  // I1: never a guessed row — measure the absolute origin ONLY from a committed yoga layout
+  // (post-commit effect; ink ran calculateLayout before onRender, passive effects run after).
+  // No dependency array on purpose: any render may follow a layout change, and the setState
+  // bails out when the origin is unchanged, so this settles instead of looping.
+  useEffect(() => {
+    const element = options.boxRef.current;
+    const next = element === null ? undefined : measureAbsoluteOrigin(element);
+    setOrigin((previous) => (sameOrigin(previous, next) ? previous : next));
+  });
+
+  const cell =
+    origin !== undefined && options.enabled
+      ? computeCursorCell({
+          absX: origin.x,
+          absY: origin.y,
+          value: options.value,
+          cursor: options.cursor,
+          ...(options.availableWidth !== undefined
+            ? { availableWidth: options.availableWidth }
+            : {}),
+        })
+      : undefined;
+
+  const realCursorActive =
+    cell !== undefined &&
+    origin !== undefined &&
+    shouldPositionRealCursor({
+      hasMeasured: metrics.hasMeasured && origin !== undefined, // I1
+      y: cell.y,
+      frameHeight: origin.frameHeight, // I2 checked inside the guard
+      viewportRows,
+      capability: options.enabled, // I5 folded in via supportsImeCursorPositioning()
+    });
+
+  // Render-phase call is safe: useCursor only records the position in a ref; propagation happens
+  // in its insertion effect, inside ink's synchronized frame write (I3). I4: when the guard fails
+  // (blur, fullscreen frame, not measured yet) we pass `undefined` — ink hides the hardware cursor
+  // and the caller falls back to today's drawn-cursor rendering; on unmount, useCursor's cleanup
+  // propagates `undefined` by itself.
+  setCursorPosition(realCursorActive && cell !== undefined ? { x: cell.x, y: cell.y } : undefined);
+
+  return { realCursorActive };
+}

--- a/packages/agent-transport-tui/src/terminal-capabilities.ts
+++ b/packages/agent-transport-tui/src/terminal-capabilities.ts
@@ -15,3 +15,24 @@ export function isInteractiveColorTerminal(): boolean {
   if (force !== undefined && force !== '') return true;
   return Boolean(process.stdout.isTTY);
 }
+
+/**
+ * CLI-062 — may this process position the REAL terminal cursor for IME composition?
+ *
+ * Precedence:
+ *  - `ROBOTA_IME_CURSOR=1` → on (explicit opt-in — the only way to enable it in Terminal.app).
+ *  - `ROBOTA_IME_CURSOR=0` → off (kill switch).
+ *  - `TERM_PROGRAM=Apple_Terminal` → off by default (invariant I5): the historical Korean-IME
+ *    SIGSEGV is an Apple-side `attributedSubstringFromRange:` bug; its trigger geometry is gone
+ *    (measured y + post-<Static> tiny frame), but Terminal.app stays opt-in until the manual
+ *    matrix passes on real hardware. The CLI-052 startup warning remains in place.
+ *  - otherwise → on only when stdout is an interactive TTY (ink writes no cursor sequences at
+ *    all on a non-TTY, so this is defense in depth).
+ */
+export function supportsImeCursorPositioning(): boolean {
+  const override = process.env.ROBOTA_IME_CURSOR;
+  if (override === '1') return true;
+  if (override === '0') return false;
+  if (process.env.TERM_PROGRAM === 'Apple_Terminal') return false; // I5
+  return Boolean(process.stdout.isTTY);
+}


### PR DESCRIPTION
## CLI-062 — real terminal-cursor positioning for CJK IME composition

Implements the CLI-062 contract exactly as specified in
`.design/investigations/2026-07-25-cli-062-ime-cursor-design.md` (POC-PASS): the hardware cursor now
rides ON the input row at the composition column, so the OS IME composition/candidate window appears
at the input position instead of the bottom of the screen.

### Mechanism
- **`src/flows/real-cursor-flow.ts`** — pure `computeCursorCell` (reuses the input's wrap-aware
  `displayOffset`: `y = absY + floor(offset/width)`, `x = absX + offset%width`) and
  `shouldPositionRealCursor` (the crash-avoidance guard).
- **`src/hooks/useRealCursorPosition.ts`** — yoga `parentNode`-chain absolute origin from a
  `<Box ref>` (resurrects `5195e326b`'s `getAbsolutePosition`, without its debug logging),
  `useBoxMetrics` as the layout-change subscription, `useCursor().setCursorPosition` so every move
  rides ink's synchronized ≤30fps frame writes. The hook writes NOTHING to any stream (PoC lesson).
- **`CjkTextInput.tsx`** — `<Box ref>` wiring; the drawn inverse cursor is suppressed ONLY while
  real positioning is active. Fallback rendering is pinned byte-identical to pre-change output
  (`cjk-fallback-render.test.tsx`).
- **`terminal-capabilities.ts`** — `supportsImeCursorPositioning()`: Apple_Terminal OFF by default
  (I5 — the historical SIGSEGV is Apple's `attributedSubstringFromRange:` bug), `ROBOTA_IME_CURSOR=1`
  opt-in, `=0` kill switch; otherwise on for interactive TTYs. CLI-052's startup warning stays.

### Invariants I1–I5 (each = code comment + test)
I1 never a guessed row (measured yoga y only) · I2 never into a frame ≥ viewport or a y outside
`[0, frameHeight)` (ink's fullscreen bottom-anchor off-by-one, noted in code, exists in 7.0.5 AND
7.1.1) · I3 never out-of-band (useCursor-only; zero process-stream writes, spy-asserted) · I4 guard
fail/blur/unmount → exactly today's rendering · I5 Apple_Terminal opt-in.

### Red-before-green (HARNESS-041)
Pre-change (develop `288608655` + pre-change binary):
```
FAIL src/__tests__/real-cursor-positioning.test.tsx
  → AssertionError: expected 0 to be greater than 0     (no positioned show existed)
FAIL src/__tests__/pty/ime-cursor.ptytest.ts > 24-row pty
  → AssertionError: expected 0 to be greater than 0     (compositionShows.length)
FAIL src/flows/__tests__/real-cursor-flow.test.ts
  → Failed to load url ../real-cursor-flow.js           (module did not exist)
```
Post-change: 21 unit + 3 component + 6 pinning + 4 capability tests green; PTY regression green
(24-row: every post-boot `ESC[?25h` on the input row, final col = prompt + 2 + 4; 5-row: zero shows).

### Verification (foreground)
- `agent-transport-tui` full unit suite: **507 passed (65 files)**
- Full PTY suite on the rebuilt binary: **17 passed (11 files)**, exit 0
- `tsc --noEmit` clean; `node scripts/harness/run-all-scans.mjs`: **all 59 scans passed**

### Housekeeping
The design doc's "lockfile resolves ink 7.0.5" note is stale: develop's lockfile resolves the
declared `^7.1.1` (7.1.1) for both TUI packages. The four cursor-relevant ink build files were
verified byte-identical between 7.0.5 and 7.1.1 — no dependency change made (no ink upgrade).

### Remaining (backlog stays open — do not archive)
Manual terminal matrix on real hardware (iTerm2 + Terminal.app ±`ROBOTA_IME_CURSOR`,
kitty/WezTerm/Ghostty/Windows Terminal/tmux) and owner-observed user-execution evidence. I5 keeps
Apple_Terminal off by default until the matrix passes. Agent-run scenario evidence recorded in
`.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC
