### PR TITLE
fix(harness): ghost-package-refs must not walk .claude/worktrees

### DIFF
--- a/scripts/harness/check-ghost-package-refs.mjs
+++ b/scripts/harness/check-ghost-package-refs.mjs
@@ -75,7 +75,13 @@ function listMarkdownFiles(root) {
   function walk(dir) {
     if (!existsSync(dir)) return;
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      // Skip VCS/deps and `.claude` (agent tooling + transient git worktrees under
+      // `.claude/worktrees/*`): worktrees are checked-out copies of OTHER branches whose new,
+      // not-yet-merged packages do not resolve against develop — walking them yields false
+      // ghost-package-ref failures locally (never in CI, which has no worktrees). Not a repo
+      // content source for this scan.
+      if (entry.name === '.git' || entry.name === 'node_modules' || entry.name === '.claude')
+        continue;
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) walk(full);
       else if (entry.isFile() && entry.name.endsWith('.md')) out.push(full);


### PR DESCRIPTION
The scan's own walk() skipped only .git/node_modules, so it scanned transient agent worktrees and false-failed on their not-yet-merged packages (local-only; never CI). A member of the HARNESS-045 'local≠CI worktree-artifact' class. Excludes .claude; verified it still catches real ghost refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)