### PR TITLE
fix(security): SEC-003 slice 1 — close the js/insecure-temporary-file class

### DIFF
--- a/.agents/backlog/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/SEC-003-codeql-alert-triage.md
@@ -124,6 +124,22 @@ justifications were needed and nothing was mass-dismissed.
 production source (`update-check.ts`, `memory/project-memory-store.ts`, `config/settings-io.ts`,
 `adapters/node-file-system.ts`) — all class B, so they clear when their tests are converted.
 
+### Adjacent finding surfaced by the fix — `js/file-system-race`
+
+Touching `session-logger.ts`'s payload write made CodeQL report a **pre-existing** `js/file-system-race`
+alert (already open on develop at that file) as "new", because the PR gate is diff-scoped: it reports
+any alert on a line the PR changes. The `existsSync`-then-`writeFileSync` pair was a genuine TOCTOU
+race between concurrent sessions externalizing the same payload, so it was fixed rather than
+dismissed — the write now uses the exclusive-create flag `wx`, and since the filename is the sha256 of
+the content, `EEXIST` provably means identical bytes.
+
+**Lesson for the sibling slice and any future sweep:** editing a line that already carries an unrelated
+open alert will fail the CodeQL PR gate even though nothing regressed. Expect it, and fix the adjacent
+finding rather than assuming the diff introduced it. `js/file-system-race` currently has **16** open
+alerts repo-wide (`agent-framework` 3, `agent-cli` 3, `dag-cli` 1, `agent-session` 1 (now fixed),
+`agent-tools` 1, `agent-command` 1, `agent-command-workflows` 1, plus 5 in `scripts/`) — a candidate
+class for a later SEC-003 slice.
+
 ### Follow-up
 
 The grep floor added here (`dag-cli/src/utils/__tests__/no-insecure-temp-path.test.ts`) is scoped to

--- a/.agents/backlog/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/SEC-003-codeql-alert-triage.md
@@ -48,6 +48,91 @@ whether each is real, and the volume now hides any NEW alert in the noise.
    (or at least its `security-severity: high` subset) becomes a REQUIRED check so this cannot silently
    re-accumulate. Coordinate with INFRA-046 (advisory→required promotion criteria).
 
