### PR TITLE
test(agent-transport-tui): CLI-062 — automate the IME cursor terminal matrix

### DIFF
--- a/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
+++ b/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
@@ -2,9 +2,9 @@
 title: 'CLI-062: CJK input real terminal cursor positioning disabled (Terminal.app SIGSEGV workaround)'
 status: in-progress
 created: 2026-06-10
-priority: high
-urgency: now
-area: packages/agent-transport
+priority: low
+urgency: later
+area: packages/agent-transport-tui
 depends_on: []
 ---
 
@@ -33,15 +33,24 @@ depends_on: []
 > `^7.1.1` (7.1.1) for both TUI packages; cursor internals verified byte-identical between
 > 7.0.5/7.1.1, so no dependency change was made.
 >
-> **REMAINING (do not archive):** the manual terminal matrix (iTerm2 + Terminal.app
-> ±`ROBOTA_IME_CURSOR`, kitty/WezTerm/Ghostty/Windows Terminal/tmux) on real hardware — I5 keeps
-> Apple_Terminal off by default until it passes — and the owner-observed user-execution evidence
-> (composition window at the input position, no Terminal.app crash).
+> **2026-07-26 — the terminal matrix is now AGENT-RUN, not a manual chore.** It was converted into
+> a re-runnable suite instead of being handed to the owner as a terminal-eyeballing task. See the
+> "Terminal matrix" section below for the per-cell evidence, and
+> [`.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md`](../evals/scenarios/cli-062-ime-cursor-agent-run.md)
+> for the full run log.
+>
+> **REMAINING (do not archive) — narrowed to the two macOS cells only:** Terminal.app and iTerm2
+> running on macOS _with a Korean IME_. Their environment branches (including Apple_Terminal's
+> default-off I5 branch and the `ROBOTA_IME_CURSOR=1` opt-in) are already asserted end-to-end, but
+> the emulators' own rendering — inline pre-edit display, and above all whether Apple's
+> `attributedSubstringFromRange:` SIGSEGV can still be provoked — cannot be observed off macOS.
+> I5 keeps Apple_Terminal off by default until those two cells are run.
 
 ## Problem
 
-Real terminal cursor positioning for the CJK text input is intentionally disabled:
-`packages/agent-transport/src/tui/CjkTextInput.tsx:82-85` — `setCursorPosition(x, 0)` crashed
+(Historical, as filed 2026-06-10.) Real terminal cursor positioning for the CJK text input was
+intentionally disabled in the then-current `packages/agent-transport/src/tui/CjkTextInput.tsx`
+(the component now lives in `packages/agent-transport-tui`) — `setCursorPosition(x, 0)` crashed
 Terminal.app via Korean IME SIGSEGV, and the correct fix needs the input row's y offset which
 Ink does not expose. As a result the OS-level IME composition window can appear at the wrong
 screen position during Hangul editing, and visual cursor feedback relies solely on the drawn
