### PR TITLE
fix(security): SEC-004 close the five remaining HIGH CodeQL alerts at source

### DIFF
--- a/.agents/backlog/SEC-004-codeql-high-alert-residue.md
+++ b/.agents/backlog/SEC-004-codeql-high-alert-residue.md
@@ -1,0 +1,178 @@
+---
+title: 'SEC-004: close the five remaining HIGH CodeQL alerts (double-escaping, redos, missing-regexp-anchor)'
+status: in-progress
+created: 2026-07-26
+priority: high
+urgency: now
+area: packages/agent-tools, packages/agent-cli, scripts/harness
+depends_on: []
+---
+
+# SEC-004: the five HIGH CodeQL alerts SEC-003 did not cover
+
+## Problem
+
+[SEC-003](SEC-003-codeql-alert-triage.md) closed both classes it opened with —
+`js/insecure-temporary-file` (109/109) and `js/polynomial-redos` (18/18) — at the source, zero
+dismissals. Five HIGH-severity alerts on `develop` belong to three other classes it never opened,
+and were still open (identical on PR #1427, so pre-existing rather than introduced there):
+
+| Alert | Rule                             | Site                                                             |
+| ----- | -------------------------------- | ---------------------------------------------------------------- |
+| 1     | `js/double-escaping`             | `agent-tools/src/builtins/web-fetch-tool.ts:85`                  |
+| 2     | `js/redos`                       | `scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs:54`  |
+| 3–5   | `js/regex/missing-regexp-anchor` | `agent-tools/src/__tests__/web-search-provider.test.ts:75,76,88` |
+
+SEC-003's own lesson applies again: the alert list is a floor, not an inventory. The sweep for both
+shapes across the repo found one more live defect of each shape that CodeQL never reported.
+
+## Alert 1 — `js/double-escaping`, `web-fetch-tool.ts` (shipped library code)
+
+`htmlToText` decoded entities as a CHAIN of `.replace()` calls with `&amp;` FIRST, so each pass
+re-scanned the previous pass's output. `&amp;lt;` — how a page encodes the literal text `&lt;` so a
+browser DISPLAYS it — became `&lt;` after the `&amp;` pass and then `<` after the `&lt;` pass.
+
+Measured on the pre-fix code:
+
+| Input                                                   | Pre-fix output              | Correct                                 |
+| ------------------------------------------------------- | --------------------------- | --------------------------------------- |
+| `&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;` | `<script>alert(1)</script>` | `&lt;script&gt;alert(1)&lt;/script&gt;` |
+| `&amp;quot;`                                            | `"`                         | `&quot;`                                |
+| `&amp;#39;`                                             | `'`                         | `&#39;`                                 |
+
+So a **tag-stripping** converter handed the model back markup that the page had deliberately escaped
+for display — the decoder was not the inverse of the encoder, which is precisely what
+`js/double-escaping` names. The output is a `WebFetch` tool result, i.e. a live response body from an
+arbitrary URL, so the attacker chooses the input.
+
+**Fix:** one alternation over all six entities, applied in a single `.replace()` pass with a lookup
+table. A global replace never re-scans its own replacement, so every entity is decoded exactly once
+and the decoder inverts the encoder for every input, not only singly-encoded ones. Ordering `&amp;`
+last would also have worked; a single pass was chosen because it is correct by construction rather
+than by argument about pass order — the same reasoning SEC-003 used when it replaced regexes with
+index scans.
+
+## Alert 2 — `js/redos`, `frontmatter-parser-ssot.test.mjs`
+
+The regex-literal extractor's character-class body was `(?:\\.|[^\]])*`. Both branches match a
+backslash — `\\.` takes it together with the next character, `[^\]]` takes it alone — so a run of
+backslashes inside a `[…]` that never closes has 2^n parses, and the engine tries all of them before
+the match fails. This is **exponential**, not the polynomial class SEC-003 handled.
+
+Measured (`' /[' + '\\'.repeat(n) + '!'`): n=30 → 8.6 ms, n=34 → 308 ms, n=38 → 2 128 ms,
+n=42 → 14 533 ms. Fixed: 0.1 ms at n=42, 1.3 ms at n=200 000.
+
+**Fix:** `[^\]]` → `[^\]\\]`, making exactly one branch match at every position. Inside a regex
+character class a backslash always begins an escape, so `\\.` already covered every well-formed
+input — the extracted literals are unchanged, pinned by an equivalence test that passes against both
+the pre-fix and post-fix pattern.
+
+**Honest scoping note:** the input is a harness `.mjs` file on disk in this repo, not
+attacker-supplied. This is a build-availability defect (any harness script that grows a `[` followed
+by a backslash run hangs `harness:verify`), not a remote DoS. It was fixed rather than dismissed
+because the fix is one character, provably behaviour-preserving, and the alert is correct about the
+regex.
+
+## Alerts 3–5 — `js/regex/missing-regexp-anchor`, `web-search-provider.test.ts`
+
+These three deserve a precise verdict, because the rule's usual narrative does not fit and the
+defect is real anyway.
+
+All three sites are **negative** assertions (`expect(x).not.toMatch(...)`). An unanchored regex in a
+negative check over-matches, which makes a test fail loudly — it cannot make it pass silently. So
+"an unanchored allow-check accepts `evil.com/notexample.com`" is not what is happening here.
+
+The defect is the mirror image, and is genuine: these are **substring searches written as regexes**,
+and the set of strings each one rejects is far narrower than the property its test name claims.
+
+- `it('the tool-layer source holds no vendor endpoint or signup-URL literal')` rejected exactly two
+  spellings (`api.search.brave.com`, `brave.com/search`). A comment reading `cdn.brave.com/docs`
+  satisfies every assertion while violating the claim.
+- `it('default missing-key error … carries no vendor signup URL')` rejected exactly
+  `https://brave.com`. The vendor's real key-signup URL, `https://api.search.brave.com/app/keys`,
+  sails straight through the check that exists to keep it out.
+
+**Fix:** state the substring search as a substring search (`not.toContain`), which removes the regex
+and with it the anchoring question, and widen the probe to the property actually claimed — the
+vendor host in ANY spelling (`brave.com` covers every subdomain, path, and scheme) plus "no URL at
+all". Both are strictly stronger than what they replace.
+
+## Same-shape sweep — instances CodeQL did not flag
+
+### Fixed here
+
+| Site                                                                              | Shape                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts:93,218` | Unanchored `toMatch(/https:\/\/remote\.example\//)` over a whole multi-line message. A pairing link served from `https://phish.test/?next=https://remote.example/` passes both assertions — proven: the pre-fix suite is 15/15 green with that origin injected. Fixed by extracting the link (it is the message's last line) and comparing `new URL(link).origin` exactly, plus asserting `search === ''` so the secret is pinned to the fragment. |
+
+### Cleared — same construct, correct as written (no change made)
+
+- `agent-provider-openai-compatible/src/gemma/pseudo-tool-call-tag-parser.ts:140-144` —
+  unescape chain with `&amp;` **last**. Correct order; `&amp;lt;` → `&lt;`.
+- `agent-framework/src/context/prompt-file-reference-format.ts:69-72`,
+  `dag-cli/src/studio/ui-html.ts:102` — escape chains with `&` **first**. Correct order.
+- `agent-playground/.../sse-client.ts:143-146` (`^wss`→`https` then `^ws`→`http`; `https` cannot be
+  re-matched by `^ws`), `apps/docs/src/lib/toc.ts`, `dag-cli/src/commands/aav.ts` (idempotent
+  slugifiers), `agent-remote-pairing/.../pairing.test.ts` (base64url encode).
+- `agent-core/src/permissions/permission-gate.ts:40` and
+  `agent-tools/src/builtins/grep-tool.ts:65` — both `globToRegex` helpers anchor with `^…$`.
+- `agent-transport-ws/src/ws-connection-guards.ts` — the `Host`/`Origin` admission guards use exact
+  `Set` membership and `new URL(origin).hostname`, never a substring or regex. This is the shape
+  done right.
+- `agent-core/src/hooks/hook-runner.ts:55` (`new RegExp(group.matcher).test(toolName)`) and
+  `agent-core/src/schema/structured-output.ts:161` (JSON Schema `pattern`) are unanchored **by
+  contract** — a hook matcher and JSON Schema `pattern` are both specified as partial matches.
+  Anchoring them would be a breaking behaviour change, not a fix.
+
+### Follow-up opened by this sweep — NOT fixed here
+
+**`packages/dag-nodes/text-template/src/index.ts:79-82` re-substitutes its own substitution output.**
+Same root cause as alert 1 (a later pass re-scans an earlier pass's replacement), different surface,
+so it is a behaviour change to a DAG node rather than a regex fix and is outside this item's file
+ownership. Measured:
+
+| Template           | `text` input                    | Produced        | Expected                   |
+| ------------------ | ------------------------------- | --------------- | -------------------------- |
+| `{{text}}`         | `a%sb`                          | `aa%sbb`        | `a%sb`                     |
+| `{{text}}`         | `x%%sy`                         | `x%x%%syy`      | `x%%sy`                    |
+| `{{text}}`         | `pre__ROBOTA_…_PERCENT_S__post` | `pre%spost`     | the sentinel back verbatim |
+| `%%s and {{text}}` | `q%sr`                          | `%s and qq%srr` | `%s and q%sr`              |
+
+The `{{text}}` substitution runs BEFORE the `%s` substitution, so any `%s` inside the user's text is
+substituted a second time; and the escape sentinel is an ordinary string a user can type. The
+correct shape is a single left-to-right scan that emits substituted text without re-reading it.
+
+## Test Plan
+
+- Red-first per fix; every red is an assertion failure carrying its own value/elapsed time, not a
+  timeout. See the evidence table below.
+- New test file `packages/agent-tools/src/__tests__/double-escaping.test.ts` (5 cases): the
+  doubly-encoded cases, a display-encoder round-trip, plus equivalence pins for singly-encoded input
+  and for entities the decoder does not handle.
+- New cases inside `scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs`: an attack-input
+  timing floor (`< 250 ms`) and a literal-extraction equivalence pin.
+- Full test suites of every touched package, plus `pnpm harness:verify-like-ci`.
+
+### Red-first evidence
+
+| Test                                                                      | Pre-fix                                    | Post-fix                                |
+| ------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------- |
+| `double-escaping` — doubly-encoded entity                                 | `<` (3 of 5 cases red)                     | `&lt;`                                  |
+| `double-escaping` — escaped-twice markup                                  | `<script>alert(1)</script>`                | `&lt;script&gt;alert(1)&lt;/script&gt;` |
+| `frontmatter-parser-ssot` — unclosed class, 42 backslashes                | 2 735 ms (budget 250 ms)                   | 12 ms for the whole file                |
+| `web-search-provider` — vendor URL leaked into the tool layer / key error | pre-fix suite 4/4 **green** (accidental)   | 2 of 4 red                              |
+| `remote-control-controller` — pairing link on `https://phish.test/`       | pre-fix suite 15/15 **green** (accidental) | 2 of 15 red                             |
+
+The two "accidental green" rows are the point: the pre-fix assertions passed on input they exist to
+reject, so those tests did not test what their names claimed.
+
+**Dismissed: none. 5 of 5 fixed at the source, plus 1 same-shape defect CodeQL never reported, plus
+1 filed as a follow-up.**
+
+## User Execution Test Scenarios
+
+Not applicable. `WebFetch`'s entity decoding is an internal correctness fix with no observable
+command, TUI, or browser surface change for a well-formed page (the singly-encoded equivalence tests
+pin that the ordinary output is byte-identical), and the other four alerts are test-code and
+harness-script fixes that deliver no user-facing behaviour. The engineering verification lives in
+`## Test Plan`.

--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts
@@ -1,3 +1,4 @@
+import { parsePairingUrl } from '@robota-sdk/agent-remote-pairing';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RemoteControlController } from '../remote-control-controller.js';
@@ -14,6 +15,23 @@ import type {
  * REMOTE-008 Step 4 — the composition-root remote-control controller. Driven with injected construction
  * seams (no real relay / werift / QR), so the enable/stop/status + fail-closed logic is unit-tested.
  */
+
+/** The client base URL `makeDeps` injects; the pairing link must be on exactly this origin. */
+const CLIENT_ORIGIN = 'https://remote.example';
+
+/**
+ * The pairing link the controller emitted: `renderPairingMessage` puts it on the message's last line.
+ *
+ * SEC-004 shape-match (the `js/regex/missing-regexp-anchor` family, unflagged here): the assertions
+ * used to be `expect(msg).toMatch(/https:\/\/remote\.example\//)` — an unanchored substring probe over
+ * the whole message, which a link like `https://phish.test/?next=https://remote.example/` satisfies
+ * just as well as the real one. Extracting the link and parsing it makes the check exact: the origin
+ * is compared, not merely found somewhere in the prose.
+ */
+function pairingLinkOf(message: string): URL {
+  const lastLine = message.split('\n').at(-1) ?? '';
+  return new URL(lastLine);
+}
 
 function makeDeps(over: Partial<IRemoteControlControllerDeps> = {}): {
   deps: IRemoteControlControllerDeps;
@@ -90,7 +108,13 @@ describe('RemoteControlController (REMOTE-008)', () => {
     expect(transport.start).toHaveBeenCalledTimes(1);
     // The pairing link is a real URL with the secret + rendezvous in the FRAGMENT (never on the server).
     expect(msg).toContain('[QR]');
-    expect(msg).toMatch(/https:\/\/remote\.example\/#.*r=.*s=/);
+    const link = pairingLinkOf(msg);
+    expect(link.origin).toBe(CLIENT_ORIGIN);
+    expect(link.pathname).toBe('/');
+    expect(link.search).toBe(''); // the secret must never reach the server as a query param
+    const pairing = parsePairingUrl(link.toString());
+    expect(pairing.rendezvous).not.toBe('');
+    expect(pairing.secret).not.toBe('');
     const status = controller.getStatus();
     expect(status.state).toBe('awaiting-pairing');
   });
@@ -215,6 +239,6 @@ describe('RemoteControlController (REMOTE-008)', () => {
     const { deps } = makeDeps({ renderQr: () => Promise.reject(new Error('no qr')) });
     const msg = await new RemoteControlController(deps).enable();
     expect(msg).not.toContain('[QR]');
-    expect(msg).toMatch(/https:\/\/remote\.example\//);
+    expect(pairingLinkOf(msg).origin).toBe(CLIENT_ORIGIN);
   });
 });

--- a/packages/agent-tools/src/__tests__/double-escaping.test.ts
+++ b/packages/agent-tools/src/__tests__/double-escaping.test.ts
@@ -1,0 +1,90 @@
+/**
+ * SEC-004 — `js/double-escaping` regression floor for `WebFetch`'s HTML-to-text conversion.
+ *
+ * The decoder used to be a CHAIN of `.replace()` calls with `&amp;` first, so each pass re-scanned
+ * the previous pass's output: `&amp;lt;` became `&lt;` and then `<`. A page that deliberately
+ * encoded markup for DISPLAY therefore came back out of a tag-STRIPPING converter as markup, which
+ * is the opposite of what the converter promises. These cases pin the decoder as a single pass:
+ * every entity is decoded exactly once, so decoding is the inverse of encoding for every input and
+ * not just for singly-encoded ones.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IToolInvocationResult } from '../types/tool-result.js';
+
+/** Encode text the way a page must in order to DISPLAY it verbatim (`&` first — correct for encoding). */
+function encodeForDisplay(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+describe('SEC-004 — WebFetch HTML entity decoding is single-pass', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  async function fetchHtml(html: string): Promise<IToolInvocationResult> {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/html; charset=utf-8' },
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(html).buffer),
+    } as unknown as Response);
+    const { webFetchTool } = await import('../builtins/web-fetch-tool.js');
+    const result = await webFetchTool.execute({ url: 'https://example.com/' } as Parameters<
+      typeof webFetchTool.execute
+    >[0]);
+    const raw =
+      typeof result === 'object' && result !== null && 'data' in result
+        ? String((result as { data: unknown }).data)
+        : String(result);
+    return JSON.parse(raw) as IToolInvocationResult;
+  }
+
+  it('does not decode a doubly-encoded entity twice', async () => {
+    // The page DISPLAYS the four characters `&lt;`; it must not come back as `<`.
+    expect((await fetchHtml('<p>&amp;lt;</p>')).output).toBe('&lt;');
+    expect((await fetchHtml('<p>&amp;gt;</p>')).output).toBe('&gt;');
+    expect((await fetchHtml('<p>&amp;quot;</p>')).output).toBe('&quot;');
+    expect((await fetchHtml('<p>&amp;#39;</p>')).output).toBe('&#39;');
+    expect((await fetchHtml('<p>&amp;amp;</p>')).output).toBe('&amp;');
+  });
+
+  it('does not resurrect markup a page escaped twice for display', async () => {
+    const page = '<p>&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;</p>';
+    const output = (await fetchHtml(page)).output;
+
+    expect(output).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(output).not.toContain('<script>');
+  });
+
+  it('is the inverse of the display encoder for text that already contains entity syntax', async () => {
+    const displayed = 'a &lt; b && c &amp; d "e" \'f\'';
+    const output = (await fetchHtml(`<p>${encodeForDisplay(displayed)}</p>`)).output;
+
+    expect(output).toBe(displayed);
+  });
+
+  it('still decodes singly-encoded entities exactly as before', async () => {
+    expect((await fetchHtml('<p>a &lt;b&gt; c</p>')).output).toBe('a <b> c');
+    expect((await fetchHtml('<p>Hi &amp; bye</p>')).output).toBe('Hi & bye');
+    expect((await fetchHtml('<p>&quot;q&quot; &#39;s&#39;</p>')).output).toBe('"q" \'s\'');
+    expect((await fetchHtml('<p>a&nbsp;b</p>')).output).toBe('a b');
+  });
+
+  it('leaves an entity it does not decode untouched rather than half-decoding it', async () => {
+    expect((await fetchHtml('<p>&copy; &#169; &ampx;</p>')).output).toBe('&copy; &#169; &ampx;');
+  });
+});

--- a/packages/agent-tools/src/__tests__/web-search-provider.test.ts
+++ b/packages/agent-tools/src/__tests__/web-search-provider.test.ts
@@ -11,6 +11,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IToolInvocationResult } from '../types/tool-result.js';
 import type { FunctionTool } from '@robota-sdk/agent-core';
 
