### PR TITLE
docs(skill): worktree-parallel orchestration policy (draft for review)

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -147,7 +147,8 @@ This rule applies even when:
    not apply because each branch edits a **disjoint file set** (the orchestrator MUST partition file ownership
    before spawning) and the PRs are merged **sequentially** after CI. Create such a branch with the inline
    override the `branch-guard` hook honors: `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1 git checkout -b <type>/<slug>`.
-   In the main clone (outside a parallel wave) the rule stands as written.
+   In the main clone (outside a parallel wave) the rule stands as written. Procedure:
+   [`worktree-parallel-orchestration`](../skills/worktree-parallel-orchestration/SKILL.md).
 
 ### PR Batching — appropriately-sized PRs (DX-001)
 

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -7,23 +7,24 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 
 ## Process & Planning
 
-| Skill                                                                     | Description                                                                                                                    |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [backlog-pipeline](backlog-pipeline/SKILL.md)                             | Spec document gate pipeline orchestrator: draft → backlog → todo → active → done                                               |
-| [backlog-writer](backlog-writer/SKILL.md)                                 | Author a new spec document with all required sections and frontmatter                                                          |
-| [backlog-gate-guard](backlog-gate-guard/SKILL.md)                         | Validate a single gate (GATE-WRITE/APPROVAL/IMPLEMENT/VERIFY/COMPLETE) and record Evidence Log                                 |
-| [user-request-gate](user-request-gate/SKILL.md)                           | Entry-point gate: backlog draft first, then implementation — invoked on every user impl request                                |
-| [spec-first-development](spec-first-development/SKILL.md)                 | Enforce spec-first workflow before touching contract boundaries                                                                |
-| [spec-writing-standard](spec-writing-standard/SKILL.md)                   | Required sections and quality gates for SPEC.md authoring                                                                      |
-| [spec-code-conformance](spec-code-conformance/SKILL.md)                   | Verification loop to align code with spec after spec changes                                                                   |
-| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                 | Kent Beck TDD cycle: Red → Green → Refactor                                                                                    |
-| [task-tracking](task-tracking/SKILL.md)                                   | Create and update task files in `.agents/tasks/`                                                                               |
-| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md) | Route-only backlog PR pipeline — sequences the gates owned by `backlog-execution.md` and routes to owner skills                |
-| [post-implementation-checklist](post-implementation-checklist/SKILL.md)   | Router: mandatory post-implementation order + gates (SPEC sync → build/test → README → PR → publish → docs)                    |
-| [delegated-refactor-green-gate](delegated-refactor-green-gate/SKILL.md)   | Delegate a large mechanical refactor to a subagent under a hard green-or-report completion gate                                |
-| [repo-change-loop](repo-change-loop/SKILL.md)                             | Standard change loop: impact → build → verify → summarize                                                                      |
-| [pr-review-orchestration](pr-review-orchestration/SKILL.md)               | Route-only PR-review loop: reviewer→writer→fixer until `ACTIONABLE FINDINGS: 0` (bounded), then gated merge path (HARNESS-018) |
-| [version-management](version-management/SKILL.md)                         | Coordinated version bumps with changesets across all packages + semver impact of public API surface changes                    |
+| Skill                                                                       | Description                                                                                                                               |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [backlog-pipeline](backlog-pipeline/SKILL.md)                               | Spec document gate pipeline orchestrator: draft → backlog → todo → active → done                                                          |
+| [backlog-writer](backlog-writer/SKILL.md)                                   | Author a new spec document with all required sections and frontmatter                                                                     |
+| [backlog-gate-guard](backlog-gate-guard/SKILL.md)                           | Validate a single gate (GATE-WRITE/APPROVAL/IMPLEMENT/VERIFY/COMPLETE) and record Evidence Log                                            |
+| [user-request-gate](user-request-gate/SKILL.md)                             | Entry-point gate: backlog draft first, then implementation — invoked on every user impl request                                           |
+| [spec-first-development](spec-first-development/SKILL.md)                   | Enforce spec-first workflow before touching contract boundaries                                                                           |
+| [spec-writing-standard](spec-writing-standard/SKILL.md)                     | Required sections and quality gates for SPEC.md authoring                                                                                 |
+| [spec-code-conformance](spec-code-conformance/SKILL.md)                     | Verification loop to align code with spec after spec changes                                                                              |
+| [tdd-red-green-refactor](tdd-red-green-refactor/SKILL.md)                   | Kent Beck TDD cycle: Red → Green → Refactor                                                                                               |
+| [task-tracking](task-tracking/SKILL.md)                                     | Create and update task files in `.agents/tasks/`                                                                                          |
+| [backlog-execution-orchestrator](backlog-execution-orchestrator/SKILL.md)   | Route-only backlog PR pipeline — sequences the gates owned by `backlog-execution.md` and routes to owner skills                           |
+| [post-implementation-checklist](post-implementation-checklist/SKILL.md)     | Router: mandatory post-implementation order + gates (SPEC sync → build/test → README → PR → publish → docs)                               |
+| [delegated-refactor-green-gate](delegated-refactor-green-gate/SKILL.md)     | Delegate a large mechanical refactor to a subagent under a hard green-or-report completion gate                                           |
+| [worktree-parallel-orchestration](worktree-parallel-orchestration/SKILL.md) | Run ≥2 independent backlog items in parallel via worktree-isolated subagents with zero merge conflicts (partition → spawn → serial merge) |
+| [repo-change-loop](repo-change-loop/SKILL.md)                               | Standard change loop: impact → build → verify → summarize                                                                                 |
+| [pr-review-orchestration](pr-review-orchestration/SKILL.md)                 | Route-only PR-review loop: reviewer→writer→fixer until `ACTIONABLE FINDINGS: 0` (bounded), then gated merge path (HARNESS-018)            |
+| [version-management](version-management/SKILL.md)                           | Coordinated version bumps with changesets across all packages + semver impact of public API surface changes                               |
 
 ## Code Quality & Architecture
 