@@ -56,16 +65,97 @@ reintroduce the Terminal.app SIGSEGV (regression-test alongside CLI-052's warnin
 
 ## Test Plan
 
-- Unit tests for the offset computation given mocked render heights.
-- Manual matrix in iTerm2 + Terminal.app with Korean IME (crash regression check).
-- `pnpm --filter @robota-sdk/agent-transport build && pnpm --filter @robota-sdk/agent-transport test`
+- Unit tests for the offset computation given mocked render heights. — **done**
+  (`src/flows/__tests__/real-cursor-flow.test.ts`)
+- Terminal matrix. — **done as an automated suite** (see below); only the two macOS cells remain.
+- `pnpm --filter @robota-sdk/agent-transport-tui build && pnpm --filter @robota-sdk/agent-transport-tui test`
+  and `pnpm --filter @robota-sdk/agent-transport-tui test:pty`
+
+## Terminal matrix (agent-run, 2026-07-26)
+
+The matrix is a suite, not a checklist. Two halves share one table
+(`src/__tests__/helpers/terminal-profiles.ts`) so terminal detection and observable behaviour can
+never drift apart:
+
+- `src/__tests__/terminal-capabilities.test.ts` — what `supportsImeCursorPositioning()` returns for
+  each terminal's real environment handshake.
+- `src/__tests__/pty/ime-cursor.ptytest.ts` — what the BUILT binary then does in a real pty:
+  24 rows, type `안녕`, and require every post-boot `ESC[?25h` to sit on the input row at the
+  composition column — or, for a gated-off cell, require zero cursor shows. Plus a 5-row probe
+  (invariant I2) wherever the gate would otherwise allow positioning.
+- `src/__tests__/pty/ime-cursor-tmux.ptytest.ts` — tmux runs the binary in a real pane and reports
+  its OWN cursor position back, so a second VT implementation confirms the cell.
+
+| Terminal             | env provenance                    | unset             | `=1`         | `=0`         |
+| -------------------- | --------------------------------- | ----------------- | ------------ | ------------ |
+| bare TTY             | measured (the pty harness itself) | ✅ positions      | ✅ positions | ✅ no cursor |
+| Ghostty 1.3.1        | measured (launched here)          | ✅ positions      | ✅ positions | ✅ no cursor |
+| GNOME Terminal / VTE | measured (launched here)          | ✅ positions      | ✅ positions | ✅ no cursor |
+| tmux 3.4             | measured + **real emulator run**  | ✅ positions      | ✅ positions | ✅ no cursor |
+| kitty                | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
+| WezTerm              | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
+| Windows Terminal     | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
+| iTerm2 (macOS)       | documented — env branch only      | ✅ positions      | ✅ positions | ✅ no cursor |
+| Terminal.app (macOS) | documented — env branch only      | ✅ no cursor (I5) | ✅ positions | ✅ no cursor |
+
+Terminals actually executed on this machine: **Ghostty 1.3.1** and **GNOME Terminal 3.52.0 / VTE
+0.76.0** (launched under Xvfb to capture the environment they export) and **tmux 3.4** (drove the
+binary end-to-end in a real pane). kitty, WezTerm and Windows Terminal are not installed here and
+the two macOS emulators cannot run on Linux at all: for those rows the cell exercises OUR branch
+under the environment that terminal exports, which is real coverage of the code but is NOT evidence
+about the emulator's own rendering or its OS IME. That distinction is recorded per row in
+`terminal-profiles.ts` (`provenance: measured | documented`).
+
+Real-emulator readout (tmux `#{cursor_x} #{cursor_y} #{cursor_flag}`):
+
+```
+24 rows, unset : 7 19 1   visible, row 19 = the ` > 안녕` input row, col 7 = 1 + '> ' + 안녕(4 cols)
+24 rows, =0    : 0 23 0   hidden, parked at the frame bottom
+ 5 rows, unset : 8  4 0   hidden — I2 refuses to position into a frame >= viewport
+```
+
+## What remains — macOS only
+
+Two cells cannot be run off macOS. Everything needed to close them is here, so it is a five-minute
+job rather than a re-derivation:
+
+```bash
+# On macOS, with a Korean IME (한글) active. Build first:
+pnpm install && pnpm build
+
+# Cell 1 — Terminal.app, default (I5): expect NO hardware-cursor positioning; the composition
+# window keeps today's behaviour and, critically, Terminal.app must not crash.
+#   Open Terminal.app, then:
+node packages/agent-cli/bin/robota.cjs
+#   Type Korean mid-line, move with arrow keys while composing. Watch for a SIGSEGV.
+
+# Cell 2 — Terminal.app, opt-in: expect the composition window AT the input position.
+ROBOTA_IME_CURSOR=1 node packages/agent-cli/bin/robota.cjs
+
+# Cell 3/4 — iTerm2, both settings (iTerm2 is on by default):
+node packages/agent-cli/bin/robota.cjs
+ROBOTA_IME_CURSOR=0 node packages/agent-cli/bin/robota.cjs   # kill switch: no positioning
+
+# The automated cells for these two terminals' env branches, runnable anywhere:
+cd packages/agent-transport-tui
+npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor.ptytest.ts -t "Terminal.app"
+npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor.ptytest.ts -t "iTerm2"
+```
+
+If Cell 1 shows no crash across a full Korean editing session, flip Apple_Terminal's default in
+`supportsImeCursorPositioning()` (drop the I5 branch) and archive this item.
 
 ## User Execution Test Scenarios
 
-- Prerequisite: macOS with Korean IME; built CLI binary. Environment already exists.
-- Steps: run `robota`, type Korean text mid-line and move the cursor with arrow keys while
-  composing.
-- Expected observable result: the IME candidate/composition window appears at the input
-  position (not at the screen origin), and no crash occurs in Terminal.app.
-- Cleanup: none.
-- Evidence: (fill after implementation — screenshot of composition window position + Terminal.app no-crash note)
+- Prerequisite: a machine with a terminal emulator; the built CLI binary. No macOS required for the
+  agent-run cells.
+- Steps: run the three suites listed under "Terminal matrix" above.
+- Expected observable result: in every enabled cell the hardware cursor sits on the input row at the
+  composition column — the cell an OS IME anchors its window to — and in every gated-off cell no
+  cursor is shown at all; tmux independently confirms the same cell.
+- Cleanup: none (each cell uses a throwaway project/HOME dir).
+- Evidence: [`.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md`](../evals/scenarios/cli-062-ime-cursor-agent-run.md)
+  — full per-cell run log, the measured terminal environments, the tmux cursor readouts, and the
+  red-before-green mutation proof.
+- **Not covered:** the macOS composition-window screenshot and the Terminal.app no-crash check —
+  see "What remains — macOS only".

--- a/.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md
+++ b/.agents/evals/scenarios/cli-062-ime-cursor-agent-run.md
@@ -7,8 +7,10 @@ the OS IME acts on — under the five crash-avoidance invariants of the implemen
 (`.design/investigations/2026-07-25-cli-062-ime-cursor-design.md`).
 **Type:** agent-executable (a real pseudo-terminal drives the BUILT robota binary and a VT
 interpreter reads the raw ANSI stream the way a terminal emulator does; no owner terminal smoke —
-per the agent-run capability rule). The Terminal.app-on-real-hardware manual matrix remains open
-(I5 keeps Apple_Terminal off by default until it passes) — tracked in the CLI-062 backlog.
+per the agent-run capability rule). The **terminal matrix is now agent-run too** — see
+"Terminal matrix" below. What remains genuinely un-runnable off macOS is only the two macOS
+emulators' own rendering and their OS IME (I5 keeps Apple_Terminal off by default until someone
+runs the two macOS cells) — tracked in the CLI-062 backlog.
 
 ## Scenario
 
@@ -64,3 +66,69 @@ FAIL src/flows/__tests__/real-cursor-flow.test.ts
 `useCursor` inside the synchronized frame write, guarded by I1 (measured y only), I2 (never a
 frame ≥ viewport / y out of frame), I3 (no out-of-band writes), I4 (guard fail → today's drawn
 cursor, byte-identical), I5 (Apple_Terminal opt-in via `ROBOTA_IME_CURSOR=1`).
