### PR TITLE
fix(release): verify published macOS artifacts, and repair the release-upload audit findings

### DIFF
--- a/.agents/backlog/DIST-002-release-artifact-verification.md
+++ b/.agents/backlog/DIST-002-release-artifact-verification.md
@@ -1,7 +1,7 @@
 ---
 id: DIST-002
 title: Nothing verifies a published release artifact — the macOS downloads do not open
-status: todo
+status: in-progress
 priority: high
 type: INFRA
 created: 2026-07-26
@@ -94,14 +94,77 @@ Docker _is_ the right tool for the Linux artifacts, and that is a separate, real
 AppImage and `.deb` inside clean distro images would catch a missing shared library or a glibc
 floor that the CI runner happens to satisfy. Worth folding in, but it is not what the owner hit.
 
+## Phase 1 — DONE (2026-07-26)
+
+The gate is built and **proven red on the published artifacts**, which was its acceptance criterion.
+
+- `scripts/harness/verify-macos-release-artifacts.sh` — the verifier.
+- `release-desktop-app.yml` job `verify-macos-artifacts` (`macos-latest`) — downloads the
+  **published** assets with `gh release download`, applies `com.apple.quarantine`, and asks
+  Gatekeeper. A `verify_only` dispatch input reruns it against an existing tag without repackaging.
+- `await-published-assets` (ubuntu, polls) — the two release workflows share a concurrency group but
+  not an order, so the darwin CLI binaries may not exist yet when the desktop workflow reaches the
+  gate. Timing out is a failure, never a skip.
+- `scripts/harness/scan-release-verification-gate.mjs` — anti-rot: the gate is red on purpose, which
+  makes it a standing temptation, so this fails if the gate is deleted, unwired, moved off macOS,
+  aimed at a local build instead of the published asset, or suppressed with `continue-on-error`/`|| true`.
+
+**Proof it is red** — run `30194492528`, `verify_only=true` against `v3.0.0-beta.79`, runner
+`macos-26-arm64`: **20 blocking checks, 8 failures**. It is discriminating, not a stub: 12 blocking
+checks pass.
+
+```
+BLOCKING   FAIL codesign --verify --strict: robota-darwin-arm64
+BLOCKING   FAIL spctl --assess --type execute: robota-darwin-arm64
+BLOCKING   FAIL codesign --verify --strict: robota-darwin-x64
+BLOCKING   FAIL spctl --assess --type execute: robota-darwin-x64
+BLOCKING   FAIL published checksum available: robota-desktop-3.0.0-beta.79-arm64.dmg
+BLOCKING   FAIL spctl --assess --type install: robota-desktop-3.0.0-beta.79-arm64.dmg
+BLOCKING   FAIL codesign --verify --deep --strict: Robota.app
+BLOCKING   FAIL spctl --assess --type execute: Robota.app
+VERDICT: FAIL — a user downloading these artifacts cannot open them.
+```
+
+### Two corrections to the diagnosis above, measured on the runner
+
+1. **The CLI binaries are not merely ad-hoc — their signature is INVALID.** `codesign --verify
+--strict` reports `invalid signature (code or signature have been modified)` on both
+   `robota-darwin-arm64` and `robota-darwin-x64`, while the published SHA-256 matches, so the file
+   is intact and the signature is broken **as built**. `bun build --compile` cross-compiling from
+   Linux emits a CodeDirectory that does not cover the final image. The desktop `.app` is the
+   originally-described case — `flags=0x20002(adhoc,linker-signed)`, `Signature=adhoc` — but the CLI
+   binaries are a strictly worse state, and signing them will not be a matter of adding a
+   certificate to the existing signature: the signature has to be produced correctly first.
+
+2. **A quarantined CLI binary still runs from a shell.** `robota-darwin-arm64 --version` printed
+   `robota 3.0.0-beta.79` on an Apple Silicon runner with the quarantine attribute set, even with an
+   invalid signature — while `spctl` rejected it. Gatekeeper assessment and shell execution are
+   different paths. This is why the failure is reported as "downloaded it and it will not open"
+   (Finder/LaunchServices) and not as a broken terminal command, and why phase 3's `xattr -d` note
+   is worth publishing: it genuinely unblocks terminal users today.
+
 ## Acceptance
 
-- [ ] A verification job that downloads the published artifact, applies the quarantine attribute,
+- [x] A verification job that downloads the published artifact, applies the quarantine attribute,
       and asserts it opens — **proven RED against `v3.0.0-beta.79`** before any credential exists.
 - [ ] The CLI darwin binaries build on a macOS runner (a precondition for ever signing them).
 - [ ] Release notes carry the quarantine workaround for as long as the artifacts are unsigned.
 - [ ] After phase 2: `spctl --assess` passes on a freshly downloaded DMG with quarantine applied,
       and the stapled ticket validates offline.
+- [ ] `xcrun stapler validate` is promoted from DIAGNOSTIC to BLOCKING in the verifier once
+      notarization exists for it to validate.
+
+## Blocked on the Apple certificate (owner)
+
+Everything below needs a credential the owner provisions; none of it was attempted.
+
+- `CSC_LINK` / `CSC_KEY_PASSWORD` (Developer ID Application `.p12`), `APPLE_ID`,
+  `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`.
+- `hardenedRuntime: true` + an entitlements file in `apps/agent-app/electron-builder.yml`
+  (`com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory` for Electron), and the
+  bundled sidecar at `resources/robota` must itself be signed or notarization rejects the bundle.
+- Moving the darwin CLI compile to a `macos-latest` leg — a build-topology change that only pays for
+  itself once there is something to sign with, so it is deliberately not done yet.
 
 ## References
 

--- a/.agents/backlog/DIST-004-linux-artifact-verification-in-clean-images.md
+++ b/.agents/backlog/DIST-004-linux-artifact-verification-in-clean-images.md
@@ -1,0 +1,48 @@
+---
+id: DIST-004
+title: The Linux release artifacts are never run anywhere but the build runner
+status: todo
+priority: medium
+type: INFRA
+created: 2026-07-26
+---
+
+# DIST-004: run the Linux artifacts in clean distro images
+
+## Problem
+
+DIST-002 built the macOS half of published-artifact verification. The Linux half is still open, and
+it is the same defect in a different coat: the AppImage, the `.deb`, and `robota-linux-{x64,arm64}`
+are only ever exercised — when they are exercised at all — **on the GitHub runner that built them**,
+which has the full build toolchain installed.
+
+That runner is the one machine in the world guaranteed to satisfy every dependency. A missing shared
+library or a glibc floor higher than the target distro's is invisible there and fatal for a user.
+
+Concretely, today `release-bun-binaries.yml` executes exactly one of five binaries
+(`robota-linux-x64 --version`, the host arch). `robota-linux-arm64` is never executed by anything.
+The desktop AppImage and `.deb` are never executed by anything.
+
+## Why Docker is the right tool here specifically
+
+DIST-002 could not use containers: macOS cannot run in one — containers share the host kernel, and
+Apple's licence confines macOS virtualization to Apple hardware. Linux has no such constraint, and
+a clean distro image is _exactly_ the missing environment: a machine with none of the build
+toolchain, which is what a user has.
+
+## Sketch
+
+- `robota-linux-x64` and the AppImage in, say, `ubuntu:22.04` and `debian:12` — bare images, no
+  build tooling — asserting `--version` prints the expected version.
+- `dpkg -i` the `.deb` in a clean image and run the installed binary; `apt-get install -f` failing
+  is the finding.
+- `robota-linux-arm64` under `--platform linux/arm64` with QEMU (`docker/setup-qemu-action`), which
+  gives that binary its first execution of any kind.
+- Assert the glibc floor deliberately (`objdump -T | grep GLIBC_` against a declared maximum)
+  rather than discovering it from whichever base image happens to be oldest.
+
+## Acceptance
+
+- [ ] Every published Linux artifact is executed in an image that did **not** build it.
+- [ ] The check is proven to fail on a deliberately broken artifact before it is believed.
+- [ ] `robota-linux-arm64` is executed at least once in the pipeline.

--- a/.agents/backlog/DIST-004-linux-artifact-verification-in-clean-images.md
+++ b/.agents/backlog/DIST-004-linux-artifact-verification-in-clean-images.md
@@ -11,7 +11,7 @@ created: 2026-07-26
 
 ## Problem
 
