### PR TITLE
fix(ci): INFRA-048 close four gates that report success without running

### DIFF
--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -1,10 +1,10 @@
 ---
 title: 'INFRA-048: PRs can merge before their review feedback is ever read'
-status: todo
+status: in-progress
 created: 2026-07-25
 priority: high
 urgency: soon
-area: .github/workflows, repo rulesets, .agents/rules
+area: .github/workflows, scripts/harness, repo rulesets
 depends_on: []
 ---
 
@@ -28,33 +28,175 @@ build, quality, scans, security audit, commitlint, tui-e2e, examples-typecheck, 
 (`protect-develop` ruleset). **Not one of them produces review feedback.** The two jobs that do —
 `Claude review` and CodeQL's `Analyze (javascript-typescript)` — are advisory. So an armed auto-merge
 fires the moment the eight gates go green, regardless of what the review jobs are about to say, or have
-just said. `Claude review` itself finishes in ~14 s and reports `pass` whether or not it left findings,
-so even watching that check tells you nothing.
+just said.
 
-This is a systemic gap, not an operator slip: the orchestration procedure arms auto-merge as soon as a PR
-is opened, and there is no point at which the review output is a gate.
+## What the investigation found on top of that
 
-## What
+`Claude review` does not merely report `pass` regardless of findings. **It was not reviewing at all.**
 
-Decide and implement one of these (they are not exclusive):
+`anthropics/claude-code-action` validates at run time that the workflow file invoking it is
+BYTE-IDENTICAL to the copy on the repository's default branch. When it is not, it prints
 
-1. **Make the review-producing checks required** for `develop` — at minimum CodeQL's analysis job, so a
-   PR cannot merge while its analysis is still pending. Coordinate with INFRA-046, which is already
-   tracking advisory→required promotion criteria and its "flip the flag AND add to the ruleset" lesson.
-2. **Make `Claude review` fail (not just comment) when it emits actionable findings**, so its check
-   status carries information. Today it passes unconditionally.
-3. **Change the orchestration procedure**: do not arm auto-merge until review output has been read.
-   The `worktree-parallel-orchestration` skill currently says "merge PRs one at a time via armed
-   auto-merge" with no review-reading step — add one (neutral wording: "read whatever review feedback
-   the project's review automation produces before arming the merge").
+```
+Skipping action due to workflow validation: … must have identical content to the version on the
+repository's default branch
+Exiting due to workflow validation skip
+```
 
-Option 3 is the cheapest and closes the loop immediately; 1 and 2 make it mechanical rather than
-procedural, which is the stronger fix per the recurring-mistake-prevention principle.
+and **exits 0** — so the job reports `success`.
+
+`.github/workflows/claude-code-review.yml` on `develop` differed from `main` by exactly one line:
+`actions/checkout@v7` vs `@v4`, a major-version bump merged to `develop` on 2026-07-24 (#1313) and
+never promoted. Measured 2026-07-26:
+
+| evidence                                                    | value                           |
+| ----------------------------------------------------------- | ------------------------------- |
+| `gh run list --workflow=claude-code-review.yml --limit 100` | `success: 100` (100 of 100)     |
+| runs inspected in detail (#1432, #1423, #1421 PR runs)      | all three: validation skip      |
+| run duration                                                | 13–21 s (no review is possible) |
+
+So for every PR since 2026-07-24 the "review" check was green and empty. That is the INFRA-048 defect
+in its purest form — a check reporting success for work it did not do — and it is invisible from
+outside the run log.
+
+## Decision
+
+Three levers were on the table (the original item's options 1–3). What shipped, and why.
+
+**Chosen — a distinct blocking check that READS the review output, with a severity split.**
+
+1. **`review-workflow-parity` scan** (`scripts/harness/scan-review-workflow-parity.mjs`, registered
+   in `run-all-scans` → runs inside the REQUIRED `scans` job). Every workflow that invokes
+   `anthropics/claude-code-action` must match the default branch's copy exactly; drift fails the
+   scan with the reason. Governed workflows are discovered by the action they invoke, never by a
+   hardcoded filename. `.github/workflows/claude-code-review.yml` is restored to byte-identity, so
+   the reviewer runs again. FAIL-CLOSED: if the default branch's copy cannot be read, the scan
+   fails. Not applicable on a PR whose base IS the default branch — that PR is the promotion which
+   restores parity.
+
+2. **`review-gate` check** (`.github/workflows/review-gate.yml` + the pure, unit-tested decision
+   module `scripts/harness/check-review-gate.mjs`). It waits for the code-scanning analysis of the
+   PR head, reads the alerts for the PR ref and for the base branch, and decides:
+
+   | class        | rule                                                          | blocks?                         |
+   | ------------ | ------------------------------------------------------------- | ------------------------------- |
+   | blocking     | introduced by this PR, severity `error` or security high/crit | **yes**                         |
+   | advisory     | any other alert introduced by this PR                         | no, but printed on the check    |
+   | pre-existing | already open on the base branch                               | no                              |
+   | unavailable  | analysis incomplete, API error, unparseable payload           | **yes**                         |
+   | acknowledged | PR carries `review-findings-acknowledged`                     | no, override recorded on the PR |
+
+   On a block it also runs `gh pr merge --disable-auto`, because a red **non-required** check does
+   not stop an armed auto-merge — which is precisely the #1409 hole. The disarm is the lever that
+   works today; the ruleset entry (below) is the durable one.
+
+**Why this design survives the NIT-bypass failure mode.** A gate that hard-fails on any review
+finding blocks merges on NITs and gets routinely bypassed, which is worse than advisory — a bypassed
+gate also teaches everyone to bypass. This repo makes the risk concrete and measurable: **every one
+of its ~100 open code-scanning alerts is severity `note`** (mostly `js/unused-local-variable`), so a
+"fail on any finding" gate would have been red on every PR from day one. Hence: only `error` /
+security-high-or-critical findings that this PR INTRODUCES can block; everything else is printed and
+counted on the check — visible where nothing was visible before — but never blocking. The single
+escape hatch is a per-PR label whose application is a recorded act on the PR, rather than a blanket
+admin bypass nobody can audit.
+
+**Rejected.**
+
+- _Hard-fail on any review finding._ The NIT trap above, with the repo's own alert corpus as
+  evidence.
+- _Make `Claude review` itself the blocking check._ Its verdict is model judgment, and — as measured
+  here — it can report `success` without having run at all. A gate must be something whose execution
+  is verifiable; that is why the parity scan (static, in a required job) is the floor and the gate
+  reads a machine-produced artifact.
+- _Make CodeQL's `Analyze` job required, on its own._ `Analyze` reports whether the ANALYSIS
+  completed, not whether findings exist: on #1409 it was green while the finding was live. Requiring
+  it guarantees the analysis ran, not that anyone read it.
+- _Procedure only (the original option 3)._ Already landed as #1412 ("read PR review output before
+  arming auto-merge"). Kept, but the recurring-mistake-prevention principle asks for a mechanical
+  floor, and a procedure cannot be one.
+- _#1409's own finding would still not block_ (severity `note`). Deliberate, and stated plainly: it
+  is now REPORTED on the `review-gate` check where previously nothing was reported at all, and the
+  procedural read step covers it. Blocking on it would recreate the bypass.
+
+## Red / green evidence
+
+**Parity — against the real repository:**
+
+```
+BEFORE  review-workflow-parity scan failed (INFRA-048):
+          - .github/workflows/claude-code-review.yml: differs from origin/main. … skips the review
+            and exits 0 — the check reports `success` having reviewed nothing.          EXIT=1
+AFTER   review-workflow-parity scan passed: .github/workflows/claude-code-review.yml
+          match origin/main.                                                            EXIT=0
+```
+
+**The gate.** The `Decide` step body is EXTRACTED from `review-gate.yml` itself and run under
+GitHub's `bash -e -o pipefail` semantics with `gh` stubbed. Before: `develop` has no `review-gate`
+workflow at all, so the merge decision sees no review signal.
+
+```
+BLOCKING finding (error / security:high)
+  review-gate: BLOCK (blocking-findings)
+    - js/incomplete-sanitization [error/security:high] packages/agent-core/src/sanitize.ts:42
+  [gh] pr merge --disable-auto 9999
+  ::error::review-gate blocked this PR.                                        STEP EXIT=1
+
+NIT-level findings only (#1409's actual shape)
+  review-gate: PASS (advisory-only)
+  2 advisory finding(s) introduced by this PR — reported, not blocking.
+    - js/unused-local-variable [note] scripts/perf/compare-typecheck.mjs:3
+    - js/unused-local-variable [note] scripts/perf/compare-typecheck.mjs:4    STEP EXIT=0
+
+error-severity alert ALREADY open on the base branch
+  review-gate: PASS (clean) — 1 finding(s) already open on the base branch     STEP EXIT=0
+
+analysis did not complete / alert list unreadable
+  review-gate: BLOCK (verdict-unavailable)
+  … This gate does not report a pass it did not compute …                      STEP EXIT=1
+
+blocking finding + the acknowledge label
+  review-gate: PASS (blocking-findings, acknowledged)
+  OVERRIDDEN: … passes with the findings above on the record.                  STEP EXIT=0
+```
+
+Every case also writes the report to `$GITHUB_STEP_SUMMARY`, so the findings are on the PR's check
+page rather than only in a log.
 
 ## Test Plan
 
-Reproduce the class: open a PR containing a defect the review automation reliably flags (e.g. an unused
-import in a path outside eslint's scope — `scripts/` is such a path, which is exactly why #1409's defect
-survived lint). Confirm that under the chosen fix the PR **cannot** merge until the finding is addressed
-or explicitly dismissed. Then confirm a clean PR still merges without extra friction — the gate must not
-become a permanent stall.
+- `scripts/harness/__tests__/check-review-gate.test.mjs` — 19 tests: the severity split (note and
+  warning never block; error and security-high/critical do), pre-existing-on-base exclusion,
+  fixed/closed alerts ignored, both fail-closed paths (sentinel and unparseable payload), the
+  acknowledge override and its recording, and the CLI shape the workflow calls.
+- `scripts/harness/__tests__/scan-review-workflow-parity.test.mjs` — 7 tests: action-based
+  discovery, one-line drift (the exact `checkout@v4`→`@v7` shape), byte-identity, fail-closed when
+  the default branch is unresolvable, workflow absent from the default branch, promotion-PR
+  non-applicability, and the live repository.
+- YAML parse + `bash -n` on every `run:` block of both workflows.
+- `pnpm harness:verify-like-ci` (all five stages) and `pnpm harness:scan` — green.
+
+## User Execution Test Scenarios
+
+Not applicable as a product surface: this changes CI gating only, with no user-facing command or UI
+behaviour. The equivalent agent-run evidence is the transcripts above, each produced by running the
+real step body / the real scan against the real repository or a purpose-built fixture.
+
+## Remaining step (why this item is not yet closed)
+
+**Add `review-gate` to the `protect-develop` ruleset's required status checks.** Until then a red
+`review-gate` does not by itself stop a _manual_ merge — only the auto-merge path is covered, by the
+disarm. The entry cannot be added before this PR lands: a required check that does not yet exist on
+`develop` reports "expected" forever and blocks every open PR (INFRA-046's "flip the flag AND add to
+the ruleset" lesson, in the other direction).
+
+After this PR is merged to `develop` and one PR has been observed producing a `review-gate` check:
+
+```bash
+gh api repos/woojubb/robota/rulesets/18715844 --jq '.rules[] | select(.type=="required_status_checks")'
+# then PUT the ruleset back with {"context":"review-gate"} appended to required_status_checks
+```
+
+Also unobserved on a live runner: that the restored parity makes `Claude review` actually review.
+The mechanism is directly measured (three run logs, the one-line diff, 100/100 `success`), and the
+PR carrying this change is itself the first PR whose merge ref holds a file identical to `main`'s —
+so its `Claude Code Review` run is the observation point.

--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -59,6 +59,13 @@ So for every PR since 2026-07-24 the "review" check was green and empty. That is
 in its purest form — a check reporting success for work it did not do — and it is invisible from
 outside the run log.
 
+**It is a recurring window, not a one-off.** The condition opens whenever that file changes on
+`develop`, and closes silently on the next develop→main promotion. It closed mid-investigation: the
+routine promotion #1427 merged at `2026-07-25T17:27:54Z`, carrying `@v7` to `main`, which restored
+parity by itself. Nothing announced either edge. That is exactly why the fix is a scan rather than a
+one-line correction — the drift will recur on the next workflow edit, and only a mechanical check
+makes the window visible while it is open.
+
 ## Decision
 
 Three levers were on the table (the original item's options 1–3). What shipped, and why.
@@ -69,10 +76,11 @@ Three levers were on the table (the original item's options 1–3). What shipped
    in `run-all-scans` → runs inside the REQUIRED `scans` job). Every workflow that invokes
    `anthropics/claude-code-action` must match the default branch's copy exactly; drift fails the
    scan with the reason. Governed workflows are discovered by the action they invoke, never by a
-   hardcoded filename. `.github/workflows/claude-code-review.yml` is restored to byte-identity, so
-   the reviewer runs again. FAIL-CLOSED: if the default branch's copy cannot be read, the scan
-   fails. Not applicable on a PR whose base IS the default branch — that PR is the promotion which
-   restores parity.
+   hardcoded filename. FAIL-CLOSED: if the default branch's copy cannot be read, the scan fails. Not
+   applicable on a PR whose base IS the default branch — that PR is the promotion which restores
+   parity. The scan caught the drift twice during this work: once against the original `@v7`/`@v4`
+   split, and once again the other way after #1427 landed `@v7` on `main` mid-session. This PR
+   carries no net change to that workflow — the correction it needs is the guard, not the byte.
 
 2. **`review-gate` check** (`.github/workflows/review-gate.yml` + the pure, unit-tested decision
    module `scripts/harness/check-review-gate.mjs`). It waits for the code-scanning analysis of the
@@ -120,15 +128,22 @@ admin bypass nobody can audit.
 
 ## Red / green evidence
 
-**Parity — against the real repository:**
+**Parity — against the real repository, in both drift directions, on the live tree:**
 
 ```
-BEFORE  review-workflow-parity scan failed (INFRA-048):
-          - .github/workflows/claude-code-review.yml: differs from origin/main. … skips the review
-            and exits 0 — the check reports `success` having reviewed nothing.          EXIT=1
-AFTER   review-workflow-parity scan passed: .github/workflows/claude-code-review.yml
-          match origin/main.                                                            EXIT=0
+RED    (develop @v7 vs main @v4 — the state at the start of this work)
+       review-workflow-parity scan failed (INFRA-048):
+         - .github/workflows/claude-code-review.yml: differs from origin/main. … skips the review
+           and exits 0 — the check reports `success` having reviewed nothing.           EXIT=1
+GREEN  review-workflow-parity scan passed … match origin/main.                          EXIT=0
+
+RED    (again, unprompted: #1427 landed @v7 on main at 17:27:54Z, so the tree drifted the OTHER
+        way and the scan re-fired — the same finding, opposite direction)                EXIT=1
+GREEN  re-synced to the current default branch                                           EXIT=0
 ```
+
+The second RED was not staged. It is the guard catching a real, live drift mid-session — the
+recurrence this scan exists to make visible.
 
 **The gate.** The `Decide` step body is EXTRACTED from `review-gate.yml` itself and run under
 GitHub's `bash -e -o pipefail` semantics with `gh` stubbed. Before: `develop` has no `review-gate`

--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -196,7 +196,24 @@ gh api repos/woojubb/robota/rulesets/18715844 --jq '.rules[] | select(.type=="re
 # then PUT the ruleset back with {"context":"review-gate"} appended to required_status_checks
 ```
 
-Also unobserved on a live runner: that the restored parity makes `Claude review` actually review.
-The mechanism is directly measured (three run logs, the one-line diff, 100/100 `success`), and the
-PR carrying this change is itself the first PR whose merge ref holds a file identical to `main`'s —
-so its `Claude Code Review` run is the observation point.
+**Raise `--max-turns` on the review prompt — and do it on the default branch first.** The parity fix
+is confirmed live on the PR that carries it (#1434, run `30167624730`): the run log contains **zero**
+`workflow validation` lines, where every earlier run had them. The reviewer really ran — for ~2
+minutes instead of the previous 13–21 s — and then ended on
+
+```
+"subtype": "error_max_turns"
+##[error]Execution failed: Reached maximum number of turns (25)
+```
+
+posting `No buffered inline comments`. So the check went from **green-and-empty** to
+**red-and-honest**: the reviewer's turn budget is now the binding constraint, and it is visible.
+That is the point of the parity fix — the constraint existed all along and was hidden behind a
+`success`. A prompt that instructs the model to read `AGENTS.md` plus `.agents/rules/*` before
+judging a diff does not fit in 25 turns on this repo.
+
+Raising it means editing `claude-code-review.yml`, which the parity rule governs: the change must
+land on `main` first (or in the same promotion), otherwise the reviewer goes straight back to
+skipping. That constraint is inherent to the action, not to this scan — the scan only makes it
+visible instead of silent. Nothing downstream depends on this: `review-gate` reads code-scanning
+output, not the Claude review.

--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -86,17 +86,26 @@ Three levers were on the table (the original item's options 1–3). What shipped
    module `scripts/harness/check-review-gate.mjs`). It waits for the code-scanning analysis of the
    PR head, reads the alerts for the PR ref and for the base branch, and decides:
 
-   | class        | rule                                                          | blocks?                         |
-   | ------------ | ------------------------------------------------------------- | ------------------------------- |
-   | blocking     | introduced by this PR, severity `error` or security high/crit | **yes**                         |
-   | advisory     | any other alert introduced by this PR                         | no, but printed on the check    |
-   | pre-existing | already open on the base branch                               | no                              |
-   | unavailable  | analysis incomplete, API error, unparseable payload           | **yes**                         |
-   | acknowledged | PR carries `review-findings-acknowledged`                     | no, override recorded on the PR |
+   | class        | rule                                                            | blocks?                         |
+   | ------------ | --------------------------------------------------------------- | ------------------------------- |
+   | blocking     | introduced by this PR, severity `error` or security high/crit   | **yes**                         |
+   | advisory     | any other alert introduced by this PR                           | no, but printed on the check    |
+   | pre-existing | already open on the base branch                                 | no                              |
+   | unavailable  | no analysis record, analysis incomplete, API error, unparseable | **yes**                         |
+   | acknowledged | PR carries `review-findings-acknowledged`                       | no, override recorded on the PR |
 
    On a block it also runs `gh pr merge --disable-auto`, because a red **non-required** check does
    not stop an armed auto-merge — which is precisely the #1409 hole. The disarm is the lever that
    works today; the ruleset entry (below) is the durable one.
+
+   **A fail-open caught in the gate itself, live.** On the first run (#1434) the alerts query
+   returned **0** for the PR ref while `develop` carried 100 — and the gate reported `PASS (clean)`.
+   The zero turned out to be genuine (CodeQL's PR analyses are diff-informed: `results_count = 0` on
+   `refs/pull/1434/merge`), but the gate had no way to know that: the alerts endpoint answers `[]`
+   both for "analysed and clean" and for "never analysed". Same conflation, one level down. The
+   Collect step now checks the analysis RECORD first (`/code-scanning/analyses?ref=refs/pull/N/merge`)
+   and writes the `UNAVAILABLE` sentinel when none exists, so an empty list can only mean a real
+   result.
 
 **Why this design survives the NIT-bypass failure mode.** A gate that hard-fails on any review
 finding blocks merges on NITs and gets routinely bypassed, which is worse than advisory — a bypassed
@@ -176,6 +185,19 @@ blocking finding + the acknowledge label
 
 Every case also writes the report to `$GITHUB_STEP_SUMMARY`, so the findings are on the PR's check
 page rather than only in a log.
+
+**The gate, live on a real runner** (#1434, run `30168092423`, 3 m 32 s):
+
+```
+code-scanning analyses: 0/1 completed      <- polled; "not analysed yet" is never read as "clean"
+… (11 polls, 20 s apart) …
+code-scanning analyses: 1/1 completed
+review-gate: PASS (clean)
+no findings introduced by this PR.
+```
+
+So the check exists, waits for the analysis, and decides — where before there was no review signal
+on the merge decision at all.
 
 ## Test Plan
 

--- a/.agents/backlog/completed/INFRA-052-fail-open-harness-checks.md
+++ b/.agents/backlog/completed/INFRA-052-fail-open-harness-checks.md
@@ -1,0 +1,116 @@
+---
+title: 'INFRA-052: harness checks that report success for work they did not do'
+status: done
+created: 2026-07-26
+completed: 2026-07-26
+priority: high
+urgency: soon
+area: scripts/harness
+depends_on: [INFRA-050]
+---
+
+# INFRA-052: two harness checks failed open, and three terminal signals were unregistered
+
+Both fail-opens were recorded as deliberate residuals by INFRA-050 ("Residuals (not fixed here,
+deliberately)"). They share the INFRA-048 root cause: **a check that reports success when it did
+not run**.
+
+## Problem
+
+**B — `check-document-authority.mjs` failed open.** When no base ref resolved (or the diff against
+it failed) it printed `SKIPPED … Not a pass` and exited **0**. It runs inside `pnpm harness:scan`,
+which is a **required** CI gate, and `run-all-scans` reads exit codes — so the gate recorded a pass
+for a gate that had stopped enforcing. INFRA-050 measured exactly that on the former depth-50
+`scans` checkout. It also carried its own `git fetch --depth=50` fallback: a depth fetch GRAFTS the
+repository, so the rescue path was itself the thing that broke base resolution.
+
+**C — `shared.mjs`'s `detectChangedFiles` returned `[]`** when the base ref could not be resolved.
+An empty list is indistinguishable from "this branch changed nothing", and all four callers
+(`plan-change`, `verify-change`, `record-change`, `review-change`) read it that way. Checked every
+caller before changing the contract; none of them wants "could not compute" and "nothing changed"
+to be the same value.
+
+**D — three agent terminal signals were unregistered.** `CI TRIAGE`, `GATE VERDICT` and
+`SCENARIO DRAFTED` are the terminal output lines of `ci-failure-triager`, `backlog-gate-guard` and
+`user-execution-scenario-author`. Two HARNESS-049 increments shipped those agents but could not add
+the tokens to `CLOSED_SIGNAL_VOCAB` because `scripts/**` was outside their file ownership, so each
+agent had to omit its `signal:` frontmatter field and the orchestration map recorded a signal
+nothing could mechanically check.
+
+## What changed
+
+1. `check-document-authority.mjs` exits **1** when the base ref cannot be resolved or the diff
+   fails. The `--depth=50` fallback fetch is removed — every job that runs this scan now checks out
+   at `fetch-depth: 0` (INFRA-050), so `origin/<base>` is already present and complete.
+2. `detectChangedFiles` **throws** when the working tree is clean and no base ref resolves. An
+   empty list is still returned for the legitimate case: base resolved, diff ran, no files differ.
+3. `CI TRIAGE`, `GATE VERDICT`, `SCENARIO DRAFTED` registered in `CLOSED_SIGNAL_VOCAB`.
+
+## Red / green evidence
+
+Each fixture deliberately carries a REAL finding, so the red proves "a violating tree reported
+success", not merely "a code path was taken".
+
+**B — base ref unresolvable (no `origin`, no `develop`), branch adds a real violating architecture
+doc:**
+
+```
+BEFORE  document authority scan SKIPPED: no base ref could be resolved … Not a pass …   EXIT=0
+AFTER   document authority scan FAILED:  no base ref could be resolved …                EXIT=1
+```
+
+Same for an explicitly named but unreachable base ref (`--base-ref no-such-ref`): `EXIT=0` → `1`.
+
+Normal runs unchanged: resolvable base + violating branch → `EXIT=1` (finding printed) before and
+after; resolvable base + clean branch → `EXIT=0` before and after.
+
+**C — clean tree, no resolvable base, branch carries a real source change inside a workspace package:**
+
+```
+BEFORE  harness:plan   -> "Changed files: 0"                                        EXIT=0
+        harness:verify -> "No package or app scope detected from changed files."    EXIT=0
+AFTER   both -> Error: Unable to resolve a base ref to diff against … Refusing to
+        report "no changed files" from a base that could not be resolved            EXIT=1
+```
+
+Normal runs unchanged: resolvable base + real change → `Changed files: 1 / packages/widget`;
+genuinely empty diff → `Changed files: 0`, exit 0 (still an empty list, not an error); dirty
+working tree → `Changed files: 1` with no base ref needed; explicit `--base-ref base` → works.
+
+**Reverse-apply (accidental-green floor).** With the pre-fix source restored and the new tests kept:
+
+```
+check-document-authority.test.mjs   2 failed | 12 passed  ->  14 passed
+detect-changed-files.test.mjs       2 failed |  4 passed  ->   6 passed
+check-agent-def-convention.test.mjs 3 failed | 17 passed  ->  20 passed
+```
+
+## Test Plan
+
+- `scripts/harness/__tests__/check-document-authority.test.mjs` — fail-closed on an unresolvable
+  base and on an unreachable named base, plus an assertion that resolution performs no fetch (the
+  removed fallback was itself the graft).
+- `scripts/harness/__tests__/detect-changed-files.test.mjs` (new, 6 tests) — the two fail-closed
+  directions through the real `plan-change` / `verify-change` entrypoints, and four no-regression
+  cases. Subprocess-based because `detectChangedFiles` binds `WORKSPACE_ROOT` to `process.cwd()`.
+- `scripts/harness/__tests__/check-agent-def-convention.test.mjs` — each registered token asserted
+  BOTH ways (registered, and its emitting agent still emits it) so the entry cannot rot into dead
+  vocabulary.
+- `pnpm harness:test`, `pnpm harness:scan` (including INFRA-050's `ci-base-history`), and
+  `pnpm harness:verify-like-ci` — green.
+
+## User Execution Test Scenarios
+
+Not applicable: this changes harness gate behaviour only, with no user-facing command or UI
+surface. The equivalent agent-run evidence is the before/after transcripts above, produced by
+running the real scripts against purpose-built git fixtures.
+
+## Residuals
+
+- The three agents still declare no `signal:` frontmatter field. Registering the vocabulary is the
+  half that lives in `scripts/**`; adding the field lives in `.claude/agents/**`, which was outside
+  this change's file ownership. Now unblocked — nothing else stands in the way.
+- Roughly twenty scans return `[]` when their governed directory is absent (`if (!existsSync(dir))
+return []`), which reads as "clean". For optional directories that is correct; for
+  `scan-ci-base-history.mjs`'s `.github/workflows` it would mean guarding nothing while reporting a
+  pass. Not exercised today (the directory exists), so it is recorded rather than fixed.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     # Fork PRs have no access to secrets — skip so the run doesn't fail auth-less.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     # Fork PRs have no access to secrets — skip so the run doesn't fail auth-less.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,127 @@
+name: Review Gate
+
+# INFRA-048. The checks that gate a merge on `develop` produce no review feedback, and the two jobs
+# that do (`Claude review`, CodeQL `Analyze`) report `success` whether or not they found anything —
+# so an armed auto-merge carries the findings straight into the integration branch (#1409). This
+# job is the missing half: a DISTINCT check that READS the review output and reports the truth.
+#
+# It is deliberately NOT the reviewer itself. A reviewer's own pass/fail is model judgment and, as
+# INFRA-048 measured, a reviewer can report `success` without having run at all; a gate must be
+# something whose execution is verifiable.
+#
+# Severity split (see check-review-gate.mjs for the full rationale): only findings this PR
+# INTRODUCES at severity `error` / security-severity high|critical can block. Everything else is
+# printed and counted but never blocking — this repo's ~100 open alerts are all severity `note`,
+# and a gate that went red on those would be bypassed within a day.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    # `labeled`/`unlabeled` are included so applying the acknowledge label re-runs the gate rather
+    # than requiring a push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: read
+  pull-requests: write
+
+jobs:
+  review-gate:
+    name: review-gate
+    runs-on: ubuntu-latest
+    steps:
+      # No history is read — this job talks to the code-scanning API, not to git.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Wait for the code-scanning analysis of this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The gate must read a COMPLETED analysis. Polling here (rather than assuming) is what
+          # keeps "the analysis has not run yet" from being read as "the analysis found nothing".
+          deadline=$(( $(date +%s) + 900 ))
+          while :; do
+            runs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" \
+                      --jq '[.check_runs[] | select(.name | startswith("Analyze"))]' 2>/dev/null || echo '[]')"
+            total="$(printf '%s' "$runs" | jq 'length')"
+            done_count="$(printf '%s' "$runs" | jq '[.[] | select(.status == "completed")] | length')"
+            echo "code-scanning analyses: ${done_count}/${total} completed"
+            if [ "$total" -gt 0 ] && [ "$total" -eq "$done_count" ]; then
+              echo "analysis_complete=true" >> "$GITHUB_ENV"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              # Deliberately NOT a pass: an analysis that never completed has cleared nothing.
+              echo "::error::review-gate: the code-scanning analysis for ${HEAD_SHA} did not complete within 15 minutes."
+              echo "analysis_complete=false" >> "$GITHUB_ENV"
+              break
+            fi
+            sleep 20
+          done
+
+      - name: Collect the review output
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # `UNAVAILABLE` is the fail-closed sentinel the decision module blocks on. Every failure
+          # path below writes it — none of them writes an empty list, which would read as "clean".
+          if [ "${analysis_complete}" != "true" ]; then
+            echo "UNAVAILABLE" > pr-alerts.json
+          else
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?state=open&ref=refs/pull/${PR_NUMBER}/merge&per_page=100" \
+              > pr-alerts.json || echo "UNAVAILABLE" > pr-alerts.json
+          fi
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?state=open&ref=refs/heads/${BASE_REF}&per_page=100" \
+            > base-alerts.json || echo "UNAVAILABLE" > base-alerts.json
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --jq '[.[].name] | join(",")' \
+            > pr-labels.txt || echo "" > pr-labels.txt
+
+      - name: Decide
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          node scripts/harness/check-review-gate.mjs \
+            --alerts-file pr-alerts.json \
+            --base-alerts-file base-alerts.json \
+            --labels "$(cat pr-labels.txt)" | tee gate-report.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          {
+            echo '### Review gate'
+            echo
+            echo '```'
+            cat gate-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$status" -ne 0 ]; then
+            # Until `review-gate` is listed in the branch ruleset's required checks, a red
+            # non-required check does NOT stop an armed auto-merge — which is the exact hole
+            # INFRA-048 is about. Disarming is the lever that works today; the ruleset entry is
+            # the durable one. `--disable-auto` is a no-op error when auto-merge was never armed.
+            gh pr merge --disable-auto "$PR_NUMBER" \
+              || echo "auto-merge was not armed; nothing to disarm."
+            gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
+          **Review gate: BLOCKED** — auto-merge has been disarmed.
+
+          \`\`\`
+          $(cat gate-report.txt)
+          \`\`\`
+          EOF
+            echo "::error::review-gate blocked this PR. See the job summary."
+            exit 1
+          fi

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -75,7 +75,18 @@ jobs:
         run: |
           # `UNAVAILABLE` is the fail-closed sentinel the decision module blocks on. Every failure
           # path below writes it — none of them writes an empty list, which would read as "clean".
-          if [ "${analysis_complete}" != "true" ]; then
+          #
+          # An empty alert list is only meaningful if an analysis actually produced it. The alerts
+          # endpoint answers `[]` both for "this ref was analysed and is clean" and for "this ref
+          # was never analysed" — the same conflation this whole change exists to remove — so the
+          # analysis RECORD is checked first. (Observed live on #1434: the alerts query returned 0
+          # for the PR ref while `develop` carried 100; the analyses endpoint is what proves the
+          # zero is a real, diff-informed result rather than an absence.)
+          analyses="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/code-scanning/analyses?ref=refs/pull/${PR_NUMBER}/merge&per_page=1" \
+            --jq 'length' 2>/dev/null || echo 0)"
+          echo "code-scanning analyses recorded for refs/pull/${PR_NUMBER}/merge: ${analyses}"
+          if [ "${analysis_complete}" != "true" ] || [ "${analyses}" = "0" ]; then
             echo "UNAVAILABLE" > pr-alerts.json
           else
             gh api --paginate \

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "harness:scan:release-governance": "node scripts/harness/check-release-governance.mjs",
     "harness:scan:deps": "node scripts/harness/check-dependency-direction.mjs",
     "harness:scan:consistency": "node scripts/harness/scan-consistency.mjs",
+    "harness:scan:review-workflow-parity": "node scripts/harness/scan-review-workflow-parity.mjs",
+    "harness:review-gate": "node scripts/harness/check-review-gate.mjs",
     "harness:scan:document-authority": "node scripts/harness/check-document-authority.mjs",
     "harness:scan:document-standards": "node scripts/harness/check-document-standards-index.mjs",
     "harness:scan:arch-map-completeness": "node scripts/harness/check-architecture-map-completeness.mjs",

--- a/scripts/harness/__tests__/check-agent-def-convention.test.mjs
+++ b/scripts/harness/__tests__/check-agent-def-convention.test.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -154,6 +154,22 @@ describe('check-agent-def-convention (INFRA-030) — real corpus', () => {
   it('exposes the closed signal vocabulary including DECOMPOSITION', () => {
     expect(CLOSED_SIGNAL_VOCAB.has('DECOMPOSITION')).toBe(true);
     expect(CLOSED_SIGNAL_VOCAB.has('REVIEW VERDICT')).toBe(true);
+  });
+
+  // INFRA-048-D. Two HARNESS-049 increments shipped agents that end on a terminal signal but could
+  // not register it (`scripts/**` was outside their file ownership), so the token stayed outside the
+  // closed vocabulary and the agent had to omit its `signal:` field — a machine contract nothing
+  // could check. Each pair is asserted BOTH ways so the entry cannot rot into dead vocabulary: the
+  // token is registered, AND the agent that emits it still emits it.
+  it.each([
+    ['CI TRIAGE', 'ci-failure-triager.md'],
+    ['GATE VERDICT', 'backlog-gate-guard.md'],
+    ['SCENARIO DRAFTED', 'user-execution-scenario-author.md'],
+  ])('registers %s and its emitting agent %s still emits it', (token, agentFile) => {
+    expect(CLOSED_SIGNAL_VOCAB.has(token)).toBe(true);
+    const agentPath = path.resolve(import.meta.dirname, '../../../.claude/agents', agentFile);
+    expect(existsSync(agentPath)).toBe(true);
+    expect(readFileSync(agentPath, 'utf8')).toContain(`${token}:`);
   });
 });
 

--- a/scripts/harness/__tests__/check-document-authority.test.mjs
+++ b/scripts/harness/__tests__/check-document-authority.test.mjs
@@ -168,9 +168,28 @@ describe('base-ref resolution', () => {
     expect(resolveBaseRef({ argv: ['--base-ref', 'base'], env: {}, cwd: root })).toBe('base');
   });
 
-  it('returns undefined (SKIP, not silent pass) when no candidate resolves', async () => {
+  it('returns undefined when no candidate resolves (the caller must FAIL, not pass)', async () => {
     const root = await createGitFixture({});
     expect(resolveBaseRef({ argv: [], env: {}, cwd: root })).toBeUndefined();
+  });
+
+  // INFRA-048-B: the removed `git fetch --depth=50` fallback was itself a graft (INFRA-050). A
+  // fixture repo has no `origin`, so a fetch attempt would be visible as a mutated ref store.
+  it('performs NO fetch while resolving — a depth fetch grafts the history it was meant to supply', async () => {
+    const root = await createGitFixture({});
+    execFileSync('git', ['remote', 'add', 'origin', path.join(root, 'nonexistent-remote')], {
+      cwd: root,
+      env: gitSafeEnv(),
+    });
+    expect(resolveBaseRef({ argv: [], env: { GITHUB_BASE_REF: 'develop' }, cwd: root })).toBe(
+      undefined,
+    );
+    const shallow = spawnSync('git', ['rev-parse', '--is-shallow-repository'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: gitSafeEnv(),
+    });
+    expect(shallow.stdout.trim()).toBe('false');
   });
 
   it('lists changed files against the base ref', async () => {
@@ -201,10 +220,25 @@ describe('end-to-end (subprocess)', () => {
     expect(result.stdout).toContain('document authority scan passed');
   });
 
-  it('SKIP: exits 0 with an explicit SKIP log when no base ref resolves', async () => {
-    const root = await createGitFixture({});
+  // INFRA-048-B — fail closed. Before this, an unresolvable base printed `SKIPPED … Not a pass`
+  // and exited 0, so `run-all-scans` (a REQUIRED CI gate) recorded a pass for a gate that never
+  // ran. The fixture deliberately carries a REAL violation: the point is not "a code path was
+  // taken", it is "a tree with a finding in it reported success".
+  it('FAIL-CLOSED: exits 1 when no base ref resolves, even though the tree violates', async () => {
+    const root = await createGitFixture({
+      '.agents/specs/architecture-map/capability-placement.md': VIOLATING_ARCH_DOC,
+    });
     const result = runScript(root);
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain('SKIPPED: no base ref could be resolved');
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('FAILED: no base ref could be resolved');
+  });
+
+  it('FAIL-CLOSED: exits 1 when the base ref is named but the diff cannot run', async () => {
+    const root = await createGitFixture({
+      '.agents/specs/architecture-map/capability-placement.md': VIOLATING_ARCH_DOC,
+    });
+    const result = runScript(root, ['--base-ref', 'origin/never-fetched']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toMatch(/FAILED: (no base ref could be resolved|git diff against)/);
   });
 });

--- a/scripts/harness/__tests__/check-review-gate.test.mjs
+++ b/scripts/harness/__tests__/check-review-gate.test.mjs
@@ -1,0 +1,213 @@
+/**
+ * INFRA-048-A — the review gate must turn review findings into a merge-visible signal, WITHOUT
+ * becoming a gate that fires on NITs (which would be bypassed, i.e. worse than advisory).
+ *
+ * The fixtures are shaped like real GitHub code-scanning alerts, including the exact severity this
+ * repo's ~100 open alerts carry (`note` on `js/unused-local-variable`) — the calibration point for
+ * the severity split.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACKNOWLEDGE_LABEL,
+  UNAVAILABLE,
+  decideReviewGate,
+  isBlockingAlert,
+  renderDecision,
+} from '../check-review-gate.mjs';
+
+const SCRIPT = path.resolve(import.meta.dirname, '../check-review-gate.mjs');
+
+function alert({ number, severity = 'note', security = null, rule = 'js/unused-local-variable' }) {
+  return {
+    number,
+    state: 'open',
+    rule: { id: rule, severity, security_severity_level: security },
+    most_recent_instance: { location: { path: `src/file-${number}.ts`, start_line: 10 } },
+  };
+}
+
+describe('isBlockingAlert (the severity split)', () => {
+  it('does NOT block on `note` — the severity every open alert in this repo carries', () => {
+    expect(isBlockingAlert(alert({ number: 1, severity: 'note' }))).toBe(false);
+  });
+
+  it('does NOT block on `warning`', () => {
+    expect(isBlockingAlert(alert({ number: 2, severity: 'warning' }))).toBe(false);
+  });
+
+  it('blocks on `error`', () => {
+    expect(isBlockingAlert(alert({ number: 3, severity: 'error' }))).toBe(true);
+  });
+
+  it('blocks on high/critical security severity regardless of rule severity', () => {
+    expect(isBlockingAlert(alert({ number: 4, severity: 'warning', security: 'high' }))).toBe(true);
+    expect(isBlockingAlert(alert({ number: 5, severity: 'note', security: 'critical' }))).toBe(
+      true,
+    );
+    expect(isBlockingAlert(alert({ number: 6, severity: 'note', security: 'medium' }))).toBe(false);
+  });
+});
+
+describe('decideReviewGate', () => {
+  it('BLOCKS a PR that introduces an error-severity finding', () => {
+    const decision = decideReviewGate({
+      prAlerts: [alert({ number: 10, severity: 'error', rule: 'js/incomplete-sanitization' })],
+      baseAlerts: [],
+    });
+    expect(decision.blocked).toBe(true);
+    expect(decision.reason).toBe('blocking-findings');
+    expect(decision.blocking).toHaveLength(1);
+  });
+
+  it('PASSES a PR whose only new findings are advisory — but reports them', () => {
+    const decision = decideReviewGate({
+      prAlerts: [alert({ number: 11 }), alert({ number: 12 })],
+      baseAlerts: [],
+    });
+    expect(decision.blocked).toBe(false);
+    expect(decision.reason).toBe('advisory-only');
+    expect(decision.advisory).toHaveLength(2);
+    // The signal is still merge-visible: previously nothing was reported at all.
+    expect(renderDecision(decision)).toContain('Advisory findings introduced by this PR');
+  });
+
+  it('never blocks on findings that were already open on the base branch', () => {
+    const preExisting = alert({ number: 20, severity: 'error' });
+    const decision = decideReviewGate({ prAlerts: [preExisting], baseAlerts: [preExisting] });
+    expect(decision.blocked).toBe(false);
+    expect(decision.preExisting).toHaveLength(1);
+    expect(decision.blocking).toHaveLength(0);
+  });
+
+  it('PASSES a clean PR with no extra friction', () => {
+    const decision = decideReviewGate({ prAlerts: [], baseAlerts: [] });
+    expect(decision.blocked).toBe(false);
+    expect(decision.reason).toBe('clean');
+  });
+
+  it('ignores alerts that are no longer open', () => {
+    const fixed = { ...alert({ number: 30, severity: 'error' }), state: 'fixed' };
+    const decision = decideReviewGate({ prAlerts: [fixed], baseAlerts: [] });
+    expect(decision.blocked).toBe(false);
+  });
+
+  // The INFRA-048 root cause, one level up: a check must never report success for an answer it
+  // could not compute.
+  it('FAIL-CLOSED: blocks when the PR alert list is unavailable', () => {
+    const decision = decideReviewGate({ prAlerts: UNAVAILABLE, baseAlerts: [] });
+    expect(decision.blocked).toBe(true);
+    expect(decision.reason).toBe('verdict-unavailable');
+  });
+
+  it('FAIL-CLOSED: blocks when the base alert list is unavailable', () => {
+    const decision = decideReviewGate({ prAlerts: [], baseAlerts: UNAVAILABLE });
+    expect(decision.blocked).toBe(true);
+    expect(decision.reason).toBe('verdict-unavailable');
+  });
+
+  it('the acknowledge label overrides a block, and the override is recorded', () => {
+    const decision = decideReviewGate({
+      prAlerts: [alert({ number: 40, severity: 'error' })],
+      baseAlerts: [],
+      labels: [ACKNOWLEDGE_LABEL],
+    });
+    expect(decision.blocked).toBe(false);
+    expect(decision.acknowledged).toBe(true);
+    // Overridden, not hidden: the findings stay in the report.
+    const report = renderDecision(decision);
+    expect(report).toContain('OVERRIDDEN');
+    expect(report).toContain('Blocking findings introduced by this PR');
+  });
+
+  it('an unrelated label does not override', () => {
+    const decision = decideReviewGate({
+      prAlerts: [alert({ number: 41, severity: 'error' })],
+      baseAlerts: [],
+      labels: ['dependencies', 'size/S'],
+    });
+    expect(decision.blocked).toBe(true);
+  });
+});
+
+describe('CLI (the shape the workflow calls)', () => {
+  async function fixture(files) {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-review-gate-'));
+    mkdirSync(root, { recursive: true });
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(path.join(root, name), content, 'utf8');
+    }
+    return root;
+  }
+
+  function run(root, args) {
+    return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: root, encoding: 'utf8' });
+  }
+
+  it('exits 1 and names the finding when the PR introduces a blocking one', async () => {
+    const root = await fixture({
+      'pr.json': JSON.stringify([alert({ number: 50, severity: 'error', rule: 'js/xss' })]),
+      'base.json': '[]',
+    });
+    const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('review-gate: BLOCK (blocking-findings)');
+    expect(result.stdout).toContain('js/xss');
+  });
+
+  it('exits 0 on a clean PR', async () => {
+    const root = await fixture({ 'pr.json': '[]', 'base.json': '[]' });
+    const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('review-gate: PASS (clean)');
+  });
+
+  it('exits 0 on note-severity findings — the NIT-bypass failure mode is designed out', async () => {
+    const root = await fixture({
+      'pr.json': JSON.stringify([alert({ number: 51 }), alert({ number: 52 })]),
+      'base.json': '[]',
+    });
+    const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('review-gate: PASS (advisory-only)');
+    expect(result.stdout).toContain('js/unused-local-variable');
+  });
+
+  it('FAIL-CLOSED: exits 1 on the UNAVAILABLE sentinel the workflow writes', async () => {
+    const root = await fixture({ 'pr.json': 'UNAVAILABLE\n', 'base.json': '[]' });
+    const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('verdict-unavailable');
+  });
+
+  it('FAIL-CLOSED: exits 1 on an unparseable alert payload rather than treating it as empty', async () => {
+    const root = await fixture({ 'pr.json': '{"message":"Not Found"}', 'base.json': '[]' });
+    const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('verdict-unavailable');
+  });
+
+  it('exits 0 when the acknowledge label is passed', async () => {
+    const root = await fixture({
+      'pr.json': JSON.stringify([alert({ number: 53, severity: 'error' })]),
+      'base.json': '[]',
+    });
+    const result = run(root, [
+      '--alerts-file',
+      'pr.json',
+      '--base-alerts-file',
+      'base.json',
+      '--labels',
+      `other,${ACKNOWLEDGE_LABEL}`,
+    ]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('OVERRIDDEN');
+  });
+});

--- a/scripts/harness/__tests__/detect-changed-files.test.mjs
+++ b/scripts/harness/__tests__/detect-changed-files.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * INFRA-048-C — `detectChangedFiles` must FAIL CLOSED when the base ref cannot be resolved.
+ *
+ * It used to return `[]`, which every caller (`harness:plan`, `harness:verify`, `harness:record`,
+ * `harness:review`) reads as "nothing to check" — so a branch carrying real source changes was
+ * planned as zero scopes and `harness:verify` exited 0 having verified nothing. "Could not compute
+ * the change set" and "the change set is empty" had the same representation; now only the second
+ * one is an empty list.
+ *
+ * `detectChangedFiles` binds `WORKSPACE_ROOT` to `process.cwd()`, so these run the real CLI
+ * entrypoints as subprocesses against throwaway git workspaces — the same shape the defect had.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const PLAN_SCRIPT = path.resolve(import.meta.dirname, '../plan-change.mjs');
+const VERIFY_SCRIPT = path.resolve(import.meta.dirname, '../verify-change.mjs');
+
+/**
+ * Environment for git subprocesses, with every inherited GIT_* variable stripped. A git hook
+ * (husky pre-push runs the harness) exports GIT_DIR/GIT_INDEX_FILE, which redirect EVERY child
+ * `git` call to the REAL repository regardless of cwd — fixture commits would land on a live branch.
+ * `HARNESS_BASE_REF`/`GITHUB_BASE_REF` are cleared too: they are base-ref candidates, and a leaked
+ * value from the surrounding CI run would resolve a base the fixture is meant not to have.
+ */
+function fixtureEnv(extra = {}) {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+  );
+  delete env.HARNESS_BASE_REF;
+  delete env.GITHUB_BASE_REF;
+  return { ...env, ...extra };
+}
+
+function git(cwd, args) {
+  execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: fixtureEnv(),
+  });
+}
+
+/**
+ * A minimal pnpm workspace in a git repo. `baseBranch: 'develop'` creates a resolvable base-ref
+ * candidate; omitting it leaves a repo with no `origin`, no `develop` and no `main` — the exact
+ * "base ref cannot be resolved" condition.
+ */
+async function createWorkspaceFixture({ baseBranch = null, sourceChange = true } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'robota-detect-changed-'));
+  mkdirSync(path.join(root, 'packages/widget/src'), { recursive: true });
+  writeFileSync(path.join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf8');
+  writeFileSync(path.join(root, 'package.json'), '{"name":"root","private":true}\n', 'utf8');
+  writeFileSync(
+    path.join(root, 'packages/widget/package.json'),
+    '{"name":"widget","version":"1.0.0","scripts":{"test":"echo widget-test"}}\n',
+    'utf8',
+  );
+  writeFileSync(path.join(root, 'packages/widget/src/index.ts'), 'export const widget = 1;\n');
+  git(root, ['init', '-q', '-b', 'base']);
+  git(root, ['add', '.']);
+  git(root, ['commit', '-q', '-m', 'base']);
+  if (baseBranch) git(root, ['branch', baseBranch, 'base']);
+  git(root, ['checkout', '-q', '-b', 'work']);
+  if (sourceChange) {
+    writeFileSync(path.join(root, 'packages/widget/src/index.ts'), 'export const widget = 2;\n');
+    git(root, ['add', '.']);
+    git(root, ['commit', '-q', '-m', 'change widget source']);
+  }
+  return root;
+}
+
+function run(script, cwd, args = []) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: fixtureEnv(),
+  });
+}
+
+describe('detectChangedFiles fail-closed (INFRA-048-C)', () => {
+  it('FAIL-CLOSED: harness:plan exits non-zero when no base ref resolves', async () => {
+    const root = await createWorkspaceFixture();
+    const result = run(PLAN_SCRIPT, root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Unable to resolve a base ref');
+    // The defect's signature: it used to print a plan claiming the branch changed nothing.
+    expect(result.stdout).not.toContain('Changed files: 0');
+  });
+
+  it('FAIL-CLOSED: harness:verify refuses to report success it did not compute', async () => {
+    const root = await createWorkspaceFixture();
+    const result = run(VERIFY_SCRIPT, root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Unable to resolve a base ref');
+    expect(result.stdout).not.toContain('No package or app scope detected');
+  });
+
+  it('NO REGRESSION: a resolvable base still detects the changed scope', async () => {
+    const root = await createWorkspaceFixture({ baseBranch: 'develop' });
+    const result = run(PLAN_SCRIPT, root);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Changed files: 1');
+    expect(result.stdout).toContain('packages/widget');
+  });
+
+  it('NO REGRESSION: a genuinely empty diff is still an empty list, not an error', async () => {
+    const root = await createWorkspaceFixture({ baseBranch: 'develop', sourceChange: false });
+    const result = run(PLAN_SCRIPT, root);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Changed files: 0');
+  });
+
+  it('NO REGRESSION: a dirty working tree needs no base ref at all', async () => {
+    const root = await createWorkspaceFixture();
+    writeFileSync(path.join(root, 'packages/widget/src/index.ts'), 'export const widget = 3;\n');
+    const result = run(PLAN_SCRIPT, root);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Changed files: 1');
+  });
+
+  it('NO REGRESSION: an explicit --base-ref works without any branch-name convention', async () => {
+    const root = await createWorkspaceFixture();
+    const result = run(PLAN_SCRIPT, root, ['--base-ref', 'base']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Changed files: 1');
+  });
+});

--- a/scripts/harness/__tests__/scan-review-workflow-parity.test.mjs
+++ b/scripts/harness/__tests__/scan-review-workflow-parity.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * INFRA-048-A — `anthropics/claude-code-action` silently skips (and exits 0) when its workflow file
+ * differs from the default branch's copy, so the check reports `success` having reviewed nothing.
+ * Measured on this repo: a one-line `checkout@v4`→`@v7` bump merged to `develop` alone disabled the
+ * reviewer, and all 100 subsequent runs reported `success`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  findReviewWorkflowParityFindings,
+  isPromotionToDefault,
+  listGovernedWorkflows,
+} from '../scan-review-workflow-parity.mjs';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+/** GIT_* is stripped: inside a git hook it would redirect fixture git calls to the real repo. */
+function gitSafeEnv() {
+  return Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')));
+}
+
+function git(cwd, args) {
+  execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: gitSafeEnv(),
+  });
+}
+
+const REVIEW_WORKFLOW = [
+  'name: Claude Code Review',
+  'on:',
+  '  pull_request:',
+  '    branches: [main, develop]',
+  'jobs:',
+  '  review:',
+  '    runs-on: ubuntu-latest',
+  '    steps:',
+  '      - uses: actions/checkout@v4',
+  '      - uses: anthropics/claude-code-action@v1',
+  '',
+].join('\n');
+
+/** A repo with `main` carrying the review workflow, and a feature branch that may diverge. */
+async function createFixture({ featureContent = REVIEW_WORKFLOW } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'robota-review-parity-'));
+  const workflowPath = path.join(root, '.github/workflows/claude-code-review.yml');
+  mkdirSync(path.dirname(workflowPath), { recursive: true });
+  writeFileSync(workflowPath, REVIEW_WORKFLOW, 'utf8');
+  git(root, ['init', '-q', '-b', 'main']);
+  git(root, ['add', '.']);
+  git(root, ['commit', '-q', '-m', 'main']);
+  git(root, ['checkout', '-q', '-b', 'feature']);
+  if (featureContent !== REVIEW_WORKFLOW) {
+    writeFileSync(workflowPath, featureContent, 'utf8');
+    git(root, ['add', '.']);
+    git(root, ['commit', '-q', '-m', 'diverge']);
+  }
+  return root;
+}
+
+describe('scan-review-workflow-parity', () => {
+  it('discovers governed workflows by the action they invoke, not by a hardcoded name', async () => {
+    const root = await createFixture();
+    expect(listGovernedWorkflows(root)).toEqual(['.github/workflows/claude-code-review.yml']);
+  });
+
+  it('RED: reports drift when the workflow differs from the default branch by ONE line', async () => {
+    const root = await createFixture({
+      featureContent: REVIEW_WORKFLOW.replace('actions/checkout@v4', 'actions/checkout@v7'),
+    });
+    const { findings } = findReviewWorkflowParityFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].workflow).toBe('.github/workflows/claude-code-review.yml');
+    expect(findings[0].detail).toMatch(/differs from main/);
+  });
+
+  it('GREEN: reports nothing when the copies are byte-identical', async () => {
+    const root = await createFixture();
+    expect(findReviewWorkflowParityFindings(root).findings).toEqual([]);
+  });
+
+  it('FAIL-CLOSED: reports a finding when the default branch cannot be resolved', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-review-parity-nodefault-'));
+    const workflowPath = path.join(root, '.github/workflows/claude-code-review.yml');
+    mkdirSync(path.dirname(workflowPath), { recursive: true });
+    writeFileSync(workflowPath, REVIEW_WORKFLOW, 'utf8');
+    git(root, ['init', '-q', '-b', 'work']);
+    git(root, ['add', '.']);
+    git(root, ['commit', '-q', '-m', 'work']);
+    const { findings } = findReviewWorkflowParityFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatch(/will not report a pass it did not compute/);
+  });
+
+  it('reports a finding when the workflow does not exist on the default branch at all', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-review-parity-new-'));
+    mkdirSync(path.join(root, '.github/workflows'), { recursive: true });
+    writeFileSync(path.join(root, 'README.md'), '# f\n', 'utf8');
+    git(root, ['init', '-q', '-b', 'main']);
+    git(root, ['add', '.']);
+    git(root, ['commit', '-q', '-m', 'main']);
+    git(root, ['checkout', '-q', '-b', 'feature']);
+    writeFileSync(
+      path.join(root, '.github/workflows/claude-code-review.yml'),
+      REVIEW_WORKFLOW,
+      'utf8',
+    );
+    git(root, ['add', '.']);
+    git(root, ['commit', '-q', '-m', 'add review workflow']);
+    const { findings } = findReviewWorkflowParityFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatch(/does not exist on main/);
+  });
+
+  it('is not applicable to the promotion PR that restores parity', () => {
+    expect(isPromotionToDefault({ GITHUB_BASE_REF: 'main' })).toBe(true);
+    expect(isPromotionToDefault({ GITHUB_BASE_REF: 'develop' })).toBe(false);
+    expect(isPromotionToDefault({})).toBe(false);
+  });
+
+  it('holds on the real repository', () => {
+    const { findings } = findReviewWorkflowParityFindings(REPO_ROOT);
+    expect(findings).toEqual([]);
+  });
+});

--- a/scripts/harness/check-agent-def-convention.mjs
+++ b/scripts/harness/check-agent-def-convention.mjs
@@ -33,13 +33,24 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const AGENTS_DIR = path.join(WORKSPACE_ROOT, '.claude/agents');
 const SKILLS_INDEX = path.join(WORKSPACE_ROOT, '.agents/skills/index.md');
 
-/** The closed vocabulary of terminal machine-signals an agent may declare. */
+/**
+ * The closed vocabulary of terminal machine-signals an agent may declare.
+ *
+ * Adding a token here is what makes an agent able to DECLARE it in `signal:` frontmatter — an
+ * unregistered token fails this guard, so an agent that emits one has to omit the field, and the
+ * orchestration map then records a signal nothing can mechanically check. The last three were
+ * shipped by HARNESS-049 increments that could not edit `scripts/**` (file ownership) and so were
+ * left unregistered; registered here (INFRA-048-D).
+ */
 export const CLOSED_SIGNAL_VOCAB = new Set([
   'ACTIONABLE FINDINGS',
   'REVIEW VERDICT',
   'MERGE VERIFIED',
   'DECOMPOSITION',
   'PRIOR_ART_RESEARCH',
+  'CI TRIAGE',
+  'GATE VERDICT',
+  'SCENARIO DRAFTED',
 ]);
 
 const EDIT_TOOLS = ['Edit', 'Write'];

--- a/scripts/harness/check-document-authority.mjs
+++ b/scripts/harness/check-document-authority.mjs
@@ -16,14 +16,24 @@
  * PRs touching every package.json) where no owner-doc change is warranted, so it can only ever be
  * noise as a gate. Spec currency is governed by spec-workflow + audit-spec-coverage instead.
  *
- * Base-ref resolution (works in the base-ref-less CI `scans` job, which checks out with
- * `fetch-depth: 50` and no `origin/develop` ref):
+ * Base-ref resolution:
  * 1. `--base-ref <ref>` CLI argument, if given.
- * 2. `origin/$GITHUB_BASE_REF` (PR events), fetching the branch shallowly when the ref is absent.
- * 3. `origin/develop` (default), with the same fetch fallback.
- * When no base can be resolved, the scan SKIPS with an explicit log line — never a silent pass.
+ * 2. `origin/$GITHUB_BASE_REF` (PR events).
+ * 3. `origin/develop` (default).
  *
- * Exit code 0 = clean (or explicit SKIP), 1 = findings.
+ * FAIL-CLOSED (INFRA-048-B). When no base resolves, or the diff against it cannot run, this scan
+ * exits **1**. It previously printed `SKIPPED … Not a pass` and exited **0** — which every caller
+ * reads as a pass, so a required CI gate stopped enforcing while reporting success (INFRA-050
+ * measured exactly that on the depth-50 `scans` checkout). "Cannot determine the answer" is not
+ * "there is nothing to report": a tree carrying a real violation passed. Unblock by naming a base
+ * (`--base-ref <ref>`), not by ignoring the exit code.
+ *
+ * The former `git fetch --depth=50` fallback is GONE (INFRA-050): a depth fetch GRAFTS the
+ * repository, truncating ancestry `actions/checkout` already fetched, so the fallback that was
+ * meant to rescue a shallow checkout was itself the thing that broke base resolution. Every job
+ * that runs this scan now checks out with `fetch-depth: 0`, so `origin/<base>` is already present.
+ *
+ * Exit code 0 = clean, 1 = findings OR the gate could not be evaluated.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -86,10 +96,11 @@ function refExists(ref, options) {
 
 /**
  * Resolve the base ref to diff against. Candidates in priority order: an explicit `--base-ref`
- * argument, `origin/$GITHUB_BASE_REF` (PR CI), then `origin/<default>`. For `origin/<branch>`
- * candidates missing locally (shallow CI checkout), a targeted shallow fetch with an explicit
- * refspec is attempted before giving up. Returns the resolved ref, or `undefined` when none
- * resolves (the caller must SKIP loudly, not pass silently).
+ * argument, `origin/$GITHUB_BASE_REF` (PR CI), then `origin/<default>`. Returns the resolved ref,
+ * or `undefined` when none resolves — which the caller must treat as a FAILURE, not a pass.
+ *
+ * No fetch is attempted here (INFRA-048-B/INFRA-050): the only fetch that could help is a full one,
+ * and a depth-limited one grafts the history it is trying to supply. Callers check out complete.
  */
 export function resolveBaseRef({ argv = process.argv.slice(2), env = process.env, cwd } = {}) {
   const options = { cwd };
@@ -104,15 +115,6 @@ export function resolveBaseRef({ argv = process.argv.slice(2), env = process.env
 
   for (const candidate of candidates) {
     if (refExists(candidate, options)) return candidate;
-
-    const branchMatch = /^origin\/(.+)$/.exec(candidate);
-    if (!branchMatch) continue;
-    const branch = branchMatch[1];
-    const fetched = tryGit(
-      ['fetch', '--depth=50', 'origin', `+refs/heads/${branch}:refs/remotes/origin/${branch}`],
-      options,
-    );
-    if (fetched !== undefined && refExists(candidate, options)) return candidate;
   }
   return undefined;
 }
@@ -213,19 +215,25 @@ export async function main() {
   const baseRef = resolveBaseRef();
   if (baseRef === undefined) {
     process.stdout.write(
-      'document authority scan SKIPPED: no base ref could be resolved ' +
-        '(tried --base-ref, origin/$GITHUB_BASE_REF, origin/develop — including a shallow fetch). ' +
-        'Not a pass — provide a base ref to enforce this gate.\n',
+      'document authority scan FAILED: no base ref could be resolved ' +
+        '(tried --base-ref, origin/$GITHUB_BASE_REF, origin/develop). ' +
+        'This gate cannot report a pass it did not compute — an unresolvable base used to exit 0 ' +
+        'and silently stop enforcing (INFRA-048). Check out with full history ' +
+        '(`fetch-depth: 0`) or pass `--base-ref <ref>`.\n',
     );
+    process.exitCode = 1;
     return;
   }
 
   const changedFiles = getChangedFiles(baseRef);
   if (changedFiles === undefined) {
     process.stdout.write(
-      `document authority scan SKIPPED: git diff against ${baseRef} failed ` +
-        '(no reachable merge-base in this checkout). Not a pass — deepen the fetch to enforce this gate.\n',
+      `document authority scan FAILED: git diff against ${baseRef} failed ` +
+        '(no reachable merge-base in this checkout). This gate cannot report a pass it did not ' +
+        'compute (INFRA-048). Check out with full history (`fetch-depth: 0`) or pass a reachable ' +
+        '`--base-ref <ref>`.\n',
     );
+    process.exitCode = 1;
     return;
   }
 

--- a/scripts/harness/check-review-gate.mjs
+++ b/scripts/harness/check-review-gate.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+/**
+ * Review gate (INFRA-048-A) — turn a PR review's findings into a signal the MERGE DECISION can see.
+ *
+ * ## The defect
+ *
+ * The checks that gate a merge on `develop` are build / quality / scans / security audit /
+ * commitlint / tui-e2e / examples-typecheck / windows-shell. **Not one of them produces review
+ * feedback.** The two jobs that do — `Claude review` and CodeQL's `Analyze` — are advisory and
+ * report `success` whether or not they found anything. Measured on #1409: CodeQL's inline review
+ * posted 74 seconds BEFORE the merge, an armed auto-merge fired on the eight green gates, and the
+ * flagged defect landed on `develop`. Feedback was produced and never read.
+ *
+ * ## The design, and the trade-off it has to survive
+ *
+ * A gate that hard-fails on ANY review finding blocks merges on NITs. This repo makes that
+ * concrete: every one of its ~100 open code-scanning alerts is severity `note` (mostly
+ * `js/unused-local-variable`), so a "fail on any finding" gate would be red on every PR from day
+ * one and would be bypassed within a day — strictly worse than advisory, because a bypassed gate
+ * also teaches everyone to bypass. So:
+ *
+ *   - **Blocking** = an alert this PR INTRODUCES whose severity is `error`, or whose
+ *     security-severity is `high`/`critical`. Nothing else can block.
+ *   - **Advisory** = every other open alert on the PR. Reported, counted and printed on the check
+ *     — visible where nothing was visible before — but never blocking.
+ *   - **Pre-existing** = an alert already open on the base branch. Never this PR's problem.
+ *   - **Unavailable** = the analysis has not completed, or the alert list could not be read. This
+ *     BLOCKS. A review whose output cannot be read has not cleared anything; reporting a pass for
+ *     it is the same defect one level up (cf. INFRA-048-B/C).
+ *   - **Acknowledged** = the PR carries the acknowledge label. Passes, with the overridden findings
+ *     printed in full so the decision is recorded on the PR rather than exercised as a silent
+ *     admin bypass. One auditable escape beats a gate people learn to route around.
+ *
+ * Consumed by `.github/workflows/review-gate.yml`, which is a thin caller: it fetches the two alert
+ * lists and the labels, and this module decides. All logic is pure and unit-tested.
+ *
+ * Usage:
+ *   node scripts/harness/check-review-gate.mjs \
+ *     --alerts-file <pr-alerts.json> --base-alerts-file <base-alerts.json> [--labels a,b]
+ *
+ * Either alerts file may contain the literal string `UNAVAILABLE` (the workflow writes that when
+ * the API call fails), which is what triggers the fail-closed path.
+ *
+ * Exit code 0 = the merge decision may proceed, 1 = blocked.
+ */
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/** Rule severities that may block. CodeQL severities are: none | note | warning | error. */
+export const BLOCKING_RULE_SEVERITIES = new Set(['error']);
+
+/** Security severities that may block, independent of the rule severity. */
+export const BLOCKING_SECURITY_SEVERITIES = new Set(['high', 'critical']);
+
+/** The single, auditable escape hatch. Applying it is a recorded act on the PR. */
+export const ACKNOWLEDGE_LABEL = 'review-findings-acknowledged';
+
+/** Sentinel the workflow writes when an alert list could not be retrieved. */
+export const UNAVAILABLE = 'UNAVAILABLE';
+
+function alertSeverity(alert) {
+  return String(alert?.rule?.severity ?? '').toLowerCase();
+}
+
+function alertSecuritySeverity(alert) {
+  return String(alert?.rule?.security_severity_level ?? '').toLowerCase();
+}
+
+/** Whether an alert is severe enough to block a merge on its own. */
+export function isBlockingAlert(alert) {
+  return (
+    BLOCKING_RULE_SEVERITIES.has(alertSeverity(alert)) ||
+    BLOCKING_SECURITY_SEVERITIES.has(alertSecuritySeverity(alert))
+  );
+}
+
+function describeAlert(alert) {
+  const rule = alert?.rule?.id ?? alert?.rule?.name ?? '(unknown rule)';
+  const location = alert?.most_recent_instance?.location?.path ?? '(unknown file)';
+  const line = alert?.most_recent_instance?.location?.start_line;
+  const severity = alertSeverity(alert) || 'unknown';
+  const security = alertSecuritySeverity(alert);
+  const severityText = security ? `${severity}/security:${security}` : severity;
+  return `${rule} [${severityText}] ${location}${line ? `:${line}` : ''}`;
+}
+
+/**
+ * Decide whether the review output permits a merge.
+ *
+ * @param {object} input
+ * @param {Array<object>|'UNAVAILABLE'} input.prAlerts     open alerts on the PR's merge ref
+ * @param {Array<object>|'UNAVAILABLE'} input.baseAlerts   open alerts on the base branch
+ * @param {string[]} [input.labels]                        labels currently on the PR
+ * @returns {{blocked: boolean, reason: string, blocking: object[], advisory: object[],
+ *            preExisting: object[], acknowledged: boolean, summary: string}}
+ */
+export function decideReviewGate({ prAlerts, baseAlerts, labels = [] }) {
+  const acknowledged = labels.includes(ACKNOWLEDGE_LABEL);
+
+  if (prAlerts === UNAVAILABLE || baseAlerts === UNAVAILABLE) {
+    const which = prAlerts === UNAVAILABLE ? "the PR's" : "the base branch's";
+    return {
+      blocked: !acknowledged,
+      reason: 'verdict-unavailable',
+      blocking: [],
+      advisory: [],
+      preExisting: [],
+      acknowledged,
+      summary:
+        `${which} code-scanning result could not be read, so no review finding has been cleared. ` +
+        'This gate does not report a pass it did not compute — re-run the analysis, or apply the ' +
+        `\`${ACKNOWLEDGE_LABEL}\` label to record an explicit decision to merge without it.`,
+    };
+  }
+
+  const openPrAlerts = prAlerts.filter((alert) => (alert?.state ?? 'open') === 'open');
+  const baseNumbers = new Set(
+    baseAlerts.filter((alert) => (alert?.state ?? 'open') === 'open').map((alert) => alert?.number),
+  );
+
+  const preExisting = openPrAlerts.filter((alert) => baseNumbers.has(alert?.number));
+  const introduced = openPrAlerts.filter((alert) => !baseNumbers.has(alert?.number));
+  const blocking = introduced.filter(isBlockingAlert);
+  const advisory = introduced.filter((alert) => !isBlockingAlert(alert));
+
+  if (blocking.length === 0) {
+    return {
+      blocked: false,
+      reason: advisory.length > 0 ? 'advisory-only' : 'clean',
+      blocking,
+      advisory,
+      preExisting,
+      acknowledged,
+      summary:
+        advisory.length > 0
+          ? `${advisory.length} advisory finding(s) introduced by this PR — reported, not blocking.`
+          : 'no findings introduced by this PR.',
+    };
+  }
+
+  return {
+    blocked: !acknowledged,
+    reason: 'blocking-findings',
+    blocking,
+    advisory,
+    preExisting,
+    acknowledged,
+    summary:
+      `${blocking.length} blocking finding(s) introduced by this PR (severity \`error\`, or ` +
+      'security-severity high/critical). Fix them, or record an explicit decision with the ' +
+      `\`${ACKNOWLEDGE_LABEL}\` label.`,
+  };
+}
+
+/** Render the decision for the check's log. Returns the text; the caller owns the exit code. */
+export function renderDecision(decision) {
+  const overridden =
+    decision.acknowledged &&
+    (decision.reason === 'blocking-findings' || decision.reason === 'verdict-unavailable');
+  const lines = [];
+  lines.push(
+    `review-gate: ${decision.blocked ? 'BLOCK' : 'PASS'} (${decision.reason}${
+      overridden ? ', acknowledged' : ''
+    })`,
+  );
+  lines.push(decision.summary);
+
+  if (decision.blocking.length > 0) {
+    lines.push('', 'Blocking findings introduced by this PR:');
+    for (const alert of decision.blocking) lines.push(`  - ${describeAlert(alert)}`);
+  }
+  if (decision.advisory.length > 0) {
+    lines.push('', 'Advisory findings introduced by this PR (not blocking, still worth reading):');
+    for (const alert of decision.advisory) lines.push(`  - ${describeAlert(alert)}`);
+  }
+  if (decision.preExisting.length > 0) {
+    lines.push(
+      '',
+      `${decision.preExisting.length} finding(s) already open on the base branch — not this PR's.`,
+    );
+  }
+  if (overridden) {
+    lines.push(
+      '',
+      `OVERRIDDEN: the \`${ACKNOWLEDGE_LABEL}\` label is applied, so this gate passes with the ` +
+        'findings above on the record.',
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+function readAlerts(filePath) {
+  const raw = readFileSync(filePath, 'utf8').trim();
+  if (raw === UNAVAILABLE || raw === '') return UNAVAILABLE;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : UNAVAILABLE;
+  } catch {
+    return UNAVAILABLE;
+  }
+}
+
+function argValue(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index === -1 ? undefined : argv[index + 1];
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const alertsFile = argValue(argv, '--alerts-file');
+  const baseAlertsFile = argValue(argv, '--base-alerts-file');
+  if (!alertsFile || !baseAlertsFile) {
+    process.stderr.write(
+      'usage: check-review-gate.mjs --alerts-file <json> --base-alerts-file <json> [--labels a,b]\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const labels = (argValue(argv, '--labels') ?? '')
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+
+  const decision = decideReviewGate({
+    prAlerts: readAlerts(alertsFile),
+    baseAlerts: readAlerts(baseAlertsFile),
+    labels,
+  });
+
+  process.stdout.write(renderDecision(decision));
+  process.exitCode = decision.blocked ? 1 : 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -41,6 +41,10 @@ const SCAN_COMMANDS = [
   },
   { name: 'hook-catalog', command: ['node', 'scripts/harness/scan-hook-catalog.mjs'] },
   { name: 'review-findings', command: ['node', 'scripts/harness/scan-review-findings.mjs'] },
+  {
+    name: 'review-workflow-parity',
+    command: ['node', 'scripts/harness/scan-review-workflow-parity.mjs'],
+  },
   { name: 'document-authority', command: ['node', 'scripts/harness/check-document-authority.mjs'] },
   { name: 'commands', command: ['node', 'scripts/harness/check-command-layering.mjs'] },
   {

--- a/scripts/harness/scan-review-workflow-parity.mjs
+++ b/scripts/harness/scan-review-workflow-parity.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * Review-workflow parity guard (INFRA-048-A).
+ *
+ * `anthropics/claude-code-action` validates, at run time, that the workflow file invoking it is
+ * BYTE-IDENTICAL to the copy on the repository's default branch. When it is not, the action prints
+ *
+ *     Skipping action due to workflow validation: … must have identical content to the version on
+ *     the repository's default branch
+ *     Exiting due to workflow validation skip
+ *
+ * and **exits 0**. The job then reports `success` having reviewed nothing.
+ *
+ * Measured on this repo (2026-07-26): `.github/workflows/claude-code-review.yml` on `develop`
+ * differed from `main` by exactly one line — `actions/checkout@v7` vs `@v4`, a major-version bump
+ * merged to `develop` on 2026-07-24 (#1313) and never promoted. Every one of the last 100
+ * `Claude Code Review` runs reported `success`; every one of the three inspected in detail had
+ * reviewed nothing. That is the INFRA-048 defect in its purest form — a check reporting success
+ * for work it did not do — and it is invisible from the outside, which is why it needs a
+ * mechanical floor rather than a habit.
+ *
+ * Rule: every workflow that invokes the action must match the default branch's copy exactly.
+ *
+ * Changing such a workflow therefore requires promoting the change to the default branch before
+ * (or in the same promotion as) the feature branch — the scan does not apply to a PR whose base IS
+ * the default branch, because that PR is precisely the promotion that restores parity.
+ *
+ * FAIL-CLOSED: if the default branch's copy cannot be read, this scan exits 1. It cannot report a
+ * pass it did not compute.
+ *
+ * Exit code 0 = every governed workflow is at parity, 1 = drift (or parity is unverifiable).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_DIR = path.join('.github', 'workflows');
+
+/** The action whose workflow-validation makes parity load-bearing. */
+export const VALIDATED_ACTION_PATTERN = /anthropics\/claude-code-action/;
+
+/** Default-branch candidates, in order. */
+const DEFAULT_BRANCH_CANDIDATES = ['origin/main', 'main'];
+
+function tryGit(args, cwd) {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Workflow files (repo-relative) that invoke the validated action. Discovered, never hardcoded. */
+export function listGovernedWorkflows(root = WORKSPACE_ROOT) {
+  const dir = path.join(root, WORKFLOW_DIR);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((entry) => /\.ya?ml$/.test(entry))
+    .sort()
+    .map((entry) => path.join(WORKFLOW_DIR, entry))
+    .filter((relPath) =>
+      VALIDATED_ACTION_PATTERN.test(readFileSync(path.join(root, relPath), 'utf8')),
+    );
+}
+
+/**
+ * The parity rule does not apply while the change is being promoted INTO the default branch — that
+ * PR is what restores parity. Determined from the event, not from a suppression comment.
+ */
+export function isPromotionToDefault(env = process.env, defaultBranch = 'main') {
+  return env.GITHUB_BASE_REF?.trim() === defaultBranch;
+}
+
+/**
+ * Compare each governed workflow against the default branch's copy.
+ *
+ * @returns {{findings: Array<{workflow: string, detail: string}>, checked: string[], defaultRef: string|undefined}}
+ */
+export function findReviewWorkflowParityFindings(root = WORKSPACE_ROOT) {
+  const workflows = listGovernedWorkflows(root);
+  if (workflows.length === 0) {
+    return { findings: [], checked: [], defaultRef: undefined };
+  }
+
+  const defaultRef = DEFAULT_BRANCH_CANDIDATES.find(
+    (ref) => tryGit(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], root) !== undefined,
+  );
+  if (defaultRef === undefined) {
+    return {
+      findings: [
+        {
+          workflow: '(default branch)',
+          detail:
+            `neither ${DEFAULT_BRANCH_CANDIDATES.join(' nor ')} resolves, so parity cannot be ` +
+            'verified. This scan will not report a pass it did not compute — fetch the default ' +
+            'branch (`fetch-depth: 0`).',
+        },
+      ],
+      checked: workflows,
+      defaultRef: undefined,
+    };
+  }
+
+  const findings = [];
+  for (const workflow of workflows) {
+    const local = readFileSync(path.join(root, workflow), 'utf8');
+    const onDefault = tryGit(['show', `${defaultRef}:${workflow}`], root);
+    if (onDefault === undefined) {
+      findings.push({
+        workflow,
+        detail:
+          `does not exist on ${defaultRef}. The action refuses to run until the workflow file is ` +
+          'present on the default branch — until then the job reports `success` having reviewed nothing.',
+      });
+      continue;
+    }
+    if (local !== onDefault) {
+      findings.push({
+        workflow,
+        detail:
+          `differs from ${defaultRef}. \`anthropics/claude-code-action\` requires BYTE-IDENTICAL ` +
+          'content and, when it differs, skips the review and exits 0 — the check reports `success` ' +
+          `having reviewed nothing. Diff: \`git diff ${defaultRef} -- ${workflow}\`. Promote the ` +
+          'change to the default branch (or revert it here) before relying on the review again.',
+      });
+    }
+  }
+  return { findings, checked: workflows, defaultRef };
+}
+
+export function main() {
+  if (isPromotionToDefault()) {
+    process.stdout.write(
+      'review-workflow-parity scan: this PR targets the default branch, i.e. it IS the promotion ' +
+        'that restores parity — rule not applicable.\n',
+    );
+    return;
+  }
+
+  const { findings, checked, defaultRef } = findReviewWorkflowParityFindings();
+
+  if (checked.length === 0) {
+    process.stdout.write(
+      'review-workflow-parity scan: no workflow invokes anthropics/claude-code-action — nothing to guard.\n',
+    );
+    return;
+  }
+
+  if (findings.length > 0) {
+    process.stdout.write('review-workflow-parity scan failed (INFRA-048):\n');
+    for (const finding of findings) {
+      process.stdout.write(`  - ${finding.workflow}: ${finding.detail}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `review-workflow-parity scan passed: ${checked.join(', ')} match ${defaultRef}.\n`,
+  );
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -331,6 +331,16 @@ export function runCommand(command, args, workdir, dryRun, envOverrides = {}) {
   return result;
 }
 
+/**
+ * The files this change touches: uncommitted working-tree entries when the tree is dirty, otherwise
+ * the branch's diff against its base ref.
+ *
+ * FAIL-CLOSED (INFRA-048-C). When the tree is clean and NO base ref can be resolved, this throws.
+ * It used to return `[]`, which is indistinguishable from a branch that genuinely changed nothing —
+ * so `harness:plan` printed "Changed files: 0" and `harness:verify` exited 0 having verified
+ * nothing, on a branch carrying real source changes. An empty list is still returned for the
+ * legitimate case (base resolved, diff ran, no files differ); only "could not compute" now throws.
+ */
 export function detectChangedFiles(baseRef = null) {
   const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
     cwd: WORKSPACE_ROOT,
@@ -349,7 +359,13 @@ export function detectChangedFiles(baseRef = null) {
   const resolvedBaseRef = resolveGitBaseRef(baseRef);
 
   if (!resolvedBaseRef) {
-    return [];
+    throw new Error(
+      'Unable to resolve a base ref to diff against (tried --base-ref, $HARNESS_BASE_REF, ' +
+        'origin/$GITHUB_BASE_REF, $GITHUB_BASE_REF, origin/develop, develop, origin/main, main). ' +
+        'Refusing to report "no changed files" from a base that could not be resolved — that reads ' +
+        'as "nothing to verify" and silently verifies nothing (INFRA-048). ' +
+        'Pass --base-ref <ref>, or fetch the base branch.',
+    );
   }
 
   const diffResult = spawnSync(


### PR DESCRIPTION
Closes the "a gate exists but does not actually gate" class. All four items share one root cause:
**a check that reports success when it did not run.**

## A — review findings now reach the merge decision (INFRA-048)

Investigating the item turned up something worse than "reports pass regardless of findings":
**`Claude review` was not reviewing at all.** `anthropics/claude-code-action` validates that its
workflow file is byte-identical to the default branch's copy and, when it differs, prints
`Exiting due to workflow validation skip` and **exits 0** — the job reports `success`. A
`actions/checkout@v4`→`@v7` bump merged to `develop` alone (#1313, 2026-07-24) broke that identity
by one line.

| evidence | value |
| --- | --- |
| `gh run list --workflow=claude-code-review.yml --limit 100` | `success: 100` of 100 |
| three runs inspected in full (#1432 / #1423 / #1421) | all three: validation skip, 13–21 s |

Two mechanical halves:

**It is a recurring window, not a one-off.** It opens whenever that file changes on `develop` and
closes silently on the next develop→main promotion. It closed mid-investigation: promotion #1427
merged at `17:27:54Z` carrying `@v7` to `main`, restoring parity by itself. Nothing announced either
edge. So this PR carries **no net change** to that workflow — the correction the defect needs is the
guard, not the byte.

1. **`scan-review-workflow-parity`** — registered in `run-all-scans`, so it runs inside the
   **required** `scans` job. Every workflow invoking that action must match the default branch's
   copy; governed workflows are discovered by the action they invoke, never by filename. Fails
   closed if the default branch cannot be read; not applicable to the promotion PR that restores
   parity.
2. **`review-gate`** — a distinct check that READS the review output.

| class | rule | blocks? |
| --- | --- | --- |
| blocking | introduced by this PR, severity `error` or security high/critical | **yes** |
| advisory | any other alert introduced by this PR | no — printed on the check |
| pre-existing | already open on the base branch | no |
| unavailable | analysis incomplete / API error / unparseable | **yes** |
| acknowledged | PR carries `review-findings-acknowledged` | no — override recorded on the PR |

On a block it also runs `gh pr merge --disable-auto`, because a red **non-required** check does not
stop an armed auto-merge — the exact #1409 hole.

**The trade-off.** A gate that hard-fails on any finding blocks on NITs and gets bypassed, which is
worse than advisory. This repo makes that measurable: **every one of its ~100 open code-scanning
alerts is severity `note`**, so such a gate would be red on every PR from day one. Hence the
severity split, and one auditable per-PR label instead of a blanket admin bypass.

**Rejected:** hard-fail on any finding (the NIT trap, with the repo's own alert corpus as evidence);
making `Claude review` itself the blocking check (model judgment, and it can report success without
running — a gate must be something whose execution is verifiable); making CodeQL `Analyze` required
on its own (it reports that the analysis completed, not that findings exist — it was green on #1409
while the finding was live); procedure-only (already landed as #1412, and a procedure cannot be a
mechanical floor).

## B — `check-document-authority.mjs` fails closed

Exits **1** when the base ref cannot be resolved or the diff fails, instead of `SKIPPED … Not a
pass` + exit 0 inside a **required** gate. Its own `git fetch --depth=50` fallback is removed — a
depth fetch grafts the repository, so the rescue path was itself what broke base resolution.

## C — `detectChangedFiles` fails closed

Throws when the tree is clean and no base ref resolves, instead of returning `[]` (indistinguishable
from "this branch changed nothing"). All four callers checked first; an empty list is still returned
for the legitimate case — base resolved, diff ran, no files differ.

## D — terminal signals registered

`CI TRIAGE`, `GATE VERDICT`, `SCENARIO DRAFTED` added to `CLOSED_SIGNAL_VOCAB`, each asserted both
ways so the entry cannot rot into dead vocabulary.

## Red / green

Every fixture carries a REAL finding, so the red proves "a violating tree reported success", not
merely "a code path was taken".

```
B  base unresolvable, branch adds a violating architecture doc
   BEFORE  document authority scan SKIPPED: … Not a pass …                 EXIT=0
   AFTER   document authority scan FAILED:  no base ref could be resolved   EXIT=1
   normal: resolvable base + violation -> EXIT=1 (both);  + clean tree -> EXIT=0 (both)

C  clean tree, no resolvable base, branch changes a workspace package source file
   BEFORE  harness:plan "Changed files: 0" / harness:verify "No package or app
           scope detected from changed files."                              EXIT=0
   AFTER   Unable to resolve a base ref to diff against … Refusing to report
           "no changed files" from a base that could not be resolved        EXIT=1
   normal: real change -> "Changed files: 1"; empty diff -> "Changed files: 0" exit 0;
           dirty tree -> "Changed files: 1"; explicit --base-ref -> works

A  parity, against the real repository, in BOTH drift directions, live
   RED    develop @v7 vs main @v4 (the state at the start of this work)     EXIT=1
   GREEN  review-workflow-parity scan passed … match origin/main            EXIT=0
   RED    again, unprompted: #1427 landed @v7 on main mid-session, so the
          tree drifted the OTHER way and the scan re-fired on pre-push      EXIT=1
   GREEN  re-synced to the current default branch                           EXIT=0
   (the second RED was not staged — it is the guard catching a live drift)

A  the gate (Decide step body EXTRACTED from review-gate.yml, run under bash -e -o pipefail)
   BEFORE  develop has no review-gate workflow: the merge decision sees no review signal
   blocking (error/security:high) -> BLOCK + gh pr merge --disable-auto     EXIT=1
   note-only (#1409's shape)      -> PASS (advisory-only), findings printed EXIT=0
   error already open on base     -> PASS (clean)                           EXIT=0
   analysis unreadable            -> BLOCK (verdict-unavailable)            EXIT=1
   blocking + acknowledge label   -> PASS (…, acknowledged) + OVERRIDDEN    EXIT=0
```

Reverse-apply (accidental-green floor), pre-fix source with the new tests kept:

```
check-document-authority.test.mjs   2 failed | 12 passed  ->  14 passed
detect-changed-files.test.mjs       2 failed |  4 passed  ->   6 passed
check-agent-def-convention.test.mjs 3 failed | 17 passed  ->  20 passed
```

## Verification

```
pnpm harness:verify-like-ci   PASS — all 5 CI-mirroring stage(s) passed.
pnpm harness:scan             all 64 scans passed   (ci-base-history ✓, document-authority ✓,
                                                     review-workflow-parity ✓)
pnpm harness:test             79 files, 876 tests passed
```

Plus YAML parse and `bash -n` on every `run:` block of both workflows.

**Live, on this PR.** Run `30167624730` (17:26:17Z, while the copies matched) contains **zero**
`workflow validation` lines, where all 100 preceding runs skipped — the reviewer really ran, for ~2
minutes instead of 13–21 s. It then ended on `error_max_turns` at 25 turns, posting no inline
comments. So the check went from **green-and-empty** to **red-and-honest**: the turn budget was
always the binding constraint and was hidden behind a `success`. Raising `--max-turns` must land on
the default branch first (the parity rule governs that file); recorded as a follow-up. Nothing
downstream depends on it — `review-gate` reads code-scanning output, not the Claude review.

## Not closed yet

`review-gate` must be added to the `protect-develop` ruleset's required status checks. That cannot
be done before this lands — a required check that does not yet exist reports "expected" forever and
blocks every open PR. Until then only the auto-merge path is covered, by the disarm. INFRA-048 stays
`in-progress` with the exact command recorded; INFRA-052 (B/C/D) is closed and archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
