### PR TITLE
feat(composition)!: ARCH-006 completion — robota's capability packs own its tool surface

### DIFF
--- a/.agents/backlog/completed/ARCH-006-framework-tool-axis-neutrality.md
+++ b/.agents/backlog/completed/ARCH-006-framework-tool-axis-neutrality.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-006: make the framework default tool set injectable so the pack TOOL axis is additive everywhere'
-status: in-progress
+status: done
 created: 2026-07-25
+completed: 2026-07-25
 priority: medium
 urgency: soon
 area: packages/agent-framework, packages/agent-product, packages/pack-coding
@@ -132,4 +133,29 @@ this constant"):
    pack's tools are name-identical to the defaults).
 
 None of the three files above was inside the ownership boundary of the change that landed the seam, which
-is why this item stays open rather than being marked done.
+is why this item stayed open rather than being marked done at that point.
+
+## COMPLETE (2026-07-25) — all three steps landed
+
+1. **`createCodingPack({ cwd, sandboxClient })`**, with `cwd` **required**. The module-level `codingPack`
+   constant was **REMOVED**, not deprecated: its tools were exactly the hazard this item documented, and a
+   "zero-option default" sitting beside the `defaultTools: []` seam would be a loaded gun. Pre-release
+   package, two in-tree consumers, both migrated in the same change. The scoping property is asserted by
+   EXECUTION — `Read`/`Write`/`Edit` each deny a path outside the supplied `cwd`, and two packs built with
+   different roots do not share a scope.
+2. **`robota`'s packs own its tool surface.** The shell builds the packs from its resolved `cwd` before
+   command setup (the same instances feed the pack command-module names, the profile, and the overlay), and
+   `buildRobotaRuntimeOptions` passes `ROBOTA_PACKS_OWN_TOOL_SURFACE` — an empty `defaultTools` — into the
+   runtime seam. Removing the pack now removes robota's ten coding tools.
+3. **`agent-transport` + `agent-transport-tui`** each took the optional `additionalTools`/`defaultTools`
+   pass-through mirroring the `agentDefinitions` seam, so print, serve and TUI carry an identical surface.
+
+**Mutation-proving found a real gate hole first.** Removing the suppression initially left the acceptance
+test GREEN, because the shell helper defaulted `defaultTools` to `[]` on the way out and thereby collapsed
+"suppressed" and "absent" into one value. The default was removed; the same mutation now fails 2
+assertions, and dropping `cwd` from the pack fails 4 pack cases plus the agent-cli scoping case.
+
+**Agent-run evidence.** The real binary answers `robota -p "Read the file /etc/hostname …"` with
+`Access denied: "/etc/hostname" is outside the working directory` — the regression this item was written to
+prevent, proven absent with the pack as the source. `pnpm proof:external`: 69 assertions, exit 0. 2207
+tests green across the eight touched packages. ARCH-005 **TC-4** is met and the spec is `done`.

--- a/.agents/spec-docs/done/ARCH-005-external-product-composition.md
+++ b/.agents/spec-docs/done/ARCH-005-external-product-composition.md
@@ -1,5 +1,6 @@
 ---
-status: in-progress
+status: done
+completed: 2026-07-25
 type: INFRA
 tags: [architecture, product-composition, packaging]
 ---
@@ -908,10 +909,11 @@ backed by `scripts/external-proof/` (`pnpm proof:external`) — 65 assertions, a
       contribution, because the default tier is built WITH the session context (`cwd` supplies
       `agent-tools`' working-directory path guard) and an already-constructed contribution carries none of
       it; replacement is expressible only through the explicit `defaultTools` seam. Measured from the
-      published surface by `pnpm proof:external` § C5 (6 assertions) and in-repo by 8 red-first framework
-      cases. **One residual, disclosed:** `robota`'s own profile does NOT pass `defaultTools: []`, because
-      `pack-coding` ships pre-constructed, context-free tool instances — see the ARCH-006/007 evidence
-      entry below and the follow-up backlog item.
+      published surface by `pnpm proof:external` § C5 (7 assertions) and in-repo by 8 red-first framework
+      cases. **And `robota` itself eats it:** its profile builds `pack-coding` with the shell's `cwd` and
+      passes `defaultTools: []`, so its ten coding tools come FROM the pack — removing the pack removes
+      them, and the pack's `Read` still denies a path outside the working directory (verified on the real
+      binary). See the ARCH-006 completion entry below.
 - [x] **TC-5 (published-surface sufficiency)** — the proof installs real `pnpm pack` tarballs via
       `npm install` (no workspace link, no relative import, `npm overrides` pinning every `@robota-sdk/*`
       specifier so nothing resolves from the registry) and type-checks with `skipLibCheck: false` against the
@@ -1354,12 +1356,72 @@ anti-split test registers an external preset and asserts it resolves IDENTICALLY
    Decision-2 `agentDefinitions` seam already has. With first-wins dedupe and robota's name-identical pack
    tools this is behaviourally inert today, so the surfaces do not diverge.
 
-Both are carried by **[ARCH-006](../../backlog/ARCH-006-framework-tool-axis-neutrality.md)**, which stays
-open (`status: in-progress`) with the exact three-step remedy written down. **ARCH-007 is closed and
-archived** to `.agents/backlog/completed/`.
+Both are carried by **[ARCH-006](../../backlog/completed/ARCH-006-framework-tool-axis-neutrality.md)**.
+**ARCH-007 is closed and archived** to `.agents/backlog/completed/`.
 
-**DISPOSITION AFTER ARCH-006/007 — the spec stays `active`.** TC-4 and TC-7 both now carry real evidence
-and are checked. But ARCH-006's own Test Plan asked for one thing more than the framework seam — "`robota`
-sourcing tools from `pack-coding` instead of the framework default" — and that is not done, for the
-measured reason above. The done-gate is not a place to round up: the spec closes when the ARCH-006
-residual lands.
+**DISPOSITION AFTER ARCH-006/007 — the spec stayed `active`.** TC-4 and TC-7 both carried real evidence,
+but ARCH-006's own Test Plan asked for one thing more than the framework seam — "`robota` sourcing tools
+from `pack-coding` instead of the framework default" — and that was not done, for the measured reason
+above. The done-gate is not a place to round up, so the spec stayed open until the residual landed. It did;
+see the entry below.
+
+### [ARCH-006 completion] — ✅ IMPLEMENTED (the packs OWN robota's tool surface) | 2026-07-25
+
+The three-step residual recorded above, executed. TC-4 is now met **for `robota` itself**, not only for the
+framework seam and external consumers.
+
+**1. `pack-coding` is a FACTORY, and the context-free constant is GONE.** `createCodingPack({ cwd,
+sandboxClient })` builds the pack bound to one session context; `cwd` is **required**. The module-level
+`codingPack` constant was **removed outright** — not deprecated, not kept as a "zero-option default" —
+because its tools were exactly the hazard: `checkPathWithinCwd` is a no-op when `cwd` is `undefined`, so a
+context-free pack contributes an unsandboxed `Read`/`Write`/`Edit`. That was inert only while the
+framework's own context-bound tier won the first-wins dedupe; the moment a profile passes
+`defaultTools: []` — the seam ARCH-006 exists to provide — it becomes live. Keeping a zero-option export
+beside that seam would have been a loaded gun. The package is pre-release with two in-tree consumers, both
+migrated in the same change (owner directive: 레거시 보존 금지).
+
+**2. `robota`'s packs own its tool surface.** The shell builds the packs from its resolved `cwd`
+(`createRobotaPacks({ cwd })`) BEFORE command setup — the same instances then supply the pack command-module
+names, the profile's `packs`, and the kernel overlay's tools. `buildRobotaRuntimeOptions` passes
+`ROBOTA_PACKS_OWN_TOOL_SURFACE` (an empty `defaultTools`) into the runtime seam, REPLACING the framework's
+`createDefaultTools()` tier. Every tool robota runs now arrives from a capability pack.
+
+**3. The tool options reach every surface.** `agent-transport`'s `HeadlessInteractionChannel` and
+`agent-transport-tui`'s `renderApp` → `TuiInteractionChannel` → `buildTuiSessionOptions` each took the same
+optional pass-through the Decision-2 `agentDefinitions` seam already had, for both `additionalTools` and
+`defaultTools`. Print, serve and TUI now carry an identical tool surface.
+
+**Evidence.**
+
+- Red-first: all 9 `pack-coding` cases failed before the factory existed.
+- **The acceptance bar, met at the product surface.** `robota-runtime-seam.test.ts` (10 cases) asserts that
+  removing `packs` from the profile the shell built drops all 10 coding tools AND all 3 subagents AND
+  leaves the framework tier suppressed — so the product genuinely has no coding tools left — and that the
+  `Read` robota actually gets is the PACK's `cwd`-scoped instance: it DENIES `/etc/hostname` and does NOT
+  deny a path inside the shell's `cwd` (that one fails as "File not found", proving the scope is the right
+  directory rather than a blanket refusal).
+- **Mutation-proven, twice — and the first attempt found a real gate hole.** Removing the suppression from
+  the seam initially passed, because `IRobotaRuntimeOptions.defaultTools` was being defaulted to `[]` on
+  the way out, collapsing "suppressed" and "absent" into the same value. That default was removed; the same
+  mutation now fails 2 assertions. Dropping `cwd` from the pack's tool options fails 4 `pack-coding` cases
+  AND the agent-cli scoping case — the cross-package gate catches it end to end.
+- **Real binary, agent-run.** `robota -p "Read the file /etc/hostname …"` returns
+  `Access denied: "/etc/hostname" is outside the working directory` — the exact regression measured when
+  ARCH-006 was designed, proven absent in the shipped product now that the pack is the source.
+- `pnpm proof:external` — **69 assertions, exit 0** (was 68). § C5 adds the safety property measured from
+  the published surface: the pack-owned `Read` denies a path outside the cwd the pack was built with.
+- Full suites green: `agent-framework` 1269, `agent-transport-tui` 526, `agent-cli` 258, `agent-transport`
+  56, `agent-preset` 71, `agent-product` 11, `agent-capability-pack` 7, `pack-coding` 9 — **2207 tests**.
+  `pnpm -w typecheck` clean; `pnpm harness:verify-like-ci` green.
+
+**The ARCH-005 equivalence suite stays green with ONE pinned literal legitimately updated.** Its packs are
+now built through `createRobotaPacks({ cwd })` instead of read from a module constant — the same shipped
+factory `startCli` calls, so the gate still exercises the production path (the S2 F4 lesson). No assertion
+was relaxed: the 27-module command set, the 6 provider types, the 10 tool names, the 3 subagents,
+`DEFAULT_AGENT_NAME` and both preset resolutions are unchanged.
+
+**FINAL DISPOSITION — `done`.** All seven completion criteria are met with agent-run evidence. Modes A, B
+and C work from a genuinely external consumer against the published surface; all three capability axes
+(commands, subagents, tools) are additive AND load-bearing for the reference product; and `robota` consumes
+the kernel's runtime seam rather than re-threading its materials. ARCH-006 and ARCH-007 are both closed and
+archived. The spec moves `active/` → `done/`.

