### PR TITLE
feat(harness): HARNESS-045 — one local entry that mirrors the CI scans/quality gate

### DIFF
--- a/.agents/backlog/completed/HARNESS-045-local-verify-mirrors-ci.md
+++ b/.agents/backlog/completed/HARNESS-045-local-verify-mirrors-ci.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-045: a single local verification entry that reproduces the CI scans/quality gate exactly'
-status: todo
+status: done
 created: 2026-07-25
+completed: 2026-07-25
 priority: high
 urgency: soon
 area: scripts/harness, package.json, .agents/skills, .agents/rules
@@ -60,7 +61,7 @@ Then wire a reference to this single entry into:
   command, not bare `run-all-scans`); and
 - the `git-branch.md` pre-merge guidance (the pre-push / pre-merge check is the CI-equivalent entry).
 
-## Why this is deferred (concrete obstacle, per lesson-to-harness step 8 "infeasible-now")
+## Why this was deferred (resolved — ARCH-005 S1 landed as #1376, unblocking the work)
 
 The mechanism lives in `scripts/harness/**`, which is currently **contended by another active agent**
 (ARCH-005 S1 is editing `scripts/harness`). Building the new entry now would conflict. Coordinate:
@@ -88,6 +89,64 @@ is the sanctioned "infeasible-now + tracked backlog" terminal state.
 
 - Not applicable (harness / CI-parity check; governance-only change with no runnable user-facing
   behavior). Evidence: the fixture red/green pairs above, run by the agent.
