### PR TITLE
docs(backlog): INFRA-053 — review turn budget and the parity window

### DIFF
--- a/.agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
+++ b/.agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
@@ -1,0 +1,75 @@
+---
+id: INFRA-053
+title: Raise the review turn budget, and close the parity window that makes workflow edits risky
+status: todo
+priority: medium
+type: INFRA
+created: 2026-07-26
+---
+
+## Problem
+
+Two coupled defects, both surfaced by INFRA-048's parity fix.
+
+### 1. The review exhausts its turn budget on large PRs
+
+`claude-code-review.yml` runs the action with `--max-turns 25`. Now that the review actually executes
+(it was silently skipping every run — see INFRA-048), the budget is the binding constraint on large
+changes. Measured 2026-07-26:
+
+| PR    | Size              | Result                                           |
+| ----- | ----------------- | ------------------------------------------------ |
+| #1434 | large, multi-area | `error_max_turns` at 25 — **no comments posted** |
+| #1435 | moderate          | completed in 1m40s                               |
+
+So the review works, and silently produces nothing on exactly the changes that most need reviewing.
+The check went from green-and-empty to red-and-honest, which is an improvement — but a red that
+posts no findings is still no review.
+
+### 2. Editing that workflow at all is a two-step with a blocking window
+
+`anthropics/claude-code-action` compares its invoking workflow byte-for-byte against the **default
+branch** (`main`) and silently skips when they differ. `scan-review-workflow-parity` now makes that
+divergence fail loudly instead — inside `scans`, which is a **required** check.
+
+The consequence: any edit to that file is red on one branch or the other until both carry it.
+
+- Edit on `develop` first → `scans` is red on **every open PR to develop** until promotion.
+- Edit on `main` first → same, in the window before the back-merge.
+
+The scan exempts PRs whose base **is** `main` (`isPromotionToDefault`), so a `release/*` → `main` PR
+passes. That gives a workable sequence, but not a window-free one.
+
+## Direction
+
+**The turn budget.** Raise it and justify the number from measurement, not taste — re-run the review
+on a PR of #1434's size at the candidate value and confirm it completes. Consider also whether the
+review should be scoped (per-area, or diff-size-aware) rather than given an ever-larger budget: a
+budget that must grow with every large PR is not a fix, and an unbounded review is its own cost.
+
+**The window.** Sequence, and preferably remove the need for one:
+
+1. Cut `release/*` from `develop`, make the edit, PR → `main` (parity-exempt), merge.
+2. Immediately back-merge `main` → `develop` so parity is restored.
+
+Run this **only on an empty queue** — no open PRs to `develop`, no implementation agents running —
+because the window blocks a required check for everyone. That is the same serial-only constraint
+PERF-004 carries, and for the same reason.
+
+Better than sequencing it carefully: make the window impossible. Options worth weighing — have the
+scan compare against the branch the PR will merge into rather than the default branch; or accept the
+divergence for the duration of a PR that demonstrably restores it. Either way the constraint is the
+action's own behaviour, so any fix must keep the action from silently skipping.
+
+## Acceptance
+
+- [ ] Review completes with findings posted on a PR the size of #1434, proven by a live run.
+- [ ] The turn budget's value is justified by a measurement, and the scoping question is answered
+      either way.
+- [ ] Either the parity window is closed, or the sequencing is written down where the next person
+      editing that workflow will actually see it (the workflow file itself, not only here).
+
+## References
+
+- INFRA-048 (`review-gate`, the parity scan, and the measurement that `Claude review` never ran)
+- `.github/workflows/claude-code-review.yml`, `scripts/harness/scan-review-workflow-parity.mjs`

--- a/.agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
+++ b/.agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
@@ -2,7 +2,7 @@
 id: INFRA-053
 title: Raise the review turn budget, and close the parity window that makes workflow edits risky
 status: todo
-priority: medium
+priority: high
 type: INFRA
 created: 2026-07-26
 ---
@@ -11,20 +11,25 @@ created: 2026-07-26
 
 Two coupled defects, both surfaced by INFRA-048's parity fix.
 
-### 1. The review exhausts its turn budget on large PRs
+### 1. The review exhausts its turn budget on essentially every PR
 
 `claude-code-review.yml` runs the action with `--max-turns 25`. Now that the review actually executes
 (it was silently skipping every run — see INFRA-048), the budget is the binding constraint on large
 changes. Measured 2026-07-26:
 
-| PR    | Size              | Result                                           |
-| ----- | ----------------- | ------------------------------------------------ |
-| #1434 | large, multi-area | `error_max_turns` at 25 — **no comments posted** |
-| #1435 | moderate          | completed in 1m40s                               |
+| PR    | Size                          | Result                                           |
+| ----- | ----------------------------- | ------------------------------------------------ |
+| #1434 | large, multi-area             | `error_max_turns` at 25 — **no comments posted** |
+| #1435 | moderate                      | completed in 1m40s                               |
+| #1436 | **one backlog file, no code** | `error_max_turns` at 25 — **no comments posted** |
 
-So the review works, and silently produces nothing on exactly the changes that most need reviewing.
-The check went from green-and-empty to red-and-honest, which is an improvement — but a red that
-posts no findings is still no review.
+**It is not a function of PR size.** A single-file, code-free backlog PR exhausted the same budget,
+so the review currently produces nothing on _most_ PRs, not only large ones. The check went from
+green-and-empty to red-and-honest, which is a real improvement — the failure is at least visible now
+— but review coverage is still effectively zero. That is why this is `high` rather than `medium`.
+
+It is not blocking, though: `Claude review` is advisory, and the required `review-gate` reads
+code-scanning output rather than this review, so the merge gate itself is unaffected.
 
 ### 2. Editing that workflow at all is a two-step with a blocking window
 


### PR DESCRIPTION
Files two coupled defects surfaced by INFRA-048's parity fix, plus the first live check that the new required gate behaves.

**The review exhausts its turn budget on large PRs.** Now that `Claude review` actually executes — INFRA-048 measured that it had been silently skipping *every* run, 100 for 100 — `--max-turns 25` is the binding constraint:

| PR | Size | Result |
| --- | --- | --- |
| #1434 | large, multi-area | `error_max_turns` at 25, **no comments posted** |
| #1435 | moderate | completed in 1m40s |

So it produces nothing on exactly the changes that most need reviewing. Red-and-honest beats green-and-empty, but it is still no review.

**Editing that workflow is a two-step with a blocking window.** The action compares its workflow byte-for-byte against the **default branch** and skips silently when they differ; `scan-review-workflow-parity` now catches that inside the **required** `scans` job. So an edit on either branch turns a required check red for every open PR until both branches carry it. The scan exempts `release/*` → `main` PRs, which gives a workable sequence — but it is serial-only on an empty queue, for the same reason PERF-004 is.

The item asks for the budget's new value to be justified by a live measurement rather than picked, raises whether the review should be *scoped* instead of given an ever-larger budget, and asks that the window either be closed or documented where the next editor will actually see it.

Backlog only — no code, no workflow change (deliberately: making the change here would open the window this item describes).

---

Also done outside this PR, completing INFRA-048's last step: **`review-gate` is now a required status check** on the `protect-develop` ruleset. Verified first that it produces a check on a real PR (#1434, pass, 3m34s) and that it carries no path filter or job-level `if:` — a required check that can skip blocks every PR forever, which is the trap INFRA-046 recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z