### PR TITLE
docs: living harness-composition design + INFRA-049 commitlint range defect

### DIFF
--- a/.agents/backlog/INFRA-049-commitlint-rejects-inherited-history.md
+++ b/.agents/backlog/INFRA-049-commitlint-rejects-inherited-history.md
@@ -1,0 +1,54 @@
+---
+title: 'INFRA-049: commitlint fails any PR that merges another branch, judging inherited commits'
+status: todo
+created: 2026-07-26
+priority: medium
+urgency: soon
+area: .github/workflows/ci.yml, commitlint.config.js
+depends_on: []
+---
+
+# INFRA-049: commitlint judges commits the PR did not author
+
+## Problem
+
+The `commitlint` job runs `commitlint --from origin/<base> --to HEAD`. For a normal feature PR that is
+exactly right. But for a PR that **merges another branch**, the range includes every commit that branch
+carries — commits the PR author never wrote and cannot rewrite.
+
+Observed on **#1415** (`main` → `develop` back-merge, 2026-07-26): the job failed on
+
+- Dependabot commit **bodies** (`Bumps [lucide-react](https://github.com/…) from 0.525.0 to 1.26.0.`),
+- and an already-merged repo commit whose subject is 126 chars
+  (`refactor(harness): HARNESS-DIET-003 remainder — …  (#1302)`).
+
+Both are **already on `main`**, i.e. already merged and unchangeable. Locally
+`commitlint --from origin/develop --to HEAD` exits **0** on the same branch — CI sees a different set
+because it fetches the base with `--depth=50`, so this also reproduces the "green locally, red in CI"
+class HARNESS-045 exists to catch.
+
+The failure is structural: **any** `main → develop` sync, and any PR that merges a long-lived branch,
+will hit it. Rewriting inherited history to satisfy a lint is not an option.
+
+## What
+
+Pick one (they are not exclusive):
+
+1. **Scope the range to the PR's own commits.** Use the merge-base and exclude commits reachable from
+   the merged-in branch — e.g. lint `--from <merge-base>` while skipping second-parent history, or lint
+   only the commits GitHub attributes to the PR (`gh pr view --json commits`).
+2. **Ignore commits the repo cannot author.** `commitlint` supports `ignores` — exempt merge commits and
+   bot-authored commits (`Bumps [...]` bodies come from Dependabot). Note the config already disables
+   `body-max-line-length` / `footer-max-line-length` for a related reason, so this is consistent with
+   existing intent.
+3. **Fetch enough history** that CI and local agree (`--depth` is currently 50) — necessary regardless,
+   since a shallow base is what made the two disagree.
+
+Whichever is chosen, keep the gate meaningful for commits the PR **does** author: the point is to stop
+judging inherited history, not to weaken the rule.
+
+## Test Plan
+
+Red-first: a branch that merges another branch containing a >100-char subject must FAIL under today's
+config and PASS after the fix, while a PR whose **own** commit has a >100-char subject must still FAIL.
+Verify CI and local `commitlint` agree on the same branch (the HARNESS-045 mirror should cover it).

