### PR TITLE
docs(backlog): PERF-002/003/004 from the TypeScript 7 typecheck investigation

### DIFF
--- a/.agents/backlog/PERF-002-typecheck-workspace-concurrency.md
+++ b/.agents/backlog/PERF-002-typecheck-workspace-concurrency.md
@@ -1,0 +1,49 @@
+---
+title: 'PERF-002: raise pnpm workspace concurrency for typecheck (no-risk, compiler-independent)'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: soon
+area: package.json
+depends_on: []
+---
+
+# PERF-002: `pnpm typecheck` only runs 2–4 packages at a time
+
+## Problem
+
+Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)
+(2026-07-25, measured; no repo change was made).
+
+The root script is `pnpm run -r --if-present typecheck` and each of the **66** workspace projects runs
+its own `tsc --noEmit`. pnpm's `--workspace-concurrency` defaults to **4**, so on a 20-core machine only
+2–4 `tsc` processes run at once (confirmed by repeated `pgrep -fc tsc`). Overall CPU stays low while each
+`tsc` pins 2–3 cores at max turbo — the package hits 43°C → 87°C in seconds, and per-package process
+startup repeats 66 times (~0.19 s each on the current compiler ≈ 12 s of pure startup).
+
+Low utilization, high heat, long wall-clock — and the fix is one flag.
+
+## What
+
+```diff
+-"typecheck": "pnpm run -r --if-present typecheck"
++"typecheck": "pnpm run -r --workspace-concurrency=12 --if-present typecheck"
+```
+
+Constraint from the investigation: **do NOT use `--parallel`** — it ignores topological order and breaks
+dependency sequencing. `--workspace-concurrency` preserves order and only raises how many run at once.
+Pick the number deliberately (12 was the investigation's suggestion for a 20-core host); consider whether
+CI runners (fewer cores) want the same value or an env-driven one.
+
+## Test Plan
+
+Measure wall-clock before/after on the same machine (3 runs, report the minimum) and record both numbers
+in the Outcome — the investigation's §7 explicitly asks for this. Verify `pgrep -fc tsc` actually rises.
+Confirm ordering is unaffected: a package that depends on another must still typecheck after it (a
+deliberate type error in a dependency must still surface downstream, not race past it).
+`pnpm harness:verify-like-ci` green.
+
+## Note
+
+Expect _higher_ instantaneous power and fan speed — the win is much shorter duration, so total heat and
+noise duration drop. That trade is intended, not a regression.

--- a/.agents/backlog/PERF-003-typescript-7-side-by-side-evaluation.md
+++ b/.agents/backlog/PERF-003-typescript-7-side-by-side-evaluation.md
@@ -1,0 +1,67 @@
+---
+title: 'PERF-003: evaluate TypeScript 7 (native) side-by-side for typecheck — measured 8.8x, not yet adoptable'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: later
+depends_on: [PERF-002]
+area: package.json, tsconfig
+---
+
+# PERF-003: TypeScript 7 native compiler — side-by-side evaluation
+
+## Problem / Opportunity
+
+Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)
+(2026-07-25). Measured on 852 files / 6 packages, same tsconfig injected into both compilers:
+
+| Allowed cores | tsc 5.9.3 | tsc 7.0.2  |
+| ------------- | --------- | ---------- |
+| 1             | 9.75 s    | 2.06 s     |
+| 4             | 5.32 s    | 0.91 s     |
+| 16            | 4.51 s    | **0.51 s** |
+
+**8.8× at 16 cores** = 4.7× native code × 1.9× parallel scaling. Startup drops 0.28 s → 0.09 s (material
+at 66 packages). Error counts were **identical** on both compilers (41 / 584 on the benchmark config),
+which is the signal that diagnostics agree.
+
+Two facts that bound the work: **6.x is still the JS compiler** (no multicore benefit — upgrading to 6 is
+pointless for performance), and TS7's `--checkers` defaults to 4 and **saturates there** for a project of
+this size, so package-level concurrency (PERF-002) is the bigger lever; the two multiply.
+
+## Blocker — TS7 has no stable programmatic API
+
+`typescript@7` does not export the legacy compiler API (`require('typescript')` → `MODULE_NOT_FOUND`;
+only `./unstable/*`). **Four in-repo consumers import it directly** (verified 2026-07-25):
+
+```
+scripts/audit/audit-implements.mjs
+scripts/harness/check-spec-public-surface.mjs
+scripts/harness/scan-composition-neutrality.mjs
+scripts/harness/scan-interface-runtime.mjs
+```
+
+plus `@typescript-eslint/*`. Replacing `typescript` wholesale would break all four harness scans and
+eslint. This is why the work is **side-by-side**, not an upgrade.
+
+## What
+
+1. `pnpm add -Dw @typescript/native-preview` (bin `tsgo` — deliberately does not collide with `tsc`).
+2. Add `"typecheck:fast": "tsgo -p tsconfig.json --noEmit"` as a SEPARATE script. **Do not touch the
+   existing `typecheck`.**
+3. Run both paths and **diff the error lists**. Agreement is the adoption criterion — record the
+   comparison, not just the timing.
+4. Keep `typescript@5.9.3` as a devDependency permanently (harness scans + eslint + vitest + IDE).
+   **Never remove it.**
+
+## Test Plan
+
+Both paths run on the real repo (not the benchmark config); the error lists are compared line-by-line and
+the diff recorded in the Outcome. Timing measured on the same machine with the method in the source doc's
+§8 (`/usr/bin/time -v`, `taskset` for core-count isolation). `pnpm harness:verify-like-ci` green — the
+four TS-API scans must still pass, proving side-by-side did not disturb them.
+
+## Out of scope
+
+Switching `typecheck` to tsgo — that is PERF-004, gated on this evaluation's error-list agreement AND on
+the tsconfig migration.

