### PR TITLE
fix(ci): declare review-gate as required, and correct INFRA-048's disarm claim

### DIFF
--- a/.agents/backlog/completed/INFRA-048-review-arrives-after-merge.md
+++ b/.agents/backlog/completed/INFRA-048-review-arrives-after-merge.md
@@ -100,6 +100,18 @@ Three levers were on the table (the original item's options 1–3). What shipped
    not stop an armed auto-merge — which is precisely the #1409 hole. The disarm is the lever that
    works today; the ruleset entry (below) is the durable one.
 
+   > **Correction, 2026-07-26 (INFRA-057).** "The disarm is the lever that works today" was **never
+   > true.** The job declared `contents: read`, and GitHub's auto-merge mutations need
+   > `contents: write`, so every call returned `Resource not accessible by integration` — and the
+   > `|| echo "auto-merge was not armed; nothing to disarm."` printed a state it had not checked,
+   > making a permission denial indistinguishable from a genuine no-op. Measured on a real armed PR
+   > (#1465): after the gate blocked, `autoMergeRequest.enabledAt` was **unchanged and still armed**.
+   > So for the whole period this document claims the lever was carrying the guarantee, only the
+   > ruleset entry ever did. Fixed in INFRA-057, which moved the disarm into its own checkout-free
+   > job, granted the scope there, and proved it on the same armed PR — `auto-merge: DISARMED`,
+   > confirmed from outside the runner. Kept rather than deleted because `protect-main` requires a
+   > different context set that does not include `review-gate`.
+
    **A fail-CLOSED caught in the gate itself, live — and it cost the ruleset entry.** See
    "Defect 2" below. The `unavailable` row above is now three rows: an analysis that exists and
    could not be read still blocks, and an analysis that was never owed passes as `not-applicable`.

--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -55,6 +55,12 @@
           "workflow": ".github/workflows/ci.yml",
           "job": "windows-shell",
           "verifies": "The cross-platform shell resolver and the Shell tool spawning PowerShell, on real `windows-latest`. Gated on the `changes` classifier reporting code."
+        },
+        {
+          "context": "review-gate",
+          "workflow": ".github/workflows/review-gate.yml",
+          "job": "review-gate",
+          "verifies": "Reads the PR's code-scanning output and blocks on findings this PR INTRODUCES at severity error or security-severity high/critical. Advisory findings are printed, never blocking, because every alert in the standing backlog would otherwise redden every PR. A PR that changes no code is PASS (not-applicable) via the same classifier ci.yml gates its build matrix on; an analysis that is missing or unreadable BLOCKS."
         }
       ],
       "deliberately_not_required": [

--- a/scripts/harness/__tests__/ci-mirror-map.test.mjs
+++ b/scripts/harness/__tests__/ci-mirror-map.test.mjs
@@ -18,7 +18,7 @@
  * hand-copied lists.
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -193,16 +193,29 @@ describe('the build predicate has ONE implementation (anti-drift)', () => {
 });
 
 describe('the ruleset declaration matches the workflow it names', () => {
+  /**
+   * Resolve against the workflow each entry DECLARES, not against `ci.yml`.
+   *
+   * This assertion used to hardcode `ci.yml`, which held only because every required context
+   * happened to live there. `review-gate` is the first that does not — it reads GitHub's
+   * code-scanning API from `.github/workflows/review-gate.yml`. Pinning the filename would have
+   * forced a genuinely-required context to be declared in the wrong workflow just to satisfy the
+   * test, which is the test dictating the architecture rather than checking it.
+   *
+   * What actually matters is unchanged and still asserted for every entry: the declared workflow
+   * exists, it really defines the named job, and the job's `name:` is the context string branch
+   * protection matches on.
+   */
   it.each(REQUIRED.map((entry) => [entry.context, entry.job]))(
-    '`%s` resolves to job `%s` in ci.yml',
+    '`%s` resolves to job `%s` in the workflow it declares',
     (context, job) => {
       const declared = REQUIRED.find((entry) => entry.context === context);
-      expect(declared.workflow).toBe('.github/workflows/ci.yml');
-      expect(() => jobRunSteps(CI_YAML, job)).not.toThrow();
+      const workflowPath = path.join(REPO_ROOT, declared.workflow);
+      expect(existsSync(workflowPath), `${declared.workflow} does not exist`).toBe(true);
+      const source = readFileSync(workflowPath, 'utf8');
+      expect(() => jobRunSteps(source, job)).not.toThrow();
       // The context string is the job's `name:`, which is what branch protection matches on.
-      expect(readFileSync(path.join(REPO_ROOT, declared.workflow), 'utf8')).toContain(
-        `name: ${context}`,
-      );
+      expect(source).toContain(`name: ${context}`);
     },
   );
 });

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -174,6 +174,17 @@ export const NOT_MIRRORED = [
     manualCommand:
       'no local equivalent off a Windows host — review the win32 branches by hand, or push and read the check.',
   },
+
+  {
+    context: 'review-gate',
+    reason:
+      "reads GitHub's code-scanning API for this PR's merge ref and compares it against the base branch. Both sides only exist once CodeQL has analysed a real pull request, so there is nothing a local run could read — a mirror would either invent the input or report a pass over an analysis that was never performed, which is the exact defect INFRA-048 built this gate to close.",
+    relevance: 'code',
+    relevantWhen:
+      'the diff changes code at all — on a docs-only PR the gate itself resolves to `PASS (not-applicable)` via the same classifier ci.yml gates its build matrix on',
+    manualCommand:
+      'no local equivalent — push and read the check, or query it directly: gh api "repos/<owner>/<repo>/code-scanning/alerts?pr=<n>&state=open" --paginate  (note --paginate: a single page silently truncates, which is how a 40-high backlog once read as clean)',
+  },
 ];
 
 /** The relevance keys the runner knows how to evaluate. */


### PR DESCRIPTION
Two leftovers I created, both surfaced by INFRA-057.

**1. `ruleset-drift` went red because I changed the live ruleset without the declaration.** Arming `review-gate` on `protect-develop` was an API call; `.github/required-status-checks.json` still listed eight contexts. `scan-main-required-checks --live` caught it and is right to: *"A required status check is enforcement only if it can FAIL."* The declaration is what proves that — an undeclared context has never been checked, which is exactly how `protect-main` ended up gated by five 3–6 second echoes. Declared with what it verifies.

**2. INFRA-048 claimed the disarm worked. It never did.** The document said *"The disarm is the lever that works today; the ruleset entry is the durable one."* INFRA-057 measured the opposite: the job declared `contents: read` while GitHub's auto-merge mutations need `contents: write`, so every call returned `Resource not accessible by integration` — and `|| echo "auto-merge was not armed; nothing to disarm."` printed a state it had never checked, making a permission denial read identically to a genuine no-op.

Proven on a real armed PR (#1465): after the gate blocked, `autoMergeRequest.enabledAt` was **unchanged and still armed**. So for the entire period the document credits the disarm, only the ruleset entry was carrying the guarantee — and there was a window where neither did, because the entry had been rolled back.

Annotated in place rather than rewritten, so the original reasoning stays readable beside its correction. The record of what we believed and why we were wrong is worth more than a clean document.

Both scans green: `unearned-done-claims`, `done-evidence`, and `scan-main-required-checks --live` now reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z