+## Slice 1 — `js/insecure-temporary-file` class analysis (2026-07-25)
+
+### Root cause — read from the query, not inferred
+
+The rule is **not** about predictable filenames. Read from
+`javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll`:
+
+| Element       | Definition                                                                                                                                                                        |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Source**    | an `os.tmpdir()` call, **or any string literal matching `/tmp/%`**                                                                                                                |
+| **Sink**      | the path argument of `fs` `open`/`writeFile`/`writeJson`/`outputFile`(+`Sync`) where **no `mode` is passed**, or the mode's low 6 bits are not all zero (i.e. not `0o600`-shaped) |
+| **Sanitizer** | a non-first leaf of a string concatenation, or argument index ≥ 1 of `path.join`                                                                                                  |
+
+So an alert means: _a temp-dir-derived path reaches a file write that does not restrict permissions._
+Two corroborating facts settled it — `dag-cli/src/commands/node.ts` already used `randomUUID()` for
+the filename and was **still** flagged (so name randomness is irrelevant), and measured on this host
+`os.tmpdir()` is mode `0777`, a file joined directly into it lands at `0664` (world-readable), while
+`mkdtemp` yields a `0700` directory.
+
+`mkdtemp` clears the flow because taint stops at its **return value** (CodeQL models no
+argument→return step through it) — not because it is a declared sanitizer. That distinction matters:
+the fix works and is also the genuinely correct CWE-377 mitigation (a private directory defeats the
+symlink pre-creation attack, which `mode: 0600` alone does not).
+
+### The class splits in two
+
+- **A — real production temp writes** (the code itself builds a path under `os.tmpdir()`): only
+  **2 sites repo-wide**, both in `dag-cli` (`commands/node.ts`, `commands/template.ts`).
+- **B — test-supplied taint** (production code writes into a _caller-supplied_ directory; the only
+  temp source is a test passing `join(tmpdir(), fixed)` or a `'/tmp/…'` literal). This is the
+  overwhelming majority — including all 4 flagged production lines in `agent-framework`. Fixing the
+  **test** clears the alert on the production file too, since it is one flow.
+
+Of all 109 alerts, 84 of the sibling's 88 are literally in `__tests__` files.
+
+### Helper home + rationale
+
+`withTempWorkspace(prefix, fn)` → **`packages/dag-cli/src/utils/temp-workspace.ts`** (module-local).
+
+Rejected alternatives, with reasons:
+
+- **`packages/agent-process`** — its own SPEC forbids it in three places: "deliberately NOT a
+  catch-all for process utilities", "only OS process termination", "Process-tree termination only".
+  A filesystem primitive there would violate the package's written charter.
+- **`packages/agent-testing`** — `"private": true`, devDependency-only test harness. `dag-cli`'s
+  **production** code needs this at runtime; a shipped package cannot depend on a private test package.
+- **A new published leaf** (e.g. `agent-tempdir`) — the installability driver in
+  `project-structure.md` does not justify a package for one ~15-line function with **2 production
+  call sites in a single package**.
+- **A shared cross-package helper at all** — unnecessary once the A/B split is known. Test sites need
+  only Node's own `mkdtemp`, which is already the established alert-free idiom in this repo
+  (`localnode-e2e.test.ts`, `run-draft-store.test.ts`, `session-artifact.test.ts`). Wrapping a
+  one-call stdlib API in a `@robota-sdk` package would be indirection with no payoff.
+
+The sibling's sweep is therefore mechanical **by pattern**, not by import: convert
+`join(tmpdir(), fixed)` → `mkdtemp(join(tmpdir(), 'prefix-'))` in tests, and add `mode: 0o600` to
+production writes of sensitive content into caller-supplied dirs.
+
+### Converted in this slice (21 alerts owned)
+
+| Package                 | Alerts | Change                                                                                                                                  |
+| ----------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `dag-cli`               | 18     | new `withTempWorkspace`; `node.ts` + `template.ts` moved onto it; `build-command.test.ts` + `doctor-command.test.ts` moved to `mkdtemp` |
+| `agent-provider-openai` | 1      | payload logs now `0600`, log dir `0700`; test fixture moved off a `/tmp/…` literal                                                      |
+| `agent-session`         | 1      | session JSONL + externalized payloads now `0600`, dirs `0700`                                                                           |
+| `dag-adapters-local`    | 1      | `cost-meta.json` now `0600`; test moved off the fixed `/tmp/robota-cost-meta-test` path                                                 |
+
+**Dismissed via `gh api`: none.** Every owned alert was fixed at the source, so no dismissal
+justifications were needed and nothing was mass-dismissed.
+
+### Remaining sweep (sibling-owned, not touched here)
+
+`agent-framework` **76** + `agent-cli` **12** = **88**. Breakdown: 84 in `__tests__` files; 4 in
+production source (`update-check.ts`, `memory/project-memory-store.ts`, `config/settings-io.ts`,
+`adapters/node-file-system.ts`) — all class B, so they clear when their tests are converted.
+
+### Follow-up
+
+The grep floor added here (`dag-cli/src/utils/__tests__/no-insecure-temp-path.test.ts`) is scoped to
+`dag-cli` only. Once the sibling slice lands, promote it to a repo-wide mechanical scan under
+`scripts/harness/` (out of this slice's ownership) so the pattern cannot re-enter any package.
+
+SEC-003 stays **open**: `js/polynomial-redos` (18), the style classes, and the
+advisory→required promotion decision are untouched.
+
 ## Test Plan
 
 Per fixed class: a red-first regression test where feasible (e.g. the temp-path helper's test proves

--- a/.changeset/sec-003-insecure-temporary-file.md
+++ b/.changeset/sec-003-insecure-temporary-file.md
@@ -1,0 +1,15 @@
+---
+'@robota-sdk/agent-provider-openai': patch
+'@robota-sdk/agent-session': patch
+---
+
+Harden on-disk log permissions against CWE-377 (SEC-003, CodeQL `js/insecure-temporary-file`).
+
+Session logs, externalized session payloads, and OpenAI request/response payload logs all carry
+conversation and prompt content, but were created with the process umask (typically `0644`) inside a
+caller-supplied directory that may be shared or world-writable. They are now created owner-only
+(`0600`), and the directories that hold them are created `0700`.
+
+This is a permissions change only — file locations, names, formats, and APIs are unchanged. Anything
+that read these logs as a _different_ OS user will no longer be able to; the owning user is
+unaffected.

--- a/packages/agent-provider-openai/docs/SPEC.md
+++ b/packages/agent-provider-openai/docs/SPEC.md
@@ -30,6 +30,10 @@ Every runtime export of the package entry (`src/index.ts`). Provider option/conf
 
 `FilePayloadLogger` and `ConsolePayloadLogger` are surfaced via the `./loggers` sub-path entry (`src/openai/loggers/index.ts`).
 
+`FilePayloadLogger` writes prompt/response content to a caller-supplied `logDir`, so it creates that
+directory with mode `0700` and each payload file with mode `0600` rather than inheriting the process
+umask (SEC-003 / CWE-377). Paths, names, and formats are unchanged.
+
 ## Dependencies
 
 | Package                                        | Role                                             |

--- a/packages/agent-provider-openai/src/openai/loggers/file-payload-logger.test.ts
+++ b/packages/agent-provider-openai/src/openai/loggers/file-payload-logger.test.ts
@@ -15,6 +15,10 @@ vi.mock('fs', () => {
   };
 });
 
+// SEC-003: `fs` is mocked, so this is an inert fixture path; it deliberately does not
+// live under the OS temp dir.
+const LOG_DIR = '/var/robota-test/openai-payload-logs';
+
 function createMockLogger(): ILogger {
   return {
     info: vi.fn(),
@@ -46,37 +50,37 @@ describe('FilePayloadLogger', () => {
 
   describe('constructor', () => {
     it('should create logger with required logDir option', () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       expect(logger.isEnabled()).toBe(true);
     });
 
     it('should default to enabled when not specified', () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       expect(logger.isEnabled()).toBe(true);
     });
 
     it('should respect enabled false option', () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs', enabled: false });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR, enabled: false });
       expect(logger.isEnabled()).toBe(false);
     });
 
     it('should create log directory if it does not exist and enabled', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      new FilePayloadLogger({ logDir: '/tmp/logs' });
+      new FilePayloadLogger({ logDir: LOG_DIR });
 
-      expect(fs.mkdirSync).toHaveBeenCalledWith('/tmp/logs', { recursive: true });
+      expect(fs.mkdirSync).toHaveBeenCalledWith(LOG_DIR, { recursive: true, mode: 0o700 });
     });
 
     it('should not create log directory when disabled', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      new FilePayloadLogger({ logDir: '/tmp/logs', enabled: false });
+      new FilePayloadLogger({ logDir: LOG_DIR, enabled: false });
 
       expect(fs.mkdirSync).not.toHaveBeenCalled();
     });
 
     it('should not create log directory if it already exists', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      new FilePayloadLogger({ logDir: '/tmp/logs' });
+      new FilePayloadLogger({ logDir: LOG_DIR });
 
       expect(fs.mkdirSync).not.toHaveBeenCalled();
     });
@@ -100,32 +104,33 @@ describe('FilePayloadLogger', () => {
 
   describe('isEnabled', () => {
     it('should return true when enabled', () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs', enabled: true });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR, enabled: true });
       expect(logger.isEnabled()).toBe(true);
     });
 
     it('should return false when disabled', () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs', enabled: false });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR, enabled: false });
       expect(logger.isEnabled()).toBe(false);
     });
   });
 
   describe('logPayload', () => {
     it('should write payload to a JSON file', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'chat');
 
       expect(fs.promises.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining('/tmp/logs/openai-chat-'),
+        expect.stringContaining(`${LOG_DIR}/openai-chat-`),
         expect.any(String),
-        'utf8',
+        // SEC-003: payload logs hold prompt content, so they must be owner-only.
+        { encoding: 'utf8', mode: 0o600 },
       );
     });
 
     it('should write valid JSON content', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'chat');
@@ -141,7 +146,7 @@ describe('FilePayloadLogger', () => {
     });
 
     it('should use stream type in filename when type is stream', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'stream');
@@ -153,7 +158,7 @@ describe('FilePayloadLogger', () => {
 
     it('should include timestamp in filename when includeTimestamp is true', async () => {
       const logger = new FilePayloadLogger({
-        logDir: '/tmp/logs',
+        logDir: LOG_DIR,
         includeTimestamp: true,
       });
       const payload = createSamplePayload();
@@ -168,7 +173,7 @@ describe('FilePayloadLogger', () => {
 
     it('should use Date.now() in filename when includeTimestamp is false', async () => {
       const logger = new FilePayloadLogger({
-        logDir: '/tmp/logs',
+        logDir: LOG_DIR,
         includeTimestamp: false,
       });
       const payload = createSamplePayload();
@@ -182,7 +187,7 @@ describe('FilePayloadLogger', () => {
     });
 
     it('should skip logging when disabled', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs', enabled: false });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR, enabled: false });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'chat');
@@ -194,7 +199,7 @@ describe('FilePayloadLogger', () => {
       const mockLogger = createMockLogger();
       vi.mocked(fs.promises.writeFile).mockRejectedValue(new Error('Disk full'));
 
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs', logger: mockLogger });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR, logger: mockLogger });
       const payload = createSamplePayload();
 
       // Should not throw
@@ -206,7 +211,7 @@ describe('FilePayloadLogger', () => {
     });
 
     it('should sanitize payload before writing', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'chat');
@@ -225,7 +230,7 @@ describe('FilePayloadLogger', () => {
     });
 
     it('should default type to chat', async () => {
-      const logger = new FilePayloadLogger({ logDir: '/tmp/logs' });
+      const logger = new FilePayloadLogger({ logDir: LOG_DIR });
       const payload = createSamplePayload();
 
       await logger.logPayload(payload, 'chat');

--- a/packages/agent-provider-openai/src/openai/loggers/file-payload-logger.ts
+++ b/packages/agent-provider-openai/src/openai/loggers/file-payload-logger.ts
@@ -9,6 +9,10 @@ import type { IPayloadLogger } from '../interfaces/payload-logger';
 import type { IOpenAILogData } from '../types/api-types';
 import type { ILogger } from '@robota-sdk/agent-core';
 
+/** Owner-only access — no group or other bits (SEC-003 / CWE-377). */
+const OWNER_ONLY_FILE_MODE = 0o600;
+const OWNER_ONLY_DIR_MODE = 0o700;
+
 /**
  * File-based payload logger for Node.js environments
  *
@@ -85,7 +89,12 @@ export class FilePayloadLogger implements IPayloadLogger {
         payload: sanitizeOpenAILogData(payload),
       };
 
-      await fs.promises.writeFile(filepath, JSON.stringify(logData, null, 2), 'utf8');
+      // SEC-003: payload logs contain prompt/response content and `logDir` is
+      // caller-supplied, so create them owner-only rather than under the process umask.
+      await fs.promises.writeFile(filepath, JSON.stringify(logData, null, 2), {
+        encoding: 'utf8',
+        mode: OWNER_ONLY_FILE_MODE,
+      });
 
       // Payload saved successfully (silent operation)
     } catch (error) {
@@ -103,7 +112,7 @@ export class FilePayloadLogger implements IPayloadLogger {
   private ensureLogDirectoryExists(): void {
     try {
       if (!fs.existsSync(this.logDir)) {
-        fs.mkdirSync(this.logDir, { recursive: true });
+        fs.mkdirSync(this.logDir, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
       }
     } catch (error) {
       this.logger.error('[FilePayloadLogger] Failed to create log directory:', {

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -277,6 +277,11 @@ world-writable location, while the JSONL entries and externalized payloads hold 
 mode `0700`, and the `{sessionId}.jsonl` and payload files with mode `0600`, instead of inheriting the
 process umask. This is a permissions contract only; paths, names, and formats are unchanged.
 
+Externalized payloads are written with the exclusive-create flag (`wx`) rather than an `existsSync`
+check followed by a write, which was a TOCTOU race between concurrent sessions externalizing the same
+payload. Because the filename is the sha256 of the content, an `EEXIST` failure means the identical
+bytes are already on disk and is safely ignored.
+
 `session-log-replay.ts` owns replay readers and validators. `replaySessionLogEntries()` reconstructs provider messages and chat history from `history_mutation` events. `validateSessionReplayLogEntries()` reports missing provider-native raw payloads, missing provider-normalized raw responses, missing normalized responses, unmatched tool requests/results, and invalid external payload references. Every `provider_request` must be paired with at least one `provider_native_raw_payload` event for the same `executionId`/`round` whose `payloadKind` is `response` or `stream_event`, plus the existing `provider_response_raw` and `provider_response_normalized` events.
 
 ## Hook Lifecycle

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -271,6 +271,12 @@ The session log records structured events to a JSONL file for diagnostics and re
 
 `FileSessionLogger` applies recursive secret redaction before persistence. Keys such as `apiKey`, `authorization`, `accessToken`, `refreshToken`, `secret`, `password`, and `xApiKey` are replaced with `[REDACTED]`. Log fields larger than the inline threshold are stored as content-addressed JSON payload files in `{sessionId}.payloads/{sha256}.json`, and the JSONL line stores an `IExternalPayloadReference`.
 
+**On-disk permissions (SEC-003).** `logDir` is supplied by the caller and may be a shared or
+world-writable location, while the JSONL entries and externalized payloads hold conversation content.
+`FileSessionLogger` therefore creates its log directory and `{sessionId}.payloads/` directory with
+mode `0700`, and the `{sessionId}.jsonl` and payload files with mode `0600`, instead of inheriting the
+process umask. This is a permissions contract only; paths, names, and formats are unchanged.
+
 `session-log-replay.ts` owns replay readers and validators. `replaySessionLogEntries()` reconstructs provider messages and chat history from `history_mutation` events. `validateSessionReplayLogEntries()` reports missing provider-native raw payloads, missing provider-normalized raw responses, missing normalized responses, unmatched tool requests/results, and invalid external payload references. Every `provider_request` must be paired with at least one `provider_native_raw_payload` event for the same `executionId`/`round` whose `payloadKind` is `response` or `stream_event`, plus the existing `provider_response_raw` and `provider_response_normalized` events.
 
 ## Hook Lifecycle

--- a/packages/agent-session/src/session-logger.ts
+++ b/packages/agent-session/src/session-logger.ts
@@ -7,7 +7,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { mkdirSync, appendFileSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdirSync, appendFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { isSensitiveKey } from './scrub-sensitive.js';
@@ -177,11 +177,17 @@ function maybeExternalizePayload(
   const payloadDir = join(logDir, payloadDirName);
   const payloadPath = join(logDir, relativePath);
   mkdirSync(payloadDir, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
-  if (!existsSync(payloadPath)) {
+  // The payload is content-addressed by its own sha256, so an existing file necessarily holds
+  // identical bytes. Create it exclusively ('wx') rather than testing existsSync first: the
+  // check-then-write pair is a TOCTOU race between concurrent sessions writing the same payload.
+  try {
     writeFileSync(payloadPath, serialized, {
       encoding: 'utf-8',
       mode: OWNER_ONLY_FILE_MODE,
+      flag: 'wx',
     });
+  } catch {
+    // allow-fallback: EEXIST means the identical content-addressed payload is already on disk
   }
   return {
     kind: 'external-payload',

--- a/packages/agent-session/src/session-logger.ts
+++ b/packages/agent-session/src/session-logger.ts
@@ -36,6 +36,14 @@ const DEFAULT_EXTERNAL_PAYLOAD_THRESHOLD_BYTES =
 const DEFAULT_REDACTED_VALUE = '[REDACTED]';
 
 /**
+ * Session logs and externalized payloads carry conversation content, so they are created
+ * owner-only rather than inheriting the process umask (SEC-003 / CWE-377). `logDir` is
+ * caller-supplied and may be a shared or world-writable location.
+ */
+const OWNER_ONLY_FILE_MODE = 0o600;
+const OWNER_ONLY_DIR_MODE = 0o700;
+
+/**
  * Session logger interface — injected into Session for pluggable logging.
  *
  * Implementations decide where and how to persist session events.
@@ -64,7 +72,7 @@ export class FileSessionLogger implements ISessionLogger {
       redactedValue: options.redactedValue ?? DEFAULT_REDACTED_VALUE,
     };
     try {
-      mkdirSync(logDir, { recursive: true });
+      mkdirSync(logDir, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
     } catch {
       // Best-effort: logging disabled if directory cannot be created
     }
@@ -80,7 +88,7 @@ export class FileSessionLogger implements ISessionLogger {
         ...normalizedData,
       });
       const logFile = join(this.logDir, `${sessionId}.jsonl`);
-      appendFileSync(logFile, entry + '\n');
+      appendFileSync(logFile, entry + '\n', { mode: OWNER_ONLY_FILE_MODE });
     } catch {
       // Logging failure must never break the session
     }
@@ -168,9 +176,12 @@ function maybeExternalizePayload(
   const relativePath = join(payloadDirName, payloadFileName);
   const payloadDir = join(logDir, payloadDirName);
   const payloadPath = join(logDir, relativePath);
-  mkdirSync(payloadDir, { recursive: true });
+  mkdirSync(payloadDir, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
   if (!existsSync(payloadPath)) {
-    writeFileSync(payloadPath, serialized, 'utf-8');
+    writeFileSync(payloadPath, serialized, {
+      encoding: 'utf-8',
+      mode: OWNER_ONLY_FILE_MODE,
+    });
   }
   return {
     kind: 'external-payload',

--- a/packages/dag-adapters-local/docs/SPEC.md
+++ b/packages/dag-adapters-local/docs/SPEC.md
@@ -31,6 +31,9 @@
 | `FileRunDraftStore`     | Class | `IRunDraftStore`       | File-based JSON storage for execution drafts                    |
 | `FileCostMetaStorage`   | Class | `ICostMetaStoragePort` | File-based JSON storage for cost metadata                       |
 
+`FileCostMetaStorage` writes `cost-meta.json` into a caller-supplied `dataDir` that may be shared, so
+the file is created with mode `0600` rather than inheriting the process umask (SEC-003 / CWE-377).
+
 ### `./testing` entry — test-support ports (Public API)
 
 Exported from the dedicated `@robota-sdk/dag-adapters-local/testing` subpath (kept out of the package's

--- a/packages/dag-adapters-local/src/__tests__/file-cost-meta-storage.test.ts
+++ b/packages/dag-adapters-local/src/__tests__/file-cost-meta-storage.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { FileCostMetaStorage } from '../file-cost-meta-storage.js';
 import type { ICostMeta } from '@robota-sdk/dag-cost';
 
-const TEST_DIR = '/tmp/robota-cost-meta-test';
-
 describe('FileCostMetaStorage', () => {
+  // SEC-003: a fixed '/tmp/...' path is world-guessable and world-writable — another
+  // local user could pre-create or symlink it. Let the OS pick a private 0700 dir.
+  let TEST_DIR: string;
   let storage: FileCostMetaStorage;
 
   const sampleMeta: ICostMeta = {
@@ -19,8 +22,7 @@ describe('FileCostMetaStorage', () => {
   };
 
   beforeEach(() => {
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(TEST_DIR, { recursive: true });
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'robota-cost-meta-test-'));
     storage = new FileCostMetaStorage(TEST_DIR);
   });
 

--- a/packages/dag-adapters-local/src/file-cost-meta-storage.ts
+++ b/packages/dag-adapters-local/src/file-cost-meta-storage.ts
@@ -3,6 +3,9 @@ import { join } from 'node:path';
 import type { ICostMetaStoragePort } from '@robota-sdk/dag-cost';
 import type { ICostMeta } from '@robota-sdk/dag-cost';
 
+/** Owner read/write only — no group or other access (SEC-003 / CWE-377). */
+const OWNER_ONLY_FILE_MODE = 0o600;
+
 export class FileCostMetaStorage implements ICostMetaStoragePort {
   private readonly filePath: string;
   private cache: Map<string, ICostMeta>;
@@ -38,6 +41,11 @@ export class FileCostMetaStorage implements ICostMetaStoragePort {
 
   private writeToFile(): void {
     const data = Array.from(this.cache.values());
-    writeFileSync(this.filePath, JSON.stringify(data, null, 2), 'utf-8');
+    // SEC-003: `dataDir` is caller-supplied and may be a shared location, so pin the
+    // file to owner-only permissions instead of inheriting the process umask.
+    writeFileSync(this.filePath, JSON.stringify(data, null, 2), {
+      encoding: 'utf-8',
+      mode: OWNER_ONLY_FILE_MODE,
+    });
   }
 }

--- a/packages/dag-cli/docs/SPEC.md
+++ b/packages/dag-cli/docs/SPEC.md
@@ -22,6 +22,25 @@ Local-first command-line workflow tool for building, running, and inspecting Rob
 - `@robota-sdk/dag-builder` supplies pipeline/spec build and workflow-file conversion helpers (`buildDagFromPipeline`, `fromDagWorkflowFile`, `isWorkflowFileFormat`) used by the build/convert/explain/view/migrate/cost commands.
 - `@robota-sdk/dag-orchestration-client` owns the shared `DagOrchestrationHttpClient` used for HTTP server-mode calls.
 - `json.ts` owns JSON parsing, file input decoding, and JSON output formatting.
+- `src/utils/temp-workspace.ts` owns `withTempWorkspace(prefix, fn)` — the single sanctioned way for
+  this package to obtain a scratch directory (see Temporary Files).
+
+## Temporary Files (SEC-003)
+
+Commands that must materialize a DAG on disk before handing it to `dag run` (`node run-example`,
+`template run`) obtain their scratch directory from `withTempWorkspace(prefix, fn)`, which wraps
+`fs.mkdtemp` and removes the whole directory when `fn` settles.
+
+Building a path by string-joining a name onto `os.tmpdir()` is **forbidden** in this package. The OS
+temp dir is world-writable (`0777` + sticky), so a file placed there directly is created
+world-readable under the process umask, at a path another local user can guess and pre-create — that
+is CWE-377, and CodeQL reports it as `js/insecure-temporary-file`. Randomizing only the _filename_
+does not fix it; the directory must be private. `mkdtemp` creates the directory `0700` with an
+OS-chosen name, so neither the contents nor the path are exposed.
+
+The rule is mechanically enforced by `src/utils/__tests__/no-insecure-temp-path.test.ts`, which fails
+if any `.ts` file under `src/` reintroduces `join(tmpdir(), …)` outside an `mkdtemp` call, or
+hardcodes a `'/tmp/…'` path in non-test source.
 
 ## Command Surface
 

--- a/packages/dag-cli/src/__tests__/build-command.test.ts
+++ b/packages/dag-cli/src/__tests__/build-command.test.ts
@@ -1,4 +1,4 @@
-import { writeFile, unlink } from 'node:fs/promises';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, afterEach } from 'vitest';
@@ -159,18 +159,25 @@ describe('buildCommand', () => {
   });
 
   describe('--spec with file path', () => {
-    const tmpFiles: string[] = [];
+    // SEC-003: spec fixtures live in an OS-chosen 0700 dir, never at a guessable
+    // path directly under the world-writable OS temp dir.
+    const tmpDirs: string[] = [];
+
+    async function specDir(): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), 'dag-build-spec-'));
+      tmpDirs.push(dir);
+      return dir;
+    }
 
     afterEach(async () => {
-      for (const f of tmpFiles) {
-        await unlink(f).catch(() => undefined);
+      for (const d of tmpDirs) {
+        await rm(d, { recursive: true, force: true }).catch(() => undefined);
       }
-      tmpFiles.length = 0;
+      tmpDirs.length = 0;
     });
 
     it('reads spec from a .json file path', async () => {
-      const specPath = join(tmpdir(), `test-spec-${Date.now()}.json`);
-      tmpFiles.push(specPath);
+      const specPath = join(await specDir(), 'test-spec.json');
       await writeFile(
         specPath,
         JSON.stringify({
@@ -189,8 +196,7 @@ describe('buildCommand', () => {
     });
 
     it('reads spec from a .spec file path', async () => {
-      const specPath = join(tmpdir(), `test-spec-${Date.now()}.spec`);
-      tmpFiles.push(specPath);
+      const specPath = join(await specDir(), 'test-spec.spec');
       await writeFile(
         specPath,
         JSON.stringify({

--- a/packages/dag-cli/src/__tests__/doctor-command.test.ts
+++ b/packages/dag-cli/src/__tests__/doctor-command.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
 import { doctorCommand } from '../commands/doctor.js';
 import type { IDoctorCommandOptions } from '../commands/doctor.js';
+
+// SEC-003: a private 0700 dir, not the shared world-writable OS temp dir itself.
+const FALLBACK_CWD = mkdtempSync(join(tmpdir(), 'dag-doctor-cwd-'));
 
 function createOptions(cwd?: string): IDoctorCommandOptions & { written: string[] } {
   const written: string[] = [];
@@ -18,7 +22,7 @@ function createOptions(cwd?: string): IDoctorCommandOptions & { written: string[
       readTextFile: async () => '',
       writeBinaryStream: async () => {},
     },
-    cwd: cwd ?? tmpdir(),
+    cwd: cwd ?? FALLBACK_CWD,
     written,
   };
 }
@@ -51,8 +55,7 @@ describe('doctorCommand', () => {
   });
 
   it('--save writes JSON to file', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-test-${Date.now()}`);
-    await mkdir(tmpDir, { recursive: true });
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-test-'));
     const savePath = join(tmpDir, 'report', 'doctor.json');
     const opts = createOptions();
     await doctorCommand(['--json', '--save', savePath], opts);
@@ -63,8 +66,7 @@ describe('doctorCommand', () => {
   });
 
   it('--save alone also outputs JSON (implicit json mode)', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-test2-${Date.now()}`);
-    await mkdir(tmpDir, { recursive: true });
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-test2-'));
     const savePath = join(tmpDir, 'auto.json');
     const opts = createOptions();
     await doctorCommand(['--save', savePath], opts);
@@ -97,7 +99,7 @@ describe('doctorCommand', () => {
   });
 
   it('outputs "All checks passed" when all required checks pass (covers result.ok=true branch)', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-allok-${Date.now()}`);
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-allok-'));
     const dagDir = join(tmpDir, '.dag');
     const workflowsDir = join(dagDir, 'workflows');
     await mkdir(workflowsDir, { recursive: true });
@@ -137,7 +139,7 @@ describe('doctorCommand', () => {
   });
 
   it('reports valid workflow file when .dag/workflows exists with dag.json files', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-wf-${Date.now()}`);
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-wf-'));
     const workflowsDir = join(tmpDir, '.dag', 'workflows');
     await mkdir(workflowsDir, { recursive: true });
     const validDag = JSON.stringify({
@@ -169,7 +171,7 @@ describe('doctorCommand', () => {
   });
 
   it('reports invalid dag.json when workflow file has invalid JSON', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-bad-${Date.now()}`);
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-bad-'));
     const workflowsDir = join(tmpDir, '.dag', 'workflows');
     await mkdir(workflowsDir, { recursive: true });
     await writeFile(join(workflowsDir, 'broken.dag.json'), 'not valid json', 'utf8');
@@ -194,7 +196,7 @@ describe('doctorCommand', () => {
   });
 
   it('shows empty result when .dag/workflows has no .dag.json files', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-empty-${Date.now()}`);
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-empty-'));
     const workflowsDir = join(tmpDir, '.dag', 'workflows');
     await mkdir(workflowsDir, { recursive: true });
     // Write a non-.dag.json file so readdir returns something but dagJsonFiles is empty
@@ -218,7 +220,7 @@ describe('doctorCommand', () => {
   });
 
   it('shows valid check for dag file without nodes array (nodeCount=null)', async () => {
-    const tmpDir = join(tmpdir(), `dag-doctor-nonodes-${Date.now()}`);
+    const tmpDir = await mkdtemp(join(tmpdir(), 'dag-doctor-nonodes-'));
     const workflowsDir = join(tmpDir, '.dag', 'workflows');
     await mkdir(workflowsDir, { recursive: true });
     // Valid JSON object but no nodes array → nodeCount = null

--- a/packages/dag-cli/src/commands/node.ts
+++ b/packages/dag-cli/src/commands/node.ts
@@ -1,5 +1,4 @@
-import { writeFile, unlink, mkdir, access } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile, mkdir, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
@@ -14,6 +13,7 @@ import {
   loadNodeFileExplicit,
 } from '../local-runner/index.js';
 import { nodesDir } from '../local-runner/persistence/paths.js';
+import { withTempWorkspace } from '../utils/temp-workspace.js';
 import { runCommand } from './run.js';
 
 const OUTPUT_FORMAT_JSON = 'json';
@@ -1125,16 +1125,14 @@ async function runExampleInPlace(
     edges,
   };
 
-  const tmpFile = join(tmpdir(), `${randomUUID()}.dag.json`);
-  try {
+  // SEC-003: write the scratch DAG inside a private 0700 dir, not straight into the
+  // world-writable OS temp dir.
+  return await withTempWorkspace('dag-node-example', async (dir) => {
+    const tmpFile = join(dir, `${randomUUID()}.dag.json`);
     await writeFile(tmpFile, JSON.stringify(example, null, 2), 'utf8');
     const inputArgs = runInputs.flatMap((v) => ['--input', v]);
     return await runCommand([tmpFile, ...inputArgs], { io });
-  } finally {
-    await unlink(tmpFile).catch(() => {
-      // allow-fallback: temp file cleanup failure is non-fatal
-    });
-  }
+  });
 }
 
 // AGENTUX-005/007: validate a local node file, check port schemas, and print its manifest

--- a/packages/dag-cli/src/commands/template.ts
+++ b/packages/dag-cli/src/commands/template.ts
@@ -1,9 +1,9 @@
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { writeFile, unlink, readFile } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
 import { buildDagFromPipeline } from '@robota-sdk/dag-builder';
 import { TEMPLATE_REGISTRY, buildPipelineFromTemplate } from '../templates/dag-templates.js';
 import type { IDagCliIo } from '../types.js';
+import { withTempWorkspace } from '../utils/temp-workspace.js';
 import { runCommand } from './run.js';
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from '../types.js';
 import type { LocalDagRunner } from '../local-runner/index.js';
@@ -115,28 +115,22 @@ async function handleRunSubcommand(
     return FAILURE_EXIT_CODE;
   }
 
-  const tmpFile = join(tmpdir(), `dag-template-${Date.now()}.dag.json`);
-
-  try {
-    // allow-fallback: file errors returned as CLI error messages
-    await writeFile(tmpFile, JSON.stringify(buildResult.definition, null, JSON_INDENT_SPACES));
-    const exitCode = await runCommand([tmpFile], { io, createRunner: options.createRunner });
-    return exitCode;
-  } catch (err) {
-    // allow-fallback: file errors returned as CLI error messages
-    io.write(
-      `Error: Failed to run template DAG: ${err instanceof Error ? err.message : String(err)}\n`,
-    );
-    return FAILURE_EXIT_CODE;
-  } finally {
+  // SEC-003: write the scratch DAG inside a private 0700 dir, not straight into the
+  // world-writable OS temp dir. The workspace (and the file in it) is removed on exit.
+  return await withTempWorkspace('dag-template', async (dir) => {
+    const tmpFile = join(dir, 'template.dag.json');
     try {
-      // allow-fallback: cleanup failure is non-fatal
-      await unlink(tmpFile);
-    } catch {
-      // allow-fallback: best-effort cleanup, non-fatal
-      // intentionally empty
+      // allow-fallback: file errors returned as CLI error messages
+      await writeFile(tmpFile, JSON.stringify(buildResult.definition, null, JSON_INDENT_SPACES));
+      return await runCommand([tmpFile], { io, createRunner: options.createRunner });
+    } catch (err) {
+      // allow-fallback: file errors returned as CLI error messages
+      io.write(
+        `Error: Failed to run template DAG: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return FAILURE_EXIT_CODE;
     }
-  }
+  });
 }
 
 export async function templateCommand(

--- a/packages/dag-cli/src/utils/__tests__/no-insecure-temp-path.test.ts
+++ b/packages/dag-cli/src/utils/__tests__/no-insecure-temp-path.test.ts
@@ -1,0 +1,72 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * SEC-003 regression floor for CodeQL `js/insecure-temporary-file` (CWE-377).
+ *
+ * The rule's taint source is an `os.tmpdir()` call or a `'/tmp/…'` string literal; its sink
+ * is the path argument of an `fs` write that does not pass an owner-only `mode`. Taint stops
+ * at `mkdtemp`/`mkdtempSync`, because the OS — not the caller — chooses that name and creates
+ * the directory `0700`.
+ *
+ * So the one pattern that must not come back is a path built by string-joining a name onto
+ * `os.tmpdir()`. `mkdtemp(join(tmpdir(), 'prefix-'))` is the sanctioned form and is allowed.
+ */
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('SEC-003 floor: no insecure temp paths in dag-cli', () => {
+  it('never string-joins a name onto os.tmpdir() outside of mkdtemp', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      const lines = source.split('\n');
+
+      lines.forEach((line, index) => {
+        // Only `join(tmpdir(), …)` matters; the `mkdtemp(join(tmpdir(), …))` wrapper is safe.
+        if (!/\bjoin\(\s*tmpdir\(\)/.test(line)) return;
+        if (/\bmkdtemp(Sync)?\s*\(/.test(line)) return;
+        // An assertion that *names* the unsafe path is proving it is not used, not using it.
+        if (/\bexpect\(/.test(line)) return;
+        // This floor file quotes the pattern in its own documentation.
+        if (file === fileURLToPath(import.meta.url)) return;
+        offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('never hardcodes a writable "/tmp/..." path in non-test sources', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      if (file.includes('__tests__') || file.endsWith('.test.ts')) continue;
+      const source = readFileSync(file, 'utf8');
+
+      source.split('\n').forEach((line, index) => {
+        if (/['"`]\/tmp\//.test(line)) {
+          offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/dag-cli/src/utils/__tests__/temp-workspace.test.ts
+++ b/packages/dag-cli/src/utils/__tests__/temp-workspace.test.ts
@@ -1,0 +1,69 @@
+import { existsSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { withTempWorkspace } from '../temp-workspace.js';
+
+const OWNER_ONLY_DIR_MODE = 0o700;
+const GROUP_AND_OTHER_BITS = 0o077;
+
+describe('withTempWorkspace (SEC-003)', () => {
+  it('creates the directory with owner-only permissions', async () => {
+    await withTempWorkspace('sec003-mode', async (dir) => {
+      const mode = statSync(dir).mode & 0o777;
+      expect(mode).toBe(OWNER_ONLY_DIR_MODE);
+      // The point of 0700: no group/other access at all.
+      expect(mode & GROUP_AND_OTHER_BITS).toBe(0);
+    });
+  });
+
+  it('is not derivable from the prefix — two calls with the same prefix differ', async () => {
+    const paths: string[] = [];
+    await withTempWorkspace('sec003-same', async (dir) => void paths.push(dir));
+    await withTempWorkspace('sec003-same', async (dir) => void paths.push(dir));
+
+    expect(paths[0]).not.toBe(paths[1]);
+    // The predictable part must be only the prefix; the rest is chosen by the OS.
+    for (const p of paths) {
+      expect(p).not.toBe(join(tmpdir(), 'sec003-same'));
+      expect(p.length).toBeGreaterThan(join(tmpdir(), 'sec003-same-').length);
+    }
+  });
+
+  it('places the workspace under the OS temp dir', async () => {
+    await withTempWorkspace('sec003-parent', async (dir) => {
+      expect(dirname(dir)).toBe(tmpdir());
+    });
+  });
+
+  it('removes the whole directory once the callback settles', async () => {
+    let captured = '';
+    await withTempWorkspace('sec003-cleanup', async (dir) => {
+      captured = dir;
+      writeFileSync(join(dir, 'nested.json'), '{}');
+      expect(existsSync(join(dir, 'nested.json'))).toBe(true);
+    });
+
+    expect(captured).not.toBe('');
+    expect(existsSync(captured)).toBe(false);
+  });
+
+  it('removes the directory even when the callback throws, and rethrows', async () => {
+    let captured = '';
+    await expect(
+      withTempWorkspace('sec003-throw', async (dir) => {
+        captured = dir;
+        writeFileSync(join(dir, 'leftover.json'), '{}');
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(existsSync(captured)).toBe(false);
+  });
+
+  it('returns the callback result', async () => {
+    const result = await withTempWorkspace('sec003-result', async () => 42);
+    expect(result).toBe(42);
+  });
+});

--- a/packages/dag-cli/src/utils/temp-workspace.ts
+++ b/packages/dag-cli/src/utils/temp-workspace.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Run `fn` against a freshly created, private temporary directory (SEC-003).
+ *
+ * The OS temp dir is world-writable (mode `0777` + sticky), so a file placed there by
+ * string-joining a name onto `os.tmpdir()` is created world-readable (`0666 & ~umask`,
+ * typically `0644`) at a path another local user can guess and pre-create. That is CWE-377:
+ * any local user can read the contents, or win the race and have the CLI write through a
+ * symlink they planted.
+ *
+ * `mkdtemp` is the correct mitigation: the kernel creates the directory with mode `0700` and
+ * a name it chooses, so nothing inside is reachable by another user and there is no path to
+ * pre-create. Callers must place temp files *inside* the returned directory rather than
+ * building their own path under `os.tmpdir()`.
+ *
+ * The whole directory is removed when `fn` settles, so callers never have to unlink
+ * individual files.
+ *
+ * @param prefix - Short label for the directory name; a random suffix is always appended.
+ * @param fn - Receives the absolute path of the private temp directory.
+ * @returns Whatever `fn` resolves to.
+ */
+export async function withTempWorkspace<T>(
+  prefix: string,
+  fn: (dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  try {
+    return await fn(dir);
+  } finally {
+    // allow-fallback: temp-workspace cleanup failure is non-fatal and must not mask fn's result
+    await rm(dir, { recursive: true, force: true }).catch(() => {
+      // intentionally empty
+    });
+  }
+}


### PR DESCRIPTION
First slice of SEC-003: the `js/insecure-temporary-file` class (109 open high-severity alerts).
Triaged as a class, not alert-by-alert.

## Root cause — read from the query, not inferred

The rule is **not** about predictable filenames. From `InsecureTemporaryFileCustomizations.qll`:

| Element | Definition |
| --- | --- |
| **Source** | an `os.tmpdir()` call, **or any string literal matching `/tmp/%`** |
| **Sink** | the path argument of `fs` `open`/`writeFile`/`writeJson`/`outputFile`(+`Sync`) where **no `mode` is passed**, or the mode's low 6 bits aren't all zero |
| **Sanitizer** | a non-first concatenation leaf, or argument index >= 1 of `path.join` |

An alert means *a temp-dir-derived path reaches a write that does not restrict permissions*.

Two facts settled it. `dag-cli/src/commands/node.ts` already used `randomUUID()` for the filename and
was **still** flagged, so name randomness is irrelevant. And measured on the runner:

```
tmpdir mode      : 777
file joined mode : 664   <- world-readable
mkdtemp dir mode : 700
```

`mkdtemp` clears the flow because taint stops at its **return value** (CodeQL models no
argument->return step through it), not because it is a declared sanitizer. That distinction matters:
it happens to also be the genuinely correct CWE-377 mitigation, since a private directory defeats the
symlink pre-creation attack that `mode: 0600` alone does not.

## The class splits in two

- **A — real production temp writes** (code builds its own path under `os.tmpdir()`): only **2 sites
  repo-wide**, both in `dag-cli`.
- **B — test-supplied taint** (production writes into a *caller-supplied* dir; the only temp source is
  a test passing `join(tmpdir(), fixed)` or a `'/tmp/...'` literal). The overwhelming majority — 84 of
  the sibling's 88 alerts are literally in `__tests__` files. Fixing the **test** clears the
  production alert too, since it is one flow.

## Helper placement

`withTempWorkspace(prefix, fn)` -> `packages/dag-cli/src/utils/temp-workspace.ts` (module-local).

Rejected, with reasons:

- **`agent-process`** — its own SPEC forbids it three times over ("deliberately NOT a catch-all for
  process utilities", "only OS process termination", "Process-tree termination only").
- **`agent-testing`** — `private: true`, devDependency-only; `dag-cli` production code needs this at
  runtime.
- **A new published leaf** — the installability driver in `project-structure.md` doesn't justify a
  package for one ~15-line function with 2 call sites in one package.
- **A shared cross-package helper at all** — unnecessary once the A/B split is known. Test sites need
  only Node's own `mkdtemp`, already the alert-free idiom here (`localnode-e2e.test.ts`,
  `run-draft-store.test.ts`, `session-artifact.test.ts`).

So the sibling's sweep is mechanical **by pattern**, not by import.

## Changes (21 owned alerts)

| Package | Alerts | Change |
| --- | --- | --- |
| `dag-cli` | 18 | new `withTempWorkspace`; `node.ts` + `template.ts` onto it; build/doctor tests to `mkdtemp` |
| `agent-provider-openai` | 1 | payload logs `0600`, dir `0700`; test fixture off a `/tmp/...` literal |
| `agent-session` | 1 | session JSONL + externalized payloads `0600`, dirs `0700` |
| `dag-adapters-local` | 1 | `cost-meta.json` `0600`; test off the fixed `/tmp/robota-cost-meta-test` |

The `0600`/`0700` changes are real hardening, not scanner appeasement: these files hold conversation
and prompt content and land in a caller-supplied directory.

**Dismissed: none.** Every owned alert was fixed at the source.

## Adjacent finding the fix surfaced — `js/file-system-race`

Touching `session-logger.ts`'s payload write made CodeQL report a **pre-existing** `js/file-system-race`
alert (already open on develop for that file) as "new" — the PR gate is diff-scoped, so it reports any
alert on a line the PR changes.

It was a genuine TOCTOU (`existsSync` then `writeFileSync`) between concurrent sessions externalizing
the same payload, so it is fixed rather than dismissed: the write now uses the exclusive-create flag
`wx`, and because the filename is the sha256 of the content, `EEXIST` provably means identical bytes.

Worth knowing for the sibling slice: expect the gate to flag unrelated pre-existing alerts on lines
you touch.

## Red-first proof

Helper test against the old pattern:

```
- 448   (expected 0o700)
+ 509   (actual   0o775)
AssertionError: expected '/tmp/sec003-same' not to be '/tmp/sec003-same'
Tests  2 failed | 4 passed (6)
```

Green after: `6 passed (6)`.

Grep floor, with `join(tmpdir(), ...)` reintroduced into `template.ts`: `1 failed | 1 passed`.
Restored: `2 passed`.

## Verification

- `pnpm harness:verify-like-ci` — **PASS, all 5 stages**
- `pnpm -w typecheck` — clean
- Full suites: dag-cli 1015, agent-framework 1269 (downstream consumer of `FileSessionLogger`),
  agent-provider-openai 162, agent-session 131, dag-adapters-local 54 — all green
- CI: **all 15 checks pass**, including `CodeQL` and `Analyze (javascript-typescript)`

## Remaining

`agent-framework` 76 + `agent-cli` 12 = **88**, owned by a sibling agent this wave; 84 are in
`__tests__`, the other 4 are class B and clear when their tests convert. SEC-003 stays **open** —
`js/polynomial-redos` (18), the style classes, and the advisory->required decision are untouched.

Follow-up recorded in the backlog: promote the dag-cli-scoped grep floor to a repo-wide scan under
`scripts/harness/` once the sibling slice lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