--- a/.agents/backlog/PERF-004-tsconfig-ts7-compatibility-migration.md
+++ b/.agents/backlog/PERF-004-tsconfig-ts7-compatibility-migration.md
@@ -1,0 +1,56 @@
+---
+title: 'PERF-004: migrate tsconfig off options TypeScript 7 removed, then switch typecheck'
+status: todo
+created: 2026-07-25
+priority: medium
+urgency: later
+depends_on: [PERF-003]
+area: tsconfig.base.json, packages, apps
+---
+
+# PERF-004: tsconfig migration + the actual switch
+
+## Problem
+
+Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)
+§6-2. TypeScript 7 removed options this repo uses. Re-measured against the current tree 2026-07-25 — two
+of the three are broader than the source doc estimated:
+
+| Option                       | Where it actually is                                                                       | TS7 state        | Action                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------ | ---------------- | ---------------------------------------------------------------- |
+| `"moduleResolution": "Node"` | `tsconfig.base.json:9`                                                                     | removed (node10) | → `"bundler"` or `"nodenext"` — decide deliberately, they differ |
+| `"baseUrl": "."`             | `tsconfig.base.json:27`                                                                    | removed          | delete (`paths` resolve relative to the tsconfig)                |
+| `"downlevelIteration": true` | **38 tsconfig files** across `packages/`+`apps/` (NOT in base, contrary to the source doc) | removed          | delete — `target: ES2022` makes it unnecessary                   |
+
+Also removed in TS7: `target: es5`, AMD/UMD/SystemJS.
+
+**`baseUrl`/`paths` blast radius — corrected.** The source doc checked only `agent-core` (0 hits) and
+flagged that a full sweep was needed. The sweep: **9 `from '@/…'` imports, all confined to
+`packages/agent-playground`.** So the removal is contained to one package, but it is not zero — that
+package needs its alias strategy settled (relative imports, or `paths` re-expressed without `baseUrl`).
+
+## What
+
+1. Migrate the three option classes above. `downlevelIteration` is a 38-file mechanical sweep — verify
+   each package's `target` really is ES2022 before deleting, rather than assuming.
+2. Settle `agent-playground`'s `@/` alias.
+3. **Only after PERF-003 confirms the two compilers produce identical error lists**, switch `typecheck`
+   to the native compiler.
+4. Keep `typescript@5.9.3` installed for the four harness TS-API scans, `@typescript-eslint`, vitest and
+   IDE tooling — per PERF-003, never remove it.
+
+## Test Plan
+
+Per migration step, `pnpm typecheck` on the OLD compiler must stay green — the tsconfig changes must be
+compiler-agnostic, so a regression here is a real regression, not a migration artifact. Then the new
+compiler's error list must match the old one (PERF-003's criterion) on the real repo. The four TS-API
+harness scans must pass throughout. `pnpm harness:verify-like-ci` green at every step.
+Red-first where a behavior can regress: assert `agent-playground` still resolves its imports after the
+alias change (a build + its test suite, not just typecheck).
+
+## Note (desktop responsiveness — optional side item)
+
+The source doc's §7 also observed builds running at `nice 0`, competing with `gnome-shell` and stuttering
+the cursor under load. If an agent-facing build wrapper is ever added, the doc suggests:
+`systemd-run --user --scope -p CPUWeight=20 -p IOWeight=20 nice -n 15 pnpm typecheck`. Not required for
+this item; recorded so it is not lost.


### PR DESCRIPTION
Turns TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md into three risk-separated backlog items, with two of its estimates re-measured against the current tree. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)