### PR TITLE
fix(security): SEC-003 slice 2 — close the js/insecure-temporary-file class

### DIFF
--- a/.agents/backlog/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/SEC-003-codeql-alert-triage.md
@@ -203,8 +203,14 @@ now exist and should collapse into one scan.
 
 ### Adjacent alerts
 
-None surfaced. The diff-scoped CodeQL PR gate hazard slice 1 warned about did not materialise here:
-no other open alert sits on a line this slice touched, so nothing was dismissed.
+Slice 1's diff-scoped-gate warning was borne out, in miniature. Adding `mkdtempSync` to the `node:fs`
+import of `context/__tests__/context-loader-memory.test.ts` made the PR analysis report a
+**pre-existing** `js/unused-local-variable` on line 1 (`Unused import writeFileSync`) — the import was
+already dead before this slice, and only became visible because the diff touches that line. It is a
+genuine (if trivial) defect, so the dead import was removed rather than dismissed. ESLint does not
+catch this class in test files, which is why it survived.
+
+`js/insecure-temporary-file` on the PR merge ref: **0**. Nothing was dismissed in either slice.
 
 ### Class state
 

--- a/.agents/backlog/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/SEC-003-codeql-alert-triage.md
@@ -149,6 +149,76 @@ The grep floor added here (`dag-cli/src/utils/__tests__/no-insecure-temp-path.te
 SEC-003 stays **open**: `js/polynomial-redos` (18), the style classes, and the
 advisory→required promotion decision are untouched.
 
+## Slice 2 — finish `js/insecure-temporary-file` (2026-07-25)
+
+Slice 1's analysis was used as-is; nothing was re-derived. Scope: the remaining **88** alerts in
+`agent-framework` (76) and `agent-cli` (12).
+
+### Converted in this slice (88 alerts owned)
+
+Mechanical by pattern, exactly as slice 1 prescribed — **no shared helper, no new dependency**:
+`join(tmpdir(), <fixed name>)` → `mkdtempSync(join(tmpdir(), 'prefix-'))`, using Node's own
+`mkdtempSync` already available from `node:fs` in each file.
+
+| Package           | Alerts | Sites converted | Files |
+| ----------------- | ------ | --------------- | ----- |
+| `agent-framework` | 76     | 29              | 27    |
+| `agent-cli`       | 12     | 6               | 6     |
+
+The sweep converted **every** `join(tmpdir(), …)` site in both packages, not only the lines CodeQL
+had completed a flow for. The unflagged ones are the same defect with a flow the scanner did not
+finish; leaving them would also have left the grep floor unenforceable.
+
+All four flagged **production** lines (`update-check.ts:92`, `memory/project-memory-store.ts:182`,
+`config/settings-io.ts:44`, `adapters/node-file-system.ts:38`) are class B exactly as slice 1
+predicted — each takes a **caller-supplied** path and none constructs a path under `os.tmpdir()`.
+Three were left alone deliberately: `node-file-system.ts` is the generic `IFileSystem` adapter the
+agent's Write tool uses for ordinary project files (forcing `0600` there would be wrong),
+`project-memory-store.ts` writes repo-tracked memory markdown meant to be shared, and
+`update-check.ts` caches a version string. Adding a mode to those would be scanner appeasement.
+
+### Real hardening found by the sweep — plaintext API key in settings
+
+Running the converted `agent-cli` suite surfaced this on stderr:
+
+> `API key stored as plain text in settings. Use --api-key-env for better security.`
+
+`command-api/provider/provider-settings.ts` does persist `provider.apiKey` verbatim when a profile
+is configured without `--api-key-env`, and `writeSettings` (`config/settings-io.ts:44`) wrote that
+file with no `mode` — measured `0o664` on this host, i.e. **a credential readable by every user on
+the machine**. This is the same class of real exposure slice 1 fixed for session/prompt content, so
+it was hardened rather than dismissed: settings files are now created `0o600`, proven by a
+red-first test (`expect(statSync(path).mode & 0o777).toBe(0o600)` — failed at `436` = `0o664`
+before the fix). `mode` applies at creation only, so a pre-existing settings file keeps its mode;
+that residual is recorded in the changeset.
+
+### Grep floor
+
+Slice 1's `dag-cli` floor was mirrored into both packages —
+`packages/agent-framework/src/__tests__/no-insecure-temp-path.test.ts` and
+`packages/agent-cli/src/__tests__/no-insecure-temp-path.test.ts`. Proven red before the sweep
+(28 offenders in `agent-framework`, 6 in `agent-cli`) and green after. The repo-wide promotion
+under `scripts/harness/` recorded in slice 1's follow-up is still open — three package-local floors
+now exist and should collapse into one scan.
+
+### Adjacent alerts
+
+None surfaced. The diff-scoped CodeQL PR gate hazard slice 1 warned about did not materialise here:
+no other open alert sits on a line this slice touched, so nothing was dismissed.
+
+### Class state
+
+`js/insecure-temporary-file` is **closed**: 21 (slice 1) + 88 (slice 2) = **109 of 109** alerts
+fixed at the source. **Zero dismissals across both slices.** One caveat to verify once CodeQL
+re-analyzes `develop`: `agent-command/src/memory/__tests__/memory-command-module.test.ts:12` still
+uses the old pattern and imports `@robota-sdk/agent-framework`. It carries no alert of its own
+today, which indicates CodeQL is not tracking taint across the package boundary — but if any
+`agent-framework` production alert survives, that line is the cause. It is outside slice 2's
+ownership and is a one-line conversion.
+
+SEC-003 remains **open** for `js/polynomial-redos` (18, sibling-owned), the style classes, the
+`js/file-system-race` class (16) slice 1 catalogued, and the advisory→required decision.
+
 ## Test Plan
 
 Per fixed class: a red-first regression test where feasible (e.g. the temp-path helper's test proves

--- a/.changeset/sec-003-settings-owner-only.md
+++ b/.changeset/sec-003-settings-owner-only.md
@@ -1,0 +1,14 @@
+---
+'@robota-sdk/agent-framework': patch
+---
+
+Create settings files owner-only (SEC-003, CodeQL `js/insecure-temporary-file`).
+
+`writeSettings` persists `provider.apiKey` verbatim when a profile is configured without
+`--api-key-env` — the CLI even warns that the key is "stored as plain text in settings" — but the
+file was created with the process umask (measured `0644`/`0664`), leaving that credential readable
+by every user on the host. It is now created `0600`.
+
+This is a permissions change only — file locations, names, formats, and APIs are unchanged. `mode`
+applies at creation, so a settings file that already exists keeps whatever mode it has; only newly
+created settings files are affected.

--- a/packages/agent-cli/src/__tests__/cli-exit-codes.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-exit-codes.test.ts
@@ -6,7 +6,7 @@
  * retry" from runtime failures (exit 1). Non-print startup keeps exit 1.
  */
 
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -21,7 +21,7 @@ import type {
   TUniversalMessage,
 } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-cli-exit-codes-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-cli-exit-codes-test-'));
 const ORIGINAL_ARGV = process.argv;
 const ORIGINAL_HOME = process.env.HOME;
 

--- a/packages/agent-cli/src/__tests__/cli-update-check.test.ts
+++ b/packages/agent-cli/src/__tests__/cli-update-check.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type {
@@ -12,7 +12,7 @@ import type {
 } from '@robota-sdk/agent-core';
 import { startCli } from '../cli.js';
 
-const TMP_BASE = join(tmpdir(), `robota-cli-update-check-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-cli-update-check-test-'));
 const ORIGINAL_ARGV = process.argv;
 const ORIGINAL_HOME = process.env.HOME;
 let lastChatMessages: TUniversalMessage[] = [];
@@ -38,10 +38,7 @@ function createFakeProvider(): IAIProvider {
   return {
     name: 'fake',
     version: 'test',
-    async chat(
-      messages: TUniversalMessage[],
-      _options?: IChatOptions,
-    ): Promise<TUniversalMessage> {
+    async chat(messages: TUniversalMessage[], _options?: IChatOptions): Promise<TUniversalMessage> {
       lastChatMessages = [...messages];
       return {
         id: 'assistant-1',
@@ -129,7 +126,8 @@ describe('CLI update check command', () => {
     expect(stderr.mock.calls.join('')).toBe('');
     expect(
       lastChatMessages.some(
-        (message) => typeof message.content === 'string' && message.content.includes('Loop objective'),
+        (message) =>
+          typeof message.content === 'string' && message.content.includes('Loop objective'),
       ),
     ).toBe(true);
     expect(lastChatMessages.some((message) => message.content === 'Summarize the task file.')).toBe(

--- a/packages/agent-cli/src/__tests__/e2e/scripted-e2e.test.ts
+++ b/packages/agent-cli/src/__tests__/e2e/scripted-e2e.test.ts
@@ -6,7 +6,7 @@
  * persistence → output transports. No model, no network, fully deterministic.
  */
 
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,7 +18,7 @@ import { startCli } from '../../cli.js';
 import type { IScriptedProvider, TScriptedTurn } from '@robota-sdk/agent-transport/testing';
 import type { IProviderDefinition } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-scripted-e2e-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-scripted-e2e-'));
 const ORIGINAL_ARGV = process.argv;
 const ORIGINAL_HOME = process.env.HOME;
 

--- a/packages/agent-cli/src/__tests__/e2e/slash-smoke.test.ts
+++ b/packages/agent-cli/src/__tests__/e2e/slash-smoke.test.ts
@@ -8,7 +8,7 @@
  * but they must never crash the CLI or emit a non-envelope.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -20,7 +20,7 @@ import { startCli } from '../../cli.js';
 import type { IScriptedProvider } from '@robota-sdk/agent-transport/testing';
 import type { IProviderDefinition } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-slash-smoke-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-slash-smoke-'));
 const ORIGINAL_ARGV = process.argv;
 const ORIGINAL_HOME = process.env.HOME;
 

--- a/packages/agent-cli/src/__tests__/no-insecure-temp-path.test.ts
+++ b/packages/agent-cli/src/__tests__/no-insecure-temp-path.test.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * SEC-003 regression floor for CodeQL `js/insecure-temporary-file` (CWE-377).
+ *
+ * The rule's taint source is an `os.tmpdir()` call or a `'/tmp/…'` string literal; its sink
+ * is the path argument of an `fs` write that does not pass an owner-only `mode`. Taint stops
+ * at `mkdtemp`/`mkdtempSync`, because the OS — not the caller — chooses that name and creates
+ * the directory `0700`.
+ *
+ * So the one pattern that must not come back is a path built by string-joining a name onto
+ * `os.tmpdir()`. `mkdtemp(join(tmpdir(), 'prefix-'))` is the sanctioned form and is allowed.
+ *
+ * Mirrors the floor slice 1 added for `dag-cli`; both are scoped to their own package until a
+ * repo-wide harness scan takes over (SEC-003 follow-up).
+ */
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('SEC-003 floor: no insecure temp paths in agent-cli', () => {
+  it('never string-joins a name onto os.tmpdir() outside of mkdtemp', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      const lines = source.split('\n');
+
+      lines.forEach((line, index) => {
+        // Only `join(tmpdir(), …)` matters; the `mkdtemp(join(tmpdir(), …))` wrapper is safe.
+        if (!/\bjoin\(\s*tmpdir\(\)/.test(line)) return;
+        if (/\bmkdtemp(Sync)?\s*\(/.test(line)) return;
+        // An assertion that *names* the unsafe path is proving it is not used, not using it.
+        if (/\bexpect\(/.test(line)) return;
+        // This floor file quotes the pattern in its own documentation.
+        if (file === fileURLToPath(import.meta.url)) return;
+        offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('never hardcodes a writable "/tmp/..." path in non-test sources', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      if (file.includes('__tests__') || file.endsWith('.test.ts')) continue;
+      const source = readFileSync(file, 'utf8');
+
+      source.split('\n').forEach((line, index) => {
+        if (/['"`]\/tmp\//.test(line)) {
+          offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/agent-cli/src/__tests__/provider-factory-integration.test.ts
+++ b/packages/agent-cli/src/__tests__/provider-factory-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createProviderFromProfile } from '@robota-sdk/agent-executor';
@@ -220,7 +220,7 @@ const DEFAULT_PROVIDER_DEFINITIONS = [
   createDeepSeekProviderDefinition(),
 ];
 
-const TMP_BASE = join(tmpdir(), `robota-provider-factory-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-provider-factory-test-'));
 const ORIGINAL_HOME = process.env.HOME;
 
 function writeJson(path: string, data: unknown): void {

--- a/packages/agent-cli/src/startup/__tests__/provider-startup.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/provider-startup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { rmSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { rmSync, readFileSync, mkdirSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IParsedCliArgs } from '../../utils/cli-args.js';
@@ -22,7 +22,7 @@ const NOOP_TERMINAL: ITerminalOutput = {
   spinner: (): ISpinner => ({ stop: () => {}, update: () => {} }),
 };
 
-const TMP_BASE = join(tmpdir(), `robota-provider-startup-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-provider-startup-test-'));
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_STDIN_TTY = process.stdin.isTTY;
 const ORIGINAL_STDOUT_TTY = process.stdout.isTTY;

--- a/packages/agent-framework/src/__tests__/config-loader.test.ts
+++ b/packages/agent-framework/src/__tests__/config-loader.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { loadConfig } from '../config/config-loader.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-cli-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-cli-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/__tests__/context-loader.test.ts
+++ b/packages/agent-framework/src/__tests__/context-loader.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { loadContext } from '../context/context-loader.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-context-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-context-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/__tests__/no-insecure-temp-path.test.ts
+++ b/packages/agent-framework/src/__tests__/no-insecure-temp-path.test.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * SEC-003 regression floor for CodeQL `js/insecure-temporary-file` (CWE-377).
+ *
+ * The rule's taint source is an `os.tmpdir()` call or a `'/tmp/…'` string literal; its sink
+ * is the path argument of an `fs` write that does not pass an owner-only `mode`. Taint stops
+ * at `mkdtemp`/`mkdtempSync`, because the OS — not the caller — chooses that name and creates
+ * the directory `0700`.
+ *
+ * So the one pattern that must not come back is a path built by string-joining a name onto
+ * `os.tmpdir()`. `mkdtemp(join(tmpdir(), 'prefix-'))` is the sanctioned form and is allowed.
+ *
+ * Mirrors the floor slice 1 added for `dag-cli`; both are scoped to their own package until a
+ * repo-wide harness scan takes over (SEC-003 follow-up).
+ */
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (full.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('SEC-003 floor: no insecure temp paths in agent-framework', () => {
+  it('never string-joins a name onto os.tmpdir() outside of mkdtemp', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      const lines = source.split('\n');
+
+      lines.forEach((line, index) => {
+        // Only `join(tmpdir(), …)` matters; the `mkdtemp(join(tmpdir(), …))` wrapper is safe.
+        if (!/\bjoin\(\s*tmpdir\(\)/.test(line)) return;
+        if (/\bmkdtemp(Sync)?\s*\(/.test(line)) return;
+        // An assertion that *names* the unsafe path is proving it is not used, not using it.
+        if (/\bexpect\(/.test(line)) return;
+        // This floor file quotes the pattern in its own documentation.
+        if (file === fileURLToPath(import.meta.url)) return;
+        offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('never hardcodes a writable "/tmp/..." path in non-test sources', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      if (file.includes('__tests__') || file.endsWith('.test.ts')) continue;
+      const source = readFileSync(file, 'utf8');
+
+      source.split('\n').forEach((line, index) => {
+        if (/['"`]\/tmp\//.test(line)) {
+          offenders.push(`${relative(SRC_ROOT, file)}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/agent-framework/src/__tests__/project-detector.test.ts
+++ b/packages/agent-framework/src/__tests__/project-detector.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { detectProject } from '../context/project-detector.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-detector-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-detector-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/__tests__/provider-configuration.test.ts
+++ b/packages/agent-framework/src/__tests__/provider-configuration.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -12,7 +12,7 @@ import {
 } from '../command-api/provider/provider-configuration.js';
 import { readProviderSettings } from '../command-api/provider/provider-factory.js';
 
-const TMP_BASE = join(tmpdir(), `robota-provider-configuration-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-provider-configuration-test-'));
 const ORIGINAL_HOME = process.env.HOME;
 
 function readJson(path: string): Record<string, unknown> {

--- a/packages/agent-framework/src/__tests__/settings-check.test.ts
+++ b/packages/agent-framework/src/__tests__/settings-check.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,7 +8,7 @@ import { checkSettingsFile } from '../command-api/provider/settings-check.js';
 
 import type { IProviderDefinition } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-settings-check-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-settings-check-test-'));
 const providerDefinitions: readonly IProviderDefinition[] = [
   {
     type: 'openai',

--- a/packages/agent-framework/src/__tests__/statusline-settings.test.ts
+++ b/packages/agent-framework/src/__tests__/statusline-settings.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,7 +9,7 @@ import {
   readStatusLineSettings,
 } from '../command-api/statusline/statusline-command-api.js';
 
-const TMP_BASE = join(tmpdir(), `robota-statusline-settings-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-statusline-settings-test-'));
 
 function readJson(path: string): Record<string, unknown> {
   return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;

--- a/packages/agent-framework/src/__tests__/subagent-integration.test.ts
+++ b/packages/agent-framework/src/__tests__/subagent-integration.test.ts
@@ -3,7 +3,7 @@
  * agent definitions, tool filtering, session creation, and agent tool wiring.
  */
 
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -239,7 +239,7 @@ describe('Subagent integration', () => {
   });
 
   it('AgentDefinitionLoader finds built-in agents when dirs are empty', () => {
-    const tmpDir = join(tmpdir(), `robota-test-${Date.now()}`);
+    const tmpDir = mkdtempSync(join(tmpdir(), 'robota-test-'));
     mkdirSync(tmpDir, { recursive: true });
 
     try {
@@ -258,7 +258,7 @@ describe('Subagent integration', () => {
   });
 
   it('Custom agent overrides built-in', () => {
-    const tmpDir = join(tmpdir(), `robota-test-${Date.now()}`);
+    const tmpDir = mkdtempSync(join(tmpdir(), 'robota-test-'));
     const agentsDir = join(tmpDir, '.claude', 'agents');
     mkdirSync(agentsDir, { recursive: true });
 
@@ -306,7 +306,7 @@ describe('Subagent transcript logger', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = join(tmpdir(), `robota-logger-test-${Date.now()}`);
+    tmpDir = mkdtempSync(join(tmpdir(), 'robota-logger-test-'));
     mkdirSync(tmpDir, { recursive: true });
   });
 

--- a/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
+++ b/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-store.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+  mkdtempSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -7,7 +15,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { EditCheckpointStore } from '../edit-checkpoint-store.js';
 import { projectPaths } from '../../paths.js';
 
-const TMP_BASE = join(tmpdir(), `robota-edit-checkpoint-store-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-edit-checkpoint-store-'));
 
 function makeProject(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
+++ b/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, readFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,7 +9,7 @@ import { wrapEditCheckpointTools } from '../edit-checkpoint-tools.js';
 
 import type { IEditCheckpointRecorder } from '../edit-checkpoint-types.js';
 
-const TMP_BASE = join(tmpdir(), `robota-edit-checkpoint-tools-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-edit-checkpoint-tools-'));
 
 function makeProject(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/config/__tests__/settings-io.test.ts
+++ b/packages/agent-framework/src/config/__tests__/settings-io.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, readFileSync, statSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -11,7 +11,7 @@ import {
   deleteSettings,
 } from '../settings-io.js';
 
-const TEST_DIR = join(tmpdir(), 'robota-settings-io-test');
+const TEST_DIR = mkdtempSync(join(tmpdir(), 'robota-settings-io-test-'));
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
@@ -47,6 +47,14 @@ describe('writeSettings', () => {
     const path = join(TEST_DIR, 'nested', 'deep', 'settings.json');
     writeSettings(path, { ok: true });
     expect(existsSync(path)).toBe(true);
+  });
+
+  // SEC-003: a settings file may hold a plaintext `provider.apiKey`, so it must not be
+  // created world-readable by the ambient umask.
+  it('creates the file owner-readable only', () => {
+    const path = join(TEST_DIR, 'credentialed.json');
+    writeSettings(path, { provider: { name: 'openai', apiKey: 'sk-secret' } });
+    expect(statSync(path).mode & 0o777).toBe(0o600);
   });
 
   it('overwrites existing file', () => {

--- a/packages/agent-framework/src/config/settings-io.ts
+++ b/packages/agent-framework/src/config/settings-io.ts
@@ -39,9 +39,15 @@ export function readSettings(path: string): TSettingsData {
   }
 }
 
+/**
+ * SEC-003: settings files can hold a plaintext provider credential — `provider-settings.ts`
+ * persists `apiKey` verbatim when `--api-key-env` is not used (and warns while doing it). A
+ * default-umask create would leave that credential world-readable, so the file is created
+ * owner-only. `mode` applies at creation; a settings file that already exists keeps its mode.
+ */
 export function writeSettings(path: string, settings: TSettingsData): void {
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
 }
 
 export function updateModelInSettings(settingsPath: string, modelId: string): void {

--- a/packages/agent-framework/src/context/__tests__/context-file-tracker.test.ts
+++ b/packages/agent-framework/src/context/__tests__/context-file-tracker.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -13,7 +13,7 @@ import {
 
 import type { IContextFileEntry } from '../context-file-tracker.js';
 
-const testDir = join(tmpdir(), `ctx-file-tracker-test-${Date.now()}`);
+const testDir = mkdtempSync(join(tmpdir(), 'ctx-file-tracker-test-'));
 
 beforeEach(() => {
   mkdirSync(testDir, { recursive: true });

--- a/packages/agent-framework/src/context/__tests__/context-loader-memory.test.ts
+++ b/packages/agent-framework/src/context/__tests__/context-loader-memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync, existsSync, mkdtempSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/packages/agent-framework/src/context/__tests__/context-loader-memory.test.ts
+++ b/packages/agent-framework/src/context/__tests__/context-loader-memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,7 +9,7 @@ import { loadContext } from '../context-loader.js';
 
 import type { IMemoryStore, IStartupMemory } from '../../memory/types.js';
 
-const TMP_BASE = join(tmpdir(), `robota-context-loader-memory-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-context-loader-memory-'));
 
 function makeWorkspace(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/context/__tests__/task-context-opt-in.test.ts
+++ b/packages/agent-framework/src/context/__tests__/task-context-opt-in.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -7,7 +7,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { SettingsSchema } from '../../config/config-types.js';
 import { loadContext } from '../context-loader.js';
 
-const TMP_BASE = join(tmpdir(), `robota-task-context-opt-in-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-task-context-opt-in-'));
 
 function makeWorkspace(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/context/__tests__/task-context.test.ts
+++ b/packages/agent-framework/src/context/__tests__/task-context.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -12,7 +12,7 @@ import {
   selectRelevantTasks,
 } from '../task-context.js';
 
-const TMP_BASE = join(tmpdir(), `robota-task-context-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-task-context-'));
 
 function makeProject(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/git/__tests__/git-branch.test.ts
+++ b/packages/agent-framework/src/git/__tests__/git-branch.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -6,7 +6,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 
 import { resolveGitBranch } from '../git-branch.js';
 
-const TMP_BASE = join(tmpdir(), `robota-git-branch-test-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-git-branch-test-'));
 
 describe('resolveGitBranch', () => {
   afterEach(() => {

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-auto-capture.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-auto-capture.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -17,7 +17,7 @@ import type { IAIProvider } from '@robota-sdk/agent-core';
  * controller's `finally`, before `persistSession()`, on the completed-turn path, guarded).
  */
 
-const TMP_BASE = join(tmpdir(), `robota-auto-capture-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-auto-capture-'));
 const ORIGINAL_HOME = process.env.HOME;
 
 function makeProject(): string {

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-checkpoints.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-checkpoints.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,7 +8,7 @@ import { InteractiveSession } from '../interactive-session.js';
 
 import type { IAIProvider, IAssistantMessage, TUniversalMessage } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-interactive-checkpoints-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-interactive-checkpoints-'));
 const ORIGINAL_HOME = process.env.HOME;
 
 function makeProject(): string {

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-memory.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-memory.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,7 +10,7 @@ import { createProjectSessionStore } from '../session-persistence.js';
 
 import type { IAIProvider, TUniversalMessage } from '@robota-sdk/agent-core';
 
-const TMP_BASE = join(tmpdir(), `robota-interactive-memory-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-interactive-memory-'));
 const ORIGINAL_HOME = process.env.HOME;
 
 function makeProject(): string {

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-recall.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-recall.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -21,7 +21,7 @@ import type { IAIProvider, TUniversalMessage } from '@robota-sdk/agent-core';
  * adapter-gated on a surface-supplied `recallMemory` policy, guarded (recall failure never breaks the turn).
  */
 
-const TMP_BASE = join(tmpdir(), `robota-recall-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-recall-'));
 const ORIGINAL_HOME = process.env.HOME;
 const RECALL_BODY = '### deploy\nThe staging deploy key rotates every 30 days.';
 const BUDGET: IMemoryBudget = { maxTopics: 4, maxTopicChars: 2000 };

--- a/packages/agent-framework/src/memory/__tests__/automatic-memory.test.ts
+++ b/packages/agent-framework/src/memory/__tests__/automatic-memory.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,7 +18,7 @@ import { ProjectMemoryStore } from '../project-memory-store.js';
 
 import type { IMemoryCandidate } from '../automatic-memory-types.js';
 
-const TMP_BASE = join(tmpdir(), `robota-automatic-memory-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-automatic-memory-'));
 const NOW = new Date('2026-05-02T00:00:00.000Z');
 
 function makeProject(): string {

--- a/packages/agent-framework/src/memory/__tests__/file-system-memory-store.test.ts
+++ b/packages/agent-framework/src/memory/__tests__/file-system-memory-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,7 +14,7 @@ import type {
   ISemanticMemoryAdapter,
 } from '../types.js';
 
-const TMP_BASE = join(tmpdir(), `robota-fs-memory-store-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-fs-memory-store-'));
 
 function makeWorkspace(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/memory/__tests__/project-memory-store.test.ts
+++ b/packages/agent-framework/src/memory/__tests__/project-memory-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,7 +10,7 @@ import {
   MEMORY_INDEX_MAX_BYTES,
 } from '../project-memory-store.js';
 
-const TMP_BASE = join(tmpdir(), `robota-memory-store-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-memory-store-'));
 
 function makeProject(): string {
   const dir = join(TMP_BASE, Math.random().toString(36).slice(2));

--- a/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,7 +10,7 @@ import { PluginSettingsStore } from '../plugin-settings-store.js';
 
 import type { TExecFn } from '../marketplace-types.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-installer-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-installer-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/plugins/__tests__/bundle-plugin-loader.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/bundle-plugin-loader.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,7 +8,7 @@ import { BundlePluginLoader } from '../bundle-plugin-loader.js';
 
 import type { IBundlePluginManifest, TEnabledPlugins } from '../bundle-plugin-types.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-bundle-plugin-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-bundle-plugin-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/plugins/__tests__/integration.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/integration.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,7 +8,7 @@ import { BundlePluginLoader } from '../bundle-plugin-loader.js';
 
 import type { IBundlePluginManifest } from '../bundle-plugin-types.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-bundle-integration-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-bundle-integration-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/plugins/__tests__/marketplace-client.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/marketplace-client.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,7 +8,7 @@ import { MarketplaceClient } from '../marketplace-client.js';
 
 import type { TMarketplaceSource } from '../marketplace-client.js';
 
-const TMP_BASE = join(tmpdir(), 'robota-marketplace-test-' + process.pid);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-marketplace-test-'));
 
 function setupDir(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
+++ b/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -16,7 +16,7 @@ import {
   shouldRunStartupCliUpdateCheck,
 } from '../update-check.js';
 
-const TEST_DIR = join(tmpdir(), `robota-update-check-test-${process.pid}`);
+const TEST_DIR = mkdtempSync(join(tmpdir(), 'robota-update-check-test-'));
 
 function cleanup(): void {
   rmSync(TEST_DIR, { recursive: true, force: true });


### PR DESCRIPTION
Finishes the `js/insecure-temporary-file` class that slice 1 (#1398) analysed. Slice 1's analysis was used as-is; nothing was re-derived.

## What

Converts the remaining **88** alerts — `agent-framework` (76) + `agent-cli` (12) — that slice 1 could not touch.

Mechanical **by pattern, not by import**, exactly as slice 1 prescribed: no shared helper, no new dependency, just Node's own `mkdtempSync`.

```diff
-const TMP_BASE = join(tmpdir(), `robota-foo-${process.pid}`);
+const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-foo-'));
```

The OS picks the name and creates the directory `0700`, so the symlink pre-creation attack on a predictable path in a world-writable tmpdir no longer applies — and CodeQL's taint stops at `mkdtemp`'s return value.

**Every** `join(tmpdir(), …)` site in both packages is converted (29 + 6 across 33 files), not only the lines CodeQL had completed a flow for. The unflagged ones are the same defect with a flow the scanner did not finish; leaving them would also have left the grep floor unenforceable.

## Production lines

All four flagged production lines are **class B** exactly as slice 1 predicted — each takes a *caller-supplied* path and none builds a path under `os.tmpdir()`, so they clear when their tests convert. Three are deliberately left without a mode, because adding one would be scanner appeasement rather than hardening:

| File | Why no mode |
| --- | --- |
| `adapters/node-file-system.ts` | the generic `IFileSystem` adapter the agent's Write tool uses for ordinary project files |
| `memory/project-memory-store.ts` | repo-tracked memory markdown, meant to be shared |
| `update-check/update-check.ts` | a cached version string |

## Real hardening the sweep surfaced

Running the converted `agent-cli` suite printed:

> `API key stored as plain text in settings. Use --api-key-env for better security.`

`command-api/provider/provider-settings.ts` really does persist `provider.apiKey` verbatim when a profile is configured without `--api-key-env`, and `writeSettings` (`config/settings-io.ts:44`, the fourth flagged line) wrote that file with no `mode` — measured `0o664` on this host, i.e. **a credential readable by every user on the machine**. Same class of real exposure slice 1 fixed for session/prompt content, so it is hardened rather than dismissed: settings files are now created `0600`.

`mode` applies at creation, so a pre-existing settings file keeps its mode; that residual is stated in the changeset.

## Red-first evidence

- **Grep floor** — slice 1's `dag-cli` floor mirrored into both packages. Failed before the sweep with **28** offenders in `agent-framework` and **6** in `agent-cli`; passes after.
- **Settings mode** — `expect(statSync(path).mode & 0o777).toBe(0o600)` failed at `436` (= `0o664`) with the source reverted, passes with the fix.

No test lost an assertion; the only test-body change is where the temp root comes from.

## Adjacent alert — found and fixed, not dismissed

Slice 1's diff-scoped-gate warning was borne out. Adding `mkdtempSync` to the `node:fs` import of `context/__tests__/context-loader-memory.test.ts` made the PR analysis report a **pre-existing** `js/unused-local-variable` on line 1 (`Unused import writeFileSync`) — dead before this branch, visible only because the diff touches that line. Genuine dead code, so it was removed. ESLint does not flag this class in test files, which is how it survived.

**Nothing was dismissed, in either slice.** The PR merge ref now reports **zero** open alerts of any rule on the diff.

## Class state

`js/insecure-temporary-file`: 21 (slice 1) + 88 (slice 2) = **109 of 109 fixed at the source, zero dismissals.**

One caveat to re-check once CodeQL re-analyses `develop`: `agent-command/src/memory/__tests__/memory-command-module.test.ts:12` still uses the old pattern and imports `@robota-sdk/agent-framework`. It carries no alert of its own today, which indicates CodeQL is not tracking taint across the package boundary — but if an `agent-framework` production alert survives, that line is the cause. Outside this slice's ownership; a one-line conversion.

SEC-003 stays **open** for `js/polynomial-redos` (18, sibling-owned), the style classes, the `js/file-system-race` class (16), and the advisory→required decision.

## Verification

- **CI: all 15 checks pass**, including CodeQL `Analyze (javascript-typescript)`
- `pnpm harness:verify-like-ci` — PASS, all 5 stages
- `agent-framework` — 154 files, **1272 tests** green
- `agent-cli` — 34 files, **260 tests** green
- downstream `writeSettings` consumers: `agent-command` 244 green, `agent-transport` 56 green
- `pnpm -w typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z