-DIST-002 built the macOS half of published-artifact verification. The Linux half is still open, and
+DIST-005 built the macOS half of published-artifact verification. The Linux half is still open, and
 it is the same defect in a different coat: the AppImage, the `.deb`, and `robota-linux-{x64,arm64}`
 are only ever exercised — when they are exercised at all — **on the GitHub runner that built them**,
 which has the full build toolchain installed.
@@ -25,7 +25,7 @@ The desktop AppImage and `.deb` are never executed by anything.
 
 ## Why Docker is the right tool here specifically
 
-DIST-002 could not use containers: macOS cannot run in one — containers share the host kernel, and
+DIST-005 could not use containers: macOS cannot run in one — containers share the host kernel, and
 Apple's licence confines macOS virtualization to Apple hardware. Linux has no such constraint, and
 a clean distro image is _exactly_ the missing environment: a machine with none of the build
 toolchain, which is what a user has.

--- a/.agents/backlog/DIST-005-release-artifact-verification.md
+++ b/.agents/backlog/DIST-005-release-artifact-verification.md
@@ -1,5 +1,5 @@
 ---
-id: DIST-002
+id: DIST-005
 title: Nothing verifies a published release artifact — the macOS downloads do not open
 status: in-progress
 priority: high
@@ -7,7 +7,7 @@ type: INFRA
 created: 2026-07-26
 ---
 
-# DIST-002: verify what we publish, before signing it
+# DIST-005: verify what we publish, before signing it
 
 ## Problem
 

--- a/.agents/backlog/INFRA-058-deploy-workflow-has-never-deployed.md
+++ b/.agents/backlog/INFRA-058-deploy-workflow-has-never-deployed.md
@@ -1,0 +1,69 @@
+---
+id: INFRA-058
+title: deploy.yml has never deployed anything — decide whether it should exist
+status: todo
+priority: medium
+type: INFRA
+created: 2026-07-26
+---
+
+# INFRA-058: `deploy.yml` has never once deployed, in 100+ runs over 8 months
+
+## The decision this needs
+
+Delete `.github/workflows/deploy.yml`, or rebuild it deliberately. **This is filed rather than
+executed because removing a deployment surface is the owner's call, not an auditor's.** The
+recommendation is deletion, and the evidence is below.
+
+## Why it fails
+
+```
+##[error]Unable to resolve action vercel/action, repository not found
+```
+
+The `vercel/action` repository does not exist. It never did — Vercel has never shipped a
+first-party GitHub Action under that name. So the `build` job dies at **`Set up job`**, before a
+single step runs. This is not a regression; it is the workflow's permanent state.
+
+## Why nobody noticed
+
+The failure is invisible from every angle someone would look from:
+
+- The job dies at runner setup, so there is no failing _step_ to read — `--log-failed` returns only
+  the provisioner banner.
+- The two `success` runs in the workflow's entire history are runs where `build` was **skipped**
+  (`test` passed, `build` never ran). A green tick on the run list means the deploy did not happen.
+- It is `workflow_dispatch`-only, so it produces no signal on ordinary pushes.
+
+## The purpose is gone, not just the mechanism
+
+| Evidence                                                             | Measured 2026-07-26                                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Successful deploys, all time                                         | **0** — the `build` job has never completed                                     |
+| `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`, repo secrets | **absent** (only `CLAUDE_CODE_OAUTH_TOKEN`, `RELEASE_DEPLOY_KEY`, `VITE_GA_ID`) |
+| Same, `staging` + `production` environment secrets                   | **0 secrets in each**                                                           |
+| `staging.robota.io`                                                  | **does not resolve** (NXDOMAIN)                                                 |
+| `robota.io`                                                          | **live, HTTP 200** — so something else already deploys it                       |
+| GitHub deployment records                                            | one `production` entry, 2026-05-18 — created by the run that then died          |
+| Any spec/doc naming `deploy.yml` as a deployment path                | **none**                                                                        |
+
+So the site this workflow claims to deploy is already being served by another mechanism, and the
+credentials this workflow would need have never existed anywhere. Even with the action reference
+repaired, it could not run.
+
+Fixing it in place would mean _choosing a deploy architecture_ — a second, competing publish path
+for a site that is already published. That is why the action reference was deliberately left
+untouched by the audit that found this.
+
+## If deletion is chosen
+
+`git rm .github/workflows/deploy.yml`. Nothing references it: no required status check, no ruleset,
+no spec, no runbook. The `test` job it also contains (lint + `test:ci` for `@robota-sdk/agent-web`)
+is worth confirming is covered by `ci.yml` before removing — that is the only part of the file that
+has ever done useful work.
+
+## If it should live
+
+It needs, in this order: a real deploy mechanism (the official `vercel` CLI, or `amondnet/vercel-action`),
+the three secrets provisioned, a `staging.robota.io` DNS record or a different staging target, and
+an explicit `permissions:` block (it currently has none and inherits the repo default).

--- a/.agents/backlog/INFRA-059-workflow-action-references-unverified.md
+++ b/.agents/backlog/INFRA-059-workflow-action-references-unverified.md
@@ -1,0 +1,50 @@
+---
+id: INFRA-059
+title: Nothing checks that a workflow's `uses:` references resolve — one has been dead for 8 months
+status: todo
+priority: medium
+type: INFRA
+created: 2026-07-26
+---
+
+# INFRA-059: a workflow can reference an action that does not exist, forever
+
+## Problem
+
+`deploy.yml` has referenced `vercel/action@v1` — **a repository that does not exist** — since it was
+written. Every run dies at `Set up job` with `Unable to resolve action`. That went undetected for
+eight months and 100+ runs (INFRA-058).
+
+The class matters more than the instance. An unresolvable `uses:` fails _before any step runs_, so:
+
+- there is no failing step in the log to read,
+- `--log-failed` returns only the runner provisioner banner,
+- and a job that is `if:`-gated or skipped reports the whole run **green**.
+
+It is the quietest possible CI failure, and nothing in this repo would catch another one.
+
+## Proposed check
+
+`actionlint` in CI over `.github/workflows/*.yml`. It is the standard tool, it catches this plus
+expression-syntax and context-typing errors, and it has no repo-specific configuration burden.
+
+**This needs an owner decision because it is a new required check**, and because the resolvability
+half needs network access at check time — which raises the question the harness cares about: a
+network-dependent check that cannot reach GitHub must **fail**, not skip. A "could not determine →
+exit 0" path here would reproduce the exact defect it is meant to catch. That argues for running it
+as a CI job rather than folding it into `pnpm harness:scan`, which developers run offline.
+
+## Scope note
+
+INFRA-038 recorded `actionlint` being run **manually** against `ci.yml` during that migration
+("actionlint clean on ci.yml"), and it found the `deploy.yml` `codecov-action@v3` warning at the
+time. So the tool has already proven itself on this repo once — it simply was never wired in, and
+the one-off run did not flag the unresolvable action because plain `actionlint` does not check
+resolvability without network.
+
+## Acceptance
+
+- [ ] A CI job runs `actionlint` over every workflow.
+- [ ] It is **proven red** against a deliberately reintroduced bad `uses:` reference before being
+      believed — the same red-first standard DIST-002's gate was held to.
+- [ ] Its network-failure path exits non-zero, and that path is exercised, not reasoned about.

--- a/.agents/backlog/INFRA-059-workflow-action-references-unverified.md
+++ b/.agents/backlog/INFRA-059-workflow-action-references-unverified.md
@@ -46,5 +46,5 @@ resolvability without network.
 
 - [ ] A CI job runs `actionlint` over every workflow.
 - [ ] It is **proven red** against a deliberately reintroduced bad `uses:` reference before being
-      believed — the same red-first standard DIST-002's gate was held to.
+      believed — the same red-first standard DIST-005's gate was held to.
 - [ ] Its network-failure path exits non-zero, and that path is exercised, not reasoned about.

--- a/.github/workflows/release-bun-binaries.yml
+++ b/.github/workflows/release-bun-binaries.yml
@@ -31,7 +31,12 @@ jobs:
     steps:
       - name: Resolve release tag
         id: tag
-        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+        # The tag is read from `env`, never interpolated into the script body: `${{ }}` inside a `run:`
+        # is textual substitution, so a tag containing shell metacharacters would execute here.
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7
         with:
