### PR TITLE
test(harness): HARNESS-025 hygiene + MOCK-001 burn-down 32 to 3

### DIFF
--- a/.agents/backlog/HARNESS-025-gate-hygiene-p3.md
+++ b/.agents/backlog/HARNESS-025-gate-hygiene-p3.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-025: 게이트 위생 잔여: MOCK allowlist 번다운·실 sleep·env 변이·PTY HOME 격리'
-status: todo
+status: in-progress
 created: 2026-07-04
 priority: low
 urgency: later
@@ -10,13 +10,85 @@ depends_on: ['HARNESS-023']
 
 # 게이트 위생 잔여: MOCK allowlist 번다운·실 sleep·env 변이·PTY HOME 격리
 
-Re-audit P3 (GATE-004/007/008/009). MOCK-001 allowlist 36파일 잔존, 실 벽시계 sleep 의존(cache
+Re-audit P3 (GATE-004/007/008/009). MOCK-001 allowlist 잔존, 실 벽시계 sleep 의존(cache
 TTL 100ms, PTY 300ms), vi.stubEnv 없는 env 변이, PTY e2e 실HOME 전달(조건부 플레이크).
 
 ## What
 
 1. PTY e2e temp HOME 주입; cache TTL fake timers; env 변이 → vi.stubEnv 전환.
 2. MOCK-001 번다운 진행률 점검 + 감축 목표 기록.
+
+## Progress (2026-07-25)
+
+### 1a. PTY e2e temp HOME — DONE
+
+`@robota-sdk/agent-testing` gained `createPtyEnv` / `createIsolatedHome` / `disposeIsolatedHomes`
+(`src/pty/isolated-home.ts`). Every PTY child now gets an empty throwaway HOME, including
+`spawnPty`'s **default** env — so the leak cannot be reintroduced by a caller who simply omits `env`.
+`agent-transport-tui`'s two PTY e2e suites use it; `pty/pty-driver.ts` already took an explicit
+`homeDir` and was the model.
+
+Four self-tests pin the contract, one of which asks the child to report the `HOME` it actually sees.
+Red-first proof — restoring the old `HOME: process.env['HOME']` default fails it:
+
+```
+× PTY HOME isolation > does not hand the real HOME to a child when no env is supplied
+  → expected '/home/ubuntu' not to be '/home/ubuntu'
+```
+
+### 1b. cache TTL fake timers — DONE
+
+`apps/agent-web/src/lib/cache.test.ts` (Jest, not vitest — so `jest.useFakeTimers()`) no longer
+sleeps on the wall clock. Both TTL cases also gained a _before-expiry_ assertion, so they now pin the
+TTL boundary rather than only its far side. Red-first proof, two independent mutations of
+`SimpleCache`:
+
+```
+# get() expiry disabled
+● SimpleCache › expires values after TTL — expect(received).toBeNull() / Received: "value1"
+# cleanup() over-evicts (ttl compare → >= 0)
+● SimpleCache › cleans up expired entries — Expected: 2 / Received: 0
+```
+
+The remaining 300ms PTY sleeps are **deliberate and load-bearing**: they pace a real child process
+through a real pseudo-terminal (waiting for the child to reach its `read()`). Fake timers cannot
+advance another process's clock, so converting them would break the test, not harden it.
+
+### 1c. env 변이 → vi.stubEnv — DONE for every owned package
+
+19 test files / ~110 mutation sites converted across `dag-cli`, `dag-nodes`, `dag-framework`,
+`agent-core`, `agent-tools`, `agent-command`, `agent-transport-tui`. Manual save/restore bookkeeping
+was deleted in favour of `vi.unstubAllEnvs()`. Four latent leaks were fixed as a side effect:
+
+- `dag-cli/init-command` restored `CI` from a possibly-`undefined` value, which Node coerces to the
+  string `"undefined"` — a truthy `CI` leaking into every later test.
+- `dag-cli/runner-cli` deleted `CI` and never restored it.
+- `dag-cli/describe-command` set `ANTHROPIC_API_KEY` with no `afterEach` at all.
+- `agent-tools/web-search-{tool,provider}` used `stubEnv` but never unstubbed, leaking
+  `BRAVE_API_KEY` out of the suite.
+
+### 2. MOCK-001 번다운 점검 — DONE
+
+Checked and acted on, not merely recorded: the allowlist went **32 → 3**. Full analysis and the
+before/after table live in `MOCK-001-hardcoded-workspace-mock-burndown.md` (the SSOT for that count).
+Headline: two thirds of the list were never hardcoded — the detector could not see the
+`vi.importActual` spread form and truncated long factories at 600 characters. The scan now extracts
+the factory by balanced parens, accepts both original-import spellings, requires the original to be
+**spread** rather than merely loaded, and fails on stale allowlist entries so the list can only shrink.
+
+## Remaining
+
+Only `1c` has a remainder, and it is purely an ownership deferral — 19 test files in packages a
+concurrent work-stream (ARCH-005 S2) owns, so they were not touched:
+
+- `packages/agent-cli/` — 8 files (`provider-startup` 14 sites, `provider-factory-integration`,
+  `cli-exit-codes`, `cli-command-composition`, `cli-update-check`, `git-worktree-isolation-adapter`,
+  `e2e/slash-smoke`, `e2e/scripted-e2e`)
+- `packages/agent-framework/` — 10 files (`config-loader`, `settings-check`, `e2e-scenarios`,
+  `filesystem-smoke`, `provider-configuration`, `provider-settings`, and 4 `interactive-session-*`)
+- `packages/agent-executor/` — 1 file (`providers/provider-factory`)
+
+Several of these swap `process.env.HOME` by hand, which is the same conditional-flake class as `1a`.
 
 ## Test Plan
 
@@ -25,3 +97,12 @@ TTL 100ms, PTY 300ms), vi.stubEnv 없는 env 변이, PTY e2e 실HOME 전달(조�
 ## User Execution Test Scenarios
 
 Not applicable — test-hygiene only. Engineering evidence: isolated-env suite runs.
+
+Evidence (2026-07-25):
+
+- `agent-testing` 6/6 (4 new HOME-isolation tests), `agent-transport-tui` 69 files / 526 tests
+  including all 3 PTY e2e suites, `agent-core` 904, `agent-command` 244, `agent-tools` 202,
+  `dag-framework` 107, `dag-cli` 63 files / 1007 tests, `dag-nodes` 351 across 20 packages,
+  `agent-web` cache 8/8. Every count matches the pre-change baseline — no test dropped or skipped.
+- `node scripts/harness/check-test-module-mocks.mjs` → `test-module-mocks scan passed (3 legacy
+allowlisted).` Scan unit tests 18/18.

--- a/.agents/backlog/MOCK-001-hardcoded-workspace-mock-burndown.md
+++ b/.agents/backlog/MOCK-001-hardcoded-workspace-mock-burndown.md
@@ -1,6 +1,6 @@
 ---
-title: 'MOCK-001: burn down the 36 allowlisted hardcoded workspace-module mocks'
-status: todo
+title: 'MOCK-001: burn down the allowlisted hardcoded workspace-module mocks'
+status: in-progress
 created: 2026-07-02
 priority: medium
 urgency: later
@@ -16,7 +16,7 @@ of the package for the whole import graph and breaks when the real module grows 
 that blocked every `git push` when TERM-008 added `resolvePlatformShell` while agent-playground's
 2-export stub of agent-core was in place (CI stayed green; only the full local suite caught it).
 
-The scan's `ALLOWLIST` (in `scripts/harness/check-test-module-mocks.mjs`) pins the 36 pre-existing
+The scan's `ALLOWLIST` (in `scripts/harness/check-test-module-mocks.mjs`) pinned the pre-existing
 violation files so the gate could land without a mass rewrite. This item tracks the burn-down.
 
 ## What
@@ -29,9 +29,48 @@ For each allowlisted file, either:
    and the import graph genuinely never reaches other exports), annotate the `vi.mock` line with
    `// allow-module-mock: <reason>` and delete its allowlist entry.
 
-Work in per-package batches (each batch = suite green). Highest risk first: broad-import-graph
-packages (agent-framework, agent-session, agent-transport-tui, agent-cli), then agent-provider,
-then the dag-\* leaves. Done when `ALLOWLIST` is empty and the scan text drops the legacy note.
+Work in per-package batches (each batch = suite green). Done when `ALLOWLIST` is empty and the scan
+text drops the legacy note.
+
+## Burn-down progress
+
+| Date                      | Allowlist size | Change                                                      |
+| ------------------------- | -------------- | ----------------------------------------------------------- |
+| 2026-07-02                | 36             | initial sweep                                               |
+| (pre-existing on develop) | 32             | 4 cleared by earlier incidental work                        |
+| 2026-07-25                | **3**          | HARNESS-025 pass — detector fix (20) + real conversions (9) |
+
+### 2026-07-25 — 32 → 3
+
+Two thirds of the list were **never hardcoded**. The detector recognized only the literal
+`importOriginal`, so the equally-correct `vi.importActual` spread form was misreported; and it
+searched a fixed 600-character window, which long factories overflowed before reaching their spread.
+Both gaps are fixed in `check-test-module-mocks.mjs` (balanced-paren factory extraction + both
+original-import spellings), and the scan now requires the original to actually be **spread**, not
+merely loaded — a factory that fetches the original and drops it severs exports just like a
+hardcoded one, which the old check would have passed.
+
+- **20 entries cleared by the detector fix** — already-correct partial mocks (all 6 `agent-session`,
+  6 of the `agent-framework` entries, `agent-provider-anthropic/response-parser`, all 3
+  `agent-transport-tui/TuiInteractionChannel.*`, and 4 `dag-cli` files). No test changed.
+- **9 entries cleared by real conversions** — 5 `dag-cli` files (`describe-command`,
+  `explain-suggest`, `fix-command`, `from-mermaid-command`, `runner-cli`; `fix-command` also had an
+  unlisted hardcoded `dag-builder` mock, converted too), 2 `dag-nodes` files
+  (`gemini-image-edit/runtime-core`, `instant-node/index` — 6 mocked modules between them), plus
+  `dag-nodes/llm-text/index` which was already clean and merely still pinned.
+- **Anti-rot guard added**: an allowlist entry whose file is now clean (or gone) fails the scan.
+  The allowlist can now only shrink, so a stale entry can never again inflate the remaining count.
+
+## Remaining (3)
+
+All three are genuine hardcoded factories. They were left untouched only because they sit in
+packages owned by a concurrent work-stream (ARCH-005 S2), not because they are load-bearing:
+
+- `packages/agent-cli/src/__tests__/provider-factory-integration.test.ts` — 4 provider modules
+- `packages/agent-framework/src/__tests__/create-subagent-session.test.ts` — `@robota-sdk/agent-session`
+- `packages/agent-framework/src/__tests__/subagent-integration.test.ts` — `@robota-sdk/agent-session`
+
+Closing these three empties the allowlist and completes the item.
 
 ## Test Plan
 
@@ -42,4 +81,8 @@ then the dag-\* leaves. Done when `ALLOWLIST` is empty and the scan text drops t
 
 - Not applicable (test-infrastructure refactor; the scan itself is the maintained gate). Evidence is
   the shrinking allowlist + green suites per batch, recorded here.
-- Evidence: _to fill per batch._
+- Evidence (2026-07-25): `node scripts/harness/check-test-module-mocks.mjs` →
+  `test-module-mocks scan passed (3 legacy allowlisted).` (was 32). Suites green and unchanged in
+  count vs. baseline: `dag-cli` 63 files / 1007 tests, `dag-nodes` 351 tests across 20 packages,
+  `agent-transport-tui` 69 files / 526 tests. Scan unit tests 18/18, including 4 new cases pinning
+  the anti-rot guard and 3 pinning the two detector gaps.

--- a/apps/agent-web/src/lib/cache.test.ts
+++ b/apps/agent-web/src/lib/cache.test.ts
@@ -1,5 +1,18 @@
 import { SimpleCache } from './cache';
 
