### PR TITLE
fix(security): SEC-003 js/polynomial-redos — the remaining 10, class closed 18/18

### DIFF
--- a/.agents/backlog/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/SEC-003-codeql-alert-triage.md
@@ -303,6 +303,164 @@ signalling channel, so unlike the rest it plausibly has a genuine remote source.
 SEC-003 stays **open**: those 10 alerts, the style classes, and the advisory→required promotion
 decision remain.
 
+### Slice 4 — the remaining 10 (2026-07-25)
+
+The methodology above was reused as-is; nothing was re-derived. Scope: the 10 alerts the previous
+slice could not touch, plus the same-shape sweep of the five packages they live in.
+
+#### Alert 46 confirmed remote-reachable, pre-authentication — and it was binding free text
+
+The prioritisation was right, and the finding is larger than DoS. Two call paths, both citing the
+remote SDP:
+
+| Peer                 | Path                                                                                                                                                                                                                                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Host (Node, offerer) | `WsSignalingClient` → relay `signal` frame → `WebRtcTransport.start`'s `onSignal` handler (`webrtc-transport.ts:125-138`) → `startPairingIfConfigured(…, message.data)` → `extractDtlsFingerprint(sdp)` at `webrtc-transport.ts:172`, whose result is `PairingGate`'s `remoteFingerprint` |
+| Browser (answerer)   | `RtcSignaling` → `handleOffer(offer)` (`rtc-session-client.ts:265`) → `extractDtlsFingerprint(offer.sdp ?? '')` at line 267 — the **first** statement, before `setRemoteDescription`                                                                                                      |
+
+The relay (`apps/remote-signaling/src/relay.ts`) is content-blind and forwards `offer`/`answer`/`ice`
+payloads verbatim; its only auth seam, `onJoinAttempt`, is optional and unset by default. The pairing
+module's own header states the threat model — a relay that substitutes a DTLS fingerprint must be
+detected — so the SDP is attacker-controlled **by design**. And the extraction is necessarily the
+first thing that happens: it produces the value the confirmation binds, so nothing can gate it.
+
+That makes this a genuine **pre-authentication remote** vector, not a library-input one:
+
+- **DoS.** 400 KB of `a=fingerprint:` blocked the event loop for 5.0 s. The relay's own
+  `maxFrameBytes` (64 KB) is not a bound — the threat model's attacker is the relay.
+- **Channel-binding surface (the bigger half).** The regex was unanchored, so it returned the first
+  `a=fingerprint:` **substring**, including one sitting inside another line's free text. Proven in
+  `pairing-redos.test.ts`: for `s=room a=fingerprint:sha-256 DE:AD:BE:EF\r\na=fingerprint:sha-256 AB:CD:EF`
+  the pre-fix code returned `DE:AD:BE:EF` — the smuggled value — while every DTLS stack negotiates
+  against the real attribute. A relay could therefore choose each peer's `remoteFingerprint`
+  independently of the certificate it actually terminates, which is exactly what the directional HMAC
+  confirmation exists to prevent.
+
+Fixed by anchoring to the start of an SDP line: `/^a=fingerprint:\S+\s+([0-9A-Fa-f:]+)/m`. Linear
+(line starts are the only start offsets, and their costs sum to the input length) and structurally
+correct (`<type>=<value>` is the SDP line grammar; a mid-line occurrence is not an attribute). The
+real two-peer werift suite (`agent-transport-webrtc`, 29 tests including `pairing-e2e` and
+`dtls-fingerprint-binding`) passes unchanged.
+
+**Residual, deliberately not fixed here:** it still returns the FIRST fingerprint line, not the one
+the DTLS stack verified for the negotiated m-section, so a relay-inserted **session-level** line can
+still shadow a media-level one. Closing that needs structural SDP parsing or a fail-closed check that
+all fingerprint lines agree — a behaviour change to the live WebRTC path that this slice did not want
+to make on a regex ticket. **Recorded as a follow-up for owner visibility (see below).**
+
+#### Per-alert verdict (10 of 10)
+
+Pumps are `n = 200_000` (`n = 400_000` for alert 46), measured on this host through the **exported
+entry point** named in each row — no private function was imported.
+
+| Alert | File:line                                                               | Reachable?                        | Evidence (call path / input source)                                                                                                                | Action                                                     | Red → green      |
+| ----- | ----------------------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------- |
+| 46    | `agent-remote-pairing/src/pairing.ts:95`                                | **yes — REMOTE, pre-auth**        | signaling relay → `webrtc-transport.ts:172` / `rtc-session-client.ts:267`, before any confirmation (table above)                                   | fixed: anchored `/^…/m`                                    | 5 040 ms → <1 ms |
+| 41    | `agent-framework/src/memory/project-memory-store.ts:83`                 | **yes — model/user topic string** | `ProjectMemoryStore.readTopic`/`append` take the topic verbatim; `-` is inside the KEPT class, so the collapse does not shorten a dash run         | fixed: `trimEdgeChars`                                     | 11 842 ms → 1 ms |
+| 43    | `agent-framework/src/update-check/update-check.ts:279`                  | **yes — public option**           | `checkForCliUpdate({ registryUrl })` → `buildPackageMetadataUrl`                                                                                   | fixed: `trimTrailingChars`                                 | 11 872 ms → 1 ms |
+| 39    | `agent-framework/src/commands/skill-source.ts:35`                       | **yes — on-disk skill file**      | `parseFrontmatter` ← `scanSkillsDir` over `.claude/skills`, `.agents/skills`, `~/.robota/skills` — content the agent itself writes and installs    | fixed: split on `','`                                      | 12 619 ms → 1 ms |
+| 40    | `agent-framework/src/context/task-context.ts:136`                       | **yes — `.git` file content**     | `readCurrentGitBranch(cwd)` → `resolveGitDirectory` reads a `.git` **file** and matches `/^gitdir:\s*(.+)$/`                                       | fixed: `(\S.*)`                                            | 14 489 ms → 1 ms |
+| 34    | `agent-cli/src/subagents/git-worktree-isolation-adapter.ts:139`         | **yes — public options/request**  | `prepare({ jobId })` and the `idFactory` option both flow into `sanitizePathSegment`; `-` is inside the KEPT class                                 | fixed: local `trimDashes`                                  | 11 836 ms → 1 ms |
+| 47    | `agent-tools/src/sandbox/workspace-manifest.ts:204`                     | **yes — public option**           | `applyWorkspaceManifest(client, manifest, { targetRoot })` → `normalizeSandboxRoot`; the backslash conversion manufactures the run                 | fixed: local `trimTrailingSlashes`                         | 12 037 ms → 1 ms |
+| 51    | `dag-framework/src/http-dag-runtime-provider.ts:121`                    | **yes — public constructor arg**  | `new HttpDagRuntimeProvider({ baseUrl })`                                                                                                          | fixed: local `trimTrailingSlashes`                         | 11 965 ms → 1 ms |
+| 38    | `agent-framework/src/command-api/provider/provider-profile-names.ts:30` | reachable, **not exploitable**    | `sanitizeProviderProfileName(value)` is exported, but the preceding `replace(/[^a-z0-9]+/g, '-')` collapses every run, so `-+$` can match one char | fixed anyway: `trimEdgeChars`                              | 0 ms (see below) |
+| 42    | `agent-framework/src/tools/model-command-tool-projection.ts:56`         | reachable, **not exploitable**    | same shape; `replace(/_+/g, '_')` collapses the underscore run first                                                                               | fixed anyway: `trimEdgeChars` + `trimTrailingChars` at :85 | 1 ms (see below) |
+
+**Dismissed: none — 10 of 10 fixed at the source.** Zero dismissals across all four slices.
+
+Alerts 38 and 42 deserve the honest note: their timing tests are **green against the pre-fix source**,
+because a collapse earlier in the same expression makes the quadratic term unreachable. They were not
+dismissed, because 41 and 34 are literally the same three-line pattern with `-` moved into the kept
+class — the shape is one character-class edit away from live, and 34 proves that edit gets made. They
+are fixed and their tests stand as equivalence pins rather than timing floors.
+
+#### Sweep — same shapes, no CodeQL alert
+
+The previous slice's "the alert list is a floor" lesson held again. Sweeping the five owned packages
+for the three shapes (trailing-run trim, `\s*<lit>\s*` split, `\s`/`.` overlap) found four more, one
+of which is the most severe defect in this slice:
+
+| Site                                                            | Shape                                    | Measured  | Verdict                                                                                               |
+| --------------------------------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| `agent-tools/src/builtins/web-fetch-tool.ts:29-31`              | `<[^>]+>`, `<script[\s\S]*?</script>`, … | 12 635 ms | **fixed — input is a live response body from an arbitrary URL**, capped only at 5 MB (≈ hours)        |
+| `agent-framework/src/agents/agent-definition-loader.ts:26`      | `/\s*,\s*/` — a literal copy of alert 39 | 12 635 ms | fixed identically                                                                                     |
+| `agent-framework/src/context/task-context.ts:88`                | `\s+(.+)$` on a task-file line           | 15 385 ms | fixed — a lone `\r` survives the `/\r?\n/` split, so a "line" can hold a run that never reaches `$`   |
+| `agent-framework/src/tools/model-command-tool-projection.ts:85` | `[_-]+$`                                 | 0 ms      | bounded by `slice(0, ≤64)` three statements earlier — converted anyway rather than left resting on it |
+
+Measured and cleared (no change made): `task-context.ts:61` `extractMetadata` (the `m` flag lets `$`
+match at end-of-line, so it succeeds immediately — 0.2 ms), `memory-candidate-extractor.ts:40-43`
+(no `$` anchor, so the capture succeeds on its first character — 0.2 ms), `skill-prompt.ts:62`
+(3.6 ms), and every `^…` leading-run trim (a start anchor gives one start offset).
+
+`web-fetch-tool.ts` is the sharpest illustration of why the sweep is mandatory: CodeQL flagged eight
+`agent-framework` sanitisers whose worst input is a config string, and did not flag the one function
+in these five packages that parses **HTML fetched from an arbitrary URL**.
+
+#### Why these fixes are index scans, not cleverer regexes
+
+A lookbehind guard (`/(?<!-)-+$/`) was measured and is equally linear (1.1 ms vs 52 s at 400 K) and
+exhaustively equivalent. It was **rejected**: CodeQL's `PolynomialBackTrackingTerm` is an NFA property
+of the regex, and whether it models a lookbehind's pruning of start offsets is not something this
+slice could verify before merge (a PR's diff-scoped analysis only reports NEW alerts, so it cannot
+confirm an old one cleared). An index scan removes the regex, and the rule cannot flag what is not
+there. This is the same reasoning the previous slice used when its simplified arrow regex tripped
+`js/bad-tag-filter` and it deleted the regex instead of dismissing.
+
+Each replacement was proven equivalent to the regex it replaced by exhaustive comparison, not by
+example — every string over the relevant alphabet up to length 12 (`trim-char.test.ts`: `^-+|-+$`,
+`^_+|_+$`, `\/+$`, `[_-]+$`), ~12 M strings for the `<script>` stripper, ~800 K for the tag stripper,
+and 349 526 trimmed inputs for `gitdir:`. Those comparisons are committed, so the shapes cannot be
+loosened back silently.
+
+#### Red-first evidence
+
+Measured by stashing the **source** files only and re-running the committed tests, so every red is an
+assertion failure carrying its own elapsed time, not a timeout.
+
+| Test                                                                | Pre-fix                | Post-fix           |
+| ------------------------------------------------------------------- | ---------------------- | ------------------ |
+| `pairing-redos` — one-line `a=fingerprint:` pump                    | 5 040 ms               | <1 ms              |
+| `pairing-redos` — pump inside an `s=` line's free text              | 5 060 ms               | <1 ms              |
+| `pairing-redos` — smuggled fingerprint is not returned              | returned `DE:AD:BE:EF` | returns `AB:CD:EF` |
+| `polynomial-redos` (fw) — `ProjectMemoryStore.readTopic` dash run   | 11 842 ms              | <1 ms              |
+| `polynomial-redos` (fw) — `checkForCliUpdate` registry slash run    | 11 872 ms              | <1 ms              |
+| `polynomial-redos` (fw) — skill frontmatter list, whitespace run    | 12 619 ms              | <1 ms              |
+| `polynomial-redos` (fw) — agent-definition list (unflagged twin)    | 12 635 ms              | <1 ms              |
+| `polynomial-redos` (fw) — `readCurrentGitBranch` `gitdir:` run      | 14 489 ms              | <1 ms              |
+| `polynomial-redos` (fw) — task open items, CR-only line (unflagged) | 15 385 ms              | <1 ms              |
+| `git-worktree-isolation-redos` — `prepare()` delta over baseline    | 11 836 ms              | <1 ms              |
+| `polynomial-redos` (tools) — `applyWorkspaceManifest` targetRoot    | 12 037 ms              | <1 ms              |
+| `polynomial-redos` (tools) — `WebFetch` unclosed `<` (unflagged)    | 12 635 ms              | ~5 ms              |
+| `polynomial-redos` (tools) — `WebFetch` unclosed `<script`          | 2 662 ms               | ~2 ms              |
+| `http-dag-runtime-provider-redos` — `baseUrl` slash run             | 11 965 ms              | <1 ms              |
+
+Every timing test asserts `< 250 ms`, so the margin over the pre-fix time is 10×–60× and over the
+post-fix time is >50×. The `agent-cli` case asserts the **delta** against an identical `prepare()` run
+with a short id, because `git init` + `worktree add` dominate that call and vary by filesystem.
+
+The 14 equivalence tests all pass against the **pre-fix** source as well — that is what makes them
+pins rather than restatements of the new behaviour. The two exceptions are the `pairing` smuggling
+tests, which are red pre-fix by design: they assert the deliberate behaviour change.
+
+#### Class state
+
+`js/polynomial-redos` is **closed**: 8 (slice 3) + 10 (slice 4) = **18 of 18** fixed at the source,
+plus 5 same-shape defects CodeQL never reported (1 in slice 3, 4 here). **Zero dismissals in any
+slice of SEC-003.**
+
+#### Follow-up opened by this slice
+
+**`extractDtlsFingerprint` should bind the fingerprint the DTLS stack verified, not the first one in
+the SDP.** Anchoring closed free-text smuggling, but a relay can still add a session-level
+`a=fingerprint` line that a media-level line overrides for the actual DTLS association — the extractor
+would bind the shadowed value. Two candidate fixes, both a behaviour change to the live WebRTC path:
+fail closed when the SDP carries more than one distinct fingerprint value (RFC 8122 + BUNDLE make a
+single value the norm; both committed fixtures satisfy it), or parse the m-section structurally. This
+needs owner sign-off and a real two-peer run, so it is **not** in this slice.
+
+SEC-003 remains **open** for `js/file-system-race` (16), the style classes (~130), and the
+advisory→required promotion decision. Both high-severity classes it opened with are now closed.
+
 ## Slice 2 — finish `js/insecure-temporary-file` (2026-07-25)
 
 Slice 1's analysis was used as-is; nothing was re-derived. Scope: the remaining **88** alerts in