+
+## Terminal matrix (agent-run, 2026-07-26)
+
+The backlog's remaining work was a MANUAL matrix ("iTerm2 + Terminal.app ±`ROBOTA_IME_CURSOR`,
+kitty/WezTerm/Ghostty/Windows Terminal/tmux on real hardware"). It is now a re-runnable suite.
+
+```bash
+# 1. Capability half — 27 cells (9 terminals x {unset, =1, =0}) asserting supportsImeCursorPositioning().
+npx vitest run packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
+# 2. Behavioural half — the SAME 27 cells driving the BUILT binary in a real pty (24-row contract,
+#    plus the 5-row I2 probe wherever the gate would otherwise allow positioning).
+cd packages/agent-transport-tui && npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor.ptytest.ts
+# 3. Real-emulator cell — tmux runs the binary in a real pane and reports its OWN cursor position.
+cd packages/agent-transport-tui && npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor-tmux.ptytest.ts
+```
+
+**Terminal environments measured on real emulators** (launched on this machine; the env handshake is
+the only channel through which an emulator's identity reaches our code):
+
+```
+Ghostty 1.3.1 (Linux/GTK4, launched under Xvfb with -e <env dump>)
+  TERM=xterm-ghostty  TERM_PROGRAM=ghostty  TERM_PROGRAM_VERSION=1.3.1  COLORTERM=truecolor
+GNOME Terminal 3.52.0 / VTE 0.76.0
+  TERM=xterm-256color  TERM_PROGRAM=<unset>  COLORTERM=truecolor
+tmux 3.4 (inside a real pane)
+  TERM=tmux-256color  TERM_PROGRAM=tmux  TMUX=set
+```
+
+**Real-emulator confirmation (tmux 3.4 reporting its own cursor, `#{cursor_x} #{cursor_y} #{cursor_flag}`):**
+
+```
+24 rows, ROBOTA_IME_CURSOR unset : 7 19 1   ← visible, row 19 = the ` > 안녕` input row, col 7 = 1 + '> ' + 안녕(4)
+24 rows, ROBOTA_IME_CURSOR=0     : 0 23 0   ← hidden, parked at the frame bottom (kill switch)
+ 5 rows, ROBOTA_IME_CURSOR unset : 8  4 0   ← hidden (I2: frame >= viewport, never positioned)
+```
+
+**Red-before-green for the matrix assertions** (each mutation applied to source, both
+`agent-transport-tui` and `agent-cli` rebuilt — the CLI bundles the TUI, so rebuilding only the TUI
+leaves the pty suite accidentally green):
+
+```
+Mutation A — reinstate the historical hardcoded y: 0 in useRealCursorPosition:
+  FAIL real-cursor-positioning.test.tsx > SIGSEGV guard: the positioned row FOLLOWS the layout
+       → AssertionError: banner=1: expected +0 to be 1
+  FAIL pty/ime-cursor.ptytest.ts > Ghostty / ROBOTA_IME_CURSOR unset
+       → AssertionError: expected 18 to be 19
+  FAIL pty/ime-cursor-tmux.ptytest.ts > 24-row pane (tmux's own cursor readout)
+       → AssertionError: expected 18 to be 19
+
+Mutation B — capability gate reduced to `Boolean(process.stdout.isTTY)`:
+  FAIL terminal-capabilities.test.ts — 12 failed / 23 passed
+       (Terminal.app unset -> disabled, and every ROBOTA_IME_CURSOR=0 cell)
+  FAIL pty/ime-cursor.ptytest.ts > Terminal.app (macOS) / ROBOTA_IME_CURSOR unset
+       → AssertionError: expected [ …(2) ] to deeply equal []
+  FAIL pty/ime-cursor.ptytest.ts > Terminal.app (macOS) / ROBOTA_IME_CURSOR=0   (same)
+  FAIL pty/ime-cursor-tmux.ptytest.ts > ROBOTA_IME_CURSOR=0 kill switch
+       → AssertionError: expected true to be false
+```
+
+Both mutations reverted; full suites green afterwards (555 unit tests / 49 pty tests).
+
+**Boundary — what these cells do NOT prove.** For a `documented` profile
+(`src/__tests__/helpers/terminal-profiles.ts`) the cell exercises OUR branch under the environment
+that terminal exports; it says nothing about that emulator's own rendering, its inline pre-edit
+display, or its OS IME. Terminal.app's historical Korean-IME SIGSEGV is an Apple-side defect and can
+only be re-checked on macOS — which is why Apple_Terminal ships off by default (I5).

--- a/packages/agent-transport-tui/src/__tests__/helpers/terminal-profiles.ts
+++ b/packages/agent-transport-tui/src/__tests__/helpers/terminal-profiles.ts
@@ -1,0 +1,142 @@
+/**
+ * CLI-062 — the terminal matrix, as data.
+ *
+ * The backlog item's remaining work was a *manual* matrix ("iTerm2 + Terminal.app
+ * ±ROBOTA_IME_CURSOR, kitty/WezTerm/Ghostty/Windows Terminal/tmux on real hardware"). This module
+ * converts it into something a machine re-runs: each row is the environment handshake a terminal
+ * emulator hands the program it launches, which is the ONLY channel through which the emulator's
+ * identity reaches our code (`supportsImeCursorPositioning()` reads `TERM_PROGRAM`).
+ *
+ * Two consumers share this table so the gate is never asserted in isolation from behaviour:
+ *  - `terminal-capabilities.test.ts` — what `supportsImeCursorPositioning()` returns per row.
+ *  - `pty/ime-cursor.ptytest.ts`     — what the REAL binary then does under a real pty per row.
+ *
+ * `provenance` is deliberately explicit about how each row's values were obtained. `measured`
+ * rows were captured by launching that emulator on the machine that recorded them and dumping the
+ * child environment; `documented` rows come from the vendor's documented behaviour because the
+ * emulator cannot run on Linux (macOS/Windows) or is not installed. A documented row still gives
+ * real coverage of OUR code — the branch it selects is exercised end-to-end — but it is NOT
+ * evidence about that emulator's own rendering or its OS IME, and must never be reported as such.
+ */
+
+export type TerminalProvenance = 'measured' | 'documented';
+
+export interface ITerminalProfile {
+  /** Stable id used in test names and in the backlog matrix table. */
+  id: string;
+  /** Human label for the matrix. */
+  label: string;
+  /** Environment the emulator exports to its child process. */
+  env: Readonly<Record<string, string>>;
+  /** How the env values above were obtained. */
+  provenance: TerminalProvenance;
+  /** Free-text provenance detail (version, capture method, or the vendor fact relied on). */
+  note: string;
+}
+
+export const TERMINAL_PROFILES: readonly ITerminalProfile[] = [
+  {
+    id: 'bare-tty',
+    label: 'bare TTY (no TERM_PROGRAM)',
+    env: { TERM: 'xterm-256color' },
+    provenance: 'measured',
+    note: 'Baseline: a pty that identifies nothing. This is also what the pty harness itself provides.',
+  },
+  {
+    id: 'ghostty',
+    label: 'Ghostty',
+    env: {
+      TERM: 'xterm-ghostty',
+      TERM_PROGRAM: 'ghostty',
+      TERM_PROGRAM_VERSION: '1.3.1',
+      COLORTERM: 'truecolor',
+    },
+    provenance: 'measured',
+    note: 'Captured from Ghostty 1.3.1 (Linux/GTK4) by launching it with `-e <env dump>`.',
+  },
+  {
+    id: 'gnome-terminal',
+    label: 'GNOME Terminal (VTE)',
+    env: { TERM: 'xterm-256color', COLORTERM: 'truecolor' },
+    provenance: 'measured',
+    note: 'Captured from GNOME Terminal 3.52.0 / VTE 0.76.0; VTE sets no TERM_PROGRAM.',
+  },
+  {
+    id: 'tmux',
+    label: 'tmux (multiplexer)',
+    env: { TERM: 'tmux-256color', TERM_PROGRAM: 'tmux', TMUX: '/tmp/tmux-fixture,1,0' },
+    provenance: 'measured',
+    note: 'Captured from tmux 3.4 inside a real pane; tmux 3.4 sets TERM_PROGRAM=tmux. The real emulator is additionally driven end-to-end in pty/ime-cursor-tmux.ptytest.ts.',
+  },
+  {
+    id: 'kitty',
+    label: 'kitty',
+    env: { TERM: 'xterm-kitty', KITTY_WINDOW_ID: '1', COLORTERM: 'truecolor' },
+    provenance: 'documented',
+    note: 'kitty identifies itself via TERM=xterm-kitty + KITTY_WINDOW_ID and sets no TERM_PROGRAM.',
+  },
+  {
+    id: 'wezterm',
+    label: 'WezTerm',
+    env: { TERM: 'xterm-256color', TERM_PROGRAM: 'WezTerm', TERM_PROGRAM_VERSION: '20240203' },
+    provenance: 'documented',
+    note: 'WezTerm sets TERM_PROGRAM=WezTerm.',
+  },
+  {
+    id: 'windows-terminal',
+    label: 'Windows Terminal',
+    env: { TERM: 'xterm-256color', WT_SESSION: '00000000-0000-0000-0000-000000000000' },
+    provenance: 'documented',
+    note: 'Windows Terminal marks its sessions with WT_SESSION and sets no TERM_PROGRAM.',
+  },
+  {
+    id: 'iterm2',
+    label: 'iTerm2 (macOS)',
+    env: { TERM: 'xterm-256color', TERM_PROGRAM: 'iTerm.app', TERM_PROGRAM_VERSION: '3.5.0' },
+    provenance: 'documented',
+    note: 'macOS-only emulator: the env branch is exercised here, its rendering and its OS IME are not.',
+  },
+  {
+    id: 'apple-terminal',
+    label: 'Terminal.app (macOS)',
+    env: { TERM: 'xterm-256color', TERM_PROGRAM: 'Apple_Terminal', TERM_PROGRAM_VERSION: '455' },
+    provenance: 'documented',
+    note: 'macOS-only emulator, and the ONE profile that is off by default (invariant I5). The env branch is exercised here; the historical Korean-IME SIGSEGV can only be re-checked on macOS.',
+  },
+];
+
+/** `ROBOTA_IME_CURSOR` settings the matrix sweeps. `undefined` means the variable is absent. */
+export const IME_CURSOR_SETTINGS: readonly (string | undefined)[] = [undefined, '1', '0'];
+
+/**
+ * The expected `supportsImeCursorPositioning()` verdict for a matrix cell, derived from the
+ * documented precedence (explicit override wins; Apple_Terminal is off by default; every other
+ * interactive TTY is on). Both the unit matrix and the pty matrix assert against this, so the
+ * capability detection and the observable behaviour can never drift apart silently.
+ */
+export function expectedImeCursorEnabled(
+  profile: ITerminalProfile,
+  override: string | undefined,
+): boolean {
+  if (override === '1') return true;
+  if (override === '0') return false;
+  return profile.env['TERM_PROGRAM'] !== 'Apple_Terminal';
+}
+
+/** Environment for a child process running "under" `profile` with the given override. */
+export function profileEnv(
+  profile: ITerminalProfile,
+  override: string | undefined,
+): Record<string, string> {
+  return {
+    ...profile.env,
+    ...(override === undefined ? {} : { ROBOTA_IME_CURSOR: override }),
+  };
+}
+
+/** Matrix label used in test names and in the backlog's evidence table. */
+export function cellLabel(profile: ITerminalProfile, override: string | undefined): string {
+  const setting =
+    override === undefined ? 'ROBOTA_IME_CURSOR unset' : `ROBOTA_IME_CURSOR=${override}`;
+  return `${profile.label} / ${setting}`;
+}

--- a/packages/agent-transport-tui/src/__tests__/pty/ime-cursor-tmux.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/ime-cursor-tmux.ptytest.ts
@@ -1,0 +1,166 @@
+/**
+ * CLI-062 — the one matrix cell where a REAL terminal emulator answers back.
+ *
+ * Every other cell reads the cursor out of the byte stream our own VT interpreter replays. tmux is
+ * a full, independent terminal emulator that can be driven headlessly AND queried: it runs the
+ * built robota binary in a real pane, receives the Korean keystrokes through its own input path,
+ * and then reports where ITS state machine put the hardware cursor
+ * (`#{cursor_x}` / `#{cursor_y}` / `#{cursor_flag}`). That makes this the strongest available
+ * confirmation short of macOS hardware: a second implementation agrees the cursor sits on the
+ * input row at the composition column — which is the cell an OS IME anchors its window to.
+ *
+ * Skipped when tmux is not installed; `ROBOTA_TMUX_BIN` overrides the binary. GitHub's ubuntu
+ * runner images ship tmux, so this runs in CI rather than quietly evaporating there.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const ROBOTA_BIN = join(REPO_ROOT, 'packages/agent-cli/bin/robota.cjs');
+const COLS = 80;
+const COMPOSITION = '안녕';
+const COMPOSITION_WIDTH = 4;
+
+function resolveTmux(): string | undefined {
+  const override = process.env['ROBOTA_TMUX_BIN'];
+  if (override !== undefined && override !== '') return override;
+  const which = spawnSync('sh', ['-c', 'command -v tmux'], { encoding: 'utf8' });
+  const found = which.stdout.trim();
+  return found === '' ? undefined : found;
+}
+
+const TMUX = resolveTmux();
+
+interface ITmuxProbe {
+  cursorX: number;
+  cursorY: number;
+  /** tmux's own DECTCEM view: is the hardware cursor visible in the pane? */
+  cursorVisible: boolean;
+  pane: string[];
+}
+
+interface ITmuxRun {
+  root: string;
+  socket: string;
+}
+
+/** Run robota inside a real tmux pane and ask tmux where the cursor ended up. */
+function runInTmux(run: ITmuxRun, rows: number, imeCursor: string | undefined): ITmuxProbe {
+  const tmux = TMUX!;
+  const projectDir = join(run.root, 'proj');
+  const homeDir = join(run.root, 'home');
+  mkdirSync(join(projectDir, '.robota'), { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, '.robota/settings.json'),
+    JSON.stringify({
+      currentProvider: 'anthropic',
+      providers: {
+        anthropic: { type: 'anthropic', model: 'claude-test-model', apiKey: 'tmux-dummy-key' },
+      },
+    }),
+    'utf8',
+  );
+
+  // A wrapper keeps the pane's env explicit (never inheriting real provider keys) while letting
+  // tmux itself set TERM/TERM_PROGRAM for the pane — the handshake under test.
+  const wrapper = join(run.root, 'wrap.sh');
+  const imeAssignment = imeCursor === undefined ? '' : `ROBOTA_IME_CURSOR=${imeCursor} `;
+  writeFileSync(
+    wrapper,
+    [
+      '#!/bin/sh',
+      `cd "${projectDir}"`,
+      `exec env -i PATH="$PATH" HOME="${homeDir}" TERM="$TERM" TERM_PROGRAM="$TERM_PROGRAM" ${imeAssignment}` +
+        `"${process.execPath}" "${ROBOTA_BIN}" --name tmux-fixture`,
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(wrapper, 0o755);
+
+  const tmuxCall = (...args: string[]): string =>
+    execFileSync(tmux, ['-S', run.socket, ...args], { encoding: 'utf8' });
+
+  tmuxCall('new-session', '-d', '-x', String(COLS), '-y', String(rows), wrapper);
+
+  const deadline = Date.now() + 40_000;
+  let pane = '';
+  while (Date.now() < deadline) {
+    pane = tmuxCall('capture-pane', '-p');
+    if (pane.includes('Type a message')) break;
+    sleepSync(250);
+  }
+  expect(pane, 'robota never reached the prompt inside tmux').toContain('Type a message');
+  sleepSync(400);
+
+  tmuxCall('send-keys', '-l', COMPOSITION);
+  sleepSync(1500);
+
+  const [x = '', y = '', flag = ''] = tmuxCall(
+    'display-message',
+    '-p',
+    '#{cursor_x} #{cursor_y} #{cursor_flag}',
+  )
+    .trim()
+    .split(' ');
+  return {
+    cursorX: Number.parseInt(x, 10),
+    cursorY: Number.parseInt(y, 10),
+    cursorVisible: flag === '1',
+    pane: tmuxCall('capture-pane', '-p').split('\n'),
+  };
+}
+
+/** Deliberate synchronous wait: tmux is driven through blocking CLI calls, not an event loop. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+describe.skipIf(TMUX === undefined)(
+  'CLI-062 terminal matrix — tmux, a real emulator reporting its own cursor',
+  () => {
+    let run: ITmuxRun;
+
+    beforeEach(() => {
+      const root = mkdtempSync(join(tmpdir(), 'robota-tmux-ime-'));
+      run = { root, socket: join(root, 'sock') };
+    });
+
+    afterEach(() => {
+      if (TMUX !== undefined) {
+        spawnSync(TMUX, ['-S', run.socket, 'kill-server'], { stdio: 'ignore' });
+      }
+      rmSync(run.root, { recursive: true, force: true });
+    });
+
+    it('24-row pane: tmux reports the cursor VISIBLE on the input row at the composition column', () => {
+      const probe = runInTmux(run, 24, undefined);
+      const inputRow = probe.pane.findIndex((line) => line.includes(`> ${COMPOSITION}`));
+      expect(inputRow, `no input row in pane:\n${probe.pane.join('\n')}`).toBeGreaterThanOrEqual(0);
+
+      expect(probe.cursorVisible).toBe(true);
+      expect(probe.cursorY).toBe(inputRow);
+      expect(probe.cursorX).toBe(probe.pane[inputRow]!.indexOf('> ') + 2 + COMPOSITION_WIDTH);
+    }, 90_000);
+
+    it('5-row pane (frame ≥ viewport, I2): tmux reports the cursor hidden, never positioned', () => {
+      const probe = runInTmux(run, 5, undefined);
+      expect(probe.pane.some((line) => line.includes(`> ${COMPOSITION}`))).toBe(true);
+      expect(probe.cursorVisible).toBe(false);
+    }, 90_000);
+
+    it('ROBOTA_IME_CURSOR=0 kill switch: tmux reports the cursor hidden even at 24 rows', () => {
+      const probe = runInTmux(run, 24, '0');
+      const inputRow = probe.pane.findIndex((line) => line.includes(`> ${COMPOSITION}`));
+      expect(inputRow).toBeGreaterThanOrEqual(0);
+      expect(probe.cursorVisible).toBe(false);
+      expect(probe.cursorY).not.toBe(inputRow);
+    }, 90_000);
+  },
+);

--- a/packages/agent-transport-tui/src/__tests__/pty/ime-cursor.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/ime-cursor.ptytest.ts
@@ -12,6 +12,11 @@
  *
  * Assertions only cover the post-boot composition window: boot may legitimately show the cursor
  * (spinners etc.), and teardown restores visibility — both are outside the invariant.
+ *
+ * The second describe block turns the backlog's MANUAL terminal matrix into a re-runnable one: the
+ * same two geometries are driven once per (terminal, ROBOTA_IME_CURSOR) cell, with the terminal
+ * applied as the environment handshake it really exports (helpers/terminal-profiles.ts documents
+ * how each row's values were obtained). What that does and does NOT prove is stated there.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -21,14 +26,80 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { spawnTui, writeTuiProviderSettings } from './pty-driver.js';
+import {
+  IME_CURSOR_SETTINGS,
+  TERMINAL_PROFILES,
+  cellLabel,
+  expectedImeCursorEnabled,
+  profileEnv,
+} from '../helpers/terminal-profiles.js';
 import { interpretVtStream } from '../helpers/vt-cursor-interpreter.js';
 
+import type { ICursorShowEvent } from '../helpers/vt-cursor-interpreter.js';
 import type { IPtySession } from './pty-driver.js';
 
 const COLS = 80;
 const PROMPT_PLACEHOLDER = /Type a message or \/help/;
+const COMPOSITION = '안녕';
+/** `안녕` occupies 4 display columns; the prompt adds `> `. */
+const COMPOSITION_WIDTH = 4;
 /** Let ink's throttled (≤30fps) frame writes flush after the last keystroke. */
 const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 400));
