### PR TITLE
docs(git): make merged-branch cleanup the agent's judgement call

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -82,8 +82,22 @@ gh pr merge 670 --squash --delete-branch
 gh pr merge 670 --squash --auto
 ```
 
-Branches must only be deleted by explicit user request. Use `git branch -D <name>` (local) or
-`gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name>` (remote) when the user says to delete a branch.
+**Deleting a merged branch is the agent's own call — no user request needed.** Once a branch's PR is
+confirmed `MERGED` and nothing further is pending on it, clean it up: `git branch -D <name>` (local) or
+`gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name>` (remote). Leaving merged branches to pile
+up is its own defect; 105 of them had accumulated by 2026-07-25.
+
+Judgement is required precisely because deletion is not always right the moment a PR merges. Do **not**
+delete when any of these hold:
+
+- the branch carries commits that are **not** in the merge (e.g. a review fix pushed after auto-merge
+  fired — see the #1409/#1410 sequence), or a follow-up PR is planned from the same branch;
+- an agent still has it checked out in a worktree, or its worktree is `locked`;
+- it is an integration branch (`develop`, `main`) or a `release/*` / `hotfix/*` branch still in flight.
+
+Repository-level _automatic_ deletion on merge (`delete_branch_on_merge`) is deliberately **off**: it
+fires before any of the above can be considered. Keeping deletion agent-driven preserves that judgement
+while the guardrails below keep it safe.
 
 **Confirm the merge landed BEFORE deleting the remote branch. Zero exceptions.** A remote branch deleted
 while its PR is still open CLOSES/orphans that PR. So a remote-branch deletion is allowed only once
@@ -94,7 +108,7 @@ which blocks `gh api -X DELETE .../git/refs/heads/<name>`, `git push <remote> --
 `git push <remote> :<name>` unless the branch has a merged PR (override for an intentional abandon:
 `BRANCH_GUARD_ALLOW_DELETE=1`).
 
-**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). Deletion is safe only after the merge is confirmed, never for integration branches.
+**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). Deletion is safe only after the merge is confirmed, never for integration branches. Note the two hazards differ in cost: a deleted `develop` is **recoverable** (re-cut it from `main`), whereas a branch deleted while its PR is unmerged **orphans work**. That asymmetry is why the ban targets the blind, automatic form — not deletion itself, which the agent should do routinely once a merge is confirmed.
 
 ### Branch Policy
 

--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -93,6 +93,13 @@ Diagnose real failures; a known fresh-worktree environment artifact (e.g. build 
 that worktree was never built) is not a code failure. Confirm each merge actually landed (Merge Landing
 Verification) before releasing any item held in step 3.
 
+**Clean up each landed branch as you go** — that is the orchestrator's call, not something to wait for a
+human to request. Once a merge is confirmed, delete the branch (and prune its worktree) unless something
+still depends on it: commits on the branch that the merge did not take, a follow-up planned from it, an
+agent still holding its worktree, or an integration/release branch. Deferring this is how a hundred stale
+branches and tens of gigabytes of worktrees accumulate. The deletion guardrails — merge confirmed first,
+integration branches never — are owned by the git rules; follow them, do not restate them.
+
 **Read the review output BEFORE arming the merge.** Review-producing automation is typically _advisory_:
 its findings arrive as PR comments, while the checks that actually gate a merge are a different set. So an
 auto-merge armed early fires on the gating checks and carries the review's findings straight into the


### PR DESCRIPTION
Owner directive: a deleted `develop` is recoverable (re-cut from `main`), so that hazard alone should not force cleanup to wait on a human — let the agent decide after a merge, and encode that in the rules and harness.

**What changed**
- Deletion no longer requires an explicit user request. Once a PR is confirmed `MERGED` and nothing is pending on the branch, the agent cleans it up.
- The rule now enumerates **when NOT to delete**: commits the merge did not take (the #1409 → #1410 sequence, where auto-merge fired while a review fix was still being pushed), a planned follow-up from the same branch, a worktree still holding it, and integration / in-flight release branches.
- Records the asymmetry that justifies the policy: a deleted `develop` is **recoverable**; a branch deleted while its PR is unmerged **orphans work**. The ban targets the blind automatic form, not deletion itself.
- Repository `delete_branch_on_merge` stays **off** — it fires before any of the above can be considered.
- The orchestration skill gains a cleanup step (neutral wording, guardrails delegated to the git rules rather than restated).

**Unchanged:** `.claude/hooks/branch-guard.sh` still mechanically blocks a remote deletion until the branch has a merged PR, and still protects integration branches.

Context: 105 stale merged branches had accumulated; they were deleted in this session (0 failures, 0 unmerged touched) and `origin` now holds only `develop` and `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)