### PR TITLE
ci(harness): HARNESS-024 env-gated live provider smoke + non-blocking scheduled workflow

### DIFF
--- a/.agents/backlog/HARNESS-024-live-provider-smoke.md
+++ b/.agents/backlog/HARNESS-024-live-provider-smoke.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-024: env-gated 프로바이더 라이브 스모크 1콜 + 로컬/CI 검증 정렬'
-status: todo
+status: in-progress
 created: 2026-07-04
 priority: medium
 urgency: soon
@@ -27,4 +27,52 @@ maxTokens 부류를 수동 라이브만 잡은 전력 3회. 로컬/CI 검증 범
 
 - agent-executable. 스모크 자체가 라이브 1콜 — 로컬 키 실행 성공 + 키 제거 환경 skip 종료코드
   실측.
-- Evidence: (record after execution)
+- Evidence: 아래 Outcome의 3가지 실측 실행 (skip / live PASS / red proof) 참조.
+
+## Outcome (2026-07-25) — What 1 delivered, What 2 covered elsewhere
+
+### What 1 — 라이브 스모크 + 스케줄드 job: DONE (로컬 실측 완료)
+
+- `scripts/harness/live-provider-smoke.mjs` — credentialed 프로바이더마다 최소 실호출 2건
+  (non-streaming `chat()` + streaming `chatStream()`, `maxTokens` 32). 프로바이더 목록과 키
+  환경변수 이름을 **프로바이더 정의의 `defaults.apiKey` `$ENV:` 참조에서 읽으므로** 이 스크립트에는
+  프로바이더 이름 표가 없다 — 새 프로바이더는 자동으로 커버된다.
+- `scripts/harness/__tests__/live-provider-smoke.test.mjs` — 순수 로직(선택/리댁션/판정/리포트)
+  단위 테스트 20건. 네트워크 없음.
+- `.github/workflows/live-provider-smoke.yml` — 매일 05:37 UTC + `workflow_dispatch`. PR
+  게이트가 아니며 required check도 아니다 (mutation-nightly와 동일한 non-blocking 롤아웃 자세).
+  미프로비저닝 시크릿은 빈 문자열로 확장 → 해당 프로바이더 skip → exit 0.
+
+**실측 (2026-07-25, 로컬):**
+
+| 시나리오                                      | 명령                                                                       | 결과                                                                                         |
+| --------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 키 부재 → clean skip                          | `env -u ANTHROPIC_API_KEY node scripts/harness/live-provider-smoke.mjs`    | `SKIPPED — no provider credentials`, **exit 0**                                              |
+| 키 존재 → 실호출                              | `node scripts/harness/live-provider-smoke.mjs`                             | `PASS anthropic (model=claude-sonnet-4-6) chat=4 chars, stream=2 chunks/4 chars`, **exit 0** |
+| red proof (잘못된 키로 accidental-green 방지) | `ANTHROPIC_API_KEY=<invalid> node scripts/harness/live-provider-smoke.mjs` | `FAIL anthropic … 401 authentication_error`, **exit 1**                                      |
+
+`node scripts/harness/run-all-scans.mjs`: 61개 중 59개 통과. 실패한 `build-contracts` / `dist`는
+전체 워크스페이스를 빌드하지 않은 이 환경의 아티팩트이며 이 변경과 무관하다.
+
+### 남은 것 — 소유자가 리포 시크릿을 넣어야 CI 절반이 증명된다
+
+워크플로가 실제로 라이브 호출을 하는 것은 리포 시크릿이 있어야만 관측된다. 그 전까지 이 job은
+초록색 no-op(전부 skip)이다. 그래서 이 항목은 `done`이 아니라 `in-progress`로 남는다.
+
+- 필수: `ANTHROPIC_API_KEY` 리포 시크릿 하나만 있어도 CI 절반이 증명된다.
+- 선택: `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY`.
+- OpenAI는 정의에 기본 모델이 없다 → 리포 **variable** `LIVE_SMOKE_MODEL_OPENAI`도 함께 필요하다.
+  없으면 FAIL이 아니라 WARN으로 보고된다 (설정 누락으로 나이틀리를 빨갛게 만들지 않는다).
+- 프로비저닝 후 `workflow_dispatch`로 1회 수동 실행 → 로그에 `PASS <provider> (model=…)`가
+  찍히면 이 항목을 `done`으로 닫고 `completed/`로 옮긴다.
+
+루트 `package.json`은 이 웨이브에서 다른 에이전트 소유라 스크립트를 추가하지 않았다. 나중에 추가할 줄:
+
+```json
+"harness:live-smoke": "node scripts/harness/live-provider-smoke.mjs"
+```
+
+### What 2 — 로컬/CI 검증 비대칭 문서화: 별도 작업이 커버
+
+같은 웨이브의 `scripts/harness/verify-like-ci.mjs` 작업이 로컬/CI 정렬을 다룬다. 여기서 중복
+구현하지 않는다. 이 항목이 닫히려면 그 작업의 결과를 확인해야 한다.