@@ -70,9 +75,57 @@ jobs:
       - name: Sanity — host binary prints the real version (no Node)
         run: ./packages/agent-cli/dist/bin/robota-linux-x64 --version
 
+      # Only the host (linux-x64) binary above can actually be EXECUTED on this runner, so the other four
+      # were previously published without a single assertion of any kind. `file` is the cheapest check that
+      # still answers the question that matters for a cross-compile: is each artifact the architecture its
+      # NAME promises. A target silently emitting the host arch — or emitting nothing — reaches users as a
+      # download that cannot run, which is exactly the failure class DIST-002 exists over.
+      - name: Assert all five targets exist, are non-trivial, and match their advertised architecture
+        working-directory: packages/agent-cli/dist/bin
+        run: |
+          set -euo pipefail
+          check() { # check <filename> <expected substring of `file` output>
+            local f="$1" want="$2" size desc
+            if [ ! -f "$f" ]; then
+              echo "::error::$f was not produced by build:bun:all"
+              exit 1
+            fi
+            size=$(wc -c <"$f")
+            # Every one of these binaries is ~70-105 MB; 10 MB only a truncated build falls below.
+            if [ "$size" -lt 10485760 ]; then
+              echo "::error::$f is $size bytes — truncated, refusing to publish."
+              exit 1
+            fi
+            desc=$(file -b "$f")
+            echo "$f  ($size bytes)  $desc"
+            case "$desc" in
+              *"$want"*) ;;
+              *) echo "::error::$f is not a $want build — file(1) says: $desc"; exit 1 ;;
+            esac
+          }
+          check robota-darwin-arm64     'Mach-O 64-bit arm64'
+          check robota-darwin-x64       'Mach-O 64-bit x86_64'
+          check robota-linux-x64        'ELF 64-bit LSB'
+          check robota-linux-arm64      'ELF 64-bit LSB'
+          check robota-windows-x64.exe  'PE32+'
+          # linux-arm64 and linux-x64 share a `file` prefix, so pin their machine type explicitly.
+          file -b robota-linux-x64   | grep -q 'x86-64'  || { echo "::error::robota-linux-x64 is not x86-64"; exit 1; }
+          file -b robota-linux-arm64 | grep -q 'ARM aarch64' || { echo "::error::robota-linux-arm64 is not aarch64"; exit 1; }
+
       - name: Generate SHA-256 checksums
         working-directory: packages/agent-cli/dist/bin
-        run: sha256sum robota-* > SHA256SUMS.txt
+        run: |
+          set -euo pipefail
+          sha256sum robota-* > SHA256SUMS.txt
+          # `sha256sum robota-*` silently produces a SHORT manifest if a target is missing, which then
+          # reads as a complete one. The five binaries are asserted above; assert the manifest describes
+          # all five so the file cannot drift from what is uploaded.
+          lines=$(wc -l <SHA256SUMS.txt)
+          if [ "$lines" -ne 5 ]; then
+            echo "::error::SHA256SUMS.txt has $lines entries, expected 5."
+            exit 1
+          fi
+          cat SHA256SUMS.txt
 
       # REL-022 — managed release notes: categorized conventional-commit notes instead of the raw
       # `--generate-notes` PR-title dump. The script auto-detects the previous v* tag (checkout above
@@ -89,6 +142,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
           NOTES: ${{ runner.temp }}/release-notes.md
         run: |
+          set -euo pipefail
           gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
           gh release upload "$TAG" \
             robota-darwin-arm64 \
@@ -98,3 +152,32 @@ jobs:
             robota-windows-x64.exe \
             SHA256SUMS.txt \
             --clobber
+
+      # An upload step exits 0 for "I sent the bytes", not "the release now serves them". Read the release
+      # back and compare each asset's PUBLISHED size against the local file, so a partial or dropped upload
+      # cannot leave a green run behind a release users cannot install from.
+      - name: Verify the assets actually landed on the Release
+        working-directory: packages/agent-cli/dist/bin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release view "$TAG" --json assets --jq '.assets[] | "\(.name) \(.size)"' > published.txt
+          cat published.txt
+          rc=0
+          for f in robota-darwin-arm64 robota-darwin-x64 robota-linux-x64 robota-linux-arm64 robota-windows-x64.exe SHA256SUMS.txt; do
+            local_size=$(wc -c <"$f")
+            published_size=$(awk -v n="$f" '$1 == n { print $2 }' published.txt)
+            if [ -z "$published_size" ]; then
+              echo "::error::$f is missing from the published release."
+              rc=1
+            elif [ "$published_size" != "$local_size" ]; then
+              echo "::error::$f published as $published_size bytes, built as $local_size — truncated upload."
+              rc=1
+            else
+              echo "ok: $f ($local_size bytes)"
+            fi
+          done
+          exit "$rc"

--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -3,6 +3,12 @@ name: Release — Desktop app
 # GUI-003 — package apps/agent-app per-OS with electron-builder (runtime bundled via extraResources) and
 # publish the installers to the tag's GitHub Release. Sibling to release-bun-binaries.yml (raw Bun binaries) and
 # release.yml (npm publish); all three leave each other untouched. Installers are UNSIGNED (no certs).
+#
+# DIST-002 — this workflow also hosts the macOS artifact VERIFICATION gate (the `verify-macos-artifacts`
+# job). It lives here, rather than beside the binaries it checks, for one reason: verifying a macOS artifact
+# requires a macOS runner, containers cannot host macOS, and this is the only release workflow with a
+# `macos-latest` leg. The gate covers BOTH product families' darwin artifacts — the agent-cli single binaries
+# (built on ubuntu-latest by release-bun-binaries.yml) and this workflow's .dmg.
 
 on:
   push:
@@ -14,6 +20,11 @@ on:
         description: 'Existing release tag to build + attach installers to (e.g. v3.0.0-beta.79). Must already exist.'
         required: true
         type: string
+      verify_only:
+        description: 'Skip packaging; only run the macOS artifact verification gate against the tag''s ALREADY-PUBLISHED assets.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -27,6 +38,8 @@ concurrency:
 jobs:
   desktop:
     name: Package + publish (${{ matrix.os }})
+    # verify_only re-runs the gate against what is already published; it must not rebuild or re-upload.
+    if: github.event.inputs.verify_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +58,12 @@ jobs:
       - name: Resolve release tag
         id: tag
         shell: bash
-        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+        # The tag is read from `env`, never interpolated into the script body: `${{ }}` inside a `run:`
+        # is textual substitution, so a tag containing shell metacharacters would execute here.
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7
         with:
@@ -82,6 +100,67 @@ jobs:
       - name: Package the desktop app (bundles the runtime)
         run: pnpm --filter @robota-sdk/agent-app dist:app
 
