### PR TITLE
docs(backlog): HARNESS-049 — split rules into thin skills + extracted agent files

### DIFF
--- a/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
+++ b/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
@@ -1,0 +1,94 @@
+---
+title: 'HARNESS-049: refactor rules into thin orchestration skills + extracted agent definitions'
+status: todo
+created: 2026-07-26
+priority: high
+urgency: soon
+area: .agents/rules, .agents/skills, .claude/agents
+depends_on: []
+---
+
+# HARNESS-049: procedure belongs in skills, roles belong in agent files
+
+## Problem
+
+Owner directive (2026-07-26): convert what is currently _rule prose_ into the right artifact —
+**an orchestration skill that owns only the pipeline, and a separate agent-definition FILE for every
+role that pipeline calls.** Roles that are already handled by an agent must exist as extracted agent
+definitions rather than being described inline.
+
+Three distinct defects, measured against the tree on 2026-07-26:
+
+**1. Procedure is trapped in rule documents.** Rules are meant to be constraints ("what must hold");
+procedure ("how to do it, in order") belongs in a skill. The four largest rule files carry the bulk of
+the repo's step-by-step content:
+
+| Rule                   | Lines | Numbered steps |
+| ---------------------- | ----- | -------------- |
+| `backlog-execution.md` | 457   | 19             |
+| `git-branch.md`        | 312   | 24             |
+| `spec-workflow.md`     | 253   | 17             |
+| `publish.md`           | 217   | 27             |
+
+A rule that reads as a runbook cannot be _enforced_ — only followed by whoever happens to read it —
+which is the same "prose without a mechanism" failure `check-backlog-placement` was created to fix.
+
+**2. Skills inline roles instead of dispatching them.** These describe reviewer/auditor duties in
+their own body and reference no agent definition:
+
+- `backlog-pipeline` (165 lines)
+- `delegated-refactor-green-gate` (56 lines)
+- `dependency-graph-extraction` (48 lines)
+
+**3. The pattern is proven, so the gap is unfinished work rather than an unknown.** All **14** existing
+agent definitions in `.claude/agents/` are wired into skills — **zero orphans** — and the most-used
+(`architecture-conformance-auditor` 7 skill refs, `proposal-reviewer` 6, `architecture-auditor` 6) are
+exactly the "judge" roles that benefit most from living in one file. The separation already works here;
+it just has not been applied to the rest.
+
+## Target shape
+
+```
+rule            → the invariant only ("X must hold", "never Y"), plus WHO owns each fact
+orchestration   → the pipeline: phases, ordering, gates, what to dispatch and when — and NOTHING else
+skill
+agent file      → one role, one file: its charter, its judgement criteria, its tool scope,
+(.claude/agents)  its terminal signal. Reusable by any pipeline that needs that role.
+```
+
+The orchestration skill must not contain a role's judgement criteria, and an agent file must not
+contain pipeline ordering. If a skill explains _how to judge_, that content belongs in an agent file;
+if an agent file explains _what runs next_, that belongs in the skill.
+
+## What
+
+1. **Inventory and classify** every `.agents/rules/*.md` section as: `invariant` (stays a rule),
+   `procedure` (moves to a skill), or `role` (becomes an agent definition). Produce the mapping table
+   FIRST — this is the deliverable that makes the rest reviewable, and it is where the judgement is.
+2. **Extract roles to `.claude/agents/*.md`**, starting with the three skills above and any role a rule
+   describes inline. Each must satisfy the repo's `agent-def-convention` guard.
+3. **Reduce the orchestration skills to pipeline-only**, dispatching the extracted agents. Follow the
+   neutrality discipline already applied to `worktree-parallel-orchestration`: a skill is universal
+   procedure and POINTS at the rule that owns a fact instead of restating it.
+4. **Leave each rule as its invariants + ownership pointers.** Content moves; it is not duplicated.
+   Each fact keeps exactly one owner document (`AGENTS.md` Document Discovery Policy).
+5. Consider dispatching the existing `capability-scout` → `proposal-reviewer` → `agent-skill-author`
+   pipeline (the `capability-extraction` skill) for the role decomposition rather than hand-rolling it —
+   that pipeline exists for exactly this, and using it dogfoods the mechanism this item is about.
+
+## Constraints
+
+- **No behavioral loss.** Every mandatory constraint must survive the move; a rule losing force because
+  its text became a skill is the failure mode to avoid. Diff the invariants before/after and show the
+  mapping.
+- **Do it incrementally, one rule at a time**, each merged and verified — not one sweeping PR across
+  four 200–450-line rules.
+- Anything referenced by a harness scan (`scan-consistency`, `check-agent-def-convention`, the skill
+  index) must keep resolving: no dangling anchors, no unregistered skill or agent.
+
+## Test Plan
+
+Per increment: `pnpm harness:verify-like-ci` green (the consistency + agent-convention scans are the
+mechanical floor here). Plus an explicit invariant-preservation check — list the mandatory statements
+in the rule before the change and show each one's post-change home. For an extracted agent, dispatch it
+once on a real task and confirm it produces the same verdict the inline version would have.