--- a/.github/workflows/live-provider-smoke.yml
+++ b/.github/workflows/live-provider-smoke.yml
@@ -1,0 +1,93 @@
+name: Live provider smoke
+
+# HARNESS-024: every provider boundary in the test suite is scripted or replayed, so auth failures,
+# vendor wire-format drift, a dropped required request field (the Anthropic 400 / maxTokens family)
+# and streaming-shape changes are invisible to PR CI by construction. This job makes one minimal
+# REAL turn per credentialed provider so that class of breakage surfaces within a day.
+#
+# NON-BLOCKING (same posture as mutation-nightly): scheduled + manual only, never a required check,
+# never a PR gate. A PR cannot be blocked by a third party's API being down or by a spent quota.
+#
+# Credential-gated by construction: each provider's key is passed through from repo secrets, and
+# scripts/harness/live-provider-smoke.mjs runs a provider ONLY when its `$ENV:` key variable is
+# present and non-empty. A secret that has not been provisioned expands to an empty string, so the
+# job SKIPS that provider and still exits 0 — it can never fail for lack of credentials. Until the
+# owner provisions at least one key secret, this workflow is a green no-op.
+#
+# Secrets consumed (all optional, add only the providers you want covered):
+#   ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, DEEPSEEK_API_KEY, DASHSCOPE_API_KEY
+# OpenAI ships no default model, so covering it also needs the repo VARIABLE
+# `LIVE_SMOKE_MODEL_OPENAI` (e.g. a small chat model id); without it OpenAI is reported WARN.
+
+on:
+  schedule:
+    # Daily 05:37 UTC — off-peak, and distinct from mutation-nightly (03:17), CodeQL (04:27) and the
+    # scheduled security scan (Mon 04:47) so the runners never contend.
+    - cron: '37 5 * * *'
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'Smoke a single provider type (blank = every credentialed provider)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  live-smoke:
+    name: live provider smoke (1 real turn per credentialed provider)
+    runs-on: ubuntu-latest
+    # A hung provider must not hold a runner: the script caps each call at 60s, this is the backstop.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: develop
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The smoke reads the provider DEFINITIONS from built output, so only the provider-defaults
+      # dependency closure needs building (js only — no d.ts is needed to execute).
+      - name: Build provider closure
+        run: pnpm --filter @robota-sdk/agent-provider-defaults... build:js
+
+      - name: Run live provider smoke
+        env:
+          # Unprovisioned secrets expand to '' → that provider is skipped, not failed.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          # Model override for providers whose definition ships no default model.
+          LIVE_SMOKE_MODEL_OPENAI: ${{ vars.LIVE_SMOKE_MODEL_OPENAI }}
+          # Read through an env var, never interpolated into the shell line, so a dispatch input
+          # cannot become shell text.
+          SMOKE_PROVIDER: ${{ inputs.provider }}
+        run: |
+          args=(--report-file reports/live-provider-smoke/summary.json)
+          if [ -n "$SMOKE_PROVIDER" ]; then args+=(--provider "$SMOKE_PROVIDER"); fi
+          node scripts/harness/live-provider-smoke.mjs "${args[@]}"
+
+      # The report records provider/model/latency and the key VARIABLE NAMES only — never a key value.
+      - name: Upload live smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-provider-smoke-report
+          path: reports/live-provider-smoke
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/harness/__tests__/live-provider-smoke.test.mjs
+++ b/scripts/harness/__tests__/live-provider-smoke.test.mjs
@@ -1,3 +1,8 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -6,6 +11,7 @@ import {
   messageText,
   modelOverrideEnvVar,
   redactSecrets,
+  resolveBuiltEntry,
   selectLiveProviders,
   smokeProvider,
 } from '../live-provider-smoke.mjs';
@@ -100,6 +106,51 @@ describe('selectLiveProviders (HARNESS-024 gating)', () => {
     );
 
     expect(selection.runnable.map((c) => c.type)).toEqual(['openai']);
+  });
+});
+
+describe('resolveBuiltEntry', () => {
+  /** Fixture workspace: one package, its manifest, and optionally its built entry file. */
+  async function workspace({ built }) {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-live-smoke-'));
+    const packageDir = path.join(root, 'packages', 'agent-core');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: '@robota-sdk/agent-core',
+        exports: { '.': { node: { import: './dist/node/index.js' } } },
+      }),
+      'utf8',
+    );
+    if (built) {
+      const distDir = path.join(packageDir, 'dist', 'node');
+      mkdirSync(distDir, { recursive: true });
+      writeFileSync(path.join(distDir, 'index.js'), 'export const x = 1;\n', 'utf8');
+    }
+    return root;
+  }
+
+  it('reads the entry location from the owning package manifest, not a hardcoded path', async () => {
+    const root = await workspace({ built: true });
+
+    expect(resolveBuiltEntry('@robota-sdk/agent-core', root)).toBe(
+      path.join(root, 'packages', 'agent-core', 'dist', 'node', 'index.js'),
+    );
+  });
+
+  // A fresh CI checkout has no build output. This is the case that must NOT be mistaken for a
+  // working workspace — the caller turns it into an explicit "not built" message, never a silent pass.
+  it('returns undefined when the package is declared but not built', async () => {
+    const root = await workspace({ built: false });
+
+    expect(resolveBuiltEntry('@robota-sdk/agent-core', root)).toBeUndefined();
+  });
+
+  it('returns undefined for a package name no workspace manifest claims', async () => {
+    const root = await workspace({ built: true });
+
+    expect(resolveBuiltEntry('@robota-sdk/does-not-exist', root)).toBeUndefined();
   });
 });
 