+
+interface IProbeResult {
+  /** Cursor shows emitted after boot — the composition window the OS IME would act on. */
+  compositionShows: ICursorShowEvent[];
+  /** Screen row holding `> 안녕`, or -1 when the composition never rendered. */
+  inputRow: number;
+  /** Column of the `> ` prompt on the input row, or -1. */
+  promptCol: number;
+}
+
+/**
+ * Boot the built binary in a pty of the given geometry, type CJK, and report the cursor shows the
+ * terminal would have acted on. Shared by the original two cases and by every matrix cell.
+ */
+async function probe(
+  projectDir: string,
+  rows: number,
+  env: Record<string, string>,
+  register: (session: IPtySession) => void,
+): Promise<IProbeResult> {
+  const session = spawnTui({
+    projectDir,
+    homeDir: join(projectDir, 'home'),
+    cols: COLS,
+    rows,
+    env,
+  });
+  register(session);
+  await session.waitFor(PROMPT_PLACEHOLDER);
+  await flush();
+
+  const bootMark = session.raw().length;
+  await session.sendKeys(COMPOSITION);
+  await session.waitFor(new RegExp(COMPOSITION));
+  await flush();
+
+  const vt = interpretVtStream(session.raw(), rows, COLS);
+  const inputRow = vt.screen.findIndex((line) => line.includes(`> ${COMPOSITION}`));
+  return {
+    compositionShows: vt.showEvents.filter((event) => event.offset >= bootMark),
+    inputRow,
+    promptCol: inputRow < 0 ? -1 : vt.screen[inputRow]!.indexOf('> '),
+  };
+}
+
+/** Every post-boot show sits on the input row at the composition column (the positive contract). */
+function expectPositionedOnInputRow(result: IProbeResult): void {
+  expect(result.compositionShows.length).toBeGreaterThan(0);
+  expect(result.inputRow).toBeGreaterThanOrEqual(0);
+  for (const event of result.compositionShows) {
+    // Never the top region (the Terminal.app SIGSEGV geometry), always the input row.
+    expect(event.row).toBe(result.inputRow);
+  }
+  expect(result.compositionShows.at(-1)!.col).toBe(result.promptCol + 2 + COMPOSITION_WIDTH);
+}
 
 describe('CLI-062 — IME hardware-cursor positioning through a real PTY', () => {
   let projectDir: string;
@@ -46,50 +117,68 @@ describe('CLI-062 — IME hardware-cursor positioning through a real PTY', () =>
   });
 
   it('24-row pty: every post-boot cursor show lands on the input row at the composition column', async () => {
-    const rows = 24;
-    session = spawnTui({ projectDir, homeDir: join(projectDir, 'home'), cols: COLS, rows });
-    await session.waitFor(PROMPT_PLACEHOLDER);
-    await flush();
-
-    const bootMark = session.raw().length;
-    await session.sendKeys('안녕');
-    await session.waitFor(/안녕/);
-    await flush();
-
-    const raw = session.raw();
-    const vt = interpretVtStream(raw, rows, COLS);
-    const compositionShows = vt.showEvents.filter((event) => event.offset >= bootMark);
-
-    // The feature must actually fire (this line is the pre-change RED):
-    expect(compositionShows.length).toBeGreaterThan(0);
-
-    // Locate the input row on the final screen ('> ' prompt followed by the typed value).
-    const inputRow = vt.screen.findIndex((line) => line.includes('> 안녕'));
-    expect(inputRow).toBeGreaterThanOrEqual(0);
-
-    for (const event of compositionShows) {
-      // Never the top region (the Terminal.app SIGSEGV geometry), always the input row.
-      expect(event.row).toBe(inputRow);
-    }
-
-    // Composition column: prompt col + '> ' (2) + 안녕 (4 display columns).
-    const promptCol = vt.screen[inputRow]!.indexOf('> ');
-    expect(compositionShows.at(-1)!.col).toBe(promptCol + 2 + 4);
+    const result = await probe(projectDir, 24, {}, (s) => (session = s));
+    expectPositionedOnInputRow(result);
   }, 60_000);
 
   it('5-row pty (frame ≥ viewport, I2): zero cursor-show sequences during composition', async () => {
-    const rows = 5;
-    session = spawnTui({ projectDir, homeDir: join(projectDir, 'home'), cols: COLS, rows });
-    await session.waitFor(PROMPT_PLACEHOLDER);
-    await flush();
-
-    const bootMark = session.raw().length;
-    await session.sendKeys('안녕');
-    await session.waitFor(/안녕/);
-    await flush();
-
-    const vt = interpretVtStream(session.raw(), rows, COLS);
-    const compositionShows = vt.showEvents.filter((event) => event.offset >= bootMark);
-    expect(compositionShows).toEqual([]);
+    const result = await probe(projectDir, 5, {}, (s) => (session = s));
+    expect(result.compositionShows).toEqual([]);
   }, 60_000);
+});
+
+/**
+ * The terminal matrix, re-runnable.
+ *
+ * PROVES, per cell: the built binary's observable cursor contract under exactly the environment
+ * that terminal exports — positioned on the input row when the capability gate says yes, and no
+ * cursor shown at all when it says no (Terminal.app's default-off I5 branch, and the
+ * `ROBOTA_IME_CURSOR=0` kill switch).
+ *
+ * DOES NOT PROVE, for a `documented` row: anything about that emulator's own rendering, its
+ * pre-edit display, or its OS IME. Terminal.app's historical Korean-IME SIGSEGV in particular is
+ * an Apple-side defect that can only be re-checked on macOS; it stays off by default (I5) until
+ * someone runs the macOS cells. tmux is additionally driven as a REAL emulator in
+ * ime-cursor-tmux.ptytest.ts, where the emulator reports its own cursor position back.
+ */
+describe('CLI-062 terminal matrix — observable cursor contract per terminal', () => {
+  let projectDir: string;
+  let session: IPtySession | undefined;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'robota-pty-ime-matrix-'));
+    writeTuiProviderSettings(projectDir);
+  });
+
+  afterEach(async () => {
+    await session?.disposeAsync();
+    session = undefined;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  for (const profile of TERMINAL_PROFILES) {
+    for (const override of IME_CURSOR_SETTINGS) {
+      const enabled = expectedImeCursorEnabled(profile, override);
+      const verdict = enabled ? 'positions on the input row' : 'never shows the cursor';
+
+      it(`${cellLabel(profile, override)} → ${verdict}`, async () => {
+        const env = profileEnv(profile, override);
+
+        const wide = await probe(projectDir, 24, env, (s) => (session = s));
+        if (!enabled) {
+          expect(wide.compositionShows).toEqual([]);
+          return;
+        }
+        expectPositionedOnInputRow(wide);
+        await session?.disposeAsync();
+        session = undefined;
+
+        // I2, checked wherever the gate would otherwise allow positioning: a frame that fills the
+        // viewport is never positioned into, however capable the terminal is. (For a gated-off
+        // cell the 24-row probe above already proves nothing is ever shown.)
+        const narrow = await probe(projectDir, 5, env, (s) => (session = s));
+        expect(narrow.compositionShows).toEqual([]);
+      }, 90_000);
+    }
+  }
 });