+
+## Outcome (done 2026-07-25)
+
+**Built:** `pnpm harness:verify-like-ci` → `scripts/harness/verify-like-ci.mjs` (+ 23-case unit suite in
+`scripts/harness/__tests__/verify-like-ci.test.mjs`). Four stages, each **derived from the real
+definition** (`.github/workflows/ci.yml`, `.lintstagedrc.json`) and printed with the definition it
+mirrors, so a failure names its own fix target:
+
+| Stage               | Mirrors                                                                              | What a bare `run-all-scans` misses                                            |
+| ------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `harness-self-test` | ci.yml → `scans` → "Harness scan test suite" (`pnpm harness:test`)                   | baseline TIGHTNESS (`notices == []`) — a below-baseline count is a local pass |
+| `format-check`      | `.lintstagedrc.json` globs via `.husky/pre-commit` (prettier)                        | a `--no-verify` push from a fresh worktree never runs the SSOT formatter      |
+| `scan-suite`        | ci.yml → `scans` "Harness scan suite" + `quality` "Build-output contracts" (w/ dist) | the dist-dependent scans silently no-op on an unbuilt tree                    |
+| `typecheck`         | ci.yml → `quality` → `harness:verify` (typecheck step)                               | the scan suite never typechecks                                               |
+
+No stage is skipped after an earlier failure (a new failure must never hide behind a known one). The
+formatter file set is **derived** from `.lintstagedrc.json`, not hardcoded; the dist check enumerates
+packages declaring `build:js` and **fails with `run pnpm build`** rather than passing silently.
+
+### Red/green evidence (agent-run)
+
+**Mode (a) — below-baseline spec-surface improvement.** Documented `AbstractNodeDefinition` in
+`packages/dag-node/docs/SPEC.md` (count 1 → 0, below its frozen baseline of 1), baseline NOT regenerated:
+
+- RED: `node scripts/harness/run-all-scans.mjs` → **exit 0, "all 61 scans passed"**.
+  `pnpm harness:verify-like-ci -- --only harness-self-test` → **exit 1**,
+  `check-spec-public-surface.test.mjs > passes on the live repository … and needs no tightening`
+  `AssertionError: expected [ Array(1) ] to deeply equal []` —
+  `"@robota-sdk/dag-node is below its frozen undocumented-export baseline — tighten the ratchet"`.
+- GREEN: after the correct fix (`node scripts/harness/check-spec-public-surface.mjs --write-baseline`)
+  → `703 passed`, `✓ harness-self-test / PASS`. Fixture reverted (dag-node is out of this PR's scope).
+
+**Mode (b) — prettier formatter drift on a spec-doc `tags:` array.** Lengthened
+`.agents/spec-docs/done/HARNESS-003-simple-harness-scans.md`'s `tags:` flow array past `printWidth: 100`:
+
+- RED: `run-all-scans` → **exit 0, "all 61 scans passed"** (the unformatted single-line form parses
+  fine). `pnpm harness:verify-like-ci -- --only format-check` → **exit 1**,
+  `[warn] .agents/spec-docs/done/HARNESS-003-simple-harness-scans.md … Run Prettier with --write to fix.`
+  (it also caught this PR's own unformatted test file — dogfooded).
+- GREEN: after `pnpm exec prettier --write …` → `All matched files use Prettier code style!`,
+  `✓ format-check / PASS`.
+- **Honest note on the literal #1369 state.** Once prettier rewrites the array to its wrapped
+  block form (`tags:\n  [\n    harness,\n    …\n  ]`), `check-spec-doc-frontmatter` reports
+  `tags missing or empty` → **exit 1**. So the multi-line state is NOT a local false-pass today;
+  `run-all-scans` catches it. The reproducible blind spot is the state a fresh worktree actually
+  pushes — the **un**formatted file, green in `run-all-scans` and red in `verify-like-ci`. The
+  parser half of the chain is HARNESS-044 (sibling-owned), and `verify-like-ci` surfaces the whole
+  chain locally instead of in CI.
+
+**Unbuilt-`dist` stage.** Temporarily removing `packages/dag-node/dist` →
+`✗ scan-suite — dist missing for 1 package(s) — run \`pnpm build\``with the actionable block message
+(instead of`build-contracts` no-op'ing into a green).
+
+### Wired in
+
+- `.agents/skills/worktree-parallel-orchestration/SKILL.md` § 4 — the implementer's foreground
+  self-verification is now `pnpm harness:verify-like-ci` on a built tree, not bare `run-all-scans`.
+- `.agents/rules/git-branch.md` — one-line pre-push/pre-merge pointer (no rule text duplicated).
 
 ## Related
 

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -47,6 +47,10 @@ git status --short
 belong to the branch). `scripts/harness/pre-push.mjs` calls `assertCleanWorkingTree()` — any push
 with uncommitted modifications or staged changes is blocked with exit code 1.
 
+**Before pushing or merging, run `pnpm harness:verify-like-ci` on a built tree** — the single entry that
+reproduces what CI's `scans`/`quality` jobs assert (`scripts/harness/verify-like-ci.mjs`); a bare
+`run-all-scans` is not that gate (HARNESS-045).
+
 **Why:** selective commits leave invisible half-states — code pushed while dependent files (SPEC.md, README, tests, backlog) are not.
 
 ### Git Operations

--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -55,8 +55,11 @@ run two agents that touch the same file concurrently.
 Each implementer produces exactly one PR and does **not** self-merge:
 
 - Red-before-green (HARNESS-041): prove the new/changed test fails pre-fix.
-- **Foreground** self-verification: `pnpm build`, `pnpm test`, `pnpm typecheck`,
-  `node scripts/harness/run-all-scans.mjs` — all green, evidence reported.
+- **Foreground** self-verification on a BUILT tree (`pnpm build` first): `pnpm harness:verify-like-ci`
+  — the CI-equivalent entry (harness self-test, prettier check, full scan suite incl. the
+  dist-dependent scans, typecheck) — plus `pnpm test`; all green, evidence reported. A bare
+  `run-all-scans` is NOT the CI gate: it reports baseline notices and an unbuilt `dist` as a pass, and
+  a fresh worktree has no husky/prettier toolchain (HARNESS-045).
 - Correct commit footers; `gh pr create --base develop`.
 - Stop-and-report on a blocker rather than merging or leaving a broken commit.
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "readme:validate": "node scripts/docs/validate-readmes.js",
     "harness:scan": "node scripts/harness/run-all-scans.mjs",
     "harness:test": "vitest run scripts/harness/__tests__",
+    "harness:verify-like-ci": "node scripts/harness/verify-like-ci.mjs",
     "harness:conformance": "node scripts/harness/check-dependency-direction.mjs --conformance-json",
     "harness:scan:done-evidence": "node scripts/harness/check-done-evidence.mjs",
     "harness:scan:task-archival": "node scripts/harness/check-task-archival.mjs",

--- a/scripts/harness/__tests__/verify-like-ci.test.mjs
+++ b/scripts/harness/__tests__/verify-like-ci.test.mjs
@@ -1,0 +1,237 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CI_STAGES,
+  collectChangedFiles,
+  findMissingDist,
+  globExtensions,
+  lintStagedExtensions,
+  listBuildablePackageDirs,
+  parseArgs,
+  parseGitFileList,
+  readLintStagedExtensions,
+  selectFormatTargets,
+  summarize,
+} from '../verify-like-ci.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+function createFixture(files) {
+  const root = mkdtempSync(path.join(tmpdir(), 'verify-like-ci-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// lint-staged glob derivation
+// ---------------------------------------------------------------------------
+
+describe('globExtensions', () => {
+  it('expands a braced lint-staged glob into every extension', () => {
+    expect(globExtensions('*.{json,md,yml,yaml}')).toEqual(['.json', '.md', '.yml', '.yaml']);
+  });
+
+  it('expands a single-extension glob', () => {
+    expect(globExtensions('*.ts')).toEqual(['.ts']);
+  });
+
+  it('ignores a non-extension glob (nothing to hand prettier)', () => {
+    expect(globExtensions('packages/**/src')).toEqual([]);
+  });
+});
+
+describe('lintStagedExtensions', () => {
+  it('derives the union of every configured glob, deduplicated and sorted', () => {
+    expect(
+      lintStagedExtensions({
+        '*.{ts,tsx}': ['eslint --fix', 'prettier --write'],
+        '*.{js,mjs,cjs}': ['prettier --write'],
+        '*.{json,md,yml,yaml}': ['prettier --write'],
+      }),
+    ).toEqual(['.cjs', '.js', '.json', '.md', '.mjs', '.ts', '.tsx', '.yaml', '.yml']);
+  });
+
+  it('is derived from the config, not hardcoded — a narrowed config narrows the set', () => {
+    expect(lintStagedExtensions({ '*.md': ['prettier --write'] })).toEqual(['.md']);
+  });
+
+  it('reads the live .lintstagedrc.json and includes the YAML/markdown drift extensions', () => {
+    const live = readLintStagedExtensions(WORKSPACE_ROOT);
+    // The #1369 drift class was a prettier-wrapped YAML array inside a markdown frontmatter block.
+    expect(live).toContain('.md');
+    expect(live).toContain('.yml');
+    expect(live).toContain('.yaml');
+    expect(live).toContain('.ts');
+  });
+});
+
+describe('selectFormatTargets', () => {
+  const extensions = ['.md', '.ts', '.yml'];
+
+  it('keeps only formatter-owned files', () => {
+    expect(
+      selectFormatTargets(
+        ['a.md', 'b.ts', 'c.png', 'd.yml', 'packages/foo/src/x.snap'],
+        extensions,
+      ),
+    ).toEqual(['a.md', 'b.ts', 'd.yml']);
+  });
+
+  it('deduplicates a file reported by more than one git query', () => {
+    expect(selectFormatTargets(['a.md', 'a.md', 'a.md'], extensions)).toEqual(['a.md']);
+  });
+
+  it('matches the extension case-insensitively', () => {
+    expect(selectFormatTargets(['README.MD'], extensions)).toEqual(['README.MD']);
+  });
+});
+
+describe('parseGitFileList', () => {
+  it('splits, trims and drops empty lines', () => {
+    expect(parseGitFileList('a.md\n b.ts \n\n')).toEqual(['a.md', 'b.ts']);
+  });
+
+  it('returns an empty list for no output', () => {
+    expect(parseGitFileList(undefined)).toEqual([]);
+  });
+});
+
+describe('collectChangedFiles', () => {
+  it('unions base-diff, working-tree and untracked files (untracked would else be invisible)', () => {
+    const calls = [];
+    const runner = (args) => {
+      calls.push(args.join(' '));
+      if (args.includes('ls-files')) return ['scripts/harness/verify-like-ci.mjs'];
+      if (args.includes('HEAD') && !args.some((a) => a.includes('...'))) return ['package.json'];
+      return ['AGENTS.md'];
+    };
+    const files = collectChangedFiles('origin/develop', runner);
+    // Only files that exist on disk survive; all three of these do in this repo.
+    expect(files).toContain('AGENTS.md');
+    expect(files).toContain('package.json');
+    expect(files).toContain('scripts/harness/verify-like-ci.mjs');
+    expect(calls.some((call) => call.includes('origin/develop...HEAD'))).toBe(true);
+    expect(calls.some((call) => call.includes('ls-files --others'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dist presence
+// ---------------------------------------------------------------------------
+
+describe('listBuildablePackageDirs', () => {
+  it('lists only packages that declare build:js (the script root `pnpm build` fans out to)', () => {
+    const root = createFixture({
+      'packages/built/package.json': JSON.stringify({ scripts: { 'build:js': 'x' } }),
+      'packages/no-build/package.json': JSON.stringify({ scripts: { test: 'x' } }),
+      'packages/dag-nodes/nested/package.json': JSON.stringify({ scripts: { 'build:js': 'x' } }),
+    });
+    expect(listBuildablePackageDirs(root)).toEqual(['packages/built', 'packages/dag-nodes/nested']);
+  });
+
+  it('finds the live workspace packages (the real dist set CI restores)', () => {
+    expect(listBuildablePackageDirs(WORKSPACE_ROOT).length).toBeGreaterThan(10);
+  });
+});
+
+describe('findMissingDist', () => {
+  it('reports every buildable package with no dist/ — an unbuilt tree must not read as a pass', () => {
+    const root = createFixture({
+      'packages/built/package.json': '{}',
+      'packages/built/dist/index.js': '',
+      'packages/unbuilt/package.json': '{}',
+    });
+    expect(findMissingDist(['packages/built', 'packages/unbuilt'], undefined, root)).toEqual([
+      'packages/unbuilt',
+    ]);
+  });
+
+  it('returns nothing when every package is built', () => {
+    const root = createFixture({ 'packages/built/dist/index.js': '' });
+    expect(findMissingDist(['packages/built'], undefined, root)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stage table + summary + args
+// ---------------------------------------------------------------------------
+
+describe('CI_STAGES', () => {
+  it('covers the four gates a bare run-all-scans misses', () => {
+    expect(CI_STAGES.map((stage) => stage.name)).toEqual([
+      'harness-self-test',
+      'format-check',
+      'scan-suite',
+      'typecheck',
+    ]);
+  });
+
+  it('names the real CI/lint-staged definition each stage mirrors (traceable, not guessed)', () => {
+    for (const stage of CI_STAGES) {
+      expect(stage.ciSource).toMatch(/ci\.yml|lintstagedrc/);
+      expect(stage.why.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('summarize', () => {
+  it('reports PASS and exit 0 when every stage passed', () => {
+    const { lines, exitCode } = summarize([
+      { name: 'harness-self-test', status: 'pass' },
+      { name: 'format-check', status: 'pass' },
+    ]);
+    expect(exitCode).toBe(0);
+    expect(lines.join('\n')).toContain('PASS');
+  });
+
+  it('names the failing stage and exits 1', () => {
+    const { lines, exitCode } = summarize([
+      { name: 'harness-self-test', status: 'fail' },
+      { name: 'format-check', status: 'pass' },
+      { name: 'scan-suite', status: 'fail', note: 'dist missing' },
+    ]);
+    expect(exitCode).toBe(1);
+    const text = lines.join('\n');
+    expect(text).toContain('FAIL — 2 of 3 stage(s) failed: harness-self-test, scan-suite');
+    expect(text).toContain('dist missing');
+    // The failing stage points at the CI definition it mirrors, so the fix target is unambiguous.
+    expect(text).toContain('harness-self-test mirrors ci.yml');
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults to every stage against origin/develop', () => {
+    const options = parseArgs([]);
+    expect(options.only.size).toBe(0);
+    expect(options.baseRef).toBe('origin/develop');
+    expect(options.allFiles).toBe(false);
+    expect(options.unknown).toEqual([]);
+  });
+
+  it('parses --only (repeatable), --base-ref and --all-files', () => {
+    const options = parseArgs([
+      '--only',
+      'format-check',
+      '--only',
+      'typecheck',
+      '--base-ref',
+      'origin/main',
+      '--all-files',
+    ]);
+    expect([...options.only]).toEqual(['format-check', 'typecheck']);
+    expect(options.baseRef).toBe('origin/main');
+    expect(options.allFiles).toBe(true);
+  });
+
+  it('reports an unknown stage name instead of silently running nothing', () => {
+    expect(parseArgs(['--only', 'nope']).unknown).toEqual(['nope']);
+  });
+});

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+/**
+ * verify-like-ci — ONE local entry that reproduces the gate a PR must clear before it is pushed.
+ *
+ * WHY (HARNESS-045). An agent's foreground verification is typically
+ * `node scripts/harness/run-all-scans.mjs`, reported as "green locally". That is NOT the same claim
+ * as "green in CI": the scan suite alone omits three things CI (or the pre-commit formatter) asserts,
+ * and each omission has already shipped a red PR:
+ *
+ *   1. The harness SELF-TEST suite (`pnpm harness:test`, run by ci.yml → `scans`). The spec-surface
+ *      scan treats a below-baseline count as a PASS with a "tighten" notice, but the self-test asserts
+ *      `notices == []`. A genuine SPEC improvement is therefore green in `run-all-scans` and red in
+ *      CI (#1346, #1357).
+ *   2. Prettier. Prettier is the repo's SSOT formatter, applied by lint-staged in `.husky/pre-commit`.
+ *      A fresh worktree that pushes with `--no-verify` never runs it, so formatter-induced drift
+ *      (a long single-line YAML array prettier would wrap) is neither produced nor caught locally
+ *      (#1369 → HARNESS-044). No CI job re-checks formatting, so this stage is the only mechanical
+ *      floor for it.
+ *   3. The build-dependent scans. `check-build-output-contracts.mjs` reads each package's `dist` and
+ *      silently no-ops without it; CI restores `dist` before running it (ci.yml → `quality`). Locally
+ *      an unbuilt tree makes that scan a no-op that LOOKS like a pass — so a missing `dist` is a
+ *      hard FAIL here with an actionable message, never a silent skip.
+ *
+ * Every stage below is derived from the real definitions — `.github/workflows/ci.yml` and
+ * `.lintstagedrc.json` — not from a hand-copied guess.
+ *
+ * Usage:
+ *   pnpm harness:verify-like-ci
+ *   pnpm harness:verify-like-ci -- --base-ref origin/main
+ *   pnpm harness:verify-like-ci -- --only format-check --only harness-self-test
+ *   pnpm harness:verify-like-ci -- --all-files      # format-check the whole repo, not just the diff
+ *
+ * Exit code 0 = every stage passed; 1 = at least one stage failed (no stage is skipped on an
+ * earlier failure — a real new failure must never hide behind a known one).
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const LINT_STAGED_CONFIG = '.lintstagedrc.json';
+const DEFAULT_BASE_REF = 'origin/develop';
+
+// ---------------------------------------------------------------------------
+// lint-staged glob → extension derivation (pure)
+// ---------------------------------------------------------------------------
+
+/** Expand one lint-staged glob key (`*.{json,md,yml,yaml}` or `*.ts`) into its extensions. */
+export function globExtensions(glob) {
+  const braced = /^\*\.\{([^}]+)\}$/.exec(glob);
+  if (braced) return braced[1].split(',').map((ext) => `.${ext.trim()}`);
+  const single = /^\*\.([A-Za-z0-9]+)$/.exec(glob);
+  return single ? [`.${single[1]}`] : [];
+}
+
+/** The set of extensions lint-staged hands to prettier, derived from the parsed config object. */
+export function lintStagedExtensions(config) {
+  const extensions = new Set();
+  for (const glob of Object.keys(config ?? {})) {
+    for (const ext of globExtensions(glob)) extensions.add(ext.toLowerCase());
+  }
+  return [...extensions].sort();
+}
+
+/** Read `.lintstagedrc.json` from disk and derive its extension set. */
+export function readLintStagedExtensions(root = WORKSPACE_ROOT) {
+  const configPath = path.join(root, LINT_STAGED_CONFIG);
+  if (!existsSync(configPath))
+    throw new Error(`${LINT_STAGED_CONFIG} not found — cannot derive the formatter's file set.`);
+  return lintStagedExtensions(JSON.parse(readFileSync(configPath, 'utf8')));
+}
+
+/** Keep only the files prettier owns, de-duplicated and ordered. */
+export function selectFormatTargets(files, extensions) {
+  const owned = new Set(extensions.map((ext) => ext.toLowerCase()));
+  return [...new Set(files)]
+    .filter((file) => file && owned.has(path.extname(file).toLowerCase()))
+    .sort();
+}
+
+/** Split `git`'s newline-separated path output into a clean list. */
+export function parseGitFileList(stdout) {
+  return (stdout ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// build-output (dist) presence (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Workspace dirs that produce build output — a package whose manifest declares `build:js`
+ * (the script the root `pnpm build` fans out to). Mirrors the `packages/*` +
+ * `packages/dag-nodes/*` set ci.yml archives as `package-dist.tgz`.
+ */
+export function listBuildablePackageDirs(root = WORKSPACE_ROOT) {
+  const roots = [path.join(root, 'packages'), path.join(root, 'packages', 'dag-nodes')];
+  const dirs = [];
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+      const manifest = path.join(base, entry.name, 'package.json');
+      if (!existsSync(manifest)) continue;
+      const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (pkg?.scripts?.['build:js']) dirs.push(path.relative(root, path.join(base, entry.name)));
+    }
+  }
+  return dirs.sort();
+}
+
+/** Buildable dirs with no `dist/` — CI restores these before the dist-dependent scans run. */
+export function findMissingDist(dirs, exists = existsSync, root = WORKSPACE_ROOT) {
+  return dirs.filter((dir) => !exists(path.join(root, dir, 'dist')));
+}
+
+// ---------------------------------------------------------------------------
+// stage table + summary (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * The CI-mirroring stage table. `ciSource` names the real definition each stage reproduces, so a
+ * drift in ci.yml is traceable to the stage that must follow it.
+ */
+export const CI_STAGES = [
+  {
+    name: 'harness-self-test',
+    ciSource: 'ci.yml → scans → "Harness scan test suite" (pnpm harness:test)',
+    why: 'asserts baseline TIGHTNESS (spec-surface notices == []), which run-all-scans reports as a pass',
+  },
+  {
+    name: 'format-check',
+    ciSource: '.lintstagedrc.json (prettier via .husky/pre-commit)',
+    why: 'a --no-verify push from a fresh worktree never runs the SSOT formatter',
+  },
+  {
+    name: 'scan-suite',
+    ciSource:
+      'ci.yml → scans "Harness scan suite" + quality "Build-output contracts scan" (built dist)',
+    why: 'the dist-dependent scans silently no-op on an unbuilt tree',
+  },
+  {
+    name: 'typecheck',
+    ciSource: 'ci.yml → quality → harness:verify (typecheck step)',
+    why: 'CI typechecks every affected scope; the scan suite never typechecks',
+  },
+];
+
+/** Render the PASS/FAIL summary and the aggregate exit code from the stage results. */
+export function summarize(results) {
+  const lines = ['', 'verify-like-ci summary:'];
+  for (const result of results) {
+    const mark = result.status === 'pass' ? '✓' : result.status === 'skip' ? '-' : '✗';
+    lines.push(`${mark} ${result.name}${result.note ? ` — ${result.note}` : ''}`);
+  }
+  const failed = results.filter((result) => result.status === 'fail');
+  if (failed.length === 0) {
+    lines.push(`PASS — all ${results.length} CI-mirroring stage(s) passed.`);
+    return { lines, exitCode: 0 };
+  }
+  lines.push(
+    `FAIL — ${failed.length} of ${results.length} stage(s) failed: ${failed
+      .map((result) => result.name)
+      .join(', ')}`,
+  );
+  for (const result of failed) {
+    const stage = CI_STAGES.find((entry) => entry.name === result.name);
+    if (stage) lines.push(`  ${result.name} mirrors ${stage.ciSource}`);
+  }
+  return { lines, exitCode: 1 };
+}
+
+/** Parse the CLI arguments this entry accepts. */
+export function parseArgs(argv) {
+  const only = new Set();
+  let baseRef = DEFAULT_BASE_REF;
+  let allFiles = false;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--only' && argv[i + 1]) only.add(argv[++i]);
+    else if (argv[i] === '--base-ref' && argv[i + 1]) baseRef = argv[++i];
+    else if (argv[i] === '--all-files') allFiles = true;
+  }
+  const unknown = [...only].filter((name) => !CI_STAGES.some((stage) => stage.name === name));
+  return { only, baseRef, allFiles, unknown };
+}
+
+// ---------------------------------------------------------------------------
+// execution
+// ---------------------------------------------------------------------------
+
+function run(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { cwd: WORKSPACE_ROOT, stdio: 'inherit', shell: false });
+    child.on('close', (code) => resolve(code ?? 1));
+    child.on('error', (error) => {
+      process.stderr.write(`${error?.message ?? error}\n`);
+      resolve(1);
+    });
+  });
+}
+
+function git(args) {
+  const result = spawnSync('git', args, { cwd: WORKSPACE_ROOT, encoding: 'utf8' });
+  return result.status === 0 ? parseGitFileList(result.stdout) : [];
+}
+
+/** Everything on this branch a formatter would have touched: base diff + working tree + untracked. */
+export function collectChangedFiles(baseRef, gitRunner = git) {
+  return [
+    ...gitRunner(['diff', '--name-only', '--diff-filter=ACMR', `${baseRef}...HEAD`]),
+    ...gitRunner(['diff', '--name-only', '--diff-filter=ACMR', 'HEAD']),
+    ...gitRunner(['ls-files', '--others', '--exclude-standard']),
+  ].filter((file) => existsSync(path.join(WORKSPACE_ROOT, file)));
+}
+
+async function runFormatCheck({ baseRef, allFiles }) {
+  const extensions = readLintStagedExtensions();
+  if (allFiles) {
+    const glob = `**/*{${extensions.join(',')}}`;
+    const code = await run('pnpm', ['exec', 'prettier', '--check', glob]);
+    return { code, note: `whole repo, ${extensions.length} formatter-owned extension(s)` };
+  }
+  const targets = selectFormatTargets(collectChangedFiles(baseRef), extensions);
+  if (targets.length === 0)
+    return { code: 0, note: `no formatter-owned files changed vs ${baseRef}` };
+  const code = await run('pnpm', ['exec', 'prettier', '--check', ...targets]);
+  if (code !== 0) {
+    process.stderr.write(
+      `\n[format-check] Prettier is the SSOT formatter (lint-staged / .husky/pre-commit). A fresh\n` +
+        `[format-check] worktree pushing with --no-verify never runs it. Fix with:\n` +
+        `[format-check]   pnpm exec prettier --write ${targets.slice(0, 6).join(' ')}${
+          targets.length > 6 ? ' …' : ''
+        }\n`,
+    );
+  }
+  return { code, note: `${targets.length} changed file(s) vs ${baseRef}` };
+}
+
+async function runScanSuite() {
+  const missing = findMissingDist(listBuildablePackageDirs());
+  if (missing.length > 0) {
+    process.stderr.write(
+      `\n[scan-suite] BLOCKED: ${missing.length} package(s) have no dist/ — the build-dependent scans\n` +
+        `[scan-suite] (build-contracts, dist freshness) would silently no-op and LOOK like a pass.\n` +
+        `[scan-suite] CI restores dist before running them (ci.yml → quality). Run:\n` +
+        `[scan-suite]   pnpm build\n` +
+        `[scan-suite] Missing: ${missing.slice(0, 5).join(', ')}${
+          missing.length > 5 ? ` … (+${missing.length - 5})` : ''
+        }\n`,
+    );
+    return { code: 1, note: `dist missing for ${missing.length} package(s) — run \`pnpm build\`` };
+  }
+  const code = await run('node', ['scripts/harness/run-all-scans.mjs']);
+  return { code, note: 'full suite incl. build-contracts + dist (built tree)' };
+}
+
+const STAGE_RUNNERS = {
+  'harness-self-test': async () => ({ code: await run('pnpm', ['harness:test']) }),
+  'format-check': runFormatCheck,
+  'scan-suite': runScanSuite,
+  typecheck: async () => ({ code: await run('pnpm', ['-w', 'typecheck']) }),
+};
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.unknown.length > 0) {
+    process.stderr.write(`unknown --only stage(s): ${options.unknown.join(', ')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const selected = CI_STAGES.filter(
+    (stage) => options.only.size === 0 || options.only.has(stage.name),
+  );
+  const results = [];
+  for (const stage of selected) {
+    process.stdout.write(`\n===== ${stage.name} =====\nmirrors: ${stage.ciSource}\n`);
+    const outcome = await STAGE_RUNNERS[stage.name](options);
+    results.push({
+      name: stage.name,
+      status: outcome.code === 0 ? 'pass' : 'fail',
+      note: outcome.note,
+    });
+  }
+  const { lines, exitCode } = summarize(results);
+  process.stdout.write(`${lines.join('\n')}\n`);
+  process.exitCode = exitCode;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}


### PR DESCRIPTION
## Problem

An agent's foreground verification is `node scripts/harness/run-all-scans.mjs`, reported as "green
locally". That is **not** the same claim as "green in CI":

- the spec-surface scan treats a **below-baseline** count as a pass (a "tighten" notice), while the CI
  self-test asserts `notices == []` (#1346, #1357);
- prettier (SSOT formatter, run by lint-staged in `.husky/pre-commit`) never runs on a fresh worktree
  that pushes with `--no-verify`, so formatter drift is neither produced nor caught locally (#1369 →
  HARNESS-044);
- `check-build-output-contracts.mjs` reads each package's `dist` and **silently no-ops** without it —
  an unbuilt local tree turns it into a green that means nothing.

## What this adds

`pnpm harness:verify-like-ci` → `scripts/harness/verify-like-ci.mjs`. Four stages, each **derived from
the real definition** (`.github/workflows/ci.yml`, `.lintstagedrc.json`) rather than hand-copied, and
each printed with the definition it mirrors so a failure names its own fix target:

| Stage | Mirrors | What a bare `run-all-scans` misses |
| --- | --- | --- |
| `harness-self-test` | ci.yml → `scans` → "Harness scan test suite" | baseline TIGHTNESS (`notices == []`) |
| `format-check` | `.lintstagedrc.json` globs via `.husky/pre-commit` | a `--no-verify` push skips the SSOT formatter |
| `scan-suite` | ci.yml → `scans` suite + `quality` "Build-output contracts" (dist restored) | dist-dependent scans no-op on an unbuilt tree |
| `typecheck` | ci.yml → `quality` → `harness:verify` typecheck step | the scan suite never typechecks |

No stage is skipped after an earlier failure. The formatter file set is derived from
`.lintstagedrc.json` (not hardcoded); a missing `dist` **fails** with `run pnpm build` instead of
passing silently.

Wired in (pointers only, no rule text duplicated):

- `.agents/skills/worktree-parallel-orchestration/SKILL.md` § 4 (the implementer's self-verification)
- `.agents/rules/git-branch.md` (one-line pre-push / pre-merge pointer)

## Red/green evidence (agent-run)

**(a) Below-baseline spec-surface improvement** — documented `AbstractNodeDefinition` in
`packages/dag-node/docs/SPEC.md` (1 → 0 undocumented, baseline still 1):

- RED: `run-all-scans` → **exit 0, "all 61 scans passed"**; `harness:verify-like-ci --only
  harness-self-test` → **exit 1**, `AssertionError: expected [ Array(1) ] to deeply equal []` —
  `"@robota-sdk/dag-node is below its frozen undocumented-export baseline — tighten the ratchet"`.
- GREEN: after `check-spec-public-surface.mjs --write-baseline` → `703 passed`, `✓ harness-self-test`.
- Fixture reverted (dag-node is out of this PR's scope).

**(b) Prettier drift on a spec-doc `tags:` array** — lengthened
`.agents/spec-docs/done/HARNESS-003-…md`'s `tags:` flow array past `printWidth: 100`:

- RED: `run-all-scans` → **exit 0, "all 61 scans passed"**; `harness:verify-like-ci --only
  format-check` → **exit 1** (`Run Prettier with --write to fix.`) — it also caught this PR's own
  unformatted test file.
- GREEN: after `prettier --write` → `All matched files use Prettier code style!`, `✓ format-check`.
- **Honest note:** once prettier rewrites it to the wrapped block form, `check-spec-doc-frontmatter`
  reports `tags missing or empty` (exit 1) — so the *wrapped* state is **not** a local false-pass
  today. The reproducible blind spot is the **un**formatted state a fresh worktree actually pushes.
  The parser half of that chain is HARNESS-044 (separately owned); this entry surfaces the whole
  chain locally instead of in CI.

**(c) Unbuilt `dist`** — temporarily removing `packages/dag-node/dist` →
``✗ scan-suite — dist missing for 1 package(s) — run `pnpm build` `` with the actionable block message.

**Accidental-green check:** breaking `globExtensions` makes 3 of the 23 new unit tests fail; restored → 23/23.

## Verification (foreground, built tree)

`pnpm harness:verify-like-ci` → **PASS, all 4 stages** (`703 passed` harness tests, `all 61 scans
passed`, prettier clean, full workspace typecheck green).

Closes HARNESS-045 (archived to `.agents/backlog/completed/` with the same evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