--- a/scripts/harness/__tests__/live-provider-smoke.test.mjs
+++ b/scripts/harness/__tests__/live-provider-smoke.test.mjs
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  apiKeyEnvVarOf,
+  formatReport,
+  messageText,
+  modelOverrideEnvVar,
+  redactSecrets,
+  selectLiveProviders,
+  smokeProvider,
+} from '../live-provider-smoke.mjs';
+
+/** Minimal stand-in for a real IProviderDefinition — only the fields the selector reads. */
+function definition(type, defaults, createProvider) {
+  return { type, defaults, ...(createProvider !== undefined && { createProvider }) };
+}
+
+const ANTHROPIC = definition('anthropic', {
+  model: 'claude-sonnet-4-6',
+  apiKey: '$ENV:ANTHROPIC_API_KEY',
+});
+const OPENAI = definition('openai', { apiKey: '$ENV:OPENAI_API_KEY' });
+const LOCAL = definition('gemma', {
+  model: 'local-model',
+  apiKey: 'lm-studio',
+  baseURL: 'http://localhost:1234/v1',
+});
+
+describe('apiKeyEnvVarOf', () => {
+  it('reads the env-var name out of an $ENV: apiKey reference', () => {
+    expect(apiKeyEnvVarOf(ANTHROPIC)).toBe('ANTHROPIC_API_KEY');
+  });
+
+  it('returns undefined for a literal apiKey (local/self-hosted definitions)', () => {
+    expect(apiKeyEnvVarOf(LOCAL)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty $ENV: reference', () => {
+    expect(apiKeyEnvVarOf(definition('x', { apiKey: '$ENV:   ' }))).toBeUndefined();
+  });
+});
+
+describe('modelOverrideEnvVar', () => {
+  it('derives a shouty env-var name from the provider type', () => {
+    expect(modelOverrideEnvVar('openai')).toBe('LIVE_SMOKE_MODEL_OPENAI');
+    expect(modelOverrideEnvVar('openai-compatible')).toBe('LIVE_SMOKE_MODEL_OPENAI_COMPATIBLE');
+  });
+});
+
+describe('selectLiveProviders (HARNESS-024 gating)', () => {
+  it('selects nothing when the environment carries no provider credential', () => {
+    const selection = selectLiveProviders([ANTHROPIC, OPENAI, LOCAL], {});
+
+    expect(selection.runnable).toEqual([]);
+    expect(selection.unconfigured).toEqual([]);
+    expect(selection.skipped.map((s) => s.type)).toEqual(['anthropic', 'openai', 'gemma']);
+  });
+
+  it('selects only the provider whose $ENV: key is present and non-empty', () => {
+    const selection = selectLiveProviders([ANTHROPIC, OPENAI, LOCAL], {
+      ANTHROPIC_API_KEY: 'sk-live-key-value',
+      OPENAI_API_KEY: '',
+    });
+
+    expect(selection.runnable).toHaveLength(1);
+    expect(selection.runnable[0]).toMatchObject({
+      type: 'anthropic',
+      apiKeyEnvVar: 'ANTHROPIC_API_KEY',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(selection.skipped.map((s) => s.type)).toEqual(['openai', 'gemma']);
+  });
+
+  it('reports a keyed provider with no model as unconfigured (WARN), not runnable', () => {
+    const selection = selectLiveProviders([OPENAI], { OPENAI_API_KEY: 'sk-openai-key-value' });
+
+    expect(selection.runnable).toEqual([]);
+    expect(selection.unconfigured[0].reason).toContain('LIVE_SMOKE_MODEL_OPENAI');
+  });
+
+  it('lets the per-provider model override supply the missing model', () => {
+    const selection = selectLiveProviders([OPENAI], {
+      OPENAI_API_KEY: 'sk-openai-key-value',
+      LIVE_SMOKE_MODEL_OPENAI: 'gpt-test',
+    });
+
+    expect(selection.unconfigured).toEqual([]);
+    expect(selection.runnable[0].model).toBe('gpt-test');
+  });
+
+  it('honours --provider by narrowing to a single type', () => {
+    const selection = selectLiveProviders(
+      [ANTHROPIC, OPENAI],
+      {
+        ANTHROPIC_API_KEY: 'sk-live-key-value',
+        OPENAI_API_KEY: 'sk-openai-key-value',
+        LIVE_SMOKE_MODEL_OPENAI: 'gpt-test',
+      },
+      { only: 'openai' },
+    );
+
+    expect(selection.runnable.map((c) => c.type)).toEqual(['openai']);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('scrubs every occurrence of a secret, including inside an echoed error body', () => {
+    const secret = 'sk-ant-super-secret-value';
+    const line = `401 invalid x-api-key: ${secret} (sent ${secret})`;
+
+    const redacted = redactSecrets(line, [secret]);
+
+    expect(redacted).not.toContain(secret);
+    expect(redacted).toBe('401 invalid x-api-key: ***REDACTED*** (sent ***REDACTED***)');
+  });
+
+  it('ignores short/absent values so ordinary text is never mangled', () => {
+    expect(redactSecrets('all good', ['', 'abc', undefined])).toBe('all good');
+  });
+});
+
+describe('messageText', () => {
+  it('reads string content and concatenates text parts', () => {
+    expect(messageText({ content: 'pong' })).toBe('pong');
+    expect(messageText({ content: [{ text: 'po' }, { text: 'ng' }] })).toBe('pong');
+    expect(messageText({})).toBe('');
+  });
+});
+
+describe('smokeProvider', () => {
+  const candidate = {
+    type: 'stub',
+    model: 'stub-model',
+    apiKey: 'sk-stub-key-value',
+    definition: {
+      createProvider: () => ({
+        chat: async () => ({ content: 'pong' }),
+        chatStream: async function* () {
+          yield { content: 'po' };
+          yield { content: 'ng' };
+        },
+      }),
+    },
+  };
+  const createUserMessage = (content) => ({ role: 'user', content });
+
+  it('passes when both the chat and the stream probe return text', async () => {
+    const result = await smokeProvider(candidate, createUserMessage);
+
+    expect(result.status).toBe('pass');
+    expect(result.chat.chars).toBe(4);
+    expect(result.stream.chunks).toBe(2);
+  });
+
+  it('fails — not throws — when the live call rejects', async () => {
+    const failing = {
+      ...candidate,
+      definition: {
+        createProvider: () => ({
+          chat: async () => {
+            throw new Error('401 authentication_error');
+          },
+        }),
+      },
+    };
+
+    const result = await smokeProvider(failing, createUserMessage);
+
+    expect(result).toMatchObject({ status: 'fail', stage: 'liveCall' });
+    expect(result.error).toContain('401');
+  });
+
+  it('fails when the provider answers with an empty message (silent-success guard)', async () => {
+    const empty = {
+      ...candidate,
+      definition: { createProvider: () => ({ chat: async () => ({ content: '   ' }) }) },
+    };
+
+    expect((await smokeProvider(empty, createUserMessage)).status).toBe('fail');
+  });
+
+  it('fails when the stream yields no chunks', async () => {
+    const silent = {
+      ...candidate,
+      definition: {
+        createProvider: () => ({
+          chat: async () => ({ content: 'pong' }),
+          // eslint-disable-next-line require-yield
+          chatStream: async function* () {},
+        }),
+      },
+    };
+
+    const result = await smokeProvider(silent, createUserMessage);
+
+    expect(result.status).toBe('fail');
+    expect(result.error).toContain('no chunks');
+  });
+
+  it('passes with a recorded note when the provider exposes no chatStream()', async () => {
+    const noStream = {
+      ...candidate,
+      definition: { createProvider: () => ({ chat: async () => ({ content: 'pong' }) }) },
+    };
+
+    const result = await smokeProvider(noStream, createUserMessage);
+
+    expect(result.status).toBe('pass');
+    expect(result.stream.skipped).toContain('no chatStream()');
+  });
+});
+
+describe('formatReport', () => {
+  it('states plainly that a credential-less run is not a failure', () => {
+    const selection = selectLiveProviders([ANTHROPIC], {});
+
+    const report = formatReport(selection, []);
+
+    expect(report).toContain('SKIPPED');
+    expect(report).toContain('not a failure');
+    expect(report).toContain('ANTHROPIC_API_KEY not set');
+  });
+
+  it('names the provider and model on a pass', () => {
+    const selection = { runnable: [{ type: 'anthropic' }], unconfigured: [], skipped: [] };
+    const results = [
+      {
+        type: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        status: 'pass',
+        chat: { chars: 4, ms: 900 },
+        stream: { chars: 4, chunks: 2, ms: 950 },
+      },
+    ];
+
+    const report = formatReport(selection, results);
+
+    expect(report).toContain('PASS anthropic (model=claude-sonnet-4-6)');
+    expect(report).toContain('live-provider-smoke: PASS (1/1 live providers reachable).');
+  });
+
+  it('summarises a failure with its stage and message', () => {
+    const selection = { runnable: [{ type: 'anthropic' }], unconfigured: [], skipped: [] };
+    const results = [
+      { type: 'anthropic', model: 'm', status: 'fail', stage: 'liveCall', error: '400 max_tokens' },
+    ];
+
+    const report = formatReport(selection, results);
+
+    expect(report).toContain('FAIL anthropic (model=m) at liveCall: 400 max_tokens');
+    expect(report).toContain('live-provider-smoke: FAIL (1/1 live providers broken).');
+  });
+});

--- a/scripts/harness/live-provider-smoke.mjs
+++ b/scripts/harness/live-provider-smoke.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+
+/**
+ * HARNESS-024 — env-gated LIVE provider smoke.
+ *
+ * Every provider/transport boundary in the test suite is scripted or replayed. That is deliberate
+ * (deterministic, free, offline), but it means a whole class of breakage is invisible to CI: the
+ * auth handshake, wire-format drift in the vendor SDK, a required request field the adapter stopped
+ * sending (the Anthropic 400 / maxTokens family), and the shape of a streaming response. Those
+ * regressions were each caught three times by a HUMAN running the CLI by hand. This script is the
+ * mechanical replacement: one minimal REAL turn per credentialed provider.
+ *
+ * Gating (the whole point — it must never be able to fail for lack of credentials):
+ *   - A provider is selected only when its definition's `defaults.apiKey` is an `$ENV:<NAME>`
+ *     reference AND `<NAME>` is present and non-empty in the environment.
+ *   - No credentialed provider at all  →  clean SKIP, exit 0. Never a failure.
+ *   - The provider list and the env-var names are read from the provider DEFINITIONS, so a newly
+ *     added provider is covered automatically and this file holds no provider-name table.
+ *
+ * What each selected provider runs (two tiny calls, `maxTokens` capped — cents, not dollars):
+ *   1. non-streaming `chat()`   — proves auth + request/response wire format.
+ *   2. streaming `chatStream()` — proves the streaming shape (chunks arrive, text assembles).
+ * Both must return non-empty assistant text or the provider is reported FAIL.
+ *
+ * Exit codes: 0 = every selected provider passed (or nothing was selected), 1 = a selected
+ * provider's live call failed, or the workspace is not built.
+ *
+ * A provider that has a key but no model to call (OpenAI ships no default model by design) is
+ * reported WARN, not FAIL, and does not change the exit code: this smoke exists to catch wire
+ * drift, and a red nightly for a missing config value only trains people to ignore the signal.
+ * The warning names the exact env var that fixes it.
+ *
+ * Secrets are never printed. Every line written by this script passes through `redactSecrets`,
+ * which scrubs the resolved key values — vendor SDK errors sometimes echo request headers back.
+ *
+ * Run:
+ *   node scripts/harness/live-provider-smoke.mjs [--provider <type>] [--report-file <path>]
+ * Prerequisite: the provider packages must be built (`pnpm --filter @robota-sdk/agent-provider-defaults... build:js`).
+ */
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** The one prompt every provider gets. Short, deterministic to grade, cheap to answer. */
+export const SMOKE_PROMPT = 'Reply with exactly one word: pong';
+/** Hard cap on generated tokens — this is a reachability probe, not a capability test. */
+export const SMOKE_MAX_TOKENS = 32;
+/** Per-call wall-clock budget. A hung provider must not hang the scheduled job. */
+export const SMOKE_TIMEOUT_MS = 60_000;
+
+const ENV_REFERENCE_PREFIX = '$ENV:';
+
+/**
+ * Per-provider model override env var, e.g. `LIVE_SMOKE_MODEL_OPENAI`.
+ * Needed for providers whose definition ships no default model.
+ */
+export function modelOverrideEnvVar(providerType) {
+  return `LIVE_SMOKE_MODEL_${providerType.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}`;
+}
+
+/** Name of the env var a definition's `$ENV:` apiKey reference points at, or undefined. */
+export function apiKeyEnvVarOf(definition) {
+  const reference = definition?.defaults?.apiKey;
+  if (typeof reference !== 'string' || !reference.startsWith(ENV_REFERENCE_PREFIX))
+    return undefined;
+  const name = reference.slice(ENV_REFERENCE_PREFIX.length).trim();
+  return name.length > 0 ? name : undefined;
+}
+
+/**
+ * Pure selection: which provider definitions can be smoked with the given environment.
+ *
+ * Returns `{ runnable, unconfigured, skipped }` where
+ *   - runnable     = key present AND a model to call (definition default or override env var)
+ *   - unconfigured = key present but no model → WARN (does not fail the run)
+ *   - skipped      = no credential in this environment → silent, expected, exit 0
+ */
+export function selectLiveProviders(definitions, env, options = {}) {
+  const only = options.only;
+  const runnable = [];
+  const unconfigured = [];
+  const skipped = [];
+
+  for (const definition of definitions) {
+    const type = definition.type;
+    if (only !== undefined && only !== type) continue;
+
+    const apiKeyEnvVar = apiKeyEnvVarOf(definition);
+    if (apiKeyEnvVar === undefined) {
+      // Local/self-hosted definitions carry a literal apiKey and a localhost baseURL. There is no
+      // remote credential to gate on, and no such server in CI, so they are out of scope here.
+      skipped.push({ type, reason: 'no $ENV: apiKey reference (local/self-hosted definition)' });
+      continue;
+    }
+
+    const apiKey = env[apiKeyEnvVar];
+    if (typeof apiKey !== 'string' || apiKey.length === 0) {
+      skipped.push({ type, reason: `${apiKeyEnvVar} not set` });
+      continue;
+    }
+
+    const overrideEnvVar = modelOverrideEnvVar(type);
+    const model = env[overrideEnvVar] || definition.defaults?.model;
+    if (typeof model !== 'string' || model.length === 0) {
+      unconfigured.push({
+        type,
+        apiKeyEnvVar,
+        reason: `${apiKeyEnvVar} is set but this provider ships no default model — set ${overrideEnvVar}`,
+      });
+      continue;
+    }
+
+    runnable.push({ type, apiKeyEnvVar, apiKey, model, definition });
+  }
+
+  return { runnable, unconfigured, skipped };
+}
+
+/** Replace every occurrence of every secret with a fixed marker. */
+export function redactSecrets(text, secrets) {
+  let output = String(text);
+  for (const secret of secrets) {
+    if (typeof secret === 'string' && secret.length >= 8) {
+      output = output.split(secret).join('***REDACTED***');
+    }
+  }
+  return output;
+}
+
+/** Extract plain text from a TUniversalMessage-ish value (content may be string or parts). */
+export function messageText(message) {
+  const content = message?.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === 'string' ? part : typeof part?.text === 'string' ? part.text : '',
+      )
+      .join('');
+  }
+  return '';
+}
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} exceeded ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** One non-streaming turn. Resolves to `{ chars, ms }`; throws when the reply carries no text. */
+async function runChatProbe(provider, createUserMessage, model) {
+  const started = Date.now();
+  const reply = await withTimeout(
+    provider.chat([createUserMessage(SMOKE_PROMPT)], {
+      model,
+      maxTokens: SMOKE_MAX_TOKENS,
+      temperature: 0,
+    }),
+    SMOKE_TIMEOUT_MS,
+    'chat()',
+  );
+  const text = messageText(reply).trim();
+  if (text.length === 0) throw new Error('chat() returned an empty assistant message');
+  return { chars: text.length, ms: Date.now() - started };
+}
+
+/** One streaming turn. Resolves to `{ chars, chunks, ms }`; throws on an empty/silent stream. */
+async function runStreamProbe(provider, createUserMessage, model) {
+  const started = Date.now();
+  const collect = (async () => {
+    let assembled = '';
+    let chunks = 0;
+    for await (const chunk of provider.chatStream([createUserMessage(SMOKE_PROMPT)], {
+      model,
+      maxTokens: SMOKE_MAX_TOKENS,
+      temperature: 0,
+    })) {
+      chunks += 1;
+      assembled += messageText(chunk);
+    }
+    return { assembled: assembled.trim(), chunks };
+  })();
+
+  const { assembled, chunks } = await withTimeout(collect, SMOKE_TIMEOUT_MS, 'chatStream()');
+  if (chunks === 0) throw new Error('chatStream() yielded no chunks');
+  if (assembled.length === 0) throw new Error('chatStream() assembled no text across its chunks');
+  return { chars: assembled.length, chunks, ms: Date.now() - started };
+}
+
+/** Smoke one selected provider. Never throws — the outcome is the return value. */
+export async function smokeProvider(candidate, createUserMessage) {
+  const { type, model, definition, apiKey } = candidate;
+  const base = { type, model };
+  let provider;
+  try {
+    provider = definition.createProvider({ apiKey, model });
+  } catch (error) {
+    return {
+      ...base,
+      status: 'fail',
+      stage: 'createProvider',
+      error: String(error?.message ?? error),
+    };
+  }
+
+  try {
+    const chat = await runChatProbe(provider, createUserMessage, model);
+
+    if (typeof provider.chatStream !== 'function') {
+      return {
+        ...base,
+        status: 'pass',
+        chat,
+        stream: { skipped: 'provider exposes no chatStream()' },
+      };
+    }
+    const stream = await runStreamProbe(provider, createUserMessage, model);
+    return { ...base, status: 'pass', chat, stream };
+  } catch (error) {
+    return { ...base, status: 'fail', stage: 'liveCall', error: String(error?.message ?? error) };
+  } finally {
+    if (typeof provider?.close === 'function') {
+      await provider.close().catch(() => {});
+    } else if (typeof provider?.dispose === 'function') {
+      await provider.dispose().catch(() => {});
+    }
+  }
+}
+
+/** Render the human-readable report. Pure — the caller redacts and prints. */
+export function formatReport({ runnable, unconfigured, skipped }, results) {
+  const lines = [];
+
+  if (runnable.length === 0) {
+    lines.push('live-provider-smoke: SKIPPED — no provider credentials in this environment.');
+    lines.push("  A provider runs only when its definition's $ENV: apiKey variable is set:");
+    for (const entry of skipped) lines.push(`  - ${entry.type}: ${entry.reason}`);
+    for (const entry of unconfigured) lines.push(`  - ${entry.type}: WARN ${entry.reason}`);
+    lines.push('  This is the expected outcome without credentials and is not a failure.');
+    return lines.join('\n');
+  }
+
+  lines.push(`live-provider-smoke: ${runnable.length} credentialed provider(s).`);
+  for (const result of results) {
+    if (result.status === 'pass') {
+      const stream = result.stream.skipped
+        ? `stream=skipped (${result.stream.skipped})`
+        : `stream=${result.stream.chunks} chunks/${result.stream.chars} chars in ${result.stream.ms}ms`;
+      lines.push(
+        `  PASS ${result.type} (model=${result.model}) chat=${result.chat.chars} chars in ${result.chat.ms}ms, ${stream}`,
+      );
+    } else {
+      lines.push(
+        `  FAIL ${result.type} (model=${result.model}) at ${result.stage}: ${result.error}`,
+      );
+    }
+  }
+  for (const entry of unconfigured) lines.push(`  WARN ${entry.type}: ${entry.reason}`);
+  for (const entry of skipped) lines.push(`  skip ${entry.type}: ${entry.reason}`);
+
+  const failed = results.filter((r) => r.status === 'fail');
+  lines.push(
+    failed.length === 0
+      ? `live-provider-smoke: PASS (${results.length}/${results.length} live providers reachable).`
+      : `live-provider-smoke: FAIL (${failed.length}/${results.length} live providers broken).`,
+  );
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--provider') options.only = argv[++i];
+    else if (argv[i] === '--report-file') options.reportFile = argv[++i];
+  }
+  return options;
+}
+
+/** Load the provider definitions + message factory from the BUILT workspace output. */
+async function loadWorkspace() {
+  const defaultsEntry = path.join(
+    WORKSPACE_ROOT,
+    'packages/agent-provider-defaults/dist/node/index.js',
+  );
+  const coreEntry = path.join(WORKSPACE_ROOT, 'packages/agent-core/dist/node/index.js');
+  if (!existsSync(defaultsEntry) || !existsSync(coreEntry)) {
+    return undefined;
+  }
+  const [{ createDefaultProviderDefinitions }, { createUserMessage }] = await Promise.all([
+    import(pathToFileURL(defaultsEntry).href),
+    import(pathToFileURL(coreEntry).href),
+  ]);
+  return { createDefaultProviderDefinitions, createUserMessage };
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const options = parseArgs(argv);
+
+  const workspace = await loadWorkspace();
+  if (workspace === undefined) {
+    process.stdout.write(
+      'live-provider-smoke: workspace is not built — run\n' +
+        '  pnpm --filter @robota-sdk/agent-provider-defaults... build:js\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const definitions = workspace.createDefaultProviderDefinitions();
+  const selection = selectLiveProviders(definitions, env, options);
+  const secrets = selection.runnable.map((candidate) => candidate.apiKey);
+
+  const results = [];
+  for (const candidate of selection.runnable) {
+    results.push(await smokeProvider(candidate, workspace.createUserMessage));
+  }
+
+  const report = redactSecrets(formatReport(selection, results), secrets);
+  process.stdout.write(`${report}\n`);
+
+  if (options.reportFile !== undefined) {
+    const summary = {
+      generatedAt: new Date().toISOString(),
+      // The key VALUES never leave this process; only the variable NAMES are recorded.
+      credentialed: selection.runnable.map((c) => ({
+        type: c.type,
+        model: c.model,
+        apiKeyEnvVar: c.apiKeyEnvVar,
+      })),
+      unconfigured: selection.unconfigured,
+      skipped: selection.skipped,
+      results,
+    };
+    const serialized = redactSecrets(JSON.stringify(summary, null, 2), secrets);
+    await mkdir(path.dirname(path.resolve(options.reportFile)), { recursive: true });
+    await writeFile(path.resolve(options.reportFile), `${serialized}\n`, 'utf-8');
+  }
+
+  if (results.some((result) => result.status === 'fail')) {
+    process.exitCode = 1;
+  }
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/live-provider-smoke.mjs
+++ b/scripts/harness/live-provider-smoke.mjs
@@ -39,11 +39,15 @@
  */
 
 import { writeFile, mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Packages the smoke loads at runtime, by manifest name — never by build-output path. */
+const PROVIDER_DEFAULTS_PACKAGE = '@robota-sdk/agent-provider-defaults';
+const CORE_PACKAGE = '@robota-sdk/agent-core';
 
 /** The one prompt every provider gets. Short, deterministic to grade, cheap to answer. */
 export const SMOKE_PROMPT = 'Reply with exactly one word: pong';
@@ -282,14 +286,40 @@ function parseArgs(argv) {
   return options;
 }
 
+/**
+ * Locate a workspace package by its manifest `name`, and return its built Node ESM entry as
+ * declared by that manifest's own `exports['.'].node.import`.
+ *
+ * The build-output location is NOT hardcoded here: it is read from the package that owns it, so a
+ * change to the build layout moves this loader with it. Returns undefined when the package is not
+ * built yet (a fresh checkout has no build output).
+ */
+export function resolveBuiltEntry(packageName, root = WORKSPACE_ROOT) {
+  const packagesRoot = path.join(root, 'packages');
+  if (!existsSync(packagesRoot)) return undefined;
+
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const packageDir = path.join(packagesRoot, entry.name);
+    const manifestPath = path.join(packageDir, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    if (manifest.name !== packageName) continue;
+
+    const nodeImport = manifest.exports?.['.']?.node?.import;
+    if (typeof nodeImport !== 'string') return undefined;
+    const absolute = path.join(packageDir, nodeImport);
+    return existsSync(absolute) ? absolute : undefined;
+  }
+  return undefined;
+}
+
 /** Load the provider definitions + message factory from the BUILT workspace output. */
 async function loadWorkspace() {
-  const defaultsEntry = path.join(
-    WORKSPACE_ROOT,
-    'packages/agent-provider-defaults/dist/node/index.js',
-  );
-  const coreEntry = path.join(WORKSPACE_ROOT, 'packages/agent-core/dist/node/index.js');
-  if (!existsSync(defaultsEntry) || !existsSync(coreEntry)) {
+  const defaultsEntry = resolveBuiltEntry(PROVIDER_DEFAULTS_PACKAGE);
+  const coreEntry = resolveBuiltEntry(CORE_PACKAGE);
+  if (defaultsEntry === undefined || coreEntry === undefined) {
     return undefined;
   }
   const [{ createDefaultProviderDefinitions }, { createUserMessage }] = await Promise.all([


### PR DESCRIPTION
## HARNESS-024 — env-gated live provider smoke

Every provider boundary in the test suite is scripted or replayed. That is the right default
(deterministic, free, offline), but it makes a whole class of breakage structurally invisible to PR
CI: the auth handshake, vendor wire-format drift, a required request field the adapter stopped
sending (the Anthropic 400 / `maxTokens` family), and the shape of a streaming response. Three such
regressions were each caught only by a human running the CLI by hand. This PR is the mechanical
replacement.

### What's here

- **`scripts/harness/live-provider-smoke.mjs`** — one minimal **real** turn per credentialed
  provider: non-streaming `chat()` (auth + request/response wire format) and streaming
  `chatStream()` (chunks arrive, text assembles), both capped at `maxTokens: 32`. Both must return
  non-empty assistant text or the provider is reported FAIL.
- **`scripts/harness/__tests__/live-provider-smoke.test.mjs`** — 20 network-free unit tests over the
  selection, redaction, verdict and report logic.
- **`.github/workflows/live-provider-smoke.yml`** — daily 05:37 UTC (a slot distinct from
  mutation-nightly 03:17, CodeQL 04:27, security Mon 04:47) + `workflow_dispatch`.

### Gating — it can never fail for lack of credentials

A provider is selected **only** when its definition's `defaults.apiKey` is an `$ENV:<NAME>`
reference **and** `<NAME>` is present and non-empty. No credential at all → clean SKIP, exit 0.

The provider list and the key env-var names are read from the provider **definitions**, so this
script contains no provider-name table and a newly added provider is covered automatically.

In the workflow, an unprovisioned secret expands to `''`, so until the owner adds a key this job is
a **green no-op**.

### Non-blocking posture

Scheduled + manual only. Not a PR gate, not a required check — same rollout posture as
`mutation-nightly`. A PR can never be blocked by a third party's API being down or a spent quota.

### Secrets are never printed

Every line the script writes — stdout and the JSON report — passes through `redactSecrets`, which
scrubs the resolved key values, because vendor SDK errors sometimes echo request headers back. The
uploaded report records provider / model / latency and the key **variable names** only.

### Verification (run locally, foreground)

| Scenario | Command | Result |
| --- | --- | --- |
| No key → clean skip | `env -u ANTHROPIC_API_KEY node scripts/harness/live-provider-smoke.mjs` | `live-provider-smoke: SKIPPED — no provider credentials in this environment.` … `This is the expected outcome without credentials and is not a failure.` — **exit 0** |
| Key present → live call | `node scripts/harness/live-provider-smoke.mjs` | `PASS anthropic (model=claude-sonnet-4-6) chat=4 chars in 2796ms, stream=2 chunks/4 chars in 1894ms` → `live-provider-smoke: PASS (1/1 live providers reachable).` — **exit 0** |
| Red proof (deliberately invalid key) | `ANTHROPIC_API_KEY=<invalid> node …` | `FAIL anthropic (model=claude-sonnet-4-6) at liveCall: 401 … authentication_error` — **exit 1** |

The red proof matters: a smoke that cannot go red is an accidental-green smoke. The invalid-key run
proves the failure path actually fails.

- `npx vitest run scripts/harness/__tests__` → **72 files / 700 tests passed** (includes the 20 new ones).
- `node scripts/harness/run-all-scans.mjs` → **59 of 61 green**. The two failures are
  `build-contracts` and `dist`, both pure artefacts of this environment not having a full workspace
  build (I built only the provider dependency closure with `build:js`, so `.d.ts` files are absent).
  Unrelated to this change.
- Workflow YAML parses; the `workflow_dispatch` input is passed through an env var rather than
  interpolated into the shell line, so a dispatch input cannot become shell text.

### Owner action required — one repo secret

The CI half cannot be observed until credentials exist, so **HARNESS-024 stays `in-progress`, not
`done`**. Honest status: the script is proven, the workflow is a green no-op.

- **Required:** `ANTHROPIC_API_KEY` as a repo secret. That alone proves the CI half.
- Optional: `OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY`.
- OpenAI's definition ships no default model by design, so covering it also needs the repo
  **variable** `LIVE_SMOKE_MODEL_OPENAI`. Without it OpenAI is reported **WARN**, not FAIL, and the
  exit code is unchanged — a red nightly for a missing config value only trains people to ignore the
  signal.

After provisioning, one `workflow_dispatch` run showing `PASS <provider> (model=…)` closes the item
and archives it to `completed/`.

### Deferred: root `package.json` script

Root `package.json` is owned by another agent this wave, so the workflow invokes the runner directly
(`node scripts/harness/live-provider-smoke.mjs`). The line to add later:

```json
"harness:live-smoke": "node scripts/harness/live-provider-smoke.mjs"
```

### Scope note — backlog item 2

HARNESS-024 also lists "document the local/CI verification asymmetry". That is being covered by the
sibling `scripts/harness/verify-like-ci.mjs` work in this same wave, so it is deliberately not
duplicated here; the backlog file records that dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