+// HARNESS-025: TTL expiry is driven by the fake clock, never by a real wall-clock sleep.
+// `SimpleCache` compares `Date.now()` against the entry timestamp, and Jest's modern fake timers
+// mock `Date` alongside the timer queue — so advancing the fake clock is what makes an entry
+// expire. A real `setTimeout` sleep made these two cases both slow and load-dependent (a stalled
+// CI box could overshoot, and a coarse clock could undershoot, the 50ms TTL).
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('SimpleCache', () => {
   it('stores and retrieves values within TTL', () => {
     const cache = new SimpleCache<string>();
@@ -12,10 +25,16 @@ describe('SimpleCache', () => {
     expect(cache.get('nonexistent')).toBeNull();
   });
 
-  it('expires values after TTL', async () => {
+  it('expires values after TTL', () => {
     const cache = new SimpleCache<string>();
     cache.set('key1', 'value1', 50); // 50ms TTL
-    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Still inside the TTL window: the entry must survive.
+    jest.advanceTimersByTime(49);
+    expect(cache.get('key1')).toBe('value1');
+
+    // Past the TTL window: the entry must be gone.
+    jest.advanceTimersByTime(2);
     expect(cache.get('key1')).toBeNull();
   });
 
@@ -57,11 +76,18 @@ describe('SimpleCache', () => {
     expect(callCount).toBe(1); // factory called only once
   });
 
-  it('cleans up expired entries', async () => {
+  it('cleans up expired entries', () => {
     const cache = new SimpleCache<string>();
     cache.set('short', 'v', 50); // expires quickly
     cache.set('long', 'v2', 60000); // stays valid
-    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Before the short TTL elapses, cleanup() must evict nothing.
+    jest.advanceTimersByTime(49);
+    cache.cleanup();
+    expect(cache.size()).toBe(2);
+
+    // Once the short TTL has elapsed, cleanup() drops only the expired entry.
+    jest.advanceTimersByTime(2);
     cache.cleanup();
     expect(cache.size()).toBe(1);
     expect(cache.get('long')).toBe('v2');

--- a/packages/agent-command/src/editor/__tests__/editor-command-functional.test.ts
+++ b/packages/agent-command/src/editor/__tests__/editor-command-functional.test.ts
@@ -10,7 +10,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { scriptedSession, type ScriptedSessionHarness } from '@robota-sdk/agent-framework/testing';
 
@@ -38,25 +38,19 @@ function installFakeEditor(content: string): string {
   return script;
 }
 
-const origEditor = process.env.EDITOR;
-const origVisual = process.env.VISUAL;
-
 let h: ScriptedSessionHarness | undefined;
 afterEach(async () => {
   await h?.dispose();
   h = undefined;
-  if (origEditor === undefined) delete process.env.EDITOR;
-  else process.env.EDITOR = origEditor;
-  if (origVisual === undefined) delete process.env.VISUAL;
-  else process.env.VISUAL = origVisual;
+  vi.unstubAllEnvs();
 });
 
 describe('/editor command (framework functional)', () => {
   it(
     'opens the editor via the handoff and returns the saved text',
     async () => {
-      delete process.env.VISUAL;
-      process.env.EDITOR = installFakeEditor('composed in editor');
+      vi.stubEnv('VISUAL', undefined);
+      vi.stubEnv('EDITOR', installFakeEditor('composed in editor'));
       h = scriptedSession({
         turns: [{ text: 'unused' }],
         terminalHandoff: fakeHandoff(true),
@@ -75,7 +69,7 @@ describe('/editor command (framework functional)', () => {
   it(
     'is unavailable when there is no interactive terminal',
     async () => {
-      process.env.EDITOR = installFakeEditor('unused');
+      vi.stubEnv('EDITOR', installFakeEditor('unused'));
       h = scriptedSession({
         turns: [{ text: 'unused' }],
         commandModules: [createEditorCommandModule()],

--- a/packages/agent-command/src/user-local/__tests__/user-local-command.test.ts
+++ b/packages/agent-command/src/user-local/__tests__/user-local-command.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { executeUserLocalDirectCommand } from '../user-local-command.js';
 
 const tempRoots: string[] = [];
@@ -13,6 +13,7 @@ async function createTempRoot(name: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(
     tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
   );
@@ -25,38 +26,29 @@ describe('user-local command', () => {
     const home = path.join(workspace, 'home');
     await fs.mkdir(repo);
     await fs.mkdir(home);
-    const originalHome = process.env.HOME;
-    process.env.HOME = home;
+    vi.stubEnv('HOME', home);
 
-    try {
-      const result = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['storage', 'list'],
-        format: 'json',
-      });
-      const parsed = JSON.parse(result.message) as {
-        root: string;
-        categories: readonly { category: string; mayExecuteCommands: boolean }[];
-      };
+    const result = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['storage', 'list'],
+      format: 'json',
+    });
+    const parsed = JSON.parse(result.message) as {
+      root: string;
+      categories: readonly { category: string; mayExecuteCommands: boolean }[];
+    };
 
-      expect(result.success).toBe(true);
-      expect(parsed.root).toBe(path.join(home, '.robota'));
-      expect(parsed.categories.map((item) => item.category)).toEqual([
-        'preferences',
-        'view-state',
-        'memory-projections',
-        'task-associations',
-        'workflow-metadata',
-        'inspection-index',
-      ]);
-      expect(parsed.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
-    } finally {
-      if (originalHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = originalHome;
-      }
-    }
+    expect(result.success).toBe(true);
+    expect(parsed.root).toBe(path.join(home, '.robota'));
+    expect(parsed.categories.map((item) => item.category)).toEqual([
+      'preferences',
+      'view-state',
+      'memory-projections',
+      'task-associations',
+      'workflow-metadata',
+      'inspection-index',
+    ]);
+    expect(parsed.categories.every((item) => item.mayExecuteCommands === false)).toBe(true);
   });
 
   it('stores, lists, inspects, disables, and deletes user-local memory items', async () => {
@@ -65,81 +57,72 @@ describe('user-local command', () => {
     const home = path.join(workspace, 'home');
     await fs.mkdir(repo);
     await fs.mkdir(home);
-    const originalHome = process.env.HOME;
-    process.env.HOME = home;
+    vi.stubEnv('HOME', home);
 
-    try {
-      const setResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'set', 'view-preference', 'last-panel', 'background'],
-        summary: 'Open the background panel',
-        source: 'user-input',
-      });
-      expect(setResult.success).toBe(true);
-      expect(setResult.message).toContain('view-preference/last-panel');
+    const setResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'set', 'view-preference', 'last-panel', 'background'],
+      summary: 'Open the background panel',
+      source: 'user-input',
+    });
+    expect(setResult.success).toBe(true);
+    expect(setResult.message).toContain('view-preference/last-panel');
 
-      const listResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'list'],
-        format: 'json',
-      });
-      const list = JSON.parse(listResult.message) as {
-        items: readonly { category: string; key: string; enabled: boolean }[];
-      };
-      expect(listResult.success).toBe(true);
-      expect(list.items).toHaveLength(1);
-      expect(list.items[0]).toMatchObject({
-        category: 'view-preference',
-        key: 'last-panel',
-        enabled: true,
-      });
+    const listResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'list'],
+      format: 'json',
+    });
+    const list = JSON.parse(listResult.message) as {
+      items: readonly { category: string; key: string; enabled: boolean }[];
+    };
+    expect(listResult.success).toBe(true);
+    expect(list.items).toHaveLength(1);
+    expect(list.items[0]).toMatchObject({
+      category: 'view-preference',
+      key: 'last-panel',
+      enabled: true,
+    });
 
-      const inspectResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
-        format: 'json',
-      });
-      const inspected = JSON.parse(inspectResult.message) as {
-        commandExecutionEffect: string;
-        displayNavigationRule: string;
-      };
-      expect(inspectResult.success).toBe(true);
-      expect(inspected.commandExecutionEffect).toBe('none');
-      expect(inspected.displayNavigationRule).toContain('display/navigation only');
+    const inspectResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+      format: 'json',
+    });
+    const inspected = JSON.parse(inspectResult.message) as {
+      commandExecutionEffect: string;
+      displayNavigationRule: string;
+    };
+    expect(inspectResult.success).toBe(true);
+    expect(inspected.commandExecutionEffect).toBe('none');
+    expect(inspected.displayNavigationRule).toContain('display/navigation only');
 
-      const disableResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'disable', 'view-preference', 'last-panel'],
-      });
-      expect(disableResult.success).toBe(true);
+    const disableResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'disable', 'view-preference', 'last-panel'],
+    });
+    expect(disableResult.success).toBe(true);
 
-      const disabledInspectResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
-        format: 'json',
-      });
-      const disabled = JSON.parse(disabledInspectResult.message) as { enabled: boolean };
-      expect(disabled.enabled).toBe(false);
+    const disabledInspectResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+      format: 'json',
+    });
+    const disabled = JSON.parse(disabledInspectResult.message) as { enabled: boolean };
+    expect(disabled.enabled).toBe(false);
 
-      const deleteResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'delete', 'view-preference', 'last-panel'],
-      });
-      expect(deleteResult.success).toBe(true);
+    const deleteResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'delete', 'view-preference', 'last-panel'],
+    });
+    expect(deleteResult.success).toBe(true);
 
-      const missingResult = await executeUserLocalDirectCommand({
-        cwd: repo,
-        argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
-        format: 'json',
-      });
-      expect(missingResult.success).toBe(false);
-      expect(missingResult.message).toBe('User-local memory item not found.');
-    } finally {
-      if (originalHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = originalHome;
-      }
-    }
+    const missingResult = await executeUserLocalDirectCommand({
+      cwd: repo,
+      argv: ['memory', 'inspect', 'view-preference', 'last-panel'],
+      format: 'json',
+    });
+    expect(missingResult.success).toBe(false);
+    expect(missingResult.message).toBe('User-local memory item not found.');
   });
 });

