### PR TITLE
perf(deps): PERF-006 remove the last TypeScript 5 copy — upgrade electron-builder 25 to 26

### DIFF
--- a/.agents/backlog/completed/PERF-006-typescript-6-7-side-by-side.md
+++ b/.agents/backlog/completed/PERF-006-typescript-6-7-side-by-side.md
@@ -9,10 +9,16 @@ created: 2026-07-26
 completed: 2026-07-26
 ---
 
-> **DONE (2026-07-26).** All four acceptance boxes are ticked; see
+> **DONE (2026-07-26).** All five acceptance boxes are ticked; see
 > [Outcome](#outcome-done-2026-07-26) at the end of this file for the measurement, the before/after
 > lint diff, the transitive-consumer audit, the timing, the guard's red/green proof, and the four
 > things the work found that this item's premise had wrong.
+>
+> **The goal is fully met as of the follow-up later that day: TypeScript 5 is gone from the
+> repository, `node_modules` included.** The first pass left one 5.x copy on disk and argued it was
+> acceptable; that reasoning was wrong on three counts and is corrected in
+> [§8](#8-the-last-5x-copy-removed-2026-07-26). The fix was an `electron-builder` 25 → 26 upgrade,
+> not the `pnpm.overrides` entry this file originally called the only lever.
 
 # PERF-006: TypeScript 6 + 7 side by side, no 5.x
 
@@ -102,6 +108,9 @@ repository is single-compiler. **Re-check both issues above rather than waiting 
 - [x] Lint findings identical before and after, over the whole workspace, with the diff shown.
 - [x] `pnpm typecheck` unchanged in result and not materially slower.
 - [x] The guard fails on a reintroduced 5.x declaration (proven red).
+- [x] **No `typescript` below 6 RESOLVES anywhere in the installed store, enforced mechanically**
+      (added by the [§8](#8-the-last-5x-copy-removed-2026-07-26) follow-up — the declaration-only
+      boxes above were all green while a 5.x copy sat in `node_modules`).
 
 ## References
 
@@ -224,6 +233,12 @@ held exactly one copy; after, the lockfile carries **both** `/typescript@5.9.3` 
 devDependency that ships in nothing, but the 5.x line has not left the tree entirely — and the guard
 cannot see it, because the guard checks _our_ manifests and this declaration is upstream's.
 
+> **SUPERSEDED — the two paragraphs below were wrong, and the goal is now actually met.** They are
+> kept verbatim rather than deleted, because the reasoning error is the useful part. See
+> [§8 The last 5.x copy, removed](#8-the-last-5x-copy-removed-2026-07-26) for what was measured and
+> what shipped. In short: the fix was not an override, it was an honest dependency upgrade, and
+> "expected, not a broken guard" was the wrong call — it was a broken guard.
+
 **Say this plainly, because the next person will trip on it.** The goal as stated is "TypeScript 5
 is gone", and it is gone from everything this repository declares or resolves. It is **not** gone
 from `node_modules`. Anyone running
@@ -332,10 +347,191 @@ lower bound. A range it cannot parse is **reported**, not passed: for a ratchet,
    the parser — a materially larger API surface for a major to break, and the reason the
    floating-promise control in §2 was worth running.
 
+### 8. The last 5.x copy, removed (2026-07-26)
+
+**The goal is met. `typescript@5` is gone from the repository, including from `node_modules`.**
+
+```
+$ find node_modules -name typescript -maxdepth 6 -type d
+node_modules/.pnpm/typescript@6.0.3/node_modules/typescript
+
+$ ls node_modules/.pnpm | grep '^typescript@'
+typescript@6.0.3
+```
+
+#### What §3 got wrong
+
+Three claims in the superseded block above, each corrected by measurement:
+
+1. **"An override is the only lever."** It was not. The chain was
+   `apps/agent-app` → `electron-builder@25.1.8` → `app-builder-lib@25.1.8` → `config-file-ts@0.2.8-rc1`,
+   and **`app-builder-lib@26` dropped `config-file-ts` entirely**, replacing it with `jiti`
+   (changeset 26.0.18: _"feat: use jiti instead of config-file-ts for loading TypeScript config"_).
+   Upgrading `electron-builder` 25 → 26 deletes the chain at its source. Upgrading `config-file-ts`
+   itself really does lead nowhere — its own latest `0.2.8-rc1` still pins `^5.4.3` — which is
+   probably why the search stopped there, but the dependency one level up was the removable one.
+2. **"Expected, not a broken guard."** It was a broken guard. Every edge the guard had inspected a
+   DECLARATION; none could see what was INSTALLED. A guard that reports success while the stated
+   goal is visibly unmet is not working as designed, whatever its scope statement says. Fixed by
+   adding the `legacy-typescript-installed` edge — see below.
+3. **"It disappears on its own."** Nothing was going to make it disappear on its own: the
+   dependency was ours to bump. `electron-builder` 26.0.0 had by then been out for 18 months.
+
+#### The upgrade, treated as the major it is
+
+`electron-builder` **25.1.8 → 26.15.7**, pinned EXACTLY rather than with a caret.
+
+**Breaking-change audit.** Researched against primary sources only (v26.0.0 release notes, the
+changesets at tag `electron-builder@26.15.7`, and 26-era docs read at the tag). There is **no
+official 25→26 migration guide**, and the release notes under-report key-level removals — so the
+audit was done against the published config JSON Schema
+(`unpkg.com/app-builder-lib@<version>/scheme.json`), diffed 25.1.8 → 26.15.7. That diff is the
+exhaustive ground truth, and the **complete** set of removed config keys is:
+
+```
+includeSubNodeModules
+NotarizeNotaryOptions.teamId          (mac.notarize object form → boolean + env vars)
+win.additionalCertificateFile  win.certificateFile  win.certificatePassword
+win.certificateSha1  win.certificateSubjectName  win.publisherName
+win.rfc3161TimeStampServer  win.sign  win.signDlls  win.signingHashAlgorithms  win.timeStampServer
+```
+
+| 26.0.0 breaking change                   | Applies to `apps/agent-app`?                                               |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `win` signing moved to `signtoolOptions` | **No** — artifacts are unsigned; no `win` signing block exists             |
+| `mac.notarize` object → boolean + env    | **No** — no `mac.notarize` key                                             |
+| `linux.desktop` string-map → object      | **No** — no `desktop` key                                                  |
+| `includeSubNodeModules` removed          | **No** — never set; behaviour is now unconditional                         |
+| HFS+ DMG conditional removed             | **No** — 26.15.7 still defaults `dmg.filesystem: HFS+`; APFS is a v27 flip |
+| node_modules in other subdirectories     | **Yes** — see the asar diff below                                          |
+
+`artifactName`, `directories.{output,buildResources}`, `files`, `extraResources`, `npmRebuild`,
+`linux.{target,category,maintainer}`, `mac.{category,target}`, `win.target`, `appId`, `productName`
+and `copyright` are **byte-identical in both schemas** — same names, same documented defaults.
+`engines.node` is `>=14.0.0` in both (the Node ≥22.12 requirement is v27).
+
+**The one change that did bite, found by running the build rather than by reading.** 26's AppImage
+target hard-rejects the derived executable name:
+
+```
+⨯ executableName contains characters that cannot be safely used in file paths: @robota-sdkagent-app.
+```
+
+`validateCriticalPathString` (`app-builder-lib/out/targets/appimage/appImageUtil.js`) enforces
+`/^[\p{L}\p{N}._\- ]+$/u` on `executableName` and `productFilename`, because both are interpolated
+into the generated `AppRun` bash script and used as filesystem paths. Left to default, the name
+derives from the scoped package `name` and collapses to `@robota-sdkagent-app` — **which 25 really
+did ship**, as the binary and as `@robota-sdkagent-app.desktop`. So 26 did not invent a rule; it
+turned a latent packaging defect into a visible error. Fixed properly, by setting
+`executableName: robota-desktop`. This validation appears in **no** 26.x changelog entry or doc —
+it was found by packaging, which is the argument for packaging rather than reading.
+
+**Why an exact pin.** Within the 26.15 patch line alone, two artifact-corrupting regressions shipped
+as ordinary patches: 26.15.0–26.15.3 dereferenced symlinks after a bundled 7-Zip upgrade, corrupting
+macOS `.framework` bundles (breaking codesign and Squirrel.Mac auto-update), and 26.15.0–26.15.6
+packed snap templates so the snap built successfully and failed at launch. Both produce a **green
+build and a broken artifact** — the failure mode a caret range cannot protect against and CI would
+not catch. 26.15.7 is past both.
+
+#### The packaging proof, and exactly how far it got
+
+Run on Linux x64 against the real `dist:app` path (`pnpm build && pnpm bundle:runtime &&
+electron-builder`), with a **baseline captured on 25.1.8 first** so every difference is attributable.
+
+| target                    | on 25.1.8 (baseline) | on 26.15.7       | note                                |
+| ------------------------- | -------------------- | ---------------- | ----------------------------------- |
+| `linux-unpacked`          | ✅                   | ✅               | full app tree                       |
+| **AppImage**              | ✅ 168,485,777 B     | ✅ 168,494,483 B | real artifact, both runs            |
+| deb                       | ❌                   | ❌               | **unreachable in this environment** |
+| mac (dmg/zip), win (nsis) | not attempted        | not attempted    | need macOS / Windows hosts          |
+
+**The deb step is unreachable here, and it fails identically on 25.** fpm reports
+`Need executable 'ar' to convert dir to deb`. `ar` comes from `binutils`, which is not installed;
+there is no passwordless sudo to install it, and `busybox ar` is extract/list-only (no create). This
+is an environment gap, **not an upgrade regression** — proven by the 25.1.8 baseline hitting the same
+error at the same step before any change was made. mac and win targets need their own hosts and were
+not attempted; CI's `release-desktop-app.yml` covers all three platforms.
+
+**What the produced artifact was checked against, beyond "a file exists":**
+
+- **`linux-unpacked` tree diff, 25 → 26 — exactly three lines**, all explained:
+  `-./@robota-sdkagent-app` / `+./robota-desktop` (the intended `executableName` fix) and
+  `+./resources/apparmor-profile` (new in 26; needed for Ubuntu 24.04+ userns restrictions).
+- **`app.asar` entry diff — purely additive, +32 entries / +20,289 B.** 26's dependency walker now
+  also resolves `@types/*` production deps (LICENSE + package.json metadata only) and nested pnpm
+  `node_modules` — this is BC-4, "support including node_modules in other subdirectories", visible.
+  **Nothing was dropped**; no first-party or runtime file changed. The workspace closure
+  (`@robota-sdk/agent-core`, `agent-transport-gui`, …) resolves correctly under pnpm's symlinked
+  store, and 26 logs `detected workspace root for project using packageManager field pm=pnpm`.
+- **The packaged app actually runs.** `test:e2e:bundled` passes against the 26-built output — the
+  bundled sidecar completes the nonce handshake, rejects a wrong token before any session data, and
+  shuts down cleanly on SIGTERM. `resources/robota` is byte-identical in size across both builds.
+
+**One pre-existing failure, explicitly not caused by this change.** `pnpm --filter @robota-sdk/agent-app test:e2e`
+(the Electron GUI e2e) times out waiting for `.agent-gui-status[data-status="connected"]`. It fails
+**identically on pristine `origin/develop` with electron-builder 25.1.8**, verified by stashing the
+whole change, reinstalling and re-running. It is not wired into any CI workflow. Untouched here.
+
+#### The guard now sees the installed tree
+
+`scan-legacy-typescript.mjs` gains a sixth finding kind, `legacy-typescript-installed`: a
+`typescript` copy below 6 materialised anywhere under `node_modules`, **whoever declared it**. This
+is the only edge that reads resolution rather than declaration, and it is the one that answers the
+owner's actual question. It walks the module-resolution structure (package dirs, `@scope` dirs,
+pnpm's `.pnpm` store), dedupes by realpath so pnpm's top-level symlinks are not double-counted, and
+confirms each candidate by `manifest.name === 'typescript'` rather than trusting the directory name —
+the same false-positive class (`@typescript-eslint/*`, `@typescript/native-preview`,
+`@scope/typescript`) the import edge already defends against.
+
+**It is deliberately not waivable** — not by the path baseline, not by the root exemption, and there
+is no annotation for it. A resolved 5.x copy is either removable or it is a decision to bring to the
+owner; an escape hatch here would just rebuild the manifest-only blind spot one suppression at a time.
+
+`collectInstalledCopies` returns `undefined` — distinct from `[]` — when there is no `node_modules`,
+and that raises a loud notice instead of passing. "Nothing installed" must never read as "tree is
+clean".
+
+- **RED**, against the tree as it stood before the upgrade: one finding, and the guard located the
+  cause on its own — `[legacy-typescript-installed] node_modules/.pnpm/config-file-ts@0.2.8-rc1/node_modules/typescript`.
+  Exit 1.
+- **GREEN** after the upgrade + a clean `pnpm install --frozen-lockfile`. Exit 0.
+- **Re-proven causally:** reverting _only_ the `electron-builder` version and reinstalling brings
+  `typescript@5.9.3` back and the guard fires again — so the edge tracks the real cause, not a
+  coincidence of that one tree.
+- **The tests bind to the floor:** flipping `MINIMUM_MAJOR` to 5 fails 3 of the new tests. 16 new
+  tests, 48 in the file (was 32); harness suite 1,127 tests / 88 files green.
+
+**A trap worth knowing: `pnpm install` does not evict an orphaned store entry; `pnpm prune` does.**
+After a dependency bump or a branch switch the old copy can sit in `.pnpm` unreferenced by the
+lockfile, and this edge will correctly report it while the lockfile is already clean. CI never sees
+it (fresh checkout, empty `node_modules`), but a local run can — so the failure message says to run
+`pnpm prune` first and only then go hunting for a real `dependencies` entry.
+
+#### Store-wide sweep — zero hard dependencies remain
+
+Re-measured by **parsing** every manifest materialised under `node_modules/.pnpm` (7,135 of them) and
+looking up the literal `typescript` key in each dependency section:
+
+| measurement                                           | before           | after     |
+| ----------------------------------------------------- | ---------------- | --------- |
+| hard `dependencies` on `typescript` anywhere in store | **1**            | **0**     |
+| resolved `typescript` copies on disk                  | 2 (5.9.3, 6.0.3) | 1 (6.0.3) |
+
+The single `before` entry was `config-file-ts@0.2.8-rc1 [dependencies] ^5.4.3`. The 714 remaining
+`devDependencies`/peer entries are irrelevant: a published package's devDependencies are never
+installed for a consumer, and every peer admits 6.
+
+**The counting method is the point, again.** `"typescript"` is a substring of `@typescript-eslint/*`,
+`@typescript/native-preview` and a script name — the same trap that produced §1's phantom 177. Parse
+and look up the literal key; never grep the string.
+
 ### Follow-ups, not closed here
 
-- `config-file-ts` keeps a private `typescript@5.9.3` in the tree (§3). Nothing first-party resolves
-  it; it disappears when `electron-builder` updates the dependency or `apps/agent-app` drops it.
+- ~~`config-file-ts` keeps a private `typescript@5.9.3` in the tree (§3).~~ **Closed** — see §8.
+- `dmg.filesystem` defaults flip HFS+ → APFS in electron-builder v27. Set it explicitly before that
+  upgrade if pre-10.13 macOS support ever matters.
+- The Electron GUI e2e (`apps/agent-app` `test:e2e`) fails on `develop` and is wired into no CI
+  workflow — pre-existing, untouched here, and worth its own item.
 - The guard does not detect **invocations of the legacy `tsc` binary** (§7.3). Moving
   `check-doc-examples` onto `tsgo` would remove the last such consumer; its tsconfig is already
   `baseUrl`-free and therefore TS7-ready.

--- a/apps/agent-app/electron-builder.yml
+++ b/apps/agent-app/electron-builder.yml
@@ -2,6 +2,20 @@
 # Bundles the host-arch Bun `robota` runtime (copied to resources-bin/ by scripts/bundle-runtime.mjs) as an
 # extraResource, so the installed app is self-contained (zero external install). Artifacts are UNSIGNED
 # (no certs — Gatekeeper/SmartScreen will warn); signing is a tracked follow-up.
+#
+# electron-builder is pinned EXACTLY (not `^`) in package.json, deliberately. Within the 26.15 patch line
+# alone, two artifact-corrupting regressions shipped as ordinary patches and were fixed several releases
+# later: 26.15.0–26.15.3 dereferenced symlinks after a bundled 7-Zip upgrade, corrupting macOS `.framework`
+# bundles (breaking codesign and Squirrel.Mac auto-update), and 26.15.0–26.15.6 packed snap templates so the
+# snap built fine but failed at launch. Both produced a GREEN build and a broken artifact — the failure mode
+# a caret range cannot protect against, and one CI would not catch either. Bump this deliberately, and read
+# the changelog for the range you are crossing.
+#
+# When upgrading, audit the config against the published JSON Schema diff rather than the release notes:
+#   https://unpkg.com/app-builder-lib@<version>/scheme.json
+# The project's release notes under-report key-level removals (25→26 dropped `includeSubNodeModules` and
+# `win.signDlls` without naming either), and there is no official 25→26 migration guide at all.
+# Known v27 blocker: `dmg.filesystem` default flips HFS+ → APFS; set it explicitly before that upgrade.
 appId: com.robota-sdk.desktop
 productName: Robota
 copyright: Robota
@@ -11,6 +25,17 @@ copyright: Robota
 # single binaries (`robota-<os>-<arch>`), which are lowercase and version-less; the two product families
 # no longer collide on the GitHub release. The installed app is still displayed as "Robota" (productName).
 artifactName: robota-desktop-${version}-${arch}.${ext}
+# REQUIRED since electron-builder 26. Left unset, executableName derives from the package `name`, and the
+# scoped `@robota-sdk/agent-app` collapses to `@robota-sdkagent-app` — which 25 really did ship as the
+# binary name and as `@robota-sdkagent-app.desktop`. 26's AppImage target rejects it outright:
+# `validateCriticalPathString` (app-builder-lib/out/targets/appimage/appImageUtil.js) enforces
+# /^[\p{L}\p{N}._\- ]+$/u on executableName and productFilename, because both are interpolated into the
+# generated AppRun bash script and used as filesystem paths. So 26 did not invent a rule — it turned a
+# latent packaging defect into a visible error. (Verified by running the build, not from the release
+# notes: this validation appears in no 26.x changelog entry or doc.)
+# `robota-desktop` matches the artifactName prefix and stays distinct from the bundled `robota` CLI
+# sidecar in extraResources, which is a DIFFERENT executable.
+executableName: robota-desktop
 # The app has NO native node modules (renderer + electron main + a bundled external runtime binary), and pnpm's
 # non-flat store confuses @electron/rebuild's dep walk — skip the native rebuild entirely.
 npmRebuild: false

--- a/apps/agent-app/package.json
+++ b/apps/agent-app/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
     "electron": "^43.2.0",
-    "electron-builder": "^25.1.8",
+    "electron-builder": "26.15.7",
     "jsdom": "^25.0.1",
     "playwright": "^1.49.1",
     "tailwindcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^43.2.0
         version: 43.2.0
       electron-builder:
-        specifier: ^25.1.8
-        version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+        specifier: 26.15.7
+        version: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -3625,10 +3625,6 @@ importers:
 
 packages:
 
-  /7zip-bin@5.2.0:
-    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
-    dev: true
-
   /@actions/core@1.11.1:
     resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
     dependencies:
@@ -4946,14 +4942,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@develar/schema-utils@2.6.5:
-    resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
-    engines: {node: '>= 8.9.0'}
-    dependencies:
-      ajv: 6.15.0
-      ajv-keywords: 3.5.2(ajv@6.15.0)
-    dev: true
-
   /@discordjs/builders@1.14.1:
     resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
     engines: {node: '>=16.11.0'}
@@ -5044,6 +5032,32 @@ packages:
       minimatch: 3.1.5
     dev: true
 
+  /@electron/fuses@1.8.0:
+    resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      fs-extra: 9.1.0
+      minimist: 1.2.8
+    dev: true
+
+  /@electron/get@3.1.0:
+    resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@electron/get@5.0.0:
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
     engines: {node: '>=22.12.0'}
@@ -5071,8 +5085,8 @@ packages:
       - supports-color
     dev: true
 
-  /@electron/osx-sign@1.3.1:
-    resolution: {integrity: sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==}
+  /@electron/osx-sign@1.3.3:
+    resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
@@ -5086,32 +5100,23 @@ packages:
       - supports-color
     dev: true
 
-  /@electron/rebuild@3.6.1:
-    resolution: {integrity: sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==}
-    engines: {node: '>=12.13.0'}
+  /@electron/rebuild@4.2.0:
+    resolution: {integrity: sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
-      chalk: 4.1.2
       debug: 4.4.3
-      detect-libc: 2.1.2
-      fs-extra: 10.1.0
-      got: 11.8.6
-      node-abi: 3.92.0
+      node-abi: 4.33.0
       node-api-version: 0.2.1
-      node-gyp: 9.4.1
-      ora: 5.4.1
+      node-gyp: 12.4.0
       read-binary-file-arch: 1.0.6
-      semver: 7.8.5
-      tar: 7.5.22
-      yargs: 17.7.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
     dev: true
 
-  /@electron/universal@2.0.1:
-    resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
+  /@electron/universal@2.0.3:
+    resolution: {integrity: sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==}
     engines: {node: '>=16.4'}
     dependencies:
       '@electron/asar': 3.4.1
@@ -5124,6 +5129,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@electron/windows-sign@1.2.2:
+    resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
+    engines: {node: '>=14.14'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      cross-dirname: 0.1.0
+      debug: 4.4.3
+      fs-extra: 11.4.0
+      minimist: 1.2.8
+      postject: 1.0.0-alpha.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+    optional: true
 
   /@emnapi/core@1.10.0:
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -5649,10 +5670,6 @@ packages:
     dependencies:
       '@formatjs/fast-memoize': 3.1.7
     dev: false
-
-  /@gar/promisify@1.1.3:
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-    dev: true
 
   /@google-cloud/firestore@8.7.0:
     resolution: {integrity: sha512-EvMpZQUXkTRdweSvOu6VL6EEQwHjHAgWz2UYZR+Mj6Ao52S+TWieHbSn15jiNnEw8F8RhbZj7IGXZ1PFB1eA+A==}
@@ -6948,9 +6965,19 @@ packages:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  /@noble/hashes@1.4.0:
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+    dev: true
+
   /@noble/hashes@1.8.0:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  /@noble/hashes@2.2.0:
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+    dev: true
 
   /@nodable/entities@2.1.1:
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
@@ -6977,23 +7004,6 @@ packages:
   /@nolyfill/is-core-module@1.0.39:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
-    dev: true
-
-  /@npmcli/fs@2.1.2:
-    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.8.5
-    dev: true
-
-  /@npmcli/move-file@2.0.1:
-    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This functionality has been moved to @npmcli/fs
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
     dev: true
 
   /@octokit/auth-token@4.0.0:
@@ -7401,10 +7411,28 @@ packages:
       asn1js: 3.0.10
       tslib: 2.8.1
 
+  /@peculiar/json-schema@1.1.12:
+    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: true
+
   /@peculiar/utils@2.0.3:
     resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
     dependencies:
       tslib: 2.8.1
+
+  /@peculiar/webcrypto@1.7.1:
+    resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      tslib: 2.8.1
+      webcrypto-core: 1.9.2
+    dev: true
 
   /@peculiar/x509@1.14.3:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
@@ -9662,6 +9690,8 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
     requiresBuild: true
+    dev: false
+    optional: true
 
   /@tybys/wasm-util@0.10.3:
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -10133,15 +10163,6 @@ packages:
     dependencies:
       undici-types: 7.18.2
 
-  /@types/plist@3.0.5:
-    resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
-    requiresBuild: true
-    dependencies:
-      '@types/node': 22.19.21
-      xmlbuilder: 15.1.1
-    dev: true
-    optional: true
-
   /@types/promise.allsettled@1.0.6:
     resolution: {integrity: sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg==}
     dev: false
@@ -10262,12 +10283,6 @@ packages:
 
   /@types/unist@3.0.3:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  /@types/verror@1.10.11:
-    resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
@@ -10880,6 +10895,11 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: false
 
+  /@xmldom/xmldom@0.8.13:
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
   /@xmldom/xmldom@0.9.10:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
@@ -11108,8 +11128,9 @@ packages:
     resolution: {integrity: sha512-hL/raFM5V9UT2lVE/lIWDTWvANqSB8TvMVp+PgICehBa96KhTl/UpGm370JXaacukR+QnaHM2Yv6O/UcrzAFGg==}
     dev: true
 
-  /abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  /abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     dev: true
 
   /abort-controller@3.0.0:
@@ -11191,6 +11212,7 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -11201,14 +11223,7 @@ packages:
     engines: {node: '>= 8.0.0'}
     dependencies:
       humanize-ms: 1.2.1
-
-  /aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-    dev: true
+    dev: false
 
   /ajv-formats@3.0.1(ajv@8.20.0):
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -11220,14 +11235,6 @@ packages:
     dependencies:
       ajv: 8.20.0
     dev: false
-
-  /ajv-keywords@3.5.2(ajv@6.15.0):
-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
-    peerDependencies:
-      ajv: ^6.9.1
-    dependencies:
-      ajv: 6.15.0
-    dev: true
 
   /ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -11327,112 +11334,58 @@ packages:
     resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
     dev: false
 
-  /app-builder-bin@5.0.0-alpha.10:
-    resolution: {integrity: sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==}
-    dev: true
-
-  /app-builder-lib@25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8):
-    resolution: {integrity: sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==}
+  /app-builder-lib@26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7):
+    resolution: {integrity: sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 25.1.8
-      electron-builder-squirrel-windows: 25.1.8
+      dmg-builder: 26.15.7
+      electron-builder-squirrel-windows: 26.15.7
     dependencies:
-      '@develar/schema-utils': 2.6.5
+      '@electron/asar': 3.4.1
+      '@electron/fuses': 1.8.0
+      '@electron/get': 3.1.0
       '@electron/notarize': 2.5.0
-      '@electron/osx-sign': 1.3.1
-      '@electron/rebuild': 3.6.1
-      '@electron/universal': 2.0.1
+      '@electron/osx-sign': 1.3.3
+      '@electron/rebuild': 4.2.0
+      '@electron/universal': 2.0.3
       '@malept/flatpak-bundler': 0.4.0
+      '@noble/hashes': 2.2.0
+      '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
+      ajv: 8.20.0
+      asn1js: 3.0.10
       async-exit-hook: 2.0.1
-      bluebird-lst: 1.0.9
-      builder-util: 25.1.7
+      builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chromium-pickle-js: 0.2.0
-      config-file-ts: 0.2.8-rc1
+      ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 25.1.8(dmg-builder@25.1.8)
-      electron-publish: 25.1.7
-      form-data: 4.0.6
+      electron-builder-squirrel-windows: 26.15.7(dmg-builder@26.15.7)
+      electron-publish: 26.15.3
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
-      is-ci: 3.0.1
       isbinaryfile: 5.0.7
+      jiti: 2.7.0
       js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
+      pkijs: 3.4.0
+      plist: 3.1.0
+      proper-lockfile: 4.1.2
       resedit: 1.7.2
-      sanitize-filename: 1.6.4
-      semver: 7.8.5
+      semver: 7.7.4
       tar: 7.5.22
       temp-file: 3.4.0
+      tiny-async-pool: 1.3.0
+      unzipper: 0.12.5
+      which: 5.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
-    dev: true
-
-  /aproba@2.1.0:
-    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
-    dev: true
-
-  /archiver-utils@2.1.0:
-    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
-    engines: {node: '>= 6'}
-    dependencies:
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      lazystream: 1.0.1
-      lodash.defaults: 4.2.0
-      lodash.difference: 4.5.0
-      lodash.flatten: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.union: 4.6.0
-      normalize-path: 3.0.0
-      readable-stream: 2.3.8
-    dev: true
-
-  /archiver-utils@3.0.4:
-    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      lazystream: 1.0.1
-      lodash.defaults: 4.2.0
-      lodash.difference: 4.5.0
-      lodash.flatten: 4.4.0
-      lodash.isplainobject: 4.0.6
-      lodash.union: 4.6.0
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: true
-
-  /archiver@5.3.2:
-    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      archiver-utils: 2.1.0
-      async: 3.2.6
-      buffer-crc32: 0.2.13
-      readable-stream: 3.6.2
-      readdir-glob: 1.1.3
-      tar-stream: 2.2.0
-      zip-stream: 4.1.1
-    dev: true
-
-  /are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
     dev: true
 
   /arg@5.0.2:
@@ -11602,13 +11555,6 @@ packages:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  /assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -11625,13 +11571,6 @@ packages:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
     dev: true
-
-  /astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -11780,6 +11719,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  /aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+    dev: true
 
   /axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
@@ -11931,12 +11874,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  /bluebird-lst@1.0.9:
-    resolution: {integrity: sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==}
-    dependencies:
-      bluebird: 3.7.2
-    dev: true
-
   /bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: true
@@ -11982,6 +11919,13 @@ packages:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: false
 
+  /boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
     dependencies:
@@ -12024,10 +11968,6 @@ packages:
       node-int64: 0.4.0
     dev: true
 
-  /buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-    dev: true
-
   /buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -12062,13 +12002,11 @@ packages:
       - supports-color
     dev: true
 
-  /builder-util@25.1.7:
-    resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
+  /builder-util@26.15.3:
+    resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
+    engines: {node: '>=14.0.0'}
     dependencies:
-      7zip-bin: 5.2.0
       '@types/debug': 4.1.13
-      app-builder-bin: 5.0.0-alpha.10
-      bluebird-lst: 1.0.9
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -12076,11 +12014,12 @@ packages:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      is-ci: 3.0.1
       js-yaml: 4.3.0
+      sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
       temp-file: 3.4.0
+      tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12107,6 +12046,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -12115,32 +12059,6 @@ packages:
   /cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
-    dev: true
-
-  /cacache@16.1.3:
-    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      '@npmcli/fs': 2.1.2
-      '@npmcli/move-file': 2.0.1
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 8.1.0
-      infer-owner: 1.0.4
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 9.0.1
-      tar: 7.5.22
-      unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
     dev: true
 
   /cacheable-lookup@5.0.4:
@@ -12269,11 +12187,6 @@ packages:
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  /chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-    dev: true
-
   /chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -12283,8 +12196,8 @@ packages:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
     dev: true
 
-  /ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+  /ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
     dev: true
 
@@ -12306,22 +12219,10 @@ packages:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
     dev: false
 
-  /clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-    dev: true
-
   /cli-boxes@4.0.1:
     resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
     engines: {node: '>=18.20 <19 || >=20.10'}
     dev: false
-
-  /cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-    dependencies:
-      restore-cursor: 3.1.0
-    dev: true
 
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
@@ -12353,6 +12254,7 @@ packages:
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+    dev: false
 
   /cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -12362,16 +12264,6 @@ packages:
     optionalDependencies:
       '@colors/colors': 1.5.0
     dev: false
-
-  /cli-truncate@2.1.0:
-    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
-    engines: {node: '>=8'}
-    requiresBuild: true
-    dependencies:
-      slice-ansi: 3.0.0
-      string-width: 4.2.3
-    dev: true
-    optional: true
 
   /cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
@@ -12437,11 +12329,6 @@ packages:
       mimic-response: 1.0.1
     dev: true
 
-  /clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
-    dev: true
-
   /clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -12475,11 +12362,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  /color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
-    dev: true
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -12529,6 +12411,13 @@ packages:
     engines: {node: '>= 12'}
     dev: false
 
+  /commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
@@ -12543,16 +12432,6 @@ packages:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
     dev: true
 
-  /compress-commons@4.1.2:
-    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
-    engines: {node: '>= 10'}
-    dependencies:
-      buffer-crc32: 0.2.13
-      crc32-stream: 4.0.3
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: true
-
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -12561,20 +12440,9 @@ packages:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
 
-  /config-file-ts@0.2.8-rc1:
-    resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
-    dependencies:
-      glob: 10.5.0
-      typescript: 5.9.3
-    dev: true
-
   /consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-    dev: true
-
-  /console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
 
   /content-disposition@0.5.4:
@@ -12656,12 +12524,6 @@ packages:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
     dev: true
 
-  /core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -12716,32 +12578,16 @@ packages:
       typescript: 6.0.3
     dev: true
 
-  /crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-    dev: true
-
-  /crc32-stream@4.0.3:
-    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
-    engines: {node: '>= 10'}
-    dependencies:
-      crc-32: 1.2.2
-      readable-stream: 3.6.2
-    dev: true
-
-  /crc@3.8.0:
-    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
-    requiresBuild: true
-    dependencies:
-      buffer: 5.7.1
-    dev: true
-    optional: true
-
   /croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
     dev: false
+
+  /cross-dirname@0.1.0:
+    resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -13281,12 +13127,6 @@ packages:
       default-browser-id: 5.0.1
     dev: false
 
-  /defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
-    dependencies:
-      clone: 1.0.4
-    dev: true
-
   /defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
@@ -13326,10 +13166,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     requiresBuild: true
-
-  /delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
-    dev: true
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -13404,6 +13240,12 @@ packages:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
     dev: false
 
+  /detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
     dev: false
@@ -13473,40 +13315,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
-    resolution: {integrity: sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==}
+  /dmg-builder@26.15.7(electron-builder-squirrel-windows@26.15.7):
+    resolution: {integrity: sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==}
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
-      builder-util: 25.1.7
-      builder-util-runtime: 9.7.0
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
+      builder-util: 26.15.3
       fs-extra: 10.1.0
-      iconv-lite: 0.6.3
       js-yaml: 4.3.0
-    optionalDependencies:
-      dmg-license: 1.0.11
     transitivePeerDependencies:
-      - bluebird
       - electron-builder-squirrel-windows
       - supports-color
     dev: true
-
-  /dmg-license@1.0.11:
-    resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
-    engines: {node: '>=8'}
-    os: [darwin]
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@types/plist': 3.0.5
-      '@types/verror': 1.10.11
-      ajv: 6.15.0
-      crc: 3.8.0
-      iconv-corefoundation: 1.1.7
-      plist: 3.1.1
-      smart-buffer: 4.2.0
-      verror: 1.10.1
-    dev: true
-    optional: true
 
   /dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -13608,6 +13427,12 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  /duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+    dependencies:
+      readable-stream: 2.3.8
+    dev: true
+
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
@@ -13644,47 +13469,46 @@ packages:
       jake: 10.9.4
     dev: true
 
-  /electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8):
-    resolution: {integrity: sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==}
+  /electron-builder-squirrel-windows@26.15.7(dmg-builder@26.15.7):
+    resolution: {integrity: sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==}
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
-      archiver: 5.3.2
-      builder-util: 25.1.7
-      fs-extra: 10.1.0
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
+      builder-util: 26.15.3
+      electron-winstaller: 5.4.0
     transitivePeerDependencies:
-      - bluebird
       - dmg-builder
       - supports-color
     dev: true
 
-  /electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
-    resolution: {integrity: sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==}
+  /electron-builder@26.15.7(electron-builder-squirrel-windows@26.15.7):
+    resolution: {integrity: sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
-      builder-util: 25.1.7
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
+      builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
-      dmg-builder: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      ci-info: 4.4.0
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       fs-extra: 10.1.0
-      is-ci: 3.0.1
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
-      yargs: 17.7.2
+      yargs: 17.7.3
     transitivePeerDependencies:
-      - bluebird
       - electron-builder-squirrel-windows
       - supports-color
     dev: true
 
-  /electron-publish@25.1.7:
-    resolution: {integrity: sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==}
+  /electron-publish@26.15.3:
+    resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
     dependencies:
       '@types/fs-extra': 9.0.13
-      builder-util: 25.1.7
+      aws4: 1.13.2
+      builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -13694,6 +13518,22 @@ packages:
 
   /electron-to-chromium@1.5.371:
     resolution: {integrity: sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==}
+
+  /electron-winstaller@5.4.0:
+    resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
+    engines: {node: '>=8.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@electron/asar': 3.4.1
+      debug: 4.4.3
+      fs-extra: 7.0.1
+      lodash: 4.18.1
+      temp: 0.9.4
+    optionalDependencies:
+      '@electron/windows-sign': 1.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /electron@43.2.0:
     resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
@@ -13739,14 +13579,6 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
     dev: false
-
-  /encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    requiresBuild: true
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: true
-    optional: true
 
   /end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -13958,6 +13790,12 @@ packages:
 
   /es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
+  /es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -14701,13 +14539,6 @@ packages:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: true
 
-  /extsprintf@1.4.1:
-    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
-    engines: {'0': node >=0.6.0}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -15097,6 +14928,15 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    dev: true
+
   /fs-extra@11.4.0:
     resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
@@ -15132,13 +14972,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    dev: true
-
-  /fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
     dev: true
 
   /fs.realpath@1.0.0:
@@ -15185,21 +15018,6 @@ packages:
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  /gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    dev: true
 
   /gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -15415,17 +15233,19 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
-  /glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+  /global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+    requiresBuild: true
     dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.5
+      serialize-error: 7.0.1
     dev: true
+    optional: true
 
   /global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -15690,10 +15510,6 @@ packages:
     dependencies:
       has-symbols: 1.1.0
 
-  /has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-    dev: true
-
   /hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -15935,6 +15751,8 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
+    optional: true
 
   /http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -15962,6 +15780,7 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -15996,23 +15815,13 @@ packages:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
       ms: 2.1.3
+    dev: false
 
   /husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true
-
-  /iconv-corefoundation@1.1.7:
-    resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
-    engines: {node: ^8.11.2 || >=10}
-    os: [darwin]
-    requiresBuild: true
-    dependencies:
-      cli-truncate: 2.1.0
-      node-addon-api: 1.7.2
-    dev: true
-    optional: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -16099,10 +15908,6 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
     dev: false
-
-  /infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
-    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -16262,6 +16067,7 @@ packages:
   /ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
+    dev: false
 
   /ip@2.0.1:
     resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
@@ -16338,13 +16144,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  /is-ci@3.0.1:
-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
-    dependencies:
-      ci-info: 3.9.0
-    dev: true
 
   /is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -16476,15 +16275,6 @@ packages:
       is-path-inside: 4.0.0
     dev: true
 
-  /is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-    dev: true
-
   /is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -16606,11 +16396,6 @@ packages:
     dependencies:
       which-typed-array: 1.1.22
 
-  /is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
-    dev: true
-
   /is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -16663,6 +16448,16 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+    dev: true
 
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -17401,6 +17196,12 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -17540,13 +17341,6 @@ packages:
 
   /lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
-    dev: true
-
-  /lazystream@1.0.1:
-    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
-    engines: {node: '>= 0.6.3'}
-    dependencies:
-      readable-stream: 2.3.8
     dev: true
 
   /leven@3.1.0:
@@ -17744,18 +17538,6 @@ packages:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
     dev: false
 
-  /lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-    dev: true
-
-  /lodash.difference@4.5.0:
-    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
-    dev: true
-
-  /lodash.flatten@4.4.0:
-    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
-    dev: true
-
   /lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
     dev: true
@@ -17778,6 +17560,7 @@ packages:
 
   /lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+    dev: false
 
   /lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
@@ -17799,20 +17582,8 @@ packages:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
 
-  /lodash.union@4.6.0:
-    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
-    dev: true
-
   /lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
-  /log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
-    dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
-    dev: true
 
   /log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -17867,11 +17638,6 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-    dev: true
-
   /lru-memoizer@3.0.0:
     resolution: {integrity: sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==}
     dependencies:
@@ -17924,31 +17690,6 @@ packages:
       semver: 7.8.5
     dev: true
 
-  /make-fetch-happen@10.2.1:
-    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 16.1.3
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 2.1.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0
-      ssri: 9.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    dev: true
-
   /makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
@@ -17995,6 +17736,15 @@ packages:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  /matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dependencies:
+      escape-string-regexp: 4.0.0
+    dev: true
+    optional: true
 
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -18690,63 +18440,9 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  /minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass-fetch@2.1.2:
-    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    dev: true
-
-  /minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: true
-
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
   /minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  /minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    dev: true
 
   /minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -18758,10 +18454,11 @@ packages:
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  /mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
+  /mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+    dependencies:
+      minimist: 1.2.8
     dev: true
 
   /mlly@1.8.2:
@@ -18861,11 +18558,6 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
     dev: false
-
-  /negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-    dev: true
 
   /negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -18983,24 +18675,18 @@ packages:
     dependencies:
       '@types/nlcst': 2.0.3
 
-  /node-abi@3.92.0:
-    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      semver: 7.8.5
-    dev: true
-
   /node-abi@3.94.0:
     resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
     engines: {node: '>=10'}
     dependencies:
       semver: 7.8.5
 
-  /node-addon-api@1.7.2:
-    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
-    requiresBuild: true
+  /node-abi@4.33.0:
+    resolution: {integrity: sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==}
+    engines: {node: '>=22.12.0'}
+    dependencies:
+      semver: 7.8.5
     dev: true
-    optional: true
 
   /node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -19066,25 +18752,21 @@ packages:
       formdata-polyfill: 4.0.10
     dev: false
 
-  /node-gyp@9.4.1:
-    resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
-    engines: {node: ^12.13 || ^14.13 || >=16}
+  /node-gyp@12.4.0:
+    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
-      glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 10.2.1
-      nopt: 6.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
+      nopt: 9.0.0
+      proc-log: 6.1.0
       semver: 7.8.5
       tar: 7.5.22
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
+      tinyglobby: 0.2.17
+      undici: 6.28.0
+      which: 6.0.1
     dev: true
 
   /node-int64@0.4.0:
@@ -19099,12 +18781,12 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
-  /nopt@6.0.0:
-    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  /nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 4.0.0
     dev: true
 
   /normalize-path@3.0.0:
@@ -19136,17 +18818,6 @@ packages:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
-    dev: true
-
-  /npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
     dev: true
 
   /nth-check@2.1.1:
@@ -19352,21 +19023,6 @@ packages:
       word-wrap: 1.2.5
     dev: true
 
-  /ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      bl: 4.1.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.9.2
-      is-interactive: 1.0.0
-      is-unicode-supported: 0.1.0
-      log-symbols: 4.1.0
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
-    dev: true
-
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
@@ -19437,13 +19093,6 @@ packages:
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
-    dev: true
-
-  /p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      aggregate-error: 3.1.0
     dev: true
 
   /p-queue@6.6.2:
@@ -19717,6 +19366,18 @@ packages:
       pathe: 2.0.3
     dev: true
 
+  /pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.10
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
+    dev: true
+
   /playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -19731,6 +19392,15 @@ packages:
       playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /plist@3.1.0:
+    resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
+    engines: {node: '>=10.4.0'}
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
     dev: true
 
   /plist@3.1.1:
@@ -19800,6 +19470,16 @@ packages:
       nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  /postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      commander: 9.5.0
+    dev: true
+    optional: true
 
   /powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -19872,6 +19552,11 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  /proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    dev: true
+
   /process-ancestry@0.1.0:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
     engines: {node: '>=18.0.0'}
@@ -19889,15 +19574,6 @@ packages:
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
     dev: true
 
   /promise-retry@2.0.1:
@@ -19934,6 +19610,14 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: true
+
+  /proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
     dev: true
 
   /property-information@7.2.0:
@@ -20218,12 +19902,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  /readdir-glob@1.1.3:
-    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
-    dependencies:
-      minimatch: 5.1.9
-    dev: true
 
   /readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -20566,14 +20244,6 @@ packages:
       lowercase-keys: 2.0.0
     dev: true
 
-  /restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-    dev: true
-
   /restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -20664,6 +20334,14 @@ packages:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
     dev: true
 
+  /rimraf@2.6.3:
+    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
+
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -20677,6 +20355,20 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.5.0
+
+  /roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+    requiresBuild: true
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    dev: true
+    optional: true
 
   /robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -20964,6 +20656,17 @@ packages:
       kind-of: 6.0.3
     dev: false
 
+  /semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: true
+
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -21032,6 +20735,15 @@ packages:
       - supports-color
     dev: false
 
+  /serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dependencies:
+      type-fest: 0.13.1
+    dev: true
+    optional: true
+
   /serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
@@ -21058,6 +20770,7 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: false
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -21262,17 +20975,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /slice-ansi@3.0.0:
-    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
-    engines: {node: '>=8'}
-    requiresBuild: true
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-    dev: true
-    optional: true
-
   /slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -21297,33 +20999,9 @@ packages:
       is-fullwidth-code-point: 5.1.0
     dev: false
 
-  /smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-    dev: true
-
   /smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
-
-  /socks-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-    dev: true
 
   /sonner@2.0.7(react-dom@19.2.8)(react@19.2.8):
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -21375,12 +21053,11 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  /ssri@9.0.1:
-    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      minipass: 3.3.6
+  /sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+    requiresBuild: true
     dev: true
+    optional: true
 
   /stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -21871,6 +21548,14 @@ packages:
       fs-extra: 10.1.0
     dev: true
 
+  /temp@0.9.4:
+    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      mkdirp: 0.5.6
+      rimraf: 2.6.3
+    dev: true
+
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -21916,6 +21601,12 @@ packages:
 
   /thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
+  /tiny-async-pool@1.3.0:
+    resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+    dependencies:
+      semver: 5.7.2
+    dev: true
 
   /tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -22252,6 +21943,13 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -22348,12 +22046,6 @@ packages:
       underscore: 1.13.8
     dev: true
 
-  /typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -22403,7 +22095,6 @@ packages:
   /undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
-    dev: false
 
   /undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -22445,20 +22136,6 @@ packages:
       ofetch: 1.5.1
       ohash: 2.0.11
     dev: false
-
-  /unique-filename@2.0.1:
-    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      unique-slug: 3.0.0
-    dev: true
-
-  /unique-slug@3.0.0:
-    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      imurmurhash: 0.1.4
-    dev: true
 
   /unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -22659,6 +22336,16 @@ packages:
       ufo: 1.6.4
     dev: false
 
+  /unzipper@0.12.5:
+    resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
+    dependencies:
+      bluebird: 3.7.2
+      duplexer2: 0.1.4
+      fs-extra: 11.3.1
+      graceful-fs: 4.2.11
+      node-int64: 0.4.0
+    dev: true
+
   /update-browserslist-db@1.2.3(browserslist@4.28.2):
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -22762,17 +22449,6 @@ packages:
     resolution: {integrity: sha512-Njrh4U8UODGajoZ44QS2C/BsoEM9DTI/aCqY5swsizb+/ap0FamvnCMcZAxrR5+aoC0ZqkawEfpC/N2SBc+xeA==}
     engines: {node: '>=18.12.0'}
     dev: true
-
-  /verror@1.10.1:
-    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
-    engines: {node: '>=0.6.0'}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.4.1
-    dev: true
-    optional: true
 
   /vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -23246,12 +22922,6 @@ packages:
     hasBin: true
     dev: true
 
-  /wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-    dependencies:
-      defaults: 1.0.4
-    dev: true
-
   /weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
     dev: true
@@ -23268,6 +22938,16 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
     dev: false
+
+  /webcrypto-core@1.9.2:
+    resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/json-schema': 1.1.12
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+    dev: true
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -23481,6 +23161,22 @@ packages:
     dependencies:
       isexe: 2.0.0
 
+  /which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+    dependencies:
+      isexe: 3.1.5
+    dev: true
+
+  /which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+    dependencies:
+      isexe: 4.0.0
+    dev: true
+
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -23488,12 +23184,6 @@ packages:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    dev: true
-
-  /wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
-    dependencies:
-      string-width: 4.2.3
     dev: true
 
   /widest-line@6.0.0:
@@ -23707,19 +23397,6 @@ packages:
       yargs-parser: 20.2.9
     dev: false
 
-  /yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-    dev: true
-
   /yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
@@ -23804,15 +23481,6 @@ packages:
       '@yuku-parser/binding-linux-x64-musl': 0.8.0
       '@yuku-parser/binding-win32-arm64': 0.8.0
       '@yuku-parser/binding-win32-x64': 0.8.0
-    dev: true
-
-  /zip-stream@4.1.1:
-    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      archiver-utils: 3.0.4
-      compress-commons: 4.1.2
-      readable-stream: 3.6.2
     dev: true
 
   /zod-to-json-schema@3.25.2(zod@3.25.76):

--- a/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
+++ b/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
@@ -1,9 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  collectInstalledCopies,
   findBelowMinimumDeclarations,
+  findBelowMinimumInstalled,
   findLegacyDependencies,
   findLegacyImportsInSource,
+  installedMajor,
   lowestMajorAdmitted,
 } from '../scan-legacy-typescript.mjs';
 
@@ -238,5 +245,162 @@ describe('scan-legacy-typescript — PERF-006 version edge (findBelowMinimumDecl
     const manifest = { devDependencies: { typescript: '^6.0.3' } };
     expect(findBelowMinimumDeclarations(manifest, 6)).toEqual([]);
     expect(findBelowMinimumDeclarations(manifest, 7)).toHaveLength(1);
+  });
+});
+
+describe('scan-legacy-typescript — store edge (installedMajor)', () => {
+  it('reads the major off a plain version', () => {
+    expect(installedMajor('5.9.3')).toBe(5);
+    expect(installedMajor('6.0.3')).toBe(6);
+    expect(installedMajor('7.0.0')).toBe(7);
+  });
+
+  it('reads the major off a prerelease and a v-prefixed version', () => {
+    expect(installedMajor('7.1.0-dev.20260725.1')).toBe(7);
+    expect(installedMajor('v6.0.3')).toBe(6);
+  });
+
+  it('reports rather than guesses at a version it cannot read', () => {
+    for (const bad of ['', 'next', undefined, null, 6, '6']) {
+      expect(installedMajor(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe('scan-legacy-typescript — store edge (findBelowMinimumInstalled)', () => {
+  it('is clean when the only installed copy is at the floor', () => {
+    expect(findBelowMinimumInstalled([{ dir: 'a', version: '6.0.3' }])).toEqual([]);
+  });
+
+  it('flags the 5.x copy — the exact thing the manifest edges could not see', () => {
+    const copies = [
+      { dir: 'node_modules/.pnpm/typescript@6.0.3/node_modules/typescript', version: '6.0.3' },
+      {
+        dir: 'node_modules/.pnpm/config-file-ts@0.2.8-rc1/node_modules/typescript',
+        version: '5.9.3',
+      },
+    ];
+    const below = findBelowMinimumInstalled(copies);
+    expect(below).toHaveLength(1);
+    expect(below[0].version).toBe('5.9.3');
+    expect(below[0].reason).toBe('resolves below');
+  });
+
+  it('flags an unreadable version with a distinct reason rather than passing it', () => {
+    const below = findBelowMinimumInstalled([{ dir: 'a', version: 'garbage' }]);
+    expect(below).toHaveLength(1);
+    expect(below[0].reason).toContain('cannot prove');
+  });
+
+  it('honours an explicit minimum, so the floor can be raised alongside the declaration edge', () => {
+    const copies = [{ dir: 'a', version: '6.0.3' }];
+    expect(findBelowMinimumInstalled(copies, 6)).toEqual([]);
+    expect(findBelowMinimumInstalled(copies, 7)).toHaveLength(1);
+  });
+
+  it('is clean for an empty tree', () => {
+    expect(findBelowMinimumInstalled([])).toEqual([]);
+  });
+});
+
+describe('scan-legacy-typescript — store edge (collectInstalledCopies)', () => {
+  let root;
+
+  /** Materialise a package at `relDir`, exactly as an installer would. */
+  const install = (relDir, manifest) => {
+    const dir = path.join(root, relDir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest), 'utf8');
+    return dir;
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'legacy-ts-store-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns undefined — NOT an empty list — when nothing is installed', () => {
+    // The distinction is the whole point: "no node_modules" must never read as "tree is clean".
+    expect(collectInstalledCopies(root)).toBeUndefined();
+  });
+
+  it('finds a copy in the pnpm virtual store, where every real copy actually lives', () => {
+    install('node_modules/.pnpm/typescript@5.9.3/node_modules/typescript', {
+      name: 'typescript',
+      version: '5.9.3',
+    });
+    expect(collectInstalledCopies(root)).toEqual([
+      {
+        dir: path.join('node_modules', '.pnpm', 'typescript@5.9.3', 'node_modules', 'typescript'),
+        version: '5.9.3',
+      },
+    ]);
+  });
+
+  it('finds every copy when several majors coexist', () => {
+    install('node_modules/.pnpm/typescript@5.9.3/node_modules/typescript', {
+      name: 'typescript',
+      version: '5.9.3',
+    });
+    install('node_modules/.pnpm/typescript@6.0.3/node_modules/typescript', {
+      name: 'typescript',
+      version: '6.0.3',
+    });
+    expect(
+      collectInstalledCopies(root)
+        .map((c) => c.version)
+        .sort(),
+    ).toEqual(['5.9.3', '6.0.3']);
+  });
+
+  it('does not mistake the ESLint toolchain or the native compiler for the legacy package', () => {
+    // Both spell the package name; neither IS it. This is the same false-positive class the
+    // import edge defends against, and the directory name alone cannot tell them apart.
+    install('node_modules/.pnpm/x/node_modules/@typescript-eslint/parser', {
+      name: '@typescript-eslint/parser',
+      version: '7.18.0',
+    });
+    install('node_modules/.pnpm/y/node_modules/@typescript/native-preview', {
+      name: '@typescript/native-preview',
+      version: '7.0.0-dev.20260707.2',
+    });
+    expect(collectInstalledCopies(root)).toEqual([]);
+  });
+
+  it('does not mistake a scoped package that merely SITS in a `typescript` directory', () => {
+    install('node_modules/.pnpm/z/node_modules/@someone/typescript', {
+      name: '@someone/typescript',
+      version: '1.0.0',
+    });
+    expect(collectInstalledCopies(root)).toEqual([]);
+  });
+
+  it('finds a nested copy, which is how npm-style layouts hide a second major', () => {
+    install('node_modules/some-tool/node_modules/typescript', {
+      name: 'typescript',
+      version: '5.4.3',
+    });
+    expect(collectInstalledCopies(root)).toEqual([
+      {
+        dir: path.join('node_modules', 'some-tool', 'node_modules', 'typescript'),
+        version: '5.4.3',
+      },
+    ]);
+  });
+
+  it('counts a copy ONCE even though pnpm symlinks it into the top level', () => {
+    const real = install('node_modules/.pnpm/typescript@6.0.3/node_modules/typescript', {
+      name: 'typescript',
+      version: '6.0.3',
+    });
+    symlinkSync(real, path.join(root, 'node_modules', 'typescript'), 'dir');
+    expect(collectInstalledCopies(root)).toHaveLength(1);
+  });
+
+  it('ignores a directory with no manifest at all', () => {
+    mkdirSync(path.join(root, 'node_modules', 'typescript'), { recursive: true });
+    expect(collectInstalledCopies(root)).toEqual([]);
   });
 });

--- a/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
+++ b/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
@@ -16,6 +16,20 @@ import {
 
 const FILE = 'scripts/probe.mjs';
 
+/** Whether this host permits creating a directory symlink (Windows needs Developer Mode or admin). */
+const CAN_SYMLINK = (() => {
+  const probe = mkdtempSync(path.join(tmpdir(), 'legacy-ts-symlink-probe-'));
+  try {
+    mkdirSync(path.join(probe, 'target'));
+    symlinkSync(path.join(probe, 'target'), path.join(probe, 'link'), 'dir');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
+
 describe('scan-legacy-typescript — import edge FAIL cases', () => {
   it('flags a default import of the legacy compiler', () => {
     const hits = findLegacyImportsInSource("import ts from 'typescript';\n", FILE);
@@ -390,14 +404,20 @@ describe('scan-legacy-typescript — store edge (collectInstalledCopies)', () =>
     ]);
   });
 
-  it('counts a copy ONCE even though pnpm symlinks it into the top level', () => {
-    const real = install('node_modules/.pnpm/typescript@6.0.3/node_modules/typescript', {
-      name: 'typescript',
-      version: '6.0.3',
-    });
-    symlinkSync(real, path.join(root, 'node_modules', 'typescript'), 'dir');
-    expect(collectInstalledCopies(root)).toHaveLength(1);
-  });
+  // Creating a directory symlink needs Developer Mode or elevation on Windows. Skip rather than
+  // fail there: this asserts a pnpm-layout property, and pnpm's store IS symlinks, so the check is
+  // only meaningful where symlinks exist at all.
+  it.skipIf(!CAN_SYMLINK)(
+    'counts a copy ONCE even though pnpm symlinks it into the top level',
+    () => {
+      const real = install('node_modules/.pnpm/typescript@6.0.3/node_modules/typescript', {
+        name: 'typescript',
+        version: '6.0.3',
+      });
+      symlinkSync(real, path.join(root, 'node_modules', 'typescript'), 'dir');
+      expect(collectInstalledCopies(root)).toHaveLength(1);
+    },
+  );
 
   it('ignores a directory with no manifest at all', () => {
     mkdirSync(path.join(root, 'node_modules', 'typescript'), { recursive: true });

--- a/scripts/harness/scan-legacy-typescript.mjs
+++ b/scripts/harness/scan-legacy-typescript.mjs
@@ -20,7 +20,17 @@
  * asks at WHAT VERSION, because a surface frozen at "97 manifests" can still rot back to 5.x one
  * manifest at a time without a single new entry appearing.
  *
- * It reports FIVE finding kinds:
+ * PERF-006 follow-up extended it AGAIN, and the gap is worth stating because it is the exact hole
+ * that let the 5.x line survive a change whose whole point was to end it. Every edge below the
+ * store edge inspects a DECLARATION — a manifest we write, an import we write. None of them can see
+ * what is actually INSTALLED. After the 6.0.3 bump all 97 of our manifests were clean, the scan was
+ * green, and `node_modules/.pnpm/typescript@5.9.3` was still on disk: a transitive package four
+ * levels down (`apps/agent-app` -> `electron-builder@25` -> `app-builder-lib` -> `config-file-ts`)
+ * took `typescript@^5.4.3` as a hard `dependencies` entry, so pnpm materialised it a private copy.
+ * A guard that only reads our own manifests reports success while the goal is unmet. The store edge
+ * closes that: it asks what the tree RESOLVES, not what we declare.
+ *
+ * It reports SIX finding kinds:
  *
  *  1. `legacy-typescript-import` — a first-party file imports the `typescript` package (static
  *     import, `export … from`, `import x = require()`, dynamic `import()`, or `require()`).
@@ -44,9 +54,19 @@
  *     exemption: those excuse the dependency's PRESENCE while upstream forces it, not its version.
  *     A baselined manifest silently reverting `^6.0.3` to `^5.9.3` would otherwise be invisible,
  *     which is the exact creep this edge exists to stop.
- *  4. `reasonless-annotation` — anti-rot on the escape hatch: an `allow-legacy-typescript`
+ *  4. `legacy-typescript-installed` — PERF-006 follow-up. A copy of `typescript` BELOW 6 is
+ *     materialised in `node_modules`, whoever declared it. This is the only edge that reads the
+ *     installed tree rather than a declaration, and it is the one that actually answers the owner's
+ *     question ("is TypeScript 5 gone?"). It is deliberately NOT waivable — not by the baseline, not
+ *     by the root exemption, and there is no annotation for it. A resolved 5.x copy is either
+ *     removable (upgrade or drop whatever pulls it) or it is a decision to bring to the owner; an
+ *     escape hatch here would just be the manifest-only blind spot rebuilt one suppression at a time.
+ *     The fix that cleared the last one was an honest dependency upgrade (`electron-builder` 25 -> 26,
+ *     whose `app-builder-lib` dropped `config-file-ts` for `jiti`), NOT a `pnpm.overrides` entry
+ *     forcing someone else's private dependency onto a major it never declared support for.
+ *  5. `reasonless-annotation` — anti-rot on the escape hatch: an `allow-legacy-typescript`
  *     annotation with no `: <reason>`. Every suppression must state WHY.
- *  5. `stale-annotation` — anti-rot the other way: an `allow-legacy-typescript: <reason>` that
+ *  6. `stale-annotation` — anti-rot the other way: an `allow-legacy-typescript: <reason>` that
  *     suppresses nothing. A suppression outliving the thing it excused is how an allowlist quietly
  *     becomes 641 entries long and switches its own gate off (the failure `check-spec-public-surface`
  *     had to be rescued from). Unlike `scan-no-fallback`, stale detection is implemented here rather
@@ -74,7 +94,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import * as ts from './lib/ts-ast.mjs';
@@ -191,6 +211,144 @@ export function findBelowMinimumDeclarations(manifest, minimumMajor = MINIMUM_MA
     }
   }
   return below;
+}
+
+/**
+ * PERF-006 follow-up — the STORE edge. Everything above reads a declaration; this reads the tree.
+ *
+ * The major an installed copy reports, or `undefined` when the version is not a form we can judge.
+ * Same ratchet stance as `lowestMajorAdmitted`: an unreadable version is reported, never passed.
+ */
+export function installedMajor(version) {
+  if (typeof version !== 'string') return undefined;
+  const match = /^\s*v?(\d+)\./.exec(version);
+  if (match === null) return undefined;
+  return Number(match[1]);
+}
+
+/**
+ * The installed copies that sit below the floor. Pure — takes the copies the walk found, so the
+ * judgement is testable without a node_modules tree on disk.
+ *
+ * Each copy is `{ dir, version }`. Returns `{ dir, version, reason }` entries.
+ */
+export function findBelowMinimumInstalled(copies, minimumMajor = MINIMUM_MAJOR) {
+  const below = [];
+  for (const copy of copies) {
+    const major = installedMajor(copy.version);
+    if (major === undefined) {
+      below.push({
+        ...copy,
+        reason: 'reports a version this guard cannot read, so it cannot prove',
+      });
+    } else if (major < minimumMajor) {
+      below.push({ ...copy, reason: 'resolves below' });
+    }
+  }
+  return below;
+}
+
+/**
+ * How many `node_modules` levels deep the walk descends. pnpm — the package manager this repo pins —
+ * materialises EVERY copy at exactly two levels (`node_modules/.pnpm/<id>/node_modules/<name>`), so
+ * this is generous headroom rather than a guess, and it also covers npm's nested layout for anyone
+ * who installs differently.
+ */
+const STORE_WALK_MAX_LEVELS = 8;
+
+/** The version of the package rooted at `dir`, but ONLY if it really is the legacy compiler. */
+function installedVersionAt(dir) {
+  const manifestPath = path.join(dir, 'package.json');
+  if (!existsSync(manifestPath)) return undefined;
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  // The authoritative confirmation, mirroring the import edge's AST check: a directory NAMED
+  // `typescript` is not enough. `@scope/typescript` would sit in a directory of that name too, and
+  // its manifest name would not be `typescript`.
+  if (manifest?.name !== LEGACY_PACKAGE) return undefined;
+  return manifest.version;
+}
+
+/**
+ * Every `typescript` copy materialised under `root/node_modules`, as `{ dir, version }` with `dir`
+ * relative to `root`. Returns `undefined` — distinct from `[]` — when there is no `node_modules` at
+ * all, because "nothing installed" is not evidence of a clean tree and must not read as one.
+ *
+ * The walk follows the module-resolution structure rather than every subdirectory, so it stays fast:
+ * a `node_modules` level holds package dirs, `@scope` dirs and pnpm's `.pnpm` store, and only those
+ * can lead to another `node_modules`. Copies are deduplicated by real path, since pnpm's top-level
+ * entries are symlinks into `.pnpm` and would otherwise be counted twice.
+ */
+export function collectInstalledCopies(root, { maxLevels = STORE_WALK_MAX_LEVELS } = {}) {
+  const entryPoint = path.join(root, 'node_modules');
+  if (!existsSync(entryPoint)) return undefined;
+
+  const copies = [];
+  const visitedRealPaths = new Set();
+
+  /** `dir` is a directory that directly contains package directories. */
+  const visitNodeModules = (dir, level) => {
+    if (level > maxLevels) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const child = path.join(dir, entry.name);
+      if (entry.name === '.pnpm') {
+        // pnpm's virtual store: each child is one package identity holding its own node_modules.
+        let storeEntries;
+        try {
+          storeEntries = readdirSync(child, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+        for (const storeEntry of storeEntries) {
+          visitNodeModules(path.join(child, storeEntry.name, 'node_modules'), level + 1);
+        }
+        continue;
+      }
+      if (entry.name.startsWith('@')) {
+        // A scope directory holds package directories, but is not itself one.
+        let scoped;
+        try {
+          scoped = readdirSync(child, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+        for (const scopedEntry of scoped) visitPackage(path.join(child, scopedEntry.name), level);
+        continue;
+      }
+      if (entry.name.startsWith('.')) continue;
+      visitPackage(child, level);
+    }
+  };
+
+  /** `dir` is one installed package. */
+  const visitPackage = (dir, level) => {
+    let realPath;
+    try {
+      realPath = realpathSync(dir);
+    } catch {
+      return;
+    }
+    if (visitedRealPaths.has(realPath)) return;
+    visitedRealPaths.add(realPath);
+
+    const version = installedVersionAt(dir);
+    if (version !== undefined) copies.push({ dir: path.relative(root, dir), version });
+    visitNodeModules(path.join(dir, 'node_modules'), level + 1);
+  };
+
+  visitNodeModules(entryPoint, 1);
+  copies.sort((a, b) => a.dir.localeCompare(b.dir));
+  return copies;
 }
 
 /** A well-formed escape hatch: the token followed by `:` and at least one non-space reason char. */
@@ -380,6 +538,29 @@ export function findLegacyTypeScriptFindings(root = WORKSPACE_ROOT, options = {}
     }
   }
 
+  // PERF-006 follow-up: the STORE edge. Asked once, over the whole installed tree, rather than
+  // per-file — it is a property of the resolution, not of any manifest we own.
+  const installed = collectInstalledCopies(root);
+  if (installed === undefined) {
+    // Not installed, so unobservable. Loud rather than silent: a scan that quietly skips its only
+    // resolution-level edge on an uninstalled tree is indistinguishable from one that passed it.
+    notices.push(
+      `no node_modules at ${root} — the installed-copy edge could not run. Run the install first; ` +
+        'CI always does, so this is only reachable locally.',
+    );
+  } else {
+    for (const { dir, version, reason } of findBelowMinimumInstalled(installed)) {
+      findings.push({
+        file: dir,
+        line: 1,
+        kind: 'legacy-typescript-installed',
+        text:
+          `'${LEGACY_PACKAGE}@${version}' is materialised here, which ${reason} ` +
+          `${MINIMUM_MAJOR} — find whatever pulls it in and upgrade or drop that (PERF-006)`,
+      });
+    }
+  }
+
   // The ratchet may only tighten: a baselined manifest that has since dropped the dependency must be
   // removed from the baseline in the same PR, or the freed slot silently stays available for reuse.
   for (const baselined of baseline) {
@@ -445,6 +626,16 @@ function main() {
       `    still need a programmatic compiler API, and must be a ${MINIMUM_MAJOR}.x range. Not\n` +
       '    waivable by the baseline or the root exemption — those excuse the presence of the\n' +
       '    dependency, never its version.\n' +
+      '  - legacy-typescript-installed: a 5.x copy is ON DISK regardless of what we declare, so the\n' +
+      '    goal is not met. FIRST run `pnpm prune`: pnpm does NOT evict a store entry that a\n' +
+      '    dependency change orphaned, so after switching branches or bumping a package the copy can\n' +
+      '    be a stale leftover the lockfile no longer references. `pnpm install` does not clear it.\n' +
+      '    If it survives a prune it is real — find the hard `dependencies` entry that pulls it: parse each manifest\n' +
+      `    under node_modules/.pnpm and look up the literal '${LEGACY_PACKAGE}' key; do NOT grep the\n` +
+      '    string, which also matches @typescript-eslint/* and @typescript/native-preview — then\n' +
+      '    UPGRADE or DROP whatever depends on it. There is no annotation for this edge on purpose:\n' +
+      '    a pnpm.overrides entry forcing a third party onto an unsupported major is a decision for\n' +
+      '    the owner, not a suppression.\n' +
       '  - reasonless-annotation: every `allow-legacy-typescript` MUST carry a `: <reason>`.\n' +
       '  - stale-annotation / unused-exemption: the excuse outlived what it excused — delete it.',
   );


### PR DESCRIPTION
Closes the owner's stated goal: **TypeScript 5 completely gone, TypeScript 6 and 7 side by side.**

PERF-006 landed the declaration half — all 97 workspace manifests on `typescript@^6.0.3`, everything compiling and type-checking on `@typescript/native-preview`. But `node_modules/.pnpm/typescript@5.9.3` was still on disk, and the record argued that was acceptable. It was not.

## The goal, proven

```console
$ find node_modules -name typescript -maxdepth 6 -type d
node_modules/.pnpm/typescript@6.0.3/node_modules/typescript

$ ls node_modules/.pnpm | grep '^typescript@'
typescript@6.0.3

$ node -p "require('typescript/package.json').version"
6.0.3
```

Store-wide sweep, **parsing** every manifest under `node_modules/.pnpm` (7,135 of them) and looking up the literal `typescript` key — never grepping the string, which is a substring of `@typescript-eslint/*`, `@typescript/native-preview` and a script name:

| measurement | before | after |
| --- | --- | --- |
| hard `dependencies` on `typescript` anywhere in the store | **1** (`config-file-ts@0.2.8-rc1` `^5.4.3`) | **0** |
| resolved `typescript` copies on disk | 2 | 1 |

## The fix is an upgrade, not an override

PERF-006 recorded that `pnpm.overrides` was the only lever and "a worse trade than one unused directory". Wrong on three counts, all corrected in the record (kept verbatim rather than deleted — the reasoning error is the useful part):

1. **An override was never the only lever.** `app-builder-lib@26` dropped `config-file-ts` entirely for `jiti` (changeset 26.0.18), so `electron-builder` 25 → 26 deletes the chain at its source. Upgrading `config-file-ts` itself really does lead nowhere — its own latest still pins `^5.4.3` — which is likely why the search stopped one level too low.
2. **"Expected, not a broken guard" was wrong — it was a broken guard.** Every edge inspected a *declaration*; none could see what *resolved*.
3. **"It disappears on its own"** — nothing was going to. `electron-builder` 26.0.0 had been out 18 months.

## The 25 → 26 breaking-change audit

There is **no official 25→26 migration guide**, and the release notes under-report key-level removals. Audited instead against the published config JSON Schema diff (`unpkg.com/app-builder-lib@<version>/scheme.json`), which is the artifact the validator actually uses. The **complete** removed-key set is `includeSubNodeModules`, `NotarizeNotaryOptions.teamId`, and eleven `win.*` signing fields.

| 26.0.0 breaking change | Applies here? |
| --- | --- |
| `win` signing → `signtoolOptions` | **No** — artifacts unsigned, no `win` signing block |
| `mac.notarize` object → boolean + env vars | **No** — key absent |
| `linux.desktop` string-map → object | **No** — key absent |
| `includeSubNodeModules` removed | **No** — never set |
| HFS+ DMG conditional removed | **No** — 26.15.7 still defaults `HFS+`; APFS is a v27 flip |
| node_modules in other subdirectories | **Yes** — visible in the asar diff below |

`artifactName`, `directories.*`, `files`, `extraResources`, `npmRebuild`, all `target` keys, `appId`, `productName`, `copyright` are byte-identical in both schemas. `engines.node` is `>=14.0.0` in both.

**One change did bite, and only packaging found it.** 26's AppImage target rejects the executable name derived from the scoped package name:

```
⨯ executableName contains characters that cannot be safely used in file paths: @robota-sdkagent-app.
```

`validateCriticalPathString` enforces `/^[\p{L}\p{N}._\- ]+$/u` because the value is interpolated into the generated `AppRun` bash script. **25 silently shipped that name**, as the binary and as `@robota-sdkagent-app.desktop`. Fixed properly with an explicit `executableName: robota-desktop` — 26 turned a latent packaging defect into a visible error. This validation appears in no 26.x changelog or doc.

**Pinned exactly, not with a caret.** Within the 26.15 line alone two artifact-corrupting regressions shipped as ordinary patches: 26.15.0–.3 corrupted macOS `.framework` bundles (breaking codesign and Squirrel.Mac auto-update), 26.15.0–.6 produced snaps that built green and failed at launch. Both give a **green build and a broken artifact** — what no caret range and no CI job would catch.

## How far the packaging proof got

Real `dist:app` path on Linux x64, with a **25.1.8 baseline captured first** so every difference is attributable.

| target | on 25.1.8 | on 26.15.7 |
| --- | --- | --- |
| `linux-unpacked` | ✅ | ✅ |
| **AppImage** | ✅ 168,485,777 B | ✅ 168,494,483 B |
| deb | ❌ | ❌ **unreachable in this environment** |
| mac / win | not attempted (need their own hosts) | — |

**The deb step is unreachable here and fails identically on 25**: fpm reports `Need executable 'ar' to convert dir to deb`. `binutils` is absent, there is no passwordless sudo, and `busybox ar` is extract/list-only. Proven an environment gap rather than an upgrade regression by the baseline hitting the same error at the same step before any change.

Checked beyond "a file exists":

- **`linux-unpacked` tree diff: exactly three lines** — `-./@robota-sdkagent-app` / `+./robota-desktop` (the intended fix) and `+./resources/apparmor-profile` (new in 26, for Ubuntu 24.04+ userns).
- **`app.asar` diff: purely additive**, +32 entries / +20,289 B — 26's walker now also resolves `@types/*` (LICENSE + package.json metadata only) and nested pnpm `node_modules`. **Nothing dropped**; no first-party or runtime file changed. The workspace closure resolves correctly under pnpm's symlinked store.
- **The packaged app runs.** `test:e2e:bundled` passes against the 26-built output — nonce handshake, wrong-token rejection before session data, clean SIGTERM shutdown.

## The guard now sees the installed tree

New sixth finding kind `legacy-typescript-installed`: a `typescript` copy below 6 materialised anywhere under `node_modules`, **whoever declared it**. Walks the module-resolution structure, dedupes by realpath (pnpm symlinks the store into the top level), and confirms by `manifest.name === 'typescript'` rather than directory name — the same false-positive class the import edge already handles. **Deliberately not waivable** by baseline, exemption, or annotation.

- **RED** on the pre-upgrade tree — one finding, and it located the cause on its own: `[legacy-typescript-installed] node_modules/.pnpm/config-file-ts@0.2.8-rc1/node_modules/typescript`. Exit 1.
- **GREEN** after the upgrade + clean `pnpm install --frozen-lockfile`. Exit 0.
- **Causally re-proven:** reverting *only* the `electron-builder` version brings `typescript@5.9.3` back and the guard fires again.
- **Tests bind to the floor:** flipping `MINIMUM_MAJOR` to 5 fails 3 of the new tests. 16 new tests, 48 in the file (was 32).

`collectInstalledCopies` returns `undefined` — distinct from `[]` — with no `node_modules`, raising a loud notice rather than passing: "nothing installed" must never read as "clean". The failure message leads with `pnpm prune`, because pnpm does not evict a store entry orphaned by a dependency change and `pnpm install` does not clear it.

## Verification

| command | result |
| --- | --- |
| `pnpm install` | clean, no new peer warning |
| `pnpm build` | green |
| `pnpm typecheck` | green |
| `pnpm lint` | **0 errors, 1,882 warnings** — identical to the PERF-006 baseline |
| `pnpm harness:scan` | **70/70** |
| `pnpm harness:test` | **1,127 tests, 88 files** |
| `pnpm harness:verify-like-ci` | **PASS — all 11 stages** |
| `apps/agent-app` `pnpm test` | 17 tests, 2 files |
| `apps/agent-app` `test:e2e:bundled` | 3/3 against the packaged output |

**One pre-existing failure, explicitly not from this change.** `apps/agent-app` `test:e2e` (the Electron GUI e2e) times out on `.agent-gui-status[data-status="connected"]`. It fails **identically on pristine `origin/develop` with electron-builder 25.1.8** — verified by stashing the whole change, reinstalling and re-running. It is wired into no CI workflow. Untouched here, and noted as a follow-up.

Two `verify-like-ci` stages cannot be mirrored locally and are relevant to this diff: `security-audit` (network + osv-scanner) and `windows-shell` (Windows host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
