### PR TITLE
chore(backlog): PROC-001 — reconcile 17 legacy completed/ status:todo files, empty the scan allowlist

### DIFF
--- a/.agents/backlog/CLI-032-git-first-class-commands.md
+++ b/.agents/backlog/CLI-032-git-first-class-commands.md
@@ -8,6 +8,13 @@ area: packages/agent-command, packages/agent-cli
 depends_on: []
 ---
 
+## Progress (PROC-001 reconciliation, 2026-07-25)
+
+Reopened: **nothing was implemented.** PR #589 (2026-05-25) archived this with checked task boxes,
+but its diff touched no git command module, and no `/status`, `/diff`, or `/commit` command exists
+anywhere in `packages/` today (rg-verified). Remaining: the entire item — re-validate the product
+direction first (git interaction currently flows through the Bash tool and `/shell`).
+
 ## Background
 
 AI 코딩 어시스턴트의 핵심 워크플로우는 코드 수정 → git commit → push다. 현재 Robota CLI에서는 Bash 도구로 `git commit -m "..."` 을 직접 실행해야 한다. Bash 도구 실행은 권한 프롬프트를 유발하고, 커밋 메시지 품질이나 staged 파일 선택을 AI가 자연스럽게 관리하기 어렵다.

--- a/.agents/backlog/CLI-034-plugin-publish-one-official.md
+++ b/.agents/backlog/CLI-034-plugin-publish-one-official.md
@@ -8,6 +8,15 @@ area: packages/
 depends_on: []
 ---
 
+## Progress (PROC-001 reconciliation, 2026-07-25)
+
+Reopened: **nothing was implemented.** PR #589's task file claimed `@robota-sdk/plugin-file-system`
+was published, but no `packages/plugin-*` package exists in the workspace and #589's diff created
+none. Remaining: the entire item — and it should be re-scoped against the current plugin
+architecture (`agent-plugin`, bundle plugin loader, marketplace source) before any work. Related
+items PM-005/CLI-020 carry terminal statuses with the same unverified-claims smell; check them
+before trusting their evidence.
+
 ## Background
 
 Robota SDK가 "플러그인 기반 확장"을 핵심 아키텍처로 내세우지만 현재 공식 npm 플러그인이 없다. 생태계를 만들려면 공식 팀이 먼저 "이렇게 만드는 거야"를 보여주는 레퍼런스 플러그인이 필요하다.

--- a/.agents/backlog/CLI-042-grep-tool-parallel.md
+++ b/.agents/backlog/CLI-042-grep-tool-parallel.md
@@ -6,6 +6,13 @@ priority: low
 category: performance
 ---
 
+## Progress (PROC-001 reconciliation, 2026-07-25)
+
+Reopened: **not implemented.** PR #589's task file checked "p-limit(50) verified", but that PR
+never touched `grep-tool.ts`, and the file still reads sequentially today
+(`packages/agent-tools/src/builtins/grep-tool.ts` L210-213: `for (const filePath of files) {
+await readFile(...) }`, no p-limit import). Remaining: the entire item as specified below.
+
 ## 문제
 
 `packages/agent-tools/src/builtins/grep-tool.ts`:

--- a/.agents/backlog/PM-026-github-action-official.md
+++ b/.agents/backlog/PM-026-github-action-official.md
@@ -8,6 +8,14 @@ area: apps/, packages/agent-cli
 depends_on: []
 ---
 