+      # `gh release upload release/*.dmg` with no match uploads nothing and still exits 0 on some gh
+      # versions, and an empty or truncated installer uploads perfectly happily. Assert the artifacts
+      # exist and are plausibly sized BEFORE publishing them, so a packaging regression cannot reach a
+      # user as a 0-byte download.
+      - name: Assert packaged artifacts exist and are non-trivial
+        shell: bash
+        working-directory: apps/agent-app
+        env:
+          ASSETS: ${{ matrix.assets }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          found=()
+          for pattern in $ASSETS; do
+            for f in $pattern; do found+=("$f"); done
+          done
+          if [ ${#found[@]} -eq 0 ]; then
+            echo "::error::no artifacts matched '$ASSETS' — electron-builder produced nothing to publish."
+            exit 1
+          fi
+          for f in "${found[@]}"; do
+            size=$(wc -c <"$f")
+            echo "$f -> $size bytes"
+            # Every real installer for this app is tens of MB; 1 MB is a generous floor that only a
+            # truncated or empty artifact falls below.
+            if [ "$size" -lt 1048576 ]; then
+              echo "::error::$f is $size bytes — truncated or empty, refusing to publish."
+              exit 1
+            fi
+          done
+
+      # DIST-002 — the desktop installers shipped with NO published checksums at all, so a user (and this
+      # repo's own verification gate) had no way to tell a complete download from a truncated one. One
+      # manifest PER MATRIX LEG: a single shared filename would have the three legs clobber each other's
+      # upload, which is how a checksum file ends up describing only the last OS to finish.
+      - name: Generate SHA-256 checksums for this OS's installers
+        shell: bash
+        working-directory: apps/agent-app
+        env:
+          ASSETS: ${{ matrix.assets }}
+          MANIFEST: SHA256SUMS-desktop-${{ matrix.os }}.txt
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          : >"release/$MANIFEST"
+          cd release
+          for pattern in $ASSETS; do
+            for f in ${pattern#release/}; do
+              if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum "$f" >>"$MANIFEST"
+              else
+                shasum -a 256 "$f" >>"$MANIFEST"
+              fi
+            done
+          done
+          if [ ! -s "$MANIFEST" ]; then
+            echo "::error::checksum manifest is empty — nothing was hashed."
+            exit 1
+          fi
+          cat "$MANIFEST"
+
       # REL-022 — managed release notes: categorized conventional-commit notes instead of the raw
       # `--generate-notes` PR-title dump. The script auto-detects the previous v* tag (checkout above
       # uses fetch-depth: 0, so full tag history is available). No network — git history only.
@@ -97,7 +176,112 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
           NOTES: ${{ runner.temp }}/release-notes.md
+          ASSETS: ${{ matrix.assets }}
+          MANIFEST: release/SHA256SUMS-desktop-${{ matrix.os }}.txt
         run: |
+          set -euo pipefail
           gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
-          gh release upload "$TAG" ${{ matrix.assets }} --clobber
+          # shellcheck disable=SC2086 -- $ASSETS is an intentional multi-pattern glob list.
+          gh release upload "$TAG" $ASSETS "$MANIFEST" --clobber
         working-directory: apps/agent-app
+
+  # -------------------------------------------------------------------------------------------------
+  # DIST-002 phase 1 — the gate.
+  #
+  # "Did the upload succeed" and "is the uploaded thing usable" are different questions, and until now
+  # this pipeline only ever answered the first. `v3.0.0-beta.79` published a macOS binary carrying an
+  # ad-hoc signature (CodeDirectory only, no certificate chain); the kernel loads it, so every check that
+  # ran on the build runner passed, while every user who downloaded it — and therefore got
+  # com.apple.quarantine — was refused by Gatekeeper. That shipped 2026-07-15 and went unnoticed for four
+  # months because nothing ever looked at a published asset.
+  #
+  # This gate downloads the PUBLISHED asset, applies the quarantine attribute, and asks Gatekeeper.
+  # It is EXPECTED TO FAIL until DIST-002 phase 2 (signing + notarization) lands. That red is the point:
+  # a verification job written after the credentials arrive, green from its first run, cannot distinguish
+  # "correctly signed" from "checks nothing".
+  # -------------------------------------------------------------------------------------------------
+
+  await-published-assets:
+    name: Wait for the tag's release assets to be published
+    # Deliberately on ubuntu: this job only polls, and macOS runner minutes bill at a large multiple.
+    runs-on: ubuntu-latest
+    needs: [desktop]
+    # The sibling workflow (release-bun-binaries.yml) publishes the darwin CLI binaries and shares this
+    # tag's concurrency group, so on a tag push the two workflows serialize in an unspecified ORDER —
+    # whichever runs first would find the other's assets missing. Poll rather than assume.
+    if: ${{ !cancelled() && (github.event.inputs.verify_only == 'true' || needs.desktop.result == 'success') }}
+    steps:
+      - name: Resolve release tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Poll until every macOS asset exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          required="robota-darwin-arm64 robota-darwin-x64 SHA256SUMS.txt"
+          deadline=$(( $(date +%s) + 1500 ))   # 25 minutes
+          while :; do
+            names=$(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null || true)
+            missing=""
+            for r in $required; do
+              printf '%s\n' "$names" | grep -qx "$r" || missing="$missing $r"
+            done
+            printf '%s\n' "$names" | grep -q '\.dmg$' || missing="$missing <a .dmg>"
+            if [ -z "$missing" ]; then
+              echo "all required assets present on $TAG"
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              # Timing out is a FAILURE, never a skip: "could not determine" must not read as "fine".
+              echo "::error::timed out waiting for release assets on $TAG; still missing:$missing"
+              exit 1
+            fi
+            echo "waiting for:$missing"
+            sleep 30
+          done
+
+  verify-macos-artifacts:
+    name: Verify published macOS artifacts open on a user's Mac
+    runs-on: macos-latest
+    needs: [await-published-assets]
+    if: ${{ !cancelled() && needs.await-published-assets.result == 'success' }}
+    steps:
+      - name: Resolve release tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+
+      # `gh release download` fetches what a user fetches — the published asset. Verifying a locally
+      # rebuilt copy instead would check a different artifact than the one that is broken.
+      - name: Download the PUBLISHED macOS assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/published"
+          cd "${{ runner.temp }}/published"
+          gh release download "$TAG" \
+            -p 'robota-darwin-arm64' \
+            -p 'robota-darwin-x64' \
+            -p 'SHA256SUMS*.txt' \
+            -p '*.dmg' \
+            --clobber
+          ls -la
+
+      - name: Verify the artifacts a user actually downloads
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: bash scripts/harness/verify-macos-release-artifacts.sh "$TAG" "${{ runner.temp }}/published"

--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       verify_only:
-        description: 'Skip packaging; only run the macOS artifact verification gate against the tag''s ALREADY-PUBLISHED assets.'
+        description: "Skip packaging; only run the macOS artifact verification gate against the tag's ALREADY-PUBLISHED assets."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -87,9 +87,11 @@ jobs:
           fi
 
       # Proves the key authenticates against this repo without mutating anything. On a dry run this is the
-      # whole point; on a real bump it turns an auth failure into a clear message before a tag is created.
+      # whole point — the credential path has never once executed, so it must be reachable WITHOUT a bump,
+      # or the dry run would exercise nothing on a tree whose version has not changed. On a real bump it
+      # turns an auth failure into a clear message before a tag is created.
       - name: Verify the deploy key authenticates
-        if: steps.resolve.outputs.bumped == 'true'
+        if: steps.resolve.outputs.bumped == 'true' || github.event.inputs.dry_run == 'true'
         run: |
           set -euo pipefail
           git ls-remote --tags origin >/dev/null

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -7,13 +7,29 @@ name: Release — tag on version bump
 #
 # Requires an owner-provisioned repo DEPLOY KEY (write) as `secrets.RELEASE_DEPLOY_KEY`. Inert without it
 # (the tag push fails loudly). See the release runbook.
+#
+# AUDIT NOTE (2026-07-26): as of this change the tag-pushing branch of this workflow had NEVER executed.
+# Every one of its ~19 runs took the `version unchanged` early return, because agent-cli has sat at
+# 3.0.0-beta.79 since before RELEASE-001 shipped. The repo's only real tag, v3.0.0-beta.79, was pushed BY
+# HAND on 2026-07-15T17:06:02Z — 39 seconds BEFORE `RELEASE_DEPLOY_KEY` was created (17:06:41Z), so the key
+# has never authenticated a push either. The `workflow_dispatch` dry run below exists so this path can be
+# exercised deliberately instead of debuting during a real release.
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Resolve the version and the would-be tag, verify the deploy key authenticates, but push nothing.'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
+  # Reading workflow runs to confirm the pushed tag actually triggered the release workflows.
+  actions: read
 
 concurrency:
   group: release-tag-${{ github.sha }}
@@ -29,21 +45,122 @@ jobs:
           fetch-depth: 2 # need HEAD^ to detect a version change
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }} # push over SSH so the tag fires the v* workflows
 
-      - name: Push v<version> tag on an agent-cli bump
+      # An unset RELEASE_DEPLOY_KEY makes actions/checkout fall back to HTTPS + GITHUB_TOKEN, and the push
+      # then fails deep in the script with an opaque permissions error. Say so up front instead.
+      - name: Assert the deploy key is provisioned
+        env:
+          KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$KEY" ]; then
+            echo "::error::secrets.RELEASE_DEPLOY_KEY is not set. A tag pushed with GITHUB_TOKEN cannot"
+            echo "::error::trigger the v* release workflows, so the release would produce no assets."
+            exit 1
+          fi
+          echo "RELEASE_DEPLOY_KEY is present."
+
+      - name: Resolve the version change
+        id: resolve
         run: |
           set -euo pipefail
           PKG=packages/agent-cli/package.json
           CUR=$(node -pe "require('./$PKG').version")
-          PREV=$(git show "HEAD^:$PKG" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).version" || echo "")
+
+          # A missing or unparseable previous manifest is "could not determine", NOT "unchanged" and NOT
+          # "changed". Distinguish it explicitly rather than letting an empty string decide by accident.
+          if PREV_JSON=$(git show "HEAD^:$PKG" 2>/dev/null); then
+            PREV=$(printf '%s' "$PREV_JSON" | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          else
+            echo "::notice::no HEAD^ copy of $PKG (first commit, or the file is new) — treating as a bump."
+            PREV=""
+          fi
+
+          echo "previous=$PREV" >> "$GITHUB_OUTPUT"
+          echo "current=$CUR" >> "$GITHUB_OUTPUT"
           if [ "$CUR" = "$PREV" ]; then
             echo "agent-cli version unchanged ($CUR) — no release tag."
-            exit 0
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "agent-cli bumped ${PREV:-<none>} -> $CUR"
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v$CUR" >> "$GITHUB_OUTPUT"
           fi
-          TAG="v$CUR"
+
+      # Proves the key authenticates against this repo without mutating anything. On a dry run this is the
+      # whole point; on a real bump it turns an auth failure into a clear message before a tag is created.
+      - name: Verify the deploy key authenticates
+        if: steps.resolve.outputs.bumped == 'true'
+        run: |
+          set -euo pipefail
+          git ls-remote --tags origin >/dev/null
+          echo "deploy key authenticated against origin."
+
+      - name: Push the tag
+        if: steps.resolve.outputs.bumped == 'true' && github.event.inputs.dry_run != 'true'
+        id: push
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
           if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG"; then
             echo "tag $TAG already exists — skip (idempotent)."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "agent-cli bumped ${PREV:-<none>} -> $CUR; pushing $TAG to fire the binary + desktop workflows"
+          echo "pushing $TAG to fire the binary + desktop workflows"
           git tag "$TAG"
           git push origin "refs/tags/$TAG"
+          # Read the ref back: `git push` reporting success is not the same as the remote serving the tag.
+          if ! git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG"; then
+            echo "::error::$TAG is not present on origin after a successful push."
+            exit 1
+          fi
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dry run — report the tag that would be pushed
+        if: github.event.inputs.dry_run == 'true'
+        env:
+          BUMPED: ${{ steps.resolve.outputs.bumped }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          PREV: ${{ steps.resolve.outputs.previous }}
+          CUR: ${{ steps.resolve.outputs.current }}
+        run: |
+          set -euo pipefail
+          echo "DRY RUN — nothing was pushed."
+          echo "  previous version : ${PREV:-<none>}"
+          echo "  current version  : $CUR"
+          echo "  bump detected    : $BUMPED"
+          echo "  tag that would be pushed: ${TAG:-<none>}"
+
+      # The failure this guards is silent and expensive: a tag that triggers nothing produces a GitHub
+      # Release with no assets, and the only symptom is a download page that is simply empty. Assert the
+      # downstream workflows actually started for this tag.
+      - name: Confirm the tag triggered the release workflows
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 300 ))   # 5 minutes; a push trigger dispatches within seconds
+          want="release-bun-binaries.yml release-desktop-app.yml"
+          while :; do
+            missing=""
+            for wf in $want; do
+              n=$(gh run list --workflow "$wf" --branch "$TAG" --limit 1 --json databaseId --jq 'length')
+              [ "$n" -ge 1 ] || missing="$missing $wf"
+            done
+            if [ -z "$missing" ]; then
+              echo "both release workflows were triggered by $TAG."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::$TAG did not trigger:$missing"
+              echo "::error::A tag pushed with GITHUB_TOKEN cannot trigger workflows — check that the"
+              echo "::error::checkout used RELEASE_DEPLOY_KEY. The release would otherwise have no assets."
+              exit 1
+            fi
+            echo "waiting for:$missing"
+            sleep 15
+          done

--- a/scripts/harness/check-backlog-placement.mjs
+++ b/scripts/harness/check-backlog-placement.mjs
@@ -23,6 +23,10 @@ import path from 'node:path';
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const BACKLOG_DIR = '.agents/backlog';
 const COMPLETED_DIR = '.agents/backlog/completed';
+const SPEC_DOCS_DIR = '.agents/spec-docs';
+
+/** The leading ID token of a backlog/spec filename, phase suffix included (`SELFHOST-008-P5`). */
+const idOf = (name) => /^([A-Z]+(?:-[A-Z]+)*-\d+(?:-P\d+)*)/.exec(name)?.[1] ?? null;
 
 const TERMINAL_STATUSES = new Set(['done', 'wontfix', 'skipped', 'superseded']);
 const OPEN_STATUSES = new Set(['todo', 'in-progress']);
@@ -109,7 +113,6 @@ export async function findDuplicateIdFindings(root = WORKSPACE_ROOT) {
   // The ID includes any phase suffix (`-P3`, `-P4-P5`): a phase follow-up filed while its parent
   // is archived (e.g. open `SELFHOST-008-P5-…` alongside completed `SELFHOST-008-…`) is the
   // intended convention, NOT a duplicate — only an identical ID in both places is.
-  const idOf = (name) => /^([A-Z]+(?:-[A-Z]+)*-\d+(?:-P\d+)*)/.exec(name)?.[1] ?? null;
 
   const completedById = new Map();
   for (const name of await listMarkdown(path.join(root, COMPLETED_DIR))) {
@@ -143,7 +146,66 @@ export async function findDuplicateIdFindings(root = WORKSPACE_ROOT) {
     });
   }
 
+  // A spec-doc ID that NO backlog file claims is a retired number, and a new item must not reuse
+  // it. The pairing itself is the convention — 111 IDs currently appear in both trees because a
+  // backlog item and its spec-doc share a number by design — so this fires only when the backlog
+  // file is the FIRST to claim an ID that spec-docs already spent.
+  //
+  // Deliberately NOT a slug-equality check. Slugs drift as an item is reworded
+  // (`cjk-ime-defer-submit` vs `ime-last-character-drop` is one item, not two), and 34 of the 111
+  // pairs differ that way. A guard firing on all 34 would be noise, and a noisy guard gets
+  // suppressed — which costs more than the collisions it would catch.
+  //
+  // Observed 2026-07-26: a new `DIST-002-release-artifact-verification` was filed while
+  // `.agents/spec-docs/done/DIST-002-bun-binary-release-workflow.md` already held that number.
+  const specIds = new Set();
+  for (const dir of await listDirectories(path.join(root, SPEC_DOCS_DIR))) {
+    for (const name of await listMarkdown(path.join(root, SPEC_DOCS_DIR, dir))) {
+      const id = idOf(name);
+      if (id !== null) specIds.add(id);
+    }
+  }
+  for (const [id, name] of rootById) {
+    if (!specIds.has(id)) continue;
+    // Paired with a spec-doc of its own is the normal case; only an ID with no backlog history
+    // before this file is a reuse. `completedById` covers items already archived.
+    if (completedById.has(id)) continue;
+    const paired = await specDocMatchesBacklog(root, id, name);
+    if (paired) continue;
+    findings.push({
+      file: path.join(BACKLOG_DIR, name),
+      problem: `backlog ID ${id} is already spent in ${SPEC_DOCS_DIR}/ by a different item — pick the next free number`,
+    });
+  }
+
   return findings;
+}
+
+/** Directory names under `.agents/spec-docs/` (draft, backlog, todo, active, done, rejected). */
+async function listDirectories(dirAbsolute) {
+  try {
+    const entries = await fs.readdir(dirAbsolute, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * True when the spec-doc holding `id` is plausibly the SAME item as the backlog file — i.e. this
+ * is the intended backlog↔spec pairing rather than a reused number. Compared on the leading slug
+ * token, which survives rewording far better than the full slug.
+ */
+async function specDocMatchesBacklog(root, id, backlogName) {
+  const lead = (name) => idOf(name) && name.slice(String(idOf(name)).length + 1).split('-')[0];
+  const backlogLead = lead(backlogName);
+  for (const dir of await listDirectories(path.join(root, SPEC_DOCS_DIR))) {
+    for (const name of await listMarkdown(path.join(root, SPEC_DOCS_DIR, dir))) {
+      if (idOf(name) !== id) continue;
+      if (lead(name) === backlogLead) return true;
+    }
+  }
+  return false;
 }
 
 export async function main() {

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -124,6 +124,10 @@ const SCAN_COMMANDS = [
   },
   { name: 'no-fallback', command: ['node', 'scripts/harness/scan-no-fallback.mjs'] },
   {
+    name: 'release-verification-gate',
+    command: ['node', 'scripts/harness/scan-release-verification-gate.mjs'],
+  },
+  {
     name: 'legacy-typescript',
     command: ['node', 'scripts/harness/scan-legacy-typescript.mjs'],
   },

--- a/scripts/harness/scan-release-verification-gate.mjs
+++ b/scripts/harness/scan-release-verification-gate.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * DIST-002 — keeps the published-artifact verification gate WIRED and HONEST.
+ *
+ * The gate itself (`verify-macos-release-artifacts.sh`, run by release-desktop-app.yml) answers "can a
+ * user open what we published". This scan protects the gate from the four ways it can be silently
+ * turned back into decoration — each of which has a real precedent in this repo:
+ *
+ *   1. the script disappears or stops being executable          -> the step errors, or worse, no-ops
+ *   2. no workflow job invokes it                               -> the file exists and nothing runs it
+ *   3. it stops checking the PUBLISHED artifact                 -> verifying a locally rebuilt copy passes
+ *                                                                  while the uploaded asset stays broken
+ *   4. it is neutered with continue-on-error / `|| true`        -> `scans` exited 0 while printing SKIPPED
+ *
+ * (3) is the important one and the reason this scan exists at all. The gate is EXPECTED TO BE RED until
+ * signing lands, and the cheapest way to make a red gate green is to point it at something that passes.
+ * A locally built binary carries the same ad-hoc signature but never acquires com.apple.quarantine, so a
+ * gate aimed at `dist/bin/` would go green without a single thing about the release having improved.
+ *
+ * (4) matters because this gate is red ON PURPOSE right now, which makes it a standing temptation.
+ * Suppressing it must be a visible, reviewable edit — not a two-character one.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const GATE_SCRIPT = 'scripts/harness/verify-macos-release-artifacts.sh';
+const WORKFLOW_DIR = '.github/workflows';
+
+/** Verifying a macOS artifact needs macOS: containers share the host kernel and Apple's licence
+ *  confines macOS virtualization to Apple hardware, so there is no Linux substitute. */
+const REQUIRED_RUNNER = 'macos-latest';
+
+const findings = [];
+
+function fail(detail) {
+  findings.push(detail);
+}
+
+// ---------------------------------------------------------------------------------------------
+// 1. The gate script exists and is executable.
+// ---------------------------------------------------------------------------------------------
+const gateAbs = path.join(WORKSPACE_ROOT, GATE_SCRIPT);
+if (!existsSync(gateAbs)) {
+  fail(
+    `${GATE_SCRIPT} is missing — the published-artifact verification gate has no implementation.`,
+  );
+} else if ((statSync(gateAbs).mode & 0o111) === 0) {
+  fail(`${GATE_SCRIPT} is not executable.`);
+}
+
+// ---------------------------------------------------------------------------------------------
+// 2..4. Some release workflow runs it, on macOS, against the published artifact, unsuppressed.
+// ---------------------------------------------------------------------------------------------
+const workflowsAbs = path.join(WORKSPACE_ROOT, WORKFLOW_DIR);
+const releaseWorkflows = existsSync(workflowsAbs)
+  ? readdirSync(workflowsAbs).filter((f) => /^release-.*\.ya?ml$/.test(f))
+  : [];
+
+let invocationFound = false;
+
+for (const file of releaseWorkflows) {
+  const rel = path.join(WORKFLOW_DIR, file);
+  const text = readFileSync(path.join(workflowsAbs, file), 'utf8');
+  if (!text.includes(GATE_SCRIPT)) continue;
+  invocationFound = true;
+
+  // Locate the job containing the invocation. Jobs are the top-level keys under `jobs:` at two-space
+  // indent; the gate's job is the last one declared at or before the invocation line.
+  const lines = text.split('\n');
+  const invocationLine = lines.findIndex((l) => l.includes(GATE_SCRIPT));
+  let jobName = null;
+  let jobStart = 0;
+  for (let i = 0; i < invocationLine; i += 1) {
+    const m = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[i]);
+    if (m) {
+      jobName = m[1];
+      jobStart = i;
+    }
+  }
+  if (!jobName) {
+    fail(`${rel}: ${GATE_SCRIPT} is invoked outside any job block.`);
+    continue;
+  }
+
+  // The job body runs to the next top-level job key.
+  let jobEnd = lines.length;
+  for (let i = invocationLine + 1; i < lines.length; i += 1) {
+    if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[i])) {
+      jobEnd = i;
+      break;
+    }
+  }
+  // Comment lines are stripped before any check that asks "does this job DO x". Matching prose would
+  // let a job satisfy the scan with a comment describing a command it does not run — and would equally
+  // let a comment explaining why a local path is avoided trip the local-path clause. Only whole-line
+  // YAML comments are removed, so a `#` inside a shell expansion (`${pattern#release/}`) survives.
+  const jobBodyCode = lines
+    .slice(jobStart, jobEnd)
+    .filter((l) => !/^\s*#/.test(l))
+    .join('\n');
+  const where = `${rel}: job "${jobName}"`;
+
+  // 2b. macOS runner.
+  if (!new RegExp(`runs-on:\\s*${REQUIRED_RUNNER}`).test(jobBodyCode)) {
+    fail(
+      `${where} runs the macOS verification gate but is not \`runs-on: ${REQUIRED_RUNNER}\`. ` +
+        `codesign/spctl do not exist off macOS, so the gate could only report a skip.`,
+    );
+  }
+
+  // 3. It must verify the PUBLISHED artifact, not a local build.
+  if (!/gh release download/.test(jobBodyCode)) {
+    fail(
+      `${where} does not \`gh release download\` — the gate must verify the PUBLISHED asset. ` +
+        `A locally built copy never carries com.apple.quarantine, so verifying one passes while the ` +
+        `artifact users download stays broken.`,
+    );
+  }
+  for (const localPath of ['dist/bin', 'apps/agent-app/release', 'packages/agent-cli/dist']) {
+    if (jobBodyCode.includes(localPath)) {
+      fail(
+        `${where} references the local build path "${localPath}". The gate must read only what was ` +
+          `published to the Release.`,
+      );
+    }
+  }
+
+  // 4. Not suppressed.
+  if (/continue-on-error:\s*true/.test(jobBodyCode)) {
+    fail(`${where} sets continue-on-error: true — the verification gate would not gate anything.`);
+  }
+  const invocationText = lines[invocationLine];
+  if (/\|\|\s*(true|:)\s*$/.test(invocationText) || /\|\|\s*echo/.test(invocationText)) {
+    fail(`${where} swallows the gate's exit code (\`|| true\`-style) on the invocation line.`);
+  }
+}
+
+if (!invocationFound) {
+  fail(
+    `No workflow under ${WORKFLOW_DIR}/release-*.yml invokes ${GATE_SCRIPT}. ` +
+      `The gate exists but nothing runs it.`,
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+
+if (findings.length > 0) {
+  console.error('release-verification-gate scan: FINDINGS');
+  for (const f of findings) console.error(`  - ${f}`);
+  console.error(
+    '\nSee .agents/backlog/DIST-002-release-artifact-verification.md. This gate is red on purpose ' +
+      'until signing lands; suppressing it is not the fix.',
+  );
+  process.exit(1);
+}
+
+console.log('release-verification-gate scan: clean');

--- a/scripts/harness/verify-macos-release-artifacts.sh
+++ b/scripts/harness/verify-macos-release-artifacts.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# DIST-002 phase 1 — verify that PUBLISHED macOS release artifacts actually open on a user's Mac.
+#
+# The question this answers is NOT "did the upload succeed" (which is all the release workflows have
+# ever checked) but "is the uploaded thing usable". Those are different questions and only the second
+# is what anyone wants from a release pipeline. `v3.0.0-beta.79` shipped a macOS binary that no user
+# could open, and the release workflow reported success for four months, because it succeeded at
+# uploading.
+#
+# SCOPE IS DELIBERATELY NARROW. This asserts exactly what a user's machine does to a downloaded
+# artifact and nothing more:
+#
+#   1. the bytes are intact                 (sha256 against the published checksum manifest)
+#   2. the signature is structurally valid  (codesign --verify --strict)
+#   3. Gatekeeper accepts it                (spctl --assess, with com.apple.quarantine APPLIED)
+#   4. it actually runs                     (execute the quarantined binary)
+#
+# A gate that asserts more than Gatekeeper does goes red on things that do not matter and gets
+# disabled. So there are no assertions here about hardened-runtime flags, entitlement contents, or
+# certificate subjects — those are means, and this checks the end.
+#
+# THE QUARANTINE ATTRIBUTE IS THE WHOLE POINT. An ad-hoc signature (which is what `bun build
+# --compile` attaches, and what electron-builder produces with no certificate) is accepted by the
+# kernel, so a check run on the build runner passes. It is Gatekeeper — which only engages on a file
+# carrying com.apple.quarantine, as every browser download does — that refuses it. A check that skips
+# the attribute passes on an artifact the user cannot open. This script therefore applies the
+# attribute and VERIFIES IT STUCK before assessing; a silently-failing xattr write would make every
+# assessment below vacuous.
+#
+# EXIT 0 only if every BLOCKING check passed. DIAGNOSTIC checks are reported with their real status
+# and never affect the exit code; they are labelled as such in the summary so nobody mistakes a
+# printed line for an enforced one. `xcrun stapler validate` is DIAGNOSTIC today and becomes BLOCKING
+# in DIST-002 phase 2, when notarization exists for it to validate.
+#
+# Usage: verify-macos-release-artifacts.sh <tag> <download-dir>
+
+set -uo pipefail
+
+TAG="${1:?usage: verify-macos-release-artifacts.sh <tag> <download-dir>}"
+DOWNLOAD_DIR="${2:?usage: verify-macos-release-artifacts.sh <tag> <download-dir>}"
+
+BLOCKING_FAILURES=0
+BLOCKING_TOTAL=0
+SUMMARY_FILE="$(mktemp)"
+
+# ---------------------------------------------------------------------------------------------
+# Preconditions. A missing tool must abort, never skip: "SKIPPED" printed under a green check is
+# the exact shape this gate exists to prevent.
+# ---------------------------------------------------------------------------------------------
+for tool in codesign spctl xattr shasum hdiutil xcrun; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "FATAL: required tool '$tool' not found — cannot verify. Refusing to report success." >&2
+    exit 2
+  fi
+done
+
+if [ ! -d "$DOWNLOAD_DIR" ]; then
+  echo "FATAL: download dir '$DOWNLOAD_DIR' does not exist." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------------------------
+# Check helpers. `record` is the only place the exit code is decided, so a check cannot be
+# accidentally rendered non-enforcing by a stray `|| true` at a call site.
+# ---------------------------------------------------------------------------------------------
+
+# record <BLOCKING|DIAGNOSTIC> <PASS|FAIL> <label>
+record() {
+  local kind="$1" status="$2" label="$3"
+  printf '%-10s %-4s %s\n' "$kind" "$status" "$label" >>"$SUMMARY_FILE"
+  if [ "$kind" = "BLOCKING" ]; then
+    BLOCKING_TOTAL=$((BLOCKING_TOTAL + 1))
+    if [ "$status" = "FAIL" ]; then
+      BLOCKING_FAILURES=$((BLOCKING_FAILURES + 1))
+    fi
+  fi
+}
+
+# run_check <BLOCKING|DIAGNOSTIC> <label> <cmd...>
+run_check() {
+  local kind="$1" label="$2"
+  shift 2
+  echo
+  echo "--- [$kind] $label"
+  echo "    \$ $*"
+  if "$@" 2>&1 | sed 's/^/    /'; then
+    record "$kind" "PASS" "$label"
+  else
+    record "$kind" "FAIL" "$label"
+  fi
+}
+
+# Applies com.apple.quarantine the way a browser download does, then PROVES the attribute is
+# present. Without that proof every Gatekeeper assessment after it would be meaningless.
+apply_quarantine() {
+  local target="$1"
+  echo
+  echo "--- [BLOCKING] com.apple.quarantine applied and readable back: $(basename "$target")"
+  # Format: <flags>;<hex timestamp>;<agent name>;<uuid> — 0081 is the "downloaded, not yet assessed"
+  # flag combination a browser writes.
+  xattr -w com.apple.quarantine \
+    "0081;$(printf '%x' "$(date +%s)");Safari;$(uuidgen)" "$target" 2>&1 | sed 's/^/    /'
+  local value
+  value="$(xattr -p com.apple.quarantine "$target" 2>/dev/null)"
+  if [ -n "$value" ]; then
+    echo "    attribute present: $value"
+    record "BLOCKING" "PASS" "quarantine attribute applied: $(basename "$target")"
+    return 0
+  fi
+  echo "    attribute ABSENT after write — every Gatekeeper assessment below would be vacuous."
+  record "BLOCKING" "FAIL" "quarantine attribute applied: $(basename "$target")"
+  return 1
+}
+
+# ---------------------------------------------------------------------------------------------
+# Integrity: the published checksum manifest. An artifact with no published checksum is itself a
+# finding — a user has no way to tell a truncated download from a complete one, and neither does
+# this gate.
+# ---------------------------------------------------------------------------------------------
+verify_checksum() {
+  local file="$1" name manifest
+  name="$(basename "$file")"
+  echo
+  echo "--- [BLOCKING] published checksum matches: $name"
+
+  manifest=""
+  for candidate in "$DOWNLOAD_DIR"/SHA256SUMS*.txt; do
+    if [ -f "$candidate" ] && grep -q " $name\$" "$candidate"; then
+      manifest="$candidate"
+      break
+    fi
+  done
+
+  if [ -z "$manifest" ]; then
+    echo "    no published SHA256 manifest covers '$name' — the download is unverifiable."
+    record "BLOCKING" "FAIL" "published checksum available: $name"
+    return 1
+  fi
+
+  local expected actual
+  expected="$(grep " $name\$" "$manifest" | awk '{print $1}')"
+  actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  echo "    manifest: $(basename "$manifest")"
+  echo "    expected: $expected"
+  echo "    actual  : $actual"
+  if [ "$expected" = "$actual" ]; then
+    record "BLOCKING" "PASS" "published checksum matches: $name"
+    return 0
+  fi
+  record "BLOCKING" "FAIL" "published checksum matches: $name"
+  return 1
+}
+
+# ---------------------------------------------------------------------------------------------
+# A flat Mach-O CLI binary (robota-darwin-*). `--deep` is not used here: it is meaningless for a
+# non-bundle and deprecated by Apple.
+# ---------------------------------------------------------------------------------------------
+verify_cli_binary() {
+  local file="$1" name
+  name="$(basename "$file")"
+  echo
+  echo "==============================================================================="
+  echo "CLI binary: $name"
+  echo "==============================================================================="
+
+  if [ ! -f "$file" ]; then
+    record "BLOCKING" "FAIL" "asset present: $name"
+    return
+  fi
+  record "BLOCKING" "PASS" "asset present: $name"
+
+  verify_checksum "$file"
+  chmod +x "$file"
+
+  run_check BLOCKING "codesign --verify --strict: $name" \
+    codesign --verify --strict --verbose=2 "$file"
+  run_check DIAGNOSTIC "codesign -dv (signing identity): $name" \
+    codesign -dv --verbose=4 "$file"
+
+  apply_quarantine "$file"
+
+  run_check BLOCKING "spctl --assess --type execute: $name" \
+    spctl --assess --type execute --verbose=4 "$file"
+
+  # The user's actual gesture. A quarantined artifact that Gatekeeper rejects may still be launchable
+  # from a shell on some macOS versions, so this is asserted independently rather than inferred.
+  run_check BLOCKING "quarantined binary executes: $name" "$file" --version
+}
+
+# ---------------------------------------------------------------------------------------------
+# The desktop .dmg, and the .app inside it. `--deep` IS meaningful here: a bundle's nested code
+# (Electron framework, helper apps, and this app's bundled `robota` sidecar) is what notarization
+# rejects a bundle over.
+# ---------------------------------------------------------------------------------------------
+verify_dmg() {
+  local file="$1" name mountpoint app
+  name="$(basename "$file")"
+  echo
+  echo "==============================================================================="
+  echo "Desktop installer: $name"
+  echo "==============================================================================="
+
+  if [ ! -f "$file" ]; then
+    record "BLOCKING" "FAIL" "asset present: $name"
+    return
+  fi
+  record "BLOCKING" "PASS" "asset present: $name"
+
+  verify_checksum "$file"
+  apply_quarantine "$file"
+
+  run_check BLOCKING "spctl --assess --type install: $name" \
+    spctl --assess --type install --verbose=4 "$file"
+  run_check DIAGNOSTIC "xcrun stapler validate (BLOCKING once notarized): $name" \
+    xcrun stapler validate "$file"
+
+  mountpoint="$(mktemp -d)"
+  echo
+  echo "--- [BLOCKING] .dmg mounts: $name"
+  if hdiutil attach "$file" -nobrowse -readonly -mountpoint "$mountpoint" 2>&1 | sed 's/^/    /'; then
+    record "BLOCKING" "PASS" ".dmg mounts: $name"
+  else
+    record "BLOCKING" "FAIL" ".dmg mounts: $name"
+    return
+  fi
+
+  app="$(find "$mountpoint" -maxdepth 1 -name '*.app' -print -quit)"
+  if [ -z "$app" ]; then
+    record "BLOCKING" "FAIL" ".app found inside: $name"
+    hdiutil detach "$mountpoint" -quiet
+    return
+  fi
+  record "BLOCKING" "PASS" ".app found inside: $name"
+
+  run_check BLOCKING "codesign --verify --deep --strict: $(basename "$app")" \
+    codesign --verify --deep --strict --verbose=2 "$app"
+  run_check BLOCKING "spctl --assess --type execute: $(basename "$app")" \
+    spctl --assess --type execute --verbose=4 "$app"
+  run_check DIAGNOSTIC "codesign -dv (signing identity): $(basename "$app")" \
+    codesign -dv --verbose=4 "$app"
+
+  hdiutil detach "$mountpoint" -quiet || hdiutil detach "$mountpoint" -force -quiet
+}
+
+# ---------------------------------------------------------------------------------------------
+
+echo "DIST-002 — verifying PUBLISHED macOS artifacts of $TAG"
+echo "download dir: $DOWNLOAD_DIR"
+echo "macOS: $(sw_vers -productVersion 2>/dev/null || echo unknown)"
+ls -la "$DOWNLOAD_DIR"
+
+for asset in robota-darwin-arm64 robota-darwin-x64; do
+  verify_cli_binary "$DOWNLOAD_DIR/$asset"
+done
+
+shopt -s nullglob
+dmgs=("$DOWNLOAD_DIR"/*.dmg)
+shopt -u nullglob
+if [ ${#dmgs[@]} -eq 0 ]; then
+  echo
+  echo "--- [BLOCKING] a macOS desktop installer (.dmg) is published for $TAG"
+  echo "    no .dmg was downloaded for this tag."
+  record "BLOCKING" "FAIL" ".dmg published for $TAG"
+else
+  for dmg in "${dmgs[@]}"; do
+    verify_dmg "$dmg"
+  done
+fi
+
+echo
+echo "==============================================================================="
+echo "SUMMARY — $TAG"
+echo "==============================================================================="
+cat "$SUMMARY_FILE"
+rm -f "$SUMMARY_FILE"
+echo "-------------------------------------------------------------------------------"
+echo "BLOCKING checks: $BLOCKING_TOTAL   failures: $BLOCKING_FAILURES"
+
+if [ "$BLOCKING_TOTAL" -eq 0 ]; then
+  echo "VERDICT: FAIL — no blocking check ran at all. A gate that asserts nothing is not a gate."
+  exit 1
+fi
+
+if [ "$BLOCKING_FAILURES" -gt 0 ]; then
+  echo
+  echo "VERDICT: FAIL — a user downloading these artifacts cannot open them."
+  echo "See .agents/backlog/DIST-002-release-artifact-verification.md for the signing work this needs."
+  exit 1
+fi
+
+echo "VERDICT: PASS — published macOS artifacts open on a stock Mac."


### PR DESCRIPTION
Audit of the four release/deploy workflows, with the DIST-002 phase-1 verification gate built and **proven red on today's published artifacts**.

## The gate, and the proof it is red

`release-desktop-app.yml` gains a `macos-latest` job that downloads the **published** asset (`gh release download`, not a local rebuild), applies `com.apple.quarantine`, and asks Gatekeeper — the question a *user's* machine asks, rather than the "did the upload succeed" the pipeline has always answered.

Run [`30194492528`](https://github.com/woojubb/robota/actions/runs/30194492528), `verify_only=true` against `v3.0.0-beta.79`, runner `macos-26-arm64` — **20 blocking checks, 8 failures**, and discriminating rather than a stub (12 blocking checks pass):

```
BLOCKING   FAIL codesign --verify --strict: robota-darwin-arm64
BLOCKING   FAIL spctl --assess --type execute: robota-darwin-arm64
BLOCKING   FAIL codesign --verify --strict: robota-darwin-x64
BLOCKING   FAIL spctl --assess --type execute: robota-darwin-x64
BLOCKING   FAIL published checksum available: robota-desktop-3.0.0-beta.79-arm64.dmg
BLOCKING   FAIL spctl --assess --type install: robota-desktop-3.0.0-beta.79-arm64.dmg
BLOCKING   FAIL codesign --verify --deep --strict: Robota.app
BLOCKING   FAIL spctl --assess --type execute: Robota.app
VERDICT: FAIL — a user downloading these artifacts cannot open them.
```

Two things the runner measured that correct DIST-002's diagnosis:

1. **The CLI binaries' signature is invalid, not merely ad-hoc.** `invalid signature (code or signature have been modified)` on both, while the published SHA-256 matches — so the file is intact and the signature is broken *as built*. Signing them is not a matter of adding a certificate to what is there.
2. **A quarantined CLI binary still runs from a shell** (`robota 3.0.0-beta.79` printed on Apple Silicon) while `spctl` rejects it. That is why the symptom is "will not open" from Finder and not a broken terminal command — and it is why this check was asserted rather than inferred.

## Also fixed (upload-side holes from the same audit)

- Four of five CLI binaries were published with **no assertion of any kind**; now size- and architecture-checked against the name each advertises.
- `sha256sum robota-*` silently produced a short manifest when a target was missing.
- Uploads were never read back — a truncated or dropped asset left a green run.
- Desktop installers shipped with **no checksums at all** (per-OS manifests, so the three legs cannot clobber each other).
- Tag inputs were interpolated into `run:` bodies (shell injection).
- The tag dry run now exercises `RELEASE_DEPLOY_KEY` — [run `30194856061`](https://github.com/woojubb/robota/actions/runs/30194856061) is the **first time that credential has ever authenticated**.

## Anti-rot

`scan-release-verification-gate.mjs` (registered in `harness:scan`, 70 → 71) fails if the gate is deleted, unwired, moved off macOS, aimed at a local build, or suppressed with `continue-on-error`/`|| true`. The gate is red on purpose, which makes it a standing temptation. Falsified against 8 mutations, including a control proving it reads commands and not comments — an earlier draft was satisfied by prose in a YAML comment.

## Filed, not executed (each changes a contract)

- **INFRA-058** — `deploy.yml` has never deployed anything: `vercel/action@v1` does not exist, so the job dies at `Set up job`. 0 successful deploys ever, no Vercel secrets anywhere, `staging.robota.io` does not resolve, and `robota.io` is already served by something else. Recommendation is deletion; removing a deployment surface is the owner's call.
- **INFRA-059** — nothing checks that a workflow's `uses:` resolves (a new required check).
- **DIST-004** — the Linux artifacts are only ever run on the machine that built them.

## Blocked on the Apple certificate

No credentials or secrets were added. Signing, notarization, `hardenedRuntime` + entitlements, signing the bundled `resources/robota` sidecar, and moving the darwin CLI compile to a macOS runner all wait on the owner provisioning a Developer ID certificate.

## Verification

`pnpm harness:scan` — all 71 pass. `pnpm harness:verify-like-ci` — PASS, all 11 stages. YAML parse + `bash -n` on every `run:` block of all four workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z