### PR TITLE
fix(harness): HARNESS-044 parse prettier-wrapped multi-line frontmatter arrays

### DIFF
--- a/.agents/backlog/completed/HARNESS-044-frontmatter-scan-multiline-tags.md
+++ b/.agents/backlog/completed/HARNESS-044-frontmatter-scan-multiline-tags.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-044: check-spec-doc-frontmatter must parse prettier-wrapped multi-line YAML arrays'
-status: todo
+status: done
+completed: 2026-07-25
 created: 2026-07-25
 priority: low
 urgency: soon
@@ -9,6 +10,27 @@ depends_on: []
 ---
 
 # HARNESS-044: frontmatter scan vs prettier multi-line arrays
+
+## Outcome (DONE 2026-07-25)
+
+`check-spec-doc-frontmatter.mjs` now parses the frontmatter block properly instead of matching
+`^tags:\s*(.+)$` on one line. A dependency-free line-based reader (`parseFrontmatterBlock`, exported)
+maps each top-level key to a scalar or a list, resolving all four forms the toolchain emits:
+
+- inline flow — `tags: [a, b]`
+- compact prettier wrap — `tags:` then the whole `[...]` on one indented line
+- exploded prettier wrap — `tags:` then one item per indented line (the ARCH-005 / #1369 shape)
+- YAML block sequence — `tags:` then `- a` / `- b`
+
+No YAML dependency was added: the repo declares none (the only `js-yaml` mention in `package.json` is
+a pnpm audit override), so a new dep was not worth it for one frontmatter block.
+
+Both prettier wrappings in the fixtures are byte-exact — produced by running the repo's own prettier
+over a single-line source, not hand-written. The check is not weakened: empty wrapped arrays
+(`tags:\n  [\n  ]`), a bare `tags:` key, and `tags: []` all still block, and a corrupted `status`
+placed _after_ a wrapped array is still reported (proving the wrapped block does not swallow the keys
+below it). Differential check over all real spec-docs: old vs new parser agree on every file
+(0 diffs) — the change is purely additive.
 
 ## Problem
 

--- a/scripts/harness/__tests__/check-spec-doc-frontmatter.test.mjs
+++ b/scripts/harness/__tests__/check-spec-doc-frontmatter.test.mjs
@@ -20,6 +20,59 @@ tags: [harness, gate]
 # RULE-001: fixture spec
 `;
 
+/**
+ * Byte-exact prettier output for a `tags` flow array past printWidth: the key stands alone
+ * and every item is exploded onto its own indented line. Verified by running the repo's
+ * prettier over the single-line source (HARNESS-044).
+ */
+const WRAPPED_TAGS_SPEC = `---
+status: draft
+type: RULE
+tags:
+  [
+    architecture,
+    harness,
+    frontmatter,
+    formatter-drift,
+    verification,
+    spec-docs,
+    backlog-execution,
+    enforcement-architecture,
+    continuous-integration,
+  ]
+completed: 2026-07-25
+---
+
+# RULE-010: prettier-wrapped tags fixture
+`;
+
+/**
+ * The other prettier wrapping: just past printWidth, the whole bracketed list moves to a
+ * single indented line below the key.
+ */
+const COMPACT_WRAPPED_TAGS_SPEC = `---
+status: draft
+type: RULE
+tags:
+  [architecture, harness, frontmatter, formatter-drift, verification, spec-docs]
+completed: 2026-07-25
+---
+
+# RULE-015: compact prettier-wrapped tags fixture
+`;
+
+/** Canonical YAML block-sequence form. */
+const BLOCK_SEQUENCE_TAGS_SPEC = `---
+status: draft
+type: RULE
+tags:
+  - harness
+  - gate
+---
+
+# RULE-012: block-sequence tags fixture
+`;
+
 async function createFixture(files) {
   const root = await mkdtemp(path.join(tmpdir(), 'robota-spec-frontmatter-'));
   for (const [relativePath, content] of Object.entries(files)) {
@@ -78,6 +131,79 @@ describe('findSpecDocFrontmatterFindings', () => {
     expect(blocking[0].detail).toBe('tags missing or empty');
   });
 
+  it('accepts a prettier-wrapped multi-line tags array (HARNESS-044)', async () => {
+    const root = await createFixture({ 'draft/RULE-010-wrapped.md': WRAPPED_TAGS_SPEC });
+
+    const { blocking, warnings } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('accepts the compact prettier wrapping (list on one indented line) (HARNESS-044)', async () => {
+    const root = await createFixture({ 'draft/RULE-015-compact.md': COMPACT_WRAPPED_TAGS_SPEC });
+
+    const { blocking } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toEqual([]);
+  });
+
+  it('still reads scalar keys that FOLLOW a wrapped multi-line array (HARNESS-044)', async () => {
+    // The wrapped block must not swallow the keys after it: corrupt `status` and prove
+    // it is still the value that gets reported.
+    const root = await createFixture({
+      'draft/RULE-011-wrapped-badstatus.md': WRAPPED_TAGS_SPEC.replace(
+        'status: draft',
+        'status: cooking',
+      ),
+    });
+
+    const { blocking } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toHaveLength(1);
+    expect(blocking[0].detail).toContain('status "cooking" not in {');
+  });
+
+  it('accepts a YAML block-sequence tags list (HARNESS-044)', async () => {
+    const root = await createFixture({ 'draft/RULE-012-sequence.md': BLOCK_SEQUENCE_TAGS_SPEC });
+
+    const { blocking } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toEqual([]);
+  });
+
+  it('still flags an EMPTY wrapped tags array (the check is not weakened)', async () => {
+    const root = await createFixture({
+      'draft/RULE-013-wrapped-empty.md': `---
+status: draft
+type: RULE
+tags:
+  [
+  ]
+---
+
+# RULE-013: empty wrapped tags
+`,
+    });
+
+    const { blocking } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toHaveLength(1);
+    expect(blocking[0].detail).toBe('tags missing or empty');
+  });
+
+  it('still flags a tags key with no value at all (the check is not weakened)', async () => {
+    const root = await createFixture({
+      'draft/RULE-014-bare-tags.md': `---
+status: draft
+type: RULE
+tags:
+---
+
+# RULE-014: bare tags key
+`,
+    });
+
+    const { blocking } = findSpecDocFrontmatterFindings(root);
+    expect(blocking).toHaveLength(1);
+    expect(blocking[0].detail).toBe('tags missing or empty');
+  });
+
   it('warns (non-blocking) on duplicate spec-doc IDs across stages', async () => {
     const root = await createFixture({
       'draft/RULE-006-dup.md': GREEN_SPEC,
@@ -126,6 +252,13 @@ describe('check-spec-doc-frontmatter CLI', () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('spec-doc frontmatter scan failed:');
     expect(result.stdout).toContain('missing frontmatter block');
+  });
+
+  it('exits 0 on a prettier-wrapped multi-line tags array (HARNESS-044)', async () => {
+    const root = await createFixture({ 'draft/RULE-010-wrapped.md': WRAPPED_TAGS_SPEC });
+    const result = runScan([root]);
+    expect(result.stdout).toContain('spec-doc frontmatter scan passed.');
+    expect(result.status).toBe(0);
   });
 
   it('exits 0 when the only findings are duplicate-ID warnings', async () => {

--- a/scripts/harness/check-spec-doc-frontmatter.mjs
+++ b/scripts/harness/check-spec-doc-frontmatter.mjs
@@ -12,6 +12,10 @@
  *     - `tags`   present (a non-empty list)
  *   Warning: duplicate `<namespace>-<NNN>` IDs across the tree.
  *
+ * `tags` is accepted in every form the toolchain can produce (HARNESS-044): inline `[a, b]`, a
+ * prettier-wrapped multi-line flow array (prettier wraps past printWidth, and it is the repo's
+ * SSOT formatter), and a YAML block sequence.
+ *
  * Recognized OPTIONAL keys (validity not enforced here; extra keys are inert to this gate):
  *   - `completed: <date>` — set at GATE-COMPLETE.
  *   - `capability: true` + `user_execution: agent-run|manual|none` + `user_execution_scenario: <path>` —
@@ -63,16 +67,84 @@ function walkMarkdown(dir) {
   return out;
 }
 
-function frontmatter(text) {
+const unquote = (s) =>
+  s
+    .trim()
+    .replace(/^(['"])(.*)\1$/s, '$2')
+    .trim();
+
+/** Split a YAML flow sequence (`[a, b, c]`, possibly already joined from several lines). */
+function parseFlowSequence(text) {
+  const open = text.indexOf('[');
+  const close = text.lastIndexOf(']');
+  if (open === -1 || close < open) return undefined;
+  return text
+    .slice(open + 1, close)
+    .split(',')
+    .map(unquote)
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Resolve one key's value from its inline part plus the indented lines beneath it.
+ *
+ * Handles every form that occurs in this repo's spec-docs:
+ *   - scalar            `status: draft`
+ *   - inline flow list  `tags: [a, b]`
+ *   - wrapped flow list `tags:\n  [\n    a,\n    b,\n  ]`   ← what prettier emits past printWidth
+ *   - block sequence    `tags:\n  - a\n  - b`
+ */
+function resolveValue(inline, continuationLines) {
+  const indented = continuationLines.map((line) => line.trim()).filter((line) => line.length > 0);
+
+  if (inline.startsWith('[')) return parseFlowSequence([inline, ...indented].join(' ')) ?? [];
+  if (inline.length > 0) return inline;
+
+  if (indented.length === 0) return undefined;
+  if (indented[0].startsWith('[')) return parseFlowSequence(indented.join(' ')) ?? [];
+  if (indented.every((line) => line.startsWith('-')))
+    return indented.map((line) => unquote(line.slice(1))).filter((item) => item.length > 0);
+
+  return indented.join(' ');
+}
+
+/**
+ * Minimal YAML-frontmatter reader: maps every top-level key to a string (scalar) or
+ * string[] (sequence). Deliberately dependency-free — the repo declares no YAML parser.
+ */
+export function parseFrontmatterBlock(text) {
   if (!text.startsWith('---')) return null;
   const end = text.indexOf('\n---', 3);
   if (end === -1) return null;
-  const block = text.slice(3, end);
-  const get = (key) => {
-    const m = block.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-    return m ? m[1].trim() : undefined;
-  };
-  return { status: get('status'), type: get('type'), tags: get('tags') };
+
+  const lines = text.slice(3, end).split('\n');
+  const entries = new Map();
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^([A-Za-z_][A-Za-z0-9_-]*):(.*)$/);
+    if (!match) continue;
+
+    // Everything indented below the key belongs to this key's value.
+    const continuation = [];
+    let next = i + 1;
+    for (; next < lines.length; next++) {
+      if (lines[next].trim() !== '' && !/^\s/.test(lines[next])) break;
+      continuation.push(lines[next]);
+    }
+    entries.set(match[1], resolveValue(match[2].trim(), continuation));
+    i = next - 1;
+  }
+  return entries;
+}
+
+function frontmatter(text) {
+  const entries = parseFrontmatterBlock(text);
+  if (!entries) return null;
+
+  const scalar = (key) => (typeof entries.get(key) === 'string' ? entries.get(key) : undefined);
+  const raw = entries.get('tags');
+  // A bare scalar (`tags: harness`) counts as a one-item list, as it always has.
+  const tags = Array.isArray(raw) ? raw : typeof raw === 'string' && raw ? [raw] : undefined;
+  return { status: scalar('status'), type: scalar('type'), tags };
 }
 
 export function findSpecDocFrontmatterFindings(target) {
@@ -100,7 +172,7 @@ export function findSpecDocFrontmatterFindings(target) {
         file: rel,
         detail: `type "${fm.type ?? ''}" not one of the 11 SDLC prefixes`,
       });
-    if (!fm.tags || !/\S/.test(fm.tags.replace(/[[\]]/g, '')))
+    if (!fm.tags || fm.tags.length === 0)
       blocking.push({ file: rel, detail: 'tags missing or empty' });
 
     const id = path.basename(file).match(/^([A-Z][A-Z0-9-]*-\d+)/)?.[1];


### PR DESCRIPTION
## Problem

`scripts/harness/check-spec-doc-frontmatter.mjs` read `tags` with a single-line regex:

```js
const m = block.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
```

Prettier — the repo's SSOT formatter, run by lint-staged on **every** commit — wraps a `tags` flow
array once it exceeds printWidth. The scan then reported `tags missing or empty` and **failed**, a
false negative caused purely by the formatter the repo mandates.

Observed on ARCH-005 (#1369): the spec passed on develop only because an earlier commit used
`--no-verify` (skipping prettier), and failed the moment a normal lint-staged commit wrapped the
array. It was worked around there by shortening the tag list — so any spec with enough tags recurs.

Prettier actually emits **two** wrappings, both verified by running the repo's own prettier over a
single-line source:

```yaml
# just past printWidth — whole list moves to one indented line
tags:
  [architecture, harness, frontmatter, formatter-drift, verification, spec-docs]
```

```yaml
# further past it — one item per line (the ARCH-005 shape)
tags:
  [
    architecture,
    harness,
    ...
  ]
```

## Fix

Replaced the regex with `parseFrontmatterBlock` (exported): a line-based reader that maps every
top-level key to a scalar or a list. For each key it collects the inline part plus every indented
line beneath it, then resolves the value by form:

| Form | Example |
| --- | --- |
| scalar | `status: draft` |
| inline flow list | `tags: [a, b]` |
| compact prettier wrap | `tags:` then the whole `[...]` on one indented line |
| exploded prettier wrap | `tags:` then one item per indented line |
| YAML block sequence | `tags:` then `- a` / `- b` |

**No dependency was added.** The repo declares no YAML parser — the only `js-yaml` mention in
`package.json` is a pnpm audit override (`"js-yaml@3.14.2": ">=3.15.0 <4.0.0"`), and there is no
`gray-matter`/`yaml` in dependencies or in any harness script. Pulling in a parser for one
frontmatter block wasn't worth it.

## Red-first

The three new failing assertions, **before** the fix:

```
FAIL  scripts/harness/__tests__/check-spec-doc-frontmatter.test.mjs > accepts a prettier-wrapped multi-line tags array (HARNESS-044)
AssertionError: expected [ { …(2) } ] to deeply equal []
+   "detail": "tags missing or empty",
+   "file": ".../draft/RULE-010-wrapped.md",

FAIL  ... > still reads scalar keys that FOLLOW a wrapped multi-line array (HARNESS-044)
AssertionError: expected [ { …(2) }, { …(2) } ] to have a length of 1 but got 2

FAIL  ... CLI > exits 0 on a prettier-wrapped multi-line tags array (HARNESS-044)
AssertionError: expected 'spec-doc frontmatter scan failed:\n- …' to contain 'spec-doc frontmatter scan passed.'
- spec-doc frontmatter scan passed.
+ spec-doc frontmatter scan failed:
+ - [frontmatter] .../draft/RULE-010-wrapped.md: tags missing or empty

 Test Files  1 failed (1)
      Tests  3 failed | 13 passed (16)
```

After the fix: **17 passed (17)**.

## The check is not weakened

Both fixtures are byte-exact prettier output, not hand-written. Still blocking, each with its own test:

- `tags: []` (unchanged case)
- an empty wrapped array `tags:\n  [\n  ]`
- a bare `tags:` key with no value
- a corrupted `status` placed **after** a wrapped array is still reported — proving the wrapped block
  does not swallow the keys below it

Plus a differential check: old vs new parser run over every real spec-doc agree on `status`, `type`,
and the tags verdict for **every file (0 diffs)**. The change is purely additive.

## Verification

- `check-spec-doc-frontmatter.test.mjs` — 17/17 green (was 13/16 red)
- `node scripts/harness/check-spec-doc-frontmatter.mjs` on the real tree — passes (only pre-existing
  duplicate-ID warnings)
- `pnpm harness:test` — **71 files, 687 tests, all green**
- `node scripts/harness/run-all-scans.mjs` — 60/61 green. The one failure is `dist`
  (`dist/ is missing or empty — run pnpm build first`), an **environment artifact** of a fresh
  unbuilt worktree; this PR touches no `packages/**`. It clears after `pnpm build`, which was then
  run so the pre-push hook passed on a real (non-`--no-verify`) push.

## Related

Member of the "green locally ≠ green in CI" class tracked by **HARNESS-045** — this is the
formatter-drift-not-applied-locally instance. Fittingly, the original bug was masked by a
`--no-verify` commit; this branch was committed and pushed with hooks fully enabled.

## Note for siblings (not edited — other agents own these files)

Two harness scans parse frontmatter with the same single-line-only assumption. Neither is broken
today, but both would misread a wrapped array:

- `scripts/harness/scan-capability-reachability.mjs` → `parseFrontmatter`, per-line
  `/^([A-Za-z_]+):\s*(.*)$/`. Reads `capability` / `user_execution` / `user_execution_scenario` — all
  short scalars, and prettier does not reflow plain YAML scalars, so this is latent only.
- `scripts/harness/check-agent-def-convention.mjs` → `parseAgentFile`, per-line
  `/^([A-Za-z0-9_-]+):\s?(.*)$/`. Reads `tools` / `name` / `description`; no `.claude/agents/*.md`
  frontmatter currently uses a `[...]` flow array, so also latent only.

`check-backlog-placement.mjs` reads only `status` and `completed` (short scalars) — safe. Worth
noting that `.agents/backlog/` carries 441 `depends_on: [` and 24 `related: [` flow arrays; no scan
reads those today, but they are the same wrapping hazard if one ever does. If these are worth
consolidating, `parseFrontmatterBlock` is exported and reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
