### PR TITLE
fix(harness): D9 — pin the workflow permission surface instead of declaring it

### DIFF
--- a/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
@@ -1,0 +1,133 @@
+/**
+ * D9 / INFRA-060 — the workflow permission surface cannot widen unnoticed.
+ *
+ * Each rule is tested on its own, because either alone is a plausible-looking guard that leaves the
+ * other hole open. `scan-main-required-checks` shipped green on three variants of its own target
+ * defect, and `HARNESS-052`'s guard shipped with three instances of the class it audited — both
+ * because the halves were only ever exercised together.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  findWorkflowPermissionFindings,
+  JUSTIFIED_WRITE_SCOPES,
+  parsePermissions,
+} from '../scan-workflow-permissions.mjs';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+/** A throwaway repo root holding only `.github/workflows`, so fixtures cannot touch the real tree. */
+function makeRoot(workflows) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-perms-'));
+  const dir = path.join(root, '.github', 'workflows');
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(workflows)) {
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+  return root;
+}
+
+let roots = [];
+beforeEach(() => {
+  roots = [];
+});
+afterEach(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+function root(workflows) {
+  const created = makeRoot(workflows);
+  roots.push(created);
+  return created;
+}
+
+describe('parsePermissions', () => {
+  it('returns null when the workflow declares no block — it inherits the repo default', () => {
+    expect(parsePermissions('name: x\non:\n  push:\n')).toBeNull();
+  });
+
+  it('reads a block and stops at the next top-level key', () => {
+    const source = 'permissions:\n  contents: read\n  id-token: write\n\nenv:\n  A: b\n';
+    expect(parsePermissions(source)).toEqual({ contents: 'read', 'id-token': 'write' });
+  });
+
+  /**
+   * Regression: the first draft took the LAST value on a duplicate key, so `write` above `read`
+   * parsed as `read` and the unjustified-scope RED case silently did not fire. Duplicate keys are
+   * invalid YAML and GitHub rejects them, so this cannot mask a real config — but a scan that
+   * under-reports its own subject is the defect this whole sweep is about.
+   */
+  it('takes the WIDEST level on a duplicate key, not the last', () => {
+    expect(parsePermissions('permissions:\n  contents: write\n  contents: read\n')).toEqual({
+      contents: 'write',
+    });
+    expect(parsePermissions('permissions:\n  contents: read\n  contents: write\n')).toEqual({
+      contents: 'write',
+    });
+  });
+});
+
+describe('rule 1 — a write scope must be justified', () => {
+  it('RED: an unjustified write grant is a finding', () => {
+    const findings = findWorkflowPermissionFindings(
+      root({ 'unknown.yml': 'permissions:\n  contents: write\n' }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatch(/no justification/);
+  });
+
+  it('GREEN: read-only workflows and undeclared blocks are not findings', () => {
+    const findings = findWorkflowPermissionFindings(
+      root({
+        'a.yml': 'permissions:\n  contents: read\n',
+        'b.yml': 'name: no block here\non:\n  push:\n',
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('rule 2 — anti-rot: a justification cannot outlive its scope', () => {
+  it('RED: an entry nobody requests is a finding', () => {
+    // `codeql.yml` is justified for `security-events: write`; a fixture that drops the grant must
+    // leave the excuse dangling.
+    const findings = findWorkflowPermissionFindings(
+      root({ 'codeql.yml': 'permissions:\n  contents: read\n' }),
+    );
+    expect(findings.some((finding) => /still excuses/.test(finding.detail))).toBe(true);
+  });
+});
+
+describe('fail-closed — the scan never passes over nothing', () => {
+  it('a missing workflow directory is a finding, not a pass', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-perms-empty-'));
+    roots.push(empty);
+    const findings = findWorkflowPermissionFindings(empty);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatch(/examined nothing/);
+  });
+
+  it('an empty workflow directory is a finding, not a pass', () => {
+    const findings = findWorkflowPermissionFindings(root({}));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toMatch(/examined nothing/);
+  });
+});
+
+describe('the real repository', () => {
+  it('holds — every declared write scope is justified and every justification is live', () => {
+    expect(findWorkflowPermissionFindings(REPO_ROOT)).toEqual([]);
+  });
+
+  it('the justification table is non-empty, so the green above is not vacuous', () => {
+    const total = Object.values(JUSTIFIED_WRITE_SCOPES).reduce(
+      (sum, scopes) => sum + Object.keys(scopes).length,
+      0,
+    );
+    expect(total).toBeGreaterThan(0);
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -45,6 +45,10 @@ const SCAN_COMMANDS = [
     name: 'review-workflow-parity',
     command: ['node', 'scripts/harness/scan-review-workflow-parity.mjs'],
   },
+  {
+    name: 'workflow-permissions',
+    command: ['node', 'scripts/harness/scan-workflow-permissions.mjs'],
+  },
   { name: 'document-authority', command: ['node', 'scripts/harness/check-document-authority.mjs'] },
   { name: 'commands', command: ['node', 'scripts/harness/check-command-layering.mjs'] },
   {

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -90,6 +90,18 @@ export const MANDATORY_TREE_GUARDS = [
     why: 'a grafted `--depth` fetch made required jobs report `skipping`, which branch protection accepts — the guard reading zero workflows is the same hole reopened',
   },
   {
+    file: 'scan-workflow-permissions.mjs',
+    finder: 'findWorkflowPermissionFindings',
+    tree: '.github/workflows',
+    why: 'it pins that no workflow holds an unjustified `write` scope; over zero workflows that claim is vacuously true, which is precisely the permission widening it exists to surface',
+  },
+  {
+    file: 'scan-required-check-needs.mjs',
+    finder: 'findRequiredCheckNeedsFindings',
+    tree: '.github/required-status-checks.json',
+    why: 'measured: throws `required-status-checks.json is missing` on an empty root. The dependency edges it asserts are quantified over the declared contexts, so reading none would certify the #1424 bypass as absent',
+  },
+  {
     file: 'scan-automerge-disarm-permission.mjs',
     finder: 'findAutomergePermissionFindings',
     tree: '.github/workflows',
@@ -136,6 +148,16 @@ export const MANDATORY_TREE_GUARDS = [
  * Every `measured` value here was produced by executing the finder, not by reading it.
  */
 export const PENDING_CLASSIFICATION = [
+  {
+    // Measured 2026-07-26: the FINDER returns `{findings: [], invocations: 0}` on an empty root —
+    // vacuous by itself. Its `main()` treats `invocations === 0` as a failure, so the CLI is
+    // fail-closed while the exported finder is not. Recorded rather than pinned because
+    // MANDATORY_TREE_GUARDS asserts the finder's behaviour, and pinning it there would certify a
+    // property the finder does not hold.
+    file: 'scan-test-selection-tolerance.mjs',
+    finder: 'findTestSelectionFindings',
+    measured: 'vacuous',
+  },
   {
     file: 'check-agent-server-boundary.mjs',
     finder: 'findAgentServerBoundaryFindings',

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Workflow permission-scope guard (D9, from INFRA-060's ci.yml audit).
+ *
+ * The audit filed "no `permissions:` block anywhere in ci.yml" as a defect. Measured, it is not one:
+ * the repository's `default_workflow_permissions` is `read`, so a workflow that declares nothing
+ * inherits read-only — already the minimum. Writing the block out changes nothing about what the
+ * token can do, and adds a copy for the next author to clone incorrectly.
+ *
+ * What IS a real exposure is the thing nobody would notice: **that default is a repository setting,
+ * not a file.** Flip it to `write` in the Actions settings UI and every workflow without an explicit
+ * block silently gains write access to the repository — no diff, no review, no failing check. The
+ * workflows would keep passing, which is exactly the shape this repository has been closing all
+ * week: a control whose weakening is invisible from outside.
+ *
+ * So this scan does two things:
+ *
+ *   1. **Pins the repository default to `read`** when it can read it (`--live`, needing a token).
+ *      Offline it asserts the declared intent below is present and internally consistent, so the
+ *      offline run is not vacuous — it just cannot see the live setting.
+ *   2. **Requires every declared `write` scope to be justified.** A write grant is the one thing a
+ *      reviewer must weigh, so each is listed here with the API call that needs it. An undeclared
+ *      write scope appearing in a workflow is a finding; so is a justification for a scope no
+ *      workflow actually asks for any more (anti-rot — a stale excuse outlives what it excused).
+ *
+ * Deliberately NOT checked: that every workflow declares a block. That would fire on every
+ * read-only workflow in the repository — noise, and a noisy guard gets suppressed, which costs more
+ * than it catches. The same reasoning `review-gate`'s severity split rests on.
+ *
+ * Exit 0 = the permission surface matches what is justified here, 1 = drift.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOW_DIR = '.github/workflows';
+
+/**
+ * Every `write` scope any workflow is allowed to hold, and why it needs it. A workflow granting a
+ * scope absent from this map is a finding; an entry here that no workflow requests any more is also
+ * a finding, so the justification cannot outlive the need.
+ */
+export const JUSTIFIED_WRITE_SCOPES = {
+  'claude-code-review.yml': {
+    'pull-requests': 'posts the review as inline comments and a summary on the PR',
+    'id-token':
+      'OIDC exchange for the action app token (see INFRA-053 — may go away with github_token)',
+  },
+  'codeql.yml': {
+    'security-events': 'uploads the SARIF analysis that becomes the code-scanning alerts',
+  },
+  'dependency-review.yml': {
+    'pull-requests': 'comments the dependency-review summary on failure (comment-summary-in-pr)',
+  },
+  'release-bun-binaries.yml': {
+    contents: 'uploads the compiled binaries as GitHub Release assets',
+  },
+  'release-desktop-app.yml': {
+    contents: 'uploads the packaged installers as GitHub Release assets',
+  },
+  'review-gate.yml': {
+    'pull-requests':
+      'posts the blocking findings to the PR so they are readable without the run log',
+  },
+};
+
+/** Parse the top-level `permissions:` block of a workflow into `{scope: level}`. */
+export function parsePermissions(source) {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => /^permissions:\s*$/.test(line));
+  if (start === -1) return null;
+  const scopes = {};
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    const match = /^\s+([a-z-]+):\s*(\S+)/.exec(line);
+    if (!match) continue;
+    const [, scope, level] = match;
+    // Take the WIDEST level on a duplicate key rather than the last one. Duplicate keys are invalid
+    // YAML and GitHub rejects them, so this cannot mask a real config — but a last-one-wins parser
+    // reports `read` for a block that also says `write`, which is a scan that under-reports its own
+    // subject. Found while red-proofing this guard: an injected `write` above an existing `read`
+    // was silently overwritten, and the RED case did not fire.
+    scopes[scope] = scopes[scope] === 'write' || level === 'write' ? 'write' : level;
+  }
+  return scopes;
+}
+
+export function findWorkflowPermissionFindings(root = WORKSPACE_ROOT) {
+  const findings = [];
+  const dir = path.join(root, WORKFLOW_DIR);
+  if (!fs.existsSync(dir)) {
+    // Fail CLOSED: the guard's whole subject is missing, which is never a pass.
+    return [
+      {
+        workflow: WORKFLOW_DIR,
+        detail: 'the workflow directory does not exist — this scan examined nothing',
+      },
+    ];
+  }
+
+  const workflows = fs.readdirSync(dir).filter((name) => name.endsWith('.yml'));
+  if (workflows.length === 0) {
+    return [{ workflow: WORKFLOW_DIR, detail: 'no workflows found — this scan examined nothing' }];
+  }
+
+  const requested = new Set();
+  for (const name of workflows) {
+    const scopes = parsePermissions(fs.readFileSync(path.join(dir, name), 'utf8'));
+    if (scopes === null) continue; // inherits the repository default, which rule 1 pins
+    for (const [scope, level] of Object.entries(scopes)) {
+      if (level !== 'write') continue;
+      requested.add(`${name}:${scope}`);
+      const justification = JUSTIFIED_WRITE_SCOPES[name]?.[scope];
+      if (justification === undefined) {
+        findings.push({
+          workflow: name,
+          detail: `grants \`${scope}: write\` with no justification in JUSTIFIED_WRITE_SCOPES. A write scope is the one grant a reviewer must weigh — record what API call needs it, or drop the scope.`,
+        });
+      }
+    }
+  }
+
+  // Anti-rot, and scoped to workflows that are actually PRESENT. A justification for a workflow the
+  // scanned tree does not contain says nothing about rot — it only says this is not the real tree.
+  // Without that guard every fixture root reported all seven entries as stale, which is a rule
+  // firing on the absence of its subject rather than on a defect.
+  const present = new Set(workflows);
+  for (const [name, scopes] of Object.entries(JUSTIFIED_WRITE_SCOPES)) {
+    if (!present.has(name)) continue;
+    for (const scope of Object.keys(scopes)) {
+      if (requested.has(`${name}:${scope}`)) continue;
+      findings.push({
+        workflow: name,
+        detail: `JUSTIFIED_WRITE_SCOPES still excuses \`${scope}: write\`, which the workflow no longer requests — delete the entry so the excuse cannot outlive what it excused.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** Read the repository's default workflow permission. Requires a token; only used under `--live`. */
+export function readLiveDefault(repo) {
+  const raw = execFileSync(
+    'gh',
+    ['api', `repos/${repo}/actions/permissions/workflow`, '--jq', '.default_workflow_permissions'],
+    { encoding: 'utf8' },
+  );
+  return raw.trim();
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const findings = findWorkflowPermissionFindings();
+
+  if (argv.includes('--live')) {
+    const repo = process.env.GITHUB_REPOSITORY ?? 'woojubb/robota';
+    let live;
+    try {
+      live = readLiveDefault(repo);
+    } catch (error) {
+      // Fail CLOSED: unable to read is not the same as correct.
+      process.stdout.write(
+        `workflow-permissions scan failed: could not read the live default for ${repo} — ${error.message}\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    if (live !== 'read') {
+      findings.push({
+        workflow: '(repository setting)',
+        detail: `default_workflow_permissions is \`${live}\`, not \`read\`. Every workflow without an explicit permissions block now holds that level — a widening no diff would show.`,
+      });
+    }
+  }
+
+  if (findings.length > 0) {
+    process.stdout.write('workflow-permissions scan failed (D9 / INFRA-060):\n');
+    for (const finding of findings) {
+      process.stdout.write(`  - ${finding.workflow}: ${finding.detail}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const count = Object.values(JUSTIFIED_WRITE_SCOPES).reduce(
+    (total, scopes) => total + Object.keys(scopes).length,
+    0,
+  );
+  process.stdout.write(
+    `workflow-permissions scan passed: ${count} declared write scope(s), each justified.` +
+      (argv.includes('--live')
+        ? ' Live default is `read`.'
+        : ' (offline — live default not read)') +
+      '\n',
+  );
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Owner-approved D9 from the ci.yml audit, resolved the opposite way to how it was filed.

**The filing was wrong, and measuring it is what showed that.** The audit recorded "no `permissions:` block anywhere in `ci.yml`" as a defect. The repository's `default_workflow_permissions` is **`read`**, so a workflow declaring nothing already inherits the minimum. Writing the block out changes nothing about what the token can do, and leaves a copy for the next author to clone incorrectly.

**What is a real exposure is invisible from the repository.** That default is a *settings* value, not a file. Flip it to `write` in the Actions UI and every workflow without an explicit block silently gains write access — no diff, no review, no failing check, and every workflow keeps passing. That is the same shape as everything else closed this week: a control whose weakening cannot be seen from outside.

So `scan-workflow-permissions` does two things instead:

1. **`--live` pins the repository default to `read`**, failing closed when it cannot read the setting. Offline it says so rather than implying it checked.
2. **Every declared `write` scope must name the API call that needs it** — 7 across 6 workflows today — with anti-rot so a justification cannot outlive the grant it excused.

It deliberately does **not** require a block on every workflow. That fires on every read-only workflow in the repo, and a noisy guard gets suppressed — the reasoning `review-gate`'s severity split already rests on.

## The red proof caught a defect in the guard itself

My first RED attempt **did not fire**. I injected `contents: write` above an existing `contents: read`; the parser took the last value, so a block that said `write` was reported as `read`. Duplicate keys are invalid YAML so it could not mask a real config — but a scan that under-reports its own subject is exactly the class this sweep is about. Fixed to take the widest level, with a regression test naming how it was found.

All three rules are now red-proofed separately: an unjustified write grant, a stale justification, and a missing/empty workflow directory (fail-closed, not a pass).

## It was then caught by the guard that landed an hour earlier

`guard-scope-fail-closed` (HARNESS-052) flagged **all three** newly registered scans as unclassified — mine plus the ci.yml audit's two. Now classified by measurement rather than by reading:

- `scan-workflow-permissions` and `scan-required-check-needs` → `MANDATORY_TREE_GUARDS`, both verified to throw or report on an absent tree.
- `scan-test-selection-tolerance` → `PENDING_CLASSIFICATION`, **measured `vacuous`**: its finder returns `{findings: [], invocations: 0}` on an empty root and only its `main()` fails closed. Pinning it would certify a property the finder does not hold.

**Verification:** `harness:scan` 76/76 · `harness:test` 94 files / 1232 tests · 10 new unit tests, each rule tested on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z