### PR TITLE
fix(ci): INFRA-048 review-gate must not block a PR that has no code to analyse

### DIFF
--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -86,17 +86,22 @@ Three levers were on the table (the original item's options 1–3). What shipped
    module `scripts/harness/check-review-gate.mjs`). It waits for the code-scanning analysis of the
    PR head, reads the alerts for the PR ref and for the base branch, and decides:
 
-   | class        | rule                                                            | blocks?                         |
-   | ------------ | --------------------------------------------------------------- | ------------------------------- |
-   | blocking     | introduced by this PR, severity `error` or security high/crit   | **yes**                         |
-   | advisory     | any other alert introduced by this PR                           | no, but printed on the check    |
-   | pre-existing | already open on the base branch                                 | no                              |
-   | unavailable  | no analysis record, analysis incomplete, API error, unparseable | **yes**                         |
-   | acknowledged | PR carries `review-findings-acknowledged`                       | no, override recorded on the PR |
+   | class          | rule                                                            | blocks?                         |
+   | -------------- | --------------------------------------------------------------- | ------------------------------- |
+   | blocking       | introduced by this PR, severity `error` or security high/crit   | **yes**                         |
+   | advisory       | any other alert introduced by this PR                           | no, but printed on the check    |
+   | pre-existing   | already open on the base branch                                 | no                              |
+   | unavailable    | no analysis record, analysis incomplete, API error, unparseable | **yes**                         |
+   | not-applicable | the `changes` classifier says this PR changes no code           | no (added by Defect 2, below)   |
+   | acknowledged   | PR carries `review-findings-acknowledged`                       | no, override recorded on the PR |
 
    On a block it also runs `gh pr merge --disable-auto`, because a red **non-required** check does
    not stop an armed auto-merge — which is precisely the #1409 hole. The disarm is the lever that
    works today; the ruleset entry (below) is the durable one.
+
+   **A fail-CLOSED caught in the gate itself, live — and it cost the ruleset entry.** See
+   "Defect 2" below. The `unavailable` row above is now three rows: an analysis that exists and
+   could not be read still blocks, and an analysis that was never owed passes as `not-applicable`.
 
    **A fail-open caught in the gate itself, live.** On the first run (#1434) the alerts query
    returned **0** for the PR ref while `develop` carried 100 — and the gate reported `PASS (clean)`.
@@ -199,18 +204,159 @@ no findings introduced by this PR.
 So the check exists, waits for the analysis, and decides — where before there was no review signal
 on the merge decision at all.
 
+## Defect 2 — the gate blocked a docs-only PR, and the ruleset entry was rolled back
+
+**Measured on #1436** (2026-07-26), the very next PR after `review-gate` was added to
+`protect-develop`'s required status checks. #1436 is **one added backlog markdown file
+(`.agents/backlog/INFRA-053-…md`, +80/−0) and nothing else** — zero code. It was BLOCKED. The gate's
+own log:
+
+```
+code-scanning analyses recorded for refs/pull/1436/merge: 0
+analysis_complete: false
+review-gate: BLOCK (verdict-unavailable)
+```
+
+Runtime **15 m 23 s**, almost all of it the "Wait for the code-scanning analysis of this PR" step
+polling for an analysis that was never going to arrive. The required-check entry was rolled back the
+same day to unblock the repository, so the gate is advisory again.
+
+**Root cause: a third state read as the second.** The hardening above was right — an empty alerts
+list must not read as "clean", because the endpoint answers `[]` both for "analysed and clean" and
+for "never analysed". But the fix collapsed a THIRD state into the same bucket: _no analysis exists
+because there was no code to analyse_. `codeql.yml` carries `paths-ignore: ['**/*.md', '**/*.mdx',
+'docs/**', 'content/**']`, so a docs-only PR never triggers CodeQL and no analysis record is ever
+written for it. **"Not applicable" is not "unreadable."** One means the answer does not exist and
+was never owed; the other means the answer exists and could not be read. Only the second is a
+reason to block.
+
+This is the same shape as the defect this item exists to fix, mirrored: INFRA-048's original defect
+was a check reporting a verdict it had not computed; this one is a check demanding a verdict that
+was never owed. Fail-closed is correct when the answer is missing; it is not correct when there is
+no question.
+
+### The fix
+
+**1. One classifier, two callers — the "no code changed" determination is not re-derived.** The
+review gate could not be allowed its own notion of "docs-only": any weaker rule would BE the bypass,
+since a PR satisfying it skips the gate entirely. So `ci.yml`'s `changes` job — the mechanism this
+repository already trusts to decide whether the required build/test matrix runs, hardened by
+INFRA-050 to read merge-base history over complete ancestry — was extracted verbatim in behaviour
+into `scripts/harness/classify-changed-paths.mjs`, and BOTH workflows now invoke it. `ci.yml` is
+touched for exactly this reason and no other: sharing the mechanism is the requirement, and two
+copies of a classifier are two classifiers.
+
+Consequence, which is the point: **a PR can only be treated as not-applicable by the same
+classification that also skipped its entire code pipeline.** A code PR cannot satisfy one without
+satisfying the other. Behaviour-identity with the previous inline body was verified differentially
+over real refs (#1436 and seven others — all `same`).
+
+**2. Fail-closed survives, at both layers.** Every undeterminable case in the classifier — no merge
+base, a failed `git diff`, an empty file list — answers `code=true`. And in the decision module,
+only the literal `false` selects not-applicable: a missing flag, an empty value, `'False'`,
+`'unknown'` all take the normal path and block on a missing analysis. The classify step also forced
+`review-gate.yml` from `fetch-depth: 1` to `fetch-depth: 0`, because a grafted ancestry would make
+the merge-base read fail — which, being fail-closed, would send every docs-only PR straight back
+into the 15-minute wait (INFRA-050's guard catches this mechanically via `ci-base-history`).
+
+**3. The wait, cut — without ever assuming success on a timeout.** Two things were conflated in one
+15-minute deadline. They are now separate:
+
+- A docs-only PR does not wait at all: the Wait and Collect steps are `if:`-gated on the classifier,
+  so the gate answers immediately.
+- **GRACE (5 min):** no `Analyze` check run has been created AT ALL. CodeQL's check runs appear
+  within seconds of the PR event, so after five minutes the honest conclusion for a PR that does
+  contain code is that no analysis was scheduled. This exit writes `analysis_complete=false` exactly
+  like the long timeout and the gate BLOCKS — it only stops the job spending another ten minutes to
+  reach the same answer.
+- **DEADLINE (15 min):** an analysis exists and is still running. That is worth waiting for, and the
+  loop still breaks the moment it completes (#1434 did so in 3 m 32 s).
+
+Neither exit can pass. The only way out of the loop with `analysis_complete=true` remains "every
+`Analyze` check run completed".
+
+### Red / green / no-regression
+
+Produced by EXTRACTING the step bodies from `review-gate.yml` itself and running them under GitHub's
+`bash -e -o pipefail` semantics with `gh` stubbed and a virtual clock (20 s per poll, `sleep` a
+no-op), the same method as the transcripts above.
+
+```
+RED — a docs-only PR under the config that blocked #1436 (the pre-fix workflow, unmodified)
+  code-scanning analyses: 0/0 completed        <- x45
+  ::error::review-gate: the code-scanning analysis for … did not complete within 15 minutes.
+      [waited 920s]
+  code-scanning analyses recorded for refs/pull/1436/merge: 0
+  review-gate: BLOCK (verdict-unavailable)
+  [gh] pr merge --disable-auto 1436                                            STEP EXIT=1
+
+GREEN — the same docs-only PR after the fix
+  === `changes` classifier verdict for this PR: code=false
+  Wait …    SKIPPED by `if: steps.classify.outputs.code == 'true'` — no code changed.
+      [waited 0s]
+  Collect … SKIPPED by `if: steps.classify.outputs.code == 'true'` — no code changed.
+  review-gate: PASS (not-applicable)
+  no code changed — this PR touches documentation only, so CodeQL never analyses it and no
+  review verdict exists to read. Nothing was skipped: the same classification also skipped
+  this PR's build and test matrix. A PR that changes code cannot reach this outcome.
+                                                                               STEP EXIT=0
+
+NO REGRESSION — a code PR whose analysis is genuinely missing
+  === `changes` classifier verdict for this PR: code=true
+  code-scanning analyses: 0/0 completed        <- x15, then the new grace cut
+  ::error::review-gate: no code-scanning analysis was scheduled for … within 5 minutes, and this
+  PR changes code. Nothing has been analysed, so nothing has been cleared.
+      [waited 320s]                            <- was 920s; still BLOCKS
+  review-gate: BLOCK (verdict-unavailable)
+  [gh] pr merge --disable-auto 1436                                            STEP EXIT=1
+
+NO REGRESSION — a code PR that introduces an `error`-severity finding
+  === `changes` classifier verdict for this PR: code=true
+  code-scanning analyses: 1/1 completed        [waited 20s]
+  review-gate: BLOCK (blocking-findings)
+    - js/incomplete-sanitization [error/security:high] packages/agent-core/src/sanitize.ts:42
+  [gh] pr merge --disable-auto 1436            <- auto-merge disarmed              STEP EXIT=1
+```
+
+The classifier's verdict on the real #1436 ref, from the real repository:
+
+```
+$ node scripts/harness/classify-changed-paths.mjs --base-ref origin/develop --head pr1436
+merge base(s) vs origin/develop:
+  95cf8e1524bb2cad5a2580dd7db875af83d17473
+changed files:
+  .agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
+→ docs-only PR: no analyzable code changed.
+code=false
+```
+
 ## Test Plan
 
-- `scripts/harness/__tests__/check-review-gate.test.mjs` — 19 tests: the severity split (note and
+- `scripts/harness/__tests__/check-review-gate.test.mjs` — 30 tests: the severity split (note and
   warning never block; error and security-high/critical do), pre-existing-on-base exclusion,
   fixed/closed alerts ignored, both fail-closed paths (sentinel and unparseable payload), the
-  acknowledge override and its recording, and the CLI shape the workflow calls.
+  acknowledge override and its recording, the CLI shape the workflow calls, and (Defect 2) the
+  not-applicable path — a docs-only PR passes without reading alert files that were never written,
+  a code PR's `error` finding still blocks, and every non-`false` classification value
+  (`undefined`, `null`, `'false'` the string, `0`, `''`, `'unknown'`, `'False'`) fails closed onto
+  `verdict-unavailable`. The not-applicable case was proven RED against the pre-fix module first
+  (`expected true to be false` on `decision.blocked`).
+- `scripts/harness/__tests__/classify-changed-paths.test.mjs` — 11 tests: the #1436 markdown-only
+  shape, one code file among many docs files, workflow/harness-script changes as code, and the
+  fail-closed trio (no merge base, failed diff, empty list). Plus an **anti-drift parity test**:
+  `DOCS_ONLY_GLOBS` must equal `codeql.yml`'s `paths-ignore` entry for entry. That equivalence is
+  what makes "docs-only" a sound predictor of "no analysis will ever exist"; if `paths-ignore` ever
+  shrank without this list following, an analysed PR would be waved through as not-applicable.
+- Differential check (agent-run, real refs): the extracted classifier vs the previous inline
+  `changes` body over `pr1436`, `HEAD`, `origin/develop~{1,2,3,5,8}` and `origin/main` — all `same`.
 - `scripts/harness/__tests__/scan-review-workflow-parity.test.mjs` — 7 tests: action-based
   discovery, one-line drift (the exact `checkout@v4`→`@v7` shape), byte-identity, fail-closed when
   the default branch is unresolvable, workflow absent from the default branch, promotion-PR
   non-applicability, and the live repository.
-- YAML parse + `bash -n` on every `run:` block of both workflows.
-- `pnpm harness:verify-like-ci` (all five stages) and `pnpm harness:scan` — green.
+- YAML parse + `bash -n` on every `run:` block of all three workflows touched
+  (`review-gate.yml` 4/4, `ci.yml` 44/44).
+- `pnpm harness:verify-like-ci` (all five stages), `pnpm harness:scan` (64/64) and
+  `pnpm harness:test` (80 files, 900 tests) — green.
 
 ## User Execution Test Scenarios
 
@@ -220,18 +366,54 @@ real step body / the real scan against the real repository or a purpose-built fi
 
 ## Remaining step (why this item is not yet closed)
 
-**Add `review-gate` to the `protect-develop` ruleset's required status checks.** Until then a red
-`review-gate` does not by itself stop a _manual_ merge — only the auto-merge path is covered, by the
-disarm. The entry cannot be added before this PR lands: a required check that does not yet exist on
-`develop` reports "expected" forever and blocks every open PR (INFRA-046's "flip the flag AND add to
-the ruleset" lesson, in the other direction).
+**Re-add `review-gate` to the `protect-develop` ruleset's required status checks — but not yet.**
+Until then a red `review-gate` does not by itself stop a _manual_ merge; only the auto-merge path is
+covered, by the disarm.
 
-After this PR is merged to `develop` and one PR has been observed producing a `review-gate` check:
+It was added once and rolled back within one PR. The entry itself was not the mistake — **the
+mistake was arming it after observing the gate on exactly one PR (#1434, a code PR), which is a
+sample that cannot contain the case that broke it.** A gate is required-ready when it has been
+watched across the KINDS of PR the repository actually produces, not after N runs.
+
+### Preconditions for making `review-gate` required again
+
+All of these must hold. Each is checkable; none is a judgement call.
+
+1. **The Defect-2 fix is merged to `develop`,** and `review-gate` is producing a check on PRs there.
+   (A required check that does not exist on the base branch reports "expected" forever and blocks
+   every open PR — INFRA-046's lesson, in the other direction.)
+2. **The gate has been observed, while still ADVISORY, on all three PR shapes:**
+   - a **docs-only** PR → expect `PASS (not-applicable)`, with the Wait/Collect steps `skipped` and
+     a total runtime on the order of a checkout, not minutes;
+   - a **code** PR → expect the analysis to be waited for and a real verdict computed
+     (`clean` / `advisory-only` / `blocking-findings`), with the wait ending on completion rather
+     than on either deadline;
+   - a **promotion** PR (`develop` → `main`, or a `release/*` branch). This shape is untested and is
+     the one most likely to surprise: its base is the default branch, its diff is large, and
+     `review-workflow-parity` deliberately does not apply to it. Confirm what `refs/pull/N/merge`
+     analyses and base-branch alerts look like when the base is `main` before trusting the verdict.
+3. **No `verdict-unavailable` block on any of those three that turns out to be spurious.** A block
+   is only acceptable evidence of health if the analysis was genuinely missing or unreadable. If one
+   of the three blocks for a reason that is really "not applicable" or "not yet scheduled", that is
+   a fourth state and it must be fixed before arming, not labelled around.
+4. **The grace cut has been seen to fire, or been reasoned about against a real run.** Confirm from
+   a live run log how quickly CodeQL's `Analyze` check run appears on a code PR; if it can
+   legitimately take longer than the 5-minute grace on a busy runner queue, raise the grace rather
+   than discover it as a false block after arming.
+5. **An escape hatch is documented and reachable**: `review-findings-acknowledged` exists as a label
+   on the repository, and whoever can merge knows it is the auditable override — otherwise the first
+   inconvenient block gets resolved with an admin bypass, which is the failure mode this whole
+   design is calibrated against.
+
+Only then:
 
 ```bash
 gh api repos/woojubb/robota/rulesets/18715844 --jq '.rules[] | select(.type=="required_status_checks")'
 # then PUT the ruleset back with {"context":"review-gate"} appended to required_status_checks
 ```
+
+And when arming: **watch the next PR of each shape**, and keep the rollback command to hand. The
+cost of rolling back is one API call; the cost of leaving a wrong gate required is every open PR.
 
 **Raise `--max-turns` on the review prompt — and do it on the default branch first.** The parity fix
 is confirmed live on the PR that carries it (#1434, run `30167624730`): the run log contains **zero**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,40 +51,24 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          # The merge base is computed EXPLICITLY (not via the `...` shorthand) so it is visible in
-          # the log, and over `--all` because a criss-cross history (this repo back-merges
-          # main <-> develop) can have several: a file changed against ANY of them counts as
-          # changed, so an ambiguous history can only over-report, never silently under-report.
-          bases="$(git merge-base --all "origin/${BASE_REF}" HEAD)" || bases=''
-          echo "merge base(s) vs origin/${BASE_REF}:"; printf '%s\n' "$bases"
-          if [ -z "$bases" ]; then
-            echo "::error::changes: no merge base between origin/${BASE_REF} and HEAD. Classifying as CODE so no required check is silently skipped."
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=''
-          for base in $bases; do
-            if ! diff_files="$(git diff --name-only --diff-filter=ACMRD "$base" HEAD)"; then
-              echo "::error::changes: git diff against merge base $base failed. Classifying as CODE so no required check is silently skipped."
-              echo "code=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            files="${files}${diff_files}
-          "
-          done
-          files="$(printf '%s\n' "$files" | sed '/^$/d' | sort -u)"
-          echo "changed files:"; printf '%s\n' "$files"
-          # 'code' = ANY changed file that is not pure documentation (markdown / docs site / versioned content).
-          # A .agents/**/*.md harness-content PR is docs-only; a scripts/**, packages/**, .github/** change is code.
-          # An EMPTY list also lands here as code=true (the empty line fails the docs pattern) — deliberate:
-          # "nothing classified" must run the checks, not skip them.
-          if printf '%s\n' "$files" | grep -qvE '(\.mdx?$|^docs/|^content/)'; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "→ code changes present: full matrix runs."
-          else
-            echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "→ docs-only PR: heavy build/test/e2e jobs are skipped."
-          fi
+          # The classification lives in scripts/harness/classify-changed-paths.mjs — ONE
+          # implementation with two callers. `review-gate.yml` invokes the same module to decide
+          # whether a code-scanning analysis is expected for this PR at all, and if it re-derived
+          # "no code changed" with its own rule, that rule would be the bypass: a PR could skip the
+          # review gate without skipping this matrix. Extracting it is what makes the two verdicts
+          # the same verdict by construction.
+          #
+          # Unchanged behaviour (asserted in __tests__/classify-changed-paths.test.mjs): the merge
+          # base is computed explicitly and over `--all` for this repo's criss-cross history, and
+          # every undeterminable case — no merge base, a failed diff, an empty file list —
+          # classifies as CODE so no required check is silently skipped.
+          #
+          # No `setup-node`: the runner's preinstalled Node runs this (the script imports only
+          # node: builtins), and adding a network-dependent setup step to the job that GATES the
+          # required matrix would trade a real risk for a cosmetic one — a flake here makes
+          # tui-e2e / examples-typecheck / windows-shell report `skipping`, which branch protection
+          # accepts. review-gate.yml has run `node scripts/harness/*.mjs` bare since #1434.
+          node scripts/harness/classify-changed-paths.mjs --base-ref "origin/${BASE_REF}"
 
   build:
     name: build

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -13,6 +13,15 @@ name: Review Gate
 # INTRODUCES at severity `error` / security-severity high|critical can block. Everything else is
 # printed and counted but never blocking — this repo's ~100 open alerts are all severity `note`,
 # and a gate that went red on those would be bypassed within a day.
+#
+# Not-applicable (the #1436 correction). A docs-only PR never triggers CodeQL (`codeql.yml`
+# `paths-ignore`), so no analysis record is ever written for it. The first version of this gate read
+# that absence as "unreadable" and blocked #1436 — one backlog markdown file, zero code — for
+# 15 m 23 s, which is why the required-check entry had to be rolled back. The classification is NOT
+# re-derived here: it comes from `scripts/harness/classify-changed-paths.mjs`, the same module whose
+# verdict decides whether ci.yml's required build/test matrix runs. A PR can only be treated as
+# not-applicable by the rule that also skipped its entire code pipeline, and if that rule cannot
+# reach a verdict it answers `code=true` — so an undeterminable classification still fails closed.
 
 on:
   pull_request:
@@ -35,19 +44,47 @@ jobs:
     name: review-gate
     runs-on: ubuntu-latest
     steps:
-      # No history is read — this job talks to the code-scanning API, not to git.
+      # INFRA-050: `fetch-depth: 0`. The classify step below reads base-relative history (a merge
+      # base against `origin/<base>`), and a depth-limited checkout GRAFTS the ancestry, which would
+      # make that read fail — and a classification that cannot be determined answers `code=true`,
+      # sending every docs-only PR back into the 15-minute wait this change removes.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Classify this PR (code vs docs-only)
+        id: classify
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # THE SAME classifier ci.yml's `changes` job uses — one implementation, two callers, so
+          # the two cannot disagree about whether this PR contains code. Fail-closed by
+          # construction: no merge base, a failed diff or an empty file list all answer `code=true`.
+          node scripts/harness/classify-changed-paths.mjs --base-ref "origin/${BASE_REF}"
 
       - name: Wait for the code-scanning analysis of this PR
+        # Skipped entirely when no code changed: there is nothing to wait for, and waiting is what
+        # cost #1436 fifteen minutes before it was blocked.
+        if: steps.classify.outputs.code == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # The gate must read a COMPLETED analysis. Polling here (rather than assuming) is what
           # keeps "the analysis has not run yet" from being read as "the analysis found nothing".
-          deadline=$(( $(date +%s) + 900 ))
+          #
+          # Two deadlines, because there are two different things being waited for:
+          #   - GRACE (5 min): no `Analyze` check run has been created AT ALL. CodeQL's check runs
+          #     appear within seconds of the PR event, so after five minutes the honest conclusion
+          #     is that no analysis was scheduled for a PR that does contain code. Concluding early
+          #     is NOT assuming success — this exit writes `analysis_complete=false` exactly like
+          #     the long timeout, and the gate blocks. It only stops the job from spending another
+          #     ten minutes to reach the same answer.
+          #   - DEADLINE (15 min): an analysis exists and is still running. That one is worth
+          #     waiting for, and the loop breaks the moment it completes.
+          start=$(date +%s)
+          grace=$(( start + 300 ))
+          deadline=$(( start + 900 ))
           while :; do
             runs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" \
                       --jq '[.check_runs[] | select(.name | startswith("Analyze"))]' 2>/dev/null || echo '[]')"
@@ -58,7 +95,14 @@ jobs:
               echo "analysis_complete=true" >> "$GITHUB_ENV"
               break
             fi
-            if [ "$(date +%s)" -ge "$deadline" ]; then
+            now=$(date +%s)
+            if [ "$total" -eq 0 ] && [ "$now" -ge "$grace" ]; then
+              # Deliberately NOT a pass: this PR changes code, and nothing analysed it.
+              echo "::error::review-gate: no code-scanning analysis was scheduled for ${HEAD_SHA} within 5 minutes, and this PR changes code. Nothing has been analysed, so nothing has been cleared."
+              echo "analysis_complete=false" >> "$GITHUB_ENV"
+              break
+            fi
+            if [ "$now" -ge "$deadline" ]; then
               # Deliberately NOT a pass: an analysis that never completed has cleared nothing.
               echo "::error::review-gate: the code-scanning analysis for ${HEAD_SHA} did not complete within 15 minutes."
               echo "analysis_complete=false" >> "$GITHUB_ENV"
@@ -68,6 +112,7 @@ jobs:
           done
 
       - name: Collect the review output
+        if: steps.classify.outputs.code == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.base_ref }}
@@ -104,12 +149,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          CODE_CHANGED: ${{ steps.classify.outputs.code }}
         run: |
+          # This step always runs — a gate that reports nothing when its inputs are missing is the
+          # INFRA-048 defect itself. `--code-changed` carries the classifier's verdict; only the
+          # literal `false` selects the not-applicable path, so an empty or unexpected value (the
+          # classify step having failed, say) takes the normal path and blocks on the missing alert
+          # files. When it IS `false` the alert files are not read, and were never written.
+          # No labels are needed on the not-applicable path: the acknowledge override only exists to
+          # overrule a block, and not-applicable never blocks.
+          labels=''
+          if [ -f pr-labels.txt ]; then labels="$(cat pr-labels.txt)"; fi
           set +e
           node scripts/harness/check-review-gate.mjs \
+            --code-changed "${CODE_CHANGED}" \
             --alerts-file pr-alerts.json \
             --base-alerts-file base-alerts.json \
-            --labels "$(cat pr-labels.txt)" | tee gate-report.txt
+            --labels "$labels" | tee gate-report.txt
           status=${PIPESTATUS[0]}
           set -e
           {

--- a/scripts/harness/__tests__/check-review-gate.test.mjs
+++ b/scripts/harness/__tests__/check-review-gate.test.mjs
@@ -137,6 +137,55 @@ describe('decideReviewGate', () => {
   });
 });
 
+// #1436: a docs-only PR (one backlog markdown file, zero code) was BLOCKED as
+// `verdict-unavailable` after 15 m 23 s of polling, and the required-check entry had to be rolled
+// back. "No analysis exists because there was nothing to analyse" is a THIRD state — not the same
+// as "the analysis exists and could not be read".
+describe('not-applicable (no code changed)', () => {
+  it('PASSES a docs-only PR and says why, without needing any alert data', () => {
+    const decision = decideReviewGate({
+      codeChanged: false,
+      prAlerts: UNAVAILABLE,
+      baseAlerts: [],
+    });
+    expect(decision.blocked).toBe(false);
+    expect(decision.reason).toBe('not-applicable');
+    expect(renderDecision(decision)).toContain('review-gate: PASS (not-applicable)');
+    expect(renderDecision(decision)).toContain('no code changed');
+  });
+
+  it('does NOT reclassify a real block: an error finding on a code PR still blocks', () => {
+    const decision = decideReviewGate({
+      codeChanged: true,
+      prAlerts: [alert({ number: 60, severity: 'error' })],
+      baseAlerts: [],
+    });
+    expect(decision.blocked).toBe(true);
+    expect(decision.reason).toBe('blocking-findings');
+  });
+
+  // The whole point of routing this through the `changes` classifier is that a code PR can never
+  // land here. These assert the module's half of that: only the literal `false` is not-applicable,
+  // so an undeterminable classification fails closed onto the INFRA-048 path.
+  it('FAIL-CLOSED: an omitted classification is treated as "code changed"', () => {
+    const decision = decideReviewGate({ prAlerts: UNAVAILABLE, baseAlerts: [] });
+    expect(decision.blocked).toBe(true);
+    expect(decision.reason).toBe('verdict-unavailable');
+  });
+
+  for (const value of [undefined, null, 'false', 0, '', 'unknown']) {
+    it(`FAIL-CLOSED: codeChanged=${JSON.stringify(value)} is NOT not-applicable`, () => {
+      const decision = decideReviewGate({
+        codeChanged: value,
+        prAlerts: UNAVAILABLE,
+        baseAlerts: [],
+      });
+      expect(decision.reason).toBe('verdict-unavailable');
+      expect(decision.blocked).toBe(true);
+    });
+  }
+});
+
 describe('CLI (the shape the workflow calls)', () => {
   async function fixture(files) {
     const root = await mkdtemp(path.join(tmpdir(), 'robota-review-gate-'));
@@ -192,6 +241,33 @@ describe('CLI (the shape the workflow calls)', () => {
     const result = run(root, ['--alerts-file', 'pr.json', '--base-alerts-file', 'base.json']);
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('verdict-unavailable');
+  });
+
+  it('--code-changed false exits 0 without reading the alert files, which do not exist', async () => {
+    // Exactly the workflow's not-applicable shape: the Collect step is skipped, so pr-alerts.json
+    // and base-alerts.json were never written. The gate must still report — a check that produces
+    // nothing when its inputs are absent is the INFRA-048 defect itself.
+    const root = await fixture({});
+    const result = run(root, ['--code-changed', 'false']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('review-gate: PASS (not-applicable)');
+    expect(result.stdout).toContain('no code changed');
+  });
+
+  it('FAIL-CLOSED: --code-changed with an unexpected value takes the normal path', async () => {
+    const root = await fixture({ 'pr.json': 'UNAVAILABLE\n', 'base.json': '[]' });
+    for (const value of ['', 'true', 'False', 'unknown', 'no']) {
+      const result = run(root, [
+        '--code-changed',
+        value,
+        '--alerts-file',
+        'pr.json',
+        '--base-alerts-file',
+        'base.json',
+      ]);
+      expect(result.status, `--code-changed ${JSON.stringify(value)}`).toBe(1);
+      expect(result.stdout).toContain('verdict-unavailable');
+    }
   });
 
   it('exits 0 when the acknowledge label is passed', async () => {

--- a/scripts/harness/__tests__/classify-changed-paths.test.mjs
+++ b/scripts/harness/__tests__/classify-changed-paths.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * The changed-path classifier is the SINGLE mechanism deciding whether a PR contains code. Two
+ * consumers depend on it and must not be able to disagree:
+ *
+ *   - ci.yml `changes` — whether the required build/test matrix runs.
+ *   - review-gate.yml — whether a code-scanning analysis is expected at all (#1436: a docs-only PR
+ *     was blocked for 15 m 23 s waiting for an analysis CodeQL never schedules).
+ *
+ * Two properties are load-bearing and both are asserted mechanically here: the docs set stays
+ * byte-equivalent to codeql.yml's `paths-ignore`, and every undeterminable case answers CODE.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DOCS_ONLY_GLOBS,
+  classifyFiles,
+  classifyRange,
+  isDocsOnlyPath,
+} from '../classify-changed-paths.mjs';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+const SCRIPT = path.resolve(import.meta.dirname, '../classify-changed-paths.mjs');
+
+describe('the docs set is pinned to codeql.yml (anti-drift)', () => {
+  // If `paths-ignore` GROWS without this list following, the classifier over-reports code and the
+  // gate waits then blocks — annoying but safe. If it SHRINKS, an analysed PR would be treated as
+  // not-applicable and skip the gate. That second direction is a hole, and this test is what
+  // prevents it.
+  it('DOCS_ONLY_GLOBS equals codeql.yml `paths-ignore`, entry for entry', () => {
+    const yaml = readFileSync(path.join(REPO_ROOT, '.github/workflows/codeql.yml'), 'utf8');
+    const block = /paths-ignore:\n((?:\s*-\s*'[^']*'\n)+)/.exec(yaml);
+    expect(block, 'codeql.yml must still declare a paths-ignore block').not.toBeNull();
+    const pathsIgnore = [...block[1].matchAll(/-\s*'([^']*)'/g)].map((match) => match[1]);
+    expect([...pathsIgnore].sort()).toEqual([...DOCS_ONLY_GLOBS].sort());
+  });
+
+  it('every path codeql.yml ignores is classified docs-only, and code paths are not', () => {
+    for (const file of ['README.md', '.agents/backlog/X.md', 'docs/a/b.mdx', 'content/post.md']) {
+      expect(isDocsOnlyPath(file), file).toBe(true);
+    }
+    for (const file of [
+      'packages/agent-core/src/index.ts',
+      'scripts/harness/check-review-gate.mjs',
+      '.github/workflows/ci.yml',
+      'package.json',
+      'apps/agent-app/src/main.tsx',
+    ]) {
+      expect(isDocsOnlyPath(file), file).toBe(false);
+    }
+  });
+});
+
+describe('classifyFiles', () => {
+  it('classifies a markdown-only change as docs-only — the #1436 shape', () => {
+    const result = classifyFiles(['.agents/backlog/INFRA-053-review-turn-budget.md']);
+    expect(result.code).toBe(false);
+  });
+
+  it('one code file among many docs files is CODE', () => {
+    const result = classifyFiles(['README.md', 'docs/guide.mdx', 'packages/a/src/x.ts']);
+    expect(result.code).toBe(true);
+  });
+
+  it('a workflow or harness script change is CODE, not docs', () => {
+    expect(classifyFiles(['.github/workflows/review-gate.yml']).code).toBe(true);
+    expect(classifyFiles(['scripts/harness/check-review-gate.mjs']).code).toBe(true);
+  });
+
+  // "Nothing classified" must run the checks, not skip them.
+  it('FAIL-CLOSED: an empty file list is CODE', () => {
+    expect(classifyFiles([]).code).toBe(true);
+    expect(classifyFiles(undefined).code).toBe(true);
+  });
+});
+
+describe('classifyRange (fail-closed on git)', () => {
+  const ok = (stdout) => ({ ok: true, stdout, stderr: '' });
+  const fail = () => ({ ok: false, stdout: '', stderr: 'fatal' });
+
+  it('FAIL-CLOSED: no merge base classifies as CODE and reports the reason', () => {
+    const result = classifyRange({ baseRef: 'origin/develop', runGit: () => fail() });
+    expect(result.code).toBe(true);
+    expect(result.error).toContain('no merge base');
+  });
+
+  it('FAIL-CLOSED: a failed diff classifies as CODE', () => {
+    const runGit = (args) => (args[0] === 'merge-base' ? ok('abc123\n') : fail());
+    const result = classifyRange({ baseRef: 'origin/develop', runGit });
+    expect(result.code).toBe(true);
+    expect(result.error).toContain('git diff against merge base abc123 failed');
+  });
+
+  // A criss-cross history (this repo back-merges main <-> develop) can have several merge bases.
+  // Taking the UNION can only over-report code, never silently under-report it.
+  it('unions the diff over every merge base', () => {
+    const runGit = (args) => {
+      if (args[0] === 'merge-base') return ok('base1\nbase2\n');
+      return ok(args[3] === 'base1' ? 'README.md\n' : 'packages/a/src/x.ts\n');
+    };
+    const result = classifyRange({ baseRef: 'origin/develop', runGit });
+    expect(result.bases).toEqual(['base1', 'base2']);
+    expect(result.files).toEqual(['README.md', 'packages/a/src/x.ts']);
+    expect(result.code).toBe(true);
+  });
+});
+
+describe('CLI (the shape both workflows call)', () => {
+  it('prints a `code=` line and exits 0 against the real repository', () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, '--base-ref', 'origin/develop', '--head', 'HEAD'],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^code=(true|false)$/m);
+  });
+
+  it('FAIL-CLOSED: an unresolvable base ref still answers code=true', () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, '--base-ref', 'origin/definitely-no-such-ref'],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('code=true');
+    expect(result.stdout).toContain('::error::changes:');
+  });
+});

--- a/scripts/harness/check-review-gate.mjs
+++ b/scripts/harness/check-review-gate.mjs
@@ -28,6 +28,18 @@
  *   - **Unavailable** = the analysis has not completed, or the alert list could not be read. This
  *     BLOCKS. A review whose output cannot be read has not cleared anything; reporting a pass for
  *     it is the same defect one level up (cf. INFRA-048-B/C).
+ *   - **Not applicable** = this PR changes no code, so no analysis is produced for it and none is
+ *     expected. PASSES. This is a THIRD state, and conflating it with `unavailable` is what blocked
+ *     #1436 — a single backlog markdown file — for 15 m 23 s and forced the required-check entry to
+ *     be rolled back. "Not applicable" is not "unreadable": one means the answer does not exist,
+ *     the other means the answer exists and could not be read.
+ *
+ *     The caller must NOT decide this for itself. `codeChanged` is supplied by
+ *     `classify-changed-paths.mjs` — the SAME module whose verdict decides whether the required
+ *     build/test matrix runs at all — so a PR can only reach this branch by being the kind of PR
+ *     that also skipped its whole code pipeline. Only the literal value `false` selects it;
+ *     anything else (missing, unknown, unparseable) is treated as "code changed" and takes the
+ *     normal path, so an undeterminable classification still fails closed.
  *   - **Acknowledged** = the PR carries the acknowledge label. Passes, with the overridden findings
  *     printed in full so the decision is recorded on the PR rather than exercised as a silent
  *     admin bypass. One auditable escape beats a gate people learn to route around.
@@ -37,10 +49,13 @@
  *
  * Usage:
  *   node scripts/harness/check-review-gate.mjs \
- *     --alerts-file <pr-alerts.json> --base-alerts-file <base-alerts.json> [--labels a,b]
+ *     --alerts-file <pr-alerts.json> --base-alerts-file <base-alerts.json> [--labels a,b] \
+ *     [--code-changed true|false]
  *
  * Either alerts file may contain the literal string `UNAVAILABLE` (the workflow writes that when
- * the API call fails), which is what triggers the fail-closed path.
+ * the API call fails), which is what triggers the fail-closed path. `--code-changed false` selects
+ * the not-applicable path, and is the only value that does; the alert files are then not read at
+ * all, because no analysis exists to have produced them.
  *
  * Exit code 0 = the merge decision may proceed, 1 = blocked.
  */
@@ -93,11 +108,31 @@ function describeAlert(alert) {
  * @param {Array<object>|'UNAVAILABLE'} input.prAlerts     open alerts on the PR's merge ref
  * @param {Array<object>|'UNAVAILABLE'} input.baseAlerts   open alerts on the base branch
  * @param {string[]} [input.labels]                        labels currently on the PR
+ * @param {boolean} [input.codeChanged]                    the `changes` classifier's verdict;
+ *                                                         only literal `false` is not-applicable
  * @returns {{blocked: boolean, reason: string, blocking: object[], advisory: object[],
  *            preExisting: object[], acknowledged: boolean, summary: string}}
  */
-export function decideReviewGate({ prAlerts, baseAlerts, labels = [] }) {
+export function decideReviewGate({ prAlerts, baseAlerts, labels = [], codeChanged = true }) {
   const acknowledged = labels.includes(ACKNOWLEDGE_LABEL);
+
+  // Checked FIRST, and only on the literal `false`. A docs-only PR never triggers CodeQL
+  // (`codeql.yml` `paths-ignore`), so its alert lists are legitimately absent — reaching the
+  // UNAVAILABLE branch below would block it on the absence of an analysis that was never owed.
+  if (codeChanged === false) {
+    return {
+      blocked: false,
+      reason: 'not-applicable',
+      blocking: [],
+      advisory: [],
+      preExisting: [],
+      acknowledged,
+      summary:
+        'no code changed — this PR touches documentation only, so CodeQL never analyses it and no ' +
+        'review verdict exists to read. Nothing was skipped: the same classification also skipped ' +
+        'this PR’s build and test matrix. A PR that changes code cannot reach this outcome.',
+    };
+  }
 
   if (prAlerts === UNAVAILABLE || baseAlerts === UNAVAILABLE) {
     const which = prAlerts === UNAVAILABLE ? "the PR's" : "the base branch's";
@@ -208,25 +243,39 @@ function argValue(argv, flag) {
 }
 
 export function main(argv = process.argv.slice(2)) {
-  const alertsFile = argValue(argv, '--alerts-file');
-  const baseAlertsFile = argValue(argv, '--base-alerts-file');
-  if (!alertsFile || !baseAlertsFile) {
-    process.stderr.write(
-      'usage: check-review-gate.mjs --alerts-file <json> --base-alerts-file <json> [--labels a,b]\n',
-    );
-    process.exitCode = 1;
-    return;
-  }
-
   const labels = (argValue(argv, '--labels') ?? '')
     .split(',')
     .map((label) => label.trim())
     .filter(Boolean);
 
+  // Fail-closed parsing: ONLY the literal `false` is "no code changed". A missing flag, an empty
+  // value, or anything the classifier could not determine leaves this `true`, which requires a
+  // readable analysis — the INFRA-048 invariant.
+  const codeChanged = (argValue(argv, '--code-changed') ?? '').trim() !== 'false';
+
+  if (!codeChanged) {
+    // The alert files are not read, and need not exist: no analysis was produced for this PR.
+    process.stdout.write(renderDecision(decideReviewGate({ codeChanged: false, labels })));
+    process.exitCode = 0;
+    return;
+  }
+
+  const alertsFile = argValue(argv, '--alerts-file');
+  const baseAlertsFile = argValue(argv, '--base-alerts-file');
+  if (!alertsFile || !baseAlertsFile) {
+    process.stderr.write(
+      'usage: check-review-gate.mjs --alerts-file <json> --base-alerts-file <json> [--labels a,b] ' +
+        '[--code-changed true|false]\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const decision = decideReviewGate({
     prAlerts: readAlerts(alertsFile),
     baseAlerts: readAlerts(baseAlertsFile),
     labels,
+    codeChanged,
   });
 
   process.stdout.write(renderDecision(decision));

--- a/scripts/harness/classify-changed-paths.mjs
+++ b/scripts/harness/classify-changed-paths.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+/**
+ * Changed-path classifier — THE single mechanism that decides whether a PR touches CODE or is
+ * documentation-only.
+ *
+ * ## Why this is a shared module and not two copies
+ *
+ * The verdict has two consumers, and they must not be able to disagree:
+ *
+ *  - `.github/workflows/ci.yml` › `changes` — decides whether the heavy matrix (`tui-e2e`,
+ *    `examples-typecheck`, `windows-shell`, patch-coverage, regression-red-proof) runs at all.
+ *  - `.github/workflows/review-gate.yml` — decides whether a code-scanning analysis is EXPECTED for
+ *    this PR. A docs-only PR never triggers CodeQL (`codeql.yml` `paths-ignore`), so no analysis
+ *    record is ever written for it; without this signal the gate waits for an analysis that will
+ *    never arrive and then blocks on its absence (INFRA-048's fail-closed path, misapplied — see
+ *    #1436, which was blocked for a single backlog markdown file).
+ *
+ * If the review gate re-derived "no code changed" with its own weaker rule, that rule would be the
+ * bypass: any PR that could satisfy it would skip the gate entirely. So there is exactly one
+ * implementation, exported here, and both callers invoke it. A PR can only be classified docs-only
+ * by the very rule that also decided to skip its build and test matrix — a code PR cannot satisfy
+ * one without satisfying the other.
+ *
+ * ## The docs set, and why it is pinned to codeql.yml
+ *
+ * `DOCS_ONLY_GLOBS` is byte-equivalent to `codeql.yml`'s `paths-ignore`. That equivalence is what
+ * makes "docs-only" a sound predictor of "no analysis will ever exist", and it is asserted
+ * mechanically in `__tests__/classify-changed-paths.test.mjs` so the two cannot drift apart. If
+ * `paths-ignore` ever grows, the classifier over-reports code (fail-closed: the gate waits and
+ * blocks). If it ever shrinks without this list following, an analysed PR would be treated as
+ * not-applicable — which is the direction the parity test exists to prevent.
+ *
+ * ## Fail-closed
+ *
+ * Every path that cannot determine the answer — no merge base, a failed diff, an empty file list —
+ * classifies as CODE. "Nothing classified" must run the checks, not skip them (INFRA-050: a
+ * `changes` job that errors makes its required dependents report `skipping`, which branch
+ * protection accepts).
+ *
+ * Usage:
+ *   node scripts/harness/classify-changed-paths.mjs --base-ref origin/develop [--head HEAD]
+ *
+ * Prints the merge base(s), the changed files, and a final `code=true|false` line, and appends
+ * `code=<value>` to `$GITHUB_OUTPUT` when running under Actions. Always exits 0 — the verdict is
+ * the output, not the exit code.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Paths that are pure documentation. Kept byte-equivalent to `codeql.yml`'s `paths-ignore`; the
+ * parity is enforced by a unit test rather than by a comment.
+ */
+export const DOCS_ONLY_GLOBS = ['**/*.md', '**/*.mdx', 'docs/**', 'content/**'];
+
+/** `DOCS_ONLY_GLOBS` as a matcher over repository-relative paths. */
+export const DOCS_ONLY_PATTERN = /(\.mdx?$|^docs\/|^content\/)/;
+
+/** Whether one repository-relative path is pure documentation. */
+export function isDocsOnlyPath(file) {
+  return DOCS_ONLY_PATTERN.test(String(file ?? ''));
+}
+
+/**
+ * Classify an already-resolved list of changed paths.
+ *
+ * @param {string[]} files repository-relative paths changed by the PR
+ * @returns {{code: boolean, reason: string}}
+ */
+export function classifyFiles(files) {
+  const changed = (files ?? []).map((file) => String(file).trim()).filter(Boolean);
+  if (changed.length === 0) {
+    return {
+      code: true,
+      reason: 'no changed files could be resolved — classifying as CODE so nothing is skipped.',
+    };
+  }
+  const codeFiles = changed.filter((file) => !isDocsOnlyPath(file));
+  return codeFiles.length > 0
+    ? {
+        code: true,
+        reason: `code changes present: full matrix runs (${codeFiles.length} file(s)).`,
+      }
+    : { code: false, reason: 'docs-only PR: no analyzable code changed.' };
+}
+
+function git(args, { cwd } = {}) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+/**
+ * Resolve the changed paths of `head` against `baseRef` and classify them.
+ *
+ * The merge base is computed EXPLICITLY (not via the `...` shorthand) so it is visible in the log,
+ * and over `--all` because a criss-cross history (this repo back-merges main <-> develop) can have
+ * several: a file changed against ANY of them counts as changed, so an ambiguous history can only
+ * over-report code, never silently under-report it.
+ *
+ * @returns {{code: boolean, reason: string, files: string[], bases: string[], error?: string}}
+ */
+export function classifyRange({ baseRef, head = 'HEAD', cwd, runGit = git } = {}) {
+  const merge = runGit(['merge-base', '--all', baseRef, head], { cwd });
+  const bases = merge.ok
+    ? merge.stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+    : [];
+  if (bases.length === 0) {
+    return {
+      code: true,
+      bases: [],
+      files: [],
+      reason: 'Classifying as CODE so no required check is silently skipped.',
+      error: `no merge base between ${baseRef} and ${head}.`,
+    };
+  }
+
+  const files = new Set();
+  for (const base of bases) {
+    const diff = runGit(['diff', '--name-only', '--diff-filter=ACMRD', base, head], { cwd });
+    if (!diff.ok) {
+      return {
+        code: true,
+        bases,
+        files: [],
+        reason: 'Classifying as CODE so no required check is silently skipped.',
+        error: `git diff against merge base ${base} failed.`,
+      };
+    }
+    for (const line of diff.stdout.split('\n')) {
+      const file = line.trim();
+      if (file) files.add(file);
+    }
+  }
+
+  const sorted = [...files].sort();
+  return { ...classifyFiles(sorted), bases, files: sorted };
+}
+
+function argValue(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index === -1 ? undefined : argv[index + 1];
+}
+
+export function main(argv = process.argv.slice(2), write = (text) => process.stdout.write(text)) {
+  const baseRef = argValue(argv, '--base-ref');
+  if (!baseRef) {
+    process.stderr.write(
+      'usage: classify-changed-paths.mjs --base-ref <ref> [--head <rev>]\n' +
+        'Classifies a PR as code vs documentation-only. Prints `code=true|false`.\n',
+    );
+    process.exitCode = 1;
+    return undefined;
+  }
+
+  const head = argValue(argv, '--head') ?? 'HEAD';
+  const result = classifyRange({ baseRef, head });
+
+  write(`merge base(s) vs ${baseRef}:\n`);
+  for (const base of result.bases) write(`  ${base}\n`);
+  if (result.error) write(`::error::changes: ${result.error} ${result.reason}\n`);
+  else {
+    write('changed files:\n');
+    for (const file of result.files) write(`  ${file}\n`);
+    write(`→ ${result.reason}\n`);
+  }
+  write(`code=${result.code}\n`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `code=${result.code}\n`);
+  }
+  return result;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## The defect, measured

`review-gate` was added to `protect-develop`'s required status checks. The very next PR — **#1436, a
single added backlog markdown file, zero code** — was BLOCKED. The gate's own log:

```
code-scanning analyses recorded for refs/pull/1436/merge: 0
analysis_complete: false
review-gate: BLOCK (verdict-unavailable)
```

Runtime **15 m 23 s**, almost all of it polling for an analysis that was never going to arrive. The
required-check entry was rolled back the same day to unblock the repository.

**Root cause: three states collapsed into two.** INFRA-048 correctly hardened the gate so an empty
alerts list cannot read as "clean" — the endpoint answers `[]` both for "analysed and clean" and for
"never analysed". But it then read a _third_ state the same way: _no analysis exists because there
was no code to analyse._ `codeql.yml` carries `paths-ignore: ['**/*.md', '**/*.mdx', 'docs/**', 'content/**']`,
so a docs-only PR never triggers CodeQL and no analysis record is ever written.

**"Not applicable" is not "unreadable."** One means the answer was never owed; the other means it
exists and could not be read. Only the second is a reason to block.

## How "no code changed" is established — and why it cannot be spoofed

The gate does **not** get its own notion of docs-only. Any weaker rule would _be_ the bypass, since a
PR satisfying it skips the gate entirely.

`ci.yml`'s `changes` job — the mechanism this repo already trusts to decide whether the required
build/test matrix runs, hardened by INFRA-050 to read merge-base history over complete ancestry —
was extracted verbatim in behaviour into `scripts/harness/classify-changed-paths.mjs`, and **both
workflows now invoke it**. `ci.yml` is touched for exactly this reason and no other: sharing the
mechanism is the requirement, and two copies of a classifier are two classifiers.

Consequence, which is the point: **a PR can only be treated as not-applicable by the same
classification that also skipped its entire code pipeline.** A code PR cannot satisfy one without
satisfying the other.

Fail-closed survives at both layers:

- classifier — no merge base, a failed `git diff`, or an empty file list all answer `code=true`;
- decision module — only the literal `false` selects not-applicable. `undefined`, `null`, `'False'`,
  `'unknown'`, `''`, `0` all take the normal path and block on a missing analysis.

The classify step also forced `review-gate.yml` from `fetch-depth: 1` to `0`: a grafted ancestry
would fail the merge-base read, which (being fail-closed) would send every docs-only PR straight back
into the 15-minute wait. `ci-base-history` enforces this mechanically.

An **anti-drift parity test** pins `DOCS_ONLY_GLOBS` to `codeql.yml`'s `paths-ignore` entry for entry
— that equivalence is what makes "docs-only" a sound predictor of "no analysis will ever exist".

## What happened to the 15-minute wait

Two different things were conflated in one deadline. They are now separate:

- a **docs-only** PR does not wait at all — Wait and Collect are `if:`-gated on the classifier;
- **GRACE (5 min)** — no `Analyze` check run has been created AT ALL. CodeQL's check runs appear
  within seconds, so after five minutes the honest conclusion for a code PR is that nothing was
  scheduled. This exit writes `analysis_complete=false` exactly like the long timeout and **the gate
  BLOCKS** — it only stops the job spending another ten minutes to reach the same answer;
- **DEADLINE (15 min)** — an analysis exists and is still running. Worth waiting for, and the loop
  still breaks the moment it completes (#1434 did so in 3 m 32 s).

Neither exit can pass. The only way out with `analysis_complete=true` remains "every `Analyze` check
run completed".

## Proofs

Step bodies **extracted from `review-gate.yml` itself** and run under `bash -e -o pipefail` with `gh`
stubbed and a virtual clock — the same method as INFRA-048's own proofs.

```
RED — a docs-only PR under the config that blocked #1436 (pre-fix workflow, unmodified)
  code-scanning analyses: 0/0 completed        <- x45
  ::error::review-gate: the code-scanning analysis for … did not complete within 15 minutes.
      [waited 920s]
  code-scanning analyses recorded for refs/pull/1436/merge: 0
  review-gate: BLOCK (verdict-unavailable)
  [gh] pr merge --disable-auto 1436                                            STEP EXIT=1

GREEN — the same docs-only PR after the fix
  === `changes` classifier verdict for this PR: code=false
  Wait …    SKIPPED by `if: steps.classify.outputs.code == 'true'` — no code changed.
      [waited 0s]
  Collect … SKIPPED by `if: steps.classify.outputs.code == 'true'` — no code changed.
  review-gate: PASS (not-applicable)
  no code changed — this PR touches documentation only, so CodeQL never analyses it and no
  review verdict exists to read. …                                             STEP EXIT=0

NO REGRESSION — a code PR whose analysis is genuinely missing
  === `changes` classifier verdict for this PR: code=true
  ::error::review-gate: no code-scanning analysis was scheduled for … within 5 minutes, and this
  PR changes code. Nothing has been analysed, so nothing has been cleared.
      [waited 320s]                            <- was 920s; still BLOCKS
  review-gate: BLOCK (verdict-unavailable)     [gh] pr merge --disable-auto    STEP EXIT=1

NO REGRESSION — a code PR that introduces an `error`-severity finding
  code-scanning analyses: 1/1 completed        [waited 20s]
  review-gate: BLOCK (blocking-findings)
    - js/incomplete-sanitization [error/security:high] packages/agent-core/src/sanitize.ts:42
  [gh] pr merge --disable-auto 1436            <- auto-merge disarmed          STEP EXIT=1
```

The classifier on the real #1436 ref, against the real repository:

```
$ node scripts/harness/classify-changed-paths.mjs --base-ref origin/develop --head pr1436
changed files:
  .agents/backlog/INFRA-053-review-turn-budget-and-parity-window.md
→ docs-only PR: no analyzable code changed.
code=false
```

The new unit case was proven RED against the pre-fix module first (`expected true to be false` on
`decision.blocked`).

## Verification

| check                         | result                                                     |
| ----------------------------- | ---------------------------------------------------------- |
| `pnpm harness:verify-like-ci` | PASS — all 5 stages                                        |
| `pnpm harness:scan`           | all 64 scans passed                                        |
| `pnpm harness:test`           | 80 files, 900 tests passed                                 |
| classifier differential       | old inline body vs module over 8 real refs — all identical |
| YAML parse + `bash -n`        | review-gate.yml 4/4, ci.yml 44/44 run blocks               |

## Not in this PR

**Re-adding `review-gate` to the ruleset.** That is deliberately the orchestrator's call. INFRA-048
now records the preconditions: the gate must be watched **while still advisory** across a docs-only
PR, a code PR **and a promotion PR** (the untested shape — base is the default branch, large diff,
parity scan deliberately N/A), with no spurious `verdict-unavailable` among them. The rollback
happened because it was armed after being observed on exactly one PR, which is a sample that cannot
contain the case that broke it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
