### PR TITLE
fix(changeset): drop dissolved agent-web-ui from config fixed[] group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,8 +16,7 @@
       "@robota-sdk/agent-session",
       "@robota-sdk/agent-subagent-runner",
       "@robota-sdk/agent-tools",
-      "@robota-sdk/agent-transport",
-      "@robota-sdk/agent-web-ui"
+      "@robota-sdk/agent-transport"
     ]
   ],
   "linked": [],


### PR DESCRIPTION
The dangling agent-web-ui in .changeset/config.json fixed[] broke changeset status/version repo-wide (flagged by REL-023, INFRA-027, ARCH-005 S1). Pruned to existing packages; changeset status now runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)