### PR TITLE
refactor(harness): HARNESS-049 extract publish.md's procedure into a nested release pipeline

### DIFF
--- a/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
+++ b/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
@@ -93,6 +93,45 @@ the companion to the design doc. Phase 2 picks up from there. Headline results:
   existing owner skill to negotiate with (`git-branch.md` has ten skill references plus eight
   enforcement surfaces).
 
+## Phase 2, increment 1 — `publish.md` — DONE (2026-07-26)
+
+Extracted the release procedure into a nested pipeline. `publish.md` keeps every invariant; what left is
+the ordering — 11 Release State Machine steps, the 10-step OTP sequence, the gate-observation cadence, and
+the failure-class vocabulary. What grew is ownership pointers.
+
+**Tree built** (matches phase 1's hypothesis except where noted):
+
+```
+release-orchestration        (NEW top-level)   ← Release State Machine, phase sequencing + routing
+├─ source-stabilization      (NEW phase)       ← steps 1–3
+├─ version-bump              (NEW phase)       ← steps 4–9   (as phase 1 predicted)
+├─ npm-otp-publish           (NEW phase)       ← steps 10–11 + the OTP Protocol (as predicted)
+└─ ci-gate-watch             (NEW, shared)     ← Long-Running Gates; dispatched by two phases
+       └─ ci-failure-triager (NEW agent)       ← CI Failure Triage criteria
+   + merge-verifier          (existing agent, reused unchanged)
+   + version-management      (existing skill, reused unchanged)
+```
+
+**Additions to phase 1's proposal for this rule:**
+
+- A fifth skill was needed: `ci-gate-watch`. Two phases wait on CI on an exact SHA, so leaving the
+  Long-Running Gates loop in either one would have duplicated it (routing gap 3 chains into triage,
+  whose exit was also undefined — both are now closed).
+- `publish.md` and `version-management` each carried the same six-step description of what the publish
+  script does. That duplication predates this item; `version-management` now owns it alone.
+- The Korean-language literal OTP prompt string was dropped rather than moved: per-message language
+  matching is owned by `naming-style.md` § Language Policy, so pinning one language in the procedure
+  contradicted its owner. The _halt-for-user_ edge it encoded is preserved in `npm-otp-publish`.
+
+**Deferred, deliberately:** `ci-failure-triager` emits the terminal line `CI TRIAGE: <class> | <repro>` but
+declares no `signal:` frontmatter field, because `CI TRIAGE` is not in `CLOSED_SIGNAL_VOCAB` and adding it
+means editing `scripts/harness/check-agent-def-convention.mjs` — outside this increment's file ownership.
+A later increment should register the token and add the field.
+
+**Not rehearsed:** the version-bump and publish phases cannot be exercised without an actual release.
+`ci-failure-triager` was dispatched on a real red CI run; the rest ships as extracted-but-unrehearsed
+procedure.
+
 ## What
 
 1. ~~**Inventory and classify**~~ **(DONE — see Phase 1 above)** every `.agents/rules/*.md` section as: `invariant` (stays a rule),

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -20,16 +20,16 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 
 ## Process Sub-Rules
 
-| Document                                       | Scope                                                                                                       |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [spec-workflow.md](spec-workflow.md)           | Spec-first development, document authority, structural docs                                                 |
-| [tdd-and-planning.md](tdd-and-planning.md)     | TDD red-green-refactor, planning requirements                                                               |
-| [verification.md](verification.md)             | Build, browser, harness, and pre-push verification gates                                                    |
-| [testing-layering.md](testing-layering.md)     | CLI = thin-wrapper/TUI tests only; feature behaviour = framework functional test                            |
-| [publish.md](publish.md)                       | Single release runbook: publish safety gate, scope approval, release state machine, CI triage, publish flow |
-| [release-operations.md](release-operations.md) | Pointer stub — merged into [publish.md](publish.md)                                                         |
-| [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates                                            |
-| [research.md](research.md)                     | Research-first implementation and recommendation authority                                                  |
-| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user execution test scenario gates, initiative PRs                            |
-| [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation, API boundary & lifecycle                           |
-| [learning-loop.md](learning-loop.md)           | Lesson capture, contract-before-automation, and mechanical enforcement preference                           |
+| Document                                       | Scope                                                                                                      |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [spec-workflow.md](spec-workflow.md)           | Spec-first development, document authority, structural docs                                                |
+| [tdd-and-planning.md](tdd-and-planning.md)     | TDD red-green-refactor, planning requirements                                                              |
+| [verification.md](verification.md)             | Build, browser, harness, and pre-push verification gates                                                   |
+| [testing-layering.md](testing-layering.md)     | CLI = thin-wrapper/TUI tests only; feature behaviour = framework functional test                           |
+| [publish.md](publish.md)                       | Release invariants: publish safety gate, scope approval, OTP prohibitions, stop conditions, triage mandate |
+| [release-operations.md](release-operations.md) | Pointer stub — merged into [publish.md](publish.md)                                                        |
+| [documentation-sync.md](documentation-sync.md) | Document role, package README, and robota.io documentation gates                                           |
+| [research.md](research.md)                     | Research-first implementation and recommendation authority                                                 |
+| [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user execution test scenario gates, initiative PRs                           |
+| [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation, API boundary & lifecycle                          |
+| [learning-loop.md](learning-loop.md)           | Lesson capture, contract-before-automation, and mechanical enforcement preference                          |

--- a/.agents/rules/publish.md
+++ b/.agents/rules/publish.md
@@ -1,15 +1,27 @@
 # Publish & Release Rules
 
-The single release runbook: release-level merges, version bumps, CI triage, publish safety, and npm publishing.
+The release invariants: what must hold during a release-level merge, a version bump, CI triage, and an npm
+publish — and **who owns each fact**.
 Parent: [rules index](index.md) — absorbed `release-operations.md` (now a pointer stub).
 
-Release work is an operation, not an exploratory coding task. It must be run from an explicit state machine with visible gates and stop conditions.
+Release work is an operation, not an exploratory coding task. It runs from an explicit state machine with
+visible gates and stop conditions.
+
+**The ordering is not here.** The release pipeline — which phase runs when, and what each outcome routes to
+— is owned by [`release-orchestration`](../skills/release-orchestration/SKILL.md) and its three phase
+skills ([`source-stabilization`](../skills/source-stabilization/SKILL.md),
+[`version-bump`](../skills/version-bump/SKILL.md),
+[`npm-otp-publish`](../skills/npm-otp-publish/SKILL.md), plus the shared
+[`ci-gate-watch`](../skills/ci-gate-watch/SKILL.md)). The judgement of _why a gate is red_ is owned by the
+[`ci-failure-triager`](../../.claude/agents/ci-failure-triager.md) agent, and _whether a merge landed_ by
+`merge-verifier`. This document states only what must hold, wherever those run.
 
 ## Release Operations
 
 ### Release Control Plane
 
-Before starting a release, main merge, version bump, or npm publish, write a short execution state in the user-visible update stream. Keep it current whenever the state changes.
+Before starting a release, main merge, version bump, or npm publish, an execution state MUST be written in
+the user-visible update stream and kept current whenever the state changes.
 
 The state MUST include:
 
@@ -20,12 +32,13 @@ The state MUST include:
 - next action after the gate passes
 - stop condition if the gate fails or stalls
 
-Do not begin OTP-sensitive work while the release state is unclear. Do not keep a long-running watcher active after the user interrupts the turn.
+Do not begin OTP-sensitive work while the release state is unclear. Do not keep a long-running watcher
+active after the user interrupts the turn.
 
 ### Release-Run Artifact
 
-For release or publish operations, create and keep a version-specific release-run file under
-`.agents/release-runs/`:
+For release or publish operations, a version-specific release-run file MUST exist under
+`.agents/release-runs/`, created with:
 
 ```bash
 pnpm harness:release:init -- --version <version>
@@ -55,33 +68,30 @@ pnpm harness:release:report -- --version <version>
 
 ### Release State Machine
 
-Run release operations in this order unless the user explicitly changes the target:
+The ordered pipeline is owned by [`release-orchestration`](../skills/release-orchestration/SKILL.md); its
+phase boundaries and failure edges are defined there and are not restated here. The constraints that hold
+regardless of how the pipeline is driven:
 
-1. Stabilize the source branch first. Fix CI blockers on task branches and merge them back to the source branch.
-2. Open or update the source-to-main PR. Wait for release-grade CI and compatibility CI on the exact source SHA.
-3. Merge source-to-main only after the release PR is green and release-level merge approval exists.
-4. Create a release bump branch from latest `origin/main`, not from a stale local branch.
-5. Apply the version bump with changesets, then run `pnpm install` if package manifests changed. Never edit `pnpm-lock.yaml` manually.
-6. Regenerate the changelog in the version bump PR: `node scripts/release/generate-release-notes.mjs --write-changelog` (refreshes the generated `Unreleased` section in root `CHANGELOG.md`).
-7. Run local release preparation checks: `pnpm build`, `pnpm harness:scan:publish`, and diff hygiene.
-8. Open a release bump PR to `main`. Wait for the release PR CI on the exact release bump SHA.
-9. Merge the release bump PR only after the release CI is green.
-10. Pull latest `main`, confirm the release version is not already fully published, then run `pnpm publish:beta`.
-11. Ask for OTP only after npm auth and dry-run have succeeded and the publish command is ready for the OTP.
+- Release operations run in the phase order that skill defines, unless the user explicitly changes the target.
+- A release-level merge to a protected branch requires explicit approval ([git-branch.md](git-branch.md)).
+- Create a release bump branch from the latest `origin/main`, never from a stale local branch.
+- Never edit `pnpm-lock.yaml` manually. Run `pnpm install` when package manifests changed.
+- The version bump PR MUST carry a regenerated changelog, produced by
+  `node scripts/release/generate-release-notes.mjs --write-changelog` (REL-022) — never hand-written.
+- Do not mix unrelated process fixes into a version bump PR. If a process defect is found during release,
+  isolate it on a separate branch unless it directly blocks the current release gate.
+- Wait for release-grade and compatibility CI on the **exact** SHA under merge; a green result on an
+  earlier SHA has not verified the current one.
 
-Do not mix unrelated process fixes into a version bump PR. If a process defect is found during release, isolate it on a separate branch unless it directly blocks the current release gate.
+Version-bump mechanics (changesets, the fixed version group, semver classification, dist-tag expectations)
+are owned by [`version-management`](../skills/version-management/SKILL.md).
 
 ### CI Failure Triage
 
-Before changing code to fix a failing release or CI gate, record the failure class and the planned validation path.
-
-Use one of these failure classes:
-
-- product defect
-- test race or flake
-- CI harness infrastructure
-- dependency or lockfile sync
-- external environment or service
+Before changing code to fix a failing release or CI gate, the failure class and the planned validation path
+MUST be recorded. The classification criteria — the closed class vocabulary and how to choose between
+classes — are owned by the [`ci-failure-triager`](../../.claude/agents/ci-failure-triager.md) agent; do not
+restate them here.
 
 The triage note MUST include:
 
@@ -91,51 +101,55 @@ The triage note MUST include:
 - minimal fix recommendation
 - validation command or CI gate that proves the fix
 
-Do not patch by inspection alone when logs are available. Do not treat a pending check as failed without checking the run status and current step.
+Do not patch by inspection alone when logs are available. Do not treat a pending check as failed without
+checking the run status and current step.
 
 ### Long-Running Gates
 
-Every wait must have a reason. For release CI, publish dry-runs, and npm publishes:
+Every wait must have a reason. Stop and triage if a gate exceeds the expected behavior for its current
+step. Report whether the process is queued, building, testing, publishing, or stalled, rather than
+repeating the same status without adding the current step or next decision.
 
-- inspect the current CI job step when a check remains pending beyond a normal short wait
-- report whether the process is queued, building, testing, publishing, or stalled
-- avoid repeating the same status without adding the current step or next decision
-- stop and triage if a gate exceeds the expected behavior for its current step
-
-Long-running release gates should be observed, not hidden behind indefinite `--watch` commands. If a watcher is used, terminate it before switching tasks or after user interruption.
+Long-running release gates are observed, not hidden behind indefinite `--watch` commands. If a watcher is
+used, it MUST be terminated before switching tasks and after user interruption. The observation loop that
+enforces this is [`ci-gate-watch`](../skills/ci-gate-watch/SKILL.md).
 
 ### Dist Artifact Invariant
 
-CI quality jobs that run with `--skip-build` depend on package build output. If the planned checks include `build`, `test`, or `typecheck`, the CI build job MUST run the root monorepo build once and pass package `dist` artifacts to the quality job.
+CI quality jobs that run with `--skip-build` depend on package build output. If the planned checks include
+`build`, `test`, or `typecheck`, the CI build job MUST run the root monorepo build once and pass package
+`dist` artifacts to the quality job.
 
 Never reintroduce per-package CI builds for a monorepo release path. Build once at the root and reuse artifacts.
 
 ## Publish Rules
 
-### Foundation Package Dependency Rule
+### Foundation Package Dependency Consequence
 
-- `agent-core` is the foundation package. It MUST NOT depend on any `@robota-sdk/agent-*` package.
-- Before any publish, verify that `agent-core/package.json` has zero `@robota-sdk/agent-*` entries in `dependencies`.
-- If agent-core needs functionality from another package, that functionality must be moved INTO agent-core or the dependency must be inverted.
-- This rule also applies to any package that is a transitive dependency of agent-core.
-- Violation of this rule blocks publishing — `npm install` will fail with 404 for unpublished upstream packages.
+The dependency-direction rule itself — which package is the foundation and what it may depend on — is owned
+by [`.agents/project-structure.md`](../project-structure.md) ("Layered Assembly Architecture") and
+mechanically enforced by `scripts/harness/check-dependency-direction.mjs`. Do not restate it here.
+
+The publish-specific consequence, which that document does not carry:
+
+- **A dependency-direction violation blocks publishing.** `npm install` fails with 404 for unpublished
+  upstream packages, so the violation surfaces to consumers rather than to CI.
+- Before any publish, `pnpm harness:scan:publish` (`check-publish-safety.mjs`) MUST confirm the foundation
+  package has zero `@robota-sdk/agent-*` entries in `dependencies`. This is a publish gate, not advice.
 
 ### Publish Command (non-negotiable)
 
-- **Always use `pnpm publish:beta`** — this is the ONLY allowed publish command.
-- `pnpm publish:beta` runs `scripts/publish/publish-packages.sh` which:
-  1. Detects version from agent-core/package.json
-  2. Runs `pnpm publish -r --dry-run` (all packages at once, ~4 seconds)
-  3. Prompts for OTP in an interactive TTY (AFTER dry-run so it doesn't expire before publish). In a non-TTY context (Claude Code's Bash tool) this prompt cannot be answered — `--otp`/`--tag-otp` MUST be passed explicitly; see the OTP Protocol below.
-  4. Runs `pnpm publish -r --otp <otp>` (all packages at once, ~4 seconds)
-  5. Syncs `beta` dist-tags for all published packages to the same version
-  6. Verifies both `latest` and `beta` dist-tags point to the published version
+- **Always use `pnpm publish:beta`** — this is the ONLY allowed publish command. What the script does
+  internally is documented once, in [`version-management`](../skills/version-management/SKILL.md).
+- **In a non-TTY context** (Claude Code's Bash tool) the script's interactive OTP prompt cannot be
+  answered — `--otp`/`--tag-otp` MUST be passed explicitly. See the OTP Protocol below.
 - **NEVER** use any of these:
   - `pnpm publish --filter` (sequential per-package = minutes, OTP expires)
   - `pnpm publish` (without -r)
   - `pnpm changeset publish`
   - `npm publish`
-- **No `--tag` flag on publish**: npm automatically sets `latest` to the newly published version. The publish script explicitly syncs and verifies `beta` afterward to prevent dist-tag drift.
+- **No `--tag` flag on publish**: npm automatically sets `latest` to the newly published version. The
+  publish script explicitly syncs and verifies `beta` afterward to prevent dist-tag drift.
 
 ### pnpm publish only — npm publish is blocked (non-negotiable)
 
@@ -159,20 +173,13 @@ Never reintroduce per-package CI builds for a monorepo release path. Build once 
 
 ### OTP Protocol (non-negotiable — no exceptions)
 
-**Claude Code's Bash tool is NOT an interactive TTY.** Running `pnpm publish:beta` without `--otp` causes `read -rp` to fail silently after dry-run and exit before any package is published. The user is left waiting for nothing.
+**Claude Code's Bash tool is NOT an interactive TTY.** Running `pnpm publish:beta` without `--otp` causes
+`read -rp` to fail silently after dry-run and exit before any package is published. The user is left
+waiting for nothing.
 
-**Mandatory sequence — every step must complete before the next:**
-
-1. `pnpm run version` → version bump (the repo script; runs `changeset version`). NOT `pnpm version` (the builtin — performs no changeset bump). Verify the bump produced version + CHANGELOG diffs, then note the new version number.
-2. `pnpm build` exits 0 → build confirmed
-3. `pnpm harness:release:init -- --version <version>` → create release-run file if it does not exist
-4. Update the release-run file: set `Gate status: passed`, `Publish ready: yes`, `NPM auth verified: yes`, `Dry run passed: yes`, `OTP requested: yes`
-5. `pnpm harness:release:check -- --version <version> --publish` passes. **If this fails for any reason, fix it before step 6. Never ask for OTP while this is failing.**
-6. `npm whoami --registry https://registry.npmjs.org/` → auth confirmed. If auth fails: tell the user to log in, wait for confirmation, rerun `npm whoami`, then continue.
-7. `pnpm publish -r --no-git-checks --dry-run` → dry-run passes
-8. **STOP. Ask the user:** "OTP를 입력해주세요 (authenticator 앱에서 확인)" — do NOT run any command yet
-9. User provides OTP in their reply
-10. Immediately run `pnpm publish:beta --otp=<otp> --tag-otp=<otp>` with the OTP from step 9
+The ordered sequence — preflight, the hard halt for the user, and the publish that must immediately follow
+it — is owned by [`npm-otp-publish`](../skills/npm-otp-publish/SKILL.md). Every step of that sequence MUST
+complete before the next begins. The prohibitions below hold however it is driven.
 
 **Violations that are absolutely forbidden:**
 
@@ -213,5 +220,9 @@ Stop the release operation and report state when:
 - npm auth or dry-run fails
 - the target version is already partially published and the publish script cannot reconcile it
 - the working tree is dirty with changes unrelated to the current release state
+
+Each condition above is a terminate edge of
+[`release-orchestration`](../skills/release-orchestration/SKILL.md); the routing lives there, the
+conditions live here.
 
 The final release report MUST list merged PRs, the published version, validation gates, and any skipped or deferred checks.

--- a/.agents/skills/ci-gate-watch/SKILL.md
+++ b/.agents/skills/ci-gate-watch/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ci-gate-watch
+description: Shared sub-orchestration for waiting on a long-running gate (a CI run, a dry-run, a publish) without spinning. Loops observe → report the current job and step → decide, escalating a gate that exceeds the expected behaviour for its current step to ci-failure-triager for the stall verdict, and terminating any watcher it started. It observes and routes only; it never decides why a check is red. Dispatched by any pipeline step that waits on a gate.
+---
+
+# CI Gate Watch — pipeline only
+
+Every wait must have a reason. This skill is the loop that supplies one: it observes a pending gate,
+reports what is actually happening inside it, and routes — rather than repeating "still pending" until
+something changes.
+
+It observes; it does not judge. "Is this stalled or just slow?" is a verdict, and verdicts belong to
+`ci-failure-triager`.
+
+## Rule Anchor
+
+- [publish.md](../../rules/publish.md) — "Long-Running Gates" (the observation invariants and the
+  watcher-cleanup mandate).
+
+## Input
+
+The gate to watch: the run or check name, the exact SHA or version it applies to, and the caller's
+expectation of how long its current step normally takes. Without the expectation there is no way to
+distinguish slow from stalled — ask for it rather than inventing a timeout.
+
+## The loop
+
+Track `observations = 0`.
+
+1. **Observe.** Read the gate's current state: which job, which step, and how long that step has been
+   running. Read the step — not merely the aggregate status, which cannot distinguish queued from stuck.
+2. **Conclusive?** Green → return `GREEN`. Red → return `RED` (the caller dispatches triage; this skill
+   does not).
+3. **Report.** State whether the gate is queued, building, testing, publishing, or unchanging, **and**
+   what the next decision will be. A report identical to the previous one, with no new step or decision,
+   is not a report — if you have nothing new to say, you have nothing to add by waiting again yet.
+4. **Within expectation?** If the current step is still inside its expected behaviour → wait, increment
+   `observations`, and return to step 1.
+5. **Beyond expectation** → dispatch `ci-failure-triager` on the gate for a stall verdict, and return
+   `STALLED` with its class and triage note.
+6. **Cap.** If `observations` exceeds 10 without the step changing, treat it as beyond expectation and
+   take step 5, whatever the stated expectation was. A loop with no bound is a defect even when every
+   individual wait was justified.
+
+## Watcher cleanup (unconditional)
+
+If this loop started any background watcher, terminate it before returning — on **every** exit edge,
+including `RED`, `STALLED`, an exception, and a user interruption. The rule makes an uncleared watcher a
+publish-blocking condition, so leaving one running does not merely litter: it stops a later gate.
+
+## Outcome contract
+
+- `GREEN` — the gate passed on the SHA/version it was asked about.
+- `RED` — the gate failed. The caller dispatches triage; this skill supplies the evidence it observed.
+- `STALLED` — the gate exceeded expectation and `ci-failure-triager` returned a class for the stall.
+
+## What This Skill Does NOT Do
+
+| Not this skill's job               | Owner                                   |
+| ---------------------------------- | --------------------------------------- |
+| Decide why a gate is red or stuck  | `ci-failure-triager` (agent)            |
+| Fix anything, re-run, or push      | the caller's own routing                |
+| Define how long a gate should take | the caller, from the gate's own history |

--- a/.agents/skills/index.md
+++ b/.agents/skills/index.md
@@ -27,6 +27,20 @@ Consult the relevant skill before starting work in its domain. Each entry links 
 | [automated-review-convergence](automated-review-convergence/SKILL.md)       | Iterate on a PR's automated review feedback until it converges: fetch findings → judge → fix/refute → push → re-read the re-run round     |
 | [version-management](version-management/SKILL.md)                           | Coordinated version bumps with changesets across all packages + semver impact of public API surface changes                               |
 
+## Release
+
+Nested release pipeline (HARNESS-049): the top-level orchestrator sequences three phase skills, which
+share one gate-observation loop and dispatch the `ci-failure-triager` / `merge-verifier` agents. All
+release invariants stay in [publish.md](../rules/publish.md); these skills carry only control flow.
+
+| Skill                                                   | Description                                                                                                                       |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [release-orchestration](release-orchestration/SKILL.md) | Top-level release state machine: source-stabilization → version-bump → npm-otp-publish, with per-phase advance/retry/regress/halt |
+| [source-stabilization](source-stabilization/SKILL.md)   | Phase 1 — get the source branch green and verified as landed on the release target                                                |
+| [version-bump](version-bump/SKILL.md)                   | Phase 2 — cut from a fresh base, apply the coordinated bump, land the bump PR cleanly                                             |
+| [npm-otp-publish](npm-otp-publish/SKILL.md)             | Phase 3 — ordered publish preflight, the hard halt for the user's OTP, publish, and post-publish verification                     |
+| [ci-gate-watch](ci-gate-watch/SKILL.md)                 | Shared observation loop for a long-running gate: observe → report the current step → route; terminates its own watcher            |
+
 ## Code Quality & Architecture
 
 | Skill                                                                   | Description                                                                        |
@@ -74,6 +88,7 @@ for orchestrator/worker/guardian wiring). One-line roles:
 | `pr-review-fixer`                  | Applies minimal verified fixes for MUST/SHOULD findings                   |
 | `doc-auditor`                      | Read-only documentation staleness/quality audit                           |
 | `doc-fixer`                        | Applies doc findings (edits docs only, verify-before-write)               |
+| `ci-failure-triager`               | Read-only CI/gate triage: one failure class + the five-field triage note  |
 
 The **agent-definition convention** they follow is a document-type contract in
 [`document-standards/index.md`](../specs/document-standards/index.md), mechanically enforced by

--- a/.agents/skills/npm-otp-publish/SKILL.md
+++ b/.agents/skills/npm-otp-publish/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: npm-otp-publish
+description: Sub-orchestration for phase 3 of a release — the publish boundary. Sequences the strictly-ordered preflight (sync and already-published check, build, state-artifact readiness, publish preflight, registry auth, full dry-run), then the hard halt for the user's one-time password, then the single sanctioned publish command as the very next action, then post-publish verification. Every step must complete before the next; it routes on each outcome and never crosses the boundary early. Holds no publish policy. Dispatched by release-orchestration.
+---
+
+# npm OTP Publish — pipeline only
+
+Phase 3 of a release: everything inside the publish boundary. The ordering **is** the safety property
+here — a one-time password has a short life, so anything that could fail must have already failed before
+the user is asked for one. Every step must complete before the next runs.
+
+This skill owns that ordering and its routing. Which publish command is permitted, which are forbidden,
+what the boundary is, and what may cross it are invariants owned by
+[publish.md](../../rules/publish.md) and are pointed at, never restated.
+
+## Rule Anchor
+
+- [publish.md](../../rules/publish.md) — "Publish Command" (the single allowed command and the forbidden
+  list), "Publish Safety Gate", "OTP Protocol" (the prohibitions), "Publish Boundary", "Publish Scope
+  Approval", "All packages must be published together", "Stop Conditions".
+- [version-management](../version-management/SKILL.md) — dist-tag expectations after a publish.
+
+## Preflight — ordered, each gate blocking
+
+Run in this order. **Nothing below may be reordered, and no step may be skipped because it "usually
+passes".** A failure at any preflight step routes as its row says; none of them proceeds toward the
+password.
+
+| #   | Gate                                                                                                           | On failure                                                                                                                                |
+| --- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Sync to the release target's latest remote head; confirm the target version is **not already fully published** | Already fully published → return `COMPLETE` with that finding (nothing to do). **Partially** published → go to **Partial publish** below. |
+| 2   | Build passes. The agent verifies this; the publish script does not run it                                      | Dispatch `ci-failure-triager`, apply the minimal fix off this branch, then **repeat step 1** — a fix changes the SHA.                     |
+| 3   | The release-run state artifact exists for this version and its publish-readiness fields are set                | Create or update it through the entry point the rule names, then repeat step 3.                                                           |
+| 4   | The publish preflight check on the state artifact passes                                                       | **Fix it here.** Never advance while this is failing — the rule makes asking for a password past a failing preflight a violation.         |
+| 5   | Registry authentication confirmed                                                                              | Tell the user to authenticate, **wait for their confirmation**, re-check, then repeat step 5. Do not run this as the flow's first step.   |
+| 6   | Full, unfiltered dry-run passes                                                                                | Go to **Dry-run failure** below.                                                                                                          |
+
+If any package in scope has never been published, the rule requires explicit user approval before it goes
+out — obtain it during preflight, not after the password is in hand.
+
+## The boundary — hard halt for the user
+
+7. **STOP and ask the user for the one-time password.** Run no command while asking. This is a
+   halt-for-user edge, not a wait: the pipeline has no way to produce this value itself, and the rule
+   forbids asking the user to type it into an interactive prompt.
+
+8. **On receiving it, the publish command is the very next action taken.** Not a status check, not a
+   re-verify, not a `git` call — the password expires in seconds and any intervening command wastes it.
+   Pass it explicitly to the single sanctioned command; the rule names both.
+
+| Outcome                                 | Route                                                                                      |
+| --------------------------------------- | ------------------------------------------------------------------------------------------ |
+| The user declines or does not answer    | Return `HALT`. Leave the state artifact showing the boundary as unreached.                 |
+| Password rejected as expired or invalid | **Return to step 7** and request a fresh one. Bounded: at most **3** requests per release. |
+| Anything ran between steps 7 and 8      | Discard the password, **return to step 7**, and request a fresh one.                       |
+
+## Post-publish verification
+
+9. Confirm every in-scope package is published at the target version and its dist-tags resolve as
+   [version-management](../version-management/SKILL.md) requires. Registry propagation lags, so a
+   mismatch seconds after publish is re-checked per package before it is treated as a failure.
+
+| Outcome                             | Route                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Every package at the target version | Return `COMPLETE`.                                                     |
+| Some packages missing               | Go to **Partial publish**.                                             |
+| Published but a dist-tag is wrong   | Re-run the tag sync, re-verify once, then return `COMPLETE` or `HALT`. |
+
+## Partial publish
+
+The publish script is idempotent: already-published packages are skipped, so recovery is **re-running the
+same script**, never publishing a package by hand — the rule forbids that outright.
+
+1. Classify the interruption with `ci-failure-triager` before retrying (an expired password and a registry
+   outage need different responses, and guessing wastes another password).
+2. Return to **step 7** with a fresh password and re-run. Bounded by the same 3-request cap.
+3. If packages are still missing after the cap, return `HALT` with the exact list of published and
+   unpublished packages — a half-published version is a state the user must be told about explicitly.
+
+## Dry-run failure
+
+A dry-run that exits after printing only a filtered package list has not told you why. Re-run the full
+unfiltered dry-run in the same permission context and read that output before concluding anything. Treat
+registry/network/cache errors as environment failures until proven otherwise, and re-run outside a
+restricted sandbox before classifying them as defects. Then:
+
+| Classified as               | Route                                                                |
+| --------------------------- | -------------------------------------------------------------------- |
+| Environment                 | Repeat step 6 after re-running outside the restriction.              |
+| A real defect               | Dispatch `ci-failure-triager`, fix off-branch, **return to step 1**. |
+| Unresolved after 2 attempts | Return `HALT`.                                                       |
+
+## Outcome contract
+
+- `COMPLETE` — every in-scope package is published at the target version with verified dist-tags.
+- `REGRESSED` — the release target changed under this phase; the caller returns to phase 1.
+- `HALT` — a stop condition fired, a cap was exceeded, or the release is partially published. Name which,
+  and list the exact package state.
+
+This phase never returns `RETRY`: re-entering the publish boundary is always an explicit, bounded,
+password-consuming decision, so the caller must see the reason rather than a silent re-run.

--- a/.agents/skills/npm-otp-publish/SKILL.md
+++ b/.agents/skills/npm-otp-publish/SKILL.md
@@ -29,7 +29,7 @@ password.
 | #   | Gate                                                                                                           | On failure                                                                                                                                |
 | --- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Sync to the release target's latest remote head; confirm the target version is **not already fully published** | Already fully published → return `COMPLETE` with that finding (nothing to do). **Partially** published → go to **Partial publish** below. |
-| 2   | Build passes. The agent verifies this; the publish script does not run it                                      | Dispatch `ci-failure-triager`, apply the minimal fix off this branch, then **repeat step 1** — a fix changes the SHA.                     |
+| 2   | Build passes, verified as the rule's Publish Safety Gate requires                                              | Dispatch `ci-failure-triager`, apply the minimal fix off this branch, then **repeat step 1** — a fix changes the SHA.                     |
 | 3   | The release-run state artifact exists for this version and its publish-readiness fields are set                | Create or update it through the entry point the rule names, then repeat step 3.                                                           |
 | 4   | The publish preflight check on the state artifact passes                                                       | **Fix it here.** Never advance while this is failing — the rule makes asking for a password past a failing preflight a violation.         |
 | 5   | Registry authentication confirmed                                                                              | Tell the user to authenticate, **wait for their confirmation**, re-check, then repeat step 5. Do not run this as the flow's first step.   |
@@ -69,7 +69,7 @@ out — obtain it during preflight, not after the password is in hand.
 ## Partial publish
 
 The publish script is idempotent: already-published packages are skipped, so recovery is **re-running the
-same script**, never publishing a package by hand — the rule forbids that outright.
+same script**, never publishing a package by hand (a Publish Boundary prohibition).
 
 1. Classify the interruption with `ci-failure-triager` before retrying (an expired password and a registry
    outage need different responses, and guessing wastes another password).

--- a/.agents/skills/release-orchestration/SKILL.md
+++ b/.agents/skills/release-orchestration/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: release-orchestration
+description: Top-level orchestrator for a release. Sequences three phases — source-stabilization → version-bump → npm-otp-publish — maintains the release control-plane state artifact across them, and routes on each phase's outcome (advance / repeat / return to an earlier phase / terminate). It holds NO release policy: every command name, gate definition, required field, and prohibition is owned by the project's publish rule and is pointed at, never restated. Use when running a release, a release-level merge, a version bump, or a publish.
+---
+
+# Release Orchestration — pipeline only
+
+The state machine for a release. This skill owns **ordering and routing between phases** and nothing else.
+It does not define what a gate is, what the state artifact must contain, which publish command is allowed,
+or when to stop — those are invariants owned by the rules below, and restating them here would create a
+second copy that drifts.
+
+Where the procedure needs a concrete command, script, artifact path, or branch name, it **points at the
+rule that owns it**. The only names used literally are the pipeline's own structure: the phase skills and
+the agents it dispatches.
+
+## Rule Anchor
+
+- `AGENTS.md` > "Rules and Skills Boundary" — skills are procedure; rules win on conflict.
+- [publish.md](../../rules/publish.md) — the release runbook's invariants: "Release Control Plane"
+  (required state fields), "Release-Run Artifact" (the state artifact and its entry points),
+  "Release State Machine" (phase order and its per-step constraints), "CI Failure Triage" (the triage-note
+  contract), "Long-Running Gates", "Dist Artifact Invariant", "Publish Boundary", "Stop Conditions".
+- [git-branch.md](../../rules/git-branch.md) — branch policy, merge approval, merge landing verification.
+- [enforcement-architecture.md](../../rules/enforcement-architecture.md) — orchestrator / worker / guardian.
+
+## Preconditions (refuse to start otherwise)
+
+1. The release target is explicit: a source branch, a target version, and the user's intent to release.
+2. The working tree is clean of anything unrelated to this release (a Stop Condition in the rule).
+3. The release-run state artifact exists for the target version, created through the entry point the rule
+   names, and reflects the current SHA and branch.
+
+If any precondition fails → **terminate** and report which one. Do not open the pipeline "provisionally":
+the rule forbids beginning gate-sensitive work while the release state is unclear.
+
+## State-artifact duty (runs at every transition, not as a step)
+
+Before entering a phase, when a phase's gate status changes, and immediately after any terminate edge
+fires, update the release-run artifact so it names the active gate, the next action, and the stop
+condition for the phase now running. This is a continuous duty of this orchestrator, not a numbered step
+any phase owns. The artifact's required fields and its update entry points belong to
+[publish.md](../../rules/publish.md) — read them there.
+
+## Phases and routing
+
+| #   | Phase                                                    | Advance when                                                           | On failure                                            |
+| --- | -------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------- |
+| 1   | [source-stabilization](../source-stabilization/SKILL.md) | the source branch has landed on the release target, verified as landed | route per the phase's own edges; it escalates to here |
+| 2   | [version-bump](../version-bump/SKILL.md)                 | the bump has landed on the release target, verified as landed          | route per the phase's own edges                       |
+| 3   | [npm-otp-publish](../npm-otp-publish/SKILL.md)           | every in-scope package is published at the target version              | route per the phase's own edges                       |
+
+Each phase returns one of four outcomes. This orchestrator routes on the outcome and forms no verdict of
+its own:
+
+| Phase outcome | Route                                                                                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `COMPLETE`    | Advance to the next phase. After phase 3, go to **Close-out**.                                                                                                                                    |
+| `RETRY`       | Re-run the same phase. Bounded: **at most 2 re-runs of any one phase per release**. On the third, terminate and hand to the user with the phase's own report.                                     |
+| `REGRESSED`   | Return to **phase 1**. A later phase discovering the source is no longer green (a new merge landed, the base diverged) invalidates stabilization; do not patch forward from inside a later phase. |
+| `HALT`        | **Terminate.** Report the release state, the failing gate, and the stop condition that fired. Do not continue to a later phase, and never skip a phase to recover.                                |
+
+Additional edges that belong to this level:
+
+- **A Stop Condition in [publish.md](../../rules/publish.md) becomes true at any point** → `HALT`
+  immediately, whichever phase is running. Each condition listed there is a terminate edge of this
+  pipeline; they are not restated here.
+- **The user interrupts the turn** → terminate any observation loop a phase left running (the rule's
+  watcher-cleanup invariant), record the interrupted state in the artifact, and stop.
+- **A process defect is discovered mid-release** → do not fold the fix into the release. Record it and
+  continue, unless it directly blocks the currently active gate — in which case treat it as that phase's
+  failure and take the phase's own edge.
+
+## Close-out
+
+After phase 3 reports `COMPLETE`:
+
+1. Update the artifact to its terminal state and clear any watcher it recorded.
+2. Generate the final release report through the entry point [publish.md](../../rules/publish.md) names.
+   Its required contents are that rule's contract — do not compose an ad-hoc summary instead.
+3. Report the outcome to the user. The pipeline ends here; it does not start another release.
+
+## What This Skill Does NOT Do
+
+| Not this skill's job                            | Owner                                                  |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| Decide why a check is red                       | `ci-failure-triager` (agent)                           |
+| Decide whether a merge truly landed             | `merge-verifier` (agent)                               |
+| Sequence the steps inside a phase               | that phase's own skill                                 |
+| Define gates, required fields, allowed commands | [publish.md](../../rules/publish.md)                   |
+| Choose the version or author changesets         | [version-management](../version-management/SKILL.md)   |
+| Merge the release target                        | the user (release-level merge needs explicit approval) |
+
+If you find yourself judging a failure, defining a gate, or running a phase's internal steps here, stop —
+route to the owner instead.

--- a/.agents/skills/source-stabilization/SKILL.md
+++ b/.agents/skills/source-stabilization/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: source-stabilization
+description: Sub-orchestration for phase 1 of a release — getting the source branch green and landed on the release target. Sequences three steps (stabilize the source branch, open/refresh the source-to-target PR and wait for release-grade CI on the exact SHA, merge after green plus explicit approval), dispatching ci-gate-watch, ci-failure-triager, and merge-verifier, and routing on each outcome. Holds no gate definitions and no failure-classification criteria. Dispatched by release-orchestration.
+---
+
+# Source Stabilization — pipeline only
+
+Phase 1 of a release. Its job is narrow: **the source branch is green, and it has demonstrably landed on
+the release target.** Nothing about versions, changesets, or publishing belongs here.
+
+This skill owns ordering and routing. Every constraint it invokes — which branches may open a PR against
+which target, when a release-level merge is allowed, what a triage note must contain — is owned by the
+rules below and is pointed at, not restated.
+
+## Rule Anchor
+
+- [publish.md](../../rules/publish.md) — "Release State Machine" (this phase's per-step constraints),
+  "CI Failure Triage" (the triage-note contract), "Long-Running Gates", "Stop Conditions".
+- [git-branch.md](../../rules/git-branch.md) — protected branches, allowed PR sources, release-level merge
+  approval, "Merge Landing Verification".
+
+## Steps and routing
+
+**1. Stabilize the source branch.** Identify every CI blocker on the task branches feeding the source
+branch, resolve them there, and merge them back into the source branch.
+
+| Outcome                                        | Route                                                                                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| No blockers remain                             | Advance to step 2.                                                                                                                          |
+| A blocker exists                               | Dispatch `ci-failure-triager` on it **before changing any code** (the rule's ordering invariant). Then take the triage routing table below. |
+| A blocker needs a decision only the user makes | Return `HALT` to the caller.                                                                                                                |
+
+**2. Open or refresh the source-to-target PR, and wait for release-grade CI on the exact SHA.** The SHA
+matters: a check that passed on an earlier SHA has not verified this one.
+
+| Outcome                                          | Route                                                                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Checks not yet conclusive                        | Dispatch [ci-gate-watch](../ci-gate-watch/SKILL.md) and route on **its** outcome.    |
+| All required checks green **on the exact SHA**   | Advance to step 3.                                                                   |
+| A required check red                             | Dispatch `ci-failure-triager`; take the triage routing table below.                  |
+| New commits landed on the source branch mid-wait | **Return to step 2** against the new SHA — never carry an older SHA's green forward. |
+
+**3. Merge the source branch into the release target, then verify it landed.** The merge requires the
+explicit approval [git-branch.md](../../rules/git-branch.md) mandates; this pipeline never substitutes its
+own judgement for it.
+
+| Outcome                                                     | Route                                                                                                                                                                                                                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Approval not given                                          | Return `HALT` — the phase is complete only when the merge has landed.                                                                                                                                                                                                            |
+| Merged → dispatch `merge-verifier` → `MERGE VERIFIED: PASS` | Return `COMPLETE`.                                                                                                                                                                                                                                                               |
+| `merge-verifier` reports `MERGE VERIFIED: FAIL`             | Do **not** re-merge blindly. Take the verifier's finding: if the merge is absent on the target's remote head, **return to step 3**; if a claimed change is missing or unrelated drift landed, return `HALT` — a bad merge on a protected target is a user decision, not a retry. |
+
+## Triage routing (steps 1 and 2)
+
+`ci-failure-triager` returns a class and a validation path; this pipeline routes on them and does not
+re-judge. Track `triage_attempts` per distinct failure signature, cap **2**.
+
+| Class returned                                                                 | Route                                                                                                                               |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `product defect` / `CI harness infrastructure` / `dependency or lockfile sync` | Apply the minimal fix on a task branch, run the triager's stated validation path, then **return to step 1**.                        |
+| `test race or flake`                                                           | Re-run the failing check once. Green → return to the step that dispatched the triage. Red again → treat as `product defect`.        |
+| `external environment or service`                                              | Re-run after the interval the triage note recommends, at most twice, then return `HALT`. Never patch code for an environment class. |
+| The validation path does **not** pass after the fix                            | Re-triage with the new signature and increment `triage_attempts`.                                                                   |
+| `triage_attempts` exceeds the cap for one signature                            | Return `HALT` — repeated failed validation means the classification is wrong, and looping cannot discover that.                     |
+
+## Outcome contract
+
+Return exactly one to the caller, with the evidence behind it:
+
+- `COMPLETE` — the source branch is merged and independently verified as landed on the release target.
+- `RETRY` — a transient condition cleared and the whole phase should re-run from step 1.
+- `HALT` — a stop condition fired, approval is missing, or a cap was exceeded. Name which.
+
+This phase never returns `REGRESSED`: it _is_ the phase a regression returns to.

--- a/.agents/skills/version-bump/SKILL.md
+++ b/.agents/skills/version-bump/SKILL.md
@@ -28,8 +28,7 @@ the failure this step exists to prevent.
 | The remote head does not contain phase 1's merge | Return `REGRESSED` — stabilization did not land what it claimed; do not bump on top of it. |
 
 **2. Apply the version bump.** Dispatch [version-management](../version-management/SKILL.md). When package
-manifests change, run the project's install so the lockfile is regenerated — never hand-edit it (the
-rule's invariant).
+manifests change, run the project's install so the lockfile is regenerated — never hand-edit it.
 
 | Outcome                                              | Route                                                                                                                  |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
@@ -53,7 +52,7 @@ branch contains the bump and nothing else).
 | All clean                                            | Advance to step 5.                                                                                                                                                                           |
 | Build or the publish-safety scan fails               | Dispatch `ci-failure-triager`; take the triage routing table below.                                                                                                                          |
 | Diff hygiene fails on **lockfile churn from step 2** | This is expected output of the bump, not contamination: confirm it is exactly the install's regeneration, keep it, advance. If it is anything more, **return to step 1** and re-cut cleanly. |
-| Diff hygiene fails on **unrelated changes**          | Remove them from this branch (the rule forbids mixing process fixes into a bump PR) and **repeat step 4**. If they cannot be separated, **return to step 1**.                                |
+| Diff hygiene fails on **unrelated changes**          | Remove them from this branch (a Release State Machine constraint) and **repeat step 4**. If they cannot be separated, **return to step 1**.                                                  |
 
 **5. Open the bump PR against the release target and wait for CI on the exact SHA.**
 

--- a/.agents/skills/version-bump/SKILL.md
+++ b/.agents/skills/version-bump/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: version-bump
+description: Sub-orchestration for phase 2 of a release — cutting the bump branch from the freshly-fetched release target, applying the coordinated version bump, regenerating the changelog, running local release preparation, and landing the bump PR. Sequences six steps, dispatching version-management for the bump itself plus ci-gate-watch, ci-failure-triager, and merge-verifier, and routes on each outcome including the lockfile/diff-hygiene edge. Holds no versioning policy. Dispatched by release-orchestration.
+---
+
+# Version Bump — pipeline only
+
+Phase 2 of a release. Its job: **the target version exists on the release target, cleanly.** How versions
+are chosen, how the bump tool is driven, and what a coordinated bump means are owned by
+[version-management](../version-management/SKILL.md) — this skill dispatches it and routes on the result.
+
+## Rule Anchor
+
+- [publish.md](../../rules/publish.md) — "Release State Machine" (this phase's per-step constraints: fresh
+  base, never hand-edit the lockfile, no unrelated process fixes in a bump PR), "Stop Conditions".
+- [version-management](../version-management/SKILL.md) — all versioning policy and the bump mechanics.
+- [git-branch.md](../../rules/git-branch.md) — branch base freshness, "Merge Landing Verification".
+
+## Steps and routing
+
+**1. Cut the bump branch from the freshly-fetched release target.** Fetch first; a stale local branch is
+the failure this step exists to prevent.
+
+| Outcome                                          | Route                                                                                      |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Branch cut from the current remote head          | Advance to step 2.                                                                         |
+| The remote head moved after the fetch            | **Repeat step 1** against the new head.                                                    |
+| The remote head does not contain phase 1's merge | Return `REGRESSED` — stabilization did not land what it claimed; do not bump on top of it. |
+
+**2. Apply the version bump.** Dispatch [version-management](../version-management/SKILL.md). When package
+manifests change, run the project's install so the lockfile is regenerated — never hand-edit it (the
+rule's invariant).
+
+| Outcome                                              | Route                                                                                                                  |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Bump produced the expected version + changelog diffs | Advance to step 3.                                                                                                     |
+| The bump produced no diff                            | **Repeat step 2** after confirming the correct bump entry point was used; if it still produces nothing, return `HALT`. |
+| A changeset is missing for a changed package         | **Repeat step 2** after adding it — an incomplete changelog is a defect, not a cosmetic issue.                         |
+
+**3. Regenerate the changelog** through the generator [publish.md](../../rules/publish.md) names. The rule
+requires the bump PR to carry a generated changelog; a hand-written one does not satisfy it.
+
+| Outcome                                    | Route                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Regenerated, and the diff matches the bump | Advance to step 4.                                                                   |
+| The generator produced nothing or errored  | **Repeat step 2** — an empty changelog usually means the bump itself was incomplete. |
+
+**4. Run local release preparation.** Build, the project's publish-safety scan, and diff hygiene (the
+branch contains the bump and nothing else).
+
+| Outcome                                              | Route                                                                                                                                                                                        |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| All clean                                            | Advance to step 5.                                                                                                                                                                           |
+| Build or the publish-safety scan fails               | Dispatch `ci-failure-triager`; take the triage routing table below.                                                                                                                          |
+| Diff hygiene fails on **lockfile churn from step 2** | This is expected output of the bump, not contamination: confirm it is exactly the install's regeneration, keep it, advance. If it is anything more, **return to step 1** and re-cut cleanly. |
+| Diff hygiene fails on **unrelated changes**          | Remove them from this branch (the rule forbids mixing process fixes into a bump PR) and **repeat step 4**. If they cannot be separated, **return to step 1**.                                |
+
+**5. Open the bump PR against the release target and wait for CI on the exact SHA.**
+
+| Outcome                               | Route                                                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------- |
+| Checks not yet conclusive             | Dispatch [ci-gate-watch](../ci-gate-watch/SKILL.md) and route on **its** outcome. |
+| Green on the exact SHA                | Advance to step 6.                                                                |
+| Red                                   | Dispatch `ci-failure-triager`; take the triage routing table below.               |
+| The release target moved under the PR | **Return to step 1** — re-cut from the new head rather than merging a stale base. |
+
+**6. Merge the bump PR, then verify it landed.** Merge only on green, with the approval
+[git-branch.md](../../rules/git-branch.md) requires.
+
+| Outcome                                                  | Route                                                                                                     |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Merged → `merge-verifier` returns `MERGE VERIFIED: PASS` | Return `COMPLETE`.                                                                                        |
+| `merge-verifier` returns `MERGE VERIFIED: FAIL`          | Merge absent on the remote head → **return to step 6**. Version files missing or drift swept in → `HALT`. |
+| Approval not given                                       | Return `HALT`.                                                                                            |
+
+## Triage routing (steps 4 and 5)
+
+Identical shape to phase 1's, because the routing belongs to the failure class rather than the phase.
+Track `triage_attempts` per distinct failure signature, cap **2**.
+
+| Class returned                                      | Route                                                                                               |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `product defect` / `CI harness infrastructure`      | Fix it **off this branch** (the bump PR stays pure), land it, then **return to step 1**.            |
+| `dependency or lockfile sync`                       | Re-run the install on this branch and **repeat step 4** — this class is in-scope for a bump branch. |
+| `test race or flake`                                | Re-run once. Green → return to the dispatching step. Red again → treat as `product defect`.         |
+| `external environment or service`                   | Re-run after the recommended interval, at most twice, then `HALT`.                                  |
+| Validation path does not pass after the fix         | Re-triage with the new signature; increment `triage_attempts`.                                      |
+| `triage_attempts` exceeds the cap for one signature | Return `HALT`.                                                                                      |
+
+## Outcome contract
+
+- `COMPLETE` — the target version is on the release target and independently verified as landed.
+- `RETRY` — re-run the phase from step 1.
+- `REGRESSED` — the release target no longer contains what phase 1 landed; the caller returns to phase 1.
+- `HALT` — a stop condition fired, approval is missing, or a cap was exceeded. Name which.

--- a/.agents/specs/orchestration-map.md
+++ b/.agents/specs/orchestration-map.md
@@ -54,16 +54,31 @@ flowchart TD
     PRF -. auto-loop → 0, bounded .-> PRO
     PRO --> MV[merge-verifier<br/>guardian · MERGE VERIFIED]
   end
+  subgraph Release["Release (HARNESS-049)"]
+    RO[release-orchestration<br/>orchestrator] --> SS[source-stabilization<br/>orchestrator · phase 1]
+    RO --> VB[version-bump<br/>orchestrator · phase 2]
+    RO --> NOP[npm-otp-publish<br/>orchestrator · phase 3]
+    SS --> CGW[ci-gate-watch<br/>orchestrator · shared]
+    VB --> CGW
+    CGW --> CFT[ci-failure-triager<br/>guardian · CI TRIAGE]
+    SS --> CFT
+    VB --> CFT
+    NOP --> CFT
+    SS --> MV
+    VB --> MV
+    NOP -. halt-for-user OTP .-> RO
+  end
 ```
 
-| Pipeline                    | Orchestrator (skill)                     | Worker(s)                                                     | Guardian(s) → signal                                                             | Loop-back                                      | Floor (scan/hook)                                                     |
-| --------------------------- | ---------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
-| **Spec-gate**               | `user-request-gate` → `backlog-pipeline` | `backlog-writer`, `prior-art-researcher` (PRIOR_ART_RESEARCH) | `backlog-gate-guard` → PASS/FAIL/NON-COMPLIANCE                                  | halt-for-user                                  | spec-doc-frontmatter, spec-research, backlog-placement, done-evidence |
-| **Architecture refresh**    | `architecture-refresh`                   | `architecture-fixer`, `architecture-implementer`              | `architecture-auditor`, `architecture-conformance-auditor` → ACTIONABLE FINDINGS | auto → 0                                       | conformance, check-architecture-conformance                           |
-| **Documentation refresh**   | `documentation-refresh`                  | `doc-fixer`                                                   | `doc-auditor` → ACTIONABLE FINDINGS                                              | auto → 0                                       | doc-examples, docs-structure                                          |
-| **Capability extraction**   | `capability-extraction`                  | `capability-scout` (DECOMPOSITION), `agent-skill-author`      | `proposal-reviewer` → REVIEW VERDICT                                             | gated on ENDORSE                               | agent-def-convention                                                  |
-| **PR review** (HARNESS-018) | `pr-review-orchestration`                | `pr-review-writer`, `pr-review-fixer`                         | `pr-review-reviewer` → ACTIONABLE FINDINGS; `merge-verifier` → MERGE VERIFIED    | auto → 0, bounded (max 3 + progress detection) | scan-review-findings (018e, pending)                                  |
-| **Backlog execution**       | `backlog-execution-orchestrator`         | (impl agents)                                                 | recommendation + user-execution-scenario gates                                   | halt-for-user                                  | done-evidence, backlog-placement                                      |
+| Pipeline                    | Orchestrator (skill)                                                                                           | Worker(s)                                                     | Guardian(s) → signal                                                             | Loop-back                                                                                                    | Floor (scan/hook)                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| **Spec-gate**               | `user-request-gate` → `backlog-pipeline`                                                                       | `backlog-writer`, `prior-art-researcher` (PRIOR_ART_RESEARCH) | `backlog-gate-guard` → PASS/FAIL/NON-COMPLIANCE                                  | halt-for-user                                                                                                | spec-doc-frontmatter, spec-research, backlog-placement, done-evidence |
+| **Architecture refresh**    | `architecture-refresh`                                                                                         | `architecture-fixer`, `architecture-implementer`              | `architecture-auditor`, `architecture-conformance-auditor` → ACTIONABLE FINDINGS | auto → 0                                                                                                     | conformance, check-architecture-conformance                           |
+| **Documentation refresh**   | `documentation-refresh`                                                                                        | `doc-fixer`                                                   | `doc-auditor` → ACTIONABLE FINDINGS                                              | auto → 0                                                                                                     | doc-examples, docs-structure                                          |
+| **Capability extraction**   | `capability-extraction`                                                                                        | `capability-scout` (DECOMPOSITION), `agent-skill-author`      | `proposal-reviewer` → REVIEW VERDICT                                             | gated on ENDORSE                                                                                             | agent-def-convention                                                  |
+| **PR review** (HARNESS-018) | `pr-review-orchestration`                                                                                      | `pr-review-writer`, `pr-review-fixer`                         | `pr-review-reviewer` → ACTIONABLE FINDINGS; `merge-verifier` → MERGE VERIFIED    | auto → 0, bounded (max 3 + progress detection)                                                               | scan-review-findings (018e, pending)                                  |
+| **Backlog execution**       | `backlog-execution-orchestrator`                                                                               | (impl agents)                                                 | recommendation + user-execution-scenario gates                                   | halt-for-user                                                                                                | done-evidence, backlog-placement                                      |
+| **Release** (HARNESS-049)   | `release-orchestration` → `source-stabilization` / `version-bump` / `npm-otp-publish`, sharing `ci-gate-watch` | (release actions run in the phase skills)                     | `ci-failure-triager` → CI TRIAGE; `merge-verifier` → MERGE VERIFIED              | auto → bounded (2 re-runs/phase, 2 triages/signature, 3 OTP requests); halt-for-user at the publish boundary | release-governance, publish-safety, release-run `--publish` check     |
 
 ## Agent roster
 
@@ -85,6 +100,12 @@ Every agent below MUST appear in this map (enforced by `scan-orchestration-map.m
 | `agent-skill-author`               | worker (edit)      | —                   | edit            |
 | `pr-review-fixer`                  | worker (edit)      | —                   | edit            |
 | `pr-review-writer`                 | worker (post)      | —                   | Read, Bash (gh) |
+| `ci-failure-triager`               | guardian           | CI TRIAGE (†)       | read-only       |
+
+† `CI TRIAGE` is the agent's terminal output line but is **not yet in `CLOSED_SIGNAL_VOCAB`**, so the
+agent deliberately declares no `signal:` frontmatter field (declaring an unregistered token fails the
+`agent-def-convention` guard). Registering it requires editing `check-agent-def-convention.mjs`, which was
+out of scope for the increment that introduced the agent — tracked in `HARNESS-049`.
 
 ## How to change the structure
 

--- a/.claude/agents/ci-failure-triager.md
+++ b/.claude/agents/ci-failure-triager.md
@@ -1,0 +1,84 @@
+---
+name: ci-failure-triager
+description: Independent, read-only triager of a RED continuous-integration check or a stalled gate. Given a failing (or suspiciously pending) check on a branch/PR, it reads the actual run logs, classifies the failure into exactly one class from a closed vocabulary, and returns a triage note — failure signature, local reproduction status, owning layer or file, minimal fix recommendation, and the validation command or gate that would prove the fix. It JUDGES ONLY: it does not edit code, push, re-run CI, or apply the fix it recommends. Universal/neutral — portable to any repo with a CI system whose logs can be read from a CLI. Use before any code change is made to fix a failing gate.
+tools: Read, Grep, Glob, Bash
+---
+
+## Working-tree safety (read-only)
+
+You are READ-ONLY. **Never run tree-mutating git in the working tree** — no `reset`, `checkout`, `clean`,
+`stash`, `rm`, `commit`, `push`, or `apply`. A release branch under triage frequently has uncommitted work in
+it; a stray `git reset --hard` / `git checkout` destroys it. To inspect another commit or branch use
+`git show` / `git diff` / `git log` against refs, or an isolated `git worktree add <tmp>` you remove afterward.
+
+# CI Failure Triager
+
+Your one job: **say what kind of failure this is, and what would prove it fixed** — before anyone changes a
+line of code. A red check is not a defect until you have named which defect it is. You classify and
+recommend; you never fix.
+
+## Read the logs first — always
+
+Patching by inspection is the failure this role exists to prevent. Before classifying:
+
+- Fetch the **actual run output** for the failing job and step (the CI CLI's log/view commands, the run
+  URL, or the job's raw log). Quote the real failing line, not a paraphrase.
+- If a check is **pending rather than failed**, read its current job and step before calling it anything.
+  A queued or building check is not a failure; a step that has produced no output far beyond its normal
+  duration is a stall, and a stall IS in scope for you.
+- When logs are genuinely unavailable, say so explicitly and mark local reproduction `unavailable` — do
+  not invent a cause to fill the field.
+
+## Classify into exactly one class
+
+The closed vocabulary. Pick the single best fit; if two look equally plausible, say which evidence would
+discriminate them and pick the one the evidence currently favours.
+
+| Class                               | Signature that points here                                                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **product defect**                  | The code under test is wrong. Reproduces locally on the same ref, deterministically. Owning layer is a source file.                              |
+| **test race or flake**              | Passes on re-run or locally without a code change; timing/ordering/shared-state signature; unstable across identical refs.                       |
+| **CI harness infrastructure**       | The check's own machinery is wrong — a scan, workflow, cache key, artifact wiring, or a gate that is green locally but red only in the pipeline. |
+| **dependency or lockfile sync**     | Manifest and lockfile disagree, a resolution changed, an install/audit step fails, or a build fails on a package boundary rather than its logic. |
+| **external environment or service** | Registry/network/DNS/rate-limit/runner-image failures; nothing in the repository would change the outcome.                                       |
+
+Discriminating questions worth answering explicitly: does it reproduce on the same SHA locally? Does it
+reproduce on the parent commit (if yes, the change under review did not cause it)? Is the failing step
+inside the product's code or inside the pipeline's own plumbing? Was anything about the environment
+different between the last green run and this one?
+
+## The triage note (required fields — all five)
+
+The note's required contents are a contract owned by the project's release rules; you produce every field:
+
+1. **Failure signature** — the exact quoted line(s) from the log that identify this failure, plus the job
+   and step they came from.
+2. **Local reproduction status** — `reproduced` / `not reproduced` / `unavailable`, with the command you
+   ran and its result. "Did not try" is not a value; either try or say why you could not.
+3. **Owning layer or file** — the concrete file, package, workflow, or external service responsible.
+4. **Minimal fix recommendation** — the smallest change that addresses the classified cause. If the class
+   is `external environment or service`, the recommendation may legitimately be "re-run, do not change
+   code" — say so plainly rather than inventing a patch.
+5. **Validation command or gate** — the exact command or named CI check that, when it passes, proves this
+   fix. It must be able to fail: a validation that cannot distinguish fixed from unfixed is not one.
+
+## What is NOT your job
+
+Do not edit files, commit, push, re-run CI, merge, or apply your own recommendation. Do not decide what
+the pipeline does next — whether to retry, roll back, or halt is the orchestrator's call on your verdict.
+Do not widen scope: triage the failure you were given, and note adjacent failures separately rather than
+folding them in. If you were given no failing check, or cannot identify one, say what you need instead of
+guessing.
+
+## Output contract
+
+Return a triage report (no mutations):
+
+- **Subject** — the branch/PR, the exact SHA, and the failing or stalled check name.
+- **Evidence** — the log excerpts you read, with their job/step.
+- **Class** — exactly one class from the table above, with the reasoning that selected it over the nearest
+  alternative.
+- **Triage note** — all five required fields, each filled.
+- **Confidence** — `high` / `medium` / `low`, and what would raise it.
+- End with the exact line `CI TRIAGE: <class> | <reproduced|not-reproduced|unavailable>` so the calling
+  pipeline can route on it mechanically without re-reading your prose.


### PR DESCRIPTION
## HARNESS-049 phase 2, increment 1 — `publish.md`

Extracts the release procedure out of `.agents/rules/publish.md` into a nested orchestration pipeline,
per [`harness-composition-design.md`](../blob/develop/.agents/specs/harness-composition-design.md). **One
rule only** — the other three large rules are untouched, as the item mandates.

`publish.md` keeps every invariant. What left is the *ordering*: 11 Release State Machine steps, the
10-step OTP sequence, the gate-observation cadence, and the failure-class vocabulary.

### The tree actually built

```
release-orchestration        (NEW top-level)   ← Release State Machine, phase sequencing + routing
├─ source-stabilization      (NEW phase)       ← steps 1–3
│    ├─ ci-gate-watch        (NEW, shared)
│    ├─ ci-failure-triager   (NEW agent)
│    └─ merge-verifier       (existing agent, reused unchanged)
├─ version-bump              (NEW phase)       ← steps 4–9
│    ├─ version-management   (existing skill, reused unchanged)
│    ├─ ci-gate-watch / ci-failure-triager / merge-verifier
├─ npm-otp-publish           (NEW phase)       ← steps 10–11 + the OTP Protocol
│    └─ ci-failure-triager
└─ ci-gate-watch             (NEW, shared)     ← Long-Running Gates
```

**Match against phase 1's hypothesis: confirmed, with one addition.** The three phases and their step
ranges (1–3 / 4–9 / 10–11) are exactly as
[`harness-composition-inventory.md` §5.1](../blob/develop/.agents/specs/harness-composition-inventory.md)
predicted, and `ci-failure-triager` is the one net-new agent it called for. The addition is a **fifth
skill, `ci-gate-watch`**: two phases wait on CI on an exact SHA, so leaving the Long-Running Gates loop
inside either one would have duplicated it. It also closes routing gap 3, whose exit chained into a
triage whose own exit was undefined.

### Routing gaps filled (decisions, not inheritance)

The rule never said what happens on failure. These edges were **decided here** and are stated as such:

| Gap (phase 1 §6)                | Decision                                                                                                                                     |
| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
| State machine steps 1–11        | Every step has a named failure edge. Phases return `COMPLETE` / `RETRY` / `REGRESSED` / `HALT`; the top level routes on it.                   |
| CI Failure Triage has no exit   | Routing is by **class**: defect/infra/lockfile → fix + revalidate + return to step 1; flake → one re-run then treat as defect; environment → bounded re-run, never a code change. Cap **2 triages per failure signature**, then `HALT`. |
| Long-Running Gates chains       | `ci-gate-watch` returns `GREEN`/`RED`/`STALLED`; stall dispatches the triager. Cap **10 unchanged observations**. Watcher cleanup on *every* exit edge. |
| OTP step 10 partial publish     | Classify first, then re-run the idempotent script with a fresh OTP; cap **3 OTP requests**; a still-partial state is a `HALT` with the exact published/unpublished package list. |
| Version bump step 5 lockfile    | Lockfile churn produced by the bump's own install is expected output and advances; anything more re-cuts the branch from a fresh base.        |
| Phase re-run bound              | **2 re-runs of any one phase per release**, then terminate to the user.                                                                      |

A later phase finding the source no longer green returns `REGRESSED` to phase 1 rather than patching
forward — the backward edge the design doc calls normal control flow.

### Invariant ledger — every mandatory statement in `publish.md` and its post-change home

All 39 ledger rows plus one the ledger missed. **Zero dropped.** Verified mechanically (a string check
per row against the post-change files), not by eye.

| ID    | Invariant                                                             | Post-change home                                                        |
| ----- | --------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| PB-01 | Release state written and kept current before any release op          | **stays** (mandate) + duty in `release-orchestration`                   |
| PB-02 | The state MUST include all six listed fields                          | **stays** — artifact contract, verbatim                                 |
| PB-03 | No OTP-sensitive work while the release state is unclear              | **stays**                                                               |
| PB-04 | A version-specific release-run file must exist                        | **stays**                                                               |
| PB-05 | The `--publish` check must pass before publish                        | **stays** (also a gate in `npm-otp-publish` step 4)                     |
| PB-06 | CI-fix work must append a triage note before code changes             | **stays**                                                               |
| PB-07 | Release ops run in the stated order unless the user changes the target | **`release-orchestration`** (+ pointer from the rule)                   |
| PB-08 | Never hand-edit the lockfile; install when manifests change           | **stays**                                                               |
| PB-09 | Bump branch from the latest remote head, not a stale local branch     | **stays**                                                               |
| PB-10 | No unrelated process fixes in a version-bump PR                       | **stays**                                                               |
| PB-11 | Record the failure class + validation path before changing code       | **stays** (mandate); criteria → `ci-failure-triager`                    |
| PB-12 | The triage note MUST include all five listed fields                   | **stays** (contract) + output contract of `ci-failure-triager`          |
| PB-13 | No patching by inspection; a pending check is not a failed check      | **stays**                                                               |
| PB-14 | Every wait has a reason; stop and triage past expectation             | **stays** (mandate); loop → `ci-gate-watch`                             |
| PB-15 | Terminate watchers before switching tasks / after interrupt           | **stays** (mandate); unconditional cleanup edge in `ci-gate-watch`      |
| PB-16 | Build once at the root; never per-package CI builds                   | **stays**                                                               |
| PB-17 | Foundation dependency violation blocks publishing                     | **stays, de-duplicated** — see below                                    |
| PB-18 | Always the single sanctioned publish command                          | **stays**                                                               |
| PB-19 | Never `--filter`, bare publish, `changeset publish`, or `npm publish` | **stays**                                                               |
| PB-20 | No `--tag` flag on publish                                            | **stays**                                                               |
| PB-21 | All publishes via `pnpm publish`; the runtime guard is a net          | **stays**                                                               |
| PB-22 | All non-private packages together; never cherry-pick                  | **stays**                                                               |
| PB-23 | Any package-directory change needs a changeset, bump, publish         | **stays**                                                               |
| PB-24 | Control plane identifies SHA/version/gate/next/stop before publish    | **stays**                                                               |
| PB-25 | Build must pass before dry-run; the agent verifies it                 | **stays** (also `npm-otp-publish` step 2)                               |
| PB-26 | First publish → remove "not yet published" references                 | **stays**                                                               |
| PB-27 | Every OTP step must complete before the next                          | **`npm-otp-publish`** (+ the mandate restated as a pointer in the rule) |
| PB-28 | Never ask for OTP before the release-run check passes                 | **stays** — forbidden list, verbatim                                    |
| PB-29 | Never publish without `--otp`, before receiving it, or after another command | **stays** — forbidden list, verbatim                              |
| PB-30 | Never ask the user to type the OTP at an interactive prompt           | **stays**                                                               |
| PB-31 | Do not run the auth check first                                       | **stays** (and `npm-otp-publish` orders auth at gate 5, not gate 1)     |
| PB-32 | Never infer a publish failure from filtered dry-run output            | **stays**                                                               |
| PB-33 | Sandbox/network/cache errors are environment failures until confirmed | **stays**                                                               |
| PB-34 | The publish command is the boundary; OTP only after dry-run inside it | **stays**                                                               |
| PB-35 | Stop before OTP when the release-run is missing/pending/failed/watched | **stays**                                                              |
| PB-36 | Classify first; retry only missing packages via the script            | **stays** (routing → `npm-otp-publish` § Partial publish)               |
| PB-37 | `private: true` never published; first publish needs approval         | **stays**                                                               |
| PB-38 | Each of the six stop conditions halts the release                     | **stays** (conditions); terminate-edges reference them, never restate   |
| PB-39 | The final release report MUST list PRs, version, gates, deferrals     | **stays** — artifact contract                                           |
| ★     | The bump PR MUST carry a **regenerated** changelog (REL-022)          | **stays** (new bullet) + step 3 of `version-bump`                       |

**★ is a real catch.** Phase 1's ledger has 39 rows for `publish.md` and omits this one — the REL-022
changelog-regeneration step (state machine step 6) is a "MUST" that the ledger does not list. It was
nearly dropped in this PR; it is restored as an explicit invariant and given a home. **Phase 1's
`publish.md` ledger is 40 statements, not 39** — worth checking whether the same undercount affects the
other three rules before their increments run.

Per §9 item 2, the six Stop Conditions are *referenced* as terminate edges rather than copied into the
skill, so the "knowingly duplicated fact" phase 1 flagged does not actually get duplicated.

### The duplicated dependency rule — resolved

Phase 1 flagged `publish.md` § Foundation Package Dependency Rule as a **third** copy. The three were:

1. `.agents/project-structure.md` § Layered Assembly Architecture — the **declared owner** (`AGENTS.md`
   routes "Package Dependencies" there), enforced by `check-dependency-direction.mjs` rule 3.
2. `.agents/rules/common-mistakes.md` #13 — a catalogue entry, which the inventory says stays.
3. `publish.md` — the copy removed here.

The section now carries **only** what the owner does not have: that a violation is *publish-blocking*
(consumers hit a 404 on install, so it never surfaces in CI), and that `check-publish-safety.mjs` must
confirm it before any publish. The rule itself is pointed at, not restated. Owner was unambiguous, so no
report-and-stop was needed.

### Rehearsal — what was and was not exercised

**Exercised:** `ci-failure-triager` was dispatched against a **real red CI run** (run `30162352938`,
workflow "CI", PR #1415). It read the actual logs, produced all five triage-note fields, and returned
`CI TRIAGE: CI harness infrastructure | not-reproduced`. It correctly identified the cause as the
depth-50 base fetch in `ci.yml` grafting ancestry so commitlint re-linted 13 already-merged commits,
proved it by showing a flagged commit is an ancestor of the base and that the same command exits 0
locally, and recommended re-running rather than rewriting history — noting the fix is already merged as
INFRA-049 (`cbb1558cd`). It also flagged the sibling run as a *different* class without folding it in.
(The agent type is not loadable mid-session, so it ran as a general-purpose agent instructed to read and
adopt the new definition file verbatim.)

**Not rehearsed, honestly:** `version-bump` and `npm-otp-publish` cannot be exercised without an actual
release — no version bump, no OTP, no publish happened. Those two phases ship as extracted-but-unrehearsed
procedure: no worse than their previous unrehearsed prose state, but no better verified. `ci-gate-watch`
was exercised only indirectly (the triager read a completed run, not a pending one).

### Deferred, deliberately

`ci-failure-triager` emits the terminal line `CI TRIAGE: <class> | <repro>` but declares **no `signal:`
frontmatter field**: `CI TRIAGE` is not in `CLOSED_SIGNAL_VOCAB`, and registering it means editing
`scripts/harness/check-agent-def-convention.mjs`, which is outside this increment's file ownership.
Declaring an unregistered token fails the guard, and reusing a semantically wrong existing token would be
worse. Recorded in the orchestration map with a footnote and in the backlog.

### Scope deviation to report

`.agents/specs/**` was on my forbidden list, but `scan-orchestration-map.mjs` **FAILs** when a new
`.claude/agents/*.md` is absent from `.agents/specs/orchestration-map.md`. I updated that registry only —
the two contract documents (`harness-composition-design.md`, `harness-composition-inventory.md`) are
untouched, which is what the restriction was protecting.

### Verification

`pnpm harness:verify-like-ci` — **PASS, all 5 stages** (harness-self-test, format-check, scan-suite,
scan-suite-dist-free, typecheck) on a built tree. `format-check` covers the 10 changed files and is green;
the repo has ~119 pre-existing prettier warnings in files this PR does not touch.

The release-governance scan is the sharpest floor here: it asserts seven `###` headings and twelve
required phrases still live in `publish.md`. All intact.