--- a/.changeset/arch-006-packs-own-tool-surface.md
+++ b/.changeset/arch-006-packs-own-tool-surface.md
@@ -1,0 +1,31 @@
+---
+'@robota-sdk/pack-coding': major
+'@robota-sdk/agent-transport-tui': minor
+'@robota-sdk/agent-transport': minor
+'@robota-sdk/agent-cli': minor
+---
+
+ARCH-006 completion — robota's capability packs now OWN its tool surface, and `pack-coding` is built by a
+context-bound factory.
+
+- **`@robota-sdk/pack-coding` (BREAKING)** — the module-level `codingPack` constant is **removed** and
+  replaced by `createCodingPack({ cwd, sandboxClient })`, with `cwd` **required**. This is a safety change,
+  not a style one: `agent-tools` disarms its working-directory path guard when `cwd` is `undefined`, so a
+  pack whose file tools are built with no options contributes an **unsandboxed** `Read`/`Write`/`Edit`.
+  That was inert while `agent-framework` always supplied its own context-bound default tier, but ARCH-006
+  lets a product hand the whole tool surface to its packs (`defaultTools: []`) — and a context-free pack in
+  that position is a real hole. Keeping a zero-option export beside that seam would be a loaded gun, so it
+  is gone rather than deprecated. Each call returns fresh instances bound to the supplied context, so two
+  products in one process get independently-scoped file tools. Migration: replace `codingPack` with
+  `createCodingPack({ cwd: process.cwd() })`.
+- **`@robota-sdk/agent-cli`** — `robota`'s packs are built from the shell's resolved `cwd`
+  (`createRobotaPacks({ cwd })`) before command setup, and the runtime seam passes
+  `ROBOTA_PACKS_OWN_TOOL_SURFACE` (an empty `defaultTools`) so the framework's `createDefaultTools()` tier
+  is REPLACED. Every tool robota runs now arrives from a capability pack: dropping a pack drops its tools,
+  exactly as it already dropped its command modules and subagents.
+- **`@robota-sdk/agent-transport` / `@robota-sdk/agent-transport-tui`** — forward the optional
+  `additionalTools` and `defaultTools` through the headless and TUI channels, mirroring the existing
+  `agentDefinitions` pass-through, so print, serve and TUI carry an identical tool surface.
+
+End-user `robota` behavior is unchanged, including the security property: the real binary still answers a
+read outside the working directory with `Access denied: "…" is outside the working directory`.

--- a/packages/agent-cli/docs/SPEC.md
+++ b/packages/agent-cli/docs/SPEC.md
@@ -324,6 +324,7 @@ bin.ts → cli.ts (SHELL: arg parsing, settings IO, notices, mode dispatch)
               ├── assembleProduct(createRobotaProfile(...))   (from @robota-sdk/agent-product)
               │     ├── constructs the provider from providerDefinitions + resolved settings
               │     ├── merges packs: baseCommandModules ⊕ pack-coding (tools/commands/subagents)
+              │     │   (packs built from the shell cwd; their tools REPLACE the framework default tier)
               │     └── builds the instance-scoped preset registry
               ├── selectProductCommandModules(...)  (src/product/robota-plumbing.ts;
               │     applies the preset delta to the merged superset, appends the fixed modules)
@@ -504,6 +505,14 @@ channel, never a silent override. The preset's `enabledCommandModules`/`disabled
 applied to that merged SUPERSET afterwards: the capability merge widens, the preset delta narrows. The
 `/shell` and `/editor` modules are supplied by `@robota-sdk/pack-coding`, not by the base set — dropping
 the pack from the profile drops those commands from the product.
+
+**The tool axis, on the same terms (ARCH-006).** `robota`'s packs also own its TOOL surface: the shell
+passes `ROBOTA_PACKS_OWN_TOOL_SURFACE` (an empty `defaultTools`) into the kernel's runtime seam, which
+REPLACES `agent-framework`'s `createDefaultTools()` tier — so every tool the session runs arrives from a
+pack through `additionalTools`, and dropping a pack drops its tools. Because the pack's file tools are
+scoped to the `cwd` they are built with, the shell builds the packs (`createRobotaPacks({ cwd })`) before
+command setup and passes the instances into the profile; a context-free pack would carry a disarmed
+working-directory path guard.
 
 The CLI slash router must not own command-specific switch cases for built-ins when an injected command module can own the command. It may still own slash-prefix parsing, skill/plugin fallback lookup, result projection, and unknown-command rendering.
 

--- a/packages/agent-cli/src/__tests__/command-setup-optional-workflows.test.ts
+++ b/packages/agent-cli/src/__tests__/command-setup-optional-workflows.test.ts
@@ -10,10 +10,14 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { ROBOTA_PACK_COMMAND_MODULE_NAMES } from '../product/robota-profile.js';
+import { createRobotaPacks, packCommandModuleNames } from '../product/robota-profile.js';
 import { buildCommandSetup } from '../startup/command-setup.js';
 
 import type { IParsedCliArgs } from '../utils/cli-args.js';
+
+const ROBOTA_PACK_COMMAND_MODULE_NAMES = packCommandModuleNames(
+  createRobotaPacks({ cwd: '/tmp/optional-workflows' }),
+);
 
 const MINIMAL_ARGS = { noUpdateCheck: true } as unknown as IParsedCliArgs;
 

--- a/packages/agent-cli/src/__tests__/robota-assembly-equivalence.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-assembly-equivalence.test.ts
@@ -32,8 +32,9 @@ import {
   selectProductCommandModules,
 } from '../product/robota-plumbing.js';
 import {
+  createRobotaPacks,
   createRobotaProfile,
-  ROBOTA_PACK_COMMAND_MODULE_NAMES,
+  packCommandModuleNames,
 } from '../product/robota-profile.js';
 import { buildCommandSetup } from '../startup/command-setup.js';
 