--- a/.changeset/sec-003-polynomial-redos-remainder.md
+++ b/.changeset/sec-003-polynomial-redos-remainder.md
@@ -1,0 +1,18 @@
+---
+'@robota-sdk/agent-remote-pairing': patch
+'@robota-sdk/agent-framework': patch
+'@robota-sdk/agent-cli': patch
+'@robota-sdk/agent-tools': patch
+---
+
+Remove the remaining polynomial-ReDoS backtracking (SEC-003, CodeQL `js/polynomial-redos`) and stop the DTLS fingerprint binding to SDP free text.
+
+**`extractDtlsFingerprint` (agent-remote-pairing) — remote-reachable, pre-authentication.** Unlike the rest of this class, the SDP it parses arrives over the signaling relay, which the pairing design treats as untrusted, and it is parsed _before_ the channel-binding confirmation — on the browser peer, before `setRemoteDescription` too. Unanchored, `a=fingerprint:\S+\s+…` restarted from every offset in a non-space run: 5.0 s on a 400 KB SDP. It is now anchored to the start of an SDP line (`/^…/m`), which is linear and also stops the extractor from returning a value smuggled into another line's free text (`s=`, `i=`, an unrelated attribute) — text no DTLS stack reads, and which a relay controls. **Behaviour change:** a mid-line `a=fingerprint:` is no longer recognised. Every SDP a WebRTC stack emits puts the attribute at the start of its own line, so no real SDP is affected. A session-level line can still shadow a media-level one; that residual is recorded in the SEC-003 backlog.
+
+**Trailing-run trims (agent-framework, agent-cli, agent-tools).** `replace(/-+$/, '')`-shaped regexes have no start anchor, so the engine retried the run from every offset inside it and each retry rescanned to the end — 3.0 s at 100 K characters, ~50 s at 400 K. The memory topic sanitiser, the provider profile-name sanitiser, the model-command tool-name projection, the npm registry URL builder, the git-worktree path-segment sanitiser and the sandbox-root normaliser now use linear index scans (`trimEdgeChars` / `trimTrailingChars` in agent-framework, local helpers elsewhere), proven equivalent to the regexes they replace over every string of the relevant alphabet up to 12 characters.
+
+**Whitespace-ambiguity parsers (agent-framework).** The skill and agent-definition frontmatter list splitters used `/\s*,\s*/`, whose whitespace run overlapped nothing after it on a failed comma — 12.6 s on a 200 K run. They now split on `','`; the padding was already removed by the `.trim()` that follows, so the parsed lists are unchanged. The `.git` `gitdir:` pointer and the task-file open-item matcher used `\s*(.+)$` / `\s+(.+)$`, where `\s` and `.` both match a space; the capture is now pinned to start non-space, which accepts exactly the same inputs (verified exhaustively) and removes 14.5 s and 15.4 s worst cases.
+
+**`WebFetch` HTML-to-text (agent-tools) — carried no CodeQL alert.** Found by sweeping for the same shapes rather than the flagged lines, and the only quadratic here whose input is a live response body from an arbitrary URL. `<[^>]+>`, `<script[\s\S]*?</script>` and `<style…>` each restarted from every opener that had no terminator: 12.6 s on 200 KB of `<`, and the 5 MB the fetch allows would have taken hours. All three are now single-pass scans, verified character-for-character identical to the regexes over ~800 K generated inputs.
+
+Apart from the `extractDtlsFingerprint` anchoring noted above, no behaviour changes: every fix accepts the same inputs and produces the same values, and each ships an equivalence test pinning that.

