### PR TITLE
perf(typecheck): evaluate the native TypeScript compiler side-by-side (PERF-003)

### DIFF
--- a/.agents/backlog/completed/PERF-003-typescript-7-side-by-side-evaluation.md
+++ b/.agents/backlog/completed/PERF-003-typescript-7-side-by-side-evaluation.md
@@ -1,6 +1,7 @@
 ---
 title: 'PERF-003: evaluate TypeScript 7 (native) side-by-side for typecheck — measured 8.8x, not yet adoptable'
-status: todo
+status: done
+completed: 2026-07-25
 created: 2026-07-25
 priority: medium
 urgency: later
@@ -84,3 +85,52 @@ four TS-API scans must still pass, proving side-by-side did not disturb them.
 
 Switching `typecheck` to tsgo — that is PERF-004, gated on this evaluation's error-list agreement AND on
 the tsconfig migration.
+
+## Outcome (DONE 2026-07-25)
+
+Side-by-side evaluation done. **Adoption criterion MET — diagnostics agree — but the switch is still
+blocked on PERF-004.**
+
+### What shipped
+
+- `@typescript/native-preview` (7.0.0-dev.20260707.2, bin `tsgo`) as a root devDependency, installed
+  **beside** `typescript@5.9.3`. The legacy compiler is untouched and the four legacy-API consumers
+  (`scripts/audit/audit-implements.mjs`, `scripts/harness/{check-spec-public-surface,scan-composition-neutrality,scan-interface-runtime}.mjs`)
+  were re-run and still exit 0.
+- `scripts/perf/compare-typecheck.mjs` + `pnpm typecheck:compare` — the diagnostics comparison made
+  **reproducible**, so PERF-004 can re-run the criterion instead of trusting one session's scrollback.
+- The existing `typecheck` entry point is **unchanged**, as this item required.
+
+### Diagnostics comparison — 5/5 agree
+
+Both compilers run against an identical synthesized probe config, so the compiler is the only variable:
+
+| Package         | legacy  | native | speed-up | diagnostics |
+| --------------- | ------- | ------ | -------- | ----------- |
+| agent-core      | 2383 ms | 530 ms | 4.5×     | identical   |
+| agent-framework | 3191 ms | 596 ms | 5.4×     | identical   |
+| agent-tools     | 1552 ms | 422 ms | 3.7×     | identical   |
+| agent-session   | 992 ms  | 355 ms | 2.8×     | identical   |
+| agent-cli       | 1797 ms | 444 ms | 4.0×     | identical   |
+
+### Two findings that change PERF-004's scope
+
+1. **`typecheck:fast` could NOT be wired per-package, and adding it would have been a lie.** The native
+   compiler rejects the real tsconfigs _outright_ on the removed options, before it ever looks at code:
+   `error TS5102: Option 'baseUrl' has been removed`, `TS5108: moduleResolution=node10 has been removed`,
+   `TS5102: downlevelIteration has been removed`. A root script guarded by `--if-present` would have
+   silently no-op'd to green. So this item ships the comparison tool instead, and **PERF-004 is the
+   hard prerequisite for any `typecheck:fast`** — the reverse of this item's original ordering.
+2. **The compilers disagree on AUTOMATIC `@types` discovery under pnpm's symlinked `node_modules`** —
+   this was not in the source investigation. With `types` unset, the legacy compiler picks up the hoisted
+   `@types/jest` (which supplies `describe`/`it`/`expect` to vitest files) and the native one does not,
+   producing 41 phantom `Cannot find name 'describe'` errors in `agent-core` alone. Setting
+   `types: ['node','jest']` explicitly makes both compilers agree exactly. **PERF-004 must decide the
+   repo-wide answer** (explicit `types` per package, or a different `@types` arrangement) — otherwise the
+   switch would surface dozens of phantom errors and look like a code regression.
+
+### Constraint honored
+
+`typescript@5.9.3` remains a devDependency and must never be removed — the four harness scans,
+`@typescript-eslint`, vitest and IDE tooling all depend on the legacy programmatic API, which the native
+compiler does not expose.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "harness:scan:deprecated-markers": "node scripts/harness/scan-deprecated-markers.mjs",
     "harness:scan:orphan-exports": "node scripts/harness/check-orphan-exports.mjs",
     "test:mutation": "stryker run",