+/**
+ * The default adapter's vendor host. Every vendor URL — endpoint, signup page, docs, any subdomain,
+ * any scheme — contains it, so one substring probe covers the whole family the neutrality rule bans.
+ */
+const VENDOR_HOST = 'brave.com';
+
 async function callTool(tool: FunctionTool, query: string): Promise<IToolInvocationResult> {
   const result = await tool.execute({ query } as Parameters<typeof tool.execute>[0]);
   const raw =
@@ -68,12 +74,16 @@ describe('web-search provider port (NEUT-008)', () => {
     // The default adapter module may hold the endpoint; the TOOL layer must not carry any
     // vendor URL literal (NEUT-008). Importing the default adapter by name is the sanctioned
     // "default provider wired via factory option" seam.
+    //
+    // SEC-004 (`js/regex/missing-regexp-anchor`): these were unanchored hostname REGEXES spelling
+    // out two exact endpoints. A substring search is what is wanted here — the literal may sit
+    // anywhere in the file — so it is written as a substring search, and the property asserted is
+    // the one the test name claims: no vendor host in ANY spelling, not two hand-picked ones.
     const toolSource = readFileSync(
       fileURLToPath(new URL('../builtins/web-search-tool.ts', import.meta.url)),
       'utf8',
     );
-    expect(toolSource).not.toMatch(/api\.search\.brave\.com/);
-    expect(toolSource).not.toMatch(/brave\.com\/search/);
+    expect(toolSource).not.toContain(VENDOR_HOST);
     expect(toolSource).not.toMatch(/https?:\/\//);
   });
 
@@ -85,6 +95,10 @@ describe('web-search provider port (NEUT-008)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/BRAVE_API_KEY/);
-    expect(result.error).not.toMatch(/https:\/\/brave\.com/);
+    // SEC-004: was `not.toMatch(/https:\/\/brave\.com/)`, which rejected exactly one spelling —
+    // the vendor's real key-signup URL (`https://api.search.brave.com/app/keys`) sailed through the
+    // check that exists to keep it out. Reject the host in any form, and any URL at all.
+    expect(result.error).not.toContain(VENDOR_HOST);
+    expect(result.error).not.toMatch(/https?:\/\//);
   });
 });

--- a/packages/agent-tools/src/builtins/web-fetch-tool.ts
+++ b/packages/agent-tools/src/builtins/web-fetch-tool.ts
@@ -80,15 +80,30 @@ function stripTags(html: string): string {
   return parts.join('');
 }
 
+/**
+ * The character entities {@link htmlToText} decodes, and the single alternation that matches them.
+ *
+ * SEC-004 (`js/double-escaping`): decoding these by CHAINED `.replace()` calls with `&amp;` first
+ * decodes twice. `&amp;lt;` — how a page encodes the literal text `&lt;` so a browser DISPLAYS it —
+ * became `&lt;` after the `&amp;` pass and then `<` after the `&lt;` pass, so a page reading
+ * `&amp;lt;script&amp;gt;` came back out of a tag-stripping converter as `<script>`. One pass over
+ * one alternation decodes each entity exactly once and never rescans its own output, so the decoder
+ * is the inverse of the encoder for every input rather than only for singly-encoded ones.
+ */
+const HTML_ENTITIES: Readonly<Record<string, string>> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&nbsp;': ' ',
+};
+const HTML_ENTITY_PATTERN = /&(?:amp|lt|gt|quot|nbsp|#39);/g;
+
 /** Strip HTML tags and decode common entities to produce readable text. */
 function htmlToText(html: string): string {
   return stripTags(stripElement(stripElement(html, 'script'), 'style'))
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
+    .replace(HTML_ENTITY_PATTERN, (entity) => HTML_ENTITIES[entity])
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs
+++ b/scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs
@@ -29,6 +29,10 @@ import {
 
 const HARNESS_DIR = fileURLToPath(new URL('..', import.meta.url));
 
+/** SEC-004 timing floor: the fixed scan is sub-millisecond, the pre-fix one took 14.5 s. */
+const REDOS_BUDGET_MS = 250;
+const REDOS_RED_TIMEOUT_MS = 120_000;
+
 /** The one module allowed to own the frontmatter key regex. */
 const SSOT_MODULE = 'frontmatter.mjs';
 
@@ -45,13 +49,23 @@ const ALLOWLIST = new Map([
   ],
 ]);
 
-/** Regex literals in a source file, as their raw pattern text. */
+/**
+ * Regex literals in a source file, as their raw pattern text.
+ *
+ * SEC-004 (`js/redos`): the character-class body was `(?:\\.|[^\]])*`, whose two branches both match
+ * a backslash — `\\.` takes it with the character after it, `[^\]]` takes it alone. A run of
+ * backslashes inside a `[…]` that never closes therefore has 2^n parses, and the engine tries all of
+ * them before failing: 42 backslashes took 14.5 s. Excluding the backslash from the second branch
+ * (`[^\]\\]`) makes exactly one branch match at every position, so the run is scanned once. Inside a
+ * regex character class a backslash always begins an escape, so `\\.` already covers every
+ * well-formed input and the extracted literals are unchanged.
+ */
 function regexLiterals(source) {
   // A regex literal: `/pattern/flags`, not preceded by an identifier/`)`/`]` (which would make `/`
   // a division), and not a `//` comment or a `/*` block opener.
   const literals = [];
   const pattern =
-    /(^|[=(,:[!&|?{};+\-*%<>~^\s])\/((?:\\.|\[(?:\\.|[^\]])*\]|[^/\\\n[])+)\/[dgimsuvy]*/g;
+    /(^|[=(,:[!&|?{};+\-*%<>~^\s])\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\\\n[])+)\/[dgimsuvy]*/g;
   for (const match of source.matchAll(pattern)) literals.push(match[2]);
   return literals;
 }
@@ -155,6 +169,32 @@ describe('HARNESS-046 anti-fork floor — one frontmatter parser', () => {
       expect(() => statSync(path.join(HARNESS_DIR, file))).not.toThrow();
       expect(reason.length).toBeGreaterThan(40);
     }
+  });
+
+  it(
+    'SEC-004: an unclosed character class full of backslashes is scanned in linear time',
+    () => {
+      // The catastrophic shape: `[` opens a class, a run of backslashes follows, and no `]` ever
+      // arrives — so every one of the 2^n ways to split that run gets tried before the match fails.
+      // 42 backslashes cost 14.5 s against the pre-fix pattern and 0.1 ms against this one.
+      const source = ` /[${'\\'.repeat(42)}!`;
+      const started = performance.now();
+      expect(regexLiterals(source)).toEqual([]);
+      expect(performance.now() - started).toBeLessThan(REDOS_BUDGET_MS);
+    },
+    REDOS_RED_TIMEOUT_MS,
+  );
+
+  it('SEC-004: extracts the same literals as before, character classes included', () => {
+    // A class holding an escaped `]`, an escaped `\`, and a `/` — the cases the class branch exists
+    // for. Each must still be read as ONE literal, ending at the real closing delimiter.
+    expect(regexLiterals('const a = /[^\\]]+/g;')).toEqual(['[^\\]]+']);
+    expect(regexLiterals('const b = /[\\\\/]+/;')).toEqual(['[\\\\/]+']);
+    expect(regexLiterals('const c = /a\\/b/;')).toEqual(['a\\/b']);
+    expect(regexLiterals('const d = /^\\s*tags:\\s*(.+)$/;')).toEqual(['^\\s*tags:\\s*(.+)$']);
+    expect(regexLiterals('const e = /[a-z]/ + /[0-9]/;')).toEqual(['[a-z]', '[0-9]']);
+    // Not literals: a division and a comment.
+    expect(regexLiterals('const f = total / count;')).toEqual([]);
   });
 
   it('the converged scans import the SSOT parser', () => {


### PR DESCRIPTION
Closes the **five remaining HIGH-severity CodeQL alerts** open on `develop` (identical on #1427 — pre-existing, not introduced there). Continues [SEC-003](../blob/develop/.agents/backlog/SEC-003-codeql-alert-triage.md), holding its standard: **fixed at source, zero dismissals**, plus a same-shape sweep that found what CodeQL missed.

Full analysis: `.agents/backlog/SEC-004-codeql-high-alert-residue.md`.

## The five alerts

### 1. `js/double-escaping` — `agent-tools/src/builtins/web-fetch-tool.ts:85` (shipped library code)

`htmlToText` decoded entities as a **chain** of `.replace()` calls with `&amp;` **first**, so each pass re-scanned the previous pass's output.

| Input | Pre-fix | Correct |
| --- | --- | --- |
| `&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;` | `<script>alert(1)</script>` | `&lt;script&gt;alert(1)&lt;/script&gt;` |
| `&amp;quot;` | `"` | `&quot;` |
| `&amp;#39;` | `'` | `&#39;` |

A page that encodes markup so a browser *displays* it came back out of a **tag-stripping** converter as markup. Input is a live response body from an arbitrary URL.

**Fix:** one alternation over all six entities in a single pass. A global replace never re-scans its own replacement, so decoding inverts encoding for *every* input, not only singly-encoded ones. (Moving `&amp;` last also works; a single pass is correct by construction rather than by argument about pass order.)

### 2. `js/redos` — `scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs:54`

`(?:\\.|[^\]])*` — both branches match a backslash, so a run inside an unclosed `[…]` has 2^n parses. Measured: n=30 8.6 ms → n=34 308 ms → n=38 2 128 ms → n=42 **14 533 ms**. **Exponential**, not the polynomial class SEC-003 handled.

**Fix:** `[^\]]` → `[^\]\\]`. Inside a character class a backslash always begins an escape, so `\\.` already covered every well-formed input — extraction is unchanged (pinned by a test that passes against both patterns). Post-fix: 0.1 ms at n=42, 1.3 ms at n=200 000.

*Honest scoping:* the input is a repo-local `.mjs` file, so this is build-availability, not remote DoS. Fixed anyway — one character, provably behaviour-preserving.

### 3–5. `js/regex/missing-regexp-anchor` — `agent-tools/src/__tests__/web-search-provider.test.ts:75,76,88`

**The rule's usual narrative does not fit, and the defect is real anyway.** All three are *negative* assertions (`not.toMatch`), where over-matching fails loudly rather than passing silently — so "an unanchored allow-check accepts `evil.com/notexample.com`" is not what happens here.

The defect is the mirror image: these are **substring searches written as regexes**, and each rejects far less than its test name claims.

- *"…holds no vendor endpoint or signup-URL literal"* rejected two exact spellings. `cdn.brave.com/docs` passes.
- *"…carries no vendor signup URL"* rejected exactly `https://brave.com`. The vendor's real key-signup URL `https://api.search.brave.com/app/keys` **sails straight through the check that exists to keep it out.**

**Fix:** state the substring search as one (`not.toContain`) — removing the regex removes the anchoring question — and widen the probe to the claimed property: the vendor host in *any* spelling, plus "no URL at all".

## Same-shape sweep

**Fixed (CodeQL never flagged it):** `agent-cli/.../remote-control-controller.test.ts:93,218` — `toMatch(/https:\/\/remote\.example\//)` over a whole multi-line message. A pairing link served from `https://phish.test/?next=https://remote.example/` satisfies it. Now the link is extracted and `new URL(link).origin` compared exactly, with `search === ''` pinning the secret to the fragment.

**Cleared, correct as written:** the gemma unescape chain (`&amp;` last), the two escape chains (`&` first), `sse-client`'s `wss`→`https` chain, both `globToRegex` helpers (anchored `^…$`), and `ws-connection-guards` (exact `Set` membership + `new URL().hostname` — the shape done right). `hook-runner`'s matcher and JSON Schema `pattern` are unanchored *by contract*.

**Follow-up opened, not fixed here:** `packages/dag-nodes/text-template/src/index.ts:79-82` re-substitutes its own substitution output — same root cause, different surface. `{{text}}` runs before `%s`, so template `{{text}}` with text `a%sb` yields `aa%sbb`; and the escape sentinel is an ordinary string a user can type (`pre<sentinel>post` → `pre%spost`). Behaviour change to a DAG node, outside this item's ownership.

## Red-first evidence

| Test | Pre-fix | Post-fix |
| --- | --- | --- |
| `double-escaping` — doubly-encoded entity | `<` (3 of 5 red) | `&lt;` |
| `double-escaping` — escaped-twice markup | `<script>alert(1)</script>` | `&lt;script&gt;…` |
| `frontmatter-parser-ssot` — unclosed class, 42 backslashes | 2 735 ms (budget 250 ms) | 12 ms whole file |
| `web-search-provider` — vendor URL injected | suite 4/4 **green** (accidental) | 2 of 4 red |
| `remote-control-controller` — link on `https://phish.test/` | suite 15/15 **green** (accidental) | 2 of 15 red |

The two "accidental green" rows are the point: those assertions passed on input they exist to reject.

## Verification

- `pnpm harness:verify-like-ci` — **PASS**, all 5 CI-mirroring stages (harness-self-test, format-check, scan-suite, scan-suite-dist-free, typecheck)
- `agent-tools` — 24 files, **215 passed**
- `agent-cli` — 35 files, **271 passed**
- `scripts/harness/__tests__` — 75 files, **830 passed**
- `pnpm build` green; eslint on touched files: 0 errors

**Dismissed: none.** 5/5 fixed at source + 1 same-shape defect CodeQL never reported + 1 filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
