### PR TITLE
ci: INFRA-058 throwaway probe — do not merge

### DIFF
--- a/.agents/backlog/INFRA-058-ci-yml-job-by-job-audit.md
+++ b/.agents/backlog/INFRA-058-ci-yml-job-by-job-audit.md
@@ -1,0 +1,223 @@
+---
+title: 'INFRA-058: ci.yml job-by-job audit — three fail-open paths closed, four fidelity gaps filed'
+status: in-progress
+created: 2026-07-26
+priority: high
+urgency: now
+area: .github/workflows/ci.yml, scripts/harness
+depends_on: []
+---
+
+## Problem
+
+`.github/workflows/ci.yml` carries 14 jobs and every required status check on `protect-develop`,
+plus three of the four on `protect-main`. In two days it produced five separate incidents in which
+a green check meant nothing (INFRA-048 `scans` exiting 0 on SKIPPED; INFRA-049/050 grafted history;
+INFRA-055 vacuous `main` contexts; INFRA-056 `verify-like-ci`; INFRA-055 the `edited` retarget).
+Each was fixed at its cause. Nobody had gone job by job asking the general question.
+
+This item is that pass, on two axes per job:
+
+- **Enforcement** — can this job actually go RED? A job not made to fail is a hypothesis.
+- **Purpose fidelity** — does what it checks match what its context NAME claims? A green check that
+  misleads the reader of the check list is the same deception as one that did nothing.
+
+Method: falsify, not reason. Each `run:` body was extracted verbatim and executed under `bash -e`
+with stubbed inputs, or its command run directly, the way INFRA-048 and INFRA-050 did their proofs.
+
+## Per-job verdict
+
+14 jobs (the brief said 13; the count is 14, confirmed by parsing `jobs:`).
+
+| #   | Job (context)                                         | Required | Purpose a reader would infer                                                                            | Fidelity                                                     | Falsified?                                                                                                                      | Verdict                               |
+| --- | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| 1   | `main-pr-source-guard` (`main PR source guard`)       | main     | A PR to `main` comes from develop/release/hotfix in THIS repo                                           | matches                                                      | **yes** — 6 cases run under `bash -e`: develop✓, feature✗, fork-named-develop✗, release/*✓, empty head_ref✗                     | PASS                                  |
+| 2   | `promotion-ancestry` (`promotion ancestry`)           | main     | The promotion carries `main`'s ancestry (INFRA-051 A1/A3)                                               | matches                                                      | **yes** — ran the scan with `GITHUB_BASE_REF=main` + a non-promotion head; exit 1 on A1                                         | PASS                                  |
+| 3   | `changes`                                             | **no**   | Classifies the PR code vs docs-only                                                                     | matches                                                      | reasoned — the classifier always exits 0 by design; the JOB's failure modes are infra-level                                     | PASS, but see D3                      |
+| 4   | `build`                                               | develop  | The monorepo builds                                                                                     | **checks the wrong thing**                                   | **yes** — see D4                                                                                                                | DEFECT (filed)                        |
+| 5   | `quality`                                             | develop  | The affected scopes' build/test/lint/typecheck pass                                                     | **checks the wrong thing** on one PR shape                   | **yes** — see D4                                                                                                                | DEFECT (filed)                        |
+| 6   | `scans`                                               | develop  | The harness suite + full dist-independent scan suite pass                                               | matches                                                      | **yes** — run in verification, 70 scans + 1153 harness tests                                                                    | PASS, but see D6                      |
+| 7   | `security-audit` (`security audit`)                   | develop  | _Reads as:_ the PR was audited for security. _Is:_ an OSV dependency scan, only when a manifest changed | **over-claims in the name**                                  | **yes** — step extracted; unresolvable base ref correctly forces `changed=true`; regex verified on nested/lock/code-only inputs | ENFORCEMENT PASS, fidelity filed (D5) |
+| 8   | `release-grade-verify` (`release-grade verification`) | main     | The FULL build/scan/test/typecheck/lint sweep                                                           | **over-claims** — `pnpm test` is `-r --if-present`           | partly — measured the 5 silently-skipped workspaces                                                                             | ENFORCEMENT PASS, fidelity filed (D7) |
+| 9   | `commitlint`                                          | develop  | Every commit this PR authored is conventional                                                           | matches                                                      | **yes** — exited **0** on an unresolvable range                                                                                 | **DEFECT — FIXED**                    |
+| 10  | `examples-typecheck`                                  | develop  | `examples/` typecheck against locally-built packages                                                    | matches                                                      | reasoned + graph-falsified (D3)                                                                                                 | PASS after D3 fix                     |
+| 11  | `windows-shell`                                       | develop  | Cross-platform shell execution verified on real Windows                                                 | **step 1 over-reaches; both steps could pass on zero tests** | **yes** — a rename made it print `No test files found, exiting with code 0`                                                     | **DEFECT — FIXED**, plus D2 filed     |
+| 12  | `tui-e2e`                                             | develop  | TUI PTY e2e against the built binary                                                                    | matches                                                      | reasoned + graph-falsified (D3)                                                                                                 | PASS after D3 fix                     |
+| 13  | `regression-red-proof (advisory)`                     | no       | Advisory — name says so                                                                                 | matches (honest name)                                        | reasoned                                                                                                                        | PASS                                  |
+| 14  | `patch-coverage (advisory)`                           | no       | Advisory — name says so                                                                                 | matches                                                      | reasoned                                                                                                                        | PASS, but see D8                      |
+
+**Falsified: 6 of 14** (1, 2, 4, 5, 7, 9, 11 — seven step-level proofs across six jobs).
+**Reasoned only: 8** — jobs 3, 6, 10, 12, 13, 14 plus the enforcement half of 7 and 8. Every
+"reasoned" row is a hypothesis, marked as such.
+
+## Defects
+
+### D1 — `windows-shell` reported green on ZERO tests — **FIXED**
+
+Both steps selected tests by name through the package `test` script, which is
+`vitest run --passWithNoTests`. Renaming `platform-shell.test.ts` to `shell-resolver.test.ts`:
+
+```
+ RUN  v3.2.6 .../packages/agent-core
+No test files found, exiting with code 0
+filter: platform-shell
+$ EXIT_CODE_WITH_ZERO_TESTS=0
+```
+
+The flag cannot be overridden at the call site — vitest's cac rejects the repeated flag
+(`Expected a single value for option "--passWithNoTests", received [true, false]`). Fixed by
+bypassing the script: `pnpm --filter <pkg> exec vitest run <pattern>`, which resolves the same
+per-package config and exits 1 on zero matches (verified: 8 and 6 tests still collected; exit 1 on
+a pattern matching nothing). Guarded by `test-selection-tolerance`.
+
+### D2 — `windows-shell` step 1 over-reaches — **FILED, not changed**
+
+`packages/agent-core/src/utils/platform-shell.test.ts` is a pure-function test:
+`resolvePlatformShell(env, platform)` takes the platform as an ARGUMENT. It never reads
+`process.platform` and spawns nothing, so its verdict on `windows-latest` is identical to its
+verdict on Linux — proven by running it on Linux (8 passed). The job's stated reason ("these tests
+exercise the win32 path that the macOS/Linux jobs cannot") is false for this half; it pays for the
+matrix's most expensive runner to re-run a pure function `quality` already covers. Step 2
+(`agent-tools`) DOES spawn a real shell and is genuinely win32-only — leave it.
+
+Not changed here: removing a step from a required check changes what gates a merge.
+
+### D3 — a red `changes` turned three REQUIRED checks into `skipped` — **FIXED**
+
+`changes` is not a required check; `tui-e2e`, `examples-typecheck` and `windows-shell` are, and all
+three `needs: changes`. GitHub reports a dependent as `skipped` when its dependency FAILS, and
+branch protection accepts a skipped required check (INFRA-050) — the #1424 shape exactly.
+
+INFRA-050 removed one CAUSE (the grafted fetch). The MECHANISM was untouched and reachable from
+every other way the job can fail: checkout failure, runner OOM, a syntax error in the classifier, a
+Node crash. `classify-changed-paths.mjs` cannot help — it always exits 0, so it can only classify
+fail-safe, never protect against the job itself failing.
+
+Fixed at all five dependents: `!cancelled()` disables GitHub's implicit `success()` over `needs`,
+and a non-success `changes` is treated as CODE — the classifier's own rule. A cancelled run still
+skips (superseded, not unverified). Guarded by `required-check-needs`.
+
+### D4 — `build` and `quality` both green having done nothing, on a build-tooling PR — **FILED**
+
+A one-line change to `scripts/build-types-ordered.mjs` — the second half of root `pnpm build` —
+resolves to `scopes: []`:
+
+```
+$ pnpm harness:plan -- --base-ref origin/develop
+Changed files: 1
+Scopes:
+- none
+Repository checks: repository-review
+$ node <the build job's Detect-build-requirement step>  →  required=false
+$ pnpm harness:verify -- --base-ref origin/develop --skip-build --skip-record-check
+No package or app scope detected from changed files.
+$ echo $?  →  0
+```
+
+So `build` never runs `pnpm build`; `quality` verifies zero scopes, skips the binary e2e (gated on
+`package_dist_required`) and runs `build-contracts` against no restored dist. Two REQUIRED checks,
+both vacuous, on a PR that changes the build tooling itself.
+
+Real build coverage does exist — `tui-e2e` and `examples-typecheck` both run `pnpm build:deps`, and
+`changes` classifies this file as CODE — so a broken build IS caught. It is caught by jobs named
+`tui-e2e` and `examples-typecheck`. That is the fidelity defect: `build`'s guarantee is delivered
+elsewhere, and its own green means only "no scope asked for dist".
+
+Not fixed here: the candidate fixes (require build whenever `changes.code == 'true'`; treat
+build-relevant unmapped files as requiring dist) each change which PRs run a multi-minute build,
+i.e. what gates a merge and what CI costs. Owner call.
+
+### D5 — `security audit` claims more than it checks — **FILED**
+
+The context name reads as "this PR was audited for security". It is an OSV **dependency** scan over
+`pnpm-lock.yaml`, gated on a manifest/lockfile diff. A PR adding a command injection, a leaked
+credential or a permissive CORS policy gets a green `security audit`. The narrow gating is itself
+sound and complemented by `security-scheduled.yml` (INFRA-044 part 2) — the defect is the NAME.
+Correcting it renames a required context: a ruleset change.
+
+### D6 — `run-all-scans` renders SKIPPED as ✓ — **FILED**
+
+A scan that prints SKIPPED and exits 0 is counted as a pass in the `N of M scans passed` line.
+`scan-promotion-ancestry.mjs` does exactly this on every develop PR (correctly — it is not a
+promotion), but the aggregation cannot distinguish "checked and clean" from "did not run". This is
+INFRA-048's defect surviving at the suite level. Out of scope here: it touches all 72 scans.
+
+### D7 — `release-grade verification` silently skips 5 workspaces — **FILED**
+
+`harness:verify:release` runs `pnpm test` = `pnpm run -r --if-present test`. Five workspaces declare
+no `test` script and are walked past silently: `packages/agent-cli-web`, `apps/blog`, `apps/docs`,
+`apps/starter-nextjs`, `apps/www`. `check-test-coverage-scripts.mjs` explicitly exempts them
+(`if (typeof testScript !== 'string') return false`), so nothing guards the absence. The manifest
+calls this context "the FULL test/typecheck/lint sweep".
+
+### D8 — `check-patch-coverage --detect` fails OPEN — **FILED**
+
+When the base ref cannot be resolved, `--detect` reports `affected=false`, so the advisory job
+prints its skip echo and computes nothing. Advisory, so low stakes, but it is the same
+"undeterminable renders as clean" shape.
+
+### D9 — `ci.yml` declares no `permissions:` — **FILED, not changed**
+
+No job restricts the `GITHUB_TOKEN`; every job inherits the repository default. ci.yml makes no API
+calls, so this is latent over-permission rather than a broken check. A top-level
+`permissions: {contents: read, actions: read}` is the fix, but it cannot be falsified locally and a
+wrong guess reddens every PR — so it is filed rather than guessed.
+
+### D10 — noted, not touched: `claude-code-review.yml` is deadlocked
+
+Independently surfaced: `scan-review-workflow-parity` exempts only base-`main` PRs while INFRA-051's
+`promotion ancestry` forbids a base-`main` PR from carrying new work, so the file cannot currently
+be modified while keeping CI green. Owner-owned.
+
+## Guards added
+
+Both proven RED against the LIVE defect (fix reverted in place, scan re-run) and GREEN after, and
+registered in `pnpm harness:scan`.
+
+- `required-check-needs` — for every required context's job and every job in its `needs:`, either
+  the dependency is itself required on that branch or the dependent's `if:` is fail-safe (a
+  job-status function AND `needs.<dep>.result`). Reverting D3 reports exactly the three contexts
+  #1424 merged on. Complements `scan-main-required-checks`'s R6, which covers `main` only and only
+  an `if:`-excluded dependency.
+- `test-selection-tolerance` — a workflow step that NARROWS a test run must not route it through a
+  script containing `--passWithNoTests`. Reverting D1 reports both windows-shell steps.
+
+Both fail loudly on ZERO edges / ZERO invocations examined, so a broken parser cannot report a
+clean pass over nothing. Each rule's two halves are unit-tested separately, because
+`scan-main-required-checks` originally shipped green on three variants of its own defect.
+
+## Where the mechanical ceiling is
+
+This audit is not, and cannot be, complete. What no pattern can reach:
+
+1. **A step whose logic is subtly wrong.** Every guard here is structural. A classifier with an
+   off-by-one glob, a scan whose regex stopped matching, a test that asserts a weaker property than
+   its name — all pass every structural check. D2 (a pure-function test standing in for a
+   platform-specific one) was found by READING the test, not by any scan, and no scan would find
+   the next one.
+2. **Unchecked command substitutions generally.** D9's class (`$(...)` in a word-list swallowing a
+   failure under `bash -e`) is a shellcheck problem (SC2312). Adding shellcheck to the scan suite
+   means a network-fetched binary in the gate; the commitlint fix is therefore a one-off, and a
+   sibling instance elsewhere would not be caught.
+3. **Whether a scan's SUBJECT is still real.** `scan-ci-base-history` has an anti-rot check for its
+   invocation list; most scans do not. A scan guarding a pattern the codebase no longer uses passes
+   forever.
+4. **The 8 jobs marked "reasoned only"** above. They are hypotheses. In particular `scans` and
+   `tui-e2e` were run, not falsified — I did not construct a broken repository and confirm they
+   redden.
+5. **Anything requiring the live GitHub API.** The `skipped`-is-accepted premise is taken from this
+   repo's own prior measurements (#1424, #1427, #1442), not re-measured here.
+
+## Test Plan
+
+- `pnpm harness:scan` — 70/70 with `--skip dist --skip build-contracts` (the CI form); the local
+  full run's only failure is `dist`, which needs a built tree and is skipped in CI by design.
+- `pnpm harness:test` — 90 files / 1153 tests.
+- `pnpm harness:verify-like-ci`.
+- Each new guard run RED against the reverted defect and GREEN against the fix.
+- YAML parse of `ci.yml` (`yaml.parse`, 14 jobs enumerated) and `bash -n` on every touched `run:`.
+
+## User Execution Test Scenarios
+
+Not applicable — CI workflow and harness-guard changes deliver no runnable user-facing surface. The
+enforcement evidence is the red/green proofs recorded above and the checks on this item's own PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,12 @@ jobs:
           # required matrix would trade a real risk for a cosmetic one — a flake here makes
           # tui-e2e / examples-typecheck / windows-shell report `skipping`, which branch protection
           # accepts. review-gate.yml has run `node scripts/harness/*.mjs` bare since #1434.
-          node scripts/harness/classify-changed-paths.mjs --base-ref "origin/${BASE_REF}"
+          # INFRA-058 THROWAWAY PROBE — do not merge. Simulates the `changes` job failing for a
+          # reason OUTSIDE the classifier (checkout failure / runner OOM / a syntax error in the
+          # script), which is the only case the fix is for. The step fails BEFORE writing
+          # `code=` to $GITHUB_OUTPUT, so the dependents see result=failure and outputs.code=''.
+          echo "INFRA-058 probe: simulating a changes-job failure"
+          exit 1
 
   # INFRA-055: `build` / `quality` / `scans` / `security audit` are DEVELOP-side gates. They used to run on a
   # `main` PR too, as a "Skip duplicate …" echo with every real step gated on `base_ref != 'main'` — a 3–6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,17 @@ jobs:
   # tui-e2e / examples-typecheck / windows-shell ARE required and DO skip on a docs-only PR; that is deliberate
   # and predates this file — a skipped required check is accepted, which is exactly why the `changes` classifier
   # is fail-safe (every undeterminable case classifies as CODE).
+  #
+  # INFRA-058: the classifier being fail-safe was only HALF the property. `classify-changed-paths.mjs`
+  # always exits 0 (the verdict is its output, not its status), so it can only classify fail-safe —
+  # it cannot protect against this JOB going red for a reason outside the classifier: a checkout
+  # failure, a runner OOM, a syntax error introduced into the script, a Node crash. When that
+  # happens GitHub reports the four dependents as `skipped`, not `failed`, and branch protection
+  # ACCEPTS a skipped required check (INFRA-050, measured on #1424 with three required contexts
+  # reporting `skipping`). `changes` is not itself required, so nothing red would remain on the PR.
+  # The fetch-depth fix removed one CAUSE; the four dependents' `if:` now removes the MECHANISM —
+  # each treats a non-success `changes` as CODE and runs anyway. `scan-required-check-needs.mjs`
+  # keeps that shape from being edited back out.
   changes:
     name: changes
     runs-on: ubuntu-latest
@@ -554,10 +565,26 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # INFRA-058: resolve the range into a variable and CHECK it, rather than expanding
+          # `$(git rev-list …)` straight into the `for` word-list. GitHub runs this block as
+          # `bash -e`, and `set -e` does NOT fire on a command substitution used as a word-list: a
+          # failing `git rev-list` produced an EMPTY list, the loop body never ran, and `exit
+          # "$status"` returned 0. MEASURED by extracting this step verbatim and running it with an
+          # unresolvable head sha: two `fatal: Invalid revision range` lines, `Linting  commit(s)`,
+          # and exit 0 — this REQUIRED check reporting green having linted nothing. "Could not
+          # determine" is not "checked and clean"; both now fail closed.
           range="origin/${BASE_REF}..${HEAD_SHA}"
-          echo "Linting $(git rev-list --count --first-parent "$range") commit(s) authored by this PR ($range, first-parent)."
+          if ! commits="$(git rev-list --first-parent "$range")"; then
+            echo "::error::commitlint: could not resolve the commit range '$range'. origin/${BASE_REF} or ${HEAD_SHA} is not present in this checkout (the job checks out with fetch-depth: 0, so this means the head sha was force-pushed away or the base ref was never fetched). Failing rather than linting zero commits."
+            exit 1
+          fi
+          if [ -z "$commits" ]; then
+            echo "::error::commitlint: the range '$range' contains no commits. A PR always authors at least one, so an empty range means the range is degenerate, not that the PR is clean. Failing rather than linting zero commits."
+            exit 1
+          fi
+          echo "Linting $(printf '%s\n' "$commits" | wc -l) commit(s) authored by this PR ($range, first-parent)."
           status=0
-          for sha in $(git rev-list --first-parent "$range"); do
+          for sha in $commits; do
             echo "── $(git log -1 --format='%h %s' "$sha")"
             git log -1 --format=%B "$sha" | pnpm exec commitlint --verbose || status=1
           done
@@ -567,7 +594,12 @@ jobs:
     name: examples-typecheck
     runs-on: ubuntu-latest
     needs: changes
-    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+    # INFRA-058 fail-safe: `!cancelled()` disables GitHub's implicit `success()` over `needs`, so a
+    # `changes` job that FAILED (as opposed to classifying docs-only) no longer turns this required
+    # check into a `skipped` conclusion that branch protection accepts — it runs, matching the
+    # classifier's own rule that every undeterminable case is CODE. A cancelled run still skips,
+    # because a cancelled run is superseded, not unverified.
+    if: ${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
 
     steps:
       - uses: actions/checkout@v7
@@ -603,7 +635,12 @@ jobs:
     name: windows-shell
     runs-on: windows-latest
     needs: changes
-    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+    # INFRA-058 fail-safe: `!cancelled()` disables GitHub's implicit `success()` over `needs`, so a
+    # `changes` job that FAILED (as opposed to classifying docs-only) no longer turns this required
+    # check into a `skipped` conclusion that branch protection accepts — it runs, matching the
+    # classifier's own rule that every undeterminable case is CODE. A cancelled run still skips,
+    # because a cancelled run is superseded, not unverified.
+    if: ${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
 
     steps:
       - uses: actions/checkout@v7
@@ -629,11 +666,21 @@ jobs:
         # minimal job resolves workspace deps from built dist, so agent-process must be built too.
         run: pnpm --filter @robota-sdk/agent-core --filter @robota-sdk/agent-process build
 
+      # INFRA-058: `pnpm exec vitest`, NOT `pnpm ... test -- --run <pattern>`. Both packages' `test`
+      # script is `vitest run --passWithNoTests`, and a name-FILTERED run through it reports success on
+      # zero matches — MEASURED locally: renaming `platform-shell.test.ts` to `shell-resolver.test.ts`
+      # made the identical command print `No test files found, exiting with code 0` and exit 0. An
+      # ordinary rename would therefore have left this REQUIRED check green while executing nothing,
+      # on the only runner in the matrix that can exercise win32 at all. The flag cannot be overridden
+      # on the command line (vitest's cac rejects a repeated `--passWithNoTests`: "Expected a single
+      # value ... received [true, false]"), so the script indirection is bypassed instead. Invoking
+      # vitest directly resolves the same per-package config and exits 1 when the filter matches
+      # nothing — the whole point of selecting tests by name here.
       - name: Verify the cross-platform shell resolver on Windows
-        run: pnpm --filter @robota-sdk/agent-core test -- --run platform-shell
+        run: pnpm --filter @robota-sdk/agent-core exec vitest run platform-shell
 
       - name: Verify the Shell tool actually spawns PowerShell on Windows
-        run: pnpm --filter @robota-sdk/agent-tools test -- --run shell-tool
+        run: pnpm --filter @robota-sdk/agent-tools exec vitest run shell-tool
 
   # TEST-010: run the TUI PTY E2E suite (`*.ptytest.ts`) against the BUILT robota binary on every PR,
   # so the live-TUI behaviours — the SCREEN-013 Ctrl+B drill-in entry point and the existing
@@ -642,7 +689,12 @@ jobs:
     name: tui-e2e
     runs-on: ubuntu-latest
     needs: changes
-    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+    # INFRA-058 fail-safe: `!cancelled()` disables GitHub's implicit `success()` over `needs`, so a
+    # `changes` job that FAILED (as opposed to classifying docs-only) no longer turns this required
+    # check into a `skipped` conclusion that branch protection accepts — it runs, matching the
+    # classifier's own rule that every undeterminable case is CODE. A cancelled run still skips,
+    # because a cancelled run is superseded, not unverified.
+    if: ${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
 
     steps:
       - uses: actions/checkout@v7
@@ -678,7 +730,12 @@ jobs:
     name: regression-red-proof (advisory)
     runs-on: ubuntu-latest
     needs: changes
-    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+    # INFRA-058 fail-safe: `!cancelled()` disables GitHub's implicit `success()` over `needs`, so a
+    # `changes` job that FAILED (as opposed to classifying docs-only) no longer turns this required
+    # check into a `skipped` conclusion that branch protection accepts — it runs, matching the
+    # classifier's own rule that every undeterminable case is CODE. A cancelled run still skips,
+    # because a cancelled run is superseded, not unverified.
+    if: ${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
 
     steps:
       # INFRA-050: full history, no `--depth` fetch — check-regression-red-proof.mjs resolves the
@@ -718,7 +775,12 @@ jobs:
     name: patch-coverage (advisory)
     runs-on: ubuntu-latest
     needs: changes
-    if: github.base_ref != 'main' && needs.changes.outputs.code == 'true'
+    # INFRA-058 fail-safe: `!cancelled()` disables GitHub's implicit `success()` over `needs`, so a
+    # `changes` job that FAILED (as opposed to classifying docs-only) no longer turns this required
+    # check into a `skipped` conclusion that branch protection accepts — it runs, matching the
+    # classifier's own rule that every undeterminable case is CODE. A cancelled run still skips,
+    # because a cancelled run is superseded, not unverified.
+    if: ${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
 
     steps:
       # INFRA-050: full history, no `--depth` fetch — check-patch-coverage.mjs takes its changed

--- a/scripts/harness/__tests__/scan-required-check-needs.test.mjs
+++ b/scripts/harness/__tests__/scan-required-check-needs.test.mjs
@@ -26,7 +26,10 @@ describe('isFailSafeFor', () => {
 
   it('rejects the PRE-FIX shape that let #1424 merge on three `skipping` required checks', () => {
     expect(
-      isFailSafeFor("github.base_ref != 'main' && needs.changes.outputs.code == 'true'", dependency),
+      isFailSafeFor(
+        "github.base_ref != 'main' && needs.changes.outputs.code == 'true'",
+        dependency,
+      ),
     ).toBe(false);
   });
 
@@ -40,9 +43,9 @@ describe('isFailSafeFor', () => {
     // Half-fix #2: the job now runs when `changes` fails, but the condition still reads only
     // `outputs.code`, which is EMPTY on a failed job — so it evaluates false and the job skips
     // anyway. Green scan, unchanged bypass.
-    expect(
-      isFailSafeFor("!cancelled() && needs.changes.outputs.code == 'true'", dependency),
-    ).toBe(false);
+    expect(isFailSafeFor("!cancelled() && needs.changes.outputs.code == 'true'", dependency)).toBe(
+      false,
+    );
   });
 
   it('rejects an absent condition', () => {
@@ -70,7 +73,7 @@ describe('isFailSafeFor', () => {
 
 describe('jobContextName', () => {
   it('prefers the declared `name:` over the job id, because branch protection matches the name', () => {
-    expect(jobContextName('security-audit', "    name: security audit\n    steps:\n")).toBe(
+    expect(jobContextName('security-audit', '    name: security audit\n    steps:\n')).toBe(
       'security audit',
     );
   });
@@ -80,7 +83,7 @@ describe('jobContextName', () => {
   });
 
   it('strips quotes so a quoted name still matches the declared context', () => {
-    expect(jobContextName('x', '    name: \'patch-coverage (advisory)\'\n')).toBe(
+    expect(jobContextName('x', "    name: 'patch-coverage (advisory)'\n")).toBe(
       'patch-coverage (advisory)',
     );
   });

--- a/scripts/harness/__tests__/scan-required-check-needs.test.mjs
+++ b/scripts/harness/__tests__/scan-required-check-needs.test.mjs
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isFailSafeFor,
+  jobContextName,
+  JOB_STATUS_FUNCTION,
+} from '../scan-required-check-needs.mjs';
+
+/**
+ * `scan-main-required-checks` originally shipped GREEN on three variants of the very defect it
+ * was written for, because its rule was a blacklist of the one spelling its author had seen.
+ * These cases exist so this scan does not repeat that: each HALF of the fail-safe rule is tested
+ * on its own, because either half alone is a plausible "fix" that leaves the bypass wide open.
+ */
+describe('isFailSafeFor', () => {
+  const dependency = 'changes';
+
+  it('accepts the shipped fail-safe shape', () => {
+    expect(
+      isFailSafeFor(
+        "${{ !cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}",
+        dependency,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects the PRE-FIX shape that let #1424 merge on three `skipping` required checks', () => {
+    expect(
+      isFailSafeFor("github.base_ref != 'main' && needs.changes.outputs.code == 'true'", dependency),
+    ).toBe(false);
+  });
+
+  it('rejects `needs.<dep>.result` WITHOUT a job-status function', () => {
+    // Half-fix #1: GitHub skips the job before this expression is ever evaluated, so naming the
+    // dependency's result here changes nothing at all.
+    expect(isFailSafeFor("needs.changes.result != 'success'", dependency)).toBe(false);
+  });
+
+  it('rejects a job-status function WITHOUT `needs.<dep>.result`', () => {
+    // Half-fix #2: the job now runs when `changes` fails, but the condition still reads only
+    // `outputs.code`, which is EMPTY on a failed job — so it evaluates false and the job skips
+    // anyway. Green scan, unchanged bypass.
+    expect(
+      isFailSafeFor("!cancelled() && needs.changes.outputs.code == 'true'", dependency),
+    ).toBe(false);
+  });
+
+  it('rejects an absent condition', () => {
+    expect(isFailSafeFor(undefined, dependency)).toBe(false);
+    expect(isFailSafeFor('', dependency)).toBe(false);
+  });
+
+  it('does not accept a fail-safe written for a DIFFERENT dependency', () => {
+    expect(isFailSafeFor("!cancelled() && needs.build.result != 'success'", dependency)).toBe(
+      false,
+    );
+  });
+
+  it('accepts `always()` and `failure()` as job-status functions', () => {
+    expect(isFailSafeFor("always() && needs.changes.result != 'skipped'", dependency)).toBe(true);
+    expect(isFailSafeFor("failure() || needs.changes.result == 'success'", dependency)).toBe(true);
+  });
+
+  it('does not mistake a bare word for a job-status function call', () => {
+    expect(JOB_STATUS_FUNCTION.test('alwaysRun && needs.changes.result')).toBe(false);
+    expect(JOB_STATUS_FUNCTION.test('always()')).toBe(true);
+    expect(JOB_STATUS_FUNCTION.test('!cancelled( )')).toBe(true);
+  });
+});
+
+describe('jobContextName', () => {
+  it('prefers the declared `name:` over the job id, because branch protection matches the name', () => {
+    expect(jobContextName('security-audit', "    name: security audit\n    steps:\n")).toBe(
+      'security audit',
+    );
+  });
+
+  it('falls back to the job id when no name is declared', () => {
+    expect(jobContextName('changes', '    runs-on: ubuntu-latest\n')).toBe('changes');
+  });
+
+  it('strips quotes so a quoted name still matches the declared context', () => {
+    expect(jobContextName('x', '    name: \'patch-coverage (advisory)\'\n')).toBe(
+      'patch-coverage (advisory)',
+    );
+  });
+});

--- a/scripts/harness/__tests__/scan-test-selection-tolerance.test.mjs
+++ b/scripts/harness/__tests__/scan-test-selection-tolerance.test.mjs
@@ -104,14 +104,14 @@ describe('stepRun', () => {
   });
 
   it('reads a block run body', () => {
-    expect(stepRun('      - name: x\n        run: |\n          line one\n          line two\n')).toBe(
-      '\nline one\nline two',
-    );
+    expect(
+      stepRun('      - name: x\n        run: |\n          line one\n          line two\n'),
+    ).toBe('\nline one\nline two');
   });
 
   it('returns undefined for a pure `uses:` step', () => {
-    expect(stepRun('      - uses: actions/checkout@v7\n        with:\n          fetch-depth: 0\n')).toBe(
-      undefined,
-    );
+    expect(
+      stepRun('      - uses: actions/checkout@v7\n        with:\n          fetch-depth: 0\n'),
+    ).toBe(undefined);
   });
 });