+## Progress (PROC-001 reconciliation, 2026-07-25)
+
+Reopened as partially shipped. Done in PR #589 (2026-05-25): `apps/action/` (action.yml +
+src/index.ts + 2 passing unit tests) and `content/integrations/github-action.md` — both still
+present. Remaining (the item's own success criterion): publish `robota-sdk/action@v1` to the
+GitHub Marketplace (owner-gated, like npm publishes) and verify the action posts a review comment
+on a real PR. Until then the integration doc describes an action nobody can `uses:` (cf. REL-018).
+
 ## Background
 
 GitHub Action은 개발자가 Robota CLI를 처음 "진짜로 써보는" 채널이 될 수 있다. 코드 리뷰, PR 설명 자동 생성, 테스트 실패 분석 같은 use case가 명확하고, Action 한 줄이면 팀 전체에 도입된다.

--- a/.agents/backlog/PM-031-readme-demo-gif.md
+++ b/.agents/backlog/PM-031-readme-demo-gif.md
@@ -6,6 +6,14 @@ priority: high
 category: marketing
 ---
 
+## Progress (PROC-001 reconciliation, 2026-07-25)
+
+Reopened: **the README currently ships a broken image.** PR #589 added the README reference
+(`packages/agent-cli/README.md` L62 `![Demo](./docs/demo.gif)`) plus `docs/DEMO-SCRIPT.md`, but
+`packages/agent-cli/docs/demo.gif` is still a 41-byte placeholder — it renders as a broken image
+on GitHub/npm. Remaining: record the real GIF per DEMO-SCRIPT.md (agent-runnable via the PTY/TUI
+e2e harness + asciinema/agg), or remove the reference until one exists.
+
 ## 문제
 
 README에 TUI가 어떻게 생겼는지 이미지가 전혀 없다.

--- a/.agents/backlog/completed/CLI-043-glob-stat-n-plus-one.md
+++ b/.agents/backlog/completed/CLI-043-glob-stat-n-plus-one.md
@@ -1,10 +1,16 @@
 ---
 title: 'CLI-043: glob-tool mtime 조회 I/O 폭발 완화'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: low
 category: performance
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place: `glob-tool.ts` wraps every `stat`
+in `pLimit(100)` (`packages/agent-tools/src/builtins/glob-tool.ts` L12/L68). Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/CLI-044-process-exit-cleanup.md
+++ b/.agents/backlog/completed/CLI-044-process-exit-cleanup.md
@@ -1,10 +1,17 @@
 ---
 title: 'CLI-044: cli.ts TUI 종료 후 process.exit 비동기 리소스 정리'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-24
 priority: low
 category: bug
 ---
+
+> **Superseded by CLI-071 + CLI-075 (both done).** The TUI exit path was redesigned after this
+> item: `cli.ts` now awaits the full TUI lifecycle (`await renderApp(...)`) and then calls an
+> explicit `process.exit(0)` (reintroduced deliberately in PLG-007, ff6f178e5) — graceful
+> shutdown/flush is owned by the CLI-071 shutdown fix and CLI-075 shutdown/channel hygiene, not by
+> removing the exit call as this item proposed. Reconciled 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/CLI-046-denied-tools-flag.md
+++ b/.agents/backlog/completed/CLI-046-denied-tools-flag.md
@@ -1,10 +1,18 @@
 ---
 title: 'CLI-046: --denied-tools 플래그 추가'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: low
 category: feature
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place: `--denied-tools` is parsed in
+`packages/agent-cli/src/utils/cli-args.ts` (L45/L97/L195/L265), threaded to both TUI
+(`renderApp({ deniedTools })` in `cli.ts`) and print mode, with tests in
+`cli-args.test.ts`. Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/CLI-047-structured-exit-codes.md
+++ b/.agents/backlog/completed/CLI-047-structured-exit-codes.md
@@ -1,10 +1,19 @@
 ---
 title: 'CLI-047: print 모드 구조화 exit code'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: low
 category: feature
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place: README has an
+"Exit Codes (print mode)" section (`packages/agent-cli/README.md` L179), stream-json error events
+carry `error_code` (`packages/agent-transport/src/headless/headless-runner.ts` L120), and config
+errors exit 3 (`cli.ts` `ProviderConfigError` → exit 3 in print mode). The exit-code contract was
+later audited and hardened by CLI-064 (done). Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/CLI-048-websearch-fallback.md
+++ b/.agents/backlog/completed/CLI-048-websearch-fallback.md
@@ -1,10 +1,19 @@
 ---
 title: 'CLI-048: WebSearch BRAVE_API_KEY 없을 때 폴백 및 문서화'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: low
 category: feature
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place — the P1 (minimum) scope plus
+graceful degradation: `web-search-tool.ts` returns a setup message when `BRAVE_API_KEY` is absent,
+and `packages/agent-cli/README.md` documents the key in the env-var table (L93) and the Built-in
+Tools section (L234/L237). The optional P2 fallback search engine was explicitly "(선택)" and was
+not pursued. Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/PM-027-korean-marketing-content.md
+++ b/.agents/backlog/completed/PM-027-korean-marketing-content.md
@@ -1,12 +1,20 @@
 ---
 title: 'PM-027: 한국어 마케팅 콘텐츠 — GeekNews, okky, velog 타겟'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-24
 priority: medium
 urgency: soon
 area: apps/www, apps/docs
 depends_on: []
 ---
+
+> **Superseded.** The only agent-executable slice shipped: the Korean README
+> (`packages/agent-cli/docs/README-KO.md`, PR #589, 2026-05-25). The remaining scope
+> (GeekNews/velog/okky posts, community Q&A cadence) is manual owner-run community action that was
+> never performed, and community/blog launch content is owned by MKT-001 (done 2026-05-18,
+> `apps/blog` + GitHub community). Do not stamp done — no community posting evidence exists.
+> Reconciled 2026-07-25 (PROC-001).
 
 ## Background
 

--- a/.agents/backlog/completed/PM-028-beta-invite-program.md
+++ b/.agents/backlog/completed/PM-028-beta-invite-program.md
@@ -1,12 +1,19 @@
 ---
 title: 'PM-028: 외부 베타 초대 프로그램 — early adopter 확보'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-24
 priority: medium
 urgency: soon
 area: apps/www
 depends_on: []
 ---
+
+> **Superseded by WEB-008 (done) for the shipped artifact.** The `/beta` signup page shipped in
+> PR #589 (`apps/www/src/app/[locale]/beta/page.tsx`, 2026-05-25) and its broken submit flow +
+> i18n were fixed by WEB-008. The program operations (recruiting 10 early adopters, Discord/
+> Discussions channel, interviews, NPS) are manual owner-run actions that never happened and have
+> no agent-executable remainder. Reconciled 2026-07-25 (PROC-001).
 
 ## Background
 

--- a/.agents/backlog/completed/PM-029-sdk-starter-kit.md
+++ b/.agents/backlog/completed/PM-029-sdk-starter-kit.md
@@ -1,12 +1,20 @@
 ---
 title: 'PM-029: SDK Starter Kit — Next.js + Express 템플릿 저장소'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-24
 priority: low
 urgency: later
 area: apps/
 depends_on: []
 ---
+
+> **Superseded.** Template A shipped in PR #589 and still exists (`apps/starter-nextjs/` +
+> `content/quickstart.md`); the Express path is covered by `examples/express` (rewritten against
+> the current SDK by EXAMPLES-002, done 2026-06-27) and adoption-path quickstart docs are owned by
+> DOCS-014 (done 2026-07-03). The remaining distribution mechanics (`npx create-robota-app`,
+> template-repo "Use this template" / Vercel deploy buttons) were never pursued and are not
+> currently roadmapped. Reconciled 2026-07-25 (PROC-001).
 
 ## Background
 

--- a/.agents/backlog/completed/PM-030-opt-in-telemetry.md
+++ b/.agents/backlog/completed/PM-030-opt-in-telemetry.md
@@ -1,12 +1,19 @@
 ---
 title: 'PM-030: opt-in 익명 텔레메트리 — 실제 사용 패턴 수집'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-24
 priority: low
 urgency: later
 area: packages/agent-cli, packages/agent-framework
 depends_on: []
 ---
+
+> **Superseded by AUDIT-001 (done).** A telemetry stub shipped in PR #589
+> (`packages/agent-cli/src/startup/telemetry.ts` + first-run opt-in prompt) but had no collection
+> backend and was deliberately removed in full by AUDIT-001 decision B ("Remove telemetry
+> entirely", commit 9c53c19d3, 2026-05-25). No telemetry code exists today; re-introducing it
+> would need a fresh spec. Reconciled 2026-07-25 (PROC-001).
 
 ## Background
 

--- a/.agents/backlog/completed/PM-033-init-inline-provider-setup.md
+++ b/.agents/backlog/completed/PM-033-init-inline-provider-setup.md
@@ -1,10 +1,19 @@
 ---
 title: 'PM-033: robota init 완료 후 프로바이더 설정 인라인 연결'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: medium
 category: ux
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place: `robota init` ends with an inline
+"Would you like to set up a provider now?" confirm that launches provider setup, with `--yes`/CI
+defaulting and a non-TTY hard error (`packages/agent-cli/src/init/init-command.ts` L94-L113,
+L205-L207). Prompt/`--yes` behavior was later fixed by CLI-049 (#684) and CLI-065 (both done).
+Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/PM-034-help-command-examples.md
+++ b/.agents/backlog/completed/PM-034-help-command-examples.md
@@ -1,10 +1,19 @@
 ---
 title: 'PM-034: /help 커맨드에 각 커맨드 사용 예시 추가'
-status: todo
+status: done
+completed: 2026-05-25
 created: 2026-05-24
 priority: low
 category: ux
 ---
+
+## Outcome
+
+Shipped in PR #589 (ba6c6036b, 2026-05-25) and still in place: `ICommand` has the optional
+`example` field (`packages/agent-framework/src/command-api/contracts.ts` L14-L15) and `/help`
+renders `Example: ...` lines for commands that define it
+(`packages/agent-framework/src/command-api/help/help-command-api.ts` L19-L20), with examples set
+on `/compact` and `/provider`. Verified 2026-07-25 (PROC-001).
 
 ## 문제
 

--- a/.agents/backlog/completed/PROC-001-completed-dir-status-reconciliation.md
+++ b/.agents/backlog/completed/PROC-001-completed-dir-status-reconciliation.md
@@ -1,6 +1,7 @@
 ---
 title: 'PROC-001: reconcile the 17 completed/-dir backlog files still carrying status: todo'
-status: todo
+status: done
+completed: 2026-07-25
 created: 2026-07-02
 priority: low
 urgency: later
@@ -36,4 +37,23 @@ PM-026/027/028/029/030/031/033/034, SITE-004):
 
 - Not applicable (backlog bookkeeping; the scan is the maintained gate). Evidence: per-item
   verification notes recorded in each reconciled file.
-- Evidence: _to fill per item._
+- Evidence: see Outcome below — each file carries its own Outcome/supersession/Progress note.
+
+## Outcome (2026-07-25)
+
+All 17 files verified item-by-item against the code, `git log --all`, and related closed items;
+`LEGACY_COMPLETED_TODO` emptied and the scan passes with no allowlist.
+
+- **done, completed 2026-05-25 (shipped in PR #589, re-verified in today's code):** CLI-043
+  (glob pLimit(100)), CLI-046 (`--denied-tools`), CLI-047 (exit codes + `error_code`, later
+  hardened by CLI-064), CLI-048 (WebSearch BRAVE_API_KEY docs + graceful message), PM-033 (init
+  inline provider prompt, later fixed by CLI-049/065), PM-034 (`ICommand.example` in /help).
+- **superseded:** CLI-044 (→ CLI-071/075 shutdown lifecycle), PM-027 (→ MKT-001; README-KO
+  shipped, community posts never made), PM-028 (→ WEB-008; beta page shipped, program never ran),
+  PM-029 (→ starter-nextjs shipped + EXAMPLES-002/DOCS-014), PM-030 (→ AUDIT-001 removed
+  telemetry entirely), SITE-004 (→ DEPLOY-001 apex migration made the www-redirect plan obsolete).
+- **reopened (moved back to the root, `status: todo`, with Progress notes):** CLI-032 (no git
+  slash commands exist — #589 claim false), CLI-034 (no plugin package exists — claim false),
+  CLI-042 (grep-tool still sequential — claim false), PM-026 (apps/action shipped; Marketplace
+  publish + real-PR verification remain), PM-031 (README references a 41-byte placeholder
+  demo.gif — broken image).

--- a/.agents/backlog/completed/SITE-004-domain-redirect-migration.md
+++ b/.agents/backlog/completed/SITE-004-domain-redirect-migration.md
@@ -1,12 +1,18 @@
 ---
 title: 'SITE-004: 도메인 리다이렉션 최종 전환 — robota.io → www.robota.io'
-status: todo
+status: superseded
+completed: 2026-07-25
 created: 2026-05-23
 priority: medium
 urgency: later
 area: Vercel DNS / 도메인 설정
 depends_on: [SITE-001, SITE-002, SITE-003]
 ---
+
+> **Superseded by DEPLOY-001 (done 2026-06-27).** The final domain architecture changed: the
+> marketing site is served directly at the apex `robota.io` (Cloudflare Pages) with docs at
+> `docs.robota.io` — the Phase-2 plan here (`robota.io` → `www.robota.io` 301) is obsolete and was
+> never executed. Reconciled 2026-07-25 (PROC-001).
 
 ## Background
 

--- a/scripts/harness/check-backlog-placement.mjs
+++ b/scripts/harness/check-backlog-placement.mjs
@@ -28,29 +28,12 @@ const TERMINAL_STATUSES = new Set(['done', 'wontfix', 'skipped', 'superseded']);
 const OPEN_STATUSES = new Set(['todo', 'in-progress']);
 
 /**
- * Historical debt: PR #589 (2026-05-25) archived these as implemented but never flipped their
- * frontmatter from `todo`. Their true state needs item-by-item verification — tracked by
- * `.agents/backlog/PROC-001-completed-dir-status-reconciliation.md`. Do not add new entries.
+ * Historical debt: PR #589 (2026-05-25) archived files as implemented while leaving their
+ * frontmatter at `todo`. All 17 were reconciled item-by-item by PROC-001 (2026-07-25) — see
+ * `.agents/backlog/completed/PROC-001-completed-dir-status-reconciliation.md`. Do not add new
+ * entries; the invariant now holds unconditionally.
  */
-const LEGACY_COMPLETED_TODO = new Set([
-  '.agents/backlog/completed/CLI-032-git-first-class-commands.md',
-  '.agents/backlog/completed/CLI-034-plugin-publish-one-official.md',
-  '.agents/backlog/completed/CLI-042-grep-tool-parallel.md',
-  '.agents/backlog/completed/CLI-043-glob-stat-n-plus-one.md',
-  '.agents/backlog/completed/CLI-044-process-exit-cleanup.md',
-  '.agents/backlog/completed/CLI-046-denied-tools-flag.md',
-  '.agents/backlog/completed/CLI-047-structured-exit-codes.md',
-  '.agents/backlog/completed/CLI-048-websearch-fallback.md',
-  '.agents/backlog/completed/PM-026-github-action-official.md',
-  '.agents/backlog/completed/PM-027-korean-marketing-content.md',
-  '.agents/backlog/completed/PM-028-beta-invite-program.md',
-  '.agents/backlog/completed/PM-029-sdk-starter-kit.md',
-  '.agents/backlog/completed/PM-030-opt-in-telemetry.md',
-  '.agents/backlog/completed/PM-031-readme-demo-gif.md',
-  '.agents/backlog/completed/PM-033-init-inline-provider-setup.md',
-  '.agents/backlog/completed/PM-034-help-command-examples.md',
-  '.agents/backlog/completed/SITE-004-domain-redirect-migration.md',
-]);
+const LEGACY_COMPLETED_TODO = new Set([]);
 
 /** @returns {{ status: string | null, hasCompletedDate: boolean }} */
 export function readBacklogFrontmatter(content) {


### PR DESCRIPTION
## PROC-001 — reconcile the 17 legacy `completed/` files still carrying `status: todo`

PR #589 (2026-05-25, "implement all 45 backlog items") archived 17 backlog files into
`.agents/backlog/completed/` without flipping their frontmatter from `todo`. Each was verified
item-by-item against the current code, `git log --all`, and related closed items, then given its
truthful terminal status — or reopened where #589's completion claims turned out to be false.
`LEGACY_COMPLETED_TODO` in `scripts/harness/check-backlog-placement.mjs` is now **empty**; the
backlog-placement invariant holds with no allowlist. PROC-001 itself is closed and archived.

### Per-file verdicts

| File | Verdict | Evidence |
| --- | --- | --- |
| CLI-043-glob-stat-n-plus-one | **done** (2026-05-25) | `glob-tool.ts` L12/L68: `pLimit(100)` around every `stat` — shipped in #589, still in place |
| CLI-046-denied-tools-flag | **done** (2026-05-25) | `cli-args.ts` parses `--denied-tools` (L45/97/195/265), threaded to TUI + print mode, tests in `cli-args.test.ts` |
| CLI-047-structured-exit-codes | **done** (2026-05-25) | README "Exit Codes (print mode)" (L179); `headless-runner.ts` L120 `error_code`; config errors exit 3; contract later hardened by CLI-064 (done) |
| CLI-048-websearch-fallback | **done** (2026-05-25) | `web-search-tool.ts` graceful no-key message; README env table (L93) + tools section (L234/237); P2 fallback engine was explicitly optional |
| PM-033-init-inline-provider-setup | **done** (2026-05-25) | `init-command.ts` L205-207 inline "set up a provider now?" + `--yes`/CI handling; later fixed by CLI-049 (#684) / CLI-065 |
| PM-034-help-command-examples | **done** (2026-05-25) | `contracts.ts` L14-15 `example?` field; `help-command-api.ts` L19-20 renders `Example:` lines |
| CLI-044-process-exit-cleanup | **superseded** → CLI-071/CLI-075 | `cli.ts` deliberately `await renderApp(...)` then `process.exit(0)` (reintroduced in PLG-007 ff6f178e5); shutdown/flush hygiene owned by CLI-071 + CLI-075 (both done) |
| PM-027-korean-marketing-content | **superseded** → MKT-001 | Only README-KO.md shipped; GeekNews/velog/okky posts are manual community actions never performed; community/blog content owned by MKT-001 (done 2026-05-18) |
| PM-028-beta-invite-program | **superseded** → WEB-008 | `/beta` page shipped in #589 and fixed/localized by WEB-008 (done); the invite-program operations (10 users, interviews, NPS) never ran |
| PM-029-sdk-starter-kit | **superseded** | `apps/starter-nextjs/` + `content/quickstart.md` shipped in #589; Express path = `examples/express` (EXAMPLES-002, done 2026-06-27); quickstarts = DOCS-014 (done 2026-07-03); `create-robota-app`/template-repo distribution never pursued |
| PM-030-opt-in-telemetry | **superseded** → AUDIT-001 | Telemetry stub shipped in #589, then removed entirely by AUDIT-001 decision B (commit 9c53c19d3, 2026-05-25); no telemetry code exists today |
| SITE-004-domain-redirect-migration | **superseded** → DEPLOY-001 | DEPLOY-001 (done 2026-06-27) serves marketing at apex `robota.io` with docs at `docs.robota.io`; the `robota.io` → `www.robota.io` 301 plan is obsolete, never executed |
| CLI-032-git-first-class-commands | **reopened** (todo) | #589 claim false: its diff touched no git command module; no `/status`, `/diff`, `/commit` exists anywhere in `packages/` (rg-verified) |
| CLI-034-plugin-publish-one-official | **reopened** (todo) | #589 claim false: no `packages/plugin-*` package exists or was created; needs re-scoping against the current plugin architecture |
| CLI-042-grep-tool-parallel | **reopened** (todo) | #589 claim false: `grep-tool.ts` L210-213 still reads files sequentially (`for … await readFile`), no p-limit; #589 never touched the file |
| PM-026-github-action-official | **reopened** (todo) | Partial: `apps/action/` + `content/integrations/github-action.md` shipped in #589 and still present; Marketplace publish + real-PR verification (the success criterion) remain |
| PM-031-readme-demo-gif | **reopened** (todo) | README L62 references `docs/demo.gif`, which is still a **41-byte placeholder** — a broken image on GitHub/npm; recording per DEMO-SCRIPT.md remains |

### Verification

- `node scripts/harness/check-backlog-placement.mjs` — passes with `LEGACY_COMPLETED_TODO = new Set([])`
- `node scripts/harness/run-all-scans.mjs` — **all 60 scans pass** (after `pnpm install --ignore-scripts && pnpm build` in the fresh worktree)
- Docs + one allowlist edit only; no product code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2UdLtg6637JWxHZg1FZyC
