### PR TITLE
fix(workflows): WORKFLOW-005 P3 — unify the /workflows subcommand surface

### DIFF
--- a/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
+++ b/.agents/backlog/WORKFLOW-005-complete-workflows-track.md
@@ -267,4 +267,64 @@ through `/workflows` + WORKFLOW-004 build).
   this inconsistency needs an explicit OWNER decision on phasing/sandboxing before implementation. Do NOT
   build it until confirmed.
 
-- **P3 surface-unification (expose create/save/build through `/workflows`) — deferred (unchanged).**
+## P3 progress log
+
+- **Surface unification — DONE (2026-07-25).** P3's original wording ("expose create/save/build
+  through `/workflows` + WORKFLOW-004 build") was **already satisfied for the exposure half** by the
+  time it was picked up: `create` shipped with FLOW-007 P4 and `build` shipped with WORKFLOW-004
+  (#1358). Assessment against the code found the remaining P3 work was not _exposure_ but genuine
+  **unification** — the six subcommands had drifted into six ad-hoc executors. What was exposed vs
+  what was missing:
+
+  | Verb       | Exposed before P3?               | Gap found                                                 |
+  | ---------- | -------------------------------- | --------------------------------------------------------- |
+  | `create`   | ✅ (FLOW-007 P4)                 | owned a private copy of the authoring pipeline            |
+  | `build`    | ✅ (WORKFLOW-004 #1358)          | ~90-line verbatim copy of `create`'s pipeline             |
+  | `save`     | ✅ transitively (create + build) | no standalone verb needed — see below                     |
+  | `list`     | ✅                               | **blind to workspace-saved instant nodes**                |
+  | `catalog`  | ✅                               | none                                                      |
+  | `validate` | ✅                               | **blind to workspace-saved nodes** + raw, ungrammared arg |
+  | `run`      | ✅                               | raw, ungrammared arg                                      |
+
+  Four seams now have exactly one owner (`packages/agent-command-workflows/docs/SPEC.md` §"One
+  surface, four shared seams"):
+  - **Node catalog** (`src/workspace-runtime.ts`) — the headline **bug**: `create`/`build`/`run`
+    reloaded `<root>/nodes/`, but `validate` and `list` built a bare provider. So `build`'s own
+    printed hand-off "Next steps: `/workflows validate <path>`" **failed** with
+    `unknown node type "<authored-node>"` for every workflow `build` authored with a `newNodes`
+    prompt node, and `list` hid the nodes the user had just created. One provider factory now serves
+    `list`/`validate`/`run`, so the catalog a workflow is validated against is the one it runs against.
+  - **Argument grammar** (`src/args.ts`) — the quote-aware tokenizer was private to `create`/`build`;
+    `validate`/`run` took the arg raw, so a quoted path was opened verbatim and surplus tokens were
+    folded into the filename (`ENOENT: 'a.json b.json'`). `parseFileArg` now serves both.
+  - **Subcommand registry** (`src/subcommands.ts`) — list, hints, usage block and every
+    per-subcommand `Usage:` line derive from one array (`validate` advertised `<file.json>` while
+    emitting `<file.dag.json>`). Two mechanical anti-drift guards: an advertised verb cannot be
+    unroutable; a hint cannot drift from its usage line.
+  - **Authoring pipeline** (`src/authoring/pipeline.ts`) — `create` and `build` now share
+    `authorAndSaveWorkflow`; `create` alone adds the run step.
+  - **`save` assessed, deliberately NOT added as a verb.** Persisting is not a user-facing operation
+    on this surface: `create`/`build` both end in a save and `list`/`catalog` read it back. A
+    standalone `save <json>` would be an _import_ of externally-supplied graph/node data — a new
+    capability (dag-cli's MCP `dag_import` / `dag_instant_node_save` already cover the MCP-side
+    need), outside P3's intent. Recorded in the package SPEC.
+  - **WORKFLOW-004 contract intact and now proven twice**: the runtime execute-canary (0 calls) plus
+    a new **static import guard** that neither `build-command.ts` nor the shared pipeline imports the
+    execution module — so no module on `build`'s import path can construct a DAG runtime, for any
+    input, not just the tested ones.
+  - **TDD**: red-first. The 4 new `surface-unification.test.ts` cases were verified RED for the right
+    reasons before the fix (`unknown node type "pirate-speak"`; `pirate-speak` absent from `list`;
+    quoted path rejected; surplus args swallowed into the path). Both anti-drift guards were proven
+    to bite by temporarily introducing the drift each guards against. The pipeline dedupe is
+    behavior-preserving — the pre-existing `create`/`build` suites (incl. the non-execution canary)
+    stayed green across it.
+  - Verification: `pnpm harness:verify-like-ci` **PASS (4/4 stages)**; `pnpm -w typecheck` clean;
+    suites green — agent-command-workflows 45 (was 37), dag-framework 107, dag-cli 1007,
+    agent-cli 248. Package lint warnings 29 → 24. No changeset (`private: true`).
+  - Branch: `feat/workflow-005-p3-surface-unification`.
+
+**WORKFLOW-005 status: P1 ✅, P2 ✅ (except Phase C), P3 ✅. The item stays OPEN for exactly one
+thing — instant-node Phase C (arbitrary code node via API), which is OWNER-GATED (see the P2 log
+entry above), not deferred by engineering judgement.** Everything in the item that is not
+owner-gated is now done; archive it once the owner rules on Phase C's phasing/sandboxing (or drops
+it).

--- a/packages/agent-command-workflows/docs/SPEC.md
+++ b/packages/agent-command-workflows/docs/SPEC.md
@@ -21,13 +21,42 @@ inside the agent CLI by composing `@robota-sdk/dag-framework` in-process. Owns t
 
 A bridge package. `createWorkflowsCommandModule({ workspace?, providerDefinitions? })` returns an
 `ICommandModule` whose `ISystemCommand.execute` parses a leading subcommand token and dispatches to an
-executor. Read/run executors construct a `LocalDagRuntimeProvider` (default node registry) from
-`dag-framework` and return an `ICommandResult`. No state is held; providers are created per invocation.
+executor. Executors return an `ICommandResult`. No state is held; providers are created per invocation.
 
-### NL authoring pipeline (`create`, FLOW-007)
+### One surface, four shared seams (WORKFLOW-005 P3)
 
-`/workflows create "<description>" [--input k=v] [--name <name>]` runs a deterministic pipeline where
-the LLM only **authors** and the runtime **executes**:
+The six subcommands are one surface, not six ad-hoc executors. Everything a subcommand shares with
+its siblings has exactly one owner module:
+
+| Seam                | Owner                       | Consumers                                                       |
+| ------------------- | --------------------------- | --------------------------------------------------------------- |
+| Subcommand registry | `src/subcommands.ts`        | the module's `ICommand[]`, the usage block, every `Usage:` line |
+| Argument grammar    | `src/args.ts`               | `parseFileArg` (`validate`/`run`), `tokenize` (authoring args)  |
+| Node catalog        | `src/workspace-runtime.ts`  | `list`, `validate`, `run`                                       |
+| Authoring pipeline  | `src/authoring/pipeline.ts` | `create`, `build`                                               |
+
+- **Subcommand registry.** `WORKFLOWS_SUBCOMMANDS` is the SSOT for the subcommand list, each
+  `argumentHint`, the `/workflows` usage block (`renderWorkflowsUsage()`), and the per-subcommand
+  `Usage:` line an executor emits on a bad argument (`subcommandUsage(name)`) — a hint and its usage
+  text cannot drift apart, and an advertised verb cannot be unroutable (both mechanically tested).
+- **Argument grammar.** One quote-aware tokenizer serves both shapes: the authoring subcommands
+  (`parseAuthoringArgs` — description + `--input`/`--name`) and the file-taking subcommands
+  (`parseFileArg` — exactly one quote-aware path). `validate`/`run` therefore accept a quoted path
+  and reject surplus/unknown tokens with their usage line instead of folding them into the path.
+- **Node catalog.** `createWorkspaceRuntime(cwd, layout)` is the ONLY place a
+  `LocalDagRuntimeProvider` is constructed for a workspace: built-in registry **plus** the instant
+  nodes saved under `<root>/nodes/`. So the catalog a workflow is _validated_ and _listed_ against is
+  exactly the catalog it _runs_ against. (Before P3, `validate` and `list` built a bare provider and
+  were blind to the workspace's own nodes — which made `build`'s "Next steps: /workflows validate
+  `<path>`" hand-off fail with `unknown node type` for every workflow `build` authored with a
+  `newNodes` prompt node.) `list` marks the saved ones `[saved in <root>/nodes]`.
+- **Authoring pipeline.** See below.
+
+### NL authoring pipeline (`create` + `build`, FLOW-007 / WORKFLOW-004)
+
+`authoring/pipeline.ts` owns the whole author→save half, shared verbatim by BOTH authoring
+subcommands (P3 — previously each carried its own copy of these steps, free to diverge). The LLM only
+**authors**; the runtime **executes**:
 
 1. **Node catalog** — `createDefaultNodeRegistrySync()` (+ any prompt nodes already saved under
    `<root>/nodes/`) → `INodeManifest[]` via `buildNodeDefinitionAssembly` (`@robota-sdk/dag-node`).
@@ -39,8 +68,10 @@ the LLM only **authors** and the runtime **executes**:
    `<root>/nodes/<type>.node.json` and reusable on later `create`s.
 4. **Assemble** — `buildDagFromPipeline` (`@robota-sdk/dag-builder`) → `IDagDefinition`; the resolved
    run input is baked into the `input` node so the artifact is self-contained.
-5. **Save + run** — the legible `IDagDefinition` is written flat to `<root>/<name><ext>` and executed
-   in-process; `run`/`create` convert it to the runtime workflow-file format via `toDagWorkflowFile`.
+5. **Save** — the legible `IDagDefinition` is written flat to `<root>/<name><ext>`. This is where the
+   shared pipeline ends and the two subcommands diverge: `create` then executes the definition
+   in-process (converting to the runtime workflow-file format via `toDagWorkflowFile`); `build`
+   stops and reports the saved path.
 
 The `workflows` command is **model-invocable** (FLOW-007 Phase 4): the agent can author + run a
 workflow from a chat request.
@@ -48,14 +79,16 @@ workflow from a chat request.
 ### Author-without-run (`build`, WORKFLOW-004)
 
 `/workflows build "<description>" [--input k=v] [--name <name>]` is the **generate-for-review**
-counterpart to `create`: the SAME authoring pipeline (steps 1–4 above, identical arg grammar via the
-shared `parseCreateArgs`) but it stops at **save** — author → parse/validate → assemble → bake input →
-persist prompt nodes + workflow — and reports the saved path with the explicit next steps
-(`/workflows validate <path>`, `/workflows run <path>`). **`build` never executes**: it does not
-import `authoring/execute-workflow.ts`, so no DAG runtime is constructed and no node (LLM or
-side-effecting) runs. Failures before assembly leave nothing on disk (no provider / invalid or
-unassemblable spec → failed `ICommandResult`, fs untouched). `build` is model-invocable — strictly
-less privileged than `create` (it cannot execute anything).
+counterpart to `create`: literally the same `authorAndSaveWorkflow` call (same arg grammar, same
+provider seam, same catalog, same persistence) — it just stops there and reports the saved path with
+the explicit next steps (`/workflows validate <path>`, `/workflows run <path>`), which now succeed
+even when the artifact uses a node `build` itself authored (P3 shared catalog). **`build` never
+executes**: neither `build-command.ts` nor the shared `authoring/pipeline.ts` imports
+`authoring/execute-workflow.ts`, so no module on `build`'s import path can construct a DAG runtime —
+enforced by a static import guard AND the runtime execute-canary. Failures before assembly leave
+nothing on disk (no provider / invalid or unassemblable spec → failed `ICommandResult`, fs
+untouched). `build` is model-invocable — strictly less privileged than `create` (it cannot execute
+anything).
 
 **Provider seam (the WORKFLOW-004 decision):** both authoring subcommands share ONE seam — deps
 injected at the composition root (`IWorkflowsCommandModuleDeps.providerDefinitions`), the provider
@@ -81,9 +114,14 @@ required, `create` and `build` migrate together in one follow-up.
 | `WorkflowsCommandSource`               | class     | `ICommandSource` exposing the `workflows` command.                                                                       |
 | `executeWorkflowsCreate`               | function  | Executor for `/workflows create` (NL authoring + run).                                                                   |
 | `executeWorkflowsBuild`                | function  | Executor for `/workflows build` (NL authoring + save — never executes).                                                  |
-| `IWorkflowsCreateDeps`                 | interface | Authoring seam (shared by `create`/`build`): `workspace?`, `providerDefinitions?`, `resolveProvider?`, `model?`, `now?`. |
-| `parseCreateArgs`                      | function  | Parse `create`/`build` args (description + `--input`/`--name` — shared grammar).                                         |
-| `executeWorkflowsList`                 | function  | Executor for `/workflows list`.                                                                                          |
+| `IWorkflowsAuthoringDeps`              | interface | Authoring seam (shared by `create`/`build`): `workspace?`, `providerDefinitions?`, `resolveProvider?`, `model?`, `now?`. |
+| `parseAuthoringArgs`                   | function  | Parse `create`/`build` args (description + `--input`/`--name` — shared grammar).                                         |
+| `IParsedAuthoringArgs`                 | interface | Result of `parseAuthoringArgs`: `description`, `nameOverride?`, `inputs`.                                                |
+| `WORKFLOWS_SUBCOMMANDS`                | const     | The subcommand registry (SSOT for names, hints, descriptions, model-invocability).                                       |
+| `IWorkflowsSubcommand`                 | interface | One registry entry.                                                                                                      |
+| `subcommandUsage`                      | function  | The `Usage: /workflows <name> <hint>` line for one subcommand, derived from the registry.                                |
+| `renderWorkflowsUsage`                 | function  | The multi-line `/workflows` usage block, derived from the registry.                                                      |
+| `executeWorkflowsList`                 | function  | Executor for `/workflows list <cwd>` (built-ins + workspace-saved nodes).                                                |
 | `executeWorkflowsRun`                  | function  | Executor for `/workflows run <file>`.                                                                                    |
 | `AGENT_COMMAND_WORKFLOWS_PACKAGE_NAME` | const     | Package-name constant.                                                                                                   |
 
@@ -92,6 +130,13 @@ The `workflows` command dispatches six first-class subcommands (in `workflows-co
 (`executeWorkflowsCatalog`, `executeWorkflowsValidate`) are **internal** — dispatched inside the module
 but not re-exported from the package root (`src/index.ts`) — so they are part of the command surface,
 not the public API. Only `create`/`build`/`list`/`run` executors are root-exported (above).
+
+**Not exposed as a subcommand: a standalone `save`.** Persisting is not a user-facing verb on this
+surface — `create` and `build` both end in a save (`persistence/workspace-writer.ts`), and
+`list`/`catalog` read back what they wrote. A separate `save <json>` verb would be an _import_ of
+externally-supplied graph/node data, i.e. a new capability (and the dag-cli MCP toolset's
+`dag_import` / `dag_instant_node_save` already cover the MCP-side need), not part of P3's
+surface-unification intent.
 
 ## Extension Points
 
@@ -108,7 +153,15 @@ swallowed; no fallback to a default workflow.
 
 `src/__tests__/workflows-command-module.test.ts` covers: module shape + slash-free name + subcommands
 (incl. `create`); model-invocability (Phase 4); `list` dispatch; usage/unknown-subcommand handling;
-`run` usage error; catalog/validate.
+`run` usage error; catalog/validate. Plus two P3 **anti-drift guards** over the subcommand SSOT:
+every registered subcommand is actually dispatched (no advertised-but-unroutable verb), and every
+registered `argumentHint` is advertised verbatim AND matches the `Usage:` line derived for it.
+
+`src/__tests__/surface-unification.test.ts` (WORKFLOW-005 P3) covers the two cross-subcommand
+invariants: **one catalog** — a workflow `build` authored with a `newNodes` prompt node validates
+cleanly (it previously failed `unknown node type` on the node `build` had just saved) and `list`
+shows the workspace-saved node alongside the built-ins; **one grammar** — `validate`/`run` accept a
+quoted path and reject surplus arguments with their usage line instead of folding them into the path.
 
 `src/__tests__/create-command.test.ts` covers the authoring pipeline with an **injected provider
 stub** (deterministic): arg parsing; spec validation (incl. Markdown code-fence tolerance); TC-02
@@ -120,8 +173,10 @@ detected/surfaced (never silently tolerated, never a real LLM call in the unit s
 
 `src/__tests__/build-command.test.ts` covers `build` with the same injected provider stub:
 author→save with NO run output and a **mechanical non-execution canary** (the `dag-framework`
-runtime execute path is spied and asserted at 0 calls); the saved artifact round-trips through the
-existing `validate` and `run` executors; invalid/unassemblable spec → failed result + fs untouched;
+runtime execute path is spied and asserted at 0 calls) plus a **static import guard** proving neither
+`build-command.ts` nor the shared `authoring/pipeline.ts` imports the execution module (the canary
+proves it for the tested runs; the guard proves it for all inputs); the saved artifact round-trips
+through the existing `validate` and `run` executors; invalid/unassemblable spec → failed result + fs untouched;
 no provider → actionable error + no write; `newNodes` manifests persisted inert under
 `<root>/nodes/` without execution.
 
@@ -161,7 +216,7 @@ None.
 | `agent-framework` command contracts + `createProviderFromSettings` | this module    | `src/`                                                                                                          |
 | `agent-core` `IAIProvider` + message factories                     | authoring      | `src/authoring/author.ts`                                                                                       |
 | `dag-core` workflow-file/node/definition + workspace-layout types  | this module    | `src/run-command.ts`, `src/validate-command.ts`, `src/catalog-command.ts`, `src/authoring/`, `src/persistence/` |
-| `dag-framework` `LocalDagRuntimeProvider` + registry               | executors      | `src/list-command.ts`, `src/run-command.ts`, `src/authoring/execute-workflow.ts`                                |
+| `dag-framework` `LocalDagRuntimeProvider` + registry               | executors      | `src/workspace-runtime.ts`, `src/authoring/execute-workflow.ts`, `src/persistence/instant-node-loader.ts`       |
 | `dag-builder` `buildDagFromPipeline` / converters                  | assembly + run | `src/authoring/assemble.ts`, `src/run-command.ts`                                                               |
 | `dag-node` `buildNodeDefinitionAssembly`                           | node catalog   | `src/authoring/node-catalog.ts`                                                                                 |
-| `dag-node-instant-node` prompt-node factory                        | Phase 3 nodes  | `src/create-command.ts`, `src/persistence/instant-node-loader.ts`                                               |
+| `dag-node-instant-node` prompt-node factory                        | Phase 3 nodes  | `src/authoring/pipeline.ts`, `src/persistence/instant-node-loader.ts`                                           |

--- a/packages/agent-command-workflows/src/__tests__/build-command.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/build-command.test.ts
@@ -14,7 +14,7 @@ import type { IAIProvider } from '@robota-sdk/agent-core';
 import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
 
 import { executeWorkflowsBuild } from '../build-command.js';
-import type { IWorkflowsCreateDeps } from '../create-command.js';
+import type { IWorkflowsAuthoringDeps } from '../authoring/args.js';
 import { executeWorkflowsRun } from '../run-command.js';
 import { executeWorkflowsValidate } from '../validate-command.js';
 
@@ -45,12 +45,34 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-function baseDeps(specJson: string): IWorkflowsCreateDeps {
+function baseDeps(specJson: string): IWorkflowsAuthoringDeps {
   return {
     resolveProvider: () => stubProvider(specJson),
     now: () => '2026-07-25T00:00:00.000Z',
   };
 }
+
+describe('build never-executes: static import guard (WORKFLOW-004 × P3)', () => {
+  /**
+   * `build` shares the authoring pipeline with `create` (WORKFLOW-005 P3). The runtime canary below
+   * proves no execution happened in these runs; this proves it structurally for ALL inputs — no
+   * module on `build`'s import path can construct a DAG runtime, because none of them imports
+   * `authoring/execute-workflow.ts`. Fails the moment the shared pipeline grows an execution step.
+   */
+  it('neither build-command nor the shared pipeline imports the DAG execution module', async () => {
+    const srcDir = join(import.meta.dirname, '..');
+    for (const file of ['build-command.ts', 'authoring/pipeline.ts']) {
+      const source = await readFile(join(srcDir, file), 'utf-8');
+      const imports = [...source.matchAll(/^\s*import\s[^;]*?from\s+'([^']+)'/gm)].map((m) => m[1]);
+      expect(imports, `${file} must not import the DAG execution module`).not.toContain(
+        './authoring/execute-workflow.js',
+      );
+      expect(imports, `${file} must not import the DAG execution module`).not.toContain(
+        './execute-workflow.js',
+      );
+    }
+  });
+});
 
 describe('executeWorkflowsBuild (TC-01: author + save, never execute)', () => {
   it('saves .workflows/<name>.json, reports the path + next steps, and produces NO run output', async () => {

--- a/packages/agent-command-workflows/src/__tests__/create-command.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/create-command.test.ts
@@ -4,11 +4,8 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAssistantMessage } from '@robota-sdk/agent-core';
 import type { IAIProvider } from '@robota-sdk/agent-core';
-import {
-  executeWorkflowsCreate,
-  parseCreateArgs,
-  type IWorkflowsCreateDeps,
-} from '../create-command.js';
+import { executeWorkflowsCreate } from '../create-command.js';
+import { parseAuthoringArgs, type IWorkflowsAuthoringDeps } from '../authoring/args.js';
 import { parseAuthoredSpec } from '../authoring/spec.js';
 import { executeWorkflowsRun } from '../run-command.js';
 
@@ -35,16 +32,16 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-function baseDeps(specJson: string): IWorkflowsCreateDeps {
+function baseDeps(specJson: string): IWorkflowsAuthoringDeps {
   return {
     resolveProvider: () => stubProvider(specJson),
     now: () => '2026-07-06T00:00:00.000Z',
   };
 }
 
-describe('parseCreateArgs', () => {
+describe('parseAuthoringArgs', () => {
   it('takes a quoted description and repeatable --input', () => {
-    const r = parseCreateArgs('"uppercase the text" --input text="hi there" --name foo');
+    const r = parseAuthoringArgs('"uppercase the text" --input text="hi there" --name foo');
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.value.description).toBe('uppercase the text');
@@ -53,19 +50,19 @@ describe('parseCreateArgs', () => {
   });
 
   it('treats leading unquoted words as the description', () => {
-    const r = parseCreateArgs('summarize my input then translate');
+    const r = parseAuthoringArgs('summarize my input then translate');
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.value.description).toBe('summarize my input then translate');
   });
 
   it('errors on an empty description', () => {
-    const r = parseCreateArgs('   ');
+    const r = parseAuthoringArgs('   ');
     expect(r.ok).toBe(false);
   });
 
   it('errors on a malformed --input', () => {
-    const r = parseCreateArgs('desc --input nope');
+    const r = parseAuthoringArgs('desc --input nope');
     expect(r.ok).toBe(false);
   });
 });

--- a/packages/agent-command-workflows/src/__tests__/surface-unification.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/surface-unification.test.ts
@@ -1,0 +1,128 @@
+/**
+ * WORKFLOW-005 P3 — surface unification across the `/workflows` subcommands.
+ *
+ * Two invariants the six subcommands must share:
+ *
+ * 1. **One node catalog.** `create`/`build`/`run` already reload the workspace-saved instant nodes
+ *    under `<root>/nodes/`; `validate` and `list` must see the SAME catalog. Otherwise `build`'s own
+ *    "Next steps: /workflows validate <path>" hand-off fails for every workflow `build` authored with
+ *    a `newNodes` prompt node, and `list` hides the nodes the user just created.
+ * 2. **One argument grammar.** The file-taking subcommands (`validate`, `run`) must parse their
+ *    argument with the same quote-aware tokenizer `create`/`build` use, and reject surplus/unknown
+ *    tokens explicitly instead of folding them into the path.
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAssistantMessage } from '@robota-sdk/agent-core';
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+import { executeWorkflowsBuild } from '../build-command.js';
+import type { IWorkflowsAuthoringDeps } from '../authoring/args.js';
+import { executeWorkflowsList } from '../list-command.js';
+import { executeWorkflowsRun } from '../run-command.js';
+import { executeWorkflowsValidate } from '../validate-command.js';
+
+/** A provider stub whose `chat` always returns the given JSON string as assistant content. */
+function stubProvider(specJson: string): IAIProvider {
+  return {
+    chat: async () => createAssistantMessage(specJson),
+  } as unknown as IAIProvider;
+}
+
+/** An authored spec that introduces a NEW prompt-backed node (`pirate-speak`). */
+const PIRATE_SPEC = JSON.stringify({
+  name: 'pirate-rewrite',
+  pipeline: [{ nodeType: 'input' }, { nodeType: 'pirate-speak' }, { nodeType: 'text-output' }],
+  newNodes: [
+    {
+      nodeType: 'pirate-speak',
+      displayName: 'Pirate Speak',
+      systemPromptTemplate: 'Rewrite as a pirate: {{text}}',
+      inputPorts: [{ key: 'text' }],
+      outputPort: { key: 'text' },
+      provider: 'anthropic',
+    },
+  ],
+  sampleInput: { text: 'hello' },
+});
+
+const UPPERCASE_SPEC = JSON.stringify({
+  name: 'uppercase-it',
+  pipeline: [{ nodeType: 'input' }, { nodeType: 'text-upper' }, { nodeType: 'text-output' }],
+  sampleInput: { text: 'hello world' },
+});
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'wf-p3-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function baseDeps(specJson: string): IWorkflowsAuthoringDeps {
+  return {
+    resolveProvider: () => stubProvider(specJson),
+    now: () => '2026-07-25T00:00:00.000Z',
+  };
+}
+
+describe('P3-A: one node catalog across subcommands', () => {
+  it('validates a workflow that `build` authored with a new prompt node', async () => {
+    const built = await executeWorkflowsBuild('"rewrite as a pirate"', dir, baseDeps(PIRATE_SPEC));
+    expect(built.success).toBe(true);
+
+    // `build` tells the user to run exactly this; it must not fail on the node build just saved.
+    const savedPath = join(dir, '.workflows', 'pirate-rewrite.json');
+    const validated = await executeWorkflowsValidate(savedPath, dir);
+    expect(validated.message).not.toContain('unknown node type');
+    expect(validated.success).toBe(true);
+  });
+
+  it('lists workspace-saved instant nodes alongside the built-in node catalog', async () => {
+    const built = await executeWorkflowsBuild('"rewrite as a pirate"', dir, baseDeps(PIRATE_SPEC));
+    expect(built.success).toBe(true);
+
+    const listed = await executeWorkflowsList(dir);
+    expect(listed.success).toBe(true);
+    expect(listed.message).toContain('pirate-speak');
+  });
+
+  it('still lists the built-in nodes when the workspace has no saved nodes', async () => {
+    const listed = await executeWorkflowsList(dir);
+    expect(listed.success).toBe(true);
+    expect(listed.message).toContain('input');
+  });
+});
+
+describe('P3-B: one argument grammar across subcommands', () => {
+  it('accepts a quoted file argument for `validate` and `run` (same tokenizer as create/build)', async () => {
+    const built = await executeWorkflowsBuild(
+      '"uppercase the text" --input text=hi',
+      dir,
+      baseDeps(UPPERCASE_SPEC),
+    );
+    expect(built.success).toBe(true);
+    const savedPath = join(dir, '.workflows', 'uppercase-it.json');
+
+    const validated = await executeWorkflowsValidate(`"${savedPath}"`, dir);
+    expect(validated.success).toBe(true);
+
+    const ran = await executeWorkflowsRun(`"${savedPath}"`, dir);
+    expect(ran.success).toBe(true);
+    expect(ran.message).toContain('HI');
+  });
+
+  it('rejects surplus arguments instead of folding them into the file path', async () => {
+    const validated = await executeWorkflowsValidate('a.json b.json', dir);
+    expect(validated.success).toBe(false);
+    expect(validated.message).toContain('Usage: /workflows validate');
+
+    const ran = await executeWorkflowsRun('a.json --input text=hi', dir);
+    expect(ran.success).toBe(false);
+    expect(ran.message).toContain('Usage: /workflows run');
+  });
+});

--- a/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
@@ -6,6 +6,7 @@ import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
 import { describe, expect, it } from 'vitest';
 
 import { executeWorkflowsCatalog } from '../catalog-command.js';
+import { subcommandUsage, WORKFLOWS_SUBCOMMANDS } from '../subcommands.js';
 import { executeWorkflowsValidate } from '../validate-command.js';
 import { createWorkflowsCommandModule } from '../workflows-command-module.js';
 
@@ -68,6 +69,33 @@ describe('workflows command module', () => {
     const cmd = workflowsCommand();
     expect((await cmd.execute(FAKE_CONTEXT, '')).message).toContain('Usage');
     expect((await cmd.execute(FAKE_CONTEXT, 'bogus')).success).toBe(false);
+  });
+
+  // WORKFLOW-005 P3 anti-drift: `subcommands.ts` is the SSOT for the surface. Every registered
+  // subcommand must be dispatched (no advertised-but-unroutable verb), every registered
+  // argumentHint must match the `Usage:` line its executor emits, and the hint must be advertised
+  // to the CLI verbatim.
+  it('dispatches every registered subcommand (no advertised-but-unroutable verb)', async () => {
+    const cmd = workflowsCommand();
+    for (const sub of WORKFLOWS_SUBCOMMANDS) {
+      const result = await cmd.execute(FAKE_CONTEXT, sub.name);
+      expect(result.message, `subcommand "${sub.name}" is not dispatched`).not.toContain(
+        'Unknown subcommand',
+      );
+    }
+  });
+
+  it('advertises each subcommand hint verbatim and derives its usage line from it', () => {
+    const advertised = new Map(
+      (workflowsCommand().subcommands ?? []).map((s) => [s.name, s.argumentHint]),
+    );
+    for (const sub of WORKFLOWS_SUBCOMMANDS) {
+      expect(advertised.get(sub.name)).toBe(sub.argumentHint);
+      const expected = sub.argumentHint
+        ? `Usage: /workflows ${sub.name} ${sub.argumentHint}`
+        : `Usage: /workflows ${sub.name}`;
+      expect(subcommandUsage(sub.name)).toBe(expected);
+    }
   });
 
   it('reports a usage error when `run`/`validate` are given no file', async () => {

--- a/packages/agent-command-workflows/src/args.ts
+++ b/packages/agent-command-workflows/src/args.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared argument grammar for every `/workflows` subcommand (WORKFLOW-005 P3).
+ *
+ * One tokenizer serves both argument shapes: the authoring subcommands (`create`/`build`, via
+ * `parseCreateArgs`) and the file-taking subcommands (`validate`/`run`, via `parseFileArg`).
+ * Previously only the authoring pair tokenized, so `validate`/`run` folded quotes and surplus tokens
+ * straight into the path and reported them as a confusing ENOENT.
+ */
+import { subcommandUsage } from './subcommands.js';
+
+/**
+ * Split an argument string into tokens shell-style: unquoted whitespace separates tokens, and
+ * single/double quotes (anywhere, e.g. `key="a b"`) protect whitespace and are stripped.
+ */
+export function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let hasContent = false;
+  let quote: '"' | "'" | null = null;
+
+  for (const ch of input) {
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      else current += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      hasContent = true;
+    } else if (/\s/.test(ch)) {
+      if (hasContent) {
+        tokens.push(current);
+        current = '';
+        hasContent = false;
+      }
+    } else {
+      current += ch;
+      hasContent = true;
+    }
+  }
+  if (hasContent) tokens.push(current);
+  return tokens;
+}
+
+/** Outcome of parsing a subcommand's arguments. */
+export type TParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+/**
+ * Parse the argument of a file-taking subcommand (`validate`, `run`): exactly one token, quote-aware.
+ * Zero tokens or more than one is a usage error — surplus tokens are never folded into the path.
+ */
+export function parseFileArg(argStr: string, subcommand: string): TParseResult<string> {
+  const usage = subcommandUsage(subcommand);
+  const tokens = tokenize(argStr.trim());
+  const file = tokens[0];
+  if (file === undefined) {
+    return { ok: false, error: usage };
+  }
+  if (tokens.length > 1) {
+    return {
+      ok: false,
+      error: `/workflows ${subcommand} takes a single file path, got ${tokens.length} arguments.\n${usage}`,
+    };
+  }
+  return { ok: true, value: file };
+}

--- a/packages/agent-command-workflows/src/authoring/args.ts
+++ b/packages/agent-command-workflows/src/authoring/args.ts
@@ -1,0 +1,75 @@
+/**
+ * The argument grammar and dependency seam shared by both natural-language authoring subcommands,
+ * `/workflows create` and `/workflows build` (WORKFLOW-005 P3). Named for the shared concern
+ * (authoring) rather than for `create`, which merely happened to define them first.
+ */
+import type { IWorkspaceLayout } from '@robota-sdk/dag-core';
+import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
+
+import { tokenize, type TParseResult } from '../args.js';
+
+/** Test/composition seam: where the workspace, the provider and the clock come from. */
+export interface IWorkflowsAuthoringDeps {
+  readonly workspace?: IWorkspaceLayout;
+  readonly providerDefinitions?: readonly IProviderDefinition[];
+  /** Override provider resolution (tests inject a stub). Default: the active provider from settings. */
+  readonly resolveProvider?: (cwd: string) => IAIProvider;
+  /** Model passed to the authoring chat call. Default path resolves it from settings. */
+  readonly model?: string;
+  /** Override the createdAt timestamp for persisted nodes (tests inject a fixed value). */
+  readonly now?: () => string;
+}
+
+export interface IParsedAuthoringArgs {
+  readonly description: string;
+  readonly nameOverride?: string;
+  readonly inputs: Record<string, string>;
+}
+
+/**
+ * Parse authoring args: leading non-flag tokens form the description; then `--input k=v` / `--name`.
+ * Unknown flags are rejected rather than silently ignored.
+ */
+export function parseAuthoringArgs(argStr: string): TParseResult<IParsedAuthoringArgs> {
+  const tokens = tokenize(argStr.trim());
+  const descriptionParts: string[] = [];
+  const inputs: Record<string, string> = {};
+  let nameOverride: string | undefined;
+
+  let i = 0;
+  // Leading non-flag tokens form the description.
+  while (i < tokens.length && !tokens[i]!.startsWith('--')) {
+    descriptionParts.push(tokens[i]!);
+    i += 1;
+  }
+  while (i < tokens.length) {
+    const flag = tokens[i]!;
+    if (flag === '--input') {
+      const pair = tokens[i + 1];
+      if (pair === undefined || pair.startsWith('--')) {
+        return { ok: false, error: '--input requires a key=value argument.' };
+      }
+      const eq = pair.indexOf('=');
+      if (eq <= 0) {
+        return { ok: false, error: `--input must be key=value, got "${pair}".` };
+      }
+      inputs[pair.slice(0, eq)] = pair.slice(eq + 1);
+      i += 2;
+    } else if (flag === '--name') {
+      const next = tokens[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        return { ok: false, error: '--name requires a value.' };
+      }
+      nameOverride = next;
+      i += 2;
+    } else {
+      return { ok: false, error: `Unexpected flag: ${flag}` };
+    }
+  }
+
+  const description = descriptionParts.join(' ').trim();
+  if (description === '') {
+    return { ok: false, error: 'A natural-language description is required.' };
+  }
+  return { ok: true, value: { description, ...(nameOverride ? { nameOverride } : {}), inputs } };
+}

--- a/packages/agent-command-workflows/src/authoring/pipeline.ts
+++ b/packages/agent-command-workflows/src/authoring/pipeline.ts
@@ -1,0 +1,247 @@
+/**
+ * The single natural-language authoring pipeline shared by `/workflows create` and `/workflows
+ * build` (WORKFLOW-005 P3 — previously each subcommand carried its own verbatim copy of these
+ * steps, so a fix to one silently diverged from the other).
+ *
+ * Steps: parse args → resolve the ACTIVE provider → build the node catalog (built-ins + workspace
+ * instant nodes) → author the spec via the provider → validate/parse it → materialize any `newNodes`
+ * as prompt-backed nodes → assemble the DAG → bake the resolved input → persist nodes + workflow.
+ *
+ * **It stops at save.** This module MUST NOT import `authoring/execute-workflow.ts`: `build`'s
+ * never-executes contract (WORKFLOW-004) is proven structurally by the fact that nothing on its
+ * import path can construct a DAG runtime. Execution is `create`'s own final step, added after this
+ * pipeline returns.
+ */
+import { createDefaultNodeRegistrySync } from '@robota-sdk/dag-nodes-default';
+import {
+  createProviderFromSettings,
+  ProviderConfigError,
+  readProviderSettings,
+} from '@robota-sdk/agent-framework';
+import { DEFAULT_WORKSPACE_LAYOUT, type IDagNodeDefinition } from '@robota-sdk/dag-core';
+import type { IDagDefinition } from '@robota-sdk/dag-core';
+import {
+  createPromptBackedNodeDefinition,
+  isInstantNodeProvider,
+  type TInstantNodeProvider,
+} from '@robota-sdk/dag-node-instant-node';
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+import { subcommandUsage } from '../subcommands.js';
+import { saveInstantNodeFile, saveWorkflowFile } from '../persistence/workspace-writer.js';
+import { loadInstantNodes } from '../persistence/instant-node-loader.js';
+import { buildCatalogManifests, renderCatalogForPrompt } from './node-catalog.js';
+import { authorWorkflowSpec } from './author.js';
+import { parseAuthoredSpec, type IAuthoredPromptNode } from './spec.js';
+import { assembleWorkflow } from './assemble.js';
+import type { IWorkflowsAuthoringDeps, IParsedAuthoringArgs } from './args.js';
+import { parseAuthoringArgs } from './args.js';
+
+/** What the pipeline produced and wrote. */
+export interface IAuthoredWorkflow {
+  readonly name: string;
+  readonly definition: IDagDefinition;
+  /** Absolute path of the saved workflow artifact. */
+  readonly workflowPath: string;
+  /** Absolute paths of any newly-saved instant-node manifests. */
+  readonly savedNodePaths: readonly string[];
+  /** Node definitions a run would need: the workspace's existing instant nodes + the authored ones. */
+  readonly runNodes: readonly IDagNodeDefinition[];
+  /** The resolved run input (explicit `--input` > the spec's `sampleInput`). */
+  readonly runInputs: Record<string, string>;
+}
+
+export type TAuthoringOutcome =
+  { ok: true; value: IAuthoredWorkflow } | { ok: false; message: string };
+
+/**
+ * Build a prompt-backed node definition from an authored `newNodes` entry. When the spec omits a
+ * provider (the common case — the LLM rarely sets one), inherit the ACTIVE provider used for
+ * authoring so the node doesn't silently hardcode-default to anthropic and fail for other providers.
+ * The chosen provider is persisted in the node manifest for a deterministic reload.
+ */
+export function buildPromptNode(
+  spec: IAuthoredPromptNode,
+  fallbackProvider: TInstantNodeProvider | undefined,
+): IDagNodeDefinition {
+  const provider = isInstantNodeProvider(spec.provider) ? spec.provider : fallbackProvider;
+  return createPromptBackedNodeDefinition({
+    nodeType: spec.nodeType,
+    displayName: spec.displayName ?? spec.nodeType,
+    systemPromptTemplate: spec.systemPromptTemplate,
+    inputPorts: spec.inputPorts,
+    outputPort: spec.outputPort,
+    ...(provider ? { provider } : {}),
+    ...(spec.model ? { model: spec.model } : {}),
+  });
+}
+
+/**
+ * Bake the resolved run input into the first `input` node's config so the saved artifact is
+ * self-contained (reproduces on a bare `/workflows run`). Returns the definition unchanged when there
+ * is no input to bake or no `input` node.
+ */
+export function bakeInputIntoDefinition(
+  definition: IDagDefinition,
+  runInputs: Record<string, string>,
+): IDagDefinition {
+  if (Object.keys(runInputs).length === 0) return definition;
+  let baked = false;
+  const nodes = definition.nodes.map((node) => {
+    if (baked || node.nodeType !== 'input') return node;
+    baked = true;
+    return {
+      ...node,
+      config: { ...node.config, ...runInputs },
+    };
+  });
+  return { ...definition, nodes };
+}
+
+/** The provider (+ model + instant-node provider tag) the authoring call runs against. */
+interface IResolvedAuthoringProvider {
+  readonly provider: IAIProvider;
+  readonly model: string | undefined;
+  readonly activeProvider: TInstantNodeProvider | undefined;
+}
+
+/**
+ * Resolve the ACTIVE provider FIRST — before writing anything (TC-04: no provider → clean error,
+ * fs untouched). The provider's chat call needs an explicit model, so the default path also resolves
+ * it from settings; the injected test seam supplies a stub (model optional).
+ */
+function resolveAuthoringProvider(
+  cwd: string,
+  deps: IWorkflowsAuthoringDeps,
+): { ok: true; value: IResolvedAuthoringProvider } | { ok: false; message: string } {
+  const providerDefinitions = deps.providerDefinitions ?? [];
+  try {
+    if (deps.resolveProvider) {
+      return {
+        ok: true,
+        value: {
+          provider: deps.resolveProvider(cwd),
+          model: deps.model,
+          activeProvider: undefined,
+        },
+      };
+    }
+    const provider = createProviderFromSettings(cwd, undefined, { providerDefinitions });
+    const settings = readProviderSettings(cwd, { providerDefinitions });
+    return {
+      ok: true,
+      value: {
+        provider,
+        model: deps.model ?? settings.model,
+        activeProvider: isInstantNodeProvider(settings.name) ? settings.name : undefined,
+      },
+    };
+  } catch (err) {
+    const detail =
+      err instanceof ProviderConfigError || err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      message: `No active LLM provider is configured. Configure one (e.g. \`/provider\` or set the provider API key) and retry.\nDetail: ${detail}`,
+    };
+  }
+}
+
+/**
+ * Run the shared authoring pipeline for `subcommand` (`create` or `build`) and persist the result.
+ * Never throws — every failure is returned as a message for the caller's `ICommandResult`.
+ */
+export async function authorAndSaveWorkflow(
+  argStr: string,
+  cwd: string,
+  subcommand: 'create' | 'build',
+  deps: IWorkflowsAuthoringDeps = {},
+): Promise<TAuthoringOutcome> {
+  const layout = deps.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
+  const now = deps.now ?? ((): string => new Date().toISOString());
+
+  const parsed = parseAuthoringArgs(argStr);
+  if (!parsed.ok) {
+    return { ok: false, message: `${parsed.error}\n${subcommandUsage(subcommand)}` };
+  }
+  const { description, nameOverride, inputs }: IParsedAuthoringArgs = parsed.value;
+
+  const resolved = resolveAuthoringProvider(cwd, deps);
+  if (!resolved.ok) return { ok: false, message: resolved.message };
+  const { provider, model, activeProvider } = resolved.value;
+
+  // Node catalog = built-ins + any instant nodes already saved (so they can be reused).
+  const existingInstantNodes = await loadInstantNodes(cwd, layout);
+  const baseNodeDefs: IDagNodeDefinition[] = [
+    ...createDefaultNodeRegistrySync(),
+    ...existingInstantNodes,
+  ];
+  const baseCatalog = buildCatalogManifests(baseNodeDefs);
+  if (!baseCatalog.ok) {
+    return { ok: false, message: `Failed to build node catalog: ${baseCatalog.error}` };
+  }
+
+  // Author the spec via the active provider.
+  const authored = await authorWorkflowSpec(
+    provider,
+    description,
+    renderCatalogForPrompt(baseCatalog.manifests),
+    model,
+  );
+  if (!authored.ok) {
+    return { ok: false, message: `Authoring failed: ${authored.error}` };
+  }
+  const specResult = parseAuthoredSpec(authored.raw);
+  if (!specResult.ok) {
+    return { ok: false, message: `Authoring produced an invalid spec: ${specResult.error}` };
+  }
+  const spec = specResult.spec;
+  const name = nameOverride ?? spec.name;
+
+  // Prompt-backed nodes for any `newNodes` — built in memory here, persisted as INERT manifests
+  // below; creating or persisting a node definition executes nothing.
+  const authoredNodes: IDagNodeDefinition[] = [];
+  const existingTypes = new Set(baseNodeDefs.map((n) => n.nodeType));
+  for (const nodeSpec of spec.newNodes ?? []) {
+    if (existingTypes.has(nodeSpec.nodeType)) continue; // reuse existing; do not clobber
+    authoredNodes.push(buildPromptNode(nodeSpec, activeProvider));
+    existingTypes.add(nodeSpec.nodeType);
+  }
+
+  const fullCatalog = buildCatalogManifests([...baseNodeDefs, ...authoredNodes]);
+  if (!fullCatalog.ok) {
+    return { ok: false, message: `Failed to build node catalog: ${fullCatalog.error}` };
+  }
+
+  // Deterministically assemble the DAG — assembly failure means nothing is written.
+  const assembled = assembleWorkflow({ ...spec, name }, fullCatalog.manifests);
+  if (!assembled.ok) {
+    return { ok: false, message: `Could not assemble workflow: ${assembled.error}` };
+  }
+
+  // Resolve the run input (explicit --input > spec.sampleInput) and bake it into the artifact's
+  // `input` node config so the saved workflow is self-contained and reproduces on a bare re-run.
+  const runInputs: Record<string, string> =
+    Object.keys(inputs).length > 0 ? inputs : (spec.sampleInput ?? {});
+  const definition = bakeInputIntoDefinition(assembled.definition, runInputs);
+
+  // Persist authored prompt nodes, then the workflow (both reusable/re-runnable afterwards).
+  const createdAt = now();
+  const savedNodePaths: string[] = [];
+  for (const node of authoredNodes) {
+    const path = await saveInstantNodeFile(cwd, node, createdAt, layout);
+    if (path) savedNodePaths.push(path);
+  }
+  const workflowPath = await saveWorkflowFile(cwd, name, definition, layout);
+
+  return {
+    ok: true,
+    value: {
+      name,
+      definition,
+      workflowPath,
+      savedNodePaths,
+      runNodes: [...existingInstantNodes, ...authoredNodes],
+      runInputs,
+    },
+  };
+}

--- a/packages/agent-command-workflows/src/authoring/pipeline.ts
+++ b/packages/agent-command-workflows/src/authoring/pipeline.ts
@@ -60,7 +60,7 @@ export type TAuthoringOutcome =
  * authoring so the node doesn't silently hardcode-default to anthropic and fail for other providers.
  * The chosen provider is persisted in the node manifest for a deterministic reload.
  */
-export function buildPromptNode(
+function buildPromptNode(
   spec: IAuthoredPromptNode,
   fallbackProvider: TInstantNodeProvider | undefined,
 ): IDagNodeDefinition {
@@ -81,7 +81,7 @@ export function buildPromptNode(
  * self-contained (reproduces on a bare `/workflows run`). Returns the definition unchanged when there
  * is no input to bake or no `input` node.
  */
-export function bakeInputIntoDefinition(
+function bakeInputIntoDefinition(
   definition: IDagDefinition,
   runInputs: Record<string, string>,
 ): IDagDefinition {

--- a/packages/agent-command-workflows/src/build-command.ts
+++ b/packages/agent-command-workflows/src/build-command.ts
@@ -4,146 +4,32 @@
  * The generate-for-review counterpart to `create` (WORKFLOW-004): authors a workflow from a
  * natural-language description via the ACTIVE provider, validates + assembles it, and saves it as a
  * reusable `.workflows/<name>.json` artifact (plus any prompt-backed nodes under
- * `.workflows/nodes/`) — and STOPS. It never executes the authored graph: this module does not
- * import `authoring/execute-workflow.ts`, so no DAG runtime is constructed and no node (LLM or
+ * `.workflows/nodes/`) — and STOPS. It never executes the authored graph: `build` runs only the
+ * shared `authoring/pipeline.ts`, which by construction does not import
+ * `authoring/execute-workflow.ts`, so no DAG runtime is constructed and no node (LLM or
  * side-effecting) runs. The explicit next steps are the existing `validate` / `run` subcommands.
  */
-import { createDefaultNodeRegistrySync } from '@robota-sdk/dag-nodes-default';
-import {
-  createProviderFromSettings,
-  ProviderConfigError,
-  readProviderSettings,
-} from '@robota-sdk/agent-framework';
-import { DEFAULT_WORKSPACE_LAYOUT, type IDagNodeDefinition } from '@robota-sdk/dag-core';
-import {
-  isInstantNodeProvider,
-  type TInstantNodeProvider,
-} from '@robota-sdk/dag-node-instant-node';
-import type { IAIProvider } from '@robota-sdk/agent-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
-import { buildCatalogManifests, renderCatalogForPrompt } from './authoring/node-catalog.js';
-import { authorWorkflowSpec } from './authoring/author.js';
-import { parseAuthoredSpec } from './authoring/spec.js';
-import { assembleWorkflow } from './authoring/assemble.js';
-import { saveInstantNodeFile, saveWorkflowFile } from './persistence/workspace-writer.js';
-import { loadInstantNodes } from './persistence/instant-node-loader.js';
-import {
-  bakeInputIntoDefinition,
-  buildPromptNode,
-  parseCreateArgs,
-  type IWorkflowsCreateDeps,
-} from './create-command.js';
+import { authorAndSaveWorkflow } from './authoring/pipeline.js';
+import type { IWorkflowsAuthoringDeps } from './authoring/args.js';
 
 /**
  * Execute `/workflows build`. Never throws — every failure (bad args, no provider, invalid spec,
  * unassemblable pipeline, write failure) is returned as a failed `ICommandResult`. Shares the
- * `create` deps seam (`IWorkflowsCreateDeps`) and arg grammar (`parseCreateArgs`).
+ * authoring deps seam (`IWorkflowsAuthoringDeps`) and arg grammar (`parseAuthoringArgs`) with
+ * `create`; the two differ only in what happens after the artifact is saved.
  */
 export async function executeWorkflowsBuild(
   argStr: string,
   cwd: string,
-  deps: IWorkflowsCreateDeps = {},
+  deps: IWorkflowsAuthoringDeps = {},
 ): Promise<ICommandResult> {
-  const layout = deps.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
-  const now = deps.now ?? ((): string => new Date().toISOString());
-
-  const parsed = parseCreateArgs(argStr);
-  if (!parsed.ok) {
-    return {
-      success: false,
-      message: `${parsed.error}\nUsage: /workflows build "<description>" [--input key=value] [--name <name>]`,
-    };
-  }
-  const { description, nameOverride, inputs } = parsed.value;
-
-  // Resolve the ACTIVE provider FIRST — before writing anything (TC-04: no provider → clean error).
-  const providerDefinitions = deps.providerDefinitions ?? [];
-  let provider: IAIProvider;
-  let model = deps.model;
-  let activeProvider: TInstantNodeProvider | undefined;
-  try {
-    if (deps.resolveProvider) {
-      provider = deps.resolveProvider(cwd);
-    } else {
-      provider = createProviderFromSettings(cwd, undefined, { providerDefinitions });
-      const settings = readProviderSettings(cwd, { providerDefinitions });
-      model = model ?? settings.model;
-      activeProvider = isInstantNodeProvider(settings.name) ? settings.name : undefined;
-    }
-  } catch (err) {
-    const detail =
-      err instanceof ProviderConfigError || err instanceof Error ? err.message : String(err);
-    return {
-      success: false,
-      message: `No active LLM provider is configured. Configure one (e.g. \`/provider\` or set the provider API key) and retry.\nDetail: ${detail}`,
-    };
-  }
-
-  // Node catalog = built-ins + any prompt nodes already saved (so they can be reused).
-  const existingInstantNodes = await loadInstantNodes(cwd, layout);
-  const baseNodeDefs: IDagNodeDefinition[] = [
-    ...createDefaultNodeRegistrySync(),
-    ...existingInstantNodes,
-  ];
-  const baseCatalog = buildCatalogManifests(baseNodeDefs);
-  if (!baseCatalog.ok) {
-    return { success: false, message: `Failed to build node catalog: ${baseCatalog.error}` };
-  }
-
-  // Author the spec via the active provider.
-  const authored = await authorWorkflowSpec(
-    provider,
-    description,
-    renderCatalogForPrompt(baseCatalog.manifests),
-    model,
-  );
+  const authored = await authorAndSaveWorkflow(argStr, cwd, 'build', deps);
   if (!authored.ok) {
-    return { success: false, message: `Authoring failed: ${authored.error}` };
+    return { success: false, message: authored.message };
   }
-  const specResult = parseAuthoredSpec(authored.raw);
-  if (!specResult.ok) {
-    return { success: false, message: `Authoring produced an invalid spec: ${specResult.error}` };
-  }
-  const spec = specResult.spec;
-  const name = nameOverride ?? spec.name;
-
-  // Prompt-backed nodes for any `newNodes` — created in memory and persisted as INERT manifests
-  // below; persisting a node definition executes nothing.
-  const authoredNodes: IDagNodeDefinition[] = [];
-  const existingTypes = new Set(baseNodeDefs.map((n) => n.nodeType));
-  for (const nodeSpec of spec.newNodes ?? []) {
-    if (existingTypes.has(nodeSpec.nodeType)) continue; // reuse existing; do not clobber
-    authoredNodes.push(buildPromptNode(nodeSpec, activeProvider));
-    existingTypes.add(nodeSpec.nodeType);
-  }
-
-  const allNodeDefs = [...baseNodeDefs, ...authoredNodes];
-  const fullCatalog = buildCatalogManifests(allNodeDefs);
-  if (!fullCatalog.ok) {
-    return { success: false, message: `Failed to build node catalog: ${fullCatalog.error}` };
-  }
-
-  // Deterministically assemble the DAG — assembly failure means nothing is written.
-  const assembled = assembleWorkflow({ ...spec, name }, fullCatalog.manifests);
-  if (!assembled.ok) {
-    return { success: false, message: `Could not assemble workflow: ${assembled.error}` };
-  }
-
-  // Bake the resolved input (explicit --input > spec.sampleInput) into the artifact's `input` node
-  // so the saved workflow is self-contained (same rule as `create`).
-  const runInputs: Record<string, string> =
-    Object.keys(inputs).length > 0 ? inputs : (spec.sampleInput ?? {});
-  const definition = bakeInputIntoDefinition(assembled.definition, runInputs);
-
-  // Persist authored prompt nodes, then the workflow. That is the end of `build` — no execution.
-  const createdAt = now();
-  const savedNodePaths: string[] = [];
-  for (const node of authoredNodes) {
-    const path = await saveInstantNodeFile(cwd, node, createdAt, layout);
-    if (path) savedNodePaths.push(path);
-  }
-  const workflowPath = await saveWorkflowFile(cwd, name, definition, layout);
+  const { name, definition, workflowPath, savedNodePaths } = authored.value;
 
   const nodeLine = savedNodePaths.length > 0 ? `\nNew nodes: ${savedNodePaths.join(', ')}` : '';
   return {

--- a/packages/agent-command-workflows/src/create-command.ts
+++ b/packages/agent-command-workflows/src/create-command.ts
@@ -5,180 +5,19 @@
  * saves it as a reusable `.workflows/<name>.json` artifact (plus any prompt-backed nodes under
  * `.workflows/nodes/`), runs it immediately in-process, and surfaces the saved path + outputs.
  *
- * FLOW-007 Phase 2 (existing nodes) + Phase 3 (on-the-fly prompt nodes).
+ * FLOW-007 Phase 2 (existing nodes) + Phase 3 (on-the-fly prompt nodes). The author→save half is the
+ * shared `authoring/pipeline.ts` (WORKFLOW-005 P3); `create` is that pipeline plus the run step —
+ * the ONLY difference between `create` and `build`.
  */
-import { createDefaultNodeRegistrySync } from '@robota-sdk/dag-nodes-default';
-import {
-  createProviderFromSettings,
-  ProviderConfigError,
-  readProviderSettings,
-} from '@robota-sdk/agent-framework';
-import {
-  DEFAULT_WORKSPACE_LAYOUT,
-  type IDagDefinition,
-  type IDagNodeDefinition,
-  type INodeManifest,
-  type IWorkspaceLayout,
-} from '@robota-sdk/dag-core';
-import {
-  createPromptBackedNodeDefinition,
-  isInstantNodeProvider,
-  type TInstantNodeProvider,
-} from '@robota-sdk/dag-node-instant-node';
-import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
 
-import { buildCatalogManifests, renderCatalogForPrompt } from './authoring/node-catalog.js';
-import { authorWorkflowSpec } from './authoring/author.js';
-import { parseAuthoredSpec, type IAuthoredPromptNode } from './authoring/spec.js';
-import { assembleWorkflow } from './authoring/assemble.js';
+import { authorAndSaveWorkflow } from './authoring/pipeline.js';
 import { executeDefinition } from './authoring/execute-workflow.js';
-import { saveInstantNodeFile, saveWorkflowFile } from './persistence/workspace-writer.js';
-import { loadInstantNodes } from './persistence/instant-node-loader.js';
-
-/** Test/composition seam: how to resolve the provider and the current time. */
-export interface IWorkflowsCreateDeps {
-  readonly workspace?: IWorkspaceLayout;
-  readonly providerDefinitions?: readonly IProviderDefinition[];
-  /** Override provider resolution (tests inject a stub). Default: the active provider from settings. */
-  readonly resolveProvider?: (cwd: string) => IAIProvider;
-  /** Model passed to the authoring chat call. Default path resolves it from settings. */
-  readonly model?: string;
-  /** Override the createdAt timestamp for persisted nodes (tests inject a fixed value). */
-  readonly now?: () => string;
-}
-
-interface IParsedCreateArgs {
-  readonly description: string;
-  readonly nameOverride?: string;
-  readonly inputs: Record<string, string>;
-}
-
-/**
- * Split an argument string into tokens shell-style: unquoted whitespace separates tokens, and
- * single/double quotes (anywhere, e.g. `key="a b"`) protect whitespace and are stripped.
- */
-function tokenize(input: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let hasContent = false;
-  let quote: '"' | "'" | null = null;
-
-  for (const ch of input) {
-    if (quote !== null) {
-      if (ch === quote) quote = null;
-      else current += ch;
-    } else if (ch === '"' || ch === "'") {
-      quote = ch;
-      hasContent = true;
-    } else if (/\s/.test(ch)) {
-      if (hasContent) {
-        tokens.push(current);
-        current = '';
-        hasContent = false;
-      }
-    } else {
-      current += ch;
-      hasContent = true;
-    }
-  }
-  if (hasContent) tokens.push(current);
-  return tokens;
-}
-
-/** Parse `create` args: leading non-flag tokens = description; then `--input k=v` / `--name`. */
-export function parseCreateArgs(
-  argStr: string,
-): { ok: true; value: IParsedCreateArgs } | { ok: false; error: string } {
-  const tokens = tokenize(argStr.trim());
-  const descriptionParts: string[] = [];
-  const inputs: Record<string, string> = {};
-  let nameOverride: string | undefined;
-
-  let i = 0;
-  // Leading non-flag tokens form the description.
-  while (i < tokens.length && !tokens[i]!.startsWith('--')) {
-    descriptionParts.push(tokens[i]!);
-    i += 1;
-  }
-  while (i < tokens.length) {
-    const flag = tokens[i]!;
-    if (flag === '--input') {
-      const pair = tokens[i + 1];
-      if (pair === undefined || pair.startsWith('--')) {
-        return { ok: false, error: '--input requires a key=value argument.' };
-      }
-      const eq = pair.indexOf('=');
-      if (eq <= 0) {
-        return { ok: false, error: `--input must be key=value, got "${pair}".` };
-      }
-      inputs[pair.slice(0, eq)] = pair.slice(eq + 1);
-      i += 2;
-    } else if (flag === '--name') {
-      const next = tokens[i + 1];
-      if (next === undefined || next.startsWith('--')) {
-        return { ok: false, error: '--name requires a value.' };
-      }
-      nameOverride = next;
-      i += 2;
-    } else {
-      return { ok: false, error: `create received unexpected flag: ${flag}` };
-    }
-  }
-
-  const description = descriptionParts.join(' ').trim();
-  if (description === '') {
-    return { ok: false, error: 'A natural-language description is required.' };
-  }
-  return { ok: true, value: { description, ...(nameOverride ? { nameOverride } : {}), inputs } };
-}
-
-/**
- * Build a prompt-backed node definition from an authored `newNodes` entry. When the spec omits a
- * provider (the common case — the LLM rarely sets one), inherit the ACTIVE provider used for
- * authoring so the node doesn't silently hardcode-default to anthropic and fail for other providers.
- * The chosen provider is persisted in the node manifest for a deterministic reload.
- */
-export function buildPromptNode(
-  spec: IAuthoredPromptNode,
-  fallbackProvider: TInstantNodeProvider | undefined,
-): IDagNodeDefinition {
-  const provider = isInstantNodeProvider(spec.provider) ? spec.provider : fallbackProvider;
-  return createPromptBackedNodeDefinition({
-    nodeType: spec.nodeType,
-    displayName: spec.displayName ?? spec.nodeType,
-    systemPromptTemplate: spec.systemPromptTemplate,
-    inputPorts: spec.inputPorts,
-    outputPort: spec.outputPort,
-    ...(provider ? { provider } : {}),
-    ...(spec.model ? { model: spec.model } : {}),
-  });
-}
+import type { IWorkflowsAuthoringDeps } from './authoring/args.js';
 
 function formatOutputs(outputs: Record<string, unknown>): string {
   return JSON.stringify(outputs, null, 2);
-}
-
-/**
- * Bake the resolved run input into the first `input` node's config so the saved artifact is
- * self-contained (reproduces on a bare `/workflows run`). Returns the definition unchanged when there
- * is no input to bake or no `input` node.
- */
-export function bakeInputIntoDefinition(
-  definition: IDagDefinition,
-  runInputs: Record<string, string>,
-): IDagDefinition {
-  if (Object.keys(runInputs).length === 0) return definition;
-  let baked = false;
-  const nodes = definition.nodes.map((node) => {
-    if (baked || node.nodeType !== 'input') return node;
-    baked = true;
-    return {
-      ...node,
-      config: { ...node.config, ...runInputs },
-    };
-  });
-  return { ...definition, nodes };
 }
 
 /**
@@ -188,112 +27,17 @@ export function bakeInputIntoDefinition(
 export async function executeWorkflowsCreate(
   argStr: string,
   cwd: string,
-  deps: IWorkflowsCreateDeps = {},
+  deps: IWorkflowsAuthoringDeps = {},
 ): Promise<ICommandResult> {
   const layout = deps.workspace ?? DEFAULT_WORKSPACE_LAYOUT;
-  const now = deps.now ?? ((): string => new Date().toISOString());
 
-  const parsed = parseCreateArgs(argStr);
-  if (!parsed.ok) {
-    return {
-      success: false,
-      message: `${parsed.error}\nUsage: /workflows create "<description>" [--input key=value] [--name <name>]`,
-    };
-  }
-  const { description, nameOverride, inputs } = parsed.value;
-
-  // Resolve the ACTIVE provider FIRST — before writing anything (TC-04: no provider → clean error).
-  // The provider's chat call needs an explicit model, so the default path also resolves it from
-  // settings; the injected test seam supplies a stub (model optional).
-  const providerDefinitions = deps.providerDefinitions ?? [];
-  let provider: IAIProvider;
-  let model = deps.model;
-  let activeProvider: TInstantNodeProvider | undefined;
-  try {
-    if (deps.resolveProvider) {
-      provider = deps.resolveProvider(cwd);
-    } else {
-      provider = createProviderFromSettings(cwd, undefined, { providerDefinitions });
-      const settings = readProviderSettings(cwd, { providerDefinitions });
-      model = model ?? settings.model;
-      activeProvider = isInstantNodeProvider(settings.name) ? settings.name : undefined;
-    }
-  } catch (err) {
-    const detail =
-      err instanceof ProviderConfigError || err instanceof Error ? err.message : String(err);
-    return {
-      success: false,
-      message: `No active LLM provider is configured. Configure one (e.g. \`/provider\` or set the provider API key) and retry.\nDetail: ${detail}`,
-    };
-  }
-
-  // Node catalog = built-ins + any prompt nodes already saved (so they can be reused).
-  const existingInstantNodes = await loadInstantNodes(cwd, layout);
-  const baseNodeDefs: IDagNodeDefinition[] = [
-    ...createDefaultNodeRegistrySync(),
-    ...existingInstantNodes,
-  ];
-  const baseCatalog = buildCatalogManifests(baseNodeDefs);
-  if (!baseCatalog.ok) {
-    return { success: false, message: `Failed to build node catalog: ${baseCatalog.error}` };
-  }
-
-  // Author the spec via the active provider.
-  const authored = await authorWorkflowSpec(
-    provider,
-    description,
-    renderCatalogForPrompt(baseCatalog.manifests),
-    model,
-  );
+  const authored = await authorAndSaveWorkflow(argStr, cwd, 'create', deps);
   if (!authored.ok) {
-    return { success: false, message: `Authoring failed: ${authored.error}` };
+    return { success: false, message: authored.message };
   }
-  const specResult = parseAuthoredSpec(authored.raw);
-  if (!specResult.ok) {
-    return { success: false, message: `Authoring produced an invalid spec: ${specResult.error}` };
-  }
-  const spec = specResult.spec;
-  const name = nameOverride ?? spec.name;
+  const { name, definition, workflowPath, savedNodePaths, runNodes, runInputs } = authored.value;
 
-  // Phase 3: create prompt-backed nodes for any `newNodes` and add them to the catalog + registry.
-  const authoredNodes: IDagNodeDefinition[] = [];
-  const existingTypes = new Set(baseNodeDefs.map((n) => n.nodeType));
-  for (const nodeSpec of spec.newNodes ?? []) {
-    if (existingTypes.has(nodeSpec.nodeType)) continue; // reuse existing; do not clobber
-    authoredNodes.push(buildPromptNode(nodeSpec, activeProvider));
-    existingTypes.add(nodeSpec.nodeType);
-  }
-
-  const allNodeDefs = [...baseNodeDefs, ...authoredNodes];
-  const fullCatalog = buildCatalogManifests(allNodeDefs);
-  if (!fullCatalog.ok) {
-    return { success: false, message: `Failed to build node catalog: ${fullCatalog.error}` };
-  }
-  const manifests: INodeManifest[] = fullCatalog.manifests;
-
-  // Deterministically assemble the DAG.
-  const assembled = assembleWorkflow({ ...spec, name }, manifests);
-  if (!assembled.ok) {
-    return { success: false, message: `Could not assemble workflow: ${assembled.error}` };
-  }
-
-  // Resolve the run input (explicit --input > spec.sampleInput) and bake it into the artifact's
-  // `input` node config so the saved workflow is self-contained and reproduces on a bare re-run.
-  const runInputs: Record<string, string> =
-    Object.keys(inputs).length > 0 ? inputs : (spec.sampleInput ?? {});
-  const definition = bakeInputIntoDefinition(assembled.definition, runInputs);
-
-  // Persist authored prompt nodes, then the workflow (both reusable/re-runnable afterwards).
-  const createdAt = now();
-  const savedNodePaths: string[] = [];
-  for (const node of authoredNodes) {
-    const path = await saveInstantNodeFile(cwd, node, createdAt, layout);
-    if (path) savedNodePaths.push(path);
-  }
-  const workflowPath = await saveWorkflowFile(cwd, name, definition, layout);
-
-  const runNodes = [...existingInstantNodes, ...authoredNodes];
-  const outcome = await executeDefinition(definition, cwd, layout, runNodes, runInputs);
+  const outcome = await executeDefinition(definition, cwd, layout, [...runNodes], runInputs);
 
   const nodeLine = savedNodePaths.length > 0 ? `\nNew nodes: ${savedNodePaths.join(', ')}` : '';
   if (!outcome.ok) {

--- a/packages/agent-command-workflows/src/index.ts
+++ b/packages/agent-command-workflows/src/index.ts
@@ -4,13 +4,20 @@ export {
   WorkflowsCommandSource,
   type IWorkflowsCommandModuleDeps,
 } from './workflows-command-module.js';
+export {
+  WORKFLOWS_SUBCOMMANDS,
+  renderWorkflowsUsage,
+  subcommandUsage,
+  type IWorkflowsSubcommand,
+} from './subcommands.js';
 export { executeWorkflowsList } from './list-command.js';
 export { executeWorkflowsRun } from './run-command.js';
-export {
-  executeWorkflowsCreate,
-  parseCreateArgs,
-  type IWorkflowsCreateDeps,
-} from './create-command.js';
+export { executeWorkflowsCreate } from './create-command.js';
 export { executeWorkflowsBuild } from './build-command.js';
+export {
+  parseAuthoringArgs,
+  type IWorkflowsAuthoringDeps,
+  type IParsedAuthoringArgs,
+} from './authoring/args.js';
 
 export const AGENT_COMMAND_WORKFLOWS_PACKAGE_NAME = '@robota-sdk/agent-command-workflows';

--- a/packages/agent-command-workflows/src/list-command.ts
+++ b/packages/agent-command-workflows/src/list-command.ts
@@ -1,18 +1,30 @@
-import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
+
+import { createWorkspaceRuntime } from './workspace-runtime.js';
 
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 /**
- * `/workflows list` — list the workflow nodes available to the in-process DAG runtime.
+ * `/workflows list` — list the workflow nodes available to the in-process DAG runtime: the built-in
+ * catalog PLUS the instant nodes saved in this workspace under `<root>/nodes/` (WORKFLOW-005 P3),
+ * which are marked so the nodes `create`/`build` authored here are distinguishable from built-ins.
  * Composes `dag-framework`'s local provider; no dependency on the `dag-cli` product.
  */
-export async function executeWorkflowsList(): Promise<ICommandResult> {
-  const provider = new LocalDagRuntimeProvider();
+export async function executeWorkflowsList(
+  cwd: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<ICommandResult> {
+  const { provider, instantNodes } = await createWorkspaceRuntime(cwd, layout);
+  const saved = new Set(instantNodes.map((n) => n.nodeType));
   const nodes = await provider.listNodes();
   const sorted = [...nodes].sort((a, b) => a.nodeType.localeCompare(b.nodeType));
-  const lines = sorted.map((n) => `  ${n.nodeType}${n.description ? ` — ${n.description}` : ''}`);
+  const lines = sorted.map((n) => {
+    const savedMark = saved.has(n.nodeType) ? ` [saved in ${layout.root}/nodes]` : '';
+    return `  ${n.nodeType}${n.description ? ` — ${n.description}` : ''}${savedMark}`;
+  });
+  const savedLine = saved.size > 0 ? ` (${saved.size} saved in ${layout.root}/nodes)` : '';
   return {
     success: true,
-    message: `Available workflow nodes (${nodes.length}):\n${lines.join('\n')}`,
+    message: `Available workflow nodes (${nodes.length})${savedLine}:\n${lines.join('\n')}`,
   };
 }

--- a/packages/agent-command-workflows/src/run-command.ts
+++ b/packages/agent-command-workflows/src/run-command.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
 import { isLegacyDefinitionFormat, toDagWorkflowFile } from '@robota-sdk/dag-builder';
 
 import {
@@ -10,7 +9,8 @@ import {
   type IWorkspaceLayout,
 } from '@robota-sdk/dag-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
-import { loadInstantNodes } from './persistence/instant-node-loader.js';
+import { parseFileArg } from './args.js';
+import { createWorkspaceRuntime } from './workspace-runtime.js';
 
 /**
  * Read a workflow file in either supported on-disk format and return the runtime workflow-file shape.
@@ -27,17 +27,22 @@ async function readDagFile(absPath: string): Promise<IDagWorkflowFile> {
 }
 
 /**
- * `/workflows run <file.dag.json>` — execute a workflow file on the in-process DAG runtime.
- * Composes `dag-framework`'s local provider; no dependency on the `dag-cli` product.
+ * `/workflows run <file.json>` — execute a workflow file on the in-process DAG runtime. The node
+ * catalog is resolved through the shared workspace runtime (built-ins + the instant nodes saved
+ * under `<root>/nodes/`), the same one `validate` and `list` see (WORKFLOW-005 P3), and the argument
+ * shares the `/workflows` grammar (`parseFileArg`). Composes `dag-framework`'s local provider; no
+ * dependency on the `dag-cli` product.
  */
 export async function executeWorkflowsRun(
-  filePath: string,
+  argStr: string,
   cwd: string,
   workspace: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<ICommandResult> {
-  if (!filePath) {
-    return { success: false, message: 'Usage: /workflows run <file.json>' };
+  const parsedArgs = parseFileArg(argStr, 'run');
+  if (!parsedArgs.ok) {
+    return { success: false, message: parsedArgs.error };
   }
+  const filePath = parsedArgs.value;
 
   // The read/parse error is surfaced as a failed command result, not silently swallowed.
   const dag = await readDagFile(resolve(cwd, filePath)).catch((err: unknown) => {
@@ -48,13 +53,8 @@ export async function executeWorkflowsRun(
     return { success: false, message: dag.message };
   }
 
-  // Reload any prompt-backed nodes from `<root>/nodes/` so workflows referencing them can run.
-  const instantNodes = await loadInstantNodes(cwd, workspace);
-  const provider = new LocalDagRuntimeProvider({
-    workspace,
-    projectDir: cwd,
-    ...(instantNodes.length > 0 ? { instantNodes } : {}),
-  });
+  // Shared workspace runtime: built-ins + any prompt/composite nodes saved under `<root>/nodes/`.
+  const { provider } = await createWorkspaceRuntime(cwd, workspace);
   const result = await provider.execute(dag, {});
   if (!result.ok) {
     return {

--- a/packages/agent-command-workflows/src/subcommands.ts
+++ b/packages/agent-command-workflows/src/subcommands.ts
@@ -1,0 +1,87 @@
+/**
+ * Single source of truth for the `/workflows` subcommand surface (WORKFLOW-005 P3).
+ *
+ * The subcommand list, the `ICommand.argumentHint`s the CLI shows, the top-level usage block, and
+ * every per-subcommand `Usage:` line an executor emits on a bad argument all derive from
+ * `WORKFLOWS_SUBCOMMANDS` — so a hint and its usage text cannot drift apart. Lives in its own module
+ * (not `workflows-command-module.ts`) so the executors can import the usage text without a cycle.
+ */
+
+/** Metadata for one `/workflows` subcommand. */
+export interface IWorkflowsSubcommand {
+  readonly name: string;
+  readonly description: string;
+  /** Argument grammar, e.g. `<file.json>`. Omitted for argument-less subcommands. */
+  readonly argumentHint?: string;
+  /** Whether the agent (not just the user) may invoke it. */
+  readonly modelInvocable: boolean;
+}
+
+/** The authoring subcommands share one argument grammar (`parseCreateArgs`). */
+const AUTHORING_HINT = '"<description>" [--input key=value] [--name <name>]';
+/** The file-taking subcommands share one argument grammar (`parseFileArg`). */
+const FILE_HINT = '<file.json>';
+
+export const WORKFLOWS_SUBCOMMANDS: readonly IWorkflowsSubcommand[] = [
+  {
+    name: 'create',
+    description: 'Author a workflow from a natural-language description and run it immediately',
+    argumentHint: AUTHORING_HINT,
+    modelInvocable: true,
+  },
+  {
+    name: 'build',
+    description:
+      'Author a workflow from a natural-language description and save it for review (no run)',
+    argumentHint: AUTHORING_HINT,
+    modelInvocable: true,
+  },
+  {
+    name: 'list',
+    description: 'List available workflow nodes (built-ins + nodes saved in this workspace)',
+    modelInvocable: false,
+  },
+  {
+    name: 'catalog',
+    description: 'List workflow files in the local .workflows catalog',
+    modelInvocable: false,
+  },
+  {
+    name: 'validate',
+    description: 'Validate a workflow file against the node catalog',
+    argumentHint: FILE_HINT,
+    modelInvocable: false,
+  },
+  {
+    name: 'run',
+    description: 'Run a workflow file',
+    argumentHint: FILE_HINT,
+    modelInvocable: false,
+  },
+];
+
+/** `Usage: /workflows <name> <hint>` — the one line an executor emits on a bad argument. */
+export function subcommandUsage(name: string): string {
+  const sub = WORKFLOWS_SUBCOMMANDS.find((s) => s.name === name);
+  if (!sub) throw new Error(`Unknown /workflows subcommand: ${name}`);
+  return `Usage: /workflows ${sub.name}${sub.argumentHint ? ` ${sub.argumentHint}` : ''}`;
+}
+
+/**
+ * A compact invocation shape for the usage block — the subcommand plus the FIRST token of its
+ * argument hint. The full grammar stays in each subcommand's own `Usage:` line.
+ */
+function compactInvocation(sub: IWorkflowsSubcommand): string {
+  return sub.argumentHint ? `${sub.name} ${sub.argumentHint.split(' ')[0]}` : sub.name;
+}
+
+/** The multi-line usage block shown for bare `/workflows` and unknown subcommands. */
+export function renderWorkflowsUsage(): string {
+  const names = WORKFLOWS_SUBCOMMANDS.map((s) => s.name).join('|');
+  const invocations = WORKFLOWS_SUBCOMMANDS.map(compactInvocation);
+  const width = Math.max(...invocations.map((i) => i.length));
+  const lines = WORKFLOWS_SUBCOMMANDS.map(
+    (sub, i) => `  ${invocations[i]!.padEnd(width)}  ${sub.description}`,
+  );
+  return [`Usage: /workflows <${names}>`, ...lines].join('\n');
+}

--- a/packages/agent-command-workflows/src/validate-command.ts
+++ b/packages/agent-command-workflows/src/validate-command.ts
@@ -6,24 +6,33 @@ import {
   isLegacyDefinitionFormat,
   isWorkflowFileFormat,
 } from '@robota-sdk/dag-builder';
-import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
+
+import { parseFileArg } from './args.js';
+import { createWorkspaceRuntime } from './workspace-runtime.js';
 
 import type { IDagDefinition } from '@robota-sdk/dag-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
 
 /**
- * `/workflows validate <file.dag.json>` — structurally validate a workflow file against the
- * in-process node catalog: recognized format, known node types, and edges that reference real
- * nodes. Composes `dag-builder` (format detection + conversion) + `dag-framework` (node catalog);
- * no dependency on the `dag-cli` product.
+ * `/workflows validate <file.json>` — structurally validate a workflow file against the workspace's
+ * node catalog: recognized format, known node types, and edges that reference real nodes. The
+ * catalog is the SAME one `run` executes against — built-ins plus the instant nodes saved under
+ * `<root>/nodes/` (WORKFLOW-005 P3) — so a workflow `build` just authored with a new prompt node
+ * validates instead of failing on its own node. Argument parsing shares the `/workflows` grammar
+ * (`parseFileArg`). Composes `dag-builder` (format detection + conversion) + `dag-framework` (node
+ * catalog); no dependency on the `dag-cli` product.
  */
 export async function executeWorkflowsValidate(
-  filePath: string,
+  argStr: string,
   cwd: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
 ): Promise<ICommandResult> {
-  if (!filePath) {
-    return { success: false, message: 'Usage: /workflows validate <file.dag.json>' };
+  const parsedArgs = parseFileArg(argStr, 'validate');
+  if (!parsedArgs.ok) {
+    return { success: false, message: parsedArgs.error };
   }
+  const filePath = parsedArgs.value;
 
   // The read/parse error is surfaced as a failed command result, not silently swallowed.
   const parsed = await readFile(resolve(cwd, filePath), 'utf-8')
@@ -48,7 +57,7 @@ export async function executeWorkflowsValidate(
     };
   }
 
-  const provider = new LocalDagRuntimeProvider();
+  const { provider } = await createWorkspaceRuntime(cwd, layout);
   const manifests = await provider.listNodes();
   const knownTypes = new Set(manifests.map((m) => m.nodeType));
   const nodeIds = new Set(definition.nodes.map((n) => n.nodeId));

--- a/packages/agent-command-workflows/src/workflows-command-module.ts
+++ b/packages/agent-command-workflows/src/workflows-command-module.ts
@@ -4,6 +4,7 @@ import { executeWorkflowsRun } from './run-command.js';
 import { executeWorkflowsValidate } from './validate-command.js';
 import { executeWorkflowsCreate } from './create-command.js';
 import { executeWorkflowsBuild } from './build-command.js';
+import { renderWorkflowsUsage, WORKFLOWS_SUBCOMMANDS } from './subcommands.js';
 
 import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
 import type { IProviderDefinition } from '@robota-sdk/agent-core';
@@ -20,61 +21,18 @@ import type {
 
 const WORKFLOWS_DESCRIPTION =
   'Author (from natural language), list, validate, and run DAG workflows on the in-process runtime';
-const WORKFLOWS_ARGUMENT_HINT = '<create|build|list|catalog|validate|run> [args]';
+const WORKFLOWS_ARGUMENT_HINT = `<${WORKFLOWS_SUBCOMMANDS.map((s) => s.name).join('|')}> [args]`;
 
-const SUBCOMMANDS: ICommand[] = [
-  {
-    name: 'create',
-    description: 'Author a workflow from a natural-language description and run it immediately',
-    source: 'workflows',
-    argumentHint: '"<description>" [--input key=value] [--name <name>]',
-    modelInvocable: true,
-  },
-  {
-    name: 'build',
-    description:
-      'Author a workflow from a natural-language description and save it for review (no run)',
-    source: 'workflows',
-    argumentHint: '"<description>" [--input key=value] [--name <name>]',
-    modelInvocable: true,
-  },
-  {
-    name: 'list',
-    description: 'List available workflow nodes',
-    source: 'workflows',
-    modelInvocable: false,
-  },
-  {
-    name: 'catalog',
-    description: 'List workflow files in the local .workflows catalog',
-    source: 'workflows',
-    modelInvocable: false,
-  },
-  {
-    name: 'validate',
-    description: 'Validate a workflow file against the node catalog',
-    source: 'workflows',
-    argumentHint: '<file.json>',
-    modelInvocable: false,
-  },
-  {
-    name: 'run',
-    description: 'Run a workflow file',
-    source: 'workflows',
-    argumentHint: '<file.json>',
-    modelInvocable: false,
-  },
-];
+/** The `ICommand` view of the shared subcommand registry (`subcommands.ts` is the SSOT). */
+const SUBCOMMANDS: ICommand[] = WORKFLOWS_SUBCOMMANDS.map((sub) => ({
+  name: sub.name,
+  description: sub.description,
+  source: 'workflows',
+  ...(sub.argumentHint ? { argumentHint: sub.argumentHint } : {}),
+  modelInvocable: sub.modelInvocable,
+}));
 
-const USAGE = [
-  'Usage: /workflows <create|build|list|catalog|validate|run>',
-  '  create "<desc>"  Author a workflow from natural language and run it',
-  '  build "<desc>"   Author a workflow from natural language and save it (no run)',
-  '  list             List available workflow nodes',
-  '  catalog          List workflow files in .workflows',
-  '  validate <file>  Validate a workflow file',
-  '  run <file>       Run a workflow file',
-].join('\n');
+const USAGE = renderWorkflowsUsage();
 
 /** Parse the leading subcommand token + remaining argument string. */
 function splitSubcommand(args: string): { sub: string; rest: string } {
@@ -101,11 +59,11 @@ async function executeWorkflowsCommand(
     case 'build':
       return executeWorkflowsBuild(rest, cwd, { workspace, providerDefinitions });
     case 'list':
-      return executeWorkflowsList();
+      return executeWorkflowsList(cwd, workspace);
     case 'catalog':
       return executeWorkflowsCatalog(cwd, workspace);
     case 'validate':
-      return executeWorkflowsValidate(rest, cwd);
+      return executeWorkflowsValidate(rest, cwd, workspace);
     case 'run':
       return executeWorkflowsRun(rest, cwd, workspace);
     default:

--- a/packages/agent-command-workflows/src/workspace-runtime.ts
+++ b/packages/agent-command-workflows/src/workspace-runtime.ts
@@ -1,0 +1,41 @@
+/**
+ * The ONE construction point for the workspace's view of the DAG runtime (WORKFLOW-005 P3).
+ *
+ * A `/workflows` workspace has two node sources: the built-in registry `LocalDagRuntimeProvider`
+ * loads by default, and the instant nodes `create`/`build` saved under `<root>/nodes/`. Every
+ * subcommand that needs a node catalog (`list`, `validate`, `run`) resolves it here, so the catalog
+ * a workflow is *validated* against is exactly the catalog it *runs* against — previously `validate`
+ * and `list` built a bare provider and were blind to the workspace's own saved nodes, which made
+ * `build`'s "Next steps: /workflows validate <path>" hand-off fail for every workflow it authored
+ * with a new prompt node.
+ */
+import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
+import type { IDagNodeDefinition } from '@robota-sdk/dag-core';
+import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
+
+import { loadInstantNodes } from './persistence/instant-node-loader.js';
+
+/** The workspace's runtime view: the provider plus the instant nodes that were folded into it. */
+export interface IWorkspaceRuntime {
+  /** Provider whose catalog = built-ins + the workspace's saved instant nodes. */
+  readonly provider: LocalDagRuntimeProvider;
+  /** The instant nodes reloaded from `<root>/nodes/` (empty when the workspace has none). */
+  readonly instantNodes: readonly IDagNodeDefinition[];
+}
+
+/**
+ * Build the workspace runtime for `cwd`: reload the saved instant nodes and hand them to a
+ * `LocalDagRuntimeProvider` so both `listNodes()` and `execute()` see the full catalog.
+ */
+export async function createWorkspaceRuntime(
+  cwd: string,
+  layout: IWorkspaceLayout = DEFAULT_WORKSPACE_LAYOUT,
+): Promise<IWorkspaceRuntime> {
+  const instantNodes = await loadInstantNodes(cwd, layout);
+  const provider = new LocalDagRuntimeProvider({
+    workspace: layout,
+    projectDir: cwd,
+    ...(instantNodes.length > 0 ? { instantNodes } : {}),
+  });
+  return { provider, instantNodes };
+}


### PR DESCRIPTION
## What & why

WORKFLOW-005 **P3 (surface unification)**. P3's original wording — "expose create/save/build through `/workflows` (+ WORKFLOW-004 build)" — was **already satisfied for the exposure half**: `create` shipped with FLOW-007 P4, `build` with WORKFLOW-004 (#1358), and P2 landed in #1374. Assessing against current code, the genuine remainder was not exposure but **unification**: the six subcommands had drifted into six ad-hoc executors, and that drift had produced a real user-facing bug.

### Assessment — exposed today vs missing

| Verb       | Exposed before P3?               | Gap found                                                  |
| ---------- | -------------------------------- | ---------------------------------------------------------- |
| `create`   | ✅ (FLOW-007 P4)                 | owned a private copy of the authoring pipeline              |
| `build`    | ✅ (WORKFLOW-004 #1358)          | ~90-line verbatim copy of `create`'s pipeline               |
| `save`     | ✅ transitively (create + build) | no standalone verb needed — see below                       |
| `list`     | ✅                               | **blind to workspace-saved instant nodes**                  |
| `catalog`  | ✅                               | none                                                        |
| `validate` | ✅                               | **blind to workspace-saved nodes** + raw, ungrammared arg   |
| `run`      | ✅                               | raw, ungrammared arg                                        |

## The headline bug

`create`/`build`/`run` reloaded the instant nodes saved under `<root>/nodes/`; `validate` and `list` built a bare provider and were blind to them. So `build`'s **own printed hand-off** — "Next steps: `/workflows validate <path>`" — **failed** with `unknown node type "<authored-node>"` for every workflow `build` authored with a `newNodes` prompt node, and `list` hid the nodes the user had just created. Existing tests missed it because the `build → validate → run` round-trip only covered built-in nodes, and the `newNodes` case never called `validate`.

## What changed — four seams, one owner each

- **Node catalog** (`src/workspace-runtime.ts`) — the only place a provider is built for a workspace (built-ins + `<root>/nodes/`), used by `list`/`validate`/`run`. The catalog a workflow is validated against is now the one it runs against. `list` marks saved nodes `[saved in <root>/nodes]`.
- **Argument grammar** (`src/args.ts`) — the quote-aware tokenizer was private to `create`/`build`; `validate`/`run` took the arg raw, so a quoted path was opened verbatim and surplus tokens were folded into the filename (`ENOENT: 'a.json b.json'`). `parseFileArg` now serves both and rejects surplus args with the subcommand's usage line.
- **Subcommand registry** (`src/subcommands.ts`) — list, hints, usage block and every per-subcommand `Usage:` line derive from one array (`validate` advertised `<file.json>` while emitting `<file.dag.json>`).
- **Authoring pipeline** (`src/authoring/pipeline.ts`) — `create` and `build` share `authorAndSaveWorkflow`; `create` alone adds the run step.

**`save` was assessed and deliberately NOT added as a verb**: `create`/`build` both end in a save and `list`/`catalog` read it back. A standalone `save <json>` would be an *import* of externally-supplied graph data — a new capability (dag-cli MCP's `dag_import` / `dag_instant_node_save` cover the MCP-side need), outside P3's intent. Recorded in the package SPEC.

## WORKFLOW-004 contract — intact, now proven twice

`build` never executes. Previously proven by the runtime execute-canary (spy asserted at 0 calls); now **also** by a static import guard that neither `build-command.ts` nor the shared pipeline imports the execution module — so no module on `build`'s import path can construct a DAG runtime, for any input, not just the tested ones.

## Red/green evidence

Red-first. The 4 new `surface-unification.test.ts` cases failed for the right reasons before the fix:

```
× validates a workflow that `build` authored with a new prompt node
  → 'Invalid workflow "…/pirate-rewrite.json" (1 issue):
       - node "pirate-speak-1": unknown node type "pirate-speak"'
× lists workspace-saved instant nodes alongside the built-in node catalog
  → expected 'Available workflow nodes (23):…' to contain 'pirate-speak'
× accepts a quoted file argument for `validate` and `run`      → expected false to be true
× rejects surplus arguments instead of folding them into the path
  → 'Failed to read DAG file "a.json b.json": ENOENT … open '/tmp/wf-p3-…/a.json b.json''
```

Both anti-drift guards were proven to bite by temporarily introducing the drift each guards against (an unrouted subcommand → `subcommand "drift-canary" is not dispatched`; a forbidden import → `authoring/pipeline.ts must not import the DAG execution module`), then reverted. The pipeline dedupe is behavior-preserving: the pre-existing `create`/`build` suites, including the non-execution canary, stayed green across it.

## Verification

- `pnpm harness:verify-like-ci` — **PASS, all 4 stages** (harness-self-test, format-check, scan-suite incl. build-contracts + dist, typecheck)
- `pnpm -w typecheck` — clean
- Suites green: `agent-command-workflows` **45** (was 37) · `dag-framework` 107 · `dag-cli` 1007 · `agent-cli` 248
- Package lint warnings 29 → 24 (no new ones)
- No changeset: `@robota-sdk/agent-command-workflows` is `private: true`

`packages/agent-command-workflows/docs/SPEC.md` is updated in the same commit as the code.

## Scope / what remains

Backlog item **stays OPEN** for exactly one thing: **instant-node Phase C** (arbitrary code node via API) — a new capability with security implications, **owner-gated**, deliberately untouched here (the backlog is internally inconsistent about its phasing and needs an owner ruling). Everything in WORKFLOW-005 that is not owner-gated is now done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