--- a/packages/agent-cli/src/subagents/__tests__/git-worktree-isolation-redos.test.ts
+++ b/packages/agent-cli/src/subagents/__tests__/git-worktree-isolation-redos.test.ts
@@ -1,0 +1,101 @@
+/**
+ * SEC-003 alert 34 — `GitWorktreeIsolationAdapter`'s path-segment sanitiser must be linear.
+ *
+ * The pump is delivered through the public `idFactory` option, which feeds `normalizeShortId` →
+ * `sanitizePathSegment`. `-` is inside the class that sanitiser KEEPS, so a long dash run survives the collapse
+ * and reaches the trailing half of the old `/^-+|-+$/g` — 3.1 s on a 100 K run. `normalizeShortId` truncates to
+ * 8 characters afterwards, so the resulting worktree is ordinary and `prepare()` completes normally.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { GitWorktreeIsolationAdapter } from '../git-worktree-isolation-adapter.js';
+
+const PUMP = 200_000;
+const BUDGET_MS = 250;
+const RED_TIMEOUT_MS = 120_000;
+
+const tempRepos: string[] = [];
+
+afterEach(() => {
+  for (const repo of tempRepos.splice(0)) rmSync(repo, { recursive: true, force: true });
+});
+
+function gitEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_')) delete env[key];
+  }
+  return env;
+}
+
+function runGit(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore', env: gitEnvironment() });
+}
+
+function createGitRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), 'robota-worktree-redos-'));
+  tempRepos.push(repo);
+  runGit(repo, ['init']);
+  runGit(repo, ['config', 'user.email', 'test@example.com']);
+  runGit(repo, ['config', 'user.name', 'Robota Test']);
+  writeFileSync(join(repo, 'README.md'), 'initial\n');
+  runGit(repo, ['add', 'README.md']);
+  runGit(repo, ['commit', '-m', 'initial']);
+  return repo;
+}
+
+describe('SEC-003 alert 34 — git worktree path segment sanitiser', () => {
+  /** `prepare()` on a real repo, timed. */
+  function timedPrepare(repo: string, shortId: string): { ms: number; branchName: string } {
+    const adapter = new GitWorktreeIsolationAdapter({ idFactory: () => shortId });
+    const started = performance.now();
+    const worktree = adapter.prepare({ jobId: 'agent_1', cwd: repo });
+    const ms = performance.now() - started;
+    expect(existsSync(worktree.worktreePath)).toBe(true);
+    adapter.remove(worktree);
+    return { ms, branchName: worktree.branchName };
+  }
+
+  it(
+    'sanitises a pumped dash run in linear time',
+    () => {
+      const repo = createGitRepo();
+      // The `git` calls dominate `prepare()` and vary with the filesystem, so the assertion is on the DELTA
+      // against an identical run with a short id — that difference is the sanitiser, and nothing else.
+      const baseline = timedPrepare(repo, 'xy');
+      const pumped = timedPrepare(repo, `x${'-'.repeat(PUMP)}y`);
+
+      expect(pumped.branchName).toMatch(/^robota\/agent_1-x-{7}$/);
+      expect(pumped.ms - baseline.ms).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it(
+    'keeps the sanitised segment for ordinary input',
+    () => {
+      const repo = createGitRepo();
+      const adapter = new GitWorktreeIsolationAdapter({ idFactory: () => '--Robota Agent--' });
+      const worktree = adapter.prepare({ jobId: '  weird/job id  ', cwd: repo });
+      expect(worktree.branchName).toBe('robota/weird-job-id-Robota-A');
+      adapter.remove(worktree);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it(
+    'reduces an all-separator id to the fallback segment, as before',
+    () => {
+      const repo = createGitRepo();
+      // `&` collapses to a single `-`, the edges are trimmed, and 8 characters are kept.
+      expect(timedPrepare(repo, `-${'&'.repeat(1_000)}-a-`).branchName).toBe('robota/agent_1-a');
+      expect(timedPrepare(repo, '---').branchName).toBe('robota/agent_1-agent');
+    },
+    RED_TIMEOUT_MS,
+  );
+});

--- a/packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts
+++ b/packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts
@@ -135,8 +135,24 @@ function normalizeShortId(value: string): string {
   return sanitized.length > 0 ? sanitized : createShortId();
 }
 
+/**
+ * Remove every leading and trailing `-`, by index scan.
+ *
+ * Not `replace(/^-+|-+$/g, '')`: the trailing half has no start anchor, so the engine retries the run from every
+ * offset inside it and each retry re-scans to the end — 3.1 s on a 100 K dash run (`js/polynomial-redos`,
+ * SEC-003). `-` survives the collapse in {@link sanitizePathSegment} (it is inside the kept class), so a long run
+ * does reach here.
+ */
+function trimDashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '-') start += 1;
+  while (end > start && value[end - 1] === '-') end -= 1;
+  return value.slice(start, end);
+}
+
 function sanitizePathSegment(value: string): string {
-  const sanitized = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  const sanitized = trimDashes(value.replace(/[^A-Za-z0-9._-]+/g, '-'));
   return sanitized.length > 0 ? sanitized : 'agent';
 }
 

--- a/packages/agent-framework/src/__tests__/polynomial-redos.test.ts
+++ b/packages/agent-framework/src/__tests__/polynomial-redos.test.ts
@@ -1,0 +1,244 @@
+/**
+ * SEC-003 — `js/polynomial-redos` regression floor for `agent-framework`.
+ *
+ * Each `describe` covers one parser whose regex was quadratic. The pair is deliberate:
+ *
+ * - a **timing** test that pumps the string CodeQL named and asserts the parse finishes under
+ *   {@link BUDGET_MS}. Every one of these ran for seconds against the pre-fix source (the numbers are in the
+ *   SEC-003 backlog), so reverting a fix turns the test red on the assertion, not on a timeout.
+ * - an **equivalence** test pinning the parse result for well-formed input, so the regex shape cannot be
+ *   loosened back to the ambiguous form without a visible behavioural diff.
+ *
+ * The pumps are all reachable through the exported entry point named in each test — no private function is
+ * imported, so the tests also assert that the fixed shape is the one the public path actually runs.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AgentDefinitionLoader } from '../agents/agent-definition-loader.js';
+import { sanitizeProviderProfileName } from '../command-api/provider/provider-profile-names.js';
+import { parseFrontmatter } from '../commands/skill-source.js';
+import { parseTaskFile, readCurrentGitBranch } from '../context/task-context.js';
+import { ProjectMemoryStore } from '../memory/project-memory-store.js';
+import { createProviderSafeModelCommandToolName } from '../tools/model-command-tool-projection.js';
+import { checkForCliUpdate } from '../update-check/update-check.js';
+
+/** Pump length. Every pre-fix measurement in the SEC-003 table used this size. */
+const PUMP = 200_000;
+/** Post-fix budget. The fixed parsers all run in single-digit milliseconds, so this is not a tight threshold. */
+const BUDGET_MS = 250;
+/** Generous per-test timeout so a reverted fix fails the assertion (with its elapsed time) instead of timing out. */
+const RED_TIMEOUT_MS = 120_000;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function elapsedMs(run: () => void): number {
+  const started = performance.now();
+  run();
+  return performance.now() - started;
+}
+
+async function elapsedMsAsync(run: () => Promise<void>): Promise<number> {
+  const started = performance.now();
+  await run();
+  return performance.now() - started;
+}
+
+describe('SEC-003 alert 41 — ProjectMemoryStore topic sanitiser', () => {
+  it(
+    'sanitises a pumped dash run in linear time',
+    () => {
+      const store = new ProjectMemoryStore(tempDir('robota-redos-memory-'));
+      const topic = `x${'-'.repeat(PUMP)}y`;
+      expect(elapsedMs(() => void store.readTopic(topic))).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the sanitised topic for ordinary input', () => {
+    const dir = tempDir('robota-redos-memory-');
+    const store = new ProjectMemoryStore(dir);
+    const result = store.append({ type: 'project', topic: '--Build & Env--', text: 'hello' });
+    expect(result.topic).toBe('build-env');
+  });
+});
+
+describe('SEC-003 alert 38 — provider profile name sanitiser', () => {
+  it(
+    'sanitises a pumped dash run in linear time',
+    () => {
+      const value = `x${'-'.repeat(PUMP)}y`;
+      expect(elapsedMs(() => void sanitizeProviderProfileName(value))).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the sanitised name for ordinary input', () => {
+    expect(sanitizeProviderProfileName('  --OpenAI Chat--  ')).toBe('openai-chat');
+    expect(sanitizeProviderProfileName('---')).toBeUndefined();
+    expect(sanitizeProviderProfileName(undefined)).toBeUndefined();
+  });
+});
+
+describe('SEC-003 alert 42 — provider-safe model command tool name', () => {
+  it(
+    'projects a pumped underscore run in linear time',
+    () => {
+      const command = `x${'_'.repeat(PUMP)}y`;
+      expect(elapsedMs(() => void createProviderSafeModelCommandToolName(command))).toBeLessThan(
+        BUDGET_MS,
+      );
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the projected tool name for ordinary input', () => {
+    expect(createProviderSafeModelCommandToolName('/schedule')).toBe('robota_command_schedule');
+    expect(createProviderSafeModelCommandToolName('remote-control')).toBe(
+      'robota_command_remote-control',
+    );
+  });
+});
+
+describe('SEC-003 alert 43 — npm registry metadata URL', () => {
+  it(
+    'builds the URL from a pumped slash run in linear time',
+    async () => {
+      const registryUrl = `https://x${'/'.repeat(PUMP)}y`;
+      const options = {
+        currentVersion: '1.0.0',
+        force: true,
+        registryUrl,
+        cachePath: join(tempDir('robota-redos-update-'), 'cache.json'),
+        fetchImpl: (async () => ({
+          ok: true,
+          json: async () => ({ 'dist-tags': { latest: '9.9.9' } }),
+        })) as unknown as typeof fetch,
+      };
+      const ms = await elapsedMsAsync(async () => void (await checkForCliUpdate(options)));
+      expect(ms).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('strips exactly the trailing slashes for ordinary input', async () => {
+    const seen: string[] = [];
+    await checkForCliUpdate({
+      currentVersion: '1.0.0',
+      force: true,
+      registryUrl: 'https://registry.npmjs.org///',
+      cachePath: join(tempDir('robota-redos-update-'), 'cache.json'),
+      fetchImpl: (async (url: string) => {
+        seen.push(url);
+        return { ok: true, json: async () => ({ 'dist-tags': { latest: '9.9.9' } }) };
+      }) as unknown as typeof fetch,
+    });
+    expect(seen).toEqual(['https://registry.npmjs.org/%40robota-sdk%2Fagent-cli']);
+  });
+});
+
+describe('SEC-003 alert 39 — skill frontmatter list values', () => {
+  const pumped = `---\nallowed-tools: ,x${' '.repeat(PUMP)}y,z\n---\nbody\n`;
+
+  it(
+    'parses a pumped whitespace run in linear time',
+    () => {
+      expect(elapsedMs(() => void parseFrontmatter(pumped))).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the list split and trimming for ordinary input', () => {
+    expect(parseFrontmatter('---\nallowed-tools: Read , Write ,,Bash\n---\n')).toEqual({
+      allowedTools: ['Read', 'Write', 'Bash'],
+    });
+    expect(parseFrontmatter('---\nallowed-tools: Read  Write\n---\n')).toEqual({
+      allowedTools: ['Read', 'Write'],
+    });
+  });
+});
+
+describe('SEC-003 sweep — agent definition frontmatter list values (unflagged twin of alert 39)', () => {
+  function loaderFor(frontmatter: string): AgentDefinitionLoader {
+    const cwd = tempDir('robota-redos-agents-');
+    const dir = join(cwd, '.robota', 'agents');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'probe.md'), frontmatter, 'utf8');
+    return new AgentDefinitionLoader(cwd, join(cwd, 'home'), undefined, []);
+  }
+
+  it(
+    'parses a pumped whitespace run in linear time',
+    () => {
+      const loader = loaderFor(`---\ntools: ,x${' '.repeat(PUMP)}y,z\n---\nbody\n`);
+      expect(elapsedMs(() => void loader.loadAll())).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the list split and trimming for ordinary input', () => {
+    const loader = loaderFor('---\nname: probe\ntools: Read , Write ,,Bash\n---\nbody\n');
+    expect(loader.loadAll()[0]?.tools).toEqual(['Read', 'Write', 'Bash']);
+  });
+});
+
+describe('SEC-003 alert 40 — git worktree `gitdir:` pointer', () => {
+  function repoWithGitFile(content: string): string {
+    const dir = tempDir('robota-redos-gitdir-');
+    writeFileSync(join(dir, '.git'), content, 'utf8');
+    return dir;
+  }
+
+  it(
+    'reads a pumped whitespace run in linear time',
+    () => {
+      const cwd = repoWithGitFile(`gitdir:${' '.repeat(PUMP)}x\ny`);
+      expect(elapsedMs(() => void readCurrentGitBranch(cwd))).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('still follows a well-formed `gitdir:` pointer to the branch', () => {
+    const gitDir = tempDir('robota-redos-realgit-');
+    writeFileSync(join(gitDir, 'HEAD'), 'ref: refs/heads/feature/x\n', 'utf8');
+    const cwd = repoWithGitFile(`gitdir: ${gitDir}\n`);
+    expect(readCurrentGitBranch(cwd)).toBe('feature/x');
+  });
+});
+
+describe('SEC-003 sweep — task file open items (unflagged, same shape as alert 40)', () => {
+  function taskFile(content: string): { path: string; cwd: string } {
+    const cwd = tempDir('robota-redos-task-');
+    const path = join(cwd, 'task.md');
+    writeFileSync(path, content, 'utf8');
+    return { path, cwd };
+  }
+
+  it(
+    'parses a pumped whitespace run on a CR-only line in linear time',
+    () => {
+      // A lone `\r` survives the `/\r?\n/` split, so one "line" can hold a run that never reaches `$`.
+      const { path, cwd } = taskFile(`# T\n- [ ]${' '.repeat(PUMP)}x\ry\n`);
+      expect(elapsedMs(() => void parseTaskFile(path, cwd))).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the open-item extraction for ordinary input', () => {
+    const { path, cwd } = taskFile('# T\n- [ ] first item\n- [x] done\n- [ ]   spaced  \n');
+    expect(parseTaskFile(path, cwd).openItems).toEqual(['first item', 'spaced']);
+  });
+});

--- a/packages/agent-framework/src/agents/agent-definition-loader.ts
+++ b/packages/agent-framework/src/agents/agent-definition-loader.ts
@@ -23,7 +23,9 @@ interface IRawFrontmatter {
 }
 
 function parseListValue(rawValue: string): string[] {
-  const separator = rawValue.includes(',') ? /\s*,\s*/ : /\s+/;
+  // A plain `','` rather than `/\s*,\s*/`: the padding that regex absorbed is stripped by the `.trim()` below
+  // anyway, and `\s*,` retried its whitespace run from every offset — quadratic on a long run (SEC-003).
+  const separator = rawValue.includes(',') ? ',' : /\s+/;
   return rawValue
     .split(separator)
     .map((value) => value.trim())

--- a/packages/agent-framework/src/command-api/provider/provider-profile-names.ts
+++ b/packages/agent-framework/src/command-api/provider/provider-profile-names.ts
@@ -1,3 +1,5 @@
+import { trimEdgeChars } from '../../utils/trim-char.js';
+
 const FALLBACK_PROFILE_NAME = 'provider';
 const FIRST_DUPLICATE_SUFFIX = 2;
 
@@ -27,10 +29,12 @@ export function suggestProviderProfileName(
 }
 
 export function sanitizeProviderProfileName(value: string | undefined): string | undefined {
-  const normalized = value
-    ?.trim()
+  if (value === undefined) return undefined;
+  const collapsed = value
+    .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return normalized !== undefined && normalized.length > 0 ? normalized : undefined;
+    .replace(/[^a-z0-9]+/g, '-');
+  // `trimEdgeChars` rather than `/^-+|-+$/g`: the trailing half of that alternation is quadratic (SEC-003).
+  const normalized = trimEdgeChars(collapsed, '-');
+  return normalized.length > 0 ? normalized : undefined;
 }

--- a/packages/agent-framework/src/commands/skill-source.ts
+++ b/packages/agent-framework/src/commands/skill-source.ts
@@ -31,7 +31,9 @@ function kebabToCamel(key: string): string {
 }
 
 function parseListValue(rawValue: string): string[] {
-  const separator = rawValue.includes(',') ? /\s*,\s*/ : /\s+/;
+  // A plain `','` rather than `/\s*,\s*/`: the padding that regex absorbed is stripped by the `.trim()` below
+  // anyway, and `\s*,` retried its whitespace run from every offset — quadratic on a long run (SEC-003).
+  const separator = rawValue.includes(',') ? ',' : /\s+/;
   return rawValue
     .split(separator)
     .map((value) => value.trim())

--- a/packages/agent-framework/src/context/task-context.ts
+++ b/packages/agent-framework/src/context/task-context.ts
@@ -83,10 +83,14 @@ function extractSection(content: string, title: string): string | undefined {
 }
 
 function extractOpenItems(content: string): string[] {
-  return content
-    .split(/\r?\n/)
-    .map((line) => /^- \[ \]\s+(.+)$/.exec(line)?.[1]?.trim())
-    .filter((item): item is string => item !== undefined && item.length > 0);
+  return (
+    content
+      .split(/\r?\n/)
+      // `(\S.*)` rather than `(.+)` — same `\s`/`.` ambiguity as the `gitdir:` line above. A lone `\r` (a CR-only
+      // line ending) survives the `/\r?\n/` split, so a "line" can hold a long space run that never reaches `$`.
+      .map((line) => /^- \[ \]\s+(\S.*)$/.exec(line)?.[1]?.trim())
+      .filter((item): item is string => item !== undefined && item.length > 0)
+  );
 }
 
 function taskSortScore(task: ITaskContextFile, currentBranch?: string): number {
@@ -118,7 +122,10 @@ function resolveGitDirectory(cwd: string, fs: IFileSystem): string | undefined {
       const stats = fs.statSync(gitPath);
       if (stats.isDirectory()) return gitPath;
       const content = fs.readFileSync(gitPath, 'utf8').trim();
-      const gitdir = content.match(/^gitdir:\s*(.+)$/)?.[1];
+      // `(\S.*)` rather than `(.+)`: `\s*` and `.` both match a space, so the split between them was ambiguous
+      // and a `.git` file with a long space run cost O(n²) (SEC-003). Greedy `\s*` already consumed every
+      // leading space, so pinning the capture to start non-space accepts exactly the same (trimmed) content.
+      const gitdir = content.match(/^gitdir:\s*(\S.*)$/)?.[1];
       if (gitdir) return isAbsolute(gitdir) ? gitdir : resolve(current, gitdir);
     }
 

--- a/packages/agent-framework/src/memory/project-memory-store.ts
+++ b/packages/agent-framework/src/memory/project-memory-store.ts
@@ -8,6 +8,8 @@ import {
 } from 'fs';
 import { basename, join } from 'path';
 
+import { trimEdgeChars } from '../utils/trim-char.js';
+
 // TMemoryType SSOT relocated to @robota-sdk/agent-interface-transport (DATA-001).
 import type { TMemoryType } from '@robota-sdk/agent-interface-transport';
 
@@ -80,12 +82,13 @@ function limitLines(value: string, maxLines: number): { content: string; truncat
 }
 
 function sanitizeTopic(topic: string): string {
-  const normalized = topic
+  const collapsed = topic
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9가-힣_-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, MAX_TOPIC_LENGTH);
+    .replace(/[^a-z0-9가-힣_-]+/g, '-');
+  // `trimEdgeChars` rather than `/^-+|-+$/g`: `-` survives the collapse above (it is inside the kept class), so
+  // a long dash run reaches the trailing half of that alternation, which is quadratic (SEC-003).
+  const normalized = trimEdgeChars(collapsed, '-').slice(0, MAX_TOPIC_LENGTH);
   return normalized || DEFAULT_TOPIC;
 }
 

--- a/packages/agent-framework/src/tools/model-command-tool-projection.ts
+++ b/packages/agent-framework/src/tools/model-command-tool-projection.ts
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto';
 import { createZodFunctionTool } from '@robota-sdk/agent-tools';
 import { z } from 'zod';
 
+import { trimEdgeChars, trimTrailingChars } from '../utils/trim-char.js';
+
 import type { ICapabilityDescriptor } from '../capabilities/types.js';
 import type { ICommandResult } from '../commands/index.js';
 
@@ -53,10 +55,11 @@ export function createProviderSafeModelCommandToolName(commandName: string): str
     throw new Error('Model command descriptor name must not be empty.');
   }
 
-  const safeBody = normalizedCommandName
-    .replace(/[^A-Za-z0-9_-]/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_+|_+$/g, '');
+  // `trimEdgeChars` rather than `/^_+|_+$/g`: the trailing half of that alternation is quadratic (SEC-003).
+  const safeBody = trimEdgeChars(
+    normalizedCommandName.replace(/[^A-Za-z0-9_-]/g, '_').replace(/_+/g, '_'),
+    '_',
+  );
   if (!safeBody) {
     throw new Error(`Model command descriptor name cannot be projected safely: ${commandName}`);
   }
@@ -79,7 +82,9 @@ export function createProviderSafeModelCommandToolName(commandName: string): str
     throw new Error('Model command tool prefix leaves no room for command names.');
   }
 
-  const truncatedBody = safeBody.slice(0, maxBodyLength).replace(/[_-]+$/g, '') || 'command';
+  // Same reason as `safeBody` above. `slice(0, maxBodyLength)` (≤ 64) does bound this one, but the bound lives
+  // three statements away — the shape is removed rather than left resting on it.
+  const truncatedBody = trimTrailingChars(safeBody.slice(0, maxBodyLength), '_-') || 'command';
   const toolName = `${MODEL_COMMAND_TOOL_PREFIX}${truncatedBody}_${hash}`;
   if (!PROVIDER_SAFE_TOOL_NAME_PATTERN.test(toolName)) {
     throw new Error(`Projected model command tool name is not provider-safe: ${toolName}`);

--- a/packages/agent-framework/src/update-check/update-check.ts
+++ b/packages/agent-framework/src/update-check/update-check.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { compareSemverVersions, isNewerSemverVersion } from '../utils/semver-compare.js';
+import { trimTrailingChars } from '../utils/trim-char.js';
 
 export const CLI_UPDATE_PACKAGE_NAME = '@robota-sdk/agent-cli';
 export const CLI_UPDATE_REGISTRY_URL = 'https://registry.npmjs.org';
@@ -61,12 +62,7 @@ interface INpmPackageMetadata {
 export { compareSemverVersions, isNewerSemverVersion };
 
 type TJsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | readonly TJsonValue[]
-  | { readonly [key: string]: TJsonValue };
+  string | number | boolean | null | readonly TJsonValue[] | { readonly [key: string]: TJsonValue };
 
 export function getUserUpdateCheckCachePath(
   home = process.env.HOME ?? process.env.USERPROFILE ?? '/',
@@ -276,7 +272,8 @@ async function fetchLatestVersion(options: {
 }
 
 function buildPackageMetadataUrl(registryUrl: string, packageName: string): string {
-  return `${registryUrl.replace(/\/+$/, '')}/${encodeURIComponent(packageName)}`;
+  // `trimTrailingChars` rather than `/\/+$/`: an unanchored trailing-run regex is quadratic (SEC-003).
+  return `${trimTrailingChars(registryUrl, '/')}/${encodeURIComponent(packageName)}`;
 }
 
 function parseUpdateCheckCache(value: TJsonValue): IUpdateCheckCache | undefined {

--- a/packages/agent-framework/src/utils/__tests__/trim-char.test.ts
+++ b/packages/agent-framework/src/utils/__tests__/trim-char.test.ts
@@ -1,0 +1,76 @@
+/**
+ * SEC-003 — the linear trimmers must be *exactly* the regexes they replaced.
+ *
+ * The equivalence is checked exhaustively rather than by example: every string over the relevant alphabet up to
+ * length 12 is compared against the original `replace(/^[c]+|[c]+$/g, '')` / `replace(/[c]+$/, '')`. That is the
+ * property a reviewer needs, because the point of the change was to keep the accepted set identical while
+ * removing the quadratic scan.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { trimEdgeChars, trimTrailingChars } from '../trim-char.js';
+
+const MAX_LEN = 12;
+
+function everyStringOver(alphabet: readonly string[], maxLen: number): string[] {
+  const all: string[] = [];
+  const walk = (prefix: string): void => {
+    all.push(prefix);
+    if (prefix.length >= maxLen) return;
+    for (const c of alphabet) walk(prefix + c);
+  };
+  walk('');
+  return all;
+}
+
+describe('trimEdgeChars', () => {
+  it('equals /^-+|-+$/g over every string of a/- up to 12 characters', () => {
+    const mismatches = everyStringOver(['a', '-'], MAX_LEN).filter(
+      (s) => trimEdgeChars(s, '-') !== s.replace(/^-+|-+$/g, ''),
+    );
+    expect(mismatches).toEqual([]);
+  });
+
+  it('equals /^_+|_+$/g over every string of a/_/- up to 8 characters', () => {
+    const mismatches = everyStringOver(['a', '_', '-'], 8).filter(
+      (s) => trimEdgeChars(s, '_') !== s.replace(/^_+|_+$/g, ''),
+    );
+    expect(mismatches).toEqual([]);
+  });
+
+  it('treats `chars` as a set, like a character class', () => {
+    expect(trimEdgeChars('_-_a-b_-_', '_-')).toBe('a-b');
+    expect(trimEdgeChars('___', '_-')).toBe('');
+  });
+});
+
+describe('trimTrailingChars', () => {
+  it('equals /\\/+$/ over every string of a// up to 12 characters', () => {
+    const mismatches = everyStringOver(['a', '/'], MAX_LEN).filter(
+      (s) => trimTrailingChars(s, '/') !== s.replace(/\/+$/, ''),
+    );
+    expect(mismatches).toEqual([]);
+  });
+
+  it('equals /[_-]+$/g over every string of a/_/- up to 8 characters', () => {
+    const mismatches = everyStringOver(['a', '_', '-'], 8).filter(
+      (s) => trimTrailingChars(s, '_-') !== s.replace(/[_-]+$/g, ''),
+    );
+    expect(mismatches).toEqual([]);
+  });
+
+  it('leaves leading characters alone', () => {
+    expect(trimTrailingChars('///a///', '/')).toBe('///a');
+  });
+});
+
+describe('linearity', () => {
+  const PUMP = 200_000;
+
+  it('trims a 200 000-character run under 250 ms', () => {
+    const started = performance.now();
+    expect(trimEdgeChars(`x${'-'.repeat(PUMP)}y`, '-')).toHaveLength(PUMP + 2);
+    expect(trimTrailingChars(`x${'/'.repeat(PUMP)}y`, '/')).toHaveLength(PUMP + 2);
+    expect(performance.now() - started).toBeLessThan(250);
+  });
+});

--- a/packages/agent-framework/src/utils/trim-char.ts
+++ b/packages/agent-framework/src/utils/trim-char.ts
@@ -1,0 +1,29 @@
+/**
+ * Linear edge trimming over a small character set.
+ *
+ * These exist instead of `replace(/[c]+$/, '')` / `replace(/^[c]+|[c]+$/g, '')`. A trailing-run regex has no start
+ * anchor, so the engine retries the run from **every** offset inside it and each retry re-scans to the end: a
+ * 400 KB run of the trimmed character cost ~50 s (`js/polynomial-redos`, SEC-003). An index scan is linear by
+ * construction, not by an argument about how the regex engine backtracks.
+ *
+ * A leading-run regex (`/^[c]+/`) is not affected — the `^` anchor already limits it to one start offset — but
+ * both ends are handled here so callers do not have to reason about which half was safe.
+ *
+ * `chars` is a **set of single characters**, matching a regex character class: `'_-'` trims both `_` and `-`.
+ */
+
+/** Remove every leading and trailing character in `chars`. Equivalent to `value.replace(/^[chars]+|[chars]+$/g, '')`. */
+export function trimEdgeChars(value: string, chars: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && chars.includes(value[start]!)) start += 1;
+  while (end > start && chars.includes(value[end - 1]!)) end -= 1;
+  return value.slice(start, end);
+}
+
+/** Remove every trailing character in `chars`. Equivalent to `value.replace(/[chars]+$/, '')`. */
+export function trimTrailingChars(value: string, chars: string): string {
+  let end = value.length;
+  while (end > 0 && chars.includes(value[end - 1]!)) end -= 1;
+  return value.slice(0, end);
+}

--- a/packages/agent-remote-pairing/src/__tests__/pairing-redos.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/pairing-redos.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SEC-003 alert 46 — `extractDtlsFingerprint` must be linear, and must not bind SDP free text.
+ *
+ * This is the one alert in the class with a genuinely **remote** source rather than a library one: the SDP is
+ * delivered by the (untrusted, content-blind) signaling relay, and `extractDtlsFingerprint` runs on it BEFORE the
+ * pairing confirmation — it produces the very value that confirmation binds. See the SEC-003 backlog for the
+ * cited call path on both peers.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { extractDtlsFingerprint } from '../pairing.js';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+/** Larger than the other SEC-003 pumps: this regex is quadratic in the SDP length, and an SDP is a whole frame. */
+const PUMP_CHARS = 400_000;
+const BUDGET_MS = 250;
+const RED_TIMEOUT_MS = 120_000;
+
+function elapsedMs(run: () => void): number {
+  const started = performance.now();
+  run();
+  return performance.now() - started;
+}
+
+describe('extractDtlsFingerprint — linearity', () => {
+  it(
+    'rejects an SDP pumped with `a=fingerprint:` on one line in under 250 ms',
+    () => {
+      const sdp = 'a=fingerprint:'.repeat(Math.floor(PUMP_CHARS / 14));
+      const ms = elapsedMs(() => {
+        expect(() => extractDtlsFingerprint(sdp)).toThrow(/no DTLS fingerprint/);
+      });
+      expect(ms).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it(
+    'rejects an SDP whose pump sits in another line’s free text in under 250 ms',
+    () => {
+      // The realistic shape: a relay stuffs the session-name line, which is free-form and which no DTLS stack
+      // reads. Unanchored, every `a=fingerprint:` inside it started a fresh scan to end of input.
+      const sdp = `s=${'a=fingerprint:'.repeat(Math.floor(PUMP_CHARS / 14))}`;
+      const ms = elapsedMs(() => {
+        expect(() => extractDtlsFingerprint(sdp)).toThrow(/no DTLS fingerprint/);
+      });
+      expect(ms).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+});
+
+describe('extractDtlsFingerprint — result is pinned', () => {
+  const EXPECTED =
+    'E9:A0:10:9D:94:1C:0A:FC:FE:76:D3:0A:B8:FB:2C:7C:82:E0:A3:83:FF:22:78:62:9B:C3:82:1F:2C:CC:25:A3';
+
+  it('still reads the werift offer fixture (CRLF, session-level line)', () => {
+    expect(extractDtlsFingerprint(readFileSync(join(FIXTURES, 'werift-offer.sdp'), 'utf8'))).toBe(
+      EXPECTED,
+    );
+  });
+
+  it('still reads a minimal LF-only SDP', () => {
+    const sdp =
+      'v=0\no=- 1 1 IN IP4 0.0.0.0\ns=-\na=fingerprint:sha-256 ab:cd:ef\nm=application 9\n';
+    expect(extractDtlsFingerprint(sdp)).toBe('AB:CD:EF');
+  });
+
+  it('still fails closed when no fingerprint attribute is present', () => {
+    expect(() => extractDtlsFingerprint('v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\n')).toThrow(
+      /no DTLS fingerprint/,
+    );
+  });
+});
+
+describe('extractDtlsFingerprint — free text is not an attribute', () => {
+  it('ignores `a=fingerprint:` smuggled into another line and takes the real attribute', () => {
+    // A signaling relay controls the SDP text. `s=` is free-form and no DTLS stack reads it, so a value placed
+    // there must never become the one the channel binding confirms.
+    const sdp =
+      's=room a=fingerprint:sha-256 DE:AD:BE:EF\r\na=fingerprint:sha-256 AB:CD:EF\r\nm=application 9\r\n';
+    expect(extractDtlsFingerprint(sdp)).toBe('AB:CD:EF');
+  });
+
+  it('fails closed when the only occurrence is mid-line free text', () => {
+    expect(() => extractDtlsFingerprint('s=room a=fingerprint:sha-256 DE:AD\r\n')).toThrow(
+      /no DTLS fingerprint/,
+    );
+  });
+});

--- a/packages/agent-remote-pairing/src/pairing.ts
+++ b/packages/agent-remote-pairing/src/pairing.ts
@@ -90,9 +90,25 @@ export function parsePairingUrl(url: string): IPairingSecret {
 
 // ── DTLS fingerprint extraction ─────────────────────────────────────────────────────────────────
 
-/** Extract the `a=fingerprint:<hash> <value>` value from an SDP. Throws if absent (fail closed). */
+/**
+ * Extract the `a=fingerprint:<hash> <value>` value from an SDP. Throws if absent (fail closed).
+ *
+ * **Anchored to the start of an SDP line (`^…/m`) — deliberately, on two counts.**
+ *
+ * 1. *Linearity.* Unanchored, the scan retried `\S+` from every offset in a non-space run, so an SDP made of
+ *    repeated `a=fingerprint:` text cost O(n²) — 5.2 s at 400 KB. The remote SDP arrives over the (untrusted,
+ *    content-blind) signaling relay and is parsed here **before** the pairing confirmation runs, so that was a
+ *    pre-authentication remote stall. `^…/m` limits the start offsets to line starts, which makes the total work
+ *    linear in the SDP length.
+ * 2. *Not binding free text.* An SDP line is `<type>=<value>`; `a=fingerprint:` appearing mid-line is inside some
+ *    other field's free text (`s=`, `i=`, an unrelated attribute value) that no DTLS stack reads. The unanchored
+ *    form returned such a value, letting a relay smuggle a fingerprint of its choosing into the channel binding.
+ *
+ * Residual (tracked in SEC-003): this still returns the FIRST fingerprint line rather than the one the DTLS stack
+ * actually verified for the negotiated m-section, so a session-level line can still shadow a media-level one.
+ */
 export function extractDtlsFingerprint(sdp: string): string {
-  const match = sdp.match(/a=fingerprint:\S+\s+([0-9A-Fa-f:]+)/);
+  const match = sdp.match(/^a=fingerprint:\S+\s+([0-9A-Fa-f:]+)/m);
   if (!match) throw new Error('no DTLS fingerprint (a=fingerprint) found in SDP');
   return match[1].toUpperCase();
 }

--- a/packages/agent-tools/src/__tests__/polynomial-redos.test.ts
+++ b/packages/agent-tools/src/__tests__/polynomial-redos.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SEC-003 — `js/polynomial-redos` regression floor for `agent-tools`.
+ *
+ * Two sites: the flagged sandbox-root normaliser (alert 47) and `WebFetch`'s HTML-to-text conversion, which
+ * CodeQL did **not** flag and which is the only quadratic in this slice whose input is a live response body from
+ * an arbitrary URL. Each fix ships a timing test (red for seconds against the pre-fix source) and an equivalence
+ * test pinning the output.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyWorkspaceManifest } from '../index.js';
+
+import type { ISandboxClient, ISandboxRunResult } from '../sandbox/types.js';
+import type { IToolInvocationResult } from '../types/tool-result.js';
+
+const PUMP = 200_000;
+const BUDGET_MS = 250;
+const RED_TIMEOUT_MS = 120_000;
+
+/**
+ * A client WITHOUT `applyManifest` — `applyWorkspaceManifest` delegates to that hook when present and would then
+ * never reach `normalizeSandboxRoot`.
+ */
+function recordingClient(): { client: ISandboxClient; paths: string[] } {
+  const paths: string[] = [];
+  const ok: ISandboxRunResult = { exitCode: 0, stdout: '', stderr: '' };
+  return {
+    paths,
+    client: {
+      run: async (command: string) => {
+        paths.push(command);
+        return ok;
+      },
+      readFile: async () => '',
+      writeFile: async (path: string) => {
+        paths.push(path);
+      },
+    },
+  };
+}
+
+describe('SEC-003 alert 47 — sandbox root normalisation', () => {
+  it(
+    'normalises a pumped separator run in linear time',
+    async () => {
+      const { client } = recordingClient();
+      // The backslash conversion inside `normalizeSandboxRoot` manufactures the `/` run.
+      const targetRoot = `/a${'\\'.repeat(PUMP)}b`;
+      const started = performance.now();
+      await applyWorkspaceManifest(client, { entries: {} }, { targetRoot });
+      expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('strips exactly the trailing separators for ordinary input', async () => {
+    const { client, paths } = recordingClient();
+    await applyWorkspaceManifest(
+      client,
+      { entries: { 'src/a.txt': { type: 'file', content: 'x' } } },
+      { targetRoot: '/workspace/sub///' },
+    );
+    expect(paths.join('\n')).toContain('/workspace/sub/src/a.txt');
+  });
+
+  it('still converts backslashes before stripping the trailing separators', async () => {
+    const { client, paths } = recordingClient();
+    await applyWorkspaceManifest(
+      client,
+      { entries: { 'a.txt': { type: 'file', content: 'x' } } },
+      { targetRoot: '\\workspace\\sub\\\\' },
+    );
+    expect(paths.join('\n')).toContain('/workspace/sub/a.txt');
+  });
+
+  it('rejects a target root that is not absolute after normalisation', async () => {
+    const { client } = recordingClient();
+    await expect(
+      applyWorkspaceManifest(client, { entries: {} }, { targetRoot: 'relative/root' }),
+    ).rejects.toThrow(/must be an absolute sandbox path/);
+  });
+});
+
+describe('SEC-003 sweep — WebFetch HTML-to-text (unflagged, remote-sourced)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  async function fetchHtml(html: string): Promise<IToolInvocationResult> {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/html; charset=utf-8' },
+      // `TextEncoder`, not `Buffer.from(html).buffer` — a Buffer is a view into a shared pool, so `.buffer`
+      // hands the decoder every neighbouring allocation as well.
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(html).buffer),
+    } as unknown as Response);
+    const { webFetchTool } = await import('../builtins/web-fetch-tool.js');
+    const result = await webFetchTool.execute({ url: 'https://example.com/' } as Parameters<
+      typeof webFetchTool.execute
+    >[0]);
+    const raw =
+      typeof result === 'object' && result !== null && 'data' in result
+        ? String((result as { data: unknown }).data)
+        : String(result);
+    return JSON.parse(raw) as IToolInvocationResult;
+  }
+
+  it(
+    'converts a page of unclosed `<` in linear time',
+    async () => {
+      const started = performance.now();
+      const result = await fetchHtml('<'.repeat(PUMP));
+      expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+      expect(result.success).toBe(true);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it(
+    'converts a page of unclosed `<script` in linear time',
+    async () => {
+      const started = performance.now();
+      const result = await fetchHtml('<script'.repeat(Math.floor(PUMP / 7)));
+      expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+      expect(result.success).toBe(true);
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('keeps the extracted text for a well-formed page', async () => {
+    const page =
+      '<html><head><style>body{color:red}</style><SCRIPT>var x = 1 < 2;</SCRIPT></head>' +
+      '<body><p class="a">Hi &amp; bye</p><!-- note --></body></html>';
+    expect((await fetchHtml(page)).output).toBe('Hi & bye');
+  });
+
+  it('leaves a literal `<>` in the text, as the previous regex did', async () => {
+    expect((await fetchHtml('<p>a &lt;&gt; b</p>')).output).toBe('a <> b');
+    expect((await fetchHtml('<p>a<>b</p>')).output).toBe('a<>b');
+  });
+});

--- a/packages/agent-tools/src/builtins/web-fetch-tool.ts
+++ b/packages/agent-tools/src/builtins/web-fetch-tool.ts
@@ -23,12 +23,66 @@ const WebFetchSchema = z.object({
 
 type TWebFetchArgs = z.infer<typeof WebFetchSchema>;
 
+/**
+ * Remove every `<tag>…</tag>` element — the linear equivalent of `replace(/<tag[\s\S]*?<\/tag>/gi, '')`.
+ *
+ * The regex form is quadratic: every `<tag` with no closing tag after it rescans to end of input, and the scan
+ * then restarts at the next one. `htmlToText`'s input is a **response body from an arbitrary URL**, capped only
+ * at {@link MAX_RESPONSE_BYTES} (5 MB) — 5 MB of `<script` would have taken minutes. Because the closing tag is
+ * searched forward, its absence at one opener means no later opener can have one either, so the scan stops.
+ *
+ * Case folding is `[A-Z]`-only, not `toLowerCase()`: `toLowerCase()` can change a string's LENGTH (U+0130
+ * lowercases to two code units), which would desynchronise the indices from the original text.
+ */
+function stripElement(html: string, tag: string): string {
+  const openTag = `<${tag}`;
+  const closeTag = `</${tag}>`;
+  const haystack = html.replace(/[A-Z]/g, (c) => c.toLowerCase());
+  const parts: string[] = [];
+  let cursor = 0;
+  for (;;) {
+    const open = haystack.indexOf(openTag, cursor);
+    if (open < 0) break;
+    const close = haystack.indexOf(closeTag, open + openTag.length);
+    if (close < 0) break;
+    parts.push(html.slice(cursor, open));
+    cursor = close + closeTag.length;
+  }
+  parts.push(html.slice(cursor));
+  return parts.join('');
+}
+
+/**
+ * Replace every `<…>` tag with a space — the linear equivalent of `replace(/<[^>]+>/g, ' ')`.
+ *
+ * Same defect, same input: `[^>]+` cannot cross a `>`, so a `<` with no `>` after it consumed the rest of the
+ * document and then backtracked over it, once per `<`. A page of 200 K `<` characters took 12.6 s; the 5 MB the
+ * fetch allows would have taken hours. `close === open + 1` reproduces the regex's `+` (a tag body must be at
+ * least one character), so a literal `<>` is left in the text exactly as before.
+ */
+function stripTags(html: string): string {
+  const parts: string[] = [];
+  let cursor = 0;
+  for (;;) {
+    const open = html.indexOf('<', cursor);
+    if (open < 0) break;
+    const close = html.indexOf('>', open + 1);
+    if (close < 0) break;
+    if (close === open + 1) {
+      parts.push(html.slice(cursor, open + 1));
+      cursor = open + 1;
+      continue;
+    }
+    parts.push(html.slice(cursor, open), ' ');
+    cursor = close + 1;
+  }
+  parts.push(html.slice(cursor));
+  return parts.join('');
+}
+
 /** Strip HTML tags and decode common entities to produce readable text. */
 function htmlToText(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, ' ')
+  return stripTags(stripElement(stripElement(html, 'script'), 'style'))
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')

--- a/packages/agent-tools/src/sandbox/workspace-manifest.ts
+++ b/packages/agent-tools/src/sandbox/workspace-manifest.ts
@@ -200,8 +200,21 @@ function resolveHostSourcePath(source: string, hostRoot: string | undefined): st
   return isAbsolute(source) ? resolve(source) : resolve(hostRoot ?? process.cwd(), source);
 }
 
+/**
+ * Remove every trailing `/`, by index scan.
+ *
+ * Not `replace(/\/+$/, '')`: that run has no start anchor, so the engine retries it from every offset inside the
+ * run and each retry re-scans to the end — 3.0 s on a 100 K run (`js/polynomial-redos`, SEC-003). The backslash
+ * conversion in {@link normalizeSandboxRoot} manufactures such a run from a Windows-style path.
+ */
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
+}
+
 function normalizeSandboxRoot(root: string): string {
-  const normalized = root.replace(/\\/g, '/').replace(/\/+$/, '');
+  const normalized = trimTrailingSlashes(root.replace(/\\/g, '/'));
   if (!normalized.startsWith('/')) {
     throw new Error('workspace manifest targetRoot must be an absolute sandbox path');
   }

--- a/packages/dag-framework/src/__tests__/http-dag-runtime-provider-redos.test.ts
+++ b/packages/dag-framework/src/__tests__/http-dag-runtime-provider-redos.test.ts
@@ -1,0 +1,36 @@
+/**
+ * SEC-003 alert 51 — `HttpDagRuntimeProvider`'s `baseUrl` normalisation must be linear.
+ *
+ * `baseUrl` is a public constructor parameter, so its length is the caller's choice. The old
+ * `replace(/\/+$/, '')` retried the slash run from every offset inside it: 3.0 s on a 100 K run.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { HttpDagRuntimeProvider } from '../http-dag-runtime-provider.js';
+
+const PUMP = 200_000;
+const BUDGET_MS = 250;
+const RED_TIMEOUT_MS = 120_000;
+
+describe('SEC-003 alert 51 — HttpDagRuntimeProvider baseUrl', () => {
+  it(
+    'normalises a pumped slash run in linear time',
+    () => {
+      const baseUrl = `http://x${'/'.repeat(PUMP)}y`;
+      const started = performance.now();
+      const provider = new HttpDagRuntimeProvider({ baseUrl });
+      expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+      expect(provider.displayName).toContain('y');
+    },
+    RED_TIMEOUT_MS,
+  );
+
+  it('strips exactly the trailing slashes for ordinary input', () => {
+    expect(new HttpDagRuntimeProvider({ baseUrl: 'http://localhost:3000///' }).displayName).toBe(
+      'HTTP (http://localhost:3000)',
+    );
+    expect(new HttpDagRuntimeProvider({ baseUrl: 'http://localhost:3000/api' }).displayName).toBe(
+      'HTTP (http://localhost:3000/api)',
+    );
+  });
+});

--- a/packages/dag-framework/src/http-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/http-dag-runtime-provider.ts
@@ -7,6 +7,7 @@ import { fromDagWorkflowFile } from '@robota-sdk/dag-builder';
 import { DagOrchestrationHttpClient } from '@robota-sdk/dag-orchestration-client';
 
 import { isTerminalStatus, mapRunToResult } from './run-result-mapping.js';
+import { trimTrailingSlashes } from './trim-trailing-slashes.js';
 
 import type {
   IDagNodeManifest,
@@ -118,7 +119,7 @@ export class HttpDagRuntimeProvider implements IDetachableRunProvider {
   private readonly client: DagOrchestrationHttpClient;
 
   public constructor(options: IHttpDagRuntimeProviderOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.baseUrl = trimTrailingSlashes(options.baseUrl);
     this.fetchImpl = options.fetch ?? fetch;
     this.displayName = `HTTP (${this.baseUrl})`;
     this.client = new DagOrchestrationHttpClient({ baseUrl: this.baseUrl, fetch: this.fetchImpl });

--- a/packages/dag-framework/src/trim-trailing-slashes.ts
+++ b/packages/dag-framework/src/trim-trailing-slashes.ts
@@ -1,0 +1,12 @@
+/**
+ * Remove every trailing `/`, by index scan.
+ *
+ * Not `replace(/\/+$/, '')`: that run has no start anchor, so the engine retries it from every offset inside the
+ * run and each retry re-scans to the end — 3.0 s on a 100 K run (`js/polynomial-redos`, SEC-003). The base URLs
+ * this normalises are public constructor parameters, so their length is the caller's choice.
+ */
+export function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
+}


### PR DESCRIPTION
Finishes the `js/polynomial-redos` class started in #1403. Scope: the 10 alerts that slice could not
touch, plus a same-shape sweep of the five packages they live in. **10 of 10 fixed at the source, zero
dismissals** — matching the bar of all three prior SEC-003 slices.

## Alert 46 (`pairing.ts`) is remote-reachable, pre-authentication — and it was binding free text

#1403 flagged this one as deserving priority. It was right, and the finding is larger than DoS.

| Peer                 | Call path                                                                                                                                                                                                                                     |
| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Host (Node, offerer) | `WsSignalingClient` → relay `signal` frame → `WebRtcTransport.start`'s `onSignal` (`webrtc-transport.ts:125-138`) → `startPairingIfConfigured(…, message.data)` → `extractDtlsFingerprint(sdp)` at `webrtc-transport.ts:172`, whose result is `PairingGate`'s `remoteFingerprint` |
| Browser (answerer)   | `RtcSignaling` → `handleOffer(offer)` (`rtc-session-client.ts:265`) → `extractDtlsFingerprint(offer.sdp ?? '')` at line 267 — the **first** statement, ahead of `setRemoteDescription`                                                            |

The relay (`apps/remote-signaling/src/relay.ts`) is content-blind and forwards `offer`/`answer`/`ice`
verbatim; its only auth seam (`onJoinAttempt`) is optional and unset by default. `pairing.ts`'s own
header states the threat model — a relay that substitutes a DTLS fingerprint must be detected — so the
SDP is attacker-controlled **by design**. And the extraction *is* the input to the confirmation, so
nothing can gate it. That makes this the one alert in the class whose source is genuinely remote and
pre-auth, not "library input".

Two consequences, both reproduced in `pairing-redos.test.ts`:

- **DoS** — 400 KB of `a=fingerprint:` blocked the event loop for **5 040 ms**. The relay's own 64 KB
  `maxFrameBytes` is not a bound; the threat model's attacker *is* the relay.
- **Channel-binding surface (the bigger half)** — unanchored, the regex returned the first
  `a=fingerprint:` **substring**, including one inside another line's free text. For
  `s=room a=fingerprint:sha-256 DE:AD:BE:EF\r\na=fingerprint:sha-256 AB:CD:EF` the pre-fix code returns
  `DE:AD:BE:EF` — the smuggled value — while every DTLS stack negotiates against the real attribute. A
  relay could therefore pick each peer's `remoteFingerprint` independently of the certificate it
  actually terminates.

Fixed by anchoring to an SDP line start: `/^a=fingerprint:\S+\s+([0-9A-Fa-f:]+)/m`. Linear, and
structurally correct (`<type>=<value>` is the line grammar; a mid-line hit is not an attribute). The
real two-peer werift suite (29 tests, incl. `pairing-e2e` and `dtls-fingerprint-binding`) passes
unchanged.

**Residual, deliberately out of scope:** it still returns the *first* fingerprint line, not the one the
DTLS stack verified for the negotiated m-section, so a session-level line can shadow a media-level one.
Closing that (fail closed on conflicting fingerprints, or structural m-section parsing) changes the live
WebRTC path and needs owner sign-off plus a real two-peer run. Recorded in the backlog.

## Per-alert verdict (10 of 10)

Pumps `n = 200_000` (`400_000` for 46), measured through the **exported entry point** in each row.

| Alert | File:line                                                               | Reachable?                        | Evidence                                                                                                                | Action                                    | Red → green      |
| ----- | ----------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | ---------------- |
| 46    | `agent-remote-pairing/src/pairing.ts:95`                                | **yes — REMOTE, pre-auth**        | table above                                                                                                             | anchored `/^…/m`                            | 5 040 ms → <1 ms |
| 41    | `agent-framework/src/memory/project-memory-store.ts:83`                 | **yes — model/user topic**        | `ProjectMemoryStore.readTopic`/`append`; `-` is inside the KEPT class so the collapse does not shorten a dash run        | `trimEdgeChars`                             | 11 842 ms → 1 ms |
| 43    | `agent-framework/src/update-check/update-check.ts:279`                  | **yes — public option**           | `checkForCliUpdate({ registryUrl })` → `buildPackageMetadataUrl`                                                         | `trimTrailingChars`                         | 11 872 ms → 1 ms |
| 39    | `agent-framework/src/commands/skill-source.ts:35`                       | **yes — on-disk skill file**      | `parseFrontmatter` ← `scanSkillsDir` over `.claude/skills`, `.agents/skills`, `~/.robota/skills`                         | split on `','`                              | 12 619 ms → 1 ms |
| 40    | `agent-framework/src/context/task-context.ts:136`                       | **yes — `.git` file content**     | `readCurrentGitBranch(cwd)` → `resolveGitDirectory` reads a `.git` **file** and matches `/^gitdir:\s*(.+)$/`             | `(\S.*)`                                    | 14 489 ms → 1 ms |
| 34    | `agent-cli/src/subagents/git-worktree-isolation-adapter.ts:139`         | **yes — public options/request**  | `prepare({ jobId })` and the `idFactory` option; `-` is inside the KEPT class                                           | local `trimDashes`                          | 11 836 ms → 1 ms |
| 47    | `agent-tools/src/sandbox/workspace-manifest.ts:204`                     | **yes — public option**           | `applyWorkspaceManifest(…, { targetRoot })`; the backslash conversion manufactures the run                              | local `trimTrailingSlashes`                 | 12 037 ms → 1 ms |
| 51    | `dag-framework/src/http-dag-runtime-provider.ts:121`                    | **yes — public constructor arg**  | `new HttpDagRuntimeProvider({ baseUrl })`                                                                                | own module `trimTrailingSlashes`            | 11 965 ms → 1 ms |
| 38    | `agent-framework/src/command-api/provider/provider-profile-names.ts:30` | reachable, **not exploitable**    | exported, but `replace(/[^a-z0-9]+/g, '-')` collapses every run first                                                    | fixed anyway: `trimEdgeChars`               | 0 ms — see below |
| 42    | `agent-framework/src/tools/model-command-tool-projection.ts:56`         | reachable, **not exploitable**    | same shape; `replace(/_+/g, '_')` collapses the run first                                                                | fixed anyway: `trimEdgeChars` + `:85`       | 1 ms — see below |

**38 and 42 are the honest exceptions**: their timing tests are green against the *pre-fix* source,
because a collapse earlier in the same expression makes the quadratic term unreachable. They were not
dismissed, because 41 and 34 are literally the same three lines with `-` moved into the kept class —
the shape is one character-class edit away from live, and 34 proves that edit gets made. They ship as
equivalence pins rather than timing floors.

## Sweep — four same-shape defects with no CodeQL alert

#1403's "the alert list is a floor" lesson held again, and produced the most severe defect here:

| Site                                                            | Measured  | Verdict                                                                                          |
| --------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------- |
| `agent-tools/src/builtins/web-fetch-tool.ts:29-31`              | 12 635 ms | **fixed — input is a live response body from an arbitrary URL**, capped only at 5 MB (≈ hours)      |
| `agent-framework/src/agents/agent-definition-loader.ts:26`      | 12 635 ms | fixed — a literal copy of alert 39                                                                  |
| `agent-framework/src/context/task-context.ts:88`                | 15 385 ms | fixed — a lone `\r` survives the `/\r?\n/` split, so a "line" can hold a run that never reaches `$` |
| `agent-framework/src/tools/model-command-tool-projection.ts:85` | 0 ms      | bounded by `slice(0, ≤64)` three statements away — converted rather than left resting on it         |

CodeQL flagged eight `agent-framework` sanitisers whose worst input is a config string, and missed the
one function in these five packages that parses **HTML fetched from an arbitrary URL**.

Measured and cleared without change: `task-context.ts:61` (0.2 ms — the `m` flag lets `$` match at
end-of-line), `memory-candidate-extractor.ts:40-43` (0.2 ms — no `$` anchor), `skill-prompt.ts:62`
(3.6 ms), and every `^…` leading-run trim (a start anchor gives one start offset).

## Why index scans, not cleverer regexes

A lookbehind guard (`/(?<!-)-+$/`) was measured — equally linear (1.1 ms vs 52 s at 400 K) and
exhaustively equivalent. **Rejected**: whether CodeQL's `PolynomialBackTrackingTerm` models a
lookbehind pruning start offsets is not verifiable before merge (a PR's diff-scoped analysis only
reports *new* alerts, so it cannot confirm an old one cleared). Removing the regex is the certain
route — the same call #1403 made when its simplified arrow regex tripped `js/bad-tag-filter`.

Equivalence is exhaustive, not by example: every string over the relevant alphabet up to length 12
(`trim-char.test.ts`), ~12 M strings for the `<script>` stripper, ~800 K for the tag stripper, 349 526
trimmed inputs for `gitdir:`. Those comparisons are committed.

## Red-first

Measured by stashing the **source** files only and re-running the committed tests, so every red is an
assertion failure carrying its own elapsed time, not a timeout.

| Test                                                                | Pre-fix                | Post-fix           |
| ------------------------------------------------------------------- | ---------------------- | ------------------ |
| `pairing-redos` — one-line `a=fingerprint:` pump                    | 5 040 ms               | <1 ms              |
| `pairing-redos` — pump inside an `s=` line's free text              | 5 060 ms               | <1 ms              |
| `pairing-redos` — smuggled fingerprint not returned                 | returned `DE:AD:BE:EF` | returns `AB:CD:EF` |
| `polynomial-redos` (fw) — `ProjectMemoryStore.readTopic`            | 11 842 ms              | <1 ms              |
| `polynomial-redos` (fw) — `checkForCliUpdate` registry URL          | 11 872 ms              | <1 ms              |
| `polynomial-redos` (fw) — skill frontmatter list                    | 12 619 ms              | <1 ms              |
| `polynomial-redos` (fw) — agent-definition list (unflagged)         | 12 635 ms              | <1 ms              |
| `polynomial-redos` (fw) — `readCurrentGitBranch` `gitdir:`          | 14 489 ms              | <1 ms              |
| `polynomial-redos` (fw) — task open items, CR-only line (unflagged) | 15 385 ms              | <1 ms              |
| `git-worktree-isolation-redos` — `prepare()` delta over baseline    | 11 836 ms              | <1 ms              |
| `polynomial-redos` (tools) — `applyWorkspaceManifest` targetRoot    | 12 037 ms              | <1 ms              |
| `polynomial-redos` (tools) — `WebFetch` unclosed `<` (unflagged)    | 12 635 ms              | ~5 ms              |
| `polynomial-redos` (tools) — `WebFetch` unclosed `<script`          | 2 662 ms               | ~2 ms              |
| `http-dag-runtime-provider-redos` — `baseUrl`                       | 11 965 ms              | <1 ms              |

Every timing test asserts `< 250 ms` (10×–60× margin over red, >50× over green). The `agent-cli` case
asserts the **delta** against an identical short-id `prepare()`, because `git init` + `worktree add`
dominate that call. The 14 equivalence tests pass against **both** revisions — that is what makes them
pins; the two `pairing` smuggling tests are the deliberate exception.

## Verification

- `pnpm harness:verify-like-ci` — **PASS**, all 5 stages (harness-self-test, format-check, scan-suite,
  scan-suite-dist-free, typecheck). Surfaced one real finding en route: the inlined `dag-framework`
  helper pushed `http-dag-runtime-provider.ts` past the 300-line ratchet, so it is its own module.
- `pnpm -w typecheck` — pass.
- Full vitest for every touched package plus both WebRTC consumers of `extractDtlsFingerprint`:
  **1 998 tests, 249 files, all green** (agent-framework 1295, agent-cli 271, agent-tools 210,
  dag-framework 109, agent-transport-webrtc-web 45, agent-remote-pairing 39, agent-transport-webrtc 29).
- Changeset covers the four published packages (`dag-framework` is private).

## Class state

`js/polynomial-redos` is **closed**: 8 (#1403) + 10 (here) = **18 of 18** fixed at the source, plus 5
same-shape defects CodeQL never reported. **Zero dismissals in any SEC-003 slice.**

SEC-003 itself stays **open** for `js/file-system-race` (16), the style classes (~130), and the
advisory→required promotion decision. Both high-severity classes it opened with are now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