--- a/packages/agent-core/src/hooks/__tests__/http-executor.test.ts
+++ b/packages/agent-core/src/hooks/__tests__/http-executor.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { HttpExecutor } from '../executors/http-executor.js';
 import type { IHookInput } from '../types.js';
 
 describe('HttpExecutor', () => {
   const executor = new HttpExecutor();
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
   it('should have type "http"', () => {
     expect(executor.type).toBe('http');
@@ -116,7 +120,7 @@ describe('HttpExecutor', () => {
   });
 
   it('should interpolate env vars in custom headers', async () => {
-    process.env['TEST_TOKEN'] = 'secret-value';
+    vi.stubEnv('TEST_TOKEN', 'secret-value');
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ ok: true }),
@@ -139,7 +143,6 @@ describe('HttpExecutor', () => {
     const headers = callArgs.headers as Record<string, string>;
     expect(headers['Authorization']).toBe('Bearer secret-value');
 
-    delete process.env['TEST_TOKEN'];
     vi.unstubAllGlobals();
   });
 

--- a/packages/agent-core/src/utils/env-ref.test.ts
+++ b/packages/agent-core/src/utils/env-ref.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   ENV_REFERENCE_PREFIX,
   isEnvReference,
@@ -43,23 +43,17 @@ describe('env-ref utilities', () => {
   });
 
   describe('resolveEnvReference', () => {
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
-
     afterEach(() => {
-      process.env = originalEnv;
+      vi.unstubAllEnvs();
     });
 
     it('returns the env value when set', () => {
-      process.env['TEST_API_KEY'] = 'sk-test-value';
+      vi.stubEnv('TEST_API_KEY', 'sk-test-value');
       expect(resolveEnvReference('$ENV:TEST_API_KEY')).toBe('sk-test-value');
     });
 
     it('returns undefined when env var is not set', () => {
-      delete process.env['MISSING_KEY'];
+      vi.stubEnv('MISSING_KEY', undefined);
       expect(resolveEnvReference('$ENV:MISSING_KEY')).toBeUndefined();
     });
 
@@ -72,20 +66,14 @@ describe('env-ref utilities', () => {
     });
 
     it('trims whitespace from the env var name', () => {
-      process.env['SPACED_KEY'] = 'spaced-value';
+      vi.stubEnv('SPACED_KEY', 'spaced-value');
       expect(resolveEnvReference('$ENV:  SPACED_KEY  ')).toBe('spaced-value');
     });
   });
 
   describe('hasUsableSecretReference', () => {
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-      process.env = { ...originalEnv };
-    });
-
     afterEach(() => {
-      process.env = originalEnv;
+      vi.unstubAllEnvs();
     });
 
     it('returns true for a plain non-empty string', () => {
@@ -93,7 +81,7 @@ describe('env-ref utilities', () => {
     });
 
     it('returns true when env reference resolves to a value', () => {
-      process.env['MY_KEY'] = 'resolved-value';
+      vi.stubEnv('MY_KEY', 'resolved-value');
       expect(hasUsableSecretReference('$ENV:MY_KEY')).toBe(true);
     });
 
@@ -106,7 +94,7 @@ describe('env-ref utilities', () => {
     });
 
     it('returns false when env reference does not resolve', () => {
-      delete process.env['MISSING_KEY'];
+      vi.stubEnv('MISSING_KEY', undefined);
       expect(hasUsableSecretReference('$ENV:MISSING_KEY')).toBe(false);
     });
   });

--- a/packages/agent-testing/docs/SPEC.md
+++ b/packages/agent-testing/docs/SPEC.md
@@ -12,6 +12,8 @@ Current surface:
 - **PTY runner** (TEST-007): `spawnPty` / `spawnPtyFixture` — drive any command (or a TSX fixture) in
   a real pseudo-terminal so Ink renders and reads input exactly as in a user terminal. Per-key paced
   input, marker/exit waiting, ANSI-stripped snapshots.
+- **Isolated HOME** (HARNESS-025): `createPtyEnv` / `createIsolatedHome` — a throwaway `HOME` for every
+  PTY child, so a suite never depends on whatever happens to be in the developer's home directory.
 
 This package is published (`@robota-sdk/*` scope) so any package — or an external consumer — can import
 the tooling as a `devDependency`.
@@ -77,6 +79,9 @@ paced), `write`, `pressEnter`, `waitFor`, `waitForSince`, `snapshot`/`snapshotSi
 | `IPtyRunOptions`       | type     | `spawnPty` options                                                                                                                |
 | `IPtyRunSession`       | type     | Driving session: `sendKeys`/`write`/`pressEnter`/`waitFor`/`waitForSince`/`snapshot`/`snapshotSince`/`raw`/`expectExit`/`dispose` |
 | `ISpawnFixtureOptions` | type     | `spawnPtyFixture` options                                                                                                         |
+| `createPtyEnv`         | function | Build a PTY child env: isolated `HOME`, real `PATH`, known `TERM`, plus caller overrides                                          |
+| `createIsolatedHome`   | function | Create one throwaway HOME directory and return its path                                                                           |
+| `disposeIsolatedHomes` | function | Remove every directory handed out by `createIsolatedHome` (also runs on process exit)                                             |
 
 ## Extension Points
 

--- a/packages/agent-testing/src/index.ts
+++ b/packages/agent-testing/src/index.ts
@@ -1,2 +1,3 @@
 export { spawnPty, spawnPtyFixture } from './pty/spawn-pty.js';
 export type { IPtyRunOptions, IPtyRunSession, ISpawnFixtureOptions } from './pty/spawn-pty.js';
+export { createIsolatedHome, createPtyEnv, disposeIsolatedHomes } from './pty/isolated-home.js';

--- a/packages/agent-testing/src/pty/__tests__/spawn-pty.test.ts
+++ b/packages/agent-testing/src/pty/__tests__/spawn-pty.test.ts
@@ -5,11 +5,17 @@
  * `waitFor` resolves on a printed marker, `expectExit` returns the real exit code, and
  * `snapshot()`/`raw()` capture output. The terminal-handoff suites (in agent-transport-tui) are the
  * harness's real-world consumers; this guards the harness itself.
+ *
+ * HARNESS-025 adds the HOME-isolation contract: a PTY child must never receive the developer's real
+ * `HOME`, or the suite silently depends on whatever is in that home directory.
  */
+import { existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createIsolatedHome, createPtyEnv } from '../isolated-home.js';
 import { spawnPty } from '../spawn-pty.js';
 
 import type { IPtyRunSession } from '../spawn-pty.js';
@@ -27,11 +33,7 @@ describe('spawnPty harness self-test', () => {
       command: process.execPath,
       args: ['-e', 'process.stdout.write("MARKER_OK\\n"); setTimeout(() => process.exit(3), 50);'],
       cwd: PACKAGE_DIR,
-      env: {
-        PATH: process.env['PATH'] ?? '',
-        HOME: process.env['HOME'] ?? '',
-        TERM: 'xterm-256color',
-      },
+      env: createPtyEnv(),
     });
     sessions.push(session);
 
@@ -45,11 +47,7 @@ describe('spawnPty harness self-test', () => {
       command: 'sh',
       args: ['-c', 'IFS= read -r line; printf "ECHO:[%s]\\n" "$line"'],
       cwd: PACKAGE_DIR,
-      env: {
-        PATH: process.env['PATH'] ?? '',
-        HOME: process.env['HOME'] ?? '',
-        TERM: 'xterm-256color',
-      },
+      env: createPtyEnv(),
     });
     sessions.push(session);
 
@@ -57,5 +55,66 @@ describe('spawnPty harness self-test', () => {
     session.write('\r');
     await session.waitFor('ECHO:[abc]', 5_000);
     expect(await session.expectExit(5_000)).toBe(0);
+  });
+});
+
+describe('PTY HOME isolation', () => {
+  /** Ask the child to report the HOME it actually sees, so the assertion is on the child's view. */
+  function spawnHomeReporter(env?: NodeJS.ProcessEnv): IPtyRunSession {
+    const session = spawnPty({
+      command: 'sh',
+      args: ['-c', 'printf "CHILD_HOME:[%s]\\n" "$HOME"'],
+      cwd: PACKAGE_DIR,
+      ...(env ? { env } : {}),
+    });
+    sessions.push(session);
+    return session;
+  }
+
+  function readReportedHome(snapshot: string): string {
+    const match = /CHILD_HOME:\[([^\]]*)\]/.exec(snapshot);
+    if (match?.[1] === undefined) throw new Error(`child never reported HOME:\n${snapshot}`);
+    return match[1];
+  }
+
+  it('does not hand the real HOME to a child when no env is supplied', async () => {
+    const realHome = process.env['HOME'];
+    expect(
+      realHome,
+      'the test host must have a HOME for this assertion to mean anything',
+    ).toBeTruthy();
+
+    const session = spawnHomeReporter();
+    await session.waitFor('CHILD_HOME:[', 5_000);
+    await session.expectExit(5_000);
+
+    const childHome = readReportedHome(session.snapshot());
+    expect(childHome).not.toBe(realHome);
+    expect(childHome.startsWith(tmpdir())).toBe(true);
+  });
+
+  it('hands the child the isolated HOME built by createPtyEnv', async () => {
+    const env = createPtyEnv();
+    const session = spawnHomeReporter(env);
+    await session.waitFor('CHILD_HOME:[', 5_000);
+    await session.expectExit(5_000);
+
+    expect(readReportedHome(session.snapshot())).toBe(env['HOME']);
+    expect(env['HOME']).not.toBe(process.env['HOME']);
+  });
+
+  it('creates an EMPTY home directory, so no user config can leak in', () => {
+    const home = createIsolatedHome();
+    expect(existsSync(home)).toBe(true);
+    expect(readdirSync(home)).toEqual([]);
+    expect(home).not.toBe(process.env['HOME']);
+  });
+
+  it('lets an override customize the env without reintroducing the real HOME', () => {
+    const env = createPtyEnv({ EDITOR: 'sh /tmp/fake-editor.sh' });
+    expect(env['EDITOR']).toBe('sh /tmp/fake-editor.sh');
+    expect(env['TERM']).toBe('xterm-256color');
+    expect(env['PATH']).toBe(process.env['PATH']);
+    expect(env['HOME']).not.toBe(process.env['HOME']);
   });
 });

--- a/packages/agent-testing/src/pty/isolated-home.ts
+++ b/packages/agent-testing/src/pty/isolated-home.ts
@@ -1,0 +1,64 @@
+/**
+ * Isolated HOME for PTY children (HARNESS-025).
+ *
+ * A PTY test that forwards the developer's real `HOME` runs its child against whatever happens to
+ * be in that home directory — a `~/.robota` settings file, a shell rc, an `$EDITOR` preference.
+ * The suite then passes or fails depending on the machine it runs on: green on CI (empty HOME),
+ * red on a developer box whose real config contradicts the fixture. That is the conditional flake
+ * this module removes.
+ *
+ * Every PTY child gets a throwaway directory instead. The directories are tracked and removed on
+ * process exit, so a test that forgets to dispose leaks nothing beyond the run.
+ *
+ * `packages/agent-transport-tui/src/__tests__/pty/pty-driver.ts` already took an explicit
+ * `homeDir`; this generalizes that discipline to every `spawnPty` caller, including the default.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const createdHomes: string[] = [];
+let exitHookInstalled = false;
+
+function installExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.on('exit', disposeIsolatedHomes);
+}
+
+/**
+ * Create a throwaway HOME directory for a PTY child and return its absolute path.
+ *
+ * The directory is empty: the child sees no `~/.robota`, no shell rc, no user preferences. Callers
+ * that need seeded content write it themselves after creating the directory.
+ */
+export function createIsolatedHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'robota-pty-home-'));
+  createdHomes.push(dir);
+  installExitHook();
+  return dir;
+}
+
+/** Remove every directory handed out by {@link createIsolatedHome}. Idempotent. */
+export function disposeIsolatedHomes(): void {
+  for (const dir of createdHomes.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Build the environment for a PTY child: an isolated HOME, the real PATH (the child still needs to
+ * find `sh`, `node`, …), and a known TERM.
+ *
+ * The environment is deliberately minimal rather than a copy of `process.env` — a PTY run must not
+ * inherit real provider API keys, and an explicit base makes every variable the child can see
+ * visible at the call site. Pass `overrides` for anything else the fixture needs (e.g. `EDITOR`).
+ */
+export function createPtyEnv(overrides: Readonly<NodeJS.ProcessEnv> = {}): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env['PATH'] ?? '',
+    HOME: createIsolatedHome(),
+    TERM: 'xterm-256color',
+    ...overrides,
+  };
+}

--- a/packages/agent-testing/src/pty/spawn-pty.ts
+++ b/packages/agent-testing/src/pty/spawn-pty.ts
@@ -17,6 +17,8 @@ import { createRequire } from 'node:module';
 
 import { spawn } from '@homebridge/node-pty-prebuilt-multiarch';
 
+import { createPtyEnv } from './isolated-home.js';
+
 import type { IPty } from '@homebridge/node-pty-prebuilt-multiarch';
 
 // eslint-disable-next-line no-control-regex
@@ -33,6 +35,11 @@ export interface IPtyRunOptions {
   command: string;
   args: string[];
   cwd: string;
+  /**
+   * Environment for the child. Defaults to {@link createPtyEnv} — a minimal env with an ISOLATED
+   * HOME. Build overrides with `createPtyEnv({ ... })` rather than by hand, so a caller cannot
+   * reintroduce the real `process.env.HOME` (which makes the suite depend on the host's `~`).
+   */
   env?: NodeJS.ProcessEnv;
   cols?: number;
   rows?: number;
@@ -88,11 +95,9 @@ export function spawnPty(options: IPtyRunOptions): IPtyRunSession {
     cols: options.cols ?? 100,
     rows: options.rows ?? 32,
     cwd: options.cwd,
-    env: options.env ?? {
-      PATH: process.env['PATH'] ?? '',
-      HOME: process.env['HOME'] ?? '',
-      TERM: 'xterm-256color',
-    },
+    // HARNESS-025: the default HOME is a throwaway directory, never the developer's real one — a
+    // PTY child that reads `~/.robota` (or any user rc) must not make the suite machine-dependent.
+    env: options.env ?? createPtyEnv(),
   });
 
   pty.onData((data) => {

--- a/packages/agent-tools/src/__tests__/web-search-provider.test.ts
+++ b/packages/agent-tools/src/__tests__/web-search-provider.test.ts
@@ -29,6 +29,7 @@ describe('web-search provider port (NEUT-008)', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     globalThis.fetch = originalFetch;
   });
 
@@ -77,7 +78,7 @@ describe('web-search provider port (NEUT-008)', () => {
   });
 
   it('default missing-key error names the env var but carries no vendor signup URL', async () => {
-    delete process.env['BRAVE_API_KEY'];
+    vi.stubEnv('BRAVE_API_KEY', undefined);
     const { webSearchTool } = await import('../builtins/web-search-tool.js');
 
     const result = await callTool(webSearchTool, 'anything');

--- a/packages/agent-tools/src/__tests__/web-search-tool.test.ts
+++ b/packages/agent-tools/src/__tests__/web-search-tool.test.ts
@@ -27,14 +27,14 @@ describe('webSearchTool', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     globalThis.fetch = originalFetch;
   });
 
   // TC-04: no API key → graceful error message, no crash
   it('TC-04: returns failure result when BRAVE_API_KEY is not set', async () => {
-    vi.stubEnv('BRAVE_API_KEY', '');
-    // delete so the check sees falsy
-    delete process.env['BRAVE_API_KEY'];
+    // unset so the check sees falsy
+    vi.stubEnv('BRAVE_API_KEY', undefined);
 
     const result = await callWebSearch('typescript tutorial');
     expect(result.success).toBe(false);

--- a/packages/agent-transport-tui/src/__tests__/command-handoff-pty-e2e.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/command-handoff-pty-e2e.test.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { spawnPtyFixture } from '@robota-sdk/agent-testing';
+import { createPtyEnv, spawnPtyFixture } from '@robota-sdk/agent-testing';
 
 import type { IPtyRunSession } from '@robota-sdk/agent-testing';
 
@@ -50,11 +50,9 @@ describe('command handoff PTY E2E', () => {
       const session = spawnPtyFixture(FIXTURE, {
         argv: ['shell', outputPath, 'IFS= read -r line; printf "SHELL_GOT:[%s]\\n" "$line"'],
         cwd: PACKAGE_DIR,
-        env: {
-          PATH: process.env['PATH'] ?? '',
-          HOME: process.env['HOME'] ?? '',
-          TERM: 'xterm-256color',
-        },
+        // HARNESS-025: isolated HOME — the subshell must not read the developer's `~` (a real
+        // shell rc there would otherwise change what the handoff child does).
+        env: createPtyEnv(),
       });
       sessions.push(session);
 
@@ -82,12 +80,9 @@ describe('command handoff PTY E2E', () => {
       const session = spawnPtyFixture(FIXTURE, {
         argv: ['editor', outputPath, ''],
         cwd: PACKAGE_DIR,
-        env: {
-          PATH: process.env['PATH'] ?? '',
-          HOME: process.env['HOME'] ?? '',
-          TERM: 'xterm-256color',
-          EDITOR: `sh ${FAKE_EDITOR}`,
-        },
+        // HARNESS-025: isolated HOME — only the EDITOR override comes from the test, so a real
+        // `~/.selected_editor` (or similar) on the host cannot influence the assertion.
+        env: createPtyEnv({ EDITOR: `sh ${FAKE_EDITOR}` }),
       });
       sessions.push(session);
 

--- a/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
@@ -1,55 +1,42 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   isInteractiveColorTerminal,
   supportsImeCursorPositioning,
 } from '../terminal-capabilities.js';
 
-const ORIG_NO_COLOR = process.env.NO_COLOR;
-const ORIG_FORCE_COLOR = process.env.FORCE_COLOR;
 const ORIG_TTY = process.stdout.isTTY;
 
 function setTty(value: boolean): void {
   Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true });
 }
 
-function restoreEnv(key: 'NO_COLOR' | 'FORCE_COLOR', value: string | undefined): void {
-  if (value === undefined) delete process.env[key];
-  else process.env[key] = value;
-}
-
-function restoreEnvKey(key: string, value: string | undefined): void {
-  if (value === undefined) delete process.env[key];
-  else process.env[key] = value;
-}
-
 describe('isInteractiveColorTerminal', () => {
   afterEach(() => {
-    restoreEnv('NO_COLOR', ORIG_NO_COLOR);
-    restoreEnv('FORCE_COLOR', ORIG_FORCE_COLOR);
+    vi.unstubAllEnvs();
     Object.defineProperty(process.stdout, 'isTTY', { value: ORIG_TTY, configurable: true });
   });
 
   it('NO_COLOR present disables even when empty (the SCREEN-008 regression)', () => {
-    delete process.env.FORCE_COLOR;
+    vi.stubEnv('FORCE_COLOR', undefined);
     setTty(true);
-    process.env.NO_COLOR = '';
+    vi.stubEnv('NO_COLOR', '');
     expect(isInteractiveColorTerminal()).toBe(false);
-    process.env.NO_COLOR = '1';
+    vi.stubEnv('NO_COLOR', '1');
     expect(isInteractiveColorTerminal()).toBe(false);
   });
 
   it('honors FORCE_COLOR (0 → off, non-zero → on)', () => {
-    delete process.env.NO_COLOR;
+    vi.stubEnv('NO_COLOR', undefined);
     setTty(false);
-    process.env.FORCE_COLOR = '0';
+    vi.stubEnv('FORCE_COLOR', '0');
     expect(isInteractiveColorTerminal()).toBe(false);
-    process.env.FORCE_COLOR = '1';
+    vi.stubEnv('FORCE_COLOR', '1');
     expect(isInteractiveColorTerminal()).toBe(true);
   });
 
   it('falls back to stdout.isTTY when no env override', () => {
-    delete process.env.NO_COLOR;
-    delete process.env.FORCE_COLOR;
+    vi.stubEnv('NO_COLOR', undefined);
+    vi.stubEnv('FORCE_COLOR', undefined);
     setTty(true);
     expect(isInteractiveColorTerminal()).toBe(true);
     setTty(false);
@@ -58,18 +45,14 @@ describe('isInteractiveColorTerminal', () => {
 });
 
 describe('supportsImeCursorPositioning (CLI-062)', () => {
-  const ORIG_IME = process.env.ROBOTA_IME_CURSOR;
-  const ORIG_TERM_PROGRAM = process.env.TERM_PROGRAM;
-
   afterEach(() => {
-    restoreEnvKey('ROBOTA_IME_CURSOR', ORIG_IME);
-    restoreEnvKey('TERM_PROGRAM', ORIG_TERM_PROGRAM);
+    vi.unstubAllEnvs();
     Object.defineProperty(process.stdout, 'isTTY', { value: ORIG_TTY, configurable: true });
   });
 
   it('on for a plain interactive TTY, off for a non-TTY', () => {
-    delete process.env.ROBOTA_IME_CURSOR;
-    delete process.env.TERM_PROGRAM;
+    vi.stubEnv('ROBOTA_IME_CURSOR', undefined);
+    vi.stubEnv('TERM_PROGRAM', undefined);
     setTty(true);
     expect(supportsImeCursorPositioning()).toBe(true);
     setTty(false);
@@ -77,23 +60,23 @@ describe('supportsImeCursorPositioning (CLI-062)', () => {
   });
 
   it('I5: Apple_Terminal is OFF by default (Korean-IME SIGSEGV is an Apple-side bug)', () => {
-    delete process.env.ROBOTA_IME_CURSOR;
+    vi.stubEnv('ROBOTA_IME_CURSOR', undefined);
     setTty(true);
-    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    vi.stubEnv('TERM_PROGRAM', 'Apple_Terminal');
     expect(supportsImeCursorPositioning()).toBe(false);
   });
 
   it('I5: ROBOTA_IME_CURSOR=1 opts Apple_Terminal in explicitly', () => {
     setTty(true);
-    process.env.TERM_PROGRAM = 'Apple_Terminal';
-    process.env.ROBOTA_IME_CURSOR = '1';
+    vi.stubEnv('TERM_PROGRAM', 'Apple_Terminal');
+    vi.stubEnv('ROBOTA_IME_CURSOR', '1');
     expect(supportsImeCursorPositioning()).toBe(true);
   });
 
   it('ROBOTA_IME_CURSOR=0 is a kill switch even on a capable terminal', () => {
     setTty(true);
-    delete process.env.TERM_PROGRAM;
-    process.env.ROBOTA_IME_CURSOR = '0';
+    vi.stubEnv('TERM_PROGRAM', undefined);
+    vi.stubEnv('ROBOTA_IME_CURSOR', '0');
     expect(supportsImeCursorPositioning()).toBe(false);
   });
 });

--- a/packages/agent-transport-tui/src/__tests__/terminal-handoff-pty-e2e.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/terminal-handoff-pty-e2e.test.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { spawnPtyFixture } from '@robota-sdk/agent-testing';
+import { createPtyEnv, spawnPtyFixture } from '@robota-sdk/agent-testing';
 
 import type { IPtyRunSession } from '@robota-sdk/agent-testing';
 
@@ -34,14 +34,6 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
-function ptyEnv(): NodeJS.ProcessEnv {
-  return {
-    PATH: process.env['PATH'] ?? '',
-    HOME: process.env['HOME'] ?? '',
-    TERM: 'xterm-256color',
-  };
-}
-
 describe('terminal handoff PTY E2E', () => {
   it(
     'hands the real terminal to a child, receives its input, and resumes the TUI',
@@ -53,7 +45,8 @@ describe('terminal handoff PTY E2E', () => {
       const session = spawnPtyFixture(FIXTURE, {
         argv: [outputPath],
         cwd: PACKAGE_DIR,
-        env: ptyEnv(),
+        // HARNESS-025: isolated HOME — the child must not read the developer's `~`.
+        env: createPtyEnv(),
       });
       sessions.push(session);
 

--- a/packages/dag-cli/src/__tests__/compare-benchmark.test.ts
+++ b/packages/dag-cli/src/__tests__/compare-benchmark.test.ts
@@ -3,7 +3,7 @@
  * happy-path and alternate-format code branches that misc-commands.test.ts
  * does not reach.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { IDagCliIo } from '../types.js';
 
 vi.mock('../local-runner/index.js', async () => {
@@ -76,22 +76,8 @@ function makeIo(): IDagCliIo & { writes: string[] } {
 // ---------------------------------------------------------------------------
 
 describe('compareCommand — execution paths', () => {
-  const savedKeys: Record<string, string | undefined> = {};
-
-  beforeEach(() => {
-    savedKeys['ANTHROPIC_API_KEY'] = process.env['ANTHROPIC_API_KEY'];
-    savedKeys['OPENAI_API_KEY'] = process.env['OPENAI_API_KEY'];
-    savedKeys['GEMINI_API_KEY'] = process.env['GEMINI_API_KEY'];
-  });
-
   afterEach(() => {
-    for (const [k, v] of Object.entries(savedKeys)) {
-      if (v === undefined) {
-        delete process.env[k];
-      } else {
-        process.env[k] = v;
-      }
-    }
+    vi.unstubAllEnvs();
   });
 
   it('shows help with --help', async () => {
@@ -110,8 +96,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('skips both providers when no API keys set', async () => {
-    delete process.env['ANTHROPIC_API_KEY'];
-    delete process.env['OPENAI_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
+    vi.stubEnv('OPENAI_API_KEY', undefined);
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -122,8 +108,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('runs both providers when API keys present', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key-anthropic';
-    process.env['OPENAI_API_KEY'] = 'test-key-openai';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key-anthropic');
+    vi.stubEnv('OPENAI_API_KEY', 'test-key-openai');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -135,8 +121,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('outputs JSON when --output json', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['OPENAI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -148,8 +134,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('includes decision section with --decide', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['OPENAI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -158,8 +144,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('includes JSON decision with --decide --output json', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['OPENAI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -177,8 +163,8 @@ describe('compareCommand — execution paths', () => {
   });
 
   it('uses --pipeline arg to build custom DAG', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['OPENAI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -598,28 +584,13 @@ describe('benchmarkCommand — additional branch coverage', () => {
 // ---------------------------------------------------------------------------
 
 describe('compareCommand — additional branch coverage', () => {
-  const savedKeys: Record<string, string | undefined> = {};
-
-  beforeEach(() => {
-    savedKeys['ANTHROPIC_API_KEY'] = process.env['ANTHROPIC_API_KEY'];
-    savedKeys['OPENAI_API_KEY'] = process.env['OPENAI_API_KEY'];
-    savedKeys['GEMINI_API_KEY'] = process.env['GEMINI_API_KEY'];
-    savedKeys['DEEPSEEK_API_KEY'] = process.env['DEEPSEEK_API_KEY'];
-  });
-
   afterEach(() => {
-    for (const [k, v] of Object.entries(savedKeys)) {
-      if (v === undefined) {
-        delete process.env[k];
-      } else {
-        process.env[k] = v;
-      }
-    }
+    vi.unstubAllEnvs();
   });
 
   it('runs with gemini provider to cover gemini cost-ternary branch', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -630,8 +601,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('runs with deepseek provider to cover fallback cost-ternary branch', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['DEEPSEEK_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('DEEPSEEK_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -642,8 +613,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('covers runnable.length===1 when one provider has no key', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    delete process.env['OPENAI_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('OPENAI_API_KEY', undefined);
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -655,8 +626,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('covers runnable.length===0 when both providers have no key', async () => {
-    delete process.env['ANTHROPIC_API_KEY'];
-    delete process.env['OPENAI_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
+    vi.stubEnv('OPENAI_API_KEY', undefined);
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -667,8 +638,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('outputs JSON with gemini provider', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -680,8 +651,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('shows decision section with --decide when both providers run', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -694,8 +665,8 @@ describe('compareCommand — additional branch coverage', () => {
   });
 
   it('covers --pipeline with {provider} substitution for gemini', async () => {
-    process.env['ANTHROPIC_API_KEY'] = 'test-key';
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
 
     const { compareCommand } = await import('../commands/compare.js');
     const io = makeIo();
@@ -712,6 +683,10 @@ describe('compareCommand — additional branch coverage', () => {
 // ---------------------------------------------------------------------------
 
 describe('perfCommand — execution paths', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('runs default measurement (--runs 3 for speed)', async () => {
     const { perfCommand } = await import('../commands/perf.js');
     const io = makeIo();
@@ -756,18 +731,13 @@ describe('perfCommand — execution paths', () => {
   });
 
   it('shows error when --publish used without GITHUB_TOKEN', async () => {
-    const savedToken = process.env['GITHUB_TOKEN'];
-    delete process.env['GITHUB_TOKEN'];
-    try {
-      const { perfCommand } = await import('../commands/perf.js');
-      const io = makeIo();
-      const code = await perfCommand(['--runs', '1', '--publish'], { io });
-      expect(code).toBe(0);
-      const output = io.writes.join('');
-      expect(output).toContain('GITHUB_TOKEN');
-    } finally {
-      if (savedToken !== undefined) process.env['GITHUB_TOKEN'] = savedToken;
-    }
+    vi.stubEnv('GITHUB_TOKEN', undefined);
+    const { perfCommand } = await import('../commands/perf.js');
+    const io = makeIo();
+    const code = await perfCommand(['--runs', '1', '--publish'], { io });
+    expect(code).toBe(0);
+    const output = io.writes.join('');
+    expect(output).toContain('GITHUB_TOKEN');
   });
 
   it('shows help with --help flag', async () => {

--- a/packages/dag-cli/src/__tests__/describe-command.test.ts
+++ b/packages/dag-cli/src/__tests__/describe-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { IDescribeCommandOptions } from '../commands/describe.js';
 import { describeCommand } from '../commands/describe.js';
 
@@ -8,7 +8,8 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
 }));
 
-vi.mock('@robota-sdk/dag-node', () => ({
+vi.mock('@robota-sdk/dag-node', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-node')>()),
   buildNodeDefinitionAssembly: vi.fn(() => ({
     ok: true,
     value: {
@@ -98,7 +99,11 @@ function getOutput(opts: { readonly written: string[] }): string {
 
 describe('describeCommand', () => {
   beforeEach(() => {
-    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-test';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('prints help with --help', async () => {
@@ -130,7 +135,7 @@ describe('describeCommand', () => {
   });
 
   it('returns exit code 1 when ANTHROPIC_API_KEY is missing', async () => {
-    delete process.env['ANTHROPIC_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
     const opts = createOptions();
     const code = await describeCommand(['translate Korean to English'], opts);
     expect(code).toBe(1);

--- a/packages/dag-cli/src/__tests__/doctor-command.test.ts
+++ b/packages/dag-cli/src/__tests__/doctor-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readFile, mkdir, writeFile } from 'node:fs/promises';
@@ -28,6 +28,10 @@ function getOutput(opts: { written: string[] }): string {
 }
 
 describe('doctorCommand', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('--json flag outputs JSON', async () => {
     const opts = createOptions();
     const code = await doctorCommand(['--json'], opts);
@@ -98,11 +102,9 @@ describe('doctorCommand', () => {
     const workflowsDir = join(dagDir, 'workflows');
     await mkdir(workflowsDir, { recursive: true });
     await writeFile(join(dagDir, '.env'), 'placeholder=value\n', 'utf8');
-    const savedAnthropic = process.env['ANTHROPIC_API_KEY'];
-    const savedOpenai = process.env['OPENAI_API_KEY'];
     // Set both required keys so errorCount = 0
-    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-validkeyformat1234567890123456';
-    process.env['OPENAI_API_KEY'] = 'sk-validopenaikeyformat1234567890123456789';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-api03-validkeyformat1234567890123456');
+    vi.stubEnv('OPENAI_API_KEY', 'sk-validopenaikeyformat1234567890123456789');
     const opts: IDoctorCommandOptions & { written: string[] } = {
       io: {
         write: (t) => {
@@ -118,32 +120,17 @@ describe('doctorCommand', () => {
       written: [],
     };
     await doctorCommand([], opts);
-    if (savedAnthropic !== undefined) process.env['ANTHROPIC_API_KEY'] = savedAnthropic;
-    else delete process.env['ANTHROPIC_API_KEY'];
-    if (savedOpenai !== undefined) process.env['OPENAI_API_KEY'] = savedOpenai;
-    else delete process.env['OPENAI_API_KEY'];
     const output = opts.written.join('');
     expect(output).toContain('All checks passed');
   });
 
   it('outputs url hint when API key is missing (covers check.url branch in renderPretty)', async () => {
-    const saved = {
-      anthropic: process.env['ANTHROPIC_API_KEY'],
-      openai: process.env['OPENAI_API_KEY'],
-      gemini: process.env['GEMINI_API_KEY'],
-      deepseek: process.env['DEEPSEEK_API_KEY'],
-    };
-    delete process.env['ANTHROPIC_API_KEY'];
-    delete process.env['OPENAI_API_KEY'];
-    delete process.env['GEMINI_API_KEY'];
-    delete process.env['DEEPSEEK_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
+    vi.stubEnv('OPENAI_API_KEY', undefined);
+    vi.stubEnv('GEMINI_API_KEY', undefined);
+    vi.stubEnv('DEEPSEEK_API_KEY', undefined);
     const opts = createOptions();
     await doctorCommand([], opts);
-    // restore
-    if (saved.anthropic !== undefined) process.env['ANTHROPIC_API_KEY'] = saved.anthropic;
-    if (saved.openai !== undefined) process.env['OPENAI_API_KEY'] = saved.openai;
-    if (saved.gemini !== undefined) process.env['GEMINI_API_KEY'] = saved.gemini;
-    if (saved.deepseek !== undefined) process.env['DEEPSEEK_API_KEY'] = saved.deepseek;
     const output = getOutput(opts);
     // renderPretty should have output the url hint
     expect(output).toContain('https://');

--- a/packages/dag-cli/src/__tests__/explain-suggest.test.ts
+++ b/packages/dag-cli/src/__tests__/explain-suggest.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { explainCommand } from '../commands/explain.js';
 import type { IExplainCommandOptions } from '../commands/explain.js';
 
-vi.mock('@robota-sdk/dag-node', () => ({
+vi.mock('@robota-sdk/dag-node', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-node')>()),
   buildNodeDefinitionAssembly: vi.fn(() => ({
     ok: true,
     value: {
@@ -56,7 +57,8 @@ vi.mock('../commands/run.js', async (importOriginal) => {
   };
 });
 
-vi.mock('@robota-sdk/dag-builder', () => ({
+vi.mock('@robota-sdk/dag-builder', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-builder')>()),
   isWorkflowFileFormat: vi.fn(() => false),
   fromDagWorkflowFile: vi.fn(),
 }));
@@ -101,11 +103,11 @@ function getOutput(opts: { readonly written: string[] }): string {
 
 describe('explainCommand --suggest', () => {
   beforeEach(() => {
-    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-test';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test');
   });
 
   afterEach(() => {
-    delete process.env['ANTHROPIC_API_KEY'];
+    vi.unstubAllEnvs();
   });
 
   it('--help includes --suggest flag', async () => {
@@ -135,7 +137,7 @@ describe('explainCommand --suggest', () => {
   });
 
   it('shows API key hint and exits 0 when --suggest is used without key', async () => {
-    delete process.env['ANTHROPIC_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
     const opts = createOptions();
     const code = await explainCommand(['pipeline.dag.json', '--suggest'], opts);
     expect(code).toBe(0);

--- a/packages/dag-cli/src/__tests__/fix-command.test.ts
+++ b/packages/dag-cli/src/__tests__/fix-command.test.ts
@@ -6,7 +6,8 @@ vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@robota-sdk/dag-node', () => ({
+vi.mock('@robota-sdk/dag-node', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-node')>()),
   buildNodeDefinitionAssembly: vi.fn(() => ({
     ok: true,
     value: {
@@ -63,7 +64,8 @@ vi.mock('../local-runner/index.js', () => ({
   })),
 }));
 
-vi.mock('@robota-sdk/dag-builder', () => ({
+vi.mock('@robota-sdk/dag-builder', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-builder')>()),
   isWorkflowFileFormat: vi.fn(() => false),
   fromDagWorkflowFile: vi.fn(),
 }));
@@ -142,12 +144,12 @@ function getOutput(opts: { readonly written: string[] }): string {
 
 describe('fixCommand', () => {
   beforeEach(() => {
-    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-test';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test');
     vi.mocked(writeFile).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
-    delete process.env['ANTHROPIC_API_KEY'];
+    vi.unstubAllEnvs();
   });
 
   it('prints help with --help', async () => {
@@ -233,7 +235,7 @@ describe('fixCommand', () => {
   });
 
   it('shows static analysis hint when no API key and no --no-llm', async () => {
-    delete process.env['ANTHROPIC_API_KEY'];
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
     const opts = createOptions(BROKEN_DAG);
     const code = await fixCommand(['broken.dag.json'], opts);
     expect(code).toBe(0);

--- a/packages/dag-cli/src/__tests__/from-mermaid-command.test.ts
+++ b/packages/dag-cli/src/__tests__/from-mermaid-command.test.ts
@@ -7,7 +7,8 @@ vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@robota-sdk/dag-node', () => ({
+vi.mock('@robota-sdk/dag-node', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-node')>()),
   buildNodeDefinitionAssembly: vi.fn(() => ({
     ok: true,
     value: {

--- a/packages/dag-cli/src/__tests__/init-command.test.ts
+++ b/packages/dag-cli/src/__tests__/init-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IDagCliIo } from '../types.js';
 
 // Mock fs/promises to avoid real filesystem writes
@@ -34,6 +34,10 @@ describe('initCommand', () => {
     vi.mocked(mkdir).mockResolvedValue(undefined);
     vi.mocked(writeFile).mockResolvedValue(undefined);
     vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('returns 0 on success with default args', async () => {
@@ -156,24 +160,16 @@ describe('initCommand', () => {
 
   it('uses --no-cta flag to suppress CTA', async () => {
     const { io, output } = makeIo();
-    const originalCi = process.env['CI'];
-    delete process.env['CI'];
+    vi.stubEnv('CI', undefined);
     const code = await initCommand(['--no-cta'], { io });
-    process.env['CI'] = originalCi;
     expect(code).toBe(0);
     expect(output.join('')).toContain('Next steps');
   });
 
   it('shows simplified next steps when CI=true', async () => {
     const { io, output } = makeIo();
-    const originalCi = process.env['CI'];
-    process.env['CI'] = 'true';
+    vi.stubEnv('CI', 'true');
     const code = await initCommand([], { io });
-    if (originalCi !== undefined) {
-      process.env['CI'] = originalCi;
-    } else {
-      delete process.env['CI'];
-    }
     expect(code).toBe(0);
     expect(output.join('')).toContain('Next steps');
   });

--- a/packages/dag-cli/src/__tests__/keys-command.test.ts
+++ b/packages/dag-cli/src/__tests__/keys-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { IDagCliIo } from '../types.js';
 
 vi.mock('node:fs/promises', () => ({
@@ -73,6 +73,10 @@ describe('keysCommand - add', () => {
 });
 
 describe('keysCommand - test', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('tests keys (none set, returns failure)', async () => {
     const io = makeIo();
     const code = await keysCommand(['test'], { io, cwd: '/tmp/fake' });
@@ -81,29 +85,17 @@ describe('keysCommand - test', () => {
   });
 
   it('tests key with valid format (sk-ant- prefix)', async () => {
-    const saved = process.env['ANTHROPIC_API_KEY'];
-    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-validkeyformat12345678901234567890';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-api03-validkeyformat12345678901234567890');
     const io = makeIo();
     const code = await keysCommand(['test'], { io, cwd: '/tmp/fake' });
-    if (saved !== undefined) {
-      process.env['ANTHROPIC_API_KEY'] = saved;
-    } else {
-      delete process.env['ANTHROPIC_API_KEY'];
-    }
     expect([0, 1]).toContain(code);
     expect(io.writes.join('')).toContain('present');
   });
 
   it('tests key with invalid format (wrong prefix)', async () => {
-    const saved = process.env['ANTHROPIC_API_KEY'];
-    process.env['ANTHROPIC_API_KEY'] = 'wrong-prefix-but-long-enough-12345678901234';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'wrong-prefix-but-long-enough-12345678901234');
     const io = makeIo();
     const code = await keysCommand(['test'], { io, cwd: '/tmp/fake' });
-    if (saved !== undefined) {
-      process.env['ANTHROPIC_API_KEY'] = saved;
-    } else {
-      delete process.env['ANTHROPIC_API_KEY'];
-    }
     expect([0, 1]).toContain(code);
     expect(io.writes.join('')).toContain('format');
   });

--- a/packages/dag-cli/src/__tests__/misc-commands.test.ts
+++ b/packages/dag-cli/src/__tests__/misc-commands.test.ts
@@ -3,7 +3,7 @@
  * These exercise the outer function entry points, achieving function coverage,
  * without triggering heavy I/O or network calls.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { IDagCliIo } from '../types.js';
 
 vi.mock('../local-runner/index.js', async () => {
@@ -155,6 +155,10 @@ describe('generateShareText', () => {
 });
 
 describe('shareCommand', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('returns error when no file argument provided', async () => {
     const { shareCommand } = await import('../commands/share.js');
     const io = makeIo();
@@ -173,13 +177,11 @@ describe('shareCommand', () => {
 
   it('returns failure when GITHUB_TOKEN is missing (with file arg)', async () => {
     const { shareCommand } = await import('../commands/share.js');
-    const savedToken = process.env['GITHUB_TOKEN'];
-    delete process.env['GITHUB_TOKEN'];
+    vi.stubEnv('GITHUB_TOKEN', undefined);
     const io = makeIo();
     const code = await shareCommand(['some.dag.json'], { io });
     expect(code).toBe(1);
     expect(io.writes.join('')).toContain('GITHUB_TOKEN');
-    if (savedToken !== undefined) process.env['GITHUB_TOKEN'] = savedToken;
   });
 });
 

--- a/packages/dag-cli/src/__tests__/run-utilities.test.ts
+++ b/packages/dag-cli/src/__tests__/run-utilities.test.ts
@@ -20,25 +20,14 @@ vi.mock('node:fs/promises', () => ({
 // ---------------------------------------------------------------------------
 
 describe('applyEnvFile', () => {
-  const savedEnv: Record<string, string | undefined> = {};
-
   beforeEach(() => {
-    savedEnv['TEST_APPLY_KEY'] = process.env['TEST_APPLY_KEY'];
-    savedEnv['QUOTED_KEY'] = process.env['QUOTED_KEY'];
-    savedEnv['SINGLE_QUOTED_KEY'] = process.env['SINGLE_QUOTED_KEY'];
-    delete process.env['TEST_APPLY_KEY'];
-    delete process.env['QUOTED_KEY'];
-    delete process.env['SINGLE_QUOTED_KEY'];
+    vi.stubEnv('TEST_APPLY_KEY', undefined);
+    vi.stubEnv('QUOTED_KEY', undefined);
+    vi.stubEnv('SINGLE_QUOTED_KEY', undefined);
   });
 
   afterEach(() => {
-    for (const [k, v] of Object.entries(savedEnv)) {
-      if (v === undefined) {
-        delete process.env[k];
-      } else {
-        process.env[k] = v;
-      }
-    }
+    vi.unstubAllEnvs();
   });
 
   it('sets environment variables from file content', async () => {
@@ -84,7 +73,7 @@ describe('applyEnvFile', () => {
   });
 
   it('does not override already-set environment variables', async () => {
-    process.env['TEST_APPLY_KEY'] = 'already_set';
+    vi.stubEnv('TEST_APPLY_KEY', 'already_set');
     const { readFile } = await import('node:fs/promises');
     vi.mocked(readFile).mockResolvedValue('TEST_APPLY_KEY=new_value\n' as never);
 

--- a/packages/dag-cli/src/__tests__/runner-cli.test.ts
+++ b/packages/dag-cli/src/__tests__/runner-cli.test.ts
@@ -3,7 +3,7 @@
  * All subcommand handlers are mocked so these tests only cover routing logic.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock all heavy dependencies that would make network/FS calls
 vi.mock('../commands/run.js', () => ({
@@ -53,7 +53,8 @@ vi.mock('../telemetry.js', () => ({
   isTelemetryEnabled: vi.fn().mockResolvedValue(false),
   readTelemetryConfig: vi.fn().mockResolvedValue({}),
 }));
-vi.mock('@robota-sdk/dag-orchestration-client', () => ({
+vi.mock('@robota-sdk/dag-orchestration-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/dag-orchestration-client')>()),
   DagOrchestrationHttpClient: vi.fn().mockImplementation(() => ({})),
 }));
 vi.mock('../runner-dispatch.js', () => ({
@@ -79,6 +80,10 @@ function makeMockIo(): IDagCliIo & { written: string[] } {
 describe('runDagCli', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('shows help text when no args given', async () => {
@@ -361,7 +366,7 @@ describe('runDagCli', () => {
     });
 
     const io = makeMockIo();
-    delete process.env['CI'];
+    vi.stubEnv('CI', undefined);
     await runDagCli(['validate', 'bad.dag.json'], { io });
     const output = io.written.join('');
     expect(output).toContain('dag doctor');

--- a/packages/dag-cli/src/__tests__/session-gate.test.ts
+++ b/packages/dag-cli/src/__tests__/session-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionPermissionGate, parseSessionPermissionsFromEnv } from '../session/session-gate.js';
 
 describe('SessionPermissionGate', () => {
@@ -90,10 +90,10 @@ describe('SessionPermissionGate', () => {
 
 describe('parseSessionPermissionsFromEnv', () => {
   beforeEach(() => {
-    delete process.env['DAG_SESSION_PERMISSIONS'];
+    vi.stubEnv('DAG_SESSION_PERMISSIONS', undefined);
   });
   afterEach(() => {
-    delete process.env['DAG_SESSION_PERMISSIONS'];
+    vi.unstubAllEnvs();
   });
 
   it('returns undefined when env var is not set', () => {
@@ -101,17 +101,20 @@ describe('parseSessionPermissionsFromEnv', () => {
   });
 
   it('parses valid JSON permissions', () => {
-    process.env['DAG_SESSION_PERMISSIONS'] = JSON.stringify({
-      allowedNodeTypes: ['input', 'text-output'],
-      maxCostUsd: 0.5,
-    });
+    vi.stubEnv(
+      'DAG_SESSION_PERMISSIONS',
+      JSON.stringify({
+        allowedNodeTypes: ['input', 'text-output'],
+        maxCostUsd: 0.5,
+      }),
+    );
     const perms = parseSessionPermissionsFromEnv();
     expect(perms?.allowedNodeTypes).toEqual(['input', 'text-output']);
     expect(perms?.maxCostUsd).toBe(0.5);
   });
 
   it('returns undefined for invalid JSON', () => {
-    process.env['DAG_SESSION_PERMISSIONS'] = 'not-valid-json{';
+    vi.stubEnv('DAG_SESSION_PERMISSIONS', 'not-valid-json{');
     expect(parseSessionPermissionsFromEnv()).toBeUndefined();
   });
 });

--- a/packages/dag-cli/src/__tests__/telemetry-command.test.ts
+++ b/packages/dag-cli/src/__tests__/telemetry-command.test.ts
@@ -24,20 +24,14 @@ function makeMockIo(): IDagCliIo & { written: string[] } {
 }
 
 describe('telemetryCommand', () => {
-  const originalCI = process.env['CI'];
-  const originalOpt = process.env['ROBOTA_DAG_TELEMETRY'];
-
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env['CI'];
-    delete process.env['ROBOTA_DAG_TELEMETRY'];
+    vi.stubEnv('CI', undefined);
+    vi.stubEnv('ROBOTA_DAG_TELEMETRY', undefined);
   });
 
   afterEach(() => {
-    if (originalCI !== undefined) process.env['CI'] = originalCI;
-    else delete process.env['CI'];
-    if (originalOpt !== undefined) process.env['ROBOTA_DAG_TELEMETRY'] = originalOpt;
-    else delete process.env['ROBOTA_DAG_TELEMETRY'];
+    vi.unstubAllEnvs();
   });
 
   it('shows help text when no subcommand is given', async () => {
@@ -70,7 +64,7 @@ describe('telemetryCommand', () => {
 
   describe('status subcommand', () => {
     it('shows disabled in CI when CI=true', async () => {
-      process.env['CI'] = 'true';
+      vi.stubEnv('CI', 'true');
       const io = makeMockIo();
       const code = await telemetryCommand(['status'], { io });
       expect(code).toBe(0);
@@ -78,7 +72,7 @@ describe('telemetryCommand', () => {
     });
 
     it('shows disabled when ROBOTA_DAG_TELEMETRY=0', async () => {
-      process.env['ROBOTA_DAG_TELEMETRY'] = '0';
+      vi.stubEnv('ROBOTA_DAG_TELEMETRY', '0');
       const io = makeMockIo();
       const code = await telemetryCommand(['status'], { io });
       expect(code).toBe(0);
@@ -110,7 +104,7 @@ describe('telemetryCommand', () => {
 
   describe('on subcommand', () => {
     it('returns error in CI environment', async () => {
-      process.env['CI'] = 'true';
+      vi.stubEnv('CI', 'true');
       const io = makeMockIo();
       const code = await telemetryCommand(['on'], { io });
       expect(code).not.toBe(0);
@@ -118,7 +112,7 @@ describe('telemetryCommand', () => {
     });
 
     it('returns error when ROBOTA_DAG_TELEMETRY=0', async () => {
-      process.env['ROBOTA_DAG_TELEMETRY'] = '0';
+      vi.stubEnv('ROBOTA_DAG_TELEMETRY', '0');
       const io = makeMockIo();
       const code = await telemetryCommand(['on'], { io });
       expect(code).not.toBe(0);

--- a/packages/dag-cli/src/__tests__/telemetry.test.ts
+++ b/packages/dag-cli/src/__tests__/telemetry.test.ts
@@ -58,30 +58,24 @@ describe('readTelemetryConfig', () => {
 });
 
 describe('isTelemetryEnabled', () => {
-  const originalCI = process.env['CI'];
-  const originalOpt = process.env['ROBOTA_DAG_TELEMETRY'];
-
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env['CI'];
-    delete process.env['ROBOTA_DAG_TELEMETRY'];
+    vi.stubEnv('CI', undefined);
+    vi.stubEnv('ROBOTA_DAG_TELEMETRY', undefined);
   });
 
   afterEach(() => {
-    if (originalCI !== undefined) process.env['CI'] = originalCI;
-    else delete process.env['CI'];
-    if (originalOpt !== undefined) process.env['ROBOTA_DAG_TELEMETRY'] = originalOpt;
-    else delete process.env['ROBOTA_DAG_TELEMETRY'];
+    vi.unstubAllEnvs();
   });
 
   it('returns false when CI=true', async () => {
-    process.env['CI'] = 'true';
+    vi.stubEnv('CI', 'true');
     const enabled = await isTelemetryEnabled();
     expect(enabled).toBe(false);
   });
 
   it('returns false when ROBOTA_DAG_TELEMETRY=0', async () => {
-    process.env['ROBOTA_DAG_TELEMETRY'] = '0';
+    vi.stubEnv('ROBOTA_DAG_TELEMETRY', '0');
     const enabled = await isTelemetryEnabled();
     expect(enabled).toBe(false);
   });
@@ -147,20 +141,17 @@ describe('disableTelemetry', () => {
 });
 
 describe('recordTelemetry', () => {
-  const originalCI = process.env['CI'];
-
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env['CI'];
+    vi.stubEnv('CI', undefined);
   });
 
   afterEach(() => {
-    if (originalCI !== undefined) process.env['CI'] = originalCI;
-    else delete process.env['CI'];
+    vi.unstubAllEnvs();
   });
 
   it('does not call fetch when telemetry is disabled', async () => {
-    process.env['CI'] = 'true';
+    vi.stubEnv('CI', 'true');
     await recordTelemetry({ command: 'run', success: true, durationMs: 100 });
     // Allow fire-and-forget to settle
     await new Promise((r) => setTimeout(r, 10));

--- a/packages/dag-cli/src/providers/__tests__/resolve-provider.test.ts
+++ b/packages/dag-cli/src/providers/__tests__/resolve-provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { listAvailableProviders, resolveProvider } from '../resolve-provider.js';
 
@@ -6,18 +6,12 @@ const RUNTIME_URL_ENV = 'DAG_RUNTIME_SERVER_URL';
 const DEFAULT_PROVIDER_ENV = 'DAG_DEFAULT_PROVIDER';
 
 describe('resolveProvider (WORKFLOW-002 Phase C)', () => {
-  const savedRuntimeUrl = process.env[RUNTIME_URL_ENV];
-  const savedDefaultProvider = process.env[DEFAULT_PROVIDER_ENV];
-
   afterEach(() => {
-    if (savedRuntimeUrl === undefined) delete process.env[RUNTIME_URL_ENV];
-    else process.env[RUNTIME_URL_ENV] = savedRuntimeUrl;
-    if (savedDefaultProvider === undefined) delete process.env[DEFAULT_PROVIDER_ENV];
-    else process.env[DEFAULT_PROVIDER_ENV] = savedDefaultProvider;
+    vi.unstubAllEnvs();
   });
 
   it('defaults to the local provider', async () => {
-    delete process.env[DEFAULT_PROVIDER_ENV];
+    vi.stubEnv(DEFAULT_PROVIDER_ENV, undefined);
     const provider = await resolveProvider();
     expect(provider.providerId).toBe('local');
   });
@@ -31,13 +25,13 @@ describe('resolveProvider (WORKFLOW-002 Phase C)', () => {
   });
 
   it('resolves the http provider against DAG_RUNTIME_SERVER_URL when no flag is given', async () => {
-    process.env[RUNTIME_URL_ENV] = 'http://env-host:3939';
+    vi.stubEnv(RUNTIME_URL_ENV, 'http://env-host:3939');
     const provider = await resolveProvider({ provider: 'http' });
     expect(provider.providerId).toBe('http');
   });
 
   it('lets --server-url override DAG_RUNTIME_SERVER_URL', async () => {
-    process.env[RUNTIME_URL_ENV] = 'http://env-host:3939';
+    vi.stubEnv(RUNTIME_URL_ENV, 'http://env-host:3939');
     const provider = await resolveProvider({
       provider: 'http',
       serverUrl: 'http://flag-host:1234',
@@ -46,7 +40,7 @@ describe('resolveProvider (WORKFLOW-002 Phase C)', () => {
   });
 
   it('throws for the http provider with no URL configured', async () => {
-    delete process.env[RUNTIME_URL_ENV];
+    vi.stubEnv(RUNTIME_URL_ENV, undefined);
     await expect(resolveProvider({ provider: 'http' })).rejects.toThrow(/requires a server URL/);
   });
 

--- a/packages/dag-framework/src/__tests__/resolve-storage-root.test.ts
+++ b/packages/dag-framework/src/__tests__/resolve-storage-root.test.ts
@@ -1,38 +1,21 @@
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveAssetRoot, resolveStorageRoot } from '../config/resolve-storage-root.js';
 
 const ENV_KEYS = ['DAG_STORAGE_ROOT', 'ASSET_STORAGE_ROOT', 'XDG_DATA_HOME'] as const;
 
-type EnvSnapshot = Partial<Record<(typeof ENV_KEYS)[number], string>>;
-
-function snapshotEnv(): EnvSnapshot {
-  const snap: EnvSnapshot = {};
-  for (const key of ENV_KEYS) {
-    snap[key] = process.env[key];
-  }
-  return snap;
-}
-
-function restoreEnv(snap: EnvSnapshot): void {
-  for (const key of ENV_KEYS) {
-    if (snap[key] === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = snap[key];
-    }
-  }
+function clearEnvKeys(): void {
+  for (const key of ENV_KEYS) vi.stubEnv(key, undefined);
 }
 
 describe('resolveStorageRoot', () => {
-  let snap: EnvSnapshot;
-
   beforeEach(() => {
-    snap = snapshotEnv();
-    for (const key of ENV_KEYS) delete process.env[key];
+    clearEnvKeys();
   });
-  afterEach(() => restoreEnv(snap));
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
   it('returns home-dir fallback when no env vars are set', () => {
     const result = resolveStorageRoot();
@@ -40,33 +23,32 @@ describe('resolveStorageRoot', () => {
   });
 
   it('returns DAG_STORAGE_ROOT when set', () => {
-    process.env['DAG_STORAGE_ROOT'] = '/custom/storage';
+    vi.stubEnv('DAG_STORAGE_ROOT', '/custom/storage');
     const result = resolveStorageRoot();
     expect(result).toBe(path.resolve('/custom/storage'));
   });
 
   it('returns XDG_DATA_HOME-based path when XDG_DATA_HOME is set', () => {
-    process.env['XDG_DATA_HOME'] = '/xdg/data';
+    vi.stubEnv('XDG_DATA_HOME', '/xdg/data');
     const result = resolveStorageRoot();
     expect(result).toBe(path.join('/xdg/data', 'robota-dag', 'storage'));
   });
 
   it('DAG_STORAGE_ROOT takes precedence over XDG_DATA_HOME', () => {
-    process.env['DAG_STORAGE_ROOT'] = '/explicit/storage';
-    process.env['XDG_DATA_HOME'] = '/xdg/data';
+    vi.stubEnv('DAG_STORAGE_ROOT', '/explicit/storage');
+    vi.stubEnv('XDG_DATA_HOME', '/xdg/data');
     const result = resolveStorageRoot();
     expect(result).toBe(path.resolve('/explicit/storage'));
   });
 });
 
 describe('resolveAssetRoot', () => {
-  let snap: EnvSnapshot;
-
   beforeEach(() => {
-    snap = snapshotEnv();
-    for (const key of ENV_KEYS) delete process.env[key];
+    clearEnvKeys();
   });
-  afterEach(() => restoreEnv(snap));
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
   it('returns home-dir fallback when no env vars are set', () => {
     const result = resolveAssetRoot();
@@ -74,20 +56,20 @@ describe('resolveAssetRoot', () => {
   });
 
   it('returns ASSET_STORAGE_ROOT when set', () => {
-    process.env['ASSET_STORAGE_ROOT'] = '/custom/assets';
+    vi.stubEnv('ASSET_STORAGE_ROOT', '/custom/assets');
     const result = resolveAssetRoot();
     expect(result).toBe(path.resolve('/custom/assets'));
   });
 
   it('returns XDG_DATA_HOME-based path when XDG_DATA_HOME is set', () => {
-    process.env['XDG_DATA_HOME'] = '/xdg/data';
+    vi.stubEnv('XDG_DATA_HOME', '/xdg/data');
     const result = resolveAssetRoot();
     expect(result).toBe(path.join('/xdg/data', 'robota-dag', 'assets'));
   });
 
   it('ASSET_STORAGE_ROOT takes precedence over XDG_DATA_HOME', () => {
-    process.env['ASSET_STORAGE_ROOT'] = '/explicit/assets';
-    process.env['XDG_DATA_HOME'] = '/xdg/data';
+    vi.stubEnv('ASSET_STORAGE_ROOT', '/explicit/assets');
+    vi.stubEnv('XDG_DATA_HOME', '/xdg/data');
     const result = resolveAssetRoot();
     expect(result).toBe(path.resolve('/explicit/assets'));
   });

--- a/packages/dag-nodes/gemini-image-edit/src/runtime-core.test.ts
+++ b/packages/dag-nodes/gemini-image-edit/src/runtime-core.test.ts
@@ -4,8 +4,10 @@ import type { IImageGenerationResult, TProviderMediaResult } from '@robota-sdk/a
 import { GeminiImageRuntime, isImageBinaryValue } from './runtime-core.js';
 import { GoogleProvider } from '@robota-sdk/agent-provider-gemini/google';
 
-// Mock GoogleProvider so no real API calls are made
-vi.mock('@robota-sdk/agent-provider-gemini/google', () => ({
+// Partial mock: keep every other export of the module real, override only GoogleProvider so no
+// real API calls are made (the real class is never constructed).
+vi.mock('@robota-sdk/agent-provider-gemini/google', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-provider-gemini/google')>()),
   GoogleProvider: vi
     .fn()
     .mockImplementation((options: { apiKey: string; imageCapableModels: string[] }) => ({
@@ -67,32 +69,17 @@ function makeSuccessComposeResult(): TProviderMediaResult<IImageGenerationResult
 }
 
 describe('GeminiImageRuntime', () => {
-  let savedEnv: Record<string, string | undefined>;
-
   beforeEach(() => {
-    savedEnv = {
-      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-      DAG_GEMINI_IMAGE_DEFAULT_MODEL: process.env.DAG_GEMINI_IMAGE_DEFAULT_MODEL,
-      DAG_GEMINI_IMAGE_ALLOWED_MODELS: process.env.DAG_GEMINI_IMAGE_ALLOWED_MODELS,
-      DAG_RUNTIME_BASE_URL: process.env.DAG_RUNTIME_BASE_URL,
-      DAG_PORT: process.env.DAG_PORT,
-    };
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.DAG_GEMINI_IMAGE_DEFAULT_MODEL;
-    delete process.env.DAG_GEMINI_IMAGE_ALLOWED_MODELS;
-    delete process.env.DAG_RUNTIME_BASE_URL;
-    delete process.env.DAG_PORT;
+    vi.stubEnv('GEMINI_API_KEY', undefined);
+    vi.stubEnv('DAG_GEMINI_IMAGE_DEFAULT_MODEL', undefined);
+    vi.stubEnv('DAG_GEMINI_IMAGE_ALLOWED_MODELS', undefined);
+    vi.stubEnv('DAG_RUNTIME_BASE_URL', undefined);
+    vi.stubEnv('DAG_PORT', undefined);
     vi.clearAllMocks();
   });
 
   afterEach(() => {
-    for (const [key, value] of Object.entries(savedEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
+    vi.unstubAllEnvs();
   });
 
   // -----------------------------------------------------------------------
@@ -249,7 +236,7 @@ describe('GeminiImageRuntime', () => {
     });
 
     it('uses env GEMINI_API_KEY when no explicit key given', async () => {
-      process.env.GEMINI_API_KEY = 'env-test-key';
+      vi.stubEnv('GEMINI_API_KEY', 'env-test-key');
 
       const mockEditImage = vi.fn().mockResolvedValue(makeSuccessEditResult());
       vi.mocked(GoogleProvider).mockImplementation(
@@ -271,8 +258,8 @@ describe('GeminiImageRuntime', () => {
     });
 
     it('uses env DAG_GEMINI_IMAGE_DEFAULT_MODEL for default model', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
-      process.env.DAG_GEMINI_IMAGE_DEFAULT_MODEL = 'gemini-2.0-flash-exp';
+      vi.stubEnv('GEMINI_API_KEY', 'test-key');
+      vi.stubEnv('DAG_GEMINI_IMAGE_DEFAULT_MODEL', 'gemini-2.0-flash-exp');
 
       const mockEditImage = vi.fn().mockResolvedValue(makeSuccessEditResult());
       vi.mocked(GoogleProvider).mockImplementation(
@@ -294,9 +281,9 @@ describe('GeminiImageRuntime', () => {
     });
 
     it('uses env DAG_GEMINI_IMAGE_ALLOWED_MODELS as CSV', async () => {
-      process.env.GEMINI_API_KEY = 'test-key';
-      process.env.DAG_GEMINI_IMAGE_DEFAULT_MODEL = 'model-a';
-      process.env.DAG_GEMINI_IMAGE_ALLOWED_MODELS = 'model-a, model-b';
+      vi.stubEnv('GEMINI_API_KEY', 'test-key');
+      vi.stubEnv('DAG_GEMINI_IMAGE_DEFAULT_MODEL', 'model-a');
+      vi.stubEnv('DAG_GEMINI_IMAGE_ALLOWED_MODELS', 'model-a, model-b');
 
       const mockEditImage = vi.fn().mockResolvedValue(makeSuccessEditResult());
       vi.mocked(GoogleProvider).mockImplementation(

--- a/packages/dag-nodes/gemini-image-edit/src/runtime-helpers.test.ts
+++ b/packages/dag-nodes/gemini-image-edit/src/runtime-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IMediaOutputRef } from '@robota-sdk/agent-core';
 import type { IPortBinaryValue } from '@robota-sdk/dag-core';
 import {
@@ -42,47 +42,32 @@ describe('parseCsv', () => {
 // resolveRuntimeBaseUrl
 // ---------------------------------------------------------------------------
 describe('resolveRuntimeBaseUrl', () => {
-  let savedEnv: Record<string, string | undefined>;
-
   beforeEach(() => {
-    savedEnv = {
-      DAG_RUNTIME_BASE_URL: process.env.DAG_RUNTIME_BASE_URL,
-      DAG_PORT: process.env.DAG_PORT,
-    };
-    delete process.env.DAG_RUNTIME_BASE_URL;
-    delete process.env.DAG_PORT;
+    vi.stubEnv('DAG_RUNTIME_BASE_URL', undefined);
+    vi.stubEnv('DAG_PORT', undefined);
   });
 
   afterEach(() => {
-    if (savedEnv.DAG_RUNTIME_BASE_URL === undefined) {
-      delete process.env.DAG_RUNTIME_BASE_URL;
-    } else {
-      process.env.DAG_RUNTIME_BASE_URL = savedEnv.DAG_RUNTIME_BASE_URL;
-    }
-    if (savedEnv.DAG_PORT === undefined) {
-      delete process.env.DAG_PORT;
-    } else {
-      process.env.DAG_PORT = savedEnv.DAG_PORT;
-    }
+    vi.unstubAllEnvs();
   });
 
   it('returns DAG_RUNTIME_BASE_URL when set', () => {
-    process.env.DAG_RUNTIME_BASE_URL = 'https://my-runtime.example.com';
+    vi.stubEnv('DAG_RUNTIME_BASE_URL', 'https://my-runtime.example.com');
     expect(resolveRuntimeBaseUrl()).toBe('https://my-runtime.example.com');
   });
 
   it('strips trailing slash from DAG_RUNTIME_BASE_URL', () => {
-    process.env.DAG_RUNTIME_BASE_URL = 'https://my-runtime.example.com/';
+    vi.stubEnv('DAG_RUNTIME_BASE_URL', 'https://my-runtime.example.com/');
     expect(resolveRuntimeBaseUrl()).toBe('https://my-runtime.example.com');
   });
 
   it('ignores whitespace-only DAG_RUNTIME_BASE_URL', () => {
-    process.env.DAG_RUNTIME_BASE_URL = '   ';
+    vi.stubEnv('DAG_RUNTIME_BASE_URL', '   ');
     expect(resolveRuntimeBaseUrl()).toBe('http://127.0.0.1:3011');
   });
 
   it('uses DAG_PORT when DAG_RUNTIME_BASE_URL is not set', () => {
-    process.env.DAG_PORT = '4000';
+    vi.stubEnv('DAG_PORT', '4000');
     expect(resolveRuntimeBaseUrl()).toBe('http://127.0.0.1:4000');
   });
 
@@ -91,17 +76,17 @@ describe('resolveRuntimeBaseUrl', () => {
   });
 
   it('falls back to default port when DAG_PORT is not a valid number', () => {
-    process.env.DAG_PORT = 'notanumber';
+    vi.stubEnv('DAG_PORT', 'notanumber');
     expect(resolveRuntimeBaseUrl()).toBe('http://127.0.0.1:3011');
   });
 
   it('falls back to default port when DAG_PORT is zero', () => {
-    process.env.DAG_PORT = '0';
+    vi.stubEnv('DAG_PORT', '0');
     expect(resolveRuntimeBaseUrl()).toBe('http://127.0.0.1:3011');
   });
 
   it('falls back to default port when DAG_PORT is negative', () => {
-    process.env.DAG_PORT = '-1';
+    vi.stubEnv('DAG_PORT', '-1');
     expect(resolveRuntimeBaseUrl()).toBe('http://127.0.0.1:3011');
   });
 });

--- a/packages/dag-nodes/instant-node/src/__tests__/index.test.ts
+++ b/packages/dag-nodes/instant-node/src/__tests__/index.test.ts
@@ -1,24 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('@robota-sdk/agent-core', () => ({
+// Partial mocks: every other export of each package stays real. Only the agent entrypoint and the
+// provider classes the node constructs are stubbed, so no provider SDK client is ever instantiated
+// and no real API call is made.
+vi.mock('@robota-sdk/agent-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-core')>()),
   Robota: vi.fn().mockImplementation(() => ({
     run: vi.fn().mockResolvedValue('mocked response'),
   })),
 }));
 
-vi.mock('@robota-sdk/agent-provider-anthropic', () => ({
+vi.mock('@robota-sdk/agent-provider-anthropic', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-provider-anthropic')>()),
   AnthropicProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-openai', () => ({
+vi.mock('@robota-sdk/agent-provider-openai', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-provider-openai')>()),
   OpenAIProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-gemini/google', () => ({
+vi.mock('@robota-sdk/agent-provider-gemini/google', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-provider-gemini/google')>()),
   GoogleProvider: vi.fn().mockImplementation(() => ({})),
 }));
 
-vi.mock('@robota-sdk/agent-provider-openai-compatible', () => ({
+vi.mock('@robota-sdk/agent-provider-openai-compatible', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@robota-sdk/agent-provider-openai-compatible')>()),
   DeepSeekProvider: vi.fn().mockImplementation(() => ({})),
   QwenProvider: vi.fn().mockImplementation(() => ({})),
 }));
@@ -114,11 +122,13 @@ describe('createPromptBackedNodeDefinition', () => {
 });
 
 describe('PromptBackedNodeDefinition.taskHandler.execute', () => {
-  const OLD_ENV = process.env;
-
   beforeEach(() => {
     vi.resetModules();
-    process.env = { ...OLD_ENV, ANTHROPIC_API_KEY: 'test-key' };
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('renders template and returns output on success', async () => {
@@ -141,7 +151,7 @@ describe('PromptBackedNodeDefinition.taskHandler.execute', () => {
   });
 
   it('returns validation error when API key is missing', async () => {
-    delete process.env.ANTHROPIC_API_KEY;
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
     const node = createPromptBackedNodeDefinition(SINGLE_PORT_SPEC);
     const result = await node.taskHandler.execute({ text: 'hello' }, MOCK_CONTEXT);
     expect(result.ok).toBe(false);
@@ -151,7 +161,7 @@ describe('PromptBackedNodeDefinition.taskHandler.execute', () => {
   });
 
   it('multi-port spec renders all variables into template', async () => {
-    process.env.ANTHROPIC_API_KEY = 'test-key';
+    vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
     const multiSpec: ICreatePromptNodeInput = {
       nodeType: 'multi-port-node',
       displayName: 'Multi Port',

--- a/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
+++ b/packages/dag-nodes/seedance-video/src/runtime-core.test.ts
@@ -22,7 +22,7 @@ const { createVideo, getVideoJob, cancelVideoJob, bytedanceMockFactory } = vi.ho
 });
 
 // Full replacement avoids loading the ByteDance HTTP client; only the video job methods are exercised.
-vi.mock('@robota-sdk/agent-provider-bytedance', bytedanceMockFactory); // allow-module-mock: BytedanceProvider hits the real ModelArk API
+vi.mock('@robota-sdk/agent-provider-bytedance', bytedanceMockFactory); // allow-module-mock: keeps the ByteDance HTTP client out of this leaf test's import graph, which reaches no other export
 
 const MODEL = 'seedance-2.0';
 
@@ -54,24 +54,16 @@ function req(overrides?: Partial<ISeedanceVideoRequest>): ISeedanceVideoRequest 
 }
 
 describe('SeedanceVideoRuntime', () => {
-  let savedEnv: Record<string, string | undefined>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    savedEnv = {
-      SEEDANCE_API_KEY: process.env.SEEDANCE_API_KEY,
-      SEEDANCE_BASE_URL: process.env.SEEDANCE_BASE_URL,
-      DAG_SEEDANCE_VIDEO_DEFAULT_MODEL: process.env.DAG_SEEDANCE_VIDEO_DEFAULT_MODEL,
-      DAG_SEEDANCE_VIDEO_ALLOWED_MODELS: process.env.DAG_SEEDANCE_VIDEO_ALLOWED_MODELS,
-    };
-    for (const key of Object.keys(savedEnv)) delete process.env[key];
+    vi.stubEnv('SEEDANCE_API_KEY', undefined);
+    vi.stubEnv('SEEDANCE_BASE_URL', undefined);
+    vi.stubEnv('DAG_SEEDANCE_VIDEO_DEFAULT_MODEL', undefined);
+    vi.stubEnv('DAG_SEEDANCE_VIDEO_ALLOWED_MODELS', undefined);
   });
 
   afterEach(() => {
-    for (const [key, value] of Object.entries(savedEnv)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
+    vi.unstubAllEnvs();
   });
 
   it('returns validation error when default model is missing', async () => {

--- a/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
+++ b/packages/dag-nodes/text-to-image/src/runtime-core.test.ts
@@ -21,7 +21,7 @@ const { sharedGenerateImage, googleMockFactory } = vi.hoisted(() => {
 });
 
 // Full replacement avoids loading the @google/genai SDK; only ctor + generateImage are exercised.
-vi.mock('@robota-sdk/agent-provider-gemini/google', googleMockFactory); // allow-module-mock: GoogleProvider hits the real Gemini API
+vi.mock('@robota-sdk/agent-provider-gemini/google', googleMockFactory); // allow-module-mock: keeps the @google/genai SDK out of this leaf test's import graph, which reaches no other export
 
 const TEST_MODEL = 'test-image-model';
 
@@ -43,25 +43,15 @@ function makeSuccessResult(): TProviderMediaResult<IImageGenerationResult> {
 }
 
 describe('TextToImageRuntime', () => {
-  let savedEnv: Record<string, string | undefined>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    savedEnv = {
-      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-      DAG_TEXT_TO_IMAGE_DEFAULT_MODEL: process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL,
-      DAG_TEXT_TO_IMAGE_ALLOWED_MODELS: process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS,
-    };
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.DAG_TEXT_TO_IMAGE_DEFAULT_MODEL;
-    delete process.env.DAG_TEXT_TO_IMAGE_ALLOWED_MODELS;
+    vi.stubEnv('GEMINI_API_KEY', undefined);
+    vi.stubEnv('DAG_TEXT_TO_IMAGE_DEFAULT_MODEL', undefined);
+    vi.stubEnv('DAG_TEXT_TO_IMAGE_ALLOWED_MODELS', undefined);
   });
 
   afterEach(() => {
-    for (const [key, value] of Object.entries(savedEnv)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
+    vi.unstubAllEnvs();
   });
 
   it('returns validation error when default model is missing', async () => {

--- a/scripts/harness/__tests__/check-test-module-mocks.test.mjs
+++ b/scripts/harness/__tests__/check-test-module-mocks.test.mjs
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { findHardcodedModuleMocks } from '../check-test-module-mocks.mjs';
+import {
+  extractMockCall,
+  findHardcodedModuleMocks,
+  findStaleAllowlistEntries,
+  spreadsOriginalModule,
+} from '../check-test-module-mocks.mjs';
 
 describe('findHardcodedModuleMocks', () => {
   it('flags a hardcoded workspace-module factory', () => {
@@ -40,5 +45,112 @@ describe('findHardcodedModuleMocks', () => {
 
   it('ignores vi.mock without a factory (auto-mock form)', () => {
     expect(findHardcodedModuleMocks("vi.mock('@robota-sdk/agent-core');")).toHaveLength(0);
+  });
+
+  // HARNESS-025: the two detection gaps that made 20 already-correct files look like violations.
+  it('accepts a partial mock that spreads vi.importActual', () => {
+    const content = [
+      "vi.mock('@robota-sdk/agent-core', async () => {",
+      "  const actual = await vi.importActual('@robota-sdk/agent-core');",
+      '  return { ...actual, SilentLogger: stub };',
+      '});',
+    ].join('\n');
+    expect(findHardcodedModuleMocks(content)).toHaveLength(0);
+  });
+
+  it('accepts a partial mock whose spread sits far past the call site', () => {
+    const content = [
+      "vi.mock('@robota-sdk/agent-core', async (importOriginal) => {",
+      '  const mod = await importOriginal();',
+      // A long factory body: the spread below used to fall outside the old 600-char window.
+      ...Array.from({ length: 40 }, (_, i) => `  const filler${i} = 'xxxxxxxxxxxxxxxxxxxxxxxx';`),
+      '  return { ...mod, SilentLogger: stub };',
+      '});',
+    ].join('\n');
+    expect(findHardcodedModuleMocks(content)).toHaveLength(0);
+  });
+
+  it('flags a factory that loads the original but never spreads it', () => {
+    const content = [
+      "vi.mock('@robota-sdk/agent-core', async () => {",
+      "  const actual = await vi.importActual('@robota-sdk/agent-core');",
+      '  return { SilentLogger: actual.SilentLogger };',
+      '});',
+    ].join('\n');
+    const findings = findHardcodedModuleMocks(content);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ module: '@robota-sdk/agent-core' });
+  });
+});
+
+describe('extractMockCall', () => {
+  it('returns the whole call, stopping at its balanced closing paren', () => {
+    const content = "vi.mock('@robota-sdk/x', () => ({ a: f(1) }));\nconst after = 1;";
+    // The nested `f(1)` must not close the call early, and the slice ends at the call's own `)`.
+    expect(extractMockCall(content, 0)).toBe("vi.mock('@robota-sdk/x', () => ({ a: f(1) }))");
+  });
+
+  it('does not let a paren inside a string or comment unbalance the scan', () => {
+    const content = [
+      "vi.mock('@robota-sdk/x', async (importOriginal) => ({",
+      '  ...(await importOriginal()),',
+      "  label: 'a ) not a real paren',",
+      '  // ) neither is this',
+      '}));',
+      'const after = 1;',
+    ].join('\n');
+    const call = extractMockCall(content, 0);
+    expect(call.endsWith('}))')).toBe(true);
+    expect(call).toContain('not a real paren');
+    expect(call).not.toContain('const after');
+  });
+});
+
+describe('spreadsOriginalModule', () => {
+  it('accepts an inline spread of importOriginal', () => {
+    expect(spreadsOriginalModule('...(await importOriginal()),')).toBe(true);
+  });
+
+  it('accepts a spread of an identifier bound from vi.importActual', () => {
+    const factory = "const mod = await vi.importActual('@robota-sdk/x');\nreturn { ...mod };";
+    expect(spreadsOriginalModule(factory)).toBe(true);
+  });
+
+  it('rejects a factory that never loads the original at all', () => {
+    expect(spreadsOriginalModule('() => ({ SilentLogger: stub })')).toBe(false);
+  });
+
+  it('rejects a spread of some unrelated object', () => {
+    const factory =
+      "const actual = await vi.importActual('@robota-sdk/x');\nreturn { ...defaults, a: actual.a };";
+    expect(spreadsOriginalModule(factory)).toBe(false);
+  });
+});
+
+// HARNESS-025: the allowlist must only ever shrink, or the burn-down count lies.
+describe('findStaleAllowlistEntries', () => {
+  it('keeps an entry whose file still violates', () => {
+    const violations = new Map([['a.test.ts', [{ module: '@robota-sdk/x', line: 1 }]]]);
+    expect(findStaleAllowlistEntries(['a.test.ts'], violations)).toEqual([]);
+  });
+
+  it('flags an entry whose file is now clean', () => {
+    const violations = new Map([['a.test.ts', []]]);
+    expect(findStaleAllowlistEntries(['a.test.ts'], violations)).toEqual(['a.test.ts']);
+  });
+
+  it('flags an entry whose file no longer exists', () => {
+    expect(findStaleAllowlistEntries(['gone.test.ts'], new Map())).toEqual(['gone.test.ts']);
+  });
+
+  it('reports stale entries sorted, and only the stale ones', () => {
+    const violations = new Map([
+      ['z.test.ts', []],
+      ['a.test.ts', []],
+      ['keep.test.ts', [{ module: '@robota-sdk/x', line: 1 }]],
+    ]);
+    expect(
+      findStaleAllowlistEntries(['z.test.ts', 'keep.test.ts', 'a.test.ts'], violations),
+    ).toEqual(['a.test.ts', 'z.test.ts']);
   });
 });

--- a/scripts/harness/check-test-module-mocks.mjs
+++ b/scripts/harness/check-test-module-mocks.mjs
@@ -11,12 +11,27 @@
  * and every `git push` in the repo was blocked by a failure in a package the change never touched
  * (while CI stayed green — the breakage surfaced only in the full local suite).
  *
- * Correct form: partial-mock with the real module spread, so unknown exports keep working:
+ * Correct form: partial-mock with the real module spread, so unknown exports keep working. Both
+ * spellings of "give me the real module" are accepted, because they are equivalent:
  *
  *   vi.mock('@robota-sdk/agent-core', async (importOriginal) => ({
  *     ...(await importOriginal<typeof import('@robota-sdk/agent-core')>()),
  *     onlyWhatThisTestOverrides: stub,
  *   }));
+ *
+ *   vi.mock('@robota-sdk/agent-core', async () => {
+ *     const actual = await vi.importActual<typeof import('@robota-sdk/agent-core')>(
+ *       '@robota-sdk/agent-core',
+ *     );
+ *     return { ...actual, onlyWhatThisTestOverrides: stub };
+ *   });
+ *
+ * What makes a factory SAFE is not which helper it calls but that the real module is **spread**
+ * into the result. A factory that fetches the original and then ignores it severs exports exactly
+ * like a hardcoded one, so the spread is what this scan actually requires (HARNESS-025).
+ *
+ * The factory is delimited by balanced parentheses rather than a fixed character window: long
+ * factories used to push their spread past the window and be misreported as hardcoded.
  *
  * This scan fails on NEW hardcoded workspace-module mock factories. Pre-existing violations are
  * pinned in ALLOWLIST below (tracked for burn-down by the MOCK-001 backlog item) — removing an
@@ -24,7 +39,10 @@
  * allowlist change. A deliberate full replacement can opt out with a same-line escape:
  * `// allow-module-mock: <reason>`.
  *
- * Exit code 0 = no new violations, 1 = new hardcoded workspace mock found.
+ * The allowlist is also checked for ROT: an entry whose file is now clean (or gone) fails the scan
+ * and must be deleted. An allowlist that can only shrink keeps the burn-down count honest.
+ *
+ * Exit code 0 = no new violations, 1 = new hardcoded workspace mock OR a stale allowlist entry.
  */
 
 import fs from 'node:fs/promises';
@@ -36,47 +54,33 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const SCAN_ROOTS = ['packages', 'apps'];
 
 const MOCK_PATTERN = /vi\.mock\(\s*(['"])(@robota-sdk\/[^'"]+)\1\s*,/g;
-/** How far past the `vi.mock(` call the factory is searched for `importOriginal`. */
-const FACTORY_WINDOW_CHARS = 600;
 const ESCAPE_PATTERN = /\/\/\s*allow-module-mock:\s*\S/;
 
+/** Either spelling of "load the real module": the `importOriginal` param, or `vi.importActual`. */
+const ORIGINAL_IMPORT_PATTERN = /\b(importOriginal|importActual)\s*[(<]/;
+/** A spread of the original loaded inline: `...(await importOriginal())`. */
+const INLINE_SPREAD_PATTERN = /\.\.\.\s*\(?\s*await\s+[\w.]*\b(importOriginal|importActual)\s*[(<]/;
+/** `const actual = await vi.importActual(...)` / `const mod = await importOriginal()`. */
+const ORIGINAL_BINDING_PATTERN =
+  /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+[\w.]*\b(?:importOriginal|importActual)\s*[(<]/g;
+
 /**
- * Pre-existing violations (2026-07-02 sweep, 36 files) — burn-down tracked by
+ * Remaining pre-existing violations — burn-down tracked by
  * `.agents/backlog/MOCK-001-hardcoded-workspace-mock-burndown.md`. Do not add entries for new code.
+ *
+ * HARNESS-025 burn-down (2026-07-25): 32 entries → 3. Two thirds of the original list were never
+ * hardcoded at all — they were correct `vi.importActual` partial mocks that the old detector could
+ * not see (it looked only for the literal `importOriginal`, inside a 600-char window that long
+ * factories overflowed). Fixing the detector cleared 20 entries; converting the genuinely hardcoded
+ * dag-cli and dag-nodes factories cleared 9 more.
+ *
+ * The 3 that remain are real hardcoded factories, left only because they sit in packages another
+ * concurrent work-stream owns. They are the whole of the remaining burn-down.
  */
 const ALLOWLIST = new Set([
   'packages/agent-cli/src/__tests__/provider-factory-integration.test.ts',
-  'packages/agent-framework/src/__tests__/create-session-new-options.test.ts',
   'packages/agent-framework/src/__tests__/create-subagent-session.test.ts',
-  'packages/agent-framework/src/__tests__/hook-wiring.test.ts',
   'packages/agent-framework/src/__tests__/subagent-integration.test.ts',
-  'packages/agent-framework/src/interactive/__tests__/interactive-session-bare.test.ts',
-  'packages/agent-framework/src/interactive/__tests__/interactive-session-manifest.test.ts',
-  'packages/agent-framework/src/interactive/__tests__/interactive-session-sandbox-snapshot.test.ts',
-  'packages/agent-framework/src/interactive/__tests__/interactive-session-system-context-regression.test.ts',
-  'packages/agent-provider-anthropic/src/anthropic/__tests__/response-parser.test.ts',
-  'packages/agent-session/src/__tests__/active-preset-state.test.ts',
-  'packages/agent-session/src/__tests__/apply-model-options.test.ts',
-  'packages/agent-session/src/__tests__/parallel-subagents-gate.test.ts',
-  'packages/agent-session/src/__tests__/session-compaction.test.ts',
-  'packages/agent-session/src/__tests__/session-id-override.test.ts',
-  'packages/agent-session/src/__tests__/session-system-prompt.test.ts',
-  'packages/agent-transport-tui/src/__tests__/TuiInteractionChannel.askUser.test.ts',
-  'packages/agent-transport-tui/src/__tests__/TuiInteractionChannel.display-contract.test.ts',
-  'packages/agent-transport-tui/src/__tests__/TuiInteractionChannel.lifecycle.test.ts',
-  'packages/dag-cli/src/__tests__/compare-benchmark.test.ts',
-  'packages/dag-cli/src/__tests__/demo-command.test.ts',
-  'packages/dag-cli/src/__tests__/describe-command.test.ts',
-  'packages/dag-cli/src/__tests__/explain-suggest.test.ts',
-  'packages/dag-cli/src/__tests__/fix-command.test.ts',
-  'packages/dag-cli/src/__tests__/from-mermaid-command.test.ts',
-  'packages/dag-cli/src/__tests__/misc-commands.test.ts',
-  'packages/dag-cli/src/__tests__/run-utilities.test.ts',
-  'packages/dag-cli/src/__tests__/runner-cli.test.ts',
-  'packages/dag-cli/src/__tests__/studio-http-server.test.ts',
-  'packages/dag-nodes/gemini-image-edit/src/runtime-core.test.ts',
-  'packages/dag-nodes/instant-node/src/__tests__/index.test.ts',
-  'packages/dag-nodes/llm-text/src/index.test.ts',
 ]);
 
 async function* walkTestFiles(dir) {
@@ -98,14 +102,84 @@ async function* walkTestFiles(dir) {
 }
 
 /**
+ * Slice out the whole `vi.mock(...)` call starting at `startIndex` by matching parentheses,
+ * skipping over string/template literals and comments so a paren inside them cannot unbalance the
+ * count. Falls back to the rest of the file if the call is never closed (unparseable source).
+ *
+ * A fixed character window used to truncate long factories before their spread, misreporting a
+ * correct partial mock as hardcoded.
+ *
+ * @param {string} content full file text
+ * @param {number} startIndex index of the `vi.mock(` match
+ * @returns {string} the source of the call, including the closing paren
+ */
+export function extractMockCall(content, startIndex) {
+  const openParen = content.indexOf('(', startIndex);
+  if (openParen === -1) return content.slice(startIndex);
+
+  let depth = 0;
+  for (let i = openParen; i < content.length; i += 1) {
+    const ch = content[i];
+
+    if (ch === '/' && content[i + 1] === '/') {
+      const nl = content.indexOf('\n', i);
+      i = nl === -1 ? content.length : nl;
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '*') {
+      const end = content.indexOf('*/', i + 2);
+      i = end === -1 ? content.length : end + 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const quote = ch;
+      i += 1;
+      while (i < content.length && content[i] !== quote) {
+        if (content[i] === '\\') i += 1;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '(') depth += 1;
+    else if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return content.slice(startIndex, i + 1);
+    }
+  }
+  return content.slice(startIndex);
+}
+
+/**
+ * Does this factory spread the REAL module into its result?
+ *
+ * Accepts the inline form (`...(await importOriginal())`) and the bound form
+ * (`const actual = await vi.importActual(...)` … `...actual`). Merely *calling* an original-import
+ * helper is not enough: a factory that loads the original and then drops it severs exports exactly
+ * like a hardcoded one.
+ *
+ * @param {string} factory source of the `vi.mock(...)` call
+ * @returns {boolean}
+ */
+export function spreadsOriginalModule(factory) {
+  if (!ORIGINAL_IMPORT_PATTERN.test(factory)) return false;
+  if (INLINE_SPREAD_PATTERN.test(factory)) return true;
+
+  for (const binding of factory.matchAll(ORIGINAL_BINDING_PATTERN)) {
+    const identifier = binding[1];
+    if (new RegExp(String.raw`\.\.\.\s*${identifier}\b`).test(factory)) return true;
+  }
+  return false;
+}
+
+/**
  * Classify one file's content.
  * @returns {Array<{ module: string, line: number }>} hardcoded workspace-mock factories found.
  */
 export function findHardcodedModuleMocks(content) {
   const violations = [];
   for (const match of content.matchAll(MOCK_PATTERN)) {
-    const window = content.slice(match.index, match.index + FACTORY_WINDOW_CHARS);
-    if (window.includes('importOriginal')) continue;
+    if (spreadsOriginalModule(extractMockCall(content, match.index))) continue;
     const lineStart = content.lastIndexOf('\n', match.index) + 1;
     const lineEnd = content.indexOf('\n', match.index);
     const line = content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
@@ -118,17 +192,47 @@ export function findHardcodedModuleMocks(content) {
   return violations;
 }
 
+/**
+ * Allowlist entries that no longer earn their place: the file is clean now, or it is gone.
+ *
+ * HARNESS-025: without this, a fixed file keeps its allowlist entry forever and the burn-down count
+ * silently overstates the remaining work — which is exactly how 20 already-correct files stayed
+ * pinned. An allowlist that can only shrink keeps the count honest.
+ *
+ * @param {Iterable<string>} allowlist allowlisted repo-relative paths
+ * @param {Map<string, Array<unknown>>} violationsByFile violations per scanned file; a path absent
+ *   from the map was not found on disk, which is stale for the same reason
+ * @returns {string[]} sorted stale entries
+ */
+export function findStaleAllowlistEntries(allowlist, violationsByFile) {
+  return [...allowlist].filter((entry) => (violationsByFile.get(entry) ?? []).length === 0).sort();
+}
+
 export async function main() {
   const findings = [];
+  /** file → its violations, for every test file actually present on disk. */
+  const violationsByFile = new Map();
   for (const rootDir of SCAN_ROOTS) {
     for await (const file of walkTestFiles(path.join(WORKSPACE_ROOT, rootDir))) {
       const relative = path.relative(WORKSPACE_ROOT, file);
-      if (ALLOWLIST.has(relative)) continue;
       const content = await fs.readFile(file, 'utf8');
-      for (const violation of findHardcodedModuleMocks(content)) {
+      const violations = findHardcodedModuleMocks(content);
+      violationsByFile.set(relative, violations);
+      if (ALLOWLIST.has(relative)) continue;
+      for (const violation of violations) {
         findings.push({ file: relative, ...violation });
       }
     }
+  }
+
+  const stale = findStaleAllowlistEntries(ALLOWLIST, violationsByFile);
+  if (stale.length > 0) {
+    process.stdout.write(
+      'test-module-mocks scan failed — stale ALLOWLIST entries (file is clean or gone; delete the entry):\n',
+    );
+    for (const entry of stale) process.stdout.write(`  - ${entry}\n`);
+    process.exitCode = 1;
+    return;
   }
 
   if (findings.length === 0) {


### PR DESCRIPTION
Executes `HARNESS-025` (test-hygiene P3) and `MOCK-001` (hardcoded workspace-mock burn-down) together, since HARNESS-025 item 2 *is* the MOCK-001 burn-down check.

Every finding was re-verified against current code before acting — two of them turned out to be measurement bugs rather than test defects.

## The headline finding

The `test-module-mocks` scan reported **32** allowlisted violations. Only **12** were real. Two detection gaps produced the other 20:

1. It recognized only the literal `importOriginal`, so the equally-correct `const actual = await vi.importActual(m); return { ...actual, x }` form read as a hardcoded factory.
2. It searched a fixed 600-character window past `vi.mock(`, so a long factory pushed its spread out of view.

Both are fixed: the factory is now delimited by **balanced parentheses** (skipping strings and comments), and both original-import spellings are accepted.

The check is also **tightened**, not merely widened. What makes a factory safe is that the real module is *spread* — not that an import helper was called. A factory that loads the original and then drops it severs exports exactly like a hardcoded one, and the old check passed it.

## Mock burn-down: 32 → 3

| | Count |
|---|---|
| Before | 32 |
| Cleared by the detector fix (already-correct partial mocks, no test changed) | 20 |
| Cleared by real conversions (12 factories across 7 files) | 9 |
| **After** | **3** |

The 3 remaining are genuine hardcoded factories, deferred **only** on ownership (ARCH-005 S2 owns `agent-cli` / `agent-framework`) — not because they are load-bearing.

None of the conversions needed the `allow-module-mock` escape: spreading the real module works even for the provider-SDK cases, because the constructors those tests intercept are exactly what the override replaces. `instant-node`'s agent-core mock now exposes 149 real exports where the hardcoded factory exposed 1.

**Anti-rot guard added**: an allowlist entry whose file is now clean (or gone) fails the scan. The allowlist can only shrink, so a stale entry can never again inflate the count — which is precisely how 20 already-correct files stayed pinned.

## HARNESS-025 items

**PTY temp HOME — fixed.** `agent-testing` gains `createPtyEnv` / `createIsolatedHome` / `disposeIsolatedHomes`. Every PTY child gets an empty throwaway HOME, **including `spawnPty`'s default env**, so the leak cannot return via a caller who omits `env`. Red-first proof — restoring the old default fails the new self-test:

```
× PTY HOME isolation > does not hand the real HOME to a child when no env is supplied
  → expected '/home/ubuntu' not to be '/home/ubuntu'
```

**Cache TTL fake timers — fixed.** `apps/agent-web` uses Jest, so `jest.useFakeTimers()`. Both cases also gained a *before-expiry* assertion, so they now pin the TTL **boundary** rather than only its far side. Red-first, two independent mutations of `SimpleCache`:

```
get() expiry disabled     → ● expires values after TTL — Received: "value1"
cleanup() over-evicts     → ● cleans up expired entries — Expected: 2 / Received: 0
```

**env → `vi.stubEnv` — done for every owned package.** 19 files / ~110 sites. Four *latent leaks* fell out of the mechanical conversion:

- `dag-cli/init-command` restored `CI` from a possibly-`undefined` value — Node coerces that to the string `"undefined"`, leaking a **truthy** `CI` into every later test.
- `dag-cli/runner-cli` deleted `CI` and never restored it.
- `dag-cli/describe-command` set `ANTHROPIC_API_KEY` with no `afterEach` at all.
- `agent-tools/web-search-{tool,provider}` used `stubEnv` but never unstubbed, leaking `BRAVE_API_KEY`.

## Deliberately not changed

The **300ms PTY sleeps** are load-bearing: they pace a real child process through a real pseudo-terminal. Fake timers cannot advance another process's clock, so converting them would break the test, not harden it.

## Deferred on ownership

- 3 mock allowlist entries (`agent-cli` ×1, `agent-framework` ×2)
- 19 env-mutation files (`agent-cli` ×8, `agent-framework` ×10, `agent-executor` ×1) — several swap `process.env.HOME` by hand, the same conditional-flake class the PTY work just removed

Both backlog items stay **open** with these remainders recorded honestly; neither is archived.

## Verification

- **No assertion weakened.** Every suite's file and test counts match the pre-change baseline exactly: `dag-cli` 63/1007, `dag-nodes` 351 across 20 packages, `agent-transport-tui` 69/526 (all 3 PTY suites), `agent-core` 904, `agent-command` 244, `agent-tools` 202, `dag-framework` 107, `agent-testing` 6/6, `agent-web` 8/8.
- `node scripts/harness/run-all-scans.mjs` → **all 61 scans passed**
- `pnpm -w typecheck` → clean
- Scan unit tests **18/18**, including 4 new cases pinning the anti-rot guard and 3 pinning the detector gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z