### PR TITLE
docs(rules): INFRA-055 follow-ups — Update-branch button, and a count read off one page

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -172,6 +172,12 @@ commit's tree, so `main`'s side of the three-way merge is empty. If it is **not*
 `develop` never integrated (a `hotfix/*`, a direct push, a conflict-resolving merge) — back-merge `main` into
 `develop` on its own PR, **merged as a merge commit**, then re-run. Never resolve that inside the promotion.
 
+**Never update a promotion PR with GitHub's "Update branch" button.** Both of its modes destroy what
+the promotion asserts: the merge form adds a `main` merge commit the tool did not place, and the rebase
+form rewrites the promotion's history so `main`'s ancestry is no longer carried. Either way the
+`promotion ancestry` gate goes red — fail-closed, so nothing unsafe merges, but the branch is then
+unrecoverable by button. Re-run `promote.mjs` instead; it rebuilds the branch from current refs.
+
 **Merge the promotion PR with `gh pr merge <n> --merge`. Never `--squash`.**
 
 **Enforcement — two mechanical layers, both pre-merge:**

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -11,8 +11,15 @@ name: Review Gate
 #
 # Severity split (see check-review-gate.mjs for the full rationale): only findings this PR
 # INTRODUCES at severity `error` / security-severity high|critical can block. Everything else is
-# printed and counted but never blocking — this repo's ~100 open alerts are all severity `note`,
-# and a gate that went red on those would be bypassed within a day.
+# printed and counted but never blocking, because a gate that went red on the standing backlog would
+# be bypassed within a day.
+#
+# The original note here claimed that backlog was "~100 alerts, all severity `note`". That was
+# measured without `--paginate`, so it read only the first page — which happened to be entirely
+# notes while 40 `high` alerts sat on page two. Corrected 2026-07-26: `develop` carries 84 open
+# alerts, 40 of them security-severity `high` (SEC-006 is triaging them). The severity split is
+# still the right design, but its justification is "a standing backlog exists", not "the backlog is
+# harmless". Re-measure with `--paginate` before citing a count here.
 #
 # Not-applicable (the #1436 correction). A docs-only PR never triggers CodeQL (`codeql.yml`
 # `paths-ignore`), so no analysis record is ever written for it. The first version of this gate read


### PR DESCRIPTION
Two leftovers the INFRA-055 agent identified but could not file from inside its own file ownership.

**1. `git-branch.md` — never use GitHub's "Update branch" button on a promotion PR.** Both of its modes destroy what the promotion asserts: the merge form adds a `main` merge commit `promote.mjs` did not place, and the rebase form rewrites history so `main`'s ancestry is no longer carried. Either way `promotion ancestry` goes red — fail-closed, so nothing unsafe merges, but the branch is then unrecoverable by button. Re-run `promote.mjs`, which rebuilds it from current refs.

**2. `review-gate.yml` — its stated justification was measured wrong.** The header read *"this repo's ~100 open alerts are all severity `note`"*, and that number came from a query without `--paginate`: it read **page one only**, which happened to be entirely notes while **40 `high` alerts sat on page two**.

I made that error myself and reported "CodeQL high: 0" from it earlier today. It is worth naming the shape rather than just fixing the number: a paginated API silently returns a subset that looks like a complete answer, and the subset was uniform enough to be convincing. `develop` actually carries 84 open alerts, 40 security-severity `high` (SEC-006 is triaging them; the count dropped from ~184 because SEC-005 closed 87 dead-code alerts, which is also why the highs are now visible on a single page).

The severity split in `review-gate` is still the right design — a gate that went red on a standing backlog would be bypassed within a day. But its justification is "a standing backlog exists", not "the backlog is harmless", and the comment now says so plus instructs re-measuring with `--paginate` before citing a count.

**Also from INFRA-055, needing the owner rather than a PR:** the agent recommends **removing `protect-main`'s `bypass_actors` entry**. It currently grants `RepositoryRole 5` `bypass_mode: always`, which makes every gate on `main` advisory for the account that performs promotions, and makes `non_fast_forward` bypassable — a force-push to `main` would put INFRA-051's `ADOPTION_BASELINE` out of reach and red-block every future promotion. Break-glass does not need it: an admin can set `enforcement: disabled`, which is timestamped and auditable, where a standing bypass is invisible at merge time. If a hatch is wanted, `bypass_mode: pull_request` beats `always`. **Not applied** — that is the repository owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z