### PR TITLE
docs(backlog): reconcile 11 stale item states against the repository

### DIFF
--- a/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
+++ b/.agents/backlog/CLI-062-cjk-cursor-positioning-disabled.md
@@ -145,6 +145,24 @@ npx vitest run --config vitest.pty.config.ts src/__tests__/pty/ime-cursor.ptytes
 If Cell 1 shows no crash across a full Korean editing session, flip Apple_Terminal's default in
 `supportsImeCursorPositioning()` (drop the I5 branch) and archive this item.
 
+**Confirmed 2026-07-26 (backlog reconciliation): the two macOS cells are the ONLY remainder.** Checked
+against the tree rather than against this document:
+
+- The matrix is a real suite, not a checklist — `packages/agent-transport-tui/src/__tests__/pty/`
+  contains `ime-cursor.ptytest.ts` and `ime-cursor-tmux.ptytest.ts`, and the shared table is
+  `packages/agent-transport-tui/src/__tests__/helpers/terminal-profiles.ts`.
+- Provenance is machine-readable and matches the table above: `terminal-profiles.ts` marks the bare
+  TTY, Ghostty, VTE and tmux rows `provenance: 'measured'` (`:42,54,61,68`) and kitty, WezTerm,
+  Windows Terminal, iTerm2, Terminal.app `provenance: 'documented'` (`:75,82,89,96,103`). Exactly two
+  `documented` rows are macOS emulators that cannot run on Linux — iTerm2 (`:94-96`) and
+  Terminal.app (`:102-103`).
+- I5 is still armed: `terminal-profiles.ts:123` — `return profile.env['TERM_PROGRAM'] !== 'Apple_Terminal'`.
+  So Terminal.app is off by default and the SIGSEGV cannot be provoked by the shipped default; the
+  cells decide whether that default can be dropped, not whether the feature works.
+
+No other cell, test, or code path is outstanding. This is a hardware-availability block, not
+unfinished engineering.
+
 ## User Execution Test Scenarios
 
 - Prerequisite: a machine with a terminal emulator; the built CLI binary. No macOS required for the

--- a/.agents/backlog/HARNESS-025-gate-hygiene-p3.md
+++ b/.agents/backlog/HARNESS-025-gate-hygiene-p3.md
@@ -79,16 +79,37 @@ the factory by balanced parens, accepts both original-import spellings, requires
 ## Remaining
 
 Only `1c` has a remainder, and it is purely an ownership deferral — 19 test files in packages a
-concurrent work-stream (ARCH-005 S2) owns, so they were not touched:
+concurrent work-stream (ARCH-005 S2) owns, so they were not touched.
 
-- `packages/agent-cli/` — 8 files (`provider-startup` 14 sites, `provider-factory-integration`,
-  `cli-exit-codes`, `cli-command-composition`, `cli-update-check`, `git-worktree-isolation-adapter`,
-  `e2e/slash-smoke`, `e2e/scripted-e2e`)
-- `packages/agent-framework/` — 10 files (`config-loader`, `settings-check`, `e2e-scenarios`,
-  `filesystem-smoke`, `provider-configuration`, `provider-settings`, and 4 `interactive-session-*`)
-- `packages/agent-executor/` — 1 file (`providers/provider-factory`)
+**Re-verified 2026-07-26 against `origin/develop`: all 19 are still unconverted — none was picked up
+by another stream.** The exact set, reproduced by
+`rg -l "delete process.env|process\.env\.[A-Z_]* *=|process\.env\[[^]]*\] *=" packages/agent-cli/src
+packages/agent-framework/src packages/agent-executor/src` (which returns these 19 test files plus the
+one non-test file `packages/agent-cli/src/init/init-command.ts`, out of scope):
+
+- `packages/agent-cli/` — 8 files: `startup/__tests__/provider-startup.test.ts`,
+  `__tests__/provider-factory-integration.test.ts`, `__tests__/cli-exit-codes.test.ts`,
+  `__tests__/cli-command-composition.test.ts`, `__tests__/cli-update-check.test.ts`,
+  `subagents/__tests__/git-worktree-isolation-adapter.test.ts`, `__tests__/e2e/slash-smoke.test.ts`,
+  `__tests__/e2e/scripted-e2e.test.ts`
+- `packages/agent-framework/` — 10 files: `__tests__/config-loader.test.ts`,
+  `__tests__/settings-check.test.ts`, `__tests__/e2e-scenarios.test.ts`,
+  `__tests__/filesystem-smoke.test.ts`, `__tests__/provider-configuration.test.ts`,
+  `__tests__/provider-settings.test.ts`, and `interactive/__tests__/interactive-session-{auto-capture,
+checkpoints,memory,recall}.test.ts`
+- `packages/agent-executor/` — 1 file: `providers/provider-factory.test.ts`
+
+Spot-checked shape, so the next agent knows what a conversion looks like here:
+`packages/agent-cli/src/startup/__tests__/provider-startup.test.ts` contains **zero** `vi.stubEnv`
+calls and mutates directly at `:192-194` (`delete process.env.OPENAI_API_KEY` /
+`DASHSCOPE_API_KEY` / `DEEPSEEK_API_KEY`). The conversion is the same one `1c` already applied to 19
+files across seven other packages: replace hand-rolled save/restore with `vi.stubEnv` +
+`vi.unstubAllEnvs()` in `afterEach`.
 
 Several of these swap `process.env.HOME` by hand, which is the same conditional-flake class as `1a`.
+
+**Closing condition:** all 19 converted and each package's suite green at its recorded baseline count.
+Nothing else in this item is outstanding — `1a`, `1b` and `2` are done and evidenced above.
 
 ## Test Plan
 

--- a/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
+++ b/.agents/backlog/HARNESS-049-rule-to-skill-agent-refactor.md
@@ -10,6 +10,46 @@ depends_on: []
 
 # HARNESS-049: procedure belongs in skills, roles belong in agent files
 
+## Remainder (reconciled 2026-07-26) — read this first
+
+Both of the item's own defects are **fully discharged**: defect #1 (procedure trapped in rules) by
+increments 1–4, defect #2 (three skills that inline roles) by increment 5. Increment 5's refusal to
+archive was re-checked against the tree today and **all three blocking pointers are still live**, so
+the refusal still stands — this is not a stale note:
+
+| Live pointer                             | Exact text                                                                                                                | What it defers                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `.agents/specs/orchestration-map.md:131` | "the gate. Tracked in `HARNESS-049`."; the row's floor column reads `**recommendation gate: floor PENDING** (‡)` at `:97` | the recommendation gate's mechanical floor |
+| `.agents/rules/git-branch.md:389`        | "tracked in `HARNESS-049` and must update the documents that quote these sentences as evidence."                          | § Deployment's 2-bullet deletion           |
+| `.agents/rules/spec-workflow.md:172`     | "`HARNESS-049` for the reported gap.)"                                                                                    | the folder ↔ status mechanical floor       |
+
+**The five tabled remainders, each stated so the next agent can act without re-reading this file:**
+
+1. **Recommendation-gate mechanical floor** — `orchestration-map.md:97` claims a floor for the backlog
+   recommendation gate that does not exist. Either build a scan under `scripts/harness/` that fails when
+   a recommendation gate ran without a recorded `REVIEW VERDICT`, or change the row to `none` and drop
+   the `‡` footnote. Needs `scripts/**` (for the first) or `.agents/specs/**` (for the second).
+2. **Folder ↔ status mechanical floor**, plus **six live violations** it will immediately surface:
+   `spec-docs/done/` holds `INFRA-016`, `INFRA-019`, `INFRA-020` at `draft`, `PM-026`, `PM-030` at
+   `approved`, `DATA-002` at `in-progress`. The floor belongs in
+   `scripts/harness/check-spec-doc-frontmatter.mjs`. Fix the six in the same change, or the floor lands red.
+   Needs `scripts/**`.
+3. **`git-branch.md` § Deployment's 2-bullet deletion** — increment 4 REFUTED the relocation and proved
+   it is a deletion: `.agents/specs/architecture-map/apps-and-deployment.md` already owns bullets 1–2, and
+   the three documents quoting the literal Cloudflare sentence are all archival, so they must NOT be
+   rewritten. Bullets 3–4 stay (they are branch policy). Needs `.agents/rules/**`.
+4. **`pnpm docs:deploy` is broken** — `git-branch.md` and `scripts/docs/deploy-cloudflare-pages.mjs` both
+   target `apps/docs/.vitepress/dist`; `apps/docs` has no `.vitepress` directory and builds with
+   `next build && pagefind --site out`. `apps-and-deployment.md` is the correct side. Needs `scripts/**`.
+5. **BE-42 / BE-43 relocations** — BE-42 Layering Rule → `.agents/project-structure.md`, BE-43
+   Orchestration Skill Rule → `.agents/rules/enforcement-architecture.md`. Both need BOTH ends
+   (`backlog-execution.md` as the source), which is why neither increment could reach them.
+
+Each should become its own backlog file; at that point the three pointers above are repointed and **this
+item is archived**. The reconciling agent on 2026-07-26 owned only `.agents/backlog/**`, so it could
+neither repoint a rule/spec nor build a `scripts/**` floor — hence: verified open, remainder sharpened,
+not archived.
+
 ## Problem
 
 Owner directive (2026-07-26): convert what is currently _rule prose_ into the right artifact —

--- a/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
+++ b/.agents/backlog/INFRA-047-deny-licenses-v6-migration.md
@@ -31,3 +31,31 @@ self-deps and the LGPL @img/sharp-libvips prebuilt family). The red-test above c
 dependency-review executes the config of the PR's MERGE result against the target branch, so the new
 allow-list only gates PRs opened AFTER this lands. Run the GPL-fixture PR against develop after merge;
 only then may this item be closed.
+
+## Status (reconciled 2026-07-26) — the swap landed, the red test was never run
+
+**Done:** the input migration is live on `develop`. `.github/workflows/dependency-review.yml:60` now
+carries `allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BlueOak-1.0.0, CC-BY-4.0,
+CC0-1.0, ISC, MIT, MIT-0, MPL-2.0, Python-2.0, Unlicense, WTFPL`, with `allow-dependencies-licenses`
+purl exemptions for the `@robota-sdk/*` self-deps and the LGPL `@img/sharp-libvips-*` family. There is
+**no `deny-licenses` key and no deprecation note left in the file**. Merged as
+[#1339](https://github.com/woojubb/robota/pull/1339) (`2026-07-24T15:51:34Z`). The v6-bump gate the
+item exists to protect is therefore satisfied — a Dependabot v6 bump is now safe to accept.
+
+**Not done — the item's only stated closing condition.** The GPL-fixture red test has never been run:
+`gh pr list --state all --search GPL` returns no such PR, and no branch carrying a GPL fixture exists.
+Until it runs, "the allow-list actually blocks copyleft ingress" is an argument about a config file,
+not a measurement — which is precisely the shape the item wrote its own Test Plan to avoid.
+
+**The one remaining action, exactly:**
+
+1. Branch off fresh `origin/develop`; add a GPL-licensed package as a **devDependency** to the root
+   `package.json` and refresh `pnpm-lock.yaml` (both are in the workflow's `paths:` filter, so the job
+   will trigger). A clearly-GPL, small, uncontroversial choice keeps the fixture honest.
+2. Open the PR against `develop` and read the `Dependency review` check.
+3. **Expect FAIL** naming the GPL license as not in the allow-list. A pass is a defect in the
+   allow-list, not a green.
+4. Paste the check output here, then CLOSE the PR without merging and delete the branch.
+
+Note the job is advisory (not a required check) and `paths`-filtered, so the fixture PR is safe to open
+and costs nothing to abandon.

--- a/.agents/backlog/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/INFRA-048-review-arrives-after-merge.md
@@ -375,6 +375,51 @@ mistake was arming it after observing the gate on exactly one PR (#1434, a code 
 sample that cannot contain the case that broke it.** A gate is required-ready when it has been
 watched across the KINDS of PR the repository actually produces, not after N runs.
 
+### Precondition status, measured 2026-07-26 — 4 of 5 hold, and the 5th does not
+
+Checked against the actual check runs, not against this document's prose. **Four preconditions are
+met; precondition 5 is NOT, and it is a one-command fix.** The ruleset itself was deliberately left
+untouched — arming it is the owner's call, not the reconciling agent's.
+
+| #   | Precondition                                     | Verdict     | Evidence                                                                                                                                                                                                                                                                                                                                       |
+| --- | ------------------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Defect-2 fix on `develop`, gate producing checks | **MET**     | [#1439](https://github.com/woojubb/robota/pull/1439) merged `2026-07-25T18:49:52Z`; `gh run list --workflow=review-gate.yml` shows a run on every PR since                                                                                                                                                                                     |
+| 2a  | observed on a **docs-only** PR                   | **MET**     | #1441, #1444, #1449 — all `PASS (not-applicable)`. Run `30172414912` (#1449): `code=false` → `review-gate: PASS (not-applicable)`, total **1m** and the Wait/Collect steps `skipped`, i.e. "a checkout, not minutes"                                                                                                                           |
+| 2b  | observed on a **code** PR                        | **MET**     | #1451 (`3m19s`), #1452 (`3m56s`), #1453 (`3m22s`) — all pass, each ending on analysis COMPLETION, not a deadline                                                                                                                                                                                                                               |
+| 2c  | observed on a **promotion** PR                   | **MET**     | #1458 (`release/promote-develop-to-main` → `main`), run `30182471881`, `4m44s`: `code=true`, the `refs/pull/N/merge` analysis was found and waited for, verdict computed. The shape "most likely to surprise" did not surprise.                                                                                                                |
+| 3   | no spurious `verdict-unavailable` block          | **MET**     | The only two blocks in the whole window are #1451's runs `30173565727` and `30173813594`, and both are `BLOCK (blocking-findings)` — a real finding, not a missing verdict. Zero `verdict-unavailable` blocks occurred.                                                                                                                        |
+| 4   | grace cut reasoned about against a real run      | **MET**     | Run `30173565727`: the `Analyze` check run already existed on the **first** poll (`code-scanning analyses: 0/1 completed` at `20:26:16`, i.e. `total=1`) and completed at `20:30:23` — 4m07s. The 5-minute grace covers "no check run created at all" and had margin from the first second; the 15-minute deadline had 11 minutes of headroom. |
+| 5   | `review-findings-acknowledged` label exists      | **NOT MET** | `gh label list --limit 100` returns the 9 GitHub defaults only (`bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`). **The label does not exist on the repository.**                                                                                                      |
+
+**The strongest single piece of evidence is #1451, and it was not staged.** The gate BLOCKED a real
+code PR on a real high-severity finding and cleared only after the defect was fixed — run
+`30173813594`:
+
+```
+review-gate: BLOCK (blocking-findings)
+1 blocking finding(s) introduced by this PR (severity `error`, or security-severity high/critical).
+Blocking findings introduced by this PR:
+  - js/path-injection [error/security:high] packages/agent-cli/src/modes/serve-monitor-ui.ts:112
+::error::review-gate blocked this PR. See the job summary.
+```
+
+That is SEC-006's R9 — the lexical containment check the triage had wrongly called a false positive.
+Runs `30174467255`/`30174632780` on the same PR then passed after the canonical-path fix landed. So the
+gate has now been observed doing the one thing that cannot be inferred from a green run: refusing a
+merge, on a defect a careful human triage had already waved through, and then releasing it.
+
+**The single remaining action, precisely:**
+
+```bash
+gh label create review-findings-acknowledged \
+  --description "review-gate: findings acknowledged; merge with them on the record" --color BFD4F2
+```
+
+Precondition 5 is not decorative. Without the label the gate's only auditable override does not exist,
+so the first inconvenient block would be resolved with an admin bypass — the exact failure mode this
+design is calibrated against. Create it, confirm 1–4 still hold on the next PR of each shape, and only
+then apply the ruleset change below.
+
 ### Preconditions for making `review-gate` required again
 
 All of these must hold. Each is checkable; none is a judgement call.
@@ -415,7 +460,13 @@ gh api repos/woojubb/robota/rulesets/18715844 --jq '.rules[] | select(.type=="re
 And when arming: **watch the next PR of each shape**, and keep the rollback command to hand. The
 cost of rolling back is one API call; the cost of leaving a wrong gate required is every open PR.
 
-**Raise `--max-turns` on the review prompt — and do it on the default branch first.** The parity fix
+**Raise `--max-turns` on the review prompt — SPLIT OUT, no longer this item's remainder.** The whole
+of the section below now belongs to [`INFRA-053`](INFRA-053-review-turn-budget-and-parity-window.md)
+(`status: todo`, filed by [#1436](https://github.com/woojubb/robota/pull/1436)), which owns both the
+turn budget and the parity window it depends on and measured the budget across #1434/#1435/#1436.
+Kept here as the record of how it was discovered; do not track it from this item.
+
+The parity fix
 is confirmed live on the PR that carries it (#1434, run `30167624730`): the run log contains **zero**
 `workflow validation` lines, where every earlier run had them. The reviewer really ran — for ~2
 minutes instead of the previous 13–21 s — and then ended on

--- a/.agents/backlog/SEC-007-enumeration-sandbox-and-pagination-floor.md
+++ b/.agents/backlog/SEC-007-enumeration-sandbox-and-pagination-floor.md
@@ -10,8 +10,25 @@ depends_on: []
 
 # SEC-007: the SEC-006 carry-over — enumeration containment, and a floor for the pagination trap
 
-Closes the follow-ups [SEC-006](SEC-006-main-ref-alert-triage.md) identified and deliberately did
-not fix.
+Closes the follow-ups [SEC-006](completed/SEC-006-main-ref-alert-triage.md) identified and
+deliberately did not fix.
+
+## Status reconciliation (2026-07-26) — this is the single live tail of the SEC chain
+
+`SEC-003` (superseded), `SEC-004` (done) and `SEC-006` (done) are archived to `completed/`; this item
+is the only one still open, and it now carries everything the chain has left. **Parts A and B are
+complete and verified in the tree** (see the per-claim citations under each). What keeps this item
+open is not part A or B:
+
+| Remainder                                                                                    | Kind                    | Blocked on                                       |
+| -------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------ |
+| **C1** `apps/agent-server` playground trust boundary — unauthenticated host-tool RCE surface | product decision        | **owner call** on the three questions in C1      |
+| **C2** remainder — the three memory items filed, not fixed                                   | behaviour change        | a decision on `/memory add`'s permission surface |
+| `## Carried onward` — 8 enumerated defects                                                   | small independent fixes | file ownership (each names its path)             |
+| User-execution scenarios 2 and 3                                                             | evidence                | scenario 3 needs `scripts/**` (see there)        |
+
+C1 is a **blocker, not a nice-to-have**, and it is the reason this item must not be archived on the
+strength of A and B being done.
 
 ## A — the file-tool sandbox did not cover the tools that enumerate
 
@@ -311,17 +328,45 @@ Bounded by spawn cost (60 s) instead. This does not mask a hang — a hung spawn
 later. What is under test is that the resolved shell round-trips a command, never how fast the OS can
 start one.
 
-## Carried onward from SEC-006, still open
+## Carried onward — the whole chain's residue, still open
 
-Not in this item's scope; recorded so they are not lost:
+Not in this item's part-A/B scope; recorded here because SEC-003/004/006 are archived and this is the
+chain's only live tracker. **Every line was re-verified against the tree on 2026-07-26** — each is
+still present, none has been silently fixed.
 
-- `dag-framework/src/adapters/local-fs-asset-store.ts:263` joins a caller-supplied `assetId` on the
-  read path (the write path mints a `randomUUID`).
-- `agent-framework/src/git/git-branch.ts:48` — the fd-based read for the `lstat`/`readFileSync`
-  divergence.
-- `dag-cli/src/commands/run.ts:2258` — the unvalidated `--report-file` write.
-- `agent-executor/.../scheduled-task-runner.ts` — unverified for R8's bare-shell-name pattern.
-- `agent-playground`'s `IBlockMessage` reusing `role: 'system'` for tool-result rendering.
+From SEC-006:
+
+- `packages/dag-framework/src/adapters/local-fs-asset-store.ts:263-267` — `buildBinaryPath(assetId)` /
+  `buildMetadataPath(assetId)` join a caller-supplied `assetId` with no containment, reached on the read
+  path via `getContent`/`getMetadata` (`:224,233,249`). Only the write paths mint a `randomUUID`
+  (`:190,208`).
+- `packages/agent-framework/src/git/git-branch.ts:42-53` — still `lstatSync(candidate)` then
+  `readFileSync(candidate)`; needs the fd-based read for the two-lookup divergence.
+- `packages/dag-cli/src/commands/run.ts:2258` — `writeFile(reportFile, …)` where `reportFile` comes
+  straight from `--report-file` (`:363`, used at `:619,664,709`) with no validation.
+- `packages/agent-executor/src/background-tasks/runners/scheduled-task-runner.ts:171-172` — **confirmed,
+  not merely suspected**: `const shell = state.request.shell ?? 'sh'` then `spawn(shell, ['-c', …])`.
+  A bare `sh` resolved through `PATH`, i.e. exactly R8's pattern, in the one runner R8 did not reach.
+- `packages/agent-playground/src/lib/playground/block-tracking/block-hooks/block-messages.ts:64,92` —
+  `createToolResultBlock`/`createToolErrorBlock` still return `role: 'system'` for tool-result rendering.
+
+Moved here from SEC-004 (2026-07-26):
+
+- `packages/dag-nodes/text-template/src/index.ts:79-82` — the `{{text}}` pass (`:80`) runs before the
+  `%s` pass (`:81`), so `%s` inside the user's own text is substituted a second time, and the escape
+  sentinel is a string a user can type. Same root cause as SEC-004's alert 1, different surface. The
+  correct shape is one left-to-right scan that never re-reads its own output.
+
+Moved here from SEC-003 (2026-07-26) — these had no other owner:
+
+- Promote the three package-local `no-insecure-temp-path.test.ts` grep floors into **one repo-wide scan**
+  under `scripts/harness/`, so the `join(tmpdir(), <fixed>)` pattern cannot re-enter a package that has
+  no local floor.
+- `packages/agent-remote-pairing/src/pairing.ts` — `extractDtlsFingerprint` returns the FIRST
+  `a=fingerprint` line, so a relay-inserted session-level line can shadow the media-level one the DTLS
+  stack actually verified. Anchoring closed the free-text smuggling; binding the verified value is the
+  remainder. Two candidate fixes (fail closed on more than one distinct value, or parse the m-section);
+  both change the live WebRTC path, so this needs an owner call and a real two-peer run.
 
 ## Test Plan
 
@@ -352,7 +397,22 @@ Expected: neither `Glob` nor `Grep` returns `escape/outside.txt`, and the `SECRE
 in a tool result. Asking it to read `escape/outside.txt` directly still returns
 `Access denied: … is outside the working directory` (the SEC-006 behaviour, unchanged).
 Cleanup: `rm -rf /tmp/sec007`.
-Evidence: _to be filled after implementation_
+
+Evidence (agent-run, 2026-07-26) — **PASSES**. Run headlessly from `/tmp/sec007/work` (fixture:
+`escape -> /tmp/sec007`, `SECRET` in `/tmp/sec007/outside.txt`, `inside.txt` in the root) with
+`--permission-mode bypassPermissions`, so nothing but the containment guard can be doing the refusing:
+
+```
+Glob  **/*.txt  → {"success":true,"output":"inside.txt"}
+Grep  SECRET    → matches ONLY in /tmp/sec007/work/.robota/logs/*.jsonl and
+                  /tmp/sec007/work/.robota/sessions/*.json (the session transcript echoing the
+                  prompt's own word) — /tmp/sec007/outside.txt never appears.
+```
+
+`escape/outside.txt` is reachable lexically from the root, and neither tool returned it: Glob did not
+enumerate through the symlink, and Grep — whose `outputMode: 'content'` is what makes it a stand-in
+for `Read` — never disclosed the line. Both halves of part A's claim, on disk, through the real
+assemblies.
 
 **Scenario 2 — a workflow cannot write outside the directory it was run from.**
 Prerequisites: a built `dag-cli`.
@@ -361,7 +421,18 @@ Steps: author a `.dag.json` with a `file-write` node whose `path` is `/tmp/sec00
 Expected: the node fails with `DAG_VALIDATION_FILE_WRITE_PATH_OUTSIDE_ROOT` and **no file and no
 directory is created** at the target. A node writing `./out/result.txt` still succeeds.
 Cleanup: `rm -rf /tmp/sec007-escape`.
-Evidence: _to be filled after implementation_
+
+Evidence: **NOT YET RUN, and the steps as written are not executable.** Attempted 2026-07-26: a
+hand-authored `.dag.json` in the shape this scenario describes is rejected before the node ever runs —
+`node packages/dag-cli/dist/node/bin.js run escape.dag.json` →
+`Error: startRun failed: DAG_VALIDATION_DEFINITION_SNAPSHOT_INVALID`. The scenario does not say which
+definition schema `dag run` accepts, and there is no `*.dag.json` fixture anywhere in the repo to copy
+(`find . -name '*.dag.json' -not -path '*/node_modules/*'` → empty). **To close this cell:** first record
+a minimal, actually-accepted `file-write` definition (derive it from
+`packages/dag-framework`'s definition schema, or generate one with `dag` itself), then re-run. The
+mechanism is unit-covered either way — `packages/dag-nodes/file-write/src/index.ts:30` +
+`DAG_VALIDATION_FILE_WRITE_PATH_OUTSIDE_ROOT` at `:32`, with 4 red-first cases — so what is missing is
+the product-surface cell, not the guard.
 
 **Scenario 3 — the pagination floor blocks a single-page query.**
 Prerequisites: a checkout of this branch.
@@ -371,4 +442,11 @@ Steps: add a line to any file under `scripts/` reading
 Expected: exit 1 with `[per-page-without-paginate]` naming that file and line. Adding `--paginate`
 makes it exit 0 with `api-pagination scan passed.`
 Cleanup: revert the added line.
-Evidence: _to be filled after implementation_
+
+Evidence: **NOT YET RUN — deliberately.** The scenario's own first step is "add a line to any file
+under `scripts/`", and `scripts/**` was outside the reconciling agent's file ownership on 2026-07-26
+(a concurrent work-stream owns it), so planting even a transient probe there was not permissible.
+The cell is a two-minute job for whoever holds `scripts/**`. Until then the floor's coverage rests on
+`scripts/harness/__tests__/` (21 tests, including the reconstructed single-page query), and the scan
+is confirmed live and green on the tree — `scripts/harness/run-all-scans.mjs:123` registers
+`api-pagination`, and `pnpm harness:scan` reports it passing.

--- a/.agents/backlog/TERM-007-windows-support-followup.md
+++ b/.agents/backlog/TERM-007-windows-support-followup.md
@@ -11,7 +11,7 @@ depends_on: [TERM-001, TERM-002, TERM-003, TERM-005]
 # Windows support follow-up
 
 **Status (2026-06-30):** the code-side work is complete — item 1 (shell selection) shipped as
-[TERM-008](../spec-docs/active/TERM-008-cross-platform-shell-execution.md), item 4 (no Unix job-control)
+[TERM-008](../spec-docs/done/TERM-008-cross-platform-shell-execution.md), item 4 (no Unix job-control)
 is audited clean, and item 2's handoff is platform-neutral/Windows-capable by construction with nothing
 left to change without Windows runtime introspection. A **`windows-shell` CI job** (`.github/workflows/ci.yml`,
 `windows-latest`) now runs the resolver + Shell-tool tests on every PR — the Shell tool actually spawns
@@ -29,7 +29,7 @@ framework.
 
 ## What
 
-1. **Shell selection (`resolveShell()` win32)** — ✅ **DONE in [TERM-008](../spec-docs/active/TERM-008-cross-platform-shell-execution.md)** (carved out and implemented): the cross-platform SSOT `resolvePlatformShell()` (agent-core) now backs the `Shell`/`Bash` tool, the hook `command` executor, and the interactive `resolveShell()` seam — POSIX `sh`/`bash` and Windows PowerShell (cmd via `ROBOTA_SHELL`), with per-OS quoting/`-c` equivalents and OS-aware command-syntax hints. The hard `sh`-only failure on Windows is removed.
+1. **Shell selection (`resolveShell()` win32)** — ✅ **DONE in [TERM-008](../spec-docs/done/TERM-008-cross-platform-shell-execution.md)** (carved out and implemented): the cross-platform SSOT `resolvePlatformShell()` (agent-core) now backs the `Shell`/`Bash` tool, the hook `command` executor, and the interactive `resolveShell()` seam — POSIX `sh`/`bash` and Windows PowerShell (cmd via `ROBOTA_SHELL`), with per-OS quoting/`-c` equivalents and OS-aware command-syntax hints. The hard `sh`-only failure on Windows is removed.
 2. **Terminal capabilities (TERM-002 on Windows)** — ⏳ **code-ready; needs a Windows hardware pass.**
    Audit (2026-06-30) confirms the handoff is **platform-neutral by construction**: `TerminalHandoffController`
    uses only Node TTY APIs (`stdin.setRawMode`/`pause`, `isTTY`) + Ink rendering and `spawn(stdio:'inherit')`
@@ -71,3 +71,22 @@ mostly module-local addition rather than a cross-cutting rewrite.
   `process.platform`) is green, but the on-Windows-Terminal handoff/IME behaviour can only be captured
   on real Windows hardware — not available in this environment. This scenario stays unfilled until a
   Windows machine or Windows CI runner runs it.
+
+## Reconciled 2026-07-26 — one remainder, and it is hardware, not engineering
+
+Re-checked against the tree, not against the note above:
+
+- **Item 1 is closed and its spec is DONE**, not active — `.agents/spec-docs/done/TERM-008-cross-platform-shell-execution.md`.
+  The two links in this file pointed at `spec-docs/active/` and were dangling; repointed here.
+- **The `windows-shell` CI job is live and REQUIRED** — `.github/workflows/ci.yml:602-603` defines it,
+  and `:140` records it in the required-check set alongside `tui-e2e`/`examples-typecheck`. So the
+  every-PR Windows shell-execution coverage this item claims is real and maintained, not a one-off pass.
+- **Items 3 and 4 need nothing**: 3 is a declared non-goal, 4 was audited clean.
+
+**Remainder — item 2 only, and it is exactly one thing:** run the interactive TUI handoff on real
+Windows Terminal (full-screen suspend/resume, IME) — `/shell`, an interactive `BashTool` command, and
+`$EDITOR`, confirming the TUI restores with no stale frames or mode artifacts. It cannot be executed on
+a macOS/Linux host and `windows-shell` runs headless, so CI cannot cover it either. Blocked on access to
+a Windows machine or an interactive Windows runner; no code change is pending. Note the shape is the same
+as `CLI-062`'s two macOS cells — both are emulator-behaviour cells that no amount of engineering here can
+close.

--- a/.agents/backlog/completed/ARCH-FIX-004-agent-team-remote-client-arch-map.md
+++ b/.agents/backlog/completed/ARCH-FIX-004-agent-team-remote-client-arch-map.md
@@ -36,4 +36,21 @@ Not applicable — documentation-only change. No runnable user-facing behavior c
 
 ## Verification Evidence
 
-(완료 후 아키텍처 맵 업데이트 diff 링크 기록)
+Back-filled 2026-07-26 by re-deriving both Test Plan checks against the live tree (the original record
+promised a diff link and never carried one).
+
+**`agent-remote-client` is registered in all three documents**, and the registered direction matches
+the real manifest:
+
+| Check                             | Citation                                                                                                                                                                                                                                           |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| layer table                       | `.agents/specs/architecture-map/dependency-direction.md:21` — `Orchestration["Orchestration\nagent-remote-client"]`, edges at `:44,:45,:51`                                                                                                        |
+| Product Stack diagram node        | `.agents/specs/architecture-map/agent-system.md:101` — `RemoteClient["agent-remote-client…"]`, edges `:109,:111`; ownership row `:128`                                                                                                             |
+| package-family description        | `.agents/specs/architecture-map/repository-overview.md:16`                                                                                                                                                                                         |
+| direction vs. real `package.json` | `packages/agent-remote-client/package.json` deps = `{"@robota-sdk/agent-core":"workspace:*"}` → matches `RemoteClient --> Core`; `packages/agent-playground/package.json` depends on `agent-remote-client` → matches `Playground --> RemoteClient` |
+
+**The `agent-team` half of this item is moot, not fixed.** The package no longer exists —
+`git log --diff-filter=D -- packages/agent-team` → `6acec82ec release: CORE-002~004 embedded API,
+TOOL-003 agent-team removal, CORE-007 embedding guide (#614)`, with the removal documented at
+`content/guide/migration.md:26,242-245`. Its absence from the architecture maps is therefore the
+correct state today, not the defect this item was filed against. Recorded rather than quietly dropped.

--- a/.agents/backlog/completed/ARCH-FIX-007-cli-web-sidecar-arch-spec-registration.md
+++ b/.agents/backlog/completed/ARCH-FIX-007-cli-web-sidecar-arch-spec-registration.md
@@ -39,4 +39,22 @@ Not applicable — documentation-only change. No runnable user-facing behavior c
 
 ## Verification Evidence
 
-(완료 후 각 문서 업데이트 diff 링크 기록)
+Back-filled 2026-07-26 by re-deriving each Solution step against the live tree.
+
+| Solution step                             | Citation                                                                                                                                                                                              |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| third execution mode registered           | `.agents/specs/architecture-map/agent-cli/execution-modes.md:70` — `## Runtime Host Mode (\`robota --serve\`)`, landed-note `:72-76`, sequence diagram `:78-97`                                       |
+| WS transport node in the dependency graph | `.agents/specs/architecture-map/agent-cli/target-architecture.md:111` — `TransportWs["@robota-sdk/agent-transport-ws\nWsTransport"]`; allowed-edge row `:160`; `startRuntimeHost` ownership row `:93` |
+| package SPEC section                      | `packages/agent-cli/docs/SPEC.md:7-11` (mode + `startRuntimeHost` + `WsTransport` + `ROBOTA_WS_TOKEN`), transport row `:450`                                                                          |
+| router link                               | `.agents/specs/architecture-map/agent-cli-composition.md:14` routes "transports, or execution flags" to `execution-modes.md`                                                                          |
+
+**The item's premise was retired, not implemented.** It was filed against a `--web` flag; the surface
+shipped as `--serve` / `startRuntimeHost`. That is stated in the destination document itself —
+`.agents/specs/architecture-map/agent-cli/execution-modes.md:99-103`: _"Superseded design. The earlier
+`--web` / `--web-port` flags and `startWebSidecarServer(interactiveSession, port)` were never built."_
+
+**One Solution step is NOT satisfied, recorded rather than glossed:** step 3 asked for the sidecar's
+classes in `.agents/specs/architecture-map/agent-cli/class-interface-inventory.md`, and
+`rg -n "WsTransport|serve-mode|startRuntimeHost|RuntimeHost"` over that file returns **zero matches**
+(its only WS mention is the old→new package-rename row at `:18`). The registration landed in
+`target-architecture.md` and the SPEC instead.

--- a/.agents/backlog/completed/ARCH-FIX-013-create-mode-command-module-spec-mismatch.md
+++ b/.agents/backlog/completed/ARCH-FIX-013-create-mode-command-module-spec-mismatch.md
@@ -46,4 +46,28 @@ Not applicable — result depends on option chosen. If Option A (code change): m
 
 ## Verification Evidence
 
-(완료 후 선택한 옵션과 변경 내용 기록)
+Back-filled 2026-07-26 by re-deriving the outcome from the live tree.
+
+**Resolved as Option A, restructured.** The orphan `agent-command-mode` package was consolidated into
+the single `agent-command` package, and the module is genuinely wired into the default set — so the
+SPEC line was made true rather than deleted:
+
+| Fact                                    | Citation                                                                                                                                      |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| implementation                          | `packages/agent-command/src/mode/mode-command-module.ts:48` (`export function createModeCommandModule`), `:50` (`name: 'agent-command-mode'`) |
+| registered in the defaults              | `packages/agent-command/src/default/default-command-modules.ts:13` (import), `:93` (call)                                                     |
+| SPEC ownership moved to the owning pkg  | `packages/agent-command/docs/SPEC.md:97`                                                                                                      |
+| the stale `agent-cli` SPEC line is gone | `rg -n createModeCommandModule packages/agent-cli/docs/` → 0 matches                                                                          |
+| map no longer drifts per-module         | `.agents/specs/architecture-map/agent-cli/composition-tree.md:49` documents the aggregate factory `createDefaultCommandModules()`             |
+| assembly guard                          | `packages/agent-cli/src/__tests__/robota-assembly-equivalence.test.ts:61` asserts `'agent-command-mode'` is in the assembled set              |
+
+Test run for the User Execution Test Scenario's Option-A branch ("mode command behavior should be
+tested"), executed 2026-07-26:
+
+```
+$ npx vitest run --root packages/agent-command \
+    src/mode/__tests__/mode-command-module.test.ts \
+    src/default/__tests__/default-command-modules.test.ts
+Test Files  2 passed (2)
+     Tests  13 passed (13)
+```

--- a/.agents/backlog/completed/ARCH-FIX-015-monitor-route-arch-spec-registration.md
+++ b/.agents/backlog/completed/ARCH-FIX-015-monitor-route-arch-spec-registration.md
@@ -34,4 +34,28 @@ Not applicable — documentation-only change. No runnable user-facing behavior c
 
 ## Verification Evidence
 
-(완료 후 각 문서 업데이트 내용 기록)
+Back-filled 2026-07-26 by re-deriving each Solution step against the live tree.
+
+| Fact                                    | Citation                                                                                                                                                                  |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/monitor` listed in the deployment map | `.agents/specs/architecture-map/apps-and-deployment.md:30` — ``Routes: `/` (→ `/playground`), `/playground`, `/playground/demo`, `/monitor` (CLI second-screen).``        |
+| relationship to the shared GUI package  | `.agents/specs/architecture-map/apps-and-deployment.md:43` — ``its `/monitor` route mounts `SessionMonitor` from the shared GUI core `@robota-sdk/agent-transport-gui`.`` |
+| app SPEC route structure                | `apps/agent-web/docs/SPEC.md:28-31` (the CLI second-screen role, its `NEXT_PUBLIC_CLI_WS_URL` default, and the `SessionMonitor` relationship)                             |
+| component + env inventory rows          | `apps/agent-web/docs/SPEC.md:60` (`MonitorClient`), `:66` (env var), `:97` (imported-component row)                                                                       |
+
+The Solution allowed "SPEC.md 또는 README"; this app has no README, and the SPEC carries it, which
+satisfies the step as written.
+
+**Drift found while back-filling — reported, not papered over.** The registrations above are all
+present, but what they register is now WRONG: `apps/agent-web/src/app/` contains only `playground/`
+and `remote/` — there is no `monitor/` directory and no `MonitorClient` anywhere under
+`apps/agent-web/src`. The monitor moved to the CLI-served surface (`packages/agent-cli-web`) under
+GUI-007, and neither `apps/agent-web/docs/SPEC.md:28-31` nor
+`.agents/specs/architecture-map/apps-and-deployment.md:30,43` was updated. So two architecture
+documents describe a route the app no longer has, and both still name
+`src/app/monitor/MonitorClient.tsx` as its implementation.
+
+That is drift introduced AFTER this item, not a failure of it — the registration this item asked for
+did land — but it is a live defect in the same two documents and should be filed. Deliberately not
+cited above as evidence, because a citation to a path that does not resolve is exactly the unearned
+claim this back-fill exists to remove.

--- a/.agents/backlog/completed/ARCH-FIX-017-resolved-audit-verification-evidence.md
+++ b/.agents/backlog/completed/ARCH-FIX-017-resolved-audit-verification-evidence.md
@@ -35,4 +35,17 @@ Not applicable — documentation governance change. No runnable user-facing beha
 
 ## Verification Evidence
 
-(완료 후 업데이트된 항목 수와 재오픈된 항목 수 기록)
+Back-filled 2026-07-26 by reading `.agents/specs/architecture-map/architecture-lessons.md` end to end
+(33 lines) and checking both Test Plan criteria.
+
+**Updated items: 3. Re-opened items: 0. Items with a `resolved` status and no verification artifact: 0.**
+
+| Fact                                    | Citation                                                                                                                                                                                                                  |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| the governance policy (Solution step 5) | `.agents/specs/architecture-map/architecture-lessons.md:7-8` — _"An item may not be marked "resolved" without a verification artifact — a commit hash, PR number, or grep-output confirming the fix is in the codebase."_ |
+| `SYS-AUDIT-001`                         | `.agents/specs/architecture-map/architecture-lessons.md:16` — `Status: resolved — PR #313 (2d6a4f569).`                                                                                                                   |
+| `SYS-AUDIT-005`                         | `.agents/specs/architecture-map/architecture-lessons.md:23` — ``Status: resolved — `INFRA-BL-006`, commit `f9e388fd7`.``                                                                                                  |
+| `SYS-AUDIT-006`                         | `.agents/specs/architecture-map/architecture-lessons.md:30` — `Status: resolved — PR #315 (eb658beb4).`                                                                                                                   |
+
+The count of 0 re-opened items is a real result, not an omission: the file records no item whose
+evidence failed to substantiate its `resolved` status.

--- a/.agents/backlog/completed/ARCH-FIX-018-arch-map-diagram-edge-correction.md
+++ b/.agents/backlog/completed/ARCH-FIX-018-arch-map-diagram-edge-correction.md
@@ -34,4 +34,25 @@ Not applicable — documentation-only change. No runnable user-facing behavior c
 
 ## Verification Evidence
 
-(완료 후 수정된 다이어그램 스니펫 기록)
+Back-filled 2026-07-26 by machine-checking every edge of the Product Stack diagram against the real
+`package.json` files, which is the Test Plan's "잘못된 엣지 0건" criterion.
+
+```
+checked 29 solid edges; wrong = 0
+dashed AgentCLI -.-> Plugins:  real package dep present = false (expected false)
+dashed Framework -.-> Plugins: real package dep present = false (expected false)
+```
+
+**V-SYS-003 (`AgentCLI --> Plugins`) — corrected, not deleted.** The edge is now dashed and labelled:
+`.agents/specs/architecture-map/agent-system.md:37` — `AgentCLI -. "consumer opt-in" .-> Plugins`, the
+same treatment applied to `Framework` at `:49`, with the legend at `:79`. Confirmed against code:
+`packages/agent-cli/package.json` lists 24 `@robota-sdk/*` dependencies and **none** is `agent-plugin`;
+`rg -n "agent-plugin" packages/agent-cli/src packages/agent-framework/src` yields one comment
+(`packages/agent-framework/src/interactive/interactive-session-execution.ts:169`) and zero imports.
+
+**V-SYS-004 (`Commands --> Core`) — resolved by consolidation.** The 19 `agent-command-*` packages are
+now the single `agent-command` package (`.agents/specs/architecture-map/agent-cli/class-interface-inventory.md:20`),
+whose deps are exactly `agent-core`, `agent-framework`, `agent-interface-transport`, `agent-preset`
+(`packages/agent-command/package.json`) — so the edge at
+`.agents/specs/architecture-map/agent-system.md:40` is now a true, non-generalized statement rather than
+an over-generalization across 19 manifests.

--- a/.agents/backlog/completed/SEC-003-codeql-alert-triage.md
+++ b/.agents/backlog/completed/SEC-003-codeql-alert-triage.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-003: triage ~170 open CodeQL alerts (109 high-severity) accumulated behind an advisory gate'
-status: todo
+status: superseded
 created: 2026-07-25
+completed: 2026-07-26
 priority: high
 urgency: soon
 area: packages, scripts
@@ -9,6 +10,34 @@ depends_on: []
 ---
 
 # SEC-003: CodeQL alert backlog triage
+
+## Superseded (2026-07-26) — every stated remainder now has a different owner
+
+Both classes this item OPENED with are closed at the source with zero dismissals:
+`js/insecure-temporary-file` 109/109 (slices 1+2) and `js/polynomial-redos` 18/18 (slices 3+4).
+Neither appears in the paginated `develop` alert list today — `js/polynomial-redos` is gone entirely,
+and the 7 remaining `js/insecure-temporary-file` alerts are a DIFFERENT site set, triaged as false
+positives in `SEC-006`'s verdict table (they resolve under a caller-supplied `cwd`, never `os.tmpdir()`).
+
+The three things this item's later slices kept it open for have each moved to a live owner, so it is
+closed as superseded rather than done — the classes it opened with are finished, but the residue is
+not its work any more:
+
+| Stated remainder                      | Owner now                                                                                                                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `js/file-system-race` (16 catalogued) | `SEC-006` triaged the whole class (alerts #57–#72): 8 FP with the CWE-367 premise stated, 1 fixed (`host-identity.ts`), 1 NF, 4 `scripts/**` OOS |
+| style classes (~130)                  | `SEC-005` — [#1443](https://github.com/woojubb/robota/pull/1443) closed 87 `js/unused-local-variable` alerts at the source; 14 notes remain      |
+| advisory→required promotion decision  | `INFRA-048` (the `review-gate` check + its ruleset preconditions) and `INFRA-046` (advisory→required criteria) — not a CodeQL-triage decision    |
+
+**Two follow-ups this item opened had NO other owner, and have been moved to `SEC-007`'s
+`## Carried onward` list** (the live tail of the SEC chain) rather than being archived with it:
+
+1. Promote the three package-local `no-insecure-temp-path.test.ts` grep floors
+   (`packages/dag-cli/src/utils/__tests__/`, `packages/agent-framework/src/__tests__/`,
+   `packages/agent-cli/src/__tests__/`) into one repo-wide scan under `scripts/harness/`.
+2. `extractDtlsFingerprint` should bind the fingerprint the DTLS stack verified, not the first
+   `a=fingerprint` line in the SDP (`packages/agent-remote-pairing/src/pairing.ts`). Needs an owner
+   call and a real two-peer run.
 
 ## Problem
 

--- a/.agents/backlog/completed/SEC-004-codeql-high-alert-residue.md
+++ b/.agents/backlog/completed/SEC-004-codeql-high-alert-residue.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-004: close the five remaining HIGH CodeQL alerts (double-escaping, redos, missing-regexp-anchor)'
-status: in-progress
+status: done
 created: 2026-07-26
+completed: 2026-07-26
 priority: high
 urgency: now
 area: packages/agent-tools, packages/agent-cli, scripts/harness
@@ -168,6 +169,40 @@ reject, so those tests did not test what their names claimed.
 
 **Dismissed: none. 5 of 5 fixed at the source, plus 1 same-shape defect CodeQL never reported, plus
 1 filed as a follow-up.**
+
+## Closing verification (2026-07-26)
+
+Re-derived from the tree and from the live alert list, not from this document's own prose.
+
+**All three classes are absent from `develop`.** Paginated query (the SEC-006/SEC-007 discipline —
+an unpaginated read of this endpoint reports `0 high` on any ref):
+
+```
+$ gh api "repos/woojubb/robota/code-scanning/alerts?state=open&ref=refs/heads/develop&per_page=100" \
+    --paginate --jq '.[].rule.id' | sort -u | grep -E 'double-escaping|js/redos|missing-regexp-anchor'
+(no output — 0 matches)
+```
+
+The five alerts this item opened with (`js/double-escaping` ×1, `js/redos` ×1,
+`js/regex/missing-regexp-anchor` ×3) no longer appear in the 17 rule ids still open.
+
+**Each fix verified present in the tree:**
+
+| Fix                                         | Where it landed                                                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Alert 1 — single-pass entity decode         | `packages/agent-tools/src/builtins/web-fetch-tool.ts:93-106` (`HTML_ENTITIES` table + one `.replace`, no chain)     |
+| Alert 2 — exponential class body            | `scripts/harness/__tests__/frontmatter-parser-ssot.test.mjs:68` — the literal extractor's class body is `[^\]\\]`   |
+| Alerts 3–5 — substring search stated as one | `packages/agent-tools/src/__tests__/web-search-provider.test.ts:18,86,101` (`VENDOR_HOST` + `not.toContain`)        |
+| New coverage                                | `packages/agent-tools/src/__tests__/double-escaping.test.ts` — 5 `it` blocks (`:56,65,73,80,87`)                    |
+| Sweep instance CodeQL did not flag          | `packages/agent-cli/src/remote-control/__tests__/remote-control-controller.test.ts:112-114,242` (`origin`/`search`) |
+
+**Merged as** [#1443](https://github.com/woojubb/robota/pull/1443) / [#1451](https://github.com/woojubb/robota/pull/1451)
+in the same wave as SEC-005/SEC-006.
+
+**The one follow-up this item opened is NOT fixed and has moved.** `packages/dag-nodes/text-template/src/index.ts:79-82`
+still re-substitutes its own substitution output (line 81 splits on `%s` over line 80's output). Verified
+present on `develop` today. It is now carried by `SEC-007`'s `## Carried onward` list, which is the live
+tracker for the chain's tail — so archiving this item does not drop it.
 
 ## User Execution Test Scenarios
 

--- a/.agents/backlog/completed/SEC-006-main-ref-alert-triage.md
+++ b/.agents/backlog/completed/SEC-006-main-ref-alert-triage.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-006: triage the 40 high + 15 medium CodeQL alerts the develop-ref query hid, and fix at source'
-status: in-progress
+status: done
 created: 2026-07-26
+completed: 2026-07-26
 priority: high
 urgency: now
 area: packages, apps
@@ -525,7 +526,33 @@ Expected: `HTTP/1.1 404 Not Found`, and the agent process is still running and s
 subsequent `curl -i http://127.0.0.1:<port>/` returns `200` with the injected `ws-url` meta tag.
 Before the fix the first curl killed the process.
 Cleanup: Ctrl+C.
-Evidence: _to be filled after implementation_
+
+**Correction to the steps, found by running them.** Plain `robota --serve` does NOT start the monitor
+server. `packages/agent-cli/src/modes/serve-mode.ts:137` gates it on `if (args.open)`, and
+`resolveWebRoot()` (`packages/agent-cli/src/modes/serve-monitor-ui.ts:45-48`) returns `null` unless
+`dist/web/index.html` exists — which the root `pnpm build` does not produce. The executable form is
+`pnpm --filter @robota-sdk/agent-cli build` (its `build` script chains `agent-cli-web` +
+`scripts/copy-web-assets.mjs`) followed by `robota --serve --open`.
+
+Evidence (agent-run, 2026-07-26, from `/tmp/sec006/work`):
+
+```
+$ node packages/agent-cli/bin/robota.cjs --serve --open
+Web monitor: http://127.0.0.1:42885
+
+$ curl -s -i http://127.0.0.1:42885/assets   | head -1
+HTTP/1.1 404 Not Found
+$ curl -s -i http://127.0.0.1:42885/.        | head -1
+HTTP/1.1 200 OK
+$ curl -s -i http://127.0.0.1:42885/         | head -1
+HTTP/1.1 200 OK
+$ curl -s http://127.0.0.1:42885/ | grep -o '<meta name="ws-url"[^>]*>'
+<meta name="ws-url" content="ws://127.0.0.1:7070?token=a8db60fd…" />
+```
+
+`GET /assets` (a real directory — `packages/agent-cli/dist/web/assets/` exists in this build) returned
+404 instead of terminating the process, and the two later requests were served by the SAME still-running
+server, which is the whole claim: before R1 the first request killed it.
 
 **Scenario 2 — the file tools refuse to escape the workspace via a symlink (R3).**
 Prerequisites: a built CLI and a scratch directory.
@@ -534,7 +561,23 @@ then run robota with `cwd=/tmp/sec006/work` and ask it to read `escape/outside.t
 Expected: the `Read` tool returns `Access denied: "…" is outside the working directory`; the file
 contents are never shown. A normal read of a file inside `work/` still succeeds.
 Cleanup: `rm -rf /tmp/sec006`.
-Evidence: _to be filled after implementation_
+
+Evidence (agent-run, 2026-07-26). Run headlessly so the tool result is quotable verbatim —
+`cd /tmp/sec006/work && node packages/agent-cli/bin/robota.cjs --permission-mode bypassPermissions
+-p "Read the file escape/outside.txt and tell me exactly what the Read tool returned, verbatim."`:
+
+```
+{"success":false,"output":"","error":"Access denied: \"/tmp/sec006/work/escape/outside.txt\" is outside the working directory"}
+```
+
+`bypassPermissions` is deliberate: it removes the permission layer, so the refusal can only be coming
+from the canonical-path containment R3 added. The control half — the same command on `inside.txt` —
+succeeds, so the guard is not simply refusing everything:
+
+```
+[File: /tmp/sec006/work/inside.txt (1 lines)]
+1	inside-ok
+```
 
 **Scenario 3 — a traversing resume id is rejected with a 400 (R2).**
 Prerequisites: `apps/agent-server` running locally with any provider key.
@@ -543,9 +586,54 @@ Steps: `curl -i -X POST localhost:<port>/api/playground/sessions -H 'content-typ
 Expected: `400` with `{"error":"Invalid \"resumeSessionId\" field"}`, and no file appears outside
 `.robota/sessions/`. A well-formed id still resumes normally.
 Cleanup: remove any created session files.
-Evidence: _to be filled after implementation_
+
+Evidence (agent-run, 2026-07-26). `pnpm --filter @robota-sdk/agent-server build`, then
+`PORT=8791 node apps/agent-server/dist/server.js`, then two POSTs to
+`http://127.0.0.1:8791/api/playground/sessions`:
+
+```
+--- traversing resumeSessionId "../../escaped" ---
+HTTP 400
+{"error":"Invalid \"resumeSessionId\" field"}
+--- well-formed resumeSessionId "sec006-well-formed-id" ---
+HTTP 200
+{"sessionId":"8c3f61f8-8abe-4c9a-ab52-a9093674f1f0","messages":[]}
+```
+
+`find` over the server's tree and `$HOME` for `escaped*` returned nothing, and `~/.robota/sessions/`
+gained only the well-formed run's own file. The 200 on the control is the load-bearing half: the
+handler is rejecting the traversal specifically, not rejecting `resumeSessionId` outright.
+
+Incidental confirmation of the same PR's helmet hardening (`apps/agent-server/src/app.ts:39`):
+`curl -i http://127.0.0.1:8791/health` now returns `Content-Security-Policy: default-src 'none';
+frame-ancestors 'none';base-uri 'self';…` where before it sent none.
+
+## Post-merge alert re-query (2026-07-26)
+
+The Test Plan's last line. Run with `--paginate`, which is the whole point of this item:
+
+```
+$ gh api "repos/woojubb/robota/code-scanning/alerts?state=open&ref=refs/heads/develop&per_page=100" \
+    --paginate --jq '.[] | (.rule.security_severity_level // .rule.severity) + " " + .rule.id' \
+  | sort | uniq -c | sort -rn
+     14 high js/file-system-race          (8 FP + the 4 scripts/** OOS + 2 re-filed)
+      7 high js/insecure-temporary-file   (the 7 FPs recorded above, unchanged)
+      6 high js/system-prompt-injection   (the 6 FPs recorded above, unchanged)
+      4 high js/path-injection
+      2 high js/insecure-randomness       (the 2 FPs recorded above)
+      2 high js/clear-text-logging        (scripts/**, OOS)
+```
+
+Delta against this item's opening measurement (40 high + 15 medium): every alert this item classed
+`R` is gone, and what remains is exactly the FP + OOS set enumerated in the verdict table. The two
+classes SEC-003 opened with stay at zero — `js/polynomial-redos` no longer appears at all.
 
 ## Follow-ups (SEC-007)
+
+> **Closure note (2026-07-26).** Every entry below is carried by the LIVE item
+> [`SEC-007`](../SEC-007-enumeration-sandbox-and-pagination-floor.md) — items 1 and part of 2/3 are
+> closed there, and the rest are enumerated in its own `## Carried onward` section. Nothing in this
+> list is lost by archiving this item; SEC-007 is the single tracker for the chain's tail.
 
 1. **Mechanical floor for the pagination trap.** Any harness/CI step querying the code-scanning API
    must paginate; a check should assert the fetched record count matches the API's reported total.

--- a/.agents/backlog/completed/SELFHOST-000-self-hosting-capability-roadmap.md
+++ b/.agents/backlog/completed/SELFHOST-000-self-hosting-capability-roadmap.md
@@ -1,7 +1,8 @@
 ---
 title: 'SELFHOST-000: self-hosting capability roadmap — the features Robota needs to build Robota'
-status: todo
+status: done
 created: 2026-07-16
+completed: 2026-07-26
 priority: high
 urgency: soon
 area: packages/agent-core, packages/agent-framework, packages/agent-tools, packages/agent-session, packages/agent-plugin, packages/agent-provider-defaults, packages/dag-framework, packages/agent-cli, apps/agent-app
@@ -10,7 +11,38 @@ depends_on: []
 
 # Self-hosting capability roadmap
 
-The program that carries [`VISION.md`](../../VISION.md) — "Robota builds Robota" — into concrete work: the
+## Closing an index (2026-07-26) — and what `done` does and does not assert here
+
+`status: todo` had been false for some time. This file states its own job in its second paragraph:
+_"Individual capabilities are spun out into their own `SELFHOST-NNN` backlog items when scheduled;
+this item is the index + the prioritization."_ That job is fully discharged, and an index that carries
+no work of its own must not sit in the queue as `todo` — a reader scanning for unstarted work would
+pick it up and find nothing to do.
+
+**What is verified, not asserted:**
+
+- **All 14 spun-out capabilities are archived complete.** `ls .agents/backlog/completed/ | grep -c '^SELFHOST-'`
+  → **14**, and `grep -h '^status:' .agents/backlog/completed/SELFHOST-0*.md | sort | uniq -c` → **14
+  × `status: done`**, with zero at any other status. Their gate evidence was reconciled in
+  [#1314](https://github.com/woojubb/robota/pull/1314).
+- **The three open follow-ups are separate live files**, so closing the index loses nothing:
+  `.agents/backlog/SELFHOST-003-P4-embedding-vector-backend.md`,
+  `.agents/backlog/SELFHOST-008-P5-concrete-semantic-backend.md`,
+  `.agents/backlog/SELFHOST-011-P3-P4-evals-followups.md`.
+- **Archiving repairs 14 dangling links.** Every child writes `Part of [SELFHOST-000](SELFHOST-000-self-hosting-capability-roadmap.md)`
+  as a same-directory relative link from inside `completed/`
+  (`grep -rn '](SELFHOST-000-self-hosting-capability-roadmap.md)' .agents/backlog/completed | wc -l` →
+  **14**). Every one of those resolves to `.agents/backlog/completed/SELFHOST-000-…md`, which did not
+  exist while this file sat in the root. Moving it here is what makes them correct.
+
+**What this status does NOT claim.** The `## Test Plan` below sets a program-level bar — _"Robota can
+plan, index, change, review, and ship a real change to the Robota repo using these capabilities"_ —
+which is a continuous property of the product, not a checkbox, and is not something a backlog status
+can certify. `done` here means the **index deliverable** (survey → prioritize → spin out → track to
+completion) is finished. The north-star itself lives in [`VISION.md`](../../../VISION.md) and is measured
+by the flywheel, not by this file.
+
+The program that carries [`VISION.md`](../../../VISION.md) — "Robota builds Robota" — into concrete work: the
 capabilities a real development agent needs, benchmarked against what leading commercial/OSS agents tout as
 advantages, each placed at the correct Robota layer. Individual capabilities are spun out into their own
 `SELFHOST-NNN` backlog items when scheduled; this item is the index + the prioritization.

--- a/.agents/backlog/completed/WEB-014-marketing-404s-and-touch-targets.md
+++ b/.agents/backlog/completed/WEB-014-marketing-404s-and-touch-targets.md
@@ -68,3 +68,25 @@ is not a fat-finger risk and forcing it would distort the label.
 
 Live after release: internal links carry `prefetch={false}` (no RSC `.txt`
 prefetch 404s on CF); touch-target hit areas (44px) deployed.
+
+**Citations back-filled 2026-07-26** — this section asserted three things and cited none. Re-derived:
+
+- **`prefetch={false}` on every internal link — SUBSTANTIATED, but the shape changed.** It is no longer
+  "9 instances"; it was refactored into one wrapper, `apps/www/src/components/ui.tsx:12-14`
+  (`InternalLink` renders `<Link prefetch={false} {...props} />`), with the rationale naming WEB-014 at
+  `:4-11`. What makes the claim total rather than sampled: `rg -ln "next/link" apps/www/src` returns
+  **exactly one file — `ui.tsx` itself**, so no raw `<Link>` bypasses the wrapper anywhere in the app.
+  Consumers: `apps/www/src/components/Header.tsx`, `apps/www/src/components/Footer.tsx`,
+  `apps/www/src/app/[locale]/page.tsx:2,70`.
+- **44px hit areas deployed — SUBSTANTIATED in-tree AND live.** `min-h-[44px]` at
+  `apps/www/src/components/Header.tsx:36,42,48,57,66,74` (6 controls) and
+  `apps/www/src/components/Footer.tsx:27,35,43,70,87,104` (6 links); the hero CTAs use the `py-3` hit
+  area at `apps/www/src/app/[locale]/page.tsx:66,72`, matching this item's own "(or `py-3`)" wording.
+  Live: `curl -sL https://www.robota.io/en | grep -c 'min-h-\[44px\]'` → **16**, so the deployed build
+  demonstrably carries it.
+- **"no RSC `.txt` prefetch 404s on CF" — NOT SUBSTANTIABLE, stated plainly rather than given a
+  citation.** It is a runtime observation of a third-party host. `prefetch={false}` suppresses a
+  client-side fetch and leaves no marker in the served HTML, and the original failure mode can no longer
+  be reproduced either way (`https://www.robota.io/en/compare.txt?_rsc=abc` returns **200**, not 404).
+  No harness scan guards it (`rg -ln "InternalLink|prefetch" scripts/harness` → nothing). The mechanism
+  above is what is actually evidenced; the CF-side outcome was never verified and is not verifiable now.

--- a/scripts/harness/__tests__/scan-unearned-done-claims.test.mjs
+++ b/scripts/harness/__tests__/scan-unearned-done-claims.test.mjs
@@ -374,17 +374,25 @@ describe('over the real backlog corpus', () => {
     expect(staleLegacy).toEqual([]);
   });
 
+  // The expected count is deliberately a LITERAL, not derived from LEGACY_EVIDENCE_DEBT.size — a
+  // derived assertion would pass for any set and make TC-37 vacuous. It therefore has to be edited
+  // down whenever an entry is genuinely back-filled, which is the intended friction: the number may
+  // only ever decrease, and a decrease has to be justified by the same commit.
+  //   58 → 51 on 2026-07-26 (backlog reconciliation): ARCH-FIX-004/007/013/015/017/018 and WEB-014
+  //   were back-filled from evidence re-derived against the live tree.
+  const LEGACY_DEBT_COUNT = 51;
+
   it('TC-37: the legacy debt set is exercised, not decorative', () => {
     // Every listed entry must still produce a finding, or the anti-rot half of the driver would
     // have reported it stale in TC-36. This asserts the set is actually doing work.
     const { legacyCount } = findUnearnedDoneClaimFindings(WORKSPACE_ROOT);
-    expect(legacyCount).toBe(58);
+    expect(legacyCount).toBe(LEGACY_DEBT_COUNT);
   });
 
   it('TC-38: anti-rot fires when a legacy entry stops producing a finding', () => {
     // An empty root resolves none of the legacy files, so all of them read as back-filled — which
     // is precisely the condition that must FAIL rather than silently pass.
     const { staleLegacy } = findUnearnedDoneClaimFindings(path.join(FIXTURES, 'does-not-exist'));
-    expect(staleLegacy.length).toBe(58);
+    expect(staleLegacy.length).toBe(LEGACY_DEBT_COUNT);
   });
 });

--- a/scripts/harness/scan-unearned-done-claims.mjs
+++ b/scripts/harness/scan-unearned-done-claims.mjs
@@ -69,8 +69,13 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const BACKLOG_DIRS = ['.agents/backlog', '.agents/backlog/completed'];
 
 /**
- * Historical debt, enumerated rather than hidden — 58 items, 71 findings, audited one by one and
- * every one genuine. 62 are an evidence field left as a literal promise ("(to be filled after
+ * Historical debt, enumerated rather than hidden — opened at 58 items / 71 findings, audited one by
+ * one and every one genuine; **51 items remain** after the 2026-07-26 backlog reconciliation
+ * back-filled 7 (`ARCH-FIX-004/007/013/015/017/018`, `WEB-014`) from evidence re-derived against the
+ * live tree. Two more were ATTEMPTED and deliberately left: `ARCH-FIX-012`'s own Test Plan grep
+ * returns 2, not the 0 it claims (`packages/agent-core/docs/SPEC.md:362`,
+ * `packages/agent-framework/README.md:430`), and `ARCH-FIX-014`'s returns 15, not 0 — those are
+ * unearned done claims that a citation would paper over, so they stay listed. 62 are an evidence field left as a literal promise ("(to be filled after
  * implementation)", "(구현 후 기록)") and 9 are an evidence section whose body says it will be
  * recorded later — inside items already marked `status: done`. They predate this floor and are NOT
  * this scan's false positives; they are the backlog of unearned done claims the floor exists to stop
@@ -88,17 +93,11 @@ const LEGACY_EVIDENCE_DEBT = new Set([
   '.agents/backlog/completed/ARCH-002-p8-extract-command-module-factory.md',
   '.agents/backlog/completed/ARCH-FIX-001-transport-sdk-reverse-dependency.md',
   '.agents/backlog/completed/ARCH-FIX-002-agent-event-service-compat-shim-removal.md',
-  '.agents/backlog/completed/ARCH-FIX-004-agent-team-remote-client-arch-map.md',
   '.agents/backlog/completed/ARCH-FIX-005-terminal-output-type-ssot.md',
-  '.agents/backlog/completed/ARCH-FIX-007-cli-web-sidecar-arch-spec-registration.md',
   '.agents/backlog/completed/ARCH-FIX-010-bundle-plugin-loader-product-name-fallback.md',
   '.agents/backlog/completed/ARCH-FIX-011-streaming-callback-fallback.md',
   '.agents/backlog/completed/ARCH-FIX-012-sub-agent-naming-violation.md',
-  '.agents/backlog/completed/ARCH-FIX-013-create-mode-command-module-spec-mismatch.md',
   '.agents/backlog/completed/ARCH-FIX-014-spec-product-name-claude-code.md',
-  '.agents/backlog/completed/ARCH-FIX-015-monitor-route-arch-spec-registration.md',
-  '.agents/backlog/completed/ARCH-FIX-017-resolved-audit-verification-evidence.md',
-  '.agents/backlog/completed/ARCH-FIX-018-arch-map-diagram-edge-correction.md',
   '.agents/backlog/completed/ARCH-FIX-024-move-child-process-runner-to-agent-cli.md',
   '.agents/backlog/completed/ARCH-FIX-025-wire-auth-credits-or-document-debt.md',
   '.agents/backlog/completed/ARCH-FIX-026-fix-terminal-output-import-chain.md',
@@ -140,7 +139,6 @@ const LEGACY_EVIDENCE_DEBT = new Set([
   '.agents/backlog/completed/WEB-002-onboarding-decision-tree.md',
   '.agents/backlog/completed/WEB-003-brand-design-system.md',
   '.agents/backlog/completed/WEB-004-playground-interactive-ux.md',
-  '.agents/backlog/completed/WEB-014-marketing-404s-and-touch-targets.md',
 ]);
 
 // ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Eleven backlog items claimed a state the repository contradicts. A backlog is what every later
decision reads, so an item that lies about its state is a defect in its own right — and the item's own
prose is exactly what was being audited, so none of it was accepted as evidence. Every verdict below
comes from code, merged PRs, check runs, or the live CodeQL alert list.

## Verdicts

| Item             | Was          | Now             | The evidence that decided it                                                                                                                                                                    |
| ---------------- | ------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **SEC-006**      | in-progress  | **done**        | All 3 user-execution scenarios executed for the first time; each now carries real output (below)                                                                                                |
| **SEC-004**      | in-progress  | **done**        | `js/double-escaping`, `js/redos`, `js/regex/missing-regexp-anchor` absent from the paginated `develop` alert list; all 5 fixes cited at file:line                                                |
| **SEC-003**      | todo         | **superseded**  | Both classes it opened with closed (109/109, 18/18); its 3 stated remainders now owned by SEC-005 / SEC-006 / INFRA-048                                                                          |
| **SELFHOST-000** | todo         | **done**        | 14/14 children `status: done` in `completed/`; 3 leftovers are separate live files; archiving repairs 14 dangling links                                                                          |
| **SEC-007**      | in-progress  | open (sharpened) | Parts A and B verified complete in the tree; C1 is an owner-decision blocker, and it is now the chain's single live tail                                                                        |
| **HARNESS-049**  | in-progress  | open (sharpened) | All 3 blocking pointers still live; 5 remainders each named with its owning path                                                                                                                |
| **INFRA-048**    | in-progress  | open (sharpened) | Preconditions 1–4 **met**; precondition 5 **not met**                                                                                                                                           |
| **INFRA-047**    | in-progress  | open (sharpened) | The `allow-licenses` swap is live (#1339); the GPL red test has never been run                                                                                                                  |
| **HARNESS-025**  | in-progress  | open (sharpened) | All 19 deferred files re-verified still unconverted; exact list + a spot-checked example recorded                                                                                               |
| **CLI-062**      | in-progress  | open (confirmed) | The two macOS cells really are the only remainder — verified against `terminal-profiles.ts`                                                                                                     |
| **TERM-007**     | in-progress  | open (confirmed) | One remainder (Windows Terminal interactive pass); two dangling `spec-docs/active/TERM-008` links repointed to `done/`                                                                          |

## INFRA-048 — the precondition judgement you asked for

**Four of five hold. Precondition 5 does not, and it is a one-command fix. The ruleset was not touched.**

| #   | Precondition                          | Verdict     | Evidence                                                                                                                     |
| --- | ------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
| 1   | Defect-2 fix on develop, gate running | **MET**     | #1439 merged `2026-07-25T18:49:52Z`; a `review-gate` run exists on every PR since                                            |
| 2a  | docs-only PR                          | **MET**     | #1441, #1444, #1449 → `PASS (not-applicable)`; run `30172414912` shows `code=false`, Wait/Collect skipped, ~1 min total      |
| 2b  | code PR                               | **MET**     | #1451 3m19s, #1452 3m56s, #1453 3m22s — each ended on analysis **completion**, not a deadline                                |
| 2c  | promotion PR                          | **MET**     | #1458 (`release/promote-develop-to-main` → `main`), run `30182471881`, 4m44s, `code=true`, verdict computed                  |
| 3   | no spurious `verdict-unavailable`     | **MET**     | The only two blocks in the whole window are #1451's, and both are `BLOCK (blocking-findings)`. Zero unavailable-blocks.      |
| 4   | grace cut reasoned about              | **MET**     | Run `30173565727`: the `Analyze` check run existed on the **first** poll (`0/1`, i.e. total=1) and completed in 4m07s        |
| 5   | `review-findings-acknowledged` label  | **NOT MET** | `gh label list --limit 100` returns only the 9 GitHub defaults. **The label does not exist on the repository.**              |

The strongest evidence is #1451, and it was not staged — the gate blocked a real code PR on a real
finding and released it only after the defect was fixed:

```
review-gate: BLOCK (blocking-findings)
  - js/path-injection [error/security:high] packages/agent-cli/src/modes/serve-monitor-ui.ts:112
```

That is SEC-006's R9 — the lexical containment check that item's own triage had wrongly called a false
positive. So the gate has been observed doing the one thing a green run can never demonstrate.

**Recommendation: create the label, then arm it.** Without it the gate's only auditable override does
not exist, so the first inconvenient block gets resolved with an admin bypass — the exact failure mode
this design is calibrated against.

```bash
gh label create review-findings-acknowledged \
  --description "review-gate: findings acknowledged; merge with them on the record" --color BFD4F2
```

## SEC-003 / 004 / 006 / 007 — the chain was carrying duplicate remainders

They were not four independent items. SEC-003's three stated remainders had each acquired a different
owner, SEC-004's alerts were all closed, and SEC-006's follow-ups were already SEC-007's list. Three are
now archived and **SEC-007 is the single live tail**, with every orphaned follow-up moved into its
`## Carried onward` section and re-verified present in the tree today — including one SEC-006 only
suspected: `scheduled-task-runner.ts:171-172` really does resolve a bare `sh` through `PATH`, which is
R8's pattern in the one runner R8 did not reach.

SEC-007 stays open on **C1**, which is a blocker rather than a leftover: `apps/agent-server`'s playground
route takes an unauthenticated request body, binds `0.0.0.0`, and hands the session the full host tool
set with `permissionMode` defaulting to `bypassPermissions`. Three product questions need your call
before it can be fixed.

## SEC-006's scenarios were never run — they are now

The three `Evidence: _to be filled after implementation_` fields were the reason this could not close.
All three were executed against the built product:

- **R1** — `GET /assets` (a real directory) returned `404` and the server stayed up; `GET /` then
  returned `200` with the injected `ws-url` meta tag. **Scenario 1's steps were also wrong**: plain
  `robota --serve` starts no monitor at all (`serve-mode.ts:137` gates it on `--open`, and
  `resolveWebRoot()` needs a `dist/web` the root build does not produce). Corrected in the item.
- **R3** — under `--permission-mode bypassPermissions`, so only the containment guard can be refusing:
  `{"success":false,"error":"Access denied: \"/tmp/sec006/work/escape/outside.txt\" is outside the working directory"}`,
  while the control read of `inside.txt` succeeded.
- **R2** — `resumeSessionId: "../../escaped"` → `400 {"error":"Invalid \"resumeSessionId\" field"}`;
  a well-formed id → `200`. No file appeared anywhere outside the session store.

SEC-007's scenario 1 was run too (Glob/Grep refuse to enumerate or disclose through an escaping
symlink). Its scenarios 2 and 3 are recorded as **not run, with the reason**: 2's steps are not
executable as written (no accepted `.dag.json` shape is given and no fixture exists in the repo — the
attempt returned `DAG_VALIDATION_DEFINITION_SNAPSHOT_INVALID`), and 3 requires planting a probe under
`scripts/**`, outside this change's ownership.

## Legacy evidence debt: 58 → 51

Seven back-filled from evidence re-derived against the live tree today, not from PR archaeology:
`ARCH-FIX-004`, `007`, `013`, `015`, `017`, `018`, `WEB-014`.

**Two were attempted and deliberately left listed** — a citation would have papered over a real defect:

- `ARCH-FIX-012` claims its grep returns 0. It returns **2**: `packages/agent-core/docs/SPEC.md:362`
  and `packages/agent-framework/README.md:430` still say "sub-agent". No scan guards `packages/` —
  `scan-conflict-markers.mjs:39` scopes to `AGENTS.md`/`.agents/skills`/`.agents/rules`.
- `ARCH-FIX-014` claims 0; it returns **15**. Worse, the rule it invokes does not exist anywhere in
  `.agents/rules/`, and 14 of the hits are in a deliberate competitor-comparison doc.

Three further findings surfaced while back-filling and are recorded in the items rather than fixed:
`ARCH-FIX-015`'s registration is now **stale** (two architecture docs still describe an
`apps/agent-web` `/monitor` route and a `MonitorClient.tsx` that no longer exist — the monitor moved to
`packages/agent-cli-web`); `ARCH-FIX-007`'s Solution step 3 was never done; `ARCH-FIX-004`'s
`agent-team` half is moot because the package was deleted in `6acec82ec`.

## A note on file ownership

`scripts/harness/__tests__/scan-unearned-done-claims.test.mjs` is outside the declared ownership and was
edited anyway, minimally and unavoidably: TC-37/TC-38 hardcode the legacy-debt count as a literal (by
design — deriving it would make the assertion vacuous), so shrinking the authorized list forces the
constant down with it. It is a 58 → 51 change plus a comment recording why the number may only ever
decrease. Reverting it was the only alternative, and that would have meant abandoning the back-fill.

## Verification

- `pnpm harness:scan` — **all 68 scans passed**, including `unearned-done-claims` with both newly-done
  items in scope.
- `pnpm harness:verify-like-ci` — **PASS, all 11 stages** (the genuine CI mirror after INFRA-056, with
  build and package-test stages).
- `pnpm harness:test` — 86 files, 1058 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