--- a/packages/agent-transport-tui/src/__tests__/real-cursor-positioning.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/real-cursor-positioning.test.tsx
@@ -63,11 +63,20 @@ class FakeStdin extends EventEmitter {
   }
 }
 
-function Harness({ focus = true }: { focus?: boolean }): React.ReactElement {
+function Harness({
+  focus = true,
+  bannerLines = 1,
+}: {
+  focus?: boolean;
+  /** Rows rendered above the input — the layout the measured y must follow. */
+  bannerLines?: number;
+}): React.ReactElement {
   const [value, setValue] = useState('');
   return (
     <Box flexDirection="column">
-      <Text>banner line</Text>
+      {Array.from({ length: bannerLines }, (_, index) => (
+        <Text key={index}>banner line {index}</Text>
+      ))}
       <Box>
         <Text>{PROMPT}</Text>
         <CjkTextInput value={value} onChange={setValue} availableWidth={COLS - 2} focus={focus} />
@@ -83,17 +92,23 @@ interface IScenario {
   unmount: () => void;
 }
 
-function renderScenario(focus?: boolean): IScenario {
+function renderScenario(focus?: boolean, bannerLines?: number): IScenario {
   const stdout = new FakeTtyStdout();
   const stdin = new FakeStdin();
-  const instance = render(<Harness {...(focus === undefined ? {} : { focus })} />, {
-    // Cast: ink wants real process streams; the fakes implement the parts its render loop uses.
-    stdout: stdout as unknown as NodeJS.WriteStream,
-    stdin: stdin as unknown as NodeJS.ReadStream,
-    interactive: true,
-    exitOnCtrlC: false,
-    patchConsole: false,
-  });
+  const instance = render(
+    <Harness
+      {...(focus === undefined ? {} : { focus })}
+      {...(bannerLines === undefined ? {} : { bannerLines })}
+    />,
+    {
+      // Cast: ink wants real process streams; the fakes implement the parts its render loop uses.
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
   return { stdout, stdin, unmount: instance.unmount };
 }
 
@@ -156,6 +171,38 @@ describe('CLI-062 — real cursor positioning (interactive ink render)', () => {
     expect(stderrSpy).not.toHaveBeenCalled();
 
     unmount();
+  });
+
+  /**
+   * SIGSEGV regression guard, as a test rather than an argument.
+   *
+   * The Terminal.app Korean-IME crash was root-caused to `setCursorPosition({x, y: 0})` — a
+   * CONSTANT row that pointed the hardware cursor at the logo area. The mechanical statement that
+   * the bug class is gone is not "the literal is absent from the source" but "the emitted row is a
+   * function of the layout": move the input box down and the positioned row must move with it. A
+   * hardcoded `y: 0` — or any other constant — cannot satisfy both halves of this test.
+   */
+  it('SIGSEGV guard: the positioned row FOLLOWS the layout, so a constant y (the y:0 bug) is unrepresentable', async () => {
+    const rowsSeen: number[] = [];
+    for (const bannerLines of [1, 4]) {
+      const { stdout, stdin, unmount } = renderScenario(true, bannerLines);
+      await settle();
+      stdin.send('안녕');
+      await settle();
+
+      const vt = interpretVtStream(stdout.stream(), ROWS, COLS);
+      expect(vt.showEvents.length, `banner=${bannerLines}`).toBeGreaterThan(0);
+      const row = vt.showEvents.at(-1)!.row;
+      // The input box starts immediately below the banner, so its measured row IS bannerLines.
+      expect(row, `banner=${bannerLines}`).toBe(bannerLines);
+      // ...and never the top of the frame while any banner occupies it (the crash geometry).
+      expect(row, `banner=${bannerLines}`).toBeGreaterThan(0);
+      rowsSeen.push(row);
+      unmount();
+      await settle();
+    }
+    // Two different layouts must yield two different rows — a constant cannot pass both.
+    expect(new Set(rowsSeen).size).toBe(2);
   });
 
   it('I4: unfocused input never positions the cursor (and keeps the fallback drawn-cursor path off)', async () => {

--- a/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/terminal-capabilities.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  IME_CURSOR_SETTINGS,
+  TERMINAL_PROFILES,
+  cellLabel,
+  expectedImeCursorEnabled,
+} from './helpers/terminal-profiles.js';
+import {
   isInteractiveColorTerminal,
   supportsImeCursorPositioning,
 } from '../terminal-capabilities.js';
@@ -78,5 +84,49 @@ describe('supportsImeCursorPositioning (CLI-062)', () => {
     vi.stubEnv('TERM_PROGRAM', undefined);
     vi.stubEnv('ROBOTA_IME_CURSOR', '0');
     expect(supportsImeCursorPositioning()).toBe(false);
+  });
+});
+
+/**
+ * CLI-062 terminal matrix — capability half.
+ *
+ * Terminal detection is ASSERTED here, never assumed: every emulator in the matrix is applied as
+ * the environment handshake it really exports (see helpers/terminal-profiles.ts for how each row's
+ * values were obtained), and the gate's verdict is compared against the shared expectation the pty
+ * matrix asserts behaviourally. The macOS rows (Terminal.app, iTerm2) cannot run their emulator on
+ * a non-macOS machine, but their env branch — including Apple_Terminal's default-off I5 branch —
+ * is fully exercised by stubbing the variables those terminals set.
+ */
+describe('CLI-062 terminal matrix — supportsImeCursorPositioning per terminal', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(process.stdout, 'isTTY', { value: ORIG_TTY, configurable: true });
+  });
+
+  for (const profile of TERMINAL_PROFILES) {
+    for (const override of IME_CURSOR_SETTINGS) {
+      const expected = expectedImeCursorEnabled(profile, override);
+      it(`${cellLabel(profile, override)} → ${expected ? 'ENABLED' : 'disabled'}`, () => {
+        setTty(true);
+        // A real terminal exports only its own variables; anything the matrix does not set must
+        // be genuinely absent, or a leaked TERM_PROGRAM would silently decide the verdict.
+        for (const key of ['TERM', 'TERM_PROGRAM', 'TERM_PROGRAM_VERSION', 'COLORTERM']) {
+          vi.stubEnv(key, undefined);
+        }
+        for (const [key, value] of Object.entries(profile.env)) vi.stubEnv(key, value);
+        vi.stubEnv('ROBOTA_IME_CURSOR', override);
+
+        expect(supportsImeCursorPositioning()).toBe(expected);
+      });
+    }
+  }
+
+  it('every matrix row keeps its provenance honest (measured rows name a real capture)', () => {
+    for (const profile of TERMINAL_PROFILES) {
+      expect(profile.note.length, profile.id).toBeGreaterThan(0);
+      if (profile.provenance === 'measured') {
+        expect(profile.note, profile.id).toMatch(/Captured|pty harness/);
+      }
+    }
   });
 });


### PR DESCRIPTION
## What

CLI-062's implementation is already merged. What remained was, in the item's own words, *"the
manual terminal matrix (iTerm2 + Terminal.app ±`ROBOTA_IME_CURSOR`,
kitty/WezTerm/Ghostty/Windows Terminal/tmux) on real hardware"*. This PR converts that matrix into
something the agent executes and re-runs, rather than a terminal-eyeballing chore handed to a human.

No production code changes — tests, one shared fixture, and the backlog/scenario docs.

## The matrix

One table (`src/__tests__/helpers/terminal-profiles.ts`) drives two halves, so terminal detection is
never asserted in isolation from behaviour:

| Terminal             | env provenance                    | unset             | `=1`         | `=0`         |
| -------------------- | --------------------------------- | ----------------- | ------------ | ------------ |
| bare TTY             | measured (the pty harness itself) | ✅ positions      | ✅ positions | ✅ no cursor |
| Ghostty 1.3.1        | measured (launched here)          | ✅ positions      | ✅ positions | ✅ no cursor |
| GNOME Terminal / VTE | measured (launched here)          | ✅ positions      | ✅ positions | ✅ no cursor |
| tmux 3.4             | measured + **real emulator run**  | ✅ positions      | ✅ positions | ✅ no cursor |
| kitty                | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
| WezTerm              | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
| Windows Terminal     | documented                        | ✅ positions      | ✅ positions | ✅ no cursor |
| iTerm2 (macOS)       | documented — env branch only      | ✅ positions      | ✅ positions | ✅ no cursor |
| Terminal.app (macOS) | documented — env branch only      | ✅ no cursor (I5) | ✅ positions | ✅ no cursor |

- **Capability half** — `terminal-capabilities.test.ts`: 27 cells asserting
  `supportsImeCursorPositioning()` under each terminal's real environment handshake, including
  Apple_Terminal's default-off I5 branch (exercisable by env even though the terminal is absent).
- **Behavioural half** — `pty/ime-cursor.ptytest.ts`: the same 27 cells drive the BUILT binary in a
  real pty. Enabled cell → every post-boot `ESC[?25h` on the input row at the composition column,
  plus a 5-row I2 probe. Gated-off cell → zero cursor shows.
- **Real-emulator cell** — `pty/ime-cursor-tmux.ptytest.ts`: tmux 3.4 runs the binary in a real pane
  and reports its OWN cursor state, so a second VT implementation confirms the cell:

  ```
  24 rows, unset : 7 19 1   visible, row 19 = the ` > 안녕` input row, col 7 = 1 + '> ' + 안녕(4 cols)
  24 rows, =0    : 0 23 0   hidden, parked at the frame bottom
   5 rows, unset : 8  4 0   hidden — I2 refuses to position into a frame >= viewport
  ```

Terminals **actually executed** on the verifying machine: Ghostty 1.3.1 and GNOME Terminal 3.52.0 /
VTE 0.76.0 (launched under Xvfb to capture the environment they export) and tmux 3.4 (drove the
binary end-to-end). `documented` rows exercise our branch under the environment that terminal
exports — real coverage of the code, but **not** evidence about that emulator's rendering or its OS
IME. That distinction is recorded per row rather than glossed over.

## SIGSEGV regression guard

The crash was root-caused to a hardcoded `y: 0`. The guard is now a test, not an argument: the
positioned row must **follow the layout** — banner of 1 row gives cursor row 1, banner of 4 rows
gives cursor row 4, and the two must differ. No constant can satisfy both halves.

## Red-before-green (HARNESS-041)

- **Mutation A** — reinstate the historical hardcoded `y: 0`:
  `SIGSEGV guard` → `expected +0 to be 1`; `Ghostty / unset` pty cell → `expected 18 to be 19`;
  tmux 24-row readout → `expected 18 to be 19`.
- **Mutation B** — capability gate reduced to `Boolean(process.stdout.isTTY)`:
  12 of 35 capability tests fail (Terminal.app-unset and every `=0` cell); both Terminal.app pty
  cells → `expected [ …(2) ] to deeply equal []`; tmux kill switch → `expected true to be false`.

Worth recording: a pty red-proof requires rebuilding **both** `agent-transport-tui` and `agent-cli` —
the CLI bundles the TUI, so rebuilding only the TUI leaves the pty suite accidentally green. That
trap fired once during this work.

## Verification

- `packages/agent-transport-tui`: 555 unit tests / 69 files — pass
- `pnpm --filter @robota-sdk/agent-transport-tui test:pty`: 49 tests / 13 files — pass
- `pnpm harness:verify-like-ci`: PASS, all 5 CI-mirroring stages

## What is NOT done

The item is **not archived**. It stays open, narrowed to exactly two cells: **Terminal.app and
iTerm2 on macOS with a Korean IME**. Their env branches are already asserted end-to-end, but the
emulators' own rendering — inline pre-edit display, and whether Apple's
`attributedSubstringFromRange:` SIGSEGV can still be provoked — cannot be observed off macOS. The
backlog item now carries the exact commands for that run so it is a five-minute job.

Also honestly out of reach here: injecting keystrokes into a GUI terminal window (Ghostty /
gnome-terminal) via XTEST under a bare Xvfb — no window manager is installable without root, and
XTEST typing is not an IME path anyway, so it would add no coverage the pty matrix lacks. What
those emulators genuinely contribute — their environment handshake — was captured by launching them
for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
