### PR TITLE
fix(security): address CodeQL review findings surfaced on the promotion PR

### DIFF
--- a/packages/agent-framework/src/memory/memory-candidate-extractor.ts
+++ b/packages/agent-framework/src/memory/memory-candidate-extractor.ts
@@ -50,7 +50,7 @@ const MAX_CANDIDATE_TEXT_LENGTH = 240;
 const HASH_ID_LENGTH = 12;
 
 function hashCandidate(seed: string): string {
-  return `mem_${createHash('sha1').update(seed).digest('hex').slice(0, HASH_ID_LENGTH)}`;
+  return `mem_${createHash('sha256').update(seed).digest('hex').slice(0, HASH_ID_LENGTH)}`;
 }
 
 function normalizeText(text: string): string {

--- a/packages/agent-transport-tui/src/hooks/useRealCursorPosition.ts
+++ b/packages/agent-transport-tui/src/hooks/useRealCursorPosition.ts
@@ -107,7 +107,7 @@ export function useRealCursorPosition(
     cell !== undefined &&
     origin !== undefined &&
     shouldPositionRealCursor({
-      hasMeasured: metrics.hasMeasured && origin !== undefined, // I1
+      hasMeasured: metrics.hasMeasured, // I1 — `origin` is already narrowed non-undefined above
       y: cell.y,
       frameHeight: origin.frameHeight, // I2 checked inside the guard
       viewportRows,

--- a/scripts/external-proof/fixture/src/mode-c.ts
+++ b/scripts/external-proof/fixture/src/mode-c.ts
@@ -23,7 +23,6 @@ import { createCodingPack } from '@robota-sdk/pack-coding';
 import {
   ACME_PROVIDER_SETTINGS,
   acmeBaseCommandModule,
-  acmeCommandModule,
   acmePack,
   acmeSubagent,
   acmeTicketTool,


### PR DESCRIPTION
The `develop → main` promotion (#1413) surfaced 7 CodeQL review comments against code already on `develop`. Fixing them here rather than blocking the promotion.

**Fixed (3 real findings):**
- **`js/weak-cryptographic-algorithm` (high)** — the memory candidate id hashed a seed containing `sessionId` with **sha1** → **sha256**. The id is a content address, not a security token, but sha1 buys nothing here and the alert is right that sensitive data reaches a weak algorithm.
- **`js/comparison-between-incompatible-types`** — `useRealCursorPosition` re-tested `origin !== undefined` inside a branch that had already narrowed it.
- **`js/unused-local-variable`** — unused `acmeCommandModule` import in the external-proof fixture.

**Assessed as false positives (not changed, reasoning recorded):**
- **`js/regex/missing-regexp-anchor` ×3** (`web-search-provider.test.ts`) — these regexes are **negative assertions on source text** (`expect(toolSource).not.toMatch(/api\.search\.brave\.com/)`), proving a vendor URL is *absent* from the tool layer. The rule assumes a regex matched *against a URL for authorization*; anchoring here would weaken the assertion.
- **`js/redos` (high)** (`frontmatter-parser-ssot.test.mjs`) — the regex-literal extractor in the anti-fork floor, run over the repo's own harness scripts, never over untrusted input. Worth revisiting under SEC-003's redos work rather than reshaping a guard mid-promotion.

**Verified:** memory suite 33 tests, real-cursor suites 24 tests, external proof 69 assertions — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)