### PR TITLE
docs(lessons): mine recurring agent mistakes + prevention-mechanism mandate

### DIFF
--- a/.agents/backlog/HARNESS-044-frontmatter-scan-multiline-tags.md
+++ b/.agents/backlog/HARNESS-044-frontmatter-scan-multiline-tags.md
@@ -41,3 +41,9 @@ before it.
 
 Fixture-based: single-line tags (green), multi-line prettier-wrapped tags (RED before, green after),
 genuinely-missing tags (still fails). `pnpm harness:test` + `run-all-scans` green.
+
+## Related
+
+- **HARNESS-045** — a single local verification entry that reproduces the CI scans/quality gate
+  exactly. This item is a member of that broader "green locally ≠ green in CI" class (the
+  formatter-drift-not-caught-locally instance).

--- a/.agents/backlog/HARNESS-045-local-verify-mirrors-ci.md
+++ b/.agents/backlog/HARNESS-045-local-verify-mirrors-ci.md
@@ -1,0 +1,97 @@
+---
+title: 'HARNESS-045: a single local verification entry that reproduces the CI scans/quality gate exactly'
+status: todo
+created: 2026-07-25
+priority: high
+urgency: soon
+area: scripts/harness, package.json, .agents/skills, .agents/rules
+depends_on: []
+---
+
+# HARNESS-045: local verification must mirror what CI asserts
+
+## The class
+
+An agent's FOREGROUND verification — typically `node scripts/harness/run-all-scans.mjs` reported as
+"green locally" — does NOT reproduce what the CI `scans` / `quality` jobs assert. So "green locally"
+is not the same claim as "green in CI," and an agent can honestly report a passing local run while the
+PR fails CI. This is a recurring **agent/technical failure class** (the same kind of "green
+locally → red in CI" failure fixed more than once), which is exactly the blind spot the
+[lesson-to-harness](../skills/lesson-to-harness/SKILL.md) recurring-failure mining scope now targets.
+The terminal state for a recurring mistake is a mechanical prevention, not another one-off fix.
+
+## Evidence (cited instances of the class)
+
+- **Spec-surface baseline false-pass.** The spec-surface scan treats a below-baseline count as a
+  pass locally ("below-baseline → tighten"), so a real improvement reads as green in a foreground
+  run. But the CI self-test asserts `notices == []`, so the same state fails in CI. Observed on
+  #1346 and #1357.
+- **Prettier-wrapped multi-line arrays.** Prettier (the repo's SSOT formatter, run via lint-staged)
+  wraps a long YAML `tags` array onto multiple lines, but `check-spec-doc-frontmatter` only parses the
+  single-line form, so it reports "tags missing." A `--no-verify` push from a fresh worktree skips
+  prettier entirely, so the drift is never produced — and never caught — locally. Observed on
+  #1369 → tracked as **HARNESS-044** (the frontmatter-parser sub-fix; a member of this class).
+
+## Root cause
+
+1. The local run treats **baseline notices** (below-baseline spec-surface) and **unbuilt `dist`** as
+   a pass, whereas CI self-tests assert `notices == []` and run scans against the built `dist`.
+2. **Fresh worktrees lack the husky / prettier toolchain**, so a `--no-verify` push bypasses
+   formatting; formatter-induced drift (e.g. multi-line arrays) is never generated locally and thus
+   never exercised by the local scans.
+
+Net: the foreground gate and the CI gate assert different things, so a green local run gives false
+assurance.
+
+## Prevention to build (the mechanism)
+
+A single `pnpm` verification entry — e.g. `pnpm harness:verify-like-ci` — that reproduces the CI gate
+exactly, so an agent's self-verification catches these BEFORE push:
+
+1. Runs the harness **self-test suite** (so the spec-surface baseline assertion `notices == []`
+   trips locally instead of silently passing below-baseline).
+2. Runs a **prettier `--check`** over the changed files (so formatter-induced drift — multi-line
+   arrays, wrapping — is surfaced even on a fresh worktree that would otherwise `--no-verify`).
+3. Runs the scans against the **built `dist`** (so unbuilt-`dist` no longer masks a failure).
+
+Then wire a reference to this single entry into:
+
+- the parallel-orchestration skill's verification step (agents self-verify with the CI-equivalent
+  command, not bare `run-all-scans`); and
+- the `git-branch.md` pre-merge guidance (the pre-push / pre-merge check is the CI-equivalent entry).
+
+## Why this is deferred (concrete obstacle, per lesson-to-harness step 8 "infeasible-now")
+
+The mechanism lives in `scripts/harness/**`, which is currently **contended by another active agent**
+(ARCH-005 S1 is editing `scripts/harness`). Building the new entry now would conflict. Coordinate:
+**build this AFTER ARCH-005 S1 merges** to avoid stepping on its in-flight changes. This is a
+scheduling obstacle, not a design blocker — hence a tracked backlog item rather than silence, which
+is the sanctioned "infeasible-now + tracked backlog" terminal state.
+
+## Red-first plan (per lesson-to-harness step 9)
+
+1. Reproduce a **below-baseline spec-surface improvement** and a **prettier-wrapped multi-line array**
+   in a fixture.
+2. Show `node scripts/harness/run-all-scans.mjs` reports GREEN on both while the new
+   `harness:verify-like-ci` entry FAILS (it asserts `notices == []`, runs prettier `--check`, and
+   scans the built `dist`).
+3. After the fix / formatting, show the new entry PASSES. Record the before/after result.
+
+## Test Plan
+
+- Fixture-based red/green pair for each cited instance (below-baseline spec-surface; prettier-wrapped
+  tags), demonstrating the new entry FAILS where `run-all-scans` passed, then PASSES after fix.
+- Register the new entry so CI and the local run assert the same thing; `pnpm harness:test` +
+  `run-all-scans` green.
+
+## User Execution Test Scenarios
+
+- Not applicable (harness / CI-parity check; governance-only change with no runnable user-facing
+  behavior). Evidence: the fixture red/green pairs above, run by the agent.
+
+## Related
+
+- **HARNESS-044** — frontmatter scan must parse prettier-wrapped multi-line arrays; a member of this
+  class (the formatter-drift-not-caught-locally instance).
+- **HARNESS-041** — mechanical accidental-green floor; sibling "the local check must actually assert
+  what it claims" floor.

--- a/.agents/rules/learning-loop.md
+++ b/.agents/rules/learning-loop.md
@@ -5,7 +5,8 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 
 ### Lesson Capture
 
-- The procedural "how" for turning repeated user corrections/preferences into enforced repo rules is the [lesson-to-harness](../skills/lesson-to-harness/SKILL.md) skill (mine → approve → normalize → wire every touchpoint → enforce → ship). Invoke it on a repeated correction or an explicit "from now on …" principle.
+- The procedural "how" for turning repeated lessons into enforced repo rules is the [lesson-to-harness](../skills/lesson-to-harness/SKILL.md) skill (mine → approve → normalize → wire every touchpoint → enforce → ship). Invoke it on **either** a repeated user correction / an explicit "from now on …" principle, **or** a recurring agent/technical failure class — the same *kind* of failure hit 2×+ in a session even with no user correction (e.g. fixing the same category of CI/scan failure twice). A recurring agent mistake is a first-class lesson trigger, not only user corrections; when you find yourself fixing the same *class* of failure a second time, invoke the loop.
+- **Fixing an instance never closes a recurring mistake.** For any recurring failure, the only terminal state is a mechanical PREVENTION that stops the cause from recurring (steps 8–9 of the skill: mechanize, or infeasible-now + tracked backlog, then prove it fails pre-fix). Correcting the current occurrence without analyzing the cause and preventing recurrence leaves the lesson open.
 - When a problem, review comment, CI failure, user correction, or debugging pattern repeats, do not leave it only in chat, PR notes, or a task file.
 - Extract the general invariant behind the event. The rule must be domain-neutral unless the invariant belongs to a package SPEC.
 - Record the invariant in the narrowest owner document:

--- a/.agents/skills/lesson-to-harness/SKILL.md
+++ b/.agents/skills/lesson-to-harness/SKILL.md
@@ -1,20 +1,29 @@
 ---
 name: lesson-to-harness
-description: Invoke when the user says "turn this session's repeated requests into rules/skills", "교훈 처리해줘", "규칙으로 박아줘", or when the agent detects a repeated user correction/preference in-session (same kind of correction 2x+, or an explicit "from now on do/don't ..."). Mines lesson candidates from the session, proposes them for approval, and institutionalizes only the approved ones as neutral, universal principles wired into the repo harness (.agents/rules, AGENTS.md, related skills, harness scan / hooks) as a single source — never memory-only. Operationalizes learning-loop.md.
+description: Invoke when the user says "turn this session's repeated requests into rules/skills", "교훈 처리해줘", "규칙으로 박아줘", or when the agent detects EITHER a repeated user correction/preference in-session (same kind of correction 2x+, or an explicit "from now on do/don't ...") OR a recurring agent/technical failure class (the same kind of failure hit 2x+ in-session — e.g. fixing the same category of CI failure twice — even with no user correction). Mines lesson candidates from the session, proposes them for approval, and institutionalizes only the approved ones as neutral, universal principles wired into the repo harness (.agents/rules, AGENTS.md, related skills, harness scan / hooks) as a single source — never memory-only. Fixing an instance never closes a recurring mistake; only a mechanical prevention does. Operationalizes learning-loop.md.
 ---
 
 # Lesson → Harness
 
 The step-by-step "how" for [learning-loop.md](../../rules/learning-loop.md): mine repeated user
-corrections, and after approval institutionalize them as rules **enforced by the repo harness**.
-The `.claude/hooks/correction-detect.sh` UserPromptSubmit hook nudges this skill on strong
-preference/principle signals — on that nudge (or self-detection), run the procedure. A one-off
-"just do X this once" is NOT a lesson.
+corrections **and recurring agent/technical failure classes**, and after approval institutionalize
+them as rules **enforced by the repo harness**. The `.claude/hooks/correction-detect.sh`
+UserPromptSubmit hook nudges this skill on strong preference/principle signals — on that nudge (or
+self-detection), run the procedure. A one-off "just do X this once" is NOT a lesson.
+
+**Trigger cue (self-detection):** when you find yourself fixing the same *class* of failure a second
+time in a session — even with no user correction, e.g. the same category of CI/scan failure twice —
+invoke this loop. Fixing the instance does not close a recurring mistake; only a mechanical
+prevention (steps 8–9) does.
 
 ## Procedure
 
-1. **Mine the session** — collect items the user repeated or explicitly turned into a principle,
-   each with evidence (where / how many times). Exclude one-off task-specific instructions.
+1. **Mine the session** — collect two kinds of candidate, each with evidence (where / how many
+   times): (a) items the user repeated or explicitly turned into a principle; and (b) **recurring
+   agent/technical failure classes** — the same *kind* of failure hit 2×+ in-session even with no
+   user correction (e.g. "fixed the same category of CI failure twice", the same scan tripped twice,
+   the same build/type error class recurred). Both kinds are lessons; the same mandatory steps 8–9
+   (mechanism + prove-it-fails) apply to each. Exclude one-off task-specific instructions.
 2. **Propose + approve** — present candidates; only user-approved ones proceed. Never
    institutionalize without approval.
 3. **Normalize** — one neutral, universal principle per lesson (`Principle / Why / How to apply`);


### PR DESCRIPTION
## Owner principle (2026-07-25)

> 자꾸 실수하는 부분은 실수의 원인을 사전에 방지하는 방법을 찾아내야 한다 — 즉시 바로잡는 것만이 아니라 원인을 분석하고 애초에 발생하지 않게 하는 방법을. 이게 교훈 스킬이 할 일 중 하나다.

Fixing an instance does NOT close a recurring mistake; only a mechanical PREVENTION does. This is the lesson-to-harness loop applied to itself. DOCS-ONLY (skill + rule + backlog); no code.

## The gap closed

`lesson-to-harness` step 8 (mechanism / infeasible-now+backlog) and step 9 (prove-it-fails-pre-fix) already mandate a mechanism. But step 1 mining scope was "repeated USER corrections/preferences" ONLY — it did not clearly include **recurring agent/technical failure classes** (the same failure hit 2×+ in a session with no user correction). That blind spot is exactly where recurring mistakes hide.

## Task 1 — broaden the mining scope

- **`SKILL.md`**: frontmatter `description` now covers EITHER a repeated user correction OR a recurring agent/technical failure class (2×+ in-session, e.g. fixing the same category of CI failure twice), plus the mandate that only a mechanical prevention closes a recurring mistake. Intro paragraph broadened; added a self-detection **trigger cue** ("when you find yourself fixing the same *class* of failure a second time … invoke this loop"). Step 1 now mines two candidate kinds (user corrections **and** recurring failure classes), both bound by the same mandatory steps 8–9. References the existing `.claude/hooks/correction-detect.sh` nudge (not edited).
- **`learning-loop.md`**: recurring agent mistake is a first-class lesson trigger, and a mechanical PREVENTION is its only terminal state. Kept domain-free.

## Task 2 — file the concrete prevention (HARNESS-045)

New `HARNESS-045-local-verify-mirrors-ci.md`. THE CLASS: an agent's foreground `run-all-scans` "green locally" does not reproduce the CI `scans`/`quality` jobs, so "green locally" ≠ "green in CI." Evidence: spec-surface below-baseline false-pass locally vs CI `notices==[]` self-test (#1346, #1357); prettier-wrapped multi-line YAML `tags` vs single-line-only `check-spec-doc-frontmatter`, and `--no-verify` fresh-worktree pushes skip prettier (#1369 → HARNESS-044). PREVENTION to build: a single `pnpm harness:verify-like-ci` entry reproducing the CI gate (self-test suite so `notices==[]` trips locally, prettier `--check`, built-`dist` scans), wired into the parallel-orchestration verification step + git-branch pre-merge guidance. Filed as **infeasible-now + tracked** (sanctioned step-8 terminal state) because the mechanism lives in `scripts/harness/**`, currently contended by ARCH-005 S1 — build AFTER S1 merges. Red-first plan and cross-reference to HARNESS-044 (reciprocal) included.

## Verification

`node scripts/harness/run-all-scans.mjs`: 59/60 content scans pass. The only failure is `dist` (unbuilt fresh-worktree artifact — "run pnpm build first"), unrelated to these docs-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb19d3LCYKqLg9TmyKRh36