-    "proof:external": "node scripts/external-proof/run-external-proof.mjs"
+    "proof:external": "node scripts/external-proof/run-external-proof.mjs",
+    "typecheck:compare": "node scripts/perf/compare-typecheck.mjs"
   },
   "keywords": [
     "ai",
@@ -141,6 +142,7 @@
     "@types/node": "^20.19.43",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vitest/coverage-v8": "^3.2.6",
     "dependency-cruiser": "^17.4.3",
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.21.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
       '@vitest/coverage-v8':
         specifier: ^3.2.6
         version: 3.2.6(vitest@3.2.6)
@@ -445,7 +448,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -549,7 +552,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1017,7 +1020,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1186,7 +1189,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -1257,7 +1260,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1306,7 +1309,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1346,7 +1349,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1377,7 +1380,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1414,7 +1417,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1433,7 +1436,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1448,7 +1451,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1581,7 +1584,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1603,7 +1606,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1622,7 +1625,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1640,7 +1643,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1671,7 +1674,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1696,7 +1699,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1718,7 +1721,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1752,7 +1755,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1777,7 +1780,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1805,7 +1808,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1830,7 +1833,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1855,7 +1858,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1877,7 +1880,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1892,7 +1895,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1917,7 +1920,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1939,7 +1942,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1976,7 +1979,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2001,7 +2004,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2019,7 +2022,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2050,7 +2053,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2081,7 +2084,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -2130,7 +2133,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -2152,7 +2155,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2174,7 +2177,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2193,7 +2196,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2263,7 +2266,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2294,7 +2297,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2334,7 +2337,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2365,7 +2368,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2387,7 +2390,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2412,7 +2415,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2437,7 +2440,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2453,7 +2456,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
 
   packages/dag-cli:
     dependencies:
@@ -2523,7 +2526,7 @@ importers:
         version: link:../dag-api
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
 
   packages/dag-core:
     dependencies:
@@ -2542,7 +2545,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2564,7 +2567,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2614,7 +2617,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
 
   packages/dag-mcp-server:
     dependencies:
@@ -2639,7 +2642,7 @@ importers:
         version: link:../dag-nodes-default
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
 
   packages/dag-node:
     dependencies:
@@ -2661,7 +2664,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2756,7 +2759,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2787,7 +2790,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2818,7 +2821,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2855,7 +2858,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2886,7 +2889,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2914,7 +2917,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2942,7 +2945,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -2970,7 +2973,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3016,7 +3019,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3050,7 +3053,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3084,7 +3087,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3112,7 +3115,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3140,7 +3143,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3177,7 +3180,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3211,7 +3214,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3239,7 +3242,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3267,7 +3270,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3304,7 +3307,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3341,7 +3344,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3369,7 +3372,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3397,7 +3400,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3425,7 +3428,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3450,7 +3453,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3475,7 +3478,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3506,7 +3509,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3531,7 +3534,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -3559,7 +3562,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -10503,6 +10506,83 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
+    dev: true
+
+  /@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@typescript/native-preview@7.0.0-dev.20260707.2:
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
     dev: true
 
   /@ungap/structured-clone@1.3.1:
@@ -20723,7 +20803,7 @@ packages:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
     dev: false
 
-  /rolldown-plugin-dts@0.27.14(rolldown@1.2.0)(typescript@5.9.3):
+  /rolldown-plugin-dts@0.27.14(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@5.9.3):
     resolution: {integrity: sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
@@ -20742,6 +20822,7 @@ packages:
       vue-tsc:
         optional: true
     dependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260707.2
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
@@ -22122,7 +22203,7 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tsdown@0.22.14(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1):
+  /tsdown@0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@5.9.3)(unrun@0.3.1):
     resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
@@ -22165,7 +22246,7 @@ packages:
       obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.0
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.0)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.27.14(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@5.9.3)
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2

--- a/scripts/perf/compare-typecheck.mjs
+++ b/scripts/perf/compare-typecheck.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+/**
+ * Compare the legacy TypeScript compiler against the native one (PERF-003).
+ *
+ * The adoption criterion for switching `typecheck` is NOT "the native compiler is faster" — it is
+ * "both compilers report the SAME diagnostics". This script makes that comparison reproducible so
+ * PERF-004 can re-run it after the tsconfig migration, instead of it living in one session's scrollback.
+ *
+ * Method: for each target package, synthesize a self-contained probe tsconfig — the package's own
+ * options merged over the base, minus the options the native compiler removed (`baseUrl`,
+ * `downlevelIteration`, `paths`) and with `moduleResolution` set to a supported value. Run both
+ * compilers against that identical config so the COMPILER is the only variable, then diff their output.
+ *
+ * Why the probe needs `types` set explicitly: the two compilers do not agree on *automatic* `@types`
+ * discovery under pnpm's symlinked `node_modules`. With `types` unset, the legacy compiler picks up the
+ * hoisted `@types/jest` (supplying `describe`/`it`/`expect` to vitest files) and the native one does not,
+ * producing dozens of phantom "Cannot find name" errors that are a resolution difference, not a code
+ * disagreement. Pinning `types` isolates the comparison to real diagnostics. PERF-004 must decide the
+ * repo-wide answer for this (explicit `types`, or a different `@types` layout).
+ *
+ * Exit code 0 = every target matched, 1 = at least one differed (or a compiler was missing).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Options the native compiler removed — a probe carrying them fails on config, never reaching the code. */
+const REMOVED_OPTIONS = ['baseUrl', 'downlevelIteration', 'paths'];
+/** Project-graph options that make a standalone probe meaningless. */
+const PROJECT_OPTIONS = ['composite', 'incremental', 'tsBuildInfoFile'];
+
+/** Packages compared by default. Override with CLI args: `pnpm typecheck:compare agent-core agent-cli`. */
+const DEFAULT_TARGETS = [
+  'agent-core',
+  'agent-framework',
+  'agent-tools',
+  'agent-session',
+  'agent-cli',
+];
+
+/** Strip `//` comments so `tsconfig` files parse as JSON. Deliberately naive — these are our own files. */
+function readJsonc(file) {
+  return JSON.parse(readFileSync(file, 'utf8').replace(/^\s*\/\/.*$/gm, ''));
+}
+
+export function buildProbeConfig(baseConfig, packageConfig) {
+  const compilerOptions = {
+    ...(baseConfig.compilerOptions ?? {}),
+    ...(packageConfig.compilerOptions ?? {}),
+  };
+  for (const key of [...REMOVED_OPTIONS, ...PROJECT_OPTIONS]) delete compilerOptions[key];
+  compilerOptions.moduleResolution = 'bundler';
+  // See the header: automatic @types discovery diverges between the compilers under pnpm.
+  compilerOptions.types = ['node', 'jest'];
+  return {
+    compilerOptions,
+    include: packageConfig.include ?? ['src'],
+    exclude: packageConfig.exclude ?? [],
+  };
+}
+
+function runCompiler(bin, projectFile, cwd) {
+  const started = Date.now();
+  try {
+    execFileSync('npx', [bin, '-p', projectFile, '--noEmit'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return { ms: Date.now() - started, output: '' };
+  } catch (error) {
+    return { ms: Date.now() - started, output: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+  }
+}
+
+export function compareTarget(pkg) {
+  const packageDir = path.join(WORKSPACE_ROOT, 'packages', pkg);
+  const probe = buildProbeConfig(
+    readJsonc(path.join(WORKSPACE_ROOT, 'tsconfig.base.json')),
+    readJsonc(path.join(packageDir, 'tsconfig.json')),
+  );
+
+  // Written inside the package so relative `include`/`extends`-free paths resolve as they normally would.
+  const probeFile = path.join(packageDir, 'tsconfig.perf-compare.json');
+  writeFileSync(probeFile, `${JSON.stringify(probe, null, 2)}\n`);
+  try {
+    const legacy = runCompiler('tsc', 'tsconfig.perf-compare.json', packageDir);
+    const native = runCompiler('tsgo', 'tsconfig.perf-compare.json', packageDir);
+    return { pkg, legacy, native, matched: legacy.output === native.output };
+  } finally {
+    rmSync(probeFile, { force: true });
+  }
+}
+
+export async function main(targets = DEFAULT_TARGETS) {
+  const results = [];
+  for (const pkg of targets) results.push(compareTarget(pkg));
+
+  process.stdout.write('typecheck compare — legacy vs native (diagnostics must match):\n');
+  for (const { pkg, legacy, native, matched } of results) {
+    const speedup = legacy.ms > 0 ? (legacy.ms / Math.max(native.ms, 1)).toFixed(1) : '?';
+    process.stdout.write(
+      `  ${matched ? '✓' : '✗'} ${pkg}: legacy ${legacy.ms}ms, native ${native.ms}ms (${speedup}x) — ` +
+        `${matched ? 'diagnostics identical' : 'DIAGNOSTICS DIFFER'}\n`,
+    );
+    if (!matched) {
+      process.stdout.write(`      legacy:\n${legacy.output || '        (none)'}\n`);
+      process.stdout.write(`      native:\n${native.output || '        (none)'}\n`);
+    }
+  }
+
+  const differing = results.filter((r) => !r.matched);
+  if (differing.length > 0) {
+    process.stdout.write(
+      `\n${differing.length} of ${results.length} target(s) disagree — do NOT switch the typecheck ` +
+        'entry point until they match (PERF-003 adoption criterion).\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(
+    `\nAll ${results.length} target(s) agree. Remaining gate before switching: the tsconfig migration ` +
+      '(PERF-004) — the native compiler rejects the real configs outright until then.\n',
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  const args = process.argv.slice(2);
+  await main(args.length > 0 ? args : DEFAULT_TARGETS);
+}


### PR DESCRIPTION
Installs `@typescript/native-preview` (bin `tsgo`) **beside** `typescript@5.9.3`. The legacy compiler stays — four harness scans plus `@typescript-eslint` use its programmatic API, which the native compiler does not expose. The existing `typecheck` entry point is untouched.

## Adoption criterion: MET

With the compiler as the only variable (identical synthesized probe config), diagnostics are **identical on 5/5 packages**:

| Package | legacy | native | speed-up |
| --- | --- | --- | --- |
| agent-core | 2383ms | 530ms | 4.5× |
| agent-framework | 3191ms | 596ms | 5.4× |
| agent-tools | 1552ms | 422ms | 3.7× |
| agent-session | 992ms | 355ms | 2.8× |
| agent-cli | 1797ms | 444ms | 4.0× |

Shipped as **`pnpm typecheck:compare`** (`scripts/perf/compare-typecheck.mjs`) so PERF-004 can re-run the criterion instead of trusting one session's scrollback.

## Two findings that reorder PERF-004

1. **`typecheck:fast` could not be wired, and adding it would have been misleading.** The native compiler rejects the real tsconfigs *outright* on removed options (`TS5102 baseUrl`, `TS5108 moduleResolution=node10`, `TS5102 downlevelIteration`) before reading any code — and a root script guarded by `--if-present` would have silently no-op'd to green. **PERF-004 is a hard prerequisite**, the reverse of this item's original ordering.
2. **The compilers disagree on automatic `@types` discovery under pnpm's symlinked `node_modules`** (not in the source investigation). With `types` unset the legacy compiler picks up the hoisted `@types/jest` and the native one does not — 41 phantom `Cannot find name 'describe'` errors in `agent-core` alone. Explicit `types` makes them agree exactly. PERF-004 must settle this repo-wide, or the switch will look like a code regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)