### PR TITLE
feat(workflows): WORKFLOW-005 P2 — composite reload fix + unified instant-node persistence

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -232,3 +232,39 @@ sessionId, baseCredits(=0) }`. `SkillResolverRuntime` loads skills via `@robota-
 possible future addition).** Next phases per the phasing plan: P2 (dynamic authoring — instant-node
 Phase C + unified persistence + composite reload fix), P3 (surface unification — expose create/save/build
 through `/workflows` + WORKFLOW-004 build).
+
+## P2 progress log
+
+- **composite reload fix + unified persistence (agent `/workflows` path) — DONE (2026-07-25).** The
+  agent-slash-command persistence path (`packages/agent-command-workflows/src/persistence/`) previously
+  **refused** composite (DAG-wrapping) instant nodes: `saveInstantNodeFile` returned `null` for them and
+  `loadInstantNodes` skipped them with a "composite reload is not supported in this workspace" warning —
+  so a composite authored via that path was dropped on reload. It now round-trips both prompt AND
+  composite instant nodes through the shared `@robota-sdk/dag-node-instant-node`
+  `toPersisted()`/`parsePersistedInstantNode`/`rehydrateInstantNode` abstraction (DATA-003/004) — the
+  same single abstraction dag-cli's persistence store uses, closing the divergence where the two paths
+  had diverged (dag-cli supported composites, the agent path did not).
+  - **Composite sub-runner** (behavioral, never serialized) is rebuilt on reload by `loadInstantNodes`,
+    backed by `dag-framework`'s `LocalDagRuntimeProvider` (already a dep — no new package edge; the agent
+    path stays free of any `dag-cli` dependency). The runner closes over the live reloaded-defs array so
+    an inner DAG can reference other reloaded instant nodes regardless of load order. Because the provider
+    consumes the ComfyUI workflow-file format (and runs `fromDagWorkflowFile(file, undefined)`, re-keying
+    nodes to `node-<numId>`), the runner remaps runtime ids back to the inner DAG's original node ids via
+    the companion `toDagWorkflowFile` emits, and reshapes the provider's flat `"<id>.<port>"` output map
+    into the nested `outputs[nodeId][portKey]` shape the composite contract reads.
+  - **TDD**: red-first. New `workspace-writer.test.ts` case saves a composite, reloads it after a
+    simulated restart, and RUNS the reloaded composite end-to-end on the in-process runtime (pure inner
+    `input` node → no credentials) asserting its exposed output flows through. Verified RED before the fix
+    (`saveInstantNodeFile` returned `null` → composite dropped), GREEN after. Full `agent-command-workflows`
+    suite green (37 pass / 5 skipped live).
+  - Files: `persistence/workspace-writer.ts` (drop the composite refusal), `persistence/instant-node-loader.ts`
+    (build the sub-runner + reload composites), `__tests__/workspace-writer.test.ts`, `docs/SPEC.md`.
+  - Branch: `feat/workflow-005-p2-reload-persistence`.
+
+- **instant-node Phase C (arbitrary code node via API) — NOT STARTED; awaits owner phasing confirmation.**
+  Phase C is a NEW capability with security implications (runtime-defined executable code, persistable).
+  The doc notes it as "explicitly out of scope today" (Current state) yet lists it under P2 (phasing) —
+  this inconsistency needs an explicit OWNER decision on phasing/sandboxing before implementation. Do NOT
+  build it until confirmed.
+
+- **P3 surface-unification (expose create/save/build through `/workflows`) — deferred (unchanged).**

--- a/packages/agent-command-workflows/docs/SPEC.md
+++ b/packages/agent-command-workflows/docs/SPEC.md
@@ -125,6 +125,14 @@ existing `validate` and `run` executors; invalid/unassemblable spec → failed r
 no provider → actionable error + no write; `newNodes` manifests persisted inert under
 `<root>/nodes/` without execution.
 
+`src/__tests__/workspace-writer.test.ts` covers the instant-node persistence round-trip on real fs:
+a prompt node save→reload; a **composite (DAG-wrapping) node** save→reload→**run** (WORKFLOW-005 P2 —
+the reloaded composite executes its inner DAG on the in-process runtime via the injected sub-runner
+`loadInstantNodes` builds, and its exposed output flows through); and a non-instant (built-in) node is
+skipped. Prompt and composite nodes both persist through the shared
+`@robota-sdk/dag-node-instant-node` `toPersisted()`/`parse`/`rehydrate` abstraction — a composite's
+behavioral sub-runner is never serialized, it is rebuilt on reload.
+
 `src/__tests__/create-command.live.test.ts` is an **opt-in live suite** hitting a REAL provider — it
 runs only when `RUN_LIVE_LLM=1` AND a provider key are both present, so normal `pnpm test` / CI skip
 it (no network, cost, or key). Run it with `pnpm --filter @robota-sdk/agent-command-workflows

--- a/packages/agent-command-workflows/src/__tests__/workspace-writer.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/workspace-writer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -7,11 +7,46 @@ import {
   createCompositeInstantNodeDefinition,
   type ICompositeSubRunner,
 } from '@robota-sdk/dag-node-instant-node';
+import type { IDagDefinition, IDagNodeDefinition, INodeExecutionContext } from '@robota-sdk/dag-core';
 import { saveInstantNodeFile } from '../persistence/workspace-writer.js';
 import { loadInstantNodes } from '../persistence/instant-node-loader.js';
 
 const AT = '2026-07-06T00:00:00.000Z';
 const RUNNER: ICompositeSubRunner = { run: async () => ({ ok: true, outputs: {} }) };
+
+/**
+ * A pure inner DAG: a single `input` node emitting a fixed `text` from its config. No LLM/provider —
+ * deterministic — so the reloaded composite can run end-to-end without credentials. Mirrors the
+ * dag-cli `composite-reload-real` fixture on the agent `/workflows` persistence path.
+ */
+const INNER_DAG = {
+  dagId: 'inner',
+  version: 1,
+  status: 'draft',
+  nodes: [
+    { nodeId: 'echo', nodeType: 'input', dependsOn: [], config: { text: 'from-inner-dag' } },
+  ],
+  edges: [],
+} as unknown as IDagDefinition;
+
+function makeExecContext(node: IDagNodeDefinition): INodeExecutionContext {
+  return {
+    dagId: 'd',
+    dagRunId: 'r',
+    taskRunId: 't',
+    nodeDefinition: { nodeId: 'c1', nodeType: node.nodeType, dependsOn: [], config: {} },
+    nodeManifest: {
+      nodeType: node.nodeType,
+      displayName: node.displayName,
+      category: node.category,
+      inputs: node.inputs,
+      outputs: node.outputs,
+    },
+    attempt: 0,
+    executionPath: [],
+    currentTotalCredits: 0,
+  } as unknown as INodeExecutionContext;
+}
 
 let dir: string;
 beforeEach(async () => {
@@ -39,19 +74,32 @@ describe('DATA-003 saveInstantNodeFile', () => {
     expect(reloaded.map((n) => n.nodeType)).toContain('pirate');
   });
 
-  it('TC-03: refuses to write a composite node (no unreloadable orphan)', async () => {
+  it('WORKFLOW-005 P2: persists a composite node, then reloads AND runs it (no drop)', async () => {
     const composite = createCompositeInstantNodeDefinition({
-      nodeType: 'wrap',
-      displayName: 'Wrap',
-      innerDag: { dagId: 'inner', version: 1, status: 'draft', nodes: [], edges: [] },
-      exposedInputPort: { key: 'text', mapsTo: { nodeId: 'a', portKey: 'text' } },
-      exposedOutputPorts: [{ key: 'out', mapsTo: { nodeId: 'b', portKey: 'text' } }],
+      nodeType: 'echo-composite',
+      displayName: 'Echo Composite',
+      innerDag: INNER_DAG,
+      exposedInputPort: { key: 'text', mapsTo: { nodeId: 'echo', portKey: 'text' } },
+      exposedOutputPorts: [{ key: 'result', mapsTo: { nodeId: 'echo', portKey: 'text' } }],
       runner: RUNNER,
     });
+
+    // 1. Persist the composite (no longer refused) → a manifest is written.
     const path = await saveInstantNodeFile(dir, composite, AT);
-    expect(path).toBeNull();
-    // nothing was written → no orphan for the loader to silently drop.
-    await expect(readdir(join(dir, '.workflows', 'nodes'))).rejects.toBeDefined();
+    expect(path).toContain('echo-composite.node.json');
+    await expect(stat(path as string)).resolves.toBeDefined();
+
+    // 2. Simulate restart: a fresh load reconstructs the composite (with an injected sub-runner).
+    const reloaded = await loadInstantNodes(dir);
+    const node = reloaded.find((n) => n.nodeType === 'echo-composite');
+    expect(node, 'composite must survive reload (not be dropped)').toBeDefined();
+
+    // 3. The reloaded composite RUNS its inner DAG for real and flows its exposed output out.
+    const runResult = await node!.taskHandler.execute({ text: 'trigger' }, makeExecContext(node!));
+    expect(runResult.ok).toBe(true);
+    if (runResult.ok) {
+      expect(runResult.value['result']).toBe('from-inner-dag');
+    }
   });
 
   it('skips a non-instant (built-in) node', async () => {

--- a/packages/agent-command-workflows/src/persistence/instant-node-loader.ts
+++ b/packages/agent-command-workflows/src/persistence/instant-node-loader.ts
@@ -1,21 +1,93 @@
 /**
- * Reloads prompt-backed nodes previously saved under `<root>/nodes/*.node.json` so authored workflows
- * that reference them can run, and so a later `create` can reuse them. Parsing + reconstruction are
- * owned by `@robota-sdk/dag-node-instant-node` (DATA-003) — this module only walks the directory.
+ * Reloads instant nodes previously saved under `<root>/nodes/*.node.json` so authored workflows that
+ * reference them can run, and so a later `create` can reuse them. Parsing + reconstruction are owned
+ * by `@robota-sdk/dag-node-instant-node` (DATA-003) — this module walks the directory and, for
+ * composite (DAG-wrapping) nodes, supplies the behavioral sub-runner that is never serialized
+ * (WORKFLOW-005 P2). The sub-runner executes the inner DAG on the in-process local runtime
+ * (`dag-framework`), so composites round-trip on the agent `/workflows` path without depending on the
+ * `dag-cli` product.
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
-import type { IDagNodeDefinition } from '@robota-sdk/dag-core';
-import { parsePersistedInstantNode, rehydrateInstantNode } from '@robota-sdk/dag-node-instant-node';
+import type { IDagNodeDefinition, IDagRuntimeResult, TPortPayload } from '@robota-sdk/dag-core';
+import {
+  parsePersistedInstantNode,
+  rehydrateInstantNode,
+  type ICompositeSubRunner,
+} from '@robota-sdk/dag-node-instant-node';
+import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
+import { toDagWorkflowFile } from '@robota-sdk/dag-builder';
 
 const NODE_MANIFEST_EXT = '.node.json';
 
 /**
+ * Reshape the runtime provider's flat `"<nodeId>.<port>"` output map into the nested
+ * `Record<nodeId, TPortPayload>` shape the composite node contract reads back
+ * (`CompositeInstantNodeDefinition` looks up `outputs[nodeId][portKey]`). Runtime node ids are
+ * remapped to the inner DAG's original node ids via `runtimeToOriginal` (see `buildCompositeRunner`),
+ * falling back to the runtime id when unmapped.
+ */
+function toNestedOutputs(
+  flat: IDagRuntimeResult['outputs'],
+  runtimeToOriginal: Map<string, string>,
+): Record<string, TPortPayload> {
+  const nested: Record<string, TPortPayload> = {};
+  for (const [compound, value] of Object.entries(flat)) {
+    const dot = compound.indexOf('.');
+    if (dot <= 0) continue;
+    const runtimeNodeId = compound.slice(0, dot);
+    const portKey = compound.slice(dot + 1);
+    const nodeId = runtimeToOriginal.get(runtimeNodeId) ?? runtimeNodeId;
+    (nested[nodeId] ??= {})[portKey] = value as TPortPayload[string];
+  }
+  return nested;
+}
+
+/**
+ * Build a composite sub-runner backed by the in-process local runtime. It closes over the **live**
+ * `liveDefs` array so an inner DAG can reference other reloaded instant nodes regardless of load
+ * order (they are resolved at run time, not load time).
+ *
+ * The provider consumes the ComfyUI-style workflow-file format and, lacking the companion, re-keys
+ * nodes to `node-<numId>`; the composite contract reads its exposed outputs by the inner DAG's
+ * ORIGINAL node ids, so the companion `toDagWorkflowFile` emits is used to remap runtime ids back.
+ */
+function buildCompositeRunner(
+  cwd: string,
+  layout: IWorkspaceLayout,
+  liveDefs: IDagNodeDefinition[],
+): ICompositeSubRunner {
+  return {
+    async run(dag, input) {
+      const provider = new LocalDagRuntimeProvider({
+        workspace: layout,
+        projectDir: cwd,
+        ...(liveDefs.length > 0 ? { instantNodes: liveDefs } : {}),
+      });
+      const { workflowFile, companion } = toDagWorkflowFile(dag);
+      // The provider runs `fromDagWorkflowFile(file, undefined)`, so an original id `<x>` at numeric
+      // id `<n>` surfaces in outputs as `node-<n>.<port>`. Rebuild `node-<n>` → `<x>` from the
+      // companion the converter just produced.
+      const runtimeToOriginal = new Map<string, string>();
+      for (const [numId, meta] of Object.entries(companion.nodes)) {
+        runtimeToOriginal.set(`node-${numId}`, meta.nodeId);
+      }
+      const result = await provider.execute(workflowFile, input);
+      return {
+        ok: result.ok,
+        outputs: toNestedOutputs(result.outputs, runtimeToOriginal),
+        ...(result.ok ? {} : { error: result.error ?? 'Inner DAG run failed' }),
+      };
+    },
+  };
+}
+
+/**
  * Load all reloadable instant nodes from `<cwd>/<root>/nodes/`. Missing dir → empty list;
- * unparseable manifests are skipped. Composite nodes need a behavioral sub-runner this package does
- * not build, so they are surfaced as an explicit skip (never silently dropped) — but
- * `saveInstantNodeFile` refuses to write composites, so a composite manifest should never appear here.
+ * unparseable manifests are skipped. Prompt and composite nodes both round-trip through the shared
+ * `@robota-sdk/dag-node-instant-node` abstraction; composites get an injected sub-runner (never
+ * serialized) that runs the inner DAG on the in-process runtime.
  */
 export async function loadInstantNodes(
   cwd: string,
@@ -30,6 +102,7 @@ export async function loadInstantNodes(
     return [];
   }
   const nodes: IDagNodeDefinition[] = [];
+  const compositeRunner = buildCompositeRunner(cwd, layout, nodes);
   for (const file of files.filter((f) => f.endsWith(NODE_MANIFEST_EXT))) {
     let record: ReturnType<typeof parsePersistedInstantNode>;
     try {
@@ -39,13 +112,9 @@ export async function loadInstantNodes(
       continue;
     }
     if (!record) continue;
-    if (record.kind === 'composite') {
-      process.stderr.write(
-        `[instant-node-loader] skipping composite node "${record.nodeType}" — composite reload is not supported in this workspace\n`,
-      );
-      continue;
-    }
-    nodes.push(rehydrateInstantNode(record));
+    nodes.push(
+      rehydrateInstantNode(record, record.kind === 'composite' ? { compositeRunner } : {}),
+    );
   }
   return nodes;
 }

--- a/packages/agent-command-workflows/src/persistence/workspace-writer.ts
+++ b/packages/agent-command-workflows/src/persistence/workspace-writer.ts
@@ -29,9 +29,10 @@ export async function saveWorkflowFile(
 
 /**
  * Persist a prompt-backed / instant node to `<cwd>/<root>/nodes/<type>.node.json`. Nodes without a
- * `toPersisted()` (built-ins) are skipped and return `null`. Composite nodes are refused (this
- * workspace cannot rebuild their sub-runner on reload, so writing one would create an orphan the
- * loader can never reconstruct — see `loadInstantNodes`); they return `null` too.
+ * `toPersisted()` (built-ins) are skipped and return `null`. Both prompt AND composite instant nodes
+ * are persisted through the shared `toPersisted()` round-trip (`@robota-sdk/dag-node-instant-node`);
+ * a composite's behavioral sub-runner is not serialized — `loadInstantNodes` rebuilds it on reload
+ * (WORKFLOW-005 P2) — so a written composite is fully reloadable, not an orphan.
  */
 export async function saveInstantNodeFile(
   cwd: string,
@@ -41,7 +42,6 @@ export async function saveInstantNodeFile(
 ): Promise<string | null> {
   if (!isPersistableInstantNode(node)) return null;
   const record = { ...node.toPersisted(), createdAt };
-  if (record.kind === 'composite') return null;
   const dir = resolve(cwd, join(layout.root, 'nodes'));
   await mkdir(dir, { recursive: true });
   const path = join(dir, `${node.nodeType}${NODE_MANIFEST_EXT}`);


### PR DESCRIPTION
## WORKFLOW-005 P2 (partial) — composite reload fix + unified instant-node persistence

Advances `.agents/backlog/WORKFLOW-005-complete-workflows-track.md` P2, doing ONLY the two clear, non-conflicting items. Scoped entirely to the owned `packages/agent-command-workflows` persistence layer — no `dag-cli`, no new packages, no Phase C.

### 1. Composite / nested-workflow reload fix
The agent `/workflows` persistence path previously **refused** composite (DAG-wrapping) instant nodes:
- `saveInstantNodeFile` returned `null` for them, and
- `loadInstantNodes` skipped them with a "composite reload is not supported" warning,

so a composite was **dropped on reload**. It now persists and reloads correctly. `loadInstantNodes` rebuilds the composite's behavioral sub-runner (never serialized) on reload, backed by `dag-framework`'s `LocalDagRuntimeProvider` (already a dependency — **no new package edge; the agent path stays free of any `dag-cli` dependency**). The runner:
- closes over the live reloaded-defs array so an inner DAG can reference other reloaded instant nodes regardless of load order;
- remaps the provider's re-keyed runtime node ids (`node-<numId>`) back to the inner DAG's **original** node ids via the companion `toDagWorkflowFile` emits;
- reshapes the flat `"<id>.<port>"` output map into the nested `outputs[nodeId][portKey]` shape the composite contract reads.

### 2. Unified persistence
Prompt AND composite instant nodes now round-trip through the single shared `@robota-sdk/dag-node-instant-node` `toPersisted()`/`parse`/`rehydrate` abstraction — the same one the dag-cli store uses — closing the divergence where the two paths had diverged (dag-cli supported composites, the agent path did not). Behavior-preserving for prompt nodes and workflows; the round-trip is pinned by tests.

### TDD (red → green)
New `workspace-writer.test.ts` case saves a composite, reloads it after a simulated restart, and **RUNS** the reloaded composite end-to-end on the in-process runtime (pure inner `input` node → no credentials), asserting its exposed output flows through. Verified **RED** before the fix (`saveInstantNodeFile` returned `null` → composite dropped), **GREEN** after.

### Verification
- `agent-command-workflows` suite: 37 pass / 5 skipped (live)
- Affected DAG packages green: dag-framework, dag-builder, dag-node, dag-runtime, dag-nodes-default, dag-node-instant-node; downstream `agent-cli` green (30 files)
- `pnpm -w typecheck` clean; ESLint clean on changed files
- `node scripts/harness/run-all-scans.mjs` → all 60 scans pass
- Pre-existing, unrelated: `dag-adapters-sqlite` fails on a native SQLite ABI env issue (documented in memory; my diff touches no sqlite code)

### Out of scope (explicitly NOT done)
- **instant-node Phase C (arbitrary code node via API)** — a NEW capability with security implications; the doc is internally inconsistent ("out of scope today" vs P2). **Awaits owner phasing confirmation** before implementation. Noted in the backlog.
- **P3 surface-unification** (expose create/save/build through `/workflows`) — deferred.
- `packages/dag-cli/**` — untouched (sibling agent territory).

Backlog kept OPEN (P2 Phase C + P3 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tb19d3LCYKqLg9TmyKRh36