--- a/scripts/harness/__tests__/scan-test-selection-tolerance.test.mjs
+++ b/scripts/harness/__tests__/scan-test-selection-tolerance.test.mjs
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  narrowsSelection,
+  parseInvocations,
+  stepRun,
+  TEST_SCRIPT,
+  ZERO_MATCH_TOLERANT,
+} from '../scan-test-selection-tolerance.mjs';
+
+describe('narrowsSelection', () => {
+  it('treats the measured windows-shell shape as narrowing', () => {
+    // The exact args behind `No test files found, exiting with code 0`.
+    expect(narrowsSelection(' -- --run platform-shell')).toBe(true);
+    expect(narrowsSelection(' -- --run shell-tool')).toBe(true);
+  });
+
+  it('treats a bare trailing pattern as narrowing', () => {
+    expect(narrowsSelection(' platform-shell')).toBe(true);
+  });
+
+  it('does NOT treat an unnarrowed whole-package run as narrowing', () => {
+    // `--passWithNoTests` on a whole-package run is a package policy about a package that may
+    // legitimately have no tests yet — a different question, deliberately out of scope.
+    expect(narrowsSelection('')).toBe(false);
+    expect(narrowsSelection('   ')).toBe(false);
+  });
+
+  it('does NOT treat a whole-PROJECT selection as narrowing', () => {
+    // `test:bin` / `test:pty` select a project whose include globs are the assertion.
+    expect(narrowsSelection(' --config vitest.bin.config.ts')).toBe(false);
+    expect(narrowsSelection(' --project e2e')).toBe(false);
+  });
+
+  it('does not read `--run` itself as a selector — it is a mode, not a pattern', () => {
+    expect(narrowsSelection(' -- --run')).toBe(false);
+  });
+});
+
+describe('parseInvocations', () => {
+  it('extracts the package, script and trailing args from the pre-fix windows-shell step', () => {
+    expect(
+      parseInvocations('pnpm --filter @robota-sdk/agent-core test -- --run platform-shell'),
+    ).toEqual([
+      {
+        packages: ['@robota-sdk/agent-core'],
+        script: 'test',
+        rest: ' -- --run platform-shell',
+      },
+    ]);
+  });
+
+  it('captures every package of a multi-filter invocation', () => {
+    const [invocation] = parseInvocations(
+      'pnpm --filter @robota-sdk/agent-core --filter @robota-sdk/agent-process build',
+    );
+    expect(invocation.packages).toEqual(['@robota-sdk/agent-core', '@robota-sdk/agent-process']);
+    expect(invocation.script).toBe('build');
+  });
+
+  it('reads the `run` spelling as well as the bare one', () => {
+    const [invocation] = parseInvocations('pnpm --filter @robota-sdk/agent-web run test:ci');
+    expect(invocation.script).toBe('test:ci');
+  });
+
+  it('recognises the FIXED shape as an `exec` invocation, not a test script', () => {
+    // The fix routes around the script, so `exec` is what the script slot holds — and `exec` is
+    // not a test script, which is exactly why the fixed workflow is green.
+    const [invocation] = parseInvocations(
+      'pnpm --filter @robota-sdk/agent-core exec vitest run platform-shell',
+    );
+    expect(invocation.script).toBe('exec');
+    expect(TEST_SCRIPT.test(invocation.script)).toBe(false);
+  });
+});
+
+describe('TEST_SCRIPT', () => {
+  it('matches test and its variants, and nothing that merely starts with those letters', () => {
+    expect(TEST_SCRIPT.test('test')).toBe(true);
+    expect(TEST_SCRIPT.test('test:bin')).toBe(true);
+    expect(TEST_SCRIPT.test('test:coverage')).toBe(true);
+    expect(TEST_SCRIPT.test('testing-utils')).toBe(false);
+    expect(TEST_SCRIPT.test('build')).toBe(false);
+  });
+});
+
+describe('ZERO_MATCH_TOLERANT', () => {
+  it('matches the flag the measured defect inherited through the script', () => {
+    expect(ZERO_MATCH_TOLERANT.test('vitest run --passWithNoTests')).toBe(true);
+    expect(ZERO_MATCH_TOLERANT.test('jest --passWithNoTests')).toBe(true);
+  });
+
+  it('does not match a runner that fails on zero matches', () => {
+    expect(ZERO_MATCH_TOLERANT.test('vitest run --config vitest.bin.config.ts')).toBe(false);
+    expect(ZERO_MATCH_TOLERANT.test('vitest run')).toBe(false);
+  });
+});
+
+describe('stepRun', () => {
+  it('reads a single-line run body', () => {
+    expect(stepRun('      - name: x\n        run: pnpm --filter a test\n')).toBe(
+      'pnpm --filter a test',
+    );
+  });
+
+  it('reads a block run body', () => {
+    expect(stepRun('      - name: x\n        run: |\n          line one\n          line two\n')).toBe(
+      '\nline one\nline two',
+    );
+  });
+
+  it('returns undefined for a pure `uses:` step', () => {
+    expect(stepRun('      - uses: actions/checkout@v7\n        with:\n          fetch-depth: 0\n')).toBe(
+      undefined,
+    );
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -122,6 +122,14 @@ const SCAN_COMMANDS = [
     name: 'main-required-checks',
     command: ['node', 'scripts/harness/scan-main-required-checks.mjs'],
   },
+  {
+    name: 'required-check-needs',
+    command: ['node', 'scripts/harness/scan-required-check-needs.mjs'],
+  },
+  {
+    name: 'test-selection-tolerance',
+    command: ['node', 'scripts/harness/scan-test-selection-tolerance.mjs'],
+  },
   { name: 'no-fallback', command: ['node', 'scripts/harness/scan-no-fallback.mjs'] },
   {
     name: 'legacy-typescript',

--- a/scripts/harness/scan-required-check-needs.mjs
+++ b/scripts/harness/scan-required-check-needs.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+/**
+ * Required-check dependency-edge guard (INFRA-058).
+ *
+ * A required status check reports `skipped` — not `failure` — when a job it `needs:` fails.
+ * Branch protection ACCEPTS a skipped required check (INFRA-050). So a required job whose
+ * dependency is NOT itself required has a silent bypass built into the job graph: the
+ * dependency goes red for any reason at all, the required check publishes `skipping`, nothing
+ * red remains on the PR, and it merges having never run the check.
+ *
+ * That is not a hypothesis. It is what #1424 did: `changes` errored on a grafted history and
+ * three required contexts (`tui-e2e`, `examples-typecheck`, `windows-shell`) reported `skipping`
+ * while the PR merged. INFRA-050 fixed the CAUSE of that particular red — the depth-limited
+ * fetch. It did not touch the MECHANISM, which is reachable from any other way `changes` can
+ * fail: a checkout failure, a runner OOM, a syntax error in the classifier, a Node crash.
+ *
+ * `scan-main-required-checks.mjs`'s R6 asserts the adjacent property on `main` only, and only
+ * for a dependency excluded by its own `if:`. This scan covers every declared branch and the
+ * other half of the shape: a dependency that RUNS and FAILS.
+ *
+ * The rule, applied per branch in `.github/required-status-checks.json`:
+ *
+ *   For each required context's job J, and each job D in J's `needs:` —
+ *     D is itself a required context on that branch  → OK. D's failure is red on the PR, so
+ *                                                      J reporting `skipping` hides nothing.
+ *     otherwise                                      → J's own `if:` must be FAIL-SAFE: it must
+ *                                                      contain a job-status function
+ *                                                      (`always()`/`cancelled()`/`success()`/
+ *                                                      `failure()`), which is what disables
+ *                                                      GitHub's implicit `success()` over
+ *                                                      `needs`, AND `needs.<D>.result`, which is
+ *                                                      what makes the non-success case a
+ *                                                      deliberate decision rather than an
+ *                                                      accident.
+ *
+ * Both halves are required because either alone is insufficient: a status function without
+ * `needs.<D>.result` runs the job unconditionally (losing the docs-only skip the gate exists
+ * to provide), and `needs.<D>.result` without a status function never evaluates at all, because
+ * GitHub skips the job before the expression is read.
+ *
+ * ANTI-ROT: this scan fails loudly when it examines ZERO dependency edges. Every assertion here
+ * is quantified over edges the parser found, so a parser that stops finding them would report a
+ * clean pass over nothing — the exact way `scan-main-required-checks` first shipped green on
+ * three variants of its own defect.
+ *
+ * Exit code 0 = no required check can be silently skipped by a dependency, 1 = at least one can.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { splitWorkflowJobs, stripComments } from './scan-ci-base-history.mjs';
+import { DECLARATION_FILE, jobNeeds } from './scan-main-required-checks.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/**
+ * A GitHub job-status check function. Its PRESENCE in an `if:` is what removes the implicit
+ * `success()` GitHub otherwise wraps every `needs:` in — without one, the job never evaluates its
+ * condition at all when a dependency fails, it is simply skipped.
+ */
+export const JOB_STATUS_FUNCTION = /\b(always|cancelled|success|failure)\s*\(\s*\)/;
+
+/** A job-level scalar key. Job blocks are dedented by `splitWorkflowJobs`, so keys sit at 4 spaces. */
+function jobLevelValue(jobText, key) {
+  const match = new RegExp(`^ {4}${key}:[ \\t]*(.*)$`, 'm').exec(stripComments(jobText));
+  return match ? match[1].trim() : undefined;
+}
+
+/** Every branch declared in the required-status-checks manifest, with its context list. */
+export function readBranches(root = WORKSPACE_ROOT) {
+  const file = path.join(root, DECLARATION_FILE);
+  if (!existsSync(file)) throw new Error(`${DECLARATION_FILE} is missing.`);
+  const declaration = JSON.parse(readFileSync(file, 'utf8'));
+  const branches = Object.entries(declaration?.branches ?? {});
+  if (branches.length === 0)
+    throw new Error(
+      `${DECLARATION_FILE} declares no branches. An empty declaration satisfies this scan vacuously.`,
+    );
+  return branches.map(([name, entry]) => ({
+    name,
+    contexts: entry?.required_status_checks ?? [],
+  }));
+}
+
+/** The display name a job publishes as its status context. */
+export function jobContextName(jobId, jobText) {
+  return (jobLevelValue(jobText, 'name') ?? jobId).replace(/^['"]|['"]$/g, '');
+}
+
+/**
+ * Whether a dependent job's `if:` is fail-safe with respect to one dependency: it both disables
+ * the implicit `needs` success gate and names that dependency's result.
+ */
+export function isFailSafeFor(condition, dependency) {
+  const text = String(condition ?? '');
+  if (!JOB_STATUS_FUNCTION.test(text)) return false;
+  return new RegExp(`needs\\.${dependency.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.result`).test(
+    text,
+  );
+}
+
+/** Findings across every declared branch, plus the number of dependency edges examined. */
+export function findRequiredCheckNeedsFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  let edges = 0;
+
+  for (const branch of readBranches(root)) {
+    const requiredContexts = new Set(branch.contexts.map((entry) => entry.context));
+
+    for (const entry of branch.contexts) {
+      const { context, workflow, job: jobId } = entry;
+      if (!context || !workflow || !jobId) continue; // shape is scan-main-required-checks' assertion
+
+      const file = path.join(root, workflow);
+      if (!existsSync(file)) {
+        findings.push({
+          branch: branch.name,
+          context,
+          detail: `workflow \`${workflow}\` does not exist, so this scan cannot see what it depends on.`,
+        });
+        continue;
+      }
+      const jobs = splitWorkflowJobs(readFileSync(file, 'utf8'));
+      const job = jobs.find((candidate) => candidate.name === jobId);
+      if (!job) {
+        findings.push({
+          branch: branch.name,
+          context,
+          detail: `workflow \`${workflow}\` declares no job \`${jobId}\`.`,
+        });
+        continue;
+      }
+
+      const condition = jobLevelValue(job.text, 'if') ?? '';
+      for (const need of jobNeeds(job.text)) {
+        edges += 1;
+        const dependency = jobs.find((candidate) => candidate.name === need);
+        const dependencyContext = dependency ? jobContextName(need, dependency.text) : need;
+        if (requiredContexts.has(dependencyContext)) continue;
+        if (isFailSafeFor(condition, need)) continue;
+
+        findings.push({
+          branch: branch.name,
+          context,
+          detail:
+            `needs \`${need}\`, which publishes the context \`${dependencyContext}\` — NOT a required ` +
+            `check on \`${branch.name}\`. When \`${need}\` fails, GitHub reports \`${context}\` as ` +
+            `\`skipped\` rather than \`failure\`, branch protection ACCEPTS a skipped required check ` +
+            `(INFRA-050), and nothing red remains on the PR — it merges having never run this gate ` +
+            `(#1424, three required contexts at once). Make \`${jobId}\`'s \`if:\` fail-safe: include a ` +
+            `job-status function (e.g. \`!cancelled()\`) so the condition is evaluated at all when a ` +
+            `dependency fails, AND \`needs.${need}.result\` so the non-success case is a decision. ` +
+            `Requiring \`${dependencyContext}\` on \`${branch.name}\` is the other admissible fix — ` +
+            `that is a ruleset change, and it must land in ${DECLARATION_FILE} in the same change.`,
+        });
+      }
+    }
+  }
+  return { findings, edges };
+}
+
+export async function main() {
+  let result;
+  try {
+    result = findRequiredCheckNeedsFindings();
+  } catch (error) {
+    process.stdout.write(`required-check-needs scan failed: ${error.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const { findings, edges } = result;
+
+  if (edges === 0) {
+    process.stdout.write(
+      'required-check-needs scan failed — it examined ZERO dependency edges.\n' +
+        'Every assertion in this scan is quantified over `needs:` edges, so finding none means the\n' +
+        'parser stopped reading the workflows, not that the graph is clean. A scan that passes over\n' +
+        'nothing is the defect it exists to catch, one level up.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (findings.length > 0) {
+    process.stdout.write('required-check-needs scan failed (INFRA-058):\n');
+    for (const finding of findings) {
+      process.stdout.write(`  - [${finding.branch}] ${finding.context}: ${finding.detail}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `required-check-needs scan passed — ${edges} dependency edge(s) examined; no required check can be silently skipped by a dependency.\n`,
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/scan-test-selection-tolerance.mjs
+++ b/scripts/harness/scan-test-selection-tolerance.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * Narrowed-test-selection tolerance guard (INFRA-058).
+ *
+ * A CI step that runs a SUBSET of a package's tests — selected by name — is asserting that those
+ * specific tests pass. If the selector matches nothing, the only honest answer is failure: the
+ * step asserted something about tests that no longer exist. Reporting success is reporting a
+ * verdict over ground it never covered.
+ *
+ * MEASURED on `ci.yml` -> `windows-shell`, the only job in the matrix that can exercise win32 at
+ * all, and a REQUIRED status check on `protect-develop`:
+ *
+ *     pnpm --filter @robota-sdk/agent-core test -- --run platform-shell
+ *
+ * `agent-core`'s `test` script is `vitest run --passWithNoTests`, so the flag the CI step never
+ * writes is inherited through the script indirection. Renaming `platform-shell.test.ts` to
+ * `shell-resolver.test.ts` — an ordinary refactor, invisible in review — made that exact command
+ * print `No test files found, exiting with code 0` and exit 0. The check stayed green having
+ * executed nothing, on both of its steps, for as long as the shape existed.
+ *
+ * The flag cannot be overridden at the call site: vitest's cac parser rejects a repeated
+ * `--passWithNoTests` outright ("Expected a single value for option ... received [true, false]"),
+ * so a CI step that inherits it has no way to opt out. The fix is to stop going through the
+ * script — `pnpm --filter <pkg> exec vitest run <pattern>` resolves the same per-package config
+ * and exits 1 when the filter matches nothing.
+ *
+ * SCOPE — deliberately narrow. This flags only the combination that is unambiguously wrong: a
+ * workflow step that NARROWS a test run AND routes it through a script that tolerates zero
+ * matches. A whole-package `pnpm --filter <pkg> test` with no selector is NOT flagged: there
+ * `--passWithNoTests` expresses a package-level policy about a package that may legitimately have
+ * no tests yet, which is a different question (and a different item) from a selector that has
+ * silently stopped selecting. Over-reaching here would make the guard noisy on a shape it cannot
+ * prove is wrong, and a noisy gate is one people learn to bypass.
+ *
+ * ANTI-ROT: fails loudly when it resolves ZERO filtered package-script invocations across all
+ * workflows. Every assertion is quantified over invocations the parser found, so finding none
+ * means the parser broke, not that CI is clean.
+ *
+ * Exit code 0 = no narrowed test selection can pass on zero matches, 1 = at least one can.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { splitJobSteps } from './scan-main-required-checks.mjs';
+import { splitWorkflowJobs, stripComments } from './scan-ci-base-history.mjs';
+import { listWorkspaceScopes } from './shared.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_DIR = path.join('.github', 'workflows');
+
+/** Runner flags that turn "no test file matched the selector" into a PASS. */
+export const ZERO_MATCH_TOLERANT = /--passWithNoTests\b/;
+
+/**
+ * A pnpm invocation of a package script, with whatever follows it.
+ *
+ * Captures the package name from `--filter <pkg>` (the LAST one, so the multi-filter build shape
+ * `--filter a --filter b build` resolves to the script's own trailing args either way), the script
+ * name, and the remainder of the line. `run` is optional because pnpm accepts both spellings.
+ */
+export const FILTERED_SCRIPT_INVOCATION =
+  /\bpnpm\b(?<flags>(?:\s+--filter\s+\S+)+)\s+(?:run\s+)?(?<script>[A-Za-z][\w:.-]*)(?<rest>[^\n]*)/g;
+
+/** Script names this scan treats as running tests. */
+export const TEST_SCRIPT = /^test(:|$)/;
+
+/** List the workflow files this scan governs. */
+export function listWorkflows(root = WORKSPACE_ROOT) {
+  const dir = path.join(root, WORKFLOW_DIR);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((entry) => /\.ya?ml$/.test(entry))
+    .sort()
+    .map((entry) => path.join(WORKFLOW_DIR, entry));
+}
+
+/**
+ * Whether what follows the script name NARROWS the run to a subset of tests.
+ *
+ * `-- --run platform-shell` and a bare trailing `platform-shell` both narrow. A trailing
+ * `--config <file>` does not: it selects a whole PROJECT (`test:bin`, `test:pty`), whose include
+ * globs are the assertion, and an empty project is a different defect from a dead selector.
+ * Nothing at all does not narrow.
+ */
+export function narrowsSelection(rest) {
+  const args = String(rest ?? '')
+    .replace(/^\s*--\s+/, ' ')
+    .trim();
+  if (args === '') return false;
+  const tokens = args.split(/\s+/).filter(Boolean);
+  const narrowing = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--config' || token === '--project' || token === '--reporter') {
+      index += 1; // its value is not a selector
+      continue;
+    }
+    if (token === '--run' || token.startsWith('-')) continue; // `--run` is a MODE, not a selector
+    narrowing.push(token);
+  }
+  return narrowing.length > 0;
+}
+
+/** Index every workspace package by its published name. */
+export async function workspaceScriptsByName(root = WORKSPACE_ROOT) {
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const scopes = await listWorkspaceScopes();
+    return new Map(
+      scopes.map((scope) => [
+        scope.workspaceName,
+        { scripts: scope.scripts ?? {}, dir: scope.relativeDir },
+      ]),
+    );
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+/** Every filtered package-script invocation in a `run:` block. */
+export function parseInvocations(runText) {
+  const found = [];
+  for (const match of String(runText ?? '').matchAll(FILTERED_SCRIPT_INVOCATION)) {
+    const filters = [...match.groups.flags.matchAll(/--filter\s+(\S+)/g)].map((one) => one[1]);
+    found.push({
+      packages: filters,
+      script: match.groups.script,
+      rest: match.groups.rest ?? '',
+    });
+  }
+  return found;
+}
+
+/** The `run:` text of a step block, if it has one. */
+export function stepRun(stepText) {
+  const lines = String(stepText ?? '').split(/\r?\n/);
+  const start = lines.findIndex((line) => /^ {8}run:/.test(line));
+  if (start === -1) return undefined;
+  const body = [lines[start].replace(/^ {8}run:\s*\|?-?\s*/, '')];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && !/^ {10}/.test(line)) break;
+    body.push(line.trim());
+  }
+  return body.join('\n').replace(/\s+$/, '');
+}
+
+/** Findings across every workflow, plus the number of filtered invocations examined. */
+export async function findTestSelectionFindings(root = WORKSPACE_ROOT) {
+  const byName = await workspaceScriptsByName(root);
+  const findings = [];
+  let invocations = 0;
+
+  for (const workflow of listWorkflows(root)) {
+    const text = readFileSync(path.join(root, workflow), 'utf8');
+    for (const job of splitWorkflowJobs(text)) {
+      for (const step of splitJobSteps(job.text)) {
+        const run = stepRun(stripComments(step));
+        if (run === undefined) continue;
+        for (const invocation of parseInvocations(run)) {
+          if (!TEST_SCRIPT.test(invocation.script)) continue;
+          invocations += 1;
+          if (!narrowsSelection(invocation.rest)) continue;
+          for (const name of invocation.packages) {
+            const resolved = byName.get(name);
+            if (!resolved) continue; // an unresolvable filter is check-workspace-refs' assertion
+            const command = resolved.scripts[invocation.script];
+            if (typeof command !== 'string' || !ZERO_MATCH_TOLERANT.test(command)) continue;
+            findings.push({
+              workflow,
+              job: job.name,
+              detail:
+                `narrows \`${name}\`'s \`${invocation.script}\` to a selector (\`${invocation.rest.trim()}\`), ` +
+                `but that script is \`${command}\` — it reports SUCCESS when the selector matches NOTHING. ` +
+                `A rename or a move of the target test file leaves this step green having executed zero ` +
+                `tests. The flag cannot be overridden at the call site (vitest rejects a repeated ` +
+                `\`--passWithNoTests\`), so invoke the runner directly instead: ` +
+                `\`pnpm --filter ${name} exec vitest run <pattern>\`, which resolves the same per-package ` +
+                `config and exits 1 on zero matches.`,
+            });
+          }
+        }
+      }
+    }
+  }
+  return { findings, invocations };
+}
+
+export async function main() {
+  const { findings, invocations } = await findTestSelectionFindings();
+
+  if (invocations === 0) {
+    process.stdout.write(
+      'test-selection-tolerance scan failed — it resolved ZERO filtered test invocations.\n' +
+        'Every assertion here is quantified over invocations the parser found, so finding none means\n' +
+        'the parser stopped reading the workflows, not that CI is clean.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (findings.length > 0) {
+    process.stdout.write('test-selection-tolerance scan failed (INFRA-058):\n');
+    for (const finding of findings) {
+      process.stdout.write(`  - ${finding.workflow} › ${finding.job}: ${finding.detail}\n`);
+    }
+    process.stdout.write(
+      '\nA step that selects tests by name and passes on zero matches reports a verdict over ground it\n' +
+        'never covered — measured on `windows-shell`, where a rename made both steps exit 0 on no tests.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `test-selection-tolerance scan passed — ${invocations} filtered test invocation(s) examined; none can pass on zero matches.\n`,
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}


### PR DESCRIPTION
**THROWAWAY. DO NOT MERGE — will be closed as soon as it is read.**

Measures the one property the INFRA-058 D3 fix (#1474) asserts rather than measures: that
`!cancelled() && (needs.changes.result != 'success' || ...)` makes the five `needs: changes`
dependents RUN when `changes` FAILS, rather than reporting `skipping` — which branch protection
accepts, and which is how #1424 merged with three required checks skipped.

The `changes` step fails before writing `code=` to $GITHUB_OUTPUT, so dependents see
`result=failure` and an EMPTY `outputs.code` — the exact shape a checkout failure, a runner OOM,
or a syntax error in the classifier would produce.

Expected: `tui-e2e`, `examples-typecheck` and `windows-shell` all RUN and report a real
conclusion. Pre-fix, all three reported `skipping`.