--- a/.agents/specs/README.md
+++ b/.agents/specs/README.md
@@ -5,20 +5,21 @@ Package-specific specs are owned by each package at `packages/<name>/docs/SPEC.m
 
 ## Index
 
-| Spec                                                                       | Scope                                                                                  |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| (See `packages/*/docs/SPEC.md` for package-level specs)                    | Per-package contracts                                                                  |
-| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                                 | Repository-level architecture map router                                               |
-| [architecture-map/README.md](architecture-map/README.md)                   | Architecture-map document tree and update policy                                       |
-| [agent-invocation-router.md](agent-invocation-router.md)                   | Agent command descriptors, deterministic invocation routing, and claim guards          |
-| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)               | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design     |
-| [background-work-state.md](background-work-state.md)                       | Switchable main-thread, process, agent, group, and skill-spawned work state contract   |
-| [background-task-layer.md](background-task-layer.md)                       | Generic background task lifecycle, composition, runners, and TUI/transport projection  |
-| [command-inventory.md](command-inventory.md)                               | Built-in command ownership, lifecycle, model visibility, and host effect surfaces      |
-| [process-execution.md](process-execution.md)                               | Transparent local process execution request, status, output, and provenance contract   |
-| [repository-situational-awareness.md](repository-situational-awareness.md) | Passive repo context display without command inference or repo writes                  |
-| [subagent-process-manager.md](subagent-process-manager.md)                 | CLI subagent process management, parallel execution, and TUI lifecycle                 |
-| [transparent-workflow.md](transparent-workflow.md)                         | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure |
-| [user-local-memory.md](user-local-memory.md)                               | Inspectable user-local memory and preference behavior for display/navigation only      |
-| [user-local-storage.md](user-local-storage.md)                             | User-local-only baseline workflow storage policy, category inspection, and path guards |
-| [verification-pipeline-plan.md](verification-pipeline-plan.md)             | Local hooks, harness verification, CI, build, and release verification planning        |
+| Spec                                                                       | Scope                                                                                   |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| (See `packages/*/docs/SPEC.md` for package-level specs)                    | Per-package contracts                                                                   |
+| [ARCHITECTURE-MAP.md](ARCHITECTURE-MAP.md)                                 | Repository-level architecture map router                                                |
+| [architecture-map/README.md](architecture-map/README.md)                   | Architecture-map document tree and update policy                                        |
+| [agent-invocation-router.md](agent-invocation-router.md)                   | Agent command descriptors, deterministic invocation routing, and claim guards           |
+| [ai-workflow-control-plane.md](ai-workflow-control-plane.md)               | Repo-native AI workflow manifest, evidence, hook, review, and CLI ownership design      |
+| [harness-composition-design.md](harness-composition-design.md)             | Living design: rules vs orchestration skills vs agent definitions; nesting + neutrality |
+| [background-work-state.md](background-work-state.md)                       | Switchable main-thread, process, agent, group, and skill-spawned work state contract    |
+| [background-task-layer.md](background-task-layer.md)                       | Generic background task lifecycle, composition, runners, and TUI/transport projection   |
+| [command-inventory.md](command-inventory.md)                               | Built-in command ownership, lifecycle, model visibility, and host effect surfaces       |
+| [process-execution.md](process-execution.md)                               | Transparent local process execution request, status, output, and provenance contract    |
+| [repository-situational-awareness.md](repository-situational-awareness.md) | Passive repo context display without command inference or repo writes                   |
+| [subagent-process-manager.md](subagent-process-manager.md)                 | CLI subagent process management, parallel execution, and TUI lifecycle                  |
+| [transparent-workflow.md](transparent-workflow.md)                         | Cross-client action provenance, state vocabulary, memory visibility, and UI disclosure  |
+| [user-local-memory.md](user-local-memory.md)                               | Inspectable user-local memory and preference behavior for display/navigation only       |
+| [user-local-storage.md](user-local-storage.md)                             | User-local-only baseline workflow storage policy, category inspection, and path guards  |
+| [verification-pipeline-plan.md](verification-pipeline-plan.md)             | Local hooks, harness verification, CI, build, and release verification planning         |

--- a/.agents/specs/harness-composition-design.md
+++ b/.agents/specs/harness-composition-design.md
@@ -7,11 +7,11 @@
 
 ## The three artifact kinds
 
-| Artifact                                              | Owns                                                               | Must NOT contain                                   |
-| ----------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
-| **Rule** (`.agents/rules/*.md`)                       | Invariants — "X must hold", "never Y" — and **who owns each fact** | Step-by-step procedure; role definitions           |
-| **Orchestration skill** (`.agents/skills/*/SKILL.md`) | A pipeline: phases, ordering, gates, what to dispatch and when     | A role's judgement criteria; restated rule text    |
-| **Agent definition** (`.claude/agents/*.md`)          | One role: charter, judgement criteria, tool scope, terminal signal | Pipeline ordering; knowledge of what runs after it |
+| Artifact                                              | Owns                                                                         | Must NOT contain                                       |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------ |
+| **Rule** (`.agents/rules/*.md`)                       | Invariants — "X must hold", "never Y" — and **who owns each fact**           | Step-by-step procedure; role definitions               |
+| **Orchestration skill** (`.agents/skills/*/SKILL.md`) | A pipeline: phases, gates, what to dispatch, and **how each outcome routes** | A role's judgement criteria; restated rule text        |
+| **Agent definition** (`.claude/agents/*.md`)          | One role: charter, judgement criteria, tool scope, terminal signal           | Pipeline control flow; knowledge of what runs after it |
 
 **The boundary test.** If a skill explains _how to judge_, that content belongs in an agent file. If an
 agent file explains _what runs next_, that belongs in the skill above it. If a rule explains _how_
@@ -30,7 +30,7 @@ router skill            → routes to the right pipeline for the request
 ```
 
 Nesting is **expected, not an exception**. Depth is whatever the work actually has. The invariant holds
-at every level: each level carries **only its own ordering** — a parent never restates a child's steps,
+at every level: each level carries **only its own control flow** — a parent never restates a child's steps,
 and a child never knows what follows its parent's phase. Only leaves are agents.
 
 ## Why this shape
@@ -65,17 +65,54 @@ rather than leaving it implicit.
 - **Mechanically checked.** Anything a harness scan references must keep resolving: registered skills,
   agent-definition conventions, anchors. The scans are the floor, not the review.
 
+## A pipeline is a state machine, not a queue
+
+"Driving the pipeline" is **not** walking a list front to back. Managing it means **reacting to each
+step's result**: on a step's outcome an orchestrator may advance, **re-run a step**, **go back to an
+earlier step**, jump to a different step, or stop. Loops and backward edges are normal control flow,
+not error handling bolted on.
+
+That is why an orchestrator legitimately reads results — and why doing so is **not** the judgement that
+belongs to agents. The split:
+
+| Orchestrator decides                                | Agent decides                                      |
+| --------------------------------------------------- | -------------------------------------------------- |
+| **Which step runs next**, given a step's outcome    | **What the outcome is**                            |
+| Whether to retry, go back, skip ahead, or terminate | Whether the thing under review is correct/complete |
+| When the pipeline has converged                     | The verdict a step reports                         |
+
+An orchestrator consuming a verdict to route on it is control flow. An orchestrator _forming_ that
+verdict itself is the violation — that work belongs in an agent file.
+
+Concretely, an orchestration skill should state, per step: what it dispatches, and **what each outcome
+routes to** (advance / repeat / return to step N / terminate). A step whose failure has no defined
+routing is an incomplete pipeline. The loop-until-convergence shape — dispatch, read the result, go
+back if it is not clean, terminate only when a fresh pass is clean — is the common case, not a special
+one; see `automated-review-convergence` for a worked instance.
+
+**Every level obeys the same rules.** An intermediate orchestration skill is an orchestrator in full: it
+owns its own ordering _and_ its own routing decisions, dispatches skills or agents, and never forms
+verdicts. It differs from the top level only in scope, never in kind.
+
+## Settled
+
+- **The router is a skill.** Routing is procedure — deciding which pipeline a request enters is the same
+  kind of work as deciding which step runs next, just at the top. It is not an invariant, so it is not a
+  rule.
+- **Intermediate orchestrators follow the orchestrator rules unchanged** (see above).
+- **Orchestrators route on results.** Reading a step's outcome to decide the next step is orchestration;
+  producing that outcome is not.
+
 ## Open questions
 
 - Is there a natural depth limit for nesting, or does it stay work-shaped? (No evidence yet either way —
   revisit once several nested pipelines exist.)
-- Should the router level be a skill at all, or a rule that routes? Current answer: a skill, because
-  routing is procedure — but this has not been stress-tested.
-- Does an intermediate orchestration skill ever legitimately need judgement (e.g. choosing which phase to
-  run)? If so, is that "ordering" or "judgement"? Not yet resolved.
+- When a pipeline can loop, what bounds it? A max-iteration count, a convergence predicate, or per-step
+  discretion? Unresolved — but a loop with no stated termination condition is a defect either way.
 
 ## Revision log
 
-| Date       | Change                                                                                                                                                                                     |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2026-07-26 | Created. Three-artifact split, boundary test, nesting, neutrality, working agreements — captured from the `HARNESS-049` framing and the `worktree-parallel-orchestration` neutrality pass. |
+| Date       | Change                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-26 | Created. Three-artifact split, boundary test, nesting, neutrality, working agreements — captured from the `HARNESS-049` framing and the `worktree-parallel-orchestration` neutrality pass.                                                                                                                                                                                   |
+| 2026-07-26 | Owner clarifications: the router IS a skill; intermediate orchestrators follow the orchestrator rules unchanged; and a pipeline is a **state machine** — an orchestrator routes on each step's outcome (advance / repeat / go back / terminate), which is control flow, not the judgement that belongs to agents. Two open questions closed, one added (what bounds a loop). |

--- a/.agents/specs/harness-composition-design.md
+++ b/.agents/specs/harness-composition-design.md
@@ -1,0 +1,81 @@
+# Harness composition design — rules, skills, agents
+
+> **Living document.** This is the current snapshot of how the harness is meant to be composed, not a
+> record of one decision. Update it whenever the shape changes; date each revision in the log at the
+> bottom so the reasoning stays traceable. Work items that apply it (e.g. `HARNESS-049`) come and go —
+> this document stays.
+
+## The three artifact kinds
+
+| Artifact                                              | Owns                                                               | Must NOT contain                                   |
+| ----------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
+| **Rule** (`.agents/rules/*.md`)                       | Invariants — "X must hold", "never Y" — and **who owns each fact** | Step-by-step procedure; role definitions           |
+| **Orchestration skill** (`.agents/skills/*/SKILL.md`) | A pipeline: phases, ordering, gates, what to dispatch and when     | A role's judgement criteria; restated rule text    |
+| **Agent definition** (`.claude/agents/*.md`)          | One role: charter, judgement criteria, tool scope, terminal signal | Pipeline ordering; knowledge of what runs after it |
+
+**The boundary test.** If a skill explains _how to judge_, that content belongs in an agent file. If an
+agent file explains _what runs next_, that belongs in the skill above it. If a rule explains _how_
+rather than _what must hold_, it belongs in a skill.
+
+## Orchestration nests
+
+A phase of a high-level pipeline is frequently a pipeline in its own right. So an orchestration skill
+may dispatch **other orchestration skills** as well as agents:
+
+```
+router skill            → routes to the right pipeline for the request
+  └─ orchestration      → sequences phases; a phase may be another orchestration skill
+       └─ orchestration → sequences that phase's own steps
+            └─ agent    → does the actual role work (the leaf)
+```
+
+Nesting is **expected, not an exception**. Depth is whatever the work actually has. The invariant holds
+at every level: each level carries **only its own ordering** — a parent never restates a child's steps,
+and a child never knows what follows its parent's phase. Only leaves are agents.
+
+## Why this shape
+
+- **A rule that reads like a runbook cannot be enforced.** It can only be followed by whoever happens to
+  read it — the "prose without a mechanism" failure this harness has hit repeatedly.
+- **A role inlined in a skill cannot be reused.** Extracted into its own file, the same reviewer or
+  auditor serves every pipeline that needs it. This is already proven here: every agent definition in
+  `.claude/agents/` is dispatched by at least two skills, and the judge roles are the most reused.
+- **A skill that carries judgement criteria drifts from the skills that copy it.** One role, one file,
+  one owner — the same single-source discipline `AGENTS.md` applies to facts.
+
+## Neutrality
+
+A skill is **universal procedure**. Repo-specific facts — script names, branch names, item IDs,
+baseline names, tool names — belong to the rule (or doc) that owns them and are **pointed at**, never
+restated. `worktree-parallel-orchestration/SKILL.md` is the reference implementation of this after its
+neutrality pass: it says "the project's CI-equivalent verification entry point", not a command name.
+
+The line to hold: abstract enough to port, concrete enough to execute. Naming the _mechanism of the
+procedure itself_ (the isolation primitive, the agent-dispatch call) is fine; naming _this repo's
+plumbing_ is not. When a fact must stay concrete for the procedure to be runnable, say so explicitly
+rather than leaving it implicit.
+
+## Working agreements
+
+- **Move, never duplicate.** When content relocates, the source loses it. Each fact keeps exactly one
+  owner document.
+- **No behavioral loss.** A mandatory constraint that becomes procedure must not lose force. Diff the
+  invariants before/after and show each one's new home.
+- **Incremental.** One rule, one skill, or one role at a time — each merged and verified.
+- **Mechanically checked.** Anything a harness scan references must keep resolving: registered skills,
+  agent-definition conventions, anchors. The scans are the floor, not the review.
+
+## Open questions
+
+- Is there a natural depth limit for nesting, or does it stay work-shaped? (No evidence yet either way —
+  revisit once several nested pipelines exist.)
+- Should the router level be a skill at all, or a rule that routes? Current answer: a skill, because
+  routing is procedure — but this has not been stress-tested.
+- Does an intermediate orchestration skill ever legitimately need judgement (e.g. choosing which phase to
+  run)? If so, is that "ordering" or "judgement"? Not yet resolved.
+
+## Revision log
+
+| Date       | Change                                                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-07-26 | Created. Three-artifact split, boundary test, nesting, neutrality, working agreements — captured from the `HARNESS-049` framing and the `worktree-parallel-orchestration` neutrality pass. |


### PR DESCRIPTION
**1. Living design document** (`.agents/specs/harness-composition-design.md`, indexed in the specs README)

Owner suggestion: keep the skill/agent design as a snapshot document that keeps evolving, rather than losing it when a backlog item is archived. Captures:
- the three-artifact split (rule = invariants + ownership / orchestration skill = pipeline only / agent file = one role) and the **boundary test** — a skill explaining *how to judge* belongs in an agent; an agent explaining *what runs next* belongs in the skill above it
- **nesting**: a phase is often a pipeline itself, so orchestration skills may own sub-orchestration skills; only leaves are agents, and every level carries only its own ordering
- the neutrality line (abstract enough to port, concrete enough to execute), working agreements, **open questions**, and a revision log

**2. INFRA-049** — `commitlint` lints `origin/<base>..HEAD`, so a PR that *merges another branch* is judged on commits it never authored and cannot rewrite. Hit on #1415 (`main` → `develop` sync): Dependabot bodies plus an already-merged 126-char subject fail the gate, while the identical range exits 0 locally — also a "green locally, red in CI" instance. Filed with three candidate fixes and a red-first test plan that keeps the gate meaningful for a PR's *own* commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)