--- a/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
+++ b/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
@@ -50,21 +50,34 @@ it just has not been applied to the rest.
 
 ```
 rule            → the invariant only ("X must hold", "never Y"), plus WHO owns each fact
-orchestration   → the pipeline: phases, ordering, gates, what to dispatch and when — and NOTHING else
-skill
+orchestration   → the pipeline: phases, ordering, gates, what to dispatch and when — and NOTHING else.
+skill             MAY dispatch a lower orchestration skill instead of an agent, when a phase is
+(nestable)        itself a pipeline. Nesting is expected, not an exception.
 agent file      → one role, one file: its charter, its judgement criteria, its tool scope,
 (.claude/agents)  its terminal signal. Reusable by any pipeline that needs that role.
 ```
 
-The orchestration skill must not contain a role's judgement criteria, and an agent file must not
-contain pipeline ordering. If a skill explains _how to judge_, that content belongs in an agent file;
-if an agent file explains _what runs next_, that belongs in the skill.
+**Orchestration nests.** A phase of a high-level pipeline is often a pipeline in its own right, so an
+orchestration skill may own **sub-orchestration skills** as well as agents: a top-level skill routes
+phases, an intermediate skill sequences that phase's own steps, and only the leaves are agents. Each
+level still carries **only** its own ordering — a parent must not restate a child's steps, and a child
+must not know what runs after its parent's phase. Depth is whatever the work actually has; the
+constraint is that every level stays pipeline-only.
+
+The invariant across all levels: an orchestration skill (at any depth) must not contain a role's
+judgement criteria, and an agent file must not contain pipeline ordering. If a skill explains _how to
+judge_, that content belongs in an agent file; if an agent file explains _what runs next_, that belongs
+in the skill above it.
 
 ## What
 
 1. **Inventory and classify** every `.agents/rules/*.md` section as: `invariant` (stays a rule),
    `procedure` (moves to a skill), or `role` (becomes an agent definition). Produce the mapping table
    FIRST — this is the deliverable that makes the rest reviewable, and it is where the judgement is.
+   For each `procedure`, also record its **level**: is it a whole pipeline (top-level skill), one
+   phase of a larger pipeline (sub-orchestration skill), or a single role's work (agent)? The four
+   large rules are likely to yield nested pipelines rather than one flat skill each — e.g. a release
+   procedure whose "verify" phase is itself an ordered sequence worth its own skill.
 2. **Extract roles to `.claude/agents/*.md`**, starting with the three skills above and any role a rule
    describes inline. Each must satisfy the repo's `agent-def-convention` guard.
 3. **Reduce the orchestration skills to pipeline-only**, dispatching the extracted agents. Follow the


### PR DESCRIPTION
Owner directive (2026-07-26): an orchestration skill should own **only the pipeline**, and every role it calls should live in its **own agent-definition file** — including roles already handled by agents but described inline.

**Measured against the tree, not asserted:**

| Defect | Evidence |
| --- | --- |
| Procedure trapped in rules | The four largest rules carry **87 numbered steps**: `backlog-execution` 457 lines/19, `git-branch` 312/24, `spec-workflow` 253/17, `publish` 217/27 |
| Skills inlining roles | `backlog-pipeline` (165 lines), `delegated-refactor-green-gate` (56), `dependency-graph-extraction` (48) — describe reviewer/auditor duties, reference no agent file |
| The pattern is already proven | All **14** agent definitions are wired into skills, **zero orphans**; the most-used are exactly the judge roles (`architecture-conformance-auditor` ×7, `proposal-reviewer` ×6, `architecture-auditor` ×6) |

So this is unfinished application of a working separation, not an experiment.

**Target shape** — rule = invariant + ownership; orchestration skill = phases/ordering/gates and nothing else; agent file = one role's charter, judgement criteria, tool scope, terminal signal. A skill explaining *how to judge* means that content belongs in an agent file; an agent file explaining *what runs next* means it belongs in the skill.

**Constraints written into the item:** no behavioral loss (diff the invariants and show each one's post-change home), one rule per increment rather than a sweep across four 200–450-line files, and everything a harness scan references must keep resolving. It also suggests dogfooding the existing `capability-extraction` pipeline (`capability-scout` → `proposal-reviewer` → `agent-skill-author`) for the decomposition instead of hand-rolling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)