### PR TITLE
feat(composition): ARCH-006 + ARCH-007 — tool axis at parity, robota eats the runtime seam

### DIFF
--- a/.agents/backlog/ARCH-006-framework-tool-axis-neutrality.md
+++ b/.agents/backlog/ARCH-006-framework-tool-axis-neutrality.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-006: make the framework default tool set injectable so the pack TOOL axis is additive everywhere'
-status: todo
+status: in-progress
 created: 2026-07-25
 priority: medium
 urgency: soon
@@ -81,3 +81,55 @@ product's preferred tool set. The composition-neutrality guards over `agent-prod
   `pack-coding` instead of the framework default.
 - The ARCH-005 external proof (`pnpm proof:external`) upgraded from "a NEW pack tool is additive" to
   "a pack fully owns the product's tool surface", with the C5 limitation notes removed.
+
+## Progress — framework half DONE (2026-07-25); one hop remains
+
+**DONE (landed with ARCH-007; see the ARCH-005 spec's `[ARCH-006 + ARCH-007]` evidence entry).** Proposed
+direction **3 (both)** was taken:
+
+- **`defaultTools`** on `ICreateSessionOptions` / `IInitOptions` / `IInteractiveSessionStandardOptions`
+  REPLACES the `createDefaultTools()` tier; `[]` suppresses it entirely — the tool-axis mirror of NEUT-003's
+  `builtInAgents`, reconciled with it explicitly in `packages/agent-framework/docs/SPEC.md`.
+- **Name dedupe** over `defaultTools ⊕ additionalTools ⊕ goalTool`, **first occurrence wins** — the rule
+  `AgentDefinitionLoader` already applies within the subagent built-in tier. Absent `defaultTools` and
+  absent a duplicate name, every path is byte-identical.
+- The edit-checkpoint wrap now covers the assembled set, so a pack-contributed `Write`/`Edit` is
+  checkpointed.
+- `pnpm proof:external` § C5 rewritten from "the tool axis's limitation" to "the tool axis at PARITY" —
+  **68 assertions, exit 0** (was 65).
+
+**PRECEDENCE — answered, and the answer is the opposite of the sketch above.** This item proposed
+"`additionalTools` wins over a default of the same name". It must NOT: the framework default tier is
+constructed WITH the session context, and `cwd` is what arms `agent-tools`' working-directory path guard.
+Measured directly — `createDefaultTools({cwd}).Read('/etc/hostname')` → `Access denied: … is outside the
+working directory`; `codingPack.tools`' `Read` on the same path → **reads the file**, because
+`checkPathWithinCwd` is a no-op when `cwd` is `undefined` and a pack builds its tools at module load with no
+options. Letting a name collision silently swap a context-free instance in for a context-bound one would
+have shipped a silent security regression. Replacement stays fully expressible — through the EXPLICIT
+`defaultTools` seam, never as a side effect of a collision (`mergeCapabilityPacks`' own rule, applied to
+tools).
+
+**REMAINING — `robota` does not yet SOURCE its tools from `pack-coding`.** The seam that would let it is
+landed and proven (a profile passing `defaultTools: []` hands its packs the whole tool surface; removing a
+pack then removes its tools — asserted in `agent-cli`'s `robota-runtime-seam.test.ts` and in the external
+proof's C5). `robota` does not use it yet for exactly the reason above: `ICapabilityPack.tools` is a list of
+PRE-CONSTRUCTED instances, so suppressing the framework tier today would hand robota `Read`/`Write`/`Edit`
+with the path guard disarmed.
+
+The fix is small and its shape is already anticipated by `pack-coding`'s own SPEC comment ("if a future
+contribution carries per-product mutable state, export a `createCodingPack()` factory instead of widening
+this constant"):
+
+1. `@robota-sdk/pack-coding` exports `createCodingPack(options?: { cwd?: string; sandboxClient?: ISandboxClient })`
+   that passes those options into the `agent-tools` factories it already calls. `codingPack` stays as the
+   zero-context constant for consumers that do not need it.
+2. `robota`'s profile builds its pack with the shell's `cwd` and passes `defaultTools: []` in the kernel's
+   runtime-seam input, so the coding tools come from the pack. The equivalence bar is unchanged: the ten
+   tool names, the CLI golden output, and the full `agent-cli` / `agent-transport-tui` suites.
+3. `agent-transport` + `agent-transport-tui` each take the same one-line optional `additionalTools`
+   pass-through the Decision-2 `agentDefinitions` seam already has, so the pack's tools reach the print and
+   TUI channels (today the overlay's tools reach `--serve` only, which is behaviourally inert while the
+   pack's tools are name-identical to the defaults).
+
+None of the three files above was inside the ownership boundary of the change that landed the seam, which
+is why this item stays open rather than being marked done.

--- a/.agents/backlog/completed/ARCH-007-robota-consumes-kernel-runtime-seam.md
+++ b/.agents/backlog/completed/ARCH-007-robota-consumes-kernel-runtime-seam.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-007: robota consumes the product kernel MATERIALS but not its runtime seam or preset resolver'
-status: todo
+status: done
 created: 2026-07-25
+completed: 2026-07-25
 priority: medium
 urgency: soon
 area: packages/agent-cli, packages/agent-product, packages/agent-preset
@@ -62,3 +63,32 @@ spec's In-kernel/stays-in-shell table must be corrected to match.
   suites, and the `robota-assembly-equivalence` test.
 - B2: whichever option is chosen, a test that a preset registered through the chosen path is visible to BOTH
   the startup module-selection delta and the in-session `/preset` command — the split-SSOT failure mode.
+
+## Outcome (2026-07-25)
+
+Both halves landed; see the ARCH-005 spec's `[ARCH-006 + ARCH-007]` evidence entry for the full record.
+
+- **B1 — runtime-build delegation. DONE.** `startCli` calls `product.buildRuntimeOptions(...)` once,
+  through the shipped `buildRobotaRuntimeOptions` helper. The shell resolves its own session inputs (the
+  preset's module-selection delta over the merged `base ⊕ packs` superset, and the explicit
+  `--permission-mode`); the kernel lays the product-owned materials on top — pack tools →
+  `additionalTools`, pack subagents → `agentDefinitions`, and the default preset's `permissionMode` when
+  the shell left it unset. All three surfaces bind to that one result. The hand-threaded
+  `const agentDefinitions = product.subagents` and the three per-surface
+  `args.permissionMode ?? resolvedPreset.permissionMode` expressions are deleted. `agent-product`'s
+  overlay was corrected to stop overwriting a caller-supplied `commandModules`, which would otherwise have
+  silently undone robota's preset delta.
+- **B2 — preset-resolve glue. DECIDED (option iii) + documented.** The shell KEEPS `agent-preset`'s
+  module-global registry as its preset SSOT, because the resolved preset is needed BEFORE the base command
+  modules are built and the in-session `/preset` command reads that same registry — moving only the shell
+  to the instance registry would split it. `IAssembledProduct.resolvePreset` is the external-consumer
+  path. The ARCH-005 In-kernel/stays-in-shell table row is corrected accordingly, and an anti-split test
+  asserts an external preset resolves identically through both paths.
+
+Red-first (all 6 new cases failed before the helper existed), mutation-proven, 255 agent-cli tests green
+including the unchanged ARCH-005 equivalence suite. ARCH-005 **TC-7** is now checked.
+
+One residual belongs to ARCH-006, not here: `additionalTools` reaches `--serve` (whose session options
+`agent-cli` owns) but not the print/TUI channels, which build theirs inside `agent-transport` /
+`agent-transport-tui` and still need the same one-line optional pass-through the `agentDefinitions` seam
+already has. Behaviourally inert today under first-wins dedupe.

--- a/.agents/spec-docs/active/ARCH-005-external-product-composition.md
+++ b/.agents/spec-docs/active/ARCH-005-external-product-composition.md
@@ -414,19 +414,19 @@ legitimate product-shell and **stays in `agent-cli`**. Only the narrow product-n
 `agent-product`. The boundary is drawn precisely so reviewers can confirm the kernel is **closed over
 data**:
 
-| Concern                                                                                                                        | Destination                                             | Rationale                                                                          |
-| ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| External-preset registration + preset-resolve glue (`loadExternalPresets` result → per-call resolver)                          | **In-kernel** (`agent-product`)                         | pure fold over preset DATA (settings/file read happens in shell, result passed in) |
-| Command-module selection / merge glue                                                                                          | **In-kernel**                                           | pure selection over module DATA                                                    |
-| `mergeCapabilityPacks` (additive pack merge)                                                                                   | **In-kernel**                                           | pure fold, additive analog of `resolvePreset`                                      |
-| Provider construction FROM `IProviderDefinition[]` + already-resolved settings                                                 | **In-kernel**                                           | pure over definitions + injected settings data (no settings-file read)             |
-| Runtime-build **delegation** to `buildRuntimeSession`/`startRuntimeHost`                                                       | **In-kernel** (delegates, never re-implements — see R2) | single framework seam                                                              |
-| `init` / `--configure` / `ensureConfig` flows                                                                                  | **Stays-in-shell** (`agent-cli`)                        | interactive IO, file writes                                                        |
-| All `terminal.write*` notices / first-run onboarding                                                                           | **Stays-in-shell**                                      | presentation                                                                       |
-| Session resume / continue / fork UX                                                                                            | **Stays-in-shell**                                      | interactive UX + store IO                                                          |
-| Arg parsing; settings/env reads                                                                                                | **Stays-in-shell**                                      | resolves inputs, feeds resolved DATA into the kernel                               |
-| Mode dispatch (print / serve / TUI) + `process.exit`                                                                           | **Stays-in-shell**                                      | presentation + process lifecycle                                                   |
-| Concrete transports (`WsTransport`), TUI (`renderApp`/`createDefaultTuiCliAdapter`), remote-control, `createDefault*` adapters | **Stays-in-shell** (injected into the profile)          | concrete I/O adapters                                                              |
+| Concern                                                                                                                        | Destination                                                                                                | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External-preset registration + preset-resolve glue (`loadExternalPresets` result → per-call resolver)                          | **In-kernel** for external consumers; the SHELL keeps the module-global registry (ARCH-007 B2, option iii) | pure fold over preset DATA (settings/file read happens in shell, result passed in). Corrected by ARCH-007: `robota` resolves through `agent-preset`'s module-global registry because the resolved preset is needed BEFORE the base command modules are built AND the in-session `/preset` command reads that same registry — moving only the shell to the instance registry would SPLIT that SSOT. `IAssembledProduct.resolvePreset` is the external-consumer path; the shell feeds the same loaded presets into the profile, so the two agree (anti-split test) |
+| Command-module selection / merge glue                                                                                          | **In-kernel**                                                                                              | pure selection over module DATA                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `mergeCapabilityPacks` (additive pack merge)                                                                                   | **In-kernel**                                                                                              | pure fold, additive analog of `resolvePreset`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Provider construction FROM `IProviderDefinition[]` + already-resolved settings                                                 | **In-kernel**                                                                                              | pure over definitions + injected settings data (no settings-file read)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Runtime-build **delegation** to `buildRuntimeSession`/`startRuntimeHost`                                                       | **In-kernel** (delegates, never re-implements — see R2)                                                    | single framework seam                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `init` / `--configure` / `ensureConfig` flows                                                                                  | **Stays-in-shell** (`agent-cli`)                                                                           | interactive IO, file writes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| All `terminal.write*` notices / first-run onboarding                                                                           | **Stays-in-shell**                                                                                         | presentation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Session resume / continue / fork UX                                                                                            | **Stays-in-shell**                                                                                         | interactive UX + store IO                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Arg parsing; settings/env reads                                                                                                | **Stays-in-shell**                                                                                         | resolves inputs, feeds resolved DATA into the kernel                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Mode dispatch (print / serve / TUI) + `process.exit`                                                                           | **Stays-in-shell**                                                                                         | presentation + process lifecycle                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Concrete transports (`WsTransport`), TUI (`renderApp`/`createDefaultTuiCliAdapter`), remote-control, `createDefault*` adapters | **Stays-in-shell** (injected into the profile)                                                             | concrete I/O adapters                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 **The DATA seam (what crosses into `assembleProduct` vs what stays behind — R4).** Everything the kernel
 consumes is plain, already-resolved DATA supplied by the shell; nothing the kernel does reaches back out to
@@ -897,13 +897,21 @@ backed by `scripts/external-proof/` (`pnpm proof:external`) — 65 assertions, a
       nothing registered, a consumer-authored `ICapabilityPack` merges additively in `base ⊕ packs` order,
       and a deliberate id collision is **reported on the rejection channel** (distinct base-vs-pack reasons,
       first registration wins) rather than silently dropped or overridden.
-- [ ] **TC-4 (Mode C: tool axis)** — **PARTIALLY MET, and deliberately not checked.** A pack tool the
-      framework does not already ship IS additive through `buildRuntime`/`buildRuntimeOptions` (proven). But
-      `createSession` assembles `[...createDefaultTools(), ...additionalTools]` with no dedupe and no
-      suppression hook, so a pack can neither remove nor replace a framework default, and a pack whose tools
-      duplicate the defaults (as `pack-coding`'s do by design) would be listed twice — which is why
-      `robota`'s own surfaces still take their tools from `createDefaultTools()`. Tracked by
-      **[ARCH-006](../../backlog/ARCH-006-framework-tool-axis-neutrality.md)**.
+- [x] **TC-4 (Mode C: tool axis)** — **MET by ARCH-006.** `createSession` no longer hard-codes its tool
+      set: `defaultTools` REPLACES the `createDefaultTools()` tier (`[]` suppresses it entirely — the
+      tool-axis mirror of NEUT-003's `builtInAgents`), and the assembled list
+      `defaultTools ⊕ additionalTools ⊕ goalTool` is **deduplicated by tool name, first occurrence wins**
+      (the rule `AgentDefinitionLoader` already applies within the subagent built-in tier). So a pack tool
+      with a NEW name is additive, a pack whose tools mirror the framework defaults is deduped rather than
+      listed twice, and a profile that passes `defaultTools: []` hands its packs the whole tool surface —
+      removing a pack then removes its tools. A name collision keeps the framework default and drops the
+      contribution, because the default tier is built WITH the session context (`cwd` supplies
+      `agent-tools`' working-directory path guard) and an already-constructed contribution carries none of
+      it; replacement is expressible only through the explicit `defaultTools` seam. Measured from the
+      published surface by `pnpm proof:external` § C5 (6 assertions) and in-repo by 8 red-first framework
+      cases. **One residual, disclosed:** `robota`'s own profile does NOT pass `defaultTools: []`, because
+      `pack-coding` ships pre-constructed, context-free tool instances — see the ARCH-006/007 evidence
+      entry below and the follow-up backlog item.
 - [x] **TC-5 (published-surface sufficiency)** — the proof installs real `pnpm pack` tarballs via
       `npm install` (no workspace link, no relative import, `npm overrides` pinning every `@robota-sdk/*`
       specifier so nothing resolves from the registry) and type-checks with `skipLibCheck: false` against the
@@ -911,13 +919,18 @@ backed by `scripts/external-proof/` (`pnpm proof:external`) — 65 assertions, a
 - [x] **TC-6 (reproducible + opt-in)** — the fixture and runner are committed at `scripts/external-proof/`
       and re-runnable with `pnpm proof:external`; they are excluded from the default test suite because they
       pack and install.
-- [ ] **TC-7 (robota eats its own runtime seam)** — **NOT MET, carried from the S2 disclosure.** `cli.ts`
-      consumes the kernel's MATERIALS but not `product.buildRuntime`/`buildRuntimeOptions` nor
-      `product.resolvePreset`. Neither is a kernel defect and neither affects any external mode, but the
-      dogfooding claim is weaker than the boundary table states. Tracked by
-      **[ARCH-007](../../backlog/ARCH-007-robota-consumes-kernel-runtime-seam.md)** — which S3 had to FILE,
-      because the S2 entry's "tracked by the follow-up backlog items filed from the review (B1/B2)" pointed
-      at items that were never actually created.
+- [x] **TC-7 (robota eats its own runtime seam)** — **MET by ARCH-007.** `startCli` now calls
+      `product.buildRuntimeOptions(...)`: the shell resolves its own session inputs and the kernel lays the
+      product-owned materials on top (pack tools → `additionalTools`, pack subagents → `agentDefinitions`,
+      the default preset's `permissionMode` when the shell left it unset), and all three surfaces bind to
+      that ONE result. The hand-threaded `product.subagents` path and the three per-surface
+      `args.permissionMode ?? resolvedPreset.permissionMode` expressions are deleted. **B2 decided
+      explicitly** (the spec's In-kernel table row is corrected below): the shell KEEPS `agent-preset`'s
+      module-global registry as its preset SSOT — option (iii) — because the resolved preset is needed
+      BEFORE the base command modules are built and the in-session `/preset` command reads that same
+      registry; `IAssembledProduct.resolvePreset` is the instance-scoped external-consumer path, and the two
+      cannot split because the shell feeds the presets it registered into the profile (asserted by a
+      dedicated anti-split test).
 
 ## Evidence Log
 
@@ -1249,3 +1262,104 @@ Completion Criteria are not met and the done-gate is not a place to round up:
 Neither blocks an external consumer, which is why S3 is recorded as ✅ IMPLEMENTED. Both are real gaps against
 what THIS spec claims, which is why the spec is **not** moved to `done/`. It moves `todo/` → `active/` with
 `status: in-progress` and closes when ARCH-006 and ARCH-007 land.
+
+### [ARCH-006 + ARCH-007] — ✅ IMPLEMENTED (tool axis at parity + robota eats the runtime seam) | 2026-07-25
+
+The two halves of one seam, filed separately only because they sit in different packages. Both TC-4 and
+TC-7 now carry real evidence.
+
+**ARCH-006 — the framework tool axis (`agent-framework`).** `createSession` no longer hard-codes its tool
+set. Two scoped additive seams, mirroring the adjacent NEUT-003 / ARCH-005 subagent precedent exactly:
+
+- **`defaultTools`** REPLACES the `createDefaultTools()` tier; `[]` suppresses it entirely. Same semantics
+  as NEUT-003's `builtInAgents`, threaded through the same option hops `agentDefinitions` uses
+  (`ICreateSessionOptions` → `IInitOptions` → `IInteractiveSessionStandardOptions`).
+- **Name dedupe** over the fixed tier order `defaultTools ⊕ additionalTools ⊕ goalTool`, **first occurrence
+  wins** — the rule `AgentDefinitionLoader` already applies within the subagent built-in tier.
+
+Absent `defaultTools` and absent a duplicate name, every path is byte-identical. Documented in
+`packages/agent-framework/docs/SPEC.md` § "Session-level tool composition", beside the `agentDefinitions`
+seam table, with the precedence stated and reconciled against it.
+
+> **The precedence question the backlog demanded be answered — and why it points the OTHER way than
+> `agentDefinitions`.** For subagents the injected tier is placed FIRST, so a pack overrides a built-in. For
+> tools a collision keeps the FRAMEWORK default and drops the contribution. The reason was found by
+> measurement, not preference: the default tier is constructed WITH the session context, and `cwd` is what
+> arms `agent-tools`' working-directory path guard. Measured directly —
+> `createDefaultTools({cwd}).Read('/etc/hostname')` → `Access denied: … is outside the working directory`;
+> `codingPack.tools.Read('/etc/hostname')` → **reads the file**, because `checkPathWithinCwd` is a no-op
+> when `cwd` is `undefined` and a pack's tools are constructed at module load with no options. Letting a
+> name collision silently swap a context-free instance in for a context-bound one would have shipped a
+> silent security regression. Replacement stays fully expressible — through the EXPLICIT `defaultTools`
+> seam, never as a side effect of a collision. That is `mergeCapabilityPacks`' own rule (additive merge,
+> never a silent override), applied to tools.
+
+The edit-checkpoint wrap now covers the assembled, deduplicated set rather than the default tier alone, so
+a pack-contributed `Write`/`Edit` is checkpointed too (byte-identical when none is contributed).
+
+**ARCH-007 — `robota` consumes the runtime seam (`agent-cli`, `agent-product`).** `startCli` calls
+`product.buildRuntimeOptions(...)` once, through the shipped `buildRobotaRuntimeOptions` helper. The shell
+resolves its own session inputs — the preset's module-selection delta over the merged `base ⊕ packs`
+superset, and the explicit `--permission-mode` — and the kernel lays the product-owned materials on top:
+pack tools → `additionalTools`, pack subagents → `agentDefinitions`, and the default preset's
+`permissionMode` when the shell left it unset. All three surfaces bind to that ONE result. Deleted: the
+hand-threaded `const agentDefinitions = product.subagents` and the three per-surface
+`args.permissionMode ?? resolvedPreset.permissionMode` expressions.
+
+`agent-product`: `buildRuntimeOptions` no longer overwrites a caller-supplied `commandModules`. Routing
+`robota` through the seam would otherwise have silently undone its preset delta — the assembled set is now
+overlaid only when the caller left it unset, the same rule `permissionMode` already followed.
+
+**B2 decided (option iii), and the In-kernel table row corrected.** The shell KEEPS `agent-preset`'s
+module-global registry as its preset SSOT: the resolved preset is needed BEFORE the base command modules
+are built, and the in-session `/preset` command reads that same registry, so moving only the shell to the
+instance registry would split it. `IAssembledProduct.resolvePreset` is the external-consumer path. An
+anti-split test registers an external preset and asserts it resolves IDENTICALLY through both.
+
+**Evidence.**
+
+- Red-first both halves: 4 of 8 new framework cases failed before ARCH-006; all 6 new agent-cli cases
+  failed before the ARCH-007 helper existed.
+- **Mutation-proven, not accidentally green:** dropping the pack tools from the kernel overlay in
+  `assemble-product.ts` fails the tool assertion (1 failed / 6 passed); reverted → 7/7.
+- **The pack-removal proof** (`robota-runtime-seam.test.ts`): stripping `packs` from the profile the shell
+  built — changing nothing else — drops all 10 coding tools AND all 3 coding subagents from robota's
+  runtime options (`additionalTools` → `[]`, `agentDefinitions` → `undefined`). It calls the SHIPPED
+  helpers (`buildCommandSetup`, `createRobotaProfile`, `selectProductCommandModules`,
+  `buildRobotaRuntimeOptions`), never a re-implementation — the S2 F4 lesson.
+- `pnpm proof:external` — **68 assertions, exit 0** (was 65). § C5 is rewritten from "the tool axis's
+  limitation" to "the tool axis at PARITY", and now MEASURES from the published surface that the overlay
+  carries every name-identical pack tool without duplication, that `defaultTools: []` is accepted by the
+  shipped `.d.ts` (`skipLibCheck: false`) and builds a live `InteractiveSession`, and that with the tier
+  suppressed every tool comes from the profile's packs.
+- Full suites green: `agent-framework` 1269, `agent-transport-tui` 526, `agent-cli` 255 (incl. the ARCH-005
+  equivalence suite, unchanged and still green — no pinned literal went stale), `agent-preset` 71,
+  `agent-product` 11, `agent-capability-pack` 7, `pack-coding` 5 — **2144 tests**. `pnpm -w typecheck`
+  clean; `pnpm harness:verify-like-ci` green; the real `robota` binary runs.
+
+**RESIDUAL — disclosed, not rounded up.** Two hops remain, and neither is a defect in the seams above:
+
+1. **`robota`'s own profile does not pass `defaultTools: []`.** The seam that would let `pack-coding` own
+   robota's tool surface exists and is proven; robota does not use it because `ICapabilityPack.tools` is a
+   list of PRE-CONSTRUCTED tool instances and `pack-coding` builds them at module load with no options —
+   so suppressing the framework tier would hand robota `Read`/`Write`/`Edit` with the working-directory
+   path guard disarmed (measured above). Closing it needs `pack-coding` to export a
+   `createCodingPack({ cwd, sandboxClient })` factory (its own SPEC comment already anticipates that
+   shape), which is outside this change's file ownership. Until then robota's effective tool list is
+   framework-sourced and the pack's tools dedupe against it — behaviour byte-identical, and the overlay is
+   genuinely exercised.
+2. **`additionalTools` reaches `--serve` but not print/TUI.** `runServeMode` builds its session options in
+   `agent-cli`, so the overlay's tools are forwarded there. The print and TUI channels build theirs inside
+   `agent-transport` / `agent-transport-tui` and still need the same one-line optional pass-through the
+   Decision-2 `agentDefinitions` seam already has. With first-wins dedupe and robota's name-identical pack
+   tools this is behaviourally inert today, so the surfaces do not diverge.
+
+Both are carried by **[ARCH-006](../../backlog/ARCH-006-framework-tool-axis-neutrality.md)**, which stays
+open (`status: in-progress`) with the exact three-step remedy written down. **ARCH-007 is closed and
+archived** to `.agents/backlog/completed/`.
+
+**DISPOSITION AFTER ARCH-006/007 — the spec stays `active`.** TC-4 and TC-7 both now carry real evidence
+and are checked. But ARCH-006's own Test Plan asked for one thing more than the framework seam — "`robota`
+sourcing tools from `pack-coding` instead of the framework default" — and that is not done, for the
+measured reason above. The done-gate is not a place to round up: the spec closes when the ARCH-006
+residual lands.

--- a/.changeset/arch-006-007-tool-axis-runtime-seam.md
+++ b/.changeset/arch-006-007-tool-axis-runtime-seam.md
@@ -1,0 +1,38 @@
+---
+'@robota-sdk/agent-framework': minor
+'@robota-sdk/agent-product': minor
+'@robota-sdk/agent-cli': minor
+---
+
+ARCH-006 + ARCH-007 — the capability-pack TOOL axis reaches parity with the command and subagent axes,
+and `robota` consumes the composition kernel's RUNTIME SEAM instead of only its materials.
+
+- **`@robota-sdk/agent-framework` (ARCH-006)** — the default tool set is no longer hard-coded.
+  `createSession` accepts `defaultTools`, which REPLACES the `createDefaultTools()` tier (`[]` suppresses
+  it entirely) — the tool-axis mirror of NEUT-003's `builtInAgents` seam for subagents. The assembled
+  list `defaultTools ⊕ additionalTools ⊕ goalTool` is now **deduplicated by tool name, first occurrence
+  wins**, the same rule `AgentDefinitionLoader` applies within the subagent built-in tier. So a
+  contributed tool with a NEW name is additive, a contributed tool that mirrors a framework default is
+  deduped rather than listed twice, and a product can hand its whole tool surface to its capability
+  packs. A name collision keeps the framework default and drops the contribution: the default tier is
+  built WITH the session context (`cwd` supplies `agent-tools`' working-directory path guard, plus the
+  sandbox client and retrieval adapter) and an already-constructed contribution carries none of it, so
+  replacement is expressible only through the explicit `defaultTools` seam — never as a side effect of a
+  collision. The edit-checkpoint wrap now covers the assembled set, so a pack-contributed `Write`/`Edit`
+  is checkpointed too. Option threaded through `ICreateSessionOptions` / `IInitOptions` /
+  `IInteractiveSessionStandardOptions`. Absent `defaultTools` and absent a duplicate name, every existing
+  path is byte-identical.
+- **`@robota-sdk/agent-product` (ARCH-007)** — `buildRuntimeOptions` no longer overwrites a
+  caller-supplied `commandModules`. A shell that has already narrowed the merged `base ⊕ packs` superset
+  (as `robota` does with its preset's enabled/disabled delta) keeps that selection; the assembled set is
+  overlaid only when the caller left it unset — the same rule `permissionMode` already followed.
+- **`@robota-sdk/agent-cli` (ARCH-007)** — `startCli` now routes through
+  `product.buildRuntimeOptions(...)`. The shell resolves its own session inputs and the kernel lays the
+  product-owned materials on top: the packs' tools (`additionalTools`), the packs' subagents
+  (`agentDefinitions`), and the default preset's permission posture when `--permission-mode` left it
+  unset. The hand-threaded `product.subagents` path and the three per-surface
+  `args.permissionMode ?? resolvedPreset.permissionMode` expressions are gone — every surface binds to
+  the one kernel result.
+
+End-user `robota` behavior is unchanged: the assembled command-module set, provider surface, tool set,
+subagent roster, preset resolution, and permission posture all match the pre-change assembly.

--- a/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ARCH-007 — `robota` consumes the composition kernel's RUNTIME SEAM, not just its materials.
+ *
+ * The ARCH-005 S2 disclosure (B1) was that `cli.ts` passed the assembled materials into
+ * `renderApp` / `runPrintMode` / `runServeMode` by hand and never called
+ * `product.buildRuntimeOptions` — so the kernel's OVERLAY (pack tools → `additionalTools`, pack
+ * subagents → `agentDefinitions`, the default preset's `permissionMode`) was exercised only by tests
+ * and by external Mode-A consumers, never by the reference product.
+ *
+ * These tests pin the seam through the SHIPPED helper (`buildRobotaRuntimeOptions`) that `cli.ts`
+ * actually calls — never a re-implementation of it. That is the S2 F4 lesson: an equivalence gate that
+ * re-derives the shipped logic tests the test, not the product.
+ */
+
+import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
+import {
+  DEFAULT_AGENT_NAME,
+  getPreset,
+  listPresets,
+  registerExternalPresets,
+  resolvePreset,
+} from '@robota-sdk/agent-preset';
+import { assembleProduct } from '@robota-sdk/agent-product';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRobotaRuntimeOptions,
+  selectProductCommandModules,
+} from '../product/robota-plumbing.js';
+import {
+  createRobotaProfile,
+  ROBOTA_PACK_COMMAND_MODULE_NAMES,
+} from '../product/robota-profile.js';
+import { buildCommandSetup } from '../startup/command-setup.js';
+
+import type { IParsedCliArgs } from '../utils/cli-args.js';
+import type { IPreset } from '@robota-sdk/agent-preset';
+
+const MINIMAL_ARGS = { noUpdateCheck: true } as unknown as IParsedCliArgs;
+
+interface IProbeOverrides {
+  packs?: 'default' | 'none';
+  permissionMode?: 'default' | 'bypassPermissions' | 'acceptEdits' | 'plan';
+  defaultPresetId?: string;
+  presets?: readonly IPreset[];
+}
+
+/** Drive the assembly exactly as `startCli` does — same shipped helpers, same order. */
+function robotaProduct(overrides: IProbeOverrides = {}) {
+  const { providerDefinitions, baseCommandModules, fixedCommandModules } = buildCommandSetup(
+    '/tmp/runtime-seam',
+    MINIMAL_ARGS,
+    {},
+    '0.0.0-test',
+    ROBOTA_PACK_COMMAND_MODULE_NAMES,
+  );
+
+  const profile = createRobotaProfile({
+    version: '0.0.0-test',
+    agentName: DEFAULT_AGENT_NAME,
+    providerDefinitions,
+    provider: createScriptedProvider([{ text: 'ok' }]).provider,
+    presets: overrides.presets ?? [],
+    defaultPresetId: overrides.defaultPresetId ?? 'default',
+    baseCommandModules,
+    backgroundTaskRunners: [],
+    subagentRunnerFactory: (() => {
+      throw new Error('not used');
+    }) as never,
+    transports: { startAll: async () => {}, stopAll: async () => {} } as never,
+  });
+
+  // The pack-removal probe: strip the packs from the profile the shell built, changing nothing else.
+  return {
+    product: assembleProduct(overrides.packs === 'none' ? { ...profile, packs: [] } : profile),
+    fixedCommandModules,
+  };
+}
+
+/** Route the assembled product through the kernel's runtime seam, as `startCli` does. */
+function robotaRuntimeOptions(overrides: IProbeOverrides = {}) {
+  const { product, fixedCommandModules } = robotaProduct(overrides);
+
+  return buildRobotaRuntimeOptions({
+    product,
+    cwd: '/tmp/runtime-seam',
+    provider: createScriptedProvider([{ text: 'ok' }]).provider,
+    commandModules: selectProductCommandModules(product, fixedCommandModules, {}),
+    ...(overrides.permissionMode !== undefined ? { permissionMode: overrides.permissionMode } : {}),
+  });
+}
+
+describe('ARCH-007 — the kernel overlay is robota’s single assembly path', () => {
+  it('carries the pack SUBAGENTS through the kernel overlay, not a hand-threaded field', () => {
+    expect(robotaRuntimeOptions().agentDefinitions?.map((a) => a.name)).toEqual([
+      'general-purpose',
+      'Explore',
+      'Plan',
+    ]);
+  });
+
+  it('carries the pack TOOLS through the kernel overlay as additionalTools', () => {
+    expect(robotaRuntimeOptions().additionalTools?.map((t) => t.getName())).toEqual([
+      'Shell',
+      'Bash',
+      'Read',
+      'Write',
+      'Edit',
+      'Glob',
+      'Grep',
+      'WebFetch',
+      'WebSearch',
+      'AskUserQuestion',
+    ]);
+  });
+
+  it('removing the coding pack removes its TOOLS and SUBAGENTS from robota’s runtime options', () => {
+    const withoutPack = robotaRuntimeOptions({ packs: 'none' });
+
+    expect(withoutPack.additionalTools ?? []).toEqual([]);
+    expect(withoutPack.agentDefinitions).toBeUndefined();
+  });
+
+  it('lets the kernel apply the default preset’s permission posture when the shell left it unset', () => {
+    // `careful-reviewer` maps autonomy 'ask-first' → permissionMode 'default' in agent-preset.
+    expect(robotaRuntimeOptions({ defaultPresetId: 'careful-reviewer' }).permissionMode).toBe(
+      'default',
+    );
+  });
+
+  it('never lets the kernel overwrite an explicit shell permission mode (--permission-mode wins)', () => {
+    expect(
+      robotaRuntimeOptions({
+        defaultPresetId: 'careful-reviewer',
+        permissionMode: 'bypassPermissions',
+      }).permissionMode,
+    ).toBe('bypassPermissions');
+  });
+
+  it('keeps ONE preset SSOT — the same external preset resolves identically on both paths (B2)', () => {
+    // ARCH-007 B2, decided: the shell keeps `agent-preset`'s MODULE-GLOBAL registry as the SSOT, because
+    // the resolved preset is needed BEFORE the base command modules are built (its module-selection delta
+    // feeds them) and because the in-session `/preset` command reads that same registry. The kernel's
+    // per-call instance registry (R8) is the EXTERNAL-consumer path; the two cannot split, because the
+    // shell feeds the very presets it registered into the profile. This test is the anti-split gate.
+    const external: IPreset = {
+      id: 'arch-007-probe',
+      title: 'probe',
+      description: 'B2 split-SSOT gate',
+      persona: 'probe persona',
+      autonomy: 'ask-first',
+    };
+    registerExternalPresets([external]);
+
+    // (a) visible to the module-global registry the startup delta + `/preset` read…
+    expect(getPreset('arch-007-probe')).toBeDefined();
+    expect(listPresets().map((p) => p.id)).toContain('arch-007-probe');
+
+    // (b) …and to the kernel's instance registry, resolving to exactly the same options.
+    const { product } = robotaProduct({ presets: [external] });
+    expect(product.resolvePreset('arch-007-probe')).toEqual(resolvePreset('arch-007-probe'));
+    expect(product.resolvePreset('arch-007-probe')).toMatchObject({
+      persona: 'probe persona',
+      permissionMode: 'default',
+    });
+  });
+
+  it('preserves the shell’s already-narrowed command-module selection (preset delta survives)', () => {
+    // The preset's enabled/disabled delta is applied by the shell over the merged superset; the kernel
+    // must not clobber that selection with its own unfiltered `base ⊕ packs` list.
+    const options = robotaRuntimeOptions();
+    const names = options.commandModules?.map((m) => m.name) ?? [];
+
+    expect(names).toContain('agent-command-shell');
+    expect(names).toContain('agent-command-workflows');
+  });
+});

--- a/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
@@ -85,14 +85,14 @@ function robotaRuntimeOptions(overrides: IProbeOverrides = {}) {
     product,
     cwd: '/tmp/runtime-seam',
     provider: createScriptedProvider([{ text: 'ok' }]).provider,
-    commandModules: selectProductCommandModules(product, fixedCommandModules, {}),
+    selectedCommandModules: selectProductCommandModules(product, fixedCommandModules, {}),
     ...(overrides.permissionMode !== undefined ? { permissionMode: overrides.permissionMode } : {}),
   });
 }
 
 describe('ARCH-007 — the kernel overlay is robota’s single assembly path', () => {
   it('carries the pack SUBAGENTS through the kernel overlay, not a hand-threaded field', () => {
-    expect(robotaRuntimeOptions().agentDefinitions?.map((a) => a.name)).toEqual([
+    expect(robotaRuntimeOptions().agentDefinitions.map((a) => a.name)).toEqual([
       'general-purpose',
       'Explore',
       'Plan',
@@ -100,7 +100,7 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   });
 
   it('carries the pack TOOLS through the kernel overlay as additionalTools', () => {
-    expect(robotaRuntimeOptions().additionalTools?.map((t) => t.getName())).toEqual([
+    expect(robotaRuntimeOptions().additionalTools.map((t) => t.getName())).toEqual([
       'Shell',
       'Bash',
       'Read',
@@ -117,8 +117,8 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   it('removing the coding pack removes its TOOLS and SUBAGENTS from robota’s runtime options', () => {
     const withoutPack = robotaRuntimeOptions({ packs: 'none' });
 
-    expect(withoutPack.additionalTools ?? []).toEqual([]);
-    expect(withoutPack.agentDefinitions).toBeUndefined();
+    expect(withoutPack.additionalTools).toEqual([]);
+    expect(withoutPack.agentDefinitions).toEqual([]);
   });
 
   it('lets the kernel apply the default preset’s permission posture when the shell left it unset', () => {
@@ -169,7 +169,7 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
     // The preset's enabled/disabled delta is applied by the shell over the merged superset; the kernel
     // must not clobber that selection with its own unfiltered `base ⊕ packs` list.
     const options = robotaRuntimeOptions();
-    const names = options.commandModules?.map((m) => m.name) ?? [];
+    const names = options.commandModules.map((m) => m.name);
 
     expect(names).toContain('agent-command-shell');
     expect(names).toContain('agent-command-workflows');

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -314,23 +314,19 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     process.exit(1);
   }
 
-  // ARCH-007 (B1): route the shell through the kernel's RUNTIME SEAM, not just its materials. The shell
-  // resolves its own session inputs — the preset's module-selection delta filters the base ⊕ pack superset
-  // the kernel merged (fixed modules appended outside the delta, as before), and `--permission-mode` is the
-  // explicit override — then `product.buildRuntimeOptions` lays the product-owned materials on top: the
-  // packs' tools (`additionalTools`), the packs' subagents (`agentDefinitions`, owner Decision 2), and the
-  // default preset's permission posture when the shell left it unset. Every surface below binds to THIS one
-  // result; nothing is re-threaded by hand, so removing a pack genuinely removes its capability.
-  const runtimeOptions = buildRobotaRuntimeOptions({
-    product,
-    cwd,
-    provider,
-    commandModules: selectProductCommandModules(product, fixedCommandModules, resolvedPreset),
-    ...(args.permissionMode !== undefined ? { permissionMode: args.permissionMode } : {}),
-  });
-  const commandModules = runtimeOptions.commandModules ?? [];
-  const agentDefinitions = runtimeOptions.agentDefinitions ?? [];
-  const additionalTools = runtimeOptions.additionalTools ?? [];
+  // ARCH-007 (B1): the kernel's RUNTIME SEAM — every surface below binds to THIS one result.
+  const { commandModules, agentDefinitions, additionalTools, permissionMode } =
+    buildRobotaRuntimeOptions({
+      product,
+      cwd,
+      provider,
+      selectedCommandModules: selectProductCommandModules(
+        product,
+        fixedCommandModules,
+        resolvedPreset,
+      ),
+      ...(args.permissionMode !== undefined ? { permissionMode: args.permissionMode } : {}),
+    });
   // A capability the merge refused (a colliding id) is reported, never silently dropped.
   for (const { kind, id, reason } of product.rejectedCapabilities) {
     terminal.writeError(`Capability ${kind} "${id}" was not composed: ${reason}.`);
@@ -384,11 +380,8 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
         agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
         activePresetId: selectedPresetId,
         persona: resolvedPreset.persona,
-        // ARCH-007: the posture the KERNEL resolved (explicit --permission-mode, else the default
-        // preset's) — not a second hand-rolled `args ?? preset` expression per surface.
-        ...(runtimeOptions.permissionMode !== undefined
-          ? { permissionMode: runtimeOptions.permissionMode }
-          : {}),
+        // ARCH-007: the posture the KERNEL resolved (explicit --permission-mode, else the preset's).
+        ...(permissionMode !== undefined ? { permissionMode } : {}),
         ...(resolvedPreset.enableParallelSubagents !== undefined
           ? { enableParallelSubagents: resolvedPreset.enableParallelSubagents }
           : {}),
@@ -414,10 +407,6 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       backgroundTaskRunners,
       subagentRunnerFactory,
       agentDefinitions,
-      // ARCH-006/007: the packs' tools reach the served runtime through the kernel overlay. `--serve` is
-      // the one surface whose session options this shell owns end to end; the print and TUI channels build
-      // theirs inside `agent-transport` / `agent-transport-tui`, which still need the same one-line
-      // `additionalTools` pass-through the Decision-2 `agentDefinitions` seam already has.
       additionalTools,
       commandModules,
       commandHostAdapters,
@@ -438,10 +427,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
         agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
         activePresetId: selectedPresetId,
         persona: resolvedPreset.persona,
-        // ARCH-007: the kernel-resolved posture (see the print-mode call above).
-        ...(runtimeOptions.permissionMode !== undefined
-          ? { permissionMode: runtimeOptions.permissionMode }
-          : {}),
+        ...(permissionMode !== undefined ? { permissionMode } : {}),
         ...(resolvedPreset.enableParallelSubagents !== undefined
           ? { enableParallelSubagents: resolvedPreset.enableParallelSubagents }
           : {}),
@@ -478,7 +464,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     providerType: providerSettings.name,
     modelId,
     language: args.language,
-    permissionMode: runtimeOptions.permissionMode,
+    permissionMode,
     maxTurns: args.maxTurns,
     allowedTools: parseToolList(args.allowedTools),
     deniedTools: parseToolList(args.deniedTools),

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -27,6 +27,7 @@ import { DEFAULT_AGENT_NAME, getPreset, loadExternalPresets } from '@robota-sdk/
 import type { IPreset, IResolvedPresetOptions } from '@robota-sdk/agent-preset';
 import { createRobotaProfile, ROBOTA_PACK_COMMAND_MODULE_NAMES } from './product/robota-profile.js';
 import {
+  buildRobotaRuntimeOptions,
   createDefaultTransportRegistry,
   findUnknownPresetModuleNames,
   loadReplayProvider,
@@ -313,12 +314,23 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     process.exit(1);
   }
 
-  // The preset's module-selection delta filters the base ⊕ pack superset the kernel merged; the fixed
-  // modules are appended outside the delta, as before.
-  const commandModules = selectProductCommandModules(product, fixedCommandModules, resolvedPreset);
-  // ARCH-005 (owner Decision 2): the packs' subagents reach the runtime through the framework's
-  // `agentDefinitions` seam, so removing a pack genuinely removes its subagents from the product.
-  const agentDefinitions = product.subagents;
+  // ARCH-007 (B1): route the shell through the kernel's RUNTIME SEAM, not just its materials. The shell
+  // resolves its own session inputs — the preset's module-selection delta filters the base ⊕ pack superset
+  // the kernel merged (fixed modules appended outside the delta, as before), and `--permission-mode` is the
+  // explicit override — then `product.buildRuntimeOptions` lays the product-owned materials on top: the
+  // packs' tools (`additionalTools`), the packs' subagents (`agentDefinitions`, owner Decision 2), and the
+  // default preset's permission posture when the shell left it unset. Every surface below binds to THIS one
+  // result; nothing is re-threaded by hand, so removing a pack genuinely removes its capability.
+  const runtimeOptions = buildRobotaRuntimeOptions({
+    product,
+    cwd,
+    provider,
+    commandModules: selectProductCommandModules(product, fixedCommandModules, resolvedPreset),
+    ...(args.permissionMode !== undefined ? { permissionMode: args.permissionMode } : {}),
+  });
+  const commandModules = runtimeOptions.commandModules ?? [];
+  const agentDefinitions = runtimeOptions.agentDefinitions ?? [];
+  const additionalTools = runtimeOptions.additionalTools ?? [];
   // A capability the merge refused (a colliding id) is reported, never silently dropped.
   for (const { kind, id, reason } of product.rejectedCapabilities) {
     terminal.writeError(`Capability ${kind} "${id}" was not composed: ${reason}.`);
@@ -372,8 +384,10 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
         agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
         activePresetId: selectedPresetId,
         persona: resolvedPreset.persona,
-        ...(resolvedPreset.permissionMode !== undefined
-          ? { permissionMode: resolvedPreset.permissionMode }
+        // ARCH-007: the posture the KERNEL resolved (explicit --permission-mode, else the default
+        // preset's) — not a second hand-rolled `args ?? preset` expression per surface.
+        ...(runtimeOptions.permissionMode !== undefined
+          ? { permissionMode: runtimeOptions.permissionMode }
           : {}),
         ...(resolvedPreset.enableParallelSubagents !== undefined
           ? { enableParallelSubagents: resolvedPreset.enableParallelSubagents }
@@ -400,6 +414,11 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       backgroundTaskRunners,
       subagentRunnerFactory,
       agentDefinitions,
+      // ARCH-006/007: the packs' tools reach the served runtime through the kernel overlay. `--serve` is
+      // the one surface whose session options this shell owns end to end; the print and TUI channels build
+      // theirs inside `agent-transport` / `agent-transport-tui`, which still need the same one-line
+      // `additionalTools` pass-through the Decision-2 `agentDefinitions` seam already has.
+      additionalTools,
       commandModules,
       commandHostAdapters,
       transportRegistry,
@@ -419,8 +438,9 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
         agentName: resolvedPreset.agentName ?? DEFAULT_AGENT_NAME,
         activePresetId: selectedPresetId,
         persona: resolvedPreset.persona,
-        ...(resolvedPreset.permissionMode !== undefined
-          ? { permissionMode: resolvedPreset.permissionMode }
+        // ARCH-007: the kernel-resolved posture (see the print-mode call above).
+        ...(runtimeOptions.permissionMode !== undefined
+          ? { permissionMode: runtimeOptions.permissionMode }
           : {}),
         ...(resolvedPreset.enableParallelSubagents !== undefined
           ? { enableParallelSubagents: resolvedPreset.enableParallelSubagents }
@@ -458,7 +478,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     providerType: providerSettings.name,
     modelId,
     language: args.language,
-    permissionMode: args.permissionMode ?? resolvedPreset.permissionMode,
+    permissionMode: runtimeOptions.permissionMode,
     maxTurns: args.maxTurns,
     allowedTools: parseToolList(args.allowedTools),
     deniedTools: parseToolList(args.deniedTools),

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -18,7 +18,7 @@ import { startRuntimeHost } from '@robota-sdk/agent-framework';
 
 import type { IParsedCliArgs } from '../utils/cli-args.js';
 import type { IMemorySessionOptions } from '../startup/memory-enablement.js';
-import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IAIProvider, IToolWithEventService } from '@robota-sdk/agent-core';
 import type {
   IAgentDefinition,
   IBackgroundTaskRunner,
@@ -53,6 +53,12 @@ export interface IServeModeOptions {
   subagentRunnerFactory: ReturnType<typeof createChildProcessSubagentRunnerFactory>;
   /** ARCH-005: composition-root-contributed subagent definitions (the profile's merged pack subagents). */
   agentDefinitions?: readonly IAgentDefinition[];
+  /**
+   * ARCH-006/007: the profile's merged pack TOOLS, laid on by the kernel overlay. Forwarded to the
+   * session's `additionalTools` seam, where the framework dedupes them by name against its own default
+   * tier (first occurrence wins — see `agent-framework/docs/SPEC.md` § "Session-level tool composition").
+   */
+  additionalTools?: IToolWithEventService[];
   commandModules: readonly ICommandModule[];
   commandHostAdapters: ICommandHostAdapters;
   transportRegistry: ITransportRegistryView<IInteractiveSession>;
@@ -94,6 +100,7 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     backgroundTaskRunners: opts.backgroundTaskRunners,
     subagentRunnerFactory: opts.subagentRunnerFactory,
     ...(opts.agentDefinitions !== undefined ? { agentDefinitions: opts.agentDefinitions } : {}),
+    ...(opts.additionalTools !== undefined ? { additionalTools: opts.additionalTools } : {}),
     commandModules: opts.commandModules,
     commandHostAdapters: opts.commandHostAdapters,
     ...(opts.remoteCommandPolicy ? { remoteCommandPolicy: opts.remoteCommandPolicy } : {}),

--- a/packages/agent-cli/src/product/robota-plumbing.ts
+++ b/packages/agent-cli/src/product/robota-plumbing.ts
@@ -17,8 +17,12 @@ import {
 import { TransportRegistry } from '@robota-sdk/agent-transport';
 import { WsTransport } from '@robota-sdk/agent-transport-ws';
 
-import type { IAIProvider } from '@robota-sdk/agent-core';
-import type { ICommandModule, IUnknownCommandModuleName } from '@robota-sdk/agent-framework';
+import type { IAIProvider, IToolWithEventService, TPermissionMode } from '@robota-sdk/agent-core';
+import type {
+  IAgentDefinition,
+  ICommandModule,
+  IUnknownCommandModuleName,
+} from '@robota-sdk/agent-framework';
 import type { IAssembledProduct } from '@robota-sdk/agent-product';
 import type { IResolvedPresetOptions } from '@robota-sdk/agent-preset';
 
@@ -121,4 +125,63 @@ export function selectProductCommandModules(
     ),
     ...fixedCommandModules,
   ];
+}
+
+/** The shell-resolved inputs `robota` hands to the kernel's runtime seam. */
+export interface IRobotaRuntimeSeamInput {
+  /** The assembled product whose overlay lays the product-owned materials on top. */
+  product: IAssembledProduct;
+  cwd: string;
+  provider: IAIProvider;
+  /** The shell's already-narrowed module selection (merged superset filtered by the preset delta). */
+  commandModules: readonly ICommandModule[];
+  /**
+   * An EXPLICIT permission mode (`--permission-mode`). Left undefined, the kernel overlays the default
+   * preset's posture — which is exactly the `args.permissionMode ?? resolvedPreset.permissionMode`
+   * expression each surface used to compute by hand.
+   */
+  permissionMode?: TPermissionMode;
+}
+
+/**
+ * The product-owned session options `robota`'s three presentation channels are bound to — produced by the
+ * KERNEL, not re-threaded by the shell.
+ *
+ * `buildRuntimeOptions` returns the `TInteractiveSessionOptions` UNION, so reading back the very fields the
+ * overlay just added requires narrowing to the standard branch (recorded as finding F1 of the ARCH-005 S3
+ * external proof). The shell supplies a standard-branch input, so the narrowing is sound; it is asserted
+ * rather than assumed.
+ */
+export interface IRobotaRuntimeOptions {
+  provider: IAIProvider;
+  commandModules?: readonly ICommandModule[];
+  additionalTools?: IToolWithEventService[];
+  agentDefinitions?: readonly IAgentDefinition[];
+  permissionMode?: TPermissionMode;
+}
+
+/**
+ * ARCH-007 (B1) — route `robota` through the composition kernel's RUNTIME SEAM.
+ *
+ * Before this, `cli.ts` consumed the kernel's MATERIALS but hand-threaded them into
+ * `runPrintMode` / `runServeMode` / `renderApp`, so the overlay — pack tools → `additionalTools`, pack
+ * subagents → `agentDefinitions`, the default preset's `permissionMode` — was exercised only by tests and
+ * by external Mode-A consumers, never by the reference product. Now the shell resolves its own session
+ * inputs, the kernel lays the product-owned materials on top, and every surface binds to that ONE result.
+ */
+export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobotaRuntimeOptions {
+  const options = input.product.buildRuntimeOptions({
+    session: {
+      cwd: input.cwd,
+      provider: input.provider,
+      commandModules: input.commandModules,
+      ...(input.permissionMode !== undefined ? { permissionMode: input.permissionMode } : {}),
+    },
+  });
+  if ('session' in options) {
+    throw new Error(
+      'buildRobotaRuntimeOptions: the kernel returned the injected-session branch for a standard-construction input.',
+    );
+  }
+  return options;
 }

--- a/packages/agent-cli/src/product/robota-plumbing.ts
+++ b/packages/agent-cli/src/product/robota-plumbing.ts
@@ -134,7 +134,7 @@ export interface IRobotaRuntimeSeamInput {
   cwd: string;
   provider: IAIProvider;
   /** The shell's already-narrowed module selection (merged superset filtered by the preset delta). */
-  commandModules: readonly ICommandModule[];
+  selectedCommandModules: readonly ICommandModule[];
   /**
    * An EXPLICIT permission mode (`--permission-mode`). Left undefined, the kernel overlays the default
    * preset's posture — which is exactly the `args.permissionMode ?? resolvedPreset.permissionMode`
@@ -154,9 +154,9 @@ export interface IRobotaRuntimeSeamInput {
  */
 export interface IRobotaRuntimeOptions {
   provider: IAIProvider;
-  commandModules?: readonly ICommandModule[];
-  additionalTools?: IToolWithEventService[];
-  agentDefinitions?: readonly IAgentDefinition[];
+  commandModules: readonly ICommandModule[];
+  additionalTools: IToolWithEventService[];
+  agentDefinitions: readonly IAgentDefinition[];
   permissionMode?: TPermissionMode;
 }
 
@@ -174,7 +174,7 @@ export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobo
     session: {
       cwd: input.cwd,
       provider: input.provider,
-      commandModules: input.commandModules,
+      commandModules: input.selectedCommandModules,
       ...(input.permissionMode !== undefined ? { permissionMode: input.permissionMode } : {}),
     },
   });
@@ -183,5 +183,10 @@ export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobo
       'buildRobotaRuntimeOptions: the kernel returned the injected-session branch for a standard-construction input.',
     );
   }
-  return options;
+  return {
+    ...options,
+    commandModules: options.commandModules ?? [],
+    additionalTools: options.additionalTools ?? [],
+    agentDefinitions: options.agentDefinitions ?? [],
+  };
 }

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -2410,6 +2410,48 @@ tier: the FIRST entry for a name wins and later duplicates are dropped, so a pac
 shadows a built-in yields one roster entry, never two. (For a tier with no duplicate names — the
 historic `BUILT_IN_AGENTS` alone — the dedupe is a no-op.)
 
+### Session-level tool composition (`defaultTools` / `additionalTools`, ARCH-006)
+
+The tool axis has the same two-seam shape as the subagent axis above, and the same precedence
+question answered explicitly. Both options are available on `IInteractiveSessionStandardOptions` /
+`IInitOptions` / `ICreateSessionOptions`.
+
+| Seam                      | Semantics                                                         | Set with no framework defaults |
+| ------------------------- | ----------------------------------------------------------------- | ------------------------------ |
+| `defaultTools` (ARCH-006) | REPLACES the `createDefaultTools()` tier                          | pass `[]`                      |
+| `additionalTools`         | APPENDS to that tier; contributes NEW names only (see precedence) | n/a                            |
+
+`createSession` assembles the fixed tier order `defaultTools ⊕ additionalTools ⊕ goalTool` and then
+**deduplicates by tool name, first occurrence wins** — the same "first entry for a name wins" rule
+`AgentDefinitionLoader` applies within the subagent built-in tier. Consequences:
+
+1. A contributed tool whose name is **new** is fully additive.
+2. A contributed tool whose name **collides** with a tool already in the list is **dropped**, never
+   listed twice. Before ARCH-006 it was listed twice, so a capability pack whose tools mirror the
+   framework defaults (as `@robota-sdk/pack-coding`'s do by design) could not be overlaid at all.
+3. A contributed tool **cannot silently displace** a framework default. That direction is deliberate
+   and is the one place this seam differs from `agentDefinitions` (where the injected tier is placed
+   FIRST and therefore wins): the default tier is constructed WITH the session context — `cwd`
+   supplies `agent-tools`' working-directory path guard, plus the sandbox client and the retrieval
+   adapter — and an already-constructed contribution carries none of it. Letting a name collision
+   swap in a context-free instance would silently disable a security guarantee. It mirrors
+   `mergeCapabilityPacks`' own rule: additive merge, never a silent override.
+
+**Replacement and suppression are still fully expressible** — through the explicit `defaultTools`
+seam, which is the intentional act rather than a side effect of a name collision. A product profile
+that wants its capability packs to OWN the tool surface passes `defaultTools: []` and lets the packs
+supply every tool through `additionalTools`; removing a pack then genuinely removes its tools. The
+injected tools are used as given: the framework cannot re-bind session context onto an
+already-constructed tool, so an injected replacement for a context-sensitive default (`Read`,
+`Write`, `Edit`, and the sandbox-aware `Shell`/`Bash`) must carry that context itself.
+
+The edit-checkpoint wrap (`wrapEditCheckpointTools`) is applied to the **assembled, deduplicated**
+set rather than to the default tier alone, so a pack-contributed `Write`/`Edit` is checkpointed too.
+With no contributed `Write`/`Edit` this is byte-identical to the previous behavior.
+
+Absent `defaultTools` **and** absent a duplicate name, the whole assembly is byte-identical to
+before ARCH-006.
+
 ### Model-Requested Agent Invocation
 
 Model-requested agent invocation is owned by `@robota-sdk/agent-command`. The command module

--- a/packages/agent-framework/src/__tests__/create-session-default-tools.test.ts
+++ b/packages/agent-framework/src/__tests__/create-session-default-tools.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ARCH-006 — the capability-pack TOOL axis at parity with the command and subagent axes.
+ *
+ * Before this change `createSession` assembled `[...createDefaultTools(), ...additionalTools]` with NO
+ * dedupe and NO suppression hook, so:
+ *
+ *  - a contributor whose tool NAME matched a framework default was listed TWICE, and
+ *  - no consumer could remove or replace a framework default at all.
+ *
+ * Two scoped additive seams close that, mirroring the adjacent NEUT-003 / ARCH-005 subagent precedent:
+ *
+ *  - `defaultTools` REPLACES the framework's `createDefaultTools()` tier (`[]` suppresses it entirely),
+ *    exactly as NEUT-003's `builtInAgents` replaces `BUILT_IN_AGENTS`;
+ *  - the assembled list is deduped BY TOOL NAME, first occurrence wins, over the fixed tier order
+ *    `defaultTier ⊕ additionalTools ⊕ goalTool` — the same "first entry for a name wins" rule
+ *    `AgentDefinitionLoader` already applies within the built-in tier.
+ *
+ * Absent `defaultTools` and absent a duplicate name, every existing path is byte-identical.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { IResolvedConfig } from '../config/config-types.js';
+import type { IToolWithEventService } from '@robota-sdk/agent-core';
+
+const sessionCtorCalls: Array<Record<string, unknown>> = [];
+
+vi.mock('@robota-sdk/agent-session', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-session');
+  return {
+    ...actual,
+    Session: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+      sessionCtorCalls.push(options);
+      return {
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
+        run: vi.fn().mockResolvedValue('mock response'),
+        abort: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        clearHistory: vi.fn(),
+        injectMessage: vi.fn(),
+      };
+    }),
+    FileSessionLogger: vi.fn().mockImplementation(() => ({})),
+  };
+});
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+} as never;
+
+function createMockProvider() {
+  return {
+    name: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      role: 'assistant',
+      content: 'mock response',
+      timestamp: new Date(),
+    }),
+  } as never;
+}
+
+function baseConfig(): IResolvedConfig {
+  return {
+    defaultTrustLevel: 'moderate' as const,
+    provider: { name: 'mock', apiKey: 'test-key', model: 'test-model' },
+    permissions: { allow: [], deny: [] },
+    language: 'en' as const,
+    env: {},
+  };
+}
+
+/** A minimal named tool double — the shape `additionalTools` / `defaultTools` accept. */
+function namedTool(name: string, marker: string): IToolWithEventService {
+  return {
+    schema: { name, description: marker, parameters: { type: 'object', properties: {} } },
+    setEventService: () => {},
+    execute: async () => ({ success: true, data: marker }),
+    validate: () => true,
+    validateParameters: () => ({ isValid: true, errors: [], warnings: [] }),
+    getDescription: () => marker,
+    getName: () => name,
+  } as unknown as IToolWithEventService;
+}
+
+async function assembleToolNames(
+  overrides: Record<string, unknown> = {},
+): Promise<{ names: string[]; tools: IToolWithEventService[] }> {
+  const { createSession } = await import('../assembly/create-session.js');
+  createSession({
+    config: baseConfig(),
+    context: { agentsMd: '', projectNotesMd: '' },
+    terminal: MOCK_TERMINAL,
+    provider: createMockProvider(),
+    ...overrides,
+  } as never);
+  const tools = sessionCtorCalls[0]!.tools as IToolWithEventService[];
+  return { names: tools.map((t) => t.getName()), tools };
+}
+
+describe('ARCH-006 — additionalTools dedupe by tool name', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('lists a name-colliding contributed tool ONCE, not twice', async () => {
+    const { names } = await assembleToolNames({
+      additionalTools: [namedTool('Read', 'contributed-Read')],
+    });
+
+    expect(names.filter((n) => n === 'Read')).toHaveLength(1);
+  });
+
+  it('keeps the FIRST occurrence of a name — the framework default wins over a collider', async () => {
+    // Precedence is deliberate and documented: the default tier is constructed WITH the session context
+    // (cwd → the working-directory path guard, sandboxClient, retrieval adapter), so a context-free
+    // contributed instance must never silently displace it. Replacement is expressible, but only through
+    // the EXPLICIT `defaultTools` seam below — never as a side effect of a name collision.
+    const { tools } = await assembleToolNames({
+      additionalTools: [namedTool('Read', 'contributed-Read')],
+    });
+
+    const read = tools.find((t) => t.getName() === 'Read')!;
+    expect(read.getDescription()).not.toBe('contributed-Read');
+  });
+
+  it('still admits a contributed tool whose name is NEW (the axis stays additive)', async () => {
+    const { names } = await assembleToolNames({
+      additionalTools: [namedTool('AcmeTicketLookup', 'new')],
+    });
+
+    expect(names).toContain('AcmeTicketLookup');
+  });
+
+  it('is byte-identical when no name collides (unchanged order: defaults, then additional)', async () => {
+    const { createDefaultTools } = await import('../assembly/create-tools.js');
+    const { names } = await assembleToolNames({
+      additionalTools: [namedTool('AcmeTicketLookup', 'new')],
+    });
+
+    expect(names).toEqual([...createDefaultTools().map((t) => t.getName()), 'AcmeTicketLookup']);
+  });
+});
+
+describe('ARCH-006 — the injectable/suppressible default tool tier', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('SUPPRESSES every framework default when `defaultTools: []` is injected', async () => {
+    const { names } = await assembleToolNames({ defaultTools: [] });
+
+    expect(names).toEqual([]);
+  });
+
+  it('lets a contributed pack OWN the whole tool surface (suppress + contribute)', async () => {
+    // This is the shape a product profile uses to hand the tool axis to its capability packs: suppress the
+    // framework tier, then let the packs supply every tool through `additionalTools`. Removing the pack
+    // then genuinely removes its tools — the same load-bearing property the command and subagent axes have.
+    const { names } = await assembleToolNames({
+      defaultTools: [],
+      additionalTools: [namedTool('Read', 'pack-Read'), namedTool('AcmeTicketLookup', 'pack-new')],
+    });
+
+    expect(names).toEqual(['Read', 'AcmeTicketLookup']);
+  });
+
+  it('REPLACES the framework tier with the injected set (NEUT-003 `builtInAgents` semantics)', async () => {
+    const { names, tools } = await assembleToolNames({
+      defaultTools: [namedTool('Read', 'injected-Read')],
+    });
+
+    expect(names).toEqual(['Read']);
+    expect(tools[0]!.getDescription()).toBe('injected-Read');
+  });
+
+  it('leaves the framework tier exactly `createDefaultTools()` when the option is absent', async () => {
+    const { createDefaultTools } = await import('../assembly/create-tools.js');
+    const { names } = await assembleToolNames();
+
+    expect(names).toEqual(createDefaultTools().map((t) => t.getName()));
+  });
+});

--- a/packages/agent-framework/src/assembly/assemble-session-tools.ts
+++ b/packages/agent-framework/src/assembly/assemble-session-tools.ts
@@ -1,0 +1,103 @@
+/**
+ * ARCH-006 — the session's TOOL assembly, split out of `createSession`.
+ *
+ * One cohesive concern: resolve the default tool tier, compose the contributed tiers on top, collapse the
+ * result to one entry per tool name, and apply the session-context wrappers (edit checkpoints, reversible
+ * execution). `createSession` keeps provider/prompt/permission assembly; this owns which tools exist.
+ *
+ * See `docs/SPEC.md` § "Session-level tool composition" for the published contract.
+ */
+
+import { createDefaultTools } from './create-tools.js';
+import { wrapEditCheckpointTools } from '../checkpoints/edit-checkpoint-tools.js';
+import { createGoalStatusTool } from '../goal/index.js';
+import { wrapReversibleExecutionTools } from '../reversible-execution/index.js';
+
+import type { ICreateSessionOptions } from './create-session-types.js';
+import type { IToolWithEventService } from '@robota-sdk/agent-core';
+
+/**
+ * Collapse the assembled tool list to one entry per tool NAME.
+ *
+ * Precedence: the FIRST occurrence of a name wins, over the fixed tier order
+ * `defaultTools ⊕ additionalTools ⊕ goalTool`. This is the same "first entry for a name wins" rule
+ * `AgentDefinitionLoader` already applies within the subagent built-in tier.
+ *
+ * So a contributed tool whose name is NEW is additive (the axis stays open), and a contributed tool whose
+ * name collides with a framework default is DROPPED rather than listed twice — it does not silently
+ * displace the default. That direction is deliberate: the default tier is built with the session context
+ * (`cwd` supplies the working-directory path guard, plus the sandbox client and retrieval adapter), and a
+ * context-free contribution replacing it would silently weaken those guarantees. Replacement stays fully
+ * expressible — through the EXPLICIT `defaultTools` injection seam, never as a side effect of a collision.
+ * That mirrors `mergeCapabilityPacks`' own rule: additive merge, never a silent override.
+ */
+function dedupeToolsByName(tools: readonly IToolWithEventService[]): IToolWithEventService[] {
+  const seen = new Set<string>();
+  const deduped: IToolWithEventService[] = [];
+  for (const tool of tools) {
+    const name = tool.getName();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    deduped.push(tool);
+  }
+  return deduped;
+}
+
+/** The assembled tool list plus the one flag the reversible-execution policy reads back. */
+export interface IAssembledSessionTools {
+  tools: IToolWithEventService[];
+  /** Host-side edit checkpointing is active (recorder present, no sandbox) — `checkpointAvailable`. */
+  checkpointAvailable: boolean;
+}
+
+/** Assemble the session's tool list from the default tier, the contributed tiers, and the wrappers. */
+export function assembleSessionTools(
+  options: ICreateSessionOptions,
+  cwd: string,
+): IAssembledSessionTools {
+  // The default tool tier is INJECTABLE. `options.defaultTools` REPLACES `createDefaultTools()` outright
+  // (an empty array suppresses every framework default), mirroring NEUT-003's `builtInAgents` seam for
+  // subagents. Absent ⇒ the framework tier is constructed exactly as before, WITH the session context
+  // (cwd → the working-directory path guard, sandbox client, retrieval adapter) — which is why a name
+  // collision must never silently displace it (see `dedupeToolsByName`).
+  const defaultTools =
+    options.defaultTools ??
+    createDefaultTools({
+      sandboxClient: options.sandboxClient,
+      cwd,
+      ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
+    });
+  const checkpointAvailable =
+    options.editCheckpointRecorder !== undefined && options.sandboxClient === undefined;
+  const dedupedTools = dedupeToolsByName([
+    ...defaultTools,
+    ...(options.additionalTools ?? []),
+    ...(options.includeGoalTool ? [createGoalStatusTool()] : []),
+  ]);
+  // The edit-checkpoint wrap covers the ASSEMBLED set, not just the default tier: once a product can hand
+  // the tool axis to its capability packs (`defaultTools: []` + pack-supplied `additionalTools`), a
+  // contributed `Write`/`Edit` must still be checkpointed. With no contributed Write/Edit this is
+  // byte-identical to wrapping the default tier alone.
+  const assembledTools =
+    checkpointAvailable && options.editCheckpointRecorder
+      ? wrapEditCheckpointTools(dedupedTools, options.editCheckpointRecorder)
+      : dedupedTools;
+  const reversibleExecution = options.reversibleExecution
+    ? {
+        ...options.reversibleExecution,
+        isolation:
+          options.reversibleExecution.isolation ??
+          (options.sandboxClient ? ('provider-sandbox' as const) : undefined),
+      }
+    : undefined;
+
+  return {
+    tools: reversibleExecution
+      ? wrapReversibleExecutionTools(assembledTools, {
+          ...reversibleExecution,
+          checkpointAvailable,
+        })
+      : assembledTools,
+    checkpointAvailable,
+  };
+}

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -81,6 +81,15 @@ export interface ICreateSessionOptions {
   ) => Promise<TPermissionResult>;
   /** Additional tools to register beyond the defaults (e.g. agent-tool) */
   additionalTools?: IToolWithEventService[];
+  /**
+   * ARCH-006: REPLACES the framework's `createDefaultTools()` tier for this session; `[]` suppresses every
+   * framework default so a product's capability packs can own the whole tool surface. Mirrors NEUT-003's
+   * `builtInAgents` seam for subagents. Absent ⇒ the framework tier is constructed as before
+   * (byte-identical). The injected tools are used as given — the framework cannot re-bind the session
+   * context (`cwd`/`sandboxClient`) onto an already-constructed tool, so an injected replacement for a
+   * context-sensitive default must carry that context itself.
+   */
+  defaultTools?: readonly IToolWithEventService[];
   /** GOAL-001: include the `report_goal_status` completion-signal tool (interactive sessions). */
   includeGoalTool?: boolean;
   /** Additional background task runners composed by the runtime shell. */

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -8,20 +8,18 @@ import { join } from 'node:path';
 import { GuardrailExecutor } from '@robota-sdk/agent-core';
 import { Session } from '@robota-sdk/agent-session';
 
+import { assembleSessionTools } from './assemble-session-tools.js';
 import {
   buildAgentRuntime,
   buildBackgroundProcessTool,
   buildSessionSystemPrompt,
   wireSessionDeps,
 } from './create-session-runtime.js';
-import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
-import { wrapEditCheckpointTools } from '../checkpoints/edit-checkpoint-tools.js';
+import { DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
 import { readSettings, writeSettings } from '../config/settings-io.js';
-import { createGoalStatusTool } from '../goal/index.js';
 import { AgentExecutor } from '../hooks/agent-executor.js';
 import { PromptExecutor } from '../hooks/prompt-executor.js';
-import { wrapReversibleExecutionTools } from '../reversible-execution/index.js';
 import {
   createModelCommandToolProjection,
   createProjectedCommandExecutionTools,
@@ -93,33 +91,6 @@ function resolveGuardrailHooks(
   };
 }
 
-/**
- * ARCH-006 — collapse the assembled tool list to one entry per tool NAME.
- *
- * Precedence: the FIRST occurrence of a name wins, over the fixed tier order
- * `defaultTools ⊕ additionalTools ⊕ goalTool`. This is the same "first entry for a name wins" rule
- * `AgentDefinitionLoader` already applies within the subagent built-in tier.
- *
- * So a contributed tool whose name is NEW is additive (the axis stays open), and a contributed tool whose
- * name collides with a framework default is DROPPED rather than listed twice — it does not silently
- * displace the default. That direction is deliberate: the default tier is built with the session context
- * (`cwd` supplies the working-directory path guard, plus the sandbox client and retrieval adapter), and a
- * context-free contribution replacing it would silently weaken those guarantees. Replacement stays fully
- * expressible — through the EXPLICIT `defaultTools` injection seam, never as a side effect of a collision.
- * That mirrors `mergeCapabilityPacks`' own rule: additive merge, never a silent override.
- */
-function dedupeToolsByName(tools: readonly IToolWithEventService[]): IToolWithEventService[] {
-  const seen = new Set<string>();
-  const deduped: IToolWithEventService[] = [];
-  for (const tool of tools) {
-    const name = tool.getName();
-    if (seen.has(name)) continue;
-    seen.add(name);
-    deduped.push(tool);
-  }
-  return deduped;
-}
-
 export function createSession(options: ICreateSessionOptions): ICreateSessionResult {
   if (!options.provider) {
     throw new Error(
@@ -147,47 +118,7 @@ export function createSession(options: ICreateSessionOptions): ICreateSessionRes
     ? skillCommandSource.getModelInvocableSkills()
     : [];
 
-  // ARCH-006: the default tool tier is INJECTABLE. `options.defaultTools` REPLACES
-  // `createDefaultTools()` outright (an empty array suppresses every framework default), mirroring
-  // NEUT-003's `builtInAgents` seam for subagents. Absent ⇒ the framework tier is constructed exactly as
-  // before, WITH the session context (cwd → the working-directory path guard, sandbox client, retrieval
-  // adapter) — which is why a name collision must never silently displace it (see `dedupeToolsByName`).
-  const defaultTools =
-    options.defaultTools ??
-    createDefaultTools({
-      sandboxClient: options.sandboxClient,
-      cwd,
-      ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
-    });
-  const shouldWrapHostEditCheckpoints =
-    options.editCheckpointRecorder !== undefined && options.sandboxClient === undefined;
-  const dedupedTools = dedupeToolsByName([
-    ...defaultTools,
-    ...(options.additionalTools ?? []),
-    ...(options.includeGoalTool ? [createGoalStatusTool()] : []),
-  ]);
-  // The edit-checkpoint wrap covers the ASSEMBLED set, not just the default tier: once a product can hand
-  // the tool axis to its capability packs (`defaultTools: []` + pack-supplied `additionalTools`), a
-  // contributed `Write`/`Edit` must still be checkpointed. With no contributed Write/Edit this is
-  // byte-identical to wrapping the default tier alone.
-  const assembledTools =
-    shouldWrapHostEditCheckpoints && options.editCheckpointRecorder
-      ? wrapEditCheckpointTools(dedupedTools, options.editCheckpointRecorder)
-      : dedupedTools;
-  const reversibleExecution = options.reversibleExecution
-    ? {
-        ...options.reversibleExecution,
-        isolation:
-          options.reversibleExecution.isolation ??
-          (options.sandboxClient ? ('provider-sandbox' as const) : undefined),
-      }
-    : undefined;
-  const tools: IToolWithEventService[] = reversibleExecution
-    ? wrapReversibleExecutionTools(assembledTools, {
-        ...reversibleExecution,
-        checkpointAvailable: shouldWrapHostEditCheckpoints,
-      })
-    : assembledTools;
+  const { tools } = assembleSessionTools(options, cwd);
   if (
     modelCommandToolsEnabled &&
     options.modelCommandExecutor !== undefined &&

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -15,7 +15,6 @@ import {
   buildSessionSystemPrompt,
   wireSessionDeps,
 } from './create-session-runtime.js';
-import { DEFAULT_TOOL_DESCRIPTIONS } from './create-tools.js';
 import { SkillCommandSource } from '../commands/skill-source.js';
 import { readSettings, writeSettings } from '../config/settings-io.js';
 import { AgentExecutor } from '../hooks/agent-executor.js';

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -93,6 +93,33 @@ function resolveGuardrailHooks(
   };
 }
 
+/**
+ * ARCH-006 — collapse the assembled tool list to one entry per tool NAME.
+ *
+ * Precedence: the FIRST occurrence of a name wins, over the fixed tier order
+ * `defaultTools ⊕ additionalTools ⊕ goalTool`. This is the same "first entry for a name wins" rule
+ * `AgentDefinitionLoader` already applies within the subagent built-in tier.
+ *
+ * So a contributed tool whose name is NEW is additive (the axis stays open), and a contributed tool whose
+ * name collides with a framework default is DROPPED rather than listed twice — it does not silently
+ * displace the default. That direction is deliberate: the default tier is built with the session context
+ * (`cwd` supplies the working-directory path guard, plus the sandbox client and retrieval adapter), and a
+ * context-free contribution replacing it would silently weaken those guarantees. Replacement stays fully
+ * expressible — through the EXPLICIT `defaultTools` injection seam, never as a side effect of a collision.
+ * That mirrors `mergeCapabilityPacks`' own rule: additive merge, never a silent override.
+ */
+function dedupeToolsByName(tools: readonly IToolWithEventService[]): IToolWithEventService[] {
+  const seen = new Set<string>();
+  const deduped: IToolWithEventService[] = [];
+  for (const tool of tools) {
+    const name = tool.getName();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    deduped.push(tool);
+  }
+  return deduped;
+}
+
 export function createSession(options: ICreateSessionOptions): ICreateSessionResult {
   if (!options.provider) {
     throw new Error(
@@ -120,22 +147,33 @@ export function createSession(options: ICreateSessionOptions): ICreateSessionRes
     ? skillCommandSource.getModelInvocableSkills()
     : [];
 
-  const baseDefaultTools = createDefaultTools({
-    sandboxClient: options.sandboxClient,
-    cwd,
-    ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
-  });
+  // ARCH-006: the default tool tier is INJECTABLE. `options.defaultTools` REPLACES
+  // `createDefaultTools()` outright (an empty array suppresses every framework default), mirroring
+  // NEUT-003's `builtInAgents` seam for subagents. Absent ⇒ the framework tier is constructed exactly as
+  // before, WITH the session context (cwd → the working-directory path guard, sandbox client, retrieval
+  // adapter) — which is why a name collision must never silently displace it (see `dedupeToolsByName`).
+  const defaultTools =
+    options.defaultTools ??
+    createDefaultTools({
+      sandboxClient: options.sandboxClient,
+      cwd,
+      ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
+    });
   const shouldWrapHostEditCheckpoints =
     options.editCheckpointRecorder !== undefined && options.sandboxClient === undefined;
-  const defaultTools =
-    shouldWrapHostEditCheckpoints && options.editCheckpointRecorder
-      ? wrapEditCheckpointTools(baseDefaultTools, options.editCheckpointRecorder)
-      : baseDefaultTools;
-  const assembledTools = [
+  const dedupedTools = dedupeToolsByName([
     ...defaultTools,
     ...(options.additionalTools ?? []),
     ...(options.includeGoalTool ? [createGoalStatusTool()] : []),
-  ];
+  ]);
+  // The edit-checkpoint wrap covers the ASSEMBLED set, not just the default tier: once a product can hand
+  // the tool axis to its capability packs (`defaultTools: []` + pack-supplied `additionalTools`), a
+  // contributed `Write`/`Edit` must still be checkpointed. With no contributed Write/Edit this is
+  // byte-identical to wrapping the default tier alone.
+  const assembledTools =
+    shouldWrapHostEditCheckpoints && options.editCheckpointRecorder
+      ? wrapEditCheckpointTools(dedupedTools, options.editCheckpointRecorder)
+      : dedupedTools;
   const reversibleExecution = options.reversibleExecution
     ? {
         ...options.reversibleExecution,

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -192,6 +192,8 @@ export async function createInteractiveSession(
     agentName: options.agentName,
     ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
+    // ARCH-006: an injected default tool tier REPLACES `createDefaultTools()` (`[]` suppresses it).
+    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}),
     // GOAL-001: every interactive session exposes the goal completion-signal tool so /goal and
     // --goal can drive autonomous pursuit. It is inert unless a goal is active.
     includeGoalTool: true,
@@ -302,6 +304,8 @@ export async function initializeInteractiveSessionAsync(
       ? { selfVerification: options.selfVerification }
       : {}),
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
+    // ARCH-006: an injected default tool tier REPLACES `createDefaultTools()` (`[]` suppresses it).
+    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}),
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
     commandDescriptors: deps.commandDescriptors,
     ...(deps.commandDescriptors.length > 0

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -192,8 +192,7 @@ export async function createInteractiveSession(
     agentName: options.agentName,
     ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
-    // ARCH-006: an injected default tool tier REPLACES `createDefaultTools()` (`[]` suppresses it).
-    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}),
+    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}), // ARCH-006
     // GOAL-001: every interactive session exposes the goal completion-signal tool so /goal and
     // --goal can drive autonomous pursuit. It is inert unless a goal is active.
     includeGoalTool: true,
@@ -304,8 +303,7 @@ export async function initializeInteractiveSessionAsync(
       ? { selfVerification: options.selfVerification }
       : {}),
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
-    // ARCH-006: an injected default tool tier REPLACES `createDefaultTools()` (`[]` suppresses it).
-    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}),
+    ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}), // ARCH-006
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
     commandDescriptors: deps.commandDescriptors,
     ...(deps.commandDescriptors.length > 0

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -147,6 +147,12 @@ export interface IInteractiveSessionStandardOptions {
   orgPolicy?: IOrgPolicy;
   /** Additional tools registered alongside the default CLI tools. */
   additionalTools?: IToolWithEventService[];
+  /**
+   * ARCH-006: REPLACES the framework's `createDefaultTools()` tier; `[]` suppresses every framework
+   * default so a product's capability packs can own the whole tool surface. Mirrors NEUT-003's
+   * `builtInAgents` seam for subagents. Absent ⇒ unchanged behavior.
+   */
+  defaultTools?: readonly IToolWithEventService[];
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }
@@ -258,6 +264,12 @@ export interface IInitOptions {
   selfVerification?: boolean | string;
   /** Additional tools registered alongside the default CLI tools. */
   additionalTools?: IToolWithEventService[];
+  /**
+   * ARCH-006: REPLACES the framework's `createDefaultTools()` tier; `[]` suppresses every framework
+   * default so a product's capability packs can own the whole tool surface. Mirrors NEUT-003's
+   * `builtInAgents` seam for subagents. Absent ⇒ unchanged behavior.
+   */
+  defaultTools?: readonly IToolWithEventService[];
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }

--- a/packages/agent-product/src/assemble-product.ts
+++ b/packages/agent-product/src/assemble-product.ts
@@ -45,12 +45,18 @@ function overlaySessionOptions(
     base.permissionMode === undefined && materials.defaultPermissionMode !== undefined
       ? { permissionMode: materials.defaultPermissionMode }
       : {};
+  // ARCH-007: the shell may hand in a selection it has ALREADY narrowed — `robota` applies its preset's
+  // enabled/disabledCommandModules delta to the merged `base ⊕ packs` superset before calling the seam
+  // (the spec's composition order: the merge widens, the preset delta narrows). Overwriting it here would
+  // silently undo that narrowing, so the assembled set is overlaid only when the caller left it unset —
+  // the same "only when the shell left it unset" rule `permissionMode` already follows.
+  const commandModules = base.commandModules ?? materials.commandModules;
 
   if ('session' in base) {
     return {
       ...base,
       provider,
-      commandModules: materials.commandModules,
+      commandModules,
       ...permissionModeOverlay,
     };
   }
@@ -64,7 +70,7 @@ function overlaySessionOptions(
   return {
     ...base,
     provider,
-    commandModules: materials.commandModules,
+    commandModules,
     additionalTools: [
       ...(base.additionalTools ?? []),
       ...(materials.tools as readonly IToolWithEventService[]),

--- a/scripts/external-proof/fixture/src/mode-c.ts
+++ b/scripts/external-proof/fixture/src/mode-c.ts
@@ -6,16 +6,16 @@
  * `pack-coding`; and a deliberate id collision is REPORTED on the rejection channel rather than silently
  * dropped or silently overridden.
  *
- * HONEST LIMITATION (recorded, not papered over). The pack TOOL axis is additive only through
- * `buildRuntime` / `buildRuntimeOptions`. `agent-framework`'s `createSession` hard-codes
- * `createDefaultTools()` and concatenates `additionalTools` without dedupe, so `robota`'s OWN surfaces
- * still take their tools from that framework default rather than from the pack. The command-module and
- * subagent axes ARE additive on both paths (subagents via the `agentDefinitions` injection seam). This
- * mode therefore exercises the tool axis THROUGH `buildRuntimeOptions` and asserts exactly that.
+ * TOOL AXIS (ARCH-006). All three axes are now additive on the same terms. `agent-framework`'s
+ * `createSession` no longer hard-codes its default tool set: `defaultTools` REPLACES that tier (`[]`
+ * suppresses it entirely) and the assembled list is deduped BY NAME, first occurrence wins. So a pack
+ * contributing a NEW tool is additive, a pack whose tools mirror the framework defaults is no longer
+ * DUPLICATED, and a product profile can hand the whole tool surface to its packs. Section C5 measures
+ * each of those from the published surface.
  */
 
 import { mergeCapabilityPacks } from '@robota-sdk/agent-capability-pack';
-import { createDefaultTools } from '@robota-sdk/agent-framework';
+import { createDefaultTools, InteractiveSession } from '@robota-sdk/agent-framework';
 import { assembleProduct } from '@robota-sdk/agent-product';
 import { createDefaultProviderDefinitions } from '@robota-sdk/agent-provider-defaults';
 import { codingPack } from '@robota-sdk/pack-coding';
@@ -164,9 +164,7 @@ export function runModeC(): void {
     'the subagent axis reaches the runtime via the agentDefinitions injection seam',
     (options.agentDefinitions ?? []).some((definition) => definition.name === 'acme-triager'),
   );
-  section(
-    "C5 — the tool axis's limitation, VERIFIED from the published surface (not just asserted)",
-  );
+  section('C5 — the tool axis at PARITY with the command and subagent axes (ARCH-006)');
   const frameworkDefaultToolNames = createDefaultTools().map((tool) => tool.getName());
   const codingPackToolNames = (codingPack.tools ?? []).map((tool) => tool.getName());
   check(
@@ -175,27 +173,77 @@ export function runModeC(): void {
       (options.additionalTools ?? []).some((tool) => tool.getName() === 'AcmeTicketLookup'),
   );
   checkEqual(
-    "but pack-coding's tools are name-identical to the framework default set",
+    "pack-coding's tools are name-identical to the framework default set (by design)",
     codingPackToolNames,
     frameworkDefaultToolNames,
   );
   check(
-    'and the overlay only APPENDS to additionalTools — it cannot suppress the framework defaults',
+    'and every one of them is overlaid — the framework now DEDUPES them by name instead of listing ' +
+      'each tool twice',
     codingPackToolNames.every((name) =>
       (options.additionalTools ?? []).some((tool) => tool.getName() === name),
     ),
   );
+
+  // The suppression seam, exercised on the PUBLISHED surface: `defaultTools: []` is accepted by the
+  // shipped `.d.ts` (this file type-checks with skipLibCheck:false) and builds a live session in which
+  // the framework contributes NO tool of its own — so the profile's packs own the whole tool surface.
+  const packOwnedSession = product.buildRuntime({
+    session: {
+      cwd: process.cwd(),
+      provider: product.provider!,
+      bare: true,
+      defaultTools: [],
+    },
+  });
+  check(
+    'a consumer can SUPPRESS the framework default tier (`defaultTools: []`) and still build a session',
+    packOwnedSession instanceof InteractiveSession,
+  );
+  const packOwnedOptions = asStandardOptions(
+    product.buildRuntimeOptions({
+      session: {
+        cwd: process.cwd(),
+        provider: product.provider!,
+        bare: true,
+        defaultTools: [],
+      },
+    }),
+  );
+  checkEqual(
+    'with the tier suppressed, every tool in the session comes from the profile’s packs',
+    (packOwnedOptions.additionalTools ?? []).map((tool) => tool.getName()),
+    [...codingPackToolNames, 'AcmeTicketLookup'],
+  );
+  checkEqual(
+    'and the suppression is carried, not silently dropped',
+    (packOwnedOptions.defaultTools ?? ['NOT-SUPPRESSED']).length,
+    0,
+  );
+
   note(
-    'THEREFORE, precisely: `createSession` assembles `[...createDefaultTools(), ...additionalTools]` with ' +
-      'no dedupe and no suppression hook. A consumer pack contributing a NEW tool is fully additive. A ' +
-      'pack contributing a tool the framework already ships (as pack-coding does, deliberately) would be ' +
-      "DUPLICATED, and no pack can remove or replace a framework default. That is why robota's own " +
-      'surfaces still take their tools from createDefaultTools() rather than from the pack.',
+    'THEREFORE, precisely: `createSession` assembles `defaultTools ⊕ additionalTools ⊕ goalTool` and ' +
+      'deduplicates by tool name (FIRST occurrence wins). A pack contributing a NEW tool is additive; a ' +
+      'pack contributing a tool the framework already ships is deduped, never duplicated; and a product ' +
+      'that wants its packs to OWN the tool surface passes `defaultTools: []`. Removing a pack from such ' +
+      'a profile removes its tools from the product — the same load-bearing property the command and ' +
+      'subagent axes already had.',
   );
   note(
-    'SCOPE OF THE CLAIM: the tool axis is additive through buildRuntime/buildRuntimeOptions for NEW tools ' +
-      'only; making the framework default tool set injectable/suppressible is out of ARCH-005 scope and is ' +
-      'filed as ARCH-006. Nothing stronger is claimed here.',
+    'PRECEDENCE, and why it points this way: a name collision keeps the FRAMEWORK default and drops the ' +
+      'contribution, rather than the reverse. The default tier is constructed WITH the session context ' +
+      "(cwd supplies agent-tools' working-directory path guard, plus the sandbox client and retrieval " +
+      'adapter); an already-constructed pack tool carries none of it, so letting a collision silently ' +
+      'swap one in would weaken a security guarantee. Replacement stays fully expressible through the ' +
+      'EXPLICIT `defaultTools` seam — never as a side effect of a collision. This mirrors ' +
+      "mergeCapabilityPacks' own rule: additive merge, never a silent override.",
+  );
+  note(
+    "NOT MEASURABLE FROM OUTSIDE: the framework exposes no public accessor for a built session's final " +
+      'tool list, so the dedupe ITSELF is measured in-repo (agent-framework ' +
+      'src/__tests__/create-session-default-tools.test.ts, 8 red-first cases). What this proof measures ' +
+      'from the published surface is the seam that makes it reachable: the `defaultTools` option on the ' +
+      'shipped session-options type, and the overlay that carries the pack tools into it.',
   );
   note(
     'COMMAND + SUBAGENT AXES: fully additive — command modules are passed as data and subagents arrive ' +

--- a/scripts/external-proof/fixture/src/surface-notes.ts
+++ b/scripts/external-proof/fixture/src/surface-notes.ts
@@ -14,6 +14,11 @@
  * return type does not track the branch of the input that produced it. Not a blocker (the narrowing below is
  * three lines), but the kernel could return the input's branch and remove the step entirely.
  *
+ * STILL OPEN after ARCH-007, and now the reference product meets it too: `agent-cli`'s
+ * `buildRobotaRuntimeOptions` performs the identical narrowing (and throws on the injected branch) to read
+ * back `additionalTools` / `agentDefinitions`. Two independent consumers writing the same three lines is
+ * the signal that the kernel should return the input's branch.
+ *
  * FINDING F2 — `IInteractiveSessionStandardOptions.provider` is REQUIRED.
  *
  * The Mode A story is "the kernel constructs the provider, you do not". But `IAssembledProduct.provider` is


### PR DESCRIPTION
Closes the two honestly-unmet completion criteria of [ARCH-005](.agents/spec-docs/active/ARCH-005-external-product-composition.md) — **TC-4** (the pack TOOL axis) and **TC-7** (robota consuming its own runtime seam). Two halves of one seam, filed separately only because they sit in different packages.

## The finding

`robota` consumed the composition kernel's MATERIALS but not its RUNTIME SEAM: `product.buildRuntime` / `buildRuntimeOptions` were dead code for it, so the kernel's overlay was exercised only by tests and by external Mode-A consumers. And the pack tool axis was half-additive — `createSession` hard-coded `createDefaultTools()` and concatenated `additionalTools` with **no dedupe and no suppression hook**, so a pack could neither remove nor replace a framework default and `pack-coding` (name-identical to the defaults by design) would have been listed twice.

## ARCH-006 — `agent-framework` (scoped additive)

Proposed direction **3 (both)**, following the Decision-2 precedent exactly:

- **`defaultTools`** REPLACES the `createDefaultTools()` tier; `[]` suppresses it entirely — the tool-axis mirror of NEUT-003's `builtInAgents`. Threaded through the same option hops `agentDefinitions` uses.
- **Name dedupe** over `defaultTools ⊕ additionalTools ⊕ goalTool`, **first occurrence wins** — the rule `AgentDefinitionLoader` already applies within the subagent built-in tier.
- The edit-checkpoint wrap now covers the assembled set, so a pack-contributed `Write`/`Edit` is checkpointed.
- Documented in `packages/agent-framework/docs/SPEC.md` § "Session-level tool composition", beside the `agentDefinitions` seam table, with the precedence stated and reconciled against it.

Absent `defaultTools` and absent a duplicate name, every existing path is byte-identical.

> **The precedence question, answered by measurement — and the answer is the OPPOSITE of the backlog's sketch.** The item proposed "`additionalTools` wins over a default of the same name". It must not: the default tier is constructed WITH the session context, and `cwd` is what arms `agent-tools`' working-directory path guard. Measured directly — `createDefaultTools({cwd}).Read('/etc/hostname')` → `Access denied: … is outside the working directory`; `codingPack.tools`' `Read` on the same path → **reads the file**, because `checkPathWithinCwd` is a no-op when `cwd` is `undefined` and a pack builds its tools at module load with no options. Letting a collision silently swap a context-free instance in for a context-bound one would have shipped a silent security regression. Replacement stays fully expressible through the EXPLICIT `defaultTools` seam — `mergeCapabilityPacks`' own rule (additive merge, never a silent override), applied to tools.

## ARCH-007 — `agent-cli` + `agent-product`

`startCli` now calls `product.buildRuntimeOptions(...)` once, through the shipped `buildRobotaRuntimeOptions` helper. The shell resolves its own session inputs; the kernel lays the product-owned materials on top — pack tools → `additionalTools`, pack subagents → `agentDefinitions`, the default preset's `permissionMode` when the shell left it unset. All three surfaces bind to that one result. **Deleted:** the hand-threaded `const agentDefinitions = product.subagents` and the three per-surface `args.permissionMode ?? resolvedPreset.permissionMode` expressions.

`agent-product`: `buildRuntimeOptions` no longer overwrites a caller-supplied `commandModules` — routing robota through the seam would otherwise have silently undone its preset delta.

**B2 decided explicitly (option iii)** and the spec's In-kernel table row corrected: the shell KEEPS `agent-preset`'s module-global registry as its preset SSOT (the resolved preset is needed before the base command modules are built, and `/preset` reads that registry). An anti-split test asserts an external preset resolves identically through both paths.

## Evidence

- **Red-first both halves** — 4 of 8 new framework cases failed before ARCH-006; all 6 new agent-cli cases failed before the helper existed.
- **Mutation-proven** — dropping the pack tools from the kernel overlay fails the tool assertion (1 failed / 6 passed); reverted → 7/7.
- **The pack-removal proof** — stripping `packs` from the profile the shell built, changing nothing else, drops all 10 coding tools AND all 3 coding subagents from robota's runtime options. It calls the SHIPPED helpers, never a re-implementation (the S2 F4 lesson).
- **`pnpm proof:external` — 68 assertions, exit 0** (was 65). § C5 rewritten from "the tool axis's limitation" to "the tool axis at PARITY", and it now MEASURES from the published surface: the overlay carries every name-identical pack tool without duplication; `defaultTools: []` is accepted by the shipped `.d.ts` under `skipLibCheck: false` and builds a live `InteractiveSession`; with the tier suppressed every tool comes from the profile's packs.
- **`pnpm harness:verify-like-ci` PASS** (all 4 stages, 62 scans).
- **2144 tests green** — `agent-framework` 1269, `agent-transport-tui` 526, `agent-cli` 255 (incl. the ARCH-005 equivalence suite, unchanged — no pinned literal went stale), `agent-preset` 71, `agent-product` 11, `agent-capability-pack` 7, `pack-coding` 5. `pnpm -w typecheck` clean.
- **Real binary** — `robota -p "say OK"` drives a live turn through the new composition path, exit 0.

The file-size ratchet fired on three files; per its own remedy the growth is **split, not waived** — `assembly/assemble-session-tools.ts` now owns the whole tool-assembly concern (`create-session.ts` 350 → 280 lines).

## Disposition

**ARCH-007 is complete and archived.** **ARCH-005 stays `active`, deliberately** — TC-4 and TC-7 are checked with evidence, but ARCH-006's Test Plan asked for one thing more than the framework seam ("robota sourcing tools from `pack-coding`") and that is not done, for the measured reason above. **ARCH-006 stays open** with the exact three-step remedy written down:

1. `pack-coding` exports `createCodingPack({ cwd, sandboxClient })` (its own SPEC comment already anticipates that shape);
2. robota's profile builds its pack with the shell's `cwd` and passes `defaultTools: []`;
3. `agent-transport` + `agent-transport-tui` each take the same one-line optional `additionalTools` pass-through the `agentDefinitions` seam already has (today the overlay's tools reach `--serve` only — behaviourally inert under first-wins dedupe).

None of those three files was inside this change's file-ownership boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z