### PR TITLE
docs: TypeScript items are serial-only (generalized to shared-ground changes)

### DIFF
--- a/.agents/backlog/PERF-002-typecheck-workspace-concurrency.md
+++ b/.agents/backlog/PERF-002-typecheck-workspace-concurrency.md
@@ -10,6 +10,25 @@ depends_on: []
 
 # PERF-002: `pnpm typecheck` only runs 2–4 packages at a time
 
+## ⛔ Execution constraint — SERIAL ONLY, after other work is drained
+
+**Owner directive (2026-07-25): the TypeScript items must NOT run in parallel with any other work.**
+
+A compiler/tsconfig change moves the ground every other task stands on: `pnpm typecheck` is the shared
+gate every agent and every CI job runs. If a TS change lands while other branches are in flight, a
+failure in those branches is ambiguous — nobody can tell whether it is their own defect or fallout from
+the version/config change. Bisecting that after the fact is far more expensive than waiting.
+
+**Preconditions before starting any PERF-002/003/004 work:**
+
+1. No other backlog item is in flight (no open PRs, no running implementation agents).
+2. `develop` is green on a full `pnpm harness:verify-like-ci`.
+3. The work runs as a **single serial track** — one item at a time, each merged and verified before the
+   next starts. Do not fan these three out to parallel agents even among themselves: PERF-003 and
+   PERF-004 both touch the typecheck path.
+
+Re-verify precondition 1 immediately before starting; other work may have been queued in the meantime.
+
 ## Problem
 
 Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)

--- a/.agents/backlog/PERF-003-typescript-7-side-by-side-evaluation.md
+++ b/.agents/backlog/PERF-003-typescript-7-side-by-side-evaluation.md
@@ -10,6 +10,25 @@ area: package.json, tsconfig
 
 # PERF-003: TypeScript 7 native compiler — side-by-side evaluation
 
+## ⛔ Execution constraint — SERIAL ONLY, after other work is drained
+
+**Owner directive (2026-07-25): the TypeScript items must NOT run in parallel with any other work.**
+
+A compiler/tsconfig change moves the ground every other task stands on: `pnpm typecheck` is the shared
+gate every agent and every CI job runs. If a TS change lands while other branches are in flight, a
+failure in those branches is ambiguous — nobody can tell whether it is their own defect or fallout from
+the version/config change. Bisecting that after the fact is far more expensive than waiting.
+
+**Preconditions before starting any PERF-002/003/004 work:**
+
+1. No other backlog item is in flight (no open PRs, no running implementation agents).
+2. `develop` is green on a full `pnpm harness:verify-like-ci`.
+3. The work runs as a **single serial track** — one item at a time, each merged and verified before the
+   next starts. Do not fan these three out to parallel agents even among themselves: PERF-003 and
+   PERF-004 both touch the typecheck path.
+
+Re-verify precondition 1 immediately before starting; other work may have been queued in the meantime.
+
 ## Problem / Opportunity
 
 Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)

--- a/.agents/backlog/PERF-004-tsconfig-ts7-compatibility-migration.md
+++ b/.agents/backlog/PERF-004-tsconfig-ts7-compatibility-migration.md
@@ -10,6 +10,25 @@ area: tsconfig.base.json, packages, apps
 
 # PERF-004: tsconfig migration + the actual switch
 
+## ⛔ Execution constraint — SERIAL ONLY, after other work is drained
+
+**Owner directive (2026-07-25): the TypeScript items must NOT run in parallel with any other work.**
+
+A compiler/tsconfig change moves the ground every other task stands on: `pnpm typecheck` is the shared
+gate every agent and every CI job runs. If a TS change lands while other branches are in flight, a
+failure in those branches is ambiguous — nobody can tell whether it is their own defect or fallout from
+the version/config change. Bisecting that after the fact is far more expensive than waiting.
+
+**Preconditions before starting any PERF-002/003/004 work:**
+
+1. No other backlog item is in flight (no open PRs, no running implementation agents).
+2. `develop` is green on a full `pnpm harness:verify-like-ci`.
+3. The work runs as a **single serial track** — one item at a time, each merged and verified before the
+   next starts. Do not fan these three out to parallel agents even among themselves: PERF-003 and
+   PERF-004 both touch the typecheck path.
+
+Re-verify precondition 1 immediately before starting; other work may have been queued in the meantime.
+
 ## Problem
 
 Source investigation: [`TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md`](../../TYPESCRIPT-7-TYPECHECK-PERFORMANCE.md)

--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -26,6 +26,15 @@ rules below and must not be restated here**.
   speedup of running them concurrently is worth the partition overhead.
 - **Do NOT use** for a **single item** (just do it on one branch) or for **tightly-coupled changes** that
   cannot be split into non-overlapping file sets — run those sequentially on one branch instead.
+- **Do NOT use — and drain everything else first — for a "shared-ground" change:** anything that alters
+  the toolchain or configuration every other task is verified against (the type-checker version or
+  `tsconfig`, the test runner, the lint/format config, the build pipeline, a workspace-wide dependency
+  bump). File ownership cannot make these disjoint: they are disjoint in _files_ but shared in _effect_.
+  Landing one while other branches are in flight makes every downstream failure ambiguous — an agent
+  cannot tell its own defect from fallout, and bisecting afterwards costs far more than waiting.
+  Run such an item **serially, on an empty queue**: no other open PRs, no running implementation agents,
+  `develop` green on `pnpm harness:verify-like-ci`. Re-check that the queue is still empty immediately
+  before starting.
 
 ## The Procedure
 


### PR DESCRIPTION
Owner directive: TS version/tsconfig work cannot run in parallel — it changes the verification ground for every other task, making concurrent failures ambiguous. Pins preconditions on PERF-002/003/004 and generalizes the rule in the parallel-orchestration skill. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)