### PR TITLE
fix(perf): drop unused imports flagged by CodeQL's review on #1409

### DIFF
--- a/scripts/perf/compare-typecheck.mjs
+++ b/scripts/perf/compare-typecheck.mjs
@@ -23,8 +23,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');


### PR DESCRIPTION
CodeQL's inline review on #1409 flagged `mkdtempSync` and `tmpdir` as unused — leftovers from an earlier temp-dir approach before the probe config moved into the package directory. The fix missed the merge window (auto-merge fired while I was still reading the review), so it lands here.

`scripts/` is outside eslint's scope, which is why the PR review caught this and lint did not.

Verified: `pnpm typecheck:compare` still reports 5/5 diagnostics-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)