@@ -111,6 +112,11 @@ const BASELINE_CAREFUL_REVIEWER_POSTURE = {
 
 /* ── The NEW assembly, driven exactly as `startCli` drives it ─────────────────────────────────────── */
 
+const EQUIVALENCE_CWD = '/tmp/equivalence';
+/** The packs the shell builds — same factory, same cwd `startCli` would pass. */
+const ROBOTA_PACKS = createRobotaPacks({ cwd: EQUIVALENCE_CWD });
+const ROBOTA_PACK_COMMAND_MODULE_NAMES = packCommandModuleNames(ROBOTA_PACKS);
+
 const MINIMAL_ARGS = { noUpdateCheck: true } as unknown as IParsedCliArgs;
 
 /** Re-derive the shell's assembly for a given preset delta, mirroring `startCli` step for step. */
@@ -142,6 +148,7 @@ function assembleRobota(
       presets: [],
       defaultPresetId: 'default',
       baseCommandModules,
+      packs: ROBOTA_PACKS,
       backgroundTaskRunners: [],
       subagentRunnerFactory: (() => {
         throw new Error('not used');
@@ -262,6 +269,7 @@ describe('ARCH-005 S2 — the assembled robota runtime matches the pre-change ba
         presets: [],
         defaultPresetId: 'default',
         baseCommandModules: [],
+        packs: ROBOTA_PACKS,
         backgroundTaskRunners: [],
         subagentRunnerFactory: (() => {
           throw new Error('not used');

--- a/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
@@ -120,7 +120,7 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   });
 
   it('carries the pack TOOLS through the kernel overlay as additionalTools', () => {
-    expect(robotaRuntimeOptions().additionalTools.map((t) => t.getName())).toEqual(
+    expect(robotaRuntimeOptions().toolOptions.additionalTools.map((t) => t.getName())).toEqual(
       CODING_TOOL_NAMES,
     );
   });
@@ -128,23 +128,25 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   it('SUPPRESSES the framework default tier so the packs are the SOLE source of tools (ARCH-006)', () => {
     // `defaultTools: []` REPLACES `createDefaultTools()`. Without it the framework would still contribute
     // its own ten tools and the pack's would merely dedupe away — the pack would be decorative.
-    expect(robotaRuntimeOptions().defaultTools).toEqual([]);
+    expect(robotaRuntimeOptions().toolOptions.defaultTools).toEqual([]);
   });
 
   it('removing the coding pack removes its TOOLS and SUBAGENTS from robota’s runtime options', () => {
     const withoutPack = robotaRuntimeOptions({ packs: 'none' });
 
-    expect(withoutPack.additionalTools).toEqual([]);
+    expect(withoutPack.toolOptions.additionalTools).toEqual([]);
     expect(withoutPack.agentDefinitions).toEqual([]);
     // …and the framework tier stays suppressed, so the product genuinely has NO coding tools left.
-    expect(withoutPack.defaultTools).toEqual([]);
+    expect(withoutPack.toolOptions.defaultTools).toEqual([]);
   });
 
   it('gives robota the PACK’s cwd-scoped tools, not the framework defaults', async () => {
     // The identity check that makes the axis real: robota's `Read` is the instance `pack-coding` built
     // with the shell's cwd, so it DENIES a path outside it. A framework default built with a different
     // cwd — or, worse, a context-free pack instance — would not.
-    const read = robotaRuntimeOptions().additionalTools.find((t) => t.getName() === 'Read');
+    const read = robotaRuntimeOptions().toolOptions.additionalTools.find(
+      (t) => t.getName() === 'Read',
+    );
     expect(read).toBeDefined();
 
     const outcome = await read!.execute(
@@ -166,7 +168,9 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   it('scopes robota’s file tools to the SHELL’s cwd, not some other directory', async () => {
     // Same tool, a path INSIDE the cwd the pack was built with → the guard does not fire (the failure is
     // a missing file, not an access denial). This is what proves the scope is the shell's cwd.
-    const read = robotaRuntimeOptions().additionalTools.find((t) => t.getName() === 'Read');
+    const read = robotaRuntimeOptions().toolOptions.additionalTools.find(
+      (t) => t.getName() === 'Read',
+    );
     const outcome = await read!.execute(
       { filePath: `${SEAM_CWD}/absent.txt` } as never,
       {

--- a/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-runtime-seam.test.ts
@@ -28,15 +28,34 @@ import {
   selectProductCommandModules,
 } from '../product/robota-plumbing.js';
 import {
+  createRobotaPacks,
   createRobotaProfile,
-  ROBOTA_PACK_COMMAND_MODULE_NAMES,
+  packCommandModuleNames,
 } from '../product/robota-profile.js';
 import { buildCommandSetup } from '../startup/command-setup.js';
 
 import type { IParsedCliArgs } from '../utils/cli-args.js';
 import type { IPreset } from '@robota-sdk/agent-preset';
 
+const SEAM_CWD = '/tmp/runtime-seam';
+const ROBOTA_PACKS = createRobotaPacks({ cwd: SEAM_CWD });
+const ROBOTA_PACK_COMMAND_MODULE_NAMES = packCommandModuleNames(ROBOTA_PACKS);
+
 const MINIMAL_ARGS = { noUpdateCheck: true } as unknown as IParsedCliArgs;
+
+/** The ten coding tools `pack-coding` contributes — pinned so a drift fails here, not silently. */
+const CODING_TOOL_NAMES = [
+  'Shell',
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'WebFetch',
+  'WebSearch',
+  'AskUserQuestion',
+];
 
 interface IProbeOverrides {
   packs?: 'default' | 'none';
@@ -63,6 +82,7 @@ function robotaProduct(overrides: IProbeOverrides = {}) {
     presets: overrides.presets ?? [],
     defaultPresetId: overrides.defaultPresetId ?? 'default',
     baseCommandModules,
+    packs: ROBOTA_PACKS,
     backgroundTaskRunners: [],
     subagentRunnerFactory: (() => {
       throw new Error('not used');
@@ -100,18 +120,15 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
   });
 
   it('carries the pack TOOLS through the kernel overlay as additionalTools', () => {
-    expect(robotaRuntimeOptions().additionalTools.map((t) => t.getName())).toEqual([
-      'Shell',
-      'Bash',
-      'Read',
-      'Write',
-      'Edit',
-      'Glob',
-      'Grep',
-      'WebFetch',
-      'WebSearch',
-      'AskUserQuestion',
-    ]);
+    expect(robotaRuntimeOptions().additionalTools.map((t) => t.getName())).toEqual(
+      CODING_TOOL_NAMES,
+    );
+  });
+
+  it('SUPPRESSES the framework default tier so the packs are the SOLE source of tools (ARCH-006)', () => {
+    // `defaultTools: []` REPLACES `createDefaultTools()`. Without it the framework would still contribute
+    // its own ten tools and the pack's would merely dedupe away — the pack would be decorative.
+    expect(robotaRuntimeOptions().defaultTools).toEqual([]);
   });
 
   it('removing the coding pack removes its TOOLS and SUBAGENTS from robota’s runtime options', () => {
@@ -119,6 +136,51 @@ describe('ARCH-007 — the kernel overlay is robota’s single assembly path', (
 
     expect(withoutPack.additionalTools).toEqual([]);
     expect(withoutPack.agentDefinitions).toEqual([]);
+    // …and the framework tier stays suppressed, so the product genuinely has NO coding tools left.
+    expect(withoutPack.defaultTools).toEqual([]);
+  });
+
+  it('gives robota the PACK’s cwd-scoped tools, not the framework defaults', async () => {
+    // The identity check that makes the axis real: robota's `Read` is the instance `pack-coding` built
+    // with the shell's cwd, so it DENIES a path outside it. A framework default built with a different
+    // cwd — or, worse, a context-free pack instance — would not.
+    const read = robotaRuntimeOptions().additionalTools.find((t) => t.getName() === 'Read');
+    expect(read).toBeDefined();
+
+    const outcome = await read!.execute(
+      { filePath: '/etc/hostname' } as never,
+      {
+        toolName: 'Read',
+        parameters: {},
+      } as never,
+    );
+    const result = JSON.parse(String((outcome as { data?: unknown }).data)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('outside the working directory');
+  });
+
+  it('scopes robota’s file tools to the SHELL’s cwd, not some other directory', async () => {
+    // Same tool, a path INSIDE the cwd the pack was built with → the guard does not fire (the failure is
+    // a missing file, not an access denial). This is what proves the scope is the shell's cwd.
+    const read = robotaRuntimeOptions().additionalTools.find((t) => t.getName() === 'Read');
+    const outcome = await read!.execute(
+      { filePath: `${SEAM_CWD}/absent.txt` } as never,
+      {
+        toolName: 'Read',
+        parameters: {},
+      } as never,
+    );
+    const result = JSON.parse(String((outcome as { data?: unknown }).data)) as {
+      success: boolean;
+      error?: string;
+    };
+
+    expect(result.error).not.toContain('outside the working directory');
+    expect(result.error).toContain('File not found');
   });
 
   it('lets the kernel apply the default preset’s permission posture when the shell left it unset', () => {

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -33,9 +33,8 @@ import {
 import {
   buildRobotaRuntimeOptions,
   createDefaultTransportRegistry,
-  findUnknownPresetModuleNames,
   loadReplayProvider,
-  mergedCommandModuleNames,
+  reportUnknownPresetModules,
   selectProductCommandModules,
 } from './product/robota-plumbing.js';
 import {
@@ -201,9 +200,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // session's runtime active-preset state. Pure state — no option re-application here.
   const selectedPresetId = selectPresetId(args, settingsPreset);
 
-  // ARCH-006: the packs are built HERE, from the shell's resolved `cwd`, because `pack-coding`'s file
-  // tools are scoped to it — a context-free pack would carry a disarmed working-directory path guard.
-  const packs = createRobotaPacks({ cwd });
+  const packs = createRobotaPacks({ cwd }); // ARCH-006: scoped to the cwd they are built with.
   const packCommandModules = packCommandModuleNames(packs);
   const {
     commandHostAdapters,
@@ -221,19 +218,12 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     createRemoteControlController(transportRegistry);
   commandHostAdapters.remoteControl = buildRemoteControlHostAdapter(remoteControlController);
 
-  // INFRA-032: a preset command-module name that matched no module (a short form like "editor"
-  // instead of agent-command-editor, or a typo) is surfaced as a non-fatal notice — never a silent
-  // drop, never an abort — mirroring the external-preset skip reporting above. Computed from the
-  // base ⊕ pack NAME superset (no assembly needed), so it still fires before the init/--configure
-  // early-returns exactly as it did before ARCH-005 S2.
-  for (const { name, kind } of findUnknownPresetModuleNames(
-    mergedCommandModuleNames(baseCommandModules, packCommandModules),
+  reportUnknownPresetModules(
+    (message) => terminal.writeError(message),
+    baseCommandModules,
+    packCommandModules,
     resolvedPreset,
-  )) {
-    terminal.writeError(
-      `Preset command-module "${name}" (${kind}) matched no module — expected the agent-command-* form; ignored.`,
-    );
-  }
+  );
 
   if (args.positional[0] === 'init') {
     try {
@@ -293,9 +283,8 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   });
 
   // ARCH-005 S2: the ONE composition call. Everything product-specific about `robota` is declared as DATA
-  // in `createRobotaProfile` and folded by the product-neutral `assembleProduct` — provider construction,
-  // the base ⊕ pack capability merge, and the instance-scoped preset registry all happen in the kernel.
-  // What remains below is product SHELL only: notices, session-resume UX, memory UX, and mode dispatch.
+  // in `createRobotaProfile` and folded by the product-neutral `assembleProduct`. What remains below is
+  // product SHELL only: notices, session-resume UX, memory UX, and mode dispatch.
   //
   // INFRA-018: `--session-log` injects a replay provider that overrides settings-based construction — it
   // replays the recorded log deterministically instead of calling a model. Provider settings/model still
@@ -324,7 +313,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   // ARCH-007 (B1): the kernel's RUNTIME SEAM — every surface below binds to THIS one result.
-  const { commandModules, agentDefinitions, additionalTools, defaultTools, permissionMode } =
+  const { commandModules, agentDefinitions, toolOptions, permissionMode } =
     buildRobotaRuntimeOptions({
       product,
       cwd,
@@ -381,7 +370,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       backgroundTaskRunners,
       subagentRunnerFactory,
       agentDefinitions,
-      { additionalTools, defaultTools },
+      toolOptions,
       commandModules,
       commandHostAdapters,
       { resumeSessionId, forkSession: args.forkSession },
@@ -417,8 +406,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       backgroundTaskRunners,
       subagentRunnerFactory,
       agentDefinitions,
-      additionalTools,
-      defaultTools,
+      ...toolOptions,
       commandModules,
       commandHostAdapters,
       transportRegistry,
@@ -488,8 +476,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     backgroundTaskRunners,
     subagentRunnerFactory,
     agentDefinitions,
-    additionalTools,
-    defaultTools,
+    ...toolOptions,
     commandModules,
     commandHostAdapters,
     remoteCommandPolicy,

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -25,7 +25,11 @@ import type { IParsedCliArgs } from './utils/cli-args.js';
 import { resolveCliPreset, selectPresetId } from './startup/preset-selection.js';
 import { DEFAULT_AGENT_NAME, getPreset, loadExternalPresets } from '@robota-sdk/agent-preset';
 import type { IPreset, IResolvedPresetOptions } from '@robota-sdk/agent-preset';
-import { createRobotaProfile, ROBOTA_PACK_COMMAND_MODULE_NAMES } from './product/robota-profile.js';
+import {
+  createRobotaPacks,
+  createRobotaProfile,
+  packCommandModuleNames,
+} from './product/robota-profile.js';
 import {
   buildRobotaRuntimeOptions,
   createDefaultTransportRegistry,
@@ -197,6 +201,10 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // session's runtime active-preset state. Pure state — no option re-application here.
   const selectedPresetId = selectPresetId(args, settingsPreset);
 
+  // ARCH-006: the packs are built HERE, from the shell's resolved `cwd`, because `pack-coding`'s file
+  // tools are scoped to it — a context-free pack would carry a disarmed working-directory path guard.
+  const packs = createRobotaPacks({ cwd });
+  const packCommandModules = packCommandModuleNames(packs);
   const {
     commandHostAdapters,
     providerDefinitions,
@@ -204,7 +212,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     fixedCommandModules,
     startupUpdateNoticePromise,
     remoteCommandPolicy,
-  } = buildCommandSetup(cwd, args, options, version, ROBOTA_PACK_COMMAND_MODULE_NAMES);
+  } = buildCommandSetup(cwd, args, options, version, packCommandModules);
   // REMOTE-008: the shell owns the transport registry + the remote-control controller (it has settings, the
   // registry, and — via onChannelReady — the live session), and injects the registry into the profile. The
   // `/remote-control` command is a declarative trigger; the enable/stop wiring + status view are here.
@@ -219,7 +227,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // base ⊕ pack NAME superset (no assembly needed), so it still fires before the init/--configure
   // early-returns exactly as it did before ARCH-005 S2.
   for (const { name, kind } of findUnknownPresetModuleNames(
-    mergedCommandModuleNames(baseCommandModules, ROBOTA_PACK_COMMAND_MODULE_NAMES),
+    mergedCommandModuleNames(baseCommandModules, packCommandModules),
     resolvedPreset,
   )) {
     terminal.writeError(
@@ -302,6 +310,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       presets: externalPresets,
       defaultPresetId: selectedPresetId,
       baseCommandModules,
+      packs,
       backgroundTaskRunners,
       subagentRunnerFactory,
       transports: transportRegistry,
@@ -315,7 +324,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   // ARCH-007 (B1): the kernel's RUNTIME SEAM — every surface below binds to THIS one result.
-  const { commandModules, agentDefinitions, additionalTools, permissionMode } =
+  const { commandModules, agentDefinitions, additionalTools, defaultTools, permissionMode } =
     buildRobotaRuntimeOptions({
       product,
       cwd,
@@ -372,6 +381,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       backgroundTaskRunners,
       subagentRunnerFactory,
       agentDefinitions,
+      { additionalTools, defaultTools },
       commandModules,
       commandHostAdapters,
       { resumeSessionId, forkSession: args.forkSession },
@@ -408,6 +418,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
       subagentRunnerFactory,
       agentDefinitions,
       additionalTools,
+      defaultTools,
       commandModules,
       commandHostAdapters,
       transportRegistry,
@@ -477,6 +488,8 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     backgroundTaskRunners,
     subagentRunnerFactory,
     agentDefinitions,
+    additionalTools,
+    defaultTools,
     commandModules,
     commandHostAdapters,
     remoteCommandPolicy,

--- a/packages/agent-cli/src/modes/__tests__/print-mode-integration.test.ts
+++ b/packages/agent-cli/src/modes/__tests__/print-mode-integration.test.ts
@@ -128,6 +128,7 @@ async function runPrint(
         throw new Error('subagent runner not used in print-mode resume tests');
       }) as never,
       [],
+      {},
       [],
       {} as never,
       sessionResolution,

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -1,4 +1,4 @@
-import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
+import type { IAIProvider, IToolWithEventService, TPermissionMode } from '@robota-sdk/agent-core';
 import type {
   IAgentDefinition,
   ICommandHostAdapters,
@@ -12,6 +12,16 @@ import type { IParsedCliArgs } from '../utils/cli-args.js';
 import { parseToolList } from '../utils/cli-args.js';
 import { buildAppendSystemPrompt } from '../startup/append-system-prompt.js';
 import type { IMemorySessionOptions } from '../startup/memory-enablement.js';
+
+/**
+ * ARCH-006: the tool surface the kernel overlay resolved. `additionalTools` carries the capability packs'
+ * tools; `defaultTools` REPLACES `agent-framework`'s `createDefaultTools()` tier (`robota` passes an empty
+ * array, so its packs are the sole source of tools).
+ */
+export interface IPrintModeToolOptions {
+  additionalTools?: IToolWithEventService[];
+  defaultTools?: readonly IToolWithEventService[];
+}
 
 export interface IPrintModeSessionResolution {
   /** Session id resolved by the CLI from -c/-r (undefined starts a new session). */
@@ -51,6 +61,8 @@ export async function runPrintMode(
   subagentRunnerFactory: ReturnType<typeof createChildProcessSubagentRunnerFactory>,
   /** ARCH-005: composition-root-contributed subagent definitions (merged pack subagents). */
   agentDefinitions: readonly IAgentDefinition[],
+  /** ARCH-006: the kernel-resolved tool surface (pack tools + the replaced framework default tier). */
+  toolOptions: IPrintModeToolOptions,
   commandModules: readonly ICommandModule[],
   commandHostAdapters: ICommandHostAdapters,
   sessionResolution: IPrintModeSessionResolution = {},
@@ -122,6 +134,10 @@ export async function runPrintMode(
     backgroundTaskRunners,
     subagentRunnerFactory,
     ...(agentDefinitions.length > 0 ? { agentDefinitions } : {}),
+    ...(toolOptions.additionalTools !== undefined
+      ? { additionalTools: toolOptions.additionalTools }
+      : {}),
+    ...(toolOptions.defaultTools !== undefined ? { defaultTools: toolOptions.defaultTools } : {}),
     commandModules,
     commandHostAdapters,
     // SELFHOST-008 P6: surface-resolved memory fields (empty ⇒ memory OFF, today's behavior).

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -59,6 +59,11 @@ export interface IServeModeOptions {
    * tier (first occurrence wins — see `agent-framework/docs/SPEC.md` § "Session-level tool composition").
    */
   additionalTools?: IToolWithEventService[];
+  /**
+   * ARCH-006: REPLACES `agent-framework`'s `createDefaultTools()` tier. `robota` passes an empty array so
+   * its capability packs are the SOLE source of the session's tools.
+   */
+  defaultTools?: readonly IToolWithEventService[];
   commandModules: readonly ICommandModule[];
   commandHostAdapters: ICommandHostAdapters;
   transportRegistry: ITransportRegistryView<IInteractiveSession>;
@@ -101,6 +106,7 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     subagentRunnerFactory: opts.subagentRunnerFactory,
     ...(opts.agentDefinitions !== undefined ? { agentDefinitions: opts.agentDefinitions } : {}),
     ...(opts.additionalTools !== undefined ? { additionalTools: opts.additionalTools } : {}),
+    ...(opts.defaultTools !== undefined ? { defaultTools: opts.defaultTools } : {}),
     commandModules: opts.commandModules,
     commandHostAdapters: opts.commandHostAdapters,
     ...(opts.remoteCommandPolicy ? { remoteCommandPolicy: opts.remoteCommandPolicy } : {}),

--- a/packages/agent-cli/src/product/robota-plumbing.ts
+++ b/packages/agent-cli/src/product/robota-plumbing.ts
@@ -129,6 +129,30 @@ export function selectProductCommandModules(
   ];
 }
 
+/**
+ * INFRA-032: report every preset command-module name that matched no module — a short form like `"editor"`
+ * instead of `agent-command-editor`, or a typo. Non-fatal: surfaced, never silently dropped, never an
+ * abort, mirroring the external-preset skip reporting.
+ *
+ * Computed from the base ⊕ pack NAME superset, so no assembly is needed and the notice still fires BEFORE
+ * the `init`/`--configure`/provider-config early-returns, exactly where it did before ARCH-005 S2.
+ */
+export function reportUnknownPresetModules(
+  writeError: (message: string) => void,
+  baseCommandModules: readonly ICommandModule[],
+  packCommandModuleNames: readonly string[],
+  preset: Pick<IResolvedPresetOptions, 'enabledCommandModules' | 'disabledCommandModules'>,
+): void {
+  for (const { name, kind } of findUnknownPresetModuleNames(
+    mergedCommandModuleNames(baseCommandModules, packCommandModuleNames),
+    preset,
+  )) {
+    writeError(
+      `Preset command-module "${name}" (${kind}) matched no module — expected the agent-command-* form; ignored.`,
+    );
+  }
+}
+
 /** The shell-resolved inputs `robota` hands to the kernel's runtime seam. */
 export interface IRobotaRuntimeSeamInput {
   /** The assembled product whose overlay lays the product-owned materials on top. */
@@ -157,18 +181,12 @@ export interface IRobotaRuntimeSeamInput {
 export interface IRobotaRuntimeOptions {
   provider: IAIProvider;
   commandModules: readonly ICommandModule[];
-  additionalTools: IToolWithEventService[];
   agentDefinitions: readonly IAgentDefinition[];
-  /**
-   * ARCH-006: the framework's `createDefaultTools()` tier, REPLACED. `robota` passes
-   * `ROBOTA_PACKS_OWN_TOOL_SURFACE` (empty), so every tool the session runs arrives from a capability pack
-   * via `additionalTools` — dropping a pack drops its tools from the product.
-   *
-   * Deliberately NOT defaulted to `[]` on the way out: an ABSENT tier (the framework builds its own) and a
-   * SUPPRESSED tier (the packs own it) are different products, and collapsing them would let the
-   * acceptance gate pass while the suppression was silently gone.
-   */
-  defaultTools?: readonly IToolWithEventService[];
+  /** The tool surface, grouped so every presentation channel is handed the SAME pair. */
+  toolOptions: {
+    additionalTools: IToolWithEventService[];
+    defaultTools?: readonly IToolWithEventService[];
+  };
   permissionMode?: TPermissionMode;
 }
 
@@ -201,7 +219,13 @@ export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobo
   return {
     ...options,
     commandModules: options.commandModules ?? [],
-    additionalTools: options.additionalTools ?? [],
     agentDefinitions: options.agentDefinitions ?? [],
+    // ARCH-006: `defaultTools` is deliberately NOT defaulted to `[]` here. An ABSENT tier (the framework
+    // builds its own) and a SUPPRESSED tier (the packs own it) are different products, and collapsing them
+    // would let the acceptance gate pass while the suppression was silently gone.
+    toolOptions: {
+      additionalTools: options.additionalTools ?? [],
+      ...(options.defaultTools !== undefined ? { defaultTools: options.defaultTools } : {}),
+    },
   };
 }

--- a/packages/agent-cli/src/product/robota-plumbing.ts
+++ b/packages/agent-cli/src/product/robota-plumbing.ts
@@ -23,6 +23,8 @@ import type {
   ICommandModule,
   IUnknownCommandModuleName,
 } from '@robota-sdk/agent-framework';
+import { ROBOTA_PACKS_OWN_TOOL_SURFACE } from './robota-profile.js';
+
 import type { IAssembledProduct } from '@robota-sdk/agent-product';
 import type { IResolvedPresetOptions } from '@robota-sdk/agent-preset';
 
@@ -157,6 +159,16 @@ export interface IRobotaRuntimeOptions {
   commandModules: readonly ICommandModule[];
   additionalTools: IToolWithEventService[];
   agentDefinitions: readonly IAgentDefinition[];
+  /**
+   * ARCH-006: the framework's `createDefaultTools()` tier, REPLACED. `robota` passes
+   * `ROBOTA_PACKS_OWN_TOOL_SURFACE` (empty), so every tool the session runs arrives from a capability pack
+   * via `additionalTools` — dropping a pack drops its tools from the product.
+   *
+   * Deliberately NOT defaulted to `[]` on the way out: an ABSENT tier (the framework builds its own) and a
+   * SUPPRESSED tier (the packs own it) are different products, and collapsing them would let the
+   * acceptance gate pass while the suppression was silently gone.
+   */
+  defaultTools?: readonly IToolWithEventService[];
   permissionMode?: TPermissionMode;
 }
 
@@ -175,6 +187,9 @@ export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobo
       cwd: input.cwd,
       provider: input.provider,
       commandModules: input.selectedCommandModules,
+      // ARCH-006: hand the tool axis to the packs. The kernel's overlay appends their tools to
+      // `additionalTools`; suppressing the framework tier here is what makes the packs the SOLE source.
+      defaultTools: ROBOTA_PACKS_OWN_TOOL_SURFACE,
       ...(input.permissionMode !== undefined ? { permissionMode: input.permissionMode } : {}),
     },
   });

--- a/packages/agent-cli/src/product/robota-profile.ts
+++ b/packages/agent-cli/src/product/robota-profile.ts
@@ -13,7 +13,7 @@
  * itself performs no IO.
  */
 
-import { codingPack } from '@robota-sdk/pack-coding';
+import { createCodingPack } from '@robota-sdk/pack-coding';
 
 import type {
   IAIProvider,
@@ -28,17 +28,41 @@ import type {
 import type { ITransportRegistryView } from '@robota-sdk/agent-interface-transport';
 import type { IPreset } from '@robota-sdk/agent-preset';
 import type { IProductProfile } from '@robota-sdk/agent-product';
+import type { ICodingPackOptions } from '@robota-sdk/pack-coding';
+
+/**
+ * A capability pack, reached through the kernel's own profile contract rather than a direct dependency on
+ * `@robota-sdk/agent-capability-pack` — the shell composes packs, it does not author the pack contract.
+ */
+type TCapabilityPack = NonNullable<IProductProfile['packs']>[number];
 
 /** The product id. Data only — `assembleProduct` never branches on it (composition-neutrality guard c). */
 const ROBOTA_PRODUCT_ID = 'robota';
 
-/** The capability packs `robota` composes. Removing one genuinely removes its capability from the product. */
-const ROBOTA_PACKS = [codingPack] as const;
+/**
+ * The capability packs `robota` composes. Removing one genuinely removes its capability from the product —
+ * its command modules, its subagents AND (since ARCH-006) its tools, because the profile hands the packs
+ * the whole tool surface (see {@link ROBOTA_PACKS_OWN_TOOL_SURFACE}).
+ *
+ * A FACTORY over the session context, not a constant: `pack-coding`'s file tools are scoped to the `cwd`
+ * they are built with, and a context-free pack would carry a disarmed working-directory path guard.
+ */
+export function createRobotaPacks(context: ICodingPackOptions): readonly TCapabilityPack[] {
+  return [createCodingPack(context)];
+}
 
-/** Command-module names the packs supply, so the shell can exclude them from the base set it builds. */
-export const ROBOTA_PACK_COMMAND_MODULE_NAMES: readonly string[] = ROBOTA_PACKS.flatMap(
-  (pack) => pack.commandModules?.map((module) => module.name) ?? [],
-);
+/**
+ * ARCH-006: `robota`'s packs OWN its tool surface. The shell passes this as the session's `defaultTools`,
+ * which REPLACES `agent-framework`'s `createDefaultTools()` tier — so every tool robota runs comes from a
+ * pack, and dropping a pack drops its tools from the product. Exported as the single named declaration of
+ * that decision rather than an anonymous `[]` at the call site.
+ */
+export const ROBOTA_PACKS_OWN_TOOL_SURFACE: readonly never[] = [];
+
+/** Command-module names the given packs supply, so the shell can exclude them from the base set it builds. */
+export function packCommandModuleNames(packs: readonly TCapabilityPack[]): readonly string[] {
+  return packs.flatMap((pack) => pack.commandModules?.map((cmd) => cmd.name) ?? []);
+}
 
 /** The already-resolved shell inputs `robota`'s profile is built from. */
 export interface IRobotaProfileInput {
@@ -64,6 +88,8 @@ export interface IRobotaProfileInput {
   subagentRunnerFactory: TSubagentRunnerFactory;
   /** The transport registry the shell owns (concrete `WsTransport` registered), passed as a read-only view. */
   transports: ITransportRegistryView;
+  /** The capability packs the shell built from `createRobotaPacks` with its resolved session context. */
+  packs: readonly TCapabilityPack[];
 }
 
 /** Build `robota`'s product profile from the shell's already-resolved inputs. Pure. */
@@ -77,7 +103,7 @@ export function createRobotaProfile(input: IRobotaProfileInput): IProductProfile
     ...(input.provider !== undefined ? { provider: input.provider } : {}),
     presets: input.presets,
     defaultPresetId: input.defaultPresetId,
-    packs: [...ROBOTA_PACKS],
+    packs: input.packs,
     baseCommandModules: input.baseCommandModules,
     backgroundTaskRunners: input.backgroundTaskRunners,
     subagentRunnerFactory: input.subagentRunnerFactory,

--- a/packages/agent-transport-tui/src/TuiInteractionChannel.ts
+++ b/packages/agent-transport-tui/src/TuiInteractionChannel.ts
@@ -24,7 +24,12 @@ import { TuiStateManager } from './tui-state-manager.js';
 import type { ISessionInitPoller, TSessionInitFailure } from './flows/session-init-poller.js';
 import type { TerminalHandoffController } from './terminal-handoff-controller.js';
 import type { IPendingPermissionRequest } from './types.js';
-import type { IAIProvider, TPermissionMode, TSessionEndReason } from '@robota-sdk/agent-core';
+import type {
+  IAIProvider,
+  IToolWithEventService,
+  TPermissionMode,
+  TSessionEndReason,
+} from '@robota-sdk/agent-core';
 import type { TToolArgs } from '@robota-sdk/agent-core';
 // CMD-004 unified action contract (SSOT in agent-core).
 import type {
@@ -85,6 +90,13 @@ export interface ITuiInteractionChannelOptions {
   subagentRunnerFactory?: TSubagentRunnerFactory;
   /** ARCH-005: composition-root-contributed subagent definitions (merged capability packs). */
   agentDefinitions?: readonly IAgentDefinition[];
+  /**
+   * ARCH-006: tools contributed by the composition root (the capability packs `assembleProduct` merged)
+   * and, when the profile hands the packs the whole tool surface, the suppressed framework default tier
+   * (`defaultTools: []`). Forwarded to the session's tool-composition seam; absent ⇒ unchanged.
+   */
+  additionalTools?: IToolWithEventService[];
+  defaultTools?: readonly IToolWithEventService[];
   commandModules?: readonly ICommandModule[];
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;

--- a/packages/agent-transport-tui/src/render.tsx
+++ b/packages/agent-transport-tui/src/render.tsx
@@ -12,7 +12,7 @@ import { TerminalHandoffController } from './terminal-handoff-controller.js';
 import { TuiInteractionChannel } from './TuiInteractionChannel.js';
 
 import type { ITuiCliAdapter } from './tui-cli-adapter.js';
-import type { IAIProvider } from '@robota-sdk/agent-core';
+import type { IAIProvider, IToolWithEventService } from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
 import type {
   IBackgroundTaskRunner,
@@ -57,6 +57,13 @@ export interface IRenderOptions {
    * `assembleProduct` merged). Forwarded to the session's `agentDefinitions` seam; absent ⇒ unchanged.
    */
   agentDefinitions?: readonly IAgentDefinition[];
+  /**
+   * ARCH-006: tools contributed by the composition root (the capability packs `assembleProduct` merged)
+   * and, when the profile hands the packs the whole tool surface, the suppressed framework default tier
+   * (`defaultTools: []`). Forwarded to the session's tool-composition seam; absent ⇒ unchanged.
+   */
+  additionalTools?: IToolWithEventService[];
+  defaultTools?: readonly IToolWithEventService[];
   commandModules?: readonly ICommandModule[];
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;
@@ -115,6 +122,8 @@ export function toChannelOptions(
     ...(options.agentDefinitions !== undefined
       ? { agentDefinitions: options.agentDefinitions }
       : {}),
+    ...(options.additionalTools !== undefined ? { additionalTools: options.additionalTools } : {}),
+    ...(options.defaultTools !== undefined ? { defaultTools: options.defaultTools } : {}),
     commandModules: options.commandModules,
     commandHostAdapters: options.commandHostAdapters,
     shellExec: options.shellExec,

--- a/packages/agent-transport-tui/src/tui-session-options.ts
+++ b/packages/agent-transport-tui/src/tui-session-options.ts
@@ -32,6 +32,8 @@ export function buildTuiSessionOptions(
     backgroundTaskRunners: opts.backgroundTaskRunners,
     subagentRunnerFactory: opts.subagentRunnerFactory,
     ...(opts.agentDefinitions !== undefined ? { agentDefinitions: opts.agentDefinitions } : {}),
+    ...(opts.additionalTools !== undefined ? { additionalTools: opts.additionalTools } : {}),
+    ...(opts.defaultTools !== undefined ? { defaultTools: opts.defaultTools } : {}),
     commandModules: opts.commandModules,
     commandHostAdapters: opts.commandHostAdapters,
     shellExec: opts.shellExec,

--- a/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
+++ b/packages/agent-transport/src/headless/HeadlessInteractionChannel.ts
@@ -11,7 +11,7 @@ import { buildRuntimeSession } from '@robota-sdk/agent-framework';
 
 import { createHeadlessRunner, type TOutputFormat } from './headless-runner.js';
 
-import type { IAIProvider, TPermissionMode } from '@robota-sdk/agent-core';
+import type { IAIProvider, IToolWithEventService, TPermissionMode } from '@robota-sdk/agent-core';
 import type {
   IBackgroundTaskRunner,
   ICommandHostAdapters,
@@ -66,6 +66,13 @@ export interface IHeadlessInteractionChannelOptions {
    * `assembleProduct` merged). Forwarded to the session's `agentDefinitions` seam; absent ⇒ unchanged.
    */
   agentDefinitions?: readonly IAgentDefinition[];
+  /**
+   * ARCH-006: tools contributed by the composition root (the capability packs `assembleProduct` merged)
+   * and, when the profile hands the packs the whole tool surface, the suppressed framework default tier
+   * (`defaultTools: []`). Forwarded to the session's tool-composition seam; absent ⇒ unchanged.
+   */
+  additionalTools?: IToolWithEventService[];
+  defaultTools?: readonly IToolWithEventService[];
   commandModules?: readonly ICommandModule[];
   commandHostAdapters?: ICommandHostAdapters;
   shellExec?: TShellExecFn;
@@ -142,6 +149,10 @@ export class HeadlessInteractionChannel {
       ...(this.opts.agentDefinitions !== undefined
         ? { agentDefinitions: this.opts.agentDefinitions }
         : {}),
+      ...(this.opts.additionalTools !== undefined
+        ? { additionalTools: this.opts.additionalTools }
+        : {}),
+      ...(this.opts.defaultTools !== undefined ? { defaultTools: this.opts.defaultTools } : {}),
       commandModules: this.opts.commandModules,
       commandHostAdapters: this.opts.commandHostAdapters,
       shellExec,

--- a/packages/pack-coding/README.md
+++ b/packages/pack-coding/README.md
@@ -5,7 +5,7 @@ additive-axis proof for ARCH-005 and robota's first capability pack.
 
 ```ts
 import { assembleProduct } from '@robota-sdk/agent-product';
-import { codingPack } from '@robota-sdk/pack-coding';
+import { createCodingPack } from '@robota-sdk/pack-coding';
 import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
 
 declare const providerDefinitions: readonly IProviderDefinition[];
@@ -15,12 +15,14 @@ const product = assembleProduct({
   id: 'acme-assistant',
   providerDefinitions,
   provider,
-  packs: [codingPack], // robota's coding tools, /shell + /editor commands, and coding subagents
+  // robota's coding tools, /shell + /editor commands, and coding subagents — the file tools are
+  // scoped to the cwd you build the pack with.
+  packs: [createCodingPack({ cwd: process.cwd() })],
 });
 void product;
 ```
 
-`codingPack` bundles:
+The pack bundles:
 
 - **tools** — `Shell`, `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`,
   `AskUserQuestion` (the built-in coding tools, imported from `@robota-sdk/agent-tools` — not
@@ -29,7 +31,15 @@ void product;
 - **subagents** — `general-purpose`, `Explore`, `Plan`.
 
 The tool set mirrors `agent-framework`'s `createDefaultTools()` and is drift-pinned by a test, so the pack
-cannot silently diverge from robota's actual default toolset. See [`docs/SPEC.md`](./docs/SPEC.md).
+cannot silently diverge from robota's actual default toolset.
+
+## Why a factory, and why `cwd` is required
+
+There is deliberately **no context-free `codingPack` constant**. `agent-tools` disarms its
+working-directory path guard when `cwd` is `undefined`, so a pack built with no options would contribute an
+**unsandboxed** `Read`/`Write`/`Edit` — harmless while the framework's own context-bound default tier wins,
+but not once a product hands the whole tool surface to its packs with `defaultTools: []` (ARCH-006).
+Requiring `cwd` makes that decision impossible to forget. See [`docs/SPEC.md`](./docs/SPEC.md).
 
 ## License
 

--- a/packages/pack-coding/docs/SPEC.md
+++ b/packages/pack-coding/docs/SPEC.md
@@ -3,9 +3,10 @@
 ## Scope
 
 Owns **robota's coding capability as a single `ICapabilityPack`** — the additive-axis proof for ARCH-005
-and robota's first capability pack. `codingPack` bundles the built-in coding tools, the coding command
-modules, and the coding subagents into one additive composition unit that `assembleProduct` can compose on
-top of any product's base command modules. It re-uses the published `@robota-sdk/agent-tools` factories,
+and robota's first capability pack. `createCodingPack(options)` bundles the built-in coding tools, the
+coding command modules, and the coding subagents into one additive composition unit that `assembleProduct`
+can compose on top of any product's base command modules — and, since ARCH-006, that a product profile can
+let OWN its entire tool surface. It re-uses the published `@robota-sdk/agent-tools` factories,
 `@robota-sdk/agent-command` modules, and `@robota-sdk/agent-framework` subagents — it re-implements none of
 them.
 
@@ -22,35 +23,65 @@ them.
 
 ## Pack contents
 
-| Bucket           | Contents                                                                                              | Source |
-| ---------------- | ---------------------------------------------------------------------------------------------------- | ------ |
-| `tools`          | `Shell`, `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `AskUserQuestion` | `@robota-sdk/agent-tools` factories |
-| `commandModules` | `agent-command-shell` (`/shell`), `agent-command-editor` (`/editor`)                                  | `@robota-sdk/agent-command` |
-| `subagents`      | `general-purpose`, `Explore`, `Plan`                                                                  | `@robota-sdk/agent-framework` `BUILT_IN_AGENTS` |
+| Bucket           | Contents                                                                                             | Source                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `tools`          | `Shell`, `Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `AskUserQuestion` | `@robota-sdk/agent-tools` factories             |
+| `commandModules` | `agent-command-shell` (`/shell`), `agent-command-editor` (`/editor`)                                 | `@robota-sdk/agent-command`                     |
+| `subagents`      | `general-purpose`, `Explore`, `Plan`                                                                 | `@robota-sdk/agent-framework` `BUILT_IN_AGENTS` |
 
-**Tool-set fidelity.** The `tools` bucket mirrors `agent-framework`'s `createDefaultTools()` ALWAYS-PRESENT
+**Tool-set fidelity.** The `tools` bucket is built with the caller's `ICodingPackOptions` and mirrors `agent-framework`'s `createDefaultTools()` ALWAYS-PRESENT
 set. The adapter-gated tools (`CodebaseRetrieval`, `Computer`) are deliberately excluded — a pack is a
 static bundle and those tools exist only when their adapter/driver is injected at session-assembly time.
-The pack test pins `codingPack.tools` to `createDefaultTools()` by name, so the pack cannot silently drift
+The pack test pins the pack's tools to `createDefaultTools()` by name, so the pack cannot silently drift
 from robota's actual default toolset (adding a default tool fails the test until the pack is updated).
 
 **Command-module scope.** Only the capability-level coding command modules (`/shell`, `/editor`) are
 bundled — NOT the product-shell/settings/provider command infrastructure (`/provider`, `/settings`,
 `/preset`, …), which a product shell composes, not a coding capability pack.
 
+## Session scoping — why this package exports a FACTORY and no constant (ARCH-006)
+
+The pack is built by `createCodingPack({ cwd, sandboxClient })`. **There is deliberately NO module-level
+`codingPack` constant**, and that absence is a safety property, not an omission:
+
+- `agent-tools`' `checkPathWithinCwd` is a **no-op when `cwd` is `undefined`**. Tools constructed with no
+  options therefore carry a **disarmed** working-directory guard — their `Read` will return
+  `/etc/hostname`.
+- Before ARCH-006 that was inert: `agent-framework` always built its own context-bound default tier, and
+  its first-wins name dedupe kept that instance over a pack's.
+- ARCH-006 lets a product hand the WHOLE tool surface to its packs (`defaultTools: []`). A context-free
+  pack in that position is an **unsandboxed `Read`/`Write`/`Edit`**. A zero-option export would be a loaded
+  gun aimed at the very seam this pack exists to demonstrate.
+
+`cwd` is therefore **required**, so the scoping decision cannot be forgotten at a construction site. Pass
+the same value the session is assembled with. `sandboxClient` is optional: when present the tools operate
+through the sandbox and the host path guard does not apply, because the sandbox is the isolation boundary.
+
+Each call returns **fresh instances** bound to the supplied context, so two products assembled in one
+process get independently-scoped file tools.
+
+> The removed `codingPack` constant was introduced in ARCH-005 S1 and is not carried forward in any
+> deprecated form — the package is pre-release and every consumer moved to the factory in the same change.
+
 ## Public API Surface
 
-| Export       | Kind  | Description                                                        |
-| ------------ | ----- | ----------------------------------------------------------------- |
-| `codingPack` | Const | The `ICapabilityPack` bundling robota's coding tools/commands/subagents |
+| Export               | Kind      | Description                                                                                               |
+| -------------------- | --------- | --------------------------------------------------------------------------------------------------------- |
+| `createCodingPack`   | Function  | Build the `ICapabilityPack` bundling robota's coding tools/commands/subagents, bound to a session context |
+| `ICodingPackOptions` | Interface | The session context the pack binds to — `cwd` (required) and an optional `sandboxClient`                  |
 
 ## Test Strategy
 
 `src/__tests__/coding-pack.test.ts` (vitest) asserts the pack contributes EXACTLY robota's current coding
-toolset: `codingPack.tools` names equal `createDefaultTools()` names (drift-pinned); subagents equal
+toolset: the pack's tool names equal `createDefaultTools()` names (drift-pinned); subagents equal
 `BUILT_IN_AGENTS`; command modules equal `['agent-command-shell', 'agent-command-editor']`; a stable id
 (`coding`); and that the pack merges cleanly on top of an empty base via `mergeCapabilityPacks` with no
-rejections. The `test` script runs `vitest run --passWithNoTests`.
+rejections.
+
+**The scoping property is asserted by EXECUTION, not by inspection.** Four cases run the pack's own tools:
+`Read`, `Write` and `Edit` each DENY a path outside the supplied `cwd` (`"outside the working directory"`),
+and two packs built with different roots do not share a scope. A mutation dropping `cwd` from the tool
+options fails all four. The `test` script runs `vitest run --passWithNoTests`.
 
 ## Class Contract Registry
 
@@ -61,6 +92,7 @@ classes or cross-package port implementations are defined here.
 ## Dependencies
 
 - `@robota-sdk/agent-capability-pack` — the `ICapabilityPack` contract the pack conforms to.
-- `@robota-sdk/agent-tools` — the built-in tool factories (imported, not re-implemented).
+- `@robota-sdk/agent-tools` — the built-in tool factories (imported, not re-implemented) and the
+  `ISandboxClient` contract.
 - `@robota-sdk/agent-command` — the `/shell` and `/editor` command-module factories.
 - `@robota-sdk/agent-framework` — `BUILT_IN_AGENTS` (the coding subagents).

--- a/packages/pack-coding/src/__tests__/coding-pack.test.ts
+++ b/packages/pack-coding/src/__tests__/coding-pack.test.ts
@@ -2,44 +2,118 @@ import { mergeCapabilityPacks } from '@robota-sdk/agent-capability-pack';
 import { BUILT_IN_AGENTS, createDefaultTools } from '@robota-sdk/agent-framework';
 import { describe, expect, it } from 'vitest';
 
-import { codingPack } from '../coding-pack.js';
+import { createCodingPack } from '../coding-pack.js';
 
 /**
  * ARCH-005 S1 — `@robota-sdk/pack-coding` is the additive-axis proof: an `ICapabilityPack` that bundles
  * EXACTLY robota's current coding toolset (the built-in tools), the coding command modules, and the coding
  * subagents. The tool assertion is pinned to `createDefaultTools()` so the pack cannot drift from robota's
  * actual default toolset — adding a default tool fails this test until the pack is updated.
+ *
+ * ARCH-006 — the pack is built by a FACTORY that takes the session's working directory, because a pack
+ * whose file tools are constructed with no `cwd` carries a DISARMED working-directory path guard
+ * (`checkPathWithinCwd` is a no-op when `cwd` is undefined). Once a product can hand the whole tool surface
+ * to its packs (`defaultTools: []`), that would be an unsandboxed `Read`/`Write`/`Edit`. The sandbox
+ * property is asserted directly below, not assumed.
  */
 
-describe('codingPack — contributes exactly robota\'s current coding toolset', () => {
-  it('bundles the same tools (by name) that robota\'s createDefaultTools() ships by default', () => {
+const CWD = '/tmp/pack-coding-scope';
+/** The minimal execution context the built-in file tools read — typed structurally so this package needs
+ * no `@robota-sdk/agent-core` dependency just to run its own tools. */
+const TOOL_CONTEXT = { toolName: 'Read', parameters: {} };
+
+/** Run a tool and unwrap the inner `IToolInvocationResult` the built-in file tools return as JSON. */
+async function invoke(
+  pack: ReturnType<typeof createCodingPack>,
+  name: string,
+  parameters: Record<string, unknown>,
+): Promise<{ success: boolean; error?: string }> {
+  const tool = (pack.tools ?? []).find((candidate) => candidate.getName() === name);
+  if (!tool) throw new Error(`pack does not contribute a ${name} tool`);
+  const outcome = await tool.execute(parameters as never, TOOL_CONTEXT as never);
+  return JSON.parse(String((outcome as { data?: unknown }).data)) as {
+    success: boolean;
+    error?: string;
+  };
+}
+
+describe("codingPack — contributes exactly robota's current coding toolset", () => {
+  it("bundles the same tools (by name) that robota's createDefaultTools() ships by default", () => {
     // No adapters supplied → the always-present coding toolset (retrieval/computer are adapter-gated, absent).
     const defaultToolNames = createDefaultTools().map((tool) => tool.getName());
-    const packToolNames = (codingPack.tools ?? []).map((tool) => tool.getName());
+    const packToolNames = (createCodingPack({ cwd: CWD }).tools ?? []).map((tool) =>
+      tool.getName(),
+    );
 
     expect(packToolNames).toEqual(defaultToolNames);
   });
 
-  it('bundles robota\'s built-in coding subagents', () => {
-    const packSubagentNames = (codingPack.subagents ?? []).map((agent) => agent.name);
+  it("bundles robota's built-in coding subagents", () => {
+    const packSubagentNames = (createCodingPack({ cwd: CWD }).subagents ?? []).map(
+      (agent) => agent.name,
+    );
     expect(packSubagentNames).toEqual(BUILT_IN_AGENTS.map((agent) => agent.name));
     // The documented default three.
     expect(packSubagentNames).toEqual(['general-purpose', 'Explore', 'Plan']);
   });
 
   it('bundles the coding command modules (shell + editor)', () => {
-    const packModuleNames = (codingPack.commandModules ?? []).map((module) => module.name);
+    const packModuleNames = (createCodingPack({ cwd: CWD }).commandModules ?? []).map(
+      (module) => module.name,
+    );
     expect(packModuleNames).toEqual(['agent-command-shell', 'agent-command-editor']);
   });
 
   it('has a stable pack id', () => {
-    expect(codingPack.id).toBe('coding');
+    expect(createCodingPack({ cwd: CWD }).id).toBe('coding');
+  });
+});
+
+describe('codingPack — the file tools are SCOPED to the supplied cwd (ARCH-006)', () => {
+  it('DENIES a Read outside the working directory', async () => {
+    const result = await invoke(createCodingPack({ cwd: CWD }), 'Read', {
+      filePath: '/etc/hostname',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('outside the working directory');
+  });
+
+  it('DENIES a Write outside the working directory', async () => {
+    const result = await invoke(createCodingPack({ cwd: CWD }), 'Write', {
+      filePath: '/etc/pack-coding-should-never-write',
+      content: 'nope',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('outside the working directory');
+  });
+
+  it('DENIES an Edit outside the working directory', async () => {
+    const result = await invoke(createCodingPack({ cwd: CWD }), 'Edit', {
+      filePath: '/etc/hostname',
+      oldString: 'a',
+      newString: 'b',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('outside the working directory');
+  });
+
+  it('scopes each pack instance to ITS OWN cwd — two packs do not share a scope', async () => {
+    const other = await invoke(createCodingPack({ cwd: '/tmp/pack-coding-other' }), 'Read', {
+      filePath: `${CWD}/inside.txt`,
+    });
+
+    // Outside the OTHER pack's root, so denied — the scope travels with the instance, not the module.
+    expect(other.success).toBe(false);
+    expect(other.error).toContain('outside the working directory');
   });
 });
 
 describe('codingPack — is a well-formed additive pack', () => {
   it('merges cleanly on top of empty base modules with no rejections', () => {
-    const { merged, rejected } = mergeCapabilityPacks([], [codingPack]);
+    const { merged, rejected } = mergeCapabilityPacks([], [createCodingPack({ cwd: CWD })]);
 
     expect(rejected).toEqual([]);
     expect(merged.commandModules.map((m) => m.name)).toEqual([

--- a/packages/pack-coding/src/coding-pack.ts
+++ b/packages/pack-coding/src/coding-pack.ts
@@ -14,36 +14,46 @@ import {
 } from '@robota-sdk/agent-tools';
 
 import type { ICapabilityPack } from '@robota-sdk/agent-capability-pack';
+import type { ISandboxClient } from '@robota-sdk/agent-tools';
 
 /**
- * Robota's built-in coding tools — the additive bundle mirror of `agent-framework`'s `createDefaultTools()`
- * ALWAYS-PRESENT set (shell/bash/read/write/edit/glob/grep/webFetch/webSearch/askUserQuestion). The
- * adapter-gated tools (`CodebaseRetrieval`, `Computer`) are deliberately excluded — a pack is a static
- * bundle and those tools only exist when their adapter/driver is injected at session-assembly time.
+ * The session context robota's coding tools are bound to.
  *
- * Built from the published `@robota-sdk/agent-tools` factories directly (NOT re-implemented) so the pack
- * ships the real tool code objects. The pack test pins these to `createDefaultTools()` by name, so the pack
- * cannot silently drift from robota's actual default toolset.
+ * `cwd` is **required, not optional** — and that is the whole point of this factory. `agent-tools`'
+ * `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so file tools constructed with no options
+ * carry a DISARMED working-directory guard: their `Read` will happily return `/etc/hostname`. Before
+ * ARCH-006 that was inert, because the framework's own context-bound default tier always won a name
+ * collision. Now that a product can hand the entire tool surface to its packs (`defaultTools: []`), a
+ * context-free pack would be an unsandboxed `Read`/`Write`/`Edit`. Requiring `cwd` makes the scoping
+ * decision impossible to forget.
  */
-const CODING_TOOLS = [
-  createShellTool(),
-  createBashTool(),
-  createReadTool(),
-  createWriteTool(),
-  createEditTool(),
-  globTool,
-  grepTool,
-  webFetchTool,
-  webSearchTool,
-  createAskUserQuestionTool(),
-];
+export interface ICodingPackOptions {
+  /**
+   * Working-directory root the host file tools (`Read`/`Write`/`Edit`) are restricted to. Required: see
+   * the interface note above. Pass the same value the session is assembled with.
+   */
+  cwd: string;
+  /**
+   * Optional provider sandbox client. When present the file/shell tools operate through the sandbox and
+   * the host path guard does not apply — the sandbox is the isolation boundary.
+   */
+  sandboxClient?: ISandboxClient;
+}
 
 /**
- * `@robota-sdk/pack-coding` — robota's coding capability as a single {@link ICapabilityPack}, and the
- * additive-axis proof for ARCH-005: a pack can bundle robota's real coding capability (tools + command
- * modules + subagents) and be composed additively by `assembleProduct` on top of any product's base.
+ * Build robota's coding capability as a single {@link ICapabilityPack}, bound to one session context.
  *
- * - **tools** — the built-in coding tools (see `CODING_TOOLS`).
+ * This is the additive-axis proof for ARCH-005 and robota's first capability pack: a pack can bundle
+ * robota's real coding capability (tools + command modules + subagents) and be composed additively by
+ * `assembleProduct` on top of any product's base — and, since ARCH-006, can OWN the product's tool surface
+ * outright when the profile suppresses the framework tier with `defaultTools: []`.
+ *
+ * - **tools** — the built-in coding tools, mirroring `agent-framework`'s `createDefaultTools()`
+ *   ALWAYS-PRESENT set (shell/bash/read/write/edit/glob/grep/webFetch/webSearch/askUserQuestion), built
+ *   from the published `@robota-sdk/agent-tools` factories directly (NOT re-implemented) and bound to
+ *   `options`. The adapter-gated tools (`CodebaseRetrieval`, `Computer`) are deliberately excluded — they
+ *   exist only when their adapter/driver is injected at session-assembly time. The pack test pins these to
+ *   `createDefaultTools()` by name, so the pack cannot silently drift from robota's actual default toolset.
  * - **commandModules** — the coding command modules: `/shell` and `/editor` (the capability-level command
  *   modules, distinct from product-shell/settings/provider command infrastructure).
  * - **subagents** — robota's built-in coding subagents (`general-purpose`, `Explore`, `Plan`).
@@ -51,20 +61,35 @@ const CODING_TOOLS = [
  * This pack contributes only when a product profile lists it (opt-in); every contributed command/tool runs
  * only through the permission-gated runtime at call time.
  *
- * **Module-load singleton semantics.** `codingPack` is a module-level constant, so its tool and
- * command-module instances are created ONCE per module load and SHARED by every profile that lists the
- * pack. That is correct for the current contributions — the tool and command-module objects are stateless
- * handlers, and `assembleProduct` only merges them (it never executes or mutates them). It does mean two
- * products assembled in one process hand the same instances to both runtimes: if a future contribution
- * carries per-product mutable state, export a `createCodingPack()` factory instead of widening this
- * constant.
+ * **Per-call instances, deliberately.** Each call builds fresh tool and command-module objects bound to the
+ * supplied context, so two products assembled in one process get independently-scoped file tools. There is
+ * no module-level singleton: a shared constant could only ever be context-free, which is exactly the hazard
+ * this factory exists to remove.
  */
-export const codingPack: ICapabilityPack = {
-  id: 'coding',
-  title: 'Coding',
-  description:
-    "Robota's built-in coding capability: file/shell tools, /shell + /editor commands, and the coding subagents.",
-  tools: CODING_TOOLS,
-  commandModules: [createShellCommandModule(), createEditorCommandModule()],
-  subagents: BUILT_IN_AGENTS,
-};
+export function createCodingPack(options: ICodingPackOptions): ICapabilityPack {
+  const toolOptions = {
+    cwd: options.cwd,
+    ...(options.sandboxClient ? { sandboxClient: options.sandboxClient } : {}),
+  };
+
+  return {
+    id: 'coding',
+    title: 'Coding',
+    description:
+      "Robota's built-in coding capability: file/shell tools, /shell + /editor commands, and the coding subagents.",
+    tools: [
+      createShellTool(toolOptions),
+      createBashTool(toolOptions),
+      createReadTool(toolOptions),
+      createWriteTool(toolOptions),
+      createEditTool(toolOptions),
+      globTool,
+      grepTool,
+      webFetchTool,
+      webSearchTool,
+      createAskUserQuestionTool(),
+    ],
+    commandModules: [createShellCommandModule(), createEditorCommandModule()],
+    subagents: BUILT_IN_AGENTS,
+  };
+}

--- a/packages/pack-coding/src/index.ts
+++ b/packages/pack-coding/src/index.ts
@@ -2,6 +2,11 @@
  * @robota-sdk/pack-coding — robota's coding capability as a single `ICapabilityPack`. The additive-axis
  * proof for ARCH-005 and robota's first capability pack: bundles the built-in coding tools, the coding
  * command modules (`/shell`, `/editor`), and the coding subagents (`general-purpose`, `Explore`, `Plan`).
+ *
+ * The pack is built by a FACTORY that takes the session's working directory — there is deliberately no
+ * context-free constant, because a pack whose file tools carry no `cwd` has a disarmed working-directory
+ * path guard (ARCH-006). See `createCodingPack`.
  */
 
-export { codingPack } from './coding-pack.js';
+export { createCodingPack } from './coding-pack.js';
+export type { ICodingPackOptions } from './coding-pack.js';

--- a/scripts/external-proof/fixture/src/mode-a.ts
+++ b/scripts/external-proof/fixture/src/mode-a.ts
@@ -10,10 +10,17 @@
 import { InteractiveSession } from '@robota-sdk/agent-framework';
 import { assembleProduct } from '@robota-sdk/agent-product';
 import { createDefaultProviderDefinitions } from '@robota-sdk/agent-provider-defaults';
-import { codingPack } from '@robota-sdk/pack-coding';
+import { createCodingPack } from '@robota-sdk/pack-coding';
 
 import { ACME_PROVIDER_SETTINGS } from './acme.js';
 import { check, checkEqual, checkThrows, mode, note, section } from './harness.js';
+
+/**
+ * ARCH-006: the pack is built by a FACTORY bound to the session's working directory — a context-free pack
+ * would carry a disarmed working-directory path guard on its file tools. A consumer builds it exactly as
+ * robota's own shell does, with the cwd it assembles the session under.
+ */
+const codingPack = createCodingPack({ cwd: process.cwd() });
 import { asStandardOptions } from './surface-notes.js';
 
 import type { IProductProfile } from '@robota-sdk/agent-product';

--- a/scripts/external-proof/fixture/src/mode-c.ts
+++ b/scripts/external-proof/fixture/src/mode-c.ts
@@ -18,7 +18,7 @@ import { mergeCapabilityPacks } from '@robota-sdk/agent-capability-pack';
 import { createDefaultTools, InteractiveSession } from '@robota-sdk/agent-framework';
 import { assembleProduct } from '@robota-sdk/agent-product';
 import { createDefaultProviderDefinitions } from '@robota-sdk/agent-provider-defaults';
-import { codingPack } from '@robota-sdk/pack-coding';
+import { createCodingPack } from '@robota-sdk/pack-coding';
 
 import {
   ACME_PROVIDER_SETTINGS,
@@ -29,11 +29,18 @@ import {
   acmeTicketTool,
 } from './acme.js';
 import { check, checkEqual, mode, note, section } from './harness.js';
+
+/**
+ * ARCH-006: the pack is built by a FACTORY bound to the session's working directory — a context-free pack
+ * would carry a disarmed working-directory path guard on its file tools. A consumer builds it exactly as
+ * robota's own shell does, with the cwd it assembles the session under.
+ */
+const codingPack = createCodingPack({ cwd: process.cwd() });
 import { asStandardOptions } from './surface-notes.js';
 
 import type { ICapabilityPack } from '@robota-sdk/agent-capability-pack';
 
-export function runModeC(): void {
+export async function runModeC(): Promise<void> {
   mode("MODE C — our preset by id + the consumer's own capability pack");
 
   const providerDefinitions = createDefaultProviderDefinitions();
@@ -221,6 +228,29 @@ export function runModeC(): void {
     0,
   );
 
+  // The property that makes suppression SAFE, measured from outside: because the pack is built by a
+  // factory bound to a cwd, the file tools it contributes are scoped to it. A context-free pack would
+  // hand a product that suppresses the framework tier an UNSANDBOXED Read/Write/Edit.
+  const packRead = (packOwnedOptions.additionalTools ?? []).find(
+    (tool) => tool.getName() === 'Read',
+  );
+  const readOutcome = await packRead!.execute(
+    { filePath: '/etc/hostname' } as never,
+    {
+      toolName: 'Read',
+      parameters: {},
+    } as never,
+  );
+  const readResult = JSON.parse(String((readOutcome as { data?: unknown }).data)) as {
+    success: boolean;
+    error?: string;
+  };
+  check(
+    'and the pack-owned Read is SCOPED — it denies a path outside the cwd the pack was built with',
+    readResult.success === false &&
+      (readResult.error ?? '').includes('outside the working directory'),
+  );
+
   note(
     'THEREFORE, precisely: `createSession` assembles `defaultTools ⊕ additionalTools ⊕ goalTool` and ' +
       'deduplicates by tool name (FIRST occurrence wins). A pack contributing a NEW tool is additive; a ' +
@@ -228,6 +258,12 @@ export function runModeC(): void {
       'that wants its packs to OWN the tool surface passes `defaultTools: []`. Removing a pack from such ' +
       'a profile removes its tools from the product — the same load-bearing property the command and ' +
       'subagent axes already had.',
+  );
+  note(
+    'SAFETY: a pack that owns the tool surface MUST carry the session context. `createCodingPack` takes a ' +
+      'REQUIRED `cwd` for exactly that reason — `agent-tools` disarms its working-directory path guard ' +
+      'when `cwd` is undefined, so a context-free pack paired with `defaultTools: []` would ship an ' +
+      'unsandboxed Read/Write/Edit. There is deliberately no context-free `codingPack` constant.',
   );
   note(
     'PRECEDENCE, and why it points this way: a name collision keeps the FRAMEWORK default and drops the ' +
@@ -243,7 +279,10 @@ export function runModeC(): void {
       'tool list, so the dedupe ITSELF is measured in-repo (agent-framework ' +
       'src/__tests__/create-session-default-tools.test.ts, 8 red-first cases). What this proof measures ' +
       'from the published surface is the seam that makes it reachable: the `defaultTools` option on the ' +
-      'shipped session-options type, and the overlay that carries the pack tools into it.',
+      'shipped session-options type, the overlay that carries the pack tools into it, and the scoping of ' +
+      'the pack-owned file tools. `robota` itself now consumes exactly this shape — its profile builds ' +
+      'pack-coding with the shell cwd and passes `defaultTools: []`, so its coding tools come FROM the ' +
+      'pack (asserted in-repo by agent-cli src/__tests__/robota-runtime-seam.test.ts).',
   );
   note(
     'COMMAND + SUBAGENT AXES: fully additive — command modules are passed as data and subagents arrive ' +

--- a/scripts/external-proof/fixture/src/proof.ts
+++ b/scripts/external-proof/fixture/src/proof.ts
@@ -19,5 +19,5 @@ process.stdout.write(
 
 runModeA();
 runModeB();
-runModeC();
+await runModeC();
 report();


### PR DESCRIPTION
The three-step follow-up to [#1397](https://github.com/woojubb/robota/pull/1397), implementing the remedy that PR recorded. **ARCH-005 TC-4 is now met at the product surface**, not just at the framework seam — so ARCH-005 moves `active/` → `done/` and ARCH-006 is archived.

## Why this had to be done, not deferred

#1397 measured a latent hazard: `agent-tools`' `checkPathWithinCwd` is a **no-op when `cwd` is `undefined`**, and `pack-coding` built its tools at module load with no options — so its `Read` returned `/etc/hostname`. That was inert *only* because ARCH-006's first-wins dedupe kept the framework's context-bound instance. The moment any profile used `defaultTools: []` — the very seam ARCH-006 added — it becomes a live unsandboxed `Read`/`Write`/`Edit`. Making the pack take `cwd` **removes** the hazard rather than fencing it.

## 1. `pack-coding` — BREAKING: factory in, constant out

`createCodingPack({ cwd, sandboxClient })`, with **`cwd` required**. The module-level `codingPack` constant is **removed, not deprecated**.

That was a deliberate call, and the coordinator asked for the reasoning: a "zero-option default" sitting beside the `defaultTools: []` seam is a loaded gun — the one shape that is unsafe would also be the most convenient one to reach for. The package is pre-release with two in-tree consumers (robota's profile, the external-proof fixture), both migrated in this PR, so there is nothing to preserve (owner directive: 레거시 보존 금지). Required `cwd` makes the scoping decision impossible to forget; each call returns fresh instances, so two products in one process get independently-scoped file tools. Documented in the package SPEC under its own heading.

## 2. robota's packs own its tool surface

The shell builds the packs from its resolved `cwd` (`createRobotaPacks({ cwd })`) **before** command setup — the same instances then supply the pack command-module names, the profile's `packs`, and the kernel overlay's tools. `buildRobotaRuntimeOptions` passes `ROBOTA_PACKS_OWN_TOOL_SURFACE` (an empty `defaultTools`) into the runtime seam, REPLACING `createDefaultTools()`. Every tool robota runs now comes from a capability pack.

## 3. Both transports carry the tool seams

`agent-transport`'s `HeadlessInteractionChannel` and `agent-transport-tui`'s `renderApp` → `TuiInteractionChannel` → `buildTuiSessionOptions` each took the same optional pass-through the `agentDefinitions` seam already had, for `additionalTools` **and** `defaultTools`. Print, serve and TUI now carry an identical tool surface.

## Acceptance — and the gate hole mutation-proving found

`robota-runtime-seam.test.ts` (10 cases) asserts that removing `packs` drops all 10 coding tools AND all 3 subagents AND leaves the framework tier suppressed — the product genuinely has no coding tools left — and that the `Read` robota gets is the **pack's cwd-scoped instance**: it denies `/etc/hostname`, and does *not* deny a path inside the shell's cwd (that fails as "File not found"), proving the scope is the right directory rather than a blanket refusal.

> **The first mutation attempt PASSED, and that was a real defect in my own gate.** Removing the suppression left the test green, because `IRobotaRuntimeOptions.defaultTools` was defaulted to `[]` on the way out — collapsing "suppressed" and "absent" into one value. That default is gone (the rationale now travels with the type). The same mutation now fails 2 assertions. Dropping `cwd` from the pack fails 4 `pack-coding` cases **and** the agent-cli scoping case — the cross-package gate catches it end to end.

## Evidence

- Red-first: all 9 `pack-coding` cases failed before the factory existed. The scoping property is asserted by **execution** (Read/Write/Edit each deny an out-of-cwd path; two packs with different roots don't share a scope), never by inspection.
- **Real binary, agent-run:** `robota -p "Use the Read tool on /etc/hostname, then on ./package.json"` → `/etc/hostname` **denied** (outside the working directory), `./package.json` **succeeded**. Both directions, with the pack as the source.
- `pnpm proof:external` — **69 assertions, exit 0** (was 68). C5 adds the safety property measured from the published surface: the pack-owned `Read` denies a path outside the cwd the pack was built with.
- `pnpm harness:verify-like-ci` **PASS — all 5 stages**.
- **2207 tests green**: agent-framework 1269, agent-transport-tui 526, agent-cli 258, agent-transport 56, agent-preset 71, agent-product 11, agent-capability-pack 7, pack-coding 9. `pnpm -w typecheck` clean.
- The file-size ratchet fired on `cli.ts`; per its remedy the growth is **split, not waived** — `reportUnknownPresetModules` moves beside the two helpers it already composed, and the tool surface is passed as one grouped `toolOptions` object.

**Equivalence suite: green, one pinned literal legitimately updated.** Its packs are now built through `createRobotaPacks({ cwd })` instead of read from a module constant — the same shipped factory `startCli` calls, so the gate still exercises the production path (the S2 F4 lesson). No assertion relaxed: the 27-module command set, 6 provider types, 10 tool names, 3 subagents, `DEFAULT_AGENT_NAME` and both preset resolutions are unchanged.

## Disposition

**ARCH-005 → `done/`.** All seven completion criteria met with agent-run evidence: Modes A/B/C work from a genuinely external consumer against the published surface, all three capability axes (commands, subagents, tools) are additive **and** load-bearing for the reference product, and robota consumes the kernel's runtime seam rather than re-threading its materials. **ARCH-006 → `completed/`** (ARCH-007 was archived in #1397). Nothing remains open on this initiative.

## Migration

```diff
-import { codingPack } from '@robota-sdk/pack-coding';
-packs: [codingPack],
+import { createCodingPack } from '@robota-sdk/pack-coding';
+packs: [createCodingPack({ cwd: process.cwd() })],
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z