--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: worktree-parallel-orchestration
+description: Procedure for running multiple independent backlog items in parallel via worktree-isolated subagents with zero merge conflicts — partition file ownership before spawning, isolate each implementer in its own worktree, sequence overlapping work behind occupants, one coherent self-verified PR per agent, and serial orchestrator merge. Use when executing 2 or more independent items concurrently.
+---
+
+# Worktree-Parallel Orchestration
+
+Procedure for the orchestrator that fans out several **independent** backlog items to
+**worktree-isolated** subagents at once, then merges their PRs serially with no conflicts. This skill is
+routing/procedure only — every git, spec, TDD, and verification constraint it invokes is **owned by the
+rules below and must not be restated here**.
+
+## Rule Anchor
+
+- `AGENTS.md` > "Rules and Skills Boundary" — skills are procedure; rules win on conflict.
+- `.agents/rules/git-branch.md` — Git Worktree (isolation + guardrails); One-Branch-At-A-Time Rule
+  (Exception 2 authorizes concurrent worktree branches on a **disjoint file set**);
+  `--delete-branch` ban; Merge Landing Verification; Delete Merged Branches; PR Batching (DX-001).
+- `.agents/rules/spec-workflow.md` + `.agents/rules/backlog-execution.md` — spec gate pipeline for code work.
+- `.agents/rules/tdd-and-planning.md` — red-before-green (HARNESS-041).
+- `.agents/rules/verification.md` — build / test / typecheck / scan gates.
+
+## When to Use / When NOT to Use
+
+- **Use** when there are **≥ 2 independent items** whose file territories can be made disjoint, and the
+  speedup of running them concurrently is worth the partition overhead.
+- **Do NOT use** for a **single item** (just do it on one branch) or for **tightly-coupled changes** that
+  cannot be split into non-overlapping file sets — run those sequentially on one branch instead.
+
+## The Procedure
+
+### 1. Partition file ownership BEFORE spawning (primary conflict-avoidance)
+
+Before any agent is spawned, assign every candidate item an explicit **OWNED path list** and a
+**FORBIDDEN path list**. The partition invariant: **no two concurrent agents may write the same file.**
+Shared/central files (index registries, baselines, cross-cutting rule docs) are the usual collision
+points — give each such file to at most one agent, or defer edits to it (see step 8). This is the
+mechanism the git-branch.md One-Branch-At-A-Time Exception 2 depends on; without a clean partition, do
+not run in parallel.
+
+### 2. Isolate each implementer in its own worktree
+
+Spawn each parallel implementer with the `Agent` tool's `isolation: "worktree"`. Each carries its own
+concurrent feature branch cut from a freshly-fetched `origin/develop` (branch-guard override:
+`BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1`). Hand each agent its OWNED + FORBIDDEN lists verbatim.
+
+### 3. Sequence overlapping work behind occupants
+
+If a candidate item's territory overlaps the OWNED paths of a **currently-running** agent, **HOLD** it —
+do not spawn it. Release it only after the occupying agent's PR merges (its files are then free). Never
+run two agents that touch the same file concurrently.
+
+### 4. One coherent PR per agent (the agent's contract)
+
+Each implementer produces exactly one PR and does **not** self-merge:
+
+- Red-before-green (HARNESS-041): prove the new/changed test fails pre-fix.
+- **Foreground** self-verification: `pnpm build`, `pnpm test`, `pnpm typecheck`,
+  `node scripts/harness/run-all-scans.mjs` — all green, evidence reported.
+- Correct commit footers; `gh pr create --base develop`.
+- Stop-and-report on a blocker rather than merging or leaving a broken commit.
+
+### 5. Orchestrator merges serially
+
+Merge PRs one at a time via armed auto-merge: `gh pr merge --auto --squash` (never `--delete-branch`).
+On a stale base or CI flake, **rebase the branch onto fresh `origin/develop` and re-arm**. Diagnose real
+failures; treat known fresh-worktree env artifacts (e.g. a missing `dist`) as non-blocking. Confirm each
+merge actually landed (Merge Landing Verification) before releasing any item held in step 3.
+
+### 6. Spec-gated (code) work clears its gate BEFORE implementation
+
+For code items requiring a spec, run draft → GATE-WRITE → independent GATE-APPROVAL (proposal-reviewer +
+architecture-auditor) first; fold REVISE items, then approve — all per `spec-workflow.md` /
+`backlog-execution.md`. Only APPROVED items enter the parallel implementation wave.
+
+### 7. Resume, don't respawn
+
+A subagent killed by a session limit is **resumed from its transcript** (`SendMessage` to the same
+agent), never re-spawned from scratch — a fresh spawn loses its partition context and its in-progress
+worktree state.
+
+### 8. Baseline reconciliation once
+
+When several concurrent PRs each tighten the same ratchet baseline (spec-surface, file-size,
+prompt-prose), do **not** regenerate the baseline per-PR (each regen races the others). Let the earlier
+PRs land, then regenerate the baseline **once on the last-merging PR**.
+
+## Worked Example — the partition step
+
+Three independent items, partitioned so no file is written twice:
+
+| Item | Agent | OWNED (may write)                             | FORBIDDEN (must not touch)                       |
+| ---- | ----- | --------------------------------------------- | ------------------------------------------------ |
+| A    | a1    | `packages/foo/**`                             | `packages/bar/**`, `packages/baz/**`, shared idx |
+| B    | a2    | `packages/bar/**`                             | `packages/foo/**`, `packages/baz/**`, shared idx |
+| C    | a3    | `packages/baz/**` + the shared registry/index | `packages/foo/**`, `packages/bar/**`             |
+
+The shared registry is owned by exactly one agent (a3). A fourth item touching `packages/bar/**` is
+**held** (step 3) until B's PR merges, since it overlaps a2's OWNED set.
+
+## What This Skill Does NOT Do
+
+| Not this skill's job                    | Owner                                          |
+| --------------------------------------- | ---------------------------------------------- |
+| Define git/branch/merge/worktree policy | `.agents/rules/git-branch.md`                  |
+| Define the spec gate pipeline           | `spec-workflow.md` / `backlog-execution.md`    |
+| Define red-before-green / verification  | `tdd-and-planning.md` / `verification.md`      |
+| Do the implementation or judge the PR   | the spawned implementer / the code-review gate |
+
+If you find yourself restating a rule here, stop — link the rule instead.


### PR DESCRIPTION
## Summary

Adds a thin, single-responsibility **leaf skill** codifying the worktree-parallel subagent orchestration procedure — running multiple independent backlog items in parallel via worktree-isolated subagents with **zero merge conflicts**. Distilled from a full session of running the workflow successfully. **Draft for owner review** — do not merge without sign-off.

New file: `.agents/skills/worktree-parallel-orchestration/SKILL.md`

## What it codifies (8 principles, as a procedure)

1. Partition file ownership (OWNED + FORBIDDEN lists) BEFORE spawning — primary conflict-avoidance.
2. Worktree isolation per implementer (`Agent isolation: "worktree"`).
3. Sequence overlapping work behind currently-running occupants.
4. One coherent, self-verified PR per agent (red-before-green, foreground build/test/typecheck/scans, no self-merge).
5. Orchestrator merges serially via armed auto-merge; rebase + re-arm on stale base; env artifacts non-blocking.
6. Spec-gated code work clears GATE-WRITE / GATE-APPROVAL before implementation.
7. Resume (SendMessage), don't respawn, a session-limited subagent.
8. Baseline reconciliation once, on the last-merging PR.

Includes a when-to-use / when-NOT-to-use section and a worked partition example.

## Skills-vs-rules boundary

Procedure only. Every git / spec / TDD / verification constraint is **referenced to its owning rule, never restated** (per `AGENTS.md` > Rules and Skills Boundary). Registered in `.agents/skills/index.md`. Added a one-line pointer from `git-branch.md`'s One-Branch-At-A-Time **Exception 2** (which already authorizes this workflow) to the new procedure skill — pointer only, no duplicated content. No new scans/enforcement invented.

## Verification

`node scripts/harness/run-all-scans.mjs`: 59/60 pass. The only failure is `dist` (fresh-worktree build artifact, resolved for the push by a local `pnpm build`) — unrelated to this docs-only change. The `scan-consistency` gate governing skill anchors/phrases passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb19d3LCYKqLg